### PR TITLE
fix(api_resource_spot_builder): don't issue commands if justDraw==true

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -277,15 +277,17 @@ local function BuildResourceExtractors(params, options, isGuard, justDraw, const
 	end
 
 	-- order secondary builders to guard main builders, equally dispersed
-	local index = 1
-	for i, uid in pairs(secondaryBuilders) do
-		if not options.shift then
-			spGiveOrderToUnit(uid, CMD_STOP, {}, CMD_OPT_RIGHT)
+	if not justDraw then
+		local index = 1
+		for i, uid in pairs(secondaryBuilders) do
+			if not options.shift then
+				spGiveOrderToUnit(uid, CMD_STOP, {}, CMD_OPT_RIGHT)
+			end
+			local mainBuilderId = mainBuilders[index]
+			spGiveOrderToUnit(uid, CMD_GUARD, { mainBuilderId }, { "shift" })
+			index = index + 1
+			if index > #mainBuilders then index = 1 end
 		end
-		local mainBuilderId = mainBuilders[index]
-		spGiveOrderToUnit(uid, CMD_GUARD, { mainBuilderId }, { "shift" })
-		index = index + 1
-		if index > #mainBuilders then index = 1 end
 	end
 
 	if #mainBuilders == 0 then return end


### PR DESCRIPTION
### Context

51392322d14b228d8a9feefdf448fb3d0ff5bfe1 refactored a bunch of this code, and inadvertently moved the code to issue guard commands to secondary builders outside of a `justDraw` check.

One result was that when t1 and t2 constructors were selected and a metal spot was hovered, `cmd_rclick_quick_build_resource_extractor` would call `BuildMex` with `justDraw==true`, and a guard command would be issued every frame. This caused flickering and repeated sound effects in addition to the unintended orders.

### Work done

Added a `justDraw` check around the guard command code

#### Test steps
1. Select a t1 and a t2 constructor
2. Hover a metal spot
