### PR TITLE
Saber dps nerf

### DIFF
--- a/units/ArmSeaplanes/armsaber.lua
+++ b/units/ArmSeaplanes/armsaber.lua
@@ -95,7 +95,7 @@ return {
 				noselfdamage = true,
 				proximitypriority = 1,
 				range = 425,
-				reloadtime = 0.8,
+				reloadtime = 0.9,
 				rgbcolor = "0.05 0.05 1",
 				soundhit = "xplosml3",
 				soundhitwet = "sizzle",


### PR DESCRIPTION
reloadtime from 0.8->0.9, resulting in a dps from 75->67.  On paper the unit's stats matched up with the T1 and T2 gunships, but in practice its weapon's instant damage and high accuracy make sabers too powerful.