### PR TITLE
fix(gui_vote_interface): fix individual player resign vote crash

### DIFF
--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -13,6 +13,9 @@ end
 -- dont show vote buttons for specs when containing the following keywords (use lowercase)
 local globalVoteWords =  { 'forcestart', 'stop', 'joinas' }
 
+local INDIVIDUAL_RESIGN_VOTE_PATTERN = "called a vote for command \"resign ([^%s]+)\""
+local TEAM_RESIGN_VOTE_PATTERN = "called a vote for command \"resign ([^%s]+) TEAM\""
+
 local voteEndDelay = 4
 local voteTimeout = 75	-- fallback timeout in case vote is aborted undetected
 
@@ -413,7 +416,17 @@ function widget:AddConsoleLine(lines, priority)
 						end
 					end
 
-					if not sfind(line, '"resign ', nil, true) or isTeamPlayer(ssub(line, sfind(line, '"resign ', nil, true) + 8, sfind(line, ' TEAM', nil, true) - 1)) then
+					local individualResignTarget = string.match(line, INDIVIDUAL_RESIGN_VOTE_PATTERN)
+					local teamResignTarget = string.match(line, TEAM_RESIGN_VOTE_PATTERN)
+
+					local isIndividualResignVote = individualResignTarget ~= nil
+					local isTeamResignVote = teamResignTarget ~= nil
+
+					local isResignVote = isIndividualResignVote or isTeamResignVote
+					local isResignVoteMyTeam = (isIndividualResignVote and isTeamPlayer(individualResignTarget))
+						or (isTeamResignVote and isTeamPlayer(teamResignTarget))
+
+					if not isResignVote or isResignVoteMyTeam then
 						eligiblePlayers = {}
 						votesRequired = nil
 						votesEligible = nil


### PR DESCRIPTION
In the rare (and often unintentional) case of a resign vote for an individual player ("!resign \<player\>" as opposed to "!resign \<player\> TEAM", this widget would previously crash when getting the index of " TEAM".

This commit rewrites the parsing for resign votes such that individual resign votes are properly handled. It also uses explicit variables, and patterns instead of string.find so that the logic is easier to understand. No actual logic is changed apart from the bug fix.

---

This is a log snippet showing the error that this fixes:

```
[t=03:02:30.313948][f=0000044] <Classic> !resign gg
[t=03:02:30.347339][f=0000045] > [teh]clusterEU4[10] * Classic called a vote for command "resign HotshotGG" [!vote y, !vote n, !vote b]
[t=03:02:30.349811][f=0000046] Error in AddConsoleLine(): [string "LuaUI/Widgets/gui_vote_interface.lua"]:416: attempt to perform arithmetic on a nil value
[t=03:02:30.349850][f=0000046] Removed widget: Vote interface
```

I am not sure how to test this outside of an actual multiplayer game or the basic tests that are in the widget code itself (which I did modify locally to do some basic testing), so any testing help would be appreciated.

---

An additional note: the existing line parsing code is pretty fragile (in that it uses string.find and index arithmetic a lot), and I think replacing the rest of the parsing with patterns might be an easy (though low impact) task.