### PR TITLE
fix(buildmenu): Dont check com clash on pregame if queued

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -1536,8 +1536,9 @@ function widget:MousePress(x, y, button)
 				local buildFacing = Spring.GetBuildFacing()
 				local buildData = { selBuildQueueDefID, bx, by, bz, buildFacing }
 				local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID) -- Returns -100, -100, -100 when none chosen
+				local _, _, meta, shift = Spring.GetModKeyState()
 
-				if cx ~= -100 then
+				if (meta or not shift) and cx ~= -100 then
 					local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
 
 					if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then -- avoid clashing building and commander position
@@ -1546,7 +1547,6 @@ function widget:MousePress(x, y, button)
 				end
 
 				if Spring.TestBuildOrder(selBuildQueueDefID, bx, by, bz, buildFacing) ~= 0 then
-					local _, _, meta, shift = Spring.GetModKeyState()
 					if meta then
 						table.insert(buildQueue, 1, buildData)
 

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2229,8 +2229,9 @@ function widget:MousePress(x, y, button)
 				local buildFacing = Spring.GetBuildFacing()
 				local buildData = { selBuildQueueDefID, bx, by, bz, buildFacing }
 				local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID) -- Returns -100, -100, -100 when none chosen
+				local _, _, meta, shift = Spring.GetModKeyState()
 
-				if cx ~= -100 then
+				if (meta or not shift) and cx ~= -100 then
 					local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
 
 					if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then -- avoid clashing building and commander position
@@ -2239,7 +2240,6 @@ function widget:MousePress(x, y, button)
 				end
 
 				if Spring.TestBuildOrder(selBuildQueueDefID, bx, by, bz, buildFacing) ~= 0 then
-					local _, _, meta, shift = Spring.GetModKeyState()
 					if meta then
 						table.insert(buildQueue, 1, buildData)
 


### PR DESCRIPTION
Avoid checking clash between commander and buildings during pregame if the building is not the first in the queue.

If building is on queue this means commander has already spawn successfully, so it won't get bugged.