### PR TITLE
[Fix - Gridmenu] Esc key now deselects active category/blueprint without deselecting unit

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1849,6 +1849,7 @@ function widget:KeyPress(key, modifier, isRepeat)
 	if currentCategory and key == KEYSYMS.ESCAPE then
 		clearCategory()
 		doUpdate = true
+		return true
 	end
 end
 


### PR DESCRIPTION
### Work done
KeyPress event was not being consumed, so it deselected the category then continued on to deselect the unit. This consumes it (only when a category is active) so that it just deselects the category/blueprint without deselecting the unit.

