### PR TITLE
Add explosionSpeed to commanderexplosion

### DIFF
--- a/weapons/Unit_Explosions.lua
+++ b/weapons/Unit_Explosions.lua
@@ -874,6 +874,7 @@ unitDeaths = {
 		weaponType = "Cannon",
 		AreaOfEffect = 725,
 		cameraShake = 720,
+		explosionSpeed = 725,
 		impulseboost = impulseboost*2,
 		impulsefactor = impulsefactor,
 		soundhitwet = "newboomuw",


### PR DESCRIPTION
comupdate explosion changes made the commander explosion propagate at a finite rate. At the edge, the damage from the explosion could be 18 frames delayed. 

This broke the mo_preventcombomb gadget because UnitPreDamaged could not get the attackerID of the commander that died many frames ago, and could not check the last commander condition.