### PR TITLE
luarules: use global checks to determine if FFA in `game_autocolors`

### DIFF
--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -408,12 +408,8 @@ local function shuffleAllColors()
 	end
 end
 
-local isFFA = false
-if #teamList == #allyTeamList and teamCount > 2 then
-	isFFA = true
-elseif not teamColors[allyTeamCount] then
-	isFFA = true
-end
+-- we don't want to use FFA colors for TeamFFA, because we want each team to have its own color theme
+local useFFAColors = Spring.Utilities.Gametype.IsFFA() and not Spring.Utilities.Gametype.IsTeams()
 
 if gadgetHandler:IsSyncedCode() then
 
@@ -445,7 +441,7 @@ if gadgetHandler:IsSyncedCode() then
 			Spring.SetTeamRulesParam(teamID, "AutoTeamColorGreen", hex2RGB(survivalColors[survivalColorNum])[2] + math.random(-survivalColorVariation, survivalColorVariation))
 			Spring.SetTeamRulesParam(teamID, "AutoTeamColorBlue", hex2RGB(survivalColors[survivalColorNum])[3] + math.random(-survivalColorVariation, survivalColorVariation))
 			survivalColorNum = survivalColorNum + 1 -- Will start from the next color next time
-		elseif isFFA then
+		elseif useFFAColors then
 			if not ffaColors[ffaColorNum] then -- If we have no color for this team anymore
 				ffaColorNum = 1 -- Starting from the first color again..
 				ffaColorVariation = ffaColorVariation + colorVariationDelta -- ..but adding random color variations with increasing amplitude with every cycle
@@ -550,7 +546,7 @@ else	-- UNSYNCED
 
 				survivalColorNum = survivalColorNum + 1 -- Will start from the next color next time
 
-			elseif isFFA then
+			elseif useFFAColors then
 
 				if not ffaColors[ffaColorNum] then -- If we have no color for this team anymore
 					ffaColorNum = 1 -- Starting from the first color again..


### PR DESCRIPTION
In 141d4946b7cfac92664eab61128aae18e427bd71, we globally reworked checks for FFA games in the codebase to use the global utility function `Spring.Utilities.Gametype.IsFFA()`.

However, this broke TeamFFA autocolors because the FFA colors should only be used for regular FFA games and not for TeamFFA games, as we explicitly want to keep each team with its own color theme. Thus, the change was partially reverted in 250f9a06b190be4ae11c10043ba57b275500d16b.

This commit reworks the check to use the global utility functions again, but properly detects TeamFFA games in order NOT to use FFA colors.