### PR TITLE
Prevent Auto Groups From Getting Reset

### DIFF
--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -328,6 +328,10 @@ function widget:Initialize()
 	if GetGameFrame() > 0 then
 		addAllUnits()
 	end
+
+	if not gotConfigData then
+		loadAutogroupDataFromOldName()
+	end
 end
 
 function widget:Shutdown()
@@ -358,10 +362,6 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	end
 
 	builtInPlace[unitID] = nil
-
-	if not gotConfigData then
-		loadAutogroupDataFromOldName()
-	end
 end
 
 function widget:GameFrame(n)


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
The autogroup widget is now renamed to `Auto Group Presets`.
This means that the old autogroup widget can't overwrite the existing settings, but the settings will be taken from the older widget's name if the new widget can't find any settings from the new name.
This makes the autogroup widget backwards-compatible, which I forgot about in the last commit, so older replays and saves can be safely used/viewed.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
