### PR TITLE
Increase the size of category buttons on gridmenu

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -995,6 +995,7 @@ function widget:ViewResize()
 	categoryFontSize = 0.0115 * ui_scale * vsy
 	pageFontSize = categoryFontSize
 	pageButtonHeight = math_floor(2.3 * categoryFontSize * ui_scale)
+	categoryButtonHeight = pageButtonHeight;
 
 	activeAreaMargin = math_ceil(bgpadding * Cfgs.cfgActiveAreaMargin)
 
@@ -1071,12 +1072,14 @@ function widget:ViewResize()
 		-- make pixel aligned
 		width = posXEnd - posX
 
+		categoryButtonHeight = pageButtonHeight * 1.4
+
 		-- assemble rects, bottom to top
 		categoriesRect = Rect:new(
 			posX + bgpadding,
 			posYEnd + bgpadding,
 			posXEnd - bgpadding,
-			posYEnd + pageButtonHeight + bgpadding
+			posYEnd + categoryButtonHeight + bgpadding
 		)
 
 		rows = 3
@@ -1397,9 +1400,9 @@ local function drawCategories()
 		for i, cat in ipairs(categories) do
 			local x1 = categoriesRect.x + (i - 1) * buttonWidth
 			catRects[cat] = Rect:new(
-				x1 + padding,
-				y2 - pageButtonHeight + padding,
-				x1 + buttonWidth - padding,
+				x1,
+				y2 - categoryButtonHeight + padding,
+				x1 + buttonWidth,
 				y2 - activeAreaMargin - padding
 			)
 		end


### PR DESCRIPTION
Just a small size increase on the left-side gridmenu, the buttons were a little hard to notice for some players before

![spring_FMmEBvtVHX](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/f52c05a2-e699-4485-9d1e-0eb4d76baaf0)

![spring_vdps0Q9NNJ](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/e23be62a-3571-446c-980b-ca893c4419ee)
