### PR TITLE
[Fix] Preserve queue: Only dismiss first command if it's not near the drop point

### DIFF
--- a/luaui/Widgets/cmd_transport_preserve_commands.lua
+++ b/luaui/Widgets/cmd_transport_preserve_commands.lua
@@ -26,15 +26,21 @@ function widget:UnitUnloaded(unitID)
 
 		for i, command in ipairs(orders[unitID]) do
 			if (#command.params >= 3) then
-				local x, y, z = Spring.GetUnitPosition(unitID)
-				local distFromCmd = math.distance3d(x, y, z, command.params[1], command.params[2], command.params[3])
-				if (distFromCmd <= distToIgnore) then
+				local dist = math.huge
+				if i == 1 then -- ditch first command if it's not near the starting point
+					local x, y, z = Spring.GetUnitPosition(unitID)
+					dist = math.distance3d(x, y, z, command.params[1], command.params[2], command.params[3])
+				else
+					dist = 0
+				end
+
+				if (dist <= distToIgnore) then
 					table.insert(newOrders, { command.id, command.params, command.options })
 				end
 			end
 		end
 
-		Spring.GiveOrderArrayToUnitArray({ unitID }, newOrders)
+		Spring.GiveOrderArrayToUnit( unitID , newOrders)
 
 		orders[unitID] = nil
 	end


### PR DESCRIPTION
### Work done
All commands were ditched after transporting if they were not near the drop point, when it should only dismiss the first command for being out of range

