### PR TITLE
Minor balance tweaks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
-﻿# March 2023
+﻿# April 2023
+
+ • [T1 Vehicle Scouts] Damage per shot increased from 30->35 
+ • Targeting improvements to tiger tank and turtle tank
+
+# March 2023
 
  • [T3 Hovertanks] Depthcharges added and main turrets can no longer target underwater units
  • [Thor] Speed nerf 60->54, spark forkdamage nerf 0.5->0.25 (now deals 750 damage as aoe instead of 1500)

--- a/units/ArmVehicles/T2/armcroc.lua
+++ b/units/ArmVehicles/T2/armcroc.lua
@@ -141,6 +141,7 @@ return {
 				impulsefactor = 0.123,
 				name = "Medium g2g gauss-cannon",
 				noselfdamage = true,
+				predictboost = 1,
 				range = 480,
 				reloadtime = 1.6,
 				soundhit = "xplomed4",

--- a/units/ArmVehicles/armfav.lua
+++ b/units/ArmVehicles/armfav.lua
@@ -163,7 +163,7 @@ return {
 				weaponvelocity = 800,
 				damage = {
 					bombers = 2,
-					default = 30,
+					default = 35,
 					fighters = 2,
 					vtol = 2,
 				},

--- a/units/CorVehicles/T2/correap.lua
+++ b/units/CorVehicles/T2/correap.lua
@@ -144,6 +144,7 @@ return {
 				impulsefactor = 0.123,
 				name = "PlasmaCannon",
 				noselfdamage = true,
+				predictboost = 0.5,
 				range = 410,
 				reloadtime = 0.7,
 				soundhit = "xplomed2",

--- a/units/CorVehicles/corfav.lua
+++ b/units/CorVehicles/corfav.lua
@@ -160,7 +160,7 @@ return {
 				weaponvelocity = 800,
 				damage = {
 					bombers = 2,
-					default = 30,
+					default = 35,
 					fighters = 2,
 					vtol = 2,
 				},


### PR DESCRIPTION
Damage increase to veh scouts to be match tick dps.  Predictboost added to correap (tiger tank) and armcroc (turtle) to improve their targeting.