### PR TITLE
Update unit_dynamic_collision_volume.lua

### DIFF
--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -196,6 +196,18 @@ if gadgetHandler:IsSyncedCode() then
 				end
 			end
 		end
+		
+		-- Check if a unit is pop-up type (the list must be entered manually)
+		-- If a building was constructed add it to the list for later radius and height scaling
+		-- Changed from UnitFinished to UnitCreated
+		-- Some building's scripting change their collision while still under construction
+		-- These buildings should be added to the list of popupUnits to update when they are created, not when finished
+		local un = unitName[unitDefID]
+		if unitCollisionVolume[un] then
+			popupUnits[unitID]={name=un, state=-1, perPiece=false}
+		elseif dynamicPieceCollisionVolume[un] then
+			popupUnits[unitID]={name=un, state=-1, perPiece=true, numPieces = #spGetPieceList(unitID)-1}
+		end
 	end
 
 
@@ -215,23 +227,7 @@ if gadgetHandler:IsSyncedCode() then
 			spSetFeatureRadiusAndHeight(featureID, spGetFeatureRadius(featureID)*rs, spGetFeatureHeight(featureID)*hs)
 		end
 	end
-
-
-	-- Check if a unit is pop-up type (the list must be entered manually)
-	-- If a building was constructed add it to the list for later radius and height scaling
-	-- Changed from UnitFinished to UnitCreated 
-	-- Some building's scripting change their collision while still under construction
-	-- These buildings should be added to the list of popupUnits to update when they are created, not when finished
-	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-		local un = unitName[unitDefID]
-		if unitCollisionVolume[un] then
-			popupUnits[unitID]={name=un, state=-1, perPiece=false}
-		elseif dynamicPieceCollisionVolume[un] then
-			popupUnits[unitID]={name=un, state=-1, perPiece=true, numPieces = #spGetPieceList(unitID)-1}
-		end
-	end
-
-
+	
 	--check if a pop-up type unit was destroyed
 	function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
 		if popupUnits[unitID] then


### PR DESCRIPTION
Oops. Turns out when I fixed the inconsistency with pop-up unit collision during construction, by changing from UnitFinished to UnitCreated, I overwrote the UnitCreated function defined earlier in the file. So pieceCollisionVolume and dynamicPieceCollisionVolume were not properly updating from LuaRules/Configs/CollisionVolumes.lua. And other various fixes/tweaks regarding flying units, underwater units, and s3o vs 3do default collision volumes.

So I just made sure only one UnitCreated function is defined.