### PR TITLE
Sensor ranges draw ordering to draw after water

### DIFF
--- a/luaui/Widgets/gui_sensor_ranges_jammer.lua
+++ b/luaui/Widgets/gui_sensor_ranges_jammer.lua
@@ -338,7 +338,7 @@ function widget:GameFrame(n)
 	end
 end
 
-function widget:DrawWorldPreUnit()
+function widget:DrawWorld()
 	if chobbyInterface then
 		return
 	end
@@ -380,6 +380,7 @@ function widget:DrawWorldPreUnit()
 	glColor(rangeColor[1], rangeColor[2], rangeColor[3], rangeColor[4])
 	glLineWidth(rangeLineWidth * lineScale * 1.0)
 	--Spring.Echo("glLineWidth",rangeLineWidth * lineScale * 1.0)
+	glDepthTest(true)
 	circleInstanceVBO.VAO:DrawArrays(GL_LINE_LOOP, circleInstanceVBO.numVertices, 0, circleInstanceVBO.usedElements, 0)
 
 	glStencilMask(255) -- enable all bits for future drawing
@@ -388,7 +389,6 @@ function widget:DrawWorldPreUnit()
 	circleShader:Deactivate()
 	gl.Texture(0, false)
 	glStencilTest(false)
-	glDepthTest(true)
 	glColor(1.0, 1.0, 1.0, 1.0) --reset like a nice boi
 	glLineWidth(1.0)
 	gl.Clear(GL.STENCIL_BUFFER_BIT)

--- a/luaui/Widgets/gui_sensor_ranges_los.lua
+++ b/luaui/Widgets/gui_sensor_ranges_los.lua
@@ -227,7 +227,7 @@ function widget:VisibleUnitRemoved(unitID)
 	end
 end
 
-function widget:DrawWorldPreUnit()
+function widget:DrawWorld()
 	--if spec and fullview then return end
 	if Spring.IsGUIHidden() or (WG['topbar'] and WG['topbar'].showingQuit()) then return end
 	if circleInstanceVBO.usedElements == 0 then return end
@@ -250,6 +250,7 @@ function widget:DrawWorldPreUnit()
 	glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE) -- Set The Stencil Buffer To 1 Where Draw Any Polygon
 	glStencilMask(1) -- Only check the first bit of the stencil buffer
 
+
 	circleInstanceVBO.VAO:DrawArrays(GL_TRIANGLE_FAN, circleInstanceVBO.numVertices, 0, circleInstanceVBO.usedElements, 0)
 
 	-- Borg_King: Draw thick ring with partial width outside of solid circle, replacing stencil to 0 (draw) where test passes
@@ -259,6 +260,7 @@ function widget:DrawWorldPreUnit()
 	--glColor(rangeColor[1], rangeColor[2], rangeColor[3], rangeColor[4])
 	glLineWidth(rangeLineWidth * lineScale * 1.0)
 	--Spring.Echo("glLineWidth",rangeLineWidth * lineScale * 1.0)
+	glDepthTest(true)
 	circleInstanceVBO.VAO:DrawArrays(GL_LINE_LOOP, circleInstanceVBO.numVertices, 0, circleInstanceVBO.usedElements, 0)
 
 	glStencilMask(255) -- enable all bits for future drawing

--- a/luaui/Widgets/gui_sensor_ranges_radar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar.lua
@@ -342,7 +342,7 @@ function widget:GameFrame(n)
 	end
 end
 
-function widget:DrawWorldPreUnit()
+function widget:DrawWorld()
     if chobbyInterface then return end
     if spec and fullview then return end
     if Spring.IsGUIHidden() or (WG['topbar'] and WG['topbar'].showingQuit()) then return end
@@ -374,6 +374,8 @@ function widget:DrawWorldPreUnit()
 	glColor(rangeColor[1], rangeColor[2], rangeColor[3], rangeColor[4])
 	glLineWidth(rangeLineWidth * lineScale * 1.0)
 	--Spring.Echo("glLineWidth",rangeLineWidth * lineScale * 1.0)
+	
+	glDepthTest(true)
 	circleInstanceVBO.VAO:DrawArrays(GL_LINE_LOOP, circleInstanceVBO.numVertices, 0, circleInstanceVBO.usedElements, 0)
 
 	glStencilMask(255) -- enable all bits for future drawing

--- a/luaui/Widgets/gui_sensor_ranges_radar_preview.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar_preview.lua
@@ -90,7 +90,7 @@ local shaderSourceCache = {
 			},
 		uniformFloat = {
 			radarcenter_range = { 2000, 100, 2000, 2000 },
-			resolution = { 32 },
+			resolution = { 64 },
 		  },
 		shaderConfig = shaderConfig,
 	}

--- a/luaui/Widgets/gui_sensor_ranges_sonar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_sonar.lua
@@ -369,10 +369,8 @@ function widget:DrawWorld()
 	glDepthTest(false)
 
 	gl.Texture(0, "$heightmap")
-	circleShader:Activate()
-	circleShader:SetUniform("circleopacity", opacity)
 
-		glColorMask(false, false, false, false) -- disable color drawing
+	glColorMask(false, false, false, false) -- disable color drawing
 	glStencilTest(true)
 	glDepthTest(false)
 
@@ -395,6 +393,9 @@ function widget:DrawWorld()
 	glColor(rangeColor[1], rangeColor[2], rangeColor[3], rangeColor[4])
 	glLineWidth(rangeLineWidth * lineScale * 1.0)
 	--Spring.Echo("glLineWidth",rangeLineWidth * lineScale * 1.0)
+	
+	--gl.DepthMask(false)
+	glDepthTest(true)
 	circleInstanceVBO.VAO:DrawArrays(GL_LINE_LOOP, circleInstanceVBO.numVertices, 0, circleInstanceVBO.usedElements, 0)
 
 	glStencilMask(255) -- enable all bits for future drawing


### PR DESCRIPTION
Currently, units are drawn before water, so we cant draw sensor ranges before units but after water. This pr moves sensor ranges to be drawn after the units and water.

This means sensor rings no longer will get distorted by water.

Also, sensor rings no longer visible through terrain.

Increased radar preview accuracy a bit.


#### Test steps
- [ ] Check the draw order to ensure it does not needlessly clip over other things. 
