### PR TITLE
BARb: restore hard hubs; enable internal mex-spots calculation

### DIFF
--- a/luarules/configs/BARb/stable/config/easy/economy.json
+++ b/luarules/configs/BARb/stable/config/easy/economy.json
@@ -64,6 +64,8 @@
 	},
 	"mex_up": 1,  // maximum number of simultaneous mex upgrades
 
+	"calc_mex": true,  // always calculate mex spots (global)
+
 	"goal_exec": 42.0,  // targeted time to finish non-build task, in seconds
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified
 

--- a/luarules/configs/BARb/stable/config/hard/build_chain.json
+++ b/luarules/configs/BARb/stable/config/hard/build_chain.json
@@ -206,7 +206,7 @@
 				[{"unit": "cortoast", "category": "defence", "offset": {"front": 150}, "priority": "low"}]
 			]
 		},
-        "coravp": {
+		"coravp": {
 			"hub": [[{"unit": "corllt", "category": "defence", "offset": {"back": 5}, "priority": "now"}]]
 		},
 
@@ -215,59 +215,59 @@
 		"armap": {
 			//"hub": [[{"unit": "armllt", "category": "defence", "offset": {"front": 5}, "priority": "now"}]]
 		},
-        "corap": {
+		"corap": {
 			//"hub": [[{"unit": "corllt", "category": "defence", "offset": {"front": 5}, "priority": "now"}]]
-//		},
+		},
 
 
 
-//		"armsy": {
-//			"hub": [
-//				[
-//				{"unit": "armfhlt", "category": "defence", "offset": {"front": 150}, "priority": "now"},
-//				{"unit": "armasy", "category": "factory", "offset": [100, 100]}
-//			]
-//		]
-//		},
-//		"armasy": {
-//			"hub": [
-//                [
-//					{"unit": "armuwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
-//					{"unit": "armatl", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"}
-//				]
-//		    ]
-//		},
+		"armsy": {
+			"hub": [
+				[
+				{"unit": "armfhlt", "category": "defence", "offset": {"front": 150}, "priority": "now"},
+				{"unit": "armasy", "category": "factory", "offset": [100, 100]}
+			]
+		]
+		},
+		"armasy": {
+			"hub": [
+				[
+					{"unit": "armuwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
+					{"unit": "armatl", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"}
+				]
+		    ]
+		},
 
 
-//		"corsy": {
-//			"hub": [
-//				[
-//				{"unit": "corfhlt", "category": "defence", "offset": {"front": 150}, "priority": "high"}
-//				//{"unit": "corasy", "category": "factory", "offset": [100, 100], "priority": "low"}
-//				],
-//				[
-//					{"unit": "coruwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
-//					{"unit": "coruwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"}
-//				],
-//				[
-//					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "normal"},
-//					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "low"},
-//					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "low"},
-//					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "low"}
-//				]
-//			]
-//		},
-//        "corasy": {
-//			"hub": [
-//				[
-//			    	{"unit": "corfhlt", "category": "defence", "offset": {"front": 150}, "priority": "high"}
-//				],
-//            	[
-//					{"unit": "coruwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
-//					{"unit": "coratl", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
-//					{"unit": "corfdoom", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"}
-//				]
-//		    ]
+		"corsy": {
+			"hub": [
+				[
+				{"unit": "corfhlt", "category": "defence", "offset": {"front": 150}, "priority": "high"}
+				//{"unit": "corasy", "category": "factory", "offset": [100, 100], "priority": "low"}
+				],
+				[
+					{"unit": "coruwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
+					{"unit": "coruwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"}
+				],
+				[
+					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "normal"},
+					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "low"},
+					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "low"},
+					{"unit": "coruwmmm", "category": "defence", "offset": {"back": 400}, "priority": "low"}
+				]
+			]
+		},
+		"corasy": {
+			"hub": [
+				[
+					{"unit": "corfhlt", "category": "defence", "offset": {"front": 150}, "priority": "high"}
+				],
+				[
+					{"unit": "coruwfus", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
+					{"unit": "coratl", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"},
+					{"unit": "corfdoom", "category": "factory", "offset": [-200, 50], "condition": {"chance":1.0}, "priority": "normal"}
+				]
+		    ]
 		}
 	},
 
@@ -298,10 +298,10 @@
 				[{"unit": "armllt", "category": "defence", "offset": {"front": 100}, "priority": "now"}],
 				[{"unit": "armrl", "category": "defence", "offset": {"back": 10},"condition": {"air": true}, "priority": "high"}],
 				[{"unit": "armguard", "category": "defence", "offset": [120, 100], "priority": "normal"}],
-                [   
-                    {"unit": "armamb", "category": "defence", "offset": [120, -100], "priority": "high"},
-                    {"unit": "armpb", "category": "defence", "offset": [140, 100], "priority": "normal"}
-                ],
+				[
+					{"unit": "armamb", "category": "defence", "offset": [120, -100], "priority": "high"},
+					{"unit": "armpb", "category": "defence", "offset": [140, 100], "priority": "normal"}
+				],
 				[
 					//{"unit": "armanni", "category": "defence", "offset": [70, -100], "priority": "normal"},
 					{"unit": "armanni", "category": "defence", "offset": [70, 100], "condition": {"chance":0.5}, "priority": "low"}
@@ -318,8 +318,8 @@
 				[{"unit": "corllt", "category": "defence", "offset": {"front": 100}, "priority": "now"}],
 				[{"unit": "corfrt", "category": "defence", "offset": {"back": 10}, "condition": {"air": true}, "priority": "high"}],
 				[{"unit": "corpun", "category": "defence", "offset": [100, -100], "priority": "normal"}],
-                [{"unit": "corvipe", "category": "defence", "offset": [100, -100], "priority": "normal"}],
-                [{"unit": "cortoast", "category": "defence", "offset": [120, 100], "priority": "high"}],
+				[{"unit": "corvipe", "category": "defence", "offset": [100, -100], "priority": "normal"}],
+				[{"unit": "cortoast", "category": "defence", "offset": [120, 100], "priority": "high"}],
 				[
 					//{"unit": "cordoom", "category": "defence", "offset": [80, -100], "priority": "normal"},
 					{"unit": "cordoom", "category": "defence", "offset": [70, 100], "condition": {"chance":0.5}, "priority": "low"}],
@@ -329,53 +329,52 @@
 					{"unit": "corint", "category": "defence", "offset": [-100, 0], "condition": {"chance":0.4}, "priority": "low"} 
 				]
 		]
-//		},
-//		"armfrad":{
-//            "hub":[
-//				[{"unit": "armsy", "category": "factory", "offset": {"front": 100}, "condition": {"chance":1.0}, "priority": "now"}],
+		},
+		"armfrad":{
+			"hub":[
+				[{"unit": "armsy", "category": "factory", "offset": {"front": 100}, "condition": {"chance":1.0}, "priority": "now"}],
 
-//				[
-//					{"unit": "cortl", "category": "defence", "offset": {"front":100},  "priority": "now"},
-//					{"unit": "corasy", "category": "factory", "offset": [50, 50],  "priority": "high"}
-//				],
+				[
+					{"unit": "cortl", "category": "defence", "offset": {"front":100},  "priority": "now"},
+					{"unit": "corasy", "category": "factory", "offset": [50, 50],  "priority": "high"}
+				],
 
-//				[{"unit": "armkraken", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
-//				[{"unit": "armatl", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
-//                [{"unit": "armfrt", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
-//				[{"unit": "armbrtha", "category": "defence", "offset": [-100, 0], "condition": {"chance":1.0}, "priority": "low"}],
-//				[{"unit": "armanni", "category": "defence", "offset": [-100, 0], "condition": {"chance":1.0}, "priority": "low"}],
-				
-//				[
-//					{"unit": "armamd", "category": "defence", "offset": [-100, 0], "condition": {"chance":0.5}, "priority": "low"},
-//					{"unit": "armjamt", "category": "defence", "offset": [-100, 0], "condition": {"chance":1.0}, "priority": "low"}
-//				]
-//			]
-//        },
-//		"corfrad":{
-//            "hub":[
-//				[{"unit": "corsy", "category": "factory", "offset": {"front": 100}, "condition": {"chance": 1.0}, "priority": "now"}],
+				[{"unit": "armkraken", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
+				[{"unit": "armatl", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
+				[{"unit": "armfrt", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
+				[{"unit": "armbrtha", "category": "defence", "offset": [-100, 0], "condition": {"chance":1.0}, "priority": "low"}],
+				[{"unit": "armanni", "category": "defence", "offset": [-100, 0], "condition": {"chance":1.0}, "priority": "low"}],
 
-//				[
-//					{"unit": "corfhlt", "category": "defence", "offset": {"front":100},  "priority": "now"},
-//					{"unit": "corasy", "category": "factory", "offset": [50, 50],  "priority": "high"}
-//				],
+				[
+					{"unit": "armamd", "category": "defence", "offset": [-100, 0], "condition": {"chance":0.5}, "priority": "low"},
+					{"unit": "armjamt", "category": "defence", "offset": [-100, 0], "condition": {"chance":1.0}, "priority": "low"}
+				]
+			]
+		},
+		"corfrad":{
+			"hub":[
+				[{"unit": "corsy", "category": "factory", "offset": {"front": 100}, "condition": {"chance": 1.0}, "priority": "now"}],
 
-//				[{"unit": "corpun", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
-//				[{"unit": "cortoast", "category": "factory", "offset": [100, 0], "condition": {"chance":1.0}, "priority": "normal"}],
-//				[{"unit": "corint", "category": "defence", "offset": [-100, 100], "condition": {"chance":1.0}, "priority": "low"}],
-				
-//				[
-//					{"unit": "corfmd", "category": "defence", "offset": [-100, 100], "condition": {"chance":0.5}, "priority": "low"},
-//					{"unit": "corjamt", "category": "defence", "offset": [-100, 100], "condition": {"chance":1.0}, "priority": "low"}
-//				],
+				[
+					{"unit": "corfhlt", "category": "defence", "offset": {"front":100},  "priority": "now"},
+					{"unit": "corasy", "category": "factory", "offset": [50, 50],  "priority": "high"}
+				],
+
+				[{"unit": "corpun", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
+				[{"unit": "cortoast", "category": "factory", "offset": [100, 0], "condition": {"chance":1.0}, "priority": "normal"}],
+				[{"unit": "corint", "category": "defence", "offset": [-100, 100], "condition": {"chance":1.0}, "priority": "low"}],
+
+				[
+					{"unit": "corfmd", "category": "defence", "offset": [-100, 100], "condition": {"chance":0.5}, "priority": "low"},
+					{"unit": "corjamt", "category": "defence", "offset": [-100, 100], "condition": {"chance":1.0}, "priority": "low"}
+				],
 
 
-//				[{"unit": "corfdoom", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
-//				[{"unit": "coratl", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}]
-				
+				[{"unit": "corfdoom", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}],
+				[{"unit": "coratl", "category": "factory", "offset": [100, 50], "condition": {"chance":1.0}, "priority": "normal"}]
 
-//			]
-        }
+			]
+		}
 
 	}
 }

--- a/luarules/configs/BARb/stable/config/hard/economy.json
+++ b/luarules/configs/BARb/stable/config/hard/economy.json
@@ -101,6 +101,7 @@
 //mspull - // Mobile constructor to static constructor metal pull ratio; [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
 
 	"mex_up": 4,  // maximum number of simultaneous mex upgrades 2/3
+	"calc_mex": true,  // always calculate mex spots (global)
 	"goal_exec": 50.0,  // assign builders till targeted time (in s) to build reached => low value: builders focus on few projects; high value: builder do more task; old values: 45, 50
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified
 	"eps_step": 0.2,

--- a/luarules/configs/BARb/stable/config/medium/economy.json
+++ b/luarules/configs/BARb/stable/config/medium/economy.json
@@ -64,6 +64,8 @@
 	},
 	"mex_up": 1,  // maximum number of simultaneous mex upgrades
 
+	"calc_mex": true,  // always calculate mex spots (global)
+
 	"goal_exec": 42.0,  // targeted time to finish non-build task, in seconds
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified
 

--- a/luarules/configs/BARb/stable/script/task.as
+++ b/luarules/configs/BARb/stable/script/task.as
@@ -76,6 +76,11 @@ SBuildTask Common(Task::BuildType type, Task::Priority priority,
 	ti.shake = shake;
 	ti.isActive = isActive;
 	ti.timeout = timeout;
+
+	ti.cost = SResource(0.f, 0.f);
+	@ti.reprDef = null;
+	ti.pointId = -1;
+	ti.isPlop = false;
 	return ti;
 }
 SBuildTask Spot(Task::BuildType type, Task::Priority priority,
@@ -283,6 +288,11 @@ SFightTask Common(Task::FightType type)
 {
 	SFightTask ti;
 	ti.type = type;
+
+	ti.check = type;
+	ti.promote = type;
+	ti.power = 0.f;
+	@ti.vip = null;
 	return ti;
 }
 SFightTask Guard(CCircuitUnit@ vip)


### PR DESCRIPTION
Revert safety changes from https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2566

Temporary fix [BARbarian AI bugged on Crubick Plains BAR v1.1](https://discord.com/channels/549281623154229250/1190706814317244478) by `"calc_mex": true` in economy.json