### PR TITLE
fix(gui_ecostats): handle nil values when drawing resource values

### DIFF
--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -667,7 +667,7 @@ local function DrawEText(numberE, vOffset)
 		local label = string.formatSI(numberE)
 		font:Begin()
 		font:SetTextColor({ 1, 1, 0, 1 })
-		font:Print(label, widgetPosX + widgetWidth - (5 * sizeMultiplier), widgetPosY + widgetHeight - vOffset + (tH * 0.22), tH / 2.3, 'rs')
+		font:Print(label or "", widgetPosX + widgetWidth - (5 * sizeMultiplier), widgetPosY + widgetHeight - vOffset + (tH * 0.22), tH / 2.3, 'rs')
 		font:End()
 	end
 end
@@ -678,7 +678,7 @@ local function DrawMText(numberM, vOffset)
 		local label = string.formatSI(numberM)
 		font:Begin()
 		font:SetTextColor({ 0.85, 0.85, 0.85, 1 })
-		font:Print(label, widgetPosX + widgetWidth - (5 * sizeMultiplier), widgetPosY + widgetHeight - vOffset + (tH * 0.58), tH / 2.3, 'rs')
+		font:Print(label or "", widgetPosX + widgetWidth - (5 * sizeMultiplier), widgetPosY + widgetHeight - vOffset + (tH * 0.58), tH / 2.3, 'rs')
 		font:End()
 	end
 end


### PR DESCRIPTION
Fixes [this error from discord](https://discord.com/channels/549281623154229250/553306256245522432/1229639086478721035):

![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/18132958/c9cfb5a0-e70f-4be8-adf5-e233b48c7d98)
