### PR TITLE
Do not assume unit ids are from 1 to #UnitDefs

### DIFF
--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -138,9 +138,11 @@ end
 local unitOrder = {}
 local unitOrderManualOverrideTable = VFS.Include("luaui/configs/buildmenu_sorting.lua")
 
--- Populate unitOrder with identity values.
-for unitDefID, _ in pairs(UnitDefs) do
-	unitOrder[unitDefID] = unitDefID
+-- Populate unitOrder with unit IDs.
+local count = 1
+for id, _ in pairs(UnitDefs) do
+	unitOrder[count] = id
+	count = count + 1
 end
 
 -- maxOrder is the largest order value found in unitOrderManualOverrideTable.


### PR DESCRIPTION
Addresses comment https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2492#discussion_r1440682613

Tested by diffing `Spring.Debug.TableEcho(unitOrder)`