### PR TITLE
Add Legion Track looping to Legion Atlas Textured Units

### DIFF
--- a/modelmaterials/001_units_s3o_assimp.lua
+++ b/modelmaterials/001_units_s3o_assimp.lua
@@ -263,6 +263,25 @@ local materials = {
 
 		UnitDamaged = UnitDamaged,
 	}),
+	unitsNormalMapLegTanks = table.merge(unitsNormalMapTemplate, {
+		texUnits  = {
+			[3] = "%TEXW1",
+			[4] = "%TEXW2",
+			[5] = "%NORMALTEX2",
+		},
+		shaderOptions = {
+			treads_leg = true,
+		},
+		deferredOptions = {
+			treads_leg = true,
+		},
+		UnitCreated = function (unitID, unitDefID, mat) UnitCreated(corTanks, unitID, unitDefID, mat) end,
+		UnitDestroyed = function (unitID, unitDefID) UnitDestroyed(corTanks, unitID, unitDefID) end,
+
+		GameFrame = function (gf, mat) GameFrame(true, corTanks, gf, mat) end,
+
+		UnitDamaged = UnitDamaged,
+	}),
 	unitsNormalMapOthersArmCor = table.merge(unitsNormalMapTemplate, {
 		texUnits  = {
 			[3] = "%TEXW1",
@@ -357,6 +376,11 @@ local wreckAtlases = {
 		"unittextures/cor_other_wreck.dds",
 		"unittextures/cor_color_wreck_normal.dds",
 	},
+	["leg"] = { -- @TODO: swap for a legion one
+		"unittextures/cor_color_wreck.dds",
+		"unittextures/cor_other_wreck.dds",
+		"unittextures/cor_color_wreck_normal.dds",
+	},
 }
 
 local blankNormal = "unittextures/blank_normal.dds"
@@ -370,7 +394,7 @@ for id = 1, #UnitDefs do
 		local lm = tonumber(udefCM.lumamult) or 1
 		local scvd = tonumber(udefCM.scavvertdisp) or 0
 
-		local udefName = udef.name or ""
+		local udefName = udef.customParams.atlas or udef.customParams.faction or udef.name or ""
 		local facName = string.sub(udefName, 1, 3)
 
 		local normalTex = udefCM.normaltex or blankNormal --assume all units have normal maps
@@ -382,6 +406,8 @@ for id = 1, #UnitDefs do
 				unitMaterials[id] = {"unitsNormalMapArmTanks", NORMALTEX = normalTex, TEXW1 = wreckAtlas[1], TEXW2 = wreckAtlas[2], NORMALTEX2 = wreckAtlas[3]}
 			elseif facName == "cor" then
 				unitMaterials[id] = {"unitsNormalMapCorTanks", NORMALTEX = normalTex, TEXW1 = wreckAtlas[1], TEXW2 = wreckAtlas[2], NORMALTEX2 = wreckAtlas[3]}
+			elseif facName == "leg" then -- temporary prefix for legion during transition from cor/arm to legion atlas
+				unitMaterials[id] = {"unitsNormalMapLegTanks", NORMALTEX = normalTex, TEXW1 = wreckAtlas[1], TEXW2 = wreckAtlas[2], NORMALTEX2 = wreckAtlas[3]}
 			end
 		else
 			if wreckAtlas then

--- a/modelmaterials/Templates/defaultMaterialTemplate.lua
+++ b/modelmaterials/Templates/defaultMaterialTemplate.lua
@@ -28,6 +28,8 @@ vertex = [[
 
 	#define OPTION_TREEWIND 11
 
+	#define OPTION_TREADS_LEG 13
+
 	#define OPTION_AUTONORMAL 21
 
 	%%GLOBAL_OPTIONS%%
@@ -268,6 +270,24 @@ vertex = [[
 				}
 			}
 
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
+				const float atlasSize = 4096.0;
+				const float gfMod = 6.9;
+				const float texSpeed = -6.0;
+				float unitSpeed = uni[instData.y].speed.w;
+				float baseOffset =  unitSpeed * mod(float(simFrame), gfMod) / atlasSize;
+				float texOffset = baseOffset * texSpeed;
+
+				// note, invert we invert Y axis
+				//const vec4 treadBoundaries = vec4(1536.0, 2048.0, atlasSize - 2048.0, atlasSize - 1792.0) / atlasSize;
+				const vec4 treadBoundaries = vec4(2559.0, 3332.0, atlasSize - 1174.0, atlasSize - 768.0) / atlasSize;
+				if (all(bvec4(
+						uvCoords.x >= treadBoundaries.x, uvCoords.x <= treadBoundaries.y,
+						uvCoords.y >= treadBoundaries.z, uvCoords.y <= treadBoundaries.w))) {
+					uvCoords.x += texOffset;
+				}
+			}
+
 			worldVertexPos = modelMatrix * modelVertexPos;
 			/***********************************************************************/
 			// Main vectors for lighting
@@ -377,6 +397,8 @@ fragment = [[
 	#define OPTION_MODELSFOG 10
 
 	#define OPTION_TREEWIND 11
+
+	#define OPTION_TREADS_LEG 13
 
 	#define OPTION_AUTONORMAL 21
 
@@ -1619,6 +1641,8 @@ local shaderPlugins = {
 	#define OPTION_MODELSFOG 10
 
 	#define OPTION_TREEWIND 11
+
+	#define OPTION_TREADS_LEG 13
 
 	#define OPTION_AUTONORMAL 21
 ]]--

--- a/modelmaterials_gl4/001_units_s3o_assimp.lua
+++ b/modelmaterials_gl4/001_units_s3o_assimp.lua
@@ -67,6 +67,7 @@ local mySetMaterialUniform = {
 
 local armTanks = {}
 local corTanks = {}
+local legTanks = {}
 local raptorUnits = {}
 local otherUnits = {}
 local spGetUnitHealth = Spring.GetUnitHealth
@@ -263,6 +264,25 @@ local materials = {
 
 		UnitDamaged = UnitDamaged,
 	}),
+	unitsNormalMapLegTanks = table.merge(unitsNormalMapTemplate, {
+		texUnits  = {
+			[3] = "%TEXW1",
+			[4] = "%TEXW2",
+			[5] = "%NORMALTEX2",
+		},
+		shaderOptions = {
+			treads_leg = true,
+		},
+		deferredOptions = {
+			treads_leg = true,
+		},
+		UnitCreated = function (unitID, unitDefID, mat) UnitCreated(corTanks, unitID, unitDefID, mat) end,
+		UnitDestroyed = function (unitID, unitDefID) UnitDestroyed(corTanks, unitID, unitDefID) end,
+
+		GameFrame = function (gf, mat) GameFrame(true, corTanks, gf, mat) end,
+
+		UnitDamaged = UnitDamaged,
+	}),
 	unitsNormalMapOthersArmCor = table.merge(unitsNormalMapTemplate, {
 		texUnits  = {
 			[3] = "%TEXW1",
@@ -369,6 +389,11 @@ local wreckAtlases = {
 		"unittextures/cor_other_wreck.dds",
 		"unittextures/cor_color_wreck_normal.dds",
 	},
+	["leg"] = { -- @TODO: swap for a legion one
+		"unittextures/cor_color_wreck.dds",
+		"unittextures/cor_other_wreck.dds",
+		"unittextures/cor_color_wreck_normal.dds",
+},
 }
 
 local blankNormal = "unittextures/blank_normal.dds"
@@ -382,7 +407,7 @@ for id = 1, #UnitDefs do
 		local lm = tonumber(udefCM.lumamult) or 1
 		local scvd = tonumber(udefCM.scavvertdisp) or 0
 
-		local udefName = udef.name or ""
+		local udefName = udef.customParams.atlas or udef.customParams.faction or udef.name or ""
 		local facName = string.sub(udefName, 1, 3)
 
 		local normalTex = udefCM.normaltex or blankNormal --assume all units have normal maps
@@ -394,6 +419,8 @@ for id = 1, #UnitDefs do
 				unitMaterials[id] = {"unitsNormalMapArmTanks", NORMALTEX = normalTex, TEXW1 = wreckAtlas[1], TEXW2 = wreckAtlas[2], NORMALTEX2 = wreckAtlas[3]}
 			elseif facName == "cor" then
 				unitMaterials[id] = {"unitsNormalMapCorTanks", NORMALTEX = normalTex, TEXW1 = wreckAtlas[1], TEXW2 = wreckAtlas[2], NORMALTEX2 = wreckAtlas[3]}
+			elseif facName == "leg" then -- temporary prefix for legion during transition from cor/arm to legion atlas
+				unitMaterials[id] = {"unitsNormalMapLegTanks", NORMALTEX = normalTex, TEXW1 = wreckAtlas[1], TEXW2 = wreckAtlas[2], NORMALTEX2 = wreckAtlas[3]}
 			end
 		else
 			if wreckAtlas then

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -470,7 +470,7 @@ vertex = [[
 			%%VERTEX_UV_TRANSFORM%%
 
 			#ifdef ENABLE_OPTION_TREADS
-			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM) || BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM) || BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE) || BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
 				#define ATLAS_SIZE 4096.0
 				#define PX_TO_UV(x) (float(x) / ATLAS_SIZE)
 				#define IN_PIXEL_RECT(uv, left, top, width, height) (all(bvec4(             \
@@ -527,27 +527,19 @@ vertex = [[
 						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult2, 28.0));
 					}
 				}
+
+				// ################# LEGION ##################
+				if (BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
+					const float texSpeedMult = -6.0;
+					if (IN_PIXEL_RECT(uvCoords, 2559, 768, 773, 406)) {
+						// Legion Track and rubber Bar pattern
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult, 56.0));
+					}
+				}
+
 				#undef ATLAS_SIZE
 				#undef IN_PIXEL_RECT
 				#undef PIXELS_TO_UV
-			}
-
-			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
-				const float atlasSize = 4096.0;
-				const float gfMod = 6.9;
-				const float texSpeed = -6.0;
-				float unitSpeed = uni[instData.y].speed.w;
-				float baseOffset =  unitSpeed * mod(float(simFrame), gfMod) / atlasSize;
-				float texOffset = baseOffset * texSpeed;
-
-				// note, invert we invert Y axis
-				//const vec4 treadBoundaries = vec4(1536.0, 2048.0, atlasSize - 2048.0, atlasSize - 1792.0) / atlasSize;
-				const vec4 treadBoundaries = vec4(2559.0, 3332.0, atlasSize - 1174.0, atlasSize - 768.0) / atlasSize;
-				if (all(bvec4(
-						uvCoords.x >= treadBoundaries.x, uvCoords.x <= treadBoundaries.y,
-						uvCoords.y >= treadBoundaries.z, uvCoords.y <= treadBoundaries.w))) {
-					uvCoords.x += texOffset;
-				}
 			}
 			#endif
 

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -83,6 +83,8 @@ vertex = [[
 
 	#define OPTION_TREEWIND 11
 
+	#define OPTION_TREADS_LEG 13
+
 	%%GLOBAL_OPTIONS%%
 
 	/***********************************************************************/
@@ -529,6 +531,24 @@ vertex = [[
 				#undef IN_PIXEL_RECT
 				#undef PIXELS_TO_UV
 			}
+
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
+				const float atlasSize = 4096.0;
+				const float gfMod = 6.9;
+				const float texSpeed = -6.0;
+				float unitSpeed = uni[instData.y].speed.w;
+				float baseOffset =  unitSpeed * mod(float(simFrame), gfMod) / atlasSize;
+				float texOffset = baseOffset * texSpeed;
+
+				// note, invert we invert Y axis
+				//const vec4 treadBoundaries = vec4(1536.0, 2048.0, atlasSize - 2048.0, atlasSize - 1792.0) / atlasSize;
+				const vec4 treadBoundaries = vec4(2559.0, 3332.0, atlasSize - 1174.0, atlasSize - 768.0) / atlasSize;
+				if (all(bvec4(
+						uvCoords.x >= treadBoundaries.x, uvCoords.x <= treadBoundaries.y,
+						uvCoords.y >= treadBoundaries.z, uvCoords.y <= treadBoundaries.w))) {
+					uvCoords.x += texOffset;
+				}
+			}
 			#endif
 
 			worldVertexPos = worldPos;
@@ -647,6 +667,7 @@ fragment = [[
 	#define OPTION_TREEWIND 11
 	#define OPTION_PBROVERRIDE 12
 
+	#define OPTION_TREADS_LEG 13
 
 	%%GLOBAL_OPTIONS%%
 

--- a/units/Legion/Bots/T2 Bots/legstr.lua
+++ b/units/Legion/Bots/T2 Bots/legstr.lua
@@ -34,6 +34,7 @@ return {
 		turnrate = 1214.40002,
 		upright = true,
 		customparams = {
+			atlas = "armada",
 			unitgroup = 'weapon',
 			model_author = "Zecrus",
 			normaltex = "unittextures/Arm_normal.dds",

--- a/units/Legion/Vehicles/leggat.lua
+++ b/units/Legion/Vehicles/leggat.lua
@@ -39,6 +39,7 @@ return {
 		turninplacespeedlimit = 1.952,
 		turnrate = 300,
 		customparams = {
+			atlas = "armada",
 			unitgroup = 'weapon',
 			basename = "base",
 			firingceg = "barrelshot-small",

--- a/units/Legion/Vehicles/legrail.lua
+++ b/units/Legion/Vehicles/legrail.lua
@@ -40,6 +40,7 @@ return {
 		turnrate = 300,
 		usepiececollisionvolumes = 1,
 		customparams = {
+			atlas = "armada",
 			unitgroup = 'weaponaa',
 			model_author = "Beherith",
 			normaltex = "unittextures/Arm_normal.dds",


### PR DESCRIPTION
Makes the track segment of the legion atlas loop
### Work done
Adds a new bit to the bitOptions of the unit shader. as well as code looping over the segment deemed to be the track to loop.

#### TODO
- [x] Tune the distance texSpeed constant
- [X] Supporting the diffrent atlas ussages of legion
> Currently the leg prefix still points to cortex shader due to lack of units

#### Test steps
- [ ] Spawn in a unit that uses the armada atlas despite it being legion, see that the track still loops
- [ ] Spawn in a unit that uses the cortex atlas desptie it being a legion unit, see that the track still loops
- [ ] Try to find a unit that uses the legion atlas, see that it loops
- [ ] Units that use their respective's faction maintain the right track looping area

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
