### PR TITLE
Accomodate changing armor types in unit stats GUI

### DIFF
--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -113,6 +113,12 @@ local GL_ONE = GL.ONE
 
 local hideBuildlist
 
+-- Reverse armor type table
+local armorIndex = {}
+for ii = 1, #Game.armorTypes do
+	armorIndex[Game.armorTypes[ii]] = ii
+end
+
 local function round(value, numDecimalPlaces)
 	if value then
 		return string.format("%0." .. numDecimalPlaces .. "f", math.round(value, numDecimalPlaces))
@@ -338,7 +344,7 @@ local function refreshUnitInfo()
 						elseif weaponDef.customParams and weaponDef.customParams.cluster then -- Bullets that shoot other, smaller bullets
 							calculateClusterDPS(weaponDef, weaponDef.damages[0])
 						elseif weapons[i].onlyTargets['vtol'] ~= nil then
-							calculateWeaponDPS(weaponDef, weaponDef.damages[14]	) --Damage to air category
+							calculateWeaponDPS(weaponDef, weaponDef.damages[armorIndex.vtol]) --Damage to air category
 						else
 							calculateWeaponDPS(weaponDef, weaponDef.damages[0]) --Damage to default armor category
 						end
@@ -393,7 +399,7 @@ local function refreshUnitInfo()
 					local defDmg
 
 					if weapons[1].onlyTargets['vtol'] ~= nil then	--if main weapon isn't dedicated aa, then all weapons calculate using default armor category
-						defDmg = weaponDef.damages[14]
+						defDmg = weaponDef.damages[armorIndex.vtol]
 					else
 						defDmg = weaponDef.damages[0]
 					end
@@ -426,7 +432,7 @@ local function refreshUnitInfo()
 					local defDmg
 
 					if weapons[1].onlyTargets['vtol'] ~= nil then	--if main weapon isn't dedicated aa, then all weapons calculate using default armor category
-						defDmg = weaponDef.damages[14]
+						defDmg = weaponDef.damages[armorIndex.vtol]
 					else
 						defDmg = weaponDef.damages[0]
 					end

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -177,6 +177,12 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
+-- Reverse armor type table
+local armorTypes = {}
+for ii = 1, #Game.armorTypes do
+	armorTypes[Game.armorTypes[ii]] = ii
+end
+
 ------------------------------------------------------------------------------------
 -- Functions
 ------------------------------------------------------------------------------------
@@ -575,29 +581,30 @@ local function drawStats(uDefID, uID)
 		local uWep = wDefs[wDefId]
 
 		-- Handle projectiles that spawn additional projectiles.
-		-- Many properties have nothing to do with the spawned projectile:
+		-- Many properties (might) have nothing to do with the spawned projectile:
 		local burst = uWep.salvoSize * uWep.projectiles
-		local defaultDamage = uWep.damages[0] > uWep.damages[14] and uWep.damages[0] or uWep.damages[14]
 		local range = uWep.range
 		local reload = uWep.reload
 		local accuracy = uWep.accuracy
 		local moveError = uWep.targetMoveError
+		local defaultDamage = uWep.damages[0]
+		if defaultDamage < uWep.damages[armorTypes.vtol] then
+			defaultDamage = uWep.damages[armorTypes.vtol]
+		end
 		if uWep.customParams then
-			if uWep.customParams.def and uWep.customParams.speceffect == "split" then
-				burst = burst * (uWep.customParams.number or 1)
-				uWep = WeaponDefNames[uWep.customParams.def] or uWep
-				defaultDamage = uWep.damages[0] > uWep.damages[14] and uWep.damages[0] or uWep.damages[14]
-			end
-			if uWep.customParams.cluster then
-				local munition = uWep.customParams.def    or uDef.name .. '_' .. 'cluster_munition'
-				local cmNumber = uWep.customParams.number or 5 -- note: keep in sync with cluster defaults
-				local cmDamage = WeaponDefNames[munition].damages[0]
-				defaultDamage = defaultDamage + cmDamage * cmNumber
-			end
 			if uWep.customParams.spark_basedamage then
 				local spDamage = uWep.customParams.spark_basedamage * uWep.customParams.spark_forkdamage
 				local spCount = uWep.customParams.spark_maxunits
 				defaultDamage = defaultDamage + spDamage * spCount
+			elseif uWep.customParams.speceffect == "split" then
+				burst = burst * (uWep.customParams.number or 1)
+				uWep = WeaponDefNames[uWep.customParams.def] or uWep
+				defaultDamage = uWep.damages[0]
+			elseif uWep.customParams.cluster then
+				local munition = uWep.customParams.def    or uDef.name .. '_' .. 'cluster_munition'
+				local cmNumber = uWep.customParams.number or 5 -- note: keep in sync with cluster defaults
+				local cmDamage = WeaponDefNames[munition].damages[0]
+				defaultDamage = defaultDamage + cmDamage * cmNumber
 			end
 		end
 


### PR DESCRIPTION
### Work done
Removed the hardcoded `damages[14]` for vtol damage in GUI. Replaced with a table of indices, eg `damages[armors.vtol]`.

This solves an issue since the evocom update which added a new armortype (probably PR#2975) named 'raptorqueen'. Array positions of armor types is alphabetical, so vtol was moved by 1. Units are displaying their damage to subs instead of to vtol since ~yesterday.