### PR TITLE
Fix a typo in corpship.lua subfolder value

### DIFF
--- a/units/CorShips/corpship.lua
+++ b/units/CorShips/corpship.lua
@@ -39,7 +39,7 @@ return {
 		customparams = {
 			unitgroup = 'weapon',
 			normaltex = "unittextures/cor_normal.dds",
-			subfolder = "coreships",
+			subfolder = "corships",
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
This should probably be "corships", as that is the actual folder it's in.