### PR TITLE
 unit_inherit_creation_xp.lua hotfix

### DIFF
--- a/luarules/gadgets/unit_inherit_creation_xp.lua
+++ b/luarules/gadgets/unit_inherit_creation_xp.lua
@@ -90,7 +90,8 @@ function gadget:GameFrame(frame)
 					local parentDefID
 					if Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id") then --estabalishes unit_carrier_spawner parenthood
 						parentID = Spring.GetUnitRulesParam(unitID, "carrier_host_unit_id")
-						if string.find(parentsInheritXP[Spring.GetUnitDefID(parentID)], "DRONE") then
+						parentDefID = Spring.GetUnitDefID(parentID)
+						if parentsInheritXP[parentDefID] ~= nil and string.find(parentsInheritXP[parentDefID], "DRONE") then
 							childrenWithParents[unitID] = {
 								unitid = unitID,
 								parentunitid = parentID,
@@ -102,7 +103,8 @@ function gadget:GameFrame(frame)
 					end
 					if Spring.GetUnitRulesParam(unitID, "parent_unit_id") then --estabalishes unit_explosion_spawner parenthood
 						parentID = Spring.GetUnitRulesParam(unitID, "parent_unit_id")
-						if string.find(parentsInheritXP[Spring.GetUnitDefID(parentID)], "BOTCANNON") then
+						parentDefID = Spring.GetUnitDefID(parentID)
+						if parentsInheritXP[parentDefID] ~= nil and string.find(parentsInheritXP[parentDefID], "BOTCANNON") then
 							childrenWithParents[unitID] = {
 								unitid = unitID,
 								parentunitid = parentID,


### PR DESCRIPTION
Received a bug report of string.find() errors from one of the values this gadget uses coming up Nil for some reason. Happened during a NuttyB game when Apex Hatchling Artillery spawned in and lobbed units. I spawned one with console commands without NuttyB with the old code and wasn't able to recreate the problem. Maybe just an issue with the mod. 

Regardless, I added a check to make sure the values used in the code aren't nil before executing nil-sensitive string.find() on them.  Should take care of this issue in weird edgecases when the unexpected occurs.
