### PR TITLE
common: additions / modifications to table functions

### DIFF
--- a/common/tableFunctionsTests.lua
+++ b/common/tableFunctionsTests.lua
@@ -1,0 +1,60 @@
+local function testMergeInPlace(deep)
+  Spring.Echo(string.format("[test] [table.mergeInPlace(deep: %s)] start", tostring(deep)))
+  local mergeTarget = {
+    shouldBeOverriden = "no",
+    shouldBeMerged = {
+      shouldBeOverriden = "no",
+      shouldBeMerged = { "no", "no", "yes", },
+      "yes",
+    },
+    shouldBeKept = "yes",
+    [1] = "no",
+    [2] = "yes",
+  }
+  local mergeData = {
+    shouldBeOverriden = "yes",
+    shouldBeMerged = {
+      shouldBeOverriden = "yes",
+      shouldBeMerged = { "yes", "yes", },
+      shouldBeAdded = { "yes", },
+    },
+    shouldBeAdded = { "yes", },
+    [1] = "yes",
+    [3] = "yes"
+  }
+
+  table.mergeInPlace(mergeTarget, mergeData, deep)
+  Spring.Echo(string.format("[test] [table.mergeInPlace(deep: %s)] %s", tostring(deep), table.toString(mergeTarget)))
+
+  local expectedYesCount = 12
+  local yesCount = 0
+  local function checkAllYes(tbl)
+    for key, value in pairs(tbl) do
+      if type(value) == "table" then
+        checkAllYes(value)
+      else
+        assert(value == "yes", string.format("expected all values to be 'yes', but go '%s' for key %s", value, key))
+        yesCount = yesCount + 1
+      end
+    end
+  end
+  checkAllYes(mergeTarget)
+  assert(yesCount == expectedYesCount, string.format("expected %s 'yes' values, got %s", expectedYesCount, yesCount))
+
+  if deep then
+    assert(mergeData.shouldBeAdded ~= mergeTarget.shouldBeAdded,
+      "expected mergeData.shouldBeAdded and mergeTarget.shouldBeAdded to be different instance, due to deep merge")
+    assert(mergeData.shouldBeMerged.shouldBeAdded ~= mergeTarget.shouldBeMerged.shouldBeAdded,
+      "expected mergeData.shouldBeMerged.shouldBeAdded and mergeTarget.shouldBeMerged.shouldBeAdded to be different instance, due to deep merge")
+  else
+    assert(mergeData.shouldBeAdded == mergeTarget.shouldBeAdded,
+      "expected mergeData.shouldBeAdded and mergeTarget.shouldBeAdded to be same instance, due to non-deep merge")
+    assert(mergeData.shouldBeMerged.shouldBeAdded == mergeTarget.shouldBeMerged.shouldBeAdded,
+      "expected mergeData.shouldBeMerged.shouldBeAdded and mergeTarget.shouldBeMerged.shouldBeAdded to be same instance, due to non-deep merge")
+  end
+
+  Spring.Echo(string.format("[test] [table.mergeInPlace(deep: %s)] success", tostring(deep)))
+end
+
+testMergeInPlace(false)
+testMergeInPlace(true)

--- a/common/tableFunctionsTests.lua
+++ b/common/tableFunctionsTests.lua
@@ -56,5 +56,82 @@ local function testMergeInPlace(deep)
   Spring.Echo(string.format("[test] [table.mergeInPlace(deep: %s)] success", tostring(deep)))
 end
 
+local function testTableRemoveIf()
+  Spring.Echo("[test] [table.removeIf] start")
+  local t = { a = 1, b = 2, c = 3, d = 4, e = 5, }
+  local tEven = table.copy(t)
+  table.removeIf(tEven, function(v) return v % 2 == 1 end)
+  local tOdd = table.copy(t)
+  table.removeIf(tOdd, function(v) return v % 2 == 0 end)
+
+  Spring.Echo(string.format("[test] [table.removeIf] tEven: %s", table.toString(tEven)))
+  Spring.Echo(string.format("[test] [table.removeIf] tOdd: %s", table.toString(tOdd)))
+
+  local assertions = {
+    tEven = { table.count(tEven), 2 },
+    tOdd = { table.count(tOdd), 3 },
+  }
+
+  for tbl, assertion in pairs(assertions) do
+    assert(assertion[1] == assertion[2],
+      string.format("expected %s to have %s values (actual: %s)", tbl, assertion[1], assertion[2]))
+  end
+  Spring.Echo("[test] [table.removeIf] success")
+end
+
+local function testTableRemoveAll()
+  Spring.Echo("[test] [table.removeAll] start")
+  local t = { a = 1, b = 2, c = 1, d = 2, e = 1, }
+  local tOnes = table.copy(t)
+  table.removeAll(tOnes, 2)
+  local tTwos = table.copy(t)
+  table.removeAll(tTwos, 1)
+
+  Spring.Echo(string.format("[test] [table.removeAll] tOnes: %s", table.toString(tOnes)))
+  Spring.Echo(string.format("[test] [table.removeAll] tTwos: %s", table.toString(tTwos)))
+
+  local assertions = {
+    tOnes = { table.count(tOnes), 3 },
+    tTwos = { table.count(tTwos), 2 },
+  }
+
+  for tbl, assertion in pairs(assertions) do
+    assert(assertion[1] == assertion[2],
+      string.format("expected %s to have %s values (actual: %s)", tbl, assertion[1], assertion[2]))
+  end
+  Spring.Echo("[test] [table.removeAll] success")
+end
+
+local function testTableRemoveFirst()
+  Spring.Echo("[test] [table.removeFirst] start")
+  local tests = {
+    sequence = { "a", "b", "c" }, -- indexes should be kept without any gaps for this one
+    notASequence = { "a", "b", [4] = "c" },
+    regularTable = { a = "a", b = "b", c = "c" },
+  }
+
+  for name, test in pairs(tests) do
+    Spring.Echo(string.format("[test] [table.removeFirst] %s: %s", name, table.toString(test)))
+    for _, value in pairs({ "b", "c", "a", }) do
+      table.removeFirst(test, value)
+      Spring.Echo(string.format("[test] [table.removeFirst] %s: %s (removed: %s)", name, table.toString(test), value))
+      -- special case for sequence: check that indexes are kept without any gaps
+      if name == "sequence" then
+        local prev_i = 0
+        for i, _ in pairs(test) do
+          i = tonumber(i)
+          assert(i == prev_i + 1, string.format("expected table %s to have continuous indexes, but it does not", name))
+          prev_i = i
+        end
+      end
+    end
+    assert(table.count(test) == 0, string.format("expected table %s to be empty, but it's not", name))
+  end
+  Spring.Echo("[test] [table.removeFirst] success")
+end
+
 testMergeInPlace(false)
 testMergeInPlace(true)
+testTableRemoveIf()
+testTableRemoveAll()
+testTableRemoveFirst()

--- a/common/tableFunctionsTests.lua
+++ b/common/tableFunctionsTests.lua
@@ -130,8 +130,71 @@ local function testTableRemoveFirst()
   Spring.Echo("[test] [table.removeFirst] success")
 end
 
+local function testTableShuffle()
+  Spring.Echo("[test] [table.shuffle] start")
+  local t = { "a", "b", "c" }
+  local t0 = { [0] = "a", "b", "c" }
+  local results = { abc = 0, acb = 0, bac = 0, bca = 0, cab = 0, cba = 0 }
+  local results0 = { abc = 0, acb = 0, bac = 0, bca = 0, cab = 0, cba = 0 }
+
+  local roundsPerCombination = 1000000
+  local rounds = roundsPerCombination * table.count(results)
+  for _ = 1, rounds do
+    table.shuffle(t)
+    table.shuffle(t0, 0)
+    local r = t[1] .. t[2] .. t[3]
+    local r0 = t0[0] .. t0[1] .. t0[2]
+    results[r] = results[r] + 1
+    results0[r0] = results0[r0] + 1
+  end
+
+  Spring.Echo(string.format("[test] [table.shuffle] results : %s", table.toString(results)))
+  Spring.Echo(string.format("[test] [table.shuffle] results0: %s", table.toString(results0)))
+
+  local function mean(tbl)
+    local sum = 0
+    local count = 0
+
+    for _, value in pairs(tbl) do
+      sum = sum + value
+      count = count + 1
+    end
+    return (sum / count)
+  end
+
+  local function standardDeviation(tbl)
+    local meanValue
+    local deviation
+    local sum = 0
+    local count = 0
+
+    meanValue = mean(tbl)
+    for _, value in pairs(tbl) do
+      deviation = value - meanValue
+      sum = sum + (deviation * deviation)
+      count = count + 1
+    end
+    return math.sqrt(sum / (count - 1))
+  end
+
+  local standardDeviationResults = standardDeviation(results)
+  local standardDeviationResults0 = standardDeviation(results0)
+  Spring.Echo(string.format("[test] [table.shuffle] [results ] standardDeviation: %s", standardDeviationResults))
+  Spring.Echo(string.format("[test] [table.shuffle] [results0] standardDeviation: %s", standardDeviationResults0))
+
+  local threshold = rounds * 0.005 -- this is not a p-norm but it'll be good enough
+  assert(standardDeviationResults < threshold,
+    string.format("expected results standard deviation to be below %s (actual: %s)", threshold, standardDeviationResults))
+  assert(standardDeviationResults0 < threshold,
+    string.format("expected results0 standard deviation to be below %s (actual: %s)", threshold,
+      standardDeviationResults0))
+
+  Spring.Echo("[test] [table.shuffle] success")
+end
+
 testMergeInPlace(false)
 testMergeInPlace(true)
 testTableRemoveIf()
 testTableRemoveAll()
 testTableRemoveFirst()
+testTableShuffle()

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -1,3 +1,9 @@
+--[[
+IMPORTANT NOTICE: Tests for these functions are provided via
+`common/tableFunctionsTests.lua`, but the tests do not run unless you uncomment
+them in `init.lua` (because they're not free to run, so we don't want them to
+run for end users.)
+]]
 
 if not table.copy then
 	function table:copy()

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -116,3 +116,49 @@ if not table.append then
 		end
 	end
 end
+
+if not table.count then
+	---Count the number of values in table.
+	---Note that this always works, whereas the default length operator (#table)
+	---only works if the table is a Lua sequence (i.e. indexes form a contiguous
+	---sequence starting from 1).
+	---@param tbl table
+	---@return integer
+	function table.count(tbl)
+		local count = 0
+		for _ in pairs(tbl) do
+			count = count + 1
+		end
+		return count
+	end
+end
+
+if not table.getKeyOf then
+	---Find key of value in table.
+	---Will always return the first key found, no matter if the table contains
+	---multiple instances of the value.
+	---@generic K, V
+	---@param tbl table<K, V>
+	---@param value V
+	---@return K? # key if found, nil otherwise
+	function table.getKeyOf(tbl, value)
+		for key, v in pairs(tbl) do
+			if v == value then
+				return key
+			end
+		end
+		return nil
+	end
+end
+
+if not table.contains then
+	---Check if value is in table.
+	---@generic V
+	---@param tbl table<any, V>
+	---@param value V
+	---@return boolean
+	function table.contains(tbl, value)
+		return table.getKeyOf(tbl, value) ~= nil
+	end
+end
+

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -162,3 +162,59 @@ if not table.contains then
 	end
 end
 
+if not table.removeIf then
+	---Remove values in table if they match the given predicate.
+	---@generic V
+	---@param tbl table<any, V>
+	---@param predicate fun(value: V): boolean
+	function table.removeIf(tbl, predicate)
+		for key, value in pairs(tbl) do
+			if predicate(value) then
+				tbl[key] = nil
+			end
+		end
+	end
+end
+
+if not table.removeAll then
+	---Remove all instances of value in table.
+	---@generic V
+	---@param tbl table<any, V>
+	---@param value V
+	function table.removeAll(tbl, value)
+		table.removeIf(tbl, function(v) return v == value end)
+	end
+end
+
+if not table.removeFirst then
+	---Remove first instance of value in table.
+	---If table is a Lua sequence (i.e. indexes form a contiguous sequence
+	---starting from 1), it will use `table.remove` to keep the sequence
+	---contiguous, otherwise it will `nil` the instance.
+	---@generic V
+	---@param tbl V[]|table<any, V>
+	---@param value V
+	---@return boolean # true if a value was removed, false otherwise
+	function table.removeFirst(tbl, value)
+		-- first, try to handle the table as a proper Lua sequence
+		-- this will fail as soon as there's a gap (missing integer index), but if
+		-- the table is a sequence then we want to keep that property by using
+		-- `table.remove` to keep the sequence intact without any gaps
+		for index, v in ipairs(tbl) do
+			if v == value then
+				table.remove(tbl, index)
+				return true
+			end
+		end
+
+		-- otherwise, try to handle the table normally and simply `nil` the value
+		local found = table.getKeyOf(tbl, value)
+		if found ~= nil then
+			tbl[found] = nil
+			return true
+		end
+
+		return false
+	end
+end
+

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -83,7 +83,7 @@ if not table.toString then
 		elseif dataType == "table" then
 			local str
 			if key then
-				str = key ..  "={"
+				str = key .. "={"
 			else
 				str = "{"
 			end
@@ -107,7 +107,6 @@ if not table.invert then
 		return inverted
 	end
 end
-
 
 if not table.append then
 	function table.append(appendTarget, appendData)
@@ -231,3 +230,29 @@ if not table.shuffle then
 	end
 end
 
+if not pairsByKeys then
+	---pairs-like iterator function traversing the table in the order of its keys.
+	---Natural sort order will be used by default, optionally pass a comparator
+	---function for custom sorting.
+	---@generic K, V
+	---@param tbl table<K, V>
+	---@param keySortFunction? fun(a: K, b: K): boolean comparator function passed to table.sort for sorting keys
+	---@return fun(table: table<K, V>, index?: K): K, V
+	---@return table<K, V>
+	---(Implementation copied straight from the docs at https://www.lua.org/pil/19.3.html.)
+	function pairsByKeys(tbl, keySortFunction)
+		local keys = {}
+		for key in pairs(tbl) do table.insert(keys, key) end
+		table.sort(keys, keySortFunction)
+		local i = 0           -- iterator variable
+		local iter = function() -- iterator function
+			i = i + 1
+			if keys[i] == nil then
+				return nil
+			else
+				return keys[i], tbl[keys[i]]
+			end
+		end
+		return iter
+	end
+end

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -218,3 +218,16 @@ if not table.removeFirst then
 	end
 end
 
+if not table.shuffle then
+	---Shuffle sequence using Knuth (Fisher–Yates) algorithm.
+	---@param sequence any[] must be a Lua sequence (i.e. indexes form a contiguous sequence starting from 1), with the exception that we optionally allow starting from 0
+	---@param firstIndex? 0|1 first index in the sequence (optional, default: 1)
+	function table.shuffle(sequence, firstIndex)
+		firstIndex = firstIndex or 1
+		for i = firstIndex, #sequence - 2 + firstIndex do
+			local j = math.random(i, #sequence)
+			sequence[i], sequence[j] = sequence[j], sequence[i]
+		end
+	end
+end
+

--- a/init.lua
+++ b/init.lua
@@ -37,3 +37,7 @@ end
 if commonFunctions.i18n[environment] then
 	Spring.I18N = Spring.I18N or VFS.Include("modules/i18n/i18n.lua")
 end
+
+-- we don't want them to run these tests for end users
+-- uncomment this only when working on functions in `common/tablefunctions.lua`
+-- VFS.Include('common/tableFunctionsTests.lua')

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -94,6 +94,7 @@ if (System == nil) then
 
 		next           = next,
 		pairs          = pairs,
+		pairsByKeys    = pairsByKeys, -- custom: defined in `common\tablefunctions.lua`
 		ipairs         = ipairs,
 
 		tonumber       = tonumber,

--- a/luaui/system.lua
+++ b/luaui/system.lua
@@ -85,6 +85,7 @@ if (System == nil) then
 
 		next           = next,
 		pairs          = pairs,
+		pairsByKeys    = pairsByKeys, -- custom: defined in `common\tablefunctions.lua`
 		ipairs         = ipairs,
 
 		tonumber       = tonumber,


### PR DESCRIPTION
(Please review per commit 😄)

This PR extends the existing table utilities we have with some new functions that should work on all table types unless specified otherwise in the docstring, and also makes some changes to the existing `table.mergeInPlace` so that it does actually do the merge in-place without a copy.

Some basic test functions are provided to verify functionality of the more interesting ones, and can be uncommented to  demonstrate how they work (however don't leave them uncommented: utilities are included at bootstrap and the shuffle test is not free).