### PR TITLE
Legion comm increased emp grenade damage, buff to Quickshot

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -217,7 +217,7 @@ function UnitDef_Post(name, uDef)
 						expl_light_heat_life_mult = "1.6",
 					},
 					damage = {
-						default = 10000,
+						default = 20000,
 					},
 				}
 			end

--- a/units/Scavengers/Legion/Commanders/legcomdef.lua
+++ b/units/Scavengers/Legion/Commanders/legcomdef.lua
@@ -353,7 +353,7 @@ return {
 					expl_light_heat_life_mult = "1.6",
 				},
 				damage = {
-					default = 10000,
+					default = 20000,
 				},
 			},
 		},

--- a/units/Scavengers/Legion/T2 veh/legmrv.lua
+++ b/units/Scavengers/Legion/T2 veh/legmrv.lua
@@ -18,7 +18,7 @@ return {
 		idleautoheal = 5,
 		idletime = 1800,
 		leavetracks = true,
-		maxdamage = 1250,
+		maxdamage = 1500,
 		maxslope = 12,
 		maxvelocity = 3.3,
 		maxwaterdepth = 100,


### PR DESCRIPTION
Emp grenade should now be able to stun T1 amphib tanks and heavy T2.  Quickshot's health increased as it was too fragile for its cost.