### PR TITLE
swap lower laser aim angles

### DIFF
--- a/units/CorGantry/corjugg.lua
+++ b/units/CorGantry/corjugg.lua
@@ -235,13 +235,13 @@ return {
 			},
 			[2] = {
 				def = "JUGGERNAUT_BOTTOM",
-				maindir = "1 0 4",
+				maindir = "-1 0 4",
 				maxangledif = 90,
 				onlytargetcategory = "SURFACE",
 			},
 			[3] = {
 				def = "JUGGERNAUT_BOTTOM",
-				maindir = "-1 0 4",
+				maindir = "1 0 4",
 				maxangledif = 90,
 				onlytargetcategory = "SURFACE",
 			},


### PR DESCRIPTION
The wrong firing arcs were assigned to the lower lasers on the behemoth, corjugg. Firing arcs have been swapped. 