### PR TITLE
Set factory hold pos widget default enabled

### DIFF
--- a/luaui/Widgets/cmd_fac_holdposition.lua
+++ b/luaui/Widgets/cmd_fac_holdposition.lua
@@ -19,7 +19,7 @@ function widget:GetInfo()
     date      = "Mar 20, 2007",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
-    enabled   = false  --  loaded by default?
+    enabled   = true
   }
 end
 


### PR DESCRIPTION
Tested by deleting `springsettings.cfg` and `LuaUI/Config` and it worked