### PR TITLE
Merge Errrr's bugfix version of state preferences into mainline

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -3,19 +3,19 @@
 
 function widget:GetInfo()
 	return {
-		name = "State Prefs",
-		desc = "Sets pre-defined units states.",
-		author = "quantum + Doo",
-		date = "2018",
+		name = "State Prefs V2",
+		desc = "Sets pre-defined units states. CTRL-click on a unit's state commands to define states for newly produced units of its type. V2 fixes bug, improves console output to show unit and state change details.",
+		author = "Errrrrrr, quantum + Doo",
+		date = "April 21, 2023",
 		license = "GNU GPL, v2 or later",
 		layer = 999999,
-		enabled = false  --  loaded by default?
+		enabled = false, --  loaded by default?
 	}
 end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-
+local unitArray = {}
 local unitName = {}
 for udid, ud in pairs(UnitDefs) do
 	unitName[udid] = ud.name
@@ -31,6 +31,29 @@ end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+local function GetCmdOpts(alt, ctrl, meta, shift, right)
+	local opts = { alt = alt, ctrl = ctrl, meta = meta, shift = shift, right = right }
+	local coded = 0
+
+	if alt then
+		coded = coded + CMD.OPT_ALT
+	end
+	if ctrl then
+		coded = coded + CMD.OPT_CTRL
+	end
+	if meta then
+		coded = coded + CMD.OPT_META
+	end
+	if shift then
+		coded = coded + CMD.OPT_SHIFT
+	end
+	if right then
+		coded = coded + CMD.OPT_RIGHT
+	end
+
+	opts.coded = coded
+	return opts
+end
 
 function widget:PlayerChanged(playerID)
 	if Spring.GetSpectatingState() then
@@ -49,6 +72,21 @@ function widget:Initialize()
 end
 
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
+	local alt, ctrl, meta, shift = Spring.GetModKeyState()
+	if not ctrl then
+		return false
+	end
+	-- need to filter only state commands!
+	if cmdID > 1000 or cmdID < 0 then
+		--Spring.Echo("Not a state change command!")
+		return false
+	end
+	local cmdName = CMD[cmdID].name
+	if cmdName and not cmdName.find("STATE") then
+		--Spring.Echo("Not a state change command!")
+		return false
+	end
+
 	local selectedUnits = Spring.GetSelectedUnits()
 	for i = 1, #selectedUnits do
 		local unitID = selectedUnits[i]
@@ -56,21 +94,31 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 		local unitTeam = Spring.GetUnitTeam(unitID)
 		local name = unitName[unitDefID]
 		unitSet[name] = unitSet[name] or {}
-		local alt, ctrl, meta, shift = Spring.GetModKeyState()
-		if ctrl and #cmdParams == 1 and not (unitSet[name][cmdID] == cmdParams[1]) then
+		if #cmdParams == 1 and not (unitSet[name][cmdID] == cmdParams[1]) then
 			unitSet[name][cmdID] = cmdParams[1]
-			Spring.Echo("State pref changed to: " .. (cmdParams[1]))
+			Spring.Echo("State pref changed:  " .. name .. ",  " .. CMD[cmdID] .. " " .. cmdParams[1])
 			table.save(unitSet, "LuaUI/config/StatesPrefs.lua", "--States prefs")
+
+			-- Spring.PlaySoundFile('LuaUI/sounds/volume_osd/pop.wav', 1.0, 'ui')
 		end
 	end
 end
 
-function widget:UnitCreated(unitID, unitDefID, unitTeam)
+function widget:UnitFinished(unitID, unitDefID, unitTeam)
+	local cmdOpts = GetCmdOpts(false, false, false, true, false)
+	--local altOpts = GetCmdOpts(true, false, false, false, false)
+
 	local name = unitName[unitDefID]
+	--local unitDef = UnitDefs[unitDefID]
+
 	unitSet[name] = unitSet[unitName[unitDefID]] or {}
 	if unitTeam == Spring.GetMyTeamID() then
 		for cmdID, cmdParam in pairs(unitSet[name]) do
-			Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, 0)
+			if cmdID == 115 then
+				return
+			end -- we're skipping "repeat" command here for now
+			local success = Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, cmdOpts)
+			--Spring.Echo("".. name .. ", " .. tostring(cmdID) .. ", " .. tostring(cmdParam) .. " success: ".. tostring(success))
 		end
 	end
 end
@@ -83,4 +131,3 @@ end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-


### PR DESCRIPTION
As per https://discord.com/channels/549281623154229250/1161535897049763851, this merges @zxbc's bugfix version version of the state preferences widgets as found in https://discord.com/channels/549281623154229250/1114665160674652221. Let me copy his description:

> By request, updated this widget. Holding CTRL and issue a state change command (such as "hold fire") on any unit will set this as default state for all future produced units of its type. This persists through games, so you can set states for all your unit types in a practice game vs AI, and the settings will take effect in all future games. Also added some details in console output when states are set. 
> 
> The state preference data is saved in a file at Beyond-All-Reason\data\LuaUI\Config\StatePrefs.lua. If you want to remove all settings, simply delete the file. You can also share your preconfigured file with others and if they load this widget with the file present in their folder, they will have the preferences loaded as well.
> 
> Updated:
> Repeat state is temporarily left out from state pref settings as it is producing undesirable rallying behavior for units coming out of factory. We'll figure something out in the future.
> 
> Added the proper checks for state change commands and will no longer give errors and bug out.

I was not aware we had a V1 in the main repo, so we should probably fix that one.

# Questions that need answering

- [ ] I copied the changes mostly verbatim, but adjusted `enabled = false` to keep in line with this being an optional widget in the main game. Might be good to have an option for it.