### PR TITLE
 Fix for scenarios not completing, because the winning team is not set.

### DIFF
--- a/luarules/gadgets/game_end.lua
+++ b/luarules/gadgets/game_end.lua
@@ -298,8 +298,8 @@ if gadgetHandler:IsSyncedCode() then
 				if not candidateWinners then
 					candidateWinners = {}
 				end
-				candidateWinners[winnerCount] = allyTeamID
 				winnerCount = winnerCount + 1
+				candidateWinners[winnerCount] = allyTeamID
 			end
 		end
 		if winnerCount > 1 then


### PR DESCRIPTION
 This was broken here: https://github.com/beyond-all-reason/Beyond-All-Reason/commit/065349c09019159b367c1da49ccea7092a203a28#diff-5cf8af6ed007025f12fe8ddfa5c89192fe13e3cadd9b0fb10254f5ec779f1e2fL297

Tested by completing a scenario and seeing my completed time update.