### PR TITLE
feat(unit_set_target_by_type): area set target by specific unit type

### DIFF
--- a/luaui/Widgets/unit_set_target_by_type.lua
+++ b/luaui/Widgets/unit_set_target_by_type.lua
@@ -1,0 +1,77 @@
+function widget:GetInfo()
+	return {
+		name = "Set Target by Unit Type",
+		desc = "Hold down Alt and give an area set target order centered on a unit of the type to target",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true
+	}
+end
+
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
+
+local CMD_SET_TARGET = 34923
+
+local allyTeam = Spring.GetMyAllyTeamID()
+local gameStarted
+
+function maybeRemoveSelf()
+	if Spring.GetSpectatingState() and (Spring.GetGameFrame() > 0 or gameStarted) then
+		widgetHandler:RemoveWidget()
+	end
+end
+
+function widget:GameStart()
+	gameStarted = true
+	maybeRemoveSelf()
+end
+
+function widget:PlayerChanged(playerID)
+	maybeRemoveSelf()
+end
+
+function widget:Initialize()
+	if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
+		maybeRemoveSelf()
+	end
+end
+
+function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
+	if cmdID ~= CMD_SET_TARGET or #cmdParams ~= 4 or not cmdOpts.alt then
+		return
+	end
+
+	local cmdX, cmdY, cmdZ = cmdParams[1], cmdParams[2], cmdParams[3]
+
+	local mouseX, mouseY = Spring.WorldToScreenCoords(cmdX, cmdY, cmdZ)
+	local targetType, targetId = Spring.TraceScreenRay(mouseX, mouseY)
+
+	if targetType ~= "unit" then
+		return
+	end
+
+	local cmdRadius = cmdParams[4]
+
+	local filterUnitDefID = spGetUnitDefID(targetId)
+	local areaUnits = Spring.GetUnitsInCylinder(cmdX, cmdZ, cmdRadius)
+
+	local newCmds = {}
+	for i = 1, #areaUnits do
+		local unitID = areaUnits[i]
+		if spGetUnitAllyTeam(unitID) ~= allyTeam and spGetUnitDefID(unitID) == filterUnitDefID then
+			local newCmdOpts = {}
+			if #newCmds ~= 0 or cmdOpts.shift then
+				newCmdOpts = { "shift" }
+			end
+			newCmds[#newCmds + 1] = { CMD_SET_TARGET, { unitID }, newCmdOpts }
+		end
+	end
+
+	if #newCmds > 0 then
+		Spring.GiveOrderArrayToUnitArray(Spring.GetSelectedUnits(), newCmds)
+		return true
+	end
+end
+
+


### PR DESCRIPTION
This is derived from, and works almost identically to unit_specific_unit_reclaimer.lua - hold alt while giving the command to filter for the unit type at the center of the command.

### Addresses Issue(s)
- https://discord.com/channels/549281623154229250/1213062609306263602

### Test steps

*Note: this only works with `settarget`, not `settargetnoground`, since you can't area set target with `settargetnoground`*.

**basic command**
1. Select a unit that can set target
2. Hover an enemy unit
3. Holding alt, issue an area set target command
4. All units of the same type (by `unitDefID`) should be targeted

**command with shift**
1. Select a unit that can set target, and have some set target commands already issued
2. Hover an enemy unit
3. Holding alt and shift, issue an area set target command
4. All units of the same type (by `unitDefID`) should be targeted, queued after the already targeted units

### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
![before](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/2f653df2-3c58-4221-bda3-4ea1c31db701)

#### AFTER:
![after](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/2a73fe16-aa25-4701-ba18-333d97c5bac5)
