### PR TITLE
Stockpiled weapon DPS

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -13,7 +13,6 @@ function widget:GetInfo()
 end
 
 local texts = {}
-local zerotext = ''
 local damageStats = (VFS.FileExists("LuaUI/Config/BAR_damageStats.lua")) and VFS.Include("LuaUI/Config/BAR_damageStats.lua")
 local gameName = Game.gameName
 
@@ -261,7 +260,6 @@ end
 
 function widget:Initialize()
 	texts = Spring.I18N('ui.unitstats')
-	zerotext = Spring.I18N('ui.topbar.wind.nowind') -- The 'No' in 'No wind'.
 
 	widget:ViewResize(vsx,vsy)
 
@@ -628,8 +626,6 @@ local function drawStats(uDefID, uID)
 			end
 			if uWep.damages.impulseBoost > 0 then
 				infoText = format("%s, %d "..texts.impulse, infoText, uWep.damages.impulseBoost*100)
-			-- elseif uWep.damages.impulseFactor == 0 then
-			-- 	infoText = format("%s %s "..texts.impulse, infoText, zerotext) -- "No impulse", e.g. for laser weapons?
 			end
 			if uWep.damages.craterBoost > 0 then
 				infoText = format("%s, %d "..texts.crater, infoText, uWep.damages.craterBoost*100)

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -725,8 +725,8 @@ local function drawStats(uDefID, uID)
 				firstreload = math.max(firstrestock, stockeddur + reloadtime)
 				-- There are three ways the evaluation window can go:
 				if stockeddur == 0 then          -- (1) Stockpiles are expended in the first salvo.
+					local initialburst = math.floor(math.min(uWep.salvoSize, evalstocks))
 					if firstreload < evaltime
-						local initialburst = math.floor(math.min(uWep.salvoSize, evalstocks))
 						damage = defaultDamage * initialburst + defaultDamage * (1.0 + (evaltime - firstrestock) / stocktime)
 					else
 						damage = defaultDamage * initialburst + defaultDamage * evaltime / firstreload 

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -759,9 +759,6 @@ local function drawStats(uDefID, uID)
 				-- if wepCount > 1 then -- Don't stockpiled weapons not work together?
 				-- 	dmgString = dmgString .. white .. " ("..texts.each..")"
 				-- end
-				if dps < 2.0 then
-					dmgString = "problem: "..evalstocks.."|"..firstrestock.."/"..firstreload.."/"..stockeddur.."|"..burst.."*"..defaultDamage
-				end
 				DrawText(texts.dmg..wip..":", dmgString)
 				-- repetitious code: modifiers are shown for all but disintegrator weapons
 				local dmgString	= white

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -722,7 +722,7 @@ local function drawStats(uDefID, uID)
 						/ reload
 					) * reload
 				end
-				firstreload = [Math]::Max(firstrestock, stockeddur + reloadtime)
+				firstreload = math.max(firstrestock, stockeddur + reloadtime)
 				-- There are three ways the evaluation window can go:
 				if stockeddur == 0 then          -- (1) Stockpiles are expended in the first salvo.
 					if firstreload < evaltime


### PR DESCRIPTION
### Work done

New DPS calculation for stockpiled weapons in the inspector widget (`gui_unit_stats.lua`). This code is dotted with questions on how stockpiling works. I have more reading to do. And there's logic to bring in step with `gui_info.lua`.

![cornuke](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/103912894/f1614b2f-83cd-4141-aa66-16272a708758)

#### Background

Stockpiled DPS is sensitive to stockpile count and time in combat. The calcs I used are a compromise between the ideal, maximum effect of a weapon system and its realistic performance by assuming a starting stockpile size so that nuke silos don't start at 0 stocks and tactical nukes don't start with 10. Then, the weapon fires for a fixed time, and the DPS over that time period is taken.

This change offers some improvements: Real nukes outperform tac-nukes; Armada nukes have higher DPS than Cortex nukes; DPS values are more realistic. It also, by happenstance, fixes the DPS value for the Mercury/Screamer, which is currently shown as 0. Being more-right uses more-math, though, which makes the change potentially confusing.

Other (like, way easier) considerations:

- This could update DPS according to the weapon's current stockpile state instead of trying to offer a general DPS calculation
    - eg `Current DPS: 140 (20% stockpiled)`.
- I can split the display into stocked/unstocked DPS. The fully-stocked DPS for the Mercury for instance is high (something like 470 dps) while its unstocked is pitiful (around 54).
    - eg `DPS: 470 (full), 53 (empty)`
    - or `DPS: 53–470`, similar to gui_info.lua, but maybe confused w/ laser dropoff

#### Test steps

Compare the old/new DPS values for stockpiled weapons. You should get results like the below from the unit stats widget:

- Screamer (corscreamer) [DPS: 0, or 417 in gui_info] [New: 165]
- Mercury (armmercury) [DPS: 0, or 417 in gui_info] [New: 165]
- Apocalypse (corsilo) [DPS: 383] [New: 458]
- Armageddon (armsilo) [DPS: 316] [New: 475]
- Catalyst (cortron) [DPS: 2000] [New: 192]
- Paralyzer (armemp) [DPS: 25000] [New: 2649]