### PR TITLE
fix: gui_reclaim_field_highlight: fix broken refactor in UpdateFeatures

### DIFF
--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -560,7 +560,7 @@ end
 local function UpdateFeatures()
 	clusterMetalUpdated = false
 
-	for _, fID in ipairs(knownFeatures) do
+	for fID, fInfo in pairs(knownFeatures) do
 		local metal, _, energy = spGetFeatureResources(fID)
 
 		if includeEnergy then metal = metal + energy * E2M end


### PR DESCRIPTION
Commit 67e4c8c982b3727da341be604a26e4e1bdf8020d changed `UpdateFeatures` to iterate over `knownFeatures` instead of `Spring.GetAllFeatures()`. But these have different structures (`Spring.GetAllFeatures()` is a list of `featureID`s, `knownFeatures` is a dictionary of `featureID -> featureInfo`).

The result was that this part of `UpdateFeatures` didn't work at all, and feature locations and metal content were only updated when a feature was created/destroyed.

This fix changes the iteration to match the different data structure.