### PR TITLE
feat(testing): add test runner widget for in-game tests 

### DIFF
--- a/common/testing/assertions.lua
+++ b/common/testing/assertions.lua
@@ -1,0 +1,51 @@
+local function assertTablesEqual(table1, table2, margin, visited, path)
+	visited = visited or {}
+	path = path or {}
+	margin = margin or 0
+
+	local function buildPathString()
+		local pathString = ""
+		for _, key in ipairs(path) do
+			pathString = pathString .. "[" .. tostring(key) .. "]"
+		end
+		return pathString
+	end
+
+	if type(table1) ~= "table" or type(table2) ~= "table" then
+		if type(table1) == "number" and type(table2) == "number" then
+			assert(math.abs(table1 - table2) <= margin, "Numbers are not close enough at path: " .. buildPathString())
+		else
+			assert(table1 == table2, "Tables are not equal at path: " .. buildPathString())
+		end
+		return
+	end
+
+	if visited[table1] or visited[table2] then
+		-- Prevent infinite recursion on circular references
+		assert(table1 == table2, "Tables are not equal (circular reference) at path: " .. buildPathString())
+		return
+	end
+
+	visited[table1] = true
+	visited[table2] = true
+
+	for key, value1 in pairs(table1) do
+		local value2 = table2[key]
+		table.insert(path, key)
+		assertTablesEqual(value1, value2, margin, visited, path)
+		table.remove(path)
+	end
+
+	for key, value2 in pairs(table2) do
+		local value1 = table1[key]
+		if value1 == nil then
+			assert(false, "Tables are not equal, extra key '" .. tostring(key) .. "' in second table at path: " .. buildPathString())
+		end
+	end
+end
+
+
+
+return {
+	assertTablesEqual = assertTablesEqual,
+}

--- a/common/testing/mocha_json_reporter.lua
+++ b/common/testing/mocha_json_reporter.lua
@@ -1,0 +1,81 @@
+local function formatTimestamp(ts)
+	return os.date("%Y-%m-%dT%H:%M:%S", ts)
+end
+
+local MochaJSONReporter = {}
+
+function MochaJSONReporter:new()
+	local obj = {
+		totalTests = 0,
+		totalPasses = 0,
+		totalFailures = 0,
+		startTime = nil,
+		endTime = nil,
+		duration = nil,
+		tests = {}
+	}
+	setmetatable(obj, self)
+	self.__index = self
+	return obj
+end
+
+function MochaJSONReporter:startTests()
+	self.startTime = os.time()
+end
+
+function MochaJSONReporter:endTests(duration)
+	self.endTime = os.time()
+	self.duration = duration
+end
+
+function MochaJSONReporter:testResult(label, filePath, success, duration, errorMessage)
+	local result = {
+		title = label,
+		fullTitle = label,
+		file = filePath,
+		duration = duration,
+	}
+	if success then
+		self.totalPasses = self.totalPasses + 1
+		result.err = {}
+	else
+		self.totalFailures = self.totalFailures + 1
+		if errorMessage ~= nil then
+			result.err = {
+				message = errorMessage,
+				stack = errorMessage
+			}
+		else
+			result.err = {
+				message = "<unknown error>",
+			}
+		end
+	end
+
+	self.totalTests = self.totalTests + 1
+	self.tests[#(self.tests) + 1] = result
+end
+
+function MochaJSONReporter:report(filePath)
+	local output = {
+		["stats"] = {
+			["suites"] = 1,
+			["tests"] = self.totalTests,
+			["passes"] = self.totalPasses,
+			["pending"] = 0,
+			["failures"] = self.totalFailures,
+			["start"] = formatTimestamp(self.startTime),
+			["end"] = formatTimestamp(self.endTime),
+			["duration"] = self.duration
+		},
+		["tests"] = self.tests
+	}
+
+	local encoded = Json.encode(output)
+
+	local file = io.open(filePath, "w")
+	file:write(encoded)
+	file:close()
+end
+
+return MochaJSONReporter

--- a/common/testing/mock.lua
+++ b/common/testing/mock.lua
@@ -1,0 +1,42 @@
+local function spy(parent, target)
+	local original = parent[target]
+	local calls = {}
+	local wrapper = function(...)
+		local args = { ... }
+		calls[#calls + 1] = table.copy(args)
+		return original(unpack(args))
+	end
+	parent[target] = wrapper
+	return {
+		original = original,
+		calls = calls,
+		remove = function()
+			parent[target] = original
+		end
+	}
+end
+
+local function mock(parent, target, fn)
+	local original = parent[target]
+	local calls = {}
+	local wrapper = function(...)
+		local args = { ... }
+		calls[#calls + 1] = table.copy(args)
+		if fn ~= nil then
+			return fn(unpack(args))
+		end
+	end
+	parent[target] = wrapper
+	return {
+		original = original,
+		calls = calls,
+		remove = function()
+			parent[target] = original
+		end
+	}
+end
+
+return {
+	spy = spy,
+	mock = mock,
+}

--- a/common/testing/results.lua
+++ b/common/testing/results.lua
@@ -1,0 +1,73 @@
+local function enum(...)
+	local args = { ... }
+	local result = {}
+	for _, v in ipairs(args) do
+		result[v] = v
+	end
+	return result
+end
+
+local TEST_RESULT = enum(
+	"PASS",
+	"FAIL",
+	"SKIP",
+	"ERROR"
+)
+
+local function clamp(min, max, num)
+	if (num < min) then
+		return min
+	elseif (num > max) then
+		return max
+	end
+	return num
+end
+
+local function rgbToColorCode(r, g, b)
+	local rs = clamp(1, 255, math.round(255 * r))
+	local gs = clamp(1, 255, math.round(255 * g))
+	local bs = clamp(1, 255, math.round(255 * b))
+	return "\255" .. string.char(rs) .. string.char(gs) .. string.char(bs)
+end
+
+local function rgbReset()
+	return rgbToColorCode(0.85, 0.85, 0.85)
+end
+
+local function formatTestResult(testResult, noColor)
+	local resultColor
+	local resetColor
+	if noColor then
+		resultColor = ""
+		resetColor = ""
+	else
+		if testResult.result == TEST_RESULT.PASS then
+			resultColor = rgbToColorCode(0, 1, 0)
+		elseif testResult.result == TEST_RESULT.FAIL then
+			resultColor = rgbToColorCode(1, 0, 0)
+		elseif testResult.result == TEST_RESULT.SKIP then
+			resultColor = rgbToColorCode(1, 0.8, 0)
+		elseif testResult.result == TEST_RESULT.ERROR then
+			resultColor = rgbToColorCode(0.8, 0, 0.8)
+		end
+		resetColor = rgbReset()
+	end
+
+	local resultStr = resultColor .. testResult.result .. resetColor
+	local s = string.format("%s: %s", resultStr, testResult.label)
+	if testResult.frames ~= nil then
+		s = s .. " [" .. testResult.frames .. " frames]"
+	end
+	if testResult.milliseconds ~= nil then
+		s = s .. " [" .. testResult.milliseconds .. " ms]"
+	end
+	if testResult.error ~= nil then
+		s = s .. " | " .. testResult.error
+	end
+	return s
+end
+
+return {
+	TEST_RESULT = TEST_RESULT,
+	formatTestResult = formatTestResult,
+}

--- a/common/testing/util.lua
+++ b/common/testing/util.lua
@@ -1,0 +1,96 @@
+local function pack(...)
+	return { ... }
+end
+
+local function splitFirstElement(tbl)
+	if type(tbl) ~= "table" then
+		error("Input must be a table")
+	end
+
+	if #tbl < 1 then
+		return nil, {}
+	end
+
+	local firstElement = table.remove(tbl, 1)
+	return firstElement, tbl
+end
+
+local function splitPhrases(input)
+	local result = {}
+	local currentPhrase = ""
+
+	local function appendPhrase(phrase)
+		table.insert(result, phrase:match("^%s*(.-)%s*$"))  -- Trim whitespace
+		currentPhrase = ""
+	end
+
+	local i = 1
+	local len = string.len(input)
+
+	while i <= len do
+		local char = string.sub(input, i, i)
+
+		if char == " " and currentPhrase ~= "" then
+			appendPhrase(currentPhrase)
+		elseif char == "\"" then
+			local quoteStart = i
+			repeat
+				i = i + 1
+				char = string.sub(input, i, i)
+				if char == "\\" then
+					i = i + 1 -- Skip escaped character
+				end
+			until char == "\"" or i > len
+
+			local quoteEnd = i
+			appendPhrase(string.sub(input, quoteStart + 1, quoteEnd - 1))
+		else
+			currentPhrase = currentPhrase .. char
+		end
+
+		i = i + 1
+	end
+
+	if currentPhrase ~= "" then
+		appendPhrase(currentPhrase)
+	end
+
+	return result
+end
+
+local function removeFileExtension(filename)
+	local lastDotIndex = filename:match(".+()%.%w+$")
+	if lastDotIndex then
+		return filename:sub(1, lastDotIndex - 1)
+	else
+		return filename
+	end
+end
+
+local function yieldable_pcall(func, ...)
+	-- this works just like pcall, but while pcall fails on yield, this handles yield transparently
+	local function helper(co, ok, ...)
+		if ok then
+			if coroutine.status(co) == "dead" then
+				return true, (...)
+			end
+			return helper(co, coroutine.resume(co, coroutine.yield(...)))
+		else
+			return false, (...)
+		end
+	end
+
+	local co = coroutine.create(function(...)
+		return func(...)
+	end)
+
+	return helper(co, coroutine.resume(co, ...))
+end
+
+return {
+	pack = pack,
+	yieldable_pcall = yieldable_pcall,
+	splitFirstElement = splitFirstElement,
+	splitPhrases = splitPhrases,
+	removeFileExtension = removeFileExtension,
+}

--- a/luarules/gadgets/dbg_synced_proxy.lua
+++ b/luarules/gadgets/dbg_synced_proxy.lua
@@ -13,8 +13,11 @@ if not gadgetHandler:IsSyncedCode() then
 end
 
 if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() then
+	Spring.SetGameRulesParam('isSyncedProxyEnabled', false)
 	return
 end
+
+Spring.SetGameRulesParam('isSyncedProxyEnabled', true)
 
 local LOG_LEVEL = LOG.INFO
 
@@ -72,4 +75,8 @@ function gadget:RecvLuaMsg(msg, playerID)
 			return
 		end
 	end
+end
+
+function gadget:Shutdown()
+	Spring.SetGameRulesParam('isSyncedProxyEnabled', false)
 end

--- a/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -1,0 +1,45 @@
+function skip()
+	return not string.find(Game.mapName, "Full Metal Plate")
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	widget = widgetHandler:FindWidget("Stop means Stop")
+	assert(widget)
+
+	local myTeamID = Spring.GetMyTeamID()
+
+	unitID = SyncedRun(function(locals)
+		local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+		local y = Spring.GetGroundHeight(x, z)
+		return Spring.CreateUnit("armpw", x, y, z, 0, locals.myTeamID)
+	end)
+
+	-- issue selfd and then issue stop
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
+	assert(Spring.GetUnitSelfDTime(unitID) > 0)
+
+	Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
+	assert(Spring.GetUnitSelfDTime(unitID) == 0)
+	assert(#(Spring.GetCommandQueue(unitID, 1)) == 0)
+
+	-- issue {move, selfd}, then issue stop
+	Spring.GiveOrderToUnit(unitID, CMD.MOVE, { 1, 1, 1 }, 0)
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, { "shift" })
+	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
+	assert(Spring.GetUnitSelfDTime(unitID) == 0)
+
+	Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.STOP, nil, nil, nil })
+	assert(Spring.GetUnitSelfDTime(unitID) == 0)
+	assert(#(Spring.GetCommandQueue(unitID, 1)) == 0)
+end

--- a/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -1,5 +1,5 @@
 function skip()
-	return not string.find(Game.mapName, "Full Metal Plate")
+	return not string.find(Game.mapName, "Full Metal Plate") or Spring.GetGameFrame() <= 0
 end
 
 function setup()

--- a/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -1,5 +1,5 @@
 function skip()
-	return not string.find(Game.mapName, "Full Metal Plate") or Spring.GetGameFrame() <= 0
+	return Spring.GetGameFrame() <= 0
 end
 
 function setup()

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
@@ -1,0 +1,58 @@
+local widgetName = "Self-Destruct Icons"
+
+function setup()
+	Test.clearMap()
+
+	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
+	if initialWidgetActive then
+		widgetHandler:DisableWidget(widgetName)
+	end
+	widgetHandler:EnableWidget(widgetName, true)
+end
+
+function cleanup()
+	Test.clearMap()
+
+	widgetHandler:DisableWidget(widgetName)
+	if initialWidgetActive then
+		widgetHandler:EnableWidget(widgetName, false)
+	end
+end
+
+function test()
+	widget = widgetHandler:FindWidget(widgetName)
+	assert(widget)
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+
+	unitID = SyncedRun(function(locals)
+		return Spring.CreateUnit(
+			"armasp",
+			locals.x, locals.y, locals.z,
+			0, 0
+		)
+	end)
+
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- standard selfd command
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 1)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- cancel selfd order
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- currently fails
+	---- queued selfd order (repair pad should not be able to queue selfd)
+	--Spring.GiveOrderToUnit(unitID, CMD.MOVE, { 1, 1, 1 }, 0)
+	--Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, { "shift" })
+	--Test.waitFrames(1)
+	--assert(table.count(widget.activeSelfD) == 0)
+	--assert(table.count(widget.queuedSelfD) == 0)
+end

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
@@ -1,5 +1,9 @@
 local widgetName = "Self-Destruct Icons"
 
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
 function setup()
 	Test.clearMap()
 

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
@@ -1,0 +1,64 @@
+local widgetName = "Self-Destruct Icons"
+
+function setup()
+	Test.clearMap()
+
+	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
+	if initialWidgetActive then
+		widgetHandler:DisableWidget(widgetName)
+	end
+	widgetHandler:EnableWidget(widgetName, true)
+end
+
+function cleanup()
+	Test.clearMap()
+
+	widgetHandler:DisableWidget(widgetName)
+	if initialWidgetActive then
+		widgetHandler:EnableWidget(widgetName, false)
+	end
+end
+
+function test()
+	widget = widgetHandler:FindWidget(widgetName)
+	assert(widget)
+
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+
+	unitID = SyncedRun(function(locals)
+		return Spring.CreateUnit(
+			"armpw",
+			locals.x, locals.y, locals.z,
+			0, 0
+		)
+	end)
+
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- standard selfd command
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 1)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- cancel selfd order
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- queued selfd order
+	Spring.GiveOrderToUnit(unitID, CMD.MOVE, { 1, 1, 1 }, 0)
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, { "shift" })
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 1)
+
+	-- remove move order
+	Spring.GiveOrderToUnit(unitID, CMD.REMOVE, { CMD.MOVE }, { "alt" })
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 1)
+	assert(table.count(widget.queuedSelfD) == 0)
+end

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
@@ -1,5 +1,9 @@
 local widgetName = "Self-Destruct Icons"
 
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
 function setup()
 	Test.clearMap()
 

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
@@ -1,0 +1,59 @@
+local widgetName = "Self-Destruct Icons"
+
+function setup()
+	Test.clearMap()
+
+	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
+	if initialWidgetActive then
+		widgetHandler:DisableWidget(widgetName)
+	end
+	widgetHandler:EnableWidget(widgetName, true)
+end
+
+function cleanup()
+	Test.clearMap()
+
+	widgetHandler:DisableWidget(widgetName)
+	if initialWidgetActive then
+		widgetHandler:EnableWidget(widgetName, false)
+	end
+end
+
+function test()
+	widget = widgetHandler:FindWidget(widgetName)
+	assert(widget)
+
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+
+	unitID = SyncedRun(function(locals)
+		return Spring.CreateUnit(
+			"armvp",
+			locals.x, locals.y, locals.z,
+			0, 0
+		)
+	end)
+
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- standard selfd command
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 1)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- cancel selfd order
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	Test.waitFrames(1)
+	assert(table.count(widget.activeSelfD) == 0)
+	assert(table.count(widget.queuedSelfD) == 0)
+
+	-- currently fails
+	---- queued selfd order (factory can queue selfd, but it applies to units it builds, not itself)
+	--Spring.GiveOrderToUnit(unitID, CMD.MOVE, { 1, 1, 1 }, 0)
+	--Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, { "shift" })
+	--Test.waitFrames(1)
+	--assert(table.count(widget.activeSelfD) == 0)
+	--assert(table.count(widget.queuedSelfD) == 0)
+end

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
@@ -1,5 +1,9 @@
 local widgetName = "Self-Destruct Icons"
 
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
 function setup()
 	Test.clearMap()
 

--- a/luaui/Widgets/Tests/mex-building/pregame_mex_queue.lua
+++ b/luaui/Widgets/Tests/mex-building/pregame_mex_queue.lua
@@ -1,0 +1,105 @@
+function skip()
+	return Spring.GetGameFrame() > 0
+end
+
+-- Test whether mexes are able to clear queued buildings by shift-clicking
+function setup()
+	Test.clearMap()
+
+	widget_cmd_extractor_snap = widgetHandler:FindWidget("Extractor Snap (mex/geo)")
+	assert(widget_cmd_extractor_snap)
+
+	widget_gui_pregame_build = widgetHandler:FindWidget("Pregame Queue")
+	assert(widget_gui_pregame_build)
+
+	WG['pregame-build'].setBuildQueue({})
+	WG["pregame-build"].setPreGamestartDefID(nil)
+
+	initialCameraState = Spring.GetCameraState()
+
+	Spring.SetCameraState({
+		mode = 5,
+	})
+
+	-- wait for camera to move
+	Test.waitTime(10)
+end
+
+function cleanup()
+	Test.clearMap()
+
+	WG['pregame-build'].setBuildQueue({})
+	WG["pregame-build"].setPreGamestartDefID(nil)
+
+	Spring.SetCameraState(initialCameraState)
+end
+
+function test()
+	mexUnitDefId = UnitDefNames["armmex"].id
+	metalSpots = WG['resource_spot_finder'].metalSpotsList
+
+	midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	targetMex = nil
+	targetMexDistance = 1e20
+	for i = 1, #metalSpots do
+		local distance2 = math.distance2dSquared(midX, midZ, metalSpots[i].x, metalSpots[i].z)
+		if distance2 < targetMexDistance then
+			targetMexDistance = distance2
+			targetMex = metalSpots[i]
+		end
+	end
+
+	-- Place a mex off of a mex spot - expect mex snap to position it on the spot, as close as possible to cursor position
+	WG["pregame-build"].setPreGamestartDefID(mexUnitDefId)
+	sx, sy, sz = Spring.WorldToScreenCoords(targetMex.x - 200, targetMex.y, targetMex.z - 200)
+	Spring.WarpMouse(sx, sy)
+
+	-- wait for widgets to respond
+	Test.waitTime(10)
+
+	-- did it snap?
+	assert(WG.ExtractorSnap.position ~= nil)
+
+	-- did it snap to the closest mex?
+	assert(math.distance2d(
+		WG.ExtractorSnap.position.x,
+		WG.ExtractorSnap.position.z,
+		targetMex.x,
+		targetMex.z
+	) < 100)
+
+	snappedPosition = table.copy(WG.ExtractorSnap.position)
+
+	-- queue the mex build
+	Script.LuaUI.MousePress(sx, sy, 1)
+
+	-- wait for widgets to respond
+	Test.waitTime(10)
+
+	-- move mouse to snapped position
+	sx, sy, sz = Spring.WorldToScreenCoords(snappedPosition.x, snappedPosition.y, snappedPosition.z)
+	Spring.WarpMouse(sx, sy)
+
+	-- select mex again
+	WG["pregame-build"].setPreGamestartDefID(mexUnitDefId)
+
+	-- wait for widgets to respond
+	Test.waitTime(10)
+
+	-- mock shift, and mouse press on top of the snapped position
+	-- this should clear the queued mex, and not try to snap it to another position
+	Test.mock(Spring, "GetModKeyState", function()
+		return false, false, false, true
+	end)
+	Script.LuaUI.MousePress(sx, sy, 1)
+
+	-- wait for widgets to respond
+	Test.waitTime(10)
+
+	-- clear blueprint
+	WG["pregame-build"].setPreGamestartDefID(nil)
+
+	-- Did the mex get de-queued?
+	buildQueue = WG['pregame-build'].getBuildQueue()
+	assert(#buildQueue == 0, "Build queue should be empty")
+end

--- a/luaui/Widgets/Tests/mex-building/pregame_mex_snap.lua
+++ b/luaui/Widgets/Tests/mex-building/pregame_mex_snap.lua
@@ -1,0 +1,88 @@
+function skip()
+	return Spring.GetGameFrame() > 0
+end
+
+function setup()
+	Test.clearMap()
+
+	widget_cmd_extractor_snap = widgetHandler:FindWidget("Extractor Snap (mex/geo)")
+	assert(widget_cmd_extractor_snap)
+
+	widget_gui_pregame_build = widgetHandler:FindWidget("Pregame Queue")
+	assert(widget_gui_pregame_build)
+
+	WG['pregame-build'].setBuildQueue({})
+	WG["pregame-build"].setPreGamestartDefID(nil)
+
+	initialCameraState = Spring.GetCameraState()
+
+	Spring.SetCameraState({
+		mode = 5,
+	})
+
+	-- wait for camera to move
+	Test.waitTime(10)
+end
+
+function cleanup()
+	Test.clearMap()
+
+	WG['pregame-build'].setBuildQueue({})
+	WG["pregame-build"].setPreGamestartDefID(nil)
+
+	Spring.SetCameraState(initialCameraState)
+end
+
+function test()
+	mexUnitDefId = UnitDefNames["armmex"].id
+	metalSpots = WG['resource_spot_finder'].metalSpotsList
+
+	midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	targetMex = nil
+	targetMexDistance = 1e20
+	for i = 1, #metalSpots do
+		local distance2 = math.distance2dSquared(midX, midZ, metalSpots[i].x, metalSpots[i].z)
+		if distance2 < targetMexDistance then
+			targetMexDistance = distance2
+			targetMex = metalSpots[i]
+		end
+	end
+
+	-- Place a mex off of a mex spot - expect mex snap to position it on the spot, as close as possible to cursor position
+	WG["pregame-build"].setPreGamestartDefID(mexUnitDefId)
+	sx, sy, sz = Spring.WorldToScreenCoords(targetMex.x - 200, targetMex.y, targetMex.z - 200)
+	Spring.WarpMouse(sx, sy)
+
+	-- wait for widgets to respond
+	Test.waitTime(10)
+
+	-- did it snap?
+	assert(WG.ExtractorSnap.position ~= nil)
+
+	-- did it snap to the closest mex?
+	assert(math.distance2d(
+		WG.ExtractorSnap.position.x,
+		WG.ExtractorSnap.position.z,
+		targetMex.x,
+		targetMex.z
+	) < 100)
+
+	snappedPosition = table.copy(WG.ExtractorSnap.position)
+
+	-- queue the mex build
+	Script.LuaUI.MousePress(sx, sy, 1)
+
+	-- wait for widgets to respond
+	Test.waitTime(10)
+
+	-- did the mex get placed in the right spot?
+	buildQueue = WG['pregame-build'].getBuildQueue()
+	assert(#buildQueue == 1)
+	assertTablesEqual(buildQueue[1], {
+		mexUnitDefId,
+		snappedPosition.x,
+		snappedPosition.y,
+		snappedPosition.z,
+		0
+	}, 0.1)
+end

--- a/luaui/Widgets/TestsExamples/balance/test_arm_vs_cor_fighters.lua
+++ b/luaui/Widgets/TestsExamples/balance/test_arm_vs_cor_fighters.lua
@@ -1,3 +1,7 @@
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
 function setup()
 	Test.clearMap()
 end

--- a/luaui/Widgets/TestsExamples/balance/test_arm_vs_cor_fighters.lua
+++ b/luaui/Widgets/TestsExamples/balance/test_arm_vs_cor_fighters.lua
@@ -1,0 +1,93 @@
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+
+	Spring.SendCommands("setspeed " .. 1)
+end
+
+function test()
+	local units = {
+		[0] = "armfig",
+		[1] = "corveng"
+	}
+	local n = 200
+
+	local midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local xOffset = 1000
+	local zStep = 10
+	local startZ = midZ - zStep * n / 2
+
+	-- make two lines of units facing each other
+	SyncedRun(function(locals)
+		do
+			local x = locals.midX - locals.xOffset
+			for i = 1, locals.n do
+				local z = locals.startZ + locals.zStep * i
+				local y = Spring.GetGroundHeight(x, z)
+				local unitID = Spring.CreateUnit(locals.units[0], x, y, z, "east", 0)
+			end
+		end
+
+		do
+			local x = locals.midX + locals.xOffset
+			for i = 1, locals.n do
+				local z = locals.startZ + locals.zStep * i
+				local y = Spring.GetGroundHeight(x, z)
+				local unitID = Spring.CreateUnit(locals.units[1], x, y, z, "west", 1)
+			end
+
+		end
+	end)
+
+	Test.waitFrames(1)
+
+	if false then
+		Spring.GiveOrderToUnitArray(Spring.GetTeamUnits(0), CMD.FIGHT, { midX, 0, midZ }, 0)
+		Spring.GiveOrderToUnitArray(Spring.GetTeamUnits(1), CMD.FIGHT, { midX, 0, midZ }, 0)
+	else
+		for _, unitID in ipairs(Spring.GetAllUnits()) do
+			local ux, uy, uz = Spring.GetUnitPosition(unitID)
+
+			Spring.GiveOrderToUnit(unitID, CMD.FIGHT, { 2 * midX - ux, 0, uz }, 0)
+			Spring.GiveOrderToUnit(unitID, CMD.FIGHT, { midX, 0, midZ }, { "shift" })
+		end
+	end
+
+	Spring.SendCommands("setspeed " .. 5)
+
+	-- wait until one team has no units left
+	Test.waitUntil(function()
+		return #(Spring.GetTeamUnits(0)) == 0 or #(Spring.GetTeamUnits(1)) == 0
+	end, 60 * 30)
+
+	Spring.SendCommands("setspeed " .. 1)
+
+	if #(Spring.GetTeamUnits(0)) > #(Spring.GetTeamUnits(1)) then
+		winner = 0
+	elseif #(Spring.GetTeamUnits(1)) > #(Spring.GetTeamUnits(0)) then
+		winner = 1
+	end
+
+	resultStr = "RESULT: "
+	if winner ~= nil then
+		unitName = units[winner]
+		if UnitDefNames and units[winner] and UnitDefNames[units[winner]] then
+			unitName = UnitDefNames[units[winner]].translatedHumanName or units[winner]
+		end
+		unitsLeft = #(Spring.GetAllUnits())
+		resultStr = resultStr .. "team " .. winner .. " wins"
+		resultStr = resultStr .. " with " .. unitsLeft
+		resultStr = resultStr .. " (" .. string.format("%.f%%", 100 * unitsLeft / n) .. ")"
+		resultStr = resultStr .. " " .. unitName .. " left"
+	else
+		resultStr = resultStr .. "tie"
+	end
+
+	Spring.Echo(resultStr)
+
+	-- cor fighters should win
+	assert(winner == 1)
+end

--- a/luaui/Widgets/TestsExamples/balance/test_grunts_vs_pawns.lua
+++ b/luaui/Widgets/TestsExamples/balance/test_grunts_vs_pawns.lua
@@ -1,0 +1,85 @@
+function skip()
+	return not string.find(Game.mapName, "Full Metal Plate")
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+
+	Spring.SendCommands("setspeed " .. 1)
+end
+
+function test()
+	local units = {
+		[0] = "armpw",
+		[1] = "corak"
+	}
+	local n = 20
+
+	local midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local xOffset = 200
+	local zStep = 30
+	local startZ = midZ - zStep * n / 2
+
+	-- make two lines of units facing each other
+	SyncedRun(function(locals)
+		do
+			local x = locals.midX - locals.xOffset
+			for i = 1, locals.n do
+				local z = locals.startZ
+				local y = Spring.GetGroundHeight(x, z)
+				Spring.CreateUnit(locals.units[0], x, y, z + locals.zStep * i, "east", 0)
+			end
+		end
+
+		do
+			local x = locals.midX + locals.xOffset
+			for i = 1, locals.n do
+				local z = locals.startZ
+				local y = Spring.GetGroundHeight(x, z)
+				Spring.CreateUnit(locals.units[1], x, y, z + locals.zStep * i, "west", 1)
+			end
+
+		end
+	end)
+
+	Test.waitFrames(1)
+
+	Spring.GiveOrderToUnitArray(Spring.GetTeamUnits(0), CMD.FIGHT, { midX, 0, midZ }, 0)
+	Spring.GiveOrderToUnitArray(Spring.GetTeamUnits(1), CMD.FIGHT, { midX, 0, midZ }, 0)
+
+	Spring.SendCommands("setspeed " .. 20)
+
+	-- wait until one team has no units left
+	Test.waitUntil(function()
+		return #(Spring.GetTeamUnits(0)) == 0 or #(Spring.GetTeamUnits(1)) == 0
+	end, 30 * 30)
+
+	Spring.SendCommands("setspeed " .. 1)
+
+	if #(Spring.GetTeamUnits(0)) > #(Spring.GetTeamUnits(1)) then
+		winner = 0
+	elseif #(Spring.GetTeamUnits(1)) > #(Spring.GetTeamUnits(0)) then
+		winner = 1
+	end
+
+	resultStr = "RESULT: "
+	if winner ~= nil then
+		unitName = units[winner]
+		if UnitDefNames and units[winner] and UnitDefNames[units[winner]] then
+			unitName = UnitDefNames[units[winner]].translatedHumanName or units[winner]
+		end
+		resultStr = resultStr .. "team " .. winner .. " wins"
+		resultStr = resultStr .. " with " .. #(Spring.GetAllUnits()) .. " " .. unitName .. " left"
+	else
+		resultStr = resultStr .. "tie"
+	end
+
+	Spring.Echo(resultStr)
+
+	-- pawns should win
+	assert(winner == 0)
+end

--- a/luaui/Widgets/TestsExamples/balance/test_grunts_vs_pawns.lua
+++ b/luaui/Widgets/TestsExamples/balance/test_grunts_vs_pawns.lua
@@ -1,5 +1,5 @@
 function skip()
-	return not string.find(Game.mapName, "Full Metal Plate")
+	return not string.find(Game.mapName, "Full Metal Plate") or Spring.GetGameFrame() <= 0
 end
 
 function setup()

--- a/luaui/Widgets/TestsExamples/balance/test_grunts_vs_pawns.lua
+++ b/luaui/Widgets/TestsExamples/balance/test_grunts_vs_pawns.lua
@@ -1,5 +1,5 @@
 function skip()
-	return not string.find(Game.mapName, "Full Metal Plate") or Spring.GetGameFrame() <= 0
+	return Spring.GetGameFrame() <= 0
 end
 
 function setup()

--- a/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
+++ b/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
@@ -1,5 +1,9 @@
 local widgetName = "Battle Resource Tracker"
 
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
 function setup()
 	assert(widgetHandler.knownWidgets[widgetName] ~= nil)
 

--- a/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
+++ b/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
@@ -1,0 +1,67 @@
+local widgetName = "Battle Resource Tracker"
+
+function setup()
+	assert(widgetHandler.knownWidgets[widgetName] ~= nil)
+
+	Test.clearMap()
+
+	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
+	if initialWidgetActive then
+		widgetHandler:DisableWidget(widgetName)
+	end
+	widgetHandler:EnableWidget(widgetName, true)
+end
+
+function cleanup()
+	Test.clearMap()
+
+	widgetHandler:DisableWidget(widgetName)
+	if initialWidgetActive then
+		widgetHandler:EnableWidget(widgetName, false)
+	end
+end
+
+function test()
+	widget = widgetHandler:FindWidget(widgetName)
+	assert(widget)
+
+	widget.spatialHash:clear()
+
+	combineEventsSpy = Test.spy(widget, "combineEvents")
+
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+	local n = 5
+
+	local unit = "armpw"
+
+	unitM = UnitDefNames[unit].metalCost
+	unitE = UnitDefNames[unit].energyCost
+
+	SyncedRun(function(locals)
+		for i = 1, locals.n do
+			Spring.CreateUnit(locals.unit, locals.x, locals.y, locals.z + 10 * i, 0, 0)
+		end
+	end)
+
+	Test.clearMap()
+
+	assert(#(combineEventsSpy.calls) == n - 1, #(combineEventsSpy.calls))
+
+	events = widget.spatialHash:allEvents()
+	assert(#events == 1)
+
+	assert(events[1].n == n, events[1].n)
+
+	totalM = 0
+	for _, v in pairs(events[1].metal) do
+		totalM = totalM + v
+	end
+	assert(totalM == n * unitM)
+
+	totalE = 0
+	for _, v in pairs(events[1].energy) do
+		totalE = totalE + v
+	end
+	assert(totalE == n * unitE)
+end

--- a/luaui/Widgets/TestsExamples/test_utilities/test_mock.lua
+++ b/luaui/Widgets/TestsExamples/test_utilities/test_mock.lua
@@ -1,0 +1,9 @@
+function test()
+	mock_SpringGetModKeyState = Test.mock(Spring, "GetModKeyState", function()
+		return true, false, true, false
+	end)
+
+	assertTablesEqual(pack(Spring.GetModKeyState()), {true, false, true, false})
+
+	assert(#(mock_SpringGetModKeyState.calls) == 1)
+end

--- a/luaui/Widgets/TestsExamples/test_utilities/test_wait.lua
+++ b/luaui/Widgets/TestsExamples/test_utilities/test_wait.lua
@@ -1,0 +1,35 @@
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	Spring.Echo("[test_wait] waiting 5 frames")
+	Test.waitFrames(5)
+
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+
+	createdUnitID = SyncedRun(function(locals)
+		return Spring.CreateUnit("armpw", locals.x, locals.y, locals.z, 0, 0)
+	end)
+
+	Spring.Echo("[test_wait] waiting for UnitCreated on unitID=" .. createdUnitID)
+	Test.waitUntilCallin("UnitCreated", function(unitID, unitDefID, unitTeam, builderID)
+		Spring.Echo("Saw UnitCreated for unitID=" .. unitID)
+		return unitID == createdUnitID
+	end, 10)
+
+	startFrame = SyncedProxy.Spring.GetGameFrame()
+
+	Spring.Echo("[test_wait] waiting 3 frames, but the hard way")
+	Test.waitUntil(function()
+		return (Spring.GetGameFrame() - startFrame > 3)
+	end)
+
+	Spring.Echo("[test_wait] waiting 1000 ms")
+	Test.waitTime(1000)
+end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -302,6 +302,15 @@ local function startTests(patterns)
 		return
 	end
 
+	if not Spring.GetGameRulesParam("isSyncedProxyEnabled") then
+		log(
+			LOG.ERROR,
+			"The Synced Proxy gadget is required in order to run tests. It requires single player, dev mode, " ..
+				"and cheating  to be enabled."
+		)
+		return
+	end
+
 	logStartTests()
 
 	resetState()

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -1,0 +1,983 @@
+function widget:GetInfo()
+	return {
+		name = "Test Runner",
+		desc = "Run tests with: /runtests <pattern1> <pattern2> ...",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+		handler = true,
+	}
+end
+
+local Proxy = VFS.Include('common/testing/synced_proxy.lua')
+local MochaJSONReporter = VFS.Include('common/testing/mocha_json_reporter.lua')
+local Assertions = VFS.Include('common/testing/assertions.lua')
+local TestResults = VFS.Include('common/testing/results.lua')
+local Util = VFS.Include('common/testing/util.lua')
+local Mock = VFS.Include('common/testing/mock.lua')
+
+local rpc = VFS.Include('common/testing/rpc.lua'):new()
+
+local LOG_LEVEL = LOG.INFO
+
+local config = {
+	returnTimeout = 30,
+	waitTimeout = 5 * 30,
+	showAllResults = true,
+	noColorOutput = false,
+	quitWhenDone = false,
+	gameStartTestPatterns = nil,
+	testResultsFilePath = nil,
+	testRoots = {
+		"LuaUI/Widgets/tests",
+		"LuaUI/Tests",
+	},
+}
+
+local testReporter = nil
+
+-- utils
+-- =====
+local function log(level, str, ...)
+	if level < LOG_LEVEL then
+		return
+	end
+	Spring.Log(
+		widget:GetInfo().name,
+		LOG.NOTICE,
+		str
+	)
+end
+
+local function logStartTests()
+	if config.testResultsFilePath == nil then
+		return
+	end
+
+	testReporter = MochaJSONReporter:new()
+	testReporter:startTests()
+end
+
+local function logEndTests(duration)
+	if config.testResultsFilePath == nil then
+		return
+	end
+	testReporter:endTests(duration)
+
+	testReporter:report(config.testResultsFilePath)
+end
+
+local function logTestResult(testResult)
+	if config.testResultsFilePath == nil then
+		return
+	end
+
+	testReporter:testResult(
+		testResult.label,
+		testResult.filename,
+		(testResult.result == TestResults.TEST_RESULT.PASS),
+		testResult.milliseconds,
+		testResult.error
+	)
+end
+
+local function registerCallins(target, callback, callins)
+	local callinNames = {
+		'UnitCreated',
+		'UnitFinished',
+		'UnitFromFactory',
+		'UnitReverseBuilt',
+		'UnitDestroyed',
+		'RenderUnitDestroyed',
+		'UnitTaken',
+		'UnitGiven',
+		'UnitIdle',
+		'UnitCommand',
+		'UnitCmdDone',
+		'UnitDamaged',
+		--'UnitStunned',
+		'UnitEnteredRadar',
+		'UnitEnteredLos',
+		'UnitLeftRadar',
+		'UnitLeftLos',
+		'UnitEnteredUnderwater',
+		'UnitEnteredWater',
+		'UnitEnteredAir',
+		'UnitLeftUnderwater',
+		'UnitLeftWater',
+		'UnitLeftAir',
+		'UnitSeismicPing',
+		'UnitLoaded',
+		'UnitUnloaded',
+		'UnitCloaked',
+		'UnitDecloaked',
+		'UnitMoveFailed',
+		'UnitHarvestStorageFull',
+	}
+
+	for _, callinName in ipairs(callinNames) do
+		if callins == nil or table.contains(callins, callinName) then
+			target[callinName] = function(...)
+				local args = { ... }
+				table.remove(args, 1)
+				callback(callinName, args)
+			end
+		end
+	end
+end
+
+local function matchesPatterns(str, patterns)
+	for _, p in ipairs(patterns) do
+		if string.match(str, p) then
+			return true
+		end
+	end
+	return false
+end
+
+-- main code
+-- =========
+
+local function findTestFiles(directory, patterns, rootDirectory, result)
+	if rootDirectory == nil then
+		if directory:sub(-1) ~= '/' then
+			directory = directory .. '/'
+		end
+		rootDirectory = directory
+	end
+
+	if result == nil then
+		result = {}
+	end
+
+	for _, filename in ipairs(VFS.DirList(directory, "*", VFS.RAW_FIRST)) do
+		local relativePath = string.sub(filename, string.len(rootDirectory) + 1)
+		local withoutExtension = Util.removeFileExtension(relativePath)
+		if patterns == nil or #patterns == 0 or matchesPatterns(withoutExtension, patterns) then
+			log(LOG.INFO, "Found test file: " .. relativePath)
+			result[#result + 1] = {
+				filename = filename,
+				label = relativePath,
+			}
+		end
+	end
+
+	for _, subDir in ipairs(VFS.SubDirs(directory, "*", VFS.RAW_FIRST)) do
+		findTestFiles(subDir, patterns, rootDirectory, result)
+	end
+
+	return result
+end
+
+local function findAllTestFiles(patterns)
+	log(LOG.DEBUG, "[findAllTestFiles] " .. table.toString({
+		patterns = patterns,
+	}))
+	local result = {}
+	for _, path in ipairs(config.testRoots) do
+		for _, testFileInfo in ipairs(findTestFiles(path, patterns)) do
+			result[#result + 1] = testFileInfo
+		end
+	end
+	return result
+end
+
+local function displayTestResults(results)
+	log(LOG.INFO, "=====TEST RESULTS=====")
+	for _, testResult in ipairs(results) do
+		log(LOG.INFO, TestResults.formatTestResult(testResult, config.noColorOutput))
+	end
+end
+
+local gameTimer
+local runTestsTimer
+local testTimer
+
+local function getGameTime()
+	if gameTimer ~= nil then
+		return Spring.DiffTimers(Spring.GetTimer(), gameTimer, true)
+	end
+end
+
+local function getRunTestsTime()
+	if runTestsTimer ~= nil then
+		return Spring.DiffTimers(Spring.GetTimer(), runTestsTimer, true)
+	end
+end
+
+local function getTestTime()
+	if testTimer ~= nil then
+		return Spring.DiffTimers(Spring.GetTimer(), testTimer, true)
+	end
+end
+
+local testRunState
+local activeTestState
+local resumeState
+local returnState
+local callinState
+local spyControls
+
+local function resetTestRunState()
+	log(LOG.DEBUG, "[resetTestRunState]")
+	testRunState = {
+		runningTests = false,
+		files = {},
+		filesIndex = nil,
+		results = {},
+	}
+end
+
+local function resetActiveTestState()
+	log(LOG.DEBUG, "[resetActiveTestState]")
+	activeTestState = {
+		coroutine = nil,
+		environment = nil,
+		startFrame = nil,
+		filename = nil,
+		label = nil,
+	}
+end
+
+local function resetResumeState()
+	log(LOG.DEBUG, "[resetResumeState]")
+	resumeState = {
+		predicate = nil,
+		timeoutExpireFrame = nil,
+	}
+end
+
+local function resetReturnState()
+	log(LOG.DEBUG, "[resetReturnState]")
+	returnState = {
+		waitingForReturnID = nil,
+		success = nil,
+		pendingValueOrError = nil,
+		timeoutExpireFrame = nil,
+	}
+end
+
+local function resetCallinState()
+	log(LOG.DEBUG, "[resetCallinState]")
+	callinState = {
+		buffer = {},
+	}
+end
+
+local function resetSpyCtrls()
+	log(LOG.DEBUG, "[resetSpyCtrls]")
+	spyControls = {}
+end
+
+local function resetState()
+	log(LOG.DEBUG, "[resetState]")
+	resetTestRunState()
+	resetActiveTestState()
+	resetResumeState()
+	resetReturnState()
+	resetCallinState()
+	resetSpyCtrls()
+end
+
+resetState()
+
+registerCallins(widget, function(name, args)
+	if not testRunState.runningTests then
+		return
+	end
+
+	if callinState.buffer[name] == nil then
+		callinState.buffer[name] = {}
+	end
+	callinState.buffer[name][#(callinState.buffer[name]) + 1] = args
+end)
+
+local function startTests(patterns)
+	log(LOG.DEBUG, "[startTests] " .. table.toString({
+		patterns = patterns,
+	}))
+
+	if testRunState.runningTests then
+		log(LOG.WARNING, "Tests are already running!")
+		return
+	end
+
+	logStartTests()
+
+	resetState()
+
+	log(LOG.NOTICE, "=====FINDING TESTS=====")
+
+	if type(patterns) == "string" then
+		patterns = { patterns }
+	end
+
+	testRunState.files = findAllTestFiles(patterns)
+
+	if testRunState.files == nil or #(testRunState.files) == 0 then
+		log(LOG.INFO, "no test files found")
+		return
+	end
+
+	testRunState.runningTests = true
+	testRunState.index = 1
+
+	log(LOG.NOTICE, "=====RUNNING TESTS=====")
+
+	runTestsTimer = Spring.GetTimer()
+end
+
+local function finishTest(result)
+	for _, control in ipairs(spyControls) do
+		control.remove()
+	end
+
+	result.index = result.index or testRunState.index
+	result.label = result.label or activeTestState.label
+	result.filename = result.filename or activeTestState.filename
+	if activeTestState and activeTestState.startFrame and result.frames == nil then
+		result.frames = Spring.GetGameFrame() - activeTestState.startFrame
+	end
+	result.milliseconds = getTestTime()
+
+	log(LOG.NOTICE, TestResults.formatTestResult(result, config.noColorOutput))
+
+	logTestResult(result)
+
+	testRunState.results[#(testRunState.results) + 1] = result
+
+	resetActiveTestState()
+	resetResumeState()
+	resetReturnState()
+	resetCallinState()
+
+	if testRunState.index < #(testRunState.files) then
+		testRunState.index = testRunState.index + 1
+	else
+		-- done
+		testRunState.index = nil
+		testRunState.runningTests = false
+		if config.showAllResults then
+			displayTestResults(testRunState.results)
+		end
+
+		logEndTests(getRunTestsTime())
+
+		if config.quitWhenDone then
+			Spring.SendCommands("quitforce")
+		end
+	end
+end
+
+local function createNestedProxy(prefix, path)
+	return setmetatable({}, {
+		__index = function(_, key)
+			local newPath = path and (path .. "." .. key) or key
+			return createNestedProxy(prefix, newPath)
+		end,
+		__call = function(_, ...)
+			local args = { ... }
+			local serializedFn, returnID = rpc:serializeFunctionCall(path, args)
+
+			returnState = {
+				waitingForReturnID = returnID,
+				success = nil,
+				pendingValueOrError = nil,
+				timeoutExpireFrame = Spring.GetGameFrame() + config.returnTimeout,
+			}
+
+			log(LOG.DEBUG, "[createNestedProxy." .. prefix .. ".send]")
+			Spring.SendLuaRulesMsg(prefix .. serializedFn)
+
+			local resumeOk, resumeResult = coroutine.yield()
+
+			log(LOG.DEBUG, "[createNestedProxy." .. prefix .. ".return] " .. table.toString({
+				resumeOk = resumeOk,
+				resumeResult = resumeResult,
+			}))
+
+			if not resumeOk then
+				error(resumeResult, 2)
+			end
+
+			return unpack(resumeResult)
+		end,
+	})
+end
+
+SyncedProxy = createNestedProxy(Proxy.PREFIX.CALL)
+
+SyncedRun = function(fn)
+	local serializedFn, returnID = rpc:serializeFunctionRun(fn, 3)
+
+	returnState = {
+		waitingForReturnID = returnID,
+		success = nil,
+		pendingValueOrError = nil,
+		timeoutExpireFrame = Spring.GetGameFrame() + config.returnTimeout,
+	}
+
+	log(LOG.DEBUG, "[SyncedRun.send]")
+	Spring.SendLuaRulesMsg(Proxy.PREFIX.RUN .. serializedFn)
+
+	local resumeOk, resumeResult = coroutine.yield()
+
+	log(LOG.DEBUG, "[SyncedRun.return] " .. table.toString({
+		resumeOk = resumeOk,
+		resumeResult = resumeResult,
+	}))
+
+	if not resumeOk then
+		error(resumeResult, 3)
+	end
+
+	return unpack(resumeResult)
+end
+
+Test = {
+	waitUntil = function(f, timeout, errorOffset)
+		timeout = timeout or config.waitTimeout
+
+		resumeState = {
+			predicate = f,
+			timeoutExpireFrame = Spring.GetGameFrame() + timeout,
+		}
+
+		local resumeOk, resumeResult = coroutine.yield()
+
+		log(LOG.DEBUG, "[waitUntil.return] " .. table.toString({
+			resumeOk = resumeOk,
+			resumeResult = resumeResult,
+		}))
+
+		resetResumeState()
+
+		if not resumeOk then
+			error(resumeResult, 2 + (errorOffset or 0))
+		end
+	end,
+	waitFrames = function(frames)
+		log(LOG.DEBUG, "[waitFrames] " .. frames)
+		local startFrame = Spring.GetGameFrame()
+		Test.waitUntil(
+			function()
+				return Spring.GetGameFrame() >= (startFrame + frames)
+			end,
+			frames + 5,
+			1
+		)
+		log(LOG.DEBUG, "[waitFrames.done]")
+	end,
+	waitTime = function(milliseconds, timeout)
+		log(LOG.DEBUG, "[waitTime] " .. milliseconds)
+		local startTimer = Spring.GetTimer()
+		Test.waitUntil(
+			function()
+				return Spring.DiffTimers(Spring.GetTimer(), startTimer, true) >= milliseconds
+			end,
+			timeout or (milliseconds * 30 / 1000 + 5),
+			1
+		)
+		log(LOG.DEBUG, "[waitTime.done]")
+	end,
+	waitUntilCallin = function(name, predicate, timeout)
+		log(LOG.DEBUG, "[waitUntilCallin] " .. name)
+		Test.waitUntil(
+			function()
+				for _, args in ipairs(callinState.buffer[name] or {}) do
+					if predicate == nil or predicate(unpack(args)) then
+						return true
+					end
+				end
+				return false
+			end,
+			timeout,
+			1
+		)
+		callinState.buffer[name] = {}
+		log(LOG.DEBUG, "[waitUntilCallin.done]")
+	end,
+	waitUntilCallinArgs = function(name, expectedArgs)
+		Test.waitUntilCallin(name, function(...)
+			local currentArgs = { ... }
+			for k, v in pairs(expectedArgs) do
+				if currentArgs[k] == nil or currentArgs[k] ~= v then
+					return false
+				end
+			end
+			return true
+		end)
+	end,
+	spy = function(...)
+		local spyCtrl = Mock.spy(...)
+		spyControls[#spyControls + 1] = spyCtrl
+		return spyCtrl
+	end,
+	mock = function(...)
+		local mockCtrl = Mock.mock(...)
+		spyControls[#spyControls + 1] = mockCtrl
+		return mockCtrl
+	end,
+	clearMap = function()
+		SyncedRun(function()
+			for _, unitID in ipairs(Spring.GetAllUnits()) do
+				Spring.DestroyUnit(unitID, false, true, nil, true)
+			end
+			for _, featureID in ipairs(Spring.GetAllFeatures()) do
+				Spring.DestroyFeature(featureID)
+			end
+		end)
+	end,
+	clearCallinBuffer = function(name)
+		if name ~= nil then
+			callinState.buffer[name] = {}
+		else
+			callinState.buffer = {}
+		end
+	end,
+}
+
+function widget:RecvLuaMsg(msg)
+	if not returnState.waitingForReturnID then
+		return
+	end
+
+	if msg:sub(1, #(Proxy.PREFIX.RETURN)) == Proxy.PREFIX.RETURN then
+		local serializedReturn = msg:sub(#Proxy.PREFIX.RETURN + 1)
+		local returnOk, returnValueOrError, returnID = rpc:deserializeFunctionReturn(serializedReturn)
+
+		log(LOG.DEBUG, "[RecvLuaMsg] " .. table.toString({
+			serializedReturn = serializedReturn,
+			returnOk = returnOk,
+			returnValue = returnValueOrError,
+			returnID = returnID,
+		}))
+
+		if returnID == returnState.waitingForReturnID then
+			-- this is the return we were waiting for (otherwise we ignore it)
+			returnState = {
+				waitingForReturnID = nil,
+				success = returnOk,
+				pendingValueOrError = returnValueOrError,
+				timeoutExpireFrame = nil,
+			}
+		end
+	end
+end
+
+local function runTestInternal()
+	log(LOG.DEBUG, "[runTestInternal]")
+
+	local skipOk, skipResult
+	if skip ~= nil then
+		log(LOG.DEBUG, "[runTestInternal.skip]")
+		skipOk, skipResult = Util.yieldable_pcall(skip)
+		log(LOG.DEBUG, "[runTestInternal.skip.done] " .. table.toString({
+			skipOk, skipResult
+		}))
+
+		if not skipOk then
+			log(LOG.DEBUG, "[runTestInternal.skip.error]")
+			error(skipResult, 2)
+		end
+
+		if skipResult then
+			return TestResults.TEST_RESULT.SKIP
+		end
+	end
+
+	local setupOk, setupResult
+	if setup ~= nil then
+		log(LOG.DEBUG, "[runTestInternal.setup]")
+		setupOk, setupResult = Util.yieldable_pcall(setup)
+		log(LOG.DEBUG, "[runTestInternal.setup.done] " .. table.toString({
+			setupOk, setupResult
+		}))
+	else
+		log(LOG.DEBUG, "[runTestInternal.setup.skipped]")
+		setupOk = true
+	end
+
+	local testOk, testResult
+	if setupOk then
+		log(LOG.DEBUG, "[runTestInternal.test]")
+		testOk, testResult = Util.yieldable_pcall(test)
+		log(LOG.DEBUG, "[runTestInternal.test.done] " .. table.toString({
+			testOk, testResult
+		}))
+	end
+
+	-- always try to run cleanup
+	local cleanupOk, cleanupResult
+	if cleanup ~= nil then
+		log(LOG.DEBUG, "[runTestInternal.cleanup]")
+		cleanupOk, cleanupResult = Util.yieldable_pcall(cleanup)
+		log(LOG.DEBUG, "[runTestInternal.cleanup.done] " .. table.toString({
+			cleanupOk, cleanupResult
+		}))
+	else
+		log(LOG.DEBUG, "[runTestInternal.cleanup.skipped]")
+		cleanupOk = true
+	end
+
+	if not cleanupOk then
+		log(LOG.DEBUG, "[runTestInternal.cleanup.error]")
+		error(cleanupResult, 2)
+	end
+
+	if not setupOk then
+		log(LOG.DEBUG, "[runTestInternal.setup.error]")
+		error(setupResult, 2)
+	end
+
+	if not testOk then
+		log(LOG.DEBUG, "[runTestInternal.test.error]")
+		error(testResult, 2)
+	end
+
+	return TestResults.TEST_RESULT.PASS
+end
+
+local function initializeTestEnvironment()
+	local env = {
+		-- test framework
+		Test = Test,
+		SyncedProxy = SyncedProxy,
+		SyncedRun = SyncedRun,
+		__runTestInternal = runTestInternal,
+		yieldable_pcall = Util.yieldable_pcall,
+		TEST_RESULT = TestResults.TEST_RESULT,
+
+		-- widgets
+		widgetHandler = widgetHandler,
+		WG = WG,
+
+		-- game
+		VFS = VFS,
+		Script = Script,
+		Spring = Spring,
+		Engine = Engine,
+		Platform = Platform,
+		Game = Game,
+		gl = gl,
+		GL = GL,
+		CMD = CMD,
+		CMDTYPE = CMDTYPE,
+		LOG = LOG,
+
+		UnitDefs = UnitDefs,
+		UnitDefNames = UnitDefNames,
+		FeatureDefs = FeatureDefs,
+		FeatureDefNames = FeatureDefNames,
+		WeaponDefs = WeaponDefs,
+		WeaponDefNames = WeaponDefNames,
+
+		pack = Util.pack,
+		pcall = pcall,
+		io = io,
+		os = os,
+		math = math,
+		debug = debug,
+		tracy = tracy,
+		table = table,
+		string = string,
+		package = package,
+		--coroutine = coroutine,
+		assert = assert,
+		error = error,
+		print = print,
+		next = next,
+		pairs = pairs,
+		ipairs = ipairs,
+		tonumber = tonumber,
+		tostring = tostring,
+		type = type,
+		unpack = unpack,
+		select = select,
+
+		Json = Json,
+	}
+
+	for k, v in pairs(Assertions) do
+		env[k] = v
+	end
+
+	return env
+end
+
+local function loadTestFromFile(filename)
+	if not VFS.FileExists(filename) then
+		return false, "missing file: " .. filename
+	end
+
+	local text = VFS.LoadFile(filename, VFS.RAW_FIRST)
+
+	if text == nil or text == "" then
+		return false, "missing file content: " .. filename
+	end
+
+	local chunk, err = loadstring(text, filename)
+	if chunk == nil then
+		return false, err
+	end
+
+	local testEnvironment = initializeTestEnvironment()
+
+	setfenv(chunk, testEnvironment)
+
+	local success, err = pcall(chunk)
+	if not success then
+		return false, err
+	end
+
+	if testEnvironment.test == nil then
+		return false, "no test() function"
+	end
+
+	setfenv(testEnvironment.__runTestInternal, testEnvironment)
+
+	return true, testEnvironment
+end
+
+local function handleReturn()
+	if returnState.success == nil and returnState.waitingForReturnID == nil then
+		-- no return to handle, so just continue
+		return {
+			status = "continue",
+		}
+	end
+
+	if returnState.timeoutExpireFrame ~= nil then
+		if Spring.GetGameFrame() >= returnState.timeoutExpireFrame then
+			-- resume took too long, result is error
+			log(LOG.DEBUG, "[handleReturn] timeout -> error")
+			return {
+				status = "error",
+				error = "waiting for synced return timed out"
+			}
+		end
+	end
+
+	if returnState.waitingForReturnID then
+		return {
+			status = "wait"
+		}
+	end
+
+	local tempReturnValue = returnState.pendingValueOrError
+	returnState.pendingValueOrError = nil
+
+	if returnState.success then
+		-- we're ok to resume
+		log(LOG.DEBUG, "[handleReturn] success -> continue")
+		resetReturnState()
+		return {
+			status = "continue",
+			returnValue = tempReturnValue
+		}
+	else
+		-- remote function errored
+		log(LOG.DEBUG, "[handleReturn] remote error -> error")
+		return {
+			status = "error",
+			error = tempReturnValue,
+		}
+	end
+end
+
+local function handleWait()
+	if resumeState.predicate == nil then
+		return {
+			status = "continue",
+		}
+	end
+
+	if Spring.GetGameFrame() >= resumeState.timeoutExpireFrame then
+		-- resume took too long, result is error
+		log(LOG.DEBUG, "[handleWait] timeout -> error")
+		return {
+			status = "error",
+			error = "resume predicate timed out",
+		}
+	end
+
+	local success, returnOrError = pcall(resumeState.predicate)
+	if success then
+		-- predicate ran successfully
+		if returnOrError then
+			-- succeeded, we can resume
+			log(LOG.DEBUG, "[handleWait] predicate success + true -> continue")
+			resetResumeState()
+			return {
+				status = "continue"
+			}
+		else
+			-- failed, wait and try again next frame
+			return {
+				status = "wait"
+			}
+		end
+	else
+		-- error during predicate
+		log(LOG.DEBUG, "[handleWait] predicate error -> error")
+		return {
+			status = "error",
+			error = returnOrError
+		}
+	end
+end
+
+local function step()
+	if not testRunState.runningTests then
+		return
+	end
+
+	--*result = {
+	--	status =
+	--		| "continue" (ok to continue to other checks and resuming test)
+	--		| "error" (an error occurred, skip directly to resuming test and pass the error for it to be handled)
+	--		| "wait" (waiting on something, return immediately)
+	--	error = (status="error" only)
+	--	returnValue = (status="continue" only, optional)
+	--}
+	local returnResult = handleReturn()
+
+	if returnResult.status == "wait" then
+		return
+	end
+
+	local waitResult = handleWait()
+
+	if waitResult.status == "wait" then
+		return
+	end
+
+	-- is there a test set up? if not, create one
+	if activeTestState.coroutine == nil then
+		activeTestState.label = testRunState.files[testRunState.index].label
+		activeTestState.filename = testRunState.files[testRunState.index].filename
+
+		local success, envOrError = loadTestFromFile(activeTestState.filename)
+
+		if success then
+			log(LOG.DEBUG, "Initializing test: " .. activeTestState.label)
+			activeTestState.environment = envOrError
+			activeTestState.coroutine = coroutine.create(activeTestState.environment.__runTestInternal)
+			activeTestState.startFrame = Spring.GetGameFrame()
+
+			testTimer = Spring.GetTimer()
+		else
+			finishTest({
+				result = TestResults.TEST_RESULT.ERROR,
+				error = envOrError
+			})
+			return
+		end
+	end
+
+	-- resume the test
+	local resumeOk, resumeResult
+	if coroutine.status(activeTestState.coroutine) == "suspended" then
+		local coroutineOk, coroutineArgs
+		if returnResult.returnValue ~= nil then
+			coroutineOk = true
+			coroutineArgs = { returnResult.returnValue }
+		elseif returnResult.status == "error" then
+			coroutineOk = false
+			coroutineArgs = { returnResult.error }
+		elseif waitResult.status == "error" then
+			coroutineOk = false
+			coroutineArgs = { waitResult.error }
+		else
+			coroutineOk = true
+			coroutineArgs = nil
+		end
+
+		log(
+			LOG.DEBUG,
+			"Resuming test: " .. activeTestState.label .. " with value: " .. table.toString({
+				coroutineOk = coroutineOk,
+				coroutineArgs = coroutineArgs,
+			})
+		)
+
+		resumeOk, resumeResult = coroutine.resume(
+			activeTestState.coroutine,
+			coroutineOk,
+			coroutineArgs and unpack(coroutineArgs) or nil
+		)
+		log(LOG.DEBUG, "Unresuming test: " .. table.toString({
+			result = resumeOk,
+			error = resumeResult,
+		}))
+		if not resumeOk then
+			-- test fail
+			finishTest({
+				result = TestResults.TEST_RESULT.FAIL,
+				error = resumeResult,
+			})
+			return
+		end
+	end
+
+	if coroutine.status(activeTestState.coroutine) == "dead" then
+		-- test did not fail or error, so may have been pass or skip
+		finishTest({
+			result = resumeResult or TestResults.TEST_RESULT.PASS,
+		})
+	end
+end
+
+function widget:GameFrame(frame)
+	if config.gameStartTestPatterns ~= nil and frame >= 0 then
+		startTests(config.gameStartTestPatterns)
+		config.gameStartTestPatterns = nil
+	end
+
+	step()
+end
+
+function widget:Update(dt)
+	if Spring.GetGameFrame() <= 0 then
+		step()
+	end
+end
+
+function widget:Initialize()
+	widgetHandler:DisableWidget("Test Runner Watchdog")
+
+	if not Spring.Utilities.IsDevMode() then
+		widgetHandler:RemoveWidget(self)
+	end
+
+	widgetHandler.actionHandler:AddAction(
+		self,
+		"runtests",
+		function(cmd, optLine, optWords, data, isRepeat, release, actions)
+			startTests(Util.splitPhrases(optLine))
+		end,
+		nil,
+		"t"
+	)
+	widgetHandler.actionHandler:AddAction(
+		self,
+		"runtestsheadless",
+		function(cmd, optLine, optWords, data, isRepeat, release, actions)
+			config.noColorOutput = true
+			config.quitWhenDone = true
+			config.gameStartTestPatterns = Util.splitPhrases(optLine)
+			config.testResultsFilePath = "testlog/results.json"
+
+			widgetHandler:EnableWidget("Test Runner Watchdog")
+		end,
+		nil,
+		"t"
+	)
+
+	gameTimer = Spring.GetTimer()
+end
+
+function widget:Shutdown()
+	widgetHandler.actionHandler:RemoveAction("runtests", "t")
+	widgetHandler.actionHandler:RemoveAction("runtestsheadless", "t")
+end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -759,6 +759,9 @@ local function handleReturn()
 	end
 
 	if returnState.waitingForReturnID then
+		log(LOG.DEBUG, string.format(
+			"[handleReturn] waiting for return ID: %s", returnState.waitingForReturnID
+		))
 		return {
 			status = "wait"
 		}
@@ -843,12 +846,14 @@ local function step()
 	local returnResult = handleReturn()
 
 	if returnResult.status == "wait" then
+		log(LOG.DEBUG, "[step] waiting for return")
 		return
 	end
 
 	local waitResult = handleWait()
 
 	if waitResult.status == "wait" then
+		log(LOG.DEBUG, "[step] waiting for explicit wait")
 		return
 	end
 

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -321,6 +321,15 @@ local function startTests(patterns)
 		return
 	end
 
+	if Spring.GetModOptions().deathmode ~= 'neverend' then
+		log(
+			LOG.ERROR,
+			"deathmode='neverend' game end mode is required in order to run tests, so that the game stays " ..
+				"active between tests"
+		)
+		return
+	end
+
 	if not Spring.IsCheatingEnabled() then
 		if not queuedStartTests then
 			-- enable cheats, then wait for it to go through

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -9,6 +9,10 @@ function widget:GetInfo()
 	}
 end
 
+if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() then
+	return
+end
+
 local Proxy = VFS.Include('common/testing/synced_proxy.lua')
 local MochaJSONReporter = VFS.Include('common/testing/mocha_json_reporter.lua')
 local Assertions = VFS.Include('common/testing/assertions.lua')

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -294,9 +294,11 @@ end)
 
 local MAX_START_TESTS_ATTEMPTS = 10
 local queuedStartTests = false
+local queuedStartTestsPatterns = nil
 local startTestsAttempts = 0
-local function queueStartTests()
+local function queueStartTests(patterns)
 	queuedStartTests = true
+	queuedStartTestsPatterns = patterns
 	startTestsAttempts = 0
 end
 
@@ -324,7 +326,7 @@ local function startTests(patterns)
 			-- enable cheats, then wait for it to go through
 			log(LOG.INFO, "Cheats are disabled; attempting to enable them...")
 			Spring.SendCommands("cheat")
-			queueStartTests()
+			queueStartTests(patterns)
 			return
 		elseif startTestsAttempts < MAX_START_TESTS_ATTEMPTS then
 			-- return and try again next step
@@ -870,7 +872,7 @@ end
 
 local function step()
 	if queuedStartTests then
-		startTests()
+		startTests(queuedStartTestsPatterns)
 		return
 	end
 

--- a/luaui/Widgets/dbg_test_runner_watchdog.lua
+++ b/luaui/Widgets/dbg_test_runner_watchdog.lua
@@ -1,0 +1,24 @@
+function widget:GetInfo()
+	return {
+		name = "Test Runner Watchdog",
+		desc = "Quits game if test runner exits",
+		license = "GNU GPL, v2 or later",
+		layer = 9999,
+		enabled = false,
+		handler = true,
+	}
+end
+
+local CHECK_PERIOD = 1
+local t = 0
+function widget:Update(dt)
+	t = t + dt
+	if t > CHECK_PERIOD then
+		t = 0
+		if widgetHandler:FindWidget("Test Runner") == nil then
+			Spring.Log(widget:GetInfo().name, LOG.WARNING, "Test runner crashed, exiting game")
+			widgetHandler:DisableWidget(widget:GetInfo().name)
+			Spring.SendCommands("quitforce")
+		end
+	end
+end

--- a/luaui/Widgets/dbg_test_runner_watchdog.lua
+++ b/luaui/Widgets/dbg_test_runner_watchdog.lua
@@ -9,6 +9,10 @@ function widget:GetInfo()
 	}
 end
 
+if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() then
+	return
+end
+
 local CHECK_PERIOD = 1
 local t = 0
 function widget:Update(dt)

--- a/tools/headless_testing/.gitattributes
+++ b/tools/headless_testing/.gitattributes
@@ -1,0 +1,1 @@
+*		text eol=lf

--- a/tools/headless_testing/.gitignore
+++ b/tools/headless_testing/.gitignore
@@ -1,0 +1,1 @@
+testlog

--- a/tools/headless_testing/Dockerfile
+++ b/tools/headless_testing/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:devel
+
+WORKDIR /bar
+
+ENV BAR_ROOT=/bar
+ENV BAR_CONFIG_JSON=./config.json
+ENV BAR_CONFIG_ENV=./config.env
+
+RUN apt-get update && \
+    apt-get install -y curl jq 7zip
+
+RUN mkdir -p maps games engine
+
+ADD https://launcher-config.beyondallreason.dev/config.json $BAR_CONFIG_JSON
+
+COPY --chmod=755 ./parse-config.sh .
+RUN ./parse-config.sh
+
+COPY --chmod=755 ./download-engine.sh .
+RUN export $(cat $BAR_CONFIG_ENV | xargs) && ./download-engine.sh
+
+COPY --chmod=755 ./download-maps.sh .
+RUN export $(cat $BAR_CONFIG_ENV | xargs) && ./download-maps.sh
+
+COPY ./startscript.txt .
+COPY ./springsettings.cfg .
+COPY --chmod=755 ./start.sh .
+
+ENTRYPOINT ./start.sh /bar /bar/startscript.txt

--- a/tools/headless_testing/docker-compose.yml
+++ b/tools/headless_testing/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  bar:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/bar/games/BAR.sdd:ro
+      - ../../../../LuaUI/Widgets:/bar/LuaUI/Widgets:ro
+      - ./testlog:/bar/testlog:rw
+      - cache:/bar/cache:rw
+
+volumes:
+  cache:

--- a/tools/headless_testing/download-engine.sh
+++ b/tools/headless_testing/download-engine.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p "$ENGINE_DESTINATION"
+
+TEMP_FILE=$(mktemp --suffix=.7z)
+
+curl -L "$ENGINE_URL" -o "$TEMP_FILE" && 7z x "$TEMP_FILE" -o"$ENGINE_DESTINATION" && rm -f temp.7z

--- a/tools/headless_testing/download-maps.sh
+++ b/tools/headless_testing/download-maps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+engine/*/pr-downloader --filesystem-writepath "$BAR_ROOT" --download-map "Full Metal Plate 1.7"

--- a/tools/headless_testing/download-maps.sh
+++ b/tools/headless_testing/download-maps.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-engine/*/pr-downloader --filesystem-writepath "$BAR_ROOT" --download-map "Full Metal Plate 1.7"
+engine/*/pr-downloader --filesystem-writepath "$BAR_ROOT" --download-map "Supreme Isthmus v1.6.4"

--- a/tools/headless_testing/parse-config.sh
+++ b/tools/headless_testing/parse-config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+url=$(cat "$BAR_CONFIG_JSON" | jq -r '.setups[] | select(.package.id == "manual-linux") | .downloads.resources[] | select(.destination | contains("engine")) | .url')
+destination=$(cat "$BAR_CONFIG_JSON" | jq -r '.setups[] | select(.package.id == "manual-linux") | .downloads.resources[] | select(.destination | contains("engine")) | .destination')
+env_variables=$(cat "$BAR_CONFIG_JSON" | jq -r '.setups[] | select(.package.id == "manual-linux") | .env_variables | to_entries[] | "\(.key)=\(.value)"')
+
+echo "$env_variables" > "$BAR_CONFIG_ENV"
+echo "ENGINE_URL=\"$url\"" >> "$BAR_CONFIG_ENV"
+echo "ENGINE_DESTINATION=\"$destination\"" >> "$BAR_CONFIG_ENV"

--- a/tools/headless_testing/springsettings.cfg
+++ b/tools/headless_testing/springsettings.cfg
@@ -1,0 +1,1 @@
+RapidTagResolutionOrder = repos-cdn.beyondallreason.dev;repos.beyondallreason.dev

--- a/tools/headless_testing/start.sh
+++ b/tools/headless_testing/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf $1/LuaUI/Config
+$1/engine/*/spring-headless --isolation --write-dir "$1" "$2"

--- a/tools/headless_testing/startscript.txt
+++ b/tools/headless_testing/startscript.txt
@@ -1,0 +1,28 @@
+[GAME]
+{
+	MapName=Full Metal Plate 1.7;
+	GameType=Beyond All Reason $VERSION;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=TestRunner;
+	IsHost=1;
+	FixedRNGSeed = 1;
+  [MODOPTIONS]
+  {
+    debugcommands=1:cheat|2:godmode|3:globallos|30:runtestsheadless;
+		deathmode=neverend;
+  }
+  [ALLYTEAM0]
+  {
+  }
+  [TEAM0]
+  {
+    allyteam=0;
+    teamleader=0;
+  }
+  [PLAYER0]
+  {
+    team=0;
+  }
+}

--- a/tools/headless_testing/startscript.txt
+++ b/tools/headless_testing/startscript.txt
@@ -1,6 +1,6 @@
 [GAME]
 {
-	MapName=Full Metal Plate 1.7;
+	MapName=Supreme Isthmus v1.6.4;
 	GameType=Beyond All Reason $VERSION;
 	GameStartDelay=0;
 	StartPosType=0;


### PR DESCRIPTION
Tests can be executed with `/runtests <pattern1> ... <patternN>`, where
any test file (excluding file extension) that matches any pattern is
included. `/runtests` by itself will run all tests.

Tests can define several special functions:
* `skip()`: return true if this test should be skipped
* `setup()`: prepare the game for the test to run
* `teardown()`: remove any leftover units or game state from the test
* `test()`: run the test

Tests pass unless they throw an error. The standard way to fail a test
is using `assert()` and having it throw the error.

Existing functions can be mocked with `mock()`, which replaces the
function with a no-op, or optionally a replacement function. All calls
to the mocked function are available through the mock control returned
from `mock()`. Any mocks last for the duration of the test, and are
automatically reset afterwards. `spy()` can be used to mock a function
without modifying the original, and just tracking calls.

Some tests require access to synced functions (for example, to create
or destroy units). These can be accessed in two ways:

* `SyncedProxy.Spring.<function>`: this calls `Spring.<function>` as if in a
  synced context. This will take at least one frame to run and return.
* `SyncedRun(function(locals) ... end)`: this runs an arbitrary block of
  code in a synced context. Local variables in the test are available
  through the locals parameter to the passed function.

---
See discussion here: https://discord.com/channels/549281623154229250/1194505222605778984 and original draft PR here: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2515

This depends on https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2623 and https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2624