### PR TITLE
Make naval nanos untransportable

### DIFF
--- a/units/ArmBuildings/SeaUtil/armnanotcplat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotcplat.lua
@@ -15,7 +15,7 @@ return {
 		canreclaim = true,
 		canrepeat = false,
 		canstop = true,
-		cantbetransported = false,
+		cantbetransported = true, -- transports cannot drop them back into water, reenable once that works
 		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "31 50 31",
@@ -49,7 +49,7 @@ return {
 			buildinggrounddecalsizey = 5,
 			buildinggrounddecalsizex = 5,
 			buildinggrounddecaldecayspeed = 30,
-			unitgroup = 'builder',
+			unitgroup = "builder",
 			model_author = "Beherith",
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "armbuildings/seautil",

--- a/units/CorBuildings/SeaUtil/cornanotcplat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotcplat.lua
@@ -15,7 +15,7 @@ return {
 		canreclaim = true,
 		canrepeat = false,
 		canstop = true,
-		cantbetransported = false,
+		cantbetransported = true, -- transports cannot drop them back into water, reenable once that works
 		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "31 50 31",
@@ -49,7 +49,7 @@ return {
 			buildinggrounddecalsizey = 5,
 			buildinggrounddecalsizex = 5,
 			buildinggrounddecaldecayspeed = 30,
-			unitgroup = 'builder',
+			unitgroup = "builder",
 			model_author = "Beherith",
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "corbuildings/seautil",


### PR DESCRIPTION
Since naval nanos cannot be dropped in the water, it would make sense - until we get that root cause fixed - to remove the option to lift them up in the first place.

I think this one-liner for each should be enough, but I haven't tested it.

I blame my linter for the `'builder' -> "builder"` change.