### PR TITLE
Reclaim Field Highlight improvements

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1488,6 +1488,12 @@
 				"language": "Language",
 				"reclaimfieldhighlight": "Reclaim Field Highlight",
 				"reclaimfieldhighlight_descr": "Highlights clusters of reclaimable metal",
+				"reclaimfieldhighlight_always": "Always enabled",
+				"reclaimfieldhighlight_resource": "Resource view only",
+				"reclaimfieldhighlight_reclaimer": "Reclaimer selected",
+				"reclaimfieldhighlight_resbot": "Resbot selected",
+				"reclaimfieldhighlight_order": "Reclaim order active",
+				"reclaimfieldhighlight_disabled": "Disabled",
 				"buildinggrid": "Building Grid",
 				"buildinggrid_descr": "Shows a grid on the ground to assist building placement",
 				"buildinggridopacity": "opacity"

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3917,7 +3917,7 @@ function init()
 
 		{ id = "givenunits", group = "ui", category = types.advanced, widget = "Given Units", name = Spring.I18N('ui.settings.option.givenunits'), type = "bool", value = GetWidgetToggleValue("Given Units"), description = Spring.I18N('ui.settings.option.givenunits_descr') },
 
-		{ id = "reclaimfieldhighlight", group = "ui", category = types.advanced, widget = "Reclaim Field Highlight", name = Spring.I18N('ui.settings.option.reclaimfieldhighlight'), type = "select", options = { "always", "resource view only", "reclaimer selected", "resbot selected", "reclaim order active", "disabled" }, value = 3, description = Spring.I18N('ui.settings.option.reclaimfieldhighlight_descr'),
+		{ id = "reclaimfieldhighlight", group = "ui", category = types.advanced, widget = "Reclaim Field Highlight", name = Spring.I18N('ui.settings.option.reclaimfieldhighlight'), type = "select", options = { "always enabled", "resource view only", "reclaimer selected", "resbot selected", "reclaim order active", "disabled" }, value = 3, description = Spring.I18N('ui.settings.option.reclaimfieldhighlight_descr'),
 			onload = function(i)
 				loadWidgetData("Reclaim Field Highlight", "reclaimfieldhighlight", { 'showOption' })
 			end,

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -176,6 +176,16 @@ local presetCodes = {}
 local presetNames = {}
 local presets = {}
 
+local reclaimFieldHighlightOptions = {
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_always'),
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_resource'),
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_reclaimer'),
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_resbot'),
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_order'),
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_disabled'),
+	Spring.I18N('ui.settings.option.reclaimfieldhighlight_always')
+}
+
 local startScript = VFS.LoadFile("_script.txt")
 if not startScript then
 	local modoptions = ''
@@ -3917,7 +3927,7 @@ function init()
 
 		{ id = "givenunits", group = "ui", category = types.advanced, widget = "Given Units", name = Spring.I18N('ui.settings.option.givenunits'), type = "bool", value = GetWidgetToggleValue("Given Units"), description = Spring.I18N('ui.settings.option.givenunits_descr') },
 
-		{ id = "reclaimfieldhighlight", group = "ui", category = types.advanced, widget = "Reclaim Field Highlight", name = Spring.I18N('ui.settings.option.reclaimfieldhighlight'), type = "select", options = { "always enabled", "resource view only", "reclaimer selected", "resbot selected", "reclaim order active", "disabled" }, value = 3, description = Spring.I18N('ui.settings.option.reclaimfieldhighlight_descr'),
+		{ id = "reclaimfieldhighlight", group = "ui", category = types.advanced, widget = "Reclaim Field Highlight", name = Spring.I18N('ui.settings.option.reclaimfieldhighlight'), type = "select", options = reclaimFieldHighlightOptions, value = 3, description = Spring.I18N('ui.settings.option.reclaimfieldhighlight_descr'),
 			onload = function(i)
 				loadWidgetData("Reclaim Field Highlight", "reclaimfieldhighlight", { 'showOption' })
 			end,

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3917,7 +3917,19 @@ function init()
 
 		{ id = "givenunits", group = "ui", category = types.advanced, widget = "Given Units", name = Spring.I18N('ui.settings.option.givenunits'), type = "bool", value = GetWidgetToggleValue("Given Units"), description = Spring.I18N('ui.settings.option.givenunits_descr') },
 
-		{ id = "reclaimfieldhighlight", group = "ui", category = types.advanced, widget = "Reclaim Field Highlight", name = Spring.I18N('ui.settings.option.reclaimfieldhighlight'), type = "bool", value = GetWidgetToggleValue("Reclaim Field Highlight"), description = Spring.I18N('ui.settings.option.reclaimfieldhighlight_descr') },
+		{ id = "reclaimfieldhighlight", group = "ui", category = types.advanced, widget = "Reclaim Field Highlight", name = Spring.I18N('ui.settings.option.reclaimfieldhighlight'), type = "select", options = { "always", "resource view only", "reclaimer selected", "resbot selected", "reclaim order active", "disabled" }, value = 3, description = Spring.I18N('ui.settings.option.reclaimfieldhighlight_descr'),
+			onload = function(i)
+				loadWidgetData("Reclaim Field Highlight", "reclaimfieldhighlight", { 'showOption' })
+			end,
+			onchange = function(i, value)
+				if widgetHandler.orderList["Reclaim Field Highlight"] and widgetHandler.orderList["Reclaim Field Highlight"] >= 0.5 then
+					widgetHandler:EnableWidget("Reclaim Field Highlight")
+					saveOptionValue('Reclaim Field Highlight', 'reclaimfieldhighlight', 'setShowOption', { 'showOption' }, value)
+				else
+					saveOptionValue('Reclaim Field Highlight', 'reclaimfieldhighlight', 'setShowOption', { 'showOption' }, value)
+				end
+			end,
+		},
 
 		{ id = "buildinggrid", group = "ui", category = types.basic, widget = "Building Grid GL4", name = Spring.I18N('ui.settings.option.buildinggrid'), type = "bool", value = GetWidgetToggleValue("Building Grid GL4"), description = Spring.I18N('ui.settings.option.buildinggrid_descr') },
 		{ id = "buildinggridopacity", group = "ui", category = types.advanced, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.buildinggridopacity'), type = "slider", min = 0.3, max = 1, step = 0.05, value = (WG['buildinggrid'] ~= nil and WG['buildinggrid'].getOpacity ~= nil and WG['buildinggrid'].getOpacity()) or 1, description = '',

--- a/luaui/Widgets/reclaim_field_highlight.lua
+++ b/luaui/Widgets/reclaim_field_highlight.lua
@@ -27,7 +27,7 @@ VFS.Include("LuaRules/Configs/customcmds.h.lua")
 local showOption = 3
 --[[
 	From settings (gui_options.lua)
-	1 - always
+	1 - always enabled
 	2 - resource view only
 	3 - reclaimer selected
 	4 - resbot selected


### PR DESCRIPTION
## Expanded options in settings
Primary goal of this PR is to add an easy way for people to decide when they want reclaim fields to show. Default remains set to "reclaimer selected".
Replaced the simple on/off toggle with a dropdown menu that has a few more options:
 - always enabled
 - resource view only (F4)
 - reclaimer selected
 - resbot selected
 - reclaim order active
 - disabled

![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/44340857/2e83ffa4-affd-4bb6-9786-6e8e7c50ef2e)


 ## Optimizations
 No longer using `Spring.GetAllFeatures()` (except at initialization), should help with late game performance.

## Cleanup
Small changes, removed scan interval...
