### PR TITLE
Fix KeyChainTimeout not loading

### DIFF
--- a/luaintro/springconfig.lua
+++ b/luaintro/springconfig.lua
@@ -161,13 +161,18 @@ Spring.SetConfigInt("VSync", Spring.GetConfigInt("VSyncGame", -1))
 local springKeyChainTimeout = 750 -- expected engine default in ms
 local barKeyChainTimeout = 333 -- the setting we want to apply in ms
 local userKeyChainTimeout = Spring.GetConfigInt("KeyChainTimeout")
--- Only apply BARs default if current setting is equal to engine default
+
+-- Apply BAR's default if current setting is equal to engine default OR BAR's default
 -- Reason is engine is unable to distinguish between:
 --   - user configuring the setting to be equal to default
 --   - the actual setting being empty and engine using default
-if userKeyChainTimeout == springKeyChainTimeout then
+if userKeyChainTimeout == springKeyChainTimeout or userKeyChainTimeout == barKeyChainTimeout then
 	-- Setting a standardized keychain timeout, 750ms is too long
 	-- A side benefit of making it smaller is reduced complexity of actions handling
 	-- since there are fewer complex and long chains between keystrokes
 	Spring.SetConfigInt("KeyChainTimeout", barKeyChainTimeout)
+else
+	-- If user has configured a custom KeyChainTimeout, restore this setting
+	Spring.SetConfigInt("KeyChainTimeout", userKeyChainTimeout)
 end
+


### PR DESCRIPTION
if it's engine default or bar default, use bar default, but if it's user configured, use user configuration

See https://github.com/beyond-all-reason/spring/issues/831 for more details

credit to resopmok for catching this originally.