### PR TITLE
refactor(tablefunctions): rewrite table.toString to be less error-prone

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -120,47 +120,6 @@ if chunk then
 end
 
 --helpers
-local function tableToString(t)
-	local result = ""
-
-	if type(t) ~= "table" then
-		result = tostring(t)
-	elseif t == nil then
-		result = "nil"
-	else
-		for k, v in pairs(t) do
-			result = result .. "[" .. tostring(k) .. "] = "
-
-			if type(v) == "table" then
-				result = result .. "{"
-
-				for k2, v2 in pairs(v) do
-					result = result .. "[" .. tostring(k2) .. "] = "
-
-					if type(v2) == "table" then
-						result = result .. "{"
-
-						for k3, v3 in pairs(v2) do
-							result = result .. "[" .. tostring(k3) .. "] = " .. tostring(v3) .. ", "
-						end
-
-						result = result .. "}, "
-					else
-						result = result .. tostring(v2) .. ", "
-					end
-				end
-
-				result = result .. "}, "
-			else
-				result = result .. tostring(v) .. ", "
-			end
-			result = result .. "  "
-		end
-	end
-
-	return "{" .. result:sub(1, -3) .. "}"
-end
-
 local function convertToBitmap(statusTable)
 	if type(statusTable) ~= "table" then
 		return 0
@@ -1101,7 +1060,7 @@ local function CycleUnitDisplay(direction)
 	-- some crude info display for now
 	Spring.Echo("Changed range display of " .. name ..
 		" to config " .. tostring(bitmap) ..
-		": " .. tableToString(unitToggles[name][allystring]))
+		": " .. table.toString(unitToggles[name][allystring]))
 
 	-- write toggle changes to file
 	table.save(unitToggles, "LuaUI/config/AttackRangeConfig2.lua", "--Attack Range Display Configuration (v2)")


### PR DESCRIPTION
This fixes several issues with the previous implementation:
* It no longer crashes when passed a function, userdata, or any other
type that is not explicitly handled.
* It no longer causes an infinite loop when passed a table that
includes cyclic references.
* Along with the above changes, it sorts keys, which makes the output
deterministic.

And adds some new features:
* It omits array indices when possible.
* It has an option to add indentation and newlines for readability.

---

There are a lot of custom table-to-string implementations all over the codebase, but most of them have some functionality specific to the use case. Ideally, these would all be replaced with this `table.toString`, and the special functionality would be part of a pre-processing step on the table.

So in practice, this PR updates one built-in widget, but presumably many custom widgets are also improved. Also, in the future, this function can be used (as opposed to custom implementations) in more situations due to its flexibility and stability.

This function is definitely slower than the previous implementation, but I think most uses of this are too infrequently called for it to make much of a difference.

One other performance note: this function isn't actually improved by using tables and `table.concat`. Benchmarks showed no significant change.