### PR TITLE
fix(buildmenu): Unbuildable wind on rosetta

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -227,7 +227,7 @@ local groups = {
 	antinuke = folder..'antinuke.png',
 }
 
-local disableWind = ((Game.windMin + Game.windMax) / 2) <= 5
+local disableWind = ((Game.windMin + Game.windMax) / 2) < 5
 
 local unitEnergyCost = {}
 local unitMetalCost = {}


### PR DESCRIPTION
There is a discrepancy between players using keybindings/gridmenu (allowing wind) and buildmenu (disabling wind).

If the game intends for a build restriction for wind this should be done at gadget level (via AllowCommand or restricting buildoptions).

The current PR mitigates the situation by allowing wind on rosetta (0-10, perfectly viable wind).