### PR TITLE
Cache weaponsDef.visuals locally

### DIFF
--- a/luaui/configs/DeferredLightsGL4WeaponsConfig.lua
+++ b/luaui/configs/DeferredLightsGL4WeaponsConfig.lua
@@ -302,10 +302,11 @@ local function AssignLightsToAllWeapons()
 		radius = ((orgMult * 75) + (radius * 2.4)) * 0.33
 
 		local r, g, b = 1, 0.8, 0.45
-		if weaponDef.visuals ~= nil and weaponDef.visuals.colorR ~= nil then
-			r = weaponDef.visuals.colorR
-			g = weaponDef.visuals.colorG
-			b = weaponDef.visuals.colorB
+		local weaponVisuals = weaponDef.visuals
+		if weaponVisuals ~= nil and weaponVisuals.colorR ~= nil then
+			r = weaponVisuals.colorR
+			g = weaponVisuals.colorG
+			b = weaponVisuals.colorB
 		end
 		local muzzleFlash = true
 		local explosionLight = true


### PR DESCRIPTION
A significant amount of time when loading the
gfx_deferred_rendering_GL4.lua widget is spent on repeated calls to weaponDef.visuals. The call-in needs to generate a sizable table, as well as make a modelLoader.FindModelPath call
(https://github.com/beyond-all-reason/spring/blob/09152f02293149be418210cdfcb547433a23d369/rts/Lua/LuaWeaponDefs.cpp#L265).

This change ensures that only a single call is made when querying the weaponDef.visuals property when assigning lights to all weapons.

Saves about ~100ms in load times.

### Screenshots:
#### BEFORE:
![Screenshot from 2024-01-05 14-06-13](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/f18ccb8d-265d-40e3-96a2-3c0325791a40)



#### AFTER:
![Screenshot from 2024-01-05 14-04-47](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/83fbd14f-468a-4895-881e-653a4f0fb5ba)

