### PR TITLE
Fix pregame crash when queuing mexes on metal maps

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -314,12 +314,14 @@ function widget:MousePress(x, y, button)
 							end
 						end
 
-						-- Special handling to check if mex position is valid
-						local spot = WG["resource_spot_finder"].GetClosestMexSpot(bx, bz)
-						local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid(spot, bx, bz) or false
-						local spotIsTaken = WG["resource_spot_builder"].SpotHasExtractorQueued(spot)
-						if isMex and not metalMap and (not validPos or spotIsTaken) then
-							return true
+						if isMex and not metalMap then
+							-- Special handling to check if mex position is valid
+							local spot = WG["resource_spot_finder"].GetClosestMexSpot(bx, bz)
+							local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid(spot, bx, bz) or false
+							local spotIsTaken = spot and WG["resource_spot_builder"].SpotHasExtractorQueued(spot) or false
+							if not validPos or spotIsTaken then
+								return true
+							end
 						end
 
 						if not anyClashes then

--- a/luaui/Widgets/gui_prospector.lua
+++ b/luaui/Widgets/gui_prospector.lua
@@ -238,6 +238,7 @@ function widget:DrawScreen()
 	end
 	if not metalMap then
 		local pos = WG["resource_spot_finder"].GetClosestMexSpot(coords[1], coords[3])
+		if not pos then return end
 		coords[1] = pos.x
 		coords[3] = pos.z
 	end


### PR DESCRIPTION
### Work done
- Fixes crash that occurs on metal maps when mexes are shift-queued during pregame.
- Fixes prospector crash on maps with no metal (greenest fields)


#### Test steps
- [ ] On any metal map, shift-queue multiple mexes during pregame, expect no errors
- [ ] On greenest fields, try to queue a mex and expect no errors (mex will not place).
- [ ] On any non-metal map, place mexes during pregame with shift and expect normal behavior.
