### PR TITLE
[Fix] Gridmenu, don't show tooltip for hidden buttons

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2095,7 +2095,7 @@ local function handleButtonHover()
 				end
 			end
 
-			if builderIsFactory and not labBuildModeActive then
+			if builderIsFactory and (useLabBuildMode and not labBuildModeActive) then
 				-- build mode button
 				if labBuildModeRect and labBuildModeRect:contains(x, y) then
 					hoveredButton = labBuildModeRect:getId()


### PR DESCRIPTION
### Work done
Factory build mode tooltip was showing when that feature was disabled, now it doesn't
