### PR TITLE
Add pregame support to context build

### DIFF
--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -178,7 +178,7 @@ end
 
 function widget:Update()
 	local _, cmdID
-	if isPregame and WG['pregame-build'].getPreGameDefID then
+	if isPregame and WG['pregame-build'] and WG['pregame-build'].getPreGameDefID then
 		cmdID = WG['pregame-build'].getPreGameDefID()
 		cmdID = cmdID and -cmdID or 0 --invert to get the correct negative value
 	else

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -396,7 +396,10 @@ end
 
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
-	WG["pregame-build"].setPreGamestartDefID(uDefID)
+	if WG["pregame-build"] and WG["pregame-build"].setPreGamestartDefID then
+		WG["pregame-build"].setPreGamestartDefID(uDefID)
+	end
+
 	if not uDefID then
 		currentCategory = nil
 		doUpdate = true

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -326,7 +326,8 @@ function widget:DrawWorld()
 	-- Avoid unnecessary overhead after buildqueue has been setup in early frames
 	if Spring.GetGameFrame() > 0 then
 		widgetHandler:RemoveWidgetCallIn('DrawWorld', self)
-
+		widgetHandler:RemoveWidgetCallIn('GameFrame', self)
+		widgetHandler:RemoveWidget()
 		return
 	end
 


### PR DESCRIPTION
### Work done
- Added support for context build during pregame
- Remove pregame build widget at game start
- Add some safety to pregame build calls

#### Test steps
- [ ] Test building any swappable buildings during pregame (eg solar<->tidal)
- [ ] Start game and make sure context build is still functioning

