### PR TITLE
Fix chat share resource message color

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -520,12 +520,6 @@ local function addChat(gameFrame, lineType, name, text, isLive)
 	-- determine text typing start time
 	local startTime = clock()
 
-	-- convert /n into lines
-	local textLines = string_lines(text)
-
-	-- word wrap text into lines
-	local wordwrappedText = wordWrap(textLines, lineMaxWidth, usedFontSize)
-
 	local sendMetal, sendEnergy
 	local msgColor = '\255\180\180\180'
 	local metalColor = '\255\255\255\255'
@@ -565,6 +559,12 @@ local function addChat(gameFrame, lineType, name, text, isLive)
 			lineType = LineType.System
 		end
 	end
+
+	-- convert /n into lines
+	local textLines = string_lines(text)
+
+	-- word wrap text into lines
+	local wordwrappedText = wordWrap(textLines, lineMaxWidth, usedFontSize)
 
 	local chatLinesCount = #chatLines
 	local lineColor = #wordwrappedText > 1 and ssub(wordwrappedText[1], 1, 4) or ''


### PR DESCRIPTION
# Changes

Fixing resource share message colors that I broke by [allowing line wrapping](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2341/files#diff-50e9e809ac9691ea91cf6bb0ce6b1cced195ea150a9fdcf978972faaf9970ab0R587) for System messages in #2341 

![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/4711112/ba8e3020-560e-46e4-9a01-8387990a7d7b)

---
[Discord thread](https://discordapp.com/channels/549281623154229250/1181052045818605598)