### PR TITLE
[Fix] Idle builders widget cache valid unitdefs on init

### DIFF
--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -489,6 +489,7 @@ function widget:Initialize()
 		widgetHandler:RemoveWidget()
 		return
 	end
+	refreshUnitDefs()
 	initializeGameFrame = Spring.GetGameFrame()
 	widget:ViewResize()
 	widget:PlayerChanged()


### PR DESCRIPTION
### Work done
Run `refreshUnitDefs` on init
