### PR TITLE
[Feature] Add tooltip for areamex when mousing over mexes in gridmenu/buildmenu

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -152,7 +152,8 @@
 			"nextPage": "Next page",
 			"previousPage": "Previous page",
 			"disabled": "%{textColor}%{unit} %{warnColor}(disabled)",
-			"nextBuilder": "Next Builder"
+			"nextBuilder": "Next Builder",
+			"areamex_tooltip": "Tip: Select this extractor twice to use area mex command"
 		},
 		"orderMenu": {
 			"hotkeyTooltip": "%{highlightColor}%{hotkey}%{textColor} - %{tooltip}",

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -777,7 +777,11 @@ function widget:DrawScreen()
 								else
 									text = UnitDefs[uDefID].translatedHumanName
 								end
-								WG['tooltip'].ShowTooltip('buildmenu', "\255\240\240\240"..unitTranslatedTooltip[uDefID], nil, nil, text)
+								local tooltip = unitTranslatedTooltip[uDefID]
+								if unitMetal_extractor[uDefID] then
+									tooltip = tooltip .. "\n" .. Spring.I18N("ui.buildMenu.areamex_tooltip")
+								end
+								WG['tooltip'].ShowTooltip('buildmenu', "\255\240\240\240"..tooltip, nil, nil, text)
 							end
 
 							-- highlight --if b and not disableInput then

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2004,9 +2004,13 @@ local function handleButtonHover()
 						else
 							text = unitTranslatedHumanName[uDefID]
 						end
+						local tooltip = unitTranslatedTooltip[uDefID]
+						if unitMetal_extractor[uDefID] then
+							tooltip = tooltip .. "\n" .. Spring.I18N("ui.buildMenu.areamex_tooltip")
+						end
 						WG["tooltip"].ShowTooltip(
 							"buildmenu",
-							"\255\240\240\240" .. unitTranslatedTooltip[uDefID],
+							"\255\240\240\240" .. tooltip,
 							nil,
 							nil,
 							text


### PR DESCRIPTION
### Work done
Add a tooltip to teach users that areamex can be activated from buildmenu and for any mex type.


### Screenshots:
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/3493638/14abdd7e-75da-4b13-b3f3-330238a9c415)
