### PR TITLE
feat(gridmenu): expose option to return to categories on assign

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1154,6 +1154,8 @@
 				"minimapcanflip_descr": "will automatically flip the minimap when camera perspective is from the other side",
 				"gridmenu": "Use Gridmenu",
 				"gridmenu_descr": "Alternative build menu, designed for comprehensive hotkey use",
+				"gridmenu_alwaysreturn": "Grid always returns to categories",
+				"gridmenu_alwaysreturn_descr": "While queueing commands, return to categories page after issuing",
 				"keylayout": "Keyboard Layout",
 				"keylayout_descr": "Set the keyboard layout",
 				"keybindings": "Keybind Preset",

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -18,11 +18,11 @@ function widget:GetInfo()
 end
 
 include("keysym.h.lua")
-VFS.Include('luarules/configs/customcmds.h.lua')
+VFS.Include("luarules/configs/customcmds.h.lua")
 
 SYMKEYS = table.invert(KEYSYMS)
 
-local returnToCategoriesOnPick = true
+local alwaysReturn = true
 
 local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
 local currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")
@@ -38,24 +38,24 @@ local BUILDCAT_UTILITY = "Utility"
 local BUILDCAT_PRODUCTION = "Build"
 local categoryFontSize, hotkeyFontSize, pageButtonHeight
 
-local folder = 'LuaUI/Images/groupicons/'
+local folder = "LuaUI/Images/groupicons/"
 local groups = {
-	energy = folder..'energy.png',
-	metal = folder..'metal.png',
-	builder = folder..'builder.png',
-	buildert2 = folder..'buildert2.png',
-	buildert3 = folder..'buildert3.png',
-	buildert4 = folder..'buildert4.png',
-	util = folder..'util.png',
-	weapon = folder..'weapon.png',
-	explo = folder..'weaponexplo.png',
-	weaponaa = folder..'weaponaa.png',
-	weaponsub = folder..'weaponsub.png',
-	aa = folder..'aa.png',
-	emp = folder..'emp.png',
-	sub = folder..'sub.png',
-	nuke = folder..'nuke.png',
-	antinuke = folder..'antinuke.png',
+	energy = folder .. "energy.png",
+	metal = folder .. "metal.png",
+	builder = folder .. "builder.png",
+	buildert2 = folder .. "buildert2.png",
+	buildert3 = folder .. "buildert3.png",
+	buildert4 = folder .. "buildert4.png",
+	util = folder .. "util.png",
+	weapon = folder .. "weapon.png",
+	explo = folder .. "weaponexplo.png",
+	weaponaa = folder .. "weaponaa.png",
+	weaponsub = folder .. "weaponsub.png",
+	aa = folder .. "aa.png",
+	emp = folder .. "emp.png",
+	sub = folder .. "sub.png",
+	nuke = folder .. "nuke.png",
+	antinuke = folder .. "antinuke.png",
 }
 
 local Cfgs = {
@@ -65,8 +65,8 @@ local Cfgs = {
 	cfgIconCornerSize = 0.025,
 	cfgPriceFontSize = 0.16,
 	cfgActiveAreaMargin = 0.1, -- (# * bgpadding) space between the background border and active area
-	sound_queue_add = 'LuaUI/Sounds/buildbar_add.wav',
-	sound_queue_rem = 'LuaUI/Sounds/buildbar_rem.wav',
+	sound_queue_add = "LuaUI/Sounds/buildbar_add.wav",
+	sound_queue_rem = "LuaUI/Sounds/buildbar_rem.wav",
 	fontFile = "fonts/" .. Spring.GetConfigString("bar_font2", "Exo2-SemiBold.otf"),
 	categoryTooltips = {
 		[BUILDCAT_ECONOMY] = "Filter economy buildings",
@@ -84,13 +84,12 @@ local Cfgs = {
 		BUILDCAT_ECONOMY,
 		BUILDCAT_COMBAT,
 		BUILDCAT_UTILITY,
-		BUILDCAT_PRODUCTION
+		BUILDCAT_PRODUCTION,
 	},
 	categoryKeys = {},
 	vKeyLayout = {},
 	keyLayout = {},
 }
-
 
 local hotkeyActions = {}
 local hoveredButton, drawnHoveredButton
@@ -99,9 +98,9 @@ local selBuildQueueDefID
 local stickToBottom = false
 local alwaysShow = false
 
-local showPrice = false		-- false will still show hover
-local showRadarIcon = true		-- false will still show hover
-local showGroupIcon = true		-- false will still show hover
+local showPrice = false -- false will still show hover
+local showRadarIcon = true -- false will still show hover
+local showGroupIcon = true -- false will still show hover
 local showBuildProgress = true
 
 local activeCmd
@@ -131,7 +130,7 @@ function Rect:new(x1, y1, x2, y2)
 		x = x1,
 		y = y1,
 		xEnd = x2,
-		yEnd = y2
+		yEnd = y2,
 	}
 
 	function this:contains(x, y)
@@ -145,20 +144,23 @@ function Rect:new(x1, y1, x2, y2)
 	return this
 end
 
-local function pairsByKeys (t, f)
+local function pairsByKeys(t, f)
 	local a = {}
-	for n in pairs(t) do table.insert(a, n) end
+	for n in pairs(t) do
+		table.insert(a, n)
+	end
 	table.sort(a, f)
-	local i = 0      -- iterator variable
-	local iter = function ()   -- iterator function
+	local i = 0 -- iterator variable
+	local iter = function() -- iterator function
 		i = i + 1
-		if a[i] == nil then return nil
-		else return a[i], t[a[i]]
+		if a[i] == nil then
+			return nil
+		else
+			return a[i], t[a[i]]
 		end
 	end
 	return iter
 end
-
 
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
@@ -171,7 +173,7 @@ local advplayerlistLeft = vsx * 0.8
 local isSpec = Spring.GetSpectatingState()
 local myTeamID = Spring.GetMyTeamID()
 
-local startDefID = Spring.GetTeamRulesParam(myTeamID, 'startUnit')
+local startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 
 local disableInput = Cfgs.disableInputWhenSpec and isSpec
 local backgroundRect = Rect:new(0, 0, 0, 0)
@@ -193,7 +195,7 @@ local pages = 1
 local backRect = Rect:new(0, 0, 0, 0)
 local nextPageRect = Rect:new(0, 0, 0, 0)
 local categoriesRect = Rect:new(0, 0, 0, 0)
-local buildpicsRect = Rect:new(0, 0, 0 ,0)
+local buildpicsRect = Rect:new(0, 0, 0, 0)
 local paginatorsRect = Rect:new(0, 0, 0, 0)
 local buildersRect = Rect:new(0, 0, 0, 0)
 local nextBuilderRect = Rect:new(0, 0, 0, 0)
@@ -222,7 +224,6 @@ local GL_ONE_MINUS_SRC_COLOR = GL.ONE_MINUS_SRC_COLOR
 local RectRound, RectRoundProgress, UiUnit, UiElement, UiButton, elementCorner, TexRectRound
 local ui_opacity, ui_scale
 
-
 local selectNextFrame, switchedCategory
 local units = VFS.Include("luaui/configs/unit_buildmenu_config.lua")
 local grid = VFS.Include("luaui/configs/gridmenu_config.lua")
@@ -230,9 +231,8 @@ local grid = VFS.Include("luaui/configs/gridmenu_config.lua")
 local showWaterUnits = false
 units.restrictWaterUnits(true)
 
-
 local function checkGuishader(force)
-	if WG['guishader'] then
+	if WG["guishader"] then
 		if force and dlistGuishader then
 			dlistGuishader = gl.DeleteList(dlistGuishader)
 		end
@@ -241,7 +241,7 @@ local function checkGuishader(force)
 				RectRound(backgroundRect.x, backgroundRect.y, backgroundRect.xEnd, backgroundRect.yEnd, elementCorner)
 			end)
 			if activeBuilder then
-				WG['guishader'].InsertDlist(dlistGuishader, 'buildmenu')
+				WG["guishader"].InsertDlist(dlistGuishader, "buildmenu")
 			end
 		end
 	elseif dlistGuishader then
@@ -250,20 +250,26 @@ local function checkGuishader(force)
 end
 
 local function checkGuishaderBuilders(force)
-	if WG['guishader'] and #builderRects > 1 then
+	if WG["guishader"] and #builderRects > 1 then
 		if prevBuildRectsCount ~= #builderRects then
 			prevBuildRectsCount = #builderRects
 			if dlistGuishaderBuilders then
 				dlistGuishaderBuilders = gl.DeleteList(dlistGuishaderBuilders)
 			end
 			dlistGuishaderBuilders = gl.CreateList(function()
-				RectRound(buildersRect.x, buildersRect.y, buildersRect.xEnd+(bgpadding*2), buildersRect.yEnd+bgpadding+(iconMargin*2), elementCorner)
+				RectRound(
+					buildersRect.x,
+					buildersRect.y,
+					buildersRect.xEnd + (bgpadding * 2),
+					buildersRect.yEnd + bgpadding + (iconMargin * 2),
+					elementCorner
+				)
 			end)
-			WG['guishader'].InsertDlist(dlistGuishaderBuilders, 'buildmenubuilders')
+			WG["guishader"].InsertDlist(dlistGuishaderBuilders, "buildmenubuilders")
 		end
 	elseif dlistGuishaderBuilders then
 		prevBuildRectsCount = 0
-		WG['guishader'].DeleteDlist('buildmenubuilders')
+		WG["guishader"].DeleteDlist("buildmenubuilders")
 		dlistGuishaderBuilders = nil
 	end
 end
@@ -274,7 +280,6 @@ function widget:PlayerChanged()
 end
 
 local function RefreshCommands()
-
 	if isPregame and startDefID then
 		activeBuilder = startDefID
 	end
@@ -284,7 +289,9 @@ local function RefreshCommands()
 
 	function tablelength(T)
 		local count = 0
-		for _ in pairs(T) do count = count + 1 end
+		for _ in pairs(T) do
+			count = count + 1
+		end
 		return count
 	end
 
@@ -307,7 +314,6 @@ local function RefreshCommands()
 	gridOptsCount = tablelength(gridOpts)
 end
 
-
 local function getActionHotkey(action)
 	local key
 	for _, keybinding in pairs(Spring.GetActionHotKeys(action)) do
@@ -315,7 +321,9 @@ local function getActionHotkey(action)
 			key = keybinding
 		end
 
-		if key:len() == 1 then break end
+		if key:len() == 1 then
+			break
+		end
 	end
 
 	return key
@@ -325,54 +333,54 @@ end
 -- with GetActionHotKeys those tags will be missed and the hotkey wont work
 local function getGridKey(action)
 	local key = getActionHotkey(action)
-		or getActionHotkey(action .. ' builder')
-		or getActionHotkey(action .. ' factory')
+		or getActionHotkey(action .. " builder")
+		or getActionHotkey(action .. " factory")
 	return key
 end
 
 local function reloadBindings()
-	currentLayout = Spring.GetConfigString("KeyboardLayout", 'qwerty')
+	currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")
 
-	Cfgs.keyLayout = {{}, {}, {}}
+	Cfgs.keyLayout = { {}, {}, {} }
 
-	for c=1,4 do
-		local categoryAction = 'gridmenu_category ' .. c
+	for c = 1, 4 do
+		local categoryAction = "gridmenu_category " .. c
 		local cKey = getActionHotkey(categoryAction)
 
 		if not cKey then
-			cKey = ''
+			cKey = ""
 		end
 
 		Cfgs.categoryKeys[c] = cKey
 
-		for r=1,3 do
-			local keyAction = 'gridmenu_key ' .. r .. ' ' .. c
+		for r = 1, 3 do
+			local keyAction = "gridmenu_key " .. r .. " " .. c
 			local key = getGridKey(keyAction)
 
 			if not key then
-				key = ''
+				key = ""
 			end
 
 			Cfgs.keyLayout[r][c] = key
 		end
 	end
 
-	local key = getActionHotkey('gridmenu_next_page')
+	local key = getActionHotkey("gridmenu_next_page")
 	if not key then
 	end
 
 	Cfgs.NEXT_PAGE_KEY = key
 
-	key = getActionHotkey('gridmenu_cycle_builder')
+	key = getActionHotkey("gridmenu_cycle_builder")
 	Cfgs.CYCLE_BUILDER_KEY = key
 
 	-- Autogenerate bottom layout keys
 	Cfgs.vKeyLayout = {}
 
 	-- For bottom layout, 1-2 row x 1-4 col positions remain the same
-	for r=1,2 do
+	for r = 1, 2 do
 		Cfgs.vKeyLayout[r] = {}
-		for c=1,4 do
+		for c = 1, 4 do
 			Cfgs.vKeyLayout[r][c] = Cfgs.keyLayout[r][c]
 		end
 	end
@@ -387,12 +395,11 @@ end
 
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
-	WG['pregame-build'].setPreGamestartDefID(uDefID)
+	WG["pregame-build"].setPreGamestartDefID(uDefID)
 	if not uDefID then
 		currentCategory = nil
 		doUpdate = true
 	end
-
 end
 
 local function gridmenuCategoryHandler(_, _, args)
@@ -402,13 +409,15 @@ local function gridmenuCategoryHandler(_, _, args)
 		return
 	end
 
-	if not activeBuilder or builderIsFactory or (currentCategory and hotkeyActions['1' .. cIndex]) then
+	if not activeBuilder or builderIsFactory or (currentCategory and hotkeyActions["1" .. cIndex]) then
 		return
 	end
 
 	local alt, ctrl, meta, _ = Spring.GetModKeyState()
 
-	if alt or ctrl or meta then return end
+	if alt or ctrl or meta then
+		return
+	end
 
 	currentCategory = categories[cIndex]
 	switchedCategory = os.clock()
@@ -450,28 +459,40 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 
 	if builderIsFactory then
-		if args[3] and args[3] == 'builder' then return false end
-		if meta then return end
+		if args[3] and args[3] == "builder" then
+			return false
+		end
+		if meta then
+			return
+		end
 
 		local opts
 
 		if ctrl then
 			opts = { "right" }
-			Spring.PlaySoundFile(Cfgs.sound_queue_rem, 0.75, 'ui')
+			Spring.PlaySoundFile(Cfgs.sound_queue_rem, 0.75, "ui")
 		else
 			opts = { "left" }
-			Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
+			Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, "ui")
 		end
 
-		if alt then table.insert(opts, 'alt') end
-		if shift then table.insert(opts, 'shift') end
+		if alt then
+			table.insert(opts, "alt")
+		end
+		if shift then
+			table.insert(opts, "shift")
+		end
 
 		enqueueUnit(uDefID, opts)
 
 		return true
 	elseif isPregame and currentCategory then
-		if alt or ctrl or meta then return end
-		if args[3] and args[3] == 'factory' then return false end
+		if alt or ctrl or meta then
+			return
+		end
+		if args[3] and args[3] == "factory" then
+			return false
+		end
 
 		setPreGamestartDefID(-uDefID)
 
@@ -479,12 +500,18 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 
 		return true
 	elseif activeBuilder and currentCategory then
-		if args[3] and args[3] == 'factory' then return false end
-		if alt or ctrl or meta then return end
+		if args[3] and args[3] == "factory" then
+			return false
+		end
+		if alt or ctrl or meta then
+			return
+		end
 
 		local uDef = UnitDefs[-uDefID]
-		local isRepeatMex = uDef.customParams.metal_extractor and uDef.name == activeCmd and not (uDef.stealth or #uDef.weapons > 0)
-		local cmd = isRepeatMex and 'areamex' or spGetCmdDescIndex(uDefID)
+		local isRepeatMex = uDef.customParams.metal_extractor
+			and uDef.name == activeCmd
+			and not (uDef.stealth or #uDef.weapons > 0)
+		local cmd = isRepeatMex and "areamex" or spGetCmdDescIndex(uDefID)
 		Spring.SetActiveCommand(cmd, 3, false, true, alt, ctrl, meta, shift)
 
 		return true
@@ -498,12 +525,11 @@ function widget:CommandNotify(cmdID, _, cmdOpts)
 		return
 	end
 
-	if returnToCategoriesOnPick or not cmdOpts.shift then
+	if alwaysReturn or not cmdOpts.shift then
 		currentCategory = nil
 		doUpdate = true
 	end
 end
-
 
 local function addBuilderToSelection(unitID, incrementCount)
 	local unitDefID = spGetUnitDefID(unitID)
@@ -555,7 +581,6 @@ local function setActiveBuilder(index)
 	end
 end
 
-
 local function cycleBuilder()
 	if selectedBuildersCount <= 1 then
 		return
@@ -576,11 +601,15 @@ local function cycleBuilder()
 end
 
 local function nextPageHandler()
-	if not activeBuilder then return end
-	if pages < 2 then return end
+	if not activeBuilder then
+		return
+	end
+	if pages < 2 then
+		return
+	end
 
-	currentPage =  currentPage + 1
-	if(currentPage > pages) then
+	currentPage = currentPage + 1
+	if currentPage > pages then
 		currentPage = 1
 	end
 	doUpdate = true
@@ -607,14 +636,14 @@ function widget:Initialize()
 	ui_scale = WG.FlowUI.scale
 
 	iconTypesMap = {}
-	if Script.LuaRules('GetIconTypes') then
+	if Script.LuaRules("GetIconTypes") then
 		iconTypesMap = Script.LuaRules.GetIconTypes()
 	end
 
 	-- Get our starting unit
 	if isPregame then
-		if not startDefID or startDefID ~= Spring.GetTeamRulesParam(myTeamID, 'startUnit') then
-			startDefID = Spring.GetTeamRulesParam(myTeamID, 'startUnit')
+		if not startDefID or startDefID ~= Spring.GetTeamRulesParam(myTeamID, "startUnit") then
+			startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 			doUpdate = true
 		end
 	end
@@ -622,55 +651,63 @@ function widget:Initialize()
 	widget:ViewResize()
 	widget:SelectionChanged(Spring.GetSelectedUnits())
 
-	WG['buildmenu'] = {}
-	WG['buildmenu'].getGroups = function()
+	WG["gridmenu"] = {}
+	WG["gridmenu"].getAlwaysReturn = function()
+		return alwaysReturn
+	end
+	WG["gridmenu"].setAlwaysReturn = function(value)
+		alwaysReturn = value
+	end
+
+	WG["buildmenu"] = {}
+	WG["buildmenu"].getGroups = function()
 		return groups, units.unitGroup
 	end
-	WG['buildmenu'].getOrder = function()
+	WG["buildmenu"].getOrder = function()
 		return units.unitOrder
 	end
-	WG['buildmenu'].getShowPrice = function()
+	WG["buildmenu"].getShowPrice = function()
 		return showPrice
 	end
-	WG['buildmenu'].setShowPrice = function(value)
+	WG["buildmenu"].setShowPrice = function(value)
 		showPrice = value
 		doUpdate = true
 	end
-	WG['buildmenu'].getAlwaysShow = function()
+	WG["buildmenu"].getAlwaysShow = function()
 		return alwaysShow
 	end
-	WG['buildmenu'].setAlwaysShow = function(value)
+	WG["buildmenu"].setAlwaysShow = function(value)
 		alwaysShow = value
 		doUpdate = true
 	end
-	WG['buildmenu'].getShowRadarIcon = function()
+	WG["buildmenu"].getShowRadarIcon = function()
 		return showRadarIcon
 	end
-	WG['buildmenu'].setShowRadarIcon = function(value)
+	WG["buildmenu"].setShowRadarIcon = function(value)
 		showRadarIcon = value
 		doUpdate = true
 	end
-	WG['buildmenu'].getShowGroupIcon = function()
+	WG["buildmenu"].getShowGroupIcon = function()
 		return showGroupIcon
 	end
-	WG['buildmenu'].setShowGroupIcon = function(value)
+	WG["buildmenu"].setShowGroupIcon = function(value)
 		showGroupIcon = value
 		doUpdate = true
 	end
-	WG['buildmenu'].getBottomPosition = function()
+	WG["buildmenu"].getBottomPosition = function()
 		return stickToBottom
 	end
-	WG['buildmenu'].setBottomPosition = function(value)
+	WG["buildmenu"].setBottomPosition = function(value)
 		stickToBottom = value
 		widget:Update(1000)
 		widget:ViewResize()
 		doUpdate = true
 	end
-	WG['buildmenu'].getSize = function()
+	WG["buildmenu"].getSize = function()
 		return backgroundRect.y, backgroundRect.yEnd
 	end
-	WG['buildmenu'].reloadBindings = reloadBindings
-	WG['buildmenu'].getIsShowing = function()
+	WG["buildmenu"].reloadBindings = reloadBindings
+	WG["buildmenu"].getIsShowing = function()
 		return buildmenuShows
 	end
 end
@@ -713,41 +750,31 @@ function widget:ViewResize()
 
 	vsx, vsy = Spring.GetViewGeometry()
 
-	font2 = WG['fonts'].getFont(Cfgs.fontFile, 1.2, 0.28, 1.6)
+	font2 = WG["fonts"].getFont(Cfgs.fontFile, 1.2, 0.28, 1.6)
 
-	if WG['minimap'] then
-		minimapHeight = WG['minimap'].getHeight()
+	if WG["minimap"] then
+		minimapHeight = WG["minimap"].getHeight()
 	end
 
 	-- if stick to bottom we know cells are 2 row by 6 column
 	if stickToBottom then
-
 		local posY = math_floor(0.14 * ui_scale * vsy)
 		local posYEnd = 0
-		local posX = math_floor(ordermenuLeft*vsx) + widgetSpaceMargin
+		local posX = math_floor(ordermenuLeft * vsx) + widgetSpaceMargin
 		local height = posY
 		builderButtonSize = pageButtonHeight * 1.75
 
 		rows = 2
 		columns = 6
-		cellSize = math_floor(((height) - bgpadding) / rows)
+		cellSize = math_floor((height - bgpadding) / rows)
 
 		local categoryWidth = 8 * categoryFontSize * ui_scale
 
 		-- assemble rects left to right
-		categoriesRect = Rect:new(
-			posX + bgpadding,
-			posYEnd + pageButtonHeight + bgpadding,
-			posX + categoryWidth,
-			posY - bgpadding
-		)
+		categoriesRect =
+			Rect:new(posX + bgpadding, posYEnd + pageButtonHeight + bgpadding, posX + categoryWidth, posY - bgpadding)
 
-		paginatorsRect = Rect:new(
-			posX + bgpadding,
-			posYEnd + bgpadding,
-			posX + categoryWidth,
-			categoriesRect.y
-		)
+		paginatorsRect = Rect:new(posX + bgpadding, posYEnd + bgpadding, posX + categoryWidth, categoriesRect.y)
 
 		buildpicsRect = Rect:new(
 			categoriesRect.xEnd + bgpadding,
@@ -756,35 +783,24 @@ function widget:ViewResize()
 			posY - bgpadding
 		)
 
-		backgroundRect = Rect:new(
-			posX,
-			posYEnd,
-			buildpicsRect.xEnd + bgpadding,
-			posY
-		)
+		backgroundRect = Rect:new(posX, posYEnd, buildpicsRect.xEnd + bgpadding, posY)
 
 		-- start with no width and grow dynamically
-		buildersRect = Rect:new(
-			posX,
-			backgroundRect.yEnd,
-			posX,
-			backgroundRect.yEnd + builderButtonSize
-		)
-
+		buildersRect = Rect:new(posX, backgroundRect.yEnd, posX, backgroundRect.yEnd + builderButtonSize)
 	else -- if stick to side we know cells are 3 row by 4 column
-		local width = 0.212 	-- hardcoded width to match bottom element
-		width = width / (vsx / vsy) * 1.78	-- make smaller for ultrawide screens
+		local width = 0.212 -- hardcoded width to match bottom element
+		width = width / (vsx / vsy) * 1.78 -- make smaller for ultrawide screens
 		width = width * ui_scale
 
 		-- 0.14 is the space required to put this above the bottom-left UI element
 		local posYEnd = math_floor(0.14 * ui_scale * vsy) + widgetSpaceMargin
-		local posY = math_floor(posYEnd + ((0.74 * vsx) * width + pageButtonHeight))/vsy
+		local posY = math_floor(posYEnd + ((0.74 * vsx) * width + pageButtonHeight)) / vsy
 		local posX = 0
 
-		if WG['ordermenu'] and not WG['ordermenu'].getBottomPosition() then
-			local _, oposY, _, oheight = WG['ordermenu'].getPosition()
+		if WG["ordermenu"] and not WG["ordermenu"].getBottomPosition() then
+			local _, oposY, _, oheight = WG["ordermenu"].getPosition()
 			if posY > oposY then
-				posY = (oposY - oheight - ((widgetSpaceMargin)/vsy))
+				posY = (oposY - oheight - (widgetSpaceMargin / vsy))
 			end
 		end
 
@@ -822,27 +838,16 @@ function widget:ViewResize()
 			buildpicsRect.yEnd + pageButtonHeight
 		)
 
-		backgroundRect = Rect:new(
-			posX,
-			posYEnd,
-			posXEnd,
-			paginatorsRect.yEnd + (bgpadding * 1.5)
-		)
+		backgroundRect = Rect:new(posX, posYEnd, posXEnd, paginatorsRect.yEnd + (bgpadding * 1.5))
 
 		-- start with no width and grow dynamically
-		buildersRect = Rect:new(
-			posX,
-			backgroundRect.yEnd,
-			posX,
-			backgroundRect.yEnd + builderButtonSize
-		)
+		buildersRect = Rect:new(posX, backgroundRect.yEnd, posX, backgroundRect.yEnd + builderButtonSize)
 	end
 
 	checkGuishader(true)
 	clear()
 	doUpdate = true
 end
-
 
 local sec = 0
 local updateSelection = true
@@ -880,7 +885,7 @@ function widget:Update(dt)
 	if sec > 0.33 then
 		sec = 0
 		checkGuishader()
-		if WG['minimap'] and minimapHeight ~= WG['minimap'].getHeight() then
+		if WG["minimap"] and minimapHeight ~= WG["minimap"].getHeight() then
 			widget:ViewResize()
 			doUpdate = true
 		end
@@ -893,12 +898,19 @@ function widget:Update(dt)
 
 		local prevOrdermenuLeft = ordermenuLeft
 		local prevOrdermenuHeight = ordermenuHeight
-		if WG['ordermenu'] then
-			local oposX, _, owidth, oheight = WG['ordermenu'].getPosition()
+		if WG["ordermenu"] then
+			local oposX, _, owidth, oheight = WG["ordermenu"].getPosition()
 			ordermenuLeft = oposX + owidth
 			ordermenuHeight = oheight
 		end
-		if not prevAdvplayerlistLeft or advplayerlistLeft ~= prevAdvplayerlistLeft or not prevOrdermenuLeft or ordermenuLeft ~= prevOrdermenuLeft  or not prevOrdermenuHeight or ordermenuHeight ~= prevOrdermenuHeight then
+		if
+			not prevAdvplayerlistLeft
+			or advplayerlistLeft ~= prevAdvplayerlistLeft
+			or not prevOrdermenuLeft
+			or ordermenuLeft ~= prevOrdermenuLeft
+			or not prevOrdermenuHeight
+			or ordermenuHeight ~= prevOrdermenuHeight
+		then
 			widget:ViewResize()
 		end
 
@@ -921,8 +933,8 @@ function widget:Update(dt)
 		-- refresh buildmenu if active cmd changed
 		local prevActiveCmd = activeCmd
 
-		if Spring.GetGameFrame() == 0 and WG['pregame-build'] then
-			activeCmd = WG['pregame-build'].selectedID
+		if Spring.GetGameFrame() == 0 and WG["pregame-build"] then
+			activeCmd = WG["pregame-build"].selectedID
 			if activeCmd then
 				activeCmd = units.unitName[activeCmd]
 			end
@@ -930,7 +942,9 @@ function widget:Update(dt)
 			activeCmd = select(4, Spring.GetActiveCommand())
 		end
 
-		if activeCmd ~= prevActiveCmd then doUpdate = true end
+		if activeCmd ~= prevActiveCmd then
+			doUpdate = true
+		end
 	end
 
 	if not (isPregame or activeBuilder or alwaysShow) then
@@ -940,13 +954,20 @@ function widget:Update(dt)
 	end
 end
 
-
 local function drawBuildMenuBg()
 	local height = backgroundRect.yEnd - backgroundRect.y
 	local posY = backgroundRect.y
-	UiElement(backgroundRect.x, backgroundRect.y, backgroundRect.xEnd, backgroundRect.yEnd, (backgroundRect.x > 0 and (#builderRects > 1 and 0 or 1) or 0), 1, ((posY-height > 0 or backgroundRect.x <= 0) and 1 or 0), 0)
+	UiElement(
+		backgroundRect.x,
+		backgroundRect.y,
+		backgroundRect.xEnd,
+		backgroundRect.yEnd,
+		(backgroundRect.x > 0 and (#builderRects > 1 and 0 or 1) or 0),
+		1,
+		((posY - height > 0 or backgroundRect.x <= 0) and 1 or 0),
+		0
+	)
 end
-
 
 local function drawButton(rect, opts, icon)
 	opts = opts or {}
@@ -958,15 +979,15 @@ local function drawButton(rect, opts, icon)
 
 	local color = highlight and 0.2 or 0
 
-	local color1 = { color, color, color, math_max(0.55, math_min(0.95, ui_opacity * 1.25)) }	-- bottom
-	local color2 = { color, color, color, math_max(0.55, math_min(0.95, ui_opacity * 1.25)) }	-- top
+	local color1 = { color, color, color, math_max(0.55, math_min(0.95, ui_opacity * 1.25)) } -- bottom
+	local color2 = { color, color, color, math_max(0.55, math_min(0.95, ui_opacity * 1.25)) } -- top
 
 	if highlight then
 		gl.Blending(GL_SRC_ALPHA, GL_ONE)
 		gl.Color(0, 0, 0, 0.1)
 	end
 
-	UiButton(rect.x, rect.y, rect.xEnd, rect.yEnd, 1,1,1,1, 1,1,1,1, nil, color1, color2, padding)
+	UiButton(rect.x, rect.y, rect.xEnd, rect.yEnd, 1, 1, 1, 1, 1, 1, 1, 1, nil, color1, color2, padding)
 
 	local dim = disabled and 0.4 or 1.0
 
@@ -975,7 +996,20 @@ local function drawButton(rect, opts, icon)
 		icon = ":l:" .. icon
 		gl.Color(dim, dim, dim, 0.9)
 		gl.Texture(icon)
-		gl.BeginEnd(GL.QUADS, TexRectRound, rect.x + (bgpadding / 2), rect.yEnd - iconSize, rect.x + iconSize, rect.yEnd - (bgpadding / 2),  0,  0,0,0,0,  0.05)	-- this method with a lil zoom prevents faint edges aroudn the image
+		gl.BeginEnd(
+			GL.QUADS,
+			TexRectRound,
+			rect.x + (bgpadding / 2),
+			rect.yEnd - iconSize,
+			rect.x + iconSize,
+			rect.yEnd - (bgpadding / 2),
+			0,
+			0,
+			0,
+			0,
+			0,
+			0.05
+		) -- this method with a lil zoom prevents faint edges aroudn the image
 		--	gl.TexRect(px, sy - iconSize, px + iconSize, sy)
 		gl.Texture(false)
 	end
@@ -987,8 +1021,32 @@ local function drawButton(rect, opts, icon)
 	if hovered then
 		-- gloss highlight
 		gl.Blending(GL_SRC_ALPHA, GL_ONE)
-		RectRound(rect.x, rect.yEnd - ((rect.yEnd - rect.y) * 0.42), rect.xEnd, (rect.yEnd), padding * 1.5, 2, 2, 0, 0, { 1, 1, 1, 0.035 }, { 1, 1, 1, (disableInput and 0.11 or 0.24) })
-		RectRound(rect.x, rect.y, rect.xEnd, (rect.y) + ((rect.yEnd - rect.y) * 0.5), padding * 1.5, 0, 0, 2, 2, { 1, 1, 1, (disableInput and 0.035 or 0.075) }, { 1, 1, 1, 0 })
+		RectRound(
+			rect.x,
+			rect.yEnd - ((rect.yEnd - rect.y) * 0.42),
+			rect.xEnd,
+			rect.yEnd,
+			padding * 1.5,
+			2,
+			2,
+			0,
+			0,
+			{ 1, 1, 1, 0.035 },
+			{ 1, 1, 1, (disableInput and 0.11 or 0.24) }
+		)
+		RectRound(
+			rect.x,
+			rect.y,
+			rect.xEnd,
+			rect.y + ((rect.yEnd - rect.y) * 0.5),
+			padding * 1.5,
+			0,
+			0,
+			2,
+			2,
+			{ 1, 1, 1, (disableInput and 0.035 or 0.075) },
+			{ 1, 1, 1, 0 }
+		)
 		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 
@@ -1013,14 +1071,22 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 		rect.y + cellPadding + iconPadding,
 		rect.xEnd - cellPadding - iconPadding,
 		rect.yEnd - cellPadding - iconPadding,
-		cornerSize, 1,1,1,1,
+		cornerSize,
+		1,
+		1,
+		1,
+		1,
 		usedZoom,
 		nil,
 		disabled and 0 or nil,
-		'#' .. uid,
-		showRadarIcon and (((units.unitIconType[uid] and iconTypesMap[units.unitIconType[uid]]) and ':l' .. (disabled and 't0.3,0.3,0.3' or '') ..':' .. iconTypesMap[units.unitIconType[uid]] or nil)) or nil,
-		showIcon and (groups[units.unitGroup[uid]] and ':l' .. (disabled and 't0.3,0.3,0.3:' or ':') ..groups[units.unitGroup[uid]] or nil) or nil,
-		{units.unitMetalCost[uid], units.unitEnergyCost[uid]},
+		"#" .. uid,
+		showRadarIcon
+				and ((units.unitIconType[uid] and iconTypesMap[units.unitIconType[uid]]) and ":l" .. (disabled and "t0.3,0.3,0.3" or "") .. ":" .. iconTypesMap[units.unitIconType[uid]] or nil)
+			or nil,
+		showIcon
+				and (groups[units.unitGroup[uid]] and ":l" .. (disabled and "t0.3,0.3,0.3:" or ":") .. groups[units.unitGroup[uid]] or nil)
+			or nil,
+		{ units.unitMetalCost[uid], units.unitEnergyCost[uid] },
 		tonumber(cmd.params[1])
 	)
 
@@ -1028,13 +1094,17 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 	if cellColor then
 		gl.Blending(GL.DST_ALPHA, GL_ONE_MINUS_SRC_COLOR)
 		gl.Color(cellColor[1], cellColor[2], cellColor[3], cellColor[4])
-		gl.Texture('#' .. uid)
+		gl.Texture("#" .. uid)
 		UiUnit(
 			rect.x + cellPadding + iconPadding,
 			rect.y + cellPadding + iconPadding,
 			rect.xEnd - cellPadding - iconPadding,
 			rect.yEnd - cellPadding - iconPadding,
-			cornerSize, 1,1,1,1,
+			cornerSize,
+			1,
+			1,
+			1,
+			1,
 			usedZoom
 		)
 		if cellColor[4] > 0 then
@@ -1044,7 +1114,11 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 				rect.y + cellPadding + iconPadding,
 				rect.xEnd - cellPadding - iconPadding,
 				rect.yEnd - cellPadding - iconPadding,
-				cornerSize, 1,1,1,1,
+				cornerSize,
+				1,
+				1,
+				1,
+				1,
 				usedZoom
 			)
 		end
@@ -1067,8 +1141,20 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 		local metalPriceText = metalColor .. metalPrice
 		local energyPriceText = energyColor .. energyPrice
 		local energyPriceTextHeight = font2:GetTextHeight(energyPriceText) * priceFontSize
-		font2:Print(metalPriceText, rect.xEnd - cellPadding - (cellInnerSize * 0.048), rect.y + cellPadding + (priceFontSize * 1.35) + energyPriceTextHeight, priceFontSize, "ro")
-		font2:Print(energyPriceText, rect.xEnd - cellPadding - (cellInnerSize * 0.048), rect.y + cellPadding + (priceFontSize * 1.35), priceFontSize, "ro")
+		font2:Print(
+			metalPriceText,
+			rect.xEnd - cellPadding - (cellInnerSize * 0.048),
+			rect.y + cellPadding + (priceFontSize * 1.35) + energyPriceTextHeight,
+			priceFontSize,
+			"ro"
+		)
+		font2:Print(
+			energyPriceText,
+			rect.xEnd - cellPadding - (cellInnerSize * 0.048),
+			rect.y + cellPadding + (priceFontSize * 1.35),
+			priceFontSize,
+			"ro"
+		)
 	end
 
 	-- hotkey draw
@@ -1077,23 +1163,42 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 
 		local keyFontSize = priceFontSize * 1.1
 		local hotkeyColor = disabled and "\255\100\100\100" or "\255\215\255\215"
-		font2:Print(hotkeyColor .. hotkeyText, rect.xEnd - cellPadding - (cellInnerSize * 0.048), rect.yEnd - cellPadding - keyFontSize, keyFontSize, "ro")
+		font2:Print(
+			hotkeyColor .. hotkeyText,
+			rect.xEnd - cellPadding - (cellInnerSize * 0.048),
+			rect.yEnd - cellPadding - keyFontSize,
+			keyFontSize,
+			"ro"
+		)
 	end
 
 	-- factory queue number
 	if cmd.params[1] then
 		local queueFontSize = cellInnerSize * 0.29
 		local pad = math_floor(cellInnerSize * 0.03)
-		local textWidth = font2:GetTextWidth(cmd.params[1] .. '	') * queueFontSize
-		RectRound(rect.x, rect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365), rect.x + textWidth, rect.yEnd - cellPadding - iconPadding, cornerSize * 3.3, 0, 0, 1, 0, { 0.15, 0.15, 0.15, 0.95 }, { 0.25, 0.25, 0.25, 0.95 })
-		font2:Print("\255\190\255\190" .. cmd.params[1],
+		local textWidth = font2:GetTextWidth(cmd.params[1] .. "	") * queueFontSize
+		RectRound(
+			rect.x,
+			rect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365),
+			rect.x + textWidth,
+			rect.yEnd - cellPadding - iconPadding,
+			cornerSize * 3.3,
+			0,
+			0,
+			1,
+			0,
+			{ 0.15, 0.15, 0.15, 0.95 },
+			{ 0.25, 0.25, 0.25, 0.95 }
+		)
+		font2:Print(
+			"\255\190\255\190" .. cmd.params[1],
 			rect.x + cellPadding + (pad * 3.5),
 			rect.y + cellPadding + math_floor(cellInnerSize * 0.735),
-			queueFontSize, "o"
+			queueFontSize,
+			"o"
 		)
 	end
 end
-
 
 local function drawEmptyCell(rect)
 	local color = { 0.1, 0.1, 0.1, 0.7 }
@@ -1101,18 +1206,24 @@ local function drawEmptyCell(rect)
 	RectRound(rect.x + pad, rect.y + pad, rect.xEnd - pad, rect.yEnd - pad, cornerSize, 1, 1, 1, 1, color, color)
 end
 
-
 local function drawButtonHotkey(rect, keyText)
-	if not rect or not keyText then return end
+	if not rect or not keyText then
+		return
+	end
 	local keyFontHeight = font2:GetTextHeight(keyText) * hotkeyFontSize
 	local keyFontHeightOffset = keyFontHeight * 0.34
 
 	local textPadding = bgpadding * 2
 
 	local text = "\255\215\255\215" .. keyText
-	font2:Print(text, rect.xEnd - textPadding, (rect.y - (rect.y - rect.yEnd) / 2) - keyFontHeightOffset, hotkeyFontSize, "ro")
+	font2:Print(
+		text,
+		rect.xEnd - textPadding,
+		(rect.y - (rect.y - rect.yEnd) / 2) - keyFontHeightOffset,
+		hotkeyFontSize,
+		"ro"
+	)
 end
-
 
 local function drawCategories()
 	local numCats = #categories
@@ -1126,12 +1237,7 @@ local function drawCategories()
 
 		for i, cat in ipairs(categories) do
 			local y1 = categoriesRect.yEnd - i * contentHeight + 2
-			catRects[cat] = Rect:new(
-				x1,
-				y1,
-				x1 + contentWidth - activeAreaMargin,
-				y1 + contentHeight - 2
-			)
+			catRects[cat] = Rect:new(x1, y1, x1 + contentWidth - activeAreaMargin, y1 + contentHeight - 2)
 		end
 	else
 		local y2 = categoriesRect.yEnd
@@ -1141,12 +1247,8 @@ local function drawCategories()
 
 		for i, cat in ipairs(categories) do
 			local x1 = categoriesRect.x + (i - 1) * buttonWidth
-			catRects[cat] = Rect:new(
-				x1,
-				y2 - categoryButtonHeight + padding,
-				x1 + buttonWidth,
-				y2 - activeAreaMargin - padding
-			)
+			catRects[cat] =
+				Rect:new(x1, y2 - categoryButtonHeight + padding, x1 + buttonWidth, y2 - activeAreaMargin - padding)
 		end
 	end
 
@@ -1165,15 +1267,19 @@ local function drawCategories()
 			hovered = (hoveredButton == rect:getId()),
 		}
 
-
-
 		local textPadding = bgpadding * 2
 
 		local fontSize = categoryFontSize
 		local fontHeight = font2:GetTextHeight(catText) * categoryFontSize
 		local fontHeightOffset = fontHeight * 0.34
 		local fontColor = disabled and "\255\100\100\100" or ""
-		font2:Print(fontColor .. catText, rect.x + (textPadding * 3), (rect.y - (rect.y - rect.yEnd) / 2) - fontHeightOffset, fontSize, "o")
+		font2:Print(
+			fontColor .. catText,
+			rect.x + (textPadding * 3),
+			(rect.y - (rect.y - rect.yEnd) / 2) - fontHeightOffset,
+			fontSize,
+			"o"
+		)
 
 		if not currentCategory then
 			drawButtonHotkey(rect, keyText)
@@ -1186,23 +1292,23 @@ local function drawCategories()
 	if currentCategory and not stickToBottom then
 		local backText = "Back"
 		local width = (paginatorsRect.xEnd - paginatorsRect.x) / 2
-		backRect = Rect:new(paginatorsRect.x, paginatorsRect.y, paginatorsRect.xEnd - width - bgpadding, paginatorsRect.yEnd)
+		backRect =
+			Rect:new(paginatorsRect.x, paginatorsRect.y, paginatorsRect.xEnd - width - bgpadding, paginatorsRect.yEnd)
 		local buttonWidth = backRect.xEnd - backRect.x
 		local buttonHeight = backRect.yEnd - backRect.y
-		local heightOffset = backRect.yEnd - font2:GetTextHeight(backText) * pageFontSize * 0.35 - buttonHeight/2
+		local heightOffset = backRect.yEnd - font2:GetTextHeight(backText) * pageFontSize * 0.35 - buttonHeight / 2
 		font2:Print("⟵", backRect.x + (bgpadding * 3), heightOffset, pageFontSize, "o")
 		font2:Print(backText, backRect.x + (buttonWidth * 0.5), heightOffset, pageFontSize * 1.1, "co")
 
 		local opts = {
 			highlight = false,
-			hovered = hoveredButton == backRect:getId()
+			hovered = hoveredButton == backRect:getId(),
 		}
 
 		drawButtonHotkey(backRect, "Shift")
 		drawButton(backRect, opts)
 	end
 end
-
 
 local function drawPaginators()
 	if pages == 1 then
@@ -1220,7 +1326,7 @@ local function drawPaginators()
 
 	local buttonHeight = nextPageRect.yEnd - nextPageRect.y
 	local buttonWidth = nextPageRect.xEnd - nextPageRect.x
-	local heightOffset = nextPageRect.yEnd - font2:GetTextHeight(pagesText) * pageFontSize * 0.2 - buttonHeight/2
+	local heightOffset = nextPageRect.yEnd - font2:GetTextHeight(pagesText) * pageFontSize * 0.2 - buttonHeight / 2
 
 	if stickToBottom then
 		nextPageRect = Rect:new(paginatorsRect.x, paginatorsRect.y, paginatorsRect.xEnd, paginatorsRect.yEnd)
@@ -1228,7 +1334,12 @@ local function drawPaginators()
 		font2:Print(nextPageText, nextPageRect.x + (bgpadding * 2), heightOffset, pageFontSize, "o")
 	else
 		local width = paginatorsRect.xEnd - paginatorsRect.x
-		nextPageRect = Rect:new(paginatorsRect.x + (width / 2) + bgpadding, paginatorsRect.y, paginatorsRect.xEnd, paginatorsRect.yEnd)
+		nextPageRect = Rect:new(
+			paginatorsRect.x + (width / 2) + bgpadding,
+			paginatorsRect.y,
+			paginatorsRect.xEnd,
+			paginatorsRect.yEnd
+		)
 		font2:Print(pagesText, nextPageRect.x + (bgpadding * 2), heightOffset, pageFontSize, "o")
 		font2:Print(nextPageText, nextPageRect.x + (buttonWidth * 0.55), heightOffset, pageFontSize, "co")
 	end
@@ -1239,42 +1350,59 @@ local function drawPaginators()
 	drawButton(nextPageRect, opts)
 end
 
-
 local function drawBuilderIcon(unitDefID, rect, count, lightness, zoom, highlightOpacity)
 	local hovered = hoveredButton == rect:getId()
 	lightness = hovered and lightness + 0.25 or lightness
 	zoom = hovered and zoom + 0.1 or zoom
 	local rectSize = rect.xEnd - rect.x
 
-	gl.Color(lightness,lightness,lightness,1)
+	gl.Color(lightness, lightness, lightness, 1)
 	UiUnit(
-		rect.x, rect.y, rect.xEnd, rect.yEnd,
-		math.ceil(bgpadding*0.5), 1,1,1,1,
+		rect.x,
+		rect.y,
+		rect.xEnd,
+		rect.yEnd,
+		math.ceil(bgpadding * 0.5),
+		1,
+		1,
+		1,
+		1,
 		zoom,
-		nil, math_max(0.1, highlightOpacity or 0.1),
-		'#'..unitDefID,
-		nil, nil, nil, nil
+		nil,
+		math_max(0.1, highlightOpacity or 0.1),
+		"#" .. unitDefID,
+		nil,
+		nil,
+		nil,
+		nil
 	)
 
 	-- builder count number
 	if count > 1 then
 		local countFontSize = rectSize * 0.3
 		local pad = math_floor(rectSize * 0.03)
-		font2:Print("\255\240\240\240" .. count,
+		font2:Print(
+			"\255\240\240\240" .. count,
 			rect.x + (pad * 2),
 			rect.y + pad + math_floor(countFontSize * 2.2),
-			countFontSize, "o"
+			countFontSize,
+			"o"
 		)
 	end
 
 	if highlightOpacity then
 		gl.Blending(GL_SRC_ALPHA, GL_ONE)
-		gl.Color(1,1,1,highlightOpacity)
-		RectRound(rect.x, rect.y, rect.xEnd, rect.yEnd, math_min(math_max(1, math_floor((rect.xEnd-rect.x) * 0.024)), math_floor((vsy*0.0015)+0.5)))
+		gl.Color(1, 1, 1, highlightOpacity)
+		RectRound(
+			rect.x,
+			rect.y,
+			rect.xEnd,
+			rect.yEnd,
+			math_min(math_max(1, math_floor((rect.xEnd - rect.x) * 0.024)), math_floor((vsy * 0.0015) + 0.5))
+		)
 		gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	end
 end
-
 
 local function drawBuilders()
 	if not activeBuilder or selectedBuildersCount <= 1 then
@@ -1292,20 +1420,11 @@ local function drawBuilders()
 		builderTypes = builderTypes + 1
 
 		-- place at the end of the bounds of the container
-		local rect = Rect:new(
-			buildersRect.xEnd,
-			buildersRect.y,
-			buildersRect.xEnd + (builderButtonSize),
-			buildersRect.yEnd
-		)
+		local rect =
+			Rect:new(buildersRect.xEnd, buildersRect.y, buildersRect.xEnd + builderButtonSize, buildersRect.yEnd)
 
 		-- grow container
-		buildersRect = Rect:new(
-			buildersRect.x,
-			buildersRect.y,
-			rect.xEnd + padding,
-			buildersRect.yEnd
-		)
+		buildersRect = Rect:new(buildersRect.x, buildersRect.y, rect.xEnd + padding, buildersRect.yEnd)
 		builderRects[builderTypes] = rect
 		builderButtons[builderTypes] = { unitDefID, count, rect }
 
@@ -1318,17 +1437,37 @@ local function drawBuilders()
 	-- draw background
 	local height = backgroundRect.yEnd - backgroundRect.y
 	local posY = backgroundRect.y
-	UiElement(buildersRect.x, buildersRect.y, buildersRect.xEnd+(bgpadding*2), buildersRect.yEnd+bgpadding+(iconMargin*2), (backgroundRect.x > 0 and 1 or 0), 1, ((posY-height > 0 or backgroundRect.x <= 0) and 1 or 0), 0, 1,1,0,1)
+	UiElement(
+		buildersRect.x,
+		buildersRect.y,
+		buildersRect.xEnd + (bgpadding * 2),
+		buildersRect.yEnd + bgpadding + (iconMargin * 2),
+		(backgroundRect.x > 0 and 1 or 0),
+		1,
+		((posY - height > 0 or backgroundRect.x <= 0) and 1 or 0),
+		0,
+		1,
+		1,
+		0,
+		1
+	)
 
 	-- draw buttons
 	for builderType, params in pairsByKeys(builderButtons) do
 		-- correct position so its withing the background
-		builderRects[builderType].x = builderRects[builderType].x+bgpadding+iconMargin
-		builderRects[builderType].y = builderRects[builderType].y+iconMargin
-		builderRects[builderType].xEnd = builderRects[builderType].xEnd+bgpadding+iconMargin
-		builderRects[builderType].yEnd = builderRects[builderType].yEnd+iconMargin
+		builderRects[builderType].x = builderRects[builderType].x + bgpadding + iconMargin
+		builderRects[builderType].y = builderRects[builderType].y + iconMargin
+		builderRects[builderType].xEnd = builderRects[builderType].xEnd + bgpadding + iconMargin
+		builderRects[builderType].yEnd = builderRects[builderType].yEnd + iconMargin
 
-		drawBuilderIcon(params[1], builderRects[builderType], params[2], activeBuilder == params[1] and 1.0 or 0.5, 0.05, 0)
+		drawBuilderIcon(
+			params[1],
+			builderRects[builderType],
+			params[2],
+			activeBuilder == params[1] and 1.0 or 0.5,
+			0.05,
+			0
+		)
 	end
 
 	local hotkey = keyConfig.sanitizeKey(Cfgs.CYCLE_BUILDER_KEY, currentLayout) or nil
@@ -1336,20 +1475,22 @@ local function drawBuilders()
 
 	-- draw hint
 	local rect = Rect:new(
-		buildersRect.xEnd+(bgpadding*3),
-		buildersRect.y + ((buildersRect.yEnd - buildersRect.y) * 0.2)+iconMargin,
-		buildersRect.xEnd + (builderButtonSize * 0.45) + hotkeyWidth+(bgpadding*3),
-		buildersRect.yEnd - ((buildersRect.yEnd - buildersRect.y) * 0.2)+iconMargin
+		buildersRect.xEnd + (bgpadding * 3),
+		buildersRect.y + ((buildersRect.yEnd - buildersRect.y) * 0.2) + iconMargin,
+		buildersRect.xEnd + (builderButtonSize * 0.45) + hotkeyWidth + (bgpadding * 3),
+		buildersRect.yEnd - ((buildersRect.yEnd - buildersRect.y) * 0.2) + iconMargin
 	)
 
 	local text = "›"
 	local rectSize = rect.yEnd - rect.y
 	local fontSize = rectSize * 1.2
 	local textHeight = font2:GetTextHeight(text) * fontSize
-	font2:Print("\255\255\255\255" .. text,
+	font2:Print(
+		"\255\255\255\255" .. text,
 		rect.x + math_floor(rectSize * 0.2),
 		rect.y + ((rect.yEnd - rect.y) / 2) - math_floor(textHeight / 2),
-		fontSize, "o"
+		fontSize,
+		"o"
 	)
 
 	local opts = {
@@ -1360,7 +1501,6 @@ local function drawBuilders()
 	drawButtonHotkey(rect, hotkey)
 	nextBuilderRect = rect
 end
-
 
 local function drawGrid()
 	local numCellsPerPage = rows * columns
@@ -1396,25 +1536,31 @@ local function drawGrid()
 			rect = Rect:new(
 				buildpicsRect.x + (acol - 1) * cellSize,
 				buildpicsRect.yEnd - (rows - arow + 1) * cellSize,
-				buildpicsRect.x + (acol) * cellSize,
+				buildpicsRect.x + acol * cellSize,
 				buildpicsRect.yEnd - (rows - arow) * cellSize
 			)
 
 			if uDefID and gridOpts[index] then
 				cellcmds[cellRectID] = gridOpts[index]
 
-				gridOpts[index].hotkey = string.gsub(string.upper(Cfgs.keyLayout[row][col]), "ANY%+", '')
+				gridOpts[index].hotkey = string.gsub(string.upper(Cfgs.keyLayout[row][col]), "ANY%+", "")
 				hotkeyActions[tostring(row) .. tostring(col)] = -uDefID
 
 				local udef = gridOpts[index]
 
 				cellRects[cellRectID] = rect
 
-				local cellIsSelected = (activeCmd and udef and activeCmd == udef.name) or
-					(isPregame and selBuildQueueDefID == uDefID)
+				local cellIsSelected = (activeCmd and udef and activeCmd == udef.name)
+					or (isPregame and selBuildQueueDefID == uDefID)
 				local usedZoom = (cellIsSelected and selectedCellZoom or defaultCellZoom)
 
-				drawCell(rect, gridOpts[index], usedZoom, cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil, units.unitRestricted[uDefID])
+				drawCell(
+					rect,
+					gridOpts[index],
+					usedZoom,
+					cellIsSelected and { 1, 0.85, 0.2, 0.25 } or nil,
+					units.unitRestricted[uDefID]
+				)
 			else
 				drawEmptyCell(rect)
 				hotkeyActions[tostring(row) .. tostring(col)] = nil
@@ -1426,7 +1572,6 @@ local function drawGrid()
 		selectNextFrame = cellcmds[1].id
 	end
 end
-
 
 local function drawBuildMenu()
 	catRects = {}
@@ -1465,27 +1610,26 @@ local function drawBuildMenu()
 	font2:End()
 end
 
-
 -- load all icons to prevent briefly showing white unit icons (will happen due to the custom texture filtering options)
 local function cacheUnitIcons()
 	local excludeScavs = not (Spring.Utilities.Gametype.IsScavengers() or Spring.GetModOptions().experimentalextraunits)
 	local excludeRaptors = not Spring.Utilities.Gametype.IsRaptors()
-	gl.Translate(-vsx,0,0)
+	gl.Translate(-vsx, 0, 0)
 	gl.Color(1, 1, 1, 0.001)
 	for id, unit in pairs(UnitDefs) do
-		if not excludeScavs or not string.find(unit.name,'_scav') then
-			if not excludeRaptors or not string.find(unit.name,'raptor') then
-				gl.Texture('#'..id)
+		if not excludeScavs or not string.find(unit.name, "_scav") then
+			if not excludeRaptors or not string.find(unit.name, "raptor") then
+				gl.Texture("#" .. id)
 				gl.TexRect(-1, -1, 0, 0)
 				if units.unitIconType[id] and iconTypesMap[units.unitIconType[id]] then
-					gl.Texture(':l:' .. iconTypesMap[units.unitIconType[id]])
+					gl.Texture(":l:" .. iconTypesMap[units.unitIconType[id]])
 					gl.TexRect(-1, -1, 0, 0)
 				end
 			end
 		end
 	end
 	gl.Color(1, 1, 1, 1)
-	gl.Translate(vsx,0,0)
+	gl.Translate(vsx, 0, 0)
 end
 
 local function drawBuildProgress()
@@ -1511,7 +1655,15 @@ local function drawBuildProgress()
 						if unitBuildDefID == cellUnitDefID then
 							drawncellRectIDs[cellRectID] = true
 							local progress = 1 - select(5, spGetUnitHealth(unitBuildID))
-							RectRoundProgress(cellRect.x + cellPadding + iconPadding, cellRect.y + cellPadding + iconPadding, cellRect.xEnd - cellPadding - iconPadding, cellRect.yEnd - cellPadding - iconPadding, cellSize * 0.03, progress, { 0.08, 0.08, 0.08, 0.6 })
+							RectRoundProgress(
+								cellRect.x + cellPadding + iconPadding,
+								cellRect.y + cellPadding + iconPadding,
+								cellRect.xEnd - cellPadding - iconPadding,
+								cellRect.yEnd - cellPadding - iconPadding,
+								cellSize * 0.03,
+								progress,
+								{ 0.08, 0.08, 0.08, 0.6 }
+							)
 						end
 					end
 				end
@@ -1526,16 +1678,16 @@ function widget:DrawScreen()
 		cacheUnitIcons()
 	end
 
-	if WG['buildmenu'] then
-		WG['buildmenu'].hoverID = nil
+	if WG["buildmenu"] then
+		WG["buildmenu"].hoverID = nil
 	end
 	if not (isPregame or activeBuilder or alwaysShow) then
-		if WG['guishader'] and dlistGuishader then
+		if WG["guishader"] and dlistGuishader then
 			if dlistGuishader then
-				WG['guishader'].RemoveDlist('buildmenu')
+				WG["guishader"].RemoveDlist("buildmenu")
 			end
 			if dlistGuishaderBuilders then
-				WG['guishader'].RemoveDlist('buildmenubuilders')
+				WG["guishader"].RemoveDlist("buildmenubuilders")
 			end
 		end
 	else
@@ -1551,8 +1703,8 @@ function widget:DrawScreen()
 		end
 
 		-- create buildmenu drawlists
-		if WG['guishader'] and dlistGuishader then
-			WG['guishader'].InsertDlist(dlistGuishader, 'buildmenu')
+		if WG["guishader"] and dlistGuishader then
+			WG["guishader"].InsertDlist(dlistGuishader, "buildmenu")
 		end
 		if not dlistBuildmenu then
 			dlistBuildmenuBg = gl.CreateList(function()
@@ -1567,7 +1719,7 @@ function widget:DrawScreen()
 
 		local hovering = false
 		if backgroundRect:contains(x, y) or buildersRect:contains(x, y) or nextBuilderRect:contains(x, y) then
-			Spring.SetMouseCursor('cursornormal')
+			Spring.SetMouseCursor("cursornormal")
 			hovering = true
 		end
 
@@ -1577,31 +1729,53 @@ function widget:DrawScreen()
 			-- pre process + 'highlight' under the icons
 			local hoveredCellID
 			local hoveredButtonNotFound = true
-			if not WG['topbar'] or not WG['topbar'].showingQuit() then
+			if not WG["topbar"] or not WG["topbar"].showingQuit() then
 				if hovering then
 					for cellRectID, cellRect in pairs(cellRects) do
 						if cellRect:contains(x, y) then
 							hoveredCellID = cellRectID
 							local cmd = cellcmds[cellRectID]
 							local uDefID = cmd.id * -1
-							WG['buildmenu'].hoverID = uDefID
+							WG["buildmenu"].hoverID = uDefID
 							gl.Color(1, 1, 1, 1)
 							local _, _, meta, _ = Spring.GetModKeyState()
-							if WG['tooltip'] and not meta then
+							if WG["tooltip"] and not meta then
 								-- when meta: unitstats does the tooltip
 								local text
 								local textColor = "\255\215\255\215"
 								if units.unitRestricted[uDefID] then
-									text = Spring.I18N('ui.buildMenu.disabled', { unit = UnitDefs[uDefID].translatedHumanName, textColor = textColor, warnColor = "\255\166\166\166" })
+									text = Spring.I18N("ui.buildMenu.disabled", {
+										unit = UnitDefs[uDefID].translatedHumanName,
+										textColor = textColor,
+										warnColor = "\255\166\166\166",
+									})
 								else
 									text = UnitDefs[uDefID].translatedHumanName
 								end
-								WG['tooltip'].ShowTooltip('buildmenu', "\255\240\240\240"..UnitDefs[uDefID].translatedTooltip, nil, nil, text)
+								WG["tooltip"].ShowTooltip(
+									"buildmenu",
+									"\255\240\240\240" .. UnitDefs[uDefID].translatedTooltip,
+									nil,
+									nil,
+									text
+								)
 							end
 
 							-- highlight --if b and not disableInput then
 							gl.Blending(GL_SRC_ALPHA, GL_ONE)
-							RectRound(cellRect.x + cellPadding, cellRect.y + cellPadding, cellRect.xEnd - cellPadding, cellRect.yEnd - cellPadding, cellSize * 0.03, 1, 1, 1, 1, { 0, 0, 0, 0.1 * ui_opacity }, { 0, 0, 0, 0.1 * ui_opacity })
+							RectRound(
+								cellRect.x + cellPadding,
+								cellRect.y + cellPadding,
+								cellRect.xEnd - cellPadding,
+								cellRect.yEnd - cellPadding,
+								cellSize * 0.03,
+								1,
+								1,
+								1,
+								1,
+								{ 0, 0, 0, 0.1 * ui_opacity },
+								{ 0, 0, 0, 0.1 * ui_opacity }
+							)
 							gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 							break
 						end
@@ -1616,14 +1790,13 @@ function widget:DrawScreen()
 								doUpdate = true
 							end
 
-
-							if WG['tooltip'] then
+							if WG["tooltip"] then
 								-- when meta: unitstats does the tooltip
 								local textColor = "\255\215\255\215"
 
-								local text =  Cfgs.categoryTooltips[cat]
-								local index=0
-								for k,v in pairs(categories) do
+								local text = Cfgs.categoryTooltips[cat]
+								local index = 0
+								for k, v in pairs(categories) do
 									if v == cat then
 										index = k
 									end
@@ -1632,7 +1805,7 @@ function widget:DrawScreen()
 								local catKey = keyConfig.sanitizeKey(Cfgs.keyLayout[1][index], currentLayout)
 								text = text .. "\255\240\240\240 - Hotkey: " .. textColor .. "[" .. catKey .. "]"
 
-								WG['tooltip'].ShowTooltip('buildmenu', text, nil, nil, cat)
+								WG["tooltip"].ShowTooltip("buildmenu", text, nil, nil, cat)
 							end
 
 							hoveredButtonNotFound = false
@@ -1644,24 +1817,24 @@ function widget:DrawScreen()
 					if nextPageRect.y and nextPageRect:contains(x, y) then
 						hoveredButton = nextPageRect:getId()
 						hoveredButtonNotFound = false
-						if WG['tooltip'] then
-							local text = "\255\240\240\240" .. Spring.I18N('ui.buildMenu.nextPage')
-							WG['tooltip'].ShowTooltip('buildmenu', text)
+						if WG["tooltip"] then
+							local text = "\255\240\240\240" .. Spring.I18N("ui.buildMenu.nextPage")
+							WG["tooltip"].ShowTooltip("buildmenu", text)
 						end
 					end
 
 					if backRect.y and backRect:contains(x, y) then
 						hoveredButton = backRect:getId()
 						hoveredButtonNotFound = false
-						if WG['tooltip'] then
-							local text = "\255\240\240\240" .. Spring.I18N('ui.buildMenu.homePage')
-							WG['tooltip'].ShowTooltip('buildmenu', text)
+						if WG["tooltip"] then
+							local text = "\255\240\240\240" .. Spring.I18N("ui.buildMenu.homePage")
+							WG["tooltip"].ShowTooltip("buildmenu", text)
 						end
 					end
 
 					-- builder buttons
 					for i, rect in pairs(builderRects) do
-						if rect:contains(x,y) then
+						if rect:contains(x, y) then
 							hoveredButton = rect:getId()
 							hovering = true
 							hoveredButtonNotFound = false
@@ -1670,9 +1843,9 @@ function widget:DrawScreen()
 							for unitDefID, _ in pairsByKeys(selectedBuilders) do
 								index = index + 1
 								if index == i then
-									if WG['tooltip'] then
+									if WG["tooltip"] then
 										name = UnitDefs[unitDefID].translatedHumanName
-										WG['tooltip'].ShowTooltip('buildmenu', "\255\240\240\240" .. name)
+										WG["tooltip"].ShowTooltip("buildmenu", "\255\240\240\240" .. name)
 									end
 								end
 							end
@@ -1683,9 +1856,9 @@ function widget:DrawScreen()
 						hoveredButton = nextBuilderRect:getId()
 						hovering = true
 						hoveredButtonNotFound = false
-						if WG['tooltip'] then
-							local text = "\255\240\240\240" .. Spring.I18N('ui.buildMenu.nextBuilder')
-							WG['tooltip'].ShowTooltip('buildmenu', text)
+						if WG["tooltip"] then
+							local text = "\255\240\240\240" .. Spring.I18N("ui.buildMenu.nextBuilder")
+							WG["tooltip"].ShowTooltip("buildmenu", text)
 						end
 					end
 
@@ -1710,14 +1883,25 @@ function widget:DrawScreen()
 			-- draw highlight
 			local usedZoom
 			local cellColor
-			if not WG['topbar'] or not WG['topbar'].showingQuit() then
+			if not WG["topbar"] or not WG["topbar"].showingQuit() then
 				if hovering then
-
 					-- cells
 					if hoveredCellID then
 						local uDefID = cellcmds[hoveredCellID].id * -1
-						local cellIsSelected = (activeCmd and cellcmds[hoveredCellID] and activeCmd == cellcmds[hoveredCellID].name)
-						if not prevHoveredCellID or hoveredCellID ~= prevHoveredCellID or uDefID ~= hoverUdefID or cellIsSelected ~= hoverCellSelected or b ~= prevB or b3 ~= prevB3 or cellcmds[hoveredCellID].params[1] ~= prevQueueNr then
+						local cellIsSelected = (
+							activeCmd
+							and cellcmds[hoveredCellID]
+							and activeCmd == cellcmds[hoveredCellID].name
+						)
+						if
+							not prevHoveredCellID
+							or hoveredCellID ~= prevHoveredCellID
+							or uDefID ~= hoverUdefID
+							or cellIsSelected ~= hoverCellSelected
+							or b ~= prevB
+							or b3 ~= prevB3
+							or cellcmds[hoveredCellID].params[1] ~= prevQueueNr
+						then
 							prevQueueNr = cellcmds[hoveredCellID].params[1]
 							prevB = b
 							prevB3 = b3
@@ -1728,7 +1912,6 @@ function widget:DrawScreen()
 								hoverDlist = gl.DeleteList(hoverDlist)
 							end
 							hoverDlist = gl.CreateList(function()
-
 								-- determine zoom amount and cell color
 								usedZoom = hoverCellZoom
 								if not cellIsSelected then
@@ -1752,7 +1935,7 @@ function widget:DrawScreen()
 									end
 								else
 									-- selected cell
-									if (b or b2 or b3) then
+									if b or b2 or b3 then
 										usedZoom = clickSelectedCellZoom
 									else
 										usedZoom = selectedCellZoom
@@ -1760,14 +1943,19 @@ function widget:DrawScreen()
 									cellColor = { 1, 0.85, 0.2, 0.25 }
 								end
 								if not units.unitRestricted[uDefID] then
-
 									local unsetShowPrice
 									if not showPrice then
 										unsetShowPrice = true
 										showPrice = true
 									end
 
-									drawCell(cellRects[hoveredCellID], cellcmds[hoveredCellID], usedZoom, cellColor, units.unitRestricted[uDefID])
+									drawCell(
+										cellRects[hoveredCellID],
+										cellcmds[hoveredCellID],
+										usedZoom,
+										cellColor,
+										units.unitRestricted[uDefID]
+									)
 
 									if unsetShowPrice then
 										showPrice = false
@@ -1794,14 +1982,16 @@ end
 function widget:DrawWorld()
 	-- Avoid unnecessary overhead after buildqueue has been setup in early frames
 	if Spring.GetGameFrame() > 0 then
-		widgetHandler:RemoveWidgetCallIn('DrawWorld', self)
+		widgetHandler:RemoveWidgetCallIn("DrawWorld", self)
 		return
 	end
 
-	if not isPregame then return end
+	if not isPregame then
+		return
+	end
 
-	if startDefID ~= Spring.GetTeamRulesParam(myTeamID, 'startUnit') then
-		startDefID = Spring.GetTeamRulesParam(myTeamID, 'startUnit')
+	if startDefID ~= Spring.GetTeamRulesParam(myTeamID, "startUnit") then
+		startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 		doUpdate = true
 	end
 
@@ -1846,7 +2036,9 @@ function clearCategory()
 end
 
 function widget:KeyRelease(key)
-	if key ~= KEYSYMS.LSHIFT then return end
+	if key ~= KEYSYMS.LSHIFT then
+		return
+	end
 
 	if isPregame then
 		setPreGamestartDefID(nil)
@@ -1859,25 +2051,28 @@ function widget:MousePress(x, y, button)
 	if Spring.IsGUIHidden() then
 		return
 	end
-	if WG['topbar'] and WG['topbar'].showingQuit() then
+	if WG["topbar"] and WG["topbar"].showingQuit() then
 		return
 	end
 
-	if buildmenuShows and (backgroundRect:contains(x, y) or buildersRect:contains(x, y) or nextBuilderRect:contains(x, y)) then
+	if
+		buildmenuShows
+		and (backgroundRect:contains(x, y) or buildersRect:contains(x, y) or nextBuilderRect:contains(x, y))
+	then
 		if activeBuilder or (isPregame and startDefID) then
 			if nextPageRect and nextPageRect:contains(x, y) then
-				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
+				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, "ui")
 				nextPageHandler()
 				return true
 			end
 
 			if backRect and backRect:contains(x, y) then
-				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
+				Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, "ui")
 				clearCategory()
 			end
 
 			for i, rect in pairs(builderRects) do
-				if rect:contains(x,y) then
+				if rect:contains(x, y) then
 					setActiveBuilder(i)
 					doUpdate = true
 					return true
@@ -1893,7 +2088,7 @@ function widget:MousePress(x, y, button)
 				for cat, catRect in pairs(catRects) do
 					if catRect:contains(x, y) then
 						currentCategory = cat
-						Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
+						Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, "ui")
 
 						doUpdate = true
 						return true
@@ -1901,18 +2096,35 @@ function widget:MousePress(x, y, button)
 				end
 
 				for cellRectID, cellRect in pairs(cellRects) do
-					if cellcmds[cellRectID].id and UnitDefs[-cellcmds[cellRectID].id].translatedHumanName and cellRect:contains(x, y) and not units.unitRestricted[-cellcmds[cellRectID].id] then
+					if
+						cellcmds[cellRectID].id
+						and UnitDefs[-cellcmds[cellRectID].id].translatedHumanName
+						and cellRect:contains(x, y)
+						and not units.unitRestricted[-cellcmds[cellRectID].id]
+					then
 						if button ~= 3 then
-							Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, 'ui')
+							Spring.PlaySoundFile(Cfgs.sound_queue_add, 0.75, "ui")
 
 							if isPregame then
 								setPreGamestartDefID(cellcmds[cellRectID].id * -1)
 							elseif spGetCmdDescIndex(cellcmds[cellRectID].id) then
-								Spring.SetActiveCommand(spGetCmdDescIndex(cellcmds[cellRectID].id), 1, true, false, Spring.GetModKeyState())
+								Spring.SetActiveCommand(
+									spGetCmdDescIndex(cellcmds[cellRectID].id),
+									1,
+									true,
+									false,
+									Spring.GetModKeyState()
+								)
 							end
 						elseif builderIsFactory and spGetCmdDescIndex(cellcmds[cellRectID].id) then
-							Spring.PlaySoundFile(Cfgs.sound_queue_rem, 0.75, 'ui')
-							Spring.SetActiveCommand(spGetCmdDescIndex(cellcmds[cellRectID].id), 3, false, true, Spring.GetModKeyState())
+							Spring.PlaySoundFile(Cfgs.sound_queue_rem, 0.75, "ui")
+							Spring.SetActiveCommand(
+								spGetCmdDescIndex(cellcmds[cellRectID].id),
+								3,
+								false,
+								true,
+								Spring.GetModKeyState()
+							)
 						end
 						doUpdateClock = os.clock() + 0.01
 						return true
@@ -1932,16 +2144,17 @@ end
 function widget:Shutdown()
 	clear()
 	hoverDlist = gl.DeleteList(hoverDlist)
-	if WG['guishader'] and dlistGuishader then
-		WG['guishader'].DeleteDlist('buildmenu')
-		WG['guishader'].DeleteDlist('buildmenubuilders')
+	if WG["guishader"] and dlistGuishader then
+		WG["guishader"].DeleteDlist("buildmenu")
+		WG["guishader"].DeleteDlist("buildmenubuilders")
 		dlistGuishader = nil
 	end
-	WG['buildmenu'] = nil
+	WG["buildmenu"] = nil
 end
 
 function widget:GetConfigData()
 	return {
+		returnToCategoriesOnPick = returnToCategoriesOnPick,
 		showPrice = showPrice,
 		showRadarIcon = showRadarIcon,
 		showGroupIcon = showGroupIcon,
@@ -1952,6 +2165,9 @@ function widget:GetConfigData()
 end
 
 function widget:SetConfigData(data)
+	if data.returnToCategoriesOnPick ~= nil then
+		returnToCategoriesOnPick = data.returnToCategoriesOnPick
+	end
 	if data.showPrice ~= nil then
 		showPrice = data.showPrice
 	end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2926,6 +2926,13 @@ function init()
 			  end
 		  end,
 		},
+		{ id = "gridmenu_alwaysreturn", group = "control", category = types.advanced, name = Spring.I18N('ui.settings.option.gridmenu_alwaysreturn'), type = "bool", value = (WG['buildmenu'] ~= nil and WG['buildmenu'].getShowPrice ~= nil and WG['buildmenu'].getShowPrice()), description = Spring.I18N('ui.settings.option.gridmenu_alwaysreturn_descr'),
+		  onload = function()
+		  end,
+		  onchange = function(_, value)
+			  saveOptionValue('Grid menu', 'gridmenu', 'setAlwaysReturn', { 'alwaysReturn' }, value)
+		  end,
+		},
 
 
 		{ id = "label_ui_cursor", group = "control", name = Spring.I18N('ui.settings.option.label_cursor'), category = types.basic },


### PR DESCRIPTION
On b825b881b5bd940914aa6986860f57c7fd8fbe9e the default was changed to always return to categories when queueing commands after assign.

This is not the behavior in other RTSs with grid commands.

This commit exposes the setting

![2023-11-10T08:42:10,215504278-03:00](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/347552/4194d7b1-d2e9-4f19-8e91-aa52749a5f53)

Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2216