### PR TITLE
New balance modoption

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1594,7 +1594,168 @@ if modOptions.air_rework == true then
 	end
 end
 
-
+--Lategame Rebalance
+if Spring.GetModOptions().lategame_rebalance == true then
+	if name == "armmart" then
+		uDef.metalcost = 320
+		uDef.energycost = 4900
+		uDef.buildtime = 6500
+	end
+	if name == "cormart" then
+		uDef.metalcost = 400
+		uDef.energycost = 4400
+		uDef.buildtime = 6500
+	end
+	if name == "armamb" then
+		uDef.weapondefs.armamb_gun.reloadtime = 2
+		uDef.weapondefs.armamb_gun_high.reloadtime = 7.7
+	end
+	if name == "cortoast" then
+		uDef.weapondefs.cortoast_gun.reloadtime = 2.35
+		uDef.weapondefs.cortoast_gun_high.reloadtime = 8.8
+	end
+	if name == "armpb" then
+		uDef.weapondefs.armpb_weapon.reloadtime = 1.7
+		uDef.weapondefs.armpb_weapon.range = 700
+	end
+	if name == "corvipe" then
+		uDef.weapondefs.vipersabot.reloadtime = 2.1
+		uDef.weapondefs.vipersabot.range = 700
+	end
+	if name == "armanni" then
+		uDef.metalcost = 4000
+		uDef.energycost = 85000
+		uDef.buildtime = 59000
+	end
+	if name == "corbhmth" then
+		uDef.metalcost = 3600
+		uDef.energycost = 40000
+		uDef.buildtime = 70000
+	end
+	if name == "armbrtha" then
+		uDef.metalcost = 5000
+		uDef.energycost = 71000
+		uDef.buildtime = 94000
+	end
+	if name == "corint" then
+		uDef.metalcost = 5100
+		uDef.energycost = 74000
+		uDef.buildtime = 103000
+	end
+	if name == "armvulc" then
+		uDef.metalcost = 75600
+		uDef.energycost = 902400
+		uDef.buildtime = 1680000
+	end
+	if name == "corbuzz" then
+		uDef.metalcost = 73200
+		uDef.energycost = 861600
+		uDef.buildtime = 1680000
+	end
+	if name == "armmar" then
+		uDef.metalcost = 1070
+		uDef.energycost = 23000
+		uDef.buildtime = 28700
+	end
+	if name == "armraz" then
+		uDef.metalcost = 4200
+		uDef.energycost = 75000
+		uDef.buildtime = 97000
+	end
+	if name == "armthor" then
+		uDef.metalcost = 9450
+		uDef.energycost = 255000
+		uDef.buildtime = 265000
+	end
+	if name == "corshiva" then
+		uDef.metalcost = 1800
+		uDef.energycost = 26500
+		uDef.buildtime = 35000
+		uDef.speed = 50.8
+		uDef.weapondefs.shiva_rocket.tracks = true
+		uDef.weapondefs.shiva_rocket.turnrate = 7500
+	end
+	if name == "corkarg" then
+		uDef.metalcost = 2625
+		uDef.energycost = 60000
+		uDef.buildtime = 79000
+	end
+	if name == "cordemont4" then
+		uDef.metalcost = 6300
+		uDef.energycost = 94500
+		uDef.buildtime = 94500
+	end
+	if name == "armstil" then
+		uDef.health = 1300
+		uDef.weapondefs.stiletto_bomb.burst = 3
+		uDef.weapondefs.stiletto_bomb.burstrate = 0.2333
+		uDef.weapondefs.stiletto_bomb.damage = {
+			default = 3000
+		}
+	end
+	if name == "armlance" then
+		uDef.health = 1750
+	end
+	if name == "cortitan" then
+		uDef.health = 1800
+	end
+	if name == "armyork" then
+		uDef.weapondefs.mobileflak.reloadtime = 0.8333
+	end
+	if name == "corsent" then
+		uDef.weapondefs.mobileflak.reloadtime = 0.8333
+	end
+	if name == "armaas" then
+		uDef.weapondefs.mobileflak.reloadtime = 0.8333
+	end
+	if name == "corarch" then
+		uDef.weapondefs.mobileflak.reloadtime = 0.8333
+	end
+	if name == "armflak" then
+		uDef.weapondefs.armflak_gun.reloadtime = 0.6
+	end
+	if name == "corflak" then
+		uDef.weapondefs.armflak_gun.reloadtime = 0.6
+	end
+	if name == "armmercury" then
+		uDef.weapondefs.arm_advsam.reloadtime = 11
+		uDef.weapondefs.arm_advsam.stockpile = false
+	end
+	if name == "corscreamer" then
+		uDef.weapondefs.cor_advsam.reloadtime = 11
+		uDef.weapondefs.cor_advsam.stockpile = false
+	end
+	if name == "armfig" then
+		uDef.metalcost = 77
+		uDef.energycost = 3100
+		uDef.buildtime = 3700
+	end
+	if name == "armsfig" then
+		uDef.metalcost = 95
+		uDef.energycost = 4750
+		uDef.buildtime = 5700
+	end
+	if name == "armhawk" then
+		uDef.metalcost = 155
+		uDef.energycost = 6300
+		uDef.buildtime = 9800
+	end
+	if name == "corveng" then
+		uDef.metalcost = 77
+		uDef.energycost = 3000
+		uDef.buildtime = 3600
+	end
+	if name == "corsfig" then
+		uDef.metalcost = 95
+		uDef.energycost = 4850
+		uDef.buildtime = 5400
+	end
+	if name == "corvamp" then
+		uDef.metalcost = 150
+		uDef.energycost = 5250
+		uDef.buildtime = 9250
+	end
+end	
 	-- Multipliers Modoptions
 
 	-- Health

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -889,6 +889,15 @@ local options={
 	},
 
 	{
+		key = 'lategame_rebalance',
+		name = 'Lategame Rebalance',
+		desc = 'T2 defenses and anti-air is weaker, giving more time for late T2 strategies to be effective.  Early T3 unit prices increased. Increased price of calamity/ragnarock by 20% so late T3 has more time to be effective.',
+		type = 'bool',
+		section = 'options_experimental',
+		def = false,
+	},
+
+	{
 		key    = 'experimentalimprovedtransports',
 		name   = 'Transport Units Rework',
 		desc   = 'Transport Units Rework',


### PR DESCRIPTION
The modoption lategame_rebalance is designed to increase the amount of time that late T2 strategies remain viable by reducing the strength of T2 defences and increasing the cost of early T3 units.  The cost of calamity and ragnarock is increased to give the T3 stage more time.