### PR TITLE
fix(camera_player_tv): only show player name when setting is enabled

### DIFF
--- a/luaui/Widgets/camera_player_tv.lua
+++ b/luaui/Widgets/camera_player_tv.lua
@@ -536,7 +536,7 @@ function widget:DrawScreen()
 					prevLockPlayerID = lockPlayerID
 				end
 			end
-			if myTeamPlayerID and (lockPlayerID or (alwaysDisplayName and isSpec)) then
+			if myTeamPlayerID and alwaysDisplayName and isSpec then
 				if lockPlayerID then
 					prevLockPlayerID = lockPlayerID
 					lockPlayerID = WG['advplayerlist_api'].GetLockPlayerID()


### PR DESCRIPTION
Previously, even with the setting disabled, the player name would still be shown when following a player's camera.

### Test steps

**setting enabled**
1. Spectate a game
2. Enable the setting: `Interface->Display selected playername`
3. Player name should show above player list in each of these situations:
    1. Normal spectating
    2. "Player View" selected
    4. "Player Camera" selected

**setting disabled**
1. Spectate a game
2. Disable the setting: `Interface->Display selected playername`
3. Player name should *not* show above player list in each of these situations:
    1. Normal spectating
    2. "Player View" selected
    4. "Player Camera" selected