### PR TITLE
Sea turnrate reduction experiment

### DIFF
--- a/units/ArmShips/armdecade.lua
+++ b/units/ArmShips/armdecade.lua
@@ -23,7 +23,7 @@ return {
 		icontype = "sea",
 		idleautoheal = 5,
 		idletime = 1800,
-		maxdamage = 825,
+		maxdamage = 875, --825,
 		maxvelocity = 3.49,
 		minwaterdepth = 12,
 		movementclass = "BOAT3",
@@ -36,7 +36,7 @@ return {
 		sightdistance = 375,
 		turninplace = true,
 		turninplaceanglelimit = 90,
-		turnrate = 631.5,
+		turnrate = 450, --631.5,
 		waterline = 0,
 		customparams = {
 			model_author = "FireStorm",

--- a/units/ArmShips/armpship.lua
+++ b/units/ArmShips/armpship.lua
@@ -38,7 +38,7 @@ return {
 		sightdistance = 500,
 		turninplace = true,
 		turninplaceanglelimit = 90,
-		turnrate = 427.5,
+		turnrate = 375, --427.5,
 		waterline = 0,
 		customparams = {
 			normaltex = "unittextures/Arm_normal.dds",

--- a/units/CorShips/coresupp.lua
+++ b/units/CorShips/coresupp.lua
@@ -36,7 +36,7 @@ return {
 		sightdistance = 500,
 		turninplace = true,
 		turninplaceanglelimit = 90,
-		turnrate = 663,
+		turnrate = 500, --663,
 		waterline = 0,
 		customparams = {
 			model_author = "Mr Bob",
@@ -151,7 +151,7 @@ return {
 				weaponvelocity = 2250,
 				damage = {
 					bombers = 6,
-					default = 37,
+					default = 41,--37,
 					fighters = 6,
 					vtol = 6,
 				},

--- a/units/CorShips/corpship.lua
+++ b/units/CorShips/corpship.lua
@@ -38,7 +38,7 @@ return {
 		sightdistance = 500,
 		turninplace = true,
 		turninplaceanglelimit = 90,
-		turnrate = 382.5,
+		turnrate = 350, --382.5,
 		waterline = 0,
 		customparams = {
 			normaltex = "unittextures/cor_normal.dds",


### PR DESCRIPTION
Turnrate of corvettes and frigates reduced so that T1 ships have a better sense of momentum.  Decade's health increased and supporter's dps increased to compensate for this nerf.