### PR TITLE
fix(gui_pregame_build): move RemoveWidget() call to after work is done

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -326,8 +326,6 @@ function widget:DrawWorld()
 	-- Avoid unnecessary overhead after buildqueue has been setup in early frames
 	if Spring.GetGameFrame() > 0 then
 		widgetHandler:RemoveWidgetCallIn('DrawWorld', self)
-		widgetHandler:RemoveWidgetCallIn('GameFrame', self)
-		widgetHandler:RemoveWidget()
 		return
 	end
 
@@ -425,6 +423,7 @@ function widget:GameFrame(n)
 	-- Avoid unnecessary overhead after buildqueue has been setup in early frames
 	if #buildQueue == 0 then
 		widgetHandler:RemoveWidgetCallIn('GameFrame', self)
+		widgetHandler:RemoveWidget()
 		return
 	end
 


### PR DESCRIPTION
### Context
Bug report in discord: https://discord.com/channels/549281623154229250/1184623025539252324/1184623025539252324

### Work done
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2403 added this `RemoveWidget()` call; this PR moves it to a slightly later time, when we can be sure that the widget is done with its work.

### Notes
This only sometimes causes issues. My understanding is that this is because it varies whether `GameFrame()` gets called between when the game starts and when `DrawWorld()` gets called and removes the widget.

This is much easier to test if you make this change in `GameFrame()`, so that the widget waits a little longer to issue orders:

```diff
- if not (n <= 90 and n > 1) then return end
+ if not (n <= 90 and n > 30) then return end
```

### Test steps
1. Start a game with builds queued
2. Queue should remain, even with the above testing changes
