### PR TITLE
Pregame Build Bugfixes

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -457,6 +457,18 @@ function widget:DrawWorld()
 		end
 	end
 
+	if startDefID == UnitDefNames["armcom"].id then
+		if corToArm[selBuildQueueDefID] ~= nil then
+			selBuildData[1] = corToArm[selBuildQueueDefID]
+			selBuildQueueDefID = corToArm[selBuildQueueDefID]
+		end
+	elseif startDefID == UnitDefNames["corcom"].id then
+		if armToCor[selBuildQueueDefID] ~= nil then
+			selBuildData[1] = armToCor[selBuildQueueDefID]
+			selBuildQueueDefID = armToCor[selBuildQueueDefID]
+		end
+	end
+
 	-- Draw all the buildings
 	local queueLineVerts = startChosen and { { v = { sx, sy, sz } } } or {}
 	for b = 1, #buildQueue do

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -193,7 +193,14 @@ function widget:Initialize()
 		return selBuildQueueDefID
 	end
 	WG['pregame-build'].setPreGamestartDefID = function(value)
-		setPreGamestartDefID(value)
+		local inBuildOptions = {}
+		for _, opt in ipairs(UnitDefs[startDefID].buildOptions) do
+			inBuildOptions[opt] = true
+		end
+
+		if inBuildOptions[value] then
+			setPreGamestartDefID(value)
+		end
 	end
 
 	WG['pregame-build'].setBuildQueue = function(value)


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
1. Only buildable units can be selected now, so that no other units can get added to the queue with context select(for example before this change, when having a vehicle plant and then hovering it in water, an amphibious lab would get selected, which isn't a build option for the commander)
2. When switching the faction, the selected unit to build will now also change the faction.

