### PR TITLE
Commander transport speed suggestion

### DIFF
--- a/luarules/gadgets/unit_transports_air_speed.lua
+++ b/luarules/gadgets/unit_transports_air_speed.lua
@@ -12,7 +12,7 @@ end
 
 if not gadgetHandler:IsSyncedCode() then return end
 
-local TRANSPORTED_MASS_SPEED_PENALTY = 0.2 -- higher makes unit slower
+local TRANSPORTED_MASS_SPEED_PENALTY = 0.43 -- higher makes unit slower
 local FRAMES_PER_SECOND = Game.gameSpeed
 
 local airTransports = {}


### PR DESCRIPTION
Increased speed penalty from 0.2 -) 0.43
Makes it a ~33% move speed debuff from current commander transport speed.

Check the "Nerf t1 transport speed carrying commander" suggestion on Discord if want more context.

