### PR TITLE
fix(gui_options): preserve custom options when running init()

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2080,6 +2080,11 @@ function init()
 		end
 	end
 
+	local oldValues = {}
+	for _, option in ipairs(options) do
+		oldValues[option.id] = option.value
+	end
+
 	options = {
 		--GFX
 		{ id = "preset", group = "gfx", category = types.basic, name = Spring.I18N('ui.settings.option.preset'), type = "select", options = presetNames, value = presetCodes[Spring.GetConfigString('graphicsPreset')],
@@ -5936,6 +5941,9 @@ function init()
 			if userwidgetOptions[name] then
 				for k, customOption in pairs(userwidgetOptions[name]) do
 					options[#options+1] = table.copy(customOptions[customOption])
+					if oldValues[options[#options].id] ~= nil then
+						options[#options].value = oldValues[options[#options].id]
+					end
 					options[#options].name = widgetOptionColor..'  '..options[#options].name
 					usedCustomOptions[customOption] = true
 				end


### PR DESCRIPTION
Explicit options within gui_options.lua have a built-in way to get the current value of themselves, but custom options do not have such a mechanism. Thus, previously, running `init()` would reset any custom options to their value when `addOption()` was called.

This change makes it so init() saves all old option values, and uses them when initializing custom options.

Many times this isn't relevant, but currently, pressing escape to close the options window triggers this bug.

#### Test steps
1. Open options window
2. Change a user widget option
3. Press escape or otherwise trigger `init()` in `gui_options`
4. If necessary, open options again
5. Options should keep the values you just set
