### PR TITLE
Fix BARb's metal-income calculator

### DIFF
--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -363,7 +363,11 @@ end
 
 function upget:Initialize()
 	if(gadget) then
-		Spring.SetGameRulesParam("base_extraction", 0.001)
+		-- With armmex.extractsMetal=0.001 and armmoho.extractsMetal=0.004
+		-- base_extraction=0.001 is meant to say that T1 mex is baseline x1, and T2 is baseline x4
+		-- as opposed to T1 being x0.5 and T2 being x2.
+		-- Unused now.
+		Spring.SetGameRulesParam("base_extraction", 1.0)
 	end
 
 


### PR DESCRIPTION
### Work done
After mex rework the way to store spot.worth was changed: doesn't include base_extraction. Which breaks BARb as it expects values modified by base_extraction.
Set base_extraction=1.0 as it's unused.

An alternative is to multiply mex.worth:
```
local mult = Spring.GetGameRulesParam("base_extraction")
spSetGameRulesParam("mex_metal" .. i, mex.worth * mult)
```
like it was before mex rework: https://github.com/beyond-all-reason/Beyond-All-Reason/blob/d4d05bc7ddf851f0b8e775e5e8da3250e2d0900f/luarules/gadgets/mex_spot_finder.lua#L189