### PR TITLE
BARb: disable internal mex-spotter

### DIFF
--- a/luarules/configs/BARb/stable/config/easy/economy.json
+++ b/luarules/configs/BARb/stable/config/easy/economy.json
@@ -64,7 +64,7 @@
 	},
 	"mex_up": 1,  // maximum number of simultaneous mex upgrades
 
-	"calc_mex": true,  // always calculate mex spots (global)
+	"calc_mex": false,  // always calculate mex spots (global)
 
 	"goal_exec": 42.0,  // targeted time to finish non-build task, in seconds
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified

--- a/luarules/configs/BARb/stable/config/economy.json
+++ b/luarules/configs/BARb/stable/config/economy.json
@@ -66,6 +66,8 @@
 	},
 	"mex_up": 2,  // maximum number of simultaneous mex upgrades
 
+	"calc_mex": false,  // always calculate mex spots (global)
+
 	"goal_exec": 42.0,  // targeted time to finish non-build task, in seconds
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified
 

--- a/luarules/configs/BARb/stable/config/hard/economy.json
+++ b/luarules/configs/BARb/stable/config/hard/economy.json
@@ -101,7 +101,7 @@
 //mspull - // Mobile constructor to static constructor metal pull ratio; [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
 
 	"mex_up": 4,  // maximum number of simultaneous mex upgrades 2/3
-	"calc_mex": true,  // always calculate mex spots (global)
+	"calc_mex": false,  // always calculate mex spots (global)
 	"goal_exec": 50.0,  // assign builders till targeted time (in s) to build reached => low value: builders focus on few projects; high value: builder do more task; old values: 45, 50
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified
 	"eps_step": 0.2,

--- a/luarules/configs/BARb/stable/config/medium/economy.json
+++ b/luarules/configs/BARb/stable/config/medium/economy.json
@@ -64,7 +64,7 @@
 	},
 	"mex_up": 1,  // maximum number of simultaneous mex upgrades
 
-	"calc_mex": true,  // always calculate mex spots (global)
+	"calc_mex": false,  // always calculate mex spots (global)
 
 	"goal_exec": 42.0,  // targeted time to finish non-build task, in seconds
 	"build_mod": 1000.0,  // default build_mod for UnitDef, if it's not specified


### PR DESCRIPTION
Revert "Temporary fix [BARbarian AI bugged on Crubick Plains BAR v1.1](https://discord.com/channels/549281623154229250/1190706814317244478) by `"calc_mex": true` in economy.json"

Revert reason: it fixed maps with very small extraction radius line `Crubick Plains` and `Silent Sea` but broke other maps with regular extraction radius.
~~Waiting for proper fix of mex-denier.~~