### PR TITLE
Extra cor T2 veh balance tweaks

### DIFF
--- a/units/Scavengers/Vehicles/corforge.lua
+++ b/units/Scavengers/Vehicles/corforge.lua
@@ -2,8 +2,8 @@ return {
 	corforge = {
 		acceleration = 0.02547,
 		brakerate = 0.05093,
-		buildcostenergy = 6500,
-		buildcostmetal = 360,
+		buildcostenergy = 4700,
+		buildcostmetal = 330,
 		buildpic = "CORFORGE.DDS",
 		buildtime = 7200,
 		builddistance = 136,
@@ -39,7 +39,7 @@ return {
 		turninplaceanglelimit = 90,
 		turninplacespeedlimit = 1.287,
 		turnrate = 363,
-		workertime = 100,
+		workertime = 140,
 		buildoptions = {
 			[1] = "corsolar",
 			[2] = "corwin",
@@ -165,13 +165,6 @@ return {
 				turret = true,
 				weapontype = "Flame",
 				weaponvelocity = 600, 
-				customparams = {
-					sizeclass_GL4 = "Micro",
-				--	expl_light_color = "1 0.33 0.04",
-				--	expl_light_life_mult = 1.1,
-				--	expl_light_radius_mult = 1.15,
-				--	light_color = "1 0.5 0.05",
-				},
 				damage = {
 					default = 5.25,
 				},

--- a/units/Scavengers/Vehicles/corprinter.lua
+++ b/units/Scavengers/Vehicles/corprinter.lua
@@ -2,7 +2,7 @@ return {
 	corprinter = {
 		acceleration = 0.02547,
 		brakerate = 0.05093,
-		buildcostenergy = 6600,
+		buildcostenergy = 4700,
 		buildcostmetal = 330,
 		buildpic = "CORPRINTER.DDS",
 		buildtime = 10250,
@@ -21,7 +21,7 @@ return {
 		idletime = 1800,
 		leavetracks = true,
 		maxdamage = 5125, 
-		maxvelocity = 1.4,
+		maxvelocity = 1.65,
 		maxwaterdepth = 0,
 		movementclass = "MTANK3",
 		nochasecategory = "NOTLAND VTOL",


### PR DESCRIPTION
Buff corforge. Reduced metal and energy costs, and increased buildpower (100->140), so that it is just as efficient as the T2 con in terms of buildpower per cost. 
Buff corprinter. Reduced energy cost, and increased speed so it can keep up with the T2 con it is intended to assist. 