### PR TITLE
Add Legion Green to Icon Dev Mode

### DIFF
--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -52,6 +52,7 @@ local corRedColor = "#FF1005" -- Cortex Red
 local scavPurpColor = "#6809A1" -- Scav Purple
 local raptorOrangeColor = "#CC8914" -- Raptor Orange
 local gaiaGrayColor = "#7F7F7F" -- Gaia Grey
+local legGreenColor = "#0CE818" -- Legion Green
 
 -- NEW IceXuick Colors V6
 local ffaColors = {
@@ -667,6 +668,7 @@ else -- UNSYNCED
 		scavpurp = scavPurpColor,
 		raptororange = raptorOrangeColor,
 		gaiagray = gaiaGrayColor,
+		leggren = legGreenColor,
 	}
 
 	local iconDevMode = Spring.GetModOptions().teamcolors_icon_dev_mode

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -983,6 +983,7 @@ local options={
 			{key="scavpurp", name="Scavenger Purple", desc="description"},
 			{key="raptororange", name="Raptor Orange", desc="description"},
 			{key="gaiagray", name="Gaia Gray", desc="description"},
+			{key="leggren", name="Legion Green", desc="description"},
 		}
 	},
 


### PR DESCRIPTION
It's the mod option used for forcing colours for icons, adds the missing legion green much needed for its development.