### PR TITLE
T1 pop up ghost fix

### DIFF
--- a/units/ArmBuildings/LandDefenceOffence/armclaw.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armclaw.lua
@@ -36,6 +36,7 @@ return {
 		stealth = true,
 		turnrate = 0,
 		upright = true,
+		yardmap = "ffff",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armclaw_aoplane.dds",

--- a/units/CorBuildings/LandDefenceOffence/cormaw.lua
+++ b/units/CorBuildings/LandDefenceOffence/cormaw.lua
@@ -33,6 +33,7 @@ return {
 		stealth = true,
 		turnrate = 0,
 		upright = true,
+		yardmap = "ffff",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormaw_aoplane.dds",

--- a/units/Scavengers/Buildings/DefenseOffense/corscavdtf.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corscavdtf.lua
@@ -34,6 +34,7 @@ return {
 		stealth = true,
 		turnrate = 0,
 		upright = true,
+		yardmap = "ffff",
 		customparams = {
 			usebuildinggrounddecal = false,
 			buildinggrounddecaltype = "decals/scavdtf_aoplane.dds",

--- a/units/Scavengers/Buildings/DefenseOffense/corscavdtl.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corscavdtl.lua
@@ -36,6 +36,7 @@ return {
 		stealth = true,
 		turnrate = 0,
 		upright = true,
+		yardmap = "ffff",
 		customparams = {
 			usebuildinggrounddecal = false,
 			buildinggrounddecaltype = "decals/scavdtf_aoplane.dds",

--- a/units/Scavengers/Buildings/DefenseOffense/corscavdtm.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corscavdtm.lua
@@ -33,6 +33,7 @@ return {
 		stealth = true,
 		turnrate = 0,
 		upright = true,
+		yardmap = "ffff",
 		customparams = {
 			usebuildinggrounddecal = false,
 			buildinggrounddecaltype = "decals/scavdtf_aoplane.dds",


### PR DESCRIPTION
Add yardmaps to T1 pop-up turrets, so ghosts and residual radar dots appear once they leave LOS, better mimicking T1 walls, making it a bit easier for players to target locations where they have seen a T1 pop-up turret. 