### PR TITLE
Hitbox benchmark test do not merge this is a performance bomb

### DIFF
--- a/units/ArmBots/armpw.lua
+++ b/units/ArmBots/armpw.lua
@@ -11,6 +11,7 @@ return {
 		collisionvolumeoffsets = "0 -1 0",
 		collisionvolumescales = "22 30 22",
 		collisionvolumetype = "CylY",
+		usepiececollisionvolumes = 1, --- dont merge this 
 		corpse = "DEAD",
 		explodeas = "smallExplosionGeneric",
 		footprintx = 2,

--- a/units/CorBots/corak.lua
+++ b/units/CorBots/corak.lua
@@ -11,6 +11,7 @@ return {
 		collisionvolumeoffsets = "0 -2 0",
 		collisionvolumescales = "24 32 24",
 		collisionvolumetype = "CylY",
+		usepiececollisionvolumes = 1,
 		corpse = "DEAD",
 		explodeas = "smallexplosiongeneric",
 		footprintx = 2,


### PR DESCRIPTION
this is to benchmark the CPU COST of collision boxes 
this makes the armpw and corak have 15 and 14 hitboxes respectively
its an unrealistic number that will be allowed