### PR TITLE
unit_hats: adjust comment on hat mass, commanders and T1 transports

### DIFF
--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -29,7 +29,7 @@ end
 
 -- Notes:
 -- hat wearing units must have unitdef holdsteady = true to give the piece orientations
--- hat wearing commander is only transportable by t2 transports (mass? unitcount? why?)
+-- hats have nonzero mass and can stop commanders from being able to use T1 transports (see 5c4b8a3)
 -- hat pos is 1 frame off :/
 
 if not gadgetHandler:IsSyncedCode() then


### PR DESCRIPTION
As pointed out by @KyleAnthonyShepherd, hats no longer prevent commanders from using T1 transports as of 5c4b8a3. This adjusts the comment in the `unit_hats` gadget to keep it up to date.