### PR TITLE
add reclaimable metal/energy to game info

### DIFF
--- a/language/de/interface.json
+++ b/language/de/interface.json
@@ -507,7 +507,9 @@
 			"windStrength": "Windgeschwindigkeit",
 			"waterDamage": "Wasserschaden ",
 			"raptorOptions": "Raptoreinstellungen",
-			"modOptions": "Modeinstellungen"
+			"modOptions": "Modeinstellungen",
+			"reclaimableMetal": "Gewinnbares Metall",
+			"reclaimableEnergy": "Gewinnbare Energie"
 		},
 		"raptors": {
 			"firstWave1": "Die Raptoren sind eingetroffen!",

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -517,7 +517,9 @@
 			"windStrength": "Wind speed",
 			"waterDamage": "Water damage",
 			"raptorOptions": "Raptor options",
-			"modOptions": "Mod options"
+			"modOptions": "Mod options",
+			"reclaimableMetal": "Reclaimable Metal",
+			"reclaimableEnergy": "Reclaimable Energy"
 		},
 		"cmdlimiter": {
 			"forceresignwarning": "You queued too much buildings a few time, continue this and you will get forcefully resigned.",

--- a/language/fr/interface.json
+++ b/language/fr/interface.json
@@ -517,7 +517,9 @@
 			"windStrength": "Vitesse du vent",
 			"waterDamage": "Dégâts d'eau",
 			"raptorOptions": "Options des Raptor",
-			"modOptions": "Options des mods"
+			"modOptions": "Options des mods",
+			"reclaimableMetal": "Métal récupérable",
+			"reclaimableEnergy": "L'énergie récupérable"
 		},
 		"cmdlimiter": {
 			"forceresignwarning": "Vous avez mis en file d'attente un trop grand nombre de bâtiments en trop peu de temps, continuer risquerait de vous voir éjecté.",

--- a/language/zh/interface.json
+++ b/language/zh/interface.json
@@ -210,7 +210,9 @@
             "tidalStrength":"浪涌速度",
             "size":"大小",
             "hardness":"硬度",
-            "engine":"引擎"
+            "engine":"引擎",
+            "reclaimableMetal": "可回收金属",
+            "reclaimableEnergy": "可回收能源"
           },
           "forceResignMessage":"你已经被强制投降: 当你仍有队友在场时,不要自毁所有单位",
           "factionPicker":{

--- a/luaui/Widgets/gui_gameinfo.lua
+++ b/luaui/Widgets/gui_gameinfo.lua
@@ -28,6 +28,8 @@ local content = ''
 
 local tidal = Game.tidal
 local map_tidal = Spring.GetModOptions().map_tidal
+local reclaimable_metal = 0
+local reclaimable_energy = 0
 
 if map_tidal == "unchanged" then
 elseif map_tidal == "low" then
@@ -410,6 +412,8 @@ local function refreshContent()
 	content = content .. keycolor .. Spring.I18N('ui.gameInfo.gravity') .. separator .. valuegreycolor .. Game.gravity .. "\n"
 	content = content .. keycolor .. Spring.I18N('ui.gameInfo.hardness') .. separator .. valuegreycolor .. Game.mapHardness .. keycolor .. "\n"
 	content = content .. keycolor .. Spring.I18N('ui.gameInfo.tidalStrength') .. separator .. valuegreycolor .. tidal .. keycolor .. "\n"
+	content = content .. keycolor .. Spring.I18N('ui.gameInfo.reclaimableMetal') .. separator .. valuegreycolor .. reclaimable_metal .. keycolor .. "\n"
+	content = content .. keycolor .. Spring.I18N('ui.gameInfo.reclaimableEnergy') .. separator .. valuegreycolor .. reclaimable_energy .. keycolor .. "\n"
 
 	if Game.windMin == Game.windMax then
 		content = content .. keycolor .. Spring.I18N('ui.gameInfo.windStrength') .. separator .. valuegreycolor .. Game.windMin .. valuegreycolor .. "\n"
@@ -455,6 +459,24 @@ local function closeInfoHandler()
 
     return true
   end
+end
+
+local spGetAllFeatures = Spring.GetAllFeatures
+local spGetFeatureResources = Spring.GetFeatureResources
+local spGetFeatureTeam = Spring.GetFeatureTeam
+local spGetGaiaTeamID = Spring.GetGaiaTeamID
+local gaiaTeamId = spGetGaiaTeamID()
+
+function widget:GamePreload()
+	for _, featureID in ipairs(spGetAllFeatures()) do
+		local metal, _, energy = spGetFeatureResources(featureID)
+		if spGetFeatureTeam(featureID) == gaiaTeamId then
+			reclaimable_metal = reclaimable_metal + metal
+			reclaimable_energy = reclaimable_energy + energy
+		end
+	end
+
+	refreshContent()
 end
 
 function widget:Initialize()


### PR DESCRIPTION
This PR adds the reclaimable metal and energy available on the map to the game info window.

I've seen players use a reclaim command on the whole map to figure out what kind of reclaim is available and also saw a video where a player said it would be helpful if this information would be available, as he was casting a game to illustrate viable strategies.

I used a translator for the French and Chinese translations, as this is my first PR, I'm not sure if there are any go to sources for translations.

Thanks to the "Reclaim Field Highlight" widget, for the code inspiration.

Before:
![before](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/241655/31dfe3e2-f1a3-4c94-9ed5-52bc89d630fe)

After:
![after](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/241655/7118ffaa-feda-4fcc-aa9b-0bb6b96f37a3)

Hope this is helpful!
KaNe23