### PR TITLE
update readme for local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,32 @@ https://www.beyondallreason.info/download
 
 ## Development Quick Start
 
-You will need a lobby for the Spring Engine, such as [SpringLobby](https://springlobby.springrts.com). Once this is set up, go to your Spring data folder, and check out a copy of the game
+Beyond All Reason (BYAR), consists of 2 primary components, the lobby (Chobby - https://github.com/beyond-all-reason/BYAR-Chobby) and the game code itself (this repository).
 
-```shell
-git clone https://github.com/beyond-all-reason/Beyond-All-Reason.git bar.sdd
+The game runs on top of the Spring engine https://github.com/spring/spring.
+
+In order to develop the game (this repository) you first need a working install of the lobby/launcher. There are 2 ways to do this:
+
+1. Follow [the guide in the Chobby README](https://github.com/beyond-all-reason/BYAR-Chobby#developing-the-lobby). First download a [release of Chobby](https://github.com/beyond-all-reason/BYAR-Chobby/releases) and then launch Chobby, this will automatically download and install the engine and other dependencies.
+
+2. [Download the full BAR application](https://www.beyondallreason.info/download#How-To-Install) from the website and run it. This is probably what you will have done if you have previously installed and played the game.
+
+Once you have a working install of BAR you need a local development copy of the game code to work with. This code will live in the BYAR install directory.
+
+1. To find the BYAR install directory simply open the launcher (not full game) and click the "Open install directory" button. This is one of the 3 buttons (`Toggle log` and `Upload log` are the other 2). For Windows installs this might be your user's `AppData/Local/Programs/Beyond-All-Reason/data` directory.
+
+2. In the BYAR install directory create the empty file `devmode.txt`.
+
+3. In the BYAR install directory in the `games` sub-directory (create if it doesn't exist) clone the code for this repository into a directory with a name ending in `.sdd`. For example:
+
+```
+git clone https://github.com/beyond-all-reason/Beyond-All-Reason.git BAR.sdd
 ```
 
-The game will now show in lobbies as `Beyond All Reason $VERSION`
+4. Now you have the game code launch the full game from the launcher as normal. Then go to `Settings > Developer > Singleplayer` and select `Beyond All Reason Dev`.
+
+5. Now you can launch a match normally through the game UI. This match will use the dev copy of the LUA code which is in `BYAR-install-directory/games/BAR.sdd`.
+
+6. If developing Chobby also clone the code into the `games` directory. Follow the guide in the [Chobby README](https://github.com/beyond-all-reason/BYAR-Chobby#developing-the-lobby).
+
+More on the `.sdd` directory to run raw LUA and the structure expected by Spring Engine is [documented here](https://springrts.com/wiki/Gamedev:Structure).


### PR DESCRIPTION
The current readme refers to SpringLobby and is a bit confusing for first time set-up. I copied some of the details from Chobby and recorded the steps for first-time setup I followed on Windows but we might want additional or less information.

I think my version of the readme might be slightly misleading since it seems like the launcher is a 3rd, separate, component to Chobby?