### PR TITLE
Drone Carrier slower spawn

### DIFF
--- a/units/ArmShips/T2/armdronecarry.lua
+++ b/units/ArmShips/T2/armdronecarry.lua
@@ -153,7 +153,7 @@ return {
 					-- carried_unit2... 			Currently not implemented, but planned.
 					engagementrange = 1200, 	
 					spawns_surface = "SEA",    -- "LAND" or "SEA". The SEA option has not been tested currently. 
-					spawnrate = 4, 				--Spawnrate roughly in seconds. 
+					spawnrate = 6.5, 				--Spawnrate roughly in seconds. 
 					maxunits = 16,				--Will spawn units until this amount has been reached. 
 					buildcostenergy = 750,--650,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working. 
 					buildcostmetal = 30,--29,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working. 

--- a/units/CorShips/T2/cordronecarry.lua
+++ b/units/CorShips/T2/cordronecarry.lua
@@ -153,7 +153,7 @@ return {
 					-- carried_unit2... 			Currently not implemented, but planned.
 					engagementrange = 1200, 	
 					spawns_surface = "SEA",    -- "LAND" or "SEA". The SEA option has not been tested currently. 
-					spawnrate = 6, 				--Spawnrate roughly in seconds. 
+					spawnrate = 10, 				--Spawnrate roughly in seconds. 
 					maxunits = 10,				--Will spawn units until this amount has been reached. 
 					buildcostenergy = 1000,--650,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working. 
 					buildcostmetal = 40,--29,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working. 


### PR DESCRIPTION
Carriers now take 100s instead of 60s to spawn all of their drones