### PR TITLE
Fix blank grid menu at game start

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1813,6 +1813,7 @@ end
 
 function widget:GameStart()
 	preGamestartPlayer = false
+	selectedBuilder = nil
 end
 
 function widget:KeyRelease(key)


### PR DESCRIPTION
If no commander is selected at game start (disabling the 'Select n Center!' widget), a blank grid would display.  This fixes that by removing the fake builder assigned during pregame.