### PR TITLE
Fix build power for Core Printer

### DIFF
--- a/units/Scavengers/Vehicles/corvac.lua
+++ b/units/Scavengers/Vehicles/corvac.lua
@@ -42,7 +42,7 @@ return {
 		turninplaceanglelimit = 90,
 		turninplacespeedlimit = 1.287,
 		turnrate = 363,
-		workertime = 1,
+		workertime = 200,
 		buildoptions = {
 			[1] = "cormex",
 			[2] = "corsolar",


### PR DESCRIPTION
Only had 1 workertime / Build power despite stating 200 in unit description.