### PR TITLE
Add default configurability to factory guard

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1431,7 +1431,7 @@
 				"autogroup_persist_descr": "Autogroups persist in new games.\nIf this is enabled, units which were added to an autogroup in previous games\n will be added to the same group in this game.",
 				"factory": "Factory",
 				"factoryguard": "guard (builders)",
-				"factoryguard_descr": "Newly created builders will assist their source factory",
+				"factoryguard_descr": "Sets factory guard to on by default, builders will automatically guard the factory that produced them",
 				"factoryholdpos": "hold position",
 				"factoryholdpos_descr": "Sets factories and units they produce, to hold position automatically (not aircraft)",
 				"factoryrepeat": "auto-repeat",

--- a/luaui/Widgets/cmd_factory_guard_pref.lua
+++ b/luaui/Widgets/cmd_factory_guard_pref.lua
@@ -1,0 +1,37 @@
+
+function widget:GetInfo()
+	return {
+		name      = "Factory Guard Default On",
+		desc      = "Sets factory guard state to on by default",
+		author    = "Hobo Joe",
+		date      = "Feb 2024",
+		license   = "GNU GPL, v2 or later",
+		layer     = 1,
+		enabled   = true
+	}
+end
+
+VFS.Include("luarules/configs/customcmds.h.lua")
+
+local isFactory = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.isFactory then
+		local buildOptions = unitDef.buildOptions
+
+		for i = 1, #buildOptions do
+			local buildOptDefID = buildOptions[i]
+			local buildOpt = UnitDefs[buildOptDefID]
+
+			if (buildOpt and buildOpt.isBuilder and buildOpt.canAssist) then
+				isFactory[unitDefID] = true  -- only factories that can build builders are included
+				break
+			end
+		end
+	end
+end
+
+function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+	if isFactory[unitDefID] then
+		Spring.GiveOrderToUnit(unitID, CMD_FACTORY_GUARD, { 1 }, 0)
+	end
+end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4275,6 +4275,7 @@ function init()
 			end,
 		},
 
+		{ id = "factoryguard", group = "game", category = types.basic, widget = "Factory Guard Default On", name = Spring.I18N('ui.settings.option.factory') .. widgetOptionColor .. "  " .. Spring.I18N('ui.settings.option.factoryguard'), type = "bool", value = GetWidgetToggleValue("Factory Guard Default On"), description = Spring.I18N('ui.settings.option.factoryguard_descr') },
 		{ id = "factoryholdpos", group = "game", category = types.basic, widget = "Factory hold position", name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.factoryholdpos'), type = "bool", value = GetWidgetToggleValue("Factory hold position"), description = Spring.I18N('ui.settings.option.factoryholdpos_descr') },
 		{ id = "factoryrepeat", group = "game", category = types.basic, widget = "Factory Auto-Repeat", name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.factoryrepeat'), type = "bool", value = GetWidgetToggleValue("Factory Auto-Repeat"), description = Spring.I18N('ui.settings.option.factoryrepeat_descr') },
 

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -111,7 +111,6 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			if cmdID == 115 then
 				return
 			end -- we're skipping "repeat" command here for now
-			Spring.Echo("giving state pref command to unit", unitID, cmdID, cmdParam, cmdOpts)
 			local success = Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, cmdOpts)
 			--Spring.Echo("".. name .. ", " .. tostring(cmdID) .. ", " .. tostring(cmdParam) .. " success: ".. tostring(success))
 		end

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -8,7 +8,7 @@ function widget:GetInfo()
 		author = "Errrrrrr, quantum + Doo",
 		date = "April 21, 2023",
 		license = "GNU GPL, v2 or later",
-		layer = 999999,
+		layer = 1000,
 		enabled = false, --  loaded by default?
 	}
 end
@@ -28,6 +28,8 @@ if chunk then
 	setfenv(chunk, tmp)
 	unitArray = chunk()
 end
+
+local CMDTYPE_ICON_MODE = CMDTYPE.ICON_MODE
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -76,40 +78,32 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	if not ctrl then
 		return false
 	end
+
+	local index = Spring.GetCmdDescIndex(cmdID)
+	local command = Spring.GetActiveCmdDesc(index)
 	-- need to filter only state commands!
-	if cmdID > 1000 or cmdID < 0 then
-		--Spring.Echo("Not a state change command!")
-		return false
-	end
-	local cmdName = CMD[cmdID].name
-	if cmdName and not cmdName.find("STATE") then
-		--Spring.Echo("Not a state change command!")
-		return false
+	if type(command) ~= "table" or command.type ~= CMDTYPE_ICON_MODE then
+		return
 	end
 
 	local selectedUnits = Spring.GetSelectedUnits()
 	for i = 1, #selectedUnits do
 		local unitID = selectedUnits[i]
 		local unitDefID = Spring.GetUnitDefID(unitID)
-		local unitTeam = Spring.GetUnitTeam(unitID)
 		local name = unitName[unitDefID]
 		unitSet[name] = unitSet[name] or {}
 		if #cmdParams == 1 and not (unitSet[name][cmdID] == cmdParams[1]) then
 			unitSet[name][cmdID] = cmdParams[1]
-			Spring.Echo("State pref changed:  " .. name .. ",  " .. CMD[cmdID] .. " " .. cmdParams[1])
+			Spring.Echo("State pref changed:  " .. name .. ",  " .. command.name .. " " .. cmdParams[1])
 			table.save(unitSet, "LuaUI/config/StatesPrefs.lua", "--States prefs")
-
-			-- Spring.PlaySoundFile('LuaUI/sounds/volume_osd/pop.wav', 1.0, 'ui')
 		end
 	end
 end
 
 function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	local cmdOpts = GetCmdOpts(false, false, false, true, false)
-	--local altOpts = GetCmdOpts(true, false, false, false, false)
 
 	local name = unitName[unitDefID]
-	--local unitDef = UnitDefs[unitDefID]
 
 	unitSet[name] = unitSet[unitName[unitDefID]] or {}
 	if unitTeam == Spring.GetMyTeamID() then
@@ -117,6 +111,7 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			if cmdID == 115 then
 				return
 			end -- we're skipping "repeat" command here for now
+			Spring.Echo("giving state pref command to unit", unitID, cmdID, cmdParam, cmdOpts)
 			local success = Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, cmdOpts)
 			--Spring.Echo("".. name .. ", " .. tostring(cmdID) .. ", " .. tostring(cmdParam) .. " success: ".. tostring(success))
 		end


### PR DESCRIPTION
### Work done
Factory guard can now have defaults set like before. Also respects state preferences now, set with the State Prefs V2 widget. States saved with this widget will override the default set by the new setting.