### PR TITLE
fix(barwidgets): fix check if Spring.Yield() needs to be called again

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -297,10 +297,7 @@ local doMoreYield = (Spring.Yield ~= nil);
 
 local function Yield()
 	if doMoreYield then
-		local doMoreYield = Spring.Yield()
-		if doMoreYield == false then --GetThreadSafety == false
-			--Spring.Echo("WidgetHandler Yield: entering critical section")
-		end
+		doMoreYield = Spring.Yield()
 	end
 end
 


### PR DESCRIPTION
`Spring.Yield()` is using during initial loading of the game, and returns false if further calls are no longer necessary.

See relevant discussion here: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2644#discussion_r1497233012