### PR TITLE
fix(gui_pregame_build): use correct RemoveWidget arguments

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -428,7 +428,7 @@ function widget:GameFrame(n)
 	-- Avoid unnecessary overhead after buildqueue has been setup in early frames
 	if #buildQueue == 0 then
 		widgetHandler:RemoveWidgetCallIn('GameFrame', self)
-		widgetHandler:RemoveWidget()
+		widgetHandler:RemoveWidget(self)
 		return
 	end
 


### PR DESCRIPTION
With `handler = true`, `RemoveWidget` requires the widget as an argument. Without it, the widget failed to remove itself properly when the game started. This change adds the missing argument.

This causes issues with the building grid widget, since, after https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2503, it is the requesting widget's responsibility to stop asking for the building grid. Since the pregame build widget never properly removed itself, it also never ran `widget:Shutdown()`, and thus never removed the grid if it was enabled when the widget was supposed to remove itself. This would happen if a building was selected while the game started.

#### Test steps
1. Open a new game
2. In pre-game, select a building (but do not place it)
3. Start the game
4. Without this fix, the building grid will be stuck on. With the fix, it will turn off.
