### PR TITLE
feat(locals_access): add a function to get a list of all locals

### DIFF
--- a/common/testing/locals_access.lua
+++ b/common/testing/locals_access.lua
@@ -25,16 +25,25 @@ return __locals
 
 local function generateLocalsAccessStr(localsNames)
 	local content = "\n__localsAccess = {\n"
+
 	content = content .. "  getters = {\n"
 	for _, name in ipairs(localsNames) do
 		content = content .. "    " .. name .. " = function() return " .. name .. " end,\n"
 	end
 	content = content .. "  },\n"
+
 	content = content .. "  setters = {\n"
 	for _, name in ipairs(localsNames) do
 		content = content .. "    " .. name .. " = function(__value) " .. name .. " = __value end,\n"
 	end
 	content = content .. "  },\n"
+
+	content = content .. "  getAllLocals = function() return {\n"
+	for _, name in ipairs(localsNames) do
+		content = content .. "    \"" .. name .. "\",\n"
+	end
+	content = content .. "  } end,\n"
+
 	content = content .. "}\n"
 	return content
 end


### PR DESCRIPTION
This is useful for things like profiling all functions within a widget, or otherwise inspecting the internal state of a widget when its structure isn't known ahead of time.