### PR TITLE
Fix Autocloak not persisting

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -5904,8 +5904,13 @@ function init()
 	local unitdefConfig = {}
 	if WG['autocloak'] ~= nil then
 		unitdefConfig = WG['autocloak'].getUnitdefConfig()
-	elseif widgetHandler.configData["autocloak"] ~= nil and widgetHandler.configData["autocloak"].unitdefConfig ~= nil then
-		unitdefConfig = widgetHandler.configData["autocloak"].unitdefConfig
+	elseif widgetHandler.configData["Auto Cloak Units"] ~= nil and widgetHandler.configData["Auto Cloak Units"].unitdefConfig ~= nil then
+		for unitName, value in pairs(widgetHandler.configData["Auto Cloak Units"].unitdefConfig) do
+			if UnitDefNames[unitName] then
+				local unitDefID = UnitDefNames[unitName].id
+				unitdefConfig[unitDefID] = value
+			end
+		end
 	end
 	unitdefConfig = table.merge(defaultUnitdefConfig, unitdefConfig)
 	if type(unitdefConfig) == 'table' then

--- a/luaui/Widgets/unit_auto_cloak.lua
+++ b/luaui/Widgets/unit_auto_cloak.lua
@@ -81,13 +81,13 @@ function widget:Initialize()
         maybeRemoveSelf()
     end
 
-    WG['autocloak'] = {}
+    --[[WG['autocloak'] = {}
 	WG['autocloak'].getUnitdefConfig = function()
 		return unitdefConfig
 	end
 	WG['autocloak'].setUnitdefConfig = function(type, value)
 		unitdefConfig[type] = value
-	end
+	end]]
 
 	local allUnits = Spring.GetAllUnits()
 	for i=1, #allUnits do
@@ -126,16 +126,25 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:GetConfigData()
+	local unitdefConfigNames = {}
+	for uDefID, params in pairs(unitdefConfig) do
+		if UnitDefs[uDefID] then
+			unitdefConfigNames[UnitDefs[uDefID].name] = params
+		end
+	end
 	return {
-		unitdefConfig = unitdefConfig,
+		unitdefConfig = unitdefConfigNames,
 	}
 end
 
 function widget:SetConfigData(cfg)
 	if cfg.unitdefConfig ~= nil then
-		for unitDefID, value in pairs(cfg.unitdefConfig) do
-			if unitdefConfig[unitDefID] ~= nil then
-				unitdefConfig[unitDefID] = value
+		for unitName, value in pairs(cfg.unitdefConfig) do
+			if UnitDefNames[unitName] then
+				local unitDefID = UnitDefNames[unitName].id
+				if unitdefConfig[unitDefID] ~= nil then
+					unitdefConfig[unitDefID] = value
+				end
 			end
 		end
 	end

--- a/luaui/Widgets/unit_auto_cloak.lua
+++ b/luaui/Widgets/unit_auto_cloak.lua
@@ -81,13 +81,13 @@ function widget:Initialize()
         maybeRemoveSelf()
     end
 
-    --[[WG['autocloak'] = {}
+    WG['autocloak'] = {}
 	WG['autocloak'].getUnitdefConfig = function()
 		return unitdefConfig
 	end
 	WG['autocloak'].setUnitdefConfig = function(type, value)
 		unitdefConfig[type] = value
-	end]]
+	end
 
 	local allUnits = Spring.GetAllUnits()
 	for i=1, #allUnits do


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Autocloak now persists reliably, by storing the unit name, not the unitDefID.



P.S. Gremlins are not autocloaked by default, but I would say there is no reason to use them except if you cloak them.