### PR TITLE
Add overview camera TAB hold widget

### DIFF
--- a/luaui/Widgets/gui_overview_cam_tab_hold.lua
+++ b/luaui/Widgets/gui_overview_cam_tab_hold.lua
@@ -1,0 +1,66 @@
+
+-- Hold 'tab' button for Overview camera
+-- Release 'tab' to go back to original view instead zooming into cursor
+-- Short 'tab' are ignored
+
+function widget:GetInfo()
+	return {
+		name = "Overview Camera TAB hold & release",
+		desc = "TAB button works as hold & release",
+		author = "klakier",
+		date = "Maj 8, 2023",
+		license = "GNU GPL, v2 or later",
+		layer = 1,
+		enabled = true
+	}
+end
+
+include("keysym.h.lua")
+
+local keyActivate = KEYSYMS.TAB -- hold this button to switch to Overview
+local isLongPress = false; -- enabled when user presses tab for longer
+
+local prevCamState = nil;
+
+function widget:KeyPress(key, modifier, isRepeat)
+	if key ~= keyActivate then
+		return false
+	end;
+
+	local camState = Spring.GetCameraState()
+	local isOverview = camState.name == "ov"
+
+	if (isOverview and isRepeat) then
+		isLongPress = true;
+		return true
+	else
+		prevCamState = camState;
+	end
+
+	-- legacy behavior here
+	Spring.SendCommands({ "toggleoverview" })
+	return true
+end
+
+function widget:KeyRelease(key, modifier)
+	if key ~= keyActivate then
+		return false
+	end
+
+	if isLongPress ~= true then
+		return false
+	end
+
+	local camState = Spring.GetCameraState()
+	local isOverview = camState.name == "ov"
+
+	isLongPress = false;
+
+	if prevCamState ~= nil and isOverview then
+		Spring.SendCommands({ "toggleoverview" })
+		Spring.SetCameraState(prevCamState, 1)
+		return true
+	end
+
+	return false
+end

--- a/luaui/Widgets/gui_overview_cam_tab_hold.lua
+++ b/luaui/Widgets/gui_overview_cam_tab_hold.lua
@@ -15,15 +15,39 @@ function widget:GetInfo()
 	}
 end
 
-include("keysym.h.lua")
 
-local keyActivate = KEYSYMS.TAB -- hold this button to switch to Overview
+local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
+local camKeys = {} -- list of buttons that switch to Overview
 local isLongPress = false; -- enabled when user presses tab for longer
-
 local prevCamState = nil;
 
+
+local function setActionHotkeys(action)
+	camKeys = {}
+	local keyTable = Spring.GetActionHotKeys(action)
+	for _, key in pairs(keyTable) do
+		local btn = keyConfig.sanitizeKey(key):upper()
+		table.insert(camKeys, btn)
+	end
+end
+
+-- works only with single key binds
+local function isCamKey(keyNum)
+	local pressedSymbol = Spring.GetKeySymbol(keyNum):upper()
+	for _, symbol in pairs(camKeys) do
+		if pressedSymbol == symbol then
+			return true
+		end
+	end
+	return false
+end
+
+function widget:Initialize()
+	setActionHotkeys("toggleoverview")
+end
+
 function widget:KeyPress(key, modifier, isRepeat)
-	if key ~= keyActivate then
+	if not isCamKey(key) then
 		return false
 	end;
 
@@ -38,12 +62,11 @@ function widget:KeyPress(key, modifier, isRepeat)
 	end
 
 	-- legacy behavior here
-	Spring.SendCommands({ "toggleoverview" })
-	return true
+	return false
 end
 
 function widget:KeyRelease(key, modifier)
-	if key ~= keyActivate then
+	if not isCamKey(key) then
 		return false
 	end
 


### PR DESCRIPTION
this widget activates overview camera as long as TAB button is held. Releasing it will go back to last camera position instead of zooming into cursor.
Short key (legacy) presses are kept without change.
Let me know what changes would you like to see to make this widget enabled by default.
Without this widget holding TAB button makes the camera erratically zoom-in and out.
Demo: https://streamable.com/izgnv5 