### PR TITLE
Simple inclusion of black outline on ETA text, bar_font2 Exo2-SemiBol…

### DIFF
--- a/luaui/Widgets/gui_build_eta.lua
+++ b/luaui/Widgets/gui_build_eta.lua
@@ -26,12 +26,6 @@ local glDrawFuncAtUnit = gl.DrawFuncAtUnit
 local glBillboard = gl.Billboard
 local glTranslate = gl.Translate
 
-local vsx, vsy = Spring.GetViewGeometry()
-local fontfile = "fonts/" .. Spring.GetConfigString("bar_font2", "Exo2-SemiBold.otf")
-local fontfileScale = (0.5 + (vsx * vsy / 5700000))
-local fontfileSize = 50
-local fontfileOutlineSize = 9
-local fontfileOutlineStrength = 10
 local font, chobbyInterface
 
 local etaTable = {}
@@ -44,8 +38,7 @@ end
 
 
 function widget:ViewResize()
-	font = gl.LoadFont(fontfile, fontfileSize * fontfileScale, fontfileOutlineSize * fontfileScale, fontfileOutlineStrength)
-	--font = WG['fonts'].getFont(nil, 1, 0.2, 1.3)
+	font = WG['fonts'].getFont(nil, 1, 0.2, 13.0)
 end
 
 local function makeETA(unitID, unitDefID)

--- a/luaui/Widgets/gui_build_eta.lua
+++ b/luaui/Widgets/gui_build_eta.lua
@@ -26,6 +26,12 @@ local glDrawFuncAtUnit = gl.DrawFuncAtUnit
 local glBillboard = gl.Billboard
 local glTranslate = gl.Translate
 
+local vsx, vsy = Spring.GetViewGeometry()
+local fontfile = "fonts/" .. Spring.GetConfigString("bar_font2", "Exo2-SemiBold.otf")
+local fontfileScale = (0.5 + (vsx * vsy / 5700000))
+local fontfileSize = 50
+local fontfileOutlineSize = 9
+local fontfileOutlineStrength = 10
 local font, chobbyInterface
 
 local etaTable = {}
@@ -38,7 +44,8 @@ end
 
 
 function widget:ViewResize()
-	font = WG['fonts'].getFont(nil, 1, 0.2, 1.3)
+	font = gl.LoadFont(fontfile, fontfileSize * fontfileScale, fontfileOutlineSize * fontfileScale, fontfileOutlineStrength)
+	--font = WG['fonts'].getFont(nil, 1, 0.2, 1.3)
 end
 
 local function makeETA(unitID, unitDefID)


### PR DESCRIPTION
bar_font2 Exo2-SemiBold.otf may not be the right font to use here.

Before and after images shown here. Some layering issue may need to be addressed for full text clarity, black outline helps for now.
![image](https://user-images.githubusercontent.com/44480662/184920856-b20088d7-3a6f-4135-b6fa-0ac3bd7cfb9e.png)
![image](https://user-images.githubusercontent.com/44480662/184921053-e7bce02f-50fa-4854-85fd-865469a153ed.png)
