### PR TITLE
Modoptions for resource sharing tax, no sharing units, and no allied build assist

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally_construction.lua
+++ b/luarules/gadgets/game_disable_assist_ally_construction.lua
@@ -1,0 +1,64 @@
+function gadget:GetInfo()
+	return {
+		name    = 'Disable Assist Ally Construction',
+		desc    = 'Disable assisting allied units (e.g. labs and units/buildings under construction) when modoption is enabled',
+		author  = 'Rimilel',
+		date    = 'April 2024',
+		license = 'GNU GPL, v2 or later',
+		layer   = 0,
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local function isComplete(u)
+    local _,_,_,_,buildProgress=Spring.GetUnitHealth(u)
+    if buildProgress and buildProgress>=1 then
+        return true
+    else
+        return false
+    end
+end
+
+function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+
+    if(not Spring.GetModOptions().disable_assist_ally_construction) then
+        return true
+    end
+
+    -- Disallow guard commands onto other ally's units. (Optional todo: disallow guards on allied build-capable units and labs only)
+
+    if (cmdID == CMD.GUARD) then
+        local targetID = cmdParams[1]
+        local targetTeam = Spring.GetUnitTeam(targetID)
+    
+        if (unitTeam ~= Spring.GetUnitTeam(targetID)) and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+            return false
+        end
+    end
+
+    -- Also disallow assisting building (caused by a repair command) units under construction 
+    -- Area repair doesn't cause assisting, so it's fine that we can't properly filter it
+
+    if (cmdID == CMD.REPAIR and #cmdParams == 1) then
+        local targetID = cmdParams[1]
+        local targetTeam = Spring.GetUnitTeam(targetID)
+
+        if (unitTeam ~= Spring.GetUnitTeam(targetID)) and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+            if(not isComplete(targetID)) then
+                return false
+            end
+        end
+        return true
+    end
+
+
+
+    return true
+end

--- a/luarules/gadgets/game_disable_unit_sharing.lua
+++ b/luarules/gadgets/game_disable_unit_sharing.lua
@@ -1,0 +1,35 @@
+function gadget:GetInfo()
+	return {
+		name    = 'Disable Unit Sharing',
+		desc    = 'Disable unit sharing when modoption is enabled',
+		author  = 'Rimilel',
+		date    = 'April 2024',
+		license = 'GNU GPL, v2 or later',
+		layer   = 0,
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+
+
+function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
+
+    if(not Spring.GetModOptions().disable_unit_sharing) then
+        return true
+    end
+
+    if(capture) then
+        return true
+    end
+    return false
+end
+
+
+

--- a/luarules/gadgets/game_prevent_excessive_share.lua
+++ b/luarules/gadgets/game_prevent_excessive_share.lua
@@ -5,7 +5,7 @@ function gadget:GetInfo()
 		author  = 'Niobium',
 		date    = 'April 2012',
 		license = 'GNU GPL, v2 or later',
-		layer   = 0,
+		layer   = 2,
 		enabled = true
 	}
 end

--- a/luarules/gadgets/game_tax_resource_sharing_and_prevent_some_reclaim_loopholes.lua
+++ b/luarules/gadgets/game_tax_resource_sharing_and_prevent_some_reclaim_loopholes.lua
@@ -1,0 +1,99 @@
+function gadget:GetInfo()
+	return {
+		name    = 'Tax Resource Sharing',
+		desc    = 'Tax Resource Sharing when modoption enabled. Modified from "Prevent Excessive Share" by Niobium', -- taxing overflow needs to be handled by the engine 
+		author  = 'Rimilel',
+		date    = 'April 2024',
+		license = 'GNU GPL, v2 or later',
+		layer   = 1, -- Needs to occur before "Prevent Excessive Share" to replace it.
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local spIsCheatingEnabled = Spring.IsCheatingEnabled
+local spGetTeamUnitCount = Spring.GetTeamUnitCount
+
+local gameMaxUnits = math.min(Spring.GetModOptions().maxunits, math.floor(32000 / #Spring.GetTeamList()))
+
+----------------------------------------------------------------
+-- Callins
+----------------------------------------------------------------
+
+
+
+function gadget:AllowResourceTransfer(senderTeamId, receiverTeamId, resourceType, amount)
+
+	if(not Spring.GetModOptions().tax_resource_sharing_and_prevent_some_reclaim_loopholes) then
+		return true
+	end
+
+	-- Spring uses 'm' and 'e' instead of the full names that we need, so we need to convert the resourceType
+	-- We also check for 'metal' or 'energy' incase Spring decides to use those in a later version
+	local resourceName
+	if (resourceType == 'm') or (resourceType == 'metal') then
+		resourceName = 'metal'
+	elseif (resourceType == 'e') or (resourceType == 'energy') then
+		resourceName = 'energy'
+	else
+		-- We don't handle whatever this resource is, allow it
+		return true
+	end
+
+	-- Calculate the maximum amount the receiver can receive
+	--Current, Storage, Pull, Income, Expense
+	local rCur, rStor, rPull, rInc, rExp, rShare = Spring.GetTeamResources(receiverTeamId, resourceName)
+
+	-- rShare is the share slider setting, don't exceed their share slider max when sharing
+	local maxShare = rStor * rShare - rCur
+
+	local sharingTax = Spring.GetModOptions().tax_resource_sharing_amount 
+	local taxedAmount = math.min((1-sharingTax)*amount, maxShare)
+	local totalAmount = taxedAmount / (1-sharingTax)
+	local transferTax = totalAmount * sharingTax	
+	
+	Spring.SetTeamResource(receiverTeamId, resourceName, rCur+taxedAmount)
+	local sCur, _, _, _, _, _ = Spring.GetTeamResources(senderTeamId, resourceName)
+	Spring.SetTeamResource(senderTeamId, resourceName, sCur-totalAmount)
+
+	-- Block the original transfer
+	return false
+end
+
+function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
+	local unitCount = spGetTeamUnitCount(newTeam)
+	if capture or spIsCheatingEnabled() or unitCount < gameMaxUnits then
+		return true
+	end
+	return false
+end
+
+
+    
+-- Disallow reclaiming allied units for metal
+function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+
+	if(not Spring.GetModOptions().tax_resource_sharing_and_prevent_some_reclaim_loopholes) then
+		return true
+	end
+
+    if (cmdID == CMD.RECLAIM and #cmdParams >= 1) then
+        local targetID = cmdParams[1]
+        local targetTeam
+        if(targetID >= Game.maxUnits) then
+            return true
+        end
+        targetTeam = Spring.GetUnitTeam(targetID)
+        if unitTeam ~= targetTeam and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+            return false
+        end
+        return true
+    end
+	return true
+end

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -210,6 +210,42 @@ local options = {
         section	= "restrictions",
         def    	= false,
     },
+    
+    {
+		key			="disable_unit_sharing",
+		name   		="Disable Unit Sharing",
+		desc   		="Disable sharing units and structures to allies",
+		type   		="bool",
+		section		="restrictions",
+		def    		= false,
+	},
+	{
+		key			="disable_assist_ally_construction",
+		name   		="Disable Assist Ally Construction",
+		desc   		="Disables assisting an allied blueprint or lab.",
+		type   		="bool",
+		section		="restrictions",
+		def    		= false,
+	},
+	{
+		key			="tax_resource_sharing_and_prevent_some_reclaim_loopholes",
+		name   		="Tax Resource Sharing",
+		desc   		="Taxes resource sharing and overflow (engine TODO), and disables reclaiming allied units for metal.",
+		type   		= "bool",
+		section		="restrictions",
+		def    		= false,
+	},
+	{
+		key    = "tax_resource_sharing_amount",
+		name   = "Resource Sharing Tax Amount",
+		desc   = "(Range: 0 - 0.99). What portion of shared resources (including overflow) will consumed as transfer tax.",
+		type   = "number",
+		def    = 0.4,
+		min    = 0,
+		max    = 0.99,
+		step   = 0.01,
+		section= "restrictions",
+	},
 
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Work done
Added modoptions for taxing resource sharing and disabling allied build assist (aka boosting), plus one that disables unit sharing.


#### Addresses Issue(s)
Game-balance wise, restricts / attempts to balance boosting by limiting it to tactical use. In high-level lobbies, on most maps, especially land+naval and role maps, boosting is an extremely powerful mechanic which favours pooling resources on the most impactful unit at any stage of the game, which comes at the expense of individual unit choice/economy management. 

This change is intended to be a option for players, not a base feature.

#### Setup
Enable the 3 modoptions under "Restrictions".

#### Test steps
Enable modoptions under "Restrictions" and Open a skirmish game with an allied Inactive AI.

Set starting metal and energy to 0. Enable cheats and use /atm. Now try giving 1000 metal to your AI ally. They should only recieve a reduced amount (600 metal for 0.4 tax)

Confirm assisting an allied blueprint doesn't work. Confirm assisting an allied lab doesn't work.
Confirm can reclaim enemy and own units, but not allies' units.
Confirm cannot share units to allies.


### Screenshots:
![spring_fHyeoIaHxb](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/5877438/06f61920-9956-4e58-a452-3c4295dc3e03)

First time contributing and doing a pull request. Let me know if there's anything amiss. 