### PR TITLE
Additional Cortex T2 Vehicles balance pass

### DIFF
--- a/units/Scavengers/Vehicles/corforge.lua
+++ b/units/Scavengers/Vehicles/corforge.lua
@@ -173,7 +173,7 @@ return {
 				--	light_color = "1 0.5 0.05",
 				},
 				damage = {
-					default = 8,
+					default = 5.25,
 				},
 			},
 		},

--- a/units/Scavengers/Vehicles/cortorch.lua
+++ b/units/Scavengers/Vehicles/cortorch.lua
@@ -28,7 +28,8 @@ return {
 		objectname = "Units/scavboss/CORTORCH.s3o",
 		script = "Units/scavboss/CORTORCH.cob",
 		seismicsignature = 0,
-		selfdestructas = "smallExplosionGenericSelfd",
+		selfdestructas = "pyroselfd",
+		selfdestructcountdown = 1,
 		sightdistance = 308,
 		trackoffset = 0,
 		trackstrength = 6,
@@ -37,7 +38,7 @@ return {
 		turninplace = false,
 		--turninplaceanglelimit = 90,
 		turninplacespeedlimit = 4.7,
-		turnrate = 145.6,
+		turnrate = 364,
 		customparams = {
 			unitgroup = 'weapon',
 			model_author = "Flaka, Itanthias kitbash",


### PR DESCRIPTION
Additional Cortex T2 Vehicles balance pass:

Nerf corforge damage by a factor of 0.66 (-33%).
It was trading too well vs main battle units at point-blank range. 

Buff cortorch
Boost turnspeed by a factor of 2.5 (+150%). 
Still has the very slow acceleration, but can maneuver into position and turn around blockers a little better.
Gave it Fiend self-d
With some micro attention, cortorch can be self destructed to the same effect at the fiend. 