### PR TITLE
gfx_DrawUnitShape_GL4.lua - Only hide dynamic units when zooming out

### DIFF
--- a/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
+++ b/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
@@ -154,7 +154,9 @@ void main() {
 
 	vec3 modelBaseToCamera = cameraViewInv[3].xyz - (pieceMatrix[3].xyz + worldposrot.xyz);
 	if ( dot (modelBaseToCamera, modelBaseToCamera) >  (iconDistance * iconDistance)) {
-		myTeamColor.a = 0.0; // do something if we are far out?
+		if (isDynamic == 1u) { // Only hide dynamic units when zoomed out
+			myTeamColor.a = 0.0; // do something if we are far out?
+		}
 	}
 
 	v_parameters = parameters;


### PR DESCRIPTION
### Work done

UnitShape ghosts drawn using the DrawUnitShape_GL4 widget are always hidden when zoomed out

In comparison, factory ghosts (rendered a different way i assume?) are allowed to be drawn even when zoomed out

This PR disables the enforced hiding of unit shapes drawn via DrawUnitShape_GL4 when zoomed out, but only if they are not dynamic.

I personally want to do this to allow the construction turret ghosts to persist when zoomed all the way out for a widget im working on

Instruction from @Beherith
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/14341953/c0b1e8ab-517d-49e1-9fdb-b65f54e78dc1)

#### Setup
Install the Construction Turret Ghosts widget here: 
- https://discord.com/channels/549281623154229250/1216915437825298442/1216915437825298442
- https://github.com/lokimckay/bar-widgets/blob/main/con_turret_ghosts.lua

#### Test steps
- [ ] Install widget
- [ ] Start a skirmish with inactive AI and cheats, godmode and globallos enabled
- [ ] Have the AI create a construction turret and pawn
- [ ] (optional) Construct a radar tower near the enemy so that they are in radar vision but not LOS
- [ ] Toggle `/globallos` off so that you see unit shapes
- [ ] Disable UI using F5 so that unit icons dont get in the way
- [ ] Zoom out

With this change, ghosts should persist.
Without change, ghosts will disappear.

### Screenshots:

#### Not in radar range (mobile unit shapes not relevant because they don't appear)

![pr](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/14341953/65da5c84-7545-46e7-96f9-d01dcc3317fd)

#### In radar range

![pr2](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/14341953/1f347787-2276-411d-86f9-3c9284b7cd01)


