### PR TITLE
[gui_attackrange_gl4] Fix range indicator for `onoff` units

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -118,7 +118,7 @@ for udid, ud in pairs(UnitDefs) do
 	unitWeapons[udid] = ud.weapons
 	unitMaxWeaponRange[udid] = ud.maxWeaponRange
 	unitOnOffable[udid] = ud.onOffable
-	if ud.customParams.onOffName then
+	if ud.customParams.onoffname then
 		unitOnOffName[udid] = ud.customParams.onoffname
 	end
 end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

Fixes a tiny bug in `gui_attckrange_gl4` widget.

Fixes #2564 

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
Just check that switching weapons does not remove the attack range indicator.

### Screenshots:

#### BEFORE:
(screenshot from master)
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/15874787/becfc452-9932-4791-8994-05e2a6171970)


#### AFTER:
(screenshot from branch)
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/15874787/5fbe2d33-1f39-4074-bed9-90697bd1f476)
