### PR TITLE
replace `ffa_mode` modoption with `IsFFA` utility, remove `ffa_mode` modoption

### DIFF
--- a/luarules/gadgets/api_damage_stats.lua
+++ b/luarules/gadgets/api_damage_stats.lua
@@ -28,7 +28,7 @@ local gameType
 function gadget:Initialize()
     local tList = Spring.GetTeamList()
 
-    if Spring.GetModOptions().ffa_mode then
+    if Spring.Utilities.Gametype.IsFFA() then
         gameType = "free for all"
         return
     end

--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -408,12 +408,7 @@ local function shuffleAllColors()
 	end
 end
 
-local isFFA = false
-if #teamList == #allyTeamList and teamCount > 2 then
-	isFFA = true
-elseif not teamColors[allyTeamCount] then
-	isFFA = true
-end
+local isFFA = Spring.Utilities.Gametype.IsFFA()
 
 if gadgetHandler:IsSyncedCode() then
 

--- a/luarules/gadgets/game_end.lua
+++ b/luarules/gadgets/game_end.lua
@@ -78,7 +78,7 @@ if gadgetHandler:IsSyncedCode() then
 	local playerIDtoAIs = {}
 	local playerList = GetPlayerList()
 	local killTeamQueue = {}
-	local isFFA = Spring.GetModOptions().ffa_mode
+	local isFFA = Spring.Utilities.Gametype.IsFFA()
 
 	local gameoverFrame
 	local gameoverWinners

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -71,7 +71,7 @@ if gadgetHandler:IsSyncedCode() then
 	----------------------------------------------------------------
 	-- ffaStartPoints is "global"
 	local useFFAStartPoints = false
-	if Spring.GetModOptions().ffa_mode then
+	if Spring.Utilities.Gametype.IsFFA() then
 		useFFAStartPoints = true
 	end
 

--- a/luarules/gadgets/game_replace_afk_players.lua
+++ b/luarules/gadgets/game_replace_afk_players.lua
@@ -277,7 +277,7 @@ else
 	end
 
 	function gadget:Initialize()
-		if isReplay or Spring.GetModOptions().ffa_mode or Spring.GetGameFrame() > 6 then
+		if isReplay or Spring.Utilities.Gametype.IsFFA() or Spring.GetGameFrame() > 6 then
 			gadgetHandler:RemoveGadget() -- don't run in FFA mode
 			return
 		end

--- a/luarules/gadgets/mo_ffa.lua
+++ b/luarules/gadgets/mo_ffa.lua
@@ -10,7 +10,7 @@ function gadget:GetInfo()
 	}
 end
 
-if not Spring.GetModOptions().ffa_mode then
+if not Spring.Utilities.Gametype.IsFFA() then
 	return false
 end
 

--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -82,7 +82,7 @@ local avgFrames = 8
 local xRelPos, yRelPos = 1, 1
 local widgetPosX, widgetPosY = xRelPos * vsx, yRelPos * vsy
 local singleTeams = (#Spring.GetTeamList() - 1 == #Spring.GetAllyTeamList() - 1)
-local enableStartposbuttons = not Spring.GetModOptions().ffa_mode	-- spots wont match when ffa
+local enableStartposbuttons = not Spring.Utilities.Gametype.IsFFA()	-- spots wont match when ffa
 local myFullview = select(2, Spring.GetSpectatingState())
 local myTeamID = Spring.GetMyTeamID()
 local myPlayerID = Spring.GetMyPlayerID()

--- a/luaui/Widgets/gui_pregameui.lua
+++ b/luaui/Widgets/gui_pregameui.lua
@@ -21,7 +21,7 @@ local font = gl.LoadFont(fontfile, fontfileSize * fontfileScale, fontfileOutline
 local uiScale = (0.7 + (vsx * vsy / 6500000))
 local myPlayerID = Spring.GetMyPlayerID()
 local _, _, mySpec, myTeamID = Spring.GetPlayerInfo(myPlayerID, false)
-local ffaMode = Spring.GetModOptions().ffa_mode
+local isFFA = Spring.Utilities.Gametype.IsFFA()
 local isReplay = Spring.IsReplay()
 
 local readyButtonColor = {0.05, 0.28, 0}
@@ -162,12 +162,12 @@ function widget:GameSetup(state, ready, playerStates)
 	end
 
 	-- if we can't choose startpositions, no need for ready button etc
-	if Game.startPosType ~= 2 or ffaMode then
+	if Game.startPosType ~= 2 or isFFA then
 		return true, true
 	end
 
 	-- set my readyState to true if ffa
-	if ffaMode and (not readied or not ready) then
+	if isFFA and (not readied or not ready) then
 		readied = true
 		return true, true
 	end
@@ -280,7 +280,7 @@ function widget:Initialize()
 	end
 
 	if mySpec and enableSubbing then
-		if numPlayers <= 4 or isReplay or ffaMode then
+		if numPlayers <= 4 or isReplay or isFFA then
 			eligibleAsSub = false
 		else
 			eligibleAsSub = true

--- a/luaui/Widgets/gui_teamstats.lua
+++ b/luaui/Widgets/gui_teamstats.lua
@@ -32,7 +32,7 @@ local math_isInRect = math.isInRect
 local playSounds = true
 local buttonclick = 'LuaUI/Sounds/buildbar_waypoint.wav'
 
-local isFFA = Spring.GetModOptions().ffa_mode
+local isFFA = Spring.Utilities.Gametype.IsFFA()
 
 local header = {
 	"frame",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -561,15 +561,6 @@ local options={
 		section= "options",
 	},
 	{
-		key    = "ffa_mode",
-		name   = "FFA Mode",
-		desc   = "Units with no player control are removed/destroyed \nUse FFA spawning mode",
-		hidden = true,
-		type   = "bool",
-		def    = false,
-		section= "options",
-	},
-	{
 		key    = "ffa_wreckage",
 		name   = "FFA Mode Wreckage",
 		desc   = "Killed players will blow up but leave wreckages",


### PR DESCRIPTION
The `ffa_mode` modoption has been historically used to denote the FFA gametype and thus calls to `Spring.GetModOptions().ffa_mode` were used to check for FFA games, in addition to sometimes custom checks based on number of ally teams. We now have a reliable `IsFFA` utility provided via `Spring.Utilities.Gametype.IsFFA()` to do the same.

This PR replaces all checks for the FFA gametype based on outdated methods with checks based on the newer `IsFFA` utility, with the following rationale:

- `ffa_mode` is currently either set automatically by SPADS as part of the FFA preset, or manually by users with `!bSet ffa_mode 1`. Since it it is statically set, is it unreliable:
  - `ffa_mode` being set does not guarantee that the match will actually be a FFA, as the FFA preset can be used for non-FFA matches.
  - `ffa_mode` not being set does not guarantee that the match will actually not be a FFA, as the FFA preset is not mandatorily used.
- Manually checking for ally teams is error-prone as there are several caveats and gotchas to be aware of, in particular around Gaia, Raptors, and Scavengers.
  - One specific example is Team games with Raptors or Scavengers added versus FFA games with Raptors or Scavengers: Team games with Raptors or Scavengers might be incorrectly classified as FFA games due to 3 ally teams being present. (Yes, I know this is complete degenerescence, but the French Discord loves both of these gametypes for some reason.)
- On the other hand, the `IsFFA` utility is very reliable in detecting which games are actually FFA and which are not, as it does so dynamically and properly handles special cases for Raptors or Scavengers. On top of that, should new special cases arise, they can  now be handled directly there instead of in individual consumers.

And since the `ffa_mode` modoption is now useless, it can be removed.