### PR TITLE
Re-add gui_language widget

### DIFF
--- a/luaui/Widgets/gui_language.lua
+++ b/luaui/Widgets/gui_language.lua
@@ -1,0 +1,47 @@
+function widget:GetInfo()
+	return {
+		name      = "Language",
+		desc      = "Handle functions related to translations",
+		date      = "November 2023",
+		layer     = -999999,
+		enabled   = true,
+	}
+end
+
+local i18nHelper = VFS.Include('luaui/i18nhelpers.lua')
+
+local customMessageProxies = {
+	['ui.chickens.queenResistant'] = function (data) return { unit = UnitDefs[data.unitDefId].translatedHumanName } end,
+	['scav.messages.reinforcements'] = function (data) return { player = data.player, unit = UnitDefNames[data.unitDefName].translatedHumanName } end,
+}
+
+local function getMessageProxy(messageKey, parameters)
+	if customMessageProxies[messageKey] then
+		return Spring.I18N( messageKey, customMessageProxies[messageKey](parameters) )
+	else
+		return Spring.I18N(messageKey, parameters)
+	end
+end
+
+function widget:LanguageChanged()
+	i18nHelper.RefreshDefs()
+end
+
+function widget:Initialize()
+	widgetHandler:RegisterGlobal('GadgetMessageProxy', getMessageProxy)
+
+	WG['language'] = {}
+
+	WG['language'].setLanguage = function(language)
+		Spring.SetConfigString('language', language)
+		Spring.I18N.setLanguage(language)
+
+		if Script.LuaUI('LanguageChanged') then
+			Script.LuaUI.LanguageChanged()
+		end
+	end
+end
+
+function widget:Shutdown()
+	WG['lang'] = nil
+end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4482,12 +4482,7 @@ function init()
 		{ id = "language", group = "dev", category = types.dev, name = Spring.I18N('ui.settings.option.language'), type = "select", options = languageNames, value = languageCodes[Spring.I18N.getLocale()],
 			onchange = function(i, value)
 				local language = languageCodes[value]
-				Spring.SetConfigString('language', language)
-				Spring.I18N.setLanguage(language)
-
-				if Script.LuaUI('LanguageChanged') then
-					Script.LuaUI.LanguageChanged()
-				end
+				WG['language'].setLanguage(language)
 			end
 		},
 		{ id = "font", group = "dev", category = types.dev, name = Spring.I18N('ui.settings.option.font'), type = "select", options = {}, value = 1, description = Spring.I18N('ui.settings.option.font_descr'),


### PR DESCRIPTION
• This widget was inadvertently deleted, removing needed functionality
• GadgetMessageProxy to be able to send messages for the UI to widgets
• Switching language refreshes unit and feature def translations