### PR TITLE
Make all commanders uncapturable

### DIFF
--- a/units/ArmBots/T2/armdecom.lua
+++ b/units/ArmBots/T2/armdecom.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		candgun = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 900,
 		category = "ALL WEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 30,

--- a/units/CorBots/T2/cordecom.lua
+++ b/units/CorBots/T2/cordecom.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		candgun = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 900,
 		category = "ALL WEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 30,

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Legion EvoCom/legcomlvl5.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl5.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Legion EvoCom/legcomlvl6.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl6.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Legion EvoCom/legcomlvl7.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl7.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Legion EvoCom/legcomlvl8.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl8.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Legion EvoCom/legcomlvl9.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl9.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Other/Commanders/legcomecon.lua
+++ b/units/Legion/Other/Commanders/legcomecon.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/Other/Commanders/legcomoff.lua
+++ b/units/Legion/Other/Commanders/legcomoff.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/Other/Commanders/legcomt2com.lua
+++ b/units/Legion/Other/Commanders/legcomt2com.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Legion/Other/Commanders/legcomt2def.lua
+++ b/units/Legion/Other/Commanders/legcomt2def.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/Other/Commanders/legcomt2off.lua
+++ b/units/Legion/Other/Commanders/legcomt2off.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/legcomlvl2.lua
+++ b/units/Legion/legcomlvl2.lua
@@ -13,6 +13,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 2100,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/legcomlvl3.lua
+++ b/units/Legion/legcomlvl3.lua
@@ -14,6 +14,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 3 0",

--- a/units/Legion/legcomlvl4.lua
+++ b/units/Legion/legcomlvl4.lua
@@ -14,6 +14,7 @@ return {
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 4 0",

--- a/units/Scavengers/Boss/armcomboss.lua
+++ b/units/Scavengers/Boss/armcomboss.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canresurrect = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 6000,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		--cloakcost = 200,

--- a/units/Scavengers/Boss/armscavengerbossv2.lua
+++ b/units/Scavengers/Boss/armscavengerbossv2.lua
@@ -64,6 +64,7 @@ for difficulty, stats in pairs(difficultyParams) do
 		cancapture = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		collisionvolumeoffsets = "0 12 0",

--- a/units/Scavengers/Boss/corcomboss.lua
+++ b/units/Scavengers/Boss/corcomboss.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canresurrect = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 6000,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		--cloakcost = 200,

--- a/units/armcom.lua
+++ b/units/armcom.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/armcomcon.lua
+++ b/units/armcomcon.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/corcom.lua
+++ b/units/corcom.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/corcomcon.lua
+++ b/units/corcomcon.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/other/evocom/armcomlvl10.lua
+++ b/units/other/evocom/armcomlvl10.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl2.lua
+++ b/units/other/evocom/armcomlvl2.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/other/evocom/armcomlvl3.lua
+++ b/units/other/evocom/armcomlvl3.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl4.lua
+++ b/units/other/evocom/armcomlvl4.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl5.lua
+++ b/units/other/evocom/armcomlvl5.lua
@@ -15,6 +15,7 @@ return {
 		canselfrepair = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl6.lua
+++ b/units/other/evocom/armcomlvl6.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl7.lua
+++ b/units/other/evocom/armcomlvl7.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl8.lua
+++ b/units/other/evocom/armcomlvl8.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/armcomlvl9.lua
+++ b/units/other/evocom/armcomlvl9.lua
@@ -15,6 +15,7 @@ return {
 		canmanualfire = true,
 		canmove = true,
 		canselfrepair = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON NOTSUB COMMANDER NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 25,

--- a/units/other/evocom/corcomlvl10.lua
+++ b/units/other/evocom/corcomlvl10.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 600,

--- a/units/other/evocom/corcomlvl2.lua
+++ b/units/other/evocom/corcomlvl2.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/other/evocom/corcomlvl3.lua
+++ b/units/other/evocom/corcomlvl3.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 100,

--- a/units/other/evocom/corcomlvl4.lua
+++ b/units/other/evocom/corcomlvl4.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 125,

--- a/units/other/evocom/corcomlvl5.lua
+++ b/units/other/evocom/corcomlvl5.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 200,

--- a/units/other/evocom/corcomlvl6.lua
+++ b/units/other/evocom/corcomlvl6.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 250,

--- a/units/other/evocom/corcomlvl7.lua
+++ b/units/other/evocom/corcomlvl7.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 300,

--- a/units/other/evocom/corcomlvl8.lua
+++ b/units/other/evocom/corcomlvl8.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 380,

--- a/units/other/evocom/corcomlvl9.lua
+++ b/units/other/evocom/corcomlvl9.lua
@@ -14,6 +14,7 @@ return {
 		cancloak = true,
 		canmanualfire = true,
 		canmove = true,
+		capturable = false,
 		capturespeed = 1800,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 475,


### PR DESCRIPTION
Watch the Fort asked me to make this PR to make commanders and commander variants uncapturable. 

There are uncommon cases where commanders are captured which isn't desirable. An example is the Scavenger Boss capturing a Commander instead of killing it.

Also, Decoy Commanders are rendered uncapturable at the discretion of Watch the Fort. I assume because otherwise you could just "capture" a group of decoys with a commander in their midst and the one you can't capture is the real deal. So. It's affected too.

What isn't affected are the scavenger bosses. They remain capturable until I'm told otherwise.