### PR TITLE
Fix case where shift could cancel mex blueprints

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -297,6 +297,7 @@ end
 function widget:KeyRelease(code)
 	if endShift and (code == KEYSYMS.LSHIFT or code == KEYSYMS.RSHIFT) then
 		Spring.SetActiveCommand(0)
+		endShift = false
 	end
 end
 


### PR DESCRIPTION
### Work done
`endShift` is supposed to make releasing shift clear a blueprint AFTER you've placed it while holding shift. But this value was never reset, so after the first instance of it happening, all shift releases would clear the blueprint.

