### PR TITLE
Fix mex upgrade behavior for off-center mexes

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -359,7 +359,7 @@ local function PreviewExtractorCommand(params, extractor, spot)
 
 	local buildingId = -extractor
 	local targetPos, targetOwner
-	local occupiedSpot = spotHasExtractor(command)
+	local occupiedSpot = spotHasExtractor(spot)
 	if occupiedSpot then
 
 		local occupiedPos = { spGetUnitPosition(occupiedSpot) }


### PR DESCRIPTION
### Work done
Off center mex handling was failing, because the call to the function `spotHasExtractor` was missing the `isMex` and `isGeo` properties.


#### Test steps
- [ ] Make t1 mexes off-center (any map with moderately large extractor radius, quicksilver workd)
- [ ] Using a t2 constructor, use the area mex command over the t1 mexes
- [ ] Expect an upgrade to be queued on the t1 mexes, rather than at the metal spot center
- [ ] Using a t2 constructor, mouse over a metal spot that has an off-center t1 mex
- [ ] Expect an upgrade to be previewed on the t1 mex, rather than the metal spot center

