### PR TITLE
Update gfx_los_colors.lua

### DIFF
--- a/luaui/Widgets/gfx_los_colors.lua
+++ b/luaui/Widgets/gfx_los_colors.lua
@@ -149,6 +149,7 @@ function widget:Initialize()
 
     spSendCommands('unbindkeyset Any+;')
     spSendCommands('bind Any+; losradar')
+    spSendCommands('bind Any+0xf6 losradar')	
 
 	WG['los'] = {}
 	WG['los'].getColorize = function()


### PR DESCRIPTION
Bind losradar to german keyboard too.
Code  0xf6 belongs to german keyboard layout "ö", which is same position as ; on USA\UK