### PR TITLE
Explicitly exclude spectators from ready checks

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -176,8 +176,11 @@ if gadgetHandler:IsSyncedCode() then
 			local playerList = Spring.GetPlayerList()
 			local all_players_joined = true
 			for _, PID in pairs(playerList) do
-				if Spring.GetGameRulesParam("player_" .. PID .. "_joined") == nil then
-					all_players_joined = false
+				local _, _, spectator_flag = Spring.GetPlayerInfo(PID)
+				if spectator_flag == false then
+					if Spring.GetGameRulesParam("player_" .. PID .. "_joined") == nil then
+						all_players_joined = false
+					end
 				end
 			end
 			if all_players_joined == true then

--- a/luaui/Widgets/gui_pregameui.lua
+++ b/luaui/Widgets/gui_pregameui.lua
@@ -184,10 +184,13 @@ function widget:GameSetup(state, ready, playerStates)
 	ready = true
 	local playerList = Spring.GetPlayerList()
 	for _, playerID in pairs(playerList) do
-		local is_player_ready = Spring.GetGameRulesParam("player_" .. playerID .. "_readyState")
-		--Spring.Echo(playerID,is_player_ready)
-		if is_player_ready == 0 or is_player_ready == 4 then
-			ready = false
+		local _, _, spectator_flag = Spring.GetPlayerInfo(playerID)
+		if spectator_flag == false then
+			local is_player_ready = Spring.GetGameRulesParam("player_" .. playerID .. "_readyState")
+			--Spring.Echo(#playerList, playerID, is_player_ready)
+			if is_player_ready == 0 or is_player_ready == 4 then
+				ready = false
+			end
 		end
 	end
 


### PR DESCRIPTION
This should fix an issue where spectators, or a startscript with numplayers > real players, prevents the game from starting when all players have readied. 