### PR TITLE
Update deferred projectile lights to be 30+ hertz refresh rate, add s…

### DIFF
--- a/luaui/Widgets/Shaders/deferred_lights_gl4.vert.glsl
+++ b/luaui/Widgets/Shaders/deferred_lights_gl4.vert.glsl
@@ -111,9 +111,6 @@ void main()
 	v_worldPosRad = worldposrad ;
 	v_worldPosRad.w = lightRadius;
 	
-	// TODO ANIMATE
-	//v_worldPosRad.xyz += 1 * sin(5*time * vec3(0.01, 0.011, 0.012) + v_worldPosRad.xyz ); 
-	
 	
 	mat4 placeInWorldMatrix = mat4(1.0); // this is unity for non-unitID tied stuff
 	
@@ -169,10 +166,10 @@ void main()
 		// the -1 is for inverting it so we always see the back faces (great for occlusion testing!) (this should be exploited later on!
 		
 		// this is centered around the target positional offset, and scaled locally
-		vec3 lightVolumePos = lightCenterPosition + -1 * position.xyz * lightRadius * 1.1; 
+		vec3 lightVertexPosition = lightCenterPosition + -1 * position.xyz * lightRadius * 1.1; 
 		
 		// tranform the vertices to world-space
-		lightVolumePos = (placeInWorldMatrix * vec4(lightVolumePos, 1.0)).xyz; 
+		lightVertexPosition = (placeInWorldMatrix * vec4(lightVertexPosition, 1.0)).xyz; 
 		
 		// tranform the center to world-space
 		lightCenterPosition = (placeInWorldMatrix * vec4(lightCenterPosition, 1.0)).xyz; 
@@ -198,17 +195,18 @@ void main()
 			}
 			if (worldposrad2.w < 1.0) {
 				lightCenterPosition += timeInfo.w * worldposrad2.xyz;
+				lightVertexPosition += timeInfo.w * worldposrad2.xyz;
 			}else{
 				// Note: worldposrad2.w is an excellent place to add orbit-style world-placement light animations
-				vec3 lightWorldMovement = sin(time * 0.017453292 * worldposrad2.xyz) * worldposrad2.w;
-				lightCenterPosition += lightWorldMovement;
+				//vec3 lightWorldMovement = sin(time * 0.017453292 * worldposrad2.xyz) * worldposrad2.w;
+				//lightCenterPosition += lightWorldMovement;
 			}
 		}
 		
 
 		v_worldPosRad.xyz = lightCenterPosition;
 		v_depths_center_map_model_min = depthAtWorldPos(vec4(lightCenterPosition,1.0)); // 
-		v_position = vec4( lightVolumePos, 1.0);
+		v_position = vec4( lightVertexPosition, 1.0);
 	}
 	#line 12000
 	else if (pointbeamcone < 1.5){ // beam

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1307,9 +1307,9 @@ local function updateProjectileLights(newgameframe)
 					--update proj pos
 					lightType = trackedProjectileTypes[projectileID]
 					if lightType ~= 'beam' then 
-						local instanceIndex = updateLightPosition(projectilePointLightVBO, projectileID, px,py,pz)
 						local dx,dy,dz = spGetProjectileVelocity(projectileID)
-						updateLightPosition(projectileConeLightVBO, projectileID, px,py,pz, nil, dx,dy,dz)
+						local instanceIndex = updateLightPosition(projectileLightVBOMap[lightType],
+							projectileID, px,py,pz, nil, dx,dy,dz)
 						if debugproj then Spring.Echo("Updated", instanceIndex, projectileID, px, py, pz,dx,dy,dz) end
 					end
 					
@@ -1379,9 +1379,12 @@ local function updateProjectileLights(newgameframe)
 			-- SO says we can modify or remove elements while iterating, we just cant add
 			-- a possible hack to keep projectiles visible, is trying to keep getting their pos
 			local px, py, pz = spGetProjectilePosition(projectileID)
-			if px then
-				if newgameframe then
-					updateLightPosition(projectilePointLightVBO, projectileID, px,py,pz)
+			if px then -- this means that this projectile 
+				local lightType = trackedProjectileTypes[projectileID]
+				if newgameframe and lightType ~= 'beam' then
+					local dx,dy,dz = spGetProjectileVelocity(projectileID)
+					updateLightPosition(projectileLightVBOMap[lightType], 
+						projectileID, px,py,pz, nil, dx,dy,dz )
 				end
 			else
 				numremoved = numremoved + 1

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -269,12 +269,13 @@ lightCacheTable[16] = 1
 local lightParamKeyOrder = { -- This table is a 'quick-ish' way of building the lua array from human-readable light parameters
 	posx = 1, posy = 2, posz = 3, radius = 4,
 	r = 9, g = 10, b = 11, a = 12,
-	color2r = 5, color2g = 6, color2b = 7, colortime = 8, -- point lights only, colortime in seconds for unit-attached
-	dirx = 5, diry = 6, dirz = 7, theta = 8,  -- cone lights only, specify direction and half-angle in radians
+	dirx = 5, diry = 6, dirz = 7, theta = 8,  -- specify direction and half-angle in radians
 	pos2x = 5, pos2y = 6, pos2z = 7, -- beam lights only, specifies the endpoint of the beam
 	modelfactor = 13, specular = 14, scattering = 15, lensflare = 16,
-	lifetime = 18, sustain = 19, animtype = 20 -- unused
-	-- NOTE THERE ARE 4 MORE UNUSED SLOTS HERE RESERVED FOR FUTURE USE!
+	lifetime = 18, sustain = 19, animtype = 20, -- animtype unused
+	
+	-- NOTE THERE ARE 4 MORE UNUSED SLOTS HERE RESERVED FOR FUTURE USE! -- Nope, beherith ate these like a greedy boy
+	color2r = 21, color2g = 22, color2b = 23, colortime = 24, -- point lights only, colortime in seconds for unit-attached
 }
 
 local autoLightInstanceID = 128000 -- as MAX_PROJECTILES = 128000, so they get unique ones
@@ -367,7 +368,7 @@ local function initGL4()
 				-- for cone, this is center.xyz and height
 				-- for beam this is center.xyz and radiusleft
 			{id = 4, name = 'worldposrad2', size = 4},
-				-- for spot, this is 0
+				-- for spot, this is direction.xyz for unitattached, or world anim params
 				-- for cone, this is direction.xyz and angle in radians
 				-- for beam this is end.xyz and radiusright
 			{id = 5, name = 'lightcolor', size = 4},
@@ -565,10 +566,10 @@ local function AddPointLight(instanceID, unitID, pieceIndex, targetVBO, px_or_ta
 		lightparams[18] = lifetime or 0
 		lightparams[19] = sustain or 1
 		lightparams[20] = animtype or 0
-		lightparams[21] = 0 -- unused
-		lightparams[22] = 0 --unused
-		lightparams[23] = 0 --unused
-		lightparams[24] = 0 --unused
+		lightparams[21] = r2 or 0
+		lightparams[22] = g2 or 0
+		lightparams[23] = b2 or 0
+		lightparams[24] = colortime or 0
 		lightparams[pieceIndexPos] = pieceIndex or 0
 	else
 		lightparams = px_or_table
@@ -1305,13 +1306,13 @@ local function updateProjectileLights(newgameframe)
 				if newgameframe then
 					--update proj pos
 					lightType = trackedProjectileTypes[projectileID]
-					if lightType == 'point' then
+					if lightType ~= 'beam' then 
 						local instanceIndex = updateLightPosition(projectilePointLightVBO, projectileID, px,py,pz)
-					elseif lightType == 'cone' then
 						local dx,dy,dz = spGetProjectileVelocity(projectileID)
 						updateLightPosition(projectileConeLightVBO, projectileID, px,py,pz, nil, dx,dy,dz)
-					end -- NOTE: WE DONT UPDATE BEAM POS!
-					if debugproj then Spring.Echo("Updated", instanceIndex, projectileID, px, py, pz) end
+						if debugproj then Spring.Echo("Updated", instanceIndex, projectileID, px, py, pz,dx,dy,dz) end
+					end
+					
 				end
 			else
 				-- add projectile
@@ -1333,19 +1334,21 @@ local function updateProjectileLights(newgameframe)
 						local lightParamTable = projectileDefLights[weaponDefID].lightParamTable
 						lightType = projectileDefLights[weaponDefID].lightType
 
+
 						lightParamTable[1] = px
 						lightParamTable[2] = py
 						lightParamTable[3] = pz
 						if debugproj then Spring.Echo(lightType, projectileDefLights[weaponDefID].lightClassName) end
 
+						local dx,dy,dz = spGetProjectileVelocity(projectileID)
+
 						if lightType == 'beam' then
-							local dx,dy,dz = spGetProjectileVelocity(projectileID)
 							lightParamTable[5] = px + dx
 							lightParamTable[6] = py + dy
 							lightParamTable[7] = pz + dz
-						elseif lightType == 'cone' then
-
-							local dx,dy,dz = spGetProjectileVelocity(projectileID)						lightParamTable[5] = dx
+						else 
+							-- for points and cones, velocity gives the pointing dir, and for cones it gives the pos super well.
+							lightParamTable[5] = dx
 							lightParamTable[6] = dy
 							lightParamTable[7] = dz
 						end


### PR DESCRIPTION
Update deferred projectile lights to be 30+ hertz refresh rate, add support for orbit-style animations for point lights.

This was achieved by splitting out point color2 from worldposrad2.

Note: color2 now technically available for beams and cones, but not plugged in yet.

smart beherith reserved himself some space in the instance VBO a year ago...

To test:

See how smooth the lights for submarine torpedos and fast-travelling projectiles like  LRPC's are