### PR TITLE
cmd_unitgroup_clear_selection_on_empty.lua: fix crash on subcommands …

### DIFF
--- a/luaui/Widgets/cmd_unitgroup_clear_selection_on_empty.lua
+++ b/luaui/Widgets/cmd_unitgroup_clear_selection_on_empty.lua
@@ -31,6 +31,9 @@ local function OnGroupSelected(_, _, args)
 
 	local groupIndex = tonumber(args[unitGroupArgIdx])
 
+	-- 2nd arg can also be e.g. "set" - but we only want to react to a selection
+	if not groupIndex then return end
+
 	ClearSelectionIfGroupSelected(groupIndex)
 end
 


### PR DESCRIPTION
…different to "select"

Hello Floris, me again :) Well sorry, there was another case that crashed the widget e.g. on `group set`.  :/

Should be fine now... I guess...