### PR TITLE
BARb: Change gantry's mask type

### DIFF
--- a/luarules/configs/BARb/stable/config/block_map.json
+++ b/luarules/configs/BARb/stable/config/block_map.json
@@ -57,7 +57,7 @@
 			"yard": [10, 12]
 		},
 		"fac_strider": {
-			"type": ["rectangle", "special"],
+			"type": ["rectangle", "factory"],
 			"offset": [0, 12],
 			"yard": [16, 20]
 		},

--- a/luarules/configs/BARb/stable/config/hard/block_map.json
+++ b/luarules/configs/BARb/stable/config/hard/block_map.json
@@ -41,7 +41,7 @@
 			"offset": [0, 4]
 		},
 		"fac_strider": {                        //t3 factory 9x9
-			"type": ["rectangle", "special"],
+			"type": ["rectangle", "factory"],
 			"size": [9, 9],
 			"yard":[20, 5],
 			"offset": [0, 5],


### PR DESCRIPTION
### Work done
Changed mask type from `special` to `factory` of T3 factories in BARb.
Current value in `hard` BARb allows building ferrets (anti-air) too close to T3 factories, blocking entrance.
And most likely `special` was initially a typo/leftover that came from Zero-K as its striderhub can build in large area around itself.