### PR TITLE
fix(SmartSelect): No selection with ctrl pressed

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1509,7 +1509,7 @@ function widgetHandler:MousePress(x, y, button)
 		end
 	end
 	if widgetHandler.WG.SmartSelect_MousePress2 then
-		widgetHandler.WG.SmartSelect_MousePress2(x, y, button, 'abc')
+		widgetHandler.WG.SmartSelect_MousePress2(x, y, button)
 	end
 	return false
 end


### PR DESCRIPTION
Check if engine has just deselected via mouserelease on selectbox and
preserve smartselect state.

Correct fix is to unhardcode engine selection modifiers.

Ideal fixes are:
  - rework mousepress and mouserelease ownership logic
  (unfeasible due to retrocompatibility concerns).
  - provide a BoxSelection callin that, together with
  `Spring.SetBoxSelectionByEngine`, provides the necessary tools to
  perform this role without the current hacky implementation.

Also:

- Simplify minimap selection
- Return early on invalid selectbox
- Remove noop parameter on special MousePress from widget manager

Second commit leverages the ability to inspect for valid selectbox coordinates and 'guessing' when engine selectbox was just released to optimize and simplify a lot of stuff.

Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1536 https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1470