### PR TITLE
feat(gui_pregame_build): show building facing arrow during pregame

### DIFF
--- a/luaui/Widgets/gui_easyFacing.lua
+++ b/luaui/Widgets/gui_easyFacing.lua
@@ -78,6 +78,16 @@ local function maybeRemoveSelf()
     end
 end
 
+---map of reason to unitDefID
+---@type table<string, number>
+local forceShow = {}
+
+local function getForceShowUnitDefID()
+	-- show facing arrow as long as any source wants us to show it (logical OR)
+	local reason = next(forceShow, nil)
+	return reason and forceShow[reason] or nil
+end
+
 local function getVector2dLen( vector )
 	return sqrt( ( vector[1] * vector[1] ) + ( vector[2] * vector[2] ) )
 end
@@ -205,16 +215,17 @@ local function manipulateFacing()
 end
 
 local function drawOrientation()
-	if not ineffect then return end
+	local forceShowUnitDefID = getForceShowUnitDefID()
+	if not ineffect and not forceShowUnitDefID then return end
 
 	local idx, cmd_id, cmd_type, cmd_name = spGetActiveCommand()
 	local cmdDesc = spGetActiveCmdDesc( idx )
-	if cmdDesc == nil or cmdDesc["type"] ~= 20 then
+	if (cmdDesc == nil or cmdDesc["type"] ~= 20) and not forceShowUnitDefID then
 		return		-- quit here if not a build command
 	end
 
 	-- check for an empty buildlist to avoid to draw for air repair pads
-	local unitDefID = -cmd_id
+	local unitDefID = forceShowUnitDefID or -cmd_id
 	if drawForAll == false and isntFactory[unitDefID] then
 		return
 	end
@@ -281,6 +292,19 @@ function widget:Initialize()
     if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
         maybeRemoveSelf()
     end
+
+	WG['easyfacing'] = {}
+	WG['easyfacing'].setForceShow = function(reason, enabled, unitDefID)
+		if enabled then
+			forceShow[reason] = unitDefID
+		else
+			forceShow[reason] = nil
+		end
+	end
+end
+
+function widget:Shutdown()
+	WG['easyfacing'] = nil
 end
 
 function widget:Update()

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -91,12 +91,16 @@ end
 ------------------------------------------
 ---          QUEUE HANDLING            ---
 ------------------------------------------
-local BUILDING_GRID_FORCE_SHOW_REASON = "gui_pregame_build"
+local FORCE_SHOW_REASON = "gui_pregame_build"
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
 
 	if WG['buildinggrid'] ~= nil and WG['buildinggrid'].setForceShow ~= nil then
-		WG['buildinggrid'].setForceShow(BUILDING_GRID_FORCE_SHOW_REASON, uDefID ~= nil)
+		WG['buildinggrid'].setForceShow(FORCE_SHOW_REASON, uDefID ~= nil)
+	end
+
+	if WG['easyfacing'] ~= nil and WG['easyfacing'].setForceShow ~= nil then
+		WG['easyfacing'].setForceShow(FORCE_SHOW_REASON, uDefID ~= nil, uDefID)
 	end
 
 	local isMex = UnitDefs[uDefID] and UnitDefs[uDefID].extractsMetal > 0
@@ -530,9 +534,14 @@ function widget:Shutdown()
 	end
 	widgetHandler:DeregisterGlobal(widget, 'GetPreGameDefID')
 	widgetHandler:DeregisterGlobal(widget, 'GetBuildQueue')
+
 	WG['pregame-build'] = nil
 	if WG['buildinggrid'] ~= nil and WG['buildinggrid'].setForceShow ~= nil then
-		WG['buildinggrid'].setForceShow(BUILDING_GRID_FORCE_SHOW_REASON, false)
+		WG['buildinggrid'].setForceShow(FORCE_SHOW_REASON, false)
+	end
+
+	if WG['easyfacing'] ~= nil and WG['easyfacing'].setForceShow ~= nil then
+		WG['easyfacing'].setForceShow(FORCE_SHOW_REASON, false)
 	end
 end
 


### PR DESCRIPTION
#### Test steps
1. Start a new game
2. Select a factory to place. An arrow should show, just like after the game has started.

### Screenshots:

#### BEFORE:
![pregame-facing-before](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/7552bf18-ed17-49b8-b59c-c92edbc16e07)

#### AFTER:
![pregame-facing-after](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/884e1f39-2705-4a5d-aa4f-f3cbf678edee)

