### PR TITLE
Fix camera_player_tv widget not saving config correctly

### DIFF
--- a/luaui/Widgets/camera_player_tv.lua
+++ b/luaui/Widgets/camera_player_tv.lua
@@ -845,7 +845,7 @@ function widget:SetConfigData(data)
 	if Spring.GetGameFrame() > 0 and data.toggled ~= nil then
 		toggled = data.toggled
 	end
-	if data.alwaysDisplayName then
+	if data.alwaysDisplayName ~= nil then
 		alwaysDisplayName = data.alwaysDisplayName
 	end
 	if data.playerChangeDelay then


### PR DESCRIPTION
Previously, `alwaysDisplayName` was always reset to true, due to a bug in the widget's `SetConfigData` function. `alwaysDisplayName` is a boolean value, so we need to compare against `nil` instead of a plain if condition.