### PR TITLE
Use VFS.DirList to quickly check presence of file

### DIFF
--- a/luarules/gadgets/gfx_unit_glass.lua
+++ b/luarules/gadgets/gfx_unit_glass.lua
@@ -289,10 +289,19 @@ local isSpec, fullview = Spring.GetSpectatingState()
 local myAllyTeamID = Spring.GetMyAllyTeamID()
 local myTeamID = Spring.GetMyTeamID()
 
+local unitTextureFilesArray = VFS.DirList("unittextures/")
+local unitTextureFiles = {}
+for _, path in pairs(unitTextureFilesArray) do
+	unitTextureFiles[path] = true
+end
+
 local normalMaps = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	if unitDef.customParams.normaltex and VFS.FileExists(unitDef.customParams.normaltex) then
-		normalMaps[unitDefID] = unitDef.customParams.normaltex
+	local unitNormalTexture = unitDef.customParams.normaltex
+	if unitNormalTexture and (
+			unitTextureFiles[string.lower(unitNormalTexture)] or
+			VFS.FileExists(unitNormalTexture)) then
+		normalMaps[unitDefID] = unitNormalTexture
 	else
 		normalMaps[unitDefID] = "unittextures/blank_normal.dds"
 	end


### PR DESCRIPTION
### Work done
Optimize loading (unsycned) gadget `luarules/gadgets/gfx_unit_glass.lua`.

Calls to VFS.FileExists is expensive inside a loop over units with normal maps defined. This change ensures that only a single callout to VFS is made for the common case when checking for the existance of a file inside the 'unittextures' directory.

This optimization is functionally no-op for the following reasons:
- VFS is case insensitive. Thus `unitTextureFiles` only looks at the lowercased file names.
- For cases when the file is not found in the `unitTextureFiles` set, we still fall back to the original code calling VFS.FileExists.

Verified by adding a `Spring.Debug.TableEcho(normalMaps)` before and after this change is applied and diffing the output (identical).

Saves around 100ms in load time.

### Screenshots:


#### BEFORE:
![Screenshot from 2024-01-01 10-58-23](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/669e631c-0bef-4b7e-b16a-ce86692e73ad)

#### AFTER:
![Screenshot from 2024-01-01 10-47-35](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/235c2375-ed76-4d7c-945b-6f4060580934)

