### PR TITLE
add two QoL unit widgets

### DIFF
--- a/luaui/Widgets/cmd_unitgroup_no_camera_move_on_group_select.lua
+++ b/luaui/Widgets/cmd_unitgroup_no_camera_move_on_group_select.lua
@@ -1,0 +1,20 @@
+local versionNumber = "1.0"
+
+function widget:GetInfo()
+	return {
+		name      = "Unit Groups - No camera move on group select",
+		desc      = "Disables the camera movement if you select a unit group twice [v" .. string.format("%s", versionNumber ) .. "]",
+		author    = "very_bad_soldier",
+		date      = "Januar 6, 2013",
+		license   = "GNU GPL v2",
+		layer     = 0,
+		enabled   = false
+	}
+end
+
+local spGetSelectedUnits = Spring.GetSelectedUnits
+local spSelectUnitArray	 = Spring.SelectUnitArray
+
+function widget:CommandsChanged( id, params, options )
+	spSelectUnitArray( spGetSelectedUnits() )
+end


### PR DESCRIPTION
Please lemme have these before custom widgets get banned ;) I would be able to play the game then with disabled user widgets

## Unit Groups - No camera move on group select

Disables camera movement to unit group when double-pressing the unit group number on keyboard. Defaults to `off`

## Unit Groups - Remove units from a group

Implements action `groupclear` to remove units from their current group. I think this is missing in general. Defaults to `on`


Thanks guys ;)