### PR TITLE
Handle meta properly for mex and geo building

### DIFF
--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -37,7 +37,8 @@ end
 
 -- function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
-	if cmdID == CMD_INSERT then
+	local isInsert = cmdID == CMD_INSERT
+	if isInsert then
 		cmdID = cmdParams[2] -- this is where the ID is placed in prepended commands with commandinsert
 	end
 
@@ -46,9 +47,10 @@ function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
 	end
 
 	local bx, bz = cmdParams[1], cmdParams[3]
-	if cmdID == CMD_INSERT then
-		bx, bx = cmdParams[4], cmdParams[6] -- this is where the cmd position is placed in prepended commands with commandinsert
+	if isInsert then
+		bx, bz = cmdParams[4], cmdParams[6] -- this is where the cmd position is placed in prepended commands with commandinsert
 	end
+
 	-- We find the closest metal spot to the assigned command position
 	local closestSpot = math.getClosestPosition(bx, bz, metalSpotsList)
 

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -321,10 +321,11 @@ local function sortBuilders(units, constructorIds, buildingId, shift)
 	for i, uid in pairs(secondaryBuilders) do
 		local mainBuilderId = mainBuilders[index]
 		if not shift then
-			spGiveOrderToUnit(uid, CMD_STOP, {}, { })
-			spGiveOrderToUnit(uid, CMD_GUARD, { mainBuilderId }, { "shift" })
+			spGiveOrderToUnit(uid, CMD_GUARD, { mainBuilderId }, { })
 			index = index + 1
 		end
+		-- if we give a guard order on a unit already guarded with shift, it will get cancelled
+		-- so do some queue analysis and avoid duplicate commands
 		if shift and not hasExistingGuardOrder(uid) then
 			spGiveOrderToUnit(uid, CMD_GUARD, { mainBuilderId }, { "shift" })
 			index = index + 1

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -412,6 +412,7 @@ local function ApplyPreviewCmds(cmds, constructorIds, shift)
 			Spring.GiveOrderToUnitArray(unitArray, CMD.INSERT, {i-1, -buildingId, 0, unpack(orderParams) }, { "alt" })
 		else
 			-- we don't want to give a stop command to clear queue because it plays an unwanted sound
+			-- issuing any command without shift will clear the queue for us,
 			-- so we use the real shift value for the first command, then we force shift for all the others
 			-- since any commands passed to this function are intended to be queued, not discarded.
 			local fakeShift = i == 1 and shift or true

--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -260,11 +260,12 @@ function widget:MousePress(x, y, button)
 	if (button == 3) then
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
 		if selectedMex then
-			return WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, mexConstructors, shift)
-
+			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, mexConstructors, shift)
+			return true
 		end
 		if selectedGeo then
-			return WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, geoConstructors, shift)
+			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, geoConstructors, shift)
+			return true
 		end
 	end
 end


### PR DESCRIPTION
### Work done
- Meta handling was very scattershot before, and did not work properly. This completely reworks it and makes all mex and geo commands get first-class meta support
- Don't give stop commands to units to clear their queue anymore, instead force shift behavior to clear or preserve queue as needed. This prevents the stop sound from playing for normal commands.

#### Test steps
- [ ] Test mex snap, expect no stop sound to play
- [ ] Test mex snap with multiple tiers of builders, expect guard commands from the cons who cannot make the target mex, and expect no stop sound to play
- [ ] Test mex snap with meta, expect no errors, expect build order to be at front of queue
- [ ] Test right-click-mex with meta, expect no errors, expect build order to be at front of queue
- [ ] Test area mex with meta, expect no errors, expect build orders to be front of queue, and expect nearest mex to be the first queued order
