### PR TITLE
Exclude corhllt from preaim

### DIFF
--- a/luarules/gadgets/unit_preaim.lua
+++ b/luarules/gadgets/unit_preaim.lua
@@ -42,6 +42,7 @@ local exludedUnits = {    -- exclude auto target range boost for popup units
 	[UnitDefNames.corexp.id] = true,
 
 	[UnitDefNames.corllt.id] = true,
+	[UnitDefNames.corhllt.id] = true,
 	[UnitDefNames.armllt.id] = true,
 }
 local scavengerPopups = {}


### PR DESCRIPTION
Better compatibility with proximitypriority = -1.5, so corhllt top turret does not prefer to aim and shoot at out-of-range targets. Also will make corhllt preaim behavior match corllt preaim behavior.