### PR TITLE
fix(unit_share_tracker): fix comparison when rulesparam is nil

### DIFF
--- a/luaui/Widgets/unit_share_tracker.lua
+++ b/luaui/Widgets/unit_share_tracker.lua
@@ -241,7 +241,8 @@ function widget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
 
 	local selfShare = (oldTeam == newTeam) -- may happen if took other player
 
-	local bought = (Spring.GetUnitRulesParam(unitID, "unitPrice") > 0)
+	local price = Spring.GetUnitRulesParam(unitID, "unitPrice")
+	local bought = price ~= nil and price > 0
 
 	if newTeam == GetMyTeamID() and not selfShare and not captured and not bought then
 		if not timeNow then


### PR DESCRIPTION
`Error in UnitTaken(): [string "LuaUI/Widgets/unit_share_tracker.lua"]:244: attempt to compare number with nil`

See https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2879