### PR TITLE
Disable "contain mouse" on bar exit without touching the Spring.Config

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -6293,6 +6293,7 @@ function widget:Shutdown()
 	WG['options'] = nil
 
 	resetUserVolume()
+	Spring.SendCommands("grabinput 0")
 end
 
 local lastOptionCommand = 0


### PR DESCRIPTION
Allows moving the mouse outside of chobby when game has ended without defocusing the window (Alt+Tab on windows)

The user defined setting to "GrabInput" stays untouched and is resumed on next widget initialization.