### PR TITLE
show invert mouse option in basic camera menu

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3043,7 +3043,7 @@ function init()
 			  end
 		  end,
 		},
-		{ id = "invertmouse", group = "control", category = types.dev, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.invertmouse'), type = "bool", value = tonumber(Spring.GetConfigInt("InvertMouse", 0)) == 1, description = "",
+		{ id = "invertmouse", group = "control", category = types.basic, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.invertmouse'), type = "bool", value = tonumber(Spring.GetConfigInt("InvertMouse", 0)) == 1, description = "",
 		  onload = function(i)
 		  end,
 		  onchange = function(i, value)


### PR DESCRIPTION
every day there's at least one person asking about inverting mouse drag behavior on reddit/game chat/discord and people tend to suggest either 
a) switch camera to f3 or f4 (both cameras respect the setting below but in opposite way)
b) use /set InvertMouse 0 or 1
but why not just give people it in gui