### PR TITLE
fix(game_autocolors): show true colors when ffa player resigns

### DIFF
--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -14,7 +14,6 @@ local anonymousMode = Spring.GetModOptions().teamcolors_anonymous_mode
 local gaiaTeamID = Spring.GetGaiaTeamID()
 local teamList = Spring.GetTeamList()
 local allyTeamList = Spring.GetAllyTeamList()
-local teamCount = #teamList - 1
 local allyTeamCount = #allyTeamList - 1
 local isSurvival = Spring.Utilities.Gametype.IsScavengers() or Spring.Utilities.Gametype.IsRaptors()
 
@@ -27,8 +26,8 @@ local allyTeamNum = 0
 local teamSizes = {}
 
 local function hex2RGB(hex)
-    hex = hex:gsub("#","")
-    return {tonumber("0x"..hex:sub(1,2)), tonumber("0x"..hex:sub(3,4)), tonumber("0x"..hex:sub(5,6))}
+	hex = hex:gsub("#", "")
+	return { tonumber("0x" .. hex:sub(1, 2)), tonumber("0x" .. hex:sub(3, 4)), tonumber("0x" .. hex:sub(5, 6)) }
 end
 
 local function shuffleTable(Table)
@@ -40,7 +39,7 @@ local function shuffleTable(Table)
 			local r = math.random(#originalTable)
 			table.insert(shuffledTable, originalTable[r])
 			table.remove(originalTable, r)
-		until(#originalTable == 0)
+		until #originalTable == 0
 	else
 		shuffledTable = originalTable
 	end
@@ -48,12 +47,11 @@ local function shuffleTable(Table)
 end
 
 -- Special colors
-local armBlueColor       = "#004DFF" -- Armada Blue
-local corRedColor        = "#FF1005" -- Cortex Red
-local scavPurpColor      = "#6809A1" -- Scav Purple
-local raptorOrangeColor  = "#CC8914" -- Raptor Orange
-local gaiaGrayColor      = "#7F7F7F" -- Gaia Grey
-
+local armBlueColor = "#004DFF" -- Armada Blue
+local corRedColor = "#FF1005" -- Cortex Red
+local scavPurpColor = "#6809A1" -- Scav Purple
+local raptorOrangeColor = "#CC8914" -- Raptor Orange
+local gaiaGrayColor = "#7F7F7F" -- Gaia Grey
 
 -- NEW IceXuick Colors V6
 local ffaColors = {
@@ -395,14 +393,13 @@ local teamColors = {
 			"#C4A9FF", -- 3
 		},
 	},
-
 }
 
 local function shuffleAllColors()
 	ffaColors = shuffleTable(ffaColors)
 	survivalColors = shuffleTable(survivalColors)
-	for i = 1,#teamColors do
-		for j = 1,#teamColors[i] do
+	for i = 1, #teamColors do
+		for j = 1, #teamColors[i] do
 			teamColors[i][j] = shuffleTable(teamColors[i][j])
 		end
 	end
@@ -412,7 +409,6 @@ end
 local useFFAColors = Spring.Utilities.Gametype.IsFFA() and not Spring.Utilities.Gametype.IsTeams()
 
 if gadgetHandler:IsSyncedCode() then
-
 	if anonymousMode ~= "disabled" then
 		shuffleAllColors()
 	end
@@ -437,9 +433,24 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			-- Assigning R,G,B values with specified color variations
-			Spring.SetTeamRulesParam(teamID, "AutoTeamColorRed", hex2RGB(survivalColors[survivalColorNum])[1] + math.random(-survivalColorVariation, survivalColorVariation))
-			Spring.SetTeamRulesParam(teamID, "AutoTeamColorGreen", hex2RGB(survivalColors[survivalColorNum])[2] + math.random(-survivalColorVariation, survivalColorVariation))
-			Spring.SetTeamRulesParam(teamID, "AutoTeamColorBlue", hex2RGB(survivalColors[survivalColorNum])[3] + math.random(-survivalColorVariation, survivalColorVariation))
+			Spring.SetTeamRulesParam(
+				teamID,
+				"AutoTeamColorRed",
+				hex2RGB(survivalColors[survivalColorNum])[1]
+					+ math.random(-survivalColorVariation, survivalColorVariation)
+			)
+			Spring.SetTeamRulesParam(
+				teamID,
+				"AutoTeamColorGreen",
+				hex2RGB(survivalColors[survivalColorNum])[2]
+					+ math.random(-survivalColorVariation, survivalColorVariation)
+			)
+			Spring.SetTeamRulesParam(
+				teamID,
+				"AutoTeamColorBlue",
+				hex2RGB(survivalColors[survivalColorNum])[3]
+					+ math.random(-survivalColorVariation, survivalColorVariation)
+			)
 			survivalColorNum = survivalColorNum + 1 -- Will start from the next color next time
 		elseif useFFAColors then
 			if not ffaColors[ffaColorNum] then -- If we have no color for this team anymore
@@ -448,27 +459,55 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			-- Assigning R,G,B values with specified color variations
-			Spring.SetTeamRulesParam(teamID, "AutoTeamColorRed", hex2RGB(ffaColors[ffaColorNum])[1] + math.random(-ffaColorVariation, ffaColorVariation))
-			Spring.SetTeamRulesParam(teamID, "AutoTeamColorGreen", hex2RGB(ffaColors[ffaColorNum])[2] + math.random(-ffaColorVariation, ffaColorVariation))
-			Spring.SetTeamRulesParam(teamID, "AutoTeamColorBlue", hex2RGB(ffaColors[ffaColorNum])[3] + math.random(-ffaColorVariation, ffaColorVariation))
+			Spring.SetTeamRulesParam(
+				teamID,
+				"AutoTeamColorRed",
+				hex2RGB(ffaColors[ffaColorNum])[1] + math.random(-ffaColorVariation, ffaColorVariation)
+			)
+			Spring.SetTeamRulesParam(
+				teamID,
+				"AutoTeamColorGreen",
+				hex2RGB(ffaColors[ffaColorNum])[2] + math.random(-ffaColorVariation, ffaColorVariation)
+			)
+			Spring.SetTeamRulesParam(
+				teamID,
+				"AutoTeamColorBlue",
+				hex2RGB(ffaColors[ffaColorNum])[3] + math.random(-ffaColorVariation, ffaColorVariation)
+			)
 			ffaColorNum = ffaColorNum + 1 -- Will start from the next color next time
-
 		else
 			if not teamSizes[allyTeamID] then
 				allyTeamNum = allyTeamNum + 1
-				teamSizes[allyTeamID] = {allyTeamNum, 1, 0} -- Team number, Starting color number, Color variation
+				teamSizes[allyTeamID] = { allyTeamNum, 1, 0 } -- Team number, Starting color number, Color variation
 			end
-			if teamColors[allyTeamCount] -- If we have the color set for this number of teams
-				and teamColors[allyTeamCount][teamSizes[allyTeamID][1]] then -- And this team number exists in the color set
+			if
+				teamColors[allyTeamCount] -- If we have the color set for this number of teams
+				and teamColors[allyTeamCount][teamSizes[allyTeamID][1]]
+			then -- And this team number exists in the color set
 				if not teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]] then -- If we have no color for this player anymore
 					teamSizes[allyTeamID][2] = 1 -- Starting from the first color again..
 					teamSizes[allyTeamID][3] = teamSizes[allyTeamID][3] + colorVariationDelta -- ..but adding random color variations with increasing amplitude with every cycle
 				end
 
 				-- Assigning R,G,B values with specified color variations
-				Spring.SetTeamRulesParam(teamID, "AutoTeamColorRed", hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[1] + math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]))
-				Spring.SetTeamRulesParam(teamID, "AutoTeamColorGreen", hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[2] + math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]))
-				Spring.SetTeamRulesParam(teamID, "AutoTeamColorBlue", hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[3] + math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]))
+				Spring.SetTeamRulesParam(
+					teamID,
+					"AutoTeamColorRed",
+					hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[1]
+						+ math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3])
+				)
+				Spring.SetTeamRulesParam(
+					teamID,
+					"AutoTeamColorGreen",
+					hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[2]
+						+ math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3])
+				)
+				Spring.SetTeamRulesParam(
+					teamID,
+					"AutoTeamColorBlue",
+					hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[3]
+						+ math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3])
+				)
 				teamSizes[allyTeamID][2] = teamSizes[allyTeamID][2] + 1 -- Will start from the next color next time
 			else
 				Spring.Echo("[AUTOCOLORS] Error: Team Colors Table is broken or missing for this allyteam set")
@@ -480,7 +519,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local AutoColors = {}
-	for i = 1,#teamList do
+	for i = 1, #teamList do
 		local teamID = teamList[i]
 		local allyTeamID = select(6, Spring.GetTeamInfo(teamID))
 		local isAI = Spring.GetTeamLuaAI(teamID)
@@ -499,39 +538,30 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	Spring.SendLuaRulesMsg("AutoColors" .. Json.encode(AutoColors))
-
-
-else	-- UNSYNCED
-	teamColorsTable = {}
+else -- UNSYNCED
+	local teamColorsTable = {}
 
 	local function setUpLocalTeamColor(teamID, allyTeamID, isAI)
 		if anonymousMode ~= "disabled" and anonymousMode ~= "global" then
 			if isAI and string.find(isAI, "Scavenger") then
-
 				teamColorsTable[teamID] = {
 					r = hex2RGB(scavPurpColor)[1],
 					g = hex2RGB(scavPurpColor)[2],
 					b = hex2RGB(scavPurpColor)[3],
 				}
-
 			elseif isAI and string.find(isAI, "Raptor") then
-
 				teamColorsTable[teamID] = {
 					r = hex2RGB(raptorOrangeColor)[1],
 					g = hex2RGB(raptorOrangeColor)[2],
 					b = hex2RGB(raptorOrangeColor)[3],
 				}
-
 			elseif teamID == gaiaTeamID then
-
 				teamColorsTable[teamID] = {
 					r = hex2RGB(gaiaGrayColor)[1],
 					g = hex2RGB(gaiaGrayColor)[2],
 					b = hex2RGB(gaiaGrayColor)[3],
 				}
-
 			elseif isSurvival then
-
 				if not survivalColors[survivalColorNum] then -- If we have no color for this team anymore
 					survivalColorNum = 1 -- Starting from the first color again..
 					survivalColorVariation = survivalColorVariation + colorVariationDelta -- ..but adding random color variations with increasing amplitude with every cycle
@@ -539,15 +569,16 @@ else	-- UNSYNCED
 
 				-- Assigning R,G,B values with specified color variations
 				teamColorsTable[teamID] = {
-					r = hex2RGB(survivalColors[survivalColorNum])[1] + math.random(-survivalColorVariation, survivalColorVariation),
-					g = hex2RGB(survivalColors[survivalColorNum])[2] + math.random(-survivalColorVariation, survivalColorVariation),
-					b = hex2RGB(survivalColors[survivalColorNum])[3] + math.random(-survivalColorVariation, survivalColorVariation),
+					r = hex2RGB(survivalColors[survivalColorNum])[1]
+						+ math.random(-survivalColorVariation, survivalColorVariation),
+					g = hex2RGB(survivalColors[survivalColorNum])[2]
+						+ math.random(-survivalColorVariation, survivalColorVariation),
+					b = hex2RGB(survivalColors[survivalColorNum])[3]
+						+ math.random(-survivalColorVariation, survivalColorVariation),
 				}
 
 				survivalColorNum = survivalColorNum + 1 -- Will start from the next color next time
-
 			elseif useFFAColors then
-
 				if not ffaColors[ffaColorNum] then -- If we have no color for this team anymore
 					ffaColorNum = 1 -- Starting from the first color again..
 					ffaColorVariation = ffaColorVariation + colorVariationDelta -- ..but adding random color variations with increasing amplitude with every cycle
@@ -561,18 +592,16 @@ else	-- UNSYNCED
 				}
 
 				ffaColorNum = ffaColorNum + 1 -- Will start from the next color next time
-
 			else
-
 				if not teamSizes[allyTeamID] then
 					allyTeamNum = allyTeamNum + 1
-					teamSizes[allyTeamID] = {allyTeamNum, 1, 0} -- Team number, Starting color number, Color variation
+					teamSizes[allyTeamID] = { allyTeamNum, 1, 0 } -- Team number, Starting color number, Color variation
 				end
 
-				if teamColors[allyTeamCount] -- If we have the color set for this number of teams
-
-					and teamColors[allyTeamCount][teamSizes[allyTeamID][1]] then -- And this team number exists in the color set
-
+				if
+					teamColors[allyTeamCount] -- If we have the color set for this number of teams
+					and teamColors[allyTeamCount][teamSizes[allyTeamID][1]]
+				then -- And this team number exists in the color set
 					if not teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]] then -- If we have no color for this player anymore
 						teamSizes[allyTeamID][2] = 1 -- Starting from the first color again..
 						teamSizes[allyTeamID][3] = teamSizes[allyTeamID][3] + colorVariationDelta -- ..but adding random color variations with increasing amplitude with every cycle
@@ -580,9 +609,12 @@ else	-- UNSYNCED
 
 					-- Assigning R,G,B values with specified color variations
 					teamColorsTable[teamID] = {
-						r = hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[1] + math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]),
-						g = hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[2] + math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]),
-						b = hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[3] + math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]),
+						r = hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[1]
+							+ math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]),
+						g = hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[2]
+							+ math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]),
+						b = hex2RGB(teamColors[allyTeamCount][teamSizes[allyTeamID][1]][teamSizes[allyTeamID][2]])[3]
+							+ math.random(-teamSizes[allyTeamID][3], teamSizes[allyTeamID][3]),
 					}
 
 					teamSizes[allyTeamID][2] = teamSizes[allyTeamID][2] + 1 -- Will start from the next color next time
@@ -612,7 +644,7 @@ else	-- UNSYNCED
 		colorVariationDelta = 128 -- Delta for color variation
 		allyTeamNum = 0
 		teamSizes = {}
-		for i = 1,#teamList do
+		for i = 1, #teamList do
 			local teamID = teamList[i]
 			local allyTeamID = select(6, Spring.GetTeamInfo(teamID))
 			local isAI = Spring.GetTeamLuaAI(teamID)
@@ -626,11 +658,11 @@ else	-- UNSYNCED
 	setUpAllLocalTeamColors()
 
 	local iconDevModeColors = {
-		armblue       = armBlueColor,
-		corred        = corRedColor,
-		scavpurp      = scavPurpColor,
-		raptororange  = raptorOrangeColor,
-		gaiagray      = gaiaGrayColor,
+		armblue = armBlueColor,
+		corred = corRedColor,
+		scavpurp = scavPurpColor,
+		raptororange = raptorOrangeColor,
+		gaiagray = gaiaGrayColor,
 	}
 
 	local iconDevMode = Spring.GetModOptions().teamcolors_icon_dev_mode
@@ -673,7 +705,7 @@ else	-- UNSYNCED
 
 		local next_team_brightness_offset = 1.0
 		local next_opponent_brightness_offset = 1.0
-		local dimming_factor = math.min( math.max(0.4, 0.05*#teamList), 0.95)
+		local dimming_factor = math.min(math.max(0.4, 0.05 * #teamList), 0.95)
 
 		for i = 1, #teamList do
 			local teamID = teamList[i]
@@ -681,38 +713,57 @@ else	-- UNSYNCED
 			local g = 1
 			local b = 1
 			if teamColorsTable[teamID] then
-				r = teamColorsTable[teamID].r/255
-				g = teamColorsTable[teamID].g/255
-				b = teamColorsTable[teamID].b/255
+				r = teamColorsTable[teamID].r / 255
+				g = teamColorsTable[teamID].g / 255
+				b = teamColorsTable[teamID].b / 255
 			end
 
 			if iconDevModeColor then
-				Spring.SetTeamColor(teamID, hex2RGB(iconDevModeColor)[1]/255, hex2RGB(iconDevModeColor)[2]/255, hex2RGB(iconDevModeColor)[3]/255)
-			elseif Spring.GetConfigInt("SimpleTeamColors", 0) == 1 or (anonymousMode == "allred" and not Spring.GetSpectatingState()) then
+				Spring.SetTeamColor(
+					teamID,
+					hex2RGB(iconDevModeColor)[1] / 255,
+					hex2RGB(iconDevModeColor)[2] / 255,
+					hex2RGB(iconDevModeColor)[3] / 255
+				)
+			elseif
+				Spring.GetConfigInt("SimpleTeamColors", 0) == 1
+				or (anonymousMode == "allred" and not Spring.GetSpectatingState())
+			then
 				local allyTeamID = select(6, Spring.GetTeamInfo(teamID))
 				if teamID == myTeamID then
-					Spring.SetTeamColor(teamID,
-						Spring.GetConfigInt("SimpleTeamColorsPlayerR", 0)/255,
-						Spring.GetConfigInt("SimpleTeamColorsPlayerG", 77)/255,
-						Spring.GetConfigInt("SimpleTeamColorsPlayerB", 255)/255)
+					Spring.SetTeamColor(
+						teamID,
+						Spring.GetConfigInt("SimpleTeamColorsPlayerR", 0) / 255,
+						Spring.GetConfigInt("SimpleTeamColorsPlayerG", 77) / 255,
+						Spring.GetConfigInt("SimpleTeamColorsPlayerB", 255) / 255
+					)
 				elseif allyTeamID == myAllyTeamID then
-					Spring.SetTeamColor(teamID,
-						next_team_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsAllyR", 0)/255,
-						next_team_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsAllyG", 255)/255,
-						next_team_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsAllyB", 0)/255)
+					Spring.SetTeamColor(
+						teamID,
+						next_team_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsAllyR", 0) / 255,
+						next_team_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsAllyG", 255) / 255,
+						next_team_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsAllyB", 0) / 255
+					)
 					if Spring.GetConfigInt("SimpleTeamColorsUseGradient", 0) == 1 and anonymousMode ~= "allred" then
 						next_team_brightness_offset = dimming_factor * next_team_brightness_offset
 					end
 				elseif allyTeamID ~= myAllyTeamID and teamID ~= gaiaTeamID then
-					Spring.SetTeamColor(teamID,
-						next_opponent_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsEnemyR", 255)/255,
-						next_opponent_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsEnemyG", 16)/255,
-						next_opponent_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsEnemyB", 5)/255)
+					Spring.SetTeamColor(
+						teamID,
+						next_opponent_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsEnemyR", 255) / 255,
+						next_opponent_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsEnemyG", 16) / 255,
+						next_opponent_brightness_offset * Spring.GetConfigInt("SimpleTeamColorsEnemyB", 5) / 255
+					)
 					if Spring.GetConfigInt("SimpleTeamColorsUseGradient", 0) == 1 and anonymousMode ~= "allred" then
 						next_opponent_brightness_offset = dimming_factor * next_opponent_brightness_offset
 					end
 				else
-					Spring.SetTeamColor(teamID, hex2RGB(gaiaGrayColor)[1]/255, hex2RGB(gaiaGrayColor)[2]/255, hex2RGB(gaiaGrayColor)[3]/255)
+					Spring.SetTeamColor(
+						teamID,
+						hex2RGB(gaiaGrayColor)[1] / 255,
+						hex2RGB(gaiaGrayColor)[2] / 255,
+						hex2RGB(gaiaGrayColor)[3] / 255
+					)
 				end
 			else
 				Spring.SetTeamColor(teamID, r, g, b)
@@ -737,4 +788,3 @@ else	-- UNSYNCED
 		end
 	end
 end
-

--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -539,6 +539,8 @@ if gadgetHandler:IsSyncedCode() then
 
 	Spring.SendLuaRulesMsg("AutoColors" .. Json.encode(AutoColors))
 else -- UNSYNCED
+	local myPlayerID = Spring.GetLocalPlayerID()
+	local mySpecState = Spring.GetSpectatingState()
 	local teamColorsTable = {}
 
 	local function setUpLocalTeamColor(teamID, allyTeamID, isAI)
@@ -669,7 +671,7 @@ else -- UNSYNCED
 	local iconDevModeColor = iconDevModeColors[iconDevMode]
 
 	local function isDiscoEnabled()
-		return anonymousMode == "disco" and not Spring.GetSpectatingState()
+		return anonymousMode == "disco" and not mySpecState
 	end
 
 	---shuffle colors for all teams except ourselves
@@ -726,8 +728,7 @@ else -- UNSYNCED
 					hex2RGB(iconDevModeColor)[3] / 255
 				)
 			elseif
-				Spring.GetConfigInt("SimpleTeamColors", 0) == 1
-				or (anonymousMode == "allred" and not Spring.GetSpectatingState())
+				Spring.GetConfigInt("SimpleTeamColors", 0) == 1 or (anonymousMode == "allred" and not mySpecState)
 			then
 				local allyTeamID = select(6, Spring.GetTeamInfo(teamID))
 				if teamID == myTeamID then
@@ -786,5 +787,15 @@ else -- UNSYNCED
 			Spring.SetConfigInt("UpdateTeamColors", 0)
 			Spring.SetConfigInt("SimpleTeamColors_Reset", 0)
 		end
+	end
+
+	function gadget:PlayerChanged(playerID)
+		if playerID ~= myPlayerID then
+			return
+		end
+
+		mySpecState = Spring.GetSpectatingState()
+
+		Spring.SetConfigInt("UpdateTeamColors", 1)
 	end
 end


### PR DESCRIPTION
Second pass.

I separated lint/autoformat commit from the actual change commit for ease of review.

Previous PR had UnsyncedRead calls in synced context, this is fixed now