### PR TITLE
CUS GL4 Tank treads shader improvement

### DIFF
--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -253,8 +253,8 @@ do --save a ton of locals
 	local OPTION_SHIFT_RGBHSV     = 4 -- userDefined[2].rgb (gl.SetUnitBufferUniforms(unitID, {math.random(),math.random()-0.5,math.random()-0.5}, 8) -- shift Hue, saturation, valence )
 	local OPTION_VERTEX_AO        = 8
 	local OPTION_FLASHLIGHTS      = 16
-	local OPTION_THREADS_ARM      = 32
-	local OPTION_THREADS_CORE     = 64
+	local OPTION_TREADS_ARM      = 32
+	local OPTION_TREADS_CORE     = 64
 	local OPTION_HEALTH_TEXTURING = 128
 	local OPTION_HEALTH_DISPLACE  = 256
 	local OPTION_HEALTH_TEXRAPTORS = 512
@@ -266,22 +266,22 @@ do --save a ton of locals
 
 	uniformBins = {
 		armunit = {
-			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_THREADS_ARM + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
+			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_ARM + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
 			baseVertexDisplacement = 0.0,
 			brightnessFactor = 1.5,
 		},
 		corunit = {
-			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_THREADS_CORE + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
+			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_CORE + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
 			baseVertexDisplacement = 0.0,
 			brightnessFactor = 1.5,
 		},
 		armscavenger = {
-			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_THREADS_ARM + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
+			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_ARM + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
 			baseVertexDisplacement = 0.4,
 			brightnessFactor = 1.5,
 		},
 		corscavenger = {
-			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_THREADS_CORE + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
+			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_CORE + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
 			baseVertexDisplacement = 0.4,
 			brightnessFactor = 1.5,
 		},
@@ -563,13 +563,13 @@ local function initMaterials()
 	unitsNormalMapTemplate = appendShaderDefinitionsToTemplate(defaultMaterialTemplate, {
 		shaderDefinitions = {
 			"#define ENABLE_OPTION_HEALTH_TEXTURING 1",
-			"#define ENABLE_OPTION_THREADS 1",
+			"#define ENABLE_OPTION_TREADS 1",
 			"#define ENABLE_OPTION_HEALTH_DISPLACE 1",
 			itsXmas and "#define XMAS 1" or "#define XMAS 0",
 		},
 		deferredDefinitions = {
 			"#define ENABLE_OPTION_HEALTH_TEXTURING 1",
-			"#define ENABLE_OPTION_THREADS 1",
+			"#define ENABLE_OPTION_TREADS 1",
 			"#define ENABLE_OPTION_HEALTH_DISPLACE 1",
 			itsXmas and "#define XMAS 1" or "#define XMAS 0",
 		},
@@ -578,7 +578,7 @@ local function initMaterials()
 		},
 		reflectionDefinitions = {
 			"#define ENABLE_OPTION_HEALTH_TEXTURING 1",
-			"#define ENABLE_OPTION_THREADS 1",
+			"#define ENABLE_OPTION_TREADS 1",
 			"#define ENABLE_OPTION_HEALTH_DISPLACE 1",
 			itsXmas and "#define XMAS 1" or "#define XMAS 0",
 		},
@@ -588,14 +588,14 @@ local function initMaterials()
 	unitsSkinningTemplate = appendShaderDefinitionsToTemplate(defaultMaterialTemplate, {
 		shaderDefinitions = {
 			"#define ENABLE_OPTION_HEALTH_TEXTURING 1",
-			"#define ENABLE_OPTION_THREADS 1",
+			"#define ENABLE_OPTION_TREADS 1",
 			"#define ENABLE_OPTION_HEALTH_DISPLACE 1",
 			"#define USESKINNING",
 			itsXmas and "#define XMAS 1" or "#define XMAS 0",
 		},
 		deferredDefinitions = {
 			"#define ENABLE_OPTION_HEALTH_TEXTURING 1",
-			"#define ENABLE_OPTION_THREADS 1",
+			"#define ENABLE_OPTION_TREADS 1",
 			"#define ENABLE_OPTION_HEALTH_DISPLACE 1",
 			"#define USESKINNING",
 			itsXmas and "#define XMAS 1" or "#define XMAS 0",
@@ -606,7 +606,7 @@ local function initMaterials()
 		},
 		reflectionDefinitions = {
 			"#define ENABLE_OPTION_HEALTH_TEXTURING 1",
-			"#define ENABLE_OPTION_THREADS 1",
+			"#define ENABLE_OPTION_TREADS 1",
 			"#define ENABLE_OPTION_HEALTH_DISPLACE 1",
 			"#define USESKINNING",
 			itsXmas and "#define XMAS 1" or "#define XMAS 0",

--- a/modelmaterials/001_units_s3o_assimp.lua
+++ b/modelmaterials/001_units_s3o_assimp.lua
@@ -150,12 +150,12 @@ end
 local spGetUnitVelocity = Spring.GetUnitVelocity
 local spGetUnitDirection = Spring.GetUnitDirection
 local floor = math.floor
-local threadSpeeds = {} --cache
-local threadsArray = {[1] = 0.0}
+local treadSpeeds = {} --cache
+local treadsArray = {[1] = 0.0}
 
 local function SendTracksOffset(unitID, hasStd, hasDef, hasShad)
-	if not threadSpeeds[unitID] then
-		threadSpeeds[unitID] = 0.0
+	if not treadSpeeds[unitID] then
+		treadSpeeds[unitID] = 0.0
 	end
 
 	local usx, usy, usz, speed = spGetUnitVelocity(unitID)
@@ -170,19 +170,19 @@ local function SendTracksOffset(unitID, hasStd, hasDef, hasShad)
 		speed = -speed
 	end
 
-	if threadSpeeds[unitID] ~= speed then
-		threadSpeeds[unitID] = speed
-		threadsArray[1] = speed
+	if treadSpeeds[unitID] ~= speed then
+		treadSpeeds[unitID] = speed
+		treadsArray[1] = speed
 		if hasStd then
-			mySetMaterialUniform[false](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, threadsArray)
+			mySetMaterialUniform[false](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, treadsArray)
 		end
 		if hasDef then
-			mySetMaterialUniform[true ](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, threadsArray)
+			mySetMaterialUniform[true ](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, treadsArray)
 		end
 		--[[
 		-- tank tracks usually don't contribute much to shadows look
 		if hasShad then
-			mySetMaterialUniform[false](unitID, "shadow", 3, "floatOptions[3]", GL_FLOAT, threadsArray)
+			mySetMaterialUniform[false](unitID, "shadow", 3, "floatOptions[3]", GL_FLOAT, treadsArray)
 		end
 		]]--
 	end
@@ -230,10 +230,10 @@ local materials = {
 			[5] = "%NORMALTEX2",
 		},
 		shaderOptions = {
-			threads_arm = true,
+			treads_arm = true,
 		},
 		deferredOptions = {
-			threads_arm = true,
+			treads_arm = true,
 			materialIndex = 1,
 		},
 		UnitCreated = function (unitID, unitDefID, mat) UnitCreated(armTanks, unitID, unitDefID, mat) end,
@@ -250,10 +250,10 @@ local materials = {
 			[5] = "%NORMALTEX2",
 		},
 		shaderOptions = {
-			threads_core = true,
+			treads_core = true,
 		},
 		deferredOptions = {
-			threads_core = true,
+			treads_core = true,
 			materialIndex = 2,
 		},
 		UnitCreated = function (unitID, unitDefID, mat) UnitCreated(corTanks, unitID, unitDefID, mat) end,

--- a/modelmaterials/Templates/defaultMaterialTemplate.lua
+++ b/modelmaterials/Templates/defaultMaterialTemplate.lua
@@ -17,8 +17,8 @@ vertex = [[
 	#define OPTION_VERTEX_AO 3
 	#define OPTION_FLASHLIGHTS 4
 
-	#define OPTION_THREADS_ARM 5
-	#define OPTION_THREADS_CORE 6
+	#define OPTION_TREADS_ARM 5
+	#define OPTION_TREADS_CORE 6
 
 	#define OPTION_HEALTH_TEXTURING 7
 	#define OPTION_HEALTH_DISPLACE 8
@@ -236,7 +236,7 @@ vertex = [[
 
 			%%VERTEX_UV_TRANSFORM%%
 
-			if (BITMASK_FIELD(bitOptions, OPTION_THREADS_ARM)) {
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM)) {
 				const float atlasSize = 4096.0;
 				const float gfMod = 8.0;
 				const float texSpeed = 4.0;
@@ -252,7 +252,7 @@ vertex = [[
 				}
 			}
 
-			if (BITMASK_FIELD(bitOptions, OPTION_THREADS_CORE)) {
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
 				const float atlasSize = 2048.0;
 				const float gfMod = 6.0;
 				const float texSpeed = -6.0;
@@ -367,8 +367,8 @@ fragment = [[
 	#define OPTION_VERTEX_AO 3
 	#define OPTION_FLASHLIGHTS 4
 
-	#define OPTION_THREADS_ARM 5
-	#define OPTION_THREADS_CORE 6
+	#define OPTION_TREADS_ARM 5
+	#define OPTION_TREADS_CORE 6
 
 	#define OPTION_HEALTH_TEXTURING 7
 	#define OPTION_HEALTH_DISPLACE 8
@@ -1531,8 +1531,8 @@ local defaultMaterialTemplate = {
 		flashlights       = false,
 		normalmap_flip    = false,
 
-		threads_arm       = false,
-		threads_core      = false,
+		treads_arm       = false,
+		treads_core      = false,
 
 		health_displace  = false,
 		health_texturing = false,
@@ -1556,8 +1556,8 @@ local defaultMaterialTemplate = {
 		flashlights      = false,
 		normalmap_flip   = false,
 
-		threads_arm      = false,
-		threads_core     = false,
+		treads_arm      = false,
+		treads_core     = false,
 
 		modelsfog        = true,
 
@@ -1609,8 +1609,8 @@ local shaderPlugins = {
 	#define OPTION_VERTEX_AO 3
 	#define OPTION_FLASHLIGHTS 4
 
-	#define OPTION_THREADS_ARM 5
-	#define OPTION_THREADS_CORE 6
+	#define OPTION_TREADS_ARM 5
+	#define OPTION_TREADS_CORE 6
 
 	#define OPTION_HEALTH_TEXTURING 7
 	#define OPTION_HEALTH_DISPLACE 8
@@ -1631,8 +1631,8 @@ local knownBitOptions = {
 	["vertex_ao"] = 3,
 	["flashlights"] = 4,
 
-	["threads_arm"] = 5,
-	["threads_core"] = 6,
+	["treads_arm"] = 5,
+	["treads_core"] = 6,
 
 	["health_texturing"] = 7,
 	["health_displace"] = 8,

--- a/modelmaterials_gl4/001_units_s3o_assimp.lua
+++ b/modelmaterials_gl4/001_units_s3o_assimp.lua
@@ -150,12 +150,12 @@ end
 local spGetUnitVelocity = Spring.GetUnitVelocity
 local spGetUnitDirection = Spring.GetUnitDirection
 local floor = math.floor
-local threadSpeeds = {} --cache
-local threadsArray = {[1] = 0.0}
+local treadSpeeds = {} --cache
+local treadsArray = {[1] = 0.0}
 
 local function SendTracksOffset(unitID, hasStd, hasDef, hasShad)
-	if not threadSpeeds[unitID] then
-		threadSpeeds[unitID] = 0.0
+	if not treadSpeeds[unitID] then
+		treadSpeeds[unitID] = 0.0
 	end
 
 	local usx, usy, usz, speed = spGetUnitVelocity(unitID)
@@ -170,19 +170,19 @@ local function SendTracksOffset(unitID, hasStd, hasDef, hasShad)
 		speed = -speed
 	end
 
-	if threadSpeeds[unitID] ~= speed then
-		threadSpeeds[unitID] = speed
-		threadsArray[1] = speed
+	if treadSpeeds[unitID] ~= speed then
+		treadSpeeds[unitID] = speed
+		treadsArray[1] = speed
 		if hasStd then
-			mySetMaterialUniform[false](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, threadsArray)
+			mySetMaterialUniform[false](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, treadsArray)
 		end
 		if hasDef then
-			mySetMaterialUniform[true ](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, threadsArray)
+			mySetMaterialUniform[true ](unitID, "opaque", 3, "floatOptions[3]", GL_FLOAT, treadsArray)
 		end
 		--[[
 		-- tank tracks usually don't contribute much to shadows look
 		if hasShad then
-			mySetMaterialUniform[false](unitID, "shadow", 3, "floatOptions[3]", GL_FLOAT, threadsArray)
+			mySetMaterialUniform[false](unitID, "shadow", 3, "floatOptions[3]", GL_FLOAT, treadsArray)
 		end
 		]]--
 	end
@@ -230,10 +230,10 @@ local materials = {
 			[5] = "%NORMALTEX2",
 		},
 		shaderOptions = {
-			threads_arm = true,
+			treads_arm = true,
 		},
 		deferredOptions = {
-			threads_arm = true,
+			treads_arm = true,
 			materialIndex = 1,
 		},
 		UnitCreated = function (unitID, unitDefID, mat) UnitCreated(armTanks, unitID, unitDefID, mat) end,
@@ -250,10 +250,10 @@ local materials = {
 			[5] = "%NORMALTEX2",
 		},
 		shaderOptions = {
-			threads_core = true,
+			treads_core = true,
 		},
 		deferredOptions = {
-			threads_core = true,
+			treads_core = true,
 			materialIndex = 2,
 		},
 		UnitCreated = function (unitID, unitDefID, mat) UnitCreated(corTanks, unitID, unitDefID, mat) end,

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -20,7 +20,7 @@ vertex = [[
 		layout (location = 7) in vec4 offsetrot;
 		layout (location = 8) in uvec4 instData;
 	#endif
-		
+
 	// u32 matOffset
 	// u32 uniOffset
 	// u32 {teamIdx, drawFlag, unused, unused}
@@ -72,8 +72,8 @@ vertex = [[
 	#define OPTION_VERTEX_AO 3
 	#define OPTION_FLASHLIGHTS 4
 
-	#define OPTION_THREADS_ARM 5
-	#define OPTION_THREADS_CORE 6
+	#define OPTION_TREADS_ARM 5
+	#define OPTION_TREADS_CORE 6
 
 	#define OPTION_HEALTH_TEXTURING 7
 	#define OPTION_HEALTH_DISPLACE 8
@@ -275,13 +275,13 @@ vertex = [[
 		mVP.xz += diff + diff2 * wind;
 		//mVP.y += float(UNITID/256);// + sin(simFrame *0.1)+15; // whoops this was meant as debug
 	}
-	
+
 	#ifdef USESKINNING
 		uint GetUnpackedValue(uint packedValue, uint byteNum) {
 			return (packedValue >> (8u * byteNum)) & 0xFFu;
 		}
 		// See: https://github.com/beyond-all-reason/spring/blob/d37412acca1ae14a602d0cf46243d0aedd132701/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl#L135C1-L191C2
-		
+
 		// The only difference is that displacedPos is passed in, and we always assume staticModel = false
 		void GetModelSpaceVertex(in vec3 displacedPos, out vec4 msPosition, out vec3 msNormal)
 		{
@@ -359,12 +359,12 @@ vertex = [[
 					   0.0, c1, -s1, 0.0,
 					   0.0, s1, c1, 0.0,
 					   0.0, 0.0, 0.0, 1.0);
-					   
+
 		mat4 ry = mat4(c2, 0.0, s2, 0.0,
 					   0.0, 1.0, 0.0, 0.0,
 					   -s2, 0.0, c2, 0.0,
 					   0.0, 0.0, 0.0, 1.0);
-					   
+
 		mat4 rz = mat4(c3, -s3, 0.0, 0.0,
 					   s3, c3, 0.0, 0.0,
 					   0.0, 0.0, 1.0, 0.0,
@@ -373,7 +373,7 @@ vertex = [[
 		// Combined rotation matrix, order is important
 		return rz * ry * rx;
 	}
-	
+
 
 	/***********************************************************************/
 	// Vertex shader main()
@@ -387,21 +387,21 @@ vertex = [[
 		#ifndef STATICMODEL
 			// pieceMatrix looks up the model-space transform matrix for unit being drawn
 			mat4 pieceMatrix = mat[instData.x + pieceIndex + 1u];
-			
+
 			// Then it places it in the world
 			mat4 worldMatrix = mat[instData.x];
 		#else
 			// First lets orient the
-		
+
 			// pieceMatrix looks up the model-space transform matrix for the unit we are drawing onto!
 			uint targetPieceIndex = uint(offsetpos_targetpiece.w);
 			mat4 pieceMatrix = mat[instData.x + targetPieceIndex + 1u];
-			
+
 			// Then it places it in the world
 			mat4 worldMatrix = mat[instData.x];
-	
+
 		#endif
-			
+
 
 		mat4 worldPieceMatrix = worldMatrix * pieceMatrix; // for the below
 		mat3 normalMatrix = mat3(worldPieceMatrix);
@@ -466,48 +466,68 @@ vertex = [[
 		#if (RENDERING_MODE != 2) //non-shadow pass
 
 			%%VERTEX_UV_TRANSFORM%%
-			#ifdef ENABLE_OPTION_THREADS
-			if (BITMASK_FIELD(bitOptions, OPTION_THREADS_ARM)) {
-				const float atlasSize = 4096.0;
-				const float gfMod = 8.0;
-				const float texSpeed = 4.0;
+
+			#ifdef ENABLE_OPTION_TREADS
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM) || BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
+				#define ATLAS_SIZE 4096.0
+				#define PX_TO_UV(x) (float(x) / ATLAS_SIZE)
+				#define IN_PIXEL_RECT(uv, left, top, width, height) (all(bvec4(             \
+						uv.x >= PX_TO_UV(left),         uv.y <= 1f - PX_TO_UV(top),         \
+						uv.x <= PX_TO_UV(left + width), uv.y >= 1f - PX_TO_UV(top + height) \
+				)))
+
+				// apply a minimum amount of "speed" when not completely stopped
+				// so that have tracks appear to "spin up/down as they dig into the ground"
+				// instead of jittering strangly at low speed
 				float unitSpeed = uni[instData.y].speed.w;
-				float texOffset = unitSpeed * mod(float(simFrame), gfMod) * (texSpeed / atlasSize);
 
-				// note, invert we invert Y axis
-				const vec4 treadBoundaries = vec4(2572.0, 3070.0, atlasSize - 1761.0, atlasSize - 1548.0) / atlasSize;
-				if (all(bvec4(
-						uvCoords.x >= treadBoundaries.x, uvCoords.x <= treadBoundaries.y,
-						uvCoords.y >= treadBoundaries.z, uvCoords.y <= treadBoundaries.w))) {
-					uvCoords.x += texOffset;
-				}
-			}
-
-			if (BITMASK_FIELD(bitOptions, OPTION_THREADS_CORE)) {
-				const float atlasSize = 2048.0;
-				const float gfMod = 6.0;
-				const float texSpeed = -6.0;
-				float unitSpeed = uni[instData.y].speed.w;
-				float baseOffset =  unitSpeed * mod(float(simFrame), gfMod) / atlasSize;
-				float texOffset = baseOffset * texSpeed;
-
-				// note, invert we invert Y axis
-				const vec4 treadBoundaries = vec4(1536.0, 2048.0, atlasSize - 2048.0, atlasSize - 1792.0) / atlasSize;
-				if (all(bvec4(
-						uvCoords.x >= treadBoundaries.x, uvCoords.x <= treadBoundaries.y,
-						uvCoords.y >= treadBoundaries.z, uvCoords.y <= treadBoundaries.w))) {
-					uvCoords.x += texOffset;
+				if (unitSpeed > 0.5) {
+					unitSpeed = max(3, unitSpeed);
 				}
 
-				const float texSpeed2 = 3.0;
-				const vec4 treadBoundaries2 = vec4(93.0, 349.0, atlasSize - 400.0, atlasSize - 316.0) / atlasSize;
-				texOffset = baseOffset * texSpeed2;
+				// unitSpeed gets multiplied by [0, 1, 2, 3, ..., loop end)
+				// keep this low or else track animation will vary too much based on abritary frame count
+				// applies a sort of "jitter" effect to the track UVs based on unit speed
 
-				if (all(bvec4(
-						uvCoords.x >= treadBoundaries2.x, uvCoords.x <= treadBoundaries2.y,
-						uvCoords.y >= treadBoundaries2.z, uvCoords.y <= treadBoundaries2.w))) {
-					uvCoords.x += texOffset;
+				// it is a very poor estimation of "distance traveled"
+				// but...
+				// as long as the end result looks like the tracks are moving it is good enough for now
+
+				const float loopingFrameCount = mod(simFrame, 8); // Greatest Common Factor (12, 20, 56, ...) = 4
+				const float baseOffset = loopingFrameCount * unitSpeed;
+
+				// ################# ARMADA ##################
+				if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM)) {
+					const float texSpeedMult = 4;
+					if (IN_PIXEL_RECT(uvCoords, 2573, 1548, 498, 82)) {
+						// Arm small (top) width 12px
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult, 12.0));
+					} else if (IN_PIXEL_RECT(uvCoords, 2572, 1631, 500, 132)) {
+						// Arm big (bot) width 20px
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult, 20.0));
+					}
 				}
+
+				// ################# CORTEX ##################
+				if (BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
+					const float texSpeedMult = -6.0;
+					const float texSpeedMult2 = 3.0;
+
+					if (IN_PIXEL_RECT(uvCoords, 3042, 3839, (ATLAS_SIZE - 3042), (ATLAS_SIZE - 3839))) {
+						// tracks are right up against the bottom right of the texture
+						// Cor big (right bot) width 56px
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult, 56.0));
+					} else if (IN_PIXEL_RECT(uvCoords, 192, 636, 511, 68)) {
+						// Cor small (top) width 24px
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult2, 24.0));
+					} else if (IN_PIXEL_RECT(uvCoords, 189, 705, 506, 94)) {
+						// Cor small (bot) width 28px
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult2, 28.0));
+					}
+				}
+				#undef ATLAS_SIZE
+				#undef IN_PIXEL_RECT
+				#undef PIXELS_TO_UV
 			}
 			#endif
 
@@ -615,8 +635,8 @@ fragment = [[
 	#define OPTION_VERTEX_AO 3
 	#define OPTION_FLASHLIGHTS 4
 
-	#define OPTION_THREADS_ARM 5
-	#define OPTION_THREADS_CORE 6
+	#define OPTION_TREADS_ARM 5
+	#define OPTION_TREADS_CORE 6
 
 	#define OPTION_HEALTH_TEXTURING 7
 	#define OPTION_HEALTH_DISPLACE 8
@@ -1723,7 +1743,7 @@ fragment = [[
 		#endif
 
 		outColor.rgb *= brightnessFactor; // this is to correct for lack of env mapping, the nastiest hack there has ever been...
-		
+
 		//iblDiffuse, iblSpecular
 		//outColor.rgb = iblSpecular;
 
@@ -1890,8 +1910,8 @@ local defaultMaterialTemplate = {
 		flashlights       = false,
 		shift_rgbhsv    = false,
 
-		threads_arm       = false,
-		threads_core      = false,
+		treads_arm       = false,
+		treads_core      = false,
 
 		health_displace  = false,
 		health_texturing = false,
@@ -1913,8 +1933,8 @@ local defaultMaterialTemplate = {
 		flashlights      = false,
 		shift_rgbhsv   = false,
 
-		threads_arm      = false,
-		threads_core     = false,
+		treads_arm      = false,
+		treads_core     = false,
 
 		modelsfog        = true,
 


### PR DESCRIPTION
### Work done
After looking into ways to improve the tank tread texture animations, I came to understand what the current code was doing.
So I ended up simply documenting and improving the existing code to a state that I'm happy with for a weekend's worth of research and work.

The only thing added in the end was a "minimum" speed for the track animations to avoid the jittering at low speeds.

Everything else is just refactoring to make the code easier to work with and tightening up the parameters. 
(Oh and fixing the "threads" typo.)

Making a treads effect that accurately tracks speed/distance traveled BUT is also performant... is a dream for another day.

#### Test steps
- [ ] Load up game on current version of BAR, build various tank units and look closely as they stop and start moving. You should see the unslightly "jittering" I mentioned.
- [ ] Load up another game on this PR and see that the tracks look less bad at low speeds.

It's hard to get good video for this because low framerates mess with the effect...
But here's one I recorded with Windows Game Bar

https://youtu.be/qiRLpwcdNr8
