### PR TITLE
Lazy load language translation files

### DIFF
--- a/modules/i18n/i18n.lua
+++ b/modules/i18n/i18n.lua
@@ -18,9 +18,7 @@ end
 local function loadLanguageFiles(languageCode)
 	Spring.Log("i18n", "debug", "Loading " .. languageCode .. " translation files.")
 	if languageFiles[languageCode] == nil then
-		Spring.Log("i18n", "warning",
-				"No language files associated with requested language code " ..
-				languageCode)
+		return
 	end
 
 	for _, file in ipairs(languageFiles[languageCode]) do

--- a/modules/i18n/i18n.lua
+++ b/modules/i18n/i18n.lua
@@ -16,7 +16,6 @@ end
 
 -- Loads all language translation files associated with languageCode.
 local function loadLanguageFiles(languageCode)
-	Spring.Log("i18n", "debug", "Loading " .. languageCode .. " translation files.")
 	if languageFiles[languageCode] == nil then
 		return
 	end


### PR DESCRIPTION
### Work done
This change makes the i18n module load language translation files on demand, rather than all at once at module initialization.

This change improves loading performance by about 1s (on my machine).

Tested by going to 'Settings' -> 'Dev' -> Switching 'Language' around.

See  for more info.

#### Addresses Issue(s)
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2414

#### Test steps
- [ ] Start BAR. Go to 'Settings' -> 'Dev' -> switch 'Language' around.
  - The first time the player switches to a new language, it engine will load the language files, which results in some visible lag.
  - Subsequent switches to the loaded language results in a smaller amount of lag.
  - There's still lag for re-rendering the gui with new glyphs due to https://github.com/beyond-all-reason/spring/issues/1126 - 

#### BEFORE:
![Screenshot from 2023-12-16 07-47-17](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/beb4bd21-66d7-4974-a31b-5df7f4cccf7f)

#### AFTER:
![Screenshot from 2023-12-16 08-03-39](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/1e635d9c-202c-4f1e-af8e-0fa6d6b5e114)
![Screenshot from 2023-12-16 08-05-06](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/2130f8ca-803d-4a3e-94f6-6ef0052b5a7e)
![Screenshot from 2023-12-16 08-05-12](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/6273c843-e1c9-47df-ad6c-1958e698e3e3)
![Screenshot from 2023-12-16 08-05-20](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/59731e9c-cc98-4d47-ab07-098a29079446)
![Screenshot from 2023-12-16 08-06-23](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/4f64ba0b-be43-4929-adf4-6c23d2e8ac38)

