### PR TITLE
Legion commander leveling enabled

### DIFF
--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -96,6 +96,11 @@ return {
 		customparams = {
 			unitgroup = 'builder',
 			area_mex_def = "legmex",
+			combatradius = 600,
+			evolution_announcement = "Legion commanders have been upgraded",
+			evolution_target = "legcomlvl2",
+			evolution_condition = "timer",
+			evolution_timer = 600,
 			iscommander = true,
 			--energyconv_capacity = 70,
 			--energyconv_efficiency = 1/70,

--- a/units/Legion/legcomlvl2.lua
+++ b/units/Legion/legcomlvl2.lua
@@ -96,6 +96,11 @@ return {
 		customparams = {
 			unitgroup = 'builder',
 			area_mex_def = "legmex",
+			combatradius = 600,
+			evolution_announcement = "Legion commanders have been upgraded",
+			evolution_target = "legcomlvl3",
+			evolution_condition = "timer",
+			evolution_timer = 600,
 			iscommander = true,
 			--energyconv_capacity = 70,
 			--energyconv_efficiency = 1/70,

--- a/units/Legion/legcomlvl3.lua
+++ b/units/Legion/legcomlvl3.lua
@@ -98,6 +98,11 @@ return {
 		customparams = {
 			unitgroup = 'builder',
 			area_mex_def = "legmex",
+			combatradius = 600,
+			evolution_announcement = "Legion commanders have been upgraded",
+			evolution_target = "legcomlvl4",
+			evolution_condition = "timer",
+			evolution_timer = 600,
 			iscommander = true,
 			--energyconv_capacity = 70,
 			--energyconv_efficiency = 1/70,


### PR DESCRIPTION
Legion commanders will now automatically level up every 10 minutes.  Each level improves the main weapon, improves the napalm rockets (alternating between range and damage), increases health, and adds a few build options.