### PR TITLE
Area mex upgraded to allow upgrading to any mex type

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -148,18 +148,12 @@ local function canExtractorBeUpgraded(x, z, extractorId)
 	local newExtractor = UnitDefs[extractorId]
 	local newExtractorStrength = mexBuildings[extractorId] or geoBuildings[extractorId]
 	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0
-	Spring.Echo("New extractor extraction amount", tostring(newExtractorStrength))
-	Spring.Echo("New extractor is special", tostring(newExtractorIsSpecial))
 
 	local units = Spring.GetUnitsInCylinder(x, z, Game_extractorRadius)
-	Spring.Echo("units in cylinder", dump(units))
-
 	for i = 1, #units do
 		local uid = units[i]
 		local uDefId = spGetUnitDefID(uid)
-		local currentExtractor = UnitDefs[spGetUnitDefID(uid)]
 		local currentExtractorStrength = mexBuildings[uDefId] or geoBuildings[uDefId]
-		-- is extractor
 		if(newExtractorStrength > currentExtractorStrength) then
 			Spring.Echo("new extractor is stronger")
 			return true
@@ -176,24 +170,6 @@ local function canExtractorBeUpgraded(x, z, extractorId)
 	end
 
 	return false
-	--local mexesatspot = Spring.GetUnitsInCylinder(x, z, Game_extractorRadius)
-	--for i = 1, #mexesatspot do
-	--	local uid = mexesatspot[i]
-	--	local isMex = mexBuildings[spGetUnitDefID(uid)]
-	--	local isAllied = Spring.AreTeamsAllied(spGetMyTeamID(), Spring.GetUnitTeam(uid))
-	--	local isBetterMex = mexBuildings[spGetUnitDefID(uid)] >= extractorStrength
-	--	Spring.Echo('isMex, isAllied, isBetterMex', isMex, isAllied, isBetterMex)
-	--	if
-	--		isMex and
-	--		isAllied and
-	--		isBetterMex
-	--	then
-	--		Spring.Echo("isAlliedMex")
-	--		return false
-	--	end
-	--end
-	--Spring.Echo("isNoAlliedMex")
-	--return true
 end
 
 
@@ -210,9 +186,6 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 	if not cr or cr < Game_extractorRadius then cr = Game_extractorRadius end
 	local units = selectedUnits
 	local extractorCount = tablelength(extractors)
-
-	Spring.Echo("extractors", dump(extractors))
-	Spring.Echo("number of extractors " .. tostring(extractorCount))
 
 	-- Get highest producing building and constructor
 	local chosenExtractorStrength = 0
@@ -236,12 +209,10 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 			-- get the naive best match out of all possible extractors
 			if extractorCount > 1 then
 				local buildingID = -constructor.building[1]
-				Spring.Echo("building id", buildingID)
 				getBestConstructorAndExtractor(id, buildingID)
 			else
 				for j, building in pairs(constructor.building) do
 					local buildingID = -building
-					Spring.Echo("building id", buildingID)
 					if(extractors[buildingID]) then
 						getBestConstructorAndExtractor(id, buildingID)
 					end
@@ -255,8 +226,6 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 		return
 	end
 
-	Spring.Echo('chosenExtractor', tostring(chosenExtractor))
-
 	-- Add highest producing constructors to mainBuilders table + give guard orders to "inferior" constructors
 	local mainBuilders = {}
 	local mainBuildersCount = 0
@@ -269,7 +238,6 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 			for j, buildingId in pairs(constructor.building) do
 				if -buildingId == chosenExtractor and extractors[chosenExtractor] then
 					-- found match
-					Spring.Echo('builder can make chosen extractor')
 					local x, _, z = spGetUnitPosition(id)
 					if z then
 						ux, uz = ux+x, uz+z
@@ -294,8 +262,6 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 
 		end
 	end
-
-	Spring.Echo("mainbuilderscount", tostring(mainBuildersCount))
 
 	if mainBuildersCount == 0 then return end
 	aveX, aveZ = ux/mainBuildersCount, uz/mainBuildersCount
@@ -411,7 +377,6 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 	if isGuard and #queuedMexes == 0 then
 		return		-- no mex buildorder made so let move go through!
 	end
-	Spring.Echo("Queued mexes " .. dump(queuedMexes))
 	return queuedMexes
 end
 

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -63,7 +63,7 @@ function widget:Update(dt)
 	end
 end
 
-local function areaMex(uDefID)
+local function setAreaMexType(uDefID)
 	selectedMex = uDefID
 	Spring.Echo('setting selectedMex to ', tostring(selectedMex))
 end
@@ -122,7 +122,7 @@ function widget:Initialize()
 	end
 
 	WG['areamex'] = {}
-	WG['areamex'].areaMex = function(uDefID)
-		areaMex(uDefID)
+	WG['areamex'].setAreaMexType = function(uDefID)
+		setAreaMexType(uDefID)
 	end
 end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -523,17 +523,14 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 		end
 
 		local uDef = UnitDefs[-uDefID]
-		-- Spring.Echo("Triggering area mex with unit def " ..tostring(uDefID))
 		local isRepeatMex = uDef.customParams.metal_extractor and uDef.name == activeCmd
-		-- and not (uDef.stealth or #uDef.weapons > 0)
 		local cmd = isRepeatMex and "areamex" or spGetCmdDescIndex(uDefID)
 
 		if isRepeatMex then
-			WG['areamex'].areaMex(uDefID)
+			WG['areamex'].setAreaMexType(uDefID)
 		end
 
 		Spring.SetActiveCommand(cmd, 3, false, true, alt, ctrl, meta, shift)
-
 		return true
 	end
 

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -438,6 +438,20 @@ local function enqueueUnit(uDefID, opts)
 	end
 end
 
+function dump(o)
+	if type(o) == 'table' then
+		local s = '{ '
+		for k,v in pairs(o) do
+			if type(k) ~= 'number' then k = '"'..k..'"' end
+			s = s .. '['..k..'] = ' .. dump(v) .. ','
+		end
+		return s .. '} '
+	else
+		return tostring(o)
+	end
+end
+
+
 local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 	-- validate args
 	local row = args and tonumber(args[1])
@@ -509,10 +523,14 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 		end
 
 		local uDef = UnitDefs[-uDefID]
-		local isRepeatMex = uDef.customParams.metal_extractor
-			and uDef.name == activeCmd
-			and not (uDef.stealth or #uDef.weapons > 0)
+		-- Spring.Echo("Triggering area mex with unit def " ..tostring(uDefID))
+		local isRepeatMex = uDef.customParams.metal_extractor and uDef.name == activeCmd
 		local cmd = isRepeatMex and "areamex" or spGetCmdDescIndex(uDefID)
+
+		if isRepeatMex then
+			WG['areamex'].areaMex(uDefID)
+		end
+
 		Spring.SetActiveCommand(cmd, 3, false, true, alt, ctrl, meta, shift)
 
 		return true

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -525,6 +525,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 		local uDef = UnitDefs[-uDefID]
 		-- Spring.Echo("Triggering area mex with unit def " ..tostring(uDefID))
 		local isRepeatMex = uDef.customParams.metal_extractor and uDef.name == activeCmd
+		-- and not (uDef.stealth or #uDef.weapons > 0)
 		local cmd = isRepeatMex and "areamex" or spGetCmdDescIndex(uDefID)
 
 		if isRepeatMex then

--- a/luaui/layout.lua
+++ b/luaui/layout.lua
@@ -45,15 +45,17 @@ local function DummyLayoutHandler(xIcons, yIcons, cmdCount, commands)
 	widgetHandler:CommandsChanged()
 	local reParamsCmds = {}
 	local customCmds = {}
-	
+
 	local cnt = 0
-	
+
 	local AddCommand = function(command)
+		Spring.Echo("Adding custom command")
 		local cc = {}
 		CopyTable(cc,command )
 		cnt = cnt + 1
 		cc.cmdDescID = cmdCount+cnt
 		if (cc.params) then
+			Spring.Echo("adding custom command with params ".. dump(cc.params))
 			if (not cc.actions) then --// workaround for params
 				local params = cc.params
 				for i=1,#params+1 do
@@ -67,10 +69,10 @@ local function DummyLayoutHandler(xIcons, yIcons, cmdCount, commands)
 		cc.pos		 = nil
 		cc.cmdDescID = nil
 		cc.params	 = nil
-		
+
 		customCmds[#customCmds+1] = cc
 	end
-	
+
 	--// preprocess the Custom Commands
 	for i=1,#widgetHandler.customCommands do
 		AddCommand(widgetHandler.customCommands[i])
@@ -79,7 +81,7 @@ local function DummyLayoutHandler(xIcons, yIcons, cmdCount, commands)
 	if (cmdCount <= 0) then
 		return "", xIcons, yIcons, {}, customCmds, {}, {}, {}, {}, reParamsCmds, {} --prevent CommandChanged() from being called twice when deselecting all units  (copied from ca_layout.lua)
 	end
-	
+
 	return "", xIcons, yIcons, {}, customCmds, {}, {}, {}, {}, reParamsCmds, {[1337]=9001}
 end
 


### PR DESCRIPTION
### Changes
- Instead of always choosing the "base" mex (t1 or t2) for area mex, now any mex type can be chosen
- This is currently only possible with gridmenu, by selecting any mex type twice
- This allows upgrades AND sidegrades. That is, if exploiter is chosen, all empty mex spots and all basic mexes will queue an exploiter. Likewise, if a t2 exploiter is chosen, all empty mexes, t1 mexes, exploiters, twilights, or t2 mexes will queue a t2 exploiter


### Testing
- Right-click build and right-click upgrade should function exactly as before, for both mexes and geos
- Test area mex on empty mex spots
- Test area mex with exploiters, twilights, t2 exploiters, and t2 twilights
- Test upgrading t1 mexes of both factions to any t2 or "special" mex with area mex