### PR TITLE
Hotkeys: Fix q to drawinmap and drawlabel

### DIFF
--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -377,6 +377,7 @@ local function makeBindsTable(keyLayout)
 		{      "Shift+"..P, "patrol"          },
 		{        "Any+"..Q, "drawinmap"       }, --some keyboards don't have ` or \
 		{        "Any+"..Q, "drawlabel"       },
+		{        Q..','..Q, "drawlabel"       }, -- double hit Q for drawlabel
 		{                R, "repair"          },
 		{      "Shift+"..R, "repair"          },
 		{                S, "stop"            },
@@ -425,10 +426,15 @@ local function makeBindsTable(keyLayout)
 		{  "Up+Any+^", "drawinmap"  },
 
 		{  "Any+`", "drawlabel" },
+		{    "`,`", "drawlabel" },
 		{ "Any+\\", "drawlabel" },
+		{  "\\,\\", "drawlabel" },
 		{  "Any+~", "drawlabel" },
+		{    "~,~", "drawlabel" },
 		{  "Any+§", "drawlabel" },
+		{    "§,§", "drawlabel" },
 		{  "Any+^", "drawlabel" },
+		{    "^,^", "drawlabel" },
 
 		{    "Any+up",       "moveforward"  },
 		{ "Up+Any+up",       "moveforward"  },

--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -177,11 +177,11 @@ local engineBinds = {
 	{ "Any+f12", "screenshot"     },
 	{ "Alt+enter", "fullscreen"  },
 
-	{ "Any+`",    "drawlabel" },
-	{ "Any+\\",  "drawlabel" },
-	{ "Any+~",    "drawlabel" },
-	{ "Any+§",    "drawlabel" },
-	{ "Any+^",    "drawlabel" },
+	{  "Any+`", "drawlabel" },
+	{ "Any+\\", "drawlabel" },
+	{  "Any+~", "drawlabel" },
+	{  "Any+§", "drawlabel" },
+	{  "Any+^", "drawlabel" },
 
 	{    "Any+`",    "drawinmap"  },
 	{ "Up+Any+`",    "drawinmap"  },
@@ -375,9 +375,8 @@ local function makeBindsTable(keyLayout)
 		{      "Shift+"..M, "move"            },
 		{                P, "patrol"          },
 		{      "Shift+"..P, "patrol"          },
-		{                Q, "groupselect"     },
-		{                Q, "groupadd"        },
-		{      "Shift+"..Q, "groupclear"      },
+		{        "Any+"..Q, "drawinmap"       }, --some keyboards don't have ` or \
+		{        "Any+"..Q, "drawlabel"       },
 		{                R, "repair"          },
 		{      "Shift+"..R, "repair"          },
 		{                S, "stop"            },
@@ -424,7 +423,6 @@ local function makeBindsTable(keyLayout)
 		{  "Up+Any+§", "drawinmap"  },
 		{     "Any+^", "drawinmap"  },
 		{  "Up+Any+^", "drawinmap"  },
-		{           Q, "drawinmap"  }, --some keyboards don't have ` or \
 
 		{  "Any+`", "drawlabel" },
 		{ "Any+\\", "drawlabel" },


### PR DESCRIPTION
I found no references to groupselect groupadd and groupclear on engine
source code, I assume these to be legacy that at some point defined
actions to trigger CMD_GROUPSELECT CMD_GROUPADD and CMD_GROUPCLEAR.

These commands seem quite useful but are - for the purposes of the current
game code - noop, so their respective keybindings are removed since they can't ever be triggered.

This PR also adds double tapping drawlabel binding keychain for the behavior defined by engine default.

Curiously the engine default is broken, if you try for example to bind (or unbind for that matter) `Any+^,Any+^` you will receive an error from the keybinding parser, but the engine registers it correctly internally.