### PR TITLE
Modoptions bugfix: Change modoptions to only use lowercase letters

### DIFF
--- a/luarules/gadgets/scavengers/API/api.lua
+++ b/luarules/gadgets/scavengers/API/api.lua
@@ -71,7 +71,7 @@ BaseCleanupQueue = {}
 
 --spawningStartFrame = (math.ceil( math.ceil(mapsizeX + mapsizeZ) / 750 ) + 30) * 5
 spawningStartFrame = (math.ceil( math.ceil(mapsizeX*mapsizeZ) / 1000000 )) * 5
-scavMaxUnits = Spring.GetModOptions().MaxUnits
+scavMaxUnits = Spring.GetModOptions().maxunits
 
 if GaiaTeamID == Spring.GetGaiaTeamID() then
 	scavMaxUnits = 10000

--- a/luaui/Widgets/gui_advplayerslist_unittotals.lua
+++ b/luaui/Widgets/gui_advplayerslist_unittotals.lua
@@ -50,7 +50,7 @@ local drawlist = {}
 local advplayerlistPos = {}
 local widgetHeight = 22
 local top, left, bottom, right = 0,0,0,0
-local gameMaxUnits = Spring.GetModOptions().MaxUnits
+local gameMaxUnits = Spring.GetModOptions().maxunits
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -98,7 +98,7 @@ local options={
 		type   	= 'section',
 	},
 	{
-		key    = 'MaxUnits',
+		key    = 'maxunits',
 		name   = 'Max units',
 		desc   = 'Maximum number of units (including buildings) for each team allowed at the same time',
 		type   = 'number',
@@ -130,7 +130,7 @@ local options={
 		section= 'restrictions',
 	},
 	{
-		key    = 'FixedAllies',
+		key    = 'fixedallies',
 		name   = 'Fixed ingame alliances',
 		desc   = 'Disables the possibility of players to dynamically change alliances ingame',
 		type   = 'bool',
@@ -568,7 +568,7 @@ local options={
 	 	section= 'options',
 	 },
 	{
-		key    = 'DisableMapDamage',
+		key    = 'disablemapdamage',
 		name   = 'Undeformable map',
 		desc   = 'Prevents the map shape from being changed by weapons',
 		type   = 'bool',


### PR DESCRIPTION
Since the engine passes all modoptions to the game as lowercase, reading the `MaxUnits` modoption always returned the default value.