### PR TITLE
Fix "length" typo in settings string (and some variables)

### DIFF
--- a/luarules/configs/Atmosphereconfigs/generic_config_setup.lua
+++ b/luarules/configs/Atmosphereconfigs/generic_config_setup.lua
@@ -11,8 +11,8 @@ local transitionSpeed = (mapsizez/mapsizex) * 0.66
 local windmin = Game.windMin
 local windmax = Game.windMax
 
-local fullcyclelenght = math.ceil(mapsizex+mapsizez)*2
-local nightlenght = math.ceil(fullcyclelenght*0.66) -- % of the cycle at which night begins and stays until the end of cycle
+local fullcyclelength = math.ceil(mapsizex+mapsizez)*2
+local nightlength = math.ceil(fullcyclelength*0.66) -- % of the cycle at which night begins and stays until the end of cycle
 
 VFS.Include("luarules/configs/map_biomes.lua")
 
@@ -67,13 +67,13 @@ end
 -- fireflieschance = 100
 
 function gadget:GameFrame(n)
-    local clock = n%fullcyclelenght
+    local clock = n%fullcyclelength
 
     if clock == 10 then -- new day
         if math_random(0,100) < badweatherchance then
             badweatherplanned = true
-            badweatherclockstart = math_random(1,math.floor(fullcyclelenght*0.75))
-            badweatherclockend = math_random(badweatherclockstart,fullcyclelenght-1)
+            badweatherclockstart = math_random(1,math.floor(fullcyclelength*0.75))
+            badweatherclockend = math_random(badweatherclockstart,fullcyclelength-1)
             if snowyMap then
                 thunderstormenabled = false
             else
@@ -88,7 +88,7 @@ function gadget:GameFrame(n)
         if thunderstormenabled and math_random(1,30) == 1 then
             SpawnCEGInRandomMapPosAvoidUnits("lightningstrike", 0, 128, lightningsounds[math_random(1,#lightningsounds)], 1)
         end
-        if clock > nightlenght then
+        if clock > nightlength then
             SendToUnsynced("MapAtmosphereConfigSetSun", 0.8, transitionSpeed, 0.8, 0.8, 0.8*atmospherelevelmult)
             SendToUnsynced("MapAtmosphereConfigSetFog", 0.5, 0.9, transitionSpeed*2.5, transitionSpeed*1.5)
         else
@@ -96,7 +96,7 @@ function gadget:GameFrame(n)
             SendToUnsynced("MapAtmosphereConfigSetFog", 0.5, 0.9, transitionSpeed*2.5, transitionSpeed*1.5)
         end
     else
-        if clock > nightlenght then
+        if clock > nightlength then
             SendToUnsynced("MapAtmosphereConfigSetSun", 0.9, transitionSpeed, 0.9, 0.9, 0.9*atmospherelevelmult)
             SendToUnsynced("MapAtmosphereConfigSetFog", 1, 1, transitionSpeed*2.5, transitionSpeed*1.5)
         else

--- a/luarules/gadgets/AILoader.lua
+++ b/luarules/gadgets/AILoader.lua
@@ -84,7 +84,7 @@ function gadget:RecvLuaMsg(msg, playerID)
 
 				spEcho('format incomplete',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
 				spEcho('recvluamsg',msg)
-				spEcho('splitting lenght',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
+				spEcho('splitting length',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
 				spEcho('GiveOrderToUnit : ')
 				spEcho('unit',unit,type(unit))
 				spEcho('id',id,type(id))
@@ -127,7 +127,7 @@ function gadget:RecvLuaMsg(msg, playerID)
 			end
 			if dbg then
 				spEcho('recvluamsg',msg)
-				spEcho('splitting lenght',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
+				spEcho('splitting length',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
 				spEcho('GiveOrderToUnit : ')
 				spEcho('unit',unit,type(unit))
 				spEcho('id',id,type(id))

--- a/luarules/gadgets/cmd_selected_units.lua
+++ b/luarules/gadgets/cmd_selected_units.lua
@@ -18,7 +18,7 @@ local minZlibSize = 130  --minimum size threshold of msg to use zlib (msg smalle
 
 local HEADER_SEL_UNCOMPRESSED = "cosu"
 local HEADER_SEL_COMPRESSED = "cosc"
-local HEADER_LENGHT = string.len(HEADER_SEL_UNCOMPRESSED)
+local HEADER_LENGTH = string.len(HEADER_SEL_UNCOMPRESSED)
 
 
 if gadgetHandler:IsSyncedCode() then
@@ -36,7 +36,7 @@ if gadgetHandler:IsSyncedCode() then
 	_G.validationSelunits = validation
 
 	function gadget:RecvLuaMsg(inMsg, playerID)
-		if inMsg:sub(1,2)==validation and (inMsg:sub(3,HEADER_LENGHT+2)==HEADER_SEL_UNCOMPRESSED or inMsg:sub(3,HEADER_LENGHT+2)==HEADER_SEL_COMPRESSED) then
+		if inMsg:sub(1,2)==validation and (inMsg:sub(3,HEADER_LENGTH+2)==HEADER_SEL_UNCOMPRESSED or inMsg:sub(3,HEADER_LENGTH+2)==HEADER_SEL_COMPRESSED) then
 			SendToUnsynced("selectionUpdate",playerID,inMsg:sub(7),inMsg:sub(6,6) == "c")
 			return true
 		end

--- a/luarules/gadgets/scavengers/API/api.lua
+++ b/luarules/gadgets/scavengers/API/api.lua
@@ -57,7 +57,7 @@ scavSpawnBeacon = {}
 scavStockpiler = {}
 scavNuke = {}
 scavConverted = {}
-UnitSuffixLenght = {}
+UnitSuffixLength = {}
 numOfSpawnBeacons = 0
 numOfSpawnBeaconsTeams = {}
 scavMaxUnits = 2000
@@ -505,4 +505,3 @@ function collectScavStats()
 
 	spSetGameRulesParam("scavStatsDifficulty", scavStatsDifficulty)
 end
-

--- a/luarules/gadgets/scavengers/API/unitaddremove.lua
+++ b/luarules/gadgets/scavengers/API/unitaddremove.lua
@@ -3,13 +3,13 @@
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 local function AddScavUnit(unitID, unitDefID, unitName, unitTeam)
 	if (UnitDefs[unitDefID].canMove == false or UnitDefs[unitDefID].isBuilding == true or scavNoSelfD[unitID]) and (unitName ~= staticUnitList.scavSpawnBeacon) then
-		BaseCleanupQueue[#BaseCleanupQueue+1] = unitID 
+		BaseCleanupQueue[#BaseCleanupQueue+1] = unitID
 	end
 	Spring.SetUnitExperience(unitID, math_random() * (spawnmultiplier*0.01*scavconfig.unitControllerModuleConfig.veterancymultiplier))
 	if string.find(unitName, scavconfig.unitnamesuffix) then
-		UnitSuffixLenght[unitID] = string.len(scavconfig.unitnamesuffix)
+		UnitSuffixLength[unitID] = string.len(scavconfig.unitnamesuffix)
 	else
-		UnitSuffixLenght[unitID] = 0
+		UnitSuffixLength[unitID] = 0
 		local frame = Spring.GetGameFrame()
 		if frame > 30 then
 			local heading = Spring.GetUnitHeading(unitID)
@@ -29,10 +29,10 @@ local function AddScavUnit(unitID, unitDefID, unitName, unitTeam)
 			initialbosshealth = Spring.GetUnitHealth(unitID)
 			local stopScavUnits = Spring.GetTeamUnits(ScavengerTeamID)
 			for y = 1,#stopScavUnits do
-				local unitID = stopScavUnits[y]							
+				local unitID = stopScavUnits[y]
 				Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
 			end
-			
+
 		end
 	end
 	if constructorUnitList.SwapUnitsToScav[unitDefID] then
@@ -187,7 +187,7 @@ local function RemoveScavUnit(unitID, unitDefID, unitTeam, unitName, attackerID,
 	scavSpawnBeacon[unitID] = nil
 	scavStockpiler[unitID] = nil
 	scavNuke[unitID] = nil
-	UnitSuffixLenght[unitID] = nil
+	UnitSuffixLength[unitID] = nil
 	ConstructorNumberOfRetries[unitID] = nil
 	CaptureProgressForBeacons[unitID] = nil
 	Spring.SetUnitHealth(unitID, {capture = 0})
@@ -228,7 +228,7 @@ local function RemoveNonScavUnit(unitID, unitDefID, unitTeam, unitName, attacker
 				FriendlyCollectors[unitID] = nil
 				FriendlyReclaimers[unitID] = nil
 				FriendlyResurrectors[unitID] = nil
-				UnitSuffixLenght[unitID] = nil
+				UnitSuffixLength[unitID] = nil
 				selfdx[unitID] = nil
 				selfdy[unitID] = nil
 				selfdz[unitID] = nil
@@ -308,7 +308,7 @@ local function CaptureScavUnit(unitID, unitDefID, unitName, unitNewTeam, unitOld
 	scavSpawnBeacon[unitID] = nil
 	scavStockpiler[unitID] = nil
 	scavNuke[unitID] = nil
-	UnitSuffixLenght[unitID] = nil
+	UnitSuffixLength[unitID] = nil
 	ConstructorNumberOfRetries[unitID] = nil
 	CaptureProgressForBeacons[unitID] = nil
 	Spring.SetUnitHealth(unitID, {capture = 0})
@@ -331,12 +331,12 @@ local function CaptureNonScavUnit(unitID, unitDefID, unitName, unitNewTeam, unit
 		end
 	end
 	if (UnitDefs[unitDefID].canMove == false or UnitDefs[unitDefID].isBuilding == true or scavNoSelfD[unitID]) and (unitName ~= staticUnitList.scavSpawnBeacon) then
-		BaseCleanupQueue[#BaseCleanupQueue+1] = unitID 
+		BaseCleanupQueue[#BaseCleanupQueue+1] = unitID
 	end
 	if string.find(unitName, scavconfig.unitnamesuffix) then
-		UnitSuffixLenght[unitID] = string.len(scavconfig.unitnamesuffix)
+		UnitSuffixLength[unitID] = string.len(scavconfig.unitnamesuffix)
 	else
-		UnitSuffixLenght[unitID] = 0
+		UnitSuffixLength[unitID] = 0
 		local frame = Spring.GetGameFrame()
 		if frame > 30 then
 			local heading = Spring.GetUnitHeading(unitID)
@@ -350,7 +350,7 @@ local function CaptureNonScavUnit(unitID, unitDefID, unitName, unitNewTeam, unit
 			end
 		end
 	end
-	--Spring.Echo("Scavs just captured me " .. UnitName .. " and my suffix lenght is " .. UnitSuffixLenght[unitID])
+	--Spring.Echo("Scavs just captured me " .. UnitName .. " and my suffix length is " .. UnitSuffixLength[unitID])
 	if UnitDefs[unitDefID].name == staticUnitList.scavSpawnBeacon then
 		scavStatsScavSpawners = scavStatsScavSpawners + 1
 		numOfSpawnBeaconsTeams[unitOldTeam] = numOfSpawnBeaconsTeams[unitOldTeam] - 1

--- a/luarules/gadgets/scavengers/Modules/reinforcements_module.lua
+++ b/luarules/gadgets/scavengers/Modules/reinforcements_module.lua
@@ -171,7 +171,7 @@ local function spawnPlayerReinforcements(n)
 									table.insert(ActiveReinforcementUnits, ReUnit)
 
 									local unitDefID = Spring.GetUnitDefID(ReUnit)
-									UnitSuffixLenght[ReUnit] = string.len(scavconfig.unitnamesuffix)
+									UnitSuffixLength[ReUnit] = string.len(scavconfig.unitnamesuffix)
 									if scavconfig.modules.constructorControllerModule then
 										if scavconfig.constructorControllerModuleConfig.useresurrectors then
 											if constructorUnitList.ResurrectorsID[unitDefID] then
@@ -226,7 +226,7 @@ local function reinforcementsMoveOrder(n)
 				local unitDefID = Spring.GetUnitDefID(unitID)
 				if unitDefID then
 					local UnitName = UnitDefs[unitDefID].name
-					UnitSuffixLenght[unitID] = string.len(scavconfig.unitnamesuffix)
+					UnitSuffixLength[unitID] = string.len(scavconfig.unitnamesuffix)
 					FriendlyArmyOrders = true
 
 					if scavconfig.modules.constructorControllerModule then

--- a/luarules/gadgets/scavengers/boot.lua
+++ b/luarules/gadgets/scavengers/boot.lua
@@ -81,7 +81,7 @@ end
 function DestroyOldBuildings()
 	local unitCount = Spring.GetTeamUnitCount(ScavengerTeamID)
 	local unitCountBuffer = scavMaxUnits*0.1
-	if unitCount + unitCountBuffer > scavMaxUnits then 
+	if unitCount + unitCountBuffer > scavMaxUnits then
 		for i = 1,((unitCount + unitCountBuffer)-scavMaxUnits) do
 			if i > 5 then
 				break
@@ -204,7 +204,7 @@ function gadget:GameFrame(n)
 	end
 
 	if n%30 == 0 and globalScore then
-		
+
 		if scavteamhasplayers == false then
 			Spring.SetTeamResource(ScavengerTeamID, "ms", 1000000)
 			Spring.SetTeamResource(ScavengerTeamID, "es", 1000000)
@@ -216,7 +216,7 @@ function gadget:GameFrame(n)
 		end
 		local scavUnits = Spring.GetTeamUnits(ScavengerTeamID)
 		local scavUnitsCount = #scavUnits
-		if (scavUnitsCount < (scavconfig.unitSpawnerModuleConfig.minimumspawnbeacons*4) or numOfSpawnBeacons == 0) and n > scavconfig.gracePeriod*3 then 
+		if (scavUnitsCount < (scavconfig.unitSpawnerModuleConfig.minimumspawnbeacons*4) or numOfSpawnBeacons == 0) and n > scavconfig.gracePeriod*3 then
 			killedscavengers = killedscavengers + 1000
 			if BossWaveStarted and (BossWaveTimeLeft and BossWaveTimeLeft > 20) then
 				BossWaveTimeLeft = 20
@@ -382,9 +382,9 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 		-- CMD.CLOAK = 37382
 		local UnitName = UnitDefs[unitDefID].name
 		if string.find(UnitName, scavconfig.unitnamesuffix) then
-			UnitSuffixLenght[unitID] = string.len(scavconfig.unitnamesuffix)
+			UnitSuffixLength[unitID] = string.len(scavconfig.unitnamesuffix)
 		else
-			UnitSuffixLenght[unitID] = 0
+			UnitSuffixLength[unitID] = 0
 		end
 
 		-- if staticUnitList.WallsID[unitDefID] then

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -266,7 +266,7 @@ local options={
 	},
 	{
 		key    = 'scavtechcurve',
-		name   = 'Game Lenght Multiplier',
+		name   = 'Game Length Multiplier',
 		desc   = 'Higher than 1 - Longer, Lower than 1 - Shorter',
 		type   = 'number',
 		section= 'options_scavengers',


### PR DESCRIPTION
Just something noticed in passing. I haven't got a full development environment setup currently so cannot 100% confirm the variable changes (still slowly learning the codebase) but it looks like it should work.

In case there is an issue with certain variable changes (wasn't sure about whether `UnitSuffixLength` is used externally, but I've searched across github and it looks quite safe), 7a43811b6 alone solves the typo for the user-visible case and the second commit can be discarded.