### PR TITLE
Removed the list of moderators from ingame

### DIFF
--- a/luarules/configs/powerusers.lua
+++ b/luarules/configs/powerusers.lua
@@ -33,13 +33,5 @@ return {
 	['IceXuick'] = everything,
 	['[teh]Beherith'] = everything,
 	['PtaQ'] = everything,
-	['TarnishedKnight'] = everything,
-
-	['Teifion'] = moderator,
-	['[Fx]Jazcash'] = moderator,
-	['Damgam98'] = moderator,
-	['[Z]ecrus'] = moderator,
-	['Fire[Z]torm_'] = moderator,
-	['Flaka'] = moderator,
-	['WatchTheFort'] = moderator,
+	['TarnishedKnight'] = everything
 }


### PR DESCRIPTION
@Beherith I believe we should be able to strip out all moderator names from this part. If not let me know and I'll re-add them with and put in serverside limits on acquiring the moderator names.