### PR TITLE
only assist dgun stall when necessary

### DIFF
--- a/luaui/Widgets/unit_dgun_stall_assist.lua
+++ b/luaui/Widgets/unit_dgun_stall_assist.lua
@@ -41,9 +41,13 @@ local spGetTeamResources = Spring.GetTeamResources
 local spGetTeamUnits = Spring.GetTeamUnits
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetSpectatingState = Spring.GetSpectatingState
+local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
 
 local CMD_DGUN = CMD.DGUN
 local CMD_WAIT = CMD.WAIT
+local CMD_MOVE = CMD.MOVE
+local CMD_REPAIR = CMD.REPAIR
+local CMD_RECLAIM = CMD.RECLAIM
 
 ----------------------------------------------------------------
 -- Callins
@@ -140,8 +144,8 @@ function widget:Update(dt)
 							waitedUnits[#waitedUnits + 1] = uID
 						end
 					else
-						local uCmd = spGetUnitCurrentCommand(uID, 1)
-						if not uCmd or uCmd ~= CMD_WAIT then
+						local uCmd, _, _, cmdParams = spGetUnitCurrentCommand(uID, 1)
+						if not uCmd or (uCmd ~= CMD_WAIT and uCmd ~= CMD_RECLAIM and uCmd ~= CMD_MOVE and (uCmd ~= CMD_REPAIR or (cmdParams and spGetUnitIsBeingBuilt(cmdParams)))) then
 							waitedUnits[#waitedUnits + 1] = uID
 						end
 					end


### PR DESCRIPTION

### Work done
Removes Dgun stall assist wait for move, reclaim, and repair


#### Addresses Issue(s)
- #2275


