### PR TITLE
Hotkeys: Fix drawlabel before drawinmap

### DIFF
--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -407,12 +407,6 @@ local function makeBindsTable(keyLayout)
 		{       "Any+f12", "screenshot" },
 		{     "Alt+enter", "fullscreen" },
 
-		{  "Any+`", "drawlabel" },
-		{ "Any+\\", "drawlabel" },
-		{  "Any+~", "drawlabel" },
-		{  "Any+§", "drawlabel" },
-		{  "Any+^", "drawlabel" },
-
 		{     "Any+`", "drawinmap"  },
 		{  "Up+Any+`", "drawinmap"  },
 		{    "Any+\\", "drawinmap"  },
@@ -424,6 +418,12 @@ local function makeBindsTable(keyLayout)
 		{     "Any+^", "drawinmap"  },
 		{  "Up+Any+^", "drawinmap"  },
 		{           Q, "drawinmap"  }, --some keyboards don't have ` or \
+
+		{  "Any+`", "drawlabel" },
+		{ "Any+\\", "drawlabel" },
+		{  "Any+~", "drawlabel" },
+		{  "Any+§", "drawlabel" },
+		{  "Any+^", "drawlabel" },
 
 		{    "Any+up",       "moveforward"  },
 		{ "Up+Any+up",       "moveforward"  },


### PR DESCRIPTION
It is asking to drawlabel before the command to drawinmap, changes to correct order