### PR TITLE
Avoid repeatedly copying Spring.GetModOptions table

### DIFF
--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -21,9 +21,15 @@ if Spring.GetModOptions then
 		end
 	end
 
+	local readOnlyModOptions = {}
+	setmetatable(readOnlyModOptions, {
+		__index = modOptions,
+		__newindex = function(t, k, v)
+			  error("attempt to update a read-only Spring.GetModOptions table", 2)
+			end
+	})
+
 	Spring.GetModOptions = function ()
-		-- Returning the table itself would allow callers to mutate the table
-		-- Copying it ensures each caller gets its own copy
-		return table.copy(modOptions)
+		return readOnlyModOptions
 	end
 end


### PR DESCRIPTION
This change makes BAR's Spring.GetModOptions always return the same read-only table. Prior to this change, every call to Spring.GetModOption returns a fresh copy of the table.

This change further speeds up the load time for BAR by ensuring that unnecessary copies of the modOptions table is not created. Saves ~200ms.

Lua tables are made read-only by following
https://www.lua.org/pil/13.4.5.html

See also
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2458 and https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2476 for changes that addresses slowness caused by repeatedly calling Spring.GetModOptions in the various loading routines. This change should obviate the need for both of those other changes.

## Screenshots

### Before
![before_getmodoptions](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/87d20e6a-1035-45d1-898b-0119759955a3)

### After
![after_getmodoptions](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/2730943/fc5c1e8f-cfba-492e-b296-9980ba289686)
