### PR TITLE
feat(gridmenu): Return to categories on pick

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -22,6 +22,8 @@ VFS.Include('luarules/configs/customcmds.h.lua')
 
 SYMKEYS = table.invert(KEYSYMS)
 
+local returnToCategoriesOnPick = true
+
 local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
 local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
 local labGrids = configs.LabGrids
@@ -862,7 +864,7 @@ function widget:CommandNotify(cmdID, _, cmdOpts)
 		return
 	end
 
-	if not cmdOpts.shift then
+	if returnToCategoriesOnPick or not cmdOpts.shift then
 		currentBuildCategory = nil
 		doUpdate = true
 	end
@@ -2150,7 +2152,11 @@ function SetBuildFacing()
 end
 
 function widget:KeyRelease(key)
-	if key == KEYSYMS.LSHIFT then
+	if key ~= KEYSYMS.LSHIFT then return end
+
+	if preGamestartPlayer then
+		setPreGamestartDefID(nil)
+	else
 		currentBuildCategory = nil
 		currentCategoryIndex = nil
 		doUpdate = true
@@ -2274,6 +2280,10 @@ function widget:MousePress(x, y, button)
 
 					if not shift then
 						setPreGamestartDefID(nil)
+					elseif returnToCategoriesOnPick then
+						currentBuildCategory = nil
+						currentCategoryIndex = nil
+						doUpdate = true
 					end
 				end
 


### PR DESCRIPTION
When user issues a buildunit_ command picked by gridmenu while holding shift, return straight to the categories page.

Rationale is that even if remaining on the same category is helpful when the intended buildoptions for the queue are in the same category; e.g. hold shift - z - x for a mex and a wind as opposed to hold shift - z - zx; it's very detrimental for the built up muscle memory when switching categories; e.g. hold shift z - release and hold shift - c as opposed to hold shift z - c.

This should make the usage of gridmenu more predictable and easier even if at the cost of some keystrokes on typical early queues (heavy on eco side). It will also make memorization and usage of gridmenu way more straightforward.