### PR TITLE
Fix emp/decloak ranges by clearing textures

### DIFF
--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -529,6 +529,9 @@ function widget:DrawWorldPreUnit()
 	if Spring.GetGameFrame() == 0 then
 		checkMetalspots()
 	end
+
+	gl.Texture(0, false)
+	gl.Texture(1, false)
 end
 
 function widget:GetConfigData(data)


### PR DESCRIPTION
This addresses this bug:
https://discord.com/channels/549281623154229250/1122437690890129468

Turns out having an active texture set seems to sometimes cause other widgets to not draw. 
`gl.Texture(1, AtlasTextureID)` was the offending one. clearing active textures after using them seems to be the norm and proper. 
Delving into why there's this cross-widget interaction is beyond me.