### PR TITLE
hotfix for draft spawn order UI and unit market

### DIFF
--- a/luaui/Widgets/gui_pregameui.lua
+++ b/luaui/Widgets/gui_pregameui.lua
@@ -222,6 +222,11 @@ local function DrawSkill(skill, posX, posY)
     font:End()
 end
 
+local function round(num, idp)
+    local mult = 10 ^ (idp or 0)
+    return math.floor(num * mult + 0.5) / mult
+end
+
 -- advplayerlist end
 local function colourNames(teamID)
 	if teamID == nil then return "\255\210\210\210" end -- debug
@@ -785,7 +790,7 @@ function widget:DrawScreen()
 							local tsMu = customtable.skill
 							local tsSigma = customtable.skilluncertainty
 							local ts = tsMu and tonumber(tsMu:match("%d+%.?%d*"))
-							if (ts ~= nil) then playerSkill = ts end
+							if (ts ~= nil) then playerSkill = round(ts, 0) end
 							if (rank ~= nil) then playerRank = rank end
 						end
 						-- | indicator/timer/sandclock | rankicon | skill/zero | [playercolor] playername |

--- a/luaui/Widgets/gui_unit_market.lua
+++ b/luaui/Widgets/gui_unit_market.lua
@@ -158,7 +158,7 @@ local function FindPlayerIDFromTeamID(teamID)
     local playerList = spGetPlayerList()
     for i = 1, #playerList do
         local playerID = playerList[i]
-        local team = select(6,spGetPlayerInfo(playerID))
+        local team = select(4,spGetPlayerInfo(playerID))
         if team == teamID then
             return playerID
         end


### PR DESCRIPTION
Bug fixes:
- Skill values showed as for example "17.25" instead of just "17" in "Team Placement" UI, fixed.
- Fixed Unit Market figuring out player team names (sale log had "Unknown team" instead).