### PR TITLE
luarules/luaui: fix TeamFFA startboxes not working

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -217,12 +217,11 @@ if gadgetHandler:IsSyncedCode() then
 		Spring.MarkerAddPoint(x,y,z,name .. " " .. readyState)
 		--]]
 
+		-- if startPosType is not set to choose-in-game, we will handle start positions manually
 		if Game.startPosType ~= 2 then
 			return true
-		end -- accept blindly unless we are in choose-in-game mode
-		if useFFAStartPoints then
-			return true
 		end
+
 		if select(4, Spring.GetTeamInfo(teamID)) then  -- isAiTeam
 			return false
 		end

--- a/luaui/Widgets/gui_pregameui.lua
+++ b/luaui/Widgets/gui_pregameui.lua
@@ -162,13 +162,11 @@ function widget:GameSetup(state, ready, playerStates)
 	end
 
 	-- if we can't choose startpositions, no need for ready button etc
-	if Game.startPosType ~= 2 or isFFA then
-		return true, true
-	end
-
-	-- set my readyState to true if ffa
-	if isFFA and (not readied or not ready) then
-		readied = true
+	if Game.startPosType ~= 2 then
+		-- additionally automatically set readyState to true if this is a FFA game
+		if isFFA and (not readied or not ready) then
+			readied = true
+		end
 		return true, true
 	end
 


### PR DESCRIPTION
In 141d4946b7cfac92664eab61128aae18e427bd71, we globally reworked checks for FFA games in the codebase to use the global utility function `Spring.Utilities.Gametype.IsFFA()`.

However, this broke TeamFFA startboxes due to the new `isFFA` check properly picking up TeamFFA games at all times, thereby enabling the codepaths that bypass startboxes and make players spawn automatically.

We initially intended to fix this as part of the FFA startpoints rework, but the review is dragging on so we extract the fix in order to merge it ASAP.

Note that this actually fixes an underlying issue that was already present in the codebase: if `ffa_mode` modoption was enabled in a TeamFFA game, then this was also happening, thereby forcing players to use the Team or Custom preset instead of the FFA preset for TeamFFA games.