### PR TITLE
luarules: enable start boxes shuffling in FFA

### DIFF
--- a/luarules/gadgets/game_ffa_start_setup.lua
+++ b/luarules/gadgets/game_ffa_start_setup.lua
@@ -163,9 +163,7 @@ function gadget:Initialize()
   local allyTeamList = Spring.Utilities.GetAllyTeamList()
 
   setFFAStartPoints(allyTeamList)
-  -- TODO: uncomment on next engine release containing dependent changes for
-  -- Spring.SetAllyTeamStartBox to be available
-  -- shuffleStartBoxes(allyTeamList)
+  shuffleStartBoxes(allyTeamList)
 
   -- our job here is done :)
   gadgetHandler:RemoveGadget(self)


### PR DESCRIPTION
Now that the new engine has been released, `Spring.SetAllyTeamStartBox` is available and we can undo the changes implemented in 656abd64218153e0c79ba738f2953e4b99752cb7.