### PR TITLE
Removed surface tag from some underwater buildings

### DIFF
--- a/effects/genericunitexplosion.lua
+++ b/effects/genericunitexplosion.lua
@@ -2935,7 +2935,7 @@ local types = {
     --sparks = { properties = {colormap           = [[0.93 0.9 0.20 0.015   0.8 0.8 0.1 0.01   0 0 0 0]]}},
   },
   uw = {
-    groundflash_small = false,
+   -- groundflash_small = false,
     groundflash_large = false,
     groundflash_white = false,
     explosion = {ground=false, water=false, air=false, underwater=false, properties={colormap=[[0 0 0 0   1 0.75 0.9 0.09   0.45 0.4 0.66 0.066   0.33 0.3 0.05 0.033   0 0 0 0]]}},

--- a/effects/genericunitexplosion.lua
+++ b/effects/genericunitexplosion.lua
@@ -2947,7 +2947,7 @@ local types = {
     --sparks = false,
   },
   phib = {
-    groundflash_small = false,
+    --groundflash_small = false,
     groundflash_large = false,
     groundflash_white = false,
     dirt = true,

--- a/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
@@ -35,6 +35,7 @@ return {
 		script = "Units/armshockwave.cob",
 		seismicsignature = 0,
 		selfdestructas = "empblast",
+		selfdestructcountdown = 1,
 		sightdistance = 455,
 		sonarstealth = true,
 		stealth = true,

--- a/units/ArmBuildings/SeaEconomy/armuwageo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwageo.lua
@@ -9,7 +9,7 @@ return {
 		buildpic = "ARMUWAGEO.DDS",
 		buildtime = 33300,
 		canrepeat = false,
-		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "107 77 107",
 		collisionvolumetype = "CylY",

--- a/units/ArmBuildings/SeaEconomy/armuwes.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwes.lua
@@ -11,7 +11,7 @@ return {
 		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE UNDERWATER EMPABLE",
 		corpse = "DEAD",
 		energystorage = 6000,
-		explodeas = "hugeBuildingExplosionGeneric-uw",
+		explodeas = "largeBuildingExplosionGeneric-uw",
 		footprintx = 4,
 		footprintz = 4,
 		idleautoheal = 5,
@@ -22,7 +22,7 @@ return {
 		objectname = "Units/ARMUWES.s3o",
 		script = "Units/ARMUWES.cob",
 		seismicsignature = 0,
-		selfdestructas = "hugeBuildingExplosionGenericSelfd-uw",
+		selfdestructas = "largeBuildingExplosionGenericSelfd-uw",
 		sightdistance = 182,
 		yardmap = "oooooooooooooooo",
 		customparams = {

--- a/units/ArmBuildings/SeaEconomy/armuwgeo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwgeo.lua
@@ -9,7 +9,7 @@ return {
 		buildpic = "ARMUWGEO.DDS",
 		buildtime = 13100,
 		canrepeat = false,
-		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 -4 0",
 		collisionvolumescales = "60 70 60",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/SeaFactories/armamsub.lua
+++ b/units/ArmBuildings/SeaFactories/armamsub.lua
@@ -8,7 +8,7 @@ return {
 		buildpic = "ARMAMSUB.DDS",
 		buildtime = 11100,
 		canmove = true,
-		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE UNDERWATER EMPABLE",
+		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "118 40 119",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/SeaFactories/armshltxuw.lua
+++ b/units/ArmBuildings/SeaFactories/armshltxuw.lua
@@ -8,7 +8,7 @@ return {
 		buildpic = "ARMSHLTXUW.DDS",
 		buildtime = 61400,
 		canmove = true,
-		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE UNDERWATER EMPABLE",
+		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 0 8",
 		collisionvolumescales = "137 75 145",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaEconomy/coruwageo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwageo.lua
@@ -9,7 +9,7 @@ return {
 		buildpic = "CORUWAGEO.DDS",
 		buildtime = 32000,
 		canrepeat = false,
-		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "96 86 96",
 		collisionvolumetype = "cylY",

--- a/units/CorBuildings/SeaEconomy/coruwgeo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwgeo.lua
@@ -9,7 +9,7 @@ return {
 		buildpic = "CORUWGEO.DDS",
 		buildtime = 12900,
 		canrepeat = false,
-		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "63 45 63",
 		collisionvolumetype = "cylY",

--- a/units/CorBuildings/SeaFactories/coramsub.lua
+++ b/units/CorBuildings/SeaFactories/coramsub.lua
@@ -8,7 +8,7 @@ return {
 		buildpic = "CORAMSUB.DDS",
 		buildtime = 11400,
 		canmove = true,
-		category = "ALL NOWEAPON NOTSUB NOTAIR NOTHOVER SURFACE UNDERWATER EMPABLE",
+		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 0 -2",
 		collisionvolumescales = "115 36 112",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corgantuw.lua
+++ b/units/CorBuildings/SeaFactories/corgantuw.lua
@@ -8,7 +8,7 @@ return {
 		buildpic = "CORGANTUW.DDS",
 		buildtime = 67300,
 		canmove = true,
-		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
+		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER UNDERWATER EMPABLE",
 		collisionvolumeoffsets = "0 -5 8",
 		collisionvolumescales = "150 43 150",
 		collisionvolumetype = "CylY",

--- a/weapons/Unit_Explosions.lua
+++ b/weapons/Unit_Explosions.lua
@@ -1290,6 +1290,38 @@ local unitDeaths = {
 			unitexplosion = 1,
 		}
 	},
+	['hugeBuildingExplosionGeneric-uw'] = {
+		weaponType = "Cannon",
+		AreaOfEffect = 420,
+		cameraShake = 420,
+		impulseboost = impulseboost,
+		impulsefactor = impulsefactor,
+		soundhit = "xplolrg4",
+		soundstart = "largegun",
+		explosiongenerator = "custom:genericbuildingexplosion-gigantic-uw",
+		damage = {
+			default = 1330,
+		},
+		customparams = {
+			unitexplosion = 1,
+		}
+	},
+	['hugeBuildingExplosionGenericSelfd-uw'] = {
+		weaponType = "Cannon",
+		AreaOfEffect = 580,
+		cameraShake = 580,
+		impulseboost = impulseboost,
+		impulsefactor = impulsefactor,
+		soundhit = "xplolrg4",
+		soundstart = "largegun",
+		explosiongenerator = "custom:genericbuildingexplosion-gigantic-uw",
+		damage = {
+			default = 3100,
+		},
+		customparams = {
+			unitexplosion = 1,
+		}
+	},
 
 
 	--UNIT DEATHS--


### PR DESCRIPTION
Some underwater buildings cause boats and planes to jam shooting at them, when they cannot damage them.

Semi provisional as there may be some edge cases where this is desired, eg uwgantry -might- be barely shootable by surface-weapon units in some cases, however even when it is partly exposed, they aim for the core which is underwater and unreachable.

Underwater explosion issues also sorted