### PR TITLE
Fix gridmenu errors for units without predefined grids

### DIFF
--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -16,6 +16,13 @@ local BUILDCAT_COMBAT = "Combat"
 local BUILDCAT_UTILITY = "Utility"
 local BUILDCAT_PRODUCTION = "Build"
 
+local categories = {
+	BUILDCAT_ECONOMY,
+	BUILDCAT_COMBAT,
+	BUILDCAT_UTILITY,
+	BUILDCAT_PRODUCTION
+}
+
 local rows = 3
 local columns = 4
 
@@ -144,12 +151,52 @@ local function constructBuildOption(uDefID, cmd)
 end
 
 
+local function getGridForCategory(builderId, buildOptions, currentCategory)
+	local options = {}
+	-- lay out the category
+	if currentCategory then
+		local undefinedOpts = {}
+		local categoryIndex = getCategoryIndex(currentCategory)
+
+		-- first we go through all the buildopts that have defined positions and place them appropriately
+		for _, opt in pairs(buildOptions) do
+			if hasUnitGrid[builderId] and hasUnitGrid[builderId][opt] then
+				if unitGridPos[builderId][categoryIndex][opt] then
+					local row = string.sub(unitGridPos[builderId][categoryIndex][opt], 2, 2)
+					local col = string.sub(unitGridPos[builderId][categoryIndex][opt], 3, 3)
+					local index = col + ((row - 1) * columns)
+					if index then
+						options[index] = constructBuildOption(opt)
+					end
+				end
+			end
+			if not (hasUnitGrid[builderId] and hasUnitGrid[builderId][opt]) and unitCategories[opt] == currentCategory then
+
+				-- if this unit doesn't have a defined position in the grid, find an empty spot for it
+				table.insert(undefinedOpts, opt)
+			end
+		end
+
+		-- everything that doesn't have a defined position (i.e. scav units) gets placed into the grid in any empty spots.
+		for i = 1, 24 do
+			if #undefinedOpts < 1 then break end
+			if not options[i] then
+				local opt = table.remove(undefinedOpts, 1)
+				options[i] = constructBuildOption(opt)
+			end
+		end
+
+		return options
+	end
+end
+
+
 -- grid indices are laid out like this
 -- 9  10 11 12
 -- 5  6  7  8
 -- 1  2  3  4
 
-function homeOptionsForBuilder(builderId)
+function homeOptionsForBuilder(builderId, buildOptions)
 	local options = {}
 	local uncategorizedOpts = homeGridPos[builderId]
 
@@ -167,6 +214,26 @@ function homeOptionsForBuilder(builderId)
 			end
 			optionsInRow = 0
 		end
+	else
+		-- if the unit doesn't have a predefined grid we still want the "home" page to have units
+		-- So we build all the categories and grab the first 3 items from each one
+		local categoryOptions = {}
+		for cat = 1, 4 do
+			categoryOptions[cat] = getGridForCategory(builderId, buildOptions, categories[cat])
+		end
+		local optionsInRow = 0
+		for cat = 1, 4 do
+			for _, opt in pairs(categoryOptions[cat]) do
+				if optionsInRow >= 3 then
+					break
+				end
+				optionsInRow = optionsInRow + 1
+				-- The grid is sorted by row, starting at the bottom. We want to order these items by column, so we switch their positions by changing the index
+				local index = (cat) + ((optionsInRow - 1) * columns)
+				options[index] = opt
+			end
+			optionsInRow = 0
+		end
 	end
 	return options
 end
@@ -177,46 +244,17 @@ local function getSortedGridForBuilder(builderId, buildOptions, currentCategory)
 		return
 	end
 
-	local options = {}
-
 	-- If it's not a factory and no category is selected, we fill out the "home page"
 	if not currentCategory then
-		return homeOptionsForBuilder(builderId)
+		return homeOptionsForBuilder(builderId, buildOptions)
 	end
 
-	-- lay out the category
+	-- get options for category
 	if currentCategory then
-		local undefinedOpts = {}
-		local categoryIndex = getCategoryIndex(currentCategory)
-
-		-- first we go through all the buildopts that have defined positions and place them appropriately
-		for _, opt in pairs(buildOptions) do
-			if hasUnitGrid[builderId][opt] then
-				if unitGridPos[builderId][categoryIndex][opt] then
-					local row = string.sub(unitGridPos[builderId][categoryIndex][opt], 2, 2)
-					local col = string.sub(unitGridPos[builderId][categoryIndex][opt], 3, 3)
-					local index = col + ((row - 1) * columns)
-					if index then
-						options[index] = constructBuildOption(opt)
-					end
-				end
-			else
-				-- if this unit doesn't have a defined position in the grid, find an empty spot for it
-				table.insert(undefinedOpts, opt)
-			end
-		end
-
-		-- everything that doesn't have a defined position (i.e. scav units) gets placed into the grid in any empty spots.
-		for i = 1, 24 do
-			if #undefinedOpts < 1 then break end
-			if not options[i] then
-				local opt = table.remove(undefinedOpts, 1)
-				options[i] = constructBuildOption(opt)
-			end
-		end
-
-		return options
+		return getGridForCategory(builderId, buildOptions, currentCategory)
 	end
+	-- last resort for units that have no grid
+	return { }
 end
 
 


### PR DESCRIPTION
### Work done

- Units without predefined grids will no longer crash
- Units without predefined grids will now get the same "home page" layout that other constructors do