### PR TITLE
Optimize and limit smart area reclaim

### DIFF
--- a/luaui/Widgets/unit_smart_area_reclaim.lua
+++ b/luaui/Widgets/unit_smart_area_reclaim.lua
@@ -91,7 +91,6 @@ end
 
 
 local function tsp(rList, tList, dx, dz)
-	Spring.Echo("processing " .. #rList .. " reclaim commands")
 	dx = dx or 0
 	dz = dz or 0
 	tList = tList or {}
@@ -220,7 +219,7 @@ function widget:CommandNotify(id, params, options)
 	local x, y, z, r = params[1], params[2], params[3], params[4]
 
 	if r > mapSize / 4 then
-		Spring.Echo("Smart reclaim area is too large, limiting size")
+		Spring.Log(widget.GetInfo().name, LOG.WARNING, "Smart reclaim area is too large, limiting size")
 		r = math.floor(mapSize / 4)
 	end
 
@@ -332,7 +331,7 @@ function widget:CommandNotify(id, params, options)
 					end
 				end
 				if mListCount > maxReclaimOrders then
-					Spring.Echo("Command count exceeded, feature selection may be incomplete")
+					Spring.Log(widget:GetInfo().name, LOG.WARNING, "Command count exceeded, feature selection may be incomplete")
 					break
 				end
 			end

--- a/luaui/Widgets/unit_smart_area_reclaim.lua
+++ b/luaui/Widgets/unit_smart_area_reclaim.lua
@@ -24,16 +24,14 @@ function widget:GetInfo()
 end
 
 local maxOrdersCheck = 100 -- max amount of orders to check for duplicate orders on units
-local maxReclaimOrders = 100 -- max amount of orders to issue at once
+local maxReclaimOrders = 1000 -- max amount of orders to issue at once
 
 local maxUnits = Game.maxUnits
 local GetSelectedUnits = Spring.GetSelectedUnits
 local GetUnitDefID = Spring.GetUnitDefID
 local GetUnitCommands = Spring.GetUnitCommands
 local GetUnitPosition = Spring.GetUnitPosition
-local GetFeaturesInRectangle = Spring.GetFeaturesInRectangle
 local GetFeaturePosition = Spring.GetFeaturePosition
-local GetFeatureRadius = Spring.GetFeatureRadius
 local GetFeatureResources = Spring.GetFeatureResources
 local GiveOrderToUnit = Spring.GiveOrderToUnit
 
@@ -93,6 +91,7 @@ end
 
 
 local function tsp(rList, tList, dx, dz)
+	Spring.Echo("processing " .. #rList .. " reclaim commands")
 	dx = dx or 0
 	dz = dz or 0
 	tList = tList or {}
@@ -324,10 +323,6 @@ function widget:CommandNotify(id, params, options)
 						if not options.shift or checkNoDuplicateOrder(uid, fid) then
 							mListCount = mListCount + 1
 							mList[mListCount] = item
-							-- early exit if count exceeds limit
-							if mListCount > maxReclaimOrders then
-								break
-							end
 						end
 					elseif stationaries[uid] ~= nil then
 						if sqrt((dx*dx)+(dz*dz)) <= stationaries[uid] and (not options.shift or checkNoDuplicateOrder(uid, fid)) then
@@ -335,6 +330,10 @@ function widget:CommandNotify(id, params, options)
 							sList[sListCount] = item
 						end
 					end
+				end
+				if mListCount > maxReclaimOrders then
+					Spring.Echo("Command count exceeded, feature selection may be incomplete")
+					break
 				end
 			end
 		end

--- a/luaui/Widgets/unit_smart_area_reclaim.lua
+++ b/luaui/Widgets/unit_smart_area_reclaim.lua
@@ -73,20 +73,24 @@ local function maybeRemoveSelf()
     end
 end
 
+
 function widget:GameStart()
     gameStarted = true
     maybeRemoveSelf()
 end
 
+
 function widget:PlayerChanged()
     maybeRemoveSelf()
 end
+
 
 function widget:Initialize()
     if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
         maybeRemoveSelf()
     end
 end
+
 
 local function tsp(rList, tList, dx, dz)
 	dx = dx or 0
@@ -118,6 +122,7 @@ local function tsp(rList, tList, dx, dz)
 	rList[closestIndex] = 0
 	return tsp(rList, tList, closestItem[1], closestItem[2])
 end
+
 
 local function stationary(rList)
 	local sList = {}
@@ -278,7 +283,7 @@ function widget:CommandNotify(id, params, options)
 				if featM > 0 then
 					rmtw[#rmtw + 1] = featureID
 				elseif featE > 0 then
-					retw[retw + 1] = featureID
+					retw[#retw + 1] = featureID
 				end
 			elseif featY > 0 then
 				if featM > 0 then


### PR DESCRIPTION
### Work done
Smart area reclaim has long been a problematic widget, it crashes games fairly frequently by people doing map-wide smart reclaim orders, which issues *thousands* of commands, all of which go through every widget that uses `UnitCommand` or `CommandNotify`. Part of this is because the widget is very poorly optimized and brute forces just about everything, but the worst part is that it has no limits whatsoever, and will happily crash everyones game trying to process all of that in a single frame. This is not a rewrite, but a fairly quick and dirty optimization that will make it slightly less egregious.

- Be much more aggressive about early-exiting heavy workloads. This widget previously executed tons of unit and feature analysis for every reclaim command, even reclaim commands on single targets or reclaim commands that aren't centered on a feature
- Hard limit the number of issued commands. I have set it at 1000 for this PR. Note that this is *total* commands, so 20 rezbots means a max of 50 commands each, or 50 features total. It can feel not great to have this limited, but it is far better than the game hitching or crashing for everyone.
- Limit the size of the command radius to a quarter of the maps largest dimension, to limit the feature processing that needs to be done.
- Slightly optimize by reducing variables and redundant work
- Slightly refactor for readability (love no comments and 2 letter variables 😬 )

#### Test steps
- [ ] Test normal reclaim commands, expect no change in behavior
- [ ] Test area reclaim commands no centered on features, expect no change in behavior
- [ ] Test area reclaim commands centered on features, expect commands to be queued for features of that type (prioritizes metal. If a feature has both metal and energy like strait center rocks, metal will be chosen)
- [ ] Test map-wide area reclaim commands centered on a feature, preferably on large maps with lots of trees or crystals. Expect little to no hitching, expect not every feature to be given a command. Expect a warning to be printed in the console that the area is too large.

#### Known issues
Sometimes, depending on cursor placement and camera movement, the center feature can be missed when the command is issued, causing it to fall back to standard area reclaim behavior. I don't believe there is anything that can meaningfully done about this, the main cause is feature colvols which can be very small sometimes.
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/d3fa46ce-da58-45c0-8de5-c02c3c2de8e6)
