### PR TITLE
Idle crashing air con bugfix

### DIFF
--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -37,6 +37,7 @@ local spGetFullBuildQueue = Spring.GetFullBuildQueue
 local spGetUnitHealth = Spring.GetUnitHealth
 local spGetCommandQueue = Spring.GetCommandQueue
 local spGetTeamUnitsSorted = Spring.GetTeamUnitsSorted
+local spGetUnitMoveTypeData = Spring.GetUnitMoveTypeData
 local myTeamID = Spring.GetMyTeamID()
 
 local floor = math.floor
@@ -106,7 +107,7 @@ local function isIdleBuilder(unitID)
 				if isFactory[udef] then
 					return true
 				else
-					if spGetCommandQueue(unitID, 0) == 0 then
+					if (spGetCommandQueue(unitID, 0) == 0) and not(spGetUnitMoveTypeData(unitID).aircraftState == "crashing") then
 						return true
 					end
 				end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Crashing air constructors no longer are marked as idle.


#### Addresses Issue #1656 

