### PR TITLE
Update bar_hotkeys_60.lua

### DIFF
--- a/luaui/configs/bar_hotkeys_60.lua
+++ b/luaui/configs/bar_hotkeys_60.lua
@@ -79,9 +79,9 @@ local bindings = {
 
 	{ "Alt+insert",  "increasespeed" },
 	{ "Alt+delete",  "decreasespeed" },
-	{ "Alt+=",       "increasespeed" },
+	{ "Alt+sc_=",    "increasespeed" },
 	{ "Alt++",       "increasespeed" },
-	{ "Alt+-",       "decreasespeed" },
+	{ "Alt+sc_-",    "decreasespeed" },
 	{ "Alt+numpad+", "increasespeed" },
 	{ "Alt+numpad-", "decreasespeed" },
 
@@ -318,8 +318,8 @@ local bindings = {
 	-- snd_volume_osd
 	{ "      +", "snd_volume_increase" },
 	{ "numpad+", "snd_volume_increase" },
-	{ "      =", "snd_volume_increase" },
-	{ "      -", "snd_volume_decrease" },
+	{ "   sc_=", "snd_volume_increase" },
+	{ "   sc_-", "snd_volume_decrease" },
 	{ "numpad-", "snd_volume_decrease" },
 
 	-- los_colors

--- a/luaui/configs/bar_hotkeys_60.lua
+++ b/luaui/configs/bar_hotkeys_60.lua
@@ -80,7 +80,6 @@ local bindings = {
 	{ "Alt+insert",  "increasespeed" },
 	{ "Alt+delete",  "decreasespeed" },
 	{ "Alt+sc_=",    "increasespeed" },
-	{ "Alt++",       "increasespeed" },
 	{ "Alt+sc_-",    "decreasespeed" },
 	{ "Alt+numpad+", "increasespeed" },
 	{ "Alt+numpad-", "decreasespeed" },
@@ -316,7 +315,6 @@ local bindings = {
 	{ "numpad1", "movefast"    },
 
 	-- snd_volume_osd
-	{ "      +", "snd_volume_increase" },
 	{ "numpad+", "snd_volume_increase" },
 	{ "   sc_=", "snd_volume_increase" },
 	{ "   sc_-", "snd_volume_decrease" },


### PR DESCRIPTION
Adds scancodes to - and = as per recent engine update allows, fixing some conflicts on non-qwerty keyboard layouts.