### PR TITLE
Fix: mex blueprint not getting deselected in very specific scenarios.

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -255,17 +255,17 @@ end
 -- Since mex snap bypasses normal building behavior, we have to hand hold gridmenu a little bit
 local endShift = false
 local function handleBuildMenu(shift)
+	endShift = shift
+	if not shift then
+		Spring.SetActiveCommand(0)
+		return
+	end
 	local grid = WG["gridmenu"]
 	if not grid or not grid.clearCategory or not grid.getAlwaysReturn or not grid.setCurrentCategory then
-		if not shift then
-			Spring.SetActiveCommand(0)
-		else
-			endShift = true
-		end
 		return
 	end
 
-	if(not shift and not grid.getAlwaysReturn()) then
+	if (not shift and not grid.getAlwaysReturn()) then
 		grid.clearCategory()
 	elseif grid.getAlwaysReturn() then
 		grid.setCurrentCategory(nil)


### PR DESCRIPTION
### Work done
If the player is using gridmenu, and if the player has the "always return to categories" option enabled, and then queues a mex via mex-snap *without* holding shift, the blueprint would remain active when it should be deselected. This fixes that.