### PR TITLE
salamander range nerf and damage buff (Additional Cortex T2 veh modoption)

### DIFF
--- a/units/Scavengers/Vehicles/corsala.lua
+++ b/units/Scavengers/Vehicles/corsala.lua
@@ -153,7 +153,7 @@ return {
 				impulsefactor = 0,
 				name = "HeatRay",
 				noselfdamage = true,
-				range = 440,
+				range = 350,
 				reloadtime = 0.7,
 				rgbcolor = "1 0.8 0",
 				rgbcolor2 = "0.8 0 0",
@@ -166,7 +166,7 @@ return {
 				weapontype = "BeamLaser",
 				damage = {
 					bombers = 4.7,
-					default = 8.25, --109
+					default = 10, --109
 					fighters = 4.7,
 					vtol = 4.7,
 				},

--- a/units/Scavengers/Vehicles/corsala.lua
+++ b/units/Scavengers/Vehicles/corsala.lua
@@ -165,18 +165,14 @@ return {
 				turret = true,
 				weapontype = "BeamLaser",
 				damage = {
-					bombers = 4.7,
 					default = 10, --109
-					fighters = 4.7,
-					vtol = 4.7,
 				},
 			},
 		},
 		weapons = {
 			[1] = {
-				badtargetcategory = "VTOL",
 				def = "cor_heat_laser",
-				onlytargetcategory = "NOTSUB",
+				onlytargetcategory = "SURFACE",
 			},
 		},
 	},


### PR DESCRIPTION
To address concerns that the 440 range weapon looks strange. Damaged buffed to compensate for laser falloff, so salamander does the same damage at 350 range as it did at 440 range. 
This puts salamander in the same range "category" as jaguar and centurion.

Salamander loses some skirmishing abilities (skirmishing is already common enough in the cor T2 veh lab), in exchange for better close-range damage. 