### PR TITLE
Fix unexpected IDE behavior in VSCode

### DIFF
--- a/luamocks/LuaSyncedCtrl.lua
+++ b/luamocks/LuaSyncedCtrl.lua
@@ -12,6 +12,7 @@
 --along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --==================================================================================================
 --Variables for the MockUp
+
 Spring ={}
 numberMock =42
 stringMock ="TestString"

--- a/luamocks/LuaUnsyncedCtrl.lua
+++ b/luamocks/LuaUnsyncedCtrl.lua
@@ -12,6 +12,7 @@
 --along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --==================================================================================================
 --Variables for the MockUp
+
 Spring ={}
 numberMock =42
 stringMock ="TestString"

--- a/luamocks/LuaUnsyncedRead.lua
+++ b/luamocks/LuaUnsyncedRead.lua
@@ -12,6 +12,7 @@
 --along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --==================================================================================================
 --Variables for the MockUp
+
 Spring ={}
 numberMock =42
 stringMock ="TestString"

--- a/luamocks/SpringLuaApi.lua
+++ b/luamocks/SpringLuaApi.lua
@@ -12,6 +12,7 @@
 --along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --==================================================================================================
 --Variables for the MockUp
+
 numberMock =42
 stringMock ="TestString"
 tableMock ={exampletable= true}


### PR DESCRIPTION
This fixes additional information being shown with certain IDE features enabled, in particular VSCode Lua extension code lens.