### PR TITLE
Arm destroyer plasma aoe increased to better match projectile size

### DIFF
--- a/units/ArmShips/armroy.lua
+++ b/units/ArmShips/armroy.lua
@@ -150,7 +150,7 @@ return {
 				},
 			},
 			plasma = {
-				areaofeffect = 32,
+				areaofeffect = 48,
 				avoidfeature = false,
 				craterareaofeffect = 0,
 				craterboost = 0,


### PR DESCRIPTION
32->48, still lower than cor destroyer (64), but higher than arm frigate now (36).