### PR TITLE
Grid UI rewrite

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1407,58 +1407,25 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 	end
 end
 
-local function labActiveArea()
-	if stickToBottom then
-		return Rect:new(
-			backgroundRect.x + bgpadding,
-			backgroundRect.y,
-			backgroundRect.xEnd,
-			backgroundRect.yEnd - bgpadding
-		)
-	else
-		return Rect:new(
-			backgroundRect.x,
-			backgroundRect.y,
-			backgroundRect.xEnd - bgpadding,
-			backgroundRect.yEnd - bgpadding
-		)
-	end
-end
-
 local function drawCategories()
 	local numCats = #categories
-	local activeArea
 
 	if stickToBottom then
-		local x1 = backgroundRect.x + bgpadding
+		local x1 = categoriesRect.x
 
-		activeArea = Rect:new(
-			x1 + pageButtonWidth,
-			backgroundRect.y - 2 * activeAreaMargin,
-			backgroundRect.xEnd,
-			backgroundRect.yEnd - bgpadding
-		)
-
-		local contentHeight = activeArea.yEnd - activeArea.y
+		local contentHeight = (categoriesRect.yEnd - categoriesRect.y) / numCats
 
 		for i, cat in ipairs(categories) do
-			local y1 = activeArea.yEnd - i * (contentHeight / numCats) + 2
+			local y1 = categoriesRect.yEnd - i * contentHeight + 2
 			catRects[cat] = Rect:new(
 				x1,
 				y1,
 				x1 + pageButtonWidth - activeAreaMargin,
-				y1 + (contentHeight / numCats) - 2
+				y1 + contentHeight - 2
 			)
 		end
 	else
 		local y2 = categoriesRect.yEnd
-
-		activeArea = Rect:new(
-			backgroundRect.x,
-			backgroundRect.y,
-			backgroundRect.xEnd - bgpadding,
-			y2 - pageButtonHeight
-		)
 
 		local buttonWidth = math.round((categoriesRect.xEnd - categoriesRect.x) / numCats)
 
@@ -1474,11 +1441,9 @@ local function drawCategories()
 	end
 
 	drawCategoryButtons()
-
-	return activeArea
 end
 
-local function drawGrid(activeArea)
+local function drawGrid()
 	local numCellsPerPage = rows * colls
 	local cellRectID = 0
 	local unitGrid
@@ -1558,7 +1523,7 @@ local function drawGrid(activeArea)
 	end
 end
 
-local function drawPaginators(activeArea)
+local function drawPaginators()
 	if pages == 1 then
 		return
 	end
@@ -1567,20 +1532,19 @@ local function drawPaginators(activeArea)
 	local nextKeyText = "\255\215\255\215[".. keyConfig.sanitizeKey(Cfgs.NEXT_PAGE_KEY, currentLayout) .."]"
 
 	if stickToBottom then
-		local contentHeight = activeArea.yEnd - activeArea.y
-		local buttonHeight = contentHeight / 3
+		local buttonHeight = (paginatorsRect.yEnd - paginatorsRect.y) / 3
 
 		prevPageRect = Rect:new(
-			activeArea.x + 6 * cellSize,
-			activeArea.y + activeAreaMargin,
-			activeArea.xEnd - bgpadding,
-			activeArea.y + buttonHeight
+			paginatorsRect.x,
+			paginatorsRect.y,
+			paginatorsRect.xEnd,
+			paginatorsRect.y + buttonHeight
 		)
 		nextPageRect = Rect:new(
-			prevPageRect.x,
-			activeArea.y + 2 * buttonHeight,
-			prevPageRect.xEnd,
-			activeArea.y + 3 * buttonHeight
+			paginatorsRect.x,
+			paginatorsRect.y + 2 * buttonHeight,
+			paginatorsRect.xEnd,
+			paginatorsRect.y + 3 * buttonHeight
 		)
 
 		local buttonWidth = prevPageRect.xEnd - prevPageRect.x
@@ -1612,46 +1576,39 @@ local function drawPaginators(activeArea)
 end
 
 local function drawBuildmenu()
-	local activeArea
-
 	catRects = {}
-
 	font2:Begin()
 
-	if selectedFactory then
-		activeArea = labActiveArea()
-	elseif selectedBuilder then
-		activeArea = drawCategories()
+	if selectedBuilder then
+		drawCategories()
 	end
 
-	if activeArea then
-		-- adjust grid size when pages are needed
-		if uidcmdsCount > colls * rows then
-			pages = math_ceil(uidcmdsCount / (rows * colls))
+	-- adjust grid size when pages are needed
+	if uidcmdsCount > colls * rows then
+		pages = math_ceil(uidcmdsCount / (rows * colls))
 
-			if currentPage > pages then
-				currentPage = pages
-			end
-		else
-			currentPage = 1
-			pages = 1
+		if currentPage > pages then
+			currentPage = pages
 		end
-
-		-- these are globals so it can be re-used (hover highlight)
-		cellPadding = math_floor(cellSize * Cfgs.cfgCellPadding)
-		iconPadding = math_max(1, math_floor(cellSize * Cfgs.cfgIconPadding))
-		cornerSize = math_floor(cellSize * Cfgs.cfgIconCornerSize)
-		cellInnerSize = cellSize - cellPadding - cellPadding
-		priceFontSize = math_floor((cellInnerSize * Cfgs.cfgPriceFontSize) + 0.5)
-
-		cellRects = {}
-		hotkeyActions = {}
-
-		drawGrid()
-		drawPaginators(activeArea)
-
-		font2:End()
+	else
+		currentPage = 1
+		pages = 1
 	end
+
+	-- these are globals so it can be re-used (hover highlight)
+	cellPadding = math_floor(cellSize * Cfgs.cfgCellPadding)
+	iconPadding = math_max(1, math_floor(cellSize * Cfgs.cfgIconPadding))
+	cornerSize = math_floor(cellSize * Cfgs.cfgIconCornerSize)
+	cellInnerSize = cellSize - cellPadding - cellPadding
+	priceFontSize = math_floor((cellInnerSize * Cfgs.cfgPriceFontSize) + 0.5)
+
+	cellRects = {}
+	hotkeyActions = {}
+
+	drawGrid()
+	drawPaginators()
+
+	font2:End()
 end
 
 local function GetBuildingDimensions(uDefID, facing)

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1006,7 +1006,7 @@ function widget:ViewResize()
 	UiButton = WG.FlowUI.Draw.Button
 	elementCorner = WG.FlowUI.elementCorner
 	categoryFontSize = 0.0115 * ui_scale * vsy
-	pageButtonHeight = math_floor(2.0 * categoryFontSize * ui_scale)
+	pageButtonHeight = math_floor(2.3 * categoryFontSize * ui_scale)
 	pageButtonWidth = 7 * categoryFontSize * ui_scale
 	if stickToBottom then
 		paginatorFontSize = categoryFontSize
@@ -1103,7 +1103,7 @@ function widget:ViewResize()
 		-- assemble rects, bottom to top
 		paginatorsRect = Rect:new(
 			posX + bgpadding,
-			posY2P + bgpadding,
+			posY2P + bgpadding * 2,
 			posX2 - bgpadding,
 			posY2P + pageButtonHeight + bgpadding
 		)
@@ -1120,17 +1120,18 @@ function widget:ViewResize()
 		)
 
 		categoriesRect = Rect:new(
-			posX + bgpadding,
+			posX ,
 			buildpicsRect.yEnd,
 			posX2 - bgpadding,
-			buildpicsRect.yEnd + pageButtonHeight + bgpadding
+			buildpicsRect.yEnd + pageButtonHeight + (bgpadding)
 		)
 
 		backgroundRect = Rect:new(
 			posX,
 			posY2P,
 			posX2,
-			categoriesRect.yEnd)
+			categoriesRect.yEnd + bgpadding
+		)
 	end
 
 	checkGuishader(true)

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -39,8 +39,7 @@ local BUILDCAT_ECONOMY = "Economy"
 local BUILDCAT_COMBAT = "Combat"
 local BUILDCAT_UTILITY = "Utility"
 local BUILDCAT_PRODUCTION = "Production"
-local categoryFontSize, pageButtonHeight, pageButtonWidth, paginatorCellWidth
-local paginatorFontSize
+local categoryFontSize, pageButtonHeight
 
 local Cfgs = {
 	disableInputWhenSpec = false, -- disable specs selecting buildoptions
@@ -998,22 +997,14 @@ function widget:ViewResize()
 	local widgetSpaceMargin = WG.FlowUI.elementMargin
 	bgpadding = WG.FlowUI.elementPadding
 	elementCorner = WG.FlowUI.elementCorner
-
 	RectRound = WG.FlowUI.Draw.RectRound
 	RectRoundProgress = WG.FlowUI.Draw.RectRoundProgress
 	UiUnit = WG.FlowUI.Draw.Unit
 	UiElement = WG.FlowUI.Draw.Element
 	UiButton = WG.FlowUI.Draw.Button
-	elementCorner = WG.FlowUI.elementCorner
 	categoryFontSize = 0.0115 * ui_scale * vsy
+	pageFontSize = categoryFontSize
 	pageButtonHeight = math_floor(2.3 * categoryFontSize * ui_scale)
-	pageButtonWidth = 7 * categoryFontSize * ui_scale
-	if stickToBottom then
-		paginatorFontSize = categoryFontSize
-	else
-		paginatorFontSize = categoryFontSize * 1.2
-	end
-	paginatorCellWidth = paginatorFontSize * 2
 
 	activeAreaMargin = math_ceil(bgpadding * Cfgs.cfgActiveAreaMargin)
 
@@ -1031,7 +1022,6 @@ function widget:ViewResize()
 		posY = math_floor(0.14 * ui_scale * vsy) / vsy
 		posY2 = 0
 		posX = math_floor(ordermenuLeft*vsx) + widgetSpaceMargin
-		posX2 = math_floor(posX + posY * vsy * 3) + paginatorCellWidth + pageButtonWidth
 		width = posX2 - posX
 		height = posY
 
@@ -1039,13 +1029,16 @@ function widget:ViewResize()
 		colls = 6
 		cellSize = math_floor(((height * vsy) - bgpadding) / rows)
 
+		local categoryWidth = 7 * categoryFontSize * ui_scale
+		local pageButtonWidth = categoryWidth / 3
+
 		local posYP = math_floor(posY * vsy)
 
 		-- assemble rects left to right
 		categoriesRect = Rect:new(
 			posX + bgpadding,
 			posY2,
-			posX + pageButtonWidth,
+			posX + categoryWidth,
 			posYP - bgpadding
 		)
 
@@ -1059,7 +1052,7 @@ function widget:ViewResize()
 		paginatorsRect = Rect:new(
 			buildpicsRect.xEnd + bgpadding,
 			posY2,
-			buildpicsRect.xEnd + paginatorCellWidth,
+			buildpicsRect.xEnd + pageButtonWidth,
 			posYP - bgpadding
 		)
 
@@ -1078,7 +1071,7 @@ function widget:ViewResize()
 		-- 0.14 is the space required to put this above the bottom-left UI element
 		posY2 = math_floor(0.14 * ui_scale * vsy) / vsy
 		posY2 = posY2 + (widgetSpaceMargin/vsy)
-		posY = posY2 + (0.74 * width * vsx + pageButtonHeight + paginatorCellWidth)/vsy
+		posY = posY2 + (0.74 * width * vsx + pageButtonHeight)/vsy
 		posX = 0
 
 		if WG['ordermenu'] and not WG['ordermenu'].getBottomPosition() then
@@ -1103,7 +1096,7 @@ function widget:ViewResize()
 		-- assemble rects, bottom to top
 		paginatorsRect = Rect:new(
 			posX + bgpadding,
-			posY2P + bgpadding * 2,
+			posY2P + bgpadding,
 			posX2 - bgpadding,
 			posY2P + pageButtonHeight + bgpadding
 		)
@@ -1116,14 +1109,14 @@ function widget:ViewResize()
 			posX + bgpadding,
 			paginatorsRect.yEnd,
 			posX2 - bgpadding,
-			paginatorsRect.yEnd + (cellSize * rows) + bgpadding
+			paginatorsRect.yEnd + (cellSize * rows)
 		)
 
 		categoriesRect = Rect:new(
 			posX ,
 			buildpicsRect.yEnd,
 			posX2 - bgpadding,
-			buildpicsRect.yEnd + pageButtonHeight + (bgpadding)
+			buildpicsRect.yEnd + pageButtonHeight + bgpadding
 		)
 
 		backgroundRect = Rect:new(
@@ -1383,13 +1376,14 @@ local function drawCategories()
 		local x1 = categoriesRect.x
 
 		local contentHeight = (categoriesRect.yEnd - categoriesRect.y) / numCats
+		local contentWidth = categoriesRect.xEnd - categoriesRect.x
 
 		for i, cat in ipairs(categories) do
 			local y1 = categoriesRect.yEnd - i * contentHeight + 2
 			catRects[cat] = Rect:new(
 				x1,
 				y1,
-				x1 + pageButtonWidth - activeAreaMargin,
+				x1 + contentWidth - activeAreaMargin,
 				y1 + contentHeight - 2
 			)
 		end
@@ -1523,7 +1517,7 @@ local function drawPaginators()
 	local opts = {
 		highlight = false,
 		hovered = false,
-		fontSize = paginatorFontSize,
+		fontSize = pageFontSize,
 	}
 
 	if stickToBottom then
@@ -1544,17 +1538,17 @@ local function drawPaginators()
 
 		font2:Print("\255\245\245\245" .. currentPage .. "/" .. pages,
 			(prevPageRect.x + prevPageRect.xEnd) * 0.5,
-			prevPageRect.yEnd + buttonHeight * 0.5 - paginatorFontSize * 0.25, paginatorFontSize, "co")
+			prevPageRect.yEnd + buttonHeight * 0.5 - pageFontSize * 0.25, pageFontSize, "co")
 	else
 		local contentWidth = paginatorsRect.xEnd - paginatorsRect.x
 		local buttonWidth = math_floor(contentWidth * 0.33)
 
-		prevPageRect = Rect:new(paginatorsRect.x, paginatorsRect.y, paginatorsRect.x + buttonWidth, paginatorsRect.yEnd)
-		nextPageRect = Rect:new(paginatorsRect.xEnd - buttonWidth, paginatorsRect.y, paginatorsRect.xEnd, paginatorsRect.yEnd)
+		prevPageRect = Rect:new(paginatorsRect.x, paginatorsRect.y + bgpadding, paginatorsRect.x + buttonWidth, paginatorsRect.yEnd - bgpadding)
+		nextPageRect = Rect:new(paginatorsRect.xEnd - buttonWidth, paginatorsRect.y + bgpadding, paginatorsRect.xEnd, paginatorsRect.yEnd - bgpadding)
 		local buttonHeight = paginatorsRect.yEnd - paginatorsRect.y
 
 		local pagesText = currentPage .. " / " .. pages
-		font2:Print("\255\245\245\245" .. pagesText, contentWidth * 0.5, prevPageRect.yEnd - font2:GetTextHeight(pagesText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
+		font2:Print("\255\245\245\245" .. pagesText, contentWidth * 0.5, prevPageRect.yEnd - font2:GetTextHeight(pagesText) * pageFontSize * 0.25 - buttonHeight/2, pageFontSize, "co")
 	end
 
 	opts.hovered = hoveredButton and prevPageRect:getId() == hoveredButton

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1267,11 +1267,7 @@ local function drawButton(rect, text, opts)
 		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 
-	local zoom = 1
-
 	if hovered then
-		zoom = 1.07
-
 		-- gloss highlight
 		local pad = 0
 		gl.Blending(GL_SRC_ALPHA, GL_ONE)
@@ -1280,9 +1276,9 @@ local function drawButton(rect, text, opts)
 		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 
-	local fontHeight = font2:GetTextHeight(text) * fontSize * zoom
+	local fontHeight = font2:GetTextHeight(text) * fontSize
 	local fontHeightOffset = fontHeight * 0.34
-	font2:Print(text, rect.x + ((rect.xEnd - rect.x) / 2), (rect.y - (rect.y - rect.yEnd) / 2) - fontHeightOffset, fontSize * zoom, "con")
+	font2:Print(text, rect.x + ((rect.xEnd - rect.x) / 2), (rect.y - (rect.y - rect.yEnd) / 2) - fontHeightOffset, fontSize, "con")
 
 	if opts.hovered then
 		drawnHoveredButton = rect:getId()
@@ -1871,7 +1867,7 @@ function widget:DrawScreen()
 			local usedZoom
 			local cellColor
 			if not WG['topbar'] or not WG['topbar'].showingQuit() then
-				if backgroundRect:contains(x, y) then
+				if hovering then
 
 					-- cells
 					if hoveredCellID then

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1090,7 +1090,6 @@ function widget:ViewResize()
 		height = (posY - posY2)
 
 		posX2 = math_floor(width * vsx)
-		local posYP = math_floor(posY * vsy)
 		local posY2P = math_floor(posY2 * vsy)
 
 		-- make pixel aligned
@@ -1269,17 +1268,12 @@ local function drawButton(rect, text, opts)
 	if hovered then
 		zoom = 1.07
 
-		local leftMargin = 0
-		local rightMargin = 0
-		local topMargin = 0
-		local bottomMargin = 0
-
 		-- gloss highlight
 		local pad = padding
 		local pad2 = 0
 		gl.Blending(GL_SRC_ALPHA, GL_ONE)
-		RectRound(rect.x + leftMargin + pad + pad2, rect.yEnd - topMargin - bgpadding - pad - pad2 - ((rect.yEnd - rect.y) * 0.42), rect.xEnd - rightMargin - pad - pad2, (rect.yEnd - topMargin - pad - pad2), padding * 1.5, 2, 2, 0, 0, { 1, 1, 1, 0.035 }, { 1, 1, 1, (disableInput and 0.11 or 0.24) })
-		RectRound(rect.x + leftMargin + pad + pad2, rect.y + bottomMargin + pad + pad2, rect.yEnd - rightMargin - pad - pad2, (rect.y - bottomMargin - pad - pad2) + ((rect.yEnd - rect.y) * 0.5), padding * 1.5, 0, 0, 2, 2, { 1, 1, 1, (disableInput and 0.035 or 0.075) }, { 1, 1, 1, 0 })
+		RectRound(rect.x + pad + pad2, rect.yEnd - bgpadding - pad - pad2 - ((rect.yEnd - rect.y) * 0.42), rect.xEnd - pad - pad2, (rect.yEnd - pad - pad2), padding * 1.5, 2, 2, 0, 0, { 1, 1, 1, 0.035 }, { 1, 1, 1, (disableInput and 0.11 or 0.24) })
+		RectRound(rect.x + pad + pad2, rect.y + pad + pad2, rect.xEnd - pad - pad2, (rect.y - pad - pad2) + ((rect.yEnd - rect.y) * 0.5), padding * 1.5, 0, 0, 2, 2, { 1, 1, 1, (disableInput and 0.035 or 0.075) }, { 1, 1, 1, 0 })
 		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 
@@ -1329,12 +1323,13 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 	end
 
 	local showIcon = showGroupIcon and not (selectedFactory or currentCategoryIndex)
+	local cellRect = cellRects[id];
 
 	UiUnit(
-		cellRects[id].x + cellPadding + iconPadding,
-		cellRects[id].y + cellPadding + iconPadding,
-		cellRects[id].xEnd - cellPadding - iconPadding,
-		cellRects[id].yEnd - cellPadding - iconPadding,
+		cellRect.x + cellPadding + iconPadding,
+		cellRect.y + cellPadding + iconPadding,
+		cellRect.xEnd - cellPadding - iconPadding,
+		cellRect.yEnd - cellPadding - iconPadding,
 		cornerSize, 1,1,1,1,
 		usedZoom,
 		nil, disabled and 0 or nil,
@@ -1351,20 +1346,20 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 		gl.Color(cellColor[1], cellColor[2], cellColor[3], cellColor[4])
 		gl.Texture('#' .. uid)
 		UiUnit(
-			cellRects[id].x + cellPadding + iconPadding,
-			cellRects[id].y + cellPadding + iconPadding,
-			cellRects[id].xEnd - cellPadding - iconPadding,
-			cellRects[id].yEnd - cellPadding - iconPadding,
+			cellRect.x + cellPadding + iconPadding,
+			cellRect.y + cellPadding + iconPadding,
+			cellRect.xEnd - cellPadding - iconPadding,
+			cellRect.yEnd - cellPadding - iconPadding,
 			cornerSize, 1,1,1,1,
 			usedZoom
 		)
 		if cellColor[4] > 0 then
 			gl.Blending(GL_SRC_ALPHA, GL_ONE)
 			UiUnit(
-				cellRects[id].x + cellPadding + iconPadding,
-				cellRects[id].y + cellPadding + iconPadding,
-				cellRects[id].xEnd - cellPadding - iconPadding,
-				cellRects[id].yEnd - cellPadding - iconPadding,
+				cellRect.x + cellPadding + iconPadding,
+				cellRect.y + cellPadding + iconPadding,
+				cellRect.xEnd - cellPadding - iconPadding,
+				cellRect.yEnd - cellPadding - iconPadding,
 				cornerSize, 1,1,1,1,
 				usedZoom
 			)
@@ -1381,7 +1376,7 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 		else
 			text = "\255\245\245\245" .. unitMetalCost[uid] .. "\n\255\255\255\000"
 		end
-		font2:Print(text .. unitEnergyCost[uid], cellRects[id].x + cellPadding + (cellInnerSize * 0.048), cellRects[id].y + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
+		font2:Print(text .. unitEnergyCost[uid], cellRect.x + cellPadding + (cellInnerSize * 0.048), cellRect.y + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
 	end
 
 	-- factory queue number
@@ -1389,12 +1384,12 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 		local pad = math_floor(cellInnerSize * 0.03)
 		local textWidth = math_floor(font2:GetTextWidth(cmd.params[1] .. '	') * cellInnerSize * 0.285)
 		local pad2 = 0
-		RectRound(cellRects[id].xEnd - cellPadding - iconPadding - textWidth - pad2, cellRects[id].yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2, cellRects[id].xEnd - cellPadding - iconPadding, cellRects[id].yEnd - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 0, 1, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
-		RectRound(cellRects[id].xEnd - cellPadding - iconPadding - textWidth - pad2, cellRects[id].yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.15) - pad2, cellRects[id].xEnd - cellPadding - iconPadding, cellRects[id].yEnd - cellPadding - iconPadding, 0, 0, 0, 0, 0, { 1, 1, 1, 0 }, { 1, 1, 1, 0.05 })
-		RectRound(cellRects[id].xEnd - cellPadding - iconPadding - textWidth - pad2 + pad, cellRects[id].yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2 + pad, cellRects[id].xEnd - cellPadding - iconPadding - pad2, cellRects[id].yEnd - cellPadding - iconPadding - pad2, cornerSize * 2.6, 0, 0, 0, 1, { 0.7, 0.7, 0.7, 0.1 }, { 1, 1, 1, 0.1 })
+		RectRound(cellRect.xEnd - cellPadding - iconPadding - textWidth - pad2, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2, cellRect.xEnd - cellPadding - iconPadding, cellRect.yEnd - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 0, 1, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
+		RectRound(cellRect.xEnd - cellPadding - iconPadding - textWidth - pad2, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.15) - pad2, cellRect.xEnd - cellPadding - iconPadding, cellRect.yEnd - cellPadding - iconPadding, 0, 0, 0, 0, 0, { 1, 1, 1, 0 }, { 1, 1, 1, 0.05 })
+		RectRound(cellRect.xEnd - cellPadding - iconPadding - textWidth - pad2 + pad, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2 + pad, cellRect.xEnd - cellPadding - iconPadding - pad2, cellRect.yEnd - cellPadding - iconPadding - pad2, cornerSize * 2.6, 0, 0, 0, 1, { 0.7, 0.7, 0.7, 0.1 }, { 1, 1, 1, 0.1 })
 		font2:Print("\255\190\255\190" .. cmd.params[1],
-			cellRects[id].x + cellPadding + math_floor(cellInnerSize * 0.96) - pad2,
-			cellRects[id].y + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
+			cellRect.x + cellPadding + math_floor(cellInnerSize * 0.96) - pad2,
+			cellRect.y + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
 			cellInnerSize * 0.29, "ro"
 		)
 	end
@@ -1403,7 +1398,7 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 		local hotkeyText = keyConfig.sanitizeKey(cmd.hotkey, currentLayout)
 
 		local hotkeyFontSize = priceFontSize * 1.1
-		font2:Print("\255\215\255\215" .. hotkeyText, cellRects[id].x + cellPadding + (cellInnerSize * 0.048), cellRects[id].yEnd - cellPadding - hotkeyFontSize, hotkeyFontSize, "o")
+		font2:Print("\255\215\255\215" .. hotkeyText, cellRect.x + cellPadding + (cellInnerSize * 0.048), cellRect.yEnd - cellPadding - hotkeyFontSize, hotkeyFontSize, "o")
 	end
 end
 
@@ -1858,14 +1853,14 @@ function widget:DrawScreen()
 			local usedZoom
 			local cellColor
 			if not WG['topbar'] or not WG['topbar'].showingQuit() then
-				if math_isInRect(x, y, backgroundRect.x, backgroundRect.y, backgroundRect.xEnd, backgroundRect.yEnd) then
+				if backgroundRect:contains(x, y) then
 
 					-- paginator buttons
 					local hoveredRect
-					if prevPageRect.x and math_isInRect(x, y, prevPageRect.x, prevPageRect.y, prevPageRect.xEnd, prevPageRect.yEnd) then
+					if prevPageRect.x and prevPageRect:contains(x, y) then
 						hoveredRect = prevPageRect
 					end
-					if nextPageRect.y and math_isInRect(x, y, nextPageRect.x, nextPageRect.y, nextPageRect.xEnd, nextPageRect.yEnd) then
+					if nextPageRect.y and nextPageRect:contains(x, y) then
 						hoveredRect = nextPageRect
 					end
 					if hoveredRect then

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1288,32 +1288,6 @@ local function drawButton(rect, text, opts)
 	end
 end
 
-local function drawCategoryButtons()
-	local catTexts = {}
-	local maxTextSize = 0
-
-	for catIndex, cat in pairs(Cfgs.buildCategories) do
-		local catText = cat .. " \255\215\255\215" .. "[" .. keyConfig.sanitizeKey(Cfgs.categoryKeys[catIndex], currentLayout) .. "]"
-		catTexts[cat] = catText
-		local catTextSize = font2:GetTextWidth(catText)
-		if maxTextSize < catTextSize then
-			maxTextSize = catTextSize
-		end
-	end
-
-	for _, cat in pairs(Cfgs.buildCategories) do
-		local rect = catRects[cat]
-
-		local opts = {
-			highlight = (cat == currentBuildCategory),
-			hovered = (hoveredButton == rect:getId()),
-			fontSize = (rect.xEnd - rect.x - (stickToBottom and 2 or 1.5) * 8 * math_max(1, math_floor(bgpadding * 0.52))) / maxTextSize,
-		}
-
-		drawButton(rect, catTexts[cat], opts)
-	end
-end
-
 local function drawCell(id, usedZoom, cellColor, disabled)
 	local cmd = cellcmds[id]
 	local uid = cmd.id * -1
@@ -1407,6 +1381,7 @@ end
 local function drawCategories()
 	local numCats = #categories
 
+	-- set up rects
 	if stickToBottom then
 		local x1 = categoriesRect.x
 
@@ -1438,7 +1413,26 @@ local function drawCategories()
 		end
 	end
 
-	drawCategoryButtons()
+	-- set up buttons
+	local maxTextSize = 0
+
+	for catIndex, cat in pairs(Cfgs.buildCategories) do
+		local catText = cat .. " \255\215\255\215" .. "[" .. keyConfig.sanitizeKey(Cfgs.categoryKeys[catIndex], currentLayout) .. "]"
+		local catTextSize = font2:GetTextWidth(catText)
+		if maxTextSize < catTextSize then
+			maxTextSize = catTextSize
+		end
+
+		local rect = catRects[cat]
+
+		local opts = {
+			highlight = (cat == currentBuildCategory),
+			hovered = (hoveredButton == rect:getId()),
+			fontSize = (rect.xEnd - rect.x - (stickToBottom and 2 or 1.5) * 8 * math_max(1, math_floor(bgpadding * 0.52))) / maxTextSize,
+		}
+
+		drawButton(rect, catText, opts)
+	end
 end
 
 local function drawGrid()

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -255,7 +255,6 @@ local math_floor = math.floor
 local math_ceil = math.ceil
 local math_max = math.max
 local math_min = math.min
-local math_isInRect = math.isInRect
 
 local GL_SRC_ALPHA = GL.SRC_ALPHA
 local GL_ONE_MINUS_SRC_ALPHA = GL.ONE_MINUS_SRC_ALPHA
@@ -1029,7 +1028,7 @@ function widget:ViewResize()
 		colls = 6
 		cellSize = math_floor(((height * vsy) - bgpadding) / rows)
 
-		local categoryWidth = 7 * categoryFontSize * ui_scale
+		local categoryWidth = 8 * categoryFontSize * ui_scale
 		local pageButtonWidth = categoryWidth / 3
 
 		local posYP = math_floor(posY * vsy)
@@ -1405,21 +1404,14 @@ local function drawCategories()
 	end
 
 	-- set up buttons
-	local maxTextSize = 0
-
 	for catIndex, cat in pairs(Cfgs.buildCategories) do
 		local catText = cat .. " \255\215\255\215" .. "[" .. keyConfig.sanitizeKey(Cfgs.categoryKeys[catIndex], currentLayout) .. "]"
-		local catTextSize = font2:GetTextWidth(catText)
-		if maxTextSize < catTextSize then
-			maxTextSize = catTextSize
-		end
-
 		local rect = catRects[cat]
 
 		local opts = {
 			highlight = (cat == currentBuildCategory),
 			hovered = (hoveredButton == rect:getId()),
-			fontSize = (rect.xEnd - rect.x - (stickToBottom and 2 or 1.5) * 8 * math_max(1, math_floor(bgpadding * 0.52))) / maxTextSize,
+			fontSize = categoryFontSize,
 		}
 
 		drawButton(rect, catText, opts)
@@ -1758,7 +1750,7 @@ function widget:DrawScreen()
 		gl.CallList(dlistBuildmenuBg)
 		if preGamestartPlayer or selectedBuilder or selectedFactory then
 			-- pre process + 'highlight' under the icons
-			local hoveredCellID = nil
+			local hoveredCellID
 			local hoveredButtonNotFound = true
 			if not WG['topbar'] or not WG['topbar'].showingQuit() then
 				if hovering then

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -154,15 +154,22 @@ local buildmenuShows = false
 
 -- Helper types to make the code more readable and easy to work with
 Rect = {}
-function Rect:new(x, y, x2, y2)
+function Rect:new(x1, y1, x2, y2)
 	local this = {
-		x = x;
-		y = y;
+		x = x1;
+		y = y1;
 		xEnd = x2;
 		yEnd = y2;
 	}
+
+	function this:contains(x, y)
+		return x >= self.x and x <= self.xEnd and y >= self.y and y <= self.yEnd
+	end
+
 	return this;
 end
+
+
 
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
@@ -598,7 +605,6 @@ function widget:ViewResize()
 	end
 	paginatorCellWidth = paginatorFontSize * 2
 
-
 	activeAreaMargin = math_ceil(bgpadding * Cfgs.cfgActiveAreaMargin)
 
 	vsx, vsy = Spring.GetViewGeometry()
@@ -644,8 +650,6 @@ function widget:ViewResize()
 		-- make pixel aligned
 		width = math_floor(width * vsx) / vsx
 		height = math_floor(height * vsy) / vsy
-
-
 	end
 
 	backgroundRect = Rect:new(posX, (posY - height) * vsy, posX2, posY * vsy)
@@ -1237,8 +1241,8 @@ local function drawCategoryButtons()
 	end
 end
 
-local function drawCell(cellRectID, usedZoom, cellColor, disabled)
-	local cmd = cellcmds[cellRectID]
+local function drawCell(id, usedZoom, cellColor, disabled)
+	local cmd = cellcmds[id]
 	local uid = cmd.id * -1
 	-- unit icon
 	if disabled then
@@ -1250,10 +1254,10 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 	local showIcon = showGroupIcon and not (selectedFactory or currentCategoryIndex)
 
 	UiUnit(
-		cellRects[cellRectID][1] + cellPadding + iconPadding,
-		cellRects[cellRectID][2] + cellPadding + iconPadding,
-		cellRects[cellRectID][3] - cellPadding - iconPadding,
-		cellRects[cellRectID][4] - cellPadding - iconPadding,
+		cellRects[id].x + cellPadding + iconPadding,
+		cellRects[id].y + cellPadding + iconPadding,
+		cellRects[id].xEnd - cellPadding - iconPadding,
+		cellRects[id].yEnd - cellPadding - iconPadding,
 		cornerSize, 1,1,1,1,
 		usedZoom,
 		nil, disabled and 0 or nil,
@@ -1270,20 +1274,20 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		gl.Color(cellColor[1], cellColor[2], cellColor[3], cellColor[4])
 		gl.Texture('#' .. uid)
 		UiUnit(
-			cellRects[cellRectID][1] + cellPadding + iconPadding,
-			cellRects[cellRectID][2] + cellPadding + iconPadding,
-			cellRects[cellRectID][3] - cellPadding - iconPadding,
-			cellRects[cellRectID][4] - cellPadding - iconPadding,
+			cellRects[id].x + cellPadding + iconPadding,
+			cellRects[id].y + cellPadding + iconPadding,
+			cellRects[id].xEnd - cellPadding - iconPadding,
+			cellRects[id].yEnd - cellPadding - iconPadding,
 			cornerSize, 1,1,1,1,
 			usedZoom
 		)
 		if cellColor[4] > 0 then
 			gl.Blending(GL_SRC_ALPHA, GL_ONE)
 			UiUnit(
-				cellRects[cellRectID][1] + cellPadding + iconPadding,
-				cellRects[cellRectID][2] + cellPadding + iconPadding,
-				cellRects[cellRectID][3] - cellPadding - iconPadding,
-				cellRects[cellRectID][4] - cellPadding - iconPadding,
+				cellRects[id].x + cellPadding + iconPadding,
+				cellRects[id].y + cellPadding + iconPadding,
+				cellRects[id].xEnd - cellPadding - iconPadding,
+				cellRects[id].yEnd - cellPadding - iconPadding,
 				cornerSize, 1,1,1,1,
 				usedZoom
 			)
@@ -1300,7 +1304,7 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		else
 			text = "\255\245\245\245" .. unitMetalCost[uid] .. "\n\255\255\255\000"
 		end
-		font2:Print(text .. unitEnergyCost[uid], cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
+		font2:Print(text .. unitEnergyCost[uid], cellRects[id].x + cellPadding + (cellInnerSize * 0.048), cellRects[id].y + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
 	end
 
 	-- factory queue number
@@ -1308,12 +1312,12 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		local pad = math_floor(cellInnerSize * 0.03)
 		local textWidth = math_floor(font2:GetTextWidth(cmd.params[1] .. '	') * cellInnerSize * 0.285)
 		local pad2 = 0
-		RectRound(cellRects[cellRectID][3] - cellPadding - iconPadding - textWidth - pad2, cellRects[cellRectID][4] - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2, cellRects[cellRectID][3] - cellPadding - iconPadding, cellRects[cellRectID][4] - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 0, 1, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
-		RectRound(cellRects[cellRectID][3] - cellPadding - iconPadding - textWidth - pad2, cellRects[cellRectID][4] - cellPadding - iconPadding - math_floor(cellInnerSize * 0.15) - pad2, cellRects[cellRectID][3] - cellPadding - iconPadding, cellRects[cellRectID][4] - cellPadding - iconPadding, 0, 0, 0, 0, 0, { 1, 1, 1, 0 }, { 1, 1, 1, 0.05 })
-		RectRound(cellRects[cellRectID][3] - cellPadding - iconPadding - textWidth - pad2 + pad, cellRects[cellRectID][4] - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2 + pad, cellRects[cellRectID][3] - cellPadding - iconPadding - pad2, cellRects[cellRectID][4] - cellPadding - iconPadding - pad2, cornerSize * 2.6, 0, 0, 0, 1, { 0.7, 0.7, 0.7, 0.1 }, { 1, 1, 1, 0.1 })
+		RectRound(cellRects[id].xEnd - cellPadding - iconPadding - textWidth - pad2, cellRects[id].yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2, cellRects[id].xEnd - cellPadding - iconPadding, cellRects[id].yEnd - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 0, 1, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
+		RectRound(cellRects[id].xEnd - cellPadding - iconPadding - textWidth - pad2, cellRects[id].yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.15) - pad2, cellRects[id].xEnd - cellPadding - iconPadding, cellRects[id].yEnd - cellPadding - iconPadding, 0, 0, 0, 0, 0, { 1, 1, 1, 0 }, { 1, 1, 1, 0.05 })
+		RectRound(cellRects[id].xEnd - cellPadding - iconPadding - textWidth - pad2 + pad, cellRects[id].yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2 + pad, cellRects[id].xEnd - cellPadding - iconPadding - pad2, cellRects[id].yEnd - cellPadding - iconPadding - pad2, cornerSize * 2.6, 0, 0, 0, 1, { 0.7, 0.7, 0.7, 0.1 }, { 1, 1, 1, 0.1 })
 		font2:Print("\255\190\255\190" .. cmd.params[1],
-			cellRects[cellRectID][1] + cellPadding + math_floor(cellInnerSize * 0.96) - pad2,
-			cellRects[cellRectID][2] + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
+			cellRects[id].x + cellPadding + math_floor(cellInnerSize * 0.96) - pad2,
+			cellRects[id].y + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
 			cellInnerSize * 0.29, "ro"
 		)
 	end
@@ -1322,7 +1326,7 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		local hotkeyText = keyConfig.sanitizeKey(cmd.hotkey, currentLayout)
 
 		local hotkeyFontSize = priceFontSize * 1.1
-		font2:Print("\255\215\255\215" .. hotkeyText, cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.048), cellRects[cellRectID][4] - cellPadding - hotkeyFontSize, hotkeyFontSize, "o")
+		font2:Print("\255\215\255\215" .. hotkeyText, cellRects[id].x + cellPadding + (cellInnerSize * 0.048), cellRects[id].y - cellPadding - hotkeyFontSize, hotkeyFontSize, "o")
 	end
 end
 
@@ -1448,12 +1452,12 @@ local function drawGrid(activeArea)
 
 				local udef = uidcmds[uDefID]
 
-				cellRects[cellRectID] = {
+				cellRects[cellRectID] = Rect:new(
 					activeArea.x + (kcol - 1) * cellSize,
 					activeArea.yEnd - (rows - krow + 1) * cellSize,
 					activeArea.x + (kcol ) * cellSize,
-					activeArea.yEnd - (rows - krow) * cellSize,
-				}
+					activeArea.yEnd - (rows - krow) * cellSize
+				)
 
 				local cellIsSelected = (activeCmd and udef and activeCmd == udef.name) or
 					(preGamestartPlayer and selBuildQueueDefID == uDefID)
@@ -1487,44 +1491,44 @@ local function drawPaginators(activeArea)
 		local contentHeight = activeArea.yEnd - activeArea.y
 		local buttonHeight = contentHeight / 3
 
-		prevButtonRect = Rect:new(
+		prevPageRect = Rect:new(
 			activeArea.x + 6 * cellSize,
 			activeArea.y + activeAreaMargin,
 			activeArea.xEnd - bgpadding,
 			activeArea.y + buttonHeight
 		)
-		nextButtonRect = Rect:new(
-			prevButtonRect.x,
+		nextPageRect = Rect:new(
+			prevPageRect.x,
 			activeArea.y + 2 * buttonHeight,
-			prevButtonRect.xEnd,
+			prevPageRect.xEnd,
 			activeArea.y + 3 * buttonHeight
 		)
 
-		local buttonWidth = prevButtonRect.xEnd - prevButtonRect.x
+		local buttonWidth = prevPageRect.xEnd - prevPageRect.x
 
-		UiButton(prevButtonRect.x + cellPadding, prevButtonRect.y + cellPadding, prevButtonRect.xEnd - cellPadding, prevButtonRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print(prevKeyText, prevButtonRect.x + buttonWidth/2, prevButtonRect.y + (buttonHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
-		UiButton(nextButtonRect.x + cellPadding, nextButtonRect.y + cellPadding, nextButtonRect.xEnd - cellPadding, nextButtonRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print(nextKeyText, nextButtonRect.x + buttonWidth/2, nextButtonRect.y + (buttonHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
+		UiButton(prevPageRect.x + cellPadding, prevPageRect.y + cellPadding, prevPageRect.xEnd - cellPadding, prevPageRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print(prevKeyText, prevPageRect.x + buttonWidth/2, prevPageRect.y + (buttonHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
+		UiButton(nextPageRect.x + cellPadding, nextPageRect.y + cellPadding, nextPageRect.xEnd - cellPadding, nextPageRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print(nextKeyText, nextPageRect.x + buttonWidth/2, nextPageRect.y + (buttonHeight * 0.5) - paginatorFontSize * 0.25, paginatorFontSize, "co")
 
 		font2:Print("\255\245\245\245" .. currentPage .. "/" .. pages,
-			(prevButtonRect.x + prevButtonRect.xEnd) * 0.5,
-			prevButtonRect.yEnd + buttonHeight * 0.5 - paginatorFontSize * 0.25, paginatorFontSize, "co")
+			(prevPageRect.x + prevPageRect.xEnd) * 0.5,
+			prevPageRect.yEnd + buttonHeight * 0.5 - paginatorFontSize * 0.25, paginatorFontSize, "co")
 	else
 		local contentWidth = activeArea.xEnd - activeArea.x
 		local buttonWidth = math_floor(contentWidth * 0.33)
 
-		prevButtonRect = Rect:new(activeArea.x + activeAreaMargin, activeArea.y, activeArea.x + buttonWidth, activeArea.yEnd - 3 * cellSize)
-		nextButtonRect = Rect:new(activeArea.xEnd - buttonWidth, prevButtonRect.y, activeArea.xEnd, prevButtonRect.yEnd)
-		local buttonHeight = prevButtonRect.yEnd - prevButtonRect.y
+		prevPageRect = Rect:new(activeArea.x + activeAreaMargin, activeArea.y, activeArea.x + buttonWidth, activeArea.yEnd - 3 * cellSize)
+		nextPageRect = Rect:new(activeArea.xEnd - buttonWidth, prevPageRect.y, activeArea.xEnd, prevPageRect.yEnd)
+		local buttonHeight = prevPageRect.yEnd - prevPageRect.y
 
-		UiButton(prevButtonRect.x + cellPadding, prevButtonRect.y + bgpadding, prevButtonRect.xEnd + cellPadding, prevButtonRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print(prevKeyText, prevButtonRect.x + (buttonWidth * 0.5), prevButtonRect.yEnd - font2:GetTextHeight(prevKeyText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
-		UiButton(nextButtonRect.x + cellPadding, nextButtonRect.y + bgpadding, nextButtonRect.xEnd - cellPadding, nextButtonRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
-		font2:Print(nextKeyText, nextButtonRect.x + (buttonWidth * 0.5), nextButtonRect.yEnd - font2:GetTextHeight(nextKeyText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
+		UiButton(prevPageRect.x + cellPadding, prevPageRect.y + bgpadding, prevPageRect.xEnd + cellPadding, prevPageRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print(prevKeyText, prevPageRect.x + (buttonWidth * 0.5), prevPageRect.yEnd - font2:GetTextHeight(prevKeyText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
+		UiButton(nextPageRect.x + cellPadding, nextPageRect.y + bgpadding, nextPageRect.xEnd - cellPadding, nextPageRect.yEnd - cellPadding, 1,1,1,1, 1,1,1,1, nil, { 0, 0, 0, 0.8 }, { 0.2, 0.2, 0.2, 0.8 }, bgpadding * 0.5)
+		font2:Print(nextKeyText, nextPageRect.x + (buttonWidth * 0.5), nextPageRect.yEnd - font2:GetTextHeight(nextKeyText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
 
 		local pagesText = currentPage .. " / " .. pages
-		font2:Print("\255\245\245\245" .. pagesText, contentWidth * 0.5, prevButtonRect.yEnd - font2:GetTextHeight(pagesText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
+		font2:Print("\255\245\245\245" .. pagesText, contentWidth * 0.5, prevPageRect.yEnd - font2:GetTextHeight(pagesText) * paginatorFontSize * 0.25 - buttonHeight/2, paginatorFontSize, "co")
 	end
 end
 
@@ -1680,7 +1684,7 @@ local function drawBuildProgress()
 			local unitBuildDefID = spGetUnitDefID(unitBuildID)
 			if unitBuildDefID then
 				-- loop all shown cells
-				for cellRectID, _ in pairs(cellRects) do
+				for cellRectID, cellRect in pairs(cellRects) do
 					if not drawncellRectIDs[cellRectID] then
 						if cellRectID > maxCellRectID then
 							break
@@ -1689,7 +1693,7 @@ local function drawBuildProgress()
 						if unitBuildDefID == cellUnitDefID then
 							drawncellRectIDs[cellRectID] = true
 							local progress = 1 - select(5, spGetUnitHealth(unitBuildID))
-							RectRoundProgress(cellRects[cellRectID][1] + cellPadding + iconPadding, cellRects[cellRectID][2] + cellPadding + iconPadding, cellRects[cellRectID][3] - cellPadding - iconPadding, cellRects[cellRectID][4] - cellPadding - iconPadding, cellSize * 0.03, progress, { 0.08, 0.08, 0.08, 0.6 })
+							RectRoundProgress(cellRect.x + cellPadding + iconPadding, cellRect.y + cellPadding + iconPadding, cellRect.xEnd - cellPadding - iconPadding, cellRect.yEnd - cellPadding - iconPadding, cellSize * 0.03, progress, { 0.08, 0.08, 0.08, 0.6 })
 						end
 					end
 				end
@@ -1737,7 +1741,7 @@ function widget:DrawScreen()
 		end
 
 		local hovering = false
-		if math_isInRect(x, y, backgroundRect.x, backgroundRect.y, backgroundRect.xEnd, backgroundRect.yEnd) then
+		if backgroundRect:contains(x, y) then
 			Spring.SetMouseCursor('cursornormal')
 			hovering = true
 		end
@@ -1751,7 +1755,7 @@ function widget:DrawScreen()
 			if not WG['topbar'] or not WG['topbar'].showingQuit() then
 				if hovering then
 					for cellRectID, cellRect in pairs(cellRects) do
-						if math_isInRect(x, y, cellRect[1], cellRect[2], cellRect[3], cellRect[4]) then
+						if cellRect:contains(x, y) then
 							hoveredCellID = cellRectID
 							local cmd = cellcmds[cellRectID]
 							local uDefID = cmd.id * -1
@@ -1772,7 +1776,7 @@ function widget:DrawScreen()
 
 							-- highlight --if b and not disableInput then
 							gl.Blending(GL_SRC_ALPHA, GL_ONE)
-							RectRound(cellRects[cellRectID][1] + cellPadding, cellRects[cellRectID][2] + cellPadding, cellRects[cellRectID][3] - cellPadding, cellRects[cellRectID][4] - cellPadding, cellSize * 0.03, 1, 1, 1, 1, { 0, 0, 0, 0.1 * ui_opacity }, { 0, 0, 0, 0.1 * ui_opacity })
+							RectRound(cellRect.x + cellPadding, cellRect.y + cellPadding, cellRect.xEnd - cellPadding, cellRect.yEnd - cellPadding, cellSize * 0.03, 1, 1, 1, 1, { 0, 0, 0, 0.1 * ui_opacity }, { 0, 0, 0, 0.1 * ui_opacity })
 							gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 							break
 						end
@@ -1800,7 +1804,7 @@ function widget:DrawScreen()
 								end
 
 								local catKey = keyConfig.sanitizeKey(Cfgs.keyLayout[1][index], currentLayout)
-								text = text .. "\255\240\240\240Hotkey: " .. textColor .. "[" .. catKey .. "]"
+								text = text .. "\255\240\240\240 - Hotkey: " .. textColor .. "[" .. catKey .. "]"
 
 								WG['tooltip'].ShowTooltip('buildmenu', text, nil, nil, cat)
 							end
@@ -1832,15 +1836,15 @@ function widget:DrawScreen()
 
 					-- paginator buttons
 					local hoveredRect
-					if prevButtonRect.x and math_isInRect(x, y, prevButtonRect.x, prevButtonRect.y, prevButtonRect.xEnd, prevButtonRect.yEnd) then
-						hoveredRect = prevButtonRect
+					if prevPageRect.x and math_isInRect(x, y, prevPageRect.x, prevPageRect.y, prevPageRect.xEnd, prevPageRect.yEnd) then
+						hoveredRect = prevPageRect
 					end
-					if nextButtonRect.y and math_isInRect(x, y, nextButtonRect.x, nextButtonRect.y, nextButtonRect.xEnd, nextButtonRect.yEnd) then
-						hoveredRect = nextButtonRect
+					if nextPageRect.y and math_isInRect(x, y, nextPageRect.x, nextPageRect.y, nextPageRect.xEnd, nextPageRect.yEnd) then
+						hoveredRect = nextPageRect
 					end
 					if hoveredRect then
 						if WG['tooltip'] then
-							local text = "\255\240\240\240" .. (hoveredRect == prevButtonRect and Spring.I18N('ui.buildMenu.previousPage') or Spring.I18N('ui.buildMenu.nextPage'))
+							local text = "\255\240\240\240" .. (hoveredRect == prevPageRect and Spring.I18N('ui.buildMenu.previousPage') or Spring.I18N('ui.buildMenu.nextPage'))
 							WG['tooltip'].ShowTooltip('buildmenu', text)
 						end
 						RectRound(hoveredRect.x + cellPadding, hoveredRect.y + cellPadding, hoveredRect.xEnd - cellPadding, hoveredRect.yEnd - cellPadding, cellSize * 0.03, 2, 2, 2, 2, { 1, 1, 1, 0 }, { 1, 1, 1, (b and 0.35 or 0.15) })
@@ -2174,14 +2178,14 @@ function widget:MousePress(x, y, button)
 		return
 	end
 
-	if buildmenuShows and math_isInRect(x, y, backgroundRect.x, backgroundRect.y, backgroundRect.xEnd, backgroundRect.yEnd) then
+	if buildmenuShows and backgroundRect:contains(x, y) then
 		if selectedBuilder or selectedFactory or (preGamestartPlayer and startDefID) then
-			if paginatorRects[1] and math_isInRect(x, y, paginatorRects[1][1], paginatorRects[1][2], paginatorRects[1][3], paginatorRects[1][4]) then
+			if prevPageRect and prevPageRect:contains(x, y) then
 				currentPage = math_max(1, currentPage - 1)
 				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
 				doUpdate = true
 				return true
-			elseif paginatorRects[2] and math_isInRect(x, y, paginatorRects[2][1], paginatorRects[2][2], paginatorRects[2][3], paginatorRects[2][4]) then
+			elseif nextPageRect and nextPageRect:contains(x, y) then
 				currentPage = math_min(pages, currentPage + 1)
 				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
 				doUpdate = true
@@ -2207,7 +2211,7 @@ function widget:MousePress(x, y, button)
 				end
 
 				for cellRectID, cellRect in pairs(cellRects) do
-					if cellcmds[cellRectID].id and UnitDefs[-cellcmds[cellRectID].id].translatedHumanName and math_isInRect(x, y, cellRect[1], cellRect[2], cellRect[3], cellRect[4]) and not unitRestricted[-cellcmds[cellRectID].id] then
+					if cellcmds[cellRectID].id and UnitDefs[-cellcmds[cellRectID].id].translatedHumanName and cellRect:contains(x, y) and not unitRestricted[-cellcmds[cellRectID].id] then
 						if button ~= 3 then
 							Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
 
@@ -2230,6 +2234,7 @@ function widget:MousePress(x, y, button)
 			return true
 		end
 
+	-- i wish i had any idea what this code did
 	elseif preGamestartPlayer then
 		local mx, my = Spring.GetMouseState()
 		local _, pos = Spring.TraceScreenRay(mx, my, true)


### PR DESCRIPTION
### Overview
This is a significant rewrite/refactor of the grid UI drawing code, I plan to only make *very minimal* UI changes along with this (mostly going to be just like, padding changes)

The goal of this is to make the grid UI a little more flexible for some proposed additions and changes to the grid UI. I have several changes I am planning to make, some of which are done and some of which aren't
- Add a new `Rect` "class". I know this is a bit flakey with LUA, but it offers a lot of utility and readability that I don't believe is present with simple arrays.
- Assemble the main UI components as inter-dependent rects, so that things can be resized and moved around without hunting down a whole host of hardcoded placement values. All of these rects are assembled in `Resize` so they should be easy to find
- Greatly simplify initial element size logic in `Widget:Resize`
- Get rid of `activeArea` as a concept all together, now the buildpic area is a static rect that does not change size, so buildpics never move around. This obviously results in some ugly empty spaces (old way did too), and I would like to fill these with something nice, however right now I believe keeping the buildpic position consistent is a worthwhile fix, even with all the ugly shortfalls. **This is the only part of this PR that will make non-negligible visible UI changes**
- Use more consistent coordinates. The existing gridmenu UI code regularly vacillates between NDC (bottom-up Y coords) and more traditional top-down Y coords. This is *exceptionally* confusing and leaves footguns lying all over the place. While NDC is very annoying to work with, since we don't have a high-level UI framework to abstract away the reality of these coordinates, I think it would be better to just use NDC everywhere.
- General cleanup and organization

This is obviously still a WIP, but I wanted to get a working version posted so that others (mostly @badosu) are aware that this is happening so our work doesn't conflict too much

### Screenshots
#### Side

##### Before
![spring_nuLxqfzDa8](https://user-images.githubusercontent.com/3493638/233282974-7dffb27d-eb98-45c8-856b-4f216379c80a.png)
![spring_O0CM9Weiu5](https://user-images.githubusercontent.com/3493638/233282976-d1c5edae-27f3-423b-b4cc-cb38cc03c7fd.png)
![spring_fNL9KTHn1D](https://user-images.githubusercontent.com/3493638/233282979-36fb6eb8-918e-46e5-8a5e-066d4859754a.png)

##### After
![spring_1Z03DEMihT](https://user-images.githubusercontent.com/3493638/233283038-7f812c15-4a8b-4705-b9dc-0c137c47008f.png)
![spring_21BVyvALWK](https://user-images.githubusercontent.com/3493638/233283040-9459597d-914b-4262-8729-be54739127bc.png)
![spring_pXBdV2UVWB](https://user-images.githubusercontent.com/3493638/233283042-7f8605c2-657f-4c70-8d17-f8fbbedf5294.png)



#### Bottom

##### Before
![spring_bA70rT12af](https://user-images.githubusercontent.com/3493638/233283082-59e2d969-341e-4627-a447-4ac77d050157.png)
![spring_V2GtAtua9t](https://user-images.githubusercontent.com/3493638/233283084-52542dfb-49fd-4ef6-9dfa-560a9a1f1cdb.png)
![spring_XgwhkEzTl7](https://user-images.githubusercontent.com/3493638/233283085-72aeac20-2208-4552-9455-83e3d2647b7b.png)


##### After

![spring_8LAQ0rz4WB](https://user-images.githubusercontent.com/3493638/233283114-cb00c014-b17a-4462-9712-8101b4a18b8e.png)
![spring_8O1ol8uSbd](https://user-images.githubusercontent.com/3493638/233283116-45453946-854d-4ddb-8102-7e2f6a0038cb.png)
![spring_KMZzeutYhh](https://user-images.githubusercontent.com/3493638/233283117-7bb441bb-a235-4947-b8ef-37cb02ee0041.png)

