### PR TITLE
Set MiniMapCanFlip config to 0

### DIFF
--- a/luaintro/springconfig.lua
+++ b/luaintro/springconfig.lua
@@ -29,7 +29,7 @@ Spring.SetConfigInt("CubeTexGenerateMipMaps", 1)
 Spring.SetConfigInt("CubeTexSizeReflection", 1024)
 
 -- Allow minimap to flip on camera rotation
-Spring.SetConfigInt("MiniMapCanFlip", 1)
+Spring.SetConfigInt("MiniMapCanFlip", 0)
 
 -- disable grass
 Spring.SetConfigInt("GrassDetail", 0)


### PR DESCRIPTION
Rotating the minimap when the camera rotates breaks the cinematography 180° rule, i.e. subjects on the left and right must not switch places. This breaks being able to use the minimap as a point of reference and causes confusion (see Willow's cast with Teifion).