### PR TITLE
Remove spec check for los radar toggle

### DIFF
--- a/luaui/Widgets/gfx_los_colors.lua
+++ b/luaui/Widgets/gfx_los_colors.lua
@@ -144,11 +144,6 @@ function setLosWithoutColors()
 end
 
 function toggleLOSRadars()
-    if specDetected and losWithRadarEnabled then
-        losWithRadarEnabled = false
-    end
-    specDetected = false
-
     if losWithRadarEnabled then
         setLosWithoutRadars()
     else


### PR DESCRIPTION
This fixes an issue where, when switching players in LoS view, toggling LoS radar would not work on first try. So for example, turn LoS view on (`L`) then attempt to toggle radar LoS (`;`) and depending on the mode it would need a second `;` to actually toggle.