### PR TITLE
Tacnuke rework

### DIFF
--- a/units/CorBuildings/LandDefenceOffence/cortron.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortron.lua
@@ -111,7 +111,7 @@ return {
 		},
 		weapondefs = {
 			cortron_weapon = {
-				areaofeffect = 512,
+				areaofeffect = 380, --512,
 				avoidfeature = false,
 				avoidfriendly = false,
 				cegtag = "cruisemissiletrail-tacnuke",
@@ -131,7 +131,7 @@ return {
 				model = "cortronmissile.s3o",
 				name = "Long range tactical g2g nuclear warheads",
 				noselfdamage = true,
-				range = 2750,
+				range = 2250,
 				reloadtime = 2,
 				smoketrail = true,
 				smokePeriod = 9,
@@ -163,8 +163,8 @@ return {
 					light_radius_mult = 1.4,
 				},
 				damage = {
-					commanders = 499,
-					default = 2500,
+					commanders = 750,
+					default = 4000,
 				},
 			},
 		},


### PR DESCRIPTION
Range of cor tacnuke reduced 2750->2250, damage increased 2500->4000, aoe reduced 512->380.  The reduced range will make it more difficult to build a tacnuke in an easily defensible position in range of an enemy base while still outranging other T2 artillery (anni has 1400 range), and the reduced aoe lowers the effectiveness of blind firing.  The increased damage will help improve the tacnuke's ability to take out heavier defenses and units.  Overall the unit should be stronger for precise strikes and weaker at area/base denial.