### PR TITLE
Fix context build not working without legion units enabled

### DIFF
--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -61,7 +61,6 @@ local unitlist = {
 	{'cormoho','coruwmme'},
 	{'armsolar','armtide'},
 	{'corsolar','cortide'},
-	{'legsolar','cortide'},
 	{'armlab','armsy'},
 	{'corlab','corsy'},
 	{'armllt','armtl'},


### PR DESCRIPTION
### Work done
Remove unloaded legion units from the list of swappable units
