### PR TITLE
Expanded T2 sea adjustments

### DIFF
--- a/units/ArmAircraft/armdrone.lua
+++ b/units/ArmAircraft/armdrone.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/ARMDRONE.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd",
-		sightdistance = 500,
+		sightdistance = 600,
 		turninplaceanglelimit = 360,
 		turnrate = 1000,
 		customparams = {

--- a/units/ArmShips/T2/armantiship.lua
+++ b/units/ArmShips/T2/armantiship.lua
@@ -43,7 +43,7 @@ return {
 		script = "Units/ARMANTISHIP.cob",
 		seismicsignature = 0,
 		selfdestructas = "minifusionExplosion",
-		sightdistance = 1105,
+		sightdistance = 1000,
 		sonardistance = 760,
 		terraformspeed = 5000,
 		turninplace = true,

--- a/units/ArmShips/T2/armdronecarry.lua
+++ b/units/ArmShips/T2/armdronecarry.lua
@@ -155,8 +155,8 @@ return {
 					spawns_surface = "SEA",    -- "LAND" or "SEA". The SEA option has not been tested currently.
 					spawnrate = 4, 				--Spawnrate roughly in seconds.
 					maxunits = 16,				--Will spawn units until this amount has been reached.
-					energycost = 750,--650,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
-					metalcost = 30,--29,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
+					energycost = 600,--650,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
+					metalcost = 25,--29,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
 					controlradius = 1400,			--The spawned units should stay within this radius. Unfinished behavior may cause exceptions. Planned: radius = 0 to disable radius limit.
 					decayrate = 6,
 					attackformationspread = 120,	--Used to spread out the drones when attacking from a docked state. Distance between each drone when spreading out.

--- a/units/CorAircraft/cordrone.lua
+++ b/units/CorAircraft/cordrone.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/CORDRONE.cob",
 		seismicsignature = 0,
 		selfdestructas = "tinyExplosionGenericSelfd",
-		sightdistance = 500,
+		sightdistance = 600,
 		turninplaceanglelimit = 360,
 		turnrate = 900,
 		upright = true,

--- a/units/CorShips/T2/corantiship.lua
+++ b/units/CorShips/T2/corantiship.lua
@@ -43,7 +43,7 @@ return {
 		script = "Units/CORANTISHIP.cob",
 		seismicsignature = 0,
 		selfdestructas = "minifusionExplosion",
-		sightdistance = 1105,
+		sightdistance = 1000,
 		sonardistance = 760,
 		terraformspeed = 5000,
 		turninplace = true,

--- a/units/CorShips/T2/cordronecarry.lua
+++ b/units/CorShips/T2/cordronecarry.lua
@@ -155,8 +155,8 @@ return {
 					spawns_surface = "SEA",    -- "LAND" or "SEA". The SEA option has not been tested currently.
 					spawnrate = 6, 				--Spawnrate roughly in seconds.
 					maxunits = 10,				--Will spawn units until this amount has been reached.
-					energycost = 1000,--650,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
-					metalcost = 40,--29,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
+					energycost = 750,--650,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
+					metalcost = 30,--29,			--Custom spawn cost. Remove this or set = nil to inherit the cost from the carried_unit unitDef. Cost inheritance is currently not working.
 					controlradius = 1400,			--The spawned units should stay within this radius. Unfinished behavior may cause exceptions. Planned: radius = 0 to disable radius limit.
 					decayrate = 9,
 					attackformationspread = 200,	--Used to spread out the drones when attacking from a docked state. Distance between each drone when spreading out.


### PR DESCRIPTION
Reduced drone cost ~20% and increased drone los (500->600) so drones can be a bit more effective when used as expendable vision.  T2 support ships los reduced 1105->1000.