### PR TITLE
luarules: hotfix `game_ffa_start_setup` due to missing engine release

### DIFF
--- a/luarules/gadgets/game_ffa_start_setup.lua
+++ b/luarules/gadgets/game_ffa_start_setup.lua
@@ -163,7 +163,9 @@ function gadget:Initialize()
   local allyTeamList = Spring.Utilities.GetAllyTeamList()
 
   setFFAStartPoints(allyTeamList)
-  shuffleStartBoxes(allyTeamList)
+  -- TODO: uncomment on next engine release containing dependent changes for
+  -- Spring.SetAllyTeamStartBox to be available
+  -- shuffleStartBoxes(allyTeamList)
 
   -- our job here is done :)
   gadgetHandler:RemoveGadget(self)


### PR DESCRIPTION
In 79a5ecf276cbbfafb2680d4485da7c9503b0b05d, we reworked FFA start points and additionally added a shuffling system for start boxes.

However, this shuffling requires `Spring.SetAllyTeamStartBox` to be available in engine, and no release has been made available with it yet. This results in a crash at startup for FFA games:

```
[string "LuaRules/Gadgets/game_ffa_start_setup.lua"]:154: attempt to call field 'SetAllyTeamStartBox' (a nil value)) ptop=3 cenv=false vfsmode=Mmb
```

As a hotfix, we temporarily comment out the start box shuffling code. It will be re-enabled later when a new engine release is out.