### PR TITLE
fix(gui_selfd_icons): ignore factory queued selfd orders on factory

### DIFF
--- a/luaui/Widgets/gui_selfd_icons.lua
+++ b/luaui/Widgets/gui_selfd_icons.lua
@@ -96,7 +96,12 @@ local function hasSelfDActive(unitID)
 end
 
 local function hasSelfDQueued(unitID)
-	local cmdQueue = spGetCommandQueue(unitID, -1) or {}
+	local limit = -1
+	local unitDefID = Spring.GetUnitDefID(unitID)
+	if unitDefID and UnitDefs[unitDefID].isFactory then
+		limit = 1
+	end
+	local cmdQueue = spGetCommandQueue(unitID, limit) or {}
 	if #cmdQueue > 0 then
 		for i = 1, #cmdQueue do
 			if cmdQueue[i].id == CMD.SELFD then
@@ -227,6 +232,10 @@ function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts
 			queuedSelfD[unitID] = nil
 		end
 	elseif cmdID == CMD.SELFD then
+		if cmdOpts.shift and UnitDefs[unitDefID].isFactory then
+			-- factories can receive shift-selfd orders, but they go to the units produced, not the factory itself
+			return
+		end
 		local cmdQueue = spGetCommandQueue(unitID, -1)
 		local hasCmdQueue = #cmdQueue > 0
 


### PR DESCRIPTION
Previously, when a factory received a queued selfd command, the factory itself would show an icon as if it was going to be self-destructed. Really, only units produced in the factory get this self-d command.

This commit adds a check so it can skip recording the factory itself as having a queued self-d command.

---

#### Test steps
1. Select a factory.
2. Issue a move command anywhere, then, holding shift, issue a self-d command.
3. There should be no self-d icon on the factory.

### Screenshots:

#### BEFORE:
![before](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/fde5c65f-2f90-422c-9daa-8f626dd06453)

#### AFTER:
![after](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/2b025799-6780-4bb1-8372-faa7c6766200)
