### PR TITLE
Fix water units in buildmenu on maps with custom water levels

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -183,6 +183,7 @@ local showWaterUnits = false
 local _, _, mapMinWater, _ = Spring.GetGroundExtremes()
 if not voidWater and mapMinWater <= minWaterUnitDepth then
 	showWaterUnits = true
+	units.restrictWaterUnits(false)
 end
 -- make them a disabled unit (instead of removing it entirely)
 if not showWaterUnits then


### PR DESCRIPTION
Water units were not being correctly enabled on dry maps that had custom water levels applied.