### PR TITLE
Skuttle: use default mass

### DIFF
--- a/units/CorBots/T2/corsktl.lua
+++ b/units/CorBots/T2/corsktl.lua
@@ -19,7 +19,6 @@ return {
 		footprintz = 2,
 		idleautoheal = 5,
 		idletime = 1800,
-		mass = 300000000,
 		maxdamage = 355,
 		maxslope = 255,
 		maxvelocity = 2.8,


### PR DESCRIPTION
It already has `cantBeTransported = true` for untransportability purposes