### PR TITLE
Underwater mex fixes

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -356,7 +356,7 @@ local function PreviewExtractorCommand(params, extractor, spot)
 
 	-- Construct the actual mex build orders
 	local facing = spGetBuildFacing() or 1
-	local finalCommand = {}
+	local finalCommand
 
 	local buildingId = -extractor
 	local targetPos, targetOwner

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -105,7 +105,9 @@ local function getCmdsForValidSpots(spots, shift)
 		if not spotHasQueue then
 			local pos = { spot.x, spot.y, spot.z }
 			local cmd = WG['resource_spot_builder'].PreviewExtractorCommand(pos, selectedMex, spot)
-			cmds[#cmds + 1] = cmd
+			if cmd then
+				cmds[#cmds + 1] = cmd
+			end
 		end
 	end
 	return cmds

--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -167,7 +167,7 @@ function widget:Update(dt)
 		end
 	elseif not metalMap then
 		-- If no valid units, check cursor position against extractor spots
-		local _, groundPos = Spring.TraceScreenRay(mx, my, true)
+		local _, groundPos = Spring.TraceScreenRay(mx, my, true, false, false, true)
 		if not groundPos or not groundPos[1] then
 			clearGhostBuild()
 			return


### PR DESCRIPTION
### Work done
Fix areamex crash if areamex is used to queue land mexes with a water con (e.g. t2 naval con)
Fix right-click mex crash if cursor mouses over land mex spot with a naval con
Fix cursor offset when building underwater mexes/geos with right-click build.

#### Test steps
- [ ] Using a naval t2 con, use area mex to queue both land and uw mexes, expect no crash (land mexes will not get queued)
- [ ] Using naval t2 con, mouse over land mex spot. Expect no crash
- [ ] Using any con, mouse over underwater mex spots with high camera tilt. Expect the preview to show only when the cursor is over the mex spot in screen space, not when the cursor is over the mex spot *at water level*

