### PR TITLE
Juno rework

### DIFF
--- a/luarules/gadgets/unit_juno_damage.lua
+++ b/luarules/gadgets/unit_juno_damage.lua
@@ -7,7 +7,7 @@ function gadget:GetInfo()
 		date = '05/2013',
 		license = 'GNU GPL, v2 or later',
 		layer = 0,
-		enabled = true
+		enabled = not Spring.GetModOptions().junorework
 	}
 end
 
@@ -46,6 +46,14 @@ if gadgetHandler:IsSyncedCode() then
 		['corspec'] = true,
 		['corvoyr'] = true,
 		['corvrad'] = true,
+		
+		['armmine1'] = true,
+		['armmine2'] = true,
+		['armmine3'] = true,
+		['cormine1'] = true,
+		['cormine2'] = true,
+		['cormine3'] = true,		
+		['cormine4'] = true,		
 
 		['corfav'] = true,
 		['armfav'] = true,

--- a/luarules/gadgets/unit_juno_rework_damage.lua
+++ b/luarules/gadgets/unit_juno_rework_damage.lua
@@ -1,0 +1,346 @@
+function gadget:GetInfo()
+	return {
+		name = 'Juno Rework Damage',
+		desc = 'Handles Juno damage',
+		author = 'Niobium, Bluestone, Hornet',
+		version = 'v3.0',
+		date = '05/2013',--rework 05/05/2024
+		license = 'GNU GPL, v2 or later',
+		layer = 0,
+		enabled = Spring.GetModOptions().junorework
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if gadgetHandler:IsSyncedCode() then
+
+
+
+--hornet todo;
+--deploy to juno_mini_damage when mechanics sorted
+--tarpit pawns & grunts while in the lingering damage area? 50% emp charge on initial, mild per X frame tick thereafter?
+
+---edited clone of old juno code
+
+	----------------------------------------------------------------
+	-- Config
+	----------------------------------------------------------------
+
+
+local tokillUnitsNames = {
+		['corfav'] = true,
+		['armfav'] = true,
+		['armflea'] = true,
+		['raptor_land_swarmer_brood_t2_v1'] = true,
+		['raptor_land_kamikaze_basic_t2_v1'] = true,
+		['raptor_land_kamikaze_emp_t2_v1'] = true,
+		['raptor_land_kamikaze_basic_t4_v1'] = true,
+		['raptor_land_kamikaze_emp_t4_v1'] = true,
+}
+
+--emp these
+local toStunUnitsNames = {
+		['armarad'] = true,
+		['armaser'] = true,
+		['armason'] = true,
+		['armfrad'] = true,
+		['armjam'] = true,
+		['armjamt'] = true,
+		['armmark'] = true,
+		['armrad'] = true,
+		['armseer'] = true,
+		['armsjam'] = true,
+		['armsonar'] = true,
+		['armveil'] = true,
+		['corarad'] = true,
+		['corason'] = true,
+		['coreter'] = true,
+		['corfrad'] = true,
+		['corjamt'] = true,
+		['corrad'] = true,
+		['corshroud'] = true,
+		['corsjam'] = true,
+		['corsonar'] = true,
+		['corspec'] = true,
+		['corvoyr'] = true,
+		['corvrad'] = true,
+
+		['coreyes'] = true,
+		['armeyes'] = true,
+		['armmine1'] = true,
+		['armmine2'] = true,
+		['armmine3'] = true,
+		['cormine1'] = true,
+		['cormine2'] = true,
+		['cormine3'] = true,
+}
+
+
+local stunDuration = Spring.GetModOptions().emprework and 30 or 20
+--hornet todo, might leave this to be decided by EMP settings and just max it out?
+
+
+local toTarpitUnitsNames = {
+	['corak'] = true,
+	['armpw'] = true,
+	['leggob'] = true,
+}
+
+local todenyUnitsNames = {
+	['corfav'] = true,
+	['armfav'] = true,
+	['armflea'] = true,
+	['raptor_land_swarmer_brood_t2_v1'] = true,
+	['raptor_land_kamikaze_basic_t2_v1'] = true,
+	['raptor_land_kamikaze_emp_t2_v1'] = true,
+	['raptor_land_kamikaze_basic_t4_v1'] = true,
+	['raptor_land_kamikaze_emp_t4_v1'] = true,
+}
+
+
+	-- convert unitname -> unitDefID
+	local tokillUnits = {}
+	for name, params in pairs(tokillUnitsNames) do
+		if UnitDefNames[name] then
+			tokillUnits[UnitDefNames[name].id] = params
+		end
+	end
+	tokillUnitsNames = nil
+	-- convert unitname -> unitDefID
+	local todenyUnits = {}
+	for name, params in pairs(todenyUnitsNames) do
+		if UnitDefNames[name] then
+			todenyUnits[UnitDefNames[name].id] = params
+		end
+	end
+	todenyUnitsNames = nil
+	-- convert unitname -> unitDefID
+	local toStunUnits = {}
+	for name, params in pairs(toStunUnitsNames) do
+		if UnitDefNames[name] then
+			toStunUnits[UnitDefNames[name].id] = params
+		end
+	end
+	toStunUnitsNames = nil
+
+	local toTarpitUnits = {}
+	for name, params in pairs(toTarpitUnitsNames) do
+		if UnitDefNames[name] then
+			toTarpitUnits[UnitDefNames[name].id] = params
+		end
+	end
+	toTarpitUnitsNames = nil
+
+
+
+
+	for udid, ud in pairs(UnitDefs) do
+		for id, v in pairs(tokillUnits) do
+			if string.find("_scav", ud.name) and string.sub(UnitDefs[id].name, 1, -5) == ud.name then
+			--if string.find(ud.name, UnitDefs[id].name) then
+				tokillUnits[udid] = v
+			end
+		end
+		for id, v in pairs(todenyUnits) do
+			if string.find("_scav", ud.name) and string.sub(UnitDefs[id].name, 1, -5) == ud.name then
+			--if string.find(ud.name, UnitDefs[id].name) then
+				todenyUnits[udid] = v
+			end
+		end
+		for id, v in pairs(toStunUnits) do
+			if string.find("_scav", ud.name) and string.sub(UnitDefs[id].name, 1, -5) == ud.name then
+			--if string.find(ud.name, UnitDefs[id].name) then
+				toStunUnits[udid] = v
+			end
+		end
+
+	end
+
+
+	--config -- see also in unsynced
+	local radius = 450 --outer radius of area denial ring
+	local width = 30 --width of area denial ring
+	local effectlength = 30 --how long area denial lasts, in seconds
+	local fadetime = 2 --how long fade in/out effect lasts, in seconds
+
+	--locals
+	local SpGetGameSeconds = Spring.GetGameSeconds
+	local SpGetUnitsInCylinder = Spring.GetUnitsInCylinder
+	local SpDestroyUnit = Spring.DestroyUnit
+	local SpGetUnitDefID = Spring.GetUnitDefID
+	local SpValidUnitID = Spring.ValidUnitID
+	local Mmin = math.min
+
+
+	-- kill appropriate things from initial juno blast --
+
+	local junoWeaponsNames = {
+		["armjuno_juno_pulse"] = true,
+		["corjuno_juno_pulse"] = true,
+		["armjuno_scav_juno_pulse"] = true,
+		["corjuno_scav_juno_pulse"] = true,
+	}
+	-- convert unitname -> unitDefID
+	local junoWeapons = {}
+	for name, params in pairs(junoWeaponsNames) do
+		if WeaponDefNames[name] then
+			junoWeapons[WeaponDefNames[name].id] = params
+		end
+	end
+	junoWeaponsNames = nil
+
+	function gadget:UnitDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, projID, aID, aDefID, aTeam)
+
+		
+		--[
+		if junoWeapons[weaponID] and toTarpitUnits[uDefID] and aID~=99 then
+			if uID and SpValidUnitID(uID) then
+				local px, py, pz = Spring.GetUnitPosition(uID)
+				if px then
+					Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
+				end
+				
+				local health, maxHealth, paralyzeDamage, capture, build = Spring.GetUnitHealth(uID)
+				Spring.AddUnitDamage (uID, maxHealth/2, 5, 99, aDefID)
+			end
+		end--]]--
+			
+
+		if junoWeapons[weaponID] and toStunUnits[uDefID] and aID~=99 then
+			if uID and SpValidUnitID(uID) then
+				local px, py, pz = Spring.GetUnitPosition(uID)
+				if px then
+					Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
+				end
+				
+				local health, maxHealth, paralyzeDamage, capture, build = Spring.GetUnitHealth(aID)
+				--hornetjuno
+				Spring.AddUnitDamage (uID, maxHealth+1, stunDuration, 0, weaponID)
+				--Spring.Echo('hornet testing')
+				--Spring.Echo(uID)
+				--Spring.Echo(maxHealth)
+				--Spring.Echo(paralyzeDamage)
+				
+				--aID check removed as -probably- only useful for kill crediting?
+
+			end
+		end
+	
+		if junoWeapons[weaponID] and tokillUnits[uDefID] then
+			if uID and SpValidUnitID(uID) then
+				local px, py, pz = Spring.GetUnitPosition(uID)
+				if px then
+					Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
+				end
+				if aID and SpValidUnitID(aID) then
+					SpDestroyUnit(uID, false, false, aID)
+				else
+					SpDestroyUnit(uID, false, false) -- leavewreck, makeselfdexplosion
+				end
+			end
+		end
+	end
+
+	-- area denial --
+	local centers = {} --table of where juno missiles hit etc
+	local counter = 1 --index each explosion of juno missile with this counter
+
+	function gadget:Initialize()
+		if WeaponDefNames.armjuno_juno_pulse then
+			Script.SetWatchExplosion(WeaponDefNames.armjuno_juno_pulse.id, true)
+		end
+		if WeaponDefNames.corjuno_juno_pulse then
+			Script.SetWatchExplosion(WeaponDefNames.corjuno_juno_pulse.id, true)
+		end
+	end
+
+	function gadget:Explosion(weaponID, px, py, pz, ownerID)
+		if junoWeapons[weaponID] then
+			local curtime = SpGetGameSeconds()
+			local junoExpl = { x = px, y = py, z = pz, t = curtime, o = ownerID }
+			centers[counter] = junoExpl
+			--SendToUnsynced("AddToCenters", counter, px, py, pz, curtime)
+			counter = counter + 1
+		end
+	end
+
+	local lastupdate = -1
+	local updatespersec = 30
+	local updategrain = 1 / updatespersec
+	local update = true
+
+	function gadget:GameFrame(frame)
+		--if frame == 10 then
+		--seems that SendToUnsynced has to happen after
+		--SendToUnsynced("RecieveConstants", width, radius, effectlength, fadetime)
+		--end
+
+		local curtime = SpGetGameSeconds()
+
+		for counter, expl in pairs(centers) do
+			if expl.t >= curtime - effectlength then
+				local q = 1
+				if expl.t + effectlength - fadetime <= curtime and curtime <= expl.t + effectlength then
+					q = (1 / fadetime) * Mmin(curtime - expl.t, expl.t + effectlength - curtime)
+				end
+
+				local unitIDsBig = SpGetUnitsInCylinder(expl.x, expl.z, q * radius)
+
+				for i = 1, #unitIDsBig do
+					-- linear and not O(n^2)
+					local unitID = unitIDsBig[i]
+					local unitDefID = SpGetUnitDefID(unitID)
+					if todenyUnits[unitDefID] then
+						local px, py, pz = Spring.GetUnitPosition(unitID)
+						local dx = expl.x - px
+						local dz = expl.z - pz
+						if (dx * dx + dz * dz) > (q * (radius - width)) * (q * (radius - width)) then
+							-- linear and not O(n^2)
+							Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
+							SpDestroyUnit(unitID, true, false)
+						end
+					end
+					--[
+					--this mostly works but has some weirdness at the end, applying a 'double tap'
+					if toTarpitUnits[unitDefID] and Spring.GetModOptions().emprework then--useless without it, just adds visual noise
+						local px, py, pz = Spring.GetUnitPosition(unitID)
+						local dx = expl.x - px
+						local dz = expl.z - pz
+						if (dx * dx + dz * dz) > (q * (radius - width)) * (q * (radius - width)) then
+							-- linear and not O(n^2)
+							Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
+							local health, maxHealth, paralyzeDamage, capture, build = Spring.GetUnitHealth(unitID)
+							Spring.AddUnitDamage (unitID, maxHealth*2, 5, 99, WeaponDefNames["corjuno_juno_pulse"].id)---...close enough?
+						end
+					end--]]--
+				end
+			else
+				--SendToUnsynced("RemoveFromCenters", counter)
+				table.remove(centers, counter)
+			end
+
+			if expl.t + fadetime >= curtime or expl.t + effectlength - fadetime <= curtime and curtime <= expl.t + effectlength then
+				update = true -- fast update during fade in/out
+			end
+		end
+
+		if #centers ~= 0 and curtime - lastupdate > 1 then
+			--slow update (to re-match ground in unsync)
+			update = true
+		end
+
+		if update == true and curtime - lastupdate > updategrain then
+			lastupdate = curtime
+			--SendToUnsynced("UpdateList", curtime)
+			update = false
+		end
+	end
+
+
+
+
+
+end
+

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1159,6 +1159,15 @@ local options = {
     },
 
     {
+        key 	= "junorework",
+        name 	= "Juno Rework",
+        desc 	= "Juno stuns certain units (such as radars and jammers) rather than magically deleting them",
+        type 	= "bool",
+        section = "options_experimental",
+        def 	= false,
+    },
+
+    {
         key 	= "air_rework",
         name 	= "Air Rework",
         desc 	= "Prototype version with more maneuverable, slower air units and more differentiation between them.",

--- a/units/ArmBuildings/LandDefenceOffence/armjuno.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armjuno.lua
@@ -148,7 +148,7 @@ return {
 				},
 				damage = {
 					default = 1,
-					mines = 1000,
+					mines = 1,
 				},
 			},
 		},

--- a/units/CorBuildings/LandDefenceOffence/corjuno.lua
+++ b/units/CorBuildings/LandDefenceOffence/corjuno.lua
@@ -148,7 +148,7 @@ return {
 				},
 				damage = {
 					default = 1,
-					mines = 1000,
+					mines = 1,
 				},
 			},
 		},


### PR DESCRIPTION
### Work done
Added a modoption for alternate Juno behaviour, wherein some units are stunned (and decloaked if applicable) rather than free deleted. Scoutspam still killed on impact and after.

#### Test steps
Verify alternate behaviour with mod enabled
Confirm vanilla behaviour with it disabled