### PR TITLE
Additions to cmd_context_build.lua

### DIFF
--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -55,6 +55,10 @@ local unitlist = {--- Human friendly list. Automatically converted to unitdef ID
 	{'corllt','cortl'},
 	{'armnanotc','armnanotcplat'},
 	{'cornanotc','cornanotcplat'},
+	{'armvp','armamsub'},
+	{'corvp','coramsub'},
+	{'armap','armplat'},
+	{'corap','corplat'},
 }
 
 local GetActiveCommand		= Spring.GetActiveCommand


### PR DESCRIPTION
Adds conversions for T1 vehicle labs -> amphibious labs and T1 air labs -> seaplane labs. Useful for players who know exactly where to find the normal T1 labs but struggle with finding the amphibious analogue.