### PR TITLE
utilities: add `GetAllyTeamList`

### DIFF
--- a/common/springFunctions.lua
+++ b/common/springFunctions.lua
@@ -12,7 +12,7 @@ local utilities = {
 
 	MakeRealTable = syncFunctions.MakeRealTable,
 
-	GetTeamCount = team.GetTeamCount,
+	GetAllyTeamCount = team.GetAllyTeamCount,
 	GetAllyTeamList = team.GetAllyTeamList,
 	GetPlayerCount = team.GetPlayerCount,
 	Gametype = team.Gametype,

--- a/common/springFunctions.lua
+++ b/common/springFunctions.lua
@@ -13,6 +13,7 @@ local utilities = {
 	MakeRealTable = syncFunctions.MakeRealTable,
 
 	GetTeamCount = team.GetTeamCount,
+	GetAllyTeamList = team.GetAllyTeamList,
 	GetPlayerCount = team.GetPlayerCount,
 	Gametype = team.Gametype,
 

--- a/common/springUtilities/teamFunctions.lua
+++ b/common/springUtilities/teamFunctions.lua
@@ -7,7 +7,7 @@ local function getSettings()
 		return settings
 	end
 
-	local teamCount, playerCount = 0, 0
+	local allyTeamCount, playerCount = 0, 0
 	local isSinglePlayer, is1v1, isTeams, isBigTeams, isSmallTeams, isRaptors, isScavengers, isPvE, isCoop, isFFA, isSandbox = false, false, false, false, false, false, false, false, false, false, false
 
 	local gaiaAllyTeamID = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
@@ -57,7 +57,7 @@ local function getSettings()
 		end
 	end
 
-	teamCount = #allyTeamList
+	allyTeamCount = #allyTeamList
 
 	isSmallTeams = true
 	for _, teamSize in ipairs(allyTeamSizes) do
@@ -73,11 +73,11 @@ local function getSettings()
 	isBigTeams = isTeams and not isSmallTeams
 	isPvE = isRaptors or isScavengers
 
-	if teamCount > 2 then
+	if allyTeamCount > 2 then
 		isFFA = true
-	elseif teamCount < 2 and not isPvE then
+	elseif allyTeamCount < 2 and not isPvE then
 		isSandbox = true
-	elseif teamCount == 2 and not isTeams then
+	elseif allyTeamCount == 2 and not isTeams then
 		is1v1 = true
 	end
 
@@ -88,7 +88,7 @@ local function getSettings()
 	initialized = true
 
 	settings = {
-		teamCount = teamCount,
+		allyTeamCount = allyTeamCount,
 		allyTeamList = allyTeamList,
 		playerCount = playerCount,
 		isSinglePlayer = isSinglePlayer,
@@ -108,8 +108,9 @@ local function getSettings()
 end
 
 return {
-	GetTeamCount     = function() return getSettings().teamCount end,
-	---Get ally team list (humans or AIs, but not Raptors and Scavengers).
+	---Get number of ally teams (humans and AIs, but not Raptors and Scavengers).
+	GetAllyTeamCount = function() return getSettings().allyTeamCount end,
+	---Get ally team list (humans and AIs, but not Raptors and Scavengers).
 	---@return integer[] allyTeamList table[i] = allyTeamID
 	GetAllyTeamList  = function () return getSettings().allyTeamList end,
 	GetPlayerCount   = function () return getSettings().playerCount end,

--- a/common/springUtilities/teamFunctions.lua
+++ b/common/springUtilities/teamFunctions.lua
@@ -11,12 +11,12 @@ local function getSettings()
 	local isSinglePlayer, is1v1, isTeams, isBigTeams, isSmallTeams, isRaptors, isScavengers, isPvE, isCoop, isFFA, isSandbox = false, false, false, false, false, false, false, false, false, false, false
 
 	local gaiaAllyTeamID = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
-	local allyTeamList = Spring.GetAllyTeamList()
-	local actualAllyTeamList = {}
-	local actualAllyTeamSizes = {}
+	local springAllyTeamList = Spring.GetAllyTeamList()
+	local allyTeamList = {}
+	local allyTeamSizes = {}
 	local entirelyHumanAllyTeams = {}
 
-	for _, allyTeam in ipairs(allyTeamList) do
+	for _, allyTeam in ipairs(springAllyTeamList) do
 		local teamList = Spring.GetTeamList(allyTeam) or {}
 		local allyteamEntirelyHuman = true
 
@@ -47,8 +47,8 @@ local function getSettings()
 			end
 
 			if isAllyTeamValid then
-				actualAllyTeamList[#actualAllyTeamList+1] = allyTeam
-				actualAllyTeamSizes[#actualAllyTeamSizes+1] = #teamList
+				allyTeamList[#allyTeamList+1] = allyTeam
+				allyTeamSizes[#allyTeamSizes+1] = #teamList
 			end
 
 			if allyteamEntirelyHuman then
@@ -57,10 +57,10 @@ local function getSettings()
 		end
 	end
 
-	teamCount = #actualAllyTeamList
+	teamCount = #allyTeamList
 
 	isSmallTeams = true
-	for _, teamSize in ipairs(actualAllyTeamSizes) do
+	for _, teamSize in ipairs(allyTeamSizes) do
 		if teamSize > 1 then
 			isTeams = true
 		end
@@ -89,6 +89,7 @@ local function getSettings()
 
 	settings = {
 		teamCount = teamCount,
+		allyTeamList = allyTeamList,
 		playerCount = playerCount,
 		isSinglePlayer = isSinglePlayer,
 		is1v1 = is1v1,
@@ -107,8 +108,11 @@ local function getSettings()
 end
 
 return {
-	GetTeamCount   = function () return getSettings().teamCount end,
-	GetPlayerCount = function () return getSettings().playerCount end,
+	GetTeamCount     = function() return getSettings().teamCount end,
+	---Get ally team list (humans or AIs, but not Raptors and Scavengers).
+	---@return integer[] allyTeamList table[i] = allyTeamID
+	GetAllyTeamList  = function () return getSettings().allyTeamList end,
+	GetPlayerCount   = function () return getSettings().playerCount end,
 	Gametype = {
 		IsSinglePlayer = function () return getSettings().isSinglePlayer end,
 		Is1v1          = function () return getSettings().is1v1          end,

--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -1,7 +1,7 @@
 local function WrappedInclude(x)
 	local env = getfenv()
 	local prevGTC = env.GetTeamCount -- typically nil but also works otherwise
-	env.GetTeamCount = Spring.Utilities.GetTeamCount -- for legacy mapside boxes
+	env.GetTeamCount = Spring.Utilities.GetAllyTeamCount -- for legacy mapside boxes
 	local ret = VFS.Include(x, env)
 	env.GetTeamCount = prevGTC
 	return ret


### PR DESCRIPTION
This PR exposes the internal `actualAllyTeamList` used for various `Spring.Utilities.Gametype` calculations via a new function `Spring.Utilities.GetAllyTeamList()`.

This is useful for gadgets/widgets to be able to retrieve a cleaned up list of ally teams (humans and AIs, but not Raptors and Scavengers), thereby avoiding manual checks on the consumer side.

We also take the chance to rename `actualAllyTeamList` to `allyTeamList` internally, and then rename `GetTeamCount` to `GetAllyTeamCount`.

"Team count" was misleading since it is counting the number of ally teams (humans or AIs, but not Raptors and Scavengers) and not the number of teams as per the engine terminology.