### PR TITLE
Gridmenu: Fixes to pregame and blueprint deselection

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -258,7 +258,6 @@ local function handleBuildMenu(shift)
 	endShift = shift
 	if not shift then
 		Spring.SetActiveCommand(0)
-		return
 	end
 	local grid = WG["gridmenu"]
 	if not grid or not grid.clearCategory or not grid.getAlwaysReturn or not grid.setCurrentCategory then

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -509,14 +509,6 @@ local function setCurrentCategory(category)
 end
 
 
-local function clearCategory()
-	setCurrentCategory(nil)
-	setLabBuildMode(false)
-	Spring.SetActiveCommand(0, 0, false, false, Spring.GetModKeyState())
-	doUpdate = true
-end
-
-
 local function queueUnit(uDefID, opts)
 	local udTable = Spring.GetSelectedUnitsSorted()
 	for udidFac, uTable in pairs(udTable) do
@@ -548,6 +540,15 @@ local function setPregameBlueprint(uDefID)
 	if not uDefID then
 		setCurrentCategory(nil)
 	end
+end
+
+
+local function clearCategory()
+	setCurrentCategory(nil)
+	setLabBuildMode(false)
+	setPregameBlueprint(nil)
+	Spring.SetActiveCommand(0, 0, false, false, Spring.GetModKeyState())
+	doUpdate = true
 end
 
 
@@ -1846,11 +1847,7 @@ function widget:KeyRelease(key)
 		setLabBuildMode(false)
 	end
 
-	if isPregame then
-		setPregameBlueprint(nil)
-	else
-		clearCategory()
-	end
+	clearCategory()
 end
 
 

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -91,6 +91,20 @@ end
 ------------------------------------------
 ---          QUEUE HANDLING            ---
 ------------------------------------------
+local function handleBuildMenu(shift)
+	local grid = WG["gridmenu"]
+	if not grid or not grid.clearCategory or not grid.getAlwaysReturn or not grid.setCurrentCategory then
+		return
+	end
+
+	if shift and grid.getAlwaysReturn() then
+		grid.setCurrentCategory(nil)
+	elseif not shift then
+		grid.clearCategory()
+	end
+end
+
+
 local FORCE_SHOW_REASON = "gui_pregame_build"
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
@@ -326,6 +340,7 @@ function widget:MousePress(x, y, button)
 
 						if not anyClashes then
 							buildQueue[#buildQueue + 1] = buildData
+							handleBuildMenu(shift)
 						end
 					else
 						-- don't place mex if the spot is not valid
@@ -335,12 +350,14 @@ function widget:MousePress(x, y, button)
 							end
 						else
 							buildQueue = { buildData }
+							handleBuildMenu(shift)
 						end
 
 					end
 
 					if not shift then
 						setPreGamestartDefID(nil)
+						handleBuildMenu(shift)
 					end
 				end
 


### PR DESCRIPTION
### Work done
A few small grid bugs
- Pregame blueprints were taking multiple right-clicks to cancel correctly
- Pregame would not return to categories after placing blueprints without shift, or with shift and "always return to categories" enabled
- Mexes would not return to categories after placement in rare cases
