### PR TITLE
luamocks: add `Spring.SetAllyTeamStartBox` synced control

### DIFF
--- a/luamocks/autogenerated/SyncedCtrl.lua
+++ b/luamocks/autogenerated/SyncedCtrl.lua
@@ -8,6 +8,15 @@
 ---@return nil
 function Spring.SetAlly(firstAllyTeamID, secondAllyTeamID, ally) end
 
+---Changes the start box position of an allyTeam.
+---@param allyTeamID integer
+---@param xMin integer left start box boundary (elmos)
+---@param zMin integer top start box boundary (elmos)
+---@param xMax integer right start box boundary (elmos)
+---@param zMax integer bottom start box boundary (elmos)
+---@return nil
+function Spring.SetAllyTeamStartBox(allyTeamID, xMin, zMin, xMax, zMax) end
+
 ---Parameters
 ---@param playerID number
 ---@param teamID number


### PR DESCRIPTION
This new control allows to change an ally team's start box from a synchronized context, thereby opening up the possibility for Lua gadgets to reposition start boxes as needed.

> [!NOTE]
> This PR depends on changes implemented engine-side in https://github.com/beyond-all-reason/spring/pull/958.