### PR TITLE
Autogroup Presets and Bugfixes

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -659,7 +659,8 @@
 		},
 		"autogroups": {
 			"unitAdded": "Added %{unit} to autogroup #%{groupNumber}.",
-			"unitRemoved": "Removed %{unit} from autogroups."
+			"unitRemoved": "Removed %{unit} from autogroups.",
+			"presetSelected": "Selected preset #%{presetNum}."
 		},
 		"moveAttackNotify": {
 			"underAttack": "%{unit} is being attacked!",

--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -148,7 +148,7 @@ local function StartVote(name)	-- when called without params its just to refresh
 		if votesEligible then
 			if votesRequired then
 				-- progress bar: required for
-				w = math.floor(((windowArea[3] - windowArea[1]) / votesEligible) * votesRequired) - bgpadding - bgpadding
+				w = math.floor(((windowArea[3] - windowArea[1] - bgpadding - bgpadding) / votesEligible) * votesRequired)
 				color1 = { 0, 0.6, 0, 0.1 }
 				color2 = { 0, 1, 0, 0.1 }
 				RectRound(windowArea[1] + bgpadding, windowArea[2] + bgpadding, windowArea[1] + bgpadding + w, windowArea[2] + bgpadding + progressbarHeight, elementCorner*0.6, 0, 0, 0, 1, color1, color2)
@@ -162,7 +162,7 @@ local function StartVote(name)	-- when called without params its just to refresh
 
 			-- progress bar: for
 			if votesCountYes > 0 then
-				w = math.floor(((windowArea[3] - windowArea[1]) / votesEligible) * votesCountYes) - bgpadding - bgpadding
+				w = math.floor(((windowArea[3] - windowArea[1] - bgpadding - bgpadding) / votesEligible) * votesCountYes)
 				color1 = { 0, 0.33, 0, 1 }
 				color2 = { 0, 0.6, 0, 1 }
 				RectRound(windowArea[1] + bgpadding, windowArea[2] + bgpadding, windowArea[1] + bgpadding + w, windowArea[2] + bgpadding + progressbarHeight, elementCorner*0.6, 0, 0, 0, 1, color1, color2)
@@ -176,7 +176,7 @@ local function StartVote(name)	-- when called without params its just to refresh
 			end
 			-- progress bar: against
 			if votesCountNo > 0 then
-				w = math.floor(((windowArea[3] - windowArea[1]) / votesEligible) * votesCountNo) - bgpadding - bgpadding
+				w = math.floor(((windowArea[3] - windowArea[1] - bgpadding - bgpadding) / votesEligible) * votesCountNo)
 				color1 = { 0.33, 0, 0, 1 }
 				color2 = { 0.6, 0, 0, 1 }
 				RectRound(windowArea[3] - bgpadding - w, windowArea[2] + bgpadding, windowArea[3] - bgpadding, windowArea[2] + bgpadding + progressbarHeight, elementCorner*0.6, 0, 0, 1, 0, color1, color2)

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -215,6 +215,9 @@ end
 
 local function loadAutogroupPreset(_, _, args, data)
 	local pr = args[1]
+	if not presets[tonumber(pr)] then
+		return
+	end
 	local prevGroup = presets[currPreset]
 
 	currPreset = tonumber(pr)

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -45,10 +45,12 @@ local immediate = true
 local persist = true
 local verbose = true
 
+local rejectedUnits = {} -- contains units, which didn't load like legion in non-legion games
 
 local presets = {} -- contains ten "presets", which can be used like unit2group
 for i = 0, 9 do
 	presets[i] = {}
+	rejectedUnits[i] = {}
 end
 local unit2group = presets[currPreset] -- list of unit types to group
 
@@ -372,6 +374,9 @@ function widget:GetConfigData()
 			for id, gr in pairs(preset) do
 				table.insert(groups, { UnitDefs[id].name, gr })
 			end
+			for name, gr in pairs(rejectedUnits[i]) do
+				table.insert(groups, { name, gr })
+			end
 		end
 		savePresets[i] = groups
 	end
@@ -426,6 +431,8 @@ function widget:SetConfigData(data)
 						local gr = UnitDefNames[group[1]]
 						if gr then
 							presets[p][gr.id] = tonumber(group[2])
+						else
+							rejectedUnits[p][group[1]] = tonumber(group[2])
 						end
 					end
 				end

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -45,7 +45,7 @@ local immediate = true
 local persist = true
 local verbose = true
 
-local rejectedUnits = {} -- contains units, which didn't load like legion in non-legion games
+local rejectedUnits = {} -- contains units, which didn't load, like legion in non-legion games
 
 local presets = {} -- contains ten "presets", which can be used like unit2group
 for i = 0, 9 do
@@ -213,14 +213,14 @@ local function RemoveOneUnitFromGroupHandler(_, _, args)
 	return true
 end
 
-local function loadAutogroupPreset(_, _, args, data)
-	local pr = args[1]
-	if not presets[tonumber(pr)] then
+local function loadAutogroupPresetHandler(cmd, optLine, optWords, data, isRepeat, release, actions)
+	local newPreset = tonumber(optWords[1])
+	if not presets[newPreset] then
 		return
 	end
 	local prevGroup = presets[currPreset]
 
-	currPreset = tonumber(pr)
+	currPreset = newPreset
 
 	Echo(Spring.I18N("ui.autogroups.presetSelected", {presetNum = currPreset}))
 	unit2group = presets[currPreset]
@@ -231,13 +231,13 @@ local function loadAutogroupPreset(_, _, args, data)
 
 	for _, uID in ipairs(Spring.GetTeamUnits(myTeam)) do
 		local unitDefID = GetUnitDefID(uID)
-		local gr = unit2group[unitDefID]
+		local group = unit2group[unitDefID]
 		if tonumber(prevGroup[unitDefID]) == GetUnitGroup(uID) then -- if in last 
 			SetUnitGroup(uID, -1)
 		end
 
-		if gr ~= nil and GetUnitGroup(uID) == nil and addall then
-			SetUnitGroup(uID, gr)
+		if group ~= nil and GetUnitGroup(uID) == nil and addall then
+			SetUnitGroup(uID, group)
 		end
 	end
 end
@@ -250,7 +250,7 @@ function widget:Initialize()
 	widgetHandler:AddAction("add_to_autogroup", ChangeUnitTypeAutogroupHandler, nil, "p") -- With a parameter, adds all units of this type to a specific autogroup
 	widgetHandler:AddAction("remove_from_autogroup", ChangeUnitTypeAutogroupHandler, { removeAll = true }, "p") -- Without a parameter, removes all units of this type from autogroups
 	widgetHandler:AddAction("remove_one_unit_from_group", RemoveOneUnitFromGroupHandler, nil, "p") -- Removes the closest of selected units from groups and selects only it
-	widgetHandler:AddAction("load_autogroup_preset", loadAutogroupPreset, nil, "p") -- Changes the autogroup preset
+	widgetHandler:AddAction("load_autogroup_preset", loadAutogroupPresetHandler, nil, "p") -- Changes the autogroup preset
 
 	WG['autogroup'] = {}
 	WG['autogroup'].getImmediate = function()

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -1,4 +1,4 @@
-local versionNum = '4.010'
+local versionNum = '5.00'
 
 function widget:GetInfo()
 	return {
@@ -15,6 +15,8 @@ end
 include("keysym.h.lua")
 
 ---- CHANGELOG -----
+-- hihoman23,       v5.00   (01nov2023) :   Allows for multiple presets, which are controlled with load_autogroup_preset,
+--											for different saved group presets.
 -- badosu born2crawl,		v4.01	(08oct2021)	: 	Use actions instead of hardcoded keybindings
 -- versus666,		v3.03	(17dec2011)	: 	Back to alt BACKQUOTE to remove selected units from group
 --											to please licho, changed help accordingly.
@@ -36,12 +38,19 @@ include("keysym.h.lua")
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+local currPreset = 1
+
 local addall = true
 local immediate = true
 local persist = true
 local verbose = true
 
-local unit2group = {} -- list of unit types to group
+
+local presets = {} -- contains ten "presets", which can be used like unit2group
+for i = 0, 9 do
+	presets[i] = {}
+end
+local unit2group = presets[currPreset] -- list of unit types to group
 
 local groupableBuildingTypes = { 'tacnuke', 'empmissile', 'napalmmissile', 'seismic' }
 local groupableBuildings = {}
@@ -140,6 +149,7 @@ local function ChangeUnitTypeAutogroupHandler(_, _, args, data)
 			end
 		end
 	end
+	presets[currPreset] = unit2group
 	if exec == false then
 		return false --nothing to do
 	end
@@ -201,12 +211,41 @@ local function RemoveOneUnitFromGroupHandler(_, _, args)
 	return true
 end
 
+local function loadAutogroupPreset(_, _, args, data)
+	local pr = args[1]
+	local prevGroup = presets[currPreset]
+
+	currPreset = tonumber(pr)
+
+	Echo(Spring.I18N("ui.autogroups.presetSelected", {presetNum = currPreset}))
+	unit2group = presets[currPreset]
+
+	if not unit2group then
+		return
+	end
+
+	for _, uID in ipairs(Spring.GetTeamUnits(myTeam)) do
+		local unitDefID = GetUnitDefID(uID)
+		local gr = unit2group[unitDefID]
+		if tonumber(prevGroup[unitDefID]) == GetUnitGroup(uID) then -- if in last 
+			SetUnitGroup(uID, -1)
+		end
+
+		if gr ~= nil and GetUnitGroup(uID) == nil and addall then
+			SetUnitGroup(uID, gr)
+		end
+	end
+end
+
+
 function widget:Initialize()
+
 	widget:PlayerChanged()
 
 	widgetHandler:AddAction("add_to_autogroup", ChangeUnitTypeAutogroupHandler, nil, "p") -- With a parameter, adds all units of this type to a specific autogroup
 	widgetHandler:AddAction("remove_from_autogroup", ChangeUnitTypeAutogroupHandler, { removeAll = true }, "p") -- Without a parameter, removes all units of this type from autogroups
 	widgetHandler:AddAction("remove_one_unit_from_group", RemoveOneUnitFromGroupHandler, nil, "p") -- Removes the closest of selected units from groups and selects only it
+	widgetHandler:AddAction("load_autogroup_preset", loadAutogroupPreset, nil, "p") -- Changes the autogroup preset
 
 	WG['autogroup'] = {}
 	WG['autogroup'].getImmediate = function()
@@ -325,15 +364,20 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 end
 
 function widget:GetConfigData()
-	local groups = {}
-	if persist then
-		for id, gr in pairs(unit2group) do
-			table.insert(groups, { UnitDefs[id].name, gr })
+	local savePresets = {}
+	for i = 0, 9 do
+		local preset = presets[i]
+		local groups = {}
+		if persist then
+			for id, gr in pairs(preset) do
+				table.insert(groups, { UnitDefs[id].name, gr })
+			end
 		end
+		savePresets[i] = groups
 	end
 	local ret = {
 		version = versionNum,
-		groups = groups,
+		presets = savePresets,
 		immediate = immediate,
 		persist = persist,
 		verbose = verbose,
@@ -343,7 +387,7 @@ function widget:GetConfigData()
 end
 
 function widget:SetConfigData(data)
-	if data and type(data) == 'table' and data.version and (data.version + 0) > 2.1 then
+	if data and type(data) == 'table' and data.version and (data.version + 0) > 2.1 and (data.version + 0) < 5 then -- still use v4 saves
 		if data.immediate ~= nil then
 			immediate = data.immediate
 			verbose = data.verbose
@@ -358,10 +402,38 @@ function widget:SetConfigData(data)
 				if type(nam) == 'table' then
 					local gr = UnitDefNames[nam[1]]
 					if gr ~= nil then
-						unit2group[gr.id] = nam[2]
+						unit2group[gr.id] = tonumber(nam[2])
 					end
 				end
 			end
 		end
+		presets[1] = unit2group
+	end
+	if data and type(data) == 'table' and data.version and (data.version + 0) >= 5 then
+		if data.immediate ~= nil then
+			immediate = data.immediate
+			verbose = data.verbose
+			addall = data.addall
+		end
+		if data.persist ~= nil then
+			persist = data.persist
+		end
+		local groupData = data.presets
+		if groupData and type(groupData) == 'table' and groupData[1] and type(groupData[1]) == 'table' then
+			for p, preset in pairs(groupData) do
+				for _, group in ipairs(preset) do
+					if type(group) == 'table' then
+						local gr = UnitDefNames[group[1]]
+						if gr then
+							presets[p][gr.id] = tonumber(group[2])
+						end
+					end
+				end
+			end
+		end
+	end
+	unit2group = presets[currPreset]
+	if GetGameFrame() > 0 then
+		addAllUnits()
 	end
 end

--- a/luaui/configs/hotkeys/num_keys.txt
+++ b/luaui/configs/hotkeys/num_keys.txt
@@ -19,6 +19,17 @@ bind Alt+7 add_to_autogroup 7
 bind Alt+8 add_to_autogroup 8
 bind Alt+9 add_to_autogroup 9
 
+bind Shift+Alt+0 load_autogroup_preset 0
+bind Shift+Alt+1 load_autogroup_preset 1
+bind Shift+Alt+2 load_autogroup_preset 2
+bind Shift+Alt+3 load_autogroup_preset 3
+bind Shift+Alt+4 load_autogroup_preset 4
+bind Shift+Alt+5 load_autogroup_preset 5
+bind Shift+Alt+6 load_autogroup_preset 6
+bind Shift+Alt+7 load_autogroup_preset 7
+bind Shift+Alt+8 load_autogroup_preset 8
+bind Shift+Alt+9 load_autogroup_preset 9
+
 bind 0,0 group focus 0
 bind 1,1 group focus 1
 bind 2,2 group focus 2
@@ -84,14 +95,3 @@ bind Ctrl+Alt+6 group selecttoggle 6
 bind Ctrl+Alt+7 group selecttoggle 7
 bind Ctrl+Alt+8 group selecttoggle 8
 bind Ctrl+Alt+9 group selecttoggle 9
-
-bind Shift+Alt+0 load_autogroup_preset 0
-bind Shift+Alt+1 load_autogroup_preset 1
-bind Shift+Alt+2 load_autogroup_preset 2
-bind Shift+Alt+3 load_autogroup_preset 3
-bind Shift+Alt+4 load_autogroup_preset 4
-bind Shift+Alt+5 load_autogroup_preset 5
-bind Shift+Alt+6 load_autogroup_preset 6
-bind Shift+Alt+7 load_autogroup_preset 7
-bind Shift+Alt+8 load_autogroup_preset 8
-bind Shift+Alt+9 load_autogroup_preset 9

--- a/luaui/configs/hotkeys/num_keys.txt
+++ b/luaui/configs/hotkeys/num_keys.txt
@@ -84,3 +84,14 @@ bind Ctrl+Alt+6 group selecttoggle 6
 bind Ctrl+Alt+7 group selecttoggle 7
 bind Ctrl+Alt+8 group selecttoggle 8
 bind Ctrl+Alt+9 group selecttoggle 9
+
+bind Shift+Alt+0 load_autogroup_preset 0
+bind Shift+Alt+1 load_autogroup_preset 1
+bind Shift+Alt+2 load_autogroup_preset 2
+bind Shift+Alt+3 load_autogroup_preset 3
+bind Shift+Alt+4 load_autogroup_preset 4
+bind Shift+Alt+5 load_autogroup_preset 5
+bind Shift+Alt+6 load_autogroup_preset 6
+bind Shift+Alt+7 load_autogroup_preset 7
+bind Shift+Alt+8 load_autogroup_preset 8
+bind Shift+Alt+9 load_autogroup_preset 9


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
1. Autogroups now have presets(numbers 0-9, keybinded by default to `alt+shift+`0-9), which are collections of autogroups, which can be toggled to fit different roles, like playing air or eco. I know I explained this badly, but if you have questions, feel free to ask.
2. Autogroups now persist also for units not in all games, like legion or scav (this should be added, even if number 1 isn't added.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->
<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
