### PR TITLE
cmd_unitgroup_clear_selection_on_empty.lua: make code robust against …

### DIFF
--- a/luaui/Widgets/cmd_unitgroup_clear_selection_on_empty.lua
+++ b/luaui/Widgets/cmd_unitgroup_clear_selection_on_empty.lua
@@ -21,15 +21,15 @@ local function ClearSelectionIfGroupSelected(groupIndex)
 end
 
 local function OnGroupSelected(_, _, args)
+	if not args then return end
+
 	local unitGroupArgIdx = 1
 	-- variant: if "select" is first argument, then unit group is second
 	if args[1] == "select" then
-		unitGroupIdx = 2
+		unitGroupArgIdx = 2
 	end
 
-	local groupIndex = args and tonumber(args[unitGroupArgIdx])
-
-	if not groupIndex then return end
+	local groupIndex = tonumber(args[unitGroupArgIdx])
 
 	ClearSelectionIfGroupSelected(groupIndex)
 end


### PR DESCRIPTION
…args being nil

Sorry Floris, missed this yesterady: the code before was robust against `args` being `nil`. Not sure if that can happen in real life but I think the modification should stick to that behavior.

Also one variable was misnamed.