### PR TITLE
Enable transport preserve queue widget, cleanup code

### DIFF
--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -228,7 +228,7 @@ if not math.HSLtoRGB then
 		end
 	end
 
-	if not math.distance3d then
+	if not math.distance3dSquared then
 		function math.distance3dSquared(x1, y1, z1, x2, y2, z2)
 			local x = x1 - x2
 			local y = y1 - y2
@@ -237,7 +237,7 @@ if not math.HSLtoRGB then
 		end
 	end
 
-	if not math.distance3dSquared then
+	if not math.distance3d then
 		function math.distance3d(x1, y1, z1, x2, y2, z2)
 			return math.diag(x1 - x2, y1 - y2, z1 - z2)
 		end

--- a/luaui/Widgets/cmd_transport_preserve_commands.lua
+++ b/luaui/Widgets/cmd_transport_preserve_commands.lua
@@ -23,19 +23,14 @@ end
 function widget:UnitUnloaded(unitID)
 	if (orders[unitID] and #orders[unitID]) then
 		local newOrders = {}
-		local cmdInsideDist = false
 
 		for i, command in ipairs(orders[unitID]) do
 			if (#command.params >= 3) then
 				local x, y, z = Spring.GetUnitPosition(unitID)
 				local distFromCmd = math.distance3d(x, y, z, command.params[1], command.params[2], command.params[3])
-				Spring.Echo("distance is", distFromCmd)
 				if (distFromCmd <= distToIgnore) then
-					cmdInsideDist = true
+					table.insert(newOrders, { command.id, command.params, command.options })
 				end
-			end
-			if (cmdInsideDist == true) then
-				table.insert(newOrders, { command.id, command.params, command.options })
 			end
 		end
 

--- a/luaui/Widgets/cmd_transport_preserve_commands.lua
+++ b/luaui/Widgets/cmd_transport_preserve_commands.lua
@@ -1,57 +1,71 @@
 function widget:GetInfo()
-    return {
-        name	= "Preserve Commands",
-        desc	= "Preserves a unit's command queue after it has been transported",
-        author  = "Jazcash",
-        date 	= "October 2023",
-        license	= "idklmao",
-        layer 	= 0,
-        enabled	= false
-    }
+	return {
+		name    = "Preserve Commands",
+		desc    = "Preserves a unit's command queue after it has been transported",
+		author  = "Jazcash",
+		date    = "October 2023",
+		license = "idklmao",
+		layer   = 0,
+		enabled = true
+	}
 end
 
 local orders = {}
-local distToIgnore = 400 -- any initial commands outside of this distance from the unload point will be ignored, to stop units walking back to their origin
+local distToIgnore = 500 -- any initial commands outside of this distance from the unload point will be ignored, to stop units walking back to their origin
+
+---------------------------------------------------------------
+
+function widget:UnitLoaded(unitID)
+	orders[unitID] = Spring.GetUnitCommands(unitID, -1)
+end
+
+
+function widget:UnitUnloaded(unitID)
+	if (orders[unitID] and #orders[unitID]) then
+		local newOrders = {}
+		local cmdInsideDist = false
+
+		for i, command in ipairs(orders[unitID]) do
+			if (#command.params >= 3) then
+				local x, y, z = Spring.GetUnitPosition(unitID)
+				local distFromCmd = math.distance3d(x, y, z, command.params[1], command.params[2], command.params[3])
+				Spring.Echo("distance is", distFromCmd)
+				if (distFromCmd <= distToIgnore) then
+					cmdInsideDist = true
+				end
+			end
+			if (cmdInsideDist == true) then
+				table.insert(newOrders, { command.id, command.params, command.options })
+			end
+		end
+
+		Spring.GiveOrderArrayToUnitArray({ unitID }, newOrders)
+
+		orders[unitID] = nil
+	end
+end
+
+
+---------------------------------------------------------------
+--- Housekeeping to manage the widget state
+---------------------------------------------------------------
+
+local function maybeRemoveSelf()
+	if Spring.IsReplay() or Spring.GetSpectatingState() and (Spring.GetGameFrame() > 0) then
+		widgetHandler:RemoveWidget()
+	end
+end
 
 function widget:Initialize()
-    if Spring.IsReplay() then
-        widgetHandler:RemoveWidget()
-    end
+	maybeRemoveSelf()
 end
 
-function widget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
-    orders[unitID] = Spring.GetUnitCommands(unitID, -1)
+function widget:GameStart()
+	maybeRemoveSelf()
 end
 
-function widget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
-    if (orders[unitID] and #orders[unitID]) then
-        local newOrders = {}
-        local cmdInsideDist = false
-
-        for i, command in ipairs(orders[unitID]) do
-            if (#command.params >= 3) then
-                local x, y, z = Spring.GetUnitPosition(unitID)
-                local unloadedPos = { x = x, y = y, z = z }
-                local cmdPos = { x = command.params[1], y = command.params[2], z = command.params[3] }
-                local distFromCmd = distance(unloadedPos, cmdPos)
-                if (distFromCmd <= distToIgnore) then
-                    cmdInsideDist = true
-                end
-            end
-            if (cmdInsideDist == true) then
-                table.insert(newOrders, {command.id, command.params, command.options})
-            end
-        end
-
-        Spring.GiveOrderArrayToUnitArray({ unitID }, newOrders)
-
-        orders[unitID] = nil
-    end
+function widget:PlayerChanged()
+	maybeRemoveSelf()
 end
 
-function distance(pos1, pos2)
-	local xd = pos1.x - pos2.x
-	local yd = pos1.z - pos2.z
-	local dist = math.sqrt(xd*xd + yd*yd)
-	return dist
-end
+---------------------------------------------------------------


### PR DESCRIPTION
### Work done
- Set distance to ignore commands at 500 instead of 400 since it felt pretty small
- Auto format code
- Use distance function from shared math code
- Remove self when not needed

I feel like it might be better to have commands get preserved based on distance from the start point rather than the end point, but that can be a design change for later.