### PR TITLE
Fix for missing Settings widget

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -1858,9 +1858,9 @@ function init()
 			  }
 			  if ShadowMapSize == 0 then
 				  --options[getOptionByID('shadowslider')].value = 1
-			  else
+			  elseif ShadowMapSize ~= nil then
 				  for k,v in pairs( options[getOptionByID('shadowslider')].options) do
-					  if quality[v] <= ShadowMapSize then
+					  if quality[v] ~= nil and quality[v] <= ShadowMapSize then
 						  options[getOptionByID('shadowslider')].value = k
 					  end
 				  end


### PR DESCRIPTION
Excerpt from infolog:
```
potato Graphics Card detected
Set "shadows" config-parameter to 1
false
Error in DrawScreen(): [string "LuaUI/Widgets/gui_options.lua"]:1863: attempt to compare nil with number
Removed widget: Options
```

I don't think it fixes the actual problem, but at least patches the issue so the Settings are shown. @Ruwetuin could you review, knowing the desired logic please?