### PR TITLE
Fix reclaim for cloaked units

### DIFF
--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -11,9 +11,6 @@ function gadget:GetInfo()
 end
 
 local builders = {}
-local toDo = {
-}
-local frame = -1
 
 
 if gadgetHandler:IsSyncedCode() then
@@ -30,17 +27,6 @@ if gadgetHandler:IsSyncedCode() then
             return false
         end
         return true
-    end
-
-    function gadget:GameFrame(n)
-        frame = n
-        if not toDo[frame] then
-            return
-        end
-        for k, doThis in ipairs(toDo[frame]) do
-            doThis[1](doThis[2])
-            toDo[frame][k] = nil
-        end
     end
     
     function gadget:AllowUnitCloak(unitID) -- cancel reclaim commands

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -1,0 +1,80 @@
+function gadget:GetInfo()
+    return {
+        name      = "Prevent Cloaked Unit Reclaim",
+        desc      = "Prevents builders from reclaiming cloaked units",
+        author    = "hihoman23",
+        date      = "Apr 2024",
+        license   = "GNU GPL, v2 or later",
+        layer     = 0,
+        enabled   = true  --  loaded by default?
+    }
+end
+
+local builders = {}
+local toDo = {
+}
+local frame = -1
+
+
+--[[if gadgetHandler:IsSyncedCode() then
+    local GetUnitAllyTeam = Spring.GetUnitAllyTeam
+    local GetUnitIsCloaked = Spring.GetUnitIsCloaked
+    local GetUnitWorkerTask = Spring.GetUnitWorkerTask
+    local GiveOrderToUnit = Spring.GiveOrderToUnit
+    local GetUnitCurrentCommand = Spring.GetUnitCurrentCommand
+    local GetAllUnits = Spring.GetAllUnits
+    local GetUnitDefID = Spring.GetUnitDefID
+
+    function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams)
+        if (cmdID == CMD.RECLAIM) and (#cmdParams == 1) and GetUnitIsCloaked(cmdParams[1]) and (GetUnitAllyTeam(unitID) ~= GetUnitAllyTeam(cmdParams[1])) then
+            return false
+        end
+        return true
+    end
+
+    function gadget:GameFrame(n)
+        frame = n
+        if not toDo[frame] then
+            return
+        end
+        for k, doThis in ipairs(toDo[frame]) do
+            doThis[1](doThis[2])
+            toDo[frame][k] = nil
+        end
+    end
+    
+    function gadget:AllowUnitCloak(unitID) -- cancel reclaim commands
+        for bID, _ in pairs(builders) do
+            local cmd, target = GetUnitWorkerTask(bID)
+            if cmd == CMD.RECLAIM and target == unitID and (GetUnitAllyTeam(bID) ~= GetUnitAllyTeam(unitID)) then
+                local _, _, cmdTag = GetUnitCurrentCommand(bID, 1)
+                GiveOrderToUnit(bID, CMD.REMOVE, {cmdTag}, {})
+            end
+        end
+        return true
+    end
+
+    local function initBuilder(unitID, unitDefID)
+        local def = UnitDefs[unitDefID]
+        if def.isBuilder then
+            builders[unitID] = true
+        end
+    end
+
+    function gadget:UnitCreated(unitID, unitDefID)
+        initBuilder(unitID, unitDefID)
+    end
+
+    function gadget:UnitDestroyed(unitID)
+        builders[unitID] = nil
+    end
+
+    function gadget:Initialize()
+        -- handle luarules reload
+        local units = GetAllUnits()
+        for _,unitID in ipairs(units) do
+            local unitDefID = GetUnitDefID(unitID)
+            initBuilder(unitID, unitDefID)
+        end
+    end
+end]]

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -21,7 +21,7 @@ if gadgetHandler:IsSyncedCode() then
     local GetUnitCurrentCommand = Spring.GetUnitCurrentCommand
     local GetAllUnits = Spring.GetAllUnits
     local GetUnitDefID = Spring.GetUnitDefID
-    local IsunitInRadar = Spring.IsUnitInRadar
+    local IsUnitInRadar = Spring.IsUnitInRadar
 
 
     function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams)

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -32,12 +32,9 @@ if gadgetHandler:IsSyncedCode() then
     end
     
     function gadget:AllowUnitCloak(unitID) -- cancel reclaim commands
-        if IsUnitInRadar(cmdParams[1], GetUnitAllyTeam(unitID)) then
-            return true
-        end
         for bID, _ in pairs(builders) do
             local cmd, target = GetUnitWorkerTask(bID)
-            if cmd == CMD.RECLAIM and target == unitID and (GetUnitAllyTeam(bID) ~= GetUnitAllyTeam(unitID)) then
+            if cmd == CMD.RECLAIM and target == unitID and (GetUnitAllyTeam(bID) ~= GetUnitAllyTeam(unitID)) and not IsUnitInRadar(unitID, GetUnitAllyTeam(bID)) then
                 local _, _, cmdTag = GetUnitCurrentCommand(bID, 1)
                 GiveOrderToUnit(bID, CMD.REMOVE, {cmdTag}, {})
             end

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -21,15 +21,20 @@ if gadgetHandler:IsSyncedCode() then
     local GetUnitCurrentCommand = Spring.GetUnitCurrentCommand
     local GetAllUnits = Spring.GetAllUnits
     local GetUnitDefID = Spring.GetUnitDefID
+    local IsunitInRadar = Spring.IsUnitInRadar
+
 
     function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams)
-        if (cmdID == CMD.RECLAIM) and (#cmdParams == 1) and GetUnitIsCloaked(cmdParams[1]) and (GetUnitAllyTeam(unitID) ~= GetUnitAllyTeam(cmdParams[1])) then
+        if (cmdID == CMD.RECLAIM) and (#cmdParams == 1) and GetUnitIsCloaked(cmdParams[1]) and (GetUnitAllyTeam(unitID) ~= GetUnitAllyTeam(cmdParams[1])) and not IsUnitInRadar(cmdParams[1], GetUnitAllyTeam(unitID)) then
             return false
         end
         return true
     end
     
     function gadget:AllowUnitCloak(unitID) -- cancel reclaim commands
+        if IsUnitInRadar(cmdParams[1], GetUnitAllyTeam(unitID)) then
+            return true
+        end
         for bID, _ in pairs(builders) do
             local cmd, target = GetUnitWorkerTask(bID)
             if cmd == CMD.RECLAIM and target == unitID and (GetUnitAllyTeam(bID) ~= GetUnitAllyTeam(unitID)) then

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -16,7 +16,7 @@ local toDo = {
 local frame = -1
 
 
---[[if gadgetHandler:IsSyncedCode() then
+if gadgetHandler:IsSyncedCode() then
     local GetUnitAllyTeam = Spring.GetUnitAllyTeam
     local GetUnitIsCloaked = Spring.GetUnitIsCloaked
     local GetUnitWorkerTask = Spring.GetUnitWorkerTask
@@ -77,4 +77,4 @@ local frame = -1
             initBuilder(unitID, unitDefID)
         end
     end
-end]]
+end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Cloaked units can't be reclaimed(if they aren't in the radar range)
This means that
- commands that are an order to reclaim a cloaked unit are denied.
- when a unit cloaks, all builders will stop reclaiming it.

I had to implement this with `gadget:AllowUnitCloak()`. Is this a bad idea?

Also:
It takes about half a second for the command to get canceled, which causes this if the player is energy stalling(the reclaim is barely interrupted:

https://github.com/beyond-all-reason/Beyond-All-Reason/assets/78002940/ee7f956c-ea20-4e44-907f-02f5a82ab83f


<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- Open a skirmish game and give yourself a nano turret and the enemy a spybot
- let the spybot walk into the nano range, and cloak it.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
