### PR TITLE
refactor(LuaShader): fix typo: "heighmap" to "heightmap"

### DIFF
--- a/luarules/gadgets/gfx_raptor_scum_gl4.lua
+++ b/luarules/gadgets/gfx_raptor_scum_gl4.lua
@@ -350,7 +350,7 @@ elseif not Spring.Utilities.Gametype.IsScavengers() then
 		mapPos.xz += xyworld_xyfract.xy *  worldposradius.w;
 
 		// Sample the heightmap to get reasonable world depth
-		vec2 uvhm = heighmapUVatWorldPos(mapPos.xz);
+		vec2 uvhm = heightmapUVatWorldPos(mapPos.xz);
 		mapPos.y = textureLod(heightmapTex, uvhm, 0.0).x + 3.0;
 
 		// sample the map normals and pass it on for later use:

--- a/luarules/gadgets/include/LuaShader.lua
+++ b/luarules/gadgets/include/LuaShader.lua
@@ -183,7 +183,7 @@ mat4 mat4mix(mat4 a, mat4 b, float alpha) {
 
 // Additional helper functions useful in Spring
 
-vec2 heighmapUVatWorldPos(vec2 worldpos){
+vec2 heightmapUVatWorldPos(vec2 worldpos){
 	const vec2 inverseMapSize = 1.0 / mapSize.xy;
 	// Some texel magic to make the heightmap tex perfectly align:
 	const vec2 heightmaptexel = vec2(8.0, 8.0);
@@ -194,7 +194,7 @@ vec2 heighmapUVatWorldPos(vec2 worldpos){
 }
 
 // This does 'mirror' style tiling of UVs like the way the map edge extension works
-vec2 heighmapUVatWorldPosMirrored(vec2 worldpos) { 
+vec2 heightmapUVatWorldPosMirrored(vec2 worldpos) {
 	const vec2 inverseMapSize = 1.0 / mapSize.xy;
 	// Some texel magic to make the heightmap tex perfectly align:
 	const vec2 heightmaptexel = vec2(8.0, 8.0);

--- a/luaui/Widgets/Include/LuaShader.lua
+++ b/luaui/Widgets/Include/LuaShader.lua
@@ -183,7 +183,7 @@ mat4 mat4mix(mat4 a, mat4 b, float alpha) {
 
 // Additional helper functions useful in Spring
 
-vec2 heighmapUVatWorldPos(vec2 worldpos){
+vec2 heightmapUVatWorldPos(vec2 worldpos){
 	const vec2 inverseMapSize = 1.0 / mapSize.xy;
 	// Some texel magic to make the heightmap tex perfectly align:
 	const vec2 heightmaptexel = vec2(8.0, 8.0);
@@ -194,7 +194,7 @@ vec2 heighmapUVatWorldPos(vec2 worldpos){
 }
 
 // This does 'mirror' style tiling of UVs like the way the map edge extension works
-vec2 heighmapUVatWorldPosMirrored(vec2 worldpos) { 
+vec2 heightmapUVatWorldPosMirrored(vec2 worldpos) {
 	const vec2 inverseMapSize = 1.0 / mapSize.xy;
 	// Some texel magic to make the heightmap tex perfectly align:
 	const vec2 heightmaptexel = vec2(8.0, 8.0);

--- a/luaui/Widgets/Shaders/decals_gl4.frag.glsl
+++ b/luaui/Widgets/Shaders/decals_gl4.frag.glsl
@@ -124,7 +124,7 @@ void main(void)
 	#endif
 
 	
-	vec2 uvhm = heighmapUVatWorldPos(g_position.xz);
+	vec2 uvhm = heightmapUVatWorldPos(g_position.xz);
 	vec4 minimapcolor = textureLod(miniMapTex, uvhm, 0.0);
 	vec3 mapnormal = textureLod(mapNormalsTex, uvhm, 0.0).raa; // seems to be in the [-1, 1] range!, raaa is its true return
 	mapnormal.g = sqrt( 1.0 - dot( mapnormal.rb, mapnormal.rb)); // reconstruct Y	from it

--- a/luaui/Widgets/Shaders/decals_gl4.geom.glsl
+++ b/luaui/Widgets/Shaders/decals_gl4.geom.glsl
@@ -50,7 +50,7 @@ void offsetVertex4( float x, float y, float z, float u, float v){
 	//vec3 vecnorm = normalize(primitiveCoords);// AHA zero case!
 	vec4 worldPos = vec4(centerpos.xyz + rotY * ( primitiveCoords ), 1.0);
 	
-	vec2 uvhm = heighmapUVatWorldPos(worldPos.xz);
+	vec2 uvhm = heightmapUVatWorldPos(worldPos.xz);
 	worldPos.y = textureLod(heightmapTex, uvhm, 0.0).x + HEIGHTOFFSET;
 	gl_Position = cameraViewProj * worldPos;
 	gl_Position.z = (gl_Position.z) - 512.0 / (gl_Position.w); // send 16 elmos forward in Z

--- a/luaui/Widgets/Shaders/decals_gl4.vert.glsl
+++ b/luaui/Widgets/Shaders/decals_gl4.vert.glsl
@@ -39,7 +39,7 @@ void main()
 	v_centerpos = worldPos;
 	
 	// texture sampling here is no longer really required, but might be needed in the future if heightmap under decal changes significantly...
-	//v_centerpos.y = textureLod(heightmapTex, heighmapUVatWorldPos(v_centerpos.xz), 0.0).x; 
+	//v_centerpos.y = textureLod(heightmapTex, heightmapUVatWorldPos(v_centerpos.xz), 0.0).x;
 	
 	// Pass all params to Geo shader
 	v_centerpos.w = 1.0;

--- a/luaui/Widgets/Shaders/decals_large_gl4.vert.glsl
+++ b/luaui/Widgets/Shaders/decals_large_gl4.vert.glsl
@@ -44,7 +44,7 @@ void offsetVertex4( float x, float y, float z, float u, float v){
 	//vec3 vecnorm = normalize(primitiveCoords);// AHA zero case!
 	vec4 worldPos = vec4(centerpos.xyz + rotY * ( primitiveCoords ), 1.0);
 	
-	vec2 uvhm = heighmapUVatWorldPos(worldPos.xz);
+	vec2 uvhm = heightmapUVatWorldPos(worldPos.xz);
 	worldPos.y = textureLod(heightmapTex, uvhm, 0.0).x + 0.01;
 	gl_Position = cameraViewProj * worldPos;
 	gl_Position.z = (gl_Position.z) - 512.0 / (gl_Position.w); // send 16 elmos forward in Z
@@ -101,7 +101,7 @@ void main()
 	vertexPos.xz += worldPos.xz;
 	
 	// get the height here:
-	vertexPos.y  = textureLod(heightmapTex, heighmapUVatWorldPos(vertexPos.xz), 0.0).x + HEIGHTOFFSET;
+	vertexPos.y  = textureLod(heightmapTex, heightmapUVatWorldPos(vertexPos.xz), 0.0).x + HEIGHTOFFSET;
 	
 	// Output it to the FS
 	gl_Position = cameraViewProj * vertexPos;

--- a/luaui/Widgets/Shaders/deferred_lights_gl4.vert.glsl
+++ b/luaui/Widgets/Shaders/deferred_lights_gl4.vert.glsl
@@ -290,7 +290,7 @@ void main()
 	#line 13000
 	// Get the heightmap and the normal map at the center position of the light in v_worldPosRad.xyz
 	
-	vec2 uvhm = heighmapUVatWorldPos(v_worldPosRad.xz);
+	vec2 uvhm = heightmapUVatWorldPos(v_worldPosRad.xz);
 	v_lightcenter_gradient_height.w = textureLod(heightmapTex, uvhm, 0.0).x;
 	
 	vec4 mapnormals = textureLod(mapnormalsTex, uvhm, 0.0);

--- a/luaui/Widgets/Shaders/global_fog.frag.glsl
+++ b/luaui/Widgets/Shaders/global_fog.frag.glsl
@@ -1541,7 +1541,7 @@ void main(void)
 	
 	//Calculate backscatter color from minimap if possible?
 	#if (USEMINIMAP == 1) 
-		vec4 minimapcolor = textureLod(miniMapTex, heighmapUVatWorldPosMirrored(mapWorldPos.xz), 4.0);
+		vec4 minimapcolor = textureLod(miniMapTex, heightmapUVatWorldPosMirrored(mapWorldPos.xz), 4.0);
 		//if (fromCameraNormalized.y > 0 && mapdepth > 0.9999) rayUpness = 0;
 		fragColor.rgb += minimapcolor.rgb * MINIMAPSCATTER * collectedShadow * rayUpness ;
 	#endif

--- a/luaui/Widgets/Shaders/ground_fog.frag.glsl
+++ b/luaui/Widgets/Shaders/ground_fog.frag.glsl
@@ -334,8 +334,8 @@ void main(void)
 		collectedNoise += localNoise.a;
 	}
 	
-	vec2 uvhmWorld = heighmapUVatWorldPos(mapWorldPos.xz);
-	vec2 uvhmFrag =  heighmapUVatWorldPos(fragWorldPos.xz);
+	vec2 uvhmWorld = heightmapUVatWorldPos(mapWorldPos.xz);
+	vec2 uvhmFrag =  heightmapUVatWorldPos(fragWorldPos.xz);
 	vec4 areaNoiseWorld = textureLod(dithernoise2d, uvhmWorld - noiseOffset.xz * 0.02, 0.0);
 	vec4 areaNoiseFrag = textureLod(dithernoise2d, uvhmFrag - noiseOffset.xz * 0.02, 0.0);
 	fragColor.rgb *= vec3(collectedShadow / steps);

--- a/luaui/Widgets/Shaders/ground_fog.vert.glsl
+++ b/luaui/Widgets/Shaders/ground_fog.vert.glsl
@@ -27,7 +27,7 @@ void main()
 	
 	vec4 vertexPos = vec4(1.0);
 	vertexPos.xz = (positionxy_xyfract.xy + mapSize.xy) * 0.5;
-	vec2 uvhm = heighmapUVatWorldPos(vertexPos.xz);
+	vec2 uvhm = heightmapUVatWorldPos(vertexPos.xz);
 	float hmaptexlod = -0.0;
 	// get height around here:
 	vertexPos.y  = textureLod(heightmapTex, uvhm, hmaptexlod).x ;

--- a/luaui/Widgets/Shaders/sensor_ranges_los.vert.glsl
+++ b/luaui/Widgets/Shaders/sensor_ranges_los.vert.glsl
@@ -52,7 +52,7 @@ out DataVS {
 #line 11000
 
 float heightAtWorldPos(vec2 w){
-	vec2 uvhm =   heighmapUVatWorldPos(w);
+	vec2 uvhm =   heightmapUVatWorldPos(w);
 	return textureLod(heightmapTex, uvhm, 0.0).x;
 }
 

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -532,7 +532,7 @@ local vsSrc = [[
 	#line 11000
 
 	float heightAtWorldPos(vec2 w){
-		vec2 uvhm =  heighmapUVatWorldPos(w);
+		vec2 uvhm =  heightmapUVatWorldPos(w);
 		return textureLod(heightmapTex, uvhm, 0.0).x;
 	}
 

--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -65,7 +65,7 @@ uniform sampler2D heightmapTex; // the heightmap texture
 void main(){
 	v_worldPos.xz = position.xy;
 	float alpha = position.z; // sneaking in an alpha value on the position input
-	vec2 uvhm = heighmapUVatWorldPos(v_worldPos.xz); // this function gets the UV coords of the heightmap texture at a world position
+	vec2 uvhm = heightmapUVatWorldPos(v_worldPos.xz); // this function gets the UV coords of the heightmap texture at a world position
 	v_worldPos.y  = textureLod(heightmapTex, uvhm, 0.0).x;
 	v_color = vec4(LINECOLOR, alpha);
 	gl_Position = cameraViewProj * vec4(v_worldPos.xyz, 1.0);  // project it into camera

--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -461,7 +461,7 @@ out DataVS {
 #line 11000
 
 float heightAtWorldPos(vec2 w){
-	vec2 uvhm =  heighmapUVatWorldPos(w);
+	vec2 uvhm =  heightmapUVatWorldPos(w);
 	return textureLod(heightmapTex, uvhm, 0.0).x;
 }
 

--- a/luaui/Widgets/gui_sensor_ranges_jammer.lua
+++ b/luaui/Widgets/gui_sensor_ranges_jammer.lua
@@ -61,7 +61,7 @@ out DataVS {
 #line 11000
 
 float heightAtWorldPos(vec2 w){
-	vec2 uvhm = heighmapUVatWorldPos(w);
+	vec2 uvhm = heightmapUVatWorldPos(w);
 	return textureLod(heightmapTex, uvhm, 0.0).x;
 }
 

--- a/luaui/Widgets/map_edge_extension2.lua
+++ b/luaui/Widgets/map_edge_extension2.lua
@@ -142,7 +142,7 @@ bool MyEmitTestVertex(vec2 xzVec, bool testme) {
 	vec4 worldPos = gl_in[0].gl_Position + vec4(xzVec.x, 0.0, xzVec.y, 0.0);
 	uv = worldPos.xz / mapSize.xy;
 	uv = uv - dataIn[0].vMirrorParams.xy; // So negative UVs mean flipping
-	vec2 UVHM =  heighmapUVatWorldPos(worldPos.xz);
+	vec2 UVHM =  heightmapUVatWorldPos(worldPos.xz);
 	worldPos.y = textureLod(heightTex, UVHM, 0.0).x;
 
 	const vec2 edgeTightening = vec2(0.5); // to tighten edges a little better


### PR DESCRIPTION
This has been around for almost two years, but fortunately the uses of it in this repo seem to be easy changes. This might break some user widgets, but the error message is pretty obvious in the case that it does.