### PR TITLE
fix: Show current unit range in gui_info.lua

### DIFF
--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1274,7 +1274,11 @@ local function drawUnitInfo()
 		if displayMode == 'unit' then
 			-- get lots of unit info from functions: https://springrts.com/wiki/Lua_SyncedRead
 			metalMake, metalUse, energyMake, energyUse = spGetUnitResources(displayUnitID)
-			maxRange = range
+			if unitDefInfo[displayUnitDefID].mainWeapon ~= nil then
+				maxRange = Spring.GetUnitWeaponState(displayUnitID, unitDefInfo[displayUnitDefID].mainWeapon, "range")
+			else
+				maxRange = range
+			end
 			if not exp then
 				exp = spGetUnitExperience(displayUnitID)
 			end


### PR DESCRIPTION
resolves https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2277

Previously, the base unitdef range was always used. In particular, the gunslinger would always show its base range rather than the upgraded range from gaining experience. This led to player confusion about if its range actually increased.

This commit partially reverts b033f730dd2a21fa32c386439443ef6cf43d26e3, where the bug was introduced.