### PR TITLE
fix(gui_selfd_icons): correctly handle removing queued commands

### DIFF
--- a/luaui/Widgets/gui_selfd_icons.lua
+++ b/luaui/Widgets/gui_selfd_icons.lua
@@ -203,14 +203,29 @@ function widget:DrawWorld()
 	glDepthTest(true)
 end
 
+local CMD_IGNORE_QUEUE = {
+	CMD.INSERT,
+	CMD.REMOVE,
+	CMD.WAIT,
+	CMD.FIRE_STATE,
+	CMD.MOVE_STATE,
+	CMD.REPEAT,
+	CMD.ONOFF,
+}
+
 function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts, cmdTag, playerID, fromSynced, fromLua)
 	if ignoreUnitDefs[unitDefID] then
 		return
 	end
 
 	if cmdID ~= CMD.SELFD and not cmdOpts.shift and queuedSelfD[unitID] then
-		-- had a queued selfd, but the queue was replaced, so mark not queued
-		queuedSelfD[unitID] = nil
+		-- had a queued selfd, but the queue was potentially replaced
+
+		-- check for commands that don't replace the queue
+		if not table.contains(CMD_IGNORE_QUEUE, cmdID) then
+			--queue was replaced, so mark not queued
+			queuedSelfD[unitID] = nil
+		end
 	elseif cmdID == CMD.SELFD then
 		local cmdQueue = spGetCommandQueue(unitID, -1)
 		local hasCmdQueue = #cmdQueue > 0


### PR DESCRIPTION
If there was a command queue ({MOVE,SELFD}, for example), then executing a REMOVE on the MOVE command would leave the widget thinking that the queue had been replaced and there was no longer a SELFD command in the queue.

This change adds a check for commands that don't necessarily clear the queue, even when executed without shift. The check is not necessarily exhaustive - these are only the ones I'm aware of.

#### Test steps
1. Queue a long-running command (move far away, for example)
2. Queue a SELFD
3. Cancel the move (such as with "N")
4. The icon should remain, and the countdown should be displayed

---

Found using secret prototype testing framework :)
