### PR TITLE
Fix unit share chat msg for spectators in radar vision

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -633,8 +633,10 @@ local function commonUnitName(unitIDs)
 	for _, unitID in pairs(unitIDs) do
 		local unitDefID = Spring.GetUnitDefID(unitID)
 
-		if commonUnitDefID and unitDefID ~= commonUnitDefID then
-			return "units"
+		-- unitDefID will be nil if shared units are visible only as unidentified radar dots
+		-- (when spectating with PlayerView ON from enemy team's point of view)
+		if (commonUnitDefID and unitDefID ~= commonUnitDefID) or not unitDefID then
+			return #unitIDs > 1 and "units" or "unit"
 		end
 
 		commonUnitDefID = unitDefID


### PR DESCRIPTION
### Work done

Partially reverts [revert](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2393) by @WatchTheFort.  

The [original PR](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2392) was fixing two issues - one with the chat widget crashing when units are shared inside the radar vision and another one with `UnitTaken` called twice (see points 1 and 2 in addressed issues of the original PR).  

The [first bugfix](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2393/files#diff-50e9e809ac9691ea91cf6bb0ce6b1cced195ea150a9fdcf978972faaf9970ab0L636) is not related to `UnitTaken` being called twice and shouldn't have been reverted. I probably should've made it into two PRs to avoid this confusion.

