### PR TITLE
Update cmd_uikeys_loader.lua to layer 200

### DIFF
--- a/luaui/Widgets/cmd_uikeys_loader.lua
+++ b/luaui/Widgets/cmd_uikeys_loader.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author    = "Doo",
 		date      = "2018",
 		license   = "GNU GPL, v2 or later",
-		layer     = 0,
+		layer     = 200,
 		enabled   = false, --enabled by default
 	}
 end


### PR DESCRIPTION
Hey,

can have this before tourney start ?
Since we can´t use custom widgets, people would need to type /keyload every game :(
And i´m sure, some will forget - like me :D

bar Hotkeys is 1
bar hotkeys yz switch is 100

let uikeys Loader be after those