### PR TITLE
fix(smartselect): Detect and propagate SelectionChanged properly

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -136,13 +136,17 @@ function widget:ViewResize()
 end
 
 function widget:SelectionChanged(sel)
-	local equalSelection = true
-	for i = 1, #sel do
-		if selectedUnits[i] ~= sel[i] then
-			equalSelection = false
-			break
+	local equalSelection = #selectedUnits == #sel
+
+	if equalSelection then
+		for i = 1, #sel do
+			if selectedUnits[i] ~= sel[i] then
+				equalSelection = false
+				break
+			end
 		end
 	end
+
 	selectedUnits = sel
 	if referenceCoords ~= nil and spGetActiveCommand() == 0 then
 		if not select(3, spGetMouseState()) and referenceSelection ~= nil and lastSelection ~= nil and equalSelection then


### PR DESCRIPTION
This is a fix in two parts for https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1470

First (this PR) we fix the selectionchanged propagation by allowing engine to propagate its built-in deselect command.

This breaks smartselection behavior when ctrl is pressed but:

- We fix possible selection clearance selection change by widgets other than smartselect
- We prepare ground for the correct fix which is unhardcoding engine selection modifiers

For now this fixes the current desync issue between selection state of widgets and engine by allowing engine to have the last say on selection when ctrl is pressed.

The second part is an engine PR for unhardcoding selection state modifiers (ctrl for deselect).