### PR TITLE
fix(screenmodeinfo): Show actual keys

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -477,13 +477,13 @@
 		},
 		"screenMode": {
 			"title": "Screen mode: %{highlightColor}%{screenMode}",
-			"overview": "Press %{highlightColor}[TAB]%{textColor} to zoom onto mouse position",
+			"overview": "Press %{highlightColor}[%{keyset}]%{textColor} to zoom onto mouse position",
 			"heightTitle": "Height",
-			"heightmap": "[F1] Displays a different color for every height level",
+			"heightmap": "[%{keyset}] Displays a different color for every height level",
 			"pathingTitle": "Traversability",
-			"pathing":"[F2] Shows where the selected unit can move, Green: okay, Red: problematic, Purple: can't move",
+			"pathing":"[%{keyset}] Shows where the selected unit can move, Green: okay, Red: problematic, Purple: can't move",
 			"resourcesTitle": "Resources",
-			"resources": "[F4] Highlights metal spots in green and geothermal vents in yellow.\n    Occupied metal spots are shown in red."
+			"resources": "[%{keyset}] Highlights metal spots in green and geothermal vents in yellow.\n    Occupied metal spots are shown in red."
 		},
 		"pauseScreen": {
 			"paused": "GAME  PAUSED"

--- a/luaui/Widgets/gui_screen_mode_info.lua
+++ b/luaui/Widgets/gui_screen_mode_info.lua
@@ -6,25 +6,59 @@ function widget:GetInfo()
 		date = "November 2020",
 		license = "GNU GPL, v2 or later",
 		layer = 0,
-		enabled = true  --  loaded by default?
+		enabled = true --  loaded by default?
 	}
 end
 
-local vsx, vsy = Spring.GetViewGeometry()
-local widgetScale = (0.80 + (vsx * vsy / 6000000))
+local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
+
+local spGetActionHotkeys = Spring.GetActionHotKeys
+local spGetCameraState = Spring.GetCameraState
+local spGetMapDrawMode = Spring.GetMapDrawMode
+local spGetConfigString = Spring.GetConfigString
+local spGetViewGeometry = Spring.GetViewGeometry
+local i18n = Spring.I18N
 
 local glPopMatrix = gl.PopMatrix
 local glPushMatrix = gl.PushMatrix
-local glText = gl.Text
 local glTranslate = gl.Translate
 
+local vsx, vsy = spGetViewGeometry()
+local widgetScale = (0.80 + (vsx * vsy / 6000000))
+
 local font, chobbyInterface
+local currentLayout
+local screenmode
+
+local heightKey, metalKey, pathKey
+
+local screenModeOverviewTable = { highlightColor = '\255\255\255\255', textColor = '\255\215\215\215', keyset = '' }
+local screenModeTitleTable = { screenMode = "", highlightColor = "\255\255\255\255" }
+
+local st = spGetCameraState() -- reduce the usage of callins that create tables
+local framecount = 0
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+
+local function getActionHotkey(action)
+	local key = spGetActionHotkeys(action)[1]
+
+	if not key then return "none" end
+
+	return keyConfig.sanitizeKey(key, currentLayout)
+end
+
+local function updateKeys()
+	currentLayout = spGetConfigString("KeyboardLayout", "qwerty")
+	screenModeOverviewTable.keyset = getActionHotkey("toggleoverview")
+	metalKey = getActionHotkey("showmetalmap")
+	heightKey = getActionHotkey("showelevation")
+	pathKey = getActionHotkey("showpathtraversability")
+end
 
 function widget:ViewResize()
-	vsx, vsy = Spring.GetViewGeometry()
+	vsx, vsy = spGetViewGeometry()
 	widgetScale = (0.80 + (vsx * vsy / 6000000))
 
 	font = WG['fonts'].getFont(nil, 1, 0.2, 1.3)
@@ -34,68 +68,65 @@ function widget:Initialize()
 	widget:ViewResize()
 end
 
-function widget:RecvLuaMsg(msg, playerID)
+function widget:RecvLuaMsg(msg)
 	if msg:sub(1, 18) == 'LobbyOverlayActive' then
 		chobbyInterface = (msg:sub(1, 19) == 'LobbyOverlayActive1')
 	end
 end
 
-local screenModeOverviewTable = { highlightColor = '\255\255\255\255', textColor = '\255\215\215\215' }
-local screenModeTitleTable = { screenMode = "", highlightColor = "\255\255\255\255" }
-
-
-local st = Spring.GetCameraState() -- reduce the usage of callins that create tables
-local framecount = 0
-
 function widget:DrawScreen()
-	if chobbyInterface then
-		return
-	end
-	if WG['topbar'] and WG['topbar'].showingQuit() then
-		return
-	end
-  framecount = framecount + 1 
-  
+	if chobbyInterface then return end
+	if WG['topbar'] and WG['topbar'].showingQuit() then return end
+
+	framecount = framecount + 1
+
 	if framecount % 10 == 0 then
-    st = Spring.GetCameraState()
-  end
-	local screenmode = Spring.GetMapDrawMode()
+		st = spGetCameraState()
+	end
+
+	local newScreenmode = spGetMapDrawMode()
+	local screenmodeChanged = newScreenmode ~= screenmode
+	screenmode = newScreenmode
+
 	if (screenmode ~= 'normal' and screenmode ~= 'los') or st.name == 'ov' then
+		if (screenmodeChanged) then updateKeys() end
+
 		local description, title = '', ''
 
 		if st.name == 'ov' then
 			screenmode = ''
 		end
-		
+
 		if st.name == 'ov' then
-			description = Spring.I18N('ui.screenMode.overview', screenModeOverviewTable )
+			description = i18n('ui.screenMode.overview', screenModeOverviewTable)
 		elseif screenmode == 'height' then
-			title = Spring.I18N('ui.screenMode.heightTitle')
-			description = Spring.I18N('ui.screenMode.heightmap')
+			title = i18n('ui.screenMode.heightTitle')
+			description = i18n('ui.screenMode.heightmap', { keyset = heightKey })
 		elseif screenmode == 'pathTraversability' then
-			title = Spring.I18N('ui.screenMode.pathingTitle')
-			description = Spring.I18N('ui.screenMode.pathing')
+			title = i18n('ui.screenMode.pathingTitle')
+			description = i18n('ui.screenMode.pathing', { keyset = pathKey })
 		elseif screenmode == 'metal' then
-			title = Spring.I18N('ui.screenMode.resourcesTitle')
-			description = Spring.I18N('ui.screenMode.resources')
+			title = i18n('ui.screenMode.resourcesTitle')
+			description = i18n('ui.screenMode.resources', { keyset = metalKey })
 		end
-    if screenmode ~= '' or description ~= '' then 
-      glPushMatrix()
-      glTranslate((vsx * 0.5), (vsy * 0.21), 0) --has to be below where newbie info appears!
 
-      font:Begin()
-      if screenmode ~= '' then
-        screenModeTitleTable.screenMode = title
-        font:Print('\255\233\233\233' .. Spring.I18N('ui.screenMode.title', screenModeTitleTable), 0, 15 * widgetScale, 20 * widgetScale, "oc") -- these are still extremely slow btw
-      end
+		if screenmode ~= '' or description ~= '' then
+			glPushMatrix()
+			glTranslate((vsx * 0.5), (vsy * 0.21), 0) --has to be below where newbie info appears!
 
-      if description ~= '' then
-        font:Print('\255\215\215\215' .. description, 0, -10 * widgetScale, 17 * widgetScale, "oc")-- these are still extremely slow btw
-      end
-      font:End()
-      glPopMatrix()
-    end
+			font:Begin()
+			if screenmode ~= '' then
+				screenModeTitleTable.screenMode = title
+				font:Print('\255\233\233\233' .. i18n('ui.screenMode.title', screenModeTitleTable), 0, 15 * widgetScale,
+					20 * widgetScale, "oc") -- these are still extremely slow btw
+			end
 
+			if description ~= '' then
+				font:Print('\255\215\215\215' .. description, 0, -10 * widgetScale, 17 * widgetScale, "oc") -- these are still extremely slow btw
+			end
+			font:End()
+			glPopMatrix()
+		end
 	end
 end
 


### PR DESCRIPTION
Show actual keys for the helper texts.

Also:

- Reformat file (according to linter, there were many tabs/spaces issues etc)
- Lint
- Localize API calls