### PR TITLE
Revert "Fix unit share chat msg for spectators in radar vision"

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -633,10 +633,8 @@ local function commonUnitName(unitIDs)
 	for _, unitID in pairs(unitIDs) do
 		local unitDefID = Spring.GetUnitDefID(unitID)
 
-		-- unitDefID will be nil if shared units are visible only as unidentified radar dots
-		-- (when spectating with PlayerView ON from enemy team's point of view)
-		if (commonUnitDefID and unitDefID ~= commonUnitDefID) or not unitDefID then
-			return #unitIDs > 1 and "units" or "unit"
+		if commonUnitDefID and unitDefID ~= commonUnitDefID then
+			return "units"
 		end
 
 		commonUnitDefID = unitDefID
@@ -745,12 +743,7 @@ function widget:UnitTaken(unitID, _, oldTeamID, newTeamID)
 		}
 	end
 
-	-- When spectating from enemy team's point of view with PlayerView OFF and
-	-- if said team has vision of shared units,
-	-- widget:UnitTaken will be called twice per unit (one time for each team i guess)
-	if not table.contains(lastUnitShare[key].unitIDs, unitID) then
-		lastUnitShare[key].unitIDs[#lastUnitShare[key].unitIDs + 1] = unitID
-	end
+	lastUnitShare[key].unitIDs[#lastUnitShare[key].unitIDs + 1] = unitID
 end
 
 function widget:PlayerChanged(playerID)


### PR DESCRIPTION
See [issue thread on Discord](https://discord.com/channels/549281623154229250/1183763760213667900)

Root cause is in the event dispatcher gadget, and affects all widgets that use the `UnitTaken` callin. The fix needs to be applied there, rather than implementing a workaround in every widget that uses this callin.
https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luarules/gadgets/api_widget_events.lua