### PR TITLE
Remove the use of obsolete VFSUtils

### DIFF
--- a/gamedata/featuredefs.lua
+++ b/gamedata/featuredefs.lua
@@ -18,7 +18,6 @@ local preProcFile  = 'gamedata/featuredefs_pre.lua'
 local postProcFile = 'gamedata/featuredefs_post.lua'
 
 local system = VFS.Include('gamedata/system.lua')
-VFS.Include('gamedata/VFSUtils.lua')
 local section='featuredefs.lua'
 
 --------------------------------------------------------------------------------
@@ -42,7 +41,7 @@ end
 --  Load the raw LUA format featuredef files
 --
 
-local luaFiles = RecursiveFileSearch('features/', '*.lua')
+local luaFiles = VFS.DirList('features/', '*.lua', nil, true)
 
 for _, filename in ipairs(luaFiles) do
 	local fdEnv = {}

--- a/gamedata/resources.lua
+++ b/gamedata/resources.lua
@@ -105,9 +105,8 @@ local resources = {
 	  }
    }
 
-VFS.Include('gamedata/VFSUtils.lua')
 local function AutoAdd(subDir, map, filter)
-	local dirList = RecursiveFileSearch("bitmaps/" .. subDir)
+	local dirList = VFS.DirList("bitmaps/" .. subDir, nil, nil, true)
 	for _, fullPath in ipairs(dirList) do
 		local path, key, ext = fullPath:match("bitmaps/(.*/(.*)%.(.*))")
 		if not fullPath:match("/%.svn") then

--- a/gamedata/unitdefs.lua
+++ b/gamedata/unitdefs.lua
@@ -20,7 +20,6 @@ local postProcFile = 'gamedata/unitdefs_post.lua'
 local DownloadBuilds = VFS.Include('gamedata/download_builds.lua')
 
 local system = VFS.Include('gamedata/system.lua')
-VFS.Include('gamedata/VFSUtils.lua')
 
 local section = 'unitdefs.lua'
 
@@ -47,7 +46,7 @@ end
 --
 
 
-local luaFiles = RecursiveFileSearch('units/', '*.lua')
+local luaFiles = VFS.DirList('units/', '*.lua', nil, true)
 
 local legionEnabled = Spring.GetModOptions().experimentallegionfaction
 local scavengersEnabled = true

--- a/gamedata/weapondefs.lua
+++ b/gamedata/weapondefs.lua
@@ -18,7 +18,6 @@ local preProcFile  = 'gamedata/weapondefs_pre.lua'
 local postProcFile = 'gamedata/weapondefs_post.lua'
 
 local system = VFS.Include('gamedata/system.lua')
-VFS.Include('gamedata/VFSUtils.lua')
 
 local section = 'weapondefs.lua'
 
@@ -42,7 +41,7 @@ end
 --  Load the raw LUA format weapondef files
 --
 
-local luaFiles = RecursiveFileSearch('weapons/', '*.lua')
+local luaFiles = VFS.DirList('weapons/', '*.lua', nil, true)
 
 for _, filename in ipairs(luaFiles) do
 	local wdEnv = {}


### PR DESCRIPTION
`VFS.DirList` does what it used to if you pass true as the 4th arg. Requires engine 105-1873 so it's not bleeding edge new.
See https://github.com/beyond-all-reason/spring/blob/BAR105/cont/base/springcontent/gamedata/VFSUtils.lua