### PR TITLE
nil lightning_info on all code branches

### DIFF
--- a/luarules/gadgets/unit_lightning_splash_dmg.lua
+++ b/luarules/gadgets/unit_lightning_splash_dmg.lua
@@ -98,6 +98,8 @@ function gadget:ProjectileDestroyed(proID)
     for i=1, #nearUnits do -- loop over nearby units
       
       if count == 0 then -- exit if maximum chain is reached
+		-- clear from table
+    	lightning_info[proID] = nil
 		return
       end
       


### PR DESCRIPTION
During exit if maximum chain is reached, the lightning_info table was not nulled, so another weapon recycling that proID would trigger spark effects at the site of the original lightning bolt