### PR TITLE
modoptions: add `teamffa_start_boxes_shuffle`

### DIFF
--- a/luarules/configs/ffa_startpoints/README.md
+++ b/luarules/configs/ffa_startpoints/README.md
@@ -32,7 +32,7 @@ The **FFA start setup** gadget's purpose is to address all of these issues.
 
 If using start boxes, the gadget will shuffle them at game start so as to make
 sure that nobody can know where anybody else is based off the start boxes
-defined in the lobby.
+defined in the lobby. (This behaviour can be disabled via ModOptions.)
 
 If not using start boxes, the gadget will try to leverage custom FFA start
 points configs to position players at the start of the game in a better way than

--- a/luarules/gadgets/game_ffa_start_setup.lua
+++ b/luarules/gadgets/game_ffa_start_setup.lua
@@ -163,7 +163,9 @@ function gadget:Initialize()
   local allyTeamList = Spring.Utilities.GetAllyTeamList()
 
   setFFAStartPoints(allyTeamList)
-  shuffleStartBoxes(allyTeamList)
+  if Spring.GetModOptions().teamffa_start_boxes_shuffle then
+    shuffleStartBoxes(allyTeamList)
+  end
 
   -- our job here is done :)
   gadgetHandler:RemoveGadget(self)

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1075,6 +1075,15 @@ local options={
 	},
 
 	{
+		key     = 'teamffa_start_boxes_shuffle',
+		name    = 'Shuffle TeamFFA start boxes',
+		desc    = "In TeamFFA games (more than 2 teams, excluding Raptors / Scavengers), start boxes will be randomly assigned to each team: team 1 might be assigned any start box rather than team 1 always being assigned start box 1.",
+		type    = 'bool',
+		section = 'options_extra',
+		def     = true,
+	},
+
+	{
 		key="ruins",
 		name="Ruins",
 		desc = "Remains of the battles once fought",


### PR DESCRIPTION
In 79a5ecf276cbbfafb2680d4485da7c9503b0b05d, we reworked FFA start points and additionally added a shuffling system for start boxes in TeamFFA games.

This was added because in multiplayer games it is desirable to hide start location, however in singleplayer it is a common scenario to play a pseudo-TeamFFA game against multiple AIs, and in this case players typically do not want to be booted off their specifically chosen start box.

To allow for toggling this behaviour on or off as needed, we add a new ModOption in the `Extra` tab (next to `Anonymous Mode` since it is another common setting tweaked in FFA games). This ModOption is set to "on" by default such that behaviour is unchanged in multiplayer games, however we also introduce a small QoL where it defaults to "off" in singleplayer games via a custom override done in Chobby (see [1]).

[1]: https://github.com/beyond-all-reason/BYAR-Chobby/pull/523