### PR TITLE
Fix mex/geo building issues when they are in close proximity

### DIFF
--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -102,6 +102,7 @@ local function GetSpotsGeo()
 			local x, y, z = Spring.GetFeaturePosition(features[i])
 			spotCount = spotCount + 1
 			spots[spotCount] = {
+				isGeo = true,
 				x = GetFootprintPos(x),
 				y = y,
 				z = GetFootprintPos(z),
@@ -340,6 +341,8 @@ local function GetSpotsMetal()
 		g.x = (gMinX + gMaxX) * 0.5
 		g.z = (g.minZ + g.maxZ) * 0.5
 		g.y = spGetGroundHeight(g.x, g.z)
+
+		g.isMex = true
 
 		spots[#spots + 1] = g
 	end

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -98,10 +98,9 @@ end
 ---@param spot table
 local function spotHasExtractor(spot)
 	local units = Spring.GetUnitsInCylinder(spot.x, spot.z, Game_extractorRadius)
+	local type = spot.isMex and mexBuildings or geoBuildings
 	for j=1, #units do
-		if mexBuildings[spGetUnitDefID(units[j])] or geoBuildings[spGetUnitDefID(units[j])] then
-			return units[j]
-		end
+		if type[spGetUnitDefID(units[j])] then return units[j] end
 	end
 	return false
 end
@@ -222,7 +221,7 @@ local function extractorCanBeBuiltOnSpot(spot, extractorId)
 	for i = 1, #units do
 		local uid = units[i]
 		local uDefId = spGetUnitDefID(uid)
-		local isExtractor = mexBuildings[uDefId] or geoBuildings[uDefId]
+		local isExtractor = spot.isMex and mexBuildings[uDefId] or geoBuildings[uDefId]
 		local canUpgrade = extractorCanBeUpgraded(uid, extractorId)
 		local isBeingBuilt, _ = spGetUnitIsBeingBuilt(uid)
 		if(isExtractor and (not canUpgrade or isBeingBuilt)) then
@@ -339,7 +338,7 @@ end
 ---ApplyPreviewCmds to actually give the orders to units
 ---@param params table
 ---@param extractor table
----@param spot table can be a spot or a position, just needs to have { x, y, z } properties
+---@param spot table must be a full spot, not just position. isMex or isGeo field required for things to work.
 ---@return table format is { buildingId, x, y, z, facing, owner }
 local function PreviewExtractorCommand(params, extractor, spot)
 	local cmdX, _, cmdZ = params[1], params[2], params[3]
@@ -356,15 +355,16 @@ local function PreviewExtractorCommand(params, extractor, spot)
 
 	-- Construct the actual mex build orders
 	local facing = spGetBuildFacing() or 1
-	local finalCommand = {}
+	local finalCommand
 
 	local buildingId = -extractor
 	local targetPos, targetOwner
-	local occupiedMex = spotHasExtractor(command)
-	if occupiedMex then
-		local occupiedPos = { spGetUnitPosition(occupiedMex) }
+	local occupiedSpot = spotHasExtractor(command)
+	if occupiedSpot then
+
+		local occupiedPos = { spGetUnitPosition(occupiedSpot) }
 		targetPos = { x=occupiedPos[1], y=occupiedPos[2], z=occupiedPos[3] }
-		targetOwner = Spring.GetUnitTeam(occupiedMex)	-- because gadget "Mex Upgrade Reclaimer" will share a t2 mex build upon ally t1 mex
+		targetOwner = Spring.GetUnitTeam(occupiedSpot)	-- because gadget "Mex Upgrade Reclaimer" will share a t2 mex build upon ally t1 mex
 	else
 		local buildingPositions = WG['resource_spot_finder'].GetBuildingPositions(spot, -buildingId, 0, true)
 		targetPos = math.getClosestPosition(cmdX, cmdZ, buildingPositions)
@@ -373,7 +373,6 @@ local function PreviewExtractorCommand(params, extractor, spot)
 	if targetPos then
 		local newx, newz = targetPos.x, targetPos.z
 		finalCommand = { math.abs(buildingId), newx, spGetGroundHeight(newx, newz), newz, facing, targetOwner }
-
 	end
 	return finalCommand
 end

--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -157,9 +157,11 @@ function widget:Update(dt)
 			if unitIsMex then
 				selectedPos = { x = x, y = y, z = z }
 				selectedMex = bestMex
+				selectedSpot = WG['resource_spot_finder'].GetClosestMexSpot(x, z)
 			else
 				selectedPos = { x = x, y = y, z = z }
 				selectedGeo = bestGeo
+				selectedSpot = WG['resource_spot_finder'].GetClosestGeoSpot(x, z)
 			end
 		else
 			clearGhostBuild()
@@ -190,7 +192,6 @@ function widget:Update(dt)
 			selectedMex = bestMex
 			extractor = bestMex
 			selectedSpot = nearestMex
-
 		elseif geoDist < math.huge and geoDist < mexDist and geoDist < geoPlacementRadius then
 			selectedGeo = bestGeo
 			extractor = bestGeo
@@ -209,11 +210,10 @@ function widget:Update(dt)
 
 
 	-- Set up ghost
-	if extractor and (selectedSpot or selectedPos) then
+	if extractor and selectedSpot then
 		-- we only want to build on the center, so we pass the spot in for the position, instead of the groundPos
 		local cmdPos = selectedPos and { selectedPos.x, selectedPos.y, selectedPos.z } or { selectedSpot.x, selectedSpot.y, selectedSpot.z}
-		local spotPos = selectedPos and selectedPos or selectedSpot -- When a specific mex is moused over, we use that position instead of the spot for previewing the command
-		local cmd = WG["resource_spot_builder"].PreviewExtractorCommand(cmdPos, extractor, spotPos)
+		local cmd = WG["resource_spot_builder"].PreviewExtractorCommand(cmdPos, extractor, selectedSpot)
 		if not cmd then
 			clearGhostBuild()
 			return


### PR DESCRIPTION
### Work done
If a mex and geo spot is very close together, and a mex is built on the mex spot, the geo build preview would *always* snap on top of the nearby mex, and vice versa. 

This PR adds a `isMex` and `isGeo` tag to all the spot descriptions to keep these distinct.

#### Test steps
- [ ] Load rivverrun
- [ ] Build a mex on one of the spires that is very close to a geo spot (they all seem to have the problem, but the closer the better for testing)
- [ ] Mouse over the geo spot with a con, expect to see a geo preview on the geo spot
- [ ] Do the same in reverse - build a geo near unoccupied mex spots
- [ ] Mouse over the mex spots with a con, expect to see a mex preview on the mex spot
