### PR TITLE
Broadcast mouse position for all players to spectators

### DIFF
--- a/luarules/gadgets/cmd_mouse_pos_broadcast.lua
+++ b/luarules/gadgets/cmd_mouse_pos_broadcast.lua
@@ -110,7 +110,7 @@ end
 function handleMousePosEvent(_,playerID,x,z,click)
 	--here we receive mouse pos from other players and dispatch to luaui
 	local spec, fullView = GetSpectatingState()
-	if not spec or not fullView then
+	if not spec then
 		local _,_,targetSpec,_,allyTeamID = GetPlayerInfo(playerID,false)
 		if targetSpec or allyTeamID ~= select(5,GetPlayerInfo(myPlayerID,false)) then
 			return

--- a/luarules/gadgets/cmd_selected_units.lua
+++ b/luarules/gadgets/cmd_selected_units.lua
@@ -71,7 +71,7 @@ else
 
 	function handleSelectionUpdateEvent(_,playerID,msg,compressed)
 		local spec, fullView = GetSpectatingState()
-		if not spec or not fullView then
+		if not spec then
 			local _,_,targetSpec,_,allyTeamID = GetPlayerInfo(playerID,false)
 			if targetSpec or allyTeamID ~= select(5,GetPlayerInfo(myPlayerID,false)) then
 				return


### PR DESCRIPTION
The `/specteam` command changes `allyTeamID` in unsynced state, but `GetPlayerInfo` reads synced state since the gadget is running synced. Therefore `allyTeamID` is always `0` in this gadget even if the user has changed their spectating team. Instead of sending the changing spec team from unsynced to synced state, widgets that show cursor info (gui_ally_cursors) can read the actual `teamID` from unsynced (which it already does with GetMyTeamID).

This will then fix the bug where spectating players from teams other than team 0 cannot update the mouse cursor light position.

The same issue is in cmd_selected_units which causes selections to not appear when spectating teams > 0.