### PR TITLE
[Fix] Properly cancel pregame build options with right-click

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -200,6 +200,8 @@ function widget:Initialize()
 
 		if inBuildOptions[value] then
 			setPreGamestartDefID(value)
+		else
+			setPreGamestartDefID(nil)
 		end
 	end
 


### PR DESCRIPTION
### Work done
Allow `setPreGamestartDefID` to be called with nil, as a way of clearing the active pregame blueprint.