### PR TITLE
Bugfix: Fix Chickens modoptions getting removed

### DIFF
--- a/luaui/Widgets/gui_gameinfo.lua
+++ b/luaui/Widgets/gui_gameinfo.lua
@@ -67,7 +67,6 @@ for key, value in pairs(modoptions) do
 				changedChickenModoptions[key] = tostring(value)
 			end
 		end
-		modoptions[key] = nil    -- filter chicken modoptions
 	end
 end
 


### PR DESCRIPTION
Tables in Lua are passed by reference, so setting Chickens modoptions to nil in the local variable sets them to nil is all subsequent calls to Spring.GetModOptions(),

This subsequently broke reloading any Chickens widget, versus this fix which causes Chickens modoptions appear twice in game info window.