### PR TITLE
Update unit_scenario_loadout.lua

### DIFF
--- a/luarules/gadgets/unit_scenario_loadout.lua
+++ b/luarules/gadgets/unit_scenario_loadout.lua
@@ -41,7 +41,7 @@ function gadget:Initialize()
 	local gaiateamid = Spring.GetGaiaTeamID()
 end
 
-function gadget:GamePreload()
+function gadget:GameStart()
   if Spring.GetGameRulesParam("loadedGame") == 1 then
     Spring.Echo("Scenario: Loading saved game, skipping loadout")
 		gadgetHandler:RemoveGadget(self)


### PR DESCRIPTION
Final and stable bug fix for Negative Resource without changing commanders stats or even Game_Team_Resources.lua , found the root of bug and its not in Team Res nor com stats but in gadget unit_scenario_loadout.lua Line 44 got>>  function gadget:GamePreload() while should be 
function gadget:GameStart() , then unit loadouts load correctly, skirmish loads correctly and scenario in FFA (mode too) ,  GamePreload in that gadget been main problem to negative resource, as GameStart overridden loadout, since gamepreload load 1st then Gamestart, changing function to Gamestart, load loadouts correctly without impacting Storages. This solution resolve this bug
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1355