### PR TITLE
enable mp3 extension in adv playerlist widget

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -70,37 +70,38 @@ local function ReloadMusicPlaylists()
 	deviceLostSafetyCheck = 0
 	---------------------------------COLLECT MUSIC------------------------------------
 
+	local allowedExtensions = "{*.ogg,*.mp3}"
 	-- New Soundtrack List
 	local musicDirNew 			= 'music/original'
-	local peaceTracksNew 			= VFS.DirList(musicDirNew..'/peace', '*.ogg')
-	local warhighTracksNew 			= VFS.DirList(musicDirNew..'/warhigh', '*.ogg')
-	local warlowTracksNew 			= VFS.DirList(musicDirNew..'/warlow', '*.ogg')
-	local gameoverTracksNew 		= VFS.DirList(musicDirNew..'/gameover', '*.ogg')
-	local bossFightTracksNew   		= VFS.DirList(musicDirNew..'/bossfight', '*.ogg')
-	local menuTracksNew 			= VFS.DirList(musicDirNew..'/menu', '*.ogg')
-	local loadingTracksNew   		= VFS.DirList(musicDirNew..'/loading', '*.ogg')
+	local peaceTracksNew 			= VFS.DirList(musicDirNew..'/peace', allowedExtensions)
+	local warhighTracksNew 			= VFS.DirList(musicDirNew..'/warhigh', allowedExtensions)
+	local warlowTracksNew 			= VFS.DirList(musicDirNew..'/warlow', allowedExtensions)
+	local gameoverTracksNew 		= VFS.DirList(musicDirNew..'/gameover', allowedExtensions)
+	local bossFightTracksNew   		= VFS.DirList(musicDirNew..'/bossfight', allowedExtensions)
+	local menuTracksNew 			= VFS.DirList(musicDirNew..'/menu', allowedExtensions)
+	local loadingTracksNew   		= VFS.DirList(musicDirNew..'/loading', allowedExtensions)
 
 	-- Old Soundtrack List
 	local musicDirOld 			= 'music/legacy'
-	local peaceTracksOld 			= VFS.DirList(musicDirOld..'/peace', '*.ogg')
-	local warhighTracksOld 			= VFS.DirList(musicDirOld..'/warhigh', '*.ogg')
-	local warlowTracksOld 			= VFS.DirList(musicDirOld..'/warlow', '*.ogg')
-	local gameoverTracksOld 		= VFS.DirList(musicDirOld..'/gameover', '*.ogg')
-	local bossFightTracksOld  		= VFS.DirList(musicDirOld..'/bossfight', '*.ogg')
-	local menuTracksOld 			= VFS.DirList(musicDirOld..'/menu', '*.ogg')
-	local loadingTracksOld   		= VFS.DirList(musicDirOld..'/loading', '*.ogg')
+	local peaceTracksOld 			= VFS.DirList(musicDirOld..'/peace', allowedExtensions)
+	local warhighTracksOld 			= VFS.DirList(musicDirOld..'/warhigh', allowedExtensions)
+	local warlowTracksOld 			= VFS.DirList(musicDirOld..'/warlow', allowedExtensions)
+	local gameoverTracksOld 		= VFS.DirList(musicDirOld..'/gameover', allowedExtensions)
+	local bossFightTracksOld  		= VFS.DirList(musicDirOld..'/bossfight', allowedExtensions)
+	local menuTracksOld 			= VFS.DirList(musicDirOld..'/menu', allowedExtensions)
+	local loadingTracksOld   		= VFS.DirList(musicDirOld..'/loading', allowedExtensions)
 
 	-- Custom Soundtrack List
 	local musicDirCustom 		= 'music/custom'
-	local baseTracksCustom 			= VFS.DirList(musicDirCustom, '*.ogg')
-	local peaceTracksCustom 		= VFS.DirList(musicDirCustom..'/peace', '*.ogg')
-	local warhighTracksCustom 		= VFS.DirList(musicDirCustom..'/warhigh', '*.ogg')
-	local warlowTracksCustom 		= VFS.DirList(musicDirCustom..'/warlow', '*.ogg')
-	local warTracksCustom 			= VFS.DirList(musicDirCustom..'/war', '*.ogg')
-	local gameoverTracksCustom 		= VFS.DirList(musicDirCustom..'/gameover', '*.ogg')
-	local bossFightTracksCustom 	= VFS.DirList(musicDirCustom..'/bossfight', '*.ogg')
-	local menuTracksCustom 			= VFS.DirList(musicDirCustom..'/menu', '*.ogg')
-	local loadingTracksCustom  		= VFS.DirList(musicDirCustom..'/loading', '*.ogg')
+	local baseTracksCustom 			= VFS.DirList(musicDirCustom, allowedExtensions)
+	local peaceTracksCustom 		= VFS.DirList(musicDirCustom..'/peace', allowedExtensions)
+	local warhighTracksCustom 		= VFS.DirList(musicDirCustom..'/warhigh', allowedExtensions)
+	local warlowTracksCustom 		= VFS.DirList(musicDirCustom..'/warlow', allowedExtensions)
+	local warTracksCustom 			= VFS.DirList(musicDirCustom..'/war', allowedExtensions)
+	local gameoverTracksCustom 		= VFS.DirList(musicDirCustom..'/gameover', allowedExtensions)
+	local bossFightTracksCustom 	= VFS.DirList(musicDirCustom..'/bossfight', allowedExtensions)
+	local menuTracksCustom 			= VFS.DirList(musicDirCustom..'/menu', allowedExtensions)
+	local loadingTracksCustom  		= VFS.DirList(musicDirCustom..'/loading', allowedExtensions)
 
 	-----------------------------------SETTINGS---------------------------------------
 
@@ -397,7 +398,7 @@ local function capitalize(text)
 end
 
 local function processTrackname(trackname)
-	trackname = string.gsub(trackname, ".ogg", "")
+	trackname = string.gsub(trackname, ".%w+$", "")
 	trackname = trackname:match("[^/|\\]*$")
 	return capitalize(trackname)
 end


### PR DESCRIPTION
what about file [luaintro/Addons/music.lua ?](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luaintro/Addons/music.lua) is it legacy and not used or same change should be applied to both files?