### PR TITLE
Prevent sharing units over the unit cap

### DIFF
--- a/luarules/gadgets/game_prevent_excessive_share.lua
+++ b/luarules/gadgets/game_prevent_excessive_share.lua
@@ -1,13 +1,12 @@
-
 function gadget:GetInfo()
 	return {
-		name      = 'Prevent Excessive Share',
-		desc      = 'Prevents sharing more resources than the receiver can hold',
-		author    = 'Niobium',
-		date      = 'April 2012',
-		license   = 'GNU GPL, v2 or later',
-		layer     = 0,
-		enabled   = true
+		name    = 'Prevent Excessive Share',
+		desc    = 'Prevents sharing more resources or units than the receiver can hold',
+		author  = 'Niobium',
+		date    = 'April 2012',
+		license = 'GNU GPL, v2 or later',
+		layer   = 0,
+		enabled = true
 	}
 end
 
@@ -18,35 +17,47 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
+local spIsCheatingEnabled = Spring.IsCheatingEnabled
+local spGetTeamUnitCount = Spring.GetTeamUnitCount
+
+local gameMaxUnits = math.min(Spring.GetModOptions().maxunits, math.floor(32000 / #Spring.GetTeamList()))
+
 ----------------------------------------------------------------
 -- Callins
 ----------------------------------------------------------------
 function gadget:AllowResourceTransfer(senderTeamId, receiverTeamId, resourceType, amount)
+	-- Spring uses 'm' and 'e' instead of the full names that we need, so we need to convert the resourceType
+	-- We also check for 'metal' or 'energy' incase Spring decides to use those in a later version
+	local resourceName
+	if (resourceType == 'm') or (resourceType == 'metal') then
+		resourceName = 'metal'
+	elseif (resourceType == 'e') or (resourceType == 'energy') then
+		resourceName = 'energy'
+	else
+		-- We don't handle whatever this resource is, allow it
+		return true
+	end
 
-    -- Spring uses 'm' and 'e' instead of the full names that we need, so we need to convert the resourceType
-    -- We also check for 'metal' or 'energy' incase Spring decides to use those in a later version
-    local resourceName
-    if (resourceType == 'm') or (resourceType == 'metal') then
-        resourceName = 'metal'
-    elseif (resourceType == 'e') or (resourceType == 'energy') then
-        resourceName = 'energy'
-    else
-        -- We don't handle whatever this resource is, allow it
-        return true
-    end
+	-- Calculate the maximum amount the receiver can receive
+	local rCur, rStor, rPull, rInc, rExp, rShare = Spring.GetTeamResources(receiverTeamId, resourceName)
+	local maxShare = rStor * rShare - rCur
 
-    -- Calculate the maximum amount the receiver can receive
-    local rCur, rStor, rPull, rInc, rExp, rShare = Spring.GetTeamResources(receiverTeamId, resourceName)
-    local maxShare = rStor * rShare - rCur
+	-- Is the sender trying to send more than the maximum? Block it, possibly sending a reduced amount instead
+	if amount > maxShare then
+		if maxShare > 0 then
+			Spring.ShareTeamResource(senderTeamId, receiverTeamId, resourceName, maxShare)
+		end
+		return false
+	end
 
-    -- Is the sender trying to send more than the maximum? Block it, possibly sending a reduced amount instead
-    if amount > maxShare then
-        if maxShare > 0 then
-            Spring.ShareTeamResource(senderTeamId, receiverTeamId, resourceName, maxShare)
-        end
-        return false
-    end
+	-- Allow anything we don't explictly block
+	return true
+end
 
-    -- Allow anything we don't explictly block
-    return true
+function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
+	local unitCount = spGetTeamUnitCount(newTeam)
+	if capture or spIsCheatingEnabled() or unitCount < gameMaxUnits then
+		return true
+	end
+	return false
 end


### PR DESCRIPTION
Blocks a unit transfer if it would put the receiver over the unit cap.