### PR TITLE
refactor(gui_attackrange_gl4): use widgetHandler directly to add actions

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -12,7 +12,6 @@ function widget:GetInfo()
 		license = "GPLv2",
 		layer   = -99,
 		enabled = true,
-		handler = true,
 	}
 end
 
@@ -442,7 +441,7 @@ local attackRangeShader = nil
 
 local function goodbye(reason)
 	Spring.Echo("AttackRange GL4 widget exiting with reason: " .. reason)
-	widgetHandler:RemoveWidget(widget)
+	widgetHandler:RemoveWidget()
 end
 
 local function makeCircleVBO(circleSegments)
@@ -1056,7 +1055,7 @@ function widget:Initialize()
 		unitToggles[i] = v
 	end
 
-	widgetHandler.actionHandler:AddAction(self, "cursor_range_toggle", ToggleCursorRange, nil, "p")
+	widgetHandler:AddAction("cursor_range_toggle", ToggleCursorRange, nil, "p")
 
 	myAllyTeam = Spring.GetMyAllyTeamID()
 	local allyteamlist = Spring.GetAllyTeamList()
@@ -1085,6 +1084,10 @@ function widget:Initialize()
 		cursor_unit_range = value
 		widget:Initialize()
 	end
+end
+
+function widget:Shutdown()
+	widgetHandler:RemoveAction("cursor_range_toggle", "p")
 end
 
 local gameFrame = 0


### PR DESCRIPTION
The action is also removed in Shutdown.

This obsoletes a4a2a7456ac6d4fac9e41e1b226e6232e0f33ce9, which had fixed the RemoveWidget call to work with handler=true.

See https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2630