### PR TITLE
Balance changes to T1 missile trucks and T1 veh artillery

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 ﻿# July 2023
+• [Whistler] Range decreased from 600 -> 575
+• [Lasher] Damage per shot decreased 47 -> 43
+• [Shellshocker] Reloadtime increased 5.7s -> 6.2s
+• [Wolverine] Reloadtime increased 6.6s -> 7.2s
 • [Dolphin] Cost increased from 165m 1400E -> 175m 1500E
 • [Herring] Cost decreased from 230m 1600E -> 210m 1400E
 • [Corsair] Depthcharge reloadtime decreased 2.24->2s

--- a/units/ArmVehicles/armart.lua
+++ b/units/ArmVehicles/armart.lua
@@ -149,7 +149,7 @@ return {
 				name = "Long-range high-trajectory g2g plasma cannon",
 				noselfdamage = true,
 				range = 710,
-				reloadtime = 5.7,
+				reloadtime = 6.1,--5.7,
 				soundhit = "tawf113a",
 				soundhitwet = "splsmed",
 				soundstart = "cannhvy3",

--- a/units/ArmVehicles/armsam.lua
+++ b/units/ArmVehicles/armsam.lua
@@ -136,7 +136,7 @@ return {
 				model = "cormissile.s3o",
 				name = "Light g2g/g2a missile launcher",
 				noselfdamage = true,
-				range = 600,
+				range = 575,--600,
 				reloadtime = 3.33333,
 				smoketrail = true,
 				smokePeriod = 8,

--- a/units/CorVehicles/cormist.lua
+++ b/units/CorVehicles/cormist.lua
@@ -160,7 +160,7 @@ return {
 				damage = {
 					bombers = 120,
 					commanders = 32,
-					default = 47,
+					default = 44,--47,
 					fighters = 120,
 					vtol = 120,
 				},

--- a/units/CorVehicles/corwolv.lua
+++ b/units/CorVehicles/corwolv.lua
@@ -154,7 +154,7 @@ return {
 				name = "LightArtillery",
 				noselfdamage = true,
 				range = 710,
-				reloadtime = 6.6,
+				reloadtime = 7.1,--6.6,
 				soundhit = "tawf113a",
 				soundhitwet = "splsmed",
 				soundstart = "cannhvy3",


### PR DESCRIPTION
Whistler range decreased 600 ->575 as it was too easy to kite enemies, especially bots.  Lasher was not as strong at kiting due to its slower speed, but an early group can still apply a lot of pressure so its damage is being reduced by 6%.  This change also helps to differentiate each missile truck to match its faction's playstyle.  The T1 vehicle artillery (Shellshocker and Wolverine) are also having their effective dps reduced by 7% in order to give the defender more time to respond to an artillery push.