### PR TITLE
buildmenu: make prices clearer by adding spacing

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -484,14 +484,21 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled)
 
 	-- price
 	if showPrice then
-		--doCircle(x, y, z, radius, sides)
-		local text
-		if disabled then
-			text = "\255\125\125\125" .. units.unitMetalCost[uDefID] .. "\n\255\135\135\135"
-		else
-			text = "\255\245\245\245" .. units.unitMetalCost[uDefID] .. "\n\255\255\255\000"
+		local metalColor = disabled and "\255\125\125\125" or "\255\245\245\245"
+		local energyColor = disabled and "\n\255\135\135\135" or "\n\255\255\255\000"
+		local function AddSpaces(price)
+			if price >= 1000 then
+				return string.format("%s %03d", AddSpaces(math_floor(price / 1000)), price % 1000)
+			end
+			return price
 		end
-		font2:Print(text .. units.unitEnergyCost[uDefID], cellRects[cellRectID][1] + cellPadding + (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
+		local metalPrice = AddSpaces(units.unitMetalCost[uDefID])
+		local energyPrice = AddSpaces(units.unitEnergyCost[uDefID])
+		local metalPriceText = metalColor .. metalPrice
+		local energyPriceText = energyColor .. energyPrice
+		local energyPriceTextHeight = font2:GetTextHeight(energyPriceText) * priceFontSize
+		font2:Print(metalPriceText, cellRects[cellRectID][3] - cellPadding - (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35) + energyPriceTextHeight, priceFontSize, "ro")
+		font2:Print(energyPriceText, cellRects[cellRectID][3] - cellPadding - (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "ro")
 	end
 
 	-- factory queue number

--- a/luaui/Widgets/gui_flowui.lua
+++ b/luaui/Widgets/gui_flowui.lua
@@ -740,7 +740,7 @@ WG.FlowUI.Draw.Unit = function(px, py, sx, sy,  cs,  tl, tr, br, bl,  zoom,  bor
 		local iconPadding = math.floor((sx - px) * 0.03)
 		gl.Color(1, 1, 1, 0.9)
 		gl.Texture(radarTexture)
-		gl.BeginEnd(GL.QUADS, WG.FlowUI.Draw.TexRectRound, sx - iconPadding - iconSize, py + iconPadding, sx - iconPadding, py + iconPadding + iconSize,  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
+		gl.BeginEnd(GL.QUADS, WG.FlowUI.Draw.TexRectRound, px + iconPadding, py + iconPadding, px + iconPadding + iconSize, py + iconPadding + iconSize,  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
 		--gl.TexRect(sx - iconPadding - iconSize, py + iconPadding, sx - iconPadding, py + iconPadding + iconSize)
 		gl.Texture(false)
 	end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1056,8 +1056,19 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 	if showPrice then
 		local metalColor = disabled and "\255\125\125\125" or "\255\245\245\245"
 		local energyColor = disabled and "\n\255\135\135\135" or "\n\255\255\255\000"
-		local text = metalColor .. units.unitMetalCost[uid] .. energyColor
-		font2:Print(text .. units.unitEnergyCost[uid], rect.x + cellPadding + (cellInnerSize * 0.048), rect.y + cellPadding + (priceFontSize * 1.35), priceFontSize, "o")
+		local function AddSpaces(price)
+			if price >= 1000 then
+				return string.format("%s %03d", AddSpaces(math_floor(price / 1000)), price % 1000)
+			end
+			return price
+		end
+		local metalPrice = AddSpaces(units.unitMetalCost[uid])
+		local energyPrice = AddSpaces(units.unitEnergyCost[uid])
+		local metalPriceText = metalColor .. metalPrice
+		local energyPriceText = energyColor .. energyPrice
+		local energyPriceTextHeight = font2:GetTextHeight(energyPriceText) * priceFontSize
+		font2:Print(metalPriceText, rect.xEnd - cellPadding - (cellInnerSize * 0.048), rect.y + cellPadding + (priceFontSize * 1.35) + energyPriceTextHeight, priceFontSize, "ro")
+		font2:Print(energyPriceText, rect.xEnd - cellPadding - (cellInnerSize * 0.048), rect.y + cellPadding + (priceFontSize * 1.35), priceFontSize, "ro")
 	end
 
 	-- hotkey draw


### PR DESCRIPTION
Separate metal and energy prices by adding spacing for every thousand. For example, 1 000, 1 000 000 etc.

Furthermore, exchange places between unit group icon and prices. I.e. unit group icon is moved from bottom right to bottom left. Metal and energy prices are moved from bottom left to bottom right.