### PR TITLE
Update cmd_bar_hotkeys.lua

### DIFF
--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -215,6 +215,7 @@ local function makeBindsTable(keyLayout)
 	local C = keyLayout[1][3]
 	local V = keyLayout[1][4]
 	local B = keyLayout[1][5]
+	local N = keyLayout[1][6]
 	local M = keyLayout[1][7]
 	local A = keyLayout[2][1]
 	local S = keyLayout[2][2]


### PR DESCRIPTION
N was missing from the keybinding table for layout support. Attempts to bind to N would have resulted in crashing the widget. Discovered while modifying the widget with a different keybind layout so I thought I should put a PR here to fix it in case someone changes the keybinds in this one and adds a bind for N.