### PR TITLE
buildmenu: fix price placement arithmetic

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -486,7 +486,7 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled, colls)
 	-- price
 	if showPrice then
 		local metalColor = disabled and "\255\125\125\125" or "\255\245\245\245"
-		local energyColor = disabled and "\n\255\135\135\135" or "\n\255\255\255\000"
+		local energyColor = disabled and "\255\135\135\135" or "\255\255\255\000"
 		local function AddSpaces(price)
 			if price >= 1000 then
 				return string.format("%s %03d", AddSpaces(math_floor(price / 1000)), price % 1000)
@@ -497,9 +497,8 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled, colls)
 		local energyPrice = AddSpaces(units.unitEnergyCost[uDefID])
 		local metalPriceText = metalColor .. metalPrice
 		local energyPriceText = energyColor .. energyPrice
-		local energyPriceTextHeight = font2:GetTextHeight(energyPriceText) * priceFontSize
-		font2:Print(metalPriceText, cellRects[cellRectID][3] - cellPadding - (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35) + energyPriceTextHeight, priceFontSize, "ro")
-		font2:Print(energyPriceText, cellRects[cellRectID][3] - cellPadding - (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "ro")
+		font2:Print(metalPriceText, cellRects[cellRectID][3] - cellPadding - (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 1.35), priceFontSize, "ro")
+		font2:Print(energyPriceText, cellRects[cellRectID][3] - cellPadding - (cellInnerSize * 0.048), cellRects[cellRectID][2] + cellPadding + (priceFontSize * 0.35), priceFontSize, "ro")
 	end
 
 	-- factory queue number

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1129,7 +1129,7 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 	-- price
 	if showPrice then
 		local metalColor = disabled and "\255\125\125\125" or "\255\245\245\245"
-		local energyColor = disabled and "\n\255\135\135\135" or "\n\255\255\255\000"
+		local energyColor = disabled and "\255\135\135\135" or "\255\255\255\000"
 		local function AddSpaces(price)
 			if price >= 1000 then
 				return string.format("%s %03d", AddSpaces(math_floor(price / 1000)), price % 1000)
@@ -1140,18 +1140,17 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 		local energyPrice = AddSpaces(units.unitEnergyCost[uid])
 		local metalPriceText = metalColor .. metalPrice
 		local energyPriceText = energyColor .. energyPrice
-		local energyPriceTextHeight = font2:GetTextHeight(energyPriceText) * priceFontSize
 		font2:Print(
 			metalPriceText,
 			rect.xEnd - cellPadding - (cellInnerSize * 0.048),
-			rect.y + cellPadding + (priceFontSize * 1.35) + energyPriceTextHeight,
+			rect.y + cellPadding + (priceFontSize * 1.35),
 			priceFontSize,
 			"ro"
 		)
 		font2:Print(
 			energyPriceText,
 			rect.xEnd - cellPadding - (cellInnerSize * 0.048),
-			rect.y + cellPadding + (priceFontSize * 1.35),
+			rect.y + cellPadding + (priceFontSize * 0.35),
 			priceFontSize,
 			"ro"
 		)


### PR DESCRIPTION
Previously, the idea was to use GetTextHeight() to calculate the y-axis placement of metal and energy price placements. However, GetTextHeight() returns 0. Instead, the reason the placement was correct was due to the linebreak in energyColor.

To make the code more readable, maintainable and extendable, do the following:

* remove variable energyPriceTextHeight
* remove linebreak from energyColor
* change priceFontSize multiplier factor from 1.35 to 0.35 for energy price y-axis placement

Same changes are done to both buildmenu and gridmenu.

This commit contains no functional changes.