### PR TITLE
wreck hitbox update

### DIFF
--- a/units/CorBots/corthud.lua
+++ b/units/CorBots/corthud.lua
@@ -50,8 +50,8 @@ return {
 			dead = {
 				blocking = true,
 				category = "corpses",
-				collisionvolumeoffsets = "0 5 -5",
-				collisionvolumescales = "25 28 35",
+				collisionvolumeoffsets = "0 0 0",
+				collisionvolumescales = "25 18 35",
 				collisionvolumetype = "Box",
 				damage = 640,
 				energy = 0,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44480662/213902925-079d37f6-8f9d-4ef0-8cde-38e6853a6aa1.png)

Shortened hitbox, was annoyed at projectiles colliding in empty space above the corthud wrecks.