### PR TITLE
feat(synced_proxy): add synced proxy gadget for running code in synced

### DIFF
--- a/common/luaUtilities/serpent.lua
+++ b/common/luaUtilities/serpent.lua
@@ -1,0 +1,153 @@
+-- provides a consistent interface for de/serialisation
+local n, v = "serpent", "0.303" -- (C) 2012-18 Paul Kulchenko; MIT License
+local c, d = "Paul Kulchenko", "Lua serializer and pretty printer"
+local snum = {[tostring(1/0)]='1/0 --[[math.huge]]',[tostring(-1/0)]='-1/0 --[[-math.huge]]',[tostring(0/0)]='0/0'}
+local badtype = {thread = true, userdata = true, cdata = true}
+local getmetatable = debug and debug.getmetatable or getmetatable
+local pairs = function(t) return next, t end -- avoid using __pairs in Lua 5.2+
+local keyword, globals, G = {}, {}, (_G or _ENV or widget or gadget)
+for _,k in ipairs({'and', 'break', 'do', 'else', 'elseif', 'end', 'false',
+  'for', 'function', 'goto', 'if', 'in', 'local', 'nil', 'not', 'or', 'repeat',
+  'return', 'then', 'true', 'until', 'while'}) do keyword[k] = true end
+for k,v in pairs(G) do globals[v] = k end -- build func to name mapping
+for _,g in ipairs({'coroutine', 'debug', 'io', 'math', 'string', 'table', 'os'}) do
+  for k,v in pairs(type(G[g]) == 'table' and G[g] or {}) do globals[v] = g..'.'..k end end
+
+local function s(t, opts)
+  local name, indent, fatal, maxnum = opts.name, opts.indent, opts.fatal, opts.maxnum
+  local sparse, custom, huge = opts.sparse, opts.custom, not opts.nohuge
+  local space, maxl = (opts.compact and '' or ' '), (opts.maxlevel or math.huge)
+  local maxlen, metatostring = tonumber(opts.maxlength), opts.metatostring
+  local iname, comm = '_'..(name or ''), opts.comment and (tonumber(opts.comment) or math.huge)
+  local numformat = opts.numformat or "%.17g"
+  local seen, sref, syms, symn = {}, {'local '..iname..'={}'}, {}, 0
+  local function gensym(val) return '_'..(tostring(tostring(val)):gsub("[^%w]",""):gsub("(%d%w+)",
+    -- tostring(val) is needed because __tostring may return a non-string value
+    function(s) if not syms[s] then symn = symn+1; syms[s] = symn end return tostring(syms[s]) end)) end
+  local function safestr(s) return type(s) == "number" and (huge and snum[tostring(s)] or numformat:format(s))
+    or type(s) ~= "string" and tostring(s) -- escape NEWLINE/010 and EOF/026
+    or ("%q"):format(s):gsub("\010","n"):gsub("\026","\\026") end
+  -- handle radix changes in some locales
+  if opts.fixradix and (".1f"):format(1.2) ~= "1.2" then
+    local origsafestr = safestr
+    safestr = function(s) return type(s) == "number"
+      and (nohuge and snum[tostring(s)] or numformat:format(s):gsub(",",".")) or origsafestr(s)
+    end
+  end
+  local function comment(s,l) return comm and (l or 0) < comm and ' --[['..select(2, pcall(tostring, s))..']]' or '' end
+  local function globerr(s,l) return globals[s] and globals[s]..comment(s,l) or not fatal
+    and safestr(select(2, pcall(tostring, s))) or error("Can't serialize "..tostring(s)) end
+  local function safename(path, name) -- generates foo.bar, foo[3], or foo['b a r']
+    local n = name == nil and '' or name
+    local plain = type(n) == "string" and n:match("^[%l%u_][%w_]*$") and not keyword[n]
+    local safe = plain and n or '['..safestr(n)..']'
+    return (path or '')..(plain and path and '.' or '')..safe, safe end
+  local alphanumsort = type(opts.sortkeys) == 'function' and opts.sortkeys or function(k, o, n) -- k=keys, o=originaltable, n=padding
+    local maxn, to = tonumber(n) or 12, {number = 'a', string = 'b'}
+    local function padnum(d) return ("%0"..tostring(maxn).."d"):format(tonumber(d)) end
+    table.sort(k, function(a,b)
+      -- sort numeric keys first: k[key] is not nil for numerical keys
+      return (k[a] ~= nil and 0 or to[type(a)] or 'z')..(tostring(a):gsub("%d+",padnum))
+           < (k[b] ~= nil and 0 or to[type(b)] or 'z')..(tostring(b):gsub("%d+",padnum)) end) end
+  local function val2str(t, name, indent, insref, path, plainindex, level)
+    local ttype, level, mt = type(t), (level or 0), getmetatable(t)
+    local spath, sname = safename(path, name)
+    local tag = plainindex and
+      ((type(name) == "number") and '' or name..space..'='..space) or
+      (name ~= nil and sname..space..'='..space or '')
+    if seen[t] then -- already seen this element
+      sref[#sref+1] = spath..space..'='..space..seen[t]
+      return tag..'nil'..comment('ref', level)
+    end
+    -- protect from those cases where __tostring may fail
+    if type(mt) == 'table' and metatostring ~= false then
+      local to, tr = pcall(function() return mt.__tostring(t) end)
+      local so, sr = pcall(function() return mt.__serialize(t) end)
+      if (to or so) then -- knows how to serialize itself
+        seen[t] = insref or spath
+        t = so and sr or tr
+        ttype = type(t)
+      end -- new value falls through to be serialized
+    end
+    if ttype == "table" then
+      if level >= maxl then return tag..'{}'..comment('maxlvl', level) end
+      seen[t] = insref or spath
+      if next(t) == nil then return tag..'{}'..comment(t, level) end -- table empty
+      if maxlen and maxlen < 0 then return tag..'{}'..comment('maxlen', level) end
+      local maxn, o, out = math.min(#t, maxnum or #t), {}, {}
+      for key = 1, maxn do o[key] = key end
+      if not maxnum or #o < maxnum then
+        local n = #o -- n = n + 1; o[n] is much faster than o[#o+1] on large tables
+        for key in pairs(t) do
+          if o[key] ~= key then n = n + 1; o[n] = key end
+        end
+      end
+      if maxnum and #o > maxnum then o[maxnum+1] = nil end
+      if opts.sortkeys and #o > maxn then alphanumsort(o, t, opts.sortkeys) end
+      local sparse = sparse and #o > maxn -- disable sparsness if only numeric keys (shorter output)
+      for n, key in ipairs(o) do
+        local value, ktype, plainindex = t[key], type(key), n <= maxn and not sparse
+        if opts.valignore and opts.valignore[value] -- skip ignored values; do nothing
+        or opts.keyallow and not opts.keyallow[key]
+        or opts.keyignore and opts.keyignore[key]
+        or opts.valtypeignore and opts.valtypeignore[type(value)] -- skipping ignored value types
+        or sparse and value == nil then -- skipping nils; do nothing
+        elseif ktype == 'table' or ktype == 'function' or badtype[ktype] then
+          if not seen[key] and not globals[key] then
+            sref[#sref+1] = 'placeholder'
+            local sname = safename(iname, gensym(key)) -- iname is table for local variables
+            sref[#sref] = val2str(key,sname,indent,sname,iname,true)
+          end
+          sref[#sref+1] = 'placeholder'
+          local path = seen[t]..'['..tostring(seen[key] or globals[key] or gensym(key))..']'
+          sref[#sref] = path..space..'='..space..tostring(seen[value] or val2str(value,nil,indent,path))
+        else
+          out[#out+1] = val2str(value,key,indent,nil,seen[t],plainindex,level+1)
+          if maxlen then
+            maxlen = maxlen - #out[#out]
+            if maxlen < 0 then break end
+          end
+        end
+      end
+      local prefix = string.rep(indent or '', level)
+      local head = indent and '{\n'..prefix..indent or '{'
+      local body = table.concat(out, ','..(indent and '\n'..prefix..indent or space))
+      local tail = indent and "\n"..prefix..'}' or '}'
+      return (custom and custom(tag,head,body,tail,level) or tag..head..body..tail)..comment(t, level)
+    elseif badtype[ttype] then
+      seen[t] = insref or spath
+      return tag..globerr(t, level)
+    elseif ttype == 'function' then
+      seen[t] = insref or spath
+      if opts.nocode then return tag.."function() --[[..skipped..]] end"..comment(t, level) end
+      local ok, res = pcall(string.dump, t)
+      local func = ok and "((loadstring or load)("..safestr(res)..",'@serialized'))"..comment(t, level)
+      return tag..(func or globerr(t, level))
+    else return tag..safestr(t) end -- handle all other types
+  end
+  local sepr = indent and "\n" or ";"..space
+  local body = val2str(t, name, indent) -- this call also populates sref
+  local tail = #sref>1 and table.concat(sref, sepr)..sepr or ''
+  local warn = opts.comment and #sref>1 and space.."--[[incomplete output with shared/self-references skipped]]" or ''
+  return not name and body..warn or "do local "..body..sepr..tail.."return "..name..sepr.."end"
+end
+
+local function deserialize(data, opts)
+  local env = (opts and opts.safe == false) and G
+    or setmetatable({}, {
+        __index = function(t,k) return t end,
+        __call = function(t,...) error("cannot call functions") end
+      })
+  local f, res = (loadstring or load)('return '..data, nil, nil, env)
+  if not f then f, res = (loadstring or load)(data, nil, nil, env) end
+  if not f then return f, res end
+  if setfenv then setfenv(f, env) end
+  return pcall(f)
+end
+
+local function merge(a, b) if b then for k,v in pairs(b) do a[k] = v end end; return a; end
+return { _NAME = n, _COPYRIGHT = c, _DESCRIPTION = d, _VERSION = v, serialize = s,
+  load = deserialize,
+  dump = function(a, opts) return s(a, merge({name = '_', compact = true, sparse = true}, opts)) end,
+  line = function(a, opts) return s(a, merge({sortkeys = true, comment = true}, opts)) end,
+  block = function(a, opts) return s(a, merge({indent = '  ', sortkeys = true, comment = true}, opts)) end }

--- a/common/testing/rpc.lua
+++ b/common/testing/rpc.lua
@@ -1,0 +1,177 @@
+local serpent = VFS.Include('common/luaUtilities/serpent.lua')
+local Util = VFS.Include('common/testing/util.lua')
+
+local function generateRandomString(length)
+	local charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	local random_string = ""
+	local charset_length = string.len(charset)
+
+	for i = 1, length do
+		local random_index = math.random(1, charset_length)
+		random_string = random_string .. string.sub(charset, random_index, random_index)
+	end
+
+	return random_string
+end
+
+local function evaluateStringPath(str, env)
+	local parts = {}
+	for part in str:gmatch("[^.]+") do
+		table.insert(parts, part)
+	end
+
+	local obj = env or _G
+
+	for _, part in ipairs(parts) do
+		obj = obj[part]
+		if obj == nil then
+			return nil
+		end
+	end
+
+	return obj
+end
+
+local function getLocals(i)
+	local result = {}
+	local j = 1
+	while true do
+		local n, v = debug.getlocal(i, j)
+		if n == nil then
+			break
+		end
+		result[#result + 1] = { n, v }
+		j = j + 1
+	end
+	return result
+end
+
+local RPC = {}
+
+function RPC:new(key)
+	local obj = {
+		key = key or generateRandomString(16),
+		currentReturnID = 0,
+	}
+	setmetatable(obj, self)
+	self.__index = self
+	return obj
+end
+
+function RPC:getNextReturnID()
+	self.currentReturnID = self.currentReturnID + 1
+	return self.key .. tostring(self.currentReturnID)
+end
+
+function RPC:serializeFunctionCall(path, args)
+	local returnID = self:getNextReturnID()
+
+	local data = {
+		path = path,
+		args = args,
+		returnID = returnID,
+	}
+
+	return serpent.dump(data), returnID
+end
+
+function RPC:deserializeFunctionCall(serializedCall, env)
+	local dataOk, data = serpent.load(serializedCall, { safe = false })
+
+	if not dataOk then
+		-- error parsing data
+		error(data)
+	end
+
+	local fn = evaluateStringPath(data.path, env)
+
+	if not fn then
+		error("could not find function: " .. data.path)
+	end
+
+	local callableFunction = function()
+		local pcallOk, pcallResult = Util.splitFirstElement(Util.pack(pcall(fn, unpack(data.args))))
+		return pcallOk, pcallResult
+	end
+
+	return callableFunction, data.returnID
+end
+
+function RPC:serializeFunctionRun(fn, stackDistance)
+	local fnLocals = getLocals(stackDistance + 1)
+	--local fnUpvalues = getUpvalues(fn)
+
+	local returnID = self:getNextReturnID()
+
+	local data = {
+		fn = fn,
+		locals = fnLocals,
+		--upvalues = fnUpvalues,
+		returnID = returnID,
+	}
+
+	return serpent.dump(data), returnID
+end
+
+function RPC:deserializeFunctionRun(serializedFn)
+	local dataOk, data = serpent.load(serializedFn, { safe = false })
+
+	if not dataOk then
+		-- error parsing data
+		error(data)
+	end
+
+	local localsDictionary = {}
+
+	for i = 1, #data.locals do
+		local key = data.locals[i][1]
+		local value = data.locals[i][2]
+
+		if key ~= nil and value ~= nil then
+			localsDictionary[key] = value
+		end
+	end
+
+	local callableFunction = function()
+		local pcallOk, pcallResult = Util.splitFirstElement(Util.pack(pcall(data.fn, localsDictionary)))
+		return pcallOk, pcallResult
+	end
+
+	return callableFunction, data.returnID
+end
+
+function RPC:serializeFunctionReturn(pcallOk, pcallResult, returnID)
+	local data = nil
+	if pcallOk then
+		data = {
+			success = true,
+			result = pcallResult,
+			returnID = returnID,
+		}
+	else
+		data = {
+			success = false,
+			error = pcallResult,
+			returnID = returnID,
+		}
+	end
+
+	return serpent.dump(data)
+end
+
+function RPC:deserializeFunctionReturn(serializedReturn)
+	local dataOk, data = serpent.load(serializedReturn)
+
+	if not dataOk then
+		-- error parsing data
+		error(data)
+	end
+
+	if data.success then
+		return data.success, data.result, data.returnID
+	else
+		return data.success, data.error, data.returnID
+	end
+end
+
+return RPC

--- a/common/testing/synced_proxy.lua
+++ b/common/testing/synced_proxy.lua
@@ -1,0 +1,10 @@
+local separator = "||||"
+
+return {
+	SEPARATOR = separator,
+	PREFIX = {
+		CALL = "synced_proxy_call" .. separator,
+		RUN = "synced_proxy_run" .. separator,
+		RETURN = "synced_proxy_return" .. separator,
+	}
+}

--- a/luarules/gadgets/dbg_synced_proxy.lua
+++ b/luarules/gadgets/dbg_synced_proxy.lua
@@ -12,7 +12,7 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
-if not Spring.Utilities.IsDevMode() then
+if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() then
 	return
 end
 
@@ -62,6 +62,10 @@ local RECEIVE_MODES = {
 }
 
 function gadget:RecvLuaMsg(msg, playerID)
+	-- check cheating here because cheats might not be enabled when the game starts
+	if not Spring.IsCheatingEnabled() then
+		return
+	end
 	for prefix, fn in pairs(RECEIVE_MODES) do
 		if msg:sub(1, #prefix) == prefix then
 			fn(msg:sub(#prefix + 1))

--- a/luarules/gadgets/dbg_synced_proxy.lua
+++ b/luarules/gadgets/dbg_synced_proxy.lua
@@ -1,0 +1,71 @@
+function gadget:GetInfo()
+	return {
+		name = "Synced Proxy",
+		desc = "Proxy that allows running arbitrary code in the synced LuaRules environment",
+		license = "GNU GPL, v2 or later",
+		layer = 9999,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+if not Spring.Utilities.IsDevMode() then
+	return
+end
+
+local LOG_LEVEL = LOG.INFO
+
+local Proxy = VFS.Include('common/testing/synced_proxy.lua')
+
+local rpc = VFS.Include('common/testing/rpc.lua'):new()
+
+local function log(level, str, ...)
+	if level < LOG_LEVEL then
+		return
+	end
+
+	Spring.Log(
+		gadget:GetInfo().name,
+		LOG.NOTICE,
+		str
+	)
+end
+
+local function processFunctionCall(fn, returnID)
+	local pcallOk, pcallResult = fn()
+
+	log(LOG.DEBUG, "[processFunctionCall] " .. table.toString({
+		pcall = { pcallOk, pcallResult },
+		returnID = returnID,
+	}))
+
+	local serializedReturn = rpc:serializeFunctionReturn(pcallOk, pcallResult, returnID)
+
+	log(LOG.DEBUG, "[processFunctionCall.SendLuaUIMsg] " .. Proxy.PREFIX.RETURN .. serializedReturn)
+	Spring.SendLuaUIMsg(Proxy.PREFIX.RETURN .. serializedReturn)
+end
+
+local RECEIVE_MODES = {
+	[Proxy.PREFIX.CALL] = function(msg)
+		log(LOG.DEBUG, "[ProxyCall] " .. msg)
+
+		processFunctionCall(rpc:deserializeFunctionCall(msg, _G))
+	end,
+	[Proxy.PREFIX.RUN] = function(msg)
+		log(LOG.DEBUG, "[ProxyRun]")
+
+		processFunctionCall(rpc:deserializeFunctionRun(msg))
+	end,
+}
+
+function gadget:RecvLuaMsg(msg, playerID)
+	for prefix, fn in pairs(RECEIVE_MODES) do
+		if msg:sub(1, #prefix) == prefix then
+			fn(msg:sub(#prefix + 1))
+			return
+		end
+	end
+end


### PR DESCRIPTION
To call a function, call `Spring.SendLuaRulesMsg(prefix .. fn)`, where the prefix is from synced_proxy.lua, and `fn` is serialized with an RPC object (rpc.lua).

The return value of the function can be accessed by `widget:RecvLuaMsg()`, where the message is composed of the return prefix from synced_proxy.lua, and a serialized return value, which can be deserialized with the same RPC object (rpc.lua).

When a function is serialized or deserialized, a `returnID` is used to correlate function calls with their associated returns. This must be checked to make sure that `widget:RecvLuaMsg()` is looking at the desired return.

---
This is intended for use with the new test runner. See discussion here: https://discord.com/channels/549281623154229250/1194505222605778984 and original draft PR here: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2515

The serpent library can be found at https://github.com/pkulchenko/serpent