### PR TITLE
luarules: improvements to `disco` anonymous mode

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1061,7 +1061,7 @@ local options={
 			{key="allred", name="Force SimpleColors", desc="All players have simple colors enabled, enemies cannot be recognized from each other."},
 			{key="global", name="Shuffle Globally", desc="Player colors order is shuffled globally, everyone see the same colors"},
 			{key="local", name="Shuffle Locally", desc="Player colors order is shuffled locally, everyone see different colors"},
-			{key="disco", name="Shuffle Locally - DiscoMode", desc="Player colors order is shuffled locally, everyone see different colors that change every once a while randomly"},
+			{key="disco", name="Shuffle Locally - DiscoMode", desc="Player colors order is shuffled locally, everyone see different colors that change every 2 minutes"},
 		}
 	},
 


### PR DESCRIPTION
We re-enabled the `disco` anonymous mode in
c112b8ef44f187497031ee96514974255054e443. Since then, players have been using it a little bit, but initial feedback suggests the mode is currently too disorienting, notably because colors switch too often and because the player's own color also changes.

This commit proposes to address this by shuffling every 2 minutes instead of at a random but generally shorter interval, and ensuring the player's own color is always kept the same.

Incidentally, this also serves to avoid some of the quirks detected with the `disco` anonymous mode, for example `unitcloaker.lua` responsible for setting transparent cloak color on cloaked units was not capable of adjusting dynamically after the player's own color had changed. This is now a non-issue since the player's own color never changes.