### PR TITLE
Add customization for grid action keys

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -25,7 +25,7 @@ SYMKEYS = table.invert(KEYSYMS)
 local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
 local labGrids = configs.LabGrids
 local unitGrids = configs.UnitGrids
-local currentLayout = 'qwerty'
+local currentLayout = 'custom'
 
 local BUILDCAT_ECONOMY = "Economy"
 local BUILDCAT_COMBAT = "Combat"
@@ -787,6 +787,20 @@ function widget:ViewResize()
 	doUpdate = true
 end
 
+local function map_key(k)
+   if k == ',' then
+      return 'COMMA'
+   elseif k == '.' then
+      return 'PERIOD'
+   elseif k == ';' then
+      return 'SEMICOLON'
+   elseif k == "'" then
+      return 'QUOTE'
+   else
+      return string.upper(k)
+   end
+end
+
 function reloadBindings()
 	local layout
 	local actionHotkey = Spring.GetActionHotKeys('gridmenu_layout')
@@ -810,6 +824,18 @@ function reloadBindings()
 	else
 		Spring.SendCommands("bind " .. string.lower(PREV_PAGE_KEY) .. " gridmenu_prev_page")
 	end
+        local custom = {}
+        for r=1,3 do
+           local row = {}
+           for c=1,4 do
+              hotkey = 'gridmenu_' .. r .. '_' .. c
+              actionHotkey = map_key(Spring.GetActionHotKeys(hotkey)[1])
+              row[c] = actionHotkey
+           end
+           custom[4 - r] = row
+        end
+        Cfgs.keyLayouts['custom'] = custom
+        genKeyLayout('custom')
 end
 
 function nextPageHandler()

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -818,7 +818,7 @@ function reloadBindings()
 	local useCustom = false
 	for r=1,3 do
 		for c=1,4 do
-			hotkey = 'gridmenu_' .. r .. '_' .. c
+			local hotkey = 'gridmenu_' .. r .. '_' .. c
 			local key = Spring.GetActionHotKeys(hotkey)[1]
 			if key then
 				Cfgs.keyLayouts['custom'][r][c] = keySymCharsReverse[string.upper(key)] or string.upper(key)
@@ -826,6 +826,7 @@ function reloadBindings()
 			end
 		end
 	end
+
 	if useCustom then
 		genKeyLayout('custom')
 		currentLayout = 'custom'

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -43,6 +43,8 @@ local PREV_PAGE_KEY = "N"
 local os_clock = os.clock
 local updateInFrames = -1
 
+local keySymCharsReverse = {}
+
 local Cfgs = {
 	disableInputWhenSpec = false, -- disable specs selecting buildoptions
 	cfgCellPadding = 0.007,
@@ -76,7 +78,6 @@ local Cfgs = {
 		QUOTE = "'",
 		PERIOD = ".",
 	},
-        keySymCharsReverse = {},
 	layoutKeys = {},
 	vKeyLayouts = {},
 	keyLayouts = {
@@ -790,7 +791,7 @@ end
 
 function reloadBindings()
 	-- initialise keySymCharsReverse from keySymChars
-	Cfgs.keySymCharsReverse = table.invert(Cfgs.keySymChars)
+	keySymCharsReverse = table.invert(Cfgs.keySymChars)
 
 	local layout
 	local actionHotkey = Spring.GetActionHotKeys('gridmenu_layout')
@@ -815,27 +816,21 @@ function reloadBindings()
 		Spring.SendCommands("bind " .. string.lower(PREV_PAGE_KEY) .. " gridmenu_prev_page")
 	end
 
-	local custom = {}
+        copyKeyLayout(currentLayout, 'custom')
 	local useCustom = false
 	for r=1,3 do
-		local row = {}
+		Cfgs.keyLayouts['custom'][r] = {}
 		for c=1,4 do
 			hotkey = 'gridmenu_' .. r .. '_' .. c
 			local key = Spring.GetActionHotKeys(hotkey)[1]
 			if key then
-				actionHotkey = Cfgs.keySymCharsReverse[string.upper(key)] or string.upper(key)
-				row[c] = actionHotkey
+				Cfgs.keyLayouts['custom'][r][c] = keySymCharsReverse[string.upper(key)] or string.upper(key)
 				useCustom = true
-			else
-				row[c] = Cfgs.keyLayouts[currentLayout][r][c]
 			end
 		end
-		custom[4 - r] = row
 	end
-	Cfgs.keyLayouts['custom'] = custom
-	genKeyLayout('custom')
 	if useCustom then
-		Spring.Echo("using 'custom' gridmenu keyboard layout, based on '" .. currentLayout .. "'")
+		genKeyLayout('custom')
 		currentLayout = 'custom'
 	end
 end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -837,6 +837,7 @@ function reloadBindings()
 	Cfgs.keyLayouts['custom'] = custom
 	genKeyLayout('custom')
 	if useCustom then
+		Spring.Echo("using 'custom' gridmenu keyboard layout, based on '" .. currentLayout .. "'")
 		currentLayout = 'custom'
 	end
 end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -790,10 +790,7 @@ end
 
 function reloadBindings()
 	-- initialise keySymCharsReverse from keySymChars
-	Cfgs.keySymCharsReverse = {}
-	for key,value in pairs(Cfgs.keySymChars) do
-		Cfgs.keySymCharsReverse[value] = key
-	end
+	Cfgs.keySymCharsReverse = table.invert(Cfgs.keySymChars)
 
 	local layout
 	local actionHotkey = Spring.GetActionHotKeys('gridmenu_layout')
@@ -817,6 +814,7 @@ function reloadBindings()
 	else
 		Spring.SendCommands("bind " .. string.lower(PREV_PAGE_KEY) .. " gridmenu_prev_page")
 	end
+
 	local custom = {}
 	local useCustom = false
 	for r=1,3 do

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -43,8 +43,6 @@ local PREV_PAGE_KEY = "N"
 local os_clock = os.clock
 local updateInFrames = -1
 
-local keySymCharsReverse = {}
-
 local Cfgs = {
 	disableInputWhenSpec = false, -- disable specs selecting buildoptions
 	cfgCellPadding = 0.007,
@@ -791,7 +789,7 @@ end
 
 function reloadBindings()
 	-- initialise keySymCharsReverse from keySymChars
-	keySymCharsReverse = table.invert(Cfgs.keySymChars)
+	local keySymCharsReverse = table.invert(Cfgs.keySymChars)
 
 	local layout
 	local actionHotkey = Spring.GetActionHotKeys('gridmenu_layout')
@@ -816,10 +814,9 @@ function reloadBindings()
 		Spring.SendCommands("bind " .. string.lower(PREV_PAGE_KEY) .. " gridmenu_prev_page")
 	end
 
-        copyKeyLayout(currentLayout, 'custom')
+	copyKeyLayout(currentLayout, 'custom')
 	local useCustom = false
 	for r=1,3 do
-		Cfgs.keyLayouts['custom'][r] = {}
 		for c=1,4 do
 			hotkey = 'gridmenu_' .. r .. '_' .. c
 			local key = Spring.GetActionHotKeys(hotkey)[1]


### PR DESCRIPTION
Add support for binding the grid menu action keys to custom bindings:
```
bind ' gridmenu_1_1
bind , gridmenu_1_2
bind . gridmenu_1_3
bind p gridmenu_1_4
bind r gridmenu_2_1
bind o gridmenu_2_2
bind a gridmenu_2_3
bind u gridmenu_2_4
bind ; gridmenu_3_1
bind q gridmenu_3_2
bind j gridmenu_3_3
bind k gridmenu_3_4
```