### PR TITLE
Fix for units being selected when given by an ally

### DIFF
--- a/luaui/Widgets/gui_allySelectedUnits.lua
+++ b/luaui/Widgets/gui_allySelectedUnits.lua
@@ -313,6 +313,14 @@ function widget:UnitDestroyed(unitID)
 	unitAllyteam[unitID] = nil
 end
 
+function widget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
+	if unitID and newTeam == myTeamID then
+		removeUnit(unitID)
+		selectedUnits[unitID] = nil
+		unitAllyteam[unitID] = nil
+	end
+end
+
 function widget:VisibleUnitAdded(unitID, unitDefID, unitTeam)
 	addUnit(unitID)
 end


### PR DESCRIPTION
When an ally gives you units (for example, a T2 constructor), the given units have the selected shape around them which looks like you selected them (but you didn't) and it couldn't be removed.

![screen00293](https://user-images.githubusercontent.com/44340857/170454744-580c8bd0-5e30-4166-8277-f1fea266f9f7.jpg)
