### PR TITLE
Mex/Geo airgap fix (removes mex swaping)

### DIFF
--- a/units/ArmBuildings/LandEconomy/armageo.lua
+++ b/units/ArmBuildings/LandEconomy/armageo.lua
@@ -29,7 +29,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "advgeo",
 		sightdistance = 273,
-		yardmap = "h bbsbbsbb bscsscsb scyoyycs bsyjjosb bsojjysb scyyoycs bscsscsb bbsbbsbb",
+		yardmap = "h cysoosyc ysbssbsy sbbjjbbs osjbbjso osjbbjso sbbjjbbs ysbssbsy cysoosyc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armageo_aoplane.dds",

--- a/units/ArmBuildings/LandEconomy/armamex.lua
+++ b/units/ArmBuildings/LandEconomy/armamex.lua
@@ -38,7 +38,7 @@ return {
 		selfdestructcountdown = 1,
 		sightdistance = 286,
 		stealth = true,
-		yardmap = "h bbbbbbbb bsyssosb bobssbyb bssccssb bssccssb bybssbob bsossysb bbbbbbbb",
+		yardmap = "h cbbbbbbc bssssosb bosbbssb bsbbbbsb bsbbbbsb bssbbsob bsossssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armamex_aoplane.dds",

--- a/units/ArmBuildings/LandEconomy/armgeo.lua
+++ b/units/ArmBuildings/LandEconomy/armgeo.lua
@@ -30,7 +30,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "geo",
 		sightdistance = 273,
-		yardmap = "h bbobbobb bocoocob ocyyyyco boyggyob boyggyob ocyyyyco bocoocob bbobbobb",
+		yardmap = "h cbobbobc boboobob obbggbbo bogbbgob bogbbgob obbggbbo boboobob cbobbobc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armgeo_aoplane.dds",

--- a/units/ArmBuildings/LandEconomy/armgmm.lua
+++ b/units/ArmBuildings/LandEconomy/armgmm.lua
@@ -30,7 +30,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
 		sightdistance = 273,
-		yardmap = "h bbsbbsbb bscsscsb scoyyocs bsyjjysb bsyjjysb scoyyocs bscsscsb bbsbbsbb",
+		yardmap = "h cysyysoc osbssbsy sbbjjbbs ysjbbjsy ysjbbjsy sbbjjbbs ysbssbso cosyysyc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armgmm_aoplane.dds",

--- a/units/ArmBuildings/LandEconomy/armmex.lua
+++ b/units/ArmBuildings/LandEconomy/armmex.lua
@@ -35,7 +35,7 @@ return {
 		selfdestructcountdown = 1,
 		sightdistance = 273,
 		--waterline = 0,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h cbbbbbbc bsossbsb bbsbbsob bsbbbbsb bsbbbbsb bosbbsbb bsbssosb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armmex_aoplane.dds",

--- a/units/ArmBuildings/LandEconomy/armmoho.lua
+++ b/units/ArmBuildings/LandEconomy/armmoho.lua
@@ -33,7 +33,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
 		sightdistance = 273,
-		yardmap = "h bobbbbob osssssso bssssssb bssccssb bssccssb bssssssb osssssso bobbbbob",
+		yardmap = "h cbbbbbbc bssssssb bsssossb bsobbssb bssbbosb bssosssb bssssssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armmoho_aoplane.dds",

--- a/units/ArmBuildings/SeaEconomy/armuwmex.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwmex.lua
@@ -36,7 +36,7 @@ return {
 		sightdistance = 182,
 		usepiececollisionvolumes = true,
 		waterline = 0,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h cbbbbbbc bsossbsb bbsbbsob bsbbbbsb bsbbbbsb bosbbsbb bsbssosb cbbbbbbc",
 		customparams = {
 			unitgroup = 'metal',
 			cvbuildable = true,

--- a/units/ArmBuildings/SeaEconomy/armuwmme.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwmme.lua
@@ -30,7 +30,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "hugeBuildingExplosionGenericSelfd-uw",
 		sightdistance = 182,
-		yardmap = "h bobbbbob osssssso bssssssb bssccssb bssccssb bssssssb osssssso bobbbbob",
+		yardmap = "h cbbbbbbc bssssssb bsssossb bsobbssb bssbbosb bssosssb bssssssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/armuwmme_aoplane.dds",

--- a/units/CorBuildings/LandDefenceOffence/corbhmth.lua
+++ b/units/CorBuildings/LandDefenceOffence/corbhmth.lua
@@ -31,7 +31,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
 		sightdistance = 650,
-		yardmap = "h bbsbbsbb bscsscsb scyyoycs bsojjysb bsyjjosb scyoyycs bscsscsb bbsbbsbb",
+		yardmap = "h cosyysyc ysbssbso sbbjjbbs ysjbbjsy ysjbbjsy sbbjjbbs osbssbsy cysyysoc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/corbhmth_aoplane.dds",

--- a/units/CorBuildings/LandDefenceOffence/corexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/corexp.lua
@@ -36,7 +36,7 @@ return {
 		selfdestructas = "mediumBuildingExplosionGeneric",
 		selfdestructcountdown = 1,
 		sightdistance = 455,
-		yardmap = "h bbbbbbbb bsossysb bybssbob bssccssb bssccssb bobssbyb bsyssosb bbbbbbbb",
+		yardmap = "h cbbbbbbc bssssosb bosbbssb bsbbbbsb bsbbbbsb bssbbsob bsossssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/corexp_aoplane.dds",

--- a/units/CorBuildings/LandDefenceOffence/cormexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/cormexp.lua
@@ -37,7 +37,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "hugeBuildingExplosionGenericSelfd",
 		sightdistance = 676,
-		yardmap = "h osooooso ssssssss osssssso ossoosso ossoosso osssssso ssssssss osooooso",
+		yardmap = "h oooooooo osssssso osssssso ossoosso ossoosso osssssso osssssso oooooooo",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormoho_aoplane.dds",

--- a/units/CorBuildings/LandEconomy/corageo.lua
+++ b/units/CorBuildings/LandEconomy/corageo.lua
@@ -29,7 +29,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "advgeo",
 		sightdistance = 273,
-		yardmap = "h bbsbbsbb bscsscsb scyoyycs bsyjjosb bsojjysb scyyoycs bscsscsb bbsbbsbb",
+		yardmap = "h cysoosyc ysbssbsy sbbjjbbs osjbbjso osjbbjso sbbjjbbs ysbssbsy cysoosyc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/corageo_aoplane.dds",

--- a/units/CorBuildings/LandEconomy/corgeo.lua
+++ b/units/CorBuildings/LandEconomy/corgeo.lua
@@ -30,7 +30,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "geo",
 		sightdistance = 273,
-		yardmap = "h bbobbobb bocoocob ocyyyyco boyggyob boyggyob ocyyyyco bocoocob bbobbobb",
+		yardmap = "h cbobbobc boboobob obbggbbo bogbbgob bogbbgob obbggbbo boboobob cbobbobc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/corgeo_aoplane.dds",

--- a/units/CorBuildings/LandEconomy/cormex.lua
+++ b/units/CorBuildings/LandEconomy/cormex.lua
@@ -34,7 +34,7 @@ return {
 		selfdestructas = "smallMex",
 		selfdestructcountdown = 1,
 		sightdistance = 273,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h cbbbbbbc bsossbsb bbsbbsob bsbbbbsb bsbbbbsb bosbbsbb bsbssosb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormex_aoplane.dds",

--- a/units/CorBuildings/LandEconomy/cormoho.lua
+++ b/units/CorBuildings/LandEconomy/cormoho.lua
@@ -33,7 +33,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
 		sightdistance = 273,
-		yardmap = "h bobbbbob osssssso bssssssb bssccssb bssccssb bssssssb osssssso bobbbbob",
+		yardmap = "h cbbbbbbc bssssssb bsssossb bsobbssb bssbbosb bssosssb bssssssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormoho_aoplane.dds",

--- a/units/CorBuildings/SeaEconomy/coruwmex.lua
+++ b/units/CorBuildings/SeaEconomy/coruwmex.lua
@@ -36,7 +36,7 @@ return {
 		sightdistance = 169,
 		usepiececollisionvolumes = true,
 		waterline = 0,
-		yardmap = "h bbbbbbbb bsyssysb bybyobyb bsoccysb bsyccosb byboybyb bsyssysb bbbbbbbb",
+		yardmap = "h cbbbbbbc bsossbsb bbsbbsob bsbbbbsb bsbbbbsb bosbbsbb bsbssosb cbbbbbbc",
 		customparams = {
 			unitgroup = 'metal',
 			cvbuildable = true,

--- a/units/CorBuildings/SeaEconomy/coruwmme.lua
+++ b/units/CorBuildings/SeaEconomy/coruwmme.lua
@@ -31,7 +31,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd-uw",
 		sightdistance = 169,
-		yardmap = "h bobbbbob osssssso bssssssb bssccssb bssccssb bssssssb osssssso bobbbbob",
+		yardmap = "h cbbbbbbc bssssssb bsssossb bsobbssb bssbbosb bssosssb bssssssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/coruwmme_aoplane.dds",

--- a/units/Legion/Economy/legmex.lua
+++ b/units/Legion/Economy/legmex.lua
@@ -34,7 +34,7 @@ return {
 		selfdestructas = "smallMex",
 		selfdestructcountdown = 1,
 		sightdistance = 273,
-		yardmap = "h bbbbbbbb boyooyob byboybyb boyccoob booccyob bybyobyb boyooyob bbbbbbbb",
+		yardmap = "h cbbbbbbc bsbssbsb bbobbobb bsbbbbsb bsbbbbsb bbobbobb bsbssbsb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormex_aoplane.dds",

--- a/units/Legion/Economy/legmext15.lua
+++ b/units/Legion/Economy/legmext15.lua
@@ -34,7 +34,7 @@ return {
 		selfdestructas = "mediumBuildingExplosionGenericSelfd",
 		selfdestructcountdown = 1,
 		sightdistance = 273,
-		yardmap = "h bbbbbbbb bssssssb bsossosb bssccssb bssccssb bsossosb bssssssb bbbbbbbb",
+		yardmap = "h cbbbbbbc bssssssb bssobssb bsbbbosb bsobbbsb bssbossb bssssssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/cormex_aoplane.dds",

--- a/units/Legion/Economy/legmext2.lua
+++ b/units/Legion/Economy/legmext2.lua
@@ -33,7 +33,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
 		sightdistance = 273,
-		yardmap = "h bobbbbob osssssso bssssssb bssccssb bssccssb bssssssb osssssso bobbbbob",
+		yardmap = "h cbbbbbbc bssssssb bsssossb bsobbssb bssbbosb bssosssb bssssssb cbbbbbbc",
 		customparams = {
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/coruwmme_aoplane.dds",


### PR DESCRIPTION
Per the following comment https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2011#issuecomment-1668990915
Removes air gaps in mexes and ensures solid mex structure.
And inturn removes the abilty to swap between the twilight and the  exploiter.
*also cleans up airgaps i left when considering allowing for swaping between legion t1 mex and cor/arm t1s.
*sorry it took me so long to get here, i just really wanted twilight/exploiter swaping
Image, from left to right, mex yardmaps of t1leg, t1cor/arm, t1spec, t1.5, t2, t2spec
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/59885012/85190abd-e387-410f-a62a-77391f1affd8)
