### PR TITLE
Fix/Expand ingame votes

### DIFF
--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -11,7 +11,7 @@ function widget:GetInfo()
 end
 
 -- dont show vote buttons for specs when containing the following keywords (use lowercase)
-local globalVoteWords =  { 'forcestart', 'stop', 'joinas' }
+local globalVoteWords =  { 'forcestart', 'stop', 'joinas', 'kickban', 'gkick', 'bkick', 'nospecchat' }
 
 local INDIVIDUAL_RESIGN_VOTE_PATTERN = "called a vote for command \"resign ([^%s]+)\""
 local TEAM_RESIGN_VOTE_PATTERN = "called a vote for command \"resign ([^%s]+) TEAM\""


### PR DESCRIPTION
Show vote buttons for all teams (ALL PLAYERS / NOT SPECS) when vote is (**kickban, gkick, bkick, nospecchat**)

Previous implementation only shows vote buttons for users that are on same team as the vote initiator.
Of course this leads to more people voting yes 
