### PR TITLE
Fix for waypoint dragger error

### DIFF
--- a/luaui/Widgets/unit_waypoint_dragger_2.lua
+++ b/luaui/Widgets/unit_waypoint_dragger_2.lua
@@ -107,7 +107,7 @@ local function GetWayPointsNearCursor(wpTbl, mx, my)
 				if cmdColorsTbl[curCmd.id] then
 					local nxtCmd      = commands[cmdNum + 1]
 					local x, y, z, fr = GetCommandWorldPosition(curCmd)
-					if x then
+					if x and y and z then
 						local p, q  = spWorldToScreenCoords(x, y, z)
 						if GetSqDist2D(mx,my,p,q) < wayPtSelDistSqr then
 							-- save the tag of the next command


### PR DESCRIPTION
I noticed waypoint dragger widget giving this error quite often and getting removed as a result.
```
Error in MousePress(): [string "LuaUI/Widgets/unit_waypoint_dragger_2.lua"]:111: bad argument #3 to 'spWorldToScreenCoords' (number expected, got nil)
Removed widget: Waypoint Dragger
```
I did some tests and was able to replicate the error by trying to move the unload command. Moving other commands doesn't give errors.
Not sure what is the cause, but this fixes the errror and stops the widget from being removed.