### PR TITLE
Add movefast/slow back to default binds

### DIFF
--- a/luaui/configs/hotkeys/default_keys.txt
+++ b/luaui/configs/hotkeys/default_keys.txt
@@ -117,6 +117,9 @@ bind Any+sc_l togglelos
 bind Ctrl+sc_t trackmode
 bind Any+sc_t track
 
+bind Any+ctrl moveslow
+bind Any+shift movefast
+
 bind Ctrl+f1 viewfps
 bind Ctrl+f2 viewta
 bind Ctrl+f3 viewspring

--- a/luaui/configs/hotkeys/default_keys_60pct.txt
+++ b/luaui/configs/hotkeys/default_keys_60pct.txt
@@ -120,6 +120,9 @@ bind Any+sc_l togglelos
 bind Ctrl+sc_t trackmode
 bind Any+sc_t track
 
+bind Any+ctrl moveslow
+bind Any+shift movefast
+
 bind Ctrl+meta+1 viewfps
 bind Ctrl+meta+2 viewta
 bind Ctrl+meta+3 viewspring

--- a/luaui/configs/hotkeys/mnemonic_keys.txt
+++ b/luaui/configs/hotkeys/mnemonic_keys.txt
@@ -122,6 +122,9 @@ bind Any+l togglelos
 bind Ctrl+t trackmode
 bind Any+t track
 
+bind Any+ctrl moveslow
+bind Any+shift movefast
+
 bind Ctrl+f1 viewfps
 bind Ctrl+f2 viewta
 bind Ctrl+f3 viewspring


### PR DESCRIPTION
Last PR accidently omitted these keys from default binds