### PR TITLE
Fix typo in features_en.json

### DIFF
--- a/language/features_en.json
+++ b/language/features_en.json
@@ -27,7 +27,7 @@
 				"metal": "Contains Metal",
 				"mushroomsOrange": "Orange Mushrooms",
 				"mushroomsTan": "Tan Mushrooms",
-				"mushrooomsPurple": "Purple Mushrooms",
+				"mushroomsPurple": "Purple Mushrooms",
 				"obelisk": "Obelisk of Seth",
 				"peyote": "Peyote",
 				"pilha_crystal1": "Small Crystal",


### PR DESCRIPTION
Typo "mushrooomsPurple" changed to "mushroomsPurple"