### PR TITLE
fix(unit_immobile_builder): only remove fight command for relevant units

### DIFF
--- a/luaui/Widgets/unit_immobile_builder.lua
+++ b/luaui/Widgets/unit_immobile_builder.lua
@@ -131,7 +131,7 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 end
 
 function widget:UnitCommand(unitID, unitDefID, _, cmdID, _, cmdOpts)
-	if cmdID ~= CMD_FIGHT then
+	if isImmobileBuilder[unitDefID] and cmdOpts.shift and cmdID ~= CMD_FIGHT then
 		local firstCmdID, _, cmdTag = spGetUnitCurrentCommand(unitID, 1)
 		if firstCmdID == CMD_FIGHT then
 			spGiveOrderToUnit(unitID, CMD.REMOVE, { cmdTag }, 0)


### PR DESCRIPTION
4b2dff025e13540d8f9c8628f01a680d948111e0 (https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2421) introduced a change that removed fight commands when another order was shift-queued. Unfortunately, it was missing a check for the relevant units, so this applied to things like factories or combat units, removing fight commands from them if any other order was given.

This commit adds two checks:

* that the unit is an immobile builder
* that the command was issued with shift

#### Test steps
1. Give any unit a fight command, and then shift-queue another order (including build commands for factories, for example)
2. The fight command should be removed for nanos, and not other units
