### PR TITLE
Increase missile flight time, 3 -> 4 sec

### DIFF
--- a/units/ArmBots/T2/armsptk.lua
+++ b/units/ArmBots/T2/armsptk.lua
@@ -123,7 +123,7 @@ return {
 				edgeeffectiveness = 0.65,
 				explosiongenerator = "custom:genericshellexplosion-small-bomb",
 				firestarter = 70,
-				flighttime = 3,
+				flighttime = 4,
 				impulseboost = 0.123,
 				impulsefactor = 0.123,
 				model = "cormissile2.s3o",


### PR DESCRIPTION
With the addition of burnblow, missiles were exploding just a little bit too early (instead of running out of fuel and crashing to the ground). Exploding shortly before maximum range on flat ground, and exploding far above ground when the recluse was firing down from a plateau or cliff face. 

This should allow missiles to reach their target when fired from an elevated position, but should still detonate/kill the missile before an errant missile flies too far out of range.