### PR TITLE
Update unit_factory_unblocking.lua

### DIFF
--- a/luarules/gadgets/unit_factory_unblocking.lua
+++ b/luarules/gadgets/unit_factory_unblocking.lua
@@ -30,11 +30,14 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 	end
 	if setBlockingOnFinished[unitID] then
 		if UnitDefs[unitDefID].canFly == true then
-			--to make sure air units do not set their ground to blocking
+			-- to make sure air units do not set their ground to blocking
 			-- to prevent rare case of aircraft already in takeoff state perma-blocking a factory
-			Spring.SetUnitBlocking(unitID, false, true)
+
+			-- also the second false is to clear CSTATE_BIT_SOLIDOBJECTS, so landing aircraft do not claim dumb spots as blocking
+			-- TODO, engine fix to prevent this nonsense
+			Spring.SetUnitBlocking(unitID, false, false)
 		else
-			Spring.SetUnitBlocking(unitID, true, true)
+			Spring.SetUnitBlocking(unitID, true)
 		end
 		setBlockingOnFinished[unitID] = nil
 	end
@@ -43,8 +46,7 @@ end
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 	if factoryUnits[builderID] then
 		-- first false is to set blocking on ground
-		-- second false is to set blocking with other solid objects and units
-		Spring.SetUnitBlocking(unitID, false, false)
+		Spring.SetUnitBlocking(unitID, false)
 		setBlockingOnFinished[unitID] = true
 	end
 end


### PR DESCRIPTION
![image (10)](https://user-images.githubusercontent.com/44480662/223957697-f32161db-feed-4df6-b798-2a47bb5ba749.png)
fix bug related to landing aircraft claiming and blocking dumb locations, as seen in attached image. 