### PR TITLE
Gridmenu: Fix render delay when exiting category during pregame

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -474,6 +474,7 @@ end
 local function setCurrentCategory(category)
 	currentCategory = category
 	setupCategoryRects()
+	doUpdate = true
 end
 
 


### PR DESCRIPTION
### Work done
Title

#### Test steps
- [ ] Test using shift to exit a category during pregame while the mouse is not hovering over the menu. Expect the menu to visually update correctly
