### PR TITLE
Update bar_hotkeys_grid.lua

### DIFF
--- a/luaui/configs/bar_hotkeys_grid.lua
+++ b/luaui/configs/bar_hotkeys_grid.lua
@@ -69,8 +69,8 @@
 
 		{ "Ctrl+v", "pastetext" },
 
-		{ "Alt+=",       "increasespeed" }, --add scancodes for = and - after engine update
-		{ "Alt+-",       "decreasespeed" },
+		{ "Alt+sc_=",    "increasespeed" }, 
+		{ "Alt+sc_-",    "decreasespeed" },
 		{ "Alt+numpad+", "increasespeed" },
 		{ "Alt+numpad-", "decreasespeed" },
 
@@ -188,8 +188,8 @@
 		{ "backspace", "MuteSound" },
 		{ "      +", "snd_volume_increase" },
 		{ "numpad+", "snd_volume_increase" },
-		{ "      =", "snd_volume_increase" },
-		{ "      -", "snd_volume_decrease" },
+		{ "   sc_=", "snd_volume_increase" },
+		{ "   sc_-", "snd_volume_decrease" },
 		{ "numpad-", "snd_volume_decrease" },
 	}
 

--- a/luaui/configs/bar_hotkeys_grid.lua
+++ b/luaui/configs/bar_hotkeys_grid.lua
@@ -186,7 +186,6 @@
 
 		-- snd_volume_osd
 		{ "backspace", "MuteSound" },
-		{ "      +", "snd_volume_increase" },
 		{ "numpad+", "snd_volume_increase" },
 		{ "   sc_=", "snd_volume_increase" },
 		{ "   sc_-", "snd_volume_decrease" },


### PR DESCRIPTION
Adds scancodes to - and = as per recent engine update allows, fixing some conflicts on non-qwerty keyboard layouts.