### PR TITLE
Update bar_hotkeys.lua

### DIFF
--- a/luaui/configs/bar_hotkeys.lua
+++ b/luaui/configs/bar_hotkeys.lua
@@ -77,9 +77,9 @@ local bindings = {
 
 	{ "Alt+insert",  "increasespeed" },
 	{ "Alt+delete",  "decreasespeed" },
-	{ "Alt+=",       "increasespeed" },
-	{ "Alt++",       "increasespeed" },
-	{ "Alt+-",       "decreasespeed" },
+	{   "Alt+sc_=",  "increasespeed" },
+	{      "Alt++",  "increasespeed" },
+	{   "Alt+sc_-",  "decreasespeed" },
 	{ "Alt+numpad+", "increasespeed" },
 	{ "Alt+numpad-", "decreasespeed" },
 
@@ -319,8 +319,8 @@ local bindings = {
 	-- snd_volume_osd
 	{ "      +", "snd_volume_increase" },
 	{ "numpad+", "snd_volume_increase" },
-	{ "      =", "snd_volume_increase" },
-	{ "      -", "snd_volume_decrease" },
+	{    "sc_=", "snd_volume_increase" },
+	{    "sc_-", "snd_volume_decrease" },
 	{ "numpad-", "snd_volume_decrease" },
 
 	-- los_colors

--- a/luaui/configs/bar_hotkeys.lua
+++ b/luaui/configs/bar_hotkeys.lua
@@ -316,6 +316,7 @@ local bindings = {
 	{ "numpad1", "movefast"    },
 
 	-- snd_volume_osd
+	{ "numpad+", "snd_volume_increase" },
 	{    "sc_=", "snd_volume_increase" },
 	{    "sc_-", "snd_volume_decrease" },
 	{ "numpad-", "snd_volume_decrease" },

--- a/luaui/configs/bar_hotkeys.lua
+++ b/luaui/configs/bar_hotkeys.lua
@@ -78,7 +78,6 @@ local bindings = {
 	{ "Alt+insert",  "increasespeed" },
 	{ "Alt+delete",  "decreasespeed" },
 	{   "Alt+sc_=",  "increasespeed" },
-	{      "Alt++",  "increasespeed" },
 	{   "Alt+sc_-",  "decreasespeed" },
 	{ "Alt+numpad+", "increasespeed" },
 	{ "Alt+numpad-", "decreasespeed" },
@@ -317,8 +316,6 @@ local bindings = {
 	{ "numpad1", "movefast"    },
 
 	-- snd_volume_osd
-	{ "      +", "snd_volume_increase" },
-	{ "numpad+", "snd_volume_increase" },
 	{    "sc_=", "snd_volume_increase" },
 	{    "sc_-", "snd_volume_decrease" },
 	{ "numpad-", "snd_volume_decrease" },


### PR DESCRIPTION
Adds scancodes to - and = as per recent engine update allows, fixing some conflicts on non-qwerty keyboard layouts.