### PR TITLE
enable buildfacing south,east,west, north in pregame state

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author = "Floris",
 		date = "April 2020",
 		license = "GNU GPL, v2 or later",
-		layer = 0,
+		layer = 2,
 		enabled = true,
 		handler = true,
 	}
@@ -56,6 +56,8 @@ local activeCmd, selBuildQueueDefID
 local prevHoveredCellID, hoverDlist
 
 local math_isInRect = math.isInRect
+
+local facingMap = {south=0, east=1, north=2, west=3}
 
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
@@ -555,7 +557,7 @@ function buildFacingHandler(_, _, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
 		return
 	end
-
+	
 	local facing = Spring.GetBuildFacing()
 	if args and args[1] == "inc" then
 		facing = facing + 1
@@ -572,6 +574,11 @@ function buildFacingHandler(_, _, args)
 		end
 		Spring.SetBuildFacing(facing)
 
+		return true
+
+	elseif args and facingMap[args[1]] then
+		Spring.SetBuildFacing(facingMap[args[1]])
+	
 		return true
 	end
 end

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author = "Floris",
 		date = "April 2020",
 		license = "GNU GPL, v2 or later",
-		layer = 2,
+		layer = 0,
 		enabled = true,
 		handler = true,
 	}


### PR DESCRIPTION
A friend of me uses Numpad2, Numpad4, Numpad6, Numpad8 to set buildfacing directions.
This works great in game. But not in pregame state.

```
bind            numpad2  buildfacing  south
bind            numpad4  buildfacing  west
bind            numpad6  buildfacing  east
bind            numpad8  buildfacing  north
```

In pregame state those actions from uikeys.txt are not processed yet, so added them here.

Original Facing_Map in spring in SpringMath.h , little funny, why Math ? 🤣 
https://github.com/beyond-all-reason/spring/blob/e9df54f060978a34f15d27e6c21de26bffba727b/rts/System/SpringMath.h#L30-L36

Here it is used:
https://github.com/beyond-all-reason/spring/blob/e9df54f060978a34f15d27e6c21de26bffba727b/rts/Game/UI/GuiHandler.cpp#L1753-L1785

While this pull request gives the possibilities to use keybinds of uikeys to actions like buildfacing south, buildfacing east etc., it won´t fix my friend´s issue, since he bound Numpad2, Numpad4, Nump6, Numpad8 to buildfacings. Those uikeys bindings are overwritten by cmd_bar_hotkeys.lua. But it´s ok in first approximation, He can disable bar_hotkeys and others are enabled to use this binding in pregame state.
