### PR TITLE
feat(gui_options): add interface to add/remove several options at once

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -6264,19 +6264,31 @@ function widget:Initialize()
 			return false
 		end
 	end
-	WG['options'].addOption = function(option)
-		option.group = "custom"
-		customOptions[#customOptions+1] = option
+	WG['options'].addOptions = function(newOptions)
+		for _, option in ipairs(newOptions) do
+			option.group = "custom"
+			customOptions[#customOptions+1] = option
+		end
+
 		init()
 	end
-	WG['options'].removeOption = function(name)
-		for i,option in pairs(customOptions) do
-			if option.id == name then
-				customOptions[i] = nil
-				init()
-				break
+	WG['options'].removeOptions = function(names)
+		for _, name in ipairs(names) do
+			for i, option in pairs(customOptions) do
+				if option.id == name then
+					customOptions[i] = nil
+					break
+				end
 			end
 		end
+
+		init()
+	end
+	WG['options'].addOption = function(option)
+		return WG['options'].addOptions({ option })
+	end
+	WG['options'].removeOption = function(name)
+		return WG['options'].removeOptions({ name })
 	end
 end
 


### PR DESCRIPTION
Since adding or removing an option calls `init()`, and `init()` is very expensive to run, adding several options one at a time ends up taking enough time to cause noticeable UI lag (1-2 seconds in some cases).

This commit adds functions that work identically to the previous ones, except that they allow multiple add/removes before calling `init()`.

---

Currently, this probably only affects my widgets (since they're almost the only ones that use custom widget options, and I like adding lots of options when I can get away with it). But it's still a good improvement, in my opinion.

In my testing with the "Player Unit Types Display" widget, which has 13 options (yes, yes, I know, see above), UI lag when toggling the widget goes from very obvious (~1-2s) to practically imperceptible.

---

A basic example use for a user widget (assuming existing common option utility functions):

```lua
function widget:Initialize()
  if WG['options'] ~= nil then
    WG['options'].addOptions(map(OPTION_SPECS, createOptionFromSpec))
  end
end

function widget:Shutdown()
  if WG['options'] ~= nil then
    WG['options'].removeOptions(map(OPTION_SPECS, getOptionId))
  end
end
```
