### PR TITLE
Fix small grid category bug with mex snap

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -251,6 +251,21 @@ function widget:Update()
 end
 
 
+-- Since mex snap bypasses normal building behavior, we have to hand hold gridmenu a little bit
+local function handleGridmenu(shift)
+	local grid = WG["gridmenu"]
+	if not grid or not grid.clearCategory or not grid.getAlwaysReturn or not grid.setCurrentCategory then
+		return
+	end
+
+	if(not shift and not grid.getAlwaysReturn()) then
+		grid.clearCategory()
+	elseif grid.getAlwaysReturn() then
+		grid.setCurrentCategory(nil)
+	end
+end
+
+
 function widget:MousePress(x, y, button)
 	if isPregame then
 		return
@@ -260,16 +275,12 @@ function widget:MousePress(x, y, button)
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
 		if selectedMex then
 			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, mexConstructors, shift)
-			if(not shift and WG["gridmenu"] and WG["gridmenu"].clearCategory) then
-				WG["gridmenu"].clearCategory()
-			end
+			handleGridmenu(shift)
 			return true
 		end
 		if selectedGeo then
 			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, geoConstructors, shift)
-			if(not shift and WG["gridmenu"] and WG["gridmenu"].clearCategory) then
-				WG["gridmenu"].clearCategory()
-			end
+			handleGridmenu(shift)
 			return true -- override other mouse presses and handle stuff manually
 		end
 	end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -650,7 +650,6 @@ function widget:CommandNotify(cmdID, _, cmdOpts)
 
 	if alwaysReturn or not cmdOpts.shift then
 		setCurrentCategory(nil)
-		doUpdate = true
 	end
 end
 
@@ -781,6 +780,9 @@ function widget:Initialize()
 	end
 	WG["gridmenu"].setAutoSelectFirst = function(value)
 		autoSelectFirst = value
+	end
+	WG["gridmenu"].setCurrentCategory = function(category)
+		setCurrentCategory(category)
 	end
 	WG["gridmenu"].clearCategory = function()
 		clearCategory()


### PR DESCRIPTION
### Work done
With the "always return to categories" option enabled, placing any structure should immediately exit out of the current category without deselecting the active blueprint. When placing mexes via mex snap this didn't work, because mex snap bypasses the normal build hooks that gridmenu uses for events. So this PR adds some more custom handling to mex snap

#### Test steps
- [ ] Hold shit, select mex, then click off of a metal spot so that mex snap takes over
- [ ] Expect the category to be exited, but the mex blueprint to remain selected.