### PR TITLE
Modoptions: Return a new copy of the modoptions table every time Spri…

### DIFF
--- a/common/springFunctions.lua
+++ b/common/springFunctions.lua
@@ -54,6 +54,8 @@ if Spring.GetModOptions then
 	end
 
 	Spring.GetModOptions = function ()
-		return modOptions
+		-- Returning the table itself would allow callers to mutate the table
+		-- Copying it ensures each caller gets its own copy
+		return table.copy(modOptions)
 	end
 end


### PR DESCRIPTION
…ng.GetModOptions() is called.

This prevents callers from mutating the table resulting in side-effects for other callers.