### PR TITLE
Restore previous LoS view when selecting units

### DIFF
--- a/luaui/Widgets/gfx_los_colors.lua
+++ b/luaui/Widgets/gfx_los_colors.lua
@@ -103,7 +103,11 @@ function widget:PlayerChanged(playerID)
     if playerID == Spring.GetMyPlayerID() then
         if Spring.GetSpectatingState() then
             specDetected = true
-            withoutRadars()
+            if losWithRadarEnabled then
+                withRadars()
+            else
+                withoutRadars()
+            end
         end
     end
 end

--- a/luaui/Widgets/gui_spectate_selected.lua
+++ b/luaui/Widgets/gui_spectate_selected.lua
@@ -32,7 +32,7 @@ function widget:SelectionChanged(sel)
 		if selTeam and selTeam ~= myTeamID then
 			switchToTeam = selTeam
 		end
-    end
+	end
 end
 
 local sec = 0
@@ -40,9 +40,19 @@ function widget:Update(dt)
 	if spec then
 		sec = sec + dt
 		if sec > 1.5 and switchToTeam ~= nil then	-- added a delay cause doing too quick changes is perf costly, happens when you area drag lots of mixed team units
+
+			local oldMapDrawMode = Spring.GetMapDrawMode()
+
 			sec = 0
 			Spring.SendCommands('specteam ' .. switchToTeam)
 			myTeamID = switchToTeam
+
+			local newMapDrawMode = Spring.GetMapDrawMode()
+
+			if oldMapDrawMode == 'los' and oldMapDrawMode ~= newMapDrawMode then
+				Spring.SendCommands("togglelos")
+			end
+
 			switchToTeam = nil
 		end
 	end


### PR DESCRIPTION
I do not know why LoS view is lost when selecting units from another team while spectating. So this is more of a workaround, but it does maintain LoS view in this case.