### PR TITLE
deactivate this gadget

### DIFF
--- a/luarules/gadgets/unit_fidorangefix.lua
+++ b/luarules/gadgets/unit_fidorangefix.lua
@@ -7,7 +7,7 @@ function gadget:GetInfo()
 		date	= "01/09/2018",
 		license	= "GNU GPL, v2 or later",
 		layer	= 0,
-		enabled = true,
+		enabled = false,
 	}
 end
 


### PR DESCRIPTION
The commands Spring.GiveOrderToUnit(unitID, CMD_WAIT, {}, 0) were causing armfido units to stutter (stop moving, forget target, etc.) when an on/off weapon change command was given.  This gadget appears to be obsolete, now that BOS/COB unit scripting better handles weapon changes.