### PR TITLE
Add Force Load Options for Legion, Scav, & Raptors

### DIFF
--- a/gamedata/unitdefs.lua
+++ b/gamedata/unitdefs.lua
@@ -90,6 +90,16 @@ elseif scavengersEnabled and Spring.GetModOptions().ruins == "scav_only" then
 	legionEnabled = true
 end
 
+if Spring.GetModOptions().forceraptors == true then
+	raptorsEnabled = true
+end
+if Spring.GetModOptions().forcescav == true then
+	scavengersEnabled = true
+end
+if Spring.GetModOptions().forcelegion == true then
+	legionEnabled = true
+end
+
 if Spring.GetModOptions().experimentalextraunits == true then
 	scavengersEnabled = true
 end

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1306,6 +1306,30 @@ local options = {
         type    = "string",
         def     = "",
     },
+	{
+		key		= "forceraptors",
+		name	= "Force Load Raptors",
+		desc	= "Load All Raptor Unit Defs even if raptor ai isn't present",
+		section = "dev",
+		type	= "bool",
+		def		= false,
+	},
+	{
+		key		= "forcescav",
+		name	= "Force Load Scavanger",
+		desc	= "Load scav units even if scav ai isn't present",
+		section = "dev",
+		type	= "bool",
+		def		= false,
+	},
+	{
+		key		= "forcelegion",
+		name	= "Force Load Legion",
+		desc	= "Load legion units even if legion isn't enabled, as such not adding it to start options but still loading the units",
+		section = "dev",
+		type	= "bool",
+		def		= false,
+	},
 }
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Work done
Allows for loading of the 3 factions even if the normal conditions for loading them are not met, whether for testing or other activity.
These can be toggled on via 3 new modoptions in the _DEV category, which is hidden if devmode.txt is not present
