### PR TITLE
Make autogroups load for all applicable units when initialized

### DIFF
--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -102,6 +102,16 @@ function widget:PlayerChanged(playerID)
 	myTeam = Spring.GetMyTeamID()
 end
 
+local function addAllUnits()
+	for _, unitID in ipairs(Spring.GetTeamUnits(myTeam)) do
+		local unitDefID = GetUnitDefID(unitID)
+		local gr = unit2group[unitDefID]
+		if gr ~= nil and GetUnitGroup(unitID) == nil then
+			SetUnitGroup(unitID, gr)
+		end
+	end
+end
+
 local function ChangeUnitTypeAutogroupHandler(_, _, args, data)
 	local gr = args[1]
 	local removeAll = data and data['removeAll']
@@ -213,6 +223,9 @@ function widget:Initialize()
 	end
 	WG['autogroup'].getGroups = function()
 		return unit2group
+	end
+	if GetGameFrame() > 0 then
+		addAllUnits()
 	end
 end
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
When the widget is initialized, it will add all units to autogroups(if  the autogroup is saved for that unit)

closes #1562

