### PR TITLE
fix(gui_options): use correct function in attackrange_gl4 options spec

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4020,7 +4020,7 @@ function init()
 			saveOptionValue('Attack Range GL4', 'attackrange', 'setShiftOnly', { 'shift_only' }, value)
 		  end,
 		},
-		{ id = "attackrange_cursorunitrange", category = types.dev, group = "ui", name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.attackrange_cursorunitrange'), type = "bool", value = (WG['attackrange'] ~= nil and WG['attackrange'].setCursorUnitRange ~= nil and WG['attackrange'].setCursorUnitRange()), description = Spring.I18N('ui.settings.option.attackrange_cursorunitrange_descr'),
+		{ id = "attackrange_cursorunitrange", category = types.dev, group = "ui", name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.attackrange_cursorunitrange'), type = "bool", value = (WG['attackrange'] ~= nil and WG['attackrange'].getCursorUnitRange ~= nil and WG['attackrange'].getCursorUnitRange()), description = Spring.I18N('ui.settings.option.attackrange_cursorunitrange_descr'),
 		  onload = function(i)
 			  loadWidgetData("Attack Range GL4", "attackrange_cursorunitrange", { 'cursor_unit_range' })
 		  end,


### PR DESCRIPTION
Previously, the value for `attackrange_cursorunitrange` was set from the return value of `setCursorUnitRange()`, not `getCursorUnitRange()`. This led to "C stack overflow" errors if `setCursorUnitRange()` was called from here, presumably because `setCursorUnitRange()` calls `widget:Initialize()`. In addition, the `gui_attackrange_gl4` widget would then be disabled.

In most cases, this wasn't an issue, because options are usually initialized before other widgets are loaded. This meant that the nil check on `setCursorUnitRange` always failed, and short-circuited the call.

But if a user widget adds a setting, `gui_options.Init()` is called again after widgets have been loaded, which means that `setCursorUnitRange` is not nil, and is called, leading to the error.

#### Test steps
1. Load widgets `gui_options`, `gui_attackrange_gl4`, and then any widget that adds options (the reported widget in this case was "Player Unit Types Display". This is usually the default order anyways if all of them are enabled.

The exact error that occurs is:

```
Error in Initialize(): [string "LuaUI/barwidgets.lua"]:829: C stack overflow
```

There is a report of this issue on discord here: https://discord.com/channels/549281623154229250/1183252603992281088/1183252603992281088