### PR TITLE
Build priority refactor

### DIFF
--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -19,8 +19,8 @@ function gadget:GetInfo()
 	return {
 		name	  = 'Builder Priority', 	-- this once was named: Passive Builders v3
 		desc	  = 'Builders marked as low priority only use resources after others builder have taken their share',
-		author	= 'BrainDamage, Bluestone',
-		date	  = 'Why is date even relevant',
+		author	= 'Beherith, Floris',
+		date	  = '2023.12.28',
 		license   = 'GNU GPL, v2 or later',
 		layer	 = 0,
 		enabled   = true

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -209,12 +209,12 @@ local function UpdatePassiveBuilders(teamID, interval)
 		local canBuildTeam = canBuild[teamID]
 		for builderID in pairs(canBuildTeam) do
 			local builtUnit = spGetUnitIsBuilding(builderID)
-			local expenseMetal = builtUnit and costIDOverride[unitID] or nil
+			local expenseMetal = builtUnit and costIDOverride[builtUnit] or nil
 			local maxbuildspeed = maxBuildSpeed[builderID]
 			if builtUnit and expenseMetal and maxbuildspeed then	-- added check for maxBuildSpeed[builderID] else line below could error (unsure why), probably units that were newly created?
 
-				local expenseEnergy = costIDOverride[unitID + energyOffset]
-				local rate = maxbuildspeed / costIDOverride[unitID + buildTimeOffset]
+				local expenseEnergy = costIDOverride[builtUnit + energyOffset]
+				local rate = maxbuildspeed / costIDOverride[builtUnit + buildTimeOffset]
 
 				-- TODO: redo solar and basic MM no-stall logic
 				
@@ -331,8 +331,9 @@ function gadget:TeamChanged(teamID)
 end
 
 function gadget:GameFrame(n)
-	-- Looping through all build target owners for godforsaken unknown reasons
-	-- but this is fast anyway, only a 75us usecs for a hundred units.
+	
+	-- Thus on the next frame, we can loop through build target owners and
+	-- set their buildpower to what we wanted instead of 0.001 we had for 1 frame.
 	if tracy then tracy.ZoneBeginN("redundant set") end
 	for  builtUnit, builderID in pairs(buildTargets) do
 		if spValidUnitID(builderID) and spGetUnitIsBuilding(builderID) == builtUnit then

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -122,7 +122,7 @@ function gadget:UnitCreated(unitID, unitDefID, teamID)
 	if canPassive[unitDefID] then
 		spInsertUnitCmdDesc(unitID, cmdPassiveDesc)
 		if not passiveCons[teamID] then passiveCons[teamID] = {} end
-		passiveCons[teamID][unitID] = spGetUnitRulesParam(unitID,ruleName) == 1 or nil
+		passiveCons[teamID][unitID] = spGetUnitRulesParam(unitID,ruleName) ~= 1 or nil
 		currentBuildSpeed[unitID] = maxBuildSpeed[unitID]
 		spSetUnitBuildSpeed(unitID, currentBuildSpeed[unitID]) -- to handle luarules reloads correctly
 	end

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -345,7 +345,8 @@ function gadget:GameFrame(n)
         end
     end
 	--buildTargetOwners = {}
-    buildTargets = (next(buildTargets) and buildTargets) or {} -- check if table is empty and if not reallocate it!
+	buildTargets = (next(buildTargets) and {}) or buildTargets -- check if table is empty and if not reallocate it!
+	
 	if tracy then tracy.ZoneEnd() end
 	for i=1, #teamList do
 		local teamID = teamList[i]


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Late game, the Builder Priority gadget is one of the top consumers of CPU and garbage creation. 
This is a complete refactor of the gadget, with the old code left in comments for ease of comparison.

To the best of my knowledge, this has the exact same result and functionality of the old gadget, twice as fast and 1/10 the garbage load. 

It uses methods some might consider nasty, like flattening of tables of tables. 

### UNEVEN PASSIVE RESOURCE DISTRIBUTION
It also highlights a problem:

The order in which passive constructors get resources is uneven, and depends on processing order of passive builders: first ones processed get remaining resources after active builders have taken their share. 

Relevant Issue:
https://github.com/beyond-all-reason/Beyond-All-Reason/issues?q=is%3Aissue+is%3Aopen+construction

### Round-robin passive resource distribution
Now extra low-prio resources are distributed in a round robin fashion. 
You may also enable the DEBUG switch of the gadget to get a display of the actual buildspeed numbers!

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Please test that builders are passive as needed, no novel stalls are detected, and that no errors are thrown. 
- [x] Remove stale comments once no regressions found

### Screenshot:
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/109391/b2f9c323-c1e5-42e4-adb4-9672782b92da)

