### PR TITLE
Fix captured units appearing as shared in chat messages

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -715,8 +715,16 @@ function widget:UnitTaken(unitID, _, oldTeamID, newTeamID)
 	local newAllyTeamID = select(6, Spring.GetTeamInfo(newTeamID))
 
 	local myAllyTeamID = Spring.GetMyAllyTeamID()
+
+	local allyTeamShare = (oldAllyTeamID == myAllyTeamID and newAllyTeamID == myAllyTeamID)
+	local selfShare = (oldTeamID == newTeamID) -- may happen if took other player
+
+	local _, _, _, captureProgress, _ = Spring.GetUnitHealth(unitID)
+	local captured = (captureProgress == 1)
+
 	local spec = Spring.GetSpectatingState()
-	if not spec and (oldAllyTeamID ~= myAllyTeamID or newAllyTeamID ~= myAllyTeamID) then -- skip captured units
+
+	if (not spec and not allyTeamShare) or selfShare or captured then
 		return
 	end
 

--- a/luaui/Widgets/unit_share_tracker.lua
+++ b/luaui/Widgets/unit_share_tracker.lua
@@ -236,7 +236,12 @@ function widget:ViewResize()
 end
 
 function widget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
-	if newTeam == GetMyTeamID() then
+	local _, _, _, captureProgress, _ = Spring.GetUnitHealth(unitID)
+	local captured = (captureProgress == 1)
+
+	local selfShare = (oldTeam == newTeam) -- may happen if took other player
+
+	if newTeam == GetMyTeamID() and not selfShare and not captured then
 		if not timeNow then
 			StartTime()
 		end


### PR DESCRIPTION
# Fixes
- The issue where captured unit appears as shared in the chat
- The issue with chat message of player sharing unit to themselves when took other player

[Discord thread](https://discord.com/channels/549281623154229250/1181498059654447104)