### PR TITLE
Fix extractor exploit

### DIFF
--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -11,6 +11,7 @@ function gadget:GetInfo()
 	}
 end
 
+local CMD_INSERT = CMD.INSERT
 
 if not gadgetHandler:IsSyncedCode() then
 	return
@@ -36,19 +37,24 @@ end
 
 -- function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
-	if #cmdParams > 4 then
+	if cmdID == CMD_INSERT then
 		cmdID = cmdParams[2] -- this is where the ID is placed in prepended commands with commandinsert
 	end
+
 	if not isMex[-cmdID] then
 		return true
 	end
 
 	local bx, bz = cmdParams[1], cmdParams[3]
+	if cmdID == CMD_INSERT then
+		bx, bx = cmdParams[4], cmdParams[6] -- this is where the cmd position is placed in prepended commands with commandinsert
+	end
 	-- We find the closest metal spot to the assigned command position
 	local closestSpot = math.getClosestPosition(bx, bz, metalSpotsList)
 
 	-- We check if current order is to build mex in closest spot
 	if not (closestSpot and GG["resource_spot_finder"].IsMexPositionValid(closestSpot, bx, bz)) then
+		Spring.Log(gadget:GetInfo().name, LOG.WARNING, "Extractors cannot be placed off of metal spots")
 		return false
 	end
 

--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -36,6 +36,9 @@ end
 
 -- function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
+	if #cmdParams > 4 then
+		cmdID = cmdParams[2] -- this is where the ID is placed in prepended commands with commandinsert
+	end
 	if not isMex[-cmdID] then
 		return true
 	end

--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -260,6 +260,7 @@ function widget:MousePress(x, y, button)
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
 		if selectedMex then
 			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, mexConstructors, shift)
+			return true
 		end
 		if selectedGeo then
 			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, geoConstructors, shift)


### PR DESCRIPTION
### Work done
Commands bypass mex denier if issued with commandinsert. This allows mexes to be built off of metal spots, which is a serious exploit.

#### Test steps
- [ ] With mex snap, place an extractor while holding space
- [ ] BEFORE: Expect two build orders to be issued, one at the cursor and one at the snapped position
- [ ] AFTER: Expect one build order to be issued at the snapped position