### PR TITLE
[gridmenu] Add support (but no default binding) for an action `gridmenu_categories'

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -857,6 +857,16 @@ function prevPageHandler()
 	return true
 end
 
+function goToCategoriesHandler()
+	if currentBuildCategory then
+		currentBuildCategory = nil
+		doUpdate = true
+		return true
+	else
+		return false
+	end
+end
+
 function buildFacingHandler(_, _, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
 		return
@@ -890,6 +900,7 @@ function widget:Initialize()
 	widgetHandler.actionHandler:AddAction(self, "buildfacing", buildFacingHandler, nil, "t")
 	widgetHandler.actionHandler:AddAction(self, "gridmenu_next_page", nextPageHandler, nil, "t")
 	widgetHandler.actionHandler:AddAction(self, "gridmenu_prev_page", prevPageHandler, nil, "t")
+	widgetHandler.actionHandler:AddAction(self, "gridmenu_categories", goToCategoriesHandler, nil, "t")
 
 	reloadBindings()
 


### PR DESCRIPTION
The command will do the following: Go back to category selection, if any category is currently active. Otherwise, it will just return false and do nothing.