### PR TITLE
Add option to not auto-select first item in category to gridmenu

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1156,6 +1156,8 @@
 				"gridmenu_descr": "Alternative build menu, designed for comprehensive hotkey use",
 				"gridmenu_alwaysreturn": "Grid always returns to categories",
 				"gridmenu_alwaysreturn_descr": "While queueing commands, return to categories page after issuing",
+				"gridmenu_autoselectfirst": "Grid category selects structure",
+				"gridmenu_autoselectfirst_descr": "When selecting a category, automatically activate the first option within that category",
 				"keylayout": "Keyboard Layout",
 				"keylayout_descr": "Set the keyboard layout",
 				"keybindings": "Keybind Preset",

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2162,6 +2162,7 @@ end
 function widget:GetConfigData()
 	return {
 		alwaysReturn = alwaysReturn,
+		autoSelectFirst = autoSelectFirst,
 		showPrice = showPrice,
 		showRadarIcon = showRadarIcon,
 		showGroupIcon = showGroupIcon,
@@ -2174,6 +2175,9 @@ end
 function widget:SetConfigData(data)
 	if data.alwaysReturn ~= nil then
 		alwaysReturn = data.alwaysReturn
+	end
+	if data.autoSelectFirst ~= nil then
+		autoSelectFirst = data.autoSelectFirst
 	end
 	if data.showPrice ~= nil then
 		showPrice = data.showPrice

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -23,6 +23,7 @@ VFS.Include("luarules/configs/customcmds.h.lua")
 SYMKEYS = table.invert(KEYSYMS)
 
 local alwaysReturn = false
+local autoSelectFirst = true
 
 local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
 local currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")
@@ -657,6 +658,12 @@ function widget:Initialize()
 	end
 	WG["gridmenu"].setAlwaysReturn = function(value)
 		alwaysReturn = value
+	end
+	WG["gridmenu"].getAutoSelectFirst = function()
+		return autoSelectFirst
+	end
+	WG["gridmenu"].setAutoSelectFirst = function(value)
+		autoSelectFirst = value
 	end
 
 	WG["buildmenu"] = {}
@@ -1568,7 +1575,7 @@ local function drawGrid()
 		end
 	end
 
-	if cellcmds[1] and (activeBuilder or isPregame) and switchedCategory then
+	if cellcmds[1] and autoSelectFirst and (activeBuilder or isPregame) and switchedCategory then
 		selectNextFrame = cellcmds[1].id
 	end
 end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2907,6 +2907,7 @@ function init()
 				  widgetHandler:DisableWidget('Grid menu')
 				  widgetHandler:EnableWidget('Build menu')
 			  end
+			  init()
 		  end,
 		},
 		{ id = "gridmenu_alwaysreturn", group = "control", category = types.advanced, name = Spring.I18N('ui.settings.option.gridmenu_alwaysreturn'), type = "bool", value = (WG['gridmenu'] ~= nil and WG['gridmenu'].getAlwaysReturn ~= nil and WG['gridmenu'].getAlwaysReturn()), description = Spring.I18N('ui.settings.option.gridmenu_alwaysreturn_descr'),
@@ -2914,6 +2915,13 @@ function init()
 		  end,
 		  onchange = function(_, value)
 			  saveOptionValue('Grid menu', 'gridmenu', 'setAlwaysReturn', { 'alwaysReturn' }, value)
+		  end,
+		},
+		{ id = "gridmenu_autoselectfirst", group = "control", category = types.advanced, name = Spring.I18N('ui.settings.option.gridmenu_autoselectfirst'), type = "bool", value = (WG['gridmenu'] ~= nil and WG['gridmenu'].getAutoSelectFirst ~= nil and WG['gridmenu'].getAutoSelectFirst()), description = Spring.I18N('ui.settings.option.gridmenu_autoselectfirst_descr'),
+		  onload = function()
+		  end,
+		  onchange = function(_, value)
+			  saveOptionValue('Grid menu', 'gridmenu', 'setAutoSelectFirst', { 'autoSelectFirst' }, value)
 		  end,
 		},
 
@@ -5486,6 +5494,7 @@ function init()
 
 	if not GetWidgetToggleValue('Grid menu') then
 		options[getOptionByID('gridmenu_alwaysreturn')] = nil
+		options[getOptionByID('gridmenu_autoselectfirst')] = nil
 	end
 
 


### PR DESCRIPTION
Normally when you select a category in gridmenu, the first structure is automatically selected, e.g. when pressing Z for economy, mex is selected. This PR adds an option to remove that behavior, so selecting a category will not auto-select a building, and it must be chosen with another keystroke (e.g. z+z for mex). Default behavior will be the same as current behavior.

![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/a2c612b2-451e-44fe-8f4e-3d4b065c7d08)

Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2280