### PR TITLE
Add Spring.GetModOptionsCopy: returns a copy of the modOptions table

### DIFF
--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -34,4 +34,10 @@ if Spring.GetModOptions then
 	Spring.GetModOptions = function ()
 		return readOnlyModOptions
 	end
+
+	-- Returns a copy of the modOptions table. Slower, but allows iterating over
+	-- the returned table using pairs/ipairs.
+	Spring.GetModOptionsCopy = function ()
+		return table.copy(modOptions)
+	end
 end

--- a/luaui/Widgets/gui_gameinfo.lua
+++ b/luaui/Widgets/gui_gameinfo.lua
@@ -51,7 +51,7 @@ for key, value in pairs(defaultModoptions) do
 	modoptionsDefault[value.key] = {name = value.name, desc = value.desc, def = value.def}
 end
 
-local modoptions = Spring.GetModOptions()
+local modoptions = Spring.GetModOptionsCopy()
 local changedModoptions = {}
 local unchangedModoptions = {}
 local changedRaptorModoptions = {}

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -207,7 +207,7 @@ local reclaimFieldHighlightOptions = {
 local startScript = VFS.LoadFile("_script.txt")
 if not startScript then
 	local modoptions = ''
-	for key, value in pairs(Spring.GetModOptions()) do
+	for key, value in pairs(Spring.GetModOptionsCopy()) do
 		local v = value
 		if type(v) == 'boolean' then
 			v = (v and '1' or '0')


### PR DESCRIPTION
With Lua 5.1, a table made read-only via a proxy table cannot be iterated over. https://stackoverflow.com/questions/47956954/read-only-iterable-table-in-lua

This change introduces Spring.GetModOptionsCopy which returns a copy of the modOptions table, which is iterable. The modOptions table is iterated over in two places `luaui/Widgets/gui_gameinfo.lua` and `luaui/Widgets/gui_options.lua`.

Alternatively, we could revert https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2518