### PR TITLE
Fix Actionhandler:KeyAction to execute

### DIFF
--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -72,7 +72,7 @@ function actionHandler:AddAction(widget, cmd, func, data, types)
   end
 
   -- default to text and keyPress  (not repeat or releases)
-  local text, keyPress, keyRepeat, keyRelease = ParseTypes(types, "tpRr")
+  local text, keyPress, keyRepeat, keyRelease = ParseTypes(types, "tp")
   
   local tSuccess, pSuccess, RSuccess, rSuccess = false, false, false, false
 
@@ -233,7 +233,8 @@ function actionHandler:KeyAction(press, key, mods, isRepeat)
       actionSet = self.keyReleaseActions
     end
     for b,bAction in ipairs(defBinds) do
-      local bCmd, bOpts = next(bAction, nil)
+	  local bCmd = bAction["command"]
+	  local bOpts = bAction["extra"]
 		  local words = MakeWords(bOpts)
       if (TryAction(actionSet, bCmd, bOpts, words, isRepeat, not press)) then
         return true


### PR DESCRIPTION
- lua´s  keyPressActions, keyRepeatActions, keyReleaseActions
Note: textActions are executed by WidgetHandler:ConfigureLayout (untouched)

Reverted actionhandler:AddAction to add textActions and keyPressActions by default
- otherwise KeyActions would be triggered twice: 1st when key is pressed, 2nd when key is released

Note: Because this wasn´t used since approx Mar `14 all lua files with defined KeyActions need to be reviewed to use compatible return values
1) If KeyAction returns true = the keyset is handled as consumed, no other Inputreceivers will be triggered
2) If KeyAction returns false or nothing = other inputreceivers are asked to use the pressed or released keyset as well after this
3) Special Case: A widget executes AddAction without defining the type AND the corresponding keyAction function returns false -> it will be bound to keyPressActions and textActions (by default) -> both will be triggered -> the keyAction function is executed twice

Note2:If a keyAction´s type is keyPressAction, it will be executed before engine actionList is asked for consume the keyset. Before this change, all keyActions with undefined types were added as textaction, which are triggered after engine actionList.