### PR TITLE
Customizable EvoCom XP Rates

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -239,6 +239,11 @@ function UnitDef_Post(name, uDef)
 
 		if modOptions.evocom then	
 			if uDef.customparams.isevocom or uDef.customparams.iscommander then
+				if uDef.power then
+					uDef.power = uDef.power/modOptions.evocomxpmultiplier 
+				else
+					uDef.power = ((uDef.metalcost+(uDef.energycost/60))/modOptions.evocomxpmultiplier)
+				end
 				uDef.customparams.evolution_timer = modOptions.evocomleveluprate*60
 				if  name == "armcom" then
 				uDef.customparams.evolution_announcement = "Armada commanders have upgraded to level 2"

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1238,7 +1238,7 @@ local options = {
     {
         key    	= "evocomleveluprate",
         name   	= "Commander Evolution Rate",
-        desc   	= "(Range 0.1 - 20 Minutes). Rate at which commanders will evolve and gain new (unbalanced) buffs, weapons and abilities.",
+        desc   	= "(Range 0.1 - 20 Minutes) Rate at which commanders will evolve and gain new (unbalanced) buffs, weapons and abilities.",
         type   	= "number",
         section	= "options_experimental",
         def    	= 5,
@@ -1247,6 +1247,17 @@ local options = {
         step   	= 0.1,
     },
 
+    {
+        key    	= "evocomxpmultiplier",
+        name   	= "Commander XP Multiplier",
+        desc   	= "(Range 0.1 - 10) Changes the rate at which Evolving Commanders gain Experience.",
+        type   	= "number",
+        section	= "options_experimental",
+        def    	= 1,
+        min    	= 0.1,
+        max    	= 10,
+        step   	= 0.1,
+    },
 
     {
 		key		= "forceallunits",


### PR DESCRIPTION
Just adds a modoption. This fixes the issue where in crazy big game modes like NuttyB's raptors, vanilla Evocom's can't keep up with the scale of those and other similar scale battles.

