### PR TITLE
Raptor eco pathing update

### DIFF
--- a/luarules/configs/raptor_spawn_defs.lua
+++ b/luarules/configs/raptor_spawn_defs.lua
@@ -1132,37 +1132,6 @@ local ecoBuildingsPenalty = { -- Additional queen hatch per second from eco buil
 	]]--
 }
 
-local highValueTargets = { -- Priority targets for Raptors. Must be immobile to prevent issues.
-	-- T2 Energy
-	[UnitDefNames["armwint2"].id] 	= true,
-	[UnitDefNames["corwint2"].id] 	= true,
-	[UnitDefNames["armfus"].id] 	= true,
-	[UnitDefNames["armckfus"].id] 	= true,
-	[UnitDefNames["corfus"].id] 	= true,
-	[UnitDefNames["armuwfus"].id] 	= true,
-	[UnitDefNames["coruwfus"].id] 	= true,
-	[UnitDefNames["armageo"].id] 	= true,
-	[UnitDefNames["corageo"].id] 	= true,
-	[UnitDefNames["armafus"].id] 	= true,
-	[UnitDefNames["corafus"].id] 	= true,
-	-- T2 Metal Makers
-	[UnitDefNames["armmmkr"].id] 	= true,
-	[UnitDefNames["cormmkr"].id] 	= true,
-	[UnitDefNames["armuwmmm"].id] 	= true,
-	[UnitDefNames["coruwmmm"].id] 	= true,
-	-- T2 Metal Extractors
-	[UnitDefNames["cormoho"].id] 	= true,
-	[UnitDefNames["armmoho"].id] 	= true,
-	-- Nukes
-	[UnitDefNames["corsilo"].id] 	= true,
-	[UnitDefNames["armsilo"].id] 	= true,
-	-- Antinukes
-	[UnitDefNames["armamd"].id] 	= true,
-	[UnitDefNames["corfmd"].id] 	= true,
-	-- Decoys
-	[UnitDefNames["armdf"].id]    	= true,
-}
-
 local config = { -- Don't touch this! ---------------------------------------------------------------------------------------------------------------------------------------------
 	useEggs 				= useEggs,
 	useScum					= useScum,
@@ -1186,7 +1155,6 @@ local config = { -- Don't touch this! ------------------------------------------
 	squadSpawnOptionsTable	= squadSpawnOptionsTable,
 	airStartAnger			= airStartAnger,
 	ecoBuildingsPenalty		= ecoBuildingsPenalty,
-	highValueTargets		= highValueTargets,
 	bossFightWaveSizeScale  = bossFightWaveSizeScale,
 	defaultRaptorFirestate = defaultRaptorFirestate,
 }

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1266,15 +1266,15 @@ if gadgetHandler:IsSyncedCode() then
 			if unitDef.energyMake then
 				ecoValue = ecoValue + unitDef.energyMake
 			end
-
 			if unitDef.energyUpkeep < 0 then
 				ecoValue = ecoValue - unitDef.energyUpkeep
 			end
-
 			if unitDef.windGenerator then
 				ecoValue = ecoValue + unitDef.windGenerator*0.75
 			end
-				
+			if unitDef.extractsMetal > 0 then
+				ecoValue = ecoValue + 400
+			end
 			if unitDef.customParams and unitDef.customParams.energyconv_capacity then
 				ecoValue = ecoValue + unitDef.customParams.energyconv_capacity / 2
 			end

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -137,8 +137,6 @@ if gadgetHandler:IsSyncedCode() then
 	local squadsTable = {}
 	local unitSquadTable = {}
 	local squadTargetsByEcoWeight = {}
-	local squadPotentialTarget = {}
-	local squadPotentialHighValueTarget = {}
 	local unitTargetPool = {}
 	local unitCowardCooldown = {}
 	local unitTeleportCooldown = {}
@@ -224,9 +222,6 @@ if gadgetHandler:IsSyncedCode() then
 	
 	local SetListUtilities = VFS.Include('common/SetList.lua')
 
-	squadPotentialTarget = SetListUtilities.NewSetListNoTable()
-	squadPotentialHighValueTarget = SetListUtilities.NewSetListNoTable()
-
 	function SetToList(set)
 		local list = {}
 		local count = 0
@@ -256,68 +251,40 @@ if gadgetHandler:IsSyncedCode() then
 		-- Pre-opt: 224 us, sigma 105 us!
 		-- Post-opt: 3 us, sigma 1us
 		tracy.ZoneBeginN("Raptors:getRandomEnemyPos")
-		local loops = 0
-		local targetCount = squadPotentialTarget.count
-		local highValueTargetCount = squadPotentialHighValueTarget.count
 		local pos = {}
 		local pickedTarget = nil
 
-		-- Mod
-		if Spring.GetModOptions().raptorsEcoWeightPathing == true then
+		local ecoTierMaxProbability = 0
+
+		for weight,units in pairs(squadTargetsByEcoWeight) do
+			ecoTierMaxProbability = ecoTierMaxProbability + weight * units.count
+		end
+
+		local random = mRandom(1, ecoTierMaxProbability)
+		ecoTierMaxProbability = 0
+
+		-- 10 tries to find a valid target
+		for try = 1, 10 do
 
 			for weight,units in pairs(squadTargetsByEcoWeight) do
 				ecoTierMaxProbability = ecoTierMaxProbability + weight * units.count
-			end
 
-			local random = mRandom(1, ecoTierMaxProbability)
-			ecoTierMaxProbability = 0
-
-			-- 10 tries to find a valid target
-			for try = 1, 10 do
-
-				for weight,units in pairs(squadTargetsByEcoWeight) do
-					ecoTierMaxProbability = ecoTierMaxProbability + weight * units.count
-
-					if random <= ecoTierMaxProbability then
-						local target = squadTargetsByEcoWeight[weight]:GetRandom()
-						if ValidUnitID(target) and not GetUnitIsDead(target) and not GetUnitNeutral(target) then
-							-- Spring.Echo("Targetting eco: " .. random .. " found " .. UnitDefs[Spring.GetUnitDefID(target)].name);
-
-							local x,y,z = Spring.GetUnitPosition(target)
-							pos = {x = x+mRandom(-32,32), y = y, z = z+mRandom(-32,32)}
-							pickedTarget = target
-							break
-						end
-					end
-				end
-
-				if pos.x then
-					break
-				end
-			end
-		else
-			local highValueTargetPickChance = math.min(0.75, highValueTargetCount*0.15)
-			repeat
-				loops = loops + 1
-				if highValueTargetCount > 0 and mRandom() <= highValueTargetPickChance then
-					local target = squadPotentialHighValueTarget:GetRandom()
+				if random <= ecoTierMaxProbability then
+					local target = squadTargetsByEcoWeight[weight]:GetRandom()
 					if ValidUnitID(target) and not GetUnitIsDead(target) and not GetUnitNeutral(target) then
-						local x,y,z = Spring.GetUnitPosition(target)
-						pos = {x = x+mRandom(-32,32), y = y, z = z+mRandom(-32,32)}
-						pickedTarget = target
-						break
-					end
-				else
-					local target = squadPotentialTarget:GetRandom()
-					if ValidUnitID(target) and not GetUnitIsDead(target) and not GetUnitNeutral(target) then
+						-- Spring.Echo("Targetting eco: " .. random .. " found " .. UnitDefs[Spring.GetUnitDefID(target)].name);
+
 						local x,y,z = Spring.GetUnitPosition(target)
 						pos = {x = x+mRandom(-32,32), y = y, z = z+mRandom(-32,32)}
 						pickedTarget = target
 						break
 					end
 				end
-	
-			until pos.x or loops >= 10
+			end
+
+			if pos.x then
+				break
+			end
 		end
 
 		if not pos.x then
@@ -1277,80 +1244,59 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 
-		-- Mod
-		if Spring.GetModOptions().raptorsEcoWeightPathing == true then
+		local unitDef = UnitDefs[unitDefID]
 
-			local unitDef = UnitDefs[unitDefID]
-
-			if unitTeam == raptorTeamID then
-				Spring.GiveOrderToUnit(unitID,CMD.FIRE_STATE,{config.defaultRaptorFirestate},0)
-				if unitDef.canCloak then
-					Spring.GiveOrderToUnit(unitID,37382,{1},0)
-				end
-				return
+		if unitTeam == raptorTeamID then
+			Spring.GiveOrderToUnit(unitID,CMD.FIRE_STATE,{config.defaultRaptorFirestate},0)
+			if unitDef.canCloak then
+				Spring.GiveOrderToUnit(unitID,37382,{1},0)
 			end
-
-			-- For each squadTargetsByEcoWeight, remove them
-			for _,unitList in pairs(squadTargetsByEcoWeight) do
-				unitList:Remove(unitID)
-			end
-
-			if not unitDef.canMove then
-				-- Calculate an eco value based on energy and metal production
-				local ecoValue = 1
-
-				if unitDef.energyMake then
-					ecoValue = ecoValue + unitDef.energyMake
-				end
-
-				if unitDef.energyUpkeep < 0 then
-					ecoValue = ecoValue - unitDef.energyUpkeep
-				end
-
-				if unitDef.windGenerator then
-					ecoValue = ecoValue + unitDef.windGenerator*0.75
-				end
-					
-				if unitDef.customParams and unitDef.customParams.energyconv_capacity then
-					ecoValue = ecoValue + unitDef.customParams.energyconv_capacity / 2
-				end
-
-				-- Spring.Echo("Built units eco value: " .. ecoValue)
-
-				-- Ends up building an object like:
-				-- {
-				--  0: [non-eco]
-				--	25: [t1 windmill, t1 solar, t1 mex],
-				--	75: [adv solar]
-				--	1000: [fusion]
-				--	3000: [adv fusion]
-				-- }
-
-				if not squadTargetsByEcoWeight[ecoValue] then
-					squadTargetsByEcoWeight[ecoValue] = SetListUtilities.NewSetListNoTable()
-				end
-
-				squadTargetsByEcoWeight[ecoValue]:Add(unitID)
-			end
-		else
-			if unitTeam == raptorTeamID then
-				Spring.GiveOrderToUnit(unitID,CMD.FIRE_STATE,{config.defaultRaptorFirestate},0)
-				if UnitDefs[unitDefID].canCloak then
-					Spring.GiveOrderToUnit(unitID,37382,{1},0)
-				end
-				return
-			end
-			
-			squadPotentialTarget:Remove(unitID)
-			squadPotentialHighValueTarget:Remove(unitID)
-
-			if not UnitDefs[unitDefID].canMove then
-				squadPotentialTarget:Add(unitID)
-				if config.highValueTargets[unitDefID] then
-					squadPotentialHighValueTarget:Add(unitID)
-				end
-			end
+			return
 		end
+
+		-- For each squadTargetsByEcoWeight, remove them
+		for _,unitList in pairs(squadTargetsByEcoWeight) do
+			unitList:Remove(unitID)
+		end
+
+		if not unitDef.canMove then
+			-- Calculate an eco value based on energy and metal production
+			local ecoValue = 1
+
+			if unitDef.energyMake then
+				ecoValue = ecoValue + unitDef.energyMake
+			end
+
+			if unitDef.energyUpkeep < 0 then
+				ecoValue = ecoValue - unitDef.energyUpkeep
+			end
+
+			if unitDef.windGenerator then
+				ecoValue = ecoValue + unitDef.windGenerator*0.75
+			end
+				
+			if unitDef.customParams and unitDef.customParams.energyconv_capacity then
+				ecoValue = ecoValue + unitDef.customParams.energyconv_capacity / 2
+			end
+
+			-- Spring.Echo("Built units eco value: " .. ecoValue)
+
+			-- Ends up building an object like:
+			-- {
+			--  0: [non-eco]
+			--	25: [t1 windmill, t1 solar, t1 mex],
+			--	75: [adv solar]
+			--	1000: [fusion]
+			--	3000: [adv fusion]
+			-- }
+
+			if not squadTargetsByEcoWeight[ecoValue] then
+				squadTargetsByEcoWeight[ecoValue] = SetListUtilities.NewSetListNoTable()
+			end
+
+			squadTargetsByEcoWeight[ecoValue]:Add(unitID)
+		end
+
 		if config.ecoBuildingsPenalty[unitDefID] then
 			playerAggressionEcoValue = playerAggressionEcoValue + (config.ecoBuildingsPenalty[unitDefID]/(config.queenTime/3600)) -- scale to 60minutes = 3600seconds queen time
 		end
@@ -1936,14 +1882,8 @@ if gadgetHandler:IsSyncedCode() then
 			unitSquadTable[unitID] = nil
 		end
 
-		-- Mod
-		if Spring.GetModOptions().raptorsEcoWeightPathing == true then
-			for _,unitList in pairs(squadTargetsByEcoWeight) do
-				unitList:Remove(unitID)
-			end
-		else
-			squadPotentialTarget:Remove(unitID)
-			squadPotentialHighValueTarget:Remove(unitID)
+		for _,unitList in pairs(squadTargetsByEcoWeight) do
+			unitList:Remove(unitID)
 		end
 
 		for squad in ipairs(unitTargetPool) do


### PR DESCRIPTION
The reason for this PR:

If you play any multiplayer raptors game (with a high number of players), you'll see talk of T2 eco in the chat.  "Don't do it!" etc.

Often, a new player will innocently early-build a T2 wind, or T2 converter.  When that happens, the entire maps worth of raptors targets them. That player will be annihilated, and left confused.  The players next to that one will be wiped out by the wave as well, leaving them salty.

The previous implementation had a naïve list of 'high value targets'.  When one existed, it drew the whole maps raptors attention.

This PR instead creates weighted sets of targets based on the eco produced by that building type.  It is performant as it uses sets based on the eco value of the unit.  

There are commented out lines of Spring.Echo() calls which show how it works.

Similar pathing code is present in scavs, so it should be ported there too.