### PR TITLE
fix(api_resource_spot_finder): Layer after side configured metal map gadget

### DIFF
--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -1,6 +1,10 @@
 local upget = gadget or widget
 local globalScope = gadget and GG or WG
 
+-- gadget side must be layered after gadgets/map_metal_spot_placer.lua
+-- so that it works with maps with side-configured metal spots
+local layer = gadget and -9 or -999999
+
 function upget:GetInfo()
 	return {
 		name = "API Resource Spot Finder",
@@ -9,7 +13,7 @@ function upget:GetInfo()
 		version = "2.0",
 		date = "November 2010: last update: April 13, 2022",
 		license = "GNU GPL, v2 or later",
-		layer = -999999,
+		layer = layer,
 		enabled = true,
 	}
 end


### PR DESCRIPTION
### Work done

Fix issue where side-configured metal maps werent being picked up by api resource spot finder API gadget side.

#### Test steps
- [x] Pick Azurite Shores map, test that you can place mexes
- [x] Pick Azurite Shores map, disable mex snap widget, test that you can't place mexes outside spots
