### PR TITLE
feat(gui_building_grid_gl4): allow other widgets to force grid to show

### DIFF
--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -120,6 +120,12 @@ function initShader()
 	end
 end
 
+local forceShow = {}
+local function getForceShow()
+	-- show grid as long as any source wants us to show it (logical OR)
+    return next(forceShow, nil) ~= nil
+end
+
 function widget:Initialize()
     WG['buildinggrid'] = {}
     WG['buildinggrid'].getOpacity = function()
@@ -128,6 +134,13 @@ function widget:Initialize()
     WG['buildinggrid'].setOpacity = function(value)
         opacity = value
         -- widget needs reloading wholly
+    end
+    WG['buildinggrid'].setForceShow = function(reason, enabled)
+        if enabled then
+            forceShow[reason] = true
+        else
+            forceShow[reason] = nil
+        end
     end
 
     initShader()
@@ -177,15 +190,9 @@ end
 
 
 function widget:Update()
-	local _, cmdID
-	if isPregame and WG['pregame-build'] and WG['pregame-build'].getPreGameDefID then
-		cmdID = WG['pregame-build'].getPreGameDefID()
-		cmdID = cmdID and -cmdID or 0 --invert to get the correct negative value
-	else
-		_, cmdID = Spring.GetActiveCommand()
-	end
+	local _, cmdID = Spring.GetActiveCommand()
 
-	showGrid = cmdID and cmdID < 0 or false
+	showGrid = (cmdID and cmdID < 0) or getForceShow()
 end
 
 function widget:DrawWorldPreUnit()

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -81,8 +81,13 @@ end
 ------------------------------------------
 ---          QUEUE HANDLING            ---
 ------------------------------------------
+local BUILDING_GRID_FORCE_SHOW_REASON = "gui_pregame_build"
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
+
+	if WG['buildinggrid'] ~= nil and WG['buildinggrid'].setForceShow ~= nil then
+		WG['buildinggrid'].setForceShow(BUILDING_GRID_FORCE_SHOW_REASON, uDefID ~= nil)
+	end
 
 	local isMex = UnitDefs[uDefID] and UnitDefs[uDefID].extractsMetal > 0
 
@@ -476,6 +481,9 @@ function widget:Shutdown()
 	widgetHandler:DeregisterGlobal(widget, 'GetPreGameDefID')
 	widgetHandler:DeregisterGlobal(widget, 'GetBuildQueue')
 	WG['pregame-build'] = nil
+	if WG['buildinggrid'] ~= nil and WG['buildinggrid'].setForceShow ~= nil then
+		WG['buildinggrid'].setForceShow(BUILDING_GRID_FORCE_SHOW_REASON, false)
+	end
 end
 
 function widget:GetConfigData()


### PR DESCRIPTION
This flips the direction of control from "grid widget looks for reasons to show the grid" to "other widgets ask the grid widget to show the grid". This makes it more straightforward to create other widgets that use the grid.

#### Test steps
1. Select and deselect buildings to build pre-game. The grid should show when a building is being placed, and not show otherwise.
