### PR TITLE
luaui: Camera Minimum Height: not active when following player camera

### DIFF
--- a/luaui/Widgets/camera_minimum_height_limiter.lua
+++ b/luaui/Widgets/camera_minimum_height_limiter.lua
@@ -15,7 +15,7 @@ local desiredLevel = Spring.GetConfigInt("MinimumCameraHeight", defaultDesiredLe
 local optionRefresh = 0
 
 function widget:Update()
-	if WG['advplayerlist_api'] and WG['advplayerlist_api'].SetLockPlayerID ~= nil then
+	if WG['advplayerlist_api'] and WG['advplayerlist_api'].GetLockPlayerID() ~= nil then
 		return
 	end
 


### PR DESCRIPTION
This fixes commit 1081857007e81a936c450bcafb90cc8d8a288e96.