### PR TITLE
Removes print() which has been flooding logs

### DIFF
--- a/luaui/Widgets/reclaim_field_highlight.lua
+++ b/luaui/Widgets/reclaim_field_highlight.lua
@@ -305,7 +305,7 @@ function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 				for j = 1, #separators - 1 do
 					local sepStart = separators[j]
 					local sepEnd = separators[j + 1]
-					print(sepEnd, sepStart, sepEnd - sepStart, self.minPoints)
+					--print(sepEnd, sepStart, sepEnd - sepStart, self.minPoints)
 					if sepEnd - sepStart >= self.minPoints then
 						--Spring.Echo("sepEnd - sepStart >= self.minPoints")
 						--self.ordered[start:end]


### PR DESCRIPTION
This is the print statement which has flooding the logs with tables such as this one:
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/20977204/7352db80-9051-457f-b2d7-923cca743f73)

Rather tricky to locate because it wasn't using Spring.Echo or log.info(). Only managed to find it because I noticed it happening at the start of maps with reclaim, and not on maps without. That then gave me the idea to reclaim stuff and see if the numbers would change, which they did! Toggling reclaim-related widgets on and off quickly led me here.