### PR TITLE
Raptor Turn Rate is too fast

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -637,7 +637,7 @@ function UnitDef_Post(name, uDef)
 
 		if (not uDef.canfly) and uDef.speed then
 			uDef.rspeed = uDef.speed*0.65
-			uDef.turnrate = uDef.speed*300
+			uDef.turnrate = uDef.speed*10
 			uDef.maxacc = uDef.speed*0.05
 			uDef.maxdec  = uDef.speed*0.05
 		elseif uDef.canfly then


### PR DESCRIPTION
Fixes the instant Turn Rate for Raptors.
1 maxvelocity to 30 speed. Changing uDef.Speed*300 to 10 will bring it back to normal