### PR TITLE
Fix subsequent calls to CMD_LAND_AT_AIRBASE

### DIFF
--- a/luarules/gadgets/unit_airbase.lua
+++ b/luarules/gadgets/unit_airbase.lua
@@ -360,7 +360,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 
 		if cmdID == CMD_LAND_AT_AIRBASE then
-			if landingPlanes[unitID] or tractorPlanes[unitID] then
+			if landingPlanes[unitID] or tractorPlanes[unitID] or landedPlanes[unitID] then
 				-- finished processing
 				return true, true
 			end


### PR DESCRIPTION
Without `landedPlanes[unitID]` check autoheal can prevent Detach() call