### PR TITLE
wade_fx micro optimization

### DIFF
--- a/luarules/gadgets/gfx_wade_fx.lua
+++ b/luarules/gadgets/gfx_wade_fx.lua
@@ -87,7 +87,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 	if maxDepth then
 		unitsCount = unitsCount + 1
 		unitsData[unitsCount] = unitID
-		unit[unitID] = {id = unitsCount, h = maxDepth, fx = wadeSfxID[unitDefID]}
+		unit[unitID] = {id = unitsCount, h = maxDepth, fx = wadeSfxID[unitDefID], defid = unitDefID}
 	end
 end
 
@@ -110,17 +110,19 @@ function gadget:GameFrame(n)
 		for i = current_fold, unitsCount, n_folds do
 			local unitID = listData[i]
 			local data = unit[unitID]
-			local unitDefID = spGetUnitDefID(unitID)
+			local unitDefID = data.defid
 			if data and data.h and unitWadeCeg[unitDefID] then
 				local x,y,z = spGetUnitPosition(unitID)
 				local h = data.h
 
-				local _, _, _, speed = spGetUnitVelocity(unitID)
-				if speed and y > h and y <= 0 and speed > 0 and not spGetUnitIsCloaked(unitID) then
-					-- 1 is the pieceID, most likely it's usually the base piece
-					-- but even if it isn't, it doesn't really matter
-					--spusCallAsUnit(unitID, spusEmitSfx, 1, data.fx)
-					spSpawnCEG(unitWadeCeg[unitDefID], x, 0, z, 0, 0, 0)
+				if y > h and y <= 0 then
+					local _, _, _, speed = spGetUnitVelocity(unitID)
+					if speed and speed > 0 and not spGetUnitIsCloaked(unitID) then
+						-- 1 is the pieceID, most likely it's usually the base piece
+						-- but even if it isn't, it doesn't really matter
+						--spusCallAsUnit(unitID, spusEmitSfx, 1, data.fx)
+						spSpawnCEG(unitWadeCeg[unitDefID], x, 0, z, 0, 0, 0)
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Small performance improvement for gfx_wade_fx. Benchmarked with 50 pawns on a patrol route in shallow water for 3000 tracy frames.
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/13026303/849d2c6b-52b9-4479-b9c3-e20829a61c75)
