### PR TITLE
[Fix] Buildings can't be placed on top of other commands

### DIFF
--- a/luaui/Widgets/unit_waypoint_dragger_2.lua
+++ b/luaui/Widgets/unit_waypoint_dragger_2.lua
@@ -232,6 +232,9 @@ function widget:MousePress(mx, my, mb)
 	--   4. our mouse cursor is within "grabbing" radius of (at least)
 	--      one waypoint of at least one of the units we have selected
 	local _, actCmdID, _, _      = spGetActiveCommand()
+	if actCmdID and actCmdID < 0 then
+		return false
+	end
 	local alt, ctrl, meta, shift = spGetModKeyState()
 	local numWayPts              = 0
 	if not shift then return false end


### PR DESCRIPTION
### Work done
When giving building orders on top of existing commands e.g. a move command, this widget would override the building order and it would do nothing. This simply makes it check if the active command is a building, and does nothing in that case (it cannot move buildings)

Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2333

#### Test steps
- [ ] Try placing any building on top of a move way point
