### PR TITLE
modified unit_dynamic_collision_volume.lua and collisionvolumes.lua

### DIFF
--- a/luarules/configs/collisionvolumes.lua
+++ b/luarules/configs/collisionvolumes.lua
@@ -178,7 +178,7 @@ dynamicPieceCollisionVolume['cortoast'] = {
 dynamicPieceCollisionVolume['corvipe'] = {
 	on = {
 		['0']={38,26,38,0,0,0,2,0},
-		['5']={25,45,25,0,25,0,1,1},
+		['1']={25,45,25,0,25,0,1,1}, -- changed to [1] so the cylinder collision is attached to the turret and not a door 
 		['offsets']={0,23,0},
 	},
 	off = {

--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -220,7 +220,10 @@ if gadgetHandler:IsSyncedCode() then
 
 	-- Check if a unit is pop-up type (the list must be entered manually)
 	-- If a building was constructed add it to the list for later radius and height scaling
-	function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+	-- Changed from UnitFinished to UnitCreated 
+	-- Some building's scripting change their collision while still under construction
+	-- These buildings should be added to the list of popupUnits to update when they are created, not when finished
+	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 		local un = unitName[unitDefID]
 		if unitCollisionVolume[un] then
 			popupUnits[unitID]={name=un, state=-1, perPiece=false}


### PR DESCRIPTION
to fix an bug where the aimpoint of the corvipe was too high and not properly updated when corvipe was under construction, causing laser and flame units to be unable to damage the corvipe