### PR TITLE
give Mukade(legpede) set target command

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -98,6 +98,9 @@ if gadgetHandler:IsSyncedCode() then
 		unitAlwaysSeen[unitDefID] = unitDef.isBuilding or unitDef.speed == 0
 	end
 
+	-- fastpass for units that don't have an attack command for other reasons
+	validUnits[UnitDefNames.legpede.id]=true
+
 	local unitTargets = {} -- data holds all unitID data
 	local pausedTargets = {}
 	--------------------------------------------------------------------------------


### PR DESCRIPTION
Does not exhibit the issues that the legpede has with a normal attack order, and there is demand for it.
Didn't know if i should make it a custom param instead, coded the unit specifiaclly into target on the move instead.