### PR TITLE
feat(barwidgets): add option to expose locals when loading widgets

### DIFF
--- a/common/testing/locals_access.lua
+++ b/common/testing/locals_access.lua
@@ -1,0 +1,73 @@
+--[[
+usage:
+* load file with localsDetectorString appended. when loaded, it will return a list of local variable names
+* load the file again, with generateLocalsAccessStr(localsNames)) appended.
+* setmetatable on the new environment to generateLocalsAccessMetatable(<old_metatable>)
+Through the metatable, local variables within the loaded file will now be accessible as if they were globals
+]]--
+
+local localsDetectorString = [[
+
+local __locals = {}
+local __i = 1
+while true do
+  local name, _ = debug.getlocal(1, __i)
+  if not name then break end
+
+  if name ~= "__i" and name ~= "__locals" then
+    table.insert(__locals, name)
+  end
+
+  __i = __i + 1
+end
+return __locals
+]]
+
+local function generateLocalsAccessStr(localsNames)
+	local content = "\n__localsAccess = {\n"
+	content = content .. "  getters = {\n"
+	for _, name in ipairs(localsNames) do
+		content = content .. "    " .. name .. " = function() return " .. name .. " end,\n"
+	end
+	content = content .. "  },\n"
+	content = content .. "  setters = {\n"
+	for _, name in ipairs(localsNames) do
+		content = content .. "    " .. name .. " = function(__value) " .. name .. " = __value end,\n"
+	end
+	content = content .. "  },\n"
+	content = content .. "}\n"
+	return content
+end
+
+local function generateLocalsAccessMetatable(baseMetatable)
+	return {
+		__index = function(t, k)
+			if t.__localsAccess and t.__localsAccess.getters[k] ~= nil then
+				return t.__localsAccess.getters[k]()
+			elseif baseMetatable and baseMetatable.__index ~= nil then
+				if type(baseMetatable.__index) == "table" then
+					return baseMetatable.__index[k]
+				else
+					return baseMetatable.__index(t, k)
+				end
+			else
+				return rawget(t, k)
+			end
+		end,
+		__newindex = function(t, k, v)
+			if t.__localsAccess and t.__localsAccess.setters[k] ~= nil then
+				return t.__localsAccess.setters[k](v)
+			elseif baseMetatable and baseMetatable.__newindex ~= nil then
+				return baseMetatable.__newindex(t, k, v)
+			else
+				return rawset(t, k, v)
+			end
+		end,
+	}
+end
+
+return {
+	localsDetectorString = localsDetectorString,
+	generateLocalsAccessStr = generateLocalsAccessStr,
+	generateLocalsAccessMetatable = generateLocalsAccessMetatable,
+}

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -438,19 +438,19 @@ end
 function widgetHandler:AddSpadsMessage(contents)
 	-- The canonical, agreed format is the following:
 	-- This must be called from an unsynced context, cause it needs playername and playerid and stuff
-	
+
 	-- The game sends a lua message, which should be base64'd to prevent wierd character bullshit:
-	-- Lua Message Format: 
+	-- Lua Message Format:
 		-- leetspeek luaspads:base64message
 		-- lu@$p@d$:ABCEDFGS==
-		-- Must contain, with triangle bracket literals <playername>[space]<contents>[space]<gameseconds> 
+		-- Must contain, with triangle bracket literals <playername>[space]<contents>[space]<gameseconds>
 	-- will get parsed by barmanager, and forwarded to autohostmonitor as:
-	-- match-event <UnnamedPlayer> <LuaUI\Widgets\test_unitshape_instancing.lua/czE3YEocdDJ8bLoO5++a2A==> <35> 
+	-- match-event <UnnamedPlayer> <LuaUI\Widgets\test_unitshape_instancing.lua/czE3YEocdDJ8bLoO5++a2A==> <35>
 	local myPlayerID = Spring.GetMyPlayerID()
 	local myPlayerName = Spring.GetPlayerInfo(myPlayerID,false)
 	local gameSeconds = math.max(0,math.round(Spring.GetGameFrame() / 30))
-	if type(contents) == 'table' then 
-		contents = Json.encode(contents) 
+	if type(contents) == 'table' then
+		contents = Json.encode(contents)
 	end
 	local rawmessage = string.format("<%s> <%s> <%d>", myPlayerName, contents, gameSeconds)
 	local b64message = 'lu@$p@d$:' .. string.base64Encode(rawmessage)
@@ -487,7 +487,7 @@ function widgetHandler:LoadWidget(filename, fromZip)
 	-- user widgets may not access widgetHandler
 	-- fixme: remove the or true part
 	if widget.GetInfo and widget:GetInfo().handler then
-		if fromZip or true then 
+		if fromZip or true then
 			widget.widgetHandler = self
 		else
 			Spring.Echo('Failed to load: ' .. basename .. '  (user widgets may not access widgetHandler)', fromZip, filename, allowuserwidgets)
@@ -554,9 +554,9 @@ function widgetHandler:LoadWidget(filename, fromZip)
 		self.knownWidgets[name].active = false
 		return nil
 	end
-	if not fromZip then 
+	if not fromZip then
 		local md5 = VFS.CalculateHash(text,0)
-		if widgetHandler.widgetHashes[md5] == nil then 
+		if widgetHandler.widgetHashes[md5] == nil then
 			widgetHandler.widgetHashes[md5] = filename
 			-- Embed LuaRules message that we enabled a new user widget
 			--local success, err = pcall(widgetHandler.AddSpadsMessage, widgetHandler, tostring(filename) .. ":" .. tostring(md5))
@@ -565,7 +565,7 @@ function widgetHandler:LoadWidget(filename, fromZip)
 			--end
 		end
 	end
-	
+
 	-- load the config data
 	local config = self.configData[name]
 	if widget.SetConfigData and config then
@@ -1581,7 +1581,7 @@ function widgetHandler:KeyPress(key, mods, isRepeat, label, unicode, scanCode, a
 	return false
 end
 
-function widgetHandler:KeyRelease(key, mods, label, unicode, scanCode, actions)	
+function widgetHandler:KeyRelease(key, mods, label, unicode, scanCode, actions)
 	tracy.ZoneBeginN("W:KeyRelease")
 	local textOwner = self.textOwner
 
@@ -1716,7 +1716,7 @@ function widgetHandler:ControllerAdded(deviceIndex)
 			return true
 		end
 	end
-	
+
 	tracy.ZoneEnd()
 	return false
 end
@@ -2196,7 +2196,7 @@ function widgetHandler:UnitIdle(unitID, unitDefID, unitTeam)
 end
 
 function widgetHandler:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams, cmdOpts, cmdTag, playerID, fromSynced, fromLua)
-	
+
 	tracy.ZoneBeginN("W:UnitCommand")
 	for _, w in ipairs(self.UnitCommandList) do
 		w:UnitCommand(unitID, unitDefID, unitTeam,

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -460,13 +460,45 @@ end
 
 
 
-function widgetHandler:LoadWidget(filename, fromZip)
+function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess)
 	local basename = Basename(filename)
 	local text = VFS.LoadFile(filename, not (self.allowUserWidgets and allowuserwidgets) and VFS.ZIP or VFS.RAW_FIRST)
 	if text == nil then
 		Spring.Echo('Failed to load: ' .. basename .. '  (missing file: ' .. filename .. ')')
 		return nil
 	end
+
+	if enableLocalsAccess then
+		-- enableLocalsAccess makes it so local variables within the widget can be accessed as if they were globals (as
+		-- opposed to not being able to access them at all from outside the widget). This is accomplished by loading the
+		-- widget with an additional code snippet to list all of the local variables, getting that result, and then
+		-- loading again with a code snippet that sets up external access to those variables.
+		localsAccess = localsAccess or VFS.Include('common/testing/locals_access.lua')
+
+		local textWithLocalsDetector = text .. localsAccess.localsDetectorString
+
+		local chunk, err = loadstring(textWithLocalsDetector, filename)
+		if chunk == nil then
+			Spring.Echo('Failed to load: ' .. basename .. '  (' .. err .. ')')
+			return nil
+		end
+
+		local widget = widgetHandler:NewWidget()
+		setfenv(chunk, widget)
+		local success, valOrErr = pcall(chunk)
+		if not success then
+			Spring.Echo('Failed to load: ' .. basename .. '  (' .. valOrErr .. ')')
+			return nil
+		end
+		if err == false then
+			return nil -- widget asked for a silent death
+		end
+
+		local localsNames = valOrErr
+
+		text = text .. localsAccess.generateLocalsAccessStr(localsNames)
+	end
+
 	local chunk, err = loadstring(text, filename)
 	if chunk == nil then
 		Spring.Echo('Failed to load: ' .. basename .. '  (' .. err .. ')')
@@ -482,6 +514,10 @@ function widgetHandler:LoadWidget(filename, fromZip)
 	end
 	if err == false then
 		return nil -- widget asked for a silent death
+	end
+
+	if enableLocalsAccess then
+		setmetatable(widget, localsAccess.generateLocalsAccessMetatable(getmetatable(widget)))
 	end
 
 	-- user widgets may not access widgetHandler
@@ -939,19 +975,19 @@ function widgetHandler:IsWidgetKnown(name)
 	return self.knownWidgets[name] and true or false
 end
 
-function widgetHandler:EnableWidget(name)
+function widgetHandler:EnableWidget(name, enableLocalsAccess)
 	local ki = self.knownWidgets[name]
 	if not ki then
 		Spring.Echo("EnableWidget(), could not find widget: " .. tostring(name))
 		return false
 	end
 	if not ki.active then
-		Spring.Echo('Loading:  ' .. ki.filename)
+		Spring.Echo('Loading:  ' .. ki.filename .. (enableLocalsAccess and " (with locals)" or ""))
 		local order = widgetHandler.orderList[name]
 		if not order or order <= 0 then
 			self.orderList[name] = 1
 		end
-		local w = self:LoadWidget(ki.filename, ki.fromZip)
+		local w = self:LoadWidget(ki.filename, ki.fromZip, enableLocalsAccess)
 		if not w then
 			return false
 		end
@@ -1189,12 +1225,12 @@ end
 
 
 function widgetHandler:Update()
-	
-	if collectgarbage("count") > 1200000 then 
+
+	if collectgarbage("count") > 1200000 then
 		Spring.Echo("Warning: Emergency garbage collection due to exceeding 1.2GB LuaRAM")
 		collectgarbage("collect")
 	end
-	
+
 	local deltaTime = Spring.GetLastUpdateSeconds()
 	-- update the hour timer
 	hourTimer = (hourTimer + deltaTime) % 3600.0


### PR DESCRIPTION
Calling `widgetHandler:EnableWidget(widgetName, true)` instead of `widgetHandler:EnableWidget(widgetName)` will now allow access to local variables as if they were globals, with `widget.localVariable`. Read and write are both supported.

---
This is intended for use with the new test runner. See discussion here: https://discord.com/channels/549281623154229250/1194505222605778984 and original draft PR here: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2515