### PR TITLE
fix(smartselect): Noop on gui_minimap camera move

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -170,6 +170,13 @@ function widget:SelectionChanged(sel)
 	selectedUnits = sel
 end
 
+-- We use this mousepress to check for mouse selection above minimap **before**
+-- gui_minimap widget. Reason for this is that gui_minimap widget will get
+-- mouse ownership before MousePress2 special handling has a chance to operate
+function widget:MousePress(x, y, button)
+	inMiniMapSel = button == 1 and spIsAboveMiniMap(x, y)
+end
+
 -- this widget gets called early due to its layer
 -- this function will get called after all widgets have had their chance with widget:MousePress
 local function mousePress(x, y, button)  --function widget:MousePress(x, y, button)
@@ -183,7 +190,6 @@ local function mousePress(x, y, button)  --function widget:MousePress(x, y, butt
 			referenceSelectionTypes[udid] = 1
 		end
 	end
-	inMiniMapSel = spIsAboveMiniMap(x, y)
 end
 
 function widget:PlayerChanged()
@@ -195,6 +201,11 @@ function widget:Update()
 	WG['smartselect'].updateSelection = true
 
 	if spGetActiveCommand() ~= 0 then
+		return
+	end
+
+	-- if minimap left click to move is set and were over minimap, we dont select
+	if inMiniMapSel and WG['minimap'] and WG['minimap'].getLeftClickMove and WG['minimap'].getLeftClickMove() then
 		return
 	end
 


### PR DESCRIPTION
Make sure smartselect gets inactive if gui_minimap widget camera move on left click functionality is active.

It retains mouse ownership but still allows engine to think it's a valid selection.