### PR TITLE
Grid UI design improvements

### DIFF
--- a/luaui/Widgets/gui_flowui.lua
+++ b/luaui/Widgets/gui_flowui.lua
@@ -599,6 +599,73 @@ WG.FlowUI.Draw.Button = function(px, py, sx, sy,  tl, tr, br, bl,  ptl, ptr, pbr
 	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
 end
 
+-- This was broken out from an internal "Unit" function, to allow drawing similar style icons in other places
+WG.FlowUI.Draw.TexRectRound = function(px, py, sx, sy,  cs,  tl, tr, br, bl,  offset)
+
+	local function drawTexCoordVertex(x, y)
+		local yc = 1 - ((y - py) / (sy - py))
+		local xc = (offset * 0.5) + ((x - px) / (sx - px)) + (-offset * ((x - px) / (sx - px)))
+		yc = 1 - (offset * 0.5) - ((y - py) / (sy - py)) + (offset * ((y - py) / (sy - py)))
+		gl.TexCoord(xc, yc)
+		gl.Vertex(x, y, 0)
+	end
+
+	-- mid section
+	drawTexCoordVertex(px + cs, py)
+	drawTexCoordVertex(sx - cs, py)
+	drawTexCoordVertex(sx - cs, sy)
+	drawTexCoordVertex(px + cs, sy)
+
+	-- left side
+	drawTexCoordVertex(px, py + cs)
+	drawTexCoordVertex(px + cs, py + cs)
+	drawTexCoordVertex(px + cs, sy - cs)
+	drawTexCoordVertex(px, sy - cs)
+
+	-- right side
+	drawTexCoordVertex(sx, py + cs)
+	drawTexCoordVertex(sx - cs, py + cs)
+	drawTexCoordVertex(sx - cs, sy - cs)
+	drawTexCoordVertex(sx, sy - cs)
+
+	-- bottom left
+	if bl ~= nil and bl == 0 then
+		drawTexCoordVertex(px, py)
+	else
+		drawTexCoordVertex(px + cs, py)
+	end
+	drawTexCoordVertex(px + cs, py)
+	drawTexCoordVertex(px + cs, py + cs)
+	drawTexCoordVertex(px, py + cs)
+	-- bottom right
+	if br ~= nil and br == 0 then
+		drawTexCoordVertex(sx, py)
+	else
+		drawTexCoordVertex(sx - cs, py)
+	end
+	drawTexCoordVertex(sx - cs, py)
+	drawTexCoordVertex(sx - cs, py + cs)
+	drawTexCoordVertex(sx, py + cs)
+	-- top left
+	if tl ~= nil and tl == 0 then
+		drawTexCoordVertex(px, sy)
+	else
+		drawTexCoordVertex(px + cs, sy)
+	end
+	drawTexCoordVertex(px + cs, sy)
+	drawTexCoordVertex(px + cs, sy - cs)
+	drawTexCoordVertex(px, sy - cs)
+	-- top right
+	if tr ~= nil and tr == 0 then
+		drawTexCoordVertex(sx, sy)
+	else
+		drawTexCoordVertex(sx - cs, sy)
+	end
+	drawTexCoordVertex(sx - cs, sy)
+	drawTexCoordVertex(sx - cs, sy - cs)
+	drawTexCoordVertex(sx, sy - cs)
+end
+
 --[[
 	Unit
 		draw a unit buildpic
@@ -617,78 +684,13 @@ WG.FlowUI.Draw.Unit = function(px, py, sx, sy,  cs,  tl, tr, br, bl,  zoom,  bor
 	local borderSize = borderSize~=nil and borderSize or math.min(math.max(1, math.floor((sx-px) * 0.024)), math.floor((WG.FlowUI.vsy*0.0015)+0.5))	-- set default with upper limit
 	local cs = cs~=nil and cs or math.max(1, math.floor((sx-px) * 0.024))
 
-	local function DrawTexRectRound(px, py, sx, sy,  cs,  tl, tr, br, bl,  offset)
-		local csyMult = 1 / ((sy - py) / cs)
 
-		local function drawTexCoordVertex(x, y)
-			local yc = 1 - ((y - py) / (sy - py))
-			local xc = (offset * 0.5) + ((x - px) / (sx - px)) + (-offset * ((x - px) / (sx - px)))
-			yc = 1 - (offset * 0.5) - ((y - py) / (sy - py)) + (offset * ((y - py) / (sy - py)))
-			gl.TexCoord(xc, yc)
-			gl.Vertex(x, y, 0)
-		end
-
-		-- mid section
-		drawTexCoordVertex(px + cs, py)
-		drawTexCoordVertex(sx - cs, py)
-		drawTexCoordVertex(sx - cs, sy)
-		drawTexCoordVertex(px + cs, sy)
-
-		-- left side
-		drawTexCoordVertex(px, py + cs)
-		drawTexCoordVertex(px + cs, py + cs)
-		drawTexCoordVertex(px + cs, sy - cs)
-		drawTexCoordVertex(px, sy - cs)
-
-		-- right side
-		drawTexCoordVertex(sx, py + cs)
-		drawTexCoordVertex(sx - cs, py + cs)
-		drawTexCoordVertex(sx - cs, sy - cs)
-		drawTexCoordVertex(sx, sy - cs)
-
-		-- bottom left
-		if bl ~= nil and bl == 0 then
-			drawTexCoordVertex(px, py)
-		else
-			drawTexCoordVertex(px + cs, py)
-		end
-		drawTexCoordVertex(px + cs, py)
-		drawTexCoordVertex(px + cs, py + cs)
-		drawTexCoordVertex(px, py + cs)
-		-- bottom right
-		if br ~= nil and br == 0 then
-			drawTexCoordVertex(sx, py)
-		else
-			drawTexCoordVertex(sx - cs, py)
-		end
-		drawTexCoordVertex(sx - cs, py)
-		drawTexCoordVertex(sx - cs, py + cs)
-		drawTexCoordVertex(sx, py + cs)
-		-- top left
-		if tl ~= nil and tl == 0 then
-			drawTexCoordVertex(px, sy)
-		else
-			drawTexCoordVertex(px + cs, sy)
-		end
-		drawTexCoordVertex(px + cs, sy)
-		drawTexCoordVertex(px + cs, sy - cs)
-		drawTexCoordVertex(px, sy - cs)
-		-- top right
-		if tr ~= nil and tr == 0 then
-			drawTexCoordVertex(sx, sy)
-		else
-			drawTexCoordVertex(sx - cs, sy)
-		end
-		drawTexCoordVertex(sx - cs, sy)
-		drawTexCoordVertex(sx - cs, sy - cs)
-		drawTexCoordVertex(sx, sy - cs)
-	end
 
 	-- draw unit
 	if texture then
 		gl.Texture(texture)
 	end
-	gl.BeginEnd(GL.QUADS, DrawTexRectRound, px, py, sx, sy,  cs,  tl, tr, br, bl,  zoom+0.02)
+	gl.BeginEnd(GL.QUADS, WG.FlowUI.Draw.TexRectRound, px, py, sx, sy,  cs,  tl, tr, br, bl,  zoom+0.02)
 	if texture then
 		gl.Texture(false)
 	end
@@ -725,7 +727,7 @@ WG.FlowUI.Draw.Unit = function(px, py, sx, sy,  cs,  tl, tr, br, bl,  zoom,  bor
 		local iconSize = math.floor((sx - px) * 0.3)
 		gl.Color(1, 1, 1, 0.9)
 		gl.Texture(groupTexture)
-		gl.BeginEnd(GL.QUADS, DrawTexRectRound, px, sy - iconSize, px + iconSize, sy,  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
+		gl.BeginEnd(GL.QUADS, WG.FlowUI.Draw.TexRectRound, px, sy - iconSize, px + iconSize, sy,  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
 		--	gl.TexRect(px, sy - iconSize, px + iconSize, sy)
 		gl.Texture(false)
 	end
@@ -734,7 +736,7 @@ WG.FlowUI.Draw.Unit = function(px, py, sx, sy,  cs,  tl, tr, br, bl,  zoom,  bor
 		local iconPadding = math.floor((sx - px) * 0.03)
 		gl.Color(1, 1, 1, 0.9)
 		gl.Texture(radarTexture)
-		gl.BeginEnd(GL.QUADS, DrawTexRectRound, sx - iconPadding - iconSize, py + iconPadding, sx - iconPadding, py + iconPadding + iconSize,  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
+		gl.BeginEnd(GL.QUADS, WG.FlowUI.Draw.TexRectRound, sx - iconPadding - iconSize, py + iconPadding, sx - iconPadding, py + iconPadding + iconSize,  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
 		--gl.TexRect(sx - iconPadding - iconSize, py + iconPadding, sx - iconPadding, py + iconPadding + iconSize)
 		gl.Texture(false)
 	end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -253,7 +253,6 @@ local catRects = {}
 local currentBuildCategory, currentCategoryIndex
 local currentPage = 1
 local pages = 1
-local prevPageRect = Rect:new(0, 0, 0, 0)
 local nextPageRect = Rect:new(0, 0, 0, 0)
 local categoriesRect = Rect:new(0, 0, 0, 0)
 local buildpicsRect = Rect:new(0, 0, 0 ,0)
@@ -1826,10 +1825,6 @@ function widget:DrawScreen()
 					end
 
 					-- paginator buttons
-					if prevPageRect.x and prevPageRect:contains(x, y) then
-						hoveredButton = prevPageRect:getId()
-						hoveredButtonNotFound = false
-					end
 					if nextPageRect.y and nextPageRect:contains(x, y) then
 						hoveredButton = nextPageRect:getId()
 						hoveredButtonNotFound = false
@@ -1839,9 +1834,9 @@ function widget:DrawScreen()
 						doUpdate = true
 					end
 
-					if hoveredButton == prevPageRect:getId() or hoveredButton == nextPageRect:getId() then
+					if hoveredButton == nextPageRect:getId() then
 						if WG['tooltip'] then
-							local text = "\255\240\240\240" .. (hoveredButton == prevPageRect:getId() and Spring.I18N('ui.buildMenu.previousPage') or Spring.I18N('ui.buildMenu.nextPage'))
+							local text = "\255\240\240\240" .. Spring.I18N('ui.buildMenu.nextPage')
 							WG['tooltip'].ShowTooltip('buildmenu', text)
 						end
 					end
@@ -2193,11 +2188,7 @@ function widget:MousePress(x, y, button)
 
 	if buildmenuShows and backgroundRect:contains(x, y) then
 		if selectedBuilder or selectedFactory or (preGamestartPlayer and startDefID) then
-			if prevPageRect and prevPageRect:contains(x, y) then
-				prevPageHandler()
-				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
-				return true
-			elseif nextPageRect and nextPageRect:contains(x, y) then
+			if nextPageRect and nextPageRect:contains(x, y) then
 				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
 				nextPageHandler()
 				return true

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1115,7 +1115,7 @@ function widget:ViewResize()
 			posX,
 			posYEnd,
 			posXEnd,
-			paginatorsRect.yEnd + (bgpadding * 2)
+			paginatorsRect.yEnd + (bgpadding * 1.5)
 		)
 	end
 
@@ -1265,7 +1265,6 @@ local function drawButton(rect, opts, icon)
 
 	if hovered then
 		-- gloss highlight
-		local pad = 0
 		gl.Blending(GL_SRC_ALPHA, GL_ONE)
 		RectRound(rect.x, rect.yEnd - ((rect.yEnd - rect.y) * 0.42), rect.xEnd, (rect.yEnd), padding * 1.5, 2, 2, 0, 0, { 1, 1, 1, 0.035 }, { 1, 1, 1, (disableInput and 0.11 or 0.24) })
 		RectRound(rect.x, rect.y, rect.xEnd, (rect.y) + ((rect.yEnd - rect.y) * 0.5), padding * 1.5, 0, 0, 2, 2, { 1, 1, 1, (disableInput and 0.035 or 0.075) }, { 1, 1, 1, 0 })
@@ -1287,7 +1286,7 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 		gl.Color(1, 1, 1, 1)
 	end
 
-	local showIcon = showGroupIcon and not (selectedFactory or currentCategoryIndex)
+	local showIcon = showGroupIcon and not (currentCategoryIndex)
 	local cellRect = cellRects[id];
 
 	UiUnit(
@@ -1344,27 +1343,33 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 		font2:Print(text .. unitEnergyCost[uid], cellRect.x + cellPadding + (cellInnerSize * 0.048), cellRect.y + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
 	end
 
-	-- factory queue number
-	if cmd.params[1] then
-		local pad = math_floor(cellInnerSize * 0.03)
-		local textWidth = math_floor(font2:GetTextWidth(cmd.params[1] .. '	') * cellInnerSize * 0.285)
-		local pad2 = 0
-		RectRound(cellRect.xEnd - cellPadding - iconPadding - textWidth - pad2, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2, cellRect.xEnd - cellPadding - iconPadding, cellRect.yEnd - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 0, 1, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
-		RectRound(cellRect.xEnd - cellPadding - iconPadding - textWidth - pad2, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.15) - pad2, cellRect.xEnd - cellPadding - iconPadding, cellRect.yEnd - cellPadding - iconPadding, 0, 0, 0, 0, 0, { 1, 1, 1, 0 }, { 1, 1, 1, 0.05 })
-		RectRound(cellRect.xEnd - cellPadding - iconPadding - textWidth - pad2 + pad, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365) - pad2 + pad, cellRect.xEnd - cellPadding - iconPadding - pad2, cellRect.yEnd - cellPadding - iconPadding - pad2, cornerSize * 2.6, 0, 0, 0, 1, { 0.7, 0.7, 0.7, 0.1 }, { 1, 1, 1, 0.1 })
-		font2:Print("\255\190\255\190" .. cmd.params[1],
-			cellRect.x + cellPadding + math_floor(cellInnerSize * 0.96) - pad2,
-			cellRect.y + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
-			cellInnerSize * 0.29, "ro"
-		)
-	end
-
+	-- hotkey draw
 	if cmd.hotkey and (selectedFactory or (selectedBuilder and currentBuildCategory)) then
 		local hotkeyText = keyConfig.sanitizeKey(cmd.hotkey, currentLayout)
 
 		local hotkeyFontSize = priceFontSize * 1.1
-		font2:Print("\255\215\255\215" .. hotkeyText, cellRect.x + cellPadding + (cellInnerSize * 0.048), cellRect.yEnd - cellPadding - hotkeyFontSize, hotkeyFontSize, "o")
+		font2:Print("\255\215\255\215" .. hotkeyText, cellRect.xEnd - cellPadding - (cellInnerSize * 0.048), cellRect.yEnd - cellPadding - hotkeyFontSize, hotkeyFontSize, "ro")
 	end
+
+
+	-- factory queue number
+	if cmd.params[1] then
+		local queueFontSize = cellInnerSize * 0.29
+		local pad = math_floor(cellInnerSize * 0.03)
+		local textWidth = font2:GetTextWidth(cmd.params[1] .. '	') * queueFontSize
+		RectRound(cellRect.x, cellRect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365), cellRect.x + textWidth, cellRect.yEnd - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 1, 0, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
+		font2:Print("\255\190\255\190" .. cmd.params[1],
+			cellRect.x + cellPadding + (pad * 3.5),
+			cellRect.y + cellPadding + math_floor(cellInnerSize * 0.735),
+			queueFontSize, "o"
+		)
+	end
+end
+
+local function drawEmptyCell(rect)
+	local color = { 0.1, 0.1, 0.1, 0.7 }
+	local pad = cellPadding + iconPadding
+	RectRound(rect.x + pad, rect.y + pad, rect.xEnd - pad, rect.yEnd - pad, cornerSize, 1, 1, 1, 1, color, color)
 end
 
 local function drawButtonHotkey(rect, keyText)
@@ -1517,6 +1522,13 @@ local function drawGrid()
 				curCmd = curCmd + 1
 			end
 
+			 local rect = Rect:new(
+				buildpicsRect.x + (kcol - 1) * cellSize,
+				buildpicsRect.yEnd - (rows - krow + 1) * cellSize,
+				buildpicsRect.x + (kcol ) * cellSize,
+				buildpicsRect.yEnd - (rows - krow) * cellSize
+			 )
+
 			if uDefID and uidcmds[uDefID] then
 				cellcmds[cellRectID] = uidcmds[uDefID]
 
@@ -1525,12 +1537,7 @@ local function drawGrid()
 
 				local udef = uidcmds[uDefID]
 
-				cellRects[cellRectID] = Rect:new(
-					buildpicsRect.x + (kcol - 1) * cellSize,
-					buildpicsRect.yEnd - (rows - krow + 1) * cellSize,
-					buildpicsRect.x + (kcol ) * cellSize,
-					buildpicsRect.yEnd - (rows - krow) * cellSize
-				)
+				cellRects[cellRectID] = rect
 
 				local cellIsSelected = (activeCmd and udef and activeCmd == udef.name) or
 					(preGamestartPlayer and selBuildQueueDefID == uDefID)
@@ -1542,6 +1549,7 @@ local function drawGrid()
 
 				drawCell(cellRectID, usedZoom, cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil, nil, unitRestricted[uDefID])
 			else
+				drawEmptyCell(rect)
 				hotkeyActions[tostring(arow) .. tostring(coll)] = nil
 			end
 		end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -181,10 +181,10 @@ local buildmenuShows = false
 Rect = {}
 function Rect:new(x1, y1, x2, y2)
 	local this = {
-		x = x1;
-		y = y1;
-		xEnd = x2;
-		yEnd = y2;
+		x = x1,
+		y = y1,
+		xEnd = x2,
+		yEnd = y2
 	}
 
 	function this:contains(x, y)
@@ -195,9 +195,8 @@ function Rect:new(x1, y1, x2, y2)
 		return self.x + self.y + self.yEnd + self.xEnd
 	end
 
-	return this;
+	return this
 end
-
 
 
 -------------------------------------------------------------------------------
@@ -1031,7 +1030,6 @@ function widget:ViewResize()
 		cellSize = math_floor(((height) - bgpadding) / rows)
 
 		local categoryWidth = 8 * categoryFontSize * ui_scale
-		local pageButtonWidth = categoryWidth / 3
 
 		-- assemble rects left to right
 		categoriesRect = Rect:new(
@@ -1286,7 +1284,7 @@ local function drawCell(id, usedZoom, cellColor, disabled)
 	end
 
 	local showIcon = showGroupIcon and not (currentCategoryIndex)
-	local cellRect = cellRects[id];
+	local cellRect = cellRects[id]
 
 	UiUnit(
 		cellRect.x + cellPadding + iconPadding,
@@ -1447,7 +1445,6 @@ local function drawPaginators()
 		return
 	end
 
-	local prevKeyText = "\255\215\255\215".. keyConfig.sanitizeKey(Cfgs.PREV_PAGE_KEY, currentLayout)
 	local nextKeyText = keyConfig.sanitizeKey(Cfgs.NEXT_PAGE_KEY, currentLayout)
 	local nextPageText = "\255\245\245\245" .. "Next Page    ➞"
 	local pagesText = "\255\245\245\245" .. currentPage .. " / " .. pages
@@ -2236,7 +2233,7 @@ function widget:MousePress(x, y, button)
 			return true
 		end
 
-	-- i wish i had any idea what this code did
+	-- Special handling for buildings before game start, since there isn't yet a unit spawned to give normal orders to
 	elseif preGamestartPlayer then
 		local mx, my = Spring.GetMouseState()
 		local _, pos = Spring.TraceScreenRay(mx, my, true)


### PR DESCRIPTION
### Changes

- Category buttons are now on the bottom, since the category keys are the bottom row of grid keys by default (ZXCV) this makes more intuitive sense.
- Category buttons now have icons that match their purpose
- Hotkey indicators no longer have brackets
- Paging buttons are simplified to a single button that rotates through all the pages
- Paging buttons are now on the top in the default left-side menu, and under the category buttons on the bottom-oriented menu
- Hotkey indicators are now on the top-right of buildpics
- Since hotkeys are on the top-right, category icons are now added to the top-left
- Factory queue placement is now in the top-left and draws over the category icon
- (experimental) Empty spaces in the grid now have a semi-opaque empty buildpic

I think that's everything :)

### Screenshots
![spring_kWtSwZupOg](https://user-images.githubusercontent.com/3493638/233818803-80b1c8af-5911-40c5-9623-cde4d0d52f01.png)
![spring_2Syi2tKQI0](https://user-images.githubusercontent.com/3493638/233818804-89f61e87-cdce-4641-b54f-a6dc0e61e909.png)
![spring_2uppPRXns7](https://user-images.githubusercontent.com/3493638/233818805-0de8555a-5289-4b5f-b415-21b022a7e57c.png)
![spring_UomwFu0lEe](https://user-images.githubusercontent.com/3493638/233818807-6d237c16-ab5e-41a0-a65d-182acddcfd26.png)


