### PR TITLE
Fixed an issue with non-square buildings being slightly offset with the pregame build queue

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -233,13 +233,10 @@ end
 
 local function addUnitShape(id, unitDefID, px, py, pz, facing, teamID)
 	local rotationY =  facing * (math.pi/2)
-	local actualX = px
-	local actualY = py
-	local actualZ = pz
 	if unitshapes[id] then
 		removeUnitShape(id)
 	end
-	unitshapes[id] = WG.DrawUnitShapeGL4(unitDefID, actualX, actualY, actualZ, rotationY, 1, teamID, nil, nil)
+	unitshapes[id] = WG.DrawUnitShapeGL4(unitDefID, px, py, pz, rotationY, 1, teamID, nil, nil)
 	return unitshapes[id]
 end
 


### PR DESCRIPTION
*Added an x/z offset based on the absolute difference in height/width to non-square buildings
*Added a few readability tweaks to a few functions

Test Steps
*Ensure pregame build queue behaves in expected manner
*Ensure incorrect offset for non-square buildings is no longer present (examples: Arm Air Lab/Arm Vehicle Bay)