### PR TITLE
As agreed on Discord, changing Autogroup Immediate mode to ON by default

### DIFF
--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -36,7 +36,7 @@ include("keysym.h.lua")
 --------------------------------------------------------------------------------
 
 local addall = true
-local immediate = false
+local immediate = true
 local verbose = true
 
 local cutoffDistance = 3500


### PR DESCRIPTION
Otherwise it seems like a bug when a just built unit is not assigned to a group (when moving to a rally point or con assisting a factory).
https://discord.com/channels/549281623154229250/722148569007521863/894754266810581032