### PR TITLE
units README for common-name to source-name reference (doc-only)

### DIFF
--- a/units/README.md
+++ b/units/README.md
@@ -1,0 +1,45 @@
+# Beyond-All-Reason/units/README.md
+
+The source code filenames for each unit can be referenced with the URL of the unit docs on the main website. 
+
+For example, the Armada Tick URL (https://www.beyondallreason.info/unit/armflea) shows that the source file should be "armflea.lua".
+
+For single-view convenience, general-purpose unit names and their corresponding source-file unit names are listed/mapped here:
+
+## Armada
+
+Category | Common Name | Source Name
+--|--|--
+Bot T1 | Armada Commander | armcom
+Bot T1 | Construction Bot | armck
+Bot T1 | Tick | armflea
+Bot T1 | Pawn | armpw
+Bot T1 | Lazarus | armrectr
+Bot T1 | Rocketeer | armrock
+Bot T1 | Crossbow | armjeth
+Bot T1 | Mace | armham
+Bot T1 | Centurion | armwar
+Bot T2 | Advanced Construction Bot | armack
+Bot T2 | Tumbleweed | armvader
+Bot T2 | Smuggler | armaser
+Bot T2 | Compass | armmark
+Bot T2 | Ghost | armspy
+Bot T2 | Sprinter | armfast
+Bot T2 | Butler | armfark
+Bot T2 | Webber | armspid
+Bot T2 | Platypus | armamph
+Bot T2 | Hound | armfido
+Bot T2 | Welder | armzeus
+Bot T2 | Recluse | armsptk
+Bot T2 | Archangel | armaak
+Bot T2 | Gunslinger | armmav
+Bot T2 | Sharpshooter | armsnipe
+Bot T2 | Decoy Commander | armdecom
+Bot T2 | Umbrella | armscab
+Bot T2 | Fatboy | armfboy
+Bot T3 | Marauder | armmar
+Bot T3 | Vanguard | armvang
+Bot T3 | Razorback | armraz
+Bot T3 | Titan | armbanth
+
+## Cortex


### PR DESCRIPTION
For new/advanced players and developers looking at the units source code, to make it easier to map between the different unit-names vs file-names. 

1. Existing mapping at main website unit URLs mentioned.
2. Single-view list-map example provided with all Armada Bots.