### PR TITLE
Gridmenu rendering fixes, consul grid layout fixes

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1181,12 +1181,12 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 	-- factory queue number
 	if cmd.params[1] then
 		local queueFontSize = cellInnerSize * 0.29
-		local pad = math_floor(cellInnerSize * 0.03)
-		local textWidth = font2:GetTextWidth(cmd.params[1] .. "	") * queueFontSize
+		local textPad = math_floor(cellInnerSize * 0.1)
+		local textWidth = font2:GetTextWidth(cmd.params[1]) * queueFontSize
 		RectRound(
 			rect.x,
 			rect.yEnd - cellPadding - iconPadding - math_floor(cellInnerSize * 0.365),
-			rect.x + textWidth,
+			rect.x + textWidth + (textPad * 2), -- double pad, for a pad at the start and end
 			rect.yEnd - cellPadding - iconPadding,
 			cornerSize * 3.3,
 			0,
@@ -1198,7 +1198,7 @@ local function drawCell(rect, cmd, usedZoom, cellColor, disabled)
 		)
 		font2:Print(
 			"\255\190\255\190" .. cmd.params[1],
-			rect.x + cellPadding + (pad * 3.5),
+			rect.x + cellPadding + textPad,
 			rect.y + cellPadding + math_floor(cellInnerSize * 0.735),
 			queueFontSize,
 			"o"
@@ -1639,13 +1639,6 @@ local function cacheUnitIcons()
 end
 
 local function drawBuildProgress()
-	local numCellsPerPage = rows * columns
-	local maxCellRectID = numCellsPerPage * currentPage
-	if maxCellRectID > gridOptsCount then
-		maxCellRectID = gridOptsCount
-	end
-
-	local drawncellRectIDs = {}
 	if activeBuilderID then
 		local unitBuildID = spGetUnitIsBuilding(activeBuilderID)
 		if unitBuildID then
@@ -1653,24 +1646,18 @@ local function drawBuildProgress()
 			if unitBuildDefID then
 				-- loop all shown cells
 				for cellRectID, cellRect in pairs(cellRects) do
-					if not drawncellRectIDs[cellRectID] then
-						if cellRectID > maxCellRectID then
-							break
-						end
-						local cellUnitDefID = cellcmds[cellRectID].id * -1
-						if unitBuildDefID == cellUnitDefID then
-							drawncellRectIDs[cellRectID] = true
-							local progress = 1 - select(5, spGetUnitHealth(unitBuildID))
-							RectRoundProgress(
-								cellRect.x + cellPadding + iconPadding,
-								cellRect.y + cellPadding + iconPadding,
-								cellRect.xEnd - cellPadding - iconPadding,
-								cellRect.yEnd - cellPadding - iconPadding,
-								cellSize * 0.03,
-								progress,
-								{ 0.08, 0.08, 0.08, 0.6 }
-							)
-						end
+					local cellUnitDefID = cellcmds[cellRectID].id * -1
+					if unitBuildDefID == cellUnitDefID then
+						local progress = 1 - select(5, spGetUnitHealth(unitBuildID))
+						RectRoundProgress(
+							cellRect.x + cellPadding + iconPadding,
+							cellRect.y + cellPadding + iconPadding,
+							cellRect.xEnd - cellPadding - iconPadding,
+							cellRect.yEnd - cellPadding - iconPadding,
+							cellSize * 0.03,
+							progress,
+							{ 0.08, 0.08, 0.08, 0.6 }
+						)
 					end
 				end
 			end

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1247,9 +1247,9 @@ local unitGrids = {
 			{ "armmine2" },                                           -- med. mine
 		},
 		{
-			{ "armvp", "armcv", },                                    -- vehicle lab, T1 veh con
-			{ "armnanotc", "armcs", },                                -- nano, sea con
-			{ },                                                      --
+			{ "armcv", "armvp" },                             	 	  -- T1 veh con, vehicle lab
+			{ "armnanotc" },                                		  -- nano
+			{ "armcs" },                                              -- sea con
 		}
 	},
 
@@ -1276,28 +1276,28 @@ local unitGrids = {
 			{ },                          --
 		}
 	},
-	
+
 	--corprinter
 	corprinter = {
 		{
-			{'corsolar', 'cormex' },        
-			{ },                                             
+			{'corsolar', 'cormex' },
+			{ },
 			{ },                          -- solar, mex
 		},
 		{
-			{ },        
-			{ },                                             
-			{ },                          
+			{ },
+			{ },
+			{ },
 		},
 		{
-			{ 'corrad','', 'corfort'},        
-			{ },                                             
+			{ 'corrad','', 'corfort'},
+			{ },
 			{ },                          --radar, t2 wall
 		},
 		{
-			{ },        
-			{ },                                             
-			{ },                          
+			{ },
+			{ },
+			{ },
 		}
 	},
 


### PR DESCRIPTION
### Changes
- Fix a layout bug that caused queue numbers to render incorrectly
![Discord_Qpdu62mE8n](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/7596bc63-8084-470d-b0d7-2bc769ea8958) ![Discord_prvugGCxjN](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/9f739628-9659-4a29-986e-18e67fe17125)
- Fix build progress not rendering for certain units in certain labs, notably whistlers in the t1 veh lab, and the top row in shipyards
- Fix consul "build" category layout, 3 out of 4 buildoptions here were in non-standard positions. Just move them to standard positions
