### PR TITLE
received unit can keep no, all, or movement orders

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -194,7 +194,7 @@
 			"morph_tooltip": "Upgrade to next Tech-level (second click to cancel)",
 			"Spawning Disabled": "Spawning disabled",
 			"Spawning Enabled": "Spawning enabled",
-			
+
 			"Fire at will": "Fire at will",
 			"Hold fire": "Hold fire",
 			"Return fire": "Return fire",
@@ -1381,6 +1381,8 @@
 				"autogroup_immediate_descr": "Units built/resurrected/received are added to autogroups immediately,\ninstead when they get to be idle.\n\n(add units to autogroup with ALT+number)",
 				"autogroup_persist": "Autogroup persist mode",
 				"autogroup_persist_descr": "Autogroups persist in new games.\nIf this is enabled, units which were added to an autogroup in previous games\n will be added to the same group in this game.",
+				"shared_unit_orders": "Shared units keep orders",
+				"shared_unit_orders_descr": "Units received from allies will keep none of their orders, all of their orders, or only movement orders.",
 				"factory": "Factory",
 				"factoryguard": "guard (builders)",
 				"factoryguard_descr": "Newly created builders will assist their source factory",

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -194,7 +194,6 @@
 			"morph_tooltip": "Upgrade to next Tech-level (second click to cancel)",
 			"Spawning Disabled": "Spawning disabled",
 			"Spawning Enabled": "Spawning enabled",
-
 			"Fire at will": "Fire at will",
 			"Hold fire": "Hold fire",
 			"Return fire": "Return fire",

--- a/luarules/gadgets/unit_cancel_orders_on_share.lua
+++ b/luarules/gadgets/unit_cancel_orders_on_share.lua
@@ -1,53 +1,33 @@
 function gadget:GetInfo()
-    return {
-        name      = "Cancel orders on share",
-        desc      = "Prevents units carrying on with orders once shared/taken and turns on mexes that have been captured",
-        author    = "Bluestone, Beherith",
-        date      = "Jan 2015",
-        license   = "GNU GPL, v2 or later",
-        layer     = 0,
-        enabled   = true
-    }
+	return {
+		name    = "Cancel orders on share",
+		desc    = "Prevents units carrying on with orders once shared/taken and turns on mexes that have been captured",
+		author  = "Bluestone, Beherith",
+		date    = "Jan 2015",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true
+	}
 end
 
+if gadgetHandler:IsSyncedCode() then
+	local recievedMexes = {}
 
-if (not gadgetHandler:IsSyncedCode()) then
+	function gadget:UnitGiven(unitID, unitDefID, unitTeam, oldTeam)
+		-- if the unit is a metal extractor, turn it on:
+		if UnitDefs[unitDefID] and UnitDefs[unitDefID].extractsMetal and UnitDefs[unitDefID].extractsMetal > 0 then
+			recievedMexes[#recievedMexes + 1] = unitID
+		end
+	end
 
-  function gadget:UnitGiven(unitID, unitDefID, unitTeam, oldTeam)
-    -- give all shared units a stop command
-    Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
-
-    -- remove their build queue
-    local buildQ = Spring.GetFullBuildQueue(unitID) or {}
-    for _,buildOrder in pairs(buildQ) do
-      for uDID,count in pairs(buildOrder) do
-        for i=1,count do
-          Spring.GiveOrderToUnit(unitID, -uDID, {}, {"right"})
-        end
-      end
-    end
-  end
-
-else -- SYNCED
-
-  local recievedMexes = {}
-
-  function gadget:UnitGiven(unitID, unitDefID, unitTeam, oldTeam)
-    -- if the unit is a metal extractor, turn it on:
-    if UnitDefs[unitDefID] and UnitDefs[unitDefID].extractsMetal and UnitDefs[unitDefID].extractsMetal > 0 then
-      recievedMexes[#recievedMexes+1] = unitID
-    end
-  end
-
-  function gadget:GameFrame(n)
-    if n%37 == 0 and #recievedMexes > 0 then
-      for i, unitID in ipairs(recievedMexes) do
-        if Spring.ValidUnitID(unitID) then
-          Spring.GiveOrderToUnit( unitID, CMD.ONOFF, { 1 }, 0 )
-        end
-      end
-      recievedMexes = {}
-    end
-  end
-
+	function gadget:GameFrame(n)
+		if n % 37 == 0 and #recievedMexes > 0 then
+			for i, unitID in ipairs(recievedMexes) do
+				if Spring.ValidUnitID(unitID) then
+					Spring.GiveOrderToUnit(unitID, CMD.ONOFF, { 1 }, 0)
+				end
+			end
+			recievedMexes = {}
+		end
+	end
 end

--- a/luarules/gadgets/unit_issue_orders_when_captured.lua
+++ b/luarules/gadgets/unit_issue_orders_when_captured.lua
@@ -1,7 +1,7 @@
 function gadget:GetInfo()
 	return {
-		name    = "Cancel orders on share",
-		desc    = "Prevents units carrying on with orders once shared/taken and turns on mexes that have been captured",
+		name    = "Issue orders when captured",
+		desc    = "Turns on mexes that have been captured",
 		author  = "Bluestone, Beherith",
 		date    = "Jan 2015",
 		license = "GNU GPL, v2 or later",

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4255,6 +4255,16 @@ function init()
 		  end,
 		},
 
+		{ id = "shared_unit_orders", group = "game", category = types.basic, name = Spring.I18N('ui.settings.option.shared_unit_orders'), type = "select", options = { 'movement', 'all', 'none'}, description = Spring.I18N('ui.settings.option.shared_unit_orders_descr'),
+			value = 1,
+			onload = function(i)
+				loadWidgetData("Handle Orders on Share", "shared_unit_orders", { 'shareCommands' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Handle Orders on Share', 'shared_unit_orders', 'setOption', { 'shareCommands' }, value, {'shareCommands', value})
+			end,
+		},
+
 		{ id = "label_ui_cloak", group = "game", name = Spring.I18N('ui.settings.option.label_cloak'), category = types.basic },
 		{ id = "label_ui_cloak_spacer", group = "game", category = types.basic },
 
@@ -6465,3 +6475,4 @@ end
 function widget:LanguageChanged()
 	init()
 end
+

--- a/luaui/Widgets/unit_handle_orders_on_share.lua
+++ b/luaui/Widgets/unit_handle_orders_on_share.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author  = "lov",
 		date    = "September 2023",
 		license = "GNU GPL, v2 or later",
-		layer   = 1,
+		layer   = 0,
 		enabled = true
 	}
 end

--- a/luaui/Widgets/unit_handle_orders_on_share.lua
+++ b/luaui/Widgets/unit_handle_orders_on_share.lua
@@ -1,0 +1,90 @@
+function widget:GetInfo()
+	return {
+		name    = "Handle Orders on Share",
+		desc    = "Handles command queue of shared units",
+		author  = "lov",
+		date    = "September 2023",
+		license = "GNU GPL, v2 or later",
+		layer   = 1,
+		enabled = true
+	}
+end
+
+local options = { shareCommands = 1 }
+local shareCommandsList = { "movement", "all", "none" }
+local myTeam
+
+local CMD_MOVE = CMD.MOVE
+local CMD_REMOVE = CMD.REMOVE
+local CMD_STOP = CMD.STOP
+local CMD_OPT_CTRL = CMD.OPT_CTRL
+local spGetFactoryCommands = Spring.GetFactoryCommands
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
+local spGetUnitCommands = Spring.GetUnitCommands
+
+local isFactory = {}
+for udid = 1, #UnitDefs do
+	local ud = UnitDefs[udid]
+	if ud.isFactory then
+		isFactory[udid] = true
+	end
+end
+
+local function getOption(param)
+	return options[param]
+end
+
+local function setOption(params)
+	if params[1] and params[2] then
+		options[params[1]] = params[2]
+	end
+end
+
+function widget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
+	if newTeam ~= myTeam then return end
+	if isFactory[unitDefID] then
+		local commands = spGetFactoryCommands(unitID, -1) or {}
+		for i = 1, #commands do
+			spGiveOrderToUnit(unitID, CMD_REMOVE, commands[i].tag, CMD_OPT_CTRL)
+		end
+		return
+	end
+	local newCommands = { { CMD_STOP, {}, {} } }
+
+	if options.shareCommands == 2 then return end
+	if options.shareCommands == 3 then
+		spGiveOrderArrayToUnit(unitID, newCommands)
+		return
+	end
+
+	local commands = spGetUnitCommands(unitID, -1)
+	if not commands then return end
+	local i
+	for i = 1, #commands do
+		local c = commands[i]
+		if c.id == CMD_MOVE then
+			newCommands[#newCommands + 1] = { c.id, c.params, c.options }
+		end
+	end
+
+	spGiveOrderArrayToUnit(unitID, newCommands)
+end
+
+function widget:GetConfigData(data)
+	return options
+end
+
+function widget:SetConfigData(data)
+	if data.shareCommands ~= nil then
+		setOption({ "shareCommands", data.shareCommands })
+	end
+end
+
+function widget:Initialize()
+	myTeam = Spring.GetMyTeamID()
+	local WG_name = 'shared_unit_orders'
+	WG[WG_name] = {}
+	WG[WG_name].getOption = getOption
+	WG[WG_name].setOption = setOption
+end


### PR DESCRIPTION
Changes the default for received units to only remove all non movement commands from their command queue. This will let shared units continue moving towards their original order location. Also adds settings to customize behavior to stop all commands, or allow all commands after receiving a unit.

This MR is contingent on https://github.com/beyond-all-reason/spring/pull/996