### PR TITLE
Add support for separate keybinds for factories and builders with grid keys

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -814,6 +814,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 
 	if selectedFactory then
+    if args[3] and args[3] == 'builder' then return false end
 		if meta then return end
 
 		local opts
@@ -834,6 +835,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 		return true
 	elseif preGamestartPlayer and currentBuildCategory then
 		if alt or ctrl or meta then return end
+    if args[3] and args[3] == 'factory' then return false end
 
 		setPreGamestartDefID(-uDefID)
 
@@ -841,6 +843,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 
 		return true
 	elseif selectedBuilder and currentBuildCategory then
+    if args[3] and args[3] == 'factory' then return false end
 		if alt or ctrl or meta then return end
 
 		local uDef = UnitDefs[-uDefID]

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -814,7 +814,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 
 	if selectedFactory then
-    if args[3] and args[3] == 'builder' then return false end
+		if args[3] and args[3] == 'builder' then return false end
 		if meta then return end
 
 		local opts
@@ -835,7 +835,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 		return true
 	elseif preGamestartPlayer and currentBuildCategory then
 		if alt or ctrl or meta then return end
-    if args[3] and args[3] == 'factory' then return false end
+		if args[3] and args[3] == 'factory' then return false end
 
 		setPreGamestartDefID(-uDefID)
 
@@ -843,7 +843,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 
 		return true
 	elseif selectedBuilder and currentBuildCategory then
-    if args[3] and args[3] == 'factory' then return false end
+		if args[3] and args[3] == 'factory' then return false end
 		if alt or ctrl or meta then return end
 
 		local uDef = UnitDefs[-uDefID]


### PR DESCRIPTION
### Changes
This code came from @badosu a long time ago to help me set up some complex binding for WASD camera control, I would like to put it into master now since many other players are trying to use WASD camera controls.

The primary purpose of this is simple - whenever you have a factory selected, all of the potential grid keys are taken over (QWER, ASDF, ZXCV) and used as queue orders for unit production. When you're using WASD keys for the camera, suddenly the camera nav has stopped working and you accidently queued up a bunch of units you didn't want.

When having just a builder selected, this is not a problem, because in order for QWER and ASDF to be "taken over" by the gridmenu, first you have to select a category with ZXCV, so WASD is safe to use.

With this change I can write keybinds like this:
```
unbind    sc_w
unbind    sc_a
unbind    sc_s
unbind    sc_d

bind        any+sc_w moveforward
bind        any+sc_a moveleft
bind        any+sc_s moveback
bind        any+sc_d moveright

bind        Any+sc_a  gridmenu_key 2 1 builder
bind        Any+sc_s  gridmenu_key 2 2 builder
bind        Any+sc_d  gridmenu_key 2 3 builder
bind        Any+sc_w  gridmenu_key 3 2 builder
```
Now WASD will move the camera, even when a factory is selected, but the WASD keys can still be used to build structures (e.g. after selecting a category with ZXCV, camera binds with wasd will be temporarily disabled until the grid state is exited).

This change will have NO impact on existing standard binds.


### Future changes
I would like to propose an optional change to factory gridmenu, to require you to enter a "queue" state before the gridkeys actually add to the queue, to open up more hotkey possibilities, much in the same way that the builder grid menu requires you to select a category before the QWER/ASDF keys do anything.