### PR TITLE
Zecrus balance adjustments

### DIFF
--- a/luarules/gadgets/unit_continuous_aim.lua
+++ b/luarules/gadgets/unit_continuous_aim.lua
@@ -65,6 +65,10 @@ local convertedUnits = {
 	[UnitDefNames.armvang.id] = 1,
 
 	-- the following units get a faster reaimtime to counteract their turret acceleration
+	[UnitDefNames.armflash.id] = 6,
+	[UnitDefNames.corgator.id] = 6,
+	[UnitDefNames.armdecade.id] = 6,
+	[UnitDefNames.coresupp.id] = 6,
 	[UnitDefNames.corhlt.id] = 5,
 	[UnitDefNames.corfhlt.id] = 5,
 	[UnitDefNames.cordoom.id] = 5,

--- a/units/ArmAircraft/armca.lua
+++ b/units/ArmAircraft/armca.lua
@@ -3,7 +3,7 @@ return {
 		acceleration = 0.07,
 		blocking = false,
 		brakerate = 0.4275,
-		buildcostenergy = 4200,
+		buildcostenergy = 3000,
 		buildcostmetal = 110,
 		builddistance = 136,
 		builder = true,

--- a/units/ArmBuildings/LandEconomy/armmex.lua
+++ b/units/ArmBuildings/LandEconomy/armmex.lua
@@ -14,7 +14,7 @@ return {
 		buildpic = "ARMMEX.PNG",
 		buildtime = 1800,
 		canrepeat = false,
-		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE CANBEUW UNDERWATER",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "48 38 48",
 		collisionvolumetype = "CylY",

--- a/units/ArmShips/armcs.lua
+++ b/units/ArmShips/armcs.lua
@@ -52,6 +52,7 @@ return {
 			"armdrag",
 			"armclaw",
 			--"armuwmex",
+			"armguard",
 			"armtide",
 			"armgeo",
 			"armfmkr",

--- a/units/ArmVehicles/armflash.lua
+++ b/units/ArmVehicles/armflash.lua
@@ -138,6 +138,8 @@ return {
 			emgx = {
 				areaofeffect = 8,
 				avoidfeature = false,
+				burst = 3,
+				burstrate = 0.1,
 				craterareaofeffect = 0,
 				craterboost = 0,
 				cratermult = 0,
@@ -150,7 +152,7 @@ return {
 				name = "Rapid-fire close-quarters plasma gun",
 				noselfdamage = true,
 				range = 180,
-				reloadtime = 0.1,
+				reloadtime = 0.3,
 				rgbcolor = "1 0.95 0.4",
 				size = 2.15,
 				soundhitwet = "splshbig",

--- a/units/ArmVehicles/armstump.lua
+++ b/units/ArmVehicles/armstump.lua
@@ -41,7 +41,7 @@ return {
 		turninplace = true,
 		turninplaceanglelimit = 90,
 		turninplacespeedlimit = 1.952,
-		turnrate = 380,
+		turnrate = 340,
 		customparams = {
 			basename = "base",
 			cannon1name = "cannon1",

--- a/units/CorAircraft/corca.lua
+++ b/units/CorAircraft/corca.lua
@@ -3,7 +3,7 @@ return {
 		acceleration = 0.06,
 		blocking = false,
 		brakerate = 0.4275,
-		buildcostenergy = 4400,
+		buildcostenergy = 3200,
 		buildcostmetal = 115,
 		builddistance = 136,
 		builder = true,

--- a/units/CorBuildings/LandEconomy/cormex.lua
+++ b/units/CorBuildings/LandEconomy/cormex.lua
@@ -14,7 +14,7 @@ return {
 		buildpic = "CORMEX.PNG",
 		buildtime = 1874,
 		canrepeat = false,
-		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE CANBEUW UNDERWATER",
 		collisionvolumeoffsets = "0 3 0",
 		collisionvolumescales = "48 33 48",
 		collisionvolumetype = "CylY",

--- a/units/CorShips/corcs.lua
+++ b/units/CorShips/corcs.lua
@@ -51,6 +51,7 @@ return {
 			"cordl",
 			"cordrag",
 			"cormaw",
+			"corpun",
 			--"coruwmex",
 			"cortide",
 			"corgeo",

--- a/units/CorVehicles/corraid.lua
+++ b/units/CorVehicles/corraid.lua
@@ -40,7 +40,7 @@ return {
 		turninplace = true,
 		turninplaceanglelimit = 90,
 		turninplacespeedlimit = 1.873,
-		turnrate = 371,
+		turnrate = 330,
 		customparams = {
 			basename = "base",
 			cannon1name = "barrel",


### PR DESCRIPTION
The following balance changes/fixes: The 1st is continuous aiming for flash, gator, corvette, and supporter.  Flash is the only unit that needs this, but the other 3 would benefit a bit as well.  The 2nd is reducing the stumpy/raider turn rate by 10%.  The 3rd is reducing the E cost of T1 con planes from 4200E and 4400E to 3000E and 3200E.  Air cons are still way more expensive than land cons (arm T1 kbot con is 1600E), and 4200E just seemed absurdly high to be able to access basic T1 buildings if you start air.  The 4th change is allowing T1 con ships to build guardian/punisher.  I think this adds an interesting strategic option to sea gameplay, where islands can be a valuable guardian location.  The 5th change is adding categories to arm and cor T1 mexes, so that uw mexes can be targeted by destroyers. The 6th change is giving the flash tank a 3-round burst fire, in order to fix a problem with its fire rate being reduced.  It now has the fire rate it was always supposed to have.  