### PR TITLE
Pass projectileID when spawning explosion

### DIFF
--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -42,6 +42,7 @@ local function addVolumetricDamage(projectileID)
 	local explosionParame ={
 		weaponDef = weaponDefID,
 		owner = ownerID,
+		projectileID = projectileID,
 		damages = dgunWeapons[weaponDefID].damages,
 		hitUnit = 1,
 		hitFeature = 1,


### PR DESCRIPTION
So that UnitPreDamaged is passed the ID of the shot that was fired, instead of -1