### PR TITLE
fix(gui_attackrange_gl4): pass a widget parameter to RemoveWidget

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -442,7 +442,7 @@ local attackRangeShader = nil
 
 local function goodbye(reason)
 	Spring.Echo("AttackRange GL4 widget exiting with reason: " .. reason)
-	widgetHandler:RemoveWidget()
+	widgetHandler:RemoveWidget(widget)
 end
 
 local function makeCircleVBO(circleSegments)


### PR DESCRIPTION
This widget has `handler=true`, so `widgetHandler:RemoveWidget(...)` requires an argument, usually `self`. Unfortunately `self` doesn't exist in a standard local function, so we need to pass `widget`.

Without this change, the widget will fail to properly exit, and any shader compilation errors will cause an endless loop of log messages about using an invalid shader.

---

Example error message:
```
[t=00:01:02.378492][f=0000575] LuaShader: [attackRangeShader GL4] shader error(s):
Trying to set uniform [lineAlphaUniform] on inactive shader object. Did you use :Activate() or :ActivateWith()?
[t=00:01:02.379203][f=0000575] Trying to set uniform [lineAlphaUniform] on inactive shader object. Did you use :Activate() or :ActivateWith()?
```

---

#### Test steps
1. Modify the shader code in the widget to cause a compilation error.
2. Start the widget, either through starting a game with it already enabled, or toggling it on.
3. It should show an error message and disable itself. Without this fix, log messages will be generated every frame (when `DrawWorldPreUnit` is called)
