### PR TITLE
Gridmenu: Major refactor

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -29,23 +29,21 @@ local unitGrids = configs.UnitGrids
 local currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")
 local userLayout
 
+local prevHoveredCellID, hoverDlist, hoverUdefID, hoverCellSelected
+local prevQueueNr, prevB, prevB3
+
+local cachedUnitIcons
+
 local BUILDCAT_ECONOMY = "Economy"
 local BUILDCAT_COMBAT = "Combat"
 local BUILDCAT_UTILITY = "Utility"
 local BUILDCAT_PRODUCTION = "Production"
-local categoryFontSize
-local pageButtonHeight
-local pageButtonWidth
-local paginatorCellWidth
-local paginatorFontSize
-local paginatorCellHeight
-
-local RESET_MENU_KEY = KEYSYMS.LSHIFT
-local NEXT_PAGE_KEY = "B"
-local PREV_PAGE_KEY = "N"
-local os_clock = os.clock
+local categoryFontSize, pageButtonHeight, pageButtonWidth, paginatorCellWidth
+local paginatorFontSize, paginatorCellHeight
 
 local Cfgs = {
+	NEXT_PAGE_KEY = "B",
+	PREV_PAGE_KEY = "N",
 	disableInputWhenSpec = false, -- disable specs selecting buildoptions
 	cfgCellPadding = 0.007,
 	cfgIconPadding = 0.015, -- space between icons
@@ -74,8 +72,60 @@ local Cfgs = {
 	},
 	categoryKeys = {},
 	vKeyLayout = {},
-	keyLayout = {}
+	keyLayout = {},
+	categoryGroupMapping = {
+		energy = BUILDCAT_ECONOMY,
+		metal = BUILDCAT_ECONOMY,
+		builder = BUILDCAT_PRODUCTION,
+		buildert2 = BUILDCAT_PRODUCTION,
+		buildert3 = BUILDCAT_PRODUCTION,
+		buildert4 = BUILDCAT_PRODUCTION,
+		util = BUILDCAT_UTILITY,
+		weapon = BUILDCAT_COMBAT,
+		explo = BUILDCAT_COMBAT,
+		weaponaa = BUILDCAT_COMBAT,
+		aa = BUILDCAT_COMBAT,
+		emp = BUILDCAT_COMBAT,
+		sub = BUILDCAT_COMBAT,
+		nuke = BUILDCAT_COMBAT,
+		antinuke = BUILDCAT_COMBAT,
+	},
+	armToCor = {
+		[UnitDefNames["armmex"].id] = UnitDefNames["cormex"].id,
+		[UnitDefNames["armuwmex"].id] = UnitDefNames["coruwmex"].id,
+		[UnitDefNames["armsolar"].id] = UnitDefNames["corsolar"].id,
+		[UnitDefNames["armwin"].id] = UnitDefNames["corwin"].id,
+		[UnitDefNames["armtide"].id] = UnitDefNames["cortide"].id,
+		[UnitDefNames["armllt"].id] = UnitDefNames["corllt"].id,
+		[UnitDefNames["armrad"].id] = UnitDefNames["corrad"].id,
+		[UnitDefNames["armrl"].id] = UnitDefNames["corrl"].id,
+		[UnitDefNames["armtl"].id] = UnitDefNames["cortl"].id,
+		[UnitDefNames["armsonar"].id] = UnitDefNames["corsonar"].id,
+		[UnitDefNames["armfrt"].id] = UnitDefNames["corfrt"].id,
+		[UnitDefNames["armlab"].id] = UnitDefNames["corlab"].id,
+		[UnitDefNames["armvp"].id] = UnitDefNames["corvp"].id,
+		[UnitDefNames["armsy"].id] = UnitDefNames["corsy"].id,
+		[UnitDefNames["armmstor"].id] = UnitDefNames["cormstor"].id,
+		[UnitDefNames["armestor"].id] = UnitDefNames["corestor"].id,
+		[UnitDefNames["armmakr"].id] = UnitDefNames["cormakr"].id,
+		[UnitDefNames["armeyes"].id] = UnitDefNames["coreyes"].id,
+		[UnitDefNames["armdrag"].id] = UnitDefNames["cordrag"].id,
+		[UnitDefNames["armdl"].id] = UnitDefNames["cordl"].id,
+		[UnitDefNames["armap"].id] = UnitDefNames["corap"].id,
+		[UnitDefNames["armfrad"].id] = UnitDefNames["corfrad"].id,
+		[UnitDefNames["armuwms"].id] = UnitDefNames["coruwms"].id,
+		[UnitDefNames["armuwes"].id] = UnitDefNames["coruwes"].id,
+		[UnitDefNames["armfmkr"].id] = UnitDefNames["corfmkr"].id,
+		[UnitDefNames["armfdrag"].id] = UnitDefNames["corfdrag"].id,
+		[UnitDefNames["armptl"].id] = UnitDefNames["corptl"].id,
+	},
 }
+
+Cfgs.corToArm = table.invert(Cfgs.armToCor)
+
+local function sanitizeKey(key)
+	return string.gsub(string.gsub(string.upper(key), "ANY%+", ''), "SC_", "")
+end
 
 local function genKeyLayout()
 	Cfgs.keyLayout = keyConfig.copyKeyLayout(currentLayout)
@@ -100,15 +150,15 @@ local function genKeyLayout()
 	end
 
 	if userLayout['next_page'] then
-		NEXT_PAGE_KEY = string.upper(userLayout['next_page'])
+		Cfgs.NEXT_PAGE_KEY = string.upper(userLayout['next_page'])
 	else
-		NEXT_PAGE_KEY = Cfgs.keyLayout[1][5]
+		Cfgs.NEXT_PAGE_KEY = Cfgs.keyLayout[1][5]
 	end
 
 	if userLayout['prev_page'] then
-		PREV_PAGE_KEY = string.upper(userLayout['prev_page'])
+		Cfgs.PREV_PAGE_KEY = string.upper(userLayout['prev_page'])
 	else
-		PREV_PAGE_KEY = Cfgs.keyLayout[1][6]
+		Cfgs.PREV_PAGE_KEY = Cfgs.keyLayout[1][6]
 	end
 
 	-- Autogenerate bottom layout keys
@@ -122,37 +172,16 @@ local function genKeyLayout()
 		end
 	end
 
-	Cfgs.vKeyLayout[1][5] = Cfgs.keyLayout[3][1]
-	Cfgs.vKeyLayout[1][6] = Cfgs.keyLayout[3][3]
-	Cfgs.vKeyLayout[2][5] = Cfgs.keyLayout[3][2]
-	Cfgs.vKeyLayout[2][6] = Cfgs.keyLayout[3][4]
+	Cfgs.vKeyLayout[1][5] = Cfgs.keyLayout[3][3]
+	Cfgs.vKeyLayout[1][6] = Cfgs.keyLayout[3][4]
+	Cfgs.vKeyLayout[2][5] = Cfgs.keyLayout[3][1]
+	Cfgs.vKeyLayout[2][6] = Cfgs.keyLayout[3][2]
 end
 
 local unitCategories = {}
 local hotkeyActions = {}
-local hoveredCat, drawnHoveredCat, hoveredLabButton, drawnHoveredLabButton
+local hoveredCat, drawnHoveredCat
 local selBuildQueueDefID
-
-local selectedFactoryIsWait, selectedFactoryIsRepeat, selectedFactoryUID
-local labActions = {
-	Repeat = function ()
-		selectedFactoryIsRepeat = select(4, Spring.GetUnitStates(selectedFactoryUID, false, true))
-		local onoff = selectedFactoryIsRepeat and { 0 } or { 1 }
-
-		GiveOrderToFactories(CMD.REPEAT, onoff)
-	end,
-	Wait = function ()
-		GiveOrderToFactories(CMD.WAIT)
-	end,
-	Clear = function ()
-		GiveOrderToFactories(CMD_STOP_PRODUCTION)
-	end,
-}
-local labKeys = {
-	[KEYSYMS.T] = "Repeat",
-	[KEYSYMS.G] = "Clear",
-	[KEYSYMS.Y] = "Wait"
-}
 
 local stickToBottom = false
 local alwaysShow = false
@@ -175,10 +204,10 @@ local selectedCellZoom = 0.135 * zoomMult
 
 local bgpadding, chobbyInterface, activeAreaMargin, iconTypesMap
 local dlistGuishader, dlistBuildmenuBg, dlistBuildmenu, font2, cmdsCount
-local doUpdateClock, ordermenuHeight, prevAdvplayerlistLeft
+local doUpdate, doUpdateClock, ordermenuHeight, prevAdvplayerlistLeft
 local cellPadding, iconPadding, cornerSize, cellInnerSize, cellSize
 
-local selectedBuilder, selectedFactory
+local selectedBuilder, selectedFactory, selectedFactoryUID
 
 local facingMap = {south=0, east=1, north=2, west=3}
 
@@ -215,7 +244,6 @@ local advplayerlistLeft = vsx * 0.8
 
 local isSpec = Spring.GetSpectatingState()
 local myTeamID = Spring.GetMyTeamID()
-local myPlayerID = Spring.GetMyPlayerID()
 
 local startDefID = Spring.GetTeamRulesParam(myTeamID, 'startUnit')
 
@@ -243,28 +271,17 @@ local currentBuildCategory, currentCategoryIndex
 local currentPage = 1
 local pages = 1
 local paginatorRects = {}
-local labButtonRects = {}
 local preGamestartPlayer = Spring.GetGameFrame() == 0 and not isSpec
 local unitshapes = {}
 
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 
-local spIsUnitSelected = Spring.IsUnitSelected
-local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetActiveCommand = Spring.GetActiveCommand
-local spGetActiveCmdDescs = Spring.GetActiveCmdDescs
 local spGetCmdDescIndex = Spring.GetCmdDescIndex
 local spGetUnitDefID = Spring.GetUnitDefID
-local spGetTeamRulesParam = Spring.GetTeamRulesParam
-local spGetMouseState = Spring.GetMouseState
-local spTraceScreenRay = Spring.TraceScreenRay
 local spGetUnitHealth = Spring.GetUnitHealth
-local SelectedUnitsCount = spGetSelectedUnitsCount()
 local spGetUnitIsBuilding = Spring.GetUnitIsBuilding
-
-local string_sub = string.sub
+local SelectedUnitsCount = Spring.GetSelectedUnitsCount()
 
 local math_floor = math.floor
 local math_ceil = math.ceil
@@ -272,50 +289,14 @@ local math_max = math.max
 local math_min = math.min
 local math_isInRect = math.isInRect
 
-local glTexture = gl.Texture
-local glColor = gl.Color
-local glBlending = gl.Blending
 local GL_SRC_ALPHA = GL.SRC_ALPHA
 local GL_ONE_MINUS_SRC_ALPHA = GL.ONE_MINUS_SRC_ALPHA
 local GL_ONE = GL.ONE
-local GL_DST_ALPHA = GL.DST_ALPHA
 local GL_ONE_MINUS_SRC_COLOR = GL.ONE_MINUS_SRC_COLOR
 
 -- Get from FlowUI
 local RectRound, RectRoundProgress, UiUnit, UiElement, UiButton, elementCorner
 local ui_opacity, ui_scale
-
--- used for pregame build queue, for switch faction buildings
-local armToCor = {
-	[UnitDefNames["armmex"].id] = UnitDefNames["cormex"].id,
-	[UnitDefNames["armuwmex"].id] = UnitDefNames["coruwmex"].id,
-	[UnitDefNames["armsolar"].id] = UnitDefNames["corsolar"].id,
-	[UnitDefNames["armwin"].id] = UnitDefNames["corwin"].id,
-	[UnitDefNames["armtide"].id] = UnitDefNames["cortide"].id,
-	[UnitDefNames["armllt"].id] = UnitDefNames["corllt"].id,
-	[UnitDefNames["armrad"].id] = UnitDefNames["corrad"].id,
-	[UnitDefNames["armrl"].id] = UnitDefNames["corrl"].id,
-	[UnitDefNames["armtl"].id] = UnitDefNames["cortl"].id,
-	[UnitDefNames["armsonar"].id] = UnitDefNames["corsonar"].id,
-	[UnitDefNames["armfrt"].id] = UnitDefNames["corfrt"].id,
-	[UnitDefNames["armlab"].id] = UnitDefNames["corlab"].id,
-	[UnitDefNames["armvp"].id] = UnitDefNames["corvp"].id,
-	[UnitDefNames["armsy"].id] = UnitDefNames["corsy"].id,
-	[UnitDefNames["armmstor"].id] = UnitDefNames["cormstor"].id,
-	[UnitDefNames["armestor"].id] = UnitDefNames["corestor"].id,
-	[UnitDefNames["armmakr"].id] = UnitDefNames["cormakr"].id,
-	[UnitDefNames["armeyes"].id] = UnitDefNames["coreyes"].id,
-	[UnitDefNames["armdrag"].id] = UnitDefNames["cordrag"].id,
-	[UnitDefNames["armdl"].id] = UnitDefNames["cordl"].id,
-	[UnitDefNames["armap"].id] = UnitDefNames["corap"].id,
-	[UnitDefNames["armfrad"].id] = UnitDefNames["corfrad"].id,
-	[UnitDefNames["armuwms"].id] = UnitDefNames["coruwms"].id,
-	[UnitDefNames["armuwes"].id] = UnitDefNames["coruwes"].id,
-	[UnitDefNames["armfmkr"].id] = UnitDefNames["corfmkr"].id,
-	[UnitDefNames["armfdrag"].id] = UnitDefNames["corfdrag"].id,
-	[UnitDefNames["armptl"].id] = UnitDefNames["corptl"].id,
-}
-local corToArm = table.invert(armToCor)
 
 local folder = 'LuaUI/Images/groupicons/'
 local groups = {
@@ -334,26 +315,6 @@ local groups = {
 	sub = folder..'sub.png',
 	nuke = folder..'nuke.png',
 	antinuke = folder..'antinuke.png',
-}
-
--- This data is not integrated into the above table because
--- the other table is exposed as a public property
-local categoryGroupMapping = {
-	energy = BUILDCAT_ECONOMY,
-	metal = BUILDCAT_ECONOMY,
-	builder = BUILDCAT_PRODUCTION,
-	buildert2 = BUILDCAT_PRODUCTION,
-	buildert3 = BUILDCAT_PRODUCTION,
-	buildert4 = BUILDCAT_PRODUCTION,
-	util = BUILDCAT_UTILITY,
-	weapon = BUILDCAT_COMBAT,
-	explo = BUILDCAT_COMBAT,
-	weaponaa = BUILDCAT_COMBAT,
-	aa = BUILDCAT_COMBAT,
-	emp = BUILDCAT_COMBAT,
-	sub = BUILDCAT_COMBAT,
-	nuke = BUILDCAT_COMBAT,
-	antinuke = BUILDCAT_COMBAT,
 }
 
 local unitEnergyCost = {}
@@ -437,7 +398,7 @@ end
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 	unitGroup[unitDefID] = unitDef.customParams.unitgroup
-	unitCategories[unitDefID] = categoryGroupMapping[unitDef.customParams.unitgroup] or BUILDCAT_UTILITY
+	unitCategories[unitDefID] = Cfgs.categoryGroupMapping[unitDef.customParams.unitgroup] or BUILDCAT_UTILITY
 
 	if unitDef.name == 'armdl' or unitDef.name == 'cordl' or unitDef.name == 'armlance' or unitDef.name == 'cortitan'	-- or unitDef.name == 'armbeaver' or unitDef.name == 'cormuskrat'
 		or (unitDef.minWaterDepth > 0 or unitDef.modCategories['ship']) then
@@ -564,10 +525,9 @@ local function checkGuishader(force)
 	end
 end
 
-function widget:PlayerChanged(playerID)
+function widget:PlayerChanged()
 	isSpec = Spring.GetSpectatingState()
 	myTeamID = Spring.GetMyTeamID()
-	myPlayerID = Spring.GetMyPlayerID()
 end
 
 local function RefreshCommands()
@@ -629,13 +589,13 @@ local function RefreshCommands()
 			end
 		end
 	else
-		local activeCmdDescs = selectedFactory and Spring.GetUnitCmdDescs(selectedFactoryUID) or spGetActiveCmdDescs()
+		local activeCmdDescs = selectedFactory and Spring.GetUnitCmdDescs(selectedFactoryUID) or Spring.GetActiveCmdDescs()
 
 		local cmdUnitdefs = {}
 
 		for index, cmd in pairs(activeCmdDescs) do
 			if type(cmd) == "table" and not cmd.disabled then
-				if string_sub(cmd.action, 1, 10) == 'buildunit_' and (showWaterUnits or not isWaterUnit[cmd.id * -1]) then
+				if string.sub(cmd.action, 1, 10) == 'buildunit_' and (showWaterUnits or not isWaterUnit[cmd.id * -1]) then
 					cmdUnitdefs[cmd.id * -1] = index
 
 					if gridPos and gridPos[cmd.id * -1] then
@@ -677,14 +637,14 @@ function widget:ViewResize()
 	UiButton = WG.FlowUI.Draw.Button
 	elementCorner = WG.FlowUI.elementCorner
 	categoryFontSize = 0.0115 * ui_scale * vsy
-	pageButtonHeight = 3 * categoryFontSize * ui_scale
-	pageButtonWidth = 9 * categoryFontSize * ui_scale
+	pageButtonHeight = 2.3 * categoryFontSize * ui_scale
+	pageButtonWidth = 7 * categoryFontSize * ui_scale
 	if stickToBottom then
 		paginatorFontSize = categoryFontSize
 	else
 		paginatorFontSize = categoryFontSize * 1.2
 	end
-	paginatorCellWidth = paginatorFontSize * 3
+	paginatorCellWidth = paginatorFontSize * 2
 	paginatorCellHeight = 3 * paginatorFontSize
 
 	activeAreaMargin = math_ceil(bgpadding * Cfgs.cfgActiveAreaMargin)
@@ -713,15 +673,13 @@ function widget:ViewResize()
 
 		posY2 = math_floor(0.14 * ui_scale * vsy) / vsy
 		posY2 = posY2 + (widgetSpaceMargin/vsy)
-		posY = posY2 + (0.72 * width * vsx + pageButtonHeight + paginatorCellWidth)/vsy
+		posY = posY2 + (0.74 * width * vsx + pageButtonHeight + paginatorCellWidth)/vsy
 		posX = 0
 
-		if WG['minimap'] then
-			if WG['ordermenu'] and not WG['ordermenu'].getBottomPosition() then
-				local oposX, oposY, owidth, oheight = WG['ordermenu'].getPosition()
-				if posY > oposY then
-					posY = oposY - oheight - ((widgetSpaceMargin)/vsy)
-				end
+		if WG['ordermenu'] and not WG['ordermenu'].getBottomPosition() then
+			local _, oposY, _, oheight = WG['ordermenu'].getPosition()
+			if posY > oposY then
+				posY = oposY - oheight - ((widgetSpaceMargin)/vsy)
 			end
 		end
 
@@ -744,9 +702,7 @@ function widget:ViewResize()
 	doUpdate = true
 end
 
-function reloadBindings()
-	local actionHotkey
-
+local function reloadBindings()
 	currentLayout = Spring.GetConfigString("KeyboardLayout", 'qwerty')
 
 	if not userLayout then
@@ -804,10 +760,10 @@ function reloadBindings()
 
 	-- bind page actions
 	Spring.SendCommands("unbindaction gridmenu_next_page")
-	Spring.SendCommands("bind " .. string.lower(NEXT_PAGE_KEY) .. " gridmenu_next_page")
+	Spring.SendCommands("bind " .. string.lower(Cfgs.NEXT_PAGE_KEY) .. " gridmenu_next_page")
 
 	Spring.SendCommands("unbindaction gridmenu_prev_page")
-	Spring.SendCommands("bind " .. string.lower(PREV_PAGE_KEY) .. " gridmenu_prev_page")
+	Spring.SendCommands("bind " .. string.lower(Cfgs.PREV_PAGE_KEY) .. " gridmenu_prev_page")
 end
 
 local function setPreGamestartDefID(uDefID)
@@ -847,10 +803,23 @@ local function gridmenuCategoryHandler(_, _, args, _, isRepeat)
 
 	currentBuildCategory = categories[cIndex]
 	currentCategoryIndex = cIndex
-	switchedCategory = os_clock()
+	switchedCategory = os.clock()
 	doUpdate = true
 
 	return true
+end
+
+local function enqueueUnit(uDefID, opts)
+	local udTable = Spring.GetSelectedUnitsSorted()
+	udTable.n = nil
+	for udidFac, uTable in pairs(udTable) do
+		if isFactory[udidFac] then
+			uTable.n = nil
+			for _, uid in ipairs(uTable) do
+				Spring.GiveOrderToUnit(uid, uDefID, {}, opts)
+			end
+		end
+	end
 end
 
 local function gridmenuKeyHandler(_, _, args, _, isRepeat)
@@ -1023,14 +992,14 @@ function widget:Initialize()
 	-- Get our starting unit
 	if preGamestartPlayer then
 		SetBuildFacing()
-		if not startDefID or startDefID ~= spGetTeamRulesParam(myTeamID, 'startUnit') then
-			startDefID = spGetTeamRulesParam(myTeamID, 'startUnit')
+		if not startDefID or startDefID ~= Spring.GetTeamRulesParam(myTeamID, 'startUnit') then
+			startDefID = Spring.GetTeamRulesParam(myTeamID, 'startUnit')
 			doUpdate = true
 		end
 	end
 
 	widget:ViewResize()
-	widget:SelectionChanged(spGetSelectedUnits())
+	widget:SelectionChanged(Spring.GetSelectedUnits())
 
 	WG['buildmenu'] = {}
 	WG['buildmenu'].getPreGameDefID = function()
@@ -1089,9 +1058,9 @@ function widget:Initialize()
 end
 
 -- update queue number
-function widget:UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)
-	if spIsUnitSelected(factID) then
-		doUpdateClock = os_clock() + 0.01
+function widget:UnitFromFactory(_, _, _, factID)
+	if Spring.IsUnitSelected(factID) then
+		doUpdateClock = os.clock() + 0.01
 	end
 end
 
@@ -1100,7 +1069,7 @@ local updateSelection = true
 function widget:Update(dt)
 	if updateSelection then
 		updateSelection = false
-		SelectedUnitsCount = spGetSelectedUnitsCount()
+		SelectedUnitsCount = Spring.GetSelectedUnitsCount()
 
 		selectedBuilder = nil
 		selectedFactory = nil
@@ -1159,7 +1128,6 @@ function widget:Update(dt)
 			doUpdate = true
 		end
 
-		local _, _, mapMinWater, _ = Spring.GetGroundExtremes()
 		if not voidWater and mapMinWater <= minWaterUnitDepth then
 			if not showWaterUnits then
 				showWaterUnits = true
@@ -1169,7 +1137,7 @@ function widget:Update(dt)
 		local prevOrdermenuLeft = ordermenuLeft
 		local prevOrdermenuHeight = ordermenuHeight
 		if WG['ordermenu'] then
-			local oposX, oposY, owidth, oheight = WG['ordermenu'].getPosition()
+			local oposX, _, owidth, oheight = WG['ordermenu'].getPosition()
 			ordermenuLeft = oposX + owidth
 			ordermenuHeight = oheight
 		end
@@ -1196,19 +1164,18 @@ function widget:Update(dt)
 		-- refresh buildmenu if active cmd changed
 		local prevActiveCmd = activeCmd
 
-		activeCmd = select(4, spGetActiveCommand())
+		activeCmd = select(4, Spring.GetActiveCommand())
 
 		if activeCmd ~= prevActiveCmd then doUpdate = true end
 	end
 end
 
-function drawBuildmenuBg()
+local function drawBuildmenuBg()
 	WG['buildmenu'].selectedID = nil
 	UiElement(backgroundRect[1], backgroundRect[2], backgroundRect[3], backgroundRect[4], (posX > 0 and 1 or 0), 1, ((posY-height > 0 or posX <= 0) and 1 or 0), 0)
 end
 
 local function drawButton(rect, text, opts)
-
 	opts = opts or {}
 	local highlight = opts.highlight
 	local fontSize = opts.fontSize
@@ -1230,14 +1197,14 @@ local function drawButton(rect, text, opts)
 	color2 = { 0, 0, 0, math_max(0.55, math_min(0.95, ui_opacity)) }	-- top
 
 	if highlight then
-		glBlending(GL_SRC_ALPHA, GL_ONE)
-		glColor(0, 0, 0, 0.75)
+		gl.Blending(GL_SRC_ALPHA, GL_ONE)
+		gl.Color(0, 0, 0, 0.75)
 	end
 
 	UiButton(rect[1] + padding + pad1, rect[2] + padding + pad1, rect[3] - padding - pad1, rect[4] - padding - pad1, 1,1,1,1, 1,1,1,1, nil, color1, color2, padding)
 
 	if highlight then
-		glBlending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 
 	local zoom = 1
@@ -1253,10 +1220,10 @@ local function drawButton(rect, text, opts)
 		-- gloss highlight
 		local pad = padding
 		local pad2 = 0
-		glBlending(GL_SRC_ALPHA, GL_ONE)
+		gl.Blending(GL_SRC_ALPHA, GL_ONE)
 		RectRound(rect[1] + leftMargin + pad + pad2, rect[4] - topMargin - bgpadding - pad - pad2 - ((rect[4] - rect[2]) * 0.42), rect[3] - rightMargin - pad - pad2, (rect[4] - topMargin - pad - pad2), padding * 1.5, 2, 2, 0, 0, { 1, 1, 1, 0.035 }, { 1, 1, 1, (disableInput and 0.11 or 0.24) })
 		RectRound(rect[1] + leftMargin + pad + pad2, rect[2] + bottomMargin + pad + pad2, rect[3] - rightMargin - pad - pad2, (rect[2] - bottomMargin - pad - pad2) + ((rect[4] - rect[2]) * 0.5), padding * 1.5, 0, 0, 2, 2, { 1, 1, 1, (disableInput and 0.035 or 0.075) }, { 1, 1, 1, 0 })
-		glBlending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 
 	local fontHeight = font2:GetTextHeight(text) * fontSize * zoom
@@ -1265,24 +1232,32 @@ local function drawButton(rect, text, opts)
 end
 
 local function drawCategoryButtons()
-	local fontSize = currentBuildCategory and categoryFontSize * 1.1 or categoryFontSize
+	local catTexts = {}
+	local maxTextSize = 0
 
 	for catIndex, cat in pairs(Cfgs.buildCategories) do
+		local catText = cat .. " \255\215\255\215" .. "[" .. sanitizeKey(Cfgs.categoryKeys[catIndex]) .. "]"
+		catTexts[cat] = catText
+		local catTextSize = font2:GetTextWidth(catText)
+		if maxTextSize < catTextSize then
+			maxTextSize = catTextSize
+		end
+	end
+
+	for _, cat in pairs(Cfgs.buildCategories) do
 		local rect = catRects[cat]
 
 		local opts = {
 			highlight = (cat == currentBuildCategory),
 			hovered = (hoveredCat == cat),
-			fontSize = fontSize * ui_scale,
+			fontSize = (rect[3] - rect[1] - (stickToBottom and 2 or 1.5) * 8 * math_max(1, math_floor(bgpadding * 0.52))) / maxTextSize,
 		}
 
 		if opts.hovered then
 			drawnHoveredCat = cat
 		end
 
-		local catText = currentBuildCategory and cat or cat .. " \255\215\255\215" .. "[" .. Cfgs.categoryKeys[catIndex] .. "]"
-
-		drawButton(rect, catText, opts)
+		drawButton(rect, catTexts[cat], opts)
 	end
 end
 
@@ -1291,10 +1266,12 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 	local uid = cmd.id * -1
 	-- unit icon
 	if disabled then
-		glColor(0.4, 0.4, 0.4, 1)
+		gl.Color(0.4, 0.4, 0.4, 1)
 	else
-		glColor(1, 1, 1, 1)
+		gl.Color(1, 1, 1, 1)
 	end
+
+	local showIcon = showGroupIcon and not (selectedFactory or currentCategoryIndex)
 
 	UiUnit(
 	cellRects[cellRectID][1] + cellPadding + iconPadding,
@@ -1306,16 +1283,16 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 	nil, disabled and 0 or nil,
 	'#' .. uid,
 	showRadarIcon and (((unitIconType[uid] and iconTypesMap[unitIconType[uid]]) and ':l' .. (disabled and 't0.35,0.35,0.35' or '') ..':' .. iconTypesMap[unitIconType[uid]] or nil)) or nil,
-	showGroupIcon and (groups[unitGroup[uid]] and ':l' .. (disabled and 'gt0.4,0.4,0.4:' or ':') ..groups[unitGroup[uid]] or nil) or nil,
+	showIcon and (groups[unitGroup[uid]] and ':l' .. (disabled and 'gt0.4,0.4,0.4:' or ':') ..groups[unitGroup[uid]] or nil) or nil,
 	{unitMetalCost[uid], unitEnergyCost[uid]},
 	tonumber(cmd.params[1])
 	)
 
 	-- colorize/highlight unit icon
 	if cellColor then
-		glBlending(GL_DST_ALPHA, GL_ONE_MINUS_SRC_COLOR)
-		glColor(cellColor[1], cellColor[2], cellColor[3], cellColor[4])
-		glTexture('#' .. uid)
+		gl.Blending(GL.DST_ALPHA, GL_ONE_MINUS_SRC_COLOR)
+		gl.Color(cellColor[1], cellColor[2], cellColor[3], cellColor[4])
+		gl.Texture('#' .. uid)
 		UiUnit(
 		cellRects[cellRectID][1] + cellPadding + iconPadding,
 		cellRects[cellRectID][2] + cellPadding + iconPadding,
@@ -1325,7 +1302,7 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		usedZoom
 		)
 		if cellColor[4] > 0 then
-			glBlending(GL_SRC_ALPHA, GL_ONE)
+			gl.Blending(GL_SRC_ALPHA, GL_ONE)
 			UiUnit(
 			cellRects[cellRectID][1] + cellPadding + iconPadding,
 			cellRects[cellRectID][2] + cellPadding + iconPadding,
@@ -1335,9 +1312,9 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 			usedZoom
 			)
 		end
-		glBlending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
-	glTexture(false)
+	gl.Texture(false)
 
 	-- price
 	if showPrice then
@@ -1363,103 +1340,35 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 			cellRects[cellRectID][2] + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
 			cellInnerSize * 0.29, "ro"
 		)
+	end
 
-	elseif cmd.hotkey and (selectedFactory or (selectedBuilder and currentBuildCategory)) then
-		local hotkeyText = cmd.hotkey
-		local fontWidth = font2:GetTextWidth(hotkeyText) * priceFontSize
-		local fontWidthOffset = fontWidth * 1.35
+	if cmd.hotkey and (selectedFactory or (selectedBuilder and currentBuildCategory)) then
+		local hotkeyText = sanitizeKey(cmd.hotkey)
 
-		-- If crazy char, put 50% to left
-		-- if Cfgs.keySymChars[cmd.hotkey] then
-		-- 	fontWidthOffset = 3 * fontWidthOffset / 2
-		-- end
-
-		font2:Print("\255\215\255\215" .. hotkeyText, cellRects[cellRectID][3] - cellPadding - fontWidthOffset, cellRects[cellRectID][4] - cellPadding - priceFontSize, priceFontSize * 1.1, "o")
+		local hotkeyFontSize = priceFontSize * 1.1
+		font2:Print("\255\215\255\215" .. hotkeyText, cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.048), cellRects[cellRectID][4] - cellPadding - hotkeyFontSize, hotkeyFontSize, "o")
 	end
 end
 
-function drawLabButtons()
-	local activeArea
-	local labButtons = { "Repeat", "Clear", "Wait" }
-	local numCats = #labButtons
-	local keyLabs = table.invert(labKeys)
-
+local function labActiveArea()
 	if stickToBottom then
-		local x1 = backgroundRect[1] + bgpadding
-
-		activeArea = {
-			x1 + pageButtonWidth + activeAreaMargin,
-			backgroundRect[2] - 2 * activeAreaMargin,
+		return {
+			backgroundRect[1] + bgpadding,
+			backgroundRect[2],
 			backgroundRect[3],
 			backgroundRect[4] - bgpadding
 		}
-
-		local contentHeight = activeArea[4] - activeArea[2]
-
-		for i, cat in ipairs(labButtons) do
-			local a1 = x1
-			local a2 = activeArea[4] - i * (contentHeight / numCats) + 2
-			local a3 = a1 + pageButtonWidth - activeAreaMargin
-			local a4 = a2 + (contentHeight / numCats) - 2
-
-			labButtonRects[cat] = { a1, a2, a3, a4 }
-		end
 	else
-		local y2 = backgroundRect[4] - bgpadding
-
-		activeArea = {
+		return {
 			backgroundRect[1],
-			backgroundRect[2] - activeAreaMargin * 2,
+			backgroundRect[2],
 			backgroundRect[3] - bgpadding,
-			y2 - pageButtonHeight - activeAreaMargin
+			backgroundRect[4] - bgpadding
 		}
-
-		local buttonWidth = math.round((activeArea[3] - activeArea[1]) / numCats)
-
-		for i, cat in ipairs(labButtons) do
-			local a1 = backgroundRect[1] + activeAreaMargin + (i - 1) * buttonWidth
-			local a2 = y2 - pageButtonHeight
-			local a3 = a1 + buttonWidth
-			local a4 = y2 - activeAreaMargin
-
-			labButtonRects[cat] = { a1, a2, a3, a4 }
-		end
 	end
-
-	local _, _, b = spGetMouseState()
-
-
-	local cmdWait = Spring.GetFactoryCommands(selectedFactoryUID, 1)[1]
-	selectedFactoryIsWait = cmdWait and cmdWait.id == CMD.WAIT
-	selectedFactoryIsRepeat = select(4, Spring.GetUnitStates(selectedFactoryUID, false, true))
-
-	local highlights = {
-		Repeat = selectedFactoryIsRepeat,
-		Wait = selectedFactoryIsWait,
-		Clear = hoveredLabButton == "Clear" and b,
-	}
-
-	for lab, rect in pairs(labButtonRects) do
-		local hovered = hoveredLabButton == lab
-		local opts = {
-			highlight = highlights[lab],
-			hovered = hovered,
-			fontSize = categoryFontSize * 1.2,
-		}
-
-		if hovered then
-			drawnHoveredLabButton = lab
-		end
-
-		local text = lab .. " \255\215\255\215" .. "[" .. SYMKEYS[keyLabs[lab]] .. "]"
-
-		drawButton(rect, text, opts)
-	end
-
-	return activeArea
 end
 
-function drawCategories()
+local function drawCategories()
 	local numCats = #categories
 	local activeArea
 
@@ -1467,7 +1376,7 @@ function drawCategories()
 		local x1 = backgroundRect[1] + bgpadding
 
 		activeArea = {
-			x1 + pageButtonWidth + activeAreaMargin,
+			x1 + pageButtonWidth,
 			backgroundRect[2] - 2 * activeAreaMargin,
 			backgroundRect[3],
 			backgroundRect[4] - bgpadding
@@ -1488,9 +1397,9 @@ function drawCategories()
 
 		activeArea = {
 			backgroundRect[1],
-			backgroundRect[2] + activeAreaMargin * 2,
+			backgroundRect[2],
 			backgroundRect[3] - bgpadding,
-			y2 - pageButtonHeight - activeAreaMargin
+			y2 - pageButtonHeight
 		}
 
 		local buttonWidth = math.round((activeArea[3] - activeArea[1] - bgpadding) / numCats)
@@ -1510,25 +1419,141 @@ function drawCategories()
 	return activeArea
 end
 
-function drawBuildmenu()
+local function drawGrid(activeArea)
+	local numCellsPerPage = rows * colls
+	local cellRectID = 0
+	local unitGrid
+	if selectedFactory then
+		unitGrid = gridPosUnit[selectedFactory]
+	else
+		unitGrid = gridPosUnit[selectedBuilder]
+	end
+	local curCmd = currentPage > 1 and (numCellsPerPage * (currentPage - 1) - (uidcmdsCount - cmdsCount) + 1) or 1
+
+	cellcmds = {}
+
+	for row = 3, 1, -1 do
+		for coll = 1, 4 do
+			cellRectID = cellRectID + 1
+
+			local uDefID
+			local kcol = coll
+			local arow = 3 - row + 1
+			local krow = arow
+			-- hotkey mapping from 2x6 -> 3x4 grid
+			-- 3,1 -> 2,5
+			-- 3,2 -> 2,6
+			-- 3,3 -> 1,5
+			-- 3,4 -> 1,6
+			if arow > 2 and stickToBottom then
+				krow = coll < 3 and 2 or 1
+				kcol = 6 - coll % 2
+			end
+
+			if selectedFactory then
+				if currentPage == 1 and unitGrid and unitGrid[arow .. coll] then
+					uDefID = unitGrid[arow .. coll]
+				elseif cmds[curCmd] then
+					uDefID = cmds[curCmd].id * -1
+					curCmd = curCmd + 1
+				end
+			elseif currentPage == 1 and currentBuildCategory and unitGrid and unitGrid[currentCategoryIndex .. arow .. coll] then
+				uDefID = unitGrid[currentCategoryIndex .. arow .. coll]
+			elseif cmds[curCmd] then
+				uDefID = cmds[curCmd].id * -1
+				curCmd = curCmd + 1
+			end
+
+			if uDefID and uidcmds[uDefID] then
+				cellcmds[cellRectID] = uidcmds[uDefID]
+
+				uidcmds[uDefID].hotkey = string.gsub(string.upper(Cfgs.keyLayout[arow][coll]), "ANY%+", '')
+				hotkeyActions[tostring(arow) .. tostring(coll)] = -uDefID
+
+				local udef = uidcmds[uDefID]
+
+				cellRects[cellRectID] = {
+					activeArea[1] + (kcol - 1) * cellSize,
+					activeArea[4] - (rows - krow + 1) * cellSize,
+					activeArea[1] + (kcol ) * cellSize,
+					activeArea[4] - (rows - krow) * cellSize,
+				}
+
+				local cellIsSelected = (activeCmd and udef and activeCmd == udef.name) or
+															 (preGamestartPlayer and selBuildQueueDefID == uDefID)
+				local usedZoom = (cellIsSelected and selectedCellZoom or defaultCellZoom)
+
+				if cellIsSelected then
+					WG['buildmenu'].selectedID = uDefID
+				end
+
+				drawCell(cellRectID, usedZoom, cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil, nil, unitRestricted[uDefID])
+			else
+				hotkeyActions[tostring(arow) .. tostring(coll)] = nil
+			end
+		end
+	end
+
+	if cellcmds[1] and (selectedBuilder or preGamestartPlayer) and switchedCategory then
+		selectNextFrame = cellcmds[1].id
+	end
+end
+
+local function drawPaginators(activeArea)
+	paginatorRects = {}
+
+	if pages == 1 then
+		return
+	end
+
+	if stickToBottom then
+		local contentHeight = activeArea[4] - activeArea[2]
+		paginatorCellHeight = contentHeight / 3
+
+		paginatorRects[1] = { activeArea[1] + 6 * cellSize, activeArea[2] + activeAreaMargin, activeArea[3] - bgpadding, activeArea[2] + paginatorCellHeight }
+		paginatorRects[2] = { paginatorRects[1][1], activeArea[2] + 2 * paginatorCellHeight, paginatorRects[1][3], activeArea[2] + 3 * paginatorCellHeight }
+
+		local paginatorWidth = paginatorRects[1][3] - paginatorRects[1][1]
+
+		UiButton(paginatorRects[1][1] + cellPadding, paginatorRects[1][2] + cellPadding, paginatorRects[1][3] - cellPadding, paginatorRects[1][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print("\255\215\255\215[".. sanitizeKey(Cfgs.PREV_PAGE_KEY) .."]", paginatorRects[1][1] + paginatorWidth/2, paginatorRects[1][2] + (paginatorCellHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
+		UiButton(paginatorRects[2][1] + cellPadding, paginatorRects[2][2] + cellPadding, paginatorRects[2][3] - cellPadding, paginatorRects[2][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print("\255\215\255\215[".. sanitizeKey(Cfgs.NEXT_PAGE_KEY) .."]", paginatorRects[2][1] + paginatorWidth/2, paginatorRects[2][2] + (paginatorCellHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
+
+		font2:Print("\255\245\245\245" .. currentPage .. "/" .. pages,
+		(paginatorRects[1][1] + paginatorRects[1][3]) * 0.5,
+		paginatorRects[1][4] + paginatorCellHeight * 0.5 - paginatorFontSize * 0.25, paginatorFontSize, "co")
+	else
+		local contentWidth = activeArea[3] - activeArea[1]
+		paginatorCellWidth = math_floor(contentWidth * 0.33)
+
+		paginatorRects[1] = { activeArea[1] + activeAreaMargin, activeArea[2], activeArea[1] + paginatorCellWidth, activeArea[4] - 3 * cellSize }
+		paginatorRects[2] = { activeArea[3] - paginatorCellWidth, paginatorRects[1][2], activeArea[3], paginatorRects[1][4] }
+		paginatorCellHeight = paginatorRects[1][4] - paginatorRects[1][2]
+		local prevText = "\255\215\255\215[".. sanitizeKey(Cfgs.PREV_PAGE_KEY) .."]"
+		local nextText = "\255\215\255\215[".. sanitizeKey(Cfgs.NEXT_PAGE_KEY) .."]"
+
+		UiButton(paginatorRects[1][1] + cellPadding, paginatorRects[1][2] + bgpadding, paginatorRects[1][3] - cellPadding, paginatorRects[1][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print(prevText, paginatorRects[1][1] + (paginatorCellWidth * 0.5), paginatorRects[1][4] - font2:GetTextHeight(prevText) * paginatorFontSize * 0.25 - paginatorCellHeight/2, paginatorFontSize, "co")
+		UiButton(paginatorRects[2][1] + cellPadding, paginatorRects[2][2] + bgpadding, paginatorRects[2][3] - cellPadding, paginatorRects[2][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print(nextText, paginatorRects[2][1] + (paginatorCellWidth * 0.5), paginatorRects[2][4] - font2:GetTextHeight(nextText) * paginatorFontSize * 0.25 - paginatorCellHeight/2, paginatorFontSize, "co")
+
+		local pagesText = currentPage .. " / " .. pages
+		font2:Print("\255\245\245\245" .. pagesText, contentWidth * 0.5, paginatorRects[1][4] - font2:GetTextHeight(pagesText) * paginatorFontSize * 0.25 - paginatorCellHeight/2, paginatorFontSize, "co")
+	end
+end
+
+local function drawBuildmenu()
 	local activeArea
 
 	catRects = {}
-	labButtonRects = {}
 
 	font2:Begin()
 
 	if selectedFactory then
-		activeArea = drawLabButtons()
-	elseif #categories > 0 then
+		activeArea = labActiveArea()
+	elseif selectedBuilder then
 		activeArea = drawCategories()
-	else
-		activeArea = {
-			backgroundRect[1] + (stickToBottom and bgpadding or 0) + activeAreaMargin,
-			backgroundRect[2] + (stickToBottom and 0 or bgpadding) + activeAreaMargin,
-			backgroundRect[3] - bgpadding - activeAreaMargin,
-			backgroundRect[4] - bgpadding - activeAreaMargin
-		}
 	end
 
 	if stickToBottom then
@@ -1569,137 +1594,7 @@ function drawBuildmenu()
 	font2:End()
 end
 
-function drawGrid(activeArea)
-	local numCellsPerPage = rows * colls
-	local cellRectID = 0
-	local unitGrid
-	if selectedFactory then
-		unitGrid = gridPosUnit[selectedFactory]
-	else
-		unitGrid = gridPosUnit[selectedBuilder]
-	end
-	local curCmd = currentPage > 1 and (numCellsPerPage * (currentPage - 1) - (uidcmdsCount - cmdsCount) + 1) or 1
-
-	cellcmds = {}
-
-	for row = rows, 1, -1 do
-		for coll = 1, colls do
-			cellRectID = cellRectID + 1
-
-			local uDefID
-			local arow = rows - row + 1
-			local kcol = coll
-			local krow = arow
-			-- hotkey mapping from 2x8 -> 3x4 grid
-			-- 1,5 -> 3,1
-			-- 1,6 -> 3,3
-			-- 2,5 -> 3,2
-			-- 2,6 -> 3,4
-			if coll > 4 and stickToBottom then
-				kcol = krow + 2 * (1 - (coll % 2))
-				krow = 3
-			end
-
-			if selectedFactory then
-				if currentPage == 1 and unitGrid and unitGrid[krow .. kcol] then
-					uDefID = unitGrid[krow .. kcol]
-				elseif cmds[curCmd] then
-					uDefID = cmds[curCmd].id * -1
-					curCmd = curCmd + 1
-				end
-			elseif currentPage == 1 and currentBuildCategory and unitGrid and unitGrid[currentCategoryIndex .. krow .. kcol] then
-				uDefID = unitGrid[currentCategoryIndex .. krow .. kcol]
-			elseif cmds[curCmd] then
-				uDefID = cmds[curCmd].id * -1
-				curCmd = curCmd + 1
-			end
-
-			if uDefID and uidcmds[uDefID] then
-				cellcmds[cellRectID] = uidcmds[uDefID]
-
-				local keyLayout = stickToBottom and Cfgs.vKeyLayout or Cfgs.keyLayout
-
-				uidcmds[uDefID].hotkey = string.gsub(string.upper(keyLayout[arow][coll]), "ANY%+", '')
-				hotkeyActions[tostring(krow) .. tostring(kcol)] = -uDefID
-
-				local udef = uidcmds[uDefID]
-
-				if stickToBottom then
-					cellRects[cellRectID] = {
-						activeArea[1] + ((coll - 1) * cellSize),
-						activeArea[4] - ((row) * cellSize),
-						activeArea[1] + (((coll)) * cellSize),
-						activeArea[4] - ((row - 1) * cellSize)
-					}
-				else
-					cellRects[cellRectID] = {
-						activeArea[3] - ((colls - coll + 1) * cellSize),
-						activeArea[4] - ((row) * cellSize),
-						activeArea[3] - (((colls - coll)) * cellSize),
-						activeArea[4] - ((row - 1) * cellSize)
-					}
-				end
-
-				local cellIsSelected = (activeCmd and udef and activeCmd == udef.name) or
-															 (preGamestartPlayer and selBuildQueueDefID == uDefID)
-				local usedZoom = (cellIsSelected and selectedCellZoom or defaultCellZoom)
-
-				if cellIsSelected then
-					WG['buildmenu'].selectedID = uDefID
-				end
-
-				drawCell(cellRectID, usedZoom, cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil, unitRestricted[uDefID])
-			else
-				hotkeyActions[tostring(arow) .. tostring(coll)] = nil
-			end
-		end
-	end
-
-	if cellcmds[1] and (selectedBuilder or preGamestartPlayer) and switchedCategory then
-		selectNextFrame = cellcmds[1].id
-	end
-end
-
-function drawPaginators(activeArea)
-	paginatorRects = {}
-
-	if pages == 1 then
-		return
-	end
-
-	if stickToBottom then
-		local contentHeight = activeArea[4] - activeArea[2]
-		paginatorCellHeight = contentHeight / 3
-
-		paginatorRects[1] = { activeArea[3] - paginatorCellWidth, activeArea[2] + activeAreaMargin, activeArea[3] - bgpadding - activeAreaMargin, activeArea[2] + paginatorCellHeight }
-		paginatorRects[2] = { activeArea[3] - paginatorCellWidth, activeArea[2] + 2 * paginatorCellHeight, activeArea[3] - bgpadding - activeAreaMargin, activeArea[2] + 3 * paginatorCellHeight - activeAreaMargin }
-
-		UiButton(paginatorRects[1][1] + cellPadding, paginatorRects[1][2] + cellPadding, paginatorRects[1][3] - cellPadding, paginatorRects[1][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print("\255\215\255\215[".. PREV_PAGE_KEY .."]", paginatorRects[1][1] + (paginatorCellWidth * 0.5), paginatorRects[1][2] + (paginatorCellHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
-		UiButton(paginatorRects[2][1] + cellPadding, paginatorRects[2][2] + cellPadding, paginatorRects[2][3] - cellPadding, paginatorRects[2][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print("\255\215\255\215[".. NEXT_PAGE_KEY .."]", paginatorRects[2][1] + (paginatorCellWidth * 0.5), paginatorRects[2][2] + (paginatorCellHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
-
-		font2:Print("\255\245\245\245" .. currentPage .. " / " .. pages,
-		(paginatorRects[1][1] + paginatorRects[1][3]) * 0.5,
-		paginatorRects[1][4] + paginatorCellHeight * 0.5 - paginatorFontSize * 0.25, paginatorFontSize, "co")
-	else
-		local contentWidth = activeArea[3] - activeArea[1]
-		paginatorCellWidth = math_floor(contentWidth * 0.33)
-
-		paginatorRects[1] = { activeArea[1] + activeAreaMargin * 2, activeArea[2] + bgpadding, activeArea[1] + paginatorCellWidth, cellRects[1][2] - 2 * activeAreaMargin  }
-		paginatorRects[2] = { activeArea[3] - paginatorCellWidth, activeArea[2] + bgpadding, activeArea[3] - activeAreaMargin * 2, cellRects[1][2] - 2 * activeAreaMargin }
-		paginatorCellHeight = paginatorRects[1][4] - paginatorRects[1][2]
-
-		UiButton(paginatorRects[1][1] + cellPadding, paginatorRects[1][2] + cellPadding, paginatorRects[1][3] - cellPadding, paginatorRects[1][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print("\255\215\255\215[".. PREV_PAGE_KEY .."]", paginatorRects[1][1] + (paginatorCellWidth * 0.5), activeArea[2] + paginatorCellHeight * 0.5, paginatorFontSize, "co")
-		UiButton(paginatorRects[2][1] + cellPadding, paginatorRects[2][2] + cellPadding, paginatorRects[2][3] - cellPadding, paginatorRects[2][4] - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print("\255\215\255\215[".. NEXT_PAGE_KEY .."]", paginatorRects[2][1] + (paginatorCellWidth * 0.5), activeArea[2] + paginatorCellHeight * 0.5, paginatorFontSize, "co")
-
-		font2:Print("\255\245\245\245" .. currentPage .. "	/  " .. pages, contentWidth * 0.5, activeArea[2] + paginatorCellHeight * 0.5, paginatorFontSize, "co")
-	end
-end
-
-function widget:RecvLuaMsg(msg, playerID)
+function widget:RecvLuaMsg(msg)
 	if msg:sub(1, 18) == 'LobbyOverlayActive' then
 		chobbyInterface = (msg:sub(1, 19) == 'LobbyOverlayActive1')
 	end
@@ -1760,25 +1655,6 @@ local function DrawBuilding(buildData, borderColor, drawRanges)
 	end
 end
 
-local function DrawUnitDef(uDefID, uTeam, ux, uy, uz, scale)
-	gl.Color(1, 1, 1, 1)
-	gl.DepthTest(GL.LEQUAL)
-	gl.DepthMask(true)
-	gl.Lighting(true)
-
-	gl.PushMatrix()
-	gl.Translate(ux, uy, uz)
-	if scale then
-		gl.Scale(scale, scale, scale)
-	end
-	gl.UnitShape(uDefID, uTeam, false, true, true)
-	gl.PopMatrix()
-
-	gl.Lighting(false)
-	gl.DepthTest(false)
-	gl.DepthMask(false)
-end
-
 local function DoBuildingsClash(buildData1, buildData2)
 	local w1, h1 = GetBuildingDimensions(buildData1[1], buildData1[5])
 	local w2, h2 = GetBuildingDimensions(buildData2[1], buildData2[5])
@@ -1809,6 +1685,38 @@ local function cacheUnitIcons()
 	gl.Translate(vsx,0,0)
 end
 
+local function drawBuildProgress()
+	local numCellsPerPage = rows * colls
+	local maxCellRectID = numCellsPerPage * currentPage
+	if maxCellRectID > uidcmdsCount then
+		maxCellRectID = uidcmdsCount
+	end
+	-- loop selected builders
+	local drawncellRectIDs = {}
+	for builderUnitID, _ in pairs(selectedBuilders) do
+		local unitBuildID = spGetUnitIsBuilding(builderUnitID)
+		if unitBuildID then
+			local unitBuildDefID = spGetUnitDefID(unitBuildID)
+			if unitBuildDefID then
+				-- loop all shown cells
+				for cellRectID, _ in pairs(cellRects) do
+					if not drawncellRectIDs[cellRectID] then
+						if cellRectID > maxCellRectID then
+							break
+						end
+						local cellUnitDefID = cellcmds[cellRectID].id * -1
+						if unitBuildDefID == cellUnitDefID then
+							drawncellRectIDs[cellRectID] = true
+							local progress = 1 - select(5, spGetUnitHealth(unitBuildID))
+							RectRoundProgress(cellRects[cellRectID][1] + cellPadding + iconPadding, cellRects[cellRectID][2] + cellPadding + iconPadding, cellRects[cellRectID][3] - cellPadding - iconPadding, cellRects[cellRectID][4] - cellPadding - iconPadding, cellSize * 0.03, progress, { 0.08, 0.08, 0.08, 0.6 })
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
 function widget:DrawScreen()
 	if (not cachedUnitIcons) and Spring.GetGameFrame() == 0 then
 		cachedUnitIcons = true
@@ -1827,8 +1735,8 @@ function widget:DrawScreen()
 			WG['guishader'].RemoveDlist('buildmenu')
 		end
 	else
-		local x, y, b, b2, b3 = spGetMouseState()
-		local now = os_clock()
+		local x, y, b, b2, b3 = Spring.GetMouseState()
+		local now = os.clock()
 		if doUpdate or (doUpdateClock and now >= doUpdateClock) then
 			if doUpdateClock and now >= doUpdateClock then
 				doUpdateClock = nil
@@ -1863,7 +1771,6 @@ function widget:DrawScreen()
 			-- pre process + 'highlight' under the icons
 			local hoveredCellID = nil
 			local hoveredCatNotFound = true
-			local hoveredLabButtonNotFound = true
 			if not WG['topbar'] or not WG['topbar'].showingQuit() then
 				if hovering then
 					for cellRectID, cellRect in pairs(cellRects) do
@@ -1873,7 +1780,7 @@ function widget:DrawScreen()
 							local uDefID = cmd.id * -1
 							WG['buildmenu'].hoverID = uDefID
 							gl.Color(1, 1, 1, 1)
-							local alt, ctrl, meta, shift = Spring.GetModKeyState()
+							local _, _, meta, _ = Spring.GetModKeyState()
 							if WG['tooltip'] and not meta then
 								-- when meta: unitstats does the tooltip
 								local text
@@ -1891,9 +1798,9 @@ function widget:DrawScreen()
 							end
 
 							-- highlight --if b and not disableInput then
-							glBlending(GL_SRC_ALPHA, GL_ONE)
+							gl.Blending(GL_SRC_ALPHA, GL_ONE)
 							RectRound(cellRects[cellRectID][1] + cellPadding, cellRects[cellRectID][2] + cellPadding, cellRects[cellRectID][3] - cellPadding, cellRects[cellRectID][4] - cellPadding, cellSize * 0.03, 1, 1, 1, 1, { 0, 0, 0, 0.1 * ui_opacity }, { 0, 0, 0, 0.1 * ui_opacity })
-							glBlending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+							gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 							break
 						end
 					end
@@ -1932,30 +1839,15 @@ function widget:DrawScreen()
 						end
 					end
 				end
-
-				for lab, labRect in pairs(labButtonRects) do
-					if math_isInRect(x, y, labRect[1], labRect[2], labRect[3], labRect[4]) then
-						hoveredLabButton = lab
-
-						if hoveredLabButton ~= drawnHoveredLabButton then
-							doUpdate = true
-						end
-
-						hoveredLabButtonNotFound = false
-						break
-					end
-				end
 			end
 
-			if (not hovering) or (selectedBuilder and hoveredCatNotFound) or (selectedFactory and hoveredLabButtonNotFound) then
-				if drawnHoveredCat or drawnHoveredLabButton then
+			if (not hovering) or (selectedBuilder and hoveredCatNotFound) then
+				if drawnHoveredCat then
 					doUpdate = true
 				end
 
 				drawnHoveredCat = nil
 				hoveredCat = nil
-				drawnHoveredLabButton = nil
-				hoveredLabButton = nil
 			end
 
 			-- draw buildmenu content
@@ -1968,7 +1860,7 @@ function widget:DrawScreen()
 				if math_isInRect(x, y, backgroundRect[1], backgroundRect[2], backgroundRect[3], backgroundRect[4]) then
 
 					-- paginator buttons
-					local paginatorHovered = false
+					local paginatorHovered
 					if paginatorRects[1] and math_isInRect(x, y, paginatorRects[1][1], paginatorRects[1][2], paginatorRects[1][3], paginatorRects[1][4]) then
 						paginatorHovered = 1
 					end
@@ -1991,6 +1883,12 @@ function widget:DrawScreen()
 						local uDefID = cellcmds[hoveredCellID].id * -1
 						local cellIsSelected = (activeCmd and cellcmds[hoveredCellID] and activeCmd == cellcmds[hoveredCellID].name)
 						if not prevHoveredCellID or hoveredCellID ~= prevHoveredCellID or uDefID ~= hoverUdefID or cellIsSelected ~= hoverCellSelected or b ~= prevB or b3 ~= prevB3 or cellcmds[hoveredCellID].params[1] ~= prevQueueNr then
+							prevQueueNr = cellcmds[hoveredCellID].params[1]
+							prevB = b
+							prevB3 = b3
+							prevHoveredCellID = hoveredCellID
+							hoverUdefID = uDefID
+							hoverCellSelected = cellIsSelected
 							if hoverDlist then
 								hoverDlist = gl.DeleteList(hoverDlist)
 							end
@@ -2052,35 +1950,7 @@ function widget:DrawScreen()
 
 			-- draw builders buildoption progress
 			if showBuildProgress then
-				local numCellsPerPage = rows * colls
-				local maxCellRectID = numCellsPerPage * currentPage
-				if maxCellRectID > uidcmdsCount then
-					maxCellRectID = uidcmdsCount
-				end
-				-- loop selected builders
-				local drawncellRectIDs = {}
-				for builderUnitID, _ in pairs(selectedBuilders) do
-					local unitBuildID = spGetUnitIsBuilding(builderUnitID)
-					if unitBuildID then
-						local unitBuildDefID = spGetUnitDefID(unitBuildID)
-						if unitBuildDefID then
-							-- loop all shown cells
-							for cellRectID, _ in pairs(cellRects) do
-								if not drawncellRectIDs[cellRectID] then
-									if cellRectID > maxCellRectID then
-										break
-									end
-									local cellUnitDefID = cellcmds[cellRectID].id * -1
-									if unitBuildDefID == cellUnitDefID then
-										drawncellRectIDs[cellRectID] = true
-										local progress = 1 - select(5, spGetUnitHealth(unitBuildID))
-										RectRoundProgress(cellRects[cellRectID][1] + cellPadding + iconPadding, cellRects[cellRectID][2] + cellPadding + iconPadding, cellRects[cellRectID][3] - cellPadding - iconPadding, cellRects[cellRectID][4] - cellPadding - iconPadding, cellSize * 0.03, progress, { 0.08, 0.08, 0.08, 0.6 })
-									end
-								end
-							end
-						end
-					end
-				end
+				drawBuildProgress()
 			end
 		end
 	end
@@ -2124,8 +1994,8 @@ function widget:DrawWorld()
 	-- We need data about currently selected building, for drawing clashes etc
 	local selBuildData
 	if selBuildQueueDefID then
-		local x, y, _ = spGetMouseState()
-		local _, pos = spTraceScreenRay(x, y, true)
+		local x, y, _ = Spring.GetMouseState()
+		local _, pos = Spring.TraceScreenRay(x, y, true)
 		if pos then
 			local bx, by, bz = Spring.Pos2BuildPos(selBuildQueueDefID, pos[1], pos[2], pos[3])
 			local buildFacing = Spring.GetBuildFacing()
@@ -2154,13 +2024,13 @@ function widget:DrawWorld()
 		local buildData = buildQueue[b]
 		local buildDataId = buildData[1]
 		if startDefID == UnitDefNames["armcom"].id then
-			if corToArm[buildDataId] ~= nil then
-				buildData[1] = corToArm[buildDataId]
+			if Cfgs.corToArm[buildDataId] ~= nil then
+				buildData[1] = Cfgs.corToArm[buildDataId]
 				buildQueue[b] = buildData
 			end
 		elseif startDefID == UnitDefNames["corcom"].id then
-			if armToCor[buildDataId] ~= nil then
-				buildData[1] = armToCor[buildDataId]
+			if Cfgs.armToCor[buildDataId] ~= nil then
+				buildData[1] = Cfgs.armToCor[buildDataId]
 				buildQueue[b] = buildData
 			end
 		end
@@ -2181,7 +2051,7 @@ function widget:DrawWorld()
 	end
 
 	-- Draw queue lines
-	glColor(buildLinesColor)
+	gl.Color(buildLinesColor)
 	gl.LineStipple("springdefault")
 	gl.Shape(GL.LINE_STRIP, queueLineVerts)
 	gl.LineStipple(false)
@@ -2196,20 +2066,20 @@ function widget:DrawWorld()
 	end
 
 	-- Reset gl
-	glColor(1, 1, 1, 1)
+	gl.Color(1, 1, 1, 1)
 	gl.LineWidth(1.0)
 end
 
-function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdOpts, cmdParams, cmdTag)
+function widget:UnitCommand(_, unitDefID, _, cmdID)
 	if isFactory[unitDefID] and cmdID < 0 then
 		-- filter away non build cmd's
 		if doUpdateClock == nil then
-			doUpdateClock = os_clock() + 0.01
+			doUpdateClock = os.clock() + 0.01
 		end
 	end
 end
 
-function widget:SelectionChanged(sel)
+function widget:SelectionChanged()
 	updateSelection = true
 end
 
@@ -2289,7 +2159,7 @@ end
 
 function SetBuildFacing()
 	local wx, wy, _, _ = Spring.GetScreenGeometry()
-	local _, pos = spTraceScreenRay(wx / 2, wy / 2, true)
+	local _, pos = Spring.TraceScreenRay(wx / 2, wy / 2, true)
 	if not pos then
 		return
 	end
@@ -2314,39 +2184,10 @@ function SetBuildFacing()
 end
 
 function widget:KeyRelease(key)
-	if key == RESET_MENU_KEY then
+	if key == KEYSYMS.LSHIFT then
 		currentBuildCategory = nil
 		currentCategoryIndex = nil
 		doUpdate = true
-	end
-end
-
-function widget:KeyPress(key, mods, isRepeat)
-	if Spring.IsGUIHidden() then
-		return
-	end
-
-	if not (mods['ctrl'] or mods['alt'] or mods['meta']) then
-		if selectedFactory and labKeys[key] then
-			labActions[labKeys[key]]()
-
-			return true
-		end
-	end
-
-	return false
-end
-
-function enqueueUnit(uDefID, opts)
-	local udTable = Spring.GetSelectedUnitsSorted()
-	udTable.n = nil
-	for udidFac, uTable in pairs(udTable) do
-		if isFactory[udidFac] then
-			uTable.n = nil
-			for _, uid in ipairs(uTable) do
-				Spring.GiveOrderToUnit(uid, uDefID, {}, opts)
-			end
-		end
 	end
 end
 
@@ -2376,7 +2217,7 @@ function widget:MousePress(x, y, button)
 				for cat, catRect in pairs(catRects) do
 					if math_isInRect(x, y, catRect[1], catRect[2], catRect[3], catRect[4]) then
 						currentBuildCategory = cat
-						switchedCategory = os_clock()
+						switchedCategory = os.clock()
 						Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
 
 						for i,c in pairs(categories) do
@@ -2386,14 +2227,6 @@ function widget:MousePress(x, y, button)
 						end
 
 						doUpdate = true
-						return true
-					end
-				end
-
-				for lab, labRect in pairs(labButtonRects) do
-					if math_isInRect(x, y, labRect[1], labRect[2], labRect[3], labRect[4]) then
-						labActions[lab]()
-
 						return true
 					end
 				end
@@ -2412,7 +2245,7 @@ function widget:MousePress(x, y, button)
 							Spring.PlaySoundFile(Cfgs.sound_queue_rem, 0.75, 'ui')
 							Spring.SetActiveCommand(spGetCmdDescIndex(cellcmds[cellRectID].id), 3, false, true, Spring.GetModKeyState())
 						end
-						doUpdateClock = os_clock() + 0.01
+						doUpdateClock = os.clock() + 0.01
 						return true
 					end
 				end
@@ -2432,8 +2265,8 @@ function widget:MousePress(x, y, button)
 				if curMexPosition then
 					pos = { curMexPosition.x, curMexPosition.y, curMexPosition.z }
 				else
-					local mx, my = spGetMouseState()
-					_, pos = spTraceScreenRay(mx, my, true)
+					local mx, my = Spring.GetMouseState()
+					_, pos = Spring.TraceScreenRay(mx, my, true)
 				end
 
 				if not pos then
@@ -2503,7 +2336,7 @@ local function restoreBindings()
 			local action = 'gridmenu_key ' .. r .. ' ' .. c
 
 			if userLayout[r] and userLayout[r][c] then
-				Spring.SendCommands("bind Any+" .. string.lower(userLayout[r][c]) .. " " .. action)
+				Spring.SendCommands("bind Any+" .. string.gsub(string.lower(userLayout[r][c]), 'any%+', '') .. " " .. action)
 			end
 		end
 	end


### PR DESCRIPTION
- Remove lab actions (repeat, wait, clear queue). This should be relied
  upon ordermenu
- Fix discrepant positions between bottom and left modes when no page
  specified
- Fix bug with any+ being prepended to binding on every gridmenu restart
- Many small GUI improvements: fine tuning borders, fitting text on
  buttons, etc
- Fixing linting and architectural issues: Globals to locals, extracting
  methods to keep upvalues count manageable, cached locals to inlined
  calls to manage upvales in main scope, removing unused variables and methods, etc
- Attempt to simplify grid rendering logic