### PR TITLE
Use local Spring.GetModOptions() on unit_paralyze_damage_limit gadget initialization

### DIFF
--- a/luarules/gadgets/unit_paralyze_damage_limit.lua
+++ b/luarules/gadgets/unit_paralyze_damage_limit.lua
@@ -16,7 +16,9 @@ if not gadgetHandler:IsSyncedCode() then
     return false
 end
 
-local maxTime = Spring.GetModOptions().emprework==true and 10 or 20 --- bug fixed
+local modOptions = Spring.GetModOptions()
+
+local maxTime = modOptions.emprework==true and 10 or 20 --- bug fixed
 
 
 local excluded = {
@@ -44,7 +46,7 @@ for udid, ud in pairs(UnitDefs) do
 	end
 
 	
-	if Spring.GetModOptions().emprework==true then
+	if modOptions.emprework==true then
 		unitOhms[udid] = ud.customParams.paralyzemultiplier or 1
 		--Spring.Echo('ohm', ud.customParams.paralyzemultiplier)
 		if tonumber(ud.customParams.paralyzemultiplier) or 0 > 0 then


### PR DESCRIPTION
Performance profiling shows the `Spring.GetModOptions()` call out is slightly expensive. Gadgets that calls Spring.GetModOptions when iterating through Unit/Feature/WeaponDefs tends to take significantly longer. This change saves ~100ms when loading the unit_paralyze_damage_limit.lua gadget.

See #2458 for a similar change but with a much more significant gain. Prior to #2458 GetModOptions was called ~20 times per iteration of UnitDef during unit postprocessing. The changes in #2458 saves about 1 sec in load times. In this change, GetModOptions is only called once per iteration of UnitDef, so the total time saved is significantly less.
