### PR TITLE
Increase Energy Conversion Cap From 1 to 2

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -556,12 +556,12 @@ local options={
 	{
 		key    = 'multiplier_energyconversion',
 		name   = 'Energy Conversion Efficiency Multiplier ',
-		desc   = '(Range 0.1 - 10). lower means you get less metal per energy converted',
+		desc   = '(Range 0.1 - 2). lower means you get less metal per energy converted',
 		type   =  "number",
 		section = 'options_resources',
 		def    = 1,
 		min    = 0.1,
-		max    = 10,
+		max    = 2,
 		step   = 0.1,
 	},
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -561,7 +561,7 @@ local options={
 		section = 'options_resources',
 		def    = 1,
 		min    = 0.1,
-		max    = 1,
+		max    = 10,
 		step   = 0.1,
 	},
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -556,7 +556,7 @@ local options={
 	{
 		key    = 'multiplier_energyconversion',
 		name   = 'Energy Conversion Efficiency Multiplier ',
-		desc   = '(Range 0.1 - 1). lower means you get less metal per energy converted',
+		desc   = '(Range 0.1 - 10). lower means you get less metal per energy converted',
 		type   =  "number",
 		section = 'options_resources',
 		def    = 1,


### PR DESCRIPTION
This will (hopefully) allow the maximum value of the "multiplier_energyconversion" modoption (displayed as "Energy Conversion Efficiency Multiplier" in the UI) to be set as high as 10. The UI already allows numbers up to 10 to be entered, but the setting will fail in a multiplayer game if set in excess of 1.

This time I'd like to ask somebody more familiar with the game if this will actually allow the intended change, as it wasn't clear when making my previous request to update the chobby that it would fail in multiplayer lobbies (it works fine in single player).