### PR TITLE
Fix mex blueprint getting stuck with mex snap

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -260,6 +260,9 @@ function widget:MousePress(x, y, button)
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
 		if selectedMex then
 			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, mexConstructors, shift)
+			if(not shift and WG["gridmenu"] and WG["gridmenu"].clearCategory) then
+				WG["gridmenu"].clearCategory()
+			end
 			return true
 		end
 		if selectedGeo then


### PR DESCRIPTION
### Work done
When selecting mex, then clicking once to build a mex via snap (without shift) the mex should be deselected. A bug caused it to get stuck