### PR TITLE
Legion bugfixes

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -462,7 +462,7 @@ function UnitDef_Post(name, uDef)
 			uDef.buildoptions[numBuildoptions+3] = "corgolt4"
 			uDef.buildoptions[numBuildoptions+4] = "corakt4"
 			uDef.buildoptions[numBuildoptions+5] = "corthermite"
-			uDef.buildoptions[numBuildoptions+6] = "legjugglite"--technically legion but also cortex
+			--uDef.buildoptions[numBuildoptions+6] = "legjugglite"--technically legion but also cortex
 		elseif name == "corgantuw" then
 			local numBuildoptions = #uDef.buildoptions
 			uDef.buildoptions[numBuildoptions+1] = "corgolt4"

--- a/units/Legion/Constructors/legack.lua
+++ b/units/Legion/Constructors/legack.lua
@@ -44,7 +44,6 @@ return {
 			"corafus",
 			"leggant",
 			"corageo",
-			"coruwageo",
 			"corbhmth",
 			"cormoho",
 			"cormexp",

--- a/units/Legion/Constructors/legacv.lua
+++ b/units/Legion/Constructors/legacv.lua
@@ -72,7 +72,6 @@ return {
 			[27] = "legvp",
 			[28] = "legavp",
 			[29] = "leggant",
-			[30] = "coruwageo",
 		},
 		customparams = {
 			unitgroup = 'buildert2',

--- a/units/Legion/Constructors/legck.lua
+++ b/units/Legion/Constructors/legck.lua
@@ -43,7 +43,6 @@ return {
 			"coradvsol",
 			"corwin",
 			"corgeo",
-			"coruwgeo",
 			"cormstor",
 			"corestor",
 			"legmex",

--- a/units/Legion/Constructors/legcv.lua
+++ b/units/Legion/Constructors/legcv.lua
@@ -48,7 +48,6 @@ return {
 			"coradvsol",
 			"corwin",
 			"corgeo",
-			"coruwgeo",
 			"cormstor",
 			"corestor",
 			"legmex",


### PR DESCRIPTION
legjugglite temporarily removed from extra units as it somehow caused the T3 gantry buildmenu to not load correctly.  UW geos removed from bot/veh con buildlists.