### PR TITLE
Gadget: Drone Carriers, Bot Launchers, and Unit Builders inherit/bequeath XP

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -264,6 +264,7 @@ function UnitDef_Post(name, uDef)
 				uDef.customparams.evolution_condition = "timer"
 				uDef.customparams.workertimeboost = 5
 				uDef.customparams.wtboostunittype = "MOBILE"
+				uDef.customparams.inheritxratemultiplier = 0.01
 				end
 			end
 		end

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -13,17 +13,17 @@ end
 -- synced only
 if not gadgetHandler:IsSyncedCode() then return false end
 
-local inheritchildrenxp = {} -- stores the value of XP rate to be derived from unitdef
+local inheritChildrenXP = {} -- stores the value of XP rate to be derived from unitdef
 -- inheritxratemultiplier = defined in unitdef customparams of the parent unit. It's a number by which XP gained by children is multiplied and passed to the parent
 
-local childrenwithparents = {} --stores the parent/child relationships format. Each entry stores key of unitID with an array of {unitID, builderID, xpInheritance}
+local childrenWithParents = {} --stores the parent/child relationships format. Each entry stores key of unitID with an array of {unitID, builderID, xpInheritance}
 for id, def in pairs(UnitDefs) do
 	if def.customParams.inheritxratemultiplier then
-		inheritchildrenxp[id] = def.customParams.inheritxratemultiplier or 0
+		inheritChildrenXP[id] = def.customParams.inheritxratemultiplier or 0
 	end
 end
 
-if table.count(inheritchildrenxp) <= 0 then -- this enables or disables the gadget
+if table.count(inheritChildrenXP) <= 0 then -- this enables or disables the gadget
 	return false
 end
 
@@ -31,23 +31,23 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 	if  builderID ~= nil then
 		local builderDefID = Spring.GetUnitDefID(builderID)
 		if builderID then
-			childrenwithparents[unitID] = {unitid=unitID, parentunitid=builderID, parentxpmultiplier=inheritchildrenxp[builderDefID]}
+			childrenWithParents[unitID] = {unitid=unitID, parentunitid=builderID, parentxpmultiplier=inheritChildrenXP[builderDefID]}
 		end
 	end
 end
 
 function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExperience)
-	if not childrenwithparents[unitID] then
+	if not childrenWithParents[unitID] then
 		if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
 		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
 		local builderDefID = Spring.GetUnitDefID(parentID)
-		childrenwithparents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritchildrenxp[builderDefID]}
+		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritChildrenXP[builderDefID]}
 		end
 	end
-	if childrenwithparents[unitID] then
-		local parentUnitID = childrenwithparents[unitID].parentunitid
+	if childrenWithParents[unitID] then
+		local parentUnitID = childrenWithParents[unitID].parentunitid
 		local parentOldXP = Spring.GetUnitExperience(parentUnitID)
-		local parentMultiplier = childrenwithparents[unitID].parentxpmultiplier
+		local parentMultiplier = childrenWithParents[unitID].parentxpmultiplier
 		local xp
 
 		if parentMultiplier then
@@ -57,5 +57,5 @@ function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExper
 	end
 end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
-		childrenwithparents[unitID] = nil --removes children from list when destroyed
+		childrenWithParents[unitID] = nil --removes children from list when destroyed
 end

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -1,0 +1,63 @@
+function gadget:GetInfo()
+	return {
+		name = "Inherit Creation Units XP",
+		desc = "Allows units with added UnitDefs to gain a defined fraction of the XP earned by their creations.",
+		author = "SethDGamre and Xehrath",
+		date = "May 2024",
+		license = "Public domain",
+		layer = 50,
+		enabled = true
+	}
+end
+
+-- synced only
+if not gadgetHandler:IsSyncedCode() then return false end
+
+local inheritchildrenxp = {} -- stores the value of XP rate to be derived from unitdef
+-- inheritxratemultiplier = defined in unitdef customparams of the parent unit. It's a number by which XP gained by children is multiplied and passed to the parent
+
+local childrenwithparents = {} --stores the parent/child relationships format. Each entry stores key of unitID with an array of {unitID, builderID, xpInheritance}
+for id, def in pairs(UnitDefs) do
+	if def.customParams then
+		if def.customParams.inheritxratemultiplier then
+			inheritchildrenxp[id] = def.customParams.inheritxratemultiplier or -1
+		end
+	end
+end
+
+if table.count(inheritchildrenxp) <= 0 then -- this enables or disables the gadget
+	return false
+end
+
+function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+	if  builderID ~= nil then
+		local builderDefID = Spring.GetUnitDefID(builderID)
+		if builderID then
+			childrenwithparents[unitID] = {unitid=unitID, parentunitid=builderID, parentxpmultiplier=inheritchildrenxp[builderDefID]}
+		end
+	end
+end
+
+function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExperience)
+	if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
+		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") or -1 --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
+		local builderDefID = Spring.GetUnitDefID(parentID)
+		childrenwithparents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritchildrenxp[builderDefID]}
+	end
+	if childrenwithparents[unitID] then
+		local parentUnitID = childrenwithparents[unitID].parentunitid
+		local parentOldXP = Spring.GetUnitExperience(parentUnitID)
+		local parentMultiplier = childrenwithparents[unitID].parentxpmultiplier
+		local xp
+
+		if parentMultiplier then
+			xp = parentOldXP + ((experience - oldExperience) * parentMultiplier)
+			Spring.SetUnitExperience(parentUnitID, xp)
+		end
+	end
+end
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+	if childrenwithparents[unitID] then
+		childrenwithparents[unitID] = nil --removes children from list when destroyed
+	end
+end

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -39,10 +39,12 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 end
 
 function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExperience)
-	if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
+	if not childrenwithparents[unitID] then
+		if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
 		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") or -1 --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
 		local builderDefID = Spring.GetUnitDefID(parentID)
 		childrenwithparents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritchildrenxp[builderDefID]}
+		end
 	end
 	if childrenwithparents[unitID] then
 		local parentUnitID = childrenwithparents[unitID].parentunitid

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -41,7 +41,7 @@ end
 function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExperience)
 	if not childrenwithparents[unitID] then
 		if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
-		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") or -1 --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
+		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
 		local builderDefID = Spring.GetUnitDefID(parentID)
 		childrenwithparents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritchildrenxp[builderDefID]}
 		end

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -28,6 +28,7 @@ if table.count(inheritChildrenXP) <= 0 then -- this enables or disables the gadg
 end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+	Spring.Echo(Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id"))
 	if  builderID ~= nil then
 		local builderDefID = Spring.GetUnitDefID(builderID)
 		if builderID then
@@ -41,14 +42,17 @@ function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExper
 		if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
 		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
 		local parentDefID = Spring.GetUnitDefID(parentID)
+		local parentCurrentXP = Spring.GetUnitExperience(parentID)
 		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritChildrenXP[parentDefID]}
-		elseif Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id") then
+		Spring.SetUnitExperience (unitID, parentCurrentXP)
+		elseif Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id") then -- this establishes parenthood of unit_carrier_spawner drone/carrier relationship
 		local parentID = Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id")
 		local parentDefID = Spring.GetUnitDefID(parentID)
+		local parentCurrentXP = Spring.GetUnitExperience(parentID)
 		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritChildrenXP[parentDefID]}
+		Spring.SetUnitExperience (unitID, parentCurrentXP)
 		end
-	end
-	if childrenWithParents[unitID] then
+	elseif childrenWithParents[unitID] then
 		local parentUnitID = childrenWithParents[unitID].parentunitid
 		local parentOldXP = Spring.GetUnitExperience(parentUnitID)
 		local parentMultiplier = childrenWithParents[unitID].parentxpmultiplier

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -18,10 +18,8 @@ local inheritchildrenxp = {} -- stores the value of XP rate to be derived from u
 
 local childrenwithparents = {} --stores the parent/child relationships format. Each entry stores key of unitID with an array of {unitID, builderID, xpInheritance}
 for id, def in pairs(UnitDefs) do
-	if def.customParams then
-		if def.customParams.inheritxratemultiplier then
-			inheritchildrenxp[id] = def.customParams.inheritxratemultiplier or -1
-		end
+	if def.customParams.inheritxratemultiplier then
+		inheritchildrenxp[id] = def.customParams.inheritxratemultiplier or 0
 	end
 end
 

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -5,7 +5,7 @@ function gadget:GetInfo()
 		author = "SethDGamre and Xehrath",
 		date = "May 2024",
 		license = "Public domain",
-		layer = 50,
+		layer = 0,
 		enabled = true
 	}
 end

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -14,17 +14,24 @@ end
 if not gadgetHandler:IsSyncedCode() then return false end
 
 local inheritChildrenXP = {} -- stores the value of XP rate to be derived from unitdef
--- inheritxratemultiplier = defined in unitdef customparams of the parent unit. It's a number by which XP gained by children is multiplied and passed to the parent
+-- inheritxratemultiplier = 1 -- defined in unitdef customparams of the parent unit. It's a number by which XP gained by children is multiplied and passed to the parent after power difference calculations
+local childrenInheritXP = {} -- stores the true/false of child xp inheritance from parents
+-- childreninheritxp = true --  determines whether or not children inherit current xp from their parents when created.
 
 local childrenWithParents = {} --stores the parent/child relationships format. Each entry stores key of unitID with an array of {unitID, builderID, xpInheritance}
-local parentlessChildren = {} --stores the unitID's to be ignored in future checks
 
 local unitPowerDefs = {}
+local unitsList = {}
 
 
 for id, def in pairs(UnitDefs) do
 	if def.customParams.inheritxratemultiplier then
 		inheritChildrenXP[id] = def.customParams.inheritxratemultiplier or 0
+	end
+	if def.customParams.childreninheritxp then
+		childrenInheritXP[id] = true
+	else
+		childrenInheritXP[id] = false
 	end
 	if def.power then
 	unitPowerDefs[id] = def.power
@@ -40,47 +47,86 @@ local function calculatePowerDiffXP(childID, parentID)
 	local parentDefID = Spring.GetUnitDefID(parentID)
 	local childPower =  unitPowerDefs[childDefID]
 	local parentPower = unitPowerDefs[parentDefID]
-
 	return (childPower/parentPower)*inheritChildrenXP[parentDefID]
 end
 
+local initializeList = {}
+local ignoreList = {}
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
-	if  builderID ~= nil then
-		local builderDefID = Spring.GetUnitDefID(builderID)
-		if builderID then
-			childrenWithParents[unitID] = {unitid=unitID, parentunitid=builderID, parentxpmultiplier=calculatePowerDiffXP(unitID, builderID)}
+	if  inheritChildrenXP[builderID] then
+			childrenWithParents[unitID] = {
+				unitid=unitID,
+				parentunitid=builderID,
+				parentxpmultiplier=calculatePowerDiffXP(unitID, builderID),
+				childinheritsXP = childrenInheritXP[Spring.GetUnitDefID(unitID)]
+			}
+	end
+	initializeList[unitID] = true
+	unitsList[unitID] = true
+end
+
+local xpGainParents = {} --stores the unitID's of parents that inherit xp
+local lastRunFrame = 0
+local oldChildXPValues = {}
+function gadget:GameFrame(frame)
+	if frame > (lastRunFrame + 30) then
+		for unitID, value in pairs(unitsList) do
+			local parentID
+			if not ignoreList[unitID] then
+				if initializeList[unitID] then -- check for parenthood
+					local unitDefID = Spring.GetUnitDefID(unitID)
+					local parentXP = 0
+					local parentDefID
+					if Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id") then --estabalishes unit_carrier_spawner parenthood
+						parentID = Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id")
+					end
+					if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then --estabalishes unit_explosion_spawner parenthood
+						parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id")
+						local xp = Spring.GetUnitExperience(parentID)
+						Spring.SetUnitExperience(unitID, xp)
+					end
+					if parentID ~= nil then -- if either of the above rulesparams return a value, then add to childrenwithparents
+						childrenWithParents[unitID] = {
+							unitid = unitID,
+							parentunitid = parentID,
+							parentxpmultiplier = calculatePowerDiffXP(unitID, parentID),
+							childinheritsXP = childrenInheritXP[unitDefID]
+						}
+					end
+					if parentID then
+						parentDefID = Spring.GetUnitDefID(parentID) or 0 -- gets the parentDefID
+					end
+					if childrenInheritXP[parentDefID] == true and childrenWithParents[unitID] then --if the parent has the unitdef, set childxp to parent xp.
+						parentXP = Spring.GetUnitExperience(childrenWithParents[parentDefID])
+						Spring.SetUnitExperience(unitID, parentXP)
+						oldChildXPValues[unitID] = parentXP	--add parent xp to the oldxp value to exclude it from inheritance
+					end
+					if inheritChildrenXP[unitDefID] then -- if parent inherits xp, then add to list of units to inherit xp
+						xpGainParents[unitID] = true
+					end
+					if not xpGainParents[unitID] and not childrenWithParents[unitID] then --if not a parent or a child of a parent who inherits xp, add to ignore list
+						ignoreList[unitID] = true
+					end
+					initializeList[unitID] = nil -- this concludes innitialization
+				end
+				if childrenWithParents[unitID] then
+					parentID = childrenWithParents[unitID].parentunitid
+					local oldXP = oldChildXPValues[unitID] or 0
+					local newXP = Spring.GetUnitExperience(unitID) or 0
+					local parentXP = Spring.GetUnitExperience(parentID) or 0
+					local multiplier = childrenWithParents[unitID].parentxpmultiplier
+					local gainedXP = parentXP + ((newXP-oldXP)*multiplier)
+					oldChildXPValues[unitID] = newXP
+					Spring.SetUnitExperience(parentID, gainedXP)
+				end
+			end
 		end
 	end
 end
 
-function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExperience)
-	local parentCurrentXP
-	if not parentlessChildren[unitID] and not childrenWithParents[unitID] then
-		if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
-		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
-		local parentDefID = Spring.GetUnitDefID(parentID)
-		parentCurrentXP = Spring.GetUnitExperience(parentID)
-		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=calculatePowerDiffXP(unitID, parentID)}
-		Spring.SetUnitExperience (unitID, parentCurrentXP)
-		elseif Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id") then -- this establishes parenthood of unit_carrier_spawner drone/carrier relationship
-		local parentID = Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id")
-		local parentDefID = Spring.GetUnitDefID(parentID)
-		parentCurrentXP = Spring.GetUnitExperience(parentID)
-		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=calculatePowerDiffXP(unitID, parentID)}
-		Spring.SetUnitExperience (unitID, parentCurrentXP)
-		else parentlessChildren[unitID] = true
-		end
-	elseif childrenWithParents[unitID] then
-		local parentUnitID = childrenWithParents[unitID].parentunitid
-		parentCurrentXP = Spring.GetUnitExperience(parentUnitID)
-		local parentMultiplier = childrenWithParents[unitID].parentxpmultiplier
-		local xp
-		if parentMultiplier then
-			xp = parentCurrentXP + ((experience - oldExperience) * parentMultiplier)
-			Spring.SetUnitExperience(parentUnitID, xp)
-		end
-	end
-end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
-		childrenWithParents[unitID] = nil --removes children from list when destroyed
+	
+	childrenWithParents[unitID] = nil --removes units from lists when destroyed
+	ignoreList[unitID] = nil
+	initializeList[unitID] = nil
 end

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -40,8 +40,12 @@ function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExper
 	if not childrenWithParents[unitID] then
 		if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then
 		local parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id") --this establishes parenthood of unit_explosion_spawner.lua unit creations E.G pawn launchers/legion Evocom Dgun. IT CANNOT BE DONE AT UnitCreated or UnitDestroyed!!! Exhibits anomolous behavior if not done at runtime.
-		local builderDefID = Spring.GetUnitDefID(parentID)
-		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritChildrenXP[builderDefID]}
+		local parentDefID = Spring.GetUnitDefID(parentID)
+		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritChildrenXP[parentDefID]}
+		elseif Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id") then
+		local parentID = Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id")
+		local parentDefID = Spring.GetUnitDefID(parentID)
+		childrenWithParents[unitID] = {unitid=unitID, parentunitid=parentID, parentxpmultiplier=inheritChildrenXP[parentDefID]}
 		end
 	end
 	if childrenWithParents[unitID] then

--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -59,7 +59,5 @@ function gadget:UnitExperience(unitID, unitDefID, unitTeam, experience, oldExper
 	end
 end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
-	if childrenwithparents[unitID] then
 		childrenwithparents[unitID] = nil --removes children from list when destroyed
-	end
 end

--- a/luarules/gadgets/unit_workertime_boost.lua
+++ b/luarules/gadgets/unit_workertime_boost.lua
@@ -5,16 +5,16 @@ function gadget:GetInfo()
 		author = "SethDGamre",
 		date = "April 2024",
 		license = "Public domain",
-		layer = 1,
+		layer = 50,
 		enabled = true
 	}
 end
 
+
+
 -- synced only
 if not gadgetHandler:IsSyncedCode() then return false end
 
--- is unba com on
-if not Spring.GetModOptions().evocom then return false end
 
 local boosttriggers = {} -- stores what words parsed from the wtboostunittype "trigger" boost
 local mobileunits = {} -- stores the names of units that can move
@@ -23,7 +23,6 @@ local originalworkertimes = {}
 -- workertimeboost = number -- in the unitdefs of the builder. This is the mulitplier by which workertime is boosted.
 -- wtboostunittype = defined in unitdef of builder, it's a table of strings such as "MOBILE" which defines what units boost buildpower for the builder.
 	
---step 1, FOR make a table containing the  names of the units that can boost
 for id, def in pairs(UnitDefs) do
 	if def.buildSpeed then
 		if def.customParams.workertimeboost then
@@ -31,14 +30,16 @@ for id, def in pairs(UnitDefs) do
 			boostedworkertimes[id] = def.buildSpeed * def.customParams.workertimeboost--adds the key "id" unitname to the list. Boostable builders represented the boosted workertime.
 		end
 	end
-
 	if def.speed and def.speed ~= 0 then
 		mobileunits[id] = true
 	end
-
 	if def.customParams.wtboostunittype then
 		boosttriggers[id] = def.customParams.wtboostunittype --stores the string of the builder that defines unit categories
 	end
+end
+
+if table.count(originalworkertimes) <= 0 then -- this enables or disables the gadget
+	return false
 end
 
 local boostedtofinish = {}-- going to store the key of unitID equal to the builderID
@@ -47,7 +48,6 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 	if  builderID ~= nil then
 		local boost = boostedworkertimes[Spring.GetUnitDefID(builderID) or -1]
 		local trigger = boosttriggers[Spring.GetUnitDefID(builderID) or -1]
-	
 		if boost and trigger and builderID then
 			if string.find(trigger, "MOBILE") and mobileunits[unitDefID] then
 				Spring.SetUnitBuildSpeed(builderID, boost)

--- a/luarules/gadgets/unit_workertime_boost.lua
+++ b/luarules/gadgets/unit_workertime_boost.lua
@@ -5,7 +5,7 @@ function gadget:GetInfo()
 		author = "SethDGamre",
 		date = "April 2024",
 		license = "Public domain",
-		layer = 50,
+		layer = 0,
 		enabled = true
 	}
 end

--- a/units/ArmShips/T2/armcarry2.lua
+++ b/units/ArmShips/T2/armcarry2.lua
@@ -54,6 +54,9 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "armships/t2",
 			techlevel = 2,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmShips/T2/armtrident.lua
+++ b/units/ArmShips/T2/armtrident.lua
@@ -44,6 +44,9 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "armships/t2",
 			techlevel = 2,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorShips/T2/corcarry2.lua
+++ b/units/CorShips/T2/corcarry2.lua
@@ -54,6 +54,9 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "corships/t2",
 			techlevel = 2,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorShips/T2/corsentinel.lua
+++ b/units/CorShips/T2/corsentinel.lua
@@ -45,6 +45,9 @@ return {
 			normaltex = "unittextures/Cor_normal.dds",
 			subfolder = "corships/t2",
 			techlevel = 2,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Defenses/legdefcarryt1.lua
+++ b/units/Legion/Defenses/legdefcarryt1.lua
@@ -45,6 +45,9 @@ return {
 			removewait = true,
 			subfolder = "corbuildings/landdefenceoffence",
 			legacyname = "Gaat Gun",
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -126,6 +126,7 @@ return {
 			workertimeboost = 6,
 			wtboostunittype = "MOBILE",
 			stockpileLimit = 4,
+			inheritxratemultiplier = 0.01
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -126,7 +126,9 @@ return {
 			workertimeboost = 6,
 			wtboostunittype = "MOBILE",
 			stockpileLimit = 4,
-			inheritxratemultiplier = 1
+			inheritxpratemultiplier = 0.5,
+			childreninheritxp = "DRONE BOTCANNON",
+			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -126,7 +126,7 @@ return {
 			workertimeboost = 6,
 			wtboostunittype = "MOBILE",
 			stockpileLimit = 4,
-			inheritxratemultiplier = 0.01
+			inheritxratemultiplier = 1
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl5.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl5.lua
@@ -127,7 +127,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
-			
+			inheritxratemultiplier = 0.01
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl5.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl5.lua
@@ -127,7 +127,9 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
-			inheritxratemultiplier = 0.01
+			inheritxpratemultiplier = 0.5,
+			childreninheritxp = "DRONE BOTCANNON",
+			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl6.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl6.lua
@@ -127,6 +127,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
+			inheritxratemultiplier = 0.01
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl6.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl6.lua
@@ -127,7 +127,9 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
-			inheritxratemultiplier = 0.01
+			inheritxpratemultiplier = 0.5,
+			childreninheritxp = "DRONE BOTCANNON",
+			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl7.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl7.lua
@@ -130,6 +130,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
+			inheritxratemultiplier = 0.01
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl7.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl7.lua
@@ -130,7 +130,9 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
-			inheritxratemultiplier = 0.01
+			inheritxpratemultiplier = 0.5,
+			childreninheritxp = "DRONE BOTCANNON",
+			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl8.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl8.lua
@@ -130,6 +130,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 210,
 			combatradius = 500,
+			inheritxratemultiplier = 0.01
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl8.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl8.lua
@@ -130,7 +130,9 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 210,
 			combatradius = 500,
-			inheritxratemultiplier = 0.01
+			inheritxpratemultiplier = 0.5,
+			childreninheritxp = "DRONE BOTCANNON",
+			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl9.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl9.lua
@@ -131,7 +131,9 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
-			inheritxratemultiplier = 0.01
+			inheritxpratemultiplier = 0.5,
+			childreninheritxp = "DRONE BOTCANNON",
+			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl9.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl9.lua
@@ -131,6 +131,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 500,
+			inheritxratemultiplier = 0.01
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/T2 Vehicles/legvcarry.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legvcarry.lua
@@ -49,6 +49,7 @@ return {
 			subfolder = "armvehicles",
 			weapon1turretx = 45,
 			weapon1turrety = 80,
+			inheritxratemultiplier = 0.05834 -- Calculated as: Drone:MetalCost+(EnergyCost/60))/Carrier:Metalcost+(EnergyCost/60)
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/T2 Vehicles/legvcarry.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legvcarry.lua
@@ -49,7 +49,9 @@ return {
 			subfolder = "armvehicles",
 			weapon1turretx = 45,
 			weapon1turrety = 80,
-			inheritxratemultiplier = 0.05834 -- Calculated as: Drone:MetalCost+(EnergyCost/60))/Carrier:Metalcost+(EnergyCost/60)
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Air/cordronecarryair.lua
+++ b/units/Scavengers/Air/cordronecarryair.lua
@@ -51,6 +51,9 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "scavengers/air",
 			techlevel = 3,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Buildings/DefenseOffense/armbotrail.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/armbotrail.lua
@@ -42,6 +42,9 @@ return {
 			--removewait = true,
 			subfolder = "armbuildings/landdefenceoffence",
 			techlevel = 2,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "BOTCANNON",
+			parentsinheritxp = "BOTCANNON",
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Vehicles/armdronecarryland.lua
+++ b/units/Scavengers/Vehicles/armdronecarryland.lua
@@ -48,6 +48,9 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "scavengers/vehicles",
 			techlevel = 3,
+			inheritxpratemultiplier = 1,
+			childreninheritxp = "DRONE",
+			parentsinheritxp = "DRONE",
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
UPDATED: https://www.youtube.com/watch?v=S_kK-8Qt6FE this shows the gadget in action.

I cleaned up workertime_boost gadget I wrote a little bit. It works as it used to.

By adding these customparams to a unitdef, units that it builds be they drones, botcannon(pawnlauncher), or conventionally built will share XP with the parent as though the parent itself was doing the fighting. The relative power level math is handled within the gadget. here are the defs:

			inheritxpratemultiplier = 1,
			This is a multiplier value that modifies how much XP should be inherited by parent from child. 1 means 1-1 ratio. .5 means half, 1.5 means 150% etc. This is a balancing tool if a unit under/over performs. 1 is the default.

			childreninheritxp = "MOBILEBUILT DRONE BOTCANNON",
                       This defines what children types that start upon creation with their parent's current XP. This allows drone carriers to have more powerful drones if the parent has gained XP.

			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
                        This defines what children types give XP to the parent at the inheritxpratemultiplier defined rate.

This is useful to balance EvoCom legion commanders who don't gain XP if they're played as intended - sitting back and building units on the frontline. Not direct confrontation. It also helps Drones gain health and damage potential and better drones as they gain XP. This also makes Botcannons potentially really, really busted.

Thanks to Xehrath for being my training wheels on this one. This wouldn't exist without him.

TESTING:

Enable Legion Faction and Extra Units Pack and Spawn legcomlvl4-10 using console commands. legcomlvl4 should not have boosted buildtime on mobile units nor inherit XP from children when Evolving Commanders is disabled. When enabled, it does. level 5-10 should have both of these features active whether EvoCom modoption is enabled or not.  Test also anything that spawns drones, I believe I added the appropriate unitDefs to all of them. They should gain XP from their children and the children they make should start with the parent's amount of XP.

EDIT EXTRA:
I had to rewrite the gadget to work on frame callin because I was getting anomolous results with XP gained callin. I believe it ended up being more efficient to execute this way anyways because the XP callins happened more frequently than every 30 frames I think.

