### PR TITLE
Fix unit share chat msg for spectators in radar vision

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -633,8 +633,10 @@ local function commonUnitName(unitIDs)
 	for _, unitID in pairs(unitIDs) do
 		local unitDefID = Spring.GetUnitDefID(unitID)
 
-		if commonUnitDefID and unitDefID ~= commonUnitDefID then
-			return "units"
+		-- unitDefID will be nil if shared units are visible only as unidentified radar dots
+		-- (when spectating with PlayerView ON from enemy team's point of view)
+		if (commonUnitDefID and unitDefID ~= commonUnitDefID) or not unitDefID then
+			return #unitIDs > 1 and "units" or "unit"
 		end
 
 		commonUnitDefID = unitDefID
@@ -743,7 +745,12 @@ function widget:UnitTaken(unitID, _, oldTeamID, newTeamID)
 		}
 	end
 
-	lastUnitShare[key].unitIDs[#lastUnitShare[key].unitIDs + 1] = unitID
+	-- When spectating from enemy team's point of view with PlayerView OFF and
+	-- if said team has vision of shared units,
+	-- widget:UnitTaken will be called twice per unit (one time for each team i guess)
+	if not table.contains(lastUnitShare[key].unitIDs, unitID) then
+		lastUnitShare[key].unitIDs[#lastUnitShare[key].unitIDs + 1] = unitID
+	end
 end
 
 function widget:PlayerChanged(playerID)


### PR DESCRIPTION


### Work done

Fixes two bugs occuring when spectating from enemy team's point of view and units are shared in radar vision:
1. With PlayerView ON gui_chat crashes because `GetUnitDefID` returns `nil`
2. With PlayerView OFF number of units displayed in chat is incorrect because `widget:UnitTaken` is called twice for each unit (once per team)

#### Addresses Issue(s)

1. [Chat widget crashes when people leave?](https://discord.com/channels/549281623154229250/1183679423032066100) - fixed by PR
2. [widget:UnitTaken is called twice for each unit for spectators if the units are visible to both teams](https://discord.com/channels/549281623154229250/1183763760213667900) - more info on the second bug

#### Test steps
1. Take a replay from [discord issue thread](https://discord.com/channels/549281623154229250/1183679423032066100)
2. Spectate as blue team
3. At f=14649 (~8 min) red shares 10 whistlers to pink inside blue's radar vision
- [ ] PR version should not crash with Player View ON
- [ ] Chat message should correctly display a share of 10 whistlers with Player View OFF