### PR TITLE
feat(ChainActions): Add ChainActions widget

### DIFF
--- a/common/stringFunctions.lua
+++ b/common/stringFunctions.lua
@@ -1,17 +1,43 @@
-local base64 = VFS.Include('common/luaUtilities/base64.lua')
+local base64 = VFS.Include("common/luaUtilities/base64.lua")
 
 if not string.split then
 	-- Split a string into a table of substrings, based on a delimiter.
 	-- If not supplied, delimiter defaults to whitespace.
 	-- Consecutive delimiters are treated as one.
 	-- string.split(csvText, ',')	csvText:split(',')
-	function string:split(delimiter)
-		delimiter = delimiter or '%s'
+	function string.split(val, delimiter)
+		delimiter = delimiter or "%s"
 		local results = {}
-		for part in self:gmatch("[^" .. delimiter .. "]+") do
+		for part in string.gmatch(val, "[^" .. delimiter .. "]+") do
 			table.insert(results, part)
 		end
 		return results
+	end
+end
+
+if not string.trim then
+	-- fast (for LuaJIT) space strimming, e.g.: " a sd   ".trim() == "a sd"
+	function string.trim(str)
+		if str == "" then
+			return str
+		else
+			local startPos = 1
+			local endPos = #str
+
+			while startPos < endPos and str:byte(startPos) <= 32 do
+				startPos = startPos + 1
+			end
+
+			if startPos >= endPos then
+				return ""
+			else
+				while endPos > 0 and str:byte(endPos) <= 32 do
+					endPos = endPos - 1
+				end
+
+				return str:sub(startPos, endPos)
+			end
+		end
 	end
 end
 
@@ -29,7 +55,7 @@ if not string.lines then
 	function string:lines()
 		local text = {}
 		local function helper(line)
-			text[#text+1] = line
+			text[#text + 1] = line
 			return ""
 		end
 		helper((self:gsub("(.-)\r?\n", helper)))
@@ -45,9 +71,9 @@ if not string.partition then
 			return self, nil, nil
 		else
 			if seppos == 1 then
-				return nil, sep, self:sub(sep:len()+1)
+				return nil, sep, self:sub(sep:len() + 1)
 			else
-				return self:sub(1, seppos -1), sep, self:sub(seppos + sep:len())
+				return self:sub(1, seppos - 1), sep, self:sub(seppos + sep:len())
 			end
 		end
 	end

--- a/luaui/Widgets/cmd_chainactions.lua
+++ b/luaui/Widgets/cmd_chainactions.lua
@@ -1,0 +1,95 @@
+-- Parses actions separated by | and attempts each one in succession
+--
+-- The action is specified as so `chain <force> <action1> <action1args> | <action2> <action2args> <...>`
+--
+-- If force is passed, then all actions in the chain will be performed
+--
+-- Otherwise the actions after the first will only be performed if the first
+-- responds.
+--
+-- Keep in mind engine actions without text command support won't work.
+--
+-- For the ones with text support (work with Spring.SendCommands) it's advised
+-- to use the force parameter since they can't be known to respond.
+--
+-- Example:
+--
+-- Selects one unit from current selection and unsets control group:
+--
+--   bind u chain force select PrevSelection++_ClearSelection_SelectOne+ | group unset
+--
+function widget:GetInfo()
+	return {
+		name = "Chain Actions",
+		desc = "Allows lua actions to be chained together",
+		author = "badosu",
+		date = "April 2024",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = false,
+		handler = true,
+	}
+end
+
+local function tryRawCmd(rawCmd, isRepeat, isRelease)
+	rawCmd = string.trim(rawCmd)
+
+	local cmd, extra = string.match(rawCmd, "^(%w+)[%s]*(.*)$")
+	local bAction = {
+		command = cmd,
+		extra = extra,
+	}
+
+	if widgetHandler.actionHandler:KeyAction(not isRelease, nil, nil, isRepeat, _, { bAction }) then
+		return true
+	end
+
+	-- Attempt text command (for engine cmds)
+	Spring.SendCommands(rawCmd)
+
+	return false
+end
+
+local function chainHandler(_, extra, bOpts, _, isRepeat, isRelease)
+	-- Wether to keep sending actions even if first does not respond
+	local force = false
+
+	if bOpts[1] == "force" then
+		force = true
+		extra = string.match(extra, "^force[%s]+(.*)$")
+	end
+
+	if not force then
+		Spring.Echo(
+			"<Chain Actions>",
+			"Missing force parameter, use like this: chain force <action1> <action1args> | <action2> <action2args>"
+		)
+
+		return false
+	end
+
+	local rawCmds = string.split(extra, "|")
+
+	if #rawCmds == 0 then
+		return false
+	end
+
+	if not force then
+		local firstRawCmd = table.remove(rawCmds, 1)
+
+		-- if the first command does not respond we return early
+		if not tryRawCmd(string.trim(firstRawCmd), isRepeat, isRelease) then
+			return false
+		end
+	end
+
+	for _, rawCmd in pairs(rawCmds) do
+		tryRawCmd(string.trim(rawCmd))
+	end
+
+	return true
+end
+
+function widget:Initialize()
+	widgetHandler.actionHandler:AddAction(self, "chain", chainHandler, nil, "p")
+end

--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -185,14 +185,6 @@ end
 --  Calls
 --
 
-local function MakeWords(line)
-  local words = {}
-  for w in string.gmatch(line, "[^%s]+") do
-    table.insert(words, w)
-  end
-  return words
-end
-
 
 local function TryAction(actionMap, cmd, optLine, optWords, isRepeat, release, actions)
   local callInfoList = actionMap[cmd]
@@ -222,11 +214,11 @@ function actionHandler:KeyAction(press, _, _, isRepeat, _, actions)
   end
 
   for _, bAction in ipairs(actions) do
-    local bCmd = bAction["command"]
-    local bOpts = bAction["extra"]
-    local words = MakeWords(bOpts)
+    local cmd = bAction["command"]
+    local extra = bAction["extra"]
+    local words = string.split(extra)
 
-    if (TryAction(actionSet, bCmd, bOpts, words, isRepeat, not press, actions)) then
+    if (TryAction(actionSet, cmd, extra, words, isRepeat, not press, actions)) then
       return true
     end
   end
@@ -236,7 +228,7 @@ end
 
 
 function actionHandler:TextAction(line)
-  local words = MakeWords(line)
+  local words = string.split(line)
   local cmd = words[1]
   if (cmd == nil) then
     return false


### PR DESCRIPTION


<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
This widget allows users to chain engine text actions via `chain force <action1> | <action2>`

The force parameter is required until I get lua actions to work, in which the behavior will change slightly, the first lua action determines if the action chain from which the widget was triggered is halted or
  not.


#### Setup

- Enable widget with `/widgetselector`
- `/cheat`
- `/give 10 armpw`
- Set armpw group to 1
- `/bind u chain force select PrevSelection++_ClearSelection_SelectOne+ | group unset`

#### Test steps
- [x] Select pawns
- [x] Press u
- [x] Observe a pawn being selected and having group unset