### PR TITLE
feat!(commandinsert): Preserve ActiveCmd when editing build order 

### DIFF
--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -93,74 +93,70 @@ end
 
 function widget:CommandNotify(id, params, options)
   local _,_,meta,_ = Spring.GetModKeyState()
-  if (meta) then
-    local opt = 0
-    local insertfront = false
-    if options.alt then opt = opt + CMD.OPT_ALT end
-    if options.ctrl then opt = opt + CMD.OPT_CTRL end    
-    if options.right then opt = opt + CMD.OPT_RIGHT end
-    if options.shift then 
-      opt = opt + CMD.OPT_SHIFT       
-    else
-      Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
 
-      -- When we are building we want to keep same active command after unset by engine
-      if id < 0 then
-      	Spring.SetActiveCommand(Spring.GetCmdDescIndex(id), 1, true, false, options.alt, options.ctrl, false, false)
-      end
+  if not meta then
+  	return false
+  end
 
-      return true
-    end
-
-    -- Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
-    local my_command = {["id"]=id, ["params"]=params, ["options"]=options}
-    local cx,cy,cz = GetCommandPos(my_command)
-    if cx < -1 then
-      return false
-    end
-
-    local units = Spring.GetSelectedUnits()
-    for i=1,#units do
-      local unit_id = units[i]
-      local commands = Spring.GetCommandQueue(unit_id,100)
-      local px,py,pz = Spring.GetUnitPosition(unit_id)
-      local min_dlen = 1000000
-      local insert_tag = 0
-      local insert_pos = 0
-      for i=1,#commands do
-        local command = commands[i]
-        --Spring.Echo("cmd:"..table.tostring(command))
-        local px2,py2,pz2 = GetCommandPos(command)
-        if px2 and px2>-1 then
-          local dlen = math_sqrt(((px2-cx)*(px2-cx)) + ((py2-cy)*(py2-cy)) + ((pz2-cz)*(pz2-cz))) + math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(pz-cz))) - math_sqrt((((px2-px)*(px2-px)) + ((py2-py)*(py2-py)) + ((py2-py)*(py2-py))))
-          --Spring.Echo("dlen "..dlen)
-          if dlen < min_dlen then
-            min_dlen = dlen
-            insert_tag = command.tag
-            insert_pos = i
-          end
-          px,py,pz = px2,py2,pz2
-        end   
-      end
-      -- check for insert at end of queue if its shortest walk.
-      local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(py-cy)))
-      if dlen < min_dlen then
-        --options.meta=nil
-        --options.shift=true
-        --Spring.GiveOrderToUnit(unit_id,id,params,options)
-        Spring.GiveOrderToUnit(unit_id, id, params, {"shift"})
-      else   
-        Spring.GiveOrderToUnit(unit_id, CMD.INSERT, {insert_pos-1, id, opt, unpack(params)}, {"alt"})
-      end
-    end
-
-    -- When we are building we want to keep same active command after unset by engine
-    if id < 0 then
-      Spring.SetActiveCommand(Spring.GetCmdDescIndex(id), 1, true, false, options.alt, options.ctrl, false, false)
-    end
+  local opt = 0
+  local insertfront = false
+  if options.alt then opt = opt + CMD.OPT_ALT end
+  if options.ctrl then opt = opt + CMD.OPT_CTRL end    
+  if options.right then opt = opt + CMD.OPT_RIGHT end
+  if options.shift then 
+    opt = opt + CMD.OPT_SHIFT       
+  else
+    Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
 
     return true
   end
 
-  return false
+  -- Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
+  local my_command = {["id"]=id, ["params"]=params, ["options"]=options}
+  local cx,cy,cz = GetCommandPos(my_command)
+  if cx < -1 then
+    return false
+  end
+
+  local units = Spring.GetSelectedUnits()
+  for i=1,#units do
+    local unit_id = units[i]
+    local commands = Spring.GetCommandQueue(unit_id,100)
+    local px,py,pz = Spring.GetUnitPosition(unit_id)
+    local min_dlen = 1000000
+    local insert_tag = 0
+    local insert_pos = 0
+    for i=1,#commands do
+      local command = commands[i]
+      --Spring.Echo("cmd:"..table.tostring(command))
+      local px2,py2,pz2 = GetCommandPos(command)
+      if px2 and px2>-1 then
+        local dlen = math_sqrt(((px2-cx)*(px2-cx)) + ((py2-cy)*(py2-cy)) + ((pz2-cz)*(pz2-cz))) + math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(pz-cz))) - math_sqrt((((px2-px)*(px2-px)) + ((py2-py)*(py2-py)) + ((py2-py)*(py2-py))))
+        --Spring.Echo("dlen "..dlen)
+        if dlen < min_dlen then
+          min_dlen = dlen
+          insert_tag = command.tag
+          insert_pos = i
+        end
+        px,py,pz = px2,py2,pz2
+      end   
+    end
+    -- check for insert at end of queue if its shortest walk.
+    local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(py-cy)))
+    if dlen < min_dlen then
+      --options.meta=nil
+      --options.shift=true
+      --Spring.GiveOrderToUnit(unit_id,id,params,options)
+      Spring.GiveOrderToUnit(unit_id, id, params, {"shift"})
+    else   
+      Spring.GiveOrderToUnit(unit_id, CMD.INSERT, {insert_pos-1, id, opt, unpack(params)}, {"alt"})
+    end
+  end
+
+  -- When we are editing the build order we want to keep same active command after unset by engine
+  if id < 0 then
+    Spring.SetActiveCommand(Spring.GetCmdDescIndex(id), 1, true, false, options.alt, options.ctrl, false, false)
+  end
+
+  return true
 end

--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -19,7 +19,7 @@ function widget:GameStart()
   widget:PlayerChanged()
 end
 
-function widget:PlayerChanged(playerID)
+function widget:PlayerChanged()
     if Spring.GetSpectatingState() and Spring.GetGameFrame() > 0 then
         widgetHandler:RemoveWidget()
     end
@@ -83,10 +83,10 @@ local function GetCommandPos(command)	--- get the command position
   command.id == CMD.RESURRECT or command.id == CMD.DGUN or command.id == CMD.GUARD or
   command.id == CMD.FIGHT or command.id == CMD.ATTACK then
     if table.getn(command.params) >= 3 then
-		  return command.params[1], command.params[2], command.params[3]			
+		  return command.params[1], command.params[2], command.params[3]
 	  elseif table.getn(command.params) >= 1 then
 		  return GetUnitOrFeaturePosition(command.params[1])
-	  end	
+	  end
 	end
   return -10,-10,-10
 end
@@ -99,12 +99,11 @@ function widget:CommandNotify(id, params, options)
   end
 
   local opt = 0
-  local insertfront = false
   if options.alt then opt = opt + CMD.OPT_ALT end
-  if options.ctrl then opt = opt + CMD.OPT_CTRL end    
+  if options.ctrl then opt = opt + CMD.OPT_CTRL end
   if options.right then opt = opt + CMD.OPT_RIGHT end
-  if options.shift then 
-    opt = opt + CMD.OPT_SHIFT       
+  if options.shift then
+    opt = opt + CMD.OPT_SHIFT
   else
     Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
 
@@ -124,10 +123,9 @@ function widget:CommandNotify(id, params, options)
     local commands = Spring.GetCommandQueue(unit_id,100)
     local px,py,pz = Spring.GetUnitPosition(unit_id)
     local min_dlen = 1000000
-    local insert_tag = 0
     local insert_pos = 0
-    for i=1,#commands do
-      local command = commands[i]
+    for j=1,#commands do
+      local command = commands[j]
       --Spring.Echo("cmd:"..table.tostring(command))
       local px2,py2,pz2 = GetCommandPos(command)
       if px2 and px2>-1 then
@@ -135,11 +133,10 @@ function widget:CommandNotify(id, params, options)
         --Spring.Echo("dlen "..dlen)
         if dlen < min_dlen then
           min_dlen = dlen
-          insert_tag = command.tag
-          insert_pos = i
+          insert_pos = j
         end
         px,py,pz = px2,py2,pz2
-      end   
+      end
     end
     -- check for insert at end of queue if its shortest walk.
     local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(py-cy)))
@@ -148,7 +145,7 @@ function widget:CommandNotify(id, params, options)
       --options.shift=true
       --Spring.GiveOrderToUnit(unit_id,id,params,options)
       Spring.GiveOrderToUnit(unit_id, id, params, {"shift"})
-    else   
+    else
       Spring.GiveOrderToUnit(unit_id, CMD.INSERT, {insert_pos-1, id, opt, unpack(params)}, {"alt"})
     end
   end

--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -103,9 +103,15 @@ function widget:CommandNotify(id, params, options)
       opt = opt + CMD.OPT_SHIFT       
     else
       Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
+
+      -- When we are building we want to keep same active command after unset by engine
+      if id < 0 then
+      	Spring.SetActiveCommand(Spring.GetCmdDescIndex(id), 1, true, false, options.alt, options.ctrl, false, false)
+      end
+
       return true
     end
-    
+
     -- Spring.GiveOrder(CMD.INSERT,{0,id,opt,unpack(params)},{"alt"})
     local my_command = {["id"]=id, ["params"]=params, ["options"]=options}
     local cx,cy,cz = GetCommandPos(my_command)
@@ -147,7 +153,14 @@ function widget:CommandNotify(id, params, options)
         Spring.GiveOrderToUnit(unit_id, CMD.INSERT, {insert_pos-1, id, opt, unpack(params)}, {"alt"})
       end
     end
+
+    -- When we are building we want to keep same active command after unset by engine
+    if id < 0 then
+      Spring.SetActiveCommand(Spring.GetCmdDescIndex(id), 1, true, false, options.alt, options.ctrl, false, false)
+    end
+
     return true
   end
+
   return false
 end


### PR DESCRIPTION
When we want to edit build order we want to preserve current
active command when it's a buildunit_ order (cmdid < 0)

Relevant commit: https://github.com/beyond-all-reason/Beyond-All-Reason/commit/f0a60a769dc9f6126f540258af15553a497851e8