### PR TITLE
Bug fix: Guard Remove Widget

### DIFF
--- a/luaui/Widgets/cmd_guard_remove.lua
+++ b/luaui/Widgets/cmd_guard_remove.lua
@@ -11,19 +11,13 @@ function widget:GetInfo()
 	}
 end
 
-include("keysym.h.lua")
-VFS.Include("LuaRules/Configs/customcmds.h.lua")
-
 local CMD_GUARD = CMD.GUARD
 local CMD_PATROL = CMD.PATROL
-
-local doCommandRemove = false
 
 local removableCommand = {
 	[CMD_GUARD] = true,
 	[CMD_PATROL] = true,
 }
-
 
 local validUnit = {}
 for udid, ud in pairs(UnitDefs) do
@@ -31,16 +25,11 @@ for udid, ud in pairs(UnitDefs) do
 end
 
 function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams, cmdOpts, cmdTag, playerID, fromSynced, fromLua)
-	if not doCommandRemove then
-		return false
-	end
-
 	if not cmdOpts.shift then
-		doCommandRemove = false
 		return false
 	end
 
-	if validUnit[Spring.GetUnitDefID(unitID)] then
+	if validUnit[unitDefID] then
 		local cmd = Spring.GetCommandQueue(unitID, -1)
 		if cmd then
 			for c = 1, #cmd do
@@ -51,12 +40,5 @@ function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams, cmdOp
 		end
 	end
 
-	doCommandRemove = false
 	return false
-end
-
-function widget:KeyPress(key, modifier, isRepeat)
-	if not isRepeat and (key == KEYSYMS.LSHIFT or key == KEYSYMS.RSHIFT) then
-		doCommandRemove = true
-	end
 end


### PR DESCRIPTION
Fixes the bug where builders got stuck guarding/patroling even while having orders in queue after the guard/patrol command.
