### PR TITLE
Cmd_customformations2.lua updated with drag threshold

### DIFF
--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -2,10 +2,10 @@
 function widget:GetInfo()
     return {
         name      = "CustomFormations2",
-        desc      = "Allows you to draw your own formation line. Modfiied by Errrrrrr",
-        author    = "Niobium", -- based on 'Custom Formations' by jK and gunblob
-        version   = "v4.3",
-        date      = "April, 2013",
+        desc      = "Allows you to draw your own formation line.",
+        author    = "Errrrrrr, Niobium", -- based on 'Custom Formations' by jK and gunblob
+        version   = "v4.4",
+        date      = "June, 2023",
         license   = "GNU GPL, v2 or later",
         layer     = 10000,
         enabled   = true,

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -596,7 +596,7 @@ function widget:MouseRelease(mx, my, mButton)
         local _, dragDeltaPos = spTraceScreenRay(mx,my+selectionThreshold, true, false, false, true)
         local _, pos = spTraceScreenRay(mx, my, true, false, false, true)
         local dragDelta = 0
-        if dragDeltaPos then
+        if dragDeltaPos and pos then
             dragDelta = pos[3] - dragDeltaPos[3]
         end
         local adjustedMinFormationLength = max(dragDelta, minFormationLength)

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -2,7 +2,7 @@
 function widget:GetInfo()
     return {
         name      = "CustomFormations2",
-        desc      = "Allows you to draw your own formation line.",
+        desc      = "Allows you to draw your own formation line. Modfiied by Errrrrrr",
         author    = "Niobium", -- based on 'Custom Formations' by jK and gunblob
         version   = "v4.3",
         date      = "April, 2013",
@@ -589,7 +589,19 @@ function widget:MouseRelease(mx, my, mButton)
 
         -- Single click ? (no line drawn)
         --if (#fNodes == 1) then
-        if fDists[#fNodes] < minFormationLength or (usingCmd == CMD.UNLOAD_UNIT and fDists[#fNodes] < 64*(selectedUnitsCount - 1)) then
+
+        -- we add the drag threshold code here  
+        -- tracing to a point with a drag threshold pixel delta added to mouse coord, to get world distance
+        local selectionThreshold = Spring.GetConfigInt("MouseDragFrontCommandThreshold")
+        local _, dragDeltaPos = spTraceScreenRay(mx,my+selectionThreshold, true, false, false, true)
+        local _, pos = spTraceScreenRay(mx, my, true, false, false, true)
+        local dragDelta = 0
+        if dragDeltaPos then
+            dragDelta = pos[3] - dragDeltaPos[3]
+        end
+        local adjustedMinFormationLength = max(dragDelta, minFormationLength)
+
+        if fDists[#fNodes] < adjustedMinFormationLength or (usingCmd == CMD.UNLOAD_UNIT and fDists[#fNodes] < 64*(selectedUnitsCount - 1)) then
             -- We should check if any units are able to execute it,
             -- but the order is small enough network-wise that the tiny bug potential isn't worth it.
 
@@ -913,8 +925,8 @@ function GetOrdersNoX(nodes, units, unitCount, shifted)
             end
         end
     end
-	
-	local fminv = 1.0/ fm
+
+    local fminv = 1.0/ fm
     local function sortFunc(a, b)
         -- y = mx + c
         -- c = y - mx

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
 	return {
 		name = "Info",
-		desc = "",
+		desc = "Persistant version, modified by Errrrrrr",
 		author = "Floris",
 		date = "April 2020",
 		license = "GNU GPL, v2 or later",
@@ -1807,12 +1807,16 @@ function checkChanges()
 	local prevDisplayUnitID = displayUnitID
 
 	-- determine what mode to display
-	displayMode = 'text'
-	displayUnitID = nil
-	displayUnitDefID = nil
+	local _, _, _, shift = spGetModKeyState()
+	if shift then
+		displayMode = 'text'
+		displayUnitID = nil
+		displayUnitDefID = nil
+	end
 
 	-- buildmenu unitdef
 	if WG['buildmenu'] and (WG['buildmenu'].hoverID or WG['buildmenu'].selectedID) then
+		displayUnitID = nil
 		displayMode = 'unitdef'
 		displayUnitDefID = WG['buildmenu'].hoverID or WG['buildmenu'].selectedID
 

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
 	return {
 		name = "Info",
-		desc = "Persistant version, modified by Errrrrrr",
+		desc = "",
 		author = "Floris",
 		date = "April 2020",
 		license = "GNU GPL, v2 or later",
@@ -1807,16 +1807,12 @@ function checkChanges()
 	local prevDisplayUnitID = displayUnitID
 
 	-- determine what mode to display
-	local _, _, _, shift = spGetModKeyState()
-	if shift then
-		displayMode = 'text'
-		displayUnitID = nil
-		displayUnitDefID = nil
-	end
+	displayMode = 'text'
+	displayUnitID = nil
+	displayUnitDefID = nil
 
 	-- buildmenu unitdef
 	if WG['buildmenu'] and (WG['buildmenu'].hoverID or WG['buildmenu'].selectedID) then
-		displayUnitID = nil
 		displayMode = 'unitdef'
 		displayUnitDefID = WG['buildmenu'].hoverID or WG['buildmenu'].selectedID
 


### PR DESCRIPTION
Added lines to retrieve drag threshold using GetConfigInt("MouseDragFrontCommandThreshold"). 

The drag threshold in screen pixels is translated using screentrace to ground distance because the widget is using a ground distance to determine threshold itself.

Fixed desc and authors field per previous PR comment, removed the gui_info.lua changes.