### PR TITLE
Fix area mex crash when using buildmenu

### DIFF
--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -71,7 +71,7 @@ function widget:CommandNotify(id, params, options)
 		local queuedMexes = WG['resource_spot_builder'].BuildMex(params, options, isGuard, false, true, selectedMex)
 		selectedMex = nil
 		if not options.shift then
-			WG["gridmenu"].clearCategory()
+			if WG["gridmenu"] then WG["gridmenu"].clearCategory() end
 		end
 		if not queuedMexes[1] then	-- used when area_mex isnt queuing a mex, to let the move cmd still pass through
 			return false


### PR DESCRIPTION
### Work done
Null check

I learned from this that unloading a widget at runtime does *NOT* remove it from WG - I had actually tested this case during development, but didn't do a full luaui reload when unloading a widget so didn't get the error :(