### PR TITLE
Enable converter efficiency icon by default

### DIFF
--- a/luaui/Widgets/gui_converter_usage.lua
+++ b/luaui/Widgets/gui_converter_usage.lua
@@ -6,7 +6,7 @@ function widget:GetInfo()
       date      = "05.08.2022",
 	  license   = "GNU GPL, v2 or later",
       layer     = 0,
-      enabled   = false  --  loaded by default?
+      enabled   = true  --  loaded by default?
     }
   end
 


### PR DESCRIPTION
We tell people to enable it during every academy event (well, unless we forget 😅). I suspect that the fact that this isn't enabled by default contributes to newbies overbuilding converters. It isn't said anywhere explicitly that "yellow and glowy" = producing resources, and that if your converters are mostly closed up, you're being rather inefficient.