### PR TITLE
Allow skip_current for area reclaim and area repair commands

### DIFF
--- a/luaui/Widgets/cmd_commandq_manager.lua
+++ b/luaui/Widgets/cmd_commandq_manager.lua
@@ -22,6 +22,9 @@ local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGetCommandQueueSize = Spring.GetCommandQueue
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
+local CMDREPAIR = CMD.REPAIR
+local CMDRECLAIM = CMD.RECLAIM
+
 -- Main functions
 function SkipCurrentCommand()
     ProcessSelectedUnits(function(id)
@@ -34,14 +37,17 @@ function CancelLastCommand()
         local commandQueueSize = spGetCommandQueueSize(id, 0)
         if commandQueueSize and commandQueueSize >= 1 then
             RemoveCommand(id, commandQueueSize)
-        end            
+        end
     end)
 end
 
 -- Helper functions
 function RemoveCommand(unitID, cmdIndex)
-    local cmdID, _, cmdTag = spGetUnitCurrentCommand(unitID, cmdIndex)
-    if cmdID then
+    local cmdID, cmdOpts, cmdTag, cmdParam1, cmdParam2, cmdParam3 = spGetUnitCurrentCommand(unitID, cmdIndex)
+    if (cmdID == CMDRECLAIM or cmdID == CMDREPAIR) and cmdParam2 then -- second param means it is an area order
+        local cmdID2, cmdOpts2, cmdTag2 = spGetUnitCurrentCommand(unitID, cmdIndex+1)
+        spGiveOrderToUnit(unitID, CMD.REMOVE, {cmdTag2, cmdTag}, 0)
+    elseif cmdID then
         spGiveOrderToUnit(unitID, CMD.REMOVE, {cmdTag}, 0)
     end
 end


### PR DESCRIPTION
Reported on discord by MrJombles.

cmd_skip_current does not work if the command being skipped is an area reclaim or area repair command. These commands seem to insert a specific command at the front of the command queue, and the skip just skips these for them to be instantly readded to the queue. Therefore if it is one of these commands, we skip two commands. Doesn't work for area resurrect commands for some reason, so that is an outstanding issue.