### PR TITLE
Use table.sort for unit order in the buildmenu

### DIFF
--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -144,7 +144,6 @@ for _, _ in pairs(UnitDefs) do
 	unitOrder[count] = count
 	count = count + 1
 end
-local totalUnits = count
 
 -- maxOrder is the largest order value found in unitOrderManualOverrideTable.
 -- Units with no value in unitOrderManualOverrideTable will implicitly take the

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -132,57 +132,46 @@ end
 -- UNIT ORDER ----------------------
 ------------------------------------
 
+-- At the end of this 'UNIT ORDER' section, unitOrder is an array with unitIDs
+-- sorted by their value specified in unitOrderManualOverrideTable. If no
+-- value is specified, the unit will be placed at the end of the array.
 local unitOrder = {}
 local unitOrderManualOverrideTable = VFS.Include("luaui/configs/buildmenu_sorting.lua")
 
-for unitDefID, _ in pairs(UnitDefs) do
-	if unitOrderManualOverrideTable[unitDefID] then
-		unitOrder[unitDefID] = -unitOrderManualOverrideTable[unitDefID]
-	else
-		unitOrder[unitDefID] = 9999999
-	end
-end
-
-local function getHighestOrderedUnit()
-	local highest = { 0, 0, false }
-	local firstOrderTest = true
-	local newSortingUnit = {}
-	for unitDefID, orderValue in pairs(unitOrder) do
-
-		if unitOrderManualOverrideTable[unitDefID] then
-			newSortingUnit[unitDefID] = true
-		else
-			newSortingUnit[unitDefID] = false
-		end
-
-		if firstOrderTest == true then
-			firstOrderTest = false
-			highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-			--elseif orderValue > highest[2] then
-		elseif highest[3] == false and newSortingUnit[unitDefID] == true then
-			highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-		elseif highest[3] == false and newSortingUnit[unitDefID] == false then
-			if orderValue > highest[2] then
-				highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-			end
-		elseif highest[3] == true and newSortingUnit[unitDefID] == true then
-			if orderValue > highest[2] then
-				highest = { unitDefID, orderValue, newSortingUnit[unitDefID]}
-			end
-		end
-	end
-	return highest[1]
-end
-
-local unitsOrdered = {}
+-- Populate unitOrder with identity values.
+local count = 1
 for _, _ in pairs(UnitDefs) do
-	local uDefID = getHighestOrderedUnit()
-	unitsOrdered[#unitsOrdered + 1] = uDefID
-	unitOrder[uDefID] = nil
+	unitOrder[count] = count
+	count = count + 1
 end
+local totalUnits = count
 
-unitOrder = unitsOrdered
-unitsOrdered = nil
+-- maxOrder is the largest order value found in unitOrderManualOverrideTable.
+-- Units with no value in unitOrderManualOverrideTable will implicitly take the
+-- maxOrder value when sorting unitOrder below.
+local maxOrder = 0
+for _, order in pairs(unitOrderManualOverrideTable) do
+	if order > maxOrder then
+		maxOrder = order
+	end
+end
+maxOrder = maxOrder + 1
+
+-- Sorts unitIDs by their order value (if one exists) specified in
+-- unitOrderManualOverrideTable. All units who do not have an order value
+-- specified in unitOrderManualOverrideTable are considered to have an order
+-- value of maxOrder.
+-- For units who have the same order value we compare the unit's IDs.
+-- This sort is always stable, as no two units should have the same ID.
+table.sort(unitOrder, function(aID, bID)
+			local aOrder = unitOrderManualOverrideTable[aID] or maxOrder
+			local bOrder = unitOrderManualOverrideTable[bID] or maxOrder
+
+			if (aOrder == bOrder) then
+			  return aID < bID
+			end
+			return aOrder < bOrder
+		end)
 
 local voidWater = false
 local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs


### PR DESCRIPTION
## Work Done
Cuts down 'luaui/configs/unit_buildmenu_config.lua' load times from ~450ms to ~30 ms.


Units in the default build menu are listed by the order specified in 'luaui/configs/buildmenu_sorting.lua'. When loading LuaUI rules, the sorting is performed by repeatedly finding the largest value in the buildmenu_sorting.lua table, contributing to ~400ms in LuaUI rules load times.

This change uses Lua's table.sort to quickly sort the units in the buildmenu.

Tested by diffing `Spring.Debug.TableEcho(unitOrder)` before and after the change. No diffs.

### Screenshots:


#### BEFORE:
![before](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/3b2e3440-5874-4973-a39b-e3cc96568e31)


#### AFTER:

![after](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/da34e505-b6f7-482e-bbe8-46ed426977a4)
