### PR TITLE
fix(gui_building_grid_gl4): use correct water level value

### DIFF
--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -24,7 +24,7 @@ local config = {
 	lineColor = { 0.70, 1.0, 0.70 }, -- color of the lines
 }
 
-local waterLevel = Spring.GetModOptions().map_waterlevel
+local waterLevel = Spring.GetWaterPlaneLevel and Spring.GetWaterPlaneLevel() or 0
 
 local cmdShowForUnitDefID
 local isPregame = Spring.GetGameFrame() == 0 and not isSpec


### PR DESCRIPTION
This fixes the grid display when `map_waterlevel` is set (which really moves the map rather than the water, which stays at zero), and uses the proper water level engine function for when the water level might actually be non-zero in the future.