### PR TITLE
Increase weapon accuracy for dolphin EMG

### DIFF
--- a/units/ArmShips/armdecade.lua
+++ b/units/ArmShips/armdecade.lua
@@ -134,7 +134,7 @@ return {
 				size = 1.75,
 				soundhitwet = "splshbig",
 				soundstart = "flashemg",
-				sprayangle = 1250,
+				sprayangle = 900,
 				tolerance = 5000,
 				turret = true,
 				weapontimer = 0.1,


### PR DESCRIPTION
EMG weapon will now miss fewer shots when skirmishing against supporters and hoverscouts.  Other matchups should be unaffected by this.