### PR TITLE
Hotkeys: Bind c+` to group unset

### DIFF
--- a/luaui/configs/bar_hotkeys.lua
+++ b/luaui/configs/bar_hotkeys.lua
@@ -337,9 +337,9 @@ local bindings = {
 	{ "Alt+sc_y", "settarget"         },
 	{     "sc_y", "settargetnoground" },
 
+	{ "Ctrl+sc_`", "group unset" },
 	-- if WG['Auto Group'] then
 	{ "Alt+sc_`",  "remove_from_autogroup" },
-	{ "Ctrl+sc_`", "remove_one_unit_from_group" },
 }
 
 for i = 0, 9 do

--- a/luaui/configs/bar_hotkeys_60.lua
+++ b/luaui/configs/bar_hotkeys_60.lua
@@ -336,9 +336,9 @@ local bindings = {
 	{ "Alt+sc_y", "settarget"         },
 	{     "sc_y", "settargetnoground" },
 
+	{ "Ctrl+meta+sc_q", "group unset" },
 	-- if WG['Auto Group'] then
 	{ "Alt+sc_q",  "remove_from_autogroup" },
-	{ "Ctrl+meta+sc_q", "remove_one_unit_from_group" },
 }
 
 for i = 0, 9 do

--- a/luaui/configs/bar_hotkeys_grid.lua
+++ b/luaui/configs/bar_hotkeys_grid.lua
@@ -155,8 +155,8 @@
 		{ "Any+f12", "screenshot"     , "png" },
 		{ "Alt+backspace", "fullscreen"       },
 
-		{ "Ctrl+sc_`", "remove_one_unit_from_group" },
-		{  "Alt+sc_`", "remove_from_autogroup"      },
+		{ "Ctrl+sc_`", "group unset" },
+		{ "Alt+sc_`",  "remove_from_autogroup" },
 
 		{ "sc_`,sc_`", "drawlabel"       }, -- double hit ` for drawlabel
 		{      "sc_`", "drawinmap"       },

--- a/luaui/configs/bar_hotkeys_grid_60.lua
+++ b/luaui/configs/bar_hotkeys_grid_60.lua
@@ -156,10 +156,10 @@
 		{ "Any+f12", "screenshot"     , "png" },
 		{ "Alt+backspace", "fullscreen"       },
 
-		{      "Ctrl+meta+sc_q", "remove_one_unit_from_group" },
-		{            "Alt+sc_q", "remove_from_autogroup"      },
-		{ "meta+sc_q,meta+sc_q", "drawlabel"                  },
-		{           "meta+sc_q", "drawinmap"                  },
+		{      "Ctrl+meta+sc_q", "group unset"           },
+		{            "Alt+sc_q", "remove_from_autogroup" },
+		{ "meta+sc_q,meta+sc_q", "drawlabel"             },
+		{           "meta+sc_q", "drawinmap"             },
 
 		{ "Any+up",       "moveforward"  },
 		{ "Any+down",     "moveback"     },

--- a/luaui/configs/bar_hotkeys_mnemonic.lua
+++ b/luaui/configs/bar_hotkeys_mnemonic.lua
@@ -320,9 +320,9 @@ local bindings = {
 	{ "Alt+y", "settarget"         },
 	{     "y", "settargetnoground" },
 
+	{ "Ctrl+sc_`", "group unset"           },
 	-- if WG['Auto Group'] then
 	{ "Alt+sc_`",  "remove_from_autogroup" },
-	{ "Ctrl+sc_`", "remove_one_unit_from_group" },
 }
 
 for i = 0, 9 do


### PR DESCRIPTION
Unsets any groups from currently selected units, in general a more natural keybinding to be used

Applicable only after next engine deployment