### PR TITLE
modoption to override map gravity

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1180,6 +1180,25 @@ function WeaponDef_Post(name, wDef)
 
 	if not SaveDefsToCustomParams then
 		-------------- EXPERIMENTAL MODOPTIONS
+		-- Standard Gravity
+		local gravityModOption = Spring.GetModOptions().experimentalstandardgravity
+
+		Spring.Echo(wDef.name,wDef.mygravity)
+		if gravityModOption == "low" then
+			if wDef.mygravity == nil then
+				wDef.mygravity = 0.0889 --80/900
+			end
+		elseif gravityModOption == "standard" then
+			if wDef.mygravity == nil then
+				wDef.mygravity = 0.1333 --120/900
+			end
+		elseif gravityModOption == "high" then
+			if wDef.mygravity == nil then
+				wDef.mygravity = 0.1667 --150/900
+			end
+		end
+
+
 		---- SHIELD CHANGES
 		local shieldModOption = Spring.GetModOptions().experimentalshields
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1233,6 +1233,21 @@ local options={
 	},
 
 	{
+		key    = 'experimentalstandardgravity',
+		name   = 'Standard Gravity',
+		desc   = 'Override map gravity for weapons',
+		type   = 'list',
+		section = 'options_experimental',
+		def  = "mapgravity",
+		items={
+			{key="mapgravity", name="Map Gravity", desc="Uses map defined gravity"},
+			{key="low", name="Low Gravity", desc="80 gravity"},
+			{key="standard", name="Standard Gravity", desc="120 gravity"},
+			{key="high", name="High Gravity", desc="150 gravity"},
+		}
+	},
+
+	{
 		key    = 'experimentalextraunits',
 		name   = 'Extra Unit Pack',
 		desc   = 'Formerly known as Scavenger units. Addon pack of units for Armada and Cortex, including various "fun" units',


### PR DESCRIPTION
Sets the mygravity weapondef parameter to a constant value for all weapons that do not have the mygravity parameter set. This overrides map gravity for ballistic weapons. 

This PR sets the default value of the modoption to just use map gravity, the current existing behavior.

In general, a higher gravity means:
1. shorter time to impact for high trajectory weapons.
2. higher arc for low trajectory weapons, allowing units to fire over more friendly stuff.
3. slightly more clustered aircraft bombs, and more centered on the actual target point.

A modoption to override map gravity allows units to perform consistently across different maps, without dependence on a "hidden" gravity value. 

If merged in, this PR for Chobby should also be merged in
https://github.com/beyond-all-reason/BYAR-Chobby/pull/443