### PR TITLE
restore user volume when game ends

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -829,6 +829,14 @@ local isOffscreen = false
 local isOffscreenTime
 local prevOffscreenVolume
 local apiUnitTrackerEnabledCount = 0
+
+function resetUserVolume()
+	if prevOffscreenVolume then
+		Spring.SetConfigInt("snd_volmaster", prevOffscreenVolume)
+		prevOffscreenVolume = nil
+	end
+end
+
 function widget:Update(dt)
 	cursorBlinkTimer = cursorBlinkTimer + dt
 	if cursorBlinkTimer > cursorBlinkDuration then cursorBlinkTimer = 0 end
@@ -860,7 +868,7 @@ function widget:Update(dt)
 				if isOffscreen then
 					Spring.SetConfigInt("snd_volmaster", 0)
 				else
-					Spring.SetConfigInt("snd_volmaster", prevOffscreenVolume)
+					resetUserVolume()
 				end
 			end
 		end
@@ -6072,6 +6080,8 @@ function widget:Shutdown()
 	glDeleteList(consoleCmdDlist)
 	glDeleteList(textInputDlist)
 	WG['options'] = nil
+
+	resetUserVolume()
 end
 
 local lastOptionCommand = 0


### PR DESCRIPTION
restore user volume when game ends when "mute when offscreen" option is enabled.
so that lobby and next game aren't muted