### PR TITLE
Return to previous camera position when tabbing out of overview

### DIFF
--- a/luaui/Widgets/gui_overview_keep_camera_position.lua
+++ b/luaui/Widgets/gui_overview_keep_camera_position.lua
@@ -37,11 +37,6 @@ end
 
 -- HELPER FUNCTIONS
 
-local function isScrollUpKey(keyNum)
-	-- todo, this
-	return false
-end
-
 -- works only with single key binds
 local function isCamKey(keyNum)
 	local pressedSymbol = Spring.GetKeySymbol(keyNum):upper()
@@ -60,13 +55,17 @@ end
 
 -- BUSINESS LOGIC
 
-local function handleScrollUp()
-	if isOverview() then
+function widget:MouseWheel(up, value)
+	if isOverview() and up then
 		Spring.SendCommands({ "toggleoverview" })
+		return true;
 	end
+	
+	--legacy behavior here
+	return false
 end
 
-local function handleCamKey()
+function widget:KeyPress(key, modifier)
 	if isOverview() then
 		if prevCamState ~= nil then
 			Spring.SetCameraState(prevCamState, 1)
@@ -75,28 +74,3 @@ local function handleCamKey()
 		prevCamState = Spring.GetCameraState()
 	end
 end
-
-function widget:KeyPress(key, modifier)
-	if isScrollUpKey(key) then
-		handleScrollUp()
-	elseif isCamKey(key) then
-		handleCamKey()
-	end
-end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/luaui/Widgets/gui_overview_keep_camera_position.lua
+++ b/luaui/Widgets/gui_overview_keep_camera_position.lua
@@ -1,0 +1,63 @@
+
+-- When the overview closes, the camera returns to its previous position
+
+function widget:GetInfo()
+	return {
+		name = "Overview Camera Keep Position",
+		desc = "When the overview closes, the camera returns to its previous position",
+		author = "FlexTerror",
+		date = "May 13, 2023",
+		license = "GNU GPL, v2 or later",
+		layer = 1,
+		enabled = true
+	}
+end
+
+
+local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
+local camKeys = {} -- list of buttons that switch to Overview
+local prevCamState = nil;
+
+
+local function storeCamKeys()
+	camKeys = {}
+	local keyTable = Spring.GetActionHotKeys("toggleoverview")
+	for _, key in pairs(keyTable) do
+		local btn = keyConfig.sanitizeKey(key):upper()
+		table.insert(camKeys, btn)
+	end
+end
+
+-- works only with single key binds
+local function isCamKey(keyNum)
+	local pressedSymbol = Spring.GetKeySymbol(keyNum):upper()
+	for _, symbol in pairs(camKeys) do
+		if pressedSymbol == symbol then
+			return true
+		end
+	end
+	return false
+end
+
+function widget:Initialize()
+	storeCamKeys()
+end
+
+function widget:KeyPress(key, modifier)
+	if not isCamKey(key) then
+		return
+	end
+
+	local camState = Spring.GetCameraState()
+	local isOverview = camState.name == "ov"
+
+
+	if not isOverview then
+		-- Entering overview
+		prevCamState = camState;
+		return
+	else
+		-- Leaving overview
+		Spring.SetCameraState(prevCamState, 1)
+	end
+end


### PR DESCRIPTION
When tabbing out of the overview, the camera DOES NOT "zoom-to-cursor"
When scrolling out of the overview, the camera DOES "zoom-to-cursor"
