### PR TITLE
adjust logic for missile reaiming

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -11,13 +11,17 @@ function gadget:GetInfo()
 end
 
 local random = math.random
-local SpGetProjectileVelocity = Spring.GetProjectileVelocity
+
 local SpSetProjectileVelocity = Spring.SetProjectileVelocity
+local SpSetProjectileTarget = Spring.SetProjectileTarget
+
+local SpGetProjectileVelocity = Spring.GetProjectileVelocity
 local SpGetProjectileOwnerID = Spring.GetProjectileOwnerID
 local SpGetUnitStates = Spring.GetUnitStates
-local SpSetProjectileTarget = Spring.SetProjectileTarget
 local SpGetProjectileTimeToLive = Spring.GetProjectileTimeToLive
 local SpGetUnitWeaponTarget = Spring.GetUnitWeaponTarget
+local SpGetProjectileTarget = Spring.GetProjectileTarget
+local SpGetUnitIsDead = Spring.GetUnitIsDead
 
 if gadgetHandler:IsSyncedCode() then
 
@@ -122,20 +126,34 @@ if gadgetHandler:IsSyncedCode() then
 		-- instead of checking each in-flight missile
 		-- but not sure if there is an easy hook function or callin function
 		-- that only runs if a unit changes target
+
+		-- refactor slightly, only do target change if the target the missile
+		-- is heading towards is dead
+		-- karganeth switches away from alive units a little too often, causing
+		-- missiles that would have hit to instead miss
 		if SpGetProjectileTimeToLive(proID) <= 0 then
 			-- stop missile retargeting when it runs out of fuel
 			return true
 		end
-		--hardcoded to assume the retarget weapon is the primary weapon.
-		--TODO, make this more general
-		local target_type,_,owner_target = SpGetUnitWeaponTarget(SpGetProjectileOwnerID(proID),1)
-		if target_type == 1 then
-			--hardcoded to assume the retarget weapon does not target features or intercept projectiles, only targets units if not shooting ground.
-			--TODO, make this more general
-			 SpSetProjectileTarget(proID,owner_target,string.byte('u'))
-		end
-		if target_type == 2 then
-			SpSetProjectileTarget(proID,owner_target[1],owner_target[2],owner_target[3])
+
+		local targetTypeInt, targetID = SpGetProjectileTarget(proID)
+		-- if the missile is heading towards a unit
+		if targetTypeInt == string.byte('u') then
+			--check if the target unit is dead or dying
+			local dead_state = SpGetUnitIsDead(targetID)
+			if dead_state == nil or dead_state == true then
+				--hardcoded to assume the retarget weapon is the primary weapon.
+				--TODO, make this more general
+				local target_type,_,owner_target = SpGetUnitWeaponTarget(SpGetProjectileOwnerID(proID),1)
+				if target_type == 1 then
+					--hardcoded to assume the retarget weapon does not target features or intercept projectiles, only targets units if not shooting ground.
+					--TODO, make this more general
+					 SpSetProjectileTarget(proID,owner_target,string.byte('u'))
+				end
+				if target_type == 2 then
+					SpSetProjectileTarget(proID,owner_target[1],owner_target[2],owner_target[3])
+				end
+			end
 		end
 
 		return false


### PR DESCRIPTION
Further tests with the karganeth and the reduced missile turn rate vs fast rover units, revealed that the karganeth would switch away from alive targets during the periodic retarget sweeps. This would cause missiles on-route to killing a rover to instead veer away and try to hit the next target, but instead usually just hit the ground. 

This changes the logic, so the missiles changes targets only if the target they were heading towards dies. 
This also remove the "odd" behavior of manual retargeting of ground or attacking a new unit would cause all in flight missiles from the karg to change targets, even if the original target was still alive. 