### PR TITLE
Mex Collision Respected Shell

### DIFF
--- a/units/ArmBuildings/LandEconomy/armamex.lua
+++ b/units/ArmBuildings/LandEconomy/armamex.lua
@@ -38,7 +38,7 @@ return {
 		selfdestructcountdown = 1,
 		sightdistance = 286,
 		stealth = true,
-		yardmap = "h bbbbbbbb bsyssosb bobssbyb bssccssb bssccssb bybssbob bsossysb bbbbbbbb",
+		yardmap = "h bbbbbbbb bssssssb bsbyobsb bsoccysb bsyccosb bsboybsb bssssssb bbbbbbbb",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armamex_aoplane.dds",

--- a/units/ArmBuildings/LandEconomy/armmex.lua
+++ b/units/ArmBuildings/LandEconomy/armmex.lua
@@ -35,7 +35,7 @@ return {
 		selfdestructcountdown = 1,
 		sightdistance = 273,
 		--waterline = 0,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h bbbbbbbb bsossosb bobbbbob bsbccbsb bsbccbsb bobbbbob bsossosb bbbbbbbb",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armmex_aoplane.dds",

--- a/units/ArmBuildings/SeaEconomy/armuwmex.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwmex.lua
@@ -36,7 +36,7 @@ return {
 		sightdistance = 182,
 		usepiececollisionvolumes = true,
 		waterline = 0,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h bbbbbbbb bsossosb bobbbbob bsbccbsb bsbccbsb bobbbbob bsossosb bbbbbbbb",
 		customparams = {
 			unitgroup = 'metal',
 			cvbuildable = true,

--- a/units/CorBuildings/LandDefenceOffence/corexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/corexp.lua
@@ -36,7 +36,7 @@ return {
 		selfdestructas = "mediumBuildingExplosionGeneric",
 		selfdestructcountdown = 1,
 		sightdistance = 455,
-		yardmap = "h bbbbbbbb bsossysb bybssbob bssccssb bssccssb bobssbyb bsyssosb bbbbbbbb",
+		yardmap = "h bbbbbbbb bssssssb bsboybsb bsyccosb bsoccysb bsbyobsb bssssssb bbbbbbbb",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/corexp_aoplane.dds",

--- a/units/CorBuildings/LandEconomy/cormex.lua
+++ b/units/CorBuildings/LandEconomy/cormex.lua
@@ -34,7 +34,7 @@ return {
 		selfdestructas = "smallMex",
 		selfdestructcountdown = 1,
 		sightdistance = 273,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h bbbbbbbb bsossosb bobbbbob bsbccbsb bsbccbsb bobbbbob bsossosb bbbbbbbb",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormex_aoplane.dds",

--- a/units/CorBuildings/SeaEconomy/coruwmex.lua
+++ b/units/CorBuildings/SeaEconomy/coruwmex.lua
@@ -36,7 +36,7 @@ return {
 		sightdistance = 169,
 		usepiececollisionvolumes = true,
 		waterline = 0,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h bbbbbbbb bsossosb bobbbbob bsbccbsb bsbccbsb bobbbbob bsossosb bbbbbbbb",
 		customparams = {
 			unitgroup = 'metal',
 			cvbuildable = true,

--- a/units/Legion/Economy/legmex.lua
+++ b/units/Legion/Economy/legmex.lua
@@ -34,7 +34,7 @@ return {
 		selfdestructas = "smallMex",
 		selfdestructcountdown = 1,
 		sightdistance = 273,
-		yardmap = "h bbbbbbbb boyooyob byboybyb boyccoob booccyob bybyobyb boyooyob bbbbbbbb",
+		yardmap = "h bbbbbbbb boboobob bbbbbbbb bobccbob bobccbob bbbbbbbb boboobob bbbbbbbb",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormex_aoplane.dds",


### PR DESCRIPTION
Removes the possibility of a unit seeping into a mex's 2x2 centre and getting stuck through being pushed in by another unit by ensuring a 2x2 collision thickness of the mexs' outer shell. _*tested using a 1,000 armfleas/ticks._
Units may still get stuck inside the 2x2 core through other means.

Image mex order row1:old row2:new
leg t1 mex, arm/cor t1 mex, cor exploiter, arm twilight
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/59885012/d10724fb-e984-42d0-8054-97548d03779a)
