### PR TITLE
Fix invert mouse not loading initial value

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3022,7 +3022,7 @@ function init()
 			  end
 		  end,
 		},
-		{ id = "invertmouse", group = "control", category = types.dev, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.invertmouse'), type = "bool", value = tonumber(Spring.GetConfigInt("InvertMouse ", 0)) == 1, description = "",
+		{ id = "invertmouse", group = "control", category = types.dev, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.invertmouse'), type = "bool", value = tonumber(Spring.GetConfigInt("InvertMouse", 0)) == 1, description = "",
 		  onload = function(i)
 		  end,
 		  onchange = function(i, value)


### PR DESCRIPTION
extra whitespace was causing error with loading initial value

on a side note, can we make this setting non-dev? types.advanced instead of types.dev ? or even not advanced as it is a common setting 