### PR TITLE
Remove dev keys from default hotkeys

### DIFF
--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -1,0 +1,58 @@
+
+// common interface keys
+bind                esc  select AllMap++_ClearSelection_SelectNum_0+
+bind                esc  quitmessage
+bind          Shift+esc  quitmenu
+bind     Ctrl+Shift+esc  quitforce
+bind      Alt+Shift+esc  reloadforce
+bind         Any+escape  edit_escape
+bind          Any+pause  pause
+bind                esc  teamstatus_close
+bind                esc  customgameinfo_close
+bind                esc  buildmenu_pregame_deselect
+
+// common selectbox keys
+bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
+bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget
+bind          Any+shift  selectbox_all      // select all units modifier | Smart Select Widget
+bind           Any+ctrl  selectbox_deselect // remove units from current selection modifier | Smart Select Widget
+bind            Any+alt  selectbox_mobile   // select only mobile units modifier | Smart Select Widget
+
+bind          Any+space  selectloop         // activate select shape | Loop Select Widget
+bind           Any+ctrl  selectloop_invert  // select units not present in current selection modifier | Loop Select Widget
+bind          Any+shift  selectloop_add     // add to selection modifier | Loop Select Widget
+
+
+// common chat keys
+bind          Any+enter  chat
+bind      Alt+ctrl+sc_a  chatswitchally
+bind      Alt+ctrl+sc_s  chatswitchspec
+
+bind            Any+tab  edit_complete
+bind      Any+backspace  edit_backspace
+bind         Any+delete  edit_delete
+bind           Any+home  edit_home
+bind           Alt+left  edit_home
+bind            Any+end  edit_end
+bind          Alt+right  edit_end
+bind             Any+up  edit_prev_line
+bind           Any+down  edit_next_line
+bind           Any+left  edit_prev_char
+bind          Any+right  edit_next_char
+bind          Ctrl+left  edit_prev_word
+bind         Ctrl+right  edit_next_word
+bind          Any+enter  edit_return
+
+bind             Ctrl+v  pastetext
+
+// common camera controls
+bind             Any+up  moveforward
+bind           Any+down  moveback
+bind          Any+right  moveright
+bind           Any+left  moveleft
+bind         Any+pageup  moveup
+bind       Any+pagedown  movedown
+
+bind            Any+alt  movereset      // fast camera reset on mousewheel
+bind            Any+alt  moverotate     // rotate on x,y with mmb hold + move (Spring Camera)
+bind           Any+ctrl  movetilt       // rotate on x with mousewheel

--- a/luaui/configs/hotkeys/default_keys.txt
+++ b/luaui/configs/hotkeys/default_keys.txt
@@ -1,22 +1,6 @@
-bind esc quitmessage
-bind Shift+esc quitmenu
-bind Ctrl+Shift+esc quitforce
-bind Alt+Shift+esc reloadforce
-bind Any+escape edit_escape
-bind Any+pause pause
-bind esc teamstatus_close
-bind esc customgameinfo_close
-bind esc buildmenu_pregame_deselect
-
-bind Any+sc_z selectbox_same // select only units that share type with current selection modifier | Smart Select Widget
-bind Any+space selectbox_idle // select only idle units modifier | Smart Select Widget
-bind Any+shift selectbox_all // select all units modifier | Smart Select Widget
-bind Any+ctrl selectbox_deselect // remove units from current selection modifier | Smart Select Widget
-bind Any+alt selectbox_mobile // select only mobile units modifier | Smart Select Widget
-
-bind Any+space selectloop // activate select shape | Loop Select Widget
-bind Any+ctrl selectloop_invert // select units not present in current selection modifier | Loop Select Widget
-bind Any+shift selectloop_add // add to selection modifier | Loop Select Widget
+// Load common keys
+keyload luaui/configs/hotkeys/chat_and_ui_keys.txt
+keyload luaui/configs/hotkeys/num_keys.txt
 
 bind Any+sc_h sharedialog
 bind sc_i customgameinfo
@@ -24,27 +8,6 @@ bind sc_i customgameinfo
 bind Shift+backspace togglecammode
 bind Ctrl+backspace togglecammode
 bind Any+tab toggleoverview
-
-bind Any+enter chat
-bind Alt+ctrl+sc_a chatswitchally
-bind Alt+ctrl+sc_s chatswitchspec
-
-bind Any+tab edit_complete
-bind Any+backspace edit_backspace
-bind Any+delete edit_delete
-bind Any+home edit_home
-bind Alt+left edit_home
-bind Any+end edit_end
-bind Alt+right edit_end
-bind Any+up edit_prev_line
-bind Any+down edit_next_line
-bind Any+left edit_prev_char
-bind Any+right edit_next_char
-bind Ctrl+left edit_prev_word
-bind Ctrl+right edit_next_word
-bind Any+enter edit_return
-
-bind Ctrl+v pastetext
 
 bind Any+home increaseViewRadius
 bind Any+end decreaseViewRadius
@@ -70,9 +33,7 @@ bind sc_a attack
 bind Shift+sc_a attack
 bind Alt+sc_a areaattack
 bind Alt+Shift+sc_a areaattack
-bind Alt+b debug
-bind Alt+v debugcolvol
-bind Alt+p debugpath
+
 bind sc_d manualfire
 bind Shift+sc_d manualfire
 bind sc_d manuallaunch
@@ -139,20 +100,6 @@ bind Alt+enter fullscreen
 
 bind sc_`,sc_` drawlabel // double hit ` for drawlabel
 bind sc_` drawinmap
-
-bind Any+up moveforward
-bind Any+down moveback
-bind Any+right moveright
-bind Any+left moveleft
-bind Any+pageup moveup
-bind Any+pagedown movedown
-
-bind Any+ctrl moveslow
-bind Any+shift movefast
-
-bind Any+alt movereset // fast camera reset on mousewheel
-bind Any+alt moverotate // rotate on x,y with mmb hold + move (Spring Camera)
-bind Any+ctrl movetilt // rotate on x with mousewheel
 
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
@@ -311,5 +258,3 @@ bind sc_y settargetnoground
 bind Ctrl+sc_` group unset
 
 bind Alt+sc_` remove_from_autogroup // Auto Group
-
-keyload luaui/configs/hotkeys/num_keys.txt

--- a/luaui/configs/hotkeys/default_keys_60pct.txt
+++ b/luaui/configs/hotkeys/default_keys_60pct.txt
@@ -264,5 +264,3 @@ bind sc_y settargetnoground
 bind Ctrl+meta+sc_q group unset
 // if WG[bind Auto Group ] then
 bind Alt+sc_q remove_from_autogroup
-
-keyload luaui/configs/hotkeys/num_keys.txt

--- a/luaui/configs/hotkeys/default_keys_60pct.txt
+++ b/luaui/configs/hotkeys/default_keys_60pct.txt
@@ -1,25 +1,9 @@
 // BAR hotkey config file: default for 60% keyboards
 // remap F-keys to use meta+ (spacebar) and ` to Q with modifiers
 
-bind esc quitmessage
-bind Shift+esc quitmenu
-bind Ctrl+Shift+esc quitforce
-bind Alt+Shift+esc reloadforce
-bind Any+escape edit_escape
-bind Any+pause pause
-bind esc teamstatus_close
-bind esc customgameinfo_close
-bind esc buildmenu_pregame_deselect
-
-bind Any+sc_z selectbox_same // select only units that share type with current selection modifier | Smart Select Widget
-bind Any+space selectbox_idle // select only idle units modifier | Smart Select Widget
-bind Any+shift selectbox_all // select all units modifier | Smart Select Widget
-bind Any+ctrl selectbox_deselect // select units not present in current selection modifier | Smart Select Widget
-bind Any+alt selectbox_mobile // select only mobile units modifier | Smart Select Widget
-
-bind Any+space selectloop // activate select shape | Loop Select Widget
-bind Any+ctrl selectloop_invert // select units not present in current selection modifier | Loop Select Widget
-bind Any+shift selectloop_add // add to selection modifier | Loop Select Widget
+// Load common keys
+keyload luaui/configs/hotkeys/chat_and_ui_keys.txt
+keyload luaui/configs/hotkeys/num_keys.txt
 
 bind Any+sc_h sharedialog
 bind sc_i customgameinfo
@@ -27,27 +11,6 @@ bind sc_i customgameinfo
 bind Shift+backspace togglecammode
 bind Ctrl+backspace togglecammode
 bind Any+tab toggleoverview
-
-bind Any+enter chat
-bind Alt+ctrl+sc_a chatswitchally
-bind Alt+ctrl+sc_s chatswitchspec
-
-bind Any+tab edit_complete
-bind Any+backspace edit_backspace
-bind Any+delete edit_delete
-bind Any+home edit_home
-bind Alt+left edit_home
-bind Any+end edit_end
-bind Alt+right edit_end
-bind Any+up edit_prev_line
-bind Any+down edit_next_line
-bind Any+left edit_prev_char
-bind Any+right edit_next_char
-bind Ctrl+left edit_prev_word
-bind Ctrl+right edit_next_word
-bind Any+enter edit_return
-
-bind Ctrl+v pastetext
 
 bind Any+home increaseViewRadius
 bind Any+end decreaseViewRadius
@@ -138,20 +101,6 @@ bind meta+8 screenshot png
 
 bind Ctrl+Shift+f8 savegame
 bind Alt+enter fullscreen
-
-bind Any+up moveforward
-bind Any+down moveback
-bind Any+right moveright
-bind Any+left moveleft
-bind Any+pageup moveup
-bind Any+pagedown movedown
-
-bind Any+ctrl moveslow
-bind Any+shift movefast
-
-bind Any+alt movereset // fast camera reset on mousewheel
-bind Any+alt moverotate // rotate on x,y with mmb hold + move (Spring Camera)
-bind Any+ctrl movetilt // rotate on x with mousewheel
 
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+

--- a/luaui/configs/hotkeys/dev_keys.txt
+++ b/luaui/configs/hotkeys/dev_keys.txt
@@ -1,0 +1,3 @@
+bind Alt+b debug
+bind Alt+v debugcolvol
+bind Alt+p debugpath

--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -1,49 +1,11 @@
 // BAR hotkey config file: ergokeys for grid menu
 
 
-bind                esc  select AllMap++_ClearSelection_SelectNum_0+
-bind                esc  quitmessage
-bind          Shift+esc  quitmenu
-bind     Ctrl+Shift+esc  quitforce
-bind      Alt+Shift+esc  reloadforce
-bind         Any+escape  edit_escape
-bind          Any+pause  pause
-bind                esc  teamstatus_close
-bind                esc  customgameinfo_close
-bind                esc  buildmenu_pregame_deselect
-
-bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
-bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget
-bind          Any+shift  selectbox_all      // select all units modifier | Smart Select Widget
-bind           Any+ctrl  selectbox_deselect // remove units from current selection modifier | Smart Select Widget
-bind            Any+alt  selectbox_mobile   // select only mobile units modifier | Smart Select Widget
-
-bind          Any+space  selectloop         // activate select shape | Loop Select Widget
-bind           Any+ctrl  selectloop_invert  // select units not present in current selection modifier | Loop Select Widget
-bind          Any+shift  selectloop_add     // add to selection modifier | Loop Select Widget
-
+// Load common keys
+keyload     luaui/configs/hotkeys/chat_and_ui_keys.txt
 keyload     luaui/configs/hotkeys/gridmenu_keys.txt
+keyload     luaui/configs/hotkeys/num_keys.txt
 
-bind          Any+enter  chat
-bind      Alt+ctrl+sc_a  chatswitchally
-bind      Alt+ctrl+sc_s  chatswitchspec
-
-bind            Any+tab  edit_complete
-bind      Any+backspace  edit_backspace
-bind         Any+delete  edit_delete
-bind           Any+home  edit_home
-bind           Alt+left  edit_home
-bind            Any+end  edit_end
-bind          Alt+right  edit_end
-bind             Any+up  edit_prev_line
-bind           Any+down  edit_next_line
-bind           Any+left  edit_prev_char
-bind          Any+right  edit_next_char
-bind          Ctrl+left  edit_prev_word
-bind         Ctrl+right  edit_next_word
-bind          Any+enter  edit_return
-
-bind             Ctrl+v  pastetext
 
 bind           Alt+sc_=  increasespeed
 bind           Alt+sc_-  decreasespeed
@@ -157,17 +119,6 @@ bind           Alt+sc_`  remove_from_autogroup
 bind          sc_`,sc_`  drawlabel
 bind               sc_`  drawinmap
 
-bind             Any+up  moveforward
-bind           Any+down  moveback
-bind          Any+right  moveright
-bind           Any+left  moveleft
-bind         Any+pageup  moveup
-bind       Any+pagedown  movedown
-
-bind            Any+alt  movereset      // fast camera reset on mousewheel
-bind            Any+alt  moverotate     // rotate on x,y with mmb hold + move (Spring Camera)
-bind           Any+ctrl  movetilt       // rotate on x with mousewheel
-
 bind          Ctrl+sc_e  select AllMap++_ClearSelection_SelectAll+
 bind           Ctrl+tab  select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
 bind                tab  select AllMap+_ManualFireUnit_Not_IdMatches_cordecom_Not_IdMatches_armdecom_Not_IdMatches_armthor+_ClearSelection_SelectOne+
@@ -192,8 +143,6 @@ bind            numpad+  snd_volume_increase
 bind               sc_=  snd_volume_increase
 bind               sc_-  snd_volume_decrease
 bind            numpad-  snd_volume_decrease
-
-keyload luaui/configs/hotkeys/num_keys.txt
 
 // camera anchors
 bind            Ctrl+F1  set_camera_anchor 1

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -1,52 +1,14 @@
 // BAR hotkey config file: grid optimized for 60% keyboards
 // remap F-keys to use meta+ (spacebar) and ` to Q with modifiers
 
-bind                esc  select AllMap++_ClearSelection_SelectNum_0+
-bind                esc  quitmessage
-bind          Shift+esc  quitmenu
-bind     Ctrl+Shift+esc  quitforce
-bind      Alt+Shift+esc  reloadforce
-bind         Any+escape  edit_escape
-bind          Any+pause  pause
-bind                esc  teamstatus_close
-bind                esc  customgameinfo_close
-bind                esc  buildmenu_pregame_deselect
+// Load common keys
+keyload     luaui/configs/hotkeys/chat_and_ui_keys.txt
+keyload     luaui/configs/hotkeys/gridmenu_keys.txt
+keyload     luaui/configs/hotkeys/num_keys.txt
 
-bind           Any+sc_z  selectbox_same         // select only units that share type with current selection modifier | Smart Select Widget
-bind          Any+space  selectbox_idle         // select only idle units modifier | Smart Select Widget
-bind          Any+shift  selectbox_all          // select all units modifier | Smart Select Widget
-bind           Any+ctrl  selectbox_deselect     // remove units from current selection modifier | Smart Select Widget
-bind            Any+alt  selectbox_mobile       // select only mobile units modifier | Smart Select Widget
 
-bind          Any+space  selectloop             // activate select shape | Loop Select Widget
-bind           Any+ctrl  selectloop_invert      // select units not present in current selection modifier | Loop Select Widget
-bind          Any+shift  selectloop_add         // add to selection modifier | Loop Select Widget
-
-keyload luaui/configs/hotkeys/gridmenu_keys.txt
-
-bind          Any+enter  chat
-bind      Alt+ctrl+sc_a  chatswitchally
-bind      Alt+ctrl+sc_s  chatswitchspec
-
-bind            Any+tab  edit_complete
-bind      Any+backspace  edit_backspace
-bind         Any+delete  edit_delete
-bind           Any+home  edit_home
-bind           Alt+left  edit_home
-bind            Any+end  edit_end
-bind          Alt+right  edit_end
-bind             Any+up  edit_prev_line
-bind           Any+down  edit_next_line
-bind           Any+left  edit_prev_char
-bind          Any+right  edit_next_char
-bind          Ctrl+left  edit_prev_word
-bind         Ctrl+right  edit_next_word
-bind          Any+enter  edit_return
-
-bind             Ctrl+v  pastetext
-
-bind              Alt+=  increasespeed
-bind              Alt+-  decreasespeed
+bind           Alt+sc_=  increasespeed
+bind           Alt+sc_-  decreasespeed
 bind        Alt+numpad+  increasespeed
 bind        Alt+numpad-  decreasespeed
 
@@ -157,17 +119,6 @@ bind           Alt+sc_q  remove_from_autogroup
 bind meta+sc_q,meta+sc_q  drawlabel
 bind          meta+sc_q  drawinmap
 
-bind             Any+up  moveforward
-bind           Any+down  moveback
-bind          Any+right  moveright
-bind           Any+left  moveleft
-bind         Any+pageup  moveup
-bind       Any+pagedown  movedown
-
-bind            Any+alt  movereset      // fast camera reset on mousewheel
-bind            Any+alt  moverotate     // rotate on x,y with mmb hold + move (Spring Camera)
-bind           Any+ctrl  movetilt       // rotate on x with mousewheel
-
 bind          Ctrl+sc_e  select AllMap++_ClearSelection_SelectAll+
 bind           Ctrl+tab  select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
 bind                tab  select AllMap+_ManualFireUnit_Not_IdMatches_cordecom_Not_IdMatches_armdecom_Not_IdMatches_armthor+_ClearSelection_SelectOne+
@@ -193,7 +144,7 @@ bind               sc_=  snd_volume_increase
 bind               sc_-  snd_volume_decrease
 bind            numpad-  snd_volume_decrease
 
-keyload luaui/configs/hotkeys/num_keys.txt
+
 
 // camera anchors
 bind        Ctrl+meta+1  set_camera_anchor 1

--- a/luaui/configs/hotkeys/mnemonic_keys.txt
+++ b/luaui/configs/hotkeys/mnemonic_keys.txt
@@ -1,25 +1,9 @@
 // BAR hotkey config file - for users with non-qwerty layouts who have
 // learned _mnemonic_ binds instead of _positional_ binds.
-local bindings = {
-bind esc quitmessage
-bind Shift+esc quitmenu
-bind Ctrl+Shift+esc quitforce
-bind Alt+Shift+esc reloadforce
-bind Any+escape edit_escape
-bind Any+pause pause
-bind esc teamstatus_close
-bind esc customgameinfo_close
-bind esc buildmenu_pregame_deselect
 
-bind Any+z selectbox_same // select only units that share type with current selection modifier | Smart Select Widget
-bind Any+space selectbox_idle // select only idle units modifier | Smart Select Widget
-bind Any+shift selectbox_all // select all units modifier | Smart Select Widget
-bind Any+ctrl selectbox_deselect // remove units from current selection modifier | Smart Select Widget
-bind Any+alt selectbox_mobile // select only mobile units modifier | Smart Select Widget
-
-bind Any+space selectloop // activate select shape | Loop Select Widget
-bind Any+ctrl selectloop_invert // select units not present in current selection modifier | Loop Select Widget
-bind Any+shift selectloop_add // add to selection modifier | Loop Select Widget
+// Load common keys
+keyload     luaui/configs/hotkeys/chat_and_ui_keys.txt
+keyload     luaui/configs/hotkeys/num_keys.txt
 
 bind Any+h sharedialog
 bind i customgameinfo
@@ -27,27 +11,6 @@ bind i customgameinfo
 bind Shift+backspace togglecammode
 bind Ctrl+backspace togglecammode
 bind Any+tab toggleoverview
-
-bind Any+enter chat
-bind Alt+ctrl+a chatswitchally
-bind Alt+ctrl+s chatswitchspec
-
-bind Any+tab edit_complete
-bind Any+backspace edit_backspace
-bind Any+delete edit_delete
-bind Any+home edit_home
-bind Alt+left edit_home
-bind Any+end edit_end
-bind Alt+right edit_end
-bind Any+up edit_prev_line
-bind Any+down edit_next_line
-bind Any+left edit_prev_char
-bind Any+right edit_next_char
-bind Ctrl+left edit_prev_word
-bind Ctrl+right edit_next_word
-bind Any+enter edit_return
-
-bind Ctrl+v pastetext
 
 bind Any+home increaseViewRadius
 bind Any+end decreaseViewRadius
@@ -145,20 +108,6 @@ bind Alt+enter fullscreen
 bind Any+sc_` drawinmap
 bind Any+sc_` drawlabel
 bind sc_`,sc_` drawlabel
-
-bind Any+up moveforward
-bind Any+down moveback
-bind Any+right moveright
-bind Any+left moveleft
-bind Any+pageup moveup
-bind Any+pagedown movedown
-
-bind Any+ctrl moveslow
-bind Any+shift movefast
-
-bind Any+alt movereset // fast camera reset on mousewheel
-bind Any+alt moverotate // rotate on x,y with mmb hold + move (Spring Camera)
-bind Any+ctrl movetilt // rotate on x with mousewheel
 
 bind Ctrl+a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
@@ -323,5 +272,3 @@ bind y settargetnoground
 bind Ctrl+sc_` group unset
 // if WG[bind Auto Group ] then
 bind Alt+sc_` remove_from_autogroup
-
-keyload luaui/configs/hotkeys/num_keys.txt


### PR DESCRIPTION
### Changes
- No more dev hotkeys in the default configuration. This, quite simply, was terrible. Caused tons of confusion for players who pressed these keys accidently.
- Moved some chat/ui hotkeys into their own file, because they were shared between *all* preset configurations. Seemed logical.

### To continue using dev keys
There are many ways. Each one will involve setting your hotkey preset to `Custom` and having a uikeys.txt file.
If you want the exact same setup as before, make a uikeys.txt like this
```
unbindall
keyload luaui/configs/hotkeys/default_keys.txt
keyload luaui/configs/hotkeys/dev_keys.txt
```
That's it.

If you want to use the dev keys in any other config, either import `dev_keys.txt` as above, or manually include each of the debug binds into your uikeys
```
bind Alt+b debug
bind Alt+v debugcolvol
bind Alt+p debugpath
```