### PR TITLE
refactor(tablefunctions): make copy and invert functions, not methods

### DIFF
--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -6,9 +6,9 @@ run for end users.)
 ]]
 
 if not table.copy then
-	function table:copy()
+	function table.copy(tbl)
 		local copy = {}
-		for key, value in pairs(self) do
+		for key, value in pairs(tbl) do
 			if type(value) == "table" then
 				copy[key] = table.copy(value)
 			else
@@ -99,9 +99,9 @@ if not table.toString then
 end
 
 if not table.invert then
-	function table:invert()
+	function table.invert(tbl)
 		local inverted = {}
-		for key, value in pairs(self) do
+		for key, value in pairs(tbl) do
 			inverted[value] = key
 		end
 		return inverted


### PR DESCRIPTION
These methods can never actually be used as methods, because tables do
not automatically share a metatable like classes do. Thus `tbl:copy()`
does not know to look in `table` to find `copy()`.

This commit doesn't actually change any functionality, it just makes it
clearer how to use the functions.