### PR TITLE
Don't ignore arrow keys when building lines

### DIFF
--- a/luaui/Widgets/cmd_line-build_hotkey_ignore.lua
+++ b/luaui/Widgets/cmd_line-build_hotkey_ignore.lua
@@ -1,3 +1,5 @@
+include("keysym.h.lua")
+
 function widget:GetInfo()
     return {
         name         = "Line-Build Hotkey Ignore",
@@ -12,14 +14,17 @@ end
 function widget:KeyPress(key, mods, isRepeat)
 
     if not mods.alt and mods.shift then
-
-		local x, y, leftPressed, middlePressed, rightPressed, offscreen = Spring.GetMouseState()
-		if leftPressed then
-
-			local idx, cmd_id, cmd_type, cmd_name = Spring.GetActiveCommand()
-			if cmd_id and cmd_id < 0 then
-				return true
-			end
-		end
+    
+        if key ~= KEYSYMS['UP'] and key ~= KEYSYMS['DOWN'] and key ~= KEYSYMS['LEFT'] and key ~= KEYSYMS['RIGHT'] then -- Don't ignore arrow keys
+        
+            local x, y, leftPressed, middlePressed, rightPressed, offscreen = Spring.GetMouseState()
+            if leftPressed then
+            
+                local idx, cmd_id, cmd_type, cmd_name = Spring.GetActiveCommand()
+                if cmd_id and cmd_id < 0 then
+                    return true
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
Scrolling the camera with arrow keys while building lines is now possible.