### PR TITLE
Added devastator/kraken to T2 ship engineer build list

### DIFF
--- a/units/ArmShips/T2/armmls.lua
+++ b/units/ArmShips/T2/armmls.lua
@@ -58,6 +58,7 @@ return {
 			[13] = "armamph",
 			[14] = "armfmine3",
 			[15] = "armamb",
+			[16] = "armkraken",
 		},
 		customparams = {
 			area_mex_def = "armmex",

--- a/units/CorShips/T2/cormls.lua
+++ b/units/CorShips/T2/cormls.lua
@@ -57,6 +57,7 @@ return {
 			[12] = "corroy",
 			[13] = "corfmine3",
 			[14] = "cortoast",
+			[15] = "corfdoom",
 		},
 		customparams = {
 			area_mex_def = "cormex",


### PR DESCRIPTION
This lets you get a devastator/kraken earlier, which will make it easier to build the unit in the stage of the game where it is most useful.