### PR TITLE
Allow other luaui widgets to adjust topbar mmLevel slider

### DIFF
--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1976,6 +1976,11 @@ function widget:Initialize()
 		return showButtons
 	end
 
+	WG['topbar'].updateTopBarEnergy = function(value)
+		mmLevel = value
+		updateResbar('energy')
+	end
+
 	widget:ViewResize()
 
 	if gameFrame > 0 then


### PR DESCRIPTION
### Work done
A call for other widget makers to call, so if they want to adjust mmLevel - topbar will reflect the new value to the player.

#### Addresses Issue(s)
As far as I know topbar doesn't know about new mmLevel value if some other widget changes the energy to metal conversation level for you.

#### Setup (for other widget makers)
If you are a widget maker you can do something like this (mock up code):
```lua
local adjustSlider = true
local dontStoreMoreThanThis = 9000 -- all energy beyond 9000 will be turned into metal
local function AdjustMMLevelSlider()
  if not adjustSlider then return end
  local eCurrMy, eStorMy,_ , eIncoMy, eExpeMy, eShare,eSent,eReceived = Spring.GetTeamResources(myTeamID, "energy")
  local energyLimit = dontStoreMoreThanThis
  if (myCalamityCount > 0) then energyLimit = 30000 end -- calamity requires more E to be stored
  conversionRate = math.floor(energyLimit/eStorMy*100)
  if conversionRate < 12 then
    conversionRate = 12
  end
  if conversionRate > 80 then
    conversionRate = 80
  end
  Spring.SendLuaRulesMsg(string.format(string.char(137) .. '%i', conversionRate))
  if WG['topbar'] and WG['topbar'].updateTopBarEnergy then
    WG['topbar'].updateTopBarEnergy(conversionRate)
  end
end
local updateRatePerSecond = 1
local updateFrameRate = updateRatePerSecond*30
function widget:GameFrame(frame)
  if Spring.GetSpectatingState() then return end
  if (frame % updateFrameRate) == 1 then
    AdjustMMLevelSlider()
  end
end
``` 

without the need to patch topbar widget for yourself.

#### Test steps
See the example above. This change doesn't impact anything else.

If you want to find any widgets in the wild that (require) use this, see "Energy Manager" [here](https://discord.com/channels/549281623154229250/1134818304142360606). It can control mmLevel for you (and help your newbie allies to stall slightly less at your own energy expense).