### PR TITLE
Bugfixes for cmd_commandq_manager.lua

### DIFF
--- a/luaui/Widgets/cmd_commandq_manager.lua
+++ b/luaui/Widgets/cmd_commandq_manager.lua
@@ -21,9 +21,12 @@ local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGetCommandQueueSize = Spring.GetCommandQueue
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spGetUnitCommands = Spring.GetUnitCommands
 
 local CMDREPAIR = CMD.REPAIR
 local CMDRECLAIM = CMD.RECLAIM
+local CMDGUARD = CMD.GUARD
+local CMDPATROL = CMD.PATROL
 
 -- Main functions
 function SkipCurrentCommand()
@@ -47,10 +50,36 @@ end
 -- Helper functions
 function RemoveCommand(unitID, cmdIndex, commandQueueSize)
 	local cmdID, _, cmdTag, _, cmdParam2 = spGetUnitCurrentCommand(unitID, cmdIndex)
-
 	if (cmdID == CMDRECLAIM or cmdID == CMDREPAIR) and cmdParam2 then -- second param means it is an area order
 		local _, _, cmdTag2 = spGetUnitCurrentCommand(unitID, cmdIndex + 1)
 		spGiveOrderToUnit(unitID, CMD.REMOVE, { cmdTag2, cmdTag }, 0)
+	elseif (cmdID == CMDREPAIR) and cmdIndex ~= commandQueueSize then
+		--dirty way to remove weird guard behaviors
+		local cmdID2, _, cmdTag2 = spGetUnitCurrentCommand(unitID, cmdIndex + 1)
+		if cmdID2 == CMDGUARD then
+			spGiveOrderToUnit(unitID, CMD.REMOVE, { cmdTag2, cmdTag }, 0)
+		end
+	elseif (cmdID == CMDGUARD) and (cmdIndex ~= 1) then
+		--again same thing
+		local cmdID2, _, cmdTag2 = spGetUnitCurrentCommand(unitID, cmdIndex - 1)
+		if cmdID2 == CMDREPAIR then
+			spGiveOrderToUnit(unitID, CMD.REMOVE, { cmdTag, cmdTag2 }, 0)
+		end
+	elseif (cmdID == CMD.FIGHT) and (cmdIndex == 1) then  --removes patrol commands too
+		local commands = spGetUnitCommands(unitID, -1)
+		if commands and (commands[2].id == CMDPATROL) then
+			commandQueueSize = commandQueueSize - 2
+			spGiveOrderToUnit(unitID, CMD.STOP, {}, {})
+
+			for i = 1, #commands do
+				if i == 1 then
+					spGiveOrderToUnit(unitID, CMD.MOVE, commands[i].params, {})
+				end
+				if (i ~= cmdIndex) then
+					spGiveOrderToUnit(unitID, commands[i].id, commands[i].params, {"shift"})
+				end
+			end
+		end
 	elseif cmdID then
 		spGiveOrderToUnit(unitID, CMD.REMOVE, { cmdTag }, 0)
 	end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
If the first command is a repair command, it checks if there is a guard command directly after for `command_skip_current`
If the last command is a guard command it also deletes a repair command if there is one for `command_cancel_last`
If the first command is a fight command, it checks for a patrol and deletes this for `command_skip_current`

Addresses #2318 


<!-- If relevant

