### PR TITLE
fix: Respect user setting for minimapcanflip

### DIFF
--- a/luaintro/springconfig.lua
+++ b/luaintro/springconfig.lua
@@ -28,9 +28,6 @@ end
 Spring.SetConfigInt("CubeTexGenerateMipMaps", 1)
 Spring.SetConfigInt("CubeTexSizeReflection", 1024)
 
--- Allow minimap to flip on camera rotation
-Spring.SetConfigInt("MiniMapCanFlip", 0)
-
 -- disable grass
 Spring.SetConfigInt("GrassDetail", 0)
 


### PR DESCRIPTION
If user has MiniMapCanFlip 1 let minimap flip as user desired so, default is 0 anyway.