### PR TITLE
Fix for #2649 (bugs in mex denier gadget)

### DIFF
--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -37,17 +37,18 @@ end
 
 -- function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
+	local adjustedCmdID = cmdID
 	if cmdID == CMD_INSERT then
-		cmdID = cmdParams[2] -- this is where the ID is placed in prepended commands with commandinsert
+		adjustedCmdID = cmdParams[2] -- this is where the ID is placed in prepended commands with commandinsert
 	end
 
-	if not isMex[-cmdID] then
+	if not isMex[-adjustedCmdID] then
 		return true
 	end
 
 	local bx, bz = cmdParams[1], cmdParams[3]
 	if cmdID == CMD_INSERT then
-		bx, bx = cmdParams[4], cmdParams[6] -- this is where the cmd position is placed in prepended commands with commandinsert
+		bx, bz = cmdParams[4], cmdParams[6] -- this is where the cmd position is placed in prepended commands with commandinsert
 	end
 	-- We find the closest metal spot to the assigned command position
 	local closestSpot = math.getClosestPosition(bx, bz, metalSpotsList)


### PR DESCRIPTION
### Work done
Fixes a bug in mex denier gadget that prevents a mex build order exactly on top of a metal spot when the "insert command at beginning of queue" hotkey is held (spacebar).

- Fixes cmdID being overwritten 
- Fixes typo with coordinate variables

#### Addresses Issue(s)
Issue #2649

#### Test steps
Issue order to build solar. Then, holding spacebar (or whatever hotkey you have bound to "insert command at beginning of queue"), issue an order to build a mex exactly on a metal spot. It should build without an error or warning. 

Issue order to build solar. Then, holding spacebar (or whatever hotkey you have bound to "insert command at beginning of queue"), issue an order to build a mex off of a metal spot (so it snaps to the metal location). It should build on the metal spot without an error or warning. 

Issue order to build solar. Then, holding shift (or whatever hotkey you have bound to "insert command at endof queue"), issue an order to build a mex exactly on a metal spot. It should build on the metal spot without an error or warning. 

Issue order to build solar. Then, holding shift (or whatever hotkey you have bound to "insert command at endof queue"), issue an order to build a mex off of a metal spot (so it snaps to the metal location). It should build on the metal spot without an error or warning. 
