### PR TITLE
Add an emergency Garbage Collector to widgethandler at 1.2 GB

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1189,6 +1189,12 @@ end
 
 
 function widgetHandler:Update()
+	
+	if collectgarbage("count") > 1200000 then 
+		Spring.Echo("Warning: Emergency garbage collection due to exceeding 1.2GB LuaRAM")
+		collectgarbage("collect")
+	end
+	
 	local deltaTime = Spring.GetLastUpdateSeconds()
 	-- update the hour timer
 	hourTimer = (hourTimer + deltaTime) % 3600.0


### PR DESCRIPTION
This is a bit of a temporary measure due to an engine bug where a lot of garbage can be created.
This is also a last-ditch effort in case user widgets go crazy.

https://github.com/beyond-all-reason/spring/issues/1220
