### PR TITLE
Legion Tank Tracks now animate

### DIFF
--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -261,6 +261,7 @@ do --save a ton of locals
 	local OPTION_MODELSFOG        = 1024
 	local OPTION_TREEWIND         = 2048
 	local OPTION_PBROVERRIDE      = 4096
+	local OPTION_TREADS_LEG       = 8192
 
 	local defaultBitShaderOptions = OPTION_SHADOWMAPPING + OPTION_NORMALMAPPING  + OPTION_MODELSFOG
 
@@ -275,6 +276,11 @@ do --save a ton of locals
 			baseVertexDisplacement = 0.0,
 			brightnessFactor = 1.5,
 		},
+		legunit = {
+			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_LEG + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
+			baseVertexDisplacement = 0.0,
+			brightnessFactor = 1.5,
+		},
 		armscavenger = {
 			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_ARM + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
 			baseVertexDisplacement = 0.4,
@@ -282,6 +288,11 @@ do --save a ton of locals
 		},
 		corscavenger = {
 			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_CORE + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
+			baseVertexDisplacement = 0.4,
+			brightnessFactor = 1.5,
+		},
+		legscavenger = {
+			bitOptions = defaultBitShaderOptions + OPTION_VERTEX_AO + OPTION_FLASHLIGHTS + OPTION_TREADS_LEG + OPTION_HEALTH_TEXTURING + OPTION_HEALTH_DISPLACE,
 			baseVertexDisplacement = 0.4,
 			brightnessFactor = 1.5,
 		},

--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -960,20 +960,22 @@ local function initBinsAndTextures()
 	Spring.Echo("[CUS GL4] Init Unit bins")
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		if unitDef.model then
+			local lowercasetex1 = string.lower(unitDef.model.textures.tex1 or "")
+			local lowercasetex2 = string.lower(unitDef.model.textures.tex2 or "")
+			local lowercasenormaltex = string.lower(normalTex or "")
+
+			-- bin units according to what faction's texture they use
+			local factionBinTag = lowercasetex1:sub(1,3)
+
 			objectDefToUniformBin[unitDefID] = "otherunit"
-			if unitDef.name:sub(1,3) == 'arm' then
+			if factionBinTag == 'arm' then
 				objectDefToUniformBin[unitDefID] = 'armunit'
-			elseif 	unitDef.name:sub(1,3) == 'cor' then
+			elseif factionBinTag == 'cor' then
 				objectDefToUniformBin[unitDefID] = 'corunit'
-			elseif 	unitDef.name:sub(1,6) == 'leggat' then
-				objectDefToUniformBin[unitDefID] = 'armunit'
-			elseif 	unitDef.name:sub(1,7) == 'legrail' then
-				objectDefToUniformBin[unitDefID] = 'armunit'
-			elseif 	unitDef.name:sub(1,6) == 'legstr' then
-				objectDefToUniformBin[unitDefID] = 'armunit'
-			elseif 	unitDef.name:sub(1,3) == 'leg' then
-				objectDefToUniformBin[unitDefID] = 'corunit'
+			elseif factionBinTag == 'leg' then
+				objectDefToUniformBin[unitDefID] = 'legunit'
 			end
+
 			local normalTex = GetNormal(unitDef, nil)
 			local textureTable = {
 				--%-102:0 = featureDef 102 s3o tex1
@@ -990,11 +992,6 @@ local function initBinsAndTextures()
 				[10] = noisetex3dcube,
 				--[10] = envLUT,
 			}
-
-			local lowercasetex1 = string.lower(unitDef.model.textures.tex1 or "")
-			local lowercasetex2 = string.lower(unitDef.model.textures.tex2 or "")
-			local lowercasenormaltex = string.lower(normalTex or "")
-
 
 			local wreckTex1 =
 					(lowercasetex1:find("arm_color", nil, true) and "unittextures/Arm_wreck_color.dds") or
@@ -1022,10 +1019,12 @@ local function initBinsAndTextures()
 				textureTable[3] = wreckTex1
 				textureTable[4] = wreckTex2
 				textureTable[5] = wreckNormalTex
-				if unitDef.name:sub(1,3) == 'arm' then
+				if factionBinTag == 'arm' then
 					objectDefToUniformBin[unitDefID] = 'armscavenger'
-				elseif 	unitDef.name:sub(1,3) == 'cor' then
+				elseif factionBinTag == 'cor' then
 					objectDefToUniformBin[unitDefID] = 'corscavenger'
+				elseif factionBinTag == 'leg' then
+					objectDefToUniformBin[unitDefID] = 'legscavenger'
 				end
 			elseif unitDef.name:find("raptor", nil, true) or unitDef.name:find("raptor_hive", nil, true) then
 				textureTable[5] = wreckAtlases['raptor'][1]

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -526,7 +526,7 @@ vertex = [[
 				}
 
 				// ################# LEGION ##################
-				if (BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
+				if (BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
 					const float texSpeedMult = -6.0;
 
 					if (IN_PIXEL_RECT(uvCoords, 2613, 768, 660, 404)) {

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -474,8 +474,8 @@ vertex = [[
 				#define IN_PIXEL_RECT(uv, left, top, width, height) (all(bvec4(	uv.x >= PX_TO_UV(left),         uv.y <= 1.f - PX_TO_UV(top),  uv.x <= PX_TO_UV(left + width), uv.y >= 1.f - PX_TO_UV(top + height) 	)))
 
 				// apply a minimum amount of "speed" when not completely stopped
-				// so that have tracks appear to "spin up/down as they dig into the ground"
-				// instead of jittering strangly at low speed
+				// so that tracks appear to "spin up/down as they dig into the ground"
+				// instead of jittering strangely at low speed
 				float unitSpeed = uni[instData.y].speed.w;
 
 				if (unitSpeed > 0.5) {

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -83,6 +83,8 @@ vertex = [[
 
 	#define OPTION_TREEWIND 11
 
+	#define OPTION_TREADS_LEG 13
+
 	%%GLOBAL_OPTIONS%%
 
 	/***********************************************************************/
@@ -468,7 +470,7 @@ vertex = [[
 			%%VERTEX_UV_TRANSFORM%%
 
 			#ifdef ENABLE_OPTION_TREADS
-			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM) || BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
+			if (BITMASK_FIELD(bitOptions, OPTION_TREADS_ARM) || BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE) || BITMASK_FIELD(bitOptions, OPTION_TREADS_LEG)) {
 				#define ATLAS_SIZE 4096.0
 				#define PX_TO_UV(x) (float(x) / ATLAS_SIZE)
 				#define IN_PIXEL_RECT(uv, left, top, width, height) (all(bvec4(	uv.x >= PX_TO_UV(left),         uv.y <= 1.f - PX_TO_UV(top),  uv.x <= PX_TO_UV(left + width), uv.y >= 1.f - PX_TO_UV(top + height) 	)))
@@ -522,6 +524,17 @@ vertex = [[
 						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult2, 28.0));
 					}
 				}
+
+				// ################# LEGION ##################
+				if (BITMASK_FIELD(bitOptions, OPTION_TREADS_CORE)) {
+					const float texSpeedMult = -6.0;
+
+					if (IN_PIXEL_RECT(uvCoords, 2613, 768, 660, 404)) {
+						// Legion Rubber and Steel tracks (top right) width 55px
+						uvCoords.x += PX_TO_UV(mod(baseOffset * texSpeedMult, 55.0));
+					}
+				}
+
 				#undef ATLAS_SIZE
 				#undef IN_PIXEL_RECT
 				#undef PIXELS_TO_UV
@@ -644,6 +657,7 @@ fragment = [[
 	#define OPTION_TREEWIND 11
 	#define OPTION_PBROVERRIDE 12
 
+	#define OPTION_TREADS_LEG 13
 
 	%%GLOBAL_OPTIONS%%
 


### PR DESCRIPTION
### Work done
Update main unit shader code so that Legion tanks now have animated treads.

Also make it so that units are binned in said shader by what faction's texture they use instead of being based on unit def name

The animating section of the track is like so, with a buffer area of "one segment" in either direction so that the UV coords can't scroll off of the track texture by accident.
![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/4379469/46c908dc-1d7f-4699-9842-f6501450a44f)
