### PR TITLE
enable buildfacing south,east,west, north in pregame state (gui_gridmenu)

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -182,6 +182,8 @@ local showWaterUnits = false
 
 local selectedBuilder, selectedFactory
 
+local facingMap = {south=0, east=1, north=2, west=3}
+
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 
@@ -809,6 +811,10 @@ function buildFacingHandler(_, _, args)
 		end
 		Spring.SetBuildFacing(facing)
 
+		return true
+	elseif args and facingMap[args[1]] then
+		Spring.SetBuildFacing(facingMap[args[1]])
+	
 		return true
 	end
 end


### PR DESCRIPTION
- added pregame support for action buildfacing <south, east,west,north>

corresponds to this:
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/577
