### PR TITLE
Hoverscout dps nerf

### DIFF
--- a/units/ArmHovercraft/armsh.lua
+++ b/units/ArmHovercraft/armsh.lua
@@ -145,7 +145,7 @@ return {
 					light_mult = "0.5",
 				},
 				damage = {
-					default = 48,
+					default = 36,
 				},
 			},
 		},

--- a/units/ArmVehicles/armpincer.lua
+++ b/units/ArmVehicles/armpincer.lua
@@ -35,7 +35,7 @@ return {
 		script = "Units/ARMPINCER.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-phib",
-		sightdistance = 240,
+		sightdistance = 305,
 		sonardistance = 180,
 		trackoffset = 3,
 		trackstrength = 6,

--- a/units/CorHovercraft/corsh.lua
+++ b/units/CorHovercraft/corsh.lua
@@ -142,8 +142,7 @@ return {
 				weapontype = "BeamLaser",
 				weaponvelocity = 450,
 				damage = {
-					default = 48,
-					subs = 2,
+					default = 36,
 				},
 			},
 		},

--- a/units/CorVehicles/corgarp.lua
+++ b/units/CorVehicles/corgarp.lua
@@ -35,7 +35,7 @@ return {
 		script = "Units/CORGARP.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-phib",
-		sightdistance = 234,
+		sightdistance = 305,
 		sonardistance = 175.5,
 		trackoffset = 0,
 		trackstrength = 6,


### PR DESCRIPTION
Hoverscout dps reduced so it will take longer to destroy a base, and to make them weaker against light units.  80dps ->60dps, still notably higher than other scouts but now lower than other T1 light raiders.  Garpike/Pincer los increased so it matches up with weapon range.