### PR TITLE
Gridmenu/Buildmenu unit sorting and category handling refactor

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -32,7 +32,6 @@ local dynamicIconsize = true
 local minColls = 4
 local maxColls = 5
 
-local showOrderDebug = false
 local smartOrderUnits = true
 
 local maxPosY = 0.74
@@ -67,29 +66,6 @@ local buildmenuShows = false
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 
-local unbaStartBuildoptions = {}
-if Spring.GetModOptions().unba then
-	VFS.Include("unbaconfigs/buildoptions.lua")
-	for unitname,level in pairs(ArmBuildOptions) do
-		if level == 1 then
-			unbaStartBuildoptions[UnitDefNames[unitname].id] = unitname
-		end
-	end
-	ArmBuildOptions = nil
-	for unitname,level in pairs(CorBuildOptions) do
-		if level == 1 then
-			unbaStartBuildoptions[UnitDefNames[unitname].id] = unitname
-		end
-	end
-	CorBuildOptions = nil
-	ArmDefsBuildOptions = nil
-	CorDefsBuildOptions = nil
-	ArmBuildOptionsStop = nil
-	CorBuildOptionsStop = nil
-else
-	unbaStartBuildoptions = nil
-end
-
 local playSounds = true
 local sound_queue_add = 'LuaUI/Sounds/buildbar_add.wav'
 local sound_queue_rem = 'LuaUI/Sounds/buildbar_rem.wav'
@@ -103,6 +79,8 @@ local advplayerlistLeft = vsx * 0.8
 
 local ui_opacity = tonumber(Spring.GetConfigFloat("ui_opacity", 0.7) or 0.6)
 local ui_scale = tonumber(Spring.GetConfigFloat("ui_scale", 1) or 1)
+
+local units = VFS.Include("luaui/configs/gridmenu_categories.lua")
 
 local isSpec = Spring.GetSpectatingState()
 local myTeamID = Spring.GetMyTeamID()
@@ -145,7 +123,6 @@ local spGetCmdDescIndex = Spring.GetCmdDescIndex
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetTeamRulesParam = Spring.GetTeamRulesParam
 local spGetMouseState = Spring.GetMouseState
-local spTraceScreenRay = Spring.TraceScreenRay
 local spGetUnitHealth = Spring.GetUnitHealth
 local spGetUnitIsBuilding = Spring.GetUnitIsBuilding
 
@@ -195,114 +172,6 @@ local groups = {
 }
 
 local disableWind = ((Game.windMin + Game.windMax) / 2) < 5
-
-local unitEnergyCost = {}
-local unitMetalCost = {}
-local unitGroup = {}
-local unitRestricted = {}
-local unitDisabled = {}
-local isBuilder = {}
-local isFactory = {}
-local unitIconType = {}
-local isMex = {}
-local isWaterUnit = {}
-local isGeothermalUnit = {}
-local unitMaxWeaponRange = {}
-local unitName = {}
-
-for unitDefID, unitDef in pairs(UnitDefs) do
-	unitName[unitDefID] = unitDef.name
-	unitIconType[unitDefID] = unitDef.iconType
-	unitEnergyCost[unitDefID] = unitDef.energyCost
-	unitMetalCost[unitDefID] = unitDef.metalCost
-	unitGroup[unitDefID] = unitDef.customParams.unitgroup
-
-	if unitDef.name == 'armdl' or unitDef.name == 'cordl' or unitDef.name == 'armlance' or unitDef.name == 'cortitan'
-		or (unitDef.minWaterDepth > 0 or unitDef.modCategories['ship']) then
-		if not (unitDef.modCategories['hover'] or (unitDef.modCategories['mobile'] and unitDef.modCategories['canbeuw'])) then
-			isWaterUnit[unitDefID] = true
-		end
-	end
-	if unitDef.maxWeaponRange > 16 then
-		unitMaxWeaponRange[unitDefID] = unitDef.maxWeaponRange
-	end
-	if unitDef.maxThisUnit == 0 then --or unitDef.name == 'armllt' or unitDef.name == 'armmakr' then
-		unitRestricted[unitDefID] = true
-	end
-	if unitDef.buildSpeed > 0 and unitDef.buildOptions[1] then
-		isBuilder[unitDefID] = unitDef.buildOptions
-	end
-	if unitDef.isFactory and #unitDef.buildOptions > 0 then
-		isFactory[unitDefID] = true
-	end
-	if unitDef.extractsMetal > 0 then
-		isMex[unitDefID] = true
-	end
-	if unitDef.needGeo then
-		isGeothermalUnit[unitDefID] = true
-	end
-	if unitDef.windGenerator > 0 and disableWind then
-		unitDisabled[unitDefID] = true
-	end
-end
-
-local unitOrder = {}
-local unitOrderManualOverrideTable = VFS.Include("luaui/configs/buildmenu_sorting.lua")
-
-for unitDefID, unitDef in pairs(UnitDefs) do
-	if unitOrderManualOverrideTable[unitDefID] then
-		unitOrder[unitDefID] = -unitOrderManualOverrideTable[unitDefID]
-	else
-		unitOrder[unitDefID] = 9999999
-	end
-end
-
-local function getHighestOrderedUnit()
-	local highest = { 0, 0, false }
-	local firstOrderTest = true
-	local newSortingUnit = {}
-	for unitDefID, orderValue in pairs(unitOrder) do
-
-		if unitOrderManualOverrideTable[unitDefID] then
-			newSortingUnit[unitDefID] = true
-		else
-			newSortingUnit[unitDefID] = false
-		end
-
-		if firstOrderTest == true then
-			firstOrderTest = false
-			highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-		--elseif orderValue > highest[2] then
-		elseif highest[3] == false and newSortingUnit[unitDefID] == true then
-			highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-		elseif highest[3] == false and newSortingUnit[unitDefID] == false then
-			if orderValue > highest[2] then
-				highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-			end
-		elseif highest[3] == true and newSortingUnit[unitDefID] == true then
-			if orderValue > highest[2] then
-				highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-			end
-		end
-	end
-	return highest[1]
-end
-
-local unitsOrdered = {}
-local unitOrderDebug = {}
-for unitDefID, unitDef in pairs(UnitDefs) do
-	local uDefID = getHighestOrderedUnit()
-	unitsOrdered[#unitsOrdered + 1] = uDefID
-	unitOrderDebug[uDefID] = unitOrder[uDefID]
-	unitOrder[uDefID] = nil
-end
-
-if not showOrderDebug then
-	unitOrderDebug = nil
-end
-unitOrder = unitsOrdered
-unitsOrdered = nil
-
 local voidWater = false
 local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs
 if success and mapinfo then
@@ -317,14 +186,11 @@ if not voidWater and mapMinWater <= minWaterUnitDepth then
 end
 -- make them a disabled unit (instead of removing it entirely)
 if not showWaterUnits then
-	for unitDefID,_ in pairs(isWaterUnit) do
-		unitDisabled[unitDefID] = true
-	end
+	units.restrictWaterUnits(true)
 end
 
-local showGeothermalUnits = false
 local function checkGeothermalFeatures()
-	showGeothermalUnits = false
+	local  showGeothermalUnits = false
 	local geoThermalFeatures = {}
 	for defID, def in pairs(FeatureDefs) do
 		if def.geoThermal then
@@ -338,15 +204,8 @@ local function checkGeothermalFeatures()
 			break
 		end
 	end
-	-- make them a disabled unit (instead of removing it entirely)
-	for unitDefID,_ in pairs(isGeothermalUnit) do
-		if not showGeothermalUnits then
-			unitDisabled[unitDefID] = true
-		else
-			if not isWaterUnit[unitDefID] or showWaterUnits then
-				unitDisabled[unitDefID] = nil
-			end
-		end
+	if not showGeothermalUnits then
+		units.restrictGeothermalUnits(true)
 	end
 end
 
@@ -387,7 +246,7 @@ local function RefreshCommands()
 					cmdUnitdefs[udefid] = i
 				end
 			end
-			for k, uDefID in pairs(unitOrder) do
+			for k, uDefID in pairs(units.unitOrder) do
 				if cmdUnitdefs[uDefID] then
 					cmdsCount = cmdsCount + 1
 					-- mimmick output of spGetActiveCmdDescs
@@ -411,7 +270,7 @@ local function RefreshCommands()
 					end
 				end
 			end
-			for k, uDefID in pairs(unitOrder) do
+			for k, uDefID in pairs(units.unitOrder) do
 				if cmdUnitdefs[uDefID] then
 					cmdsCount = cmdsCount + 1
 					cmds[cmdsCount] = activeCmdDescs[cmdUnitdefs[uDefID]]
@@ -532,11 +391,11 @@ function widget:Update(dt)
 		if SelectedUnitsCount > 0 then
 			local sel = Spring.GetSelectedUnits()
 			for _, unitID in pairs(sel) do
-				if isFactory[spGetUnitDefID(unitID)] then
+				if units.isFactory[spGetUnitDefID(unitID)] then
 					selectedFactories[unitID] = true
 					selectedFactoryCount = selectedFactoryCount + 1
 				end
-				if isBuilder[spGetUnitDefID(unitID)] then
+				if units.isBuilder[spGetUnitDefID(unitID)] then
 					selectedBuilders[unitID] = true
 					selectedBuilderCount = selectedBuilderCount + 1
 					doUpdate = true
@@ -554,24 +413,9 @@ function widget:Update(dt)
 			doUpdate = true
 		end
 
-		local _, _, mapMinWater, _ = Spring.GetGroundExtremes()
-		if not voidWater and mapMinWater <= minWaterUnitDepth then
-			if not showWaterUnits then
-				showWaterUnits = true
-
-				for unitDefID,_ in pairs(isWaterUnit) do
-					if not isGeothermalUnit[unitDefID] or showGeothermalUnits then	-- make sure geothermal units keep being disabled if that should be the case
-						unitDisabled[unitDefID] = nil
-					end
-				end
-			end
-		end
-
 		if stickToBottom then
 			if WG['advplayerlist_api'] ~= nil then
-				local prevPos = advplayerlistPos
 				local advplayerlistPos = WG['advplayerlist_api'].GetPosition()		-- returns {top,left,bottom,right,widgetScale}
-				local prevAdvplayerlistLeft = advplayerlistLeft
 				advplayerlistLeft = advplayerlistPos[2]
 			end
 		end
@@ -621,9 +465,9 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		usedZoom,
 		nil, disabled and 0 or nil,
 		'#' .. uDefID,
-		showRadarIcon and (((unitIconType[uDefID] and iconTypesMap[unitIconType[uDefID]]) and ':l' .. (disabled and 't0.3,0.3,0.3' or '') ..':' .. iconTypesMap[unitIconType[uDefID]] or nil)) or nil,
-		showGroupIcon and (groups[unitGroup[uDefID]] and ':l' .. (disabled and 't0.3,0.3,0.3:' or ':') ..groups[unitGroup[uDefID]] or nil) or nil,
-		{unitMetalCost[uDefID], unitEnergyCost[uDefID]},
+		showRadarIcon and (((units.unitIconType[uDefID] and iconTypesMap[units.unitIconType[uDefID]]) and ':l' .. (disabled and 't0.3,0.3,0.3' or '') ..':' .. iconTypesMap[units.unitIconType[uDefID]] or nil)) or nil,
+		showGroupIcon and (groups[units.unitGroup[uDefID]] and ':l' .. (disabled and 't0.3,0.3,0.3:' or ':') ..groups[units.unitGroup[uDefID]] or nil) or nil,
+		{units.unitMetalCost[uDefID], units.unitEnergyCost[uDefID]},
 		tonumber(cmds[cellRectID].params[1])
 	)
 
@@ -660,17 +504,11 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 		--doCircle(x, y, z, radius, sides)
 		local text
 		if disabled then
-			text = "\255\125\125\125" .. unitMetalCost[uDefID] .. "\n\255\135\135\135"
+			text = "\255\125\125\125" .. units.unitMetalCost[uDefID] .. "\n\255\135\135\135"
 		else
-			text = "\255\245\245\245" .. unitMetalCost[uDefID] .. "\n\255\255\255\000"
+			text = "\255\245\245\245" .. units.unitMetalCost[uDefID] .. "\n\255\255\255\000"
 		end
-		font2:Print(text .. unitEnergyCost[uDefID], cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
-	end
-
-	-- debug order value
-	if showOrderDebug and smartOrderUnits and unitOrderDebug[uDefID] then
-		local text = unitOrderDebug[uDefID]
-		font2:Print("\255\175\175\175" .. text, cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.05), cellRects[cellRectID][4] - cellPadding - priceFontSize, priceFontSize * 0.82, "o")
+		font2:Print(text .. units.unitEnergyCost[uDefID], cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
 	end
 
 	-- factory queue number
@@ -811,7 +649,7 @@ function drawBuildmenu()
 			local usedZoom = cellIsSelected and selectedCellZoom or defaultCellZoom
 
 
-			drawCell(cellRectID, usedZoom, cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil, unitRestricted[uDefID] or unitDisabled[uDefID])
+			drawCell(cellRectID, usedZoom, cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil, units.unitRestricted[uDefID])
 		end
 	end
 
@@ -848,8 +686,8 @@ local function cacheUnitIcons()
 			if not excludeChickens or not string.find(unit.name,'chicken') then
 				gl.Texture('#'..id)
 				gl.TexRect(-1, -1, 0, 0)
-				if unitIconType[id] and iconTypesMap[unitIconType[id]] then
-					gl.Texture(':l:' .. iconTypesMap[unitIconType[id]])
+				if units.unitIconType[id] and iconTypesMap[units.unitIconType[id]] then
+					gl.Texture(':l:' .. iconTypesMap[units.unitIconType[id]])
 					gl.TexRect(-1, -1, 0, 0)
 				end
 			end
@@ -870,7 +708,7 @@ function widget:DrawScreen()
 	if Spring.GetGameFrame() == 0 and WG['pregame-build'] then
 		activeCmd = WG['pregame-build'].selectedID
 		if activeCmd then
-			activeCmd = unitName[activeCmd]
+			activeCmd = units.unitName[activeCmd]
 		end
 	else
 		activeCmd = select(4, spGetActiveCommand())
@@ -936,7 +774,7 @@ function widget:DrawScreen()
 								-- when meta: unitstats does the tooltip
 								local text
 								local textColor = "\255\215\255\215"
-								if unitRestricted[uDefID] or unitDisabled[uDefID] then
+								if units.unitRestricted[uDefID] then
 									text = Spring.I18N('ui.buildMenu.disabled', { unit = UnitDefs[uDefID].translatedHumanName, textColor = textColor, warnColor = "\255\166\166\166" })
 								else
 									text = UnitDefs[uDefID].translatedHumanName
@@ -1028,7 +866,7 @@ function widget:DrawScreen()
 									end
 									cellColor = { 1, 0.85, 0.2, 0.25 }
 								end
-								if not (unitRestricted[uDefID] or unitDisabled[uDefID]) then
+								if not (units.unitRestricted[uDefID]) then
 
 									local unsetShowPrice
 									if not showPrice then
@@ -1037,7 +875,7 @@ function widget:DrawScreen()
 									end
 
 									-- re-draw cell with hover zoom (and price shown)
-									drawCell(hoveredCellID, usedZoom, cellColor, unitRestricted[uDefID] or unitDisabled[uDefID])
+									drawCell(hoveredCellID, usedZoom, cellColor, units.unitRestricted[uDefID])
 
 									if unsetShowPrice then
 										showPrice = false
@@ -1106,7 +944,7 @@ function widget:DrawWorld()
 end
 
 function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdOpts, cmdParams, cmdTag)
-	if isFactory[unitDefID] and cmdID < 0 then
+	if units.isFactory[unitDefID] and cmdID < 0 then
 		-- filter away non build cmd's
 		if doUpdateClock == nil then
 			doUpdateClock = os_clock() + 0.01
@@ -1169,7 +1007,7 @@ function widget:MousePress(x, y, button)
 			end
 			if not disableInput then
 				for cellRectID, cellRect in pairs(cellRects) do
-					if cmds[cellRectID].id and UnitDefs[-cmds[cellRectID].id].translatedHumanName and math_isInRect(x, y, cellRect[1], cellRect[2], cellRect[3], cellRect[4]) and not (unitRestricted[-cmds[cellRectID].id] or unitDisabled[-cmds[cellRectID].id]) then
+					if cmds[cellRectID].id and UnitDefs[-cmds[cellRectID].id].translatedHumanName and math_isInRect(x, y, cellRect[1], cellRect[2], cellRect[3], cellRect[4]) and not (units.unitRestricted[-cmds[cellRectID].id]) then
 						if button ~= 3 then
 							if playSounds then
 								Spring.PlaySoundFile(sound_queue_add, 0.75, 'ui')
@@ -1206,7 +1044,7 @@ end
 local function buildUnitHandler(_, _, _, data)
 	-- sanity check
 	if not preGamestartPlayer then return end
-	if unitDisabled[data.unitDefID] then return end
+	if units.unitRestricted[data.unitDefID] then return end
 
 	local comDef = UnitDefs[startDefID]
 
@@ -1250,7 +1088,7 @@ local function buildUnitHandler(_, _, _, data)
 		if string.sub(keybind.command, 1, 10) == 'buildunit_' then
 			local uDefName = string.sub(keybind.command, 11)
 			local uDef = UnitDefNames[uDefName]
-			if comBuildOptions[comDef.name][uDef.id] and not unitDisabled[uDef.id] then
+			if comBuildOptions[comDef.name][uDef.id] and not units.unitRestricted[uDef.id] then
 				table.insert(buildCycle, uDef.id)
 			end
 		end
@@ -1288,7 +1126,7 @@ local function bindBuildUnits(widget)
 
 	for _, comDefName in ipairs({ "armcom", "corcom" }) do
 		for _, buildOption in ipairs(UnitDefNames[comDefName].buildOptions) do
-			if not unitDisabled[buildOption] then
+			if not units.unitRestricted[buildOption] then
 				local unitDefName = UnitDefs[buildOption].name
 
 				comBuildOptions[comDefName][buildOption] = true
@@ -1301,6 +1139,10 @@ end
 
 function widget:Initialize()
 	checkGeothermalFeatures()
+	if disableWind then
+		units.restrictWindUnits(true)
+	end
+
 
 	iconTypesMap = {}
 	if Script.LuaRules('GetIconTypes') then
@@ -1321,10 +1163,10 @@ function widget:Initialize()
 
 	WG['buildmenu'] = {}
 	WG['buildmenu'].getGroups = function()
-		return groups, unitGroup
+		return groups, units.unitGroup
 	end
 	WG['buildmenu'].getOrder = function()
-		return unitOrder
+		return units.unitOrder
 	end
 	WG['buildmenu'].getShowPrice = function()
 		return showPrice

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -80,7 +80,7 @@ local advplayerlistLeft = vsx * 0.8
 local ui_opacity = tonumber(Spring.GetConfigFloat("ui_opacity", 0.7) or 0.6)
 local ui_scale = tonumber(Spring.GetConfigFloat("ui_scale", 1) or 1)
 
-local units = VFS.Include("luaui/configs/gridmenu_categories.lua")
+local units = VFS.Include("luaui/configs/unit_config.lua")
 
 local isSpec = Spring.GetSpectatingState()
 local myTeamID = Spring.GetMyTeamID()

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -274,7 +274,7 @@ local function RefreshCommands()
 
 	-- convenience function, figure out if we're looking for categorized build options
 	function noCategory(udefid)
-		return currentCategory == nil or (grid.unitCategories[udefid] == currentCategory and not lHasUnitGrid[udefid])
+		return currentCategory == nil or (grid.unitCategories[udefid] == currentCategory and not (lHasUnitGrid and lHasUnitGrid[udefid]))
 	end
 
 	-- handle pregame build options
@@ -285,7 +285,7 @@ local function RefreshCommands()
 			for _, udefid in pairs(UnitDefs[startDefID].buildOptions) do
 				if not units.unbaStartBuildoptions or units.unbaStartBuildoptions[udefid] then
 					if not units.unitRestricted[udefid] then
-						if gridPos[udefid] then
+						if gridPos and gridPos[udefid] then
 							setBuildOpt(udefid)
 						elseif noCategory(udefid) then
 							setBuildOpt(udefid)
@@ -304,7 +304,7 @@ local function RefreshCommands()
 				local id = -cmd.id
 				if string.sub(cmd.action, 1, 10) == 'buildunit_' and not units.unitRestricted[id] then
 
-					if gridPos[id] then
+					if gridPos and gridPos[id] then
 						setBuildOpt(id, activeCmdDescs[index])
 					elseif noCategory(id) then
 						setBuildOpt(id, activeCmdDescs[index])
@@ -1600,6 +1600,7 @@ function widget:KeyRelease(key)
 	else
 		currentCategory = nil
 		currentCategoryIndex = nil
+		Spring.SetActiveCommand(0, 0, false, false, Spring.GetModKeyState())
 		doUpdate = true
 	end
 end

--- a/luaui/configs/gridmenu_categories.lua
+++ b/luaui/configs/gridmenu_categories.lua
@@ -1,0 +1,304 @@
+---
+--- Created by Hobo Joe.
+--- DateTime: 4/26/2023 8:48 PM
+---
+
+
+local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
+local labGrids = configs.LabGrids
+local unitGrids = configs.UnitGrids
+
+local unitName = {}
+local unitEnergyCost = {}
+local unitMetalCost = {}
+local unitGroup = {}
+local unitRestricted = {}
+local isBuilder = {}
+local isFactory = {}
+local unitIconType = {}
+local isMex = {}
+local isWind = {}
+local isWaterUnit = {}
+local isGeothermal = {}
+local unitMaxWeaponRange = {}
+
+local unitGridPos = { }
+local gridPosUnit = { }
+local hasUnitGrid = { }
+
+local unitCategories = {}
+
+local categoryGroupMapping = {
+	energy = BUILDCAT_ECONOMY,
+	metal = BUILDCAT_ECONOMY,
+	builder = BUILDCAT_PRODUCTION,
+	buildert2 = BUILDCAT_PRODUCTION,
+	buildert3 = BUILDCAT_PRODUCTION,
+	buildert4 = BUILDCAT_PRODUCTION,
+	util = BUILDCAT_UTILITY,
+	weapon = BUILDCAT_COMBAT,
+	explo = BUILDCAT_COMBAT,
+	weaponaa = BUILDCAT_COMBAT,
+	weaponsub = BUILDCAT_COMBAT,
+	aa = BUILDCAT_COMBAT,
+	emp = BUILDCAT_COMBAT,
+	sub = BUILDCAT_COMBAT,
+	nuke = BUILDCAT_COMBAT,
+	antinuke = BUILDCAT_COMBAT,
+}
+
+local unbaStartBuildoptions = {}
+if Spring.GetModOptions().unba then
+	VFS.Include("unbaconfigs/buildoptions.lua")
+	for unitname,level in pairs(ArmBuildOptions) do
+		if level == 1 then
+			unbaStartBuildoptions[UnitDefNames[unitname].id] = unitname
+		end
+	end
+	ArmBuildOptions = nil
+	for unitname,level in pairs(CorBuildOptions) do
+		if level == 1 then
+			unbaStartBuildoptions[UnitDefNames[unitname].id] = unitname
+		end
+	end
+	CorBuildOptions = nil
+	ArmDefsBuildOptions = nil
+	CorDefsBuildOptions = nil
+	ArmBuildOptionsStop = nil
+	CorBuildOptionsStop = nil
+else
+	unbaStartBuildoptions = nil
+end
+
+function processUnits()
+	for uname, ugrid in pairs(unitGrids) do
+		local builder = UnitDefNames[uname]
+		local uid = builder.id
+
+		unitGridPos[uid] = {{},{},{},{}}
+		gridPosUnit[uid] = {}
+		hasUnitGrid[uid] = {}
+		local uCanBuild = {}
+
+		local uBuilds = builder.buildOptions
+		for i = 1, #uBuilds do
+			uCanBuild[uBuilds[i]] = true
+		end
+
+		for cat=1,4 do
+			for r=1,3 do
+				for c=1,4 do
+					local ugdefname = ugrid[cat] and ugrid[cat][r] and ugrid[cat][r][c]
+
+					if ugdefname then
+						local ugdef = UnitDefNames[ugdefname]
+
+						if ugdef and ugdef.id and uCanBuild[ugdef.id] then
+							gridPosUnit[uid][cat .. r .. c] = ugdef.id
+							unitGridPos[uid][cat][ugdef.id] = cat .. r .. c
+							hasUnitGrid[uid][ugdef.id] = true
+						end
+					end
+				end
+			end
+		end
+	end
+
+	for uname, ugrid in pairs(labGrids) do
+		local udef = UnitDefNames[uname]
+		local uid = udef.id
+
+		unitGridPos[uid] = {}
+		gridPosUnit[uid] = {}
+		local uCanBuild = {}
+
+		local uBuilds = udef.buildOptions
+		for i = 1, #uBuilds do
+			uCanBuild[uBuilds[i]] = true
+		end
+
+		for r=1,3 do
+			for c=1,4 do
+				local index = (r - 1) * 4 + c
+				local ugdefname = ugrid[index]
+
+				if ugdefname then
+					local ugdef = UnitDefNames[ugdefname]
+
+					if ugdef and ugdef.id and uCanBuild[ugdef.id] then
+						gridPosUnit[uid][r .. c] = ugdef.id
+						unitGridPos[uid][ugdef.id] = r .. c
+					end
+				end
+			end
+		end
+	end
+
+	for unitDefID, unitDef in pairs(UnitDefs) do
+		unitName[unitDefID] = unitDef.name
+		unitGroup[unitDefID] = unitDef.customParams.unitgroup
+		unitCategories[unitDefID] = categoryGroupMapping[unitDef.customParams.unitgroup] or BUILDCAT_UTILITY
+
+		if unitDef.name == 'armdl' or unitDef.name == 'cordl' or unitDef.name == 'armlance' or unitDef.name == 'cortitan'	-- or unitDef.name == 'armbeaver' or unitDef.name == 'cormuskrat'
+			or (unitDef.minWaterDepth > 0 or unitDef.modCategories['ship']) then
+			isWaterUnit[unitDefID] = true
+		end
+		if unitDef.name == 'armthovr' or unitDef.name == 'corintr' then
+			isWaterUnit[unitDefID] = nil
+		end
+
+		if unitDef.needGeo then
+			isGeothermal[unitDefID] = true
+		end
+
+		if unitDef.maxWeaponRange > 16 then
+			unitMaxWeaponRange[unitDefID] = unitDef.maxWeaponRange
+		end
+
+		unitIconType[unitDefID] = unitDef.iconType
+		unitEnergyCost[unitDefID] = unitDef.energyCost
+		unitMetalCost[unitDefID] = unitDef.metalCost
+
+		if unitDef.maxThisUnit == 0 then
+			unitRestricted[unitDefID] = true
+		end
+
+		if unitDef.buildSpeed > 0 and unitDef.buildOptions[1] then
+			isBuilder[unitDefID] = unitDef.buildOptions
+		end
+
+		if unitDef.isFactory and #unitDef.buildOptions > 0 then
+			isFactory[unitDefID] = true
+		end
+
+		if unitDef.extractsMetal > 0 then
+			isMex[unitDefID] = true
+		end
+
+		if unitDef.windGenerator > 0 then
+			isWind[unitDefID] = true
+		end
+	end
+end
+
+function restrictWindUnits(disable)
+	for unitDefID,_ in pairs(isWind) do
+		unitRestricted[unitDefID] = disable
+	end
+end
+
+function restrictGeothermalUnits(disable)
+	for unitDefID,_ in pairs(isGeothermal) do
+		unitRestricted[unitDefID] = disable
+	end
+end
+
+function restrictWaterUnits(disable)
+	for unitDefID,_ in pairs(isWaterUnit) do
+		unitRestricted[unitDefID] = disable
+	end
+end
+
+
+processUnits()
+
+------------------------------------
+-- UNIT ORDER ----------------------
+------------------------------------
+
+local unitOrder = {}
+local unitOrderManualOverrideTable = VFS.Include("luaui/configs/buildmenu_sorting.lua")
+
+for unitDefID, _ in pairs(UnitDefs) do
+	if unitOrderManualOverrideTable[unitDefID] then
+		unitOrder[unitDefID] = -unitOrderManualOverrideTable[unitDefID]
+	else
+		unitOrder[unitDefID] = 9999999
+	end
+end
+
+local function getHighestOrderedUnit()
+	local highest = { 0, 0, false }
+	local firstOrderTest = true
+	local newSortingUnit = {}
+	for unitDefID, orderValue in pairs(unitOrder) do
+
+		if unitOrderManualOverrideTable[unitDefID] then
+			newSortingUnit[unitDefID] = true
+		else
+			newSortingUnit[unitDefID] = false
+		end
+
+		if firstOrderTest == true then
+			firstOrderTest = false
+			highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
+			--elseif orderValue > highest[2] then
+		elseif highest[3] == false and newSortingUnit[unitDefID] == true then
+			highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
+		elseif highest[3] == false and newSortingUnit[unitDefID] == false then
+			if orderValue > highest[2] then
+				highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
+			end
+		elseif highest[3] == true and newSortingUnit[unitDefID] == true then
+			if orderValue > highest[2] then
+				highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
+			end
+		end
+	end
+	return highest[1]
+end
+
+local unitsOrdered = {}
+for _, _ in pairs(UnitDefs) do
+	local uDefID = getHighestOrderedUnit()
+	unitsOrdered[#unitsOrdered + 1] = uDefID
+	unitOrder[uDefID] = nil
+end
+
+unitOrder = unitsOrdered
+unitsOrdered = nil
+
+local voidWater = false
+local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs
+if success and mapinfo then
+	voidWater = mapinfo.voidwater
+end
+
+local minWaterUnitDepth = -11
+
+
+------------------------------------
+-- /UNIT ORDER ----------------------
+------------------------------------
+
+return {
+	unitGrids = unitGrids,
+	labGrids = labGrids,
+
+	unbaStartBuildoptions = unbaStartBuildoptions,
+
+	unitName = unitName,
+	unitEnergyCost = unitEnergyCost,
+	unitMetalCost = unitMetalCost,
+	unitGroup = unitGroup,
+	unitRestricted = unitRestricted,
+	isBuilder = isBuilder,
+	isFactory = isFactory,
+	unitIconType = unitIconType,
+	isMex = isMex,
+	isWind = isWind,
+	isWaterUnit = isWaterUnit,
+	isGeothermal = isGeothermal,
+	unitMaxWeaponRange = unitMaxWeaponRange,
+	unitGridPos = unitGridPos,
+	gridPosUnit = gridPosUnit,
+	hasUnitGrid = hasUnitGrid,
+	unitCategories = unitCategories,
+
+	minWaterUnitDepth = minWaterUnitDepth,
+	unitOrder = unitOrder,
+
+	restrictGeothermalUnits = restrictGeothermalUnits,
+	restrictWindUnits = restrictWindUnits,
+	restrictWaterUnits = restrictWaterUnits,
+}

--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -1,0 +1,109 @@
+
+
+local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
+local labGrids = configs.LabGrids
+local unitGrids = configs.UnitGrids
+
+local unitGridPos = { }
+local gridPosUnit = { }
+local hasUnitGrid = { }
+
+local unitCategories = {}
+
+local BUILDCAT_ECONOMY = "Economy"
+local BUILDCAT_COMBAT = "Combat"
+local BUILDCAT_UTILITY = "Utility"
+local BUILDCAT_PRODUCTION = "Build"
+
+local categoryGroupMapping = {
+	energy = BUILDCAT_ECONOMY,
+	metal = BUILDCAT_ECONOMY,
+	builder = BUILDCAT_PRODUCTION,
+	buildert2 = BUILDCAT_PRODUCTION,
+	buildert3 = BUILDCAT_PRODUCTION,
+	buildert4 = BUILDCAT_PRODUCTION,
+	util = BUILDCAT_UTILITY,
+	weapon = BUILDCAT_COMBAT,
+	explo = BUILDCAT_COMBAT,
+	weaponaa = BUILDCAT_COMBAT,
+	weaponsub = BUILDCAT_COMBAT,
+	aa = BUILDCAT_COMBAT,
+	emp = BUILDCAT_COMBAT,
+	sub = BUILDCAT_COMBAT,
+	nuke = BUILDCAT_COMBAT,
+	antinuke = BUILDCAT_COMBAT,
+}
+
+for uname, ugrid in pairs(unitGrids) do
+	local builder = UnitDefNames[uname]
+	local uid = builder.id
+
+	unitGridPos[uid] = {{},{},{},{}}
+	gridPosUnit[uid] = {}
+	hasUnitGrid[uid] = {}
+	local uCanBuild = {}
+
+	local uBuilds = builder.buildOptions
+	for i = 1, #uBuilds do
+		uCanBuild[uBuilds[i]] = true
+	end
+
+	for cat=1,4 do
+		for r=1,3 do
+			for c=1,4 do
+				local ugdefname = ugrid[cat] and ugrid[cat][r] and ugrid[cat][r][c]
+
+				if ugdefname then
+					local ugdef = UnitDefNames[ugdefname]
+
+					if ugdef and ugdef.id and uCanBuild[ugdef.id] then
+						gridPosUnit[uid][cat .. r .. c] = ugdef.id
+						unitGridPos[uid][cat][ugdef.id] = cat .. r .. c
+						hasUnitGrid[uid][ugdef.id] = true
+					end
+				end
+			end
+		end
+	end
+end
+
+for uname, ugrid in pairs(labGrids) do
+	local udef = UnitDefNames[uname]
+	local uid = udef.id
+
+	unitGridPos[uid] = {}
+	gridPosUnit[uid] = {}
+	local uCanBuild = {}
+
+	local uBuilds = udef.buildOptions
+	for i = 1, #uBuilds do
+		uCanBuild[uBuilds[i]] = true
+	end
+
+	for r=1,3 do
+		for c=1,4 do
+			local index = (r - 1) * 4 + c
+			local ugdefname = ugrid[index]
+
+			if ugdefname then
+				local ugdef = UnitDefNames[ugdefname]
+
+				if ugdef and ugdef.id and uCanBuild[ugdef.id] then
+					gridPosUnit[uid][r .. c] = ugdef.id
+					unitGridPos[uid][ugdef.id] = r .. c
+				end
+			end
+		end
+	end
+end
+
+for unitDefID, unitDef in pairs(UnitDefs) do
+	unitCategories[unitDefID] = categoryGroupMapping[unitDef.customParams.unitgroup] or BUILDCAT_UTILITY
+end
+
+return {
+	unitGridPos = unitGridPos,
+	gridPosUnit = gridPosUnit,
+	hasUnitGrid = hasUnitGrid,
+	unitCategories = unitCategories,
+}

--- a/luaui/configs/unit_config.lua
+++ b/luaui/configs/unit_config.lua
@@ -4,10 +4,6 @@
 ---
 
 
-local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
-local labGrids = configs.LabGrids
-local unitGrids = configs.UnitGrids
-
 local unitName = {}
 local unitEnergyCost = {}
 local unitMetalCost = {}
@@ -22,30 +18,50 @@ local isWaterUnit = {}
 local isGeothermal = {}
 local unitMaxWeaponRange = {}
 
-local unitGridPos = { }
-local gridPosUnit = { }
-local hasUnitGrid = { }
+local showWaterUnits = false
 
-local unitCategories = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
 
-local categoryGroupMapping = {
-	energy = BUILDCAT_ECONOMY,
-	metal = BUILDCAT_ECONOMY,
-	builder = BUILDCAT_PRODUCTION,
-	buildert2 = BUILDCAT_PRODUCTION,
-	buildert3 = BUILDCAT_PRODUCTION,
-	buildert4 = BUILDCAT_PRODUCTION,
-	util = BUILDCAT_UTILITY,
-	weapon = BUILDCAT_COMBAT,
-	explo = BUILDCAT_COMBAT,
-	weaponaa = BUILDCAT_COMBAT,
-	weaponsub = BUILDCAT_COMBAT,
-	aa = BUILDCAT_COMBAT,
-	emp = BUILDCAT_COMBAT,
-	sub = BUILDCAT_COMBAT,
-	nuke = BUILDCAT_COMBAT,
-	antinuke = BUILDCAT_COMBAT,
-}
+	if unitDef.name == 'armdl' or unitDef.name == 'cordl' or unitDef.name == 'armlance' or unitDef.name == 'cortitan'	-- or unitDef.name == 'armbeaver' or unitDef.name == 'cormuskrat'
+		or (unitDef.minWaterDepth > 0 or unitDef.modCategories['ship']) then
+		isWaterUnit[unitDefID] = true
+	end
+	if unitDef.name == 'armthovr' or unitDef.name == 'corintr' then
+		isWaterUnit[unitDefID] = nil
+	end
+
+	if unitDef.needGeo then
+		isGeothermal[unitDefID] = true
+	end
+
+	if unitDef.maxWeaponRange > 16 then
+		unitMaxWeaponRange[unitDefID] = unitDef.maxWeaponRange
+	end
+
+	unitIconType[unitDefID] = unitDef.iconType
+	unitEnergyCost[unitDefID] = unitDef.energyCost
+	unitMetalCost[unitDefID] = unitDef.metalCost
+
+	if unitDef.maxThisUnit == 0 then
+		unitRestricted[unitDefID] = true
+	end
+
+	if unitDef.buildSpeed > 0 and unitDef.buildOptions[1] then
+		isBuilder[unitDefID] = unitDef.buildOptions
+	end
+
+	if unitDef.isFactory and #unitDef.buildOptions > 0 then
+		isFactory[unitDefID] = true
+	end
+
+	if unitDef.extractsMetal > 0 then
+		isMex[unitDefID] = true
+	end
+
+	if unitDef.windGenerator > 0 then
+		isWind[unitDefID] = true
+	end
+end
 
 local unbaStartBuildoptions = {}
 if Spring.GetModOptions().unba then
@@ -70,116 +86,6 @@ else
 	unbaStartBuildoptions = nil
 end
 
-function processUnits()
-	for uname, ugrid in pairs(unitGrids) do
-		local builder = UnitDefNames[uname]
-		local uid = builder.id
-
-		unitGridPos[uid] = {{},{},{},{}}
-		gridPosUnit[uid] = {}
-		hasUnitGrid[uid] = {}
-		local uCanBuild = {}
-
-		local uBuilds = builder.buildOptions
-		for i = 1, #uBuilds do
-			uCanBuild[uBuilds[i]] = true
-		end
-
-		for cat=1,4 do
-			for r=1,3 do
-				for c=1,4 do
-					local ugdefname = ugrid[cat] and ugrid[cat][r] and ugrid[cat][r][c]
-
-					if ugdefname then
-						local ugdef = UnitDefNames[ugdefname]
-
-						if ugdef and ugdef.id and uCanBuild[ugdef.id] then
-							gridPosUnit[uid][cat .. r .. c] = ugdef.id
-							unitGridPos[uid][cat][ugdef.id] = cat .. r .. c
-							hasUnitGrid[uid][ugdef.id] = true
-						end
-					end
-				end
-			end
-		end
-	end
-
-	for uname, ugrid in pairs(labGrids) do
-		local udef = UnitDefNames[uname]
-		local uid = udef.id
-
-		unitGridPos[uid] = {}
-		gridPosUnit[uid] = {}
-		local uCanBuild = {}
-
-		local uBuilds = udef.buildOptions
-		for i = 1, #uBuilds do
-			uCanBuild[uBuilds[i]] = true
-		end
-
-		for r=1,3 do
-			for c=1,4 do
-				local index = (r - 1) * 4 + c
-				local ugdefname = ugrid[index]
-
-				if ugdefname then
-					local ugdef = UnitDefNames[ugdefname]
-
-					if ugdef and ugdef.id and uCanBuild[ugdef.id] then
-						gridPosUnit[uid][r .. c] = ugdef.id
-						unitGridPos[uid][ugdef.id] = r .. c
-					end
-				end
-			end
-		end
-	end
-
-	for unitDefID, unitDef in pairs(UnitDefs) do
-		unitName[unitDefID] = unitDef.name
-		unitGroup[unitDefID] = unitDef.customParams.unitgroup
-		unitCategories[unitDefID] = categoryGroupMapping[unitDef.customParams.unitgroup] or BUILDCAT_UTILITY
-
-		if unitDef.name == 'armdl' or unitDef.name == 'cordl' or unitDef.name == 'armlance' or unitDef.name == 'cortitan'	-- or unitDef.name == 'armbeaver' or unitDef.name == 'cormuskrat'
-			or (unitDef.minWaterDepth > 0 or unitDef.modCategories['ship']) then
-			isWaterUnit[unitDefID] = true
-		end
-		if unitDef.name == 'armthovr' or unitDef.name == 'corintr' then
-			isWaterUnit[unitDefID] = nil
-		end
-
-		if unitDef.needGeo then
-			isGeothermal[unitDefID] = true
-		end
-
-		if unitDef.maxWeaponRange > 16 then
-			unitMaxWeaponRange[unitDefID] = unitDef.maxWeaponRange
-		end
-
-		unitIconType[unitDefID] = unitDef.iconType
-		unitEnergyCost[unitDefID] = unitDef.energyCost
-		unitMetalCost[unitDefID] = unitDef.metalCost
-
-		if unitDef.maxThisUnit == 0 then
-			unitRestricted[unitDefID] = true
-		end
-
-		if unitDef.buildSpeed > 0 and unitDef.buildOptions[1] then
-			isBuilder[unitDefID] = unitDef.buildOptions
-		end
-
-		if unitDef.isFactory and #unitDef.buildOptions > 0 then
-			isFactory[unitDefID] = true
-		end
-
-		if unitDef.extractsMetal > 0 then
-			isMex[unitDefID] = true
-		end
-
-		if unitDef.windGenerator > 0 then
-			isWind[unitDefID] = true
-		end
-	end
-end
 
 function restrictWindUnits(disable)
 	for unitDefID,_ in pairs(isWind) do
@@ -199,8 +105,6 @@ function restrictWaterUnits(disable)
 	end
 end
 
-
-processUnits()
 
 ------------------------------------
 -- UNIT ORDER ----------------------
@@ -272,9 +176,6 @@ local minWaterUnitDepth = -11
 ------------------------------------
 
 return {
-	unitGrids = unitGrids,
-	labGrids = labGrids,
-
 	unbaStartBuildoptions = unbaStartBuildoptions,
 
 	unitName = unitName,
@@ -290,13 +191,11 @@ return {
 	isWaterUnit = isWaterUnit,
 	isGeothermal = isGeothermal,
 	unitMaxWeaponRange = unitMaxWeaponRange,
-	unitGridPos = unitGridPos,
-	gridPosUnit = gridPosUnit,
-	hasUnitGrid = hasUnitGrid,
-	unitCategories = unitCategories,
 
 	minWaterUnitDepth = minWaterUnitDepth,
 	unitOrder = unitOrder,
+
+	showWaterUnits = showWaterUnits,
 
 	restrictGeothermalUnits = restrictGeothermalUnits,
 	restrictWindUnits = restrictWindUnits,

--- a/luaui/configs/unit_config.lua
+++ b/luaui/configs/unit_config.lua
@@ -22,6 +22,8 @@ local showWaterUnits = false
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 
+	unitGroup[unitDefID] = unitDef.customParams.unitgroup
+
 	if unitDef.name == 'armdl' or unitDef.name == 'cordl' or unitDef.name == 'armlance' or unitDef.name == 'cortitan'	-- or unitDef.name == 'armbeaver' or unitDef.name == 'cormuskrat'
 		or (unitDef.minWaterDepth > 0 or unitDef.modCategories['ship']) then
 		isWaterUnit[unitDefID] = true


### PR DESCRIPTION
### Changes

Another refactor, another PR that is intended to make *zero* functional changes. This is purely for cleanup to enable further improvements.

- This breaks all the unit sorting handling into its own file, to allow unification and code reduction between gridmenu and buildmenu
- This breaks out all the grid pre-sorting into its own file. There is no unification here, I just wanted to get some code out of the giant gridmenu file.
- Cleanup and code reduction of the command sorting on selection change and category change for gridmenu

