### PR TITLE
[Tests] Update pregame test to check for active blueprint

### DIFF
--- a/luaui/Widgets/Tests/mex-building/pregame_mex_queue.lua
+++ b/luaui/Widgets/Tests/mex-building/pregame_mex_queue.lua
@@ -6,10 +6,10 @@ end
 function setup()
 	Test.clearMap()
 
-	widget_cmd_extractor_snap = widgetHandler:FindWidget("Extractor Snap (mex/geo)")
+	local widget_cmd_extractor_snap = widgetHandler:FindWidget("Extractor Snap (mex/geo)")
 	assert(widget_cmd_extractor_snap)
 
-	widget_gui_pregame_build = widgetHandler:FindWidget("Pregame Queue")
+	local widget_gui_pregame_build = widgetHandler:FindWidget("Pregame Queue")
 	assert(widget_gui_pregame_build)
 
 	WG['pregame-build'].setBuildQueue({})
@@ -34,13 +34,14 @@ function cleanup()
 	Spring.SetCameraState(initialCameraState)
 end
 
+-- tests both pregame mex snap behavior, as well as basic queue and blueprint handling
 function test()
-	mexUnitDefId = UnitDefNames["armmex"].id
-	metalSpots = WG['resource_spot_finder'].metalSpotsList
+	local mexUnitDefId = UnitDefNames["armmex"].id
+	local metalSpots = WG['resource_spot_finder'].metalSpotsList
 
-	midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
-	targetMex = nil
-	targetMexDistance = 1e20
+	local midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local targetMex = nil
+	local targetMexDistance = 1e20
 	for i = 1, #metalSpots do
 		local distance2 = math.distance2dSquared(midX, midZ, metalSpots[i].x, metalSpots[i].z)
 		if distance2 < targetMexDistance then
@@ -51,7 +52,9 @@ function test()
 
 	-- Place a mex off of a mex spot - expect mex snap to position it on the spot, as close as possible to cursor position
 	WG["pregame-build"].setPreGamestartDefID(mexUnitDefId)
-	sx, sy, sz = Spring.WorldToScreenCoords(targetMex.x - 200, targetMex.y, targetMex.z - 200)
+	local activeBlueprint = WG["pregame-build"].getPreGameDefID()
+	assert(activeBlueprint == mexUnitDefId, "Active blueprint should be armmex")
+	local sx, sy, sz = Spring.WorldToScreenCoords(targetMex.x - 200, targetMex.y, targetMex.z - 200)
 	Spring.WarpMouse(sx, sy)
 
 	-- wait for widgets to respond
@@ -68,7 +71,7 @@ function test()
 		targetMex.z
 	) < 100)
 
-	snappedPosition = table.copy(WG.ExtractorSnap.position)
+	local snappedPosition = table.copy(WG.ExtractorSnap.position)
 
 	-- queue the mex build
 	Script.LuaUI.MousePress(sx, sy, 1)
@@ -98,8 +101,10 @@ function test()
 
 	-- clear blueprint
 	WG["pregame-build"].setPreGamestartDefID(nil)
+	activeBlueprint = WG["pregame-build"].getPreGameDefID()
+	assert(activeBlueprint == nil, "Active blueprint should be nil")
 
 	-- Did the mex get de-queued?
-	buildQueue = WG['pregame-build'].getBuildQueue()
+	local buildQueue = WG['pregame-build'].getBuildQueue()
 	assert(#buildQueue == 0, "Build queue should be empty")
 end


### PR DESCRIPTION
### Work done
Pregame test will now check if setting and unsetting active blueprints works as intended. Prompted by a regression to this behavior.