### PR TITLE
refactor(gui_idle_builders): remove unused variable

### DIFF
--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -72,7 +72,6 @@ local existingGroups = {}
 local clicks = {}
 
 local nearIdle = 0 -- this means that factories with only X build items left will be shown as idle
-local qCount = {}
 local idleList = {}
 
 local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, backgroundRect, ordermenuPosY
@@ -95,7 +94,6 @@ end
 
 local function isIdleBuilder(unitID)
 	local udef = spGetUnitDefID(unitID)
-	local qCount = 0
 	if isBuilder[udef] then
 		--- can build
 		local buildQueue = spGetFullBuildQueue(unitID)
@@ -113,13 +111,13 @@ local function isIdleBuilder(unitID)
 				end
 			end
 		elseif isFactory[udef] then
+			local qCount = 0
 			for _, thing in ipairs(buildQueue) do
 				for _, count in pairs(thing) do
 					qCount = qCount + count
 				end
 			end
 			if qCount <= nearIdle then
-				qCount[unitID] = qCount
 				return true
 			end
 		end
@@ -169,7 +167,6 @@ local function updateList()
 	end
 
 	idleList = {}
-	qCount = {}
 	local myUnits = spGetTeamUnitsSorted(myTeamID)
 	for unitDefID, units in pairs(myUnits) do
 		if type(units) == 'table' then


### PR DESCRIPTION
This variable was abandoned in commit https://github.com/beyond-all-reason/Beyond-All-Reason/commit/9673326ace805ec150682f2725bc0667f8787dd4, but the top-level variable remained.