### PR TITLE
unit_carrier_spawner "hold fire" docking command commented out

### DIFF
--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -723,11 +723,11 @@ local function UpdateCarrier(carrierID, carrierMetaData, frame)
 	--local activeSpawning = true
 	local idleRadius = carrierMetaData.radius
 	if carrierStates then
-		if carrierStates.firestate == 0 then
+		if carrierStates.movestate == 0 then
 			idleRadius = 0
-			--activeSpawning = false
-		elseif carrierStates.movestate == 0 then
-			idleRadius = 0
+		--elseif carrierStates.firestate == 0 then --This is disabled to allow cloaking carriers to retreat while keeping drones undocked (armada unbacom)
+		--idleRadius = 0
+		--activeSpawning = false
 		elseif carrierStates.movestate == 1 then
 			idleRadius = 200
 		end


### PR DESCRIPTION
Now "hold fire" doesn't call drones back to dock on the carrier.  This allows better control of their behavior.

Unchanged behavior:
1. Hold position docks drones.
2. Maneuver sets their movement range to 200.
3. Roam sets movement range to whatever their maximum range is defined in the unitdef.

1. Normal carriers wanting to not wanting their units to attack but to provide "fodder" targets while they retreat or reposition rather than having the carrier suffer the full brunt of the assault.

2. Armada unbalanced commanders automatically "hold fire" when cloaked which before this change causes the distracting EMP tumbleweeds surrounding it to dock. This defeats their purpose.

Units tested working as expected:
Armada Commander (unbacom) level 10.
Legion Hive (carrier turret)
Legion Mantis (carrier vehicle)
Cortex Disperser Omni (flying carrier, extra units pack)
Cortex Oasis Drone Carrier (ship carrier, extra units pack)
Armada Haven Drone Carrier (ship carrier, extra units pack)

This is really important for Armada unbacom to work properly and doesn't hurt anything else I'm aware of. Thanks to Xehrath for showing me how to do this.