### PR TITLE
fix(barwidgets): only SafeWrapFunc Initialize() once

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -836,9 +836,10 @@ local function SafeWrapWidget(widget)
 		if widget[ciName] then
 			widget[ciName] = SafeWrapFunc(widget[ciName], ciName)
 		end
-		if widget.Initialize then
-			widget.Initialize = SafeWrapFunc(widget.Initialize, 'Initialize')
-		end
+	end
+
+	if widget.Initialize then
+		widget.Initialize = SafeWrapFunc(widget.Initialize, 'Initialize')
 	end
 end
 


### PR DESCRIPTION
Previously, Initialize() was wrapped dozens of times for each widget.

#### Test steps
1. Log calls to the inner function of `SafeWrapFuncGL`
2. Only one such call should happen for each `widget:Initialize()` call (once per widget loaded)
