### PR TITLE
Allow longer Chicken Grace Period (20 min)

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -545,7 +545,7 @@ local options={
 		type   = "number",
 		def    = 5,
 		min    = 1,
-		max    = 10,
+		max    = 20,
 		step   = 1,
 		section= "chicken_defense_options",
 	},


### PR DESCRIPTION
Setting the max chicken grace period to 20 min, same as for scavengers, to allow players a higher setting. Have not checked downstream implications.