### PR TITLE
Partial Fix Music fade & volchange conflict (& associated cleanup)

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -388,7 +388,7 @@ function widget:Initialize()
 		maxMusicVolume = value
 		Spring.SetConfigInt("snd_volmusic", math.floor(maxMusicVolume))
 		if fadeDirection then
-			setVolume(fadeLevel)
+			setMusicVolume(fadeLevel)
 		end
 		createList()
 	end
@@ -465,7 +465,7 @@ function widget:MouseMove(x, y)
 			maxMusicVolume = math.floor(getVolumeCoef(getSliderValue(draggingSlider, x)) * 100)
 			Spring.SetConfigInt("snd_volmusic", maxMusicVolume)
 			if fadeDirection then
-				setVolume(fadeLevel)
+				setMusicVolume(fadeLevel)
 			end
 			createList()
 		end
@@ -591,14 +591,14 @@ local function getMusicVolume()
 	return Spring.GetConfigInt("snd_volmusic", defaultMusicVolume) * 0.01
 end
 
-local function setVolume(fadeLevel)
+local function setMusicVolume(fadeLevel)
 	Spring.SetSoundStreamVolume(getMusicVolume() * math.max(math.min(fadeLevel, 100), 0) * 0.01)
 end
 
 local function updateFade()
 	if fadeDirection then
 		fadeLevel = fadeLevel + fadeChange()
-		setVolume(fadeLevel)
+		setMusicVolume(fadeLevel)
 
 		if fadeDirection < 0 and fadeLevel <= 0 then
 			fadeDirection = nil
@@ -746,9 +746,9 @@ function PlayNewTrack(paused)
 	if currentTrack then
 		Spring.PlaySoundStream(currentTrack, 1)
 		if fadeDirection then
-			setVolume(fadeLevel)
+			setMusicVolume(fadeLevel)
 		else
-			Spring.SetSoundStreamVolume(musicVolume)
+			Spring.SetSoundStreamVolume(maxMusicVolume)
 		end
 	end
 

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -167,7 +167,7 @@ local defaultMusicVolume = 50
 local warMeter = 0
 local gameOver = false
 local playedGameOverTrack = false
-local fadelevel = 100
+local fadeLevel = 100
 local faderMin = 45 -- range in dB for volume faders, from -faderMin to 0dB
 
 local playedTime, totalTime = Spring.GetSoundStreamTime()
@@ -387,6 +387,9 @@ function widget:Initialize()
 	WG['music'].SetMusicVolume = function(value)
 		maxMusicVolume = value
 		Spring.SetConfigInt("snd_volmusic", math.floor(maxMusicVolume))
+		if fadeDirection then
+			setVolume(fadeLevel)
+		end
 		createList()
 	end
 	WG['music'].getTracksConfig = function(value)
@@ -461,6 +464,9 @@ function widget:MouseMove(x, y)
 		if draggingSlider == 'musicvolume' then
 			maxMusicVolume = math.floor(getVolumeCoef(getSliderValue(draggingSlider, x)) * 100)
 			Spring.SetConfigInt("snd_volmusic", maxMusicVolume)
+			if fadeDirection then
+				setVolume(fadeLevel)
+			end
 			createList()
 		end
 		if draggingSlider == 'volume' then
@@ -591,17 +597,17 @@ end
 
 local function updateFade()
 	if fadeDirection then
-		fadelevel = fadelevel + fadeChange()
-		setVolume(fadelevel)
+		fadeLevel = fadeLevel + fadeChange()
+		setVolume(fadeLevel)
 
-		if fadeDirection < 0 and fadelevel <= 0 then
+		if fadeDirection < 0 and fadeLevel <= 0 then
 			fadeDirection = nil
 			if fadeOutSkipTrack then
 				PlayNewTrack()
 			else
 				Spring.StopSoundStream()
 			end
-		elseif fadeDirection > 0 and fadelevel >= 100 then
+		elseif fadeDirection > 0 and fadeLevel >= 100 then
 			fadeDirection = nil
 		end
 	end
@@ -677,11 +683,10 @@ function PlayNewTrack(paused)
 	warMeter = warMeter * 0.75
 	
 	if (not gameOver) and Spring.GetGameFrame() > 1 then
-		fadelevel = 0
+		fadeLevel = 0
 		fadeDirection = 1
 	else
 		-- Fade in only when game is in progress
-		fadelevel = 100
 		fadeDirection = nil
 	end
 	currentTrack = nil
@@ -741,7 +746,7 @@ function PlayNewTrack(paused)
 	if currentTrack then
 		Spring.PlaySoundStream(currentTrack, 1)
 		if fadeDirection then
-			setVolume(fadelevel)
+			setVolume(fadeLevel)
 		else
 			Spring.SetSoundStreamVolume(musicVolume)
 		end


### PR DESCRIPTION
(Addresses https://github.com/beyond-all-reason/Beyond-All-Reason/issues/994 - Music distorting during fade in and fade out phase)

`Spring.SetConfigInt("snd_volmusic", ...)` was being used to update the config value in `widget:MouseMove`, without fading being applied, and then `Spring.SetSoundStreamVolume(#)` was called sufficiently later (`widget:GameFrame` - up to 33 ms later) with the modified (faded) volume that the audio had time to distort. Spring automatically applies the config value when it is set, so in essence the value was being set twice at different volumes with a slight delay. 

Placing a call to `Spring.SetSoundStreamVolume` directly after setting the config value appears to mitigate this issue.

This may not entirely fix things because of threading - see https://github.com/beyond-all-reason/spring/blob/BAR105/rts/System/Sound/OpenAL/AudioChannel.cpp#L28

Or even just because of the nearly-negligible latency between the two sets.

It's a LOT smoother now, though.

---

Re cleanup - cut out a lot of duplication to make control flow clearer, and make it easier to diagnose & resolve the issue.