### PR TITLE
fix(gui_advplayerlist): include eco display for AI teams

### DIFF
--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -1307,7 +1307,7 @@ function UpdatePlayerResources()
     local energyIncome, metalIncome
     local displayedPlayers = 0
     for playerID, _ in pairs(player) do
-        if playerID < specOffset and player[playerID].name and not player[playerID].spec and player[playerID].team then
+        if player[playerID].name and not player[playerID].spec and player[playerID].team then
 			if aliveAllyTeams[player[playerID].allyteam] ~= nil and (mySpecStatus or myAllyTeamID == player[playerID].allyteam) then
 				if (mySpecStatus and enemyListShow) or player[playerID].allyteam == myAllyTeamID then	-- only keep track when its being displayed
                     displayedPlayers = displayedPlayers + 1


### PR DESCRIPTION
This feature was broken in e812d14cb829822682a1701d8d598eb1da0c4fee

#### Test steps
1. Start a game that includes AI players.
2. Check if economy values show up for all visible players.

#### BEFORE:
![before](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/dac49d0c-2fc7-4362-a5a2-f196ac9188ab)

#### AFTER:
![after](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/19c3071e-5567-45a1-b3d9-76f2427d503b)
