### PR TITLE
Heap value standardization

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -618,7 +618,11 @@ function UnitDef_Post(name, uDef)
 				uDef.featuredefs.dead.damage = uDef.health
 				if uDef.metalcost and uDef.energycost then
 					if name and not string.find(name, "_scav") then
-						uDef.featuredefs.dead.metal = math.floor(uDef.metalcost * 0.6)
+						if uDef.featuredefs.dead.category == "heaps" then
+							uDef.featuredefs.dead.metal = math.floor(uDef.metalcost * 0.25)
+						else
+							uDef.featuredefs.dead.metal = math.floor(uDef.metalcost * 0.6)
+						end
 					end
 				end
 			end


### PR DESCRIPTION
Units without a wreck, but with a heap, have had that heap be the same size as other units' wrecks (60% cost). This change makes them the same size as heaps usually (25%).

Afaik this only concerns Fiend rn.

Not 100% which way is the desired behavior, Zecrus can decide to merge or not.

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Write the steps needed to test out the changes. Include the expected result.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
