### PR TITLE
fix(cmd_mex_denier): Some metal maps have lots of spots

### DIFF
--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -11,6 +11,16 @@ function gadget:GetInfo()
 	}
 end
 
+-- Some of these maps have more than 2 metal spots, disable mex denier
+local metalMaps = {
+	["Oort_Cloud_V2"] = true,
+	["Asteroid_Mines_V2.1"] = true,
+	["Cloud9_V2"] = true,
+	["Iron_Isle_V1"] = true,
+	["Nine_Metal_Islands_V1"] = true,
+	["SpeedMetal BAR V2"] = true,
+}
+
 if not gadgetHandler:IsSyncedCode() then
 	return
 end
@@ -42,12 +52,18 @@ end
 local metalSpotsList
 
 function gadget:Initialize()
+	if metalMaps[Game.mapName] then
+		Spring.Echo(gadget:GetInfo().name, "Indiscrete metal map detected, removing self")
+
+		gadgetHandler:RemoveGadget(self)
+	end
+
 	metalSpotsList = GG["resource_spot_finder"] and GG["resource_spot_finder"].metalSpotsList
 
 	-- no metal spots in map or metalmap
 	-- gadget is not required
 	if not metalSpotsList or #metalSpotsList <= 2 then
-		Spring.Echo("<gadgets/cmd_mex_denier.lua> No, 1 or 2 metal spots found, removing self")
+		Spring.Echo(gadget:GetInfo().name, "None, 1 or 2 metal spots found, removing self")
 
 		gadgetHandler:RemoveGadget(self)
 	end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Some metal maps have more than 2 mex spots, in this PR we add hardcoded checks for these maps.

#### Setup
Pick Cloud9_V2 map or any other speedmetal map with more than 2 mex spots.

#### Test steps
- [ ] Placing a mex should be successful