### PR TITLE
Arm sniper movespeed increase

### DIFF
--- a/units/ArmBots/T2/armsnipe.lua
+++ b/units/ArmBots/T2/armsnipe.lua
@@ -21,7 +21,7 @@ return {
 		idletime = 1800,
 		maxdamage = 520,
 		maxslope = 14,
-		maxvelocity = 1,
+		maxvelocity = 1.1,
 		maxwaterdepth = 22,
 		mincloakdistance = 80,
 		movementclass = "BOT3",


### PR DESCRIPTION
Snipers's movespeed changed from 30->33 (pre-nerf was 35.4).  I like how the nerf changed the unit, making it easier to counter and making proper positioning and planning more important, but it takes too long to get to the front line, falls too far behind welders when moving them together, and can't keep distance as effectively against T3.  Having a larger change made it easier to see how the change would affect overall balance.  I was also expecting the meta to shift more than it did, and while there is more unit variety (fatboys and rocket spiders see use now instead of being memes), sniper compositions are still the main unit for late T2 arm bot viability.