### PR TITLE
[Controls] Add back default_keys files to allow keyload imports to contine to work

### DIFF
--- a/luaui/configs/hotkeys/default_keys.txt
+++ b/luaui/configs/hotkeys/default_keys.txt
@@ -1,0 +1,4 @@
+// This is a placeholder file to ease the transition to grid as default
+// lots of custom hotkey setups got broken by this namechange.
+// TODO: After 1 year (may 2025) delete these
+keyload luaui/configs/hotkeys/legacy_keys.txt

--- a/luaui/configs/hotkeys/default_keys_60pct.txt
+++ b/luaui/configs/hotkeys/default_keys_60pct.txt
@@ -1,0 +1,4 @@
+// This is a placeholder file to ease the transition to grid as default
+// lots of custom hotkey setups got broken by this namechange.
+// TODO: After 1 year (may 2025) delete these
+keyload luaui/configs/hotkeys/legacy_keys_60pct.txt


### PR DESCRIPTION
### Work done
Default hotkey files were renamed to legacy. For people who use built in presets, this rename did not matter, but for people who imported those files, it means their custom hotkeys do not work. This puts back those files with a keyload pointing to legacy key files to keep them maintainable.
