### PR TITLE
BARb: version 1.6.16

### DIFF
--- a/luarules/configs/BARb/stable/config/easy/economy.json
+++ b/luarules/configs/BARb/stable/config/easy/economy.json
@@ -3,41 +3,29 @@
 "economy": {
 	"energy": {
 		// If land area >= 40% of the map then "land" config used, "water" otherwise
-		"side": {
-			"armada": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
-					// limit = random(<lower limit>..<upper limit>)
-					"armwin": [10, 20],
-					"armsolar": [50, 100, 0, 0, 0.030],
-					"armadvsol": [12, 16, 30, 1000, 0.200],
-					"armfus": [1, 2]
-				},
-				"water": {
-					"armtide": [14, 25],
-					"armwin": [10, 20],
-					"armsolar": [1],
-					"armadvsol": [12, 16],
-					"armuwfus": [1, 2]
-				}
-			},
-			"cortex": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>]
-					// limit = random(<lower limit>..<upper limit>)
-					"corwin": [10, 20],
-					"corsolar": [50, 100, 0, 0, 0.030],
-					"coradvsol": [12, 16, 30, 1000, 0.200],
-					"corfus": [1, 2]
-				},
-				"water": {
-					"cortide": [14, 25],
-					"corwin": [10, 20],
-					"corsolar": [1],
-					"coradvsol": [12, 16],
-					"coruwfus": [1, 2]
-				}
-			}
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
+			// limit = random(<lower limit>..<upper limit>)
+			"armwin": [10, 20],
+			"armsolar": [50, 100, 0, 0, 0.030],
+			"armadvsol": [12, 16, 30, 1000, 0.200],
+			"armfus": [1, 2],
+			"corwin": [10, 20],
+			"corsolar": [50, 100, 0, 0, 0.030],
+			"coradvsol": [12, 16, 30, 1000, 0.200],
+			"corfus": [1, 2]
+		},
+		"water": {
+			"armtide": [14, 25],
+			"armwin": [10, 20],
+			"armsolar": [1],
+			"armadvsol": [12, 16],
+			"armuwfus": [1, 2],
+			"cortide": [14, 25],
+			"corwin": [10, 20],
+			"corsolar": [1],
+			"coradvsol": [12, 16],
+			"coruwfus": [1, 2]
 		},
 		// income factor for energy, time is in seconds
 		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]

--- a/luarules/configs/BARb/stable/config/economy.json
+++ b/luarules/configs/BARb/stable/config/economy.json
@@ -3,43 +3,31 @@
 "economy": {
 	"energy": {
 		// If land area >= 40% of the map then "land" config used, "water" otherwise
-		"side": {
-			"armada": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
-					// limit = random(<lower limit>..<upper limit>)
-					"armwin": [10, 20],
-					"armsolar": [8, 12],
-					"armadvsol": [8, 12],
-					"armfus": [3, 4],
-					"armafus": [4, 5]
-				},
-				"water": {
-					"armtide": [14, 25],
-					"armwin": [10, 20],
-					"armsolar": [1],
-					"armadvsol": [12, 16],
-					"armuwfus": [1, 2]
-				}
-			},
-			"cortex": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>]
-					// limit = random(<lower limit>..<upper limit>)
-					"corwin": [10, 20],
-					"corsolar": [8, 12],
-					"coradvsol": [8, 12],
-					"corfus": [3, 4],
-					"corafus": [4, 5]
-				},
-				"water": {
-					"cortide": [14, 25],
-					"corwin": [10, 20],
-					"corsolar": [1],
-					"coradvsol": [12, 16],
-					"coruwfus": [1, 2]
-				}
-			}
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
+			// limit = random(<lower limit>..<upper limit>)
+			"armwin": [10, 20],
+			"armsolar": [8, 12],
+			"armadvsol": [8, 12],
+			"armfus": [3, 4],
+			"armafus": [4, 5],
+			"corwin": [10, 20],
+			"corsolar": [8, 12],
+			"coradvsol": [8, 12],
+			"corfus": [3, 4],
+			"corafus": [4, 5]
+		},
+		"water": {
+			"armtide": [14, 25],
+			"armwin": [10, 20],
+			"armsolar": [1],
+			"armadvsol": [12, 16],
+			"armuwfus": [1, 2],
+			"cortide": [14, 25],
+			"corwin": [10, 20],
+			"corsolar": [1],
+			"coradvsol": [12, 16],
+			"coruwfus": [1, 2]
 		},
 		// income factor for energy, time is in seconds
 		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]

--- a/luarules/configs/BARb/stable/config/hard/economy.json
+++ b/luarules/configs/BARb/stable/config/hard/economy.json
@@ -3,64 +3,53 @@
 "economy": {
 	"energy": {
 		// If land area >= 40% of the map then "land" config used, "water" otherwise
-		"side": {
-			"armada": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
-					// limit = random(<lower limit>..<upper limit>)
-					//efficiency calculation: engy.cond.score = SQUARE(engy.make) / (cdef->GetCostM() * cdef->GetDef()->GetXSize() * cdef->GetDef()->GetZSize());
-					//higer value => more efficient | e-output * e-output / mcost*x*y
-					"armwin": [30, 60],
-					"armsolar": [12, 14, 0, 0, 0.030],  // efficiency=0.025806 --- increased eff to make it better against wind
-					"armadvsol": [20, 30, 12, 220, 0.200], 	// efficiency=0.237542
-					//"armgeo": [4, 8, 16, 300, 0.6], //eff 0.6
-					"armgmm":[4, 8, 25, 600, 2.2],
-					//"armageo":[0, 1, 35, 1000, 3.0], //eff 3.0
-					"armfus": [3, 4, 50, 900, 1.9],		// efficiency=1.937984
-					"armckfus": [1, 3, 50, 2000, 0.230], // efficiency=2.400266
-					"armafus": [50,100, 70, 4000, 6.44],
-                    "armuwfus": [6, 12, 35, 600, 2.8]  // efficiency=6.443299
-				},
-				"water": {
-					"armtide": [45, 60],
-					"armwin": [30, 60],
-                    "armsolar": [12, 14, 0, 0, 0.030],
-                    "armadvsol": [16, 20, 12, 220, 0.200],
-                    //"armgeo": [4, 8, 16, 300, 0.6], //0.6
-                    "armgmm":[4,8, 25, 600, 2.2], 
-                    //"armageo": [0, 1, 35, 1000, 3.0], //3.0
-                    "armfus": [4, 6, 30, 900, 2.0],	
-					"armckfus": [1, 3, 50, 2000, 2.1], // efficiency=2.400266
-					"armafus": [50,100, 70, 4000, 6.44],  // efficiency=6.443299					
-					"armuwfus": [50, 100, 35, 600, 2.8]
-				}
-			},
-			"cortex": {
-				"land": {
-					"corwin": [30, 60],
-					"corsolar": [9, 12, 0, 0, 0.060], // efficiency=0.026667
-                    "coradvsol": [20, 30, 12, 220, 0.220], //efficiency=0.237542
-                    //"corgeo": [4, 8, 16, 300, 0.6], //0.6
-                   // "corageo": [0, 1, 35, 1000, 3.0], //eff 3.0
-					"corfus": [4, 6, 50, 600, 2.06],  // efficiency=2.057844
-					"corafus": [50, 100, 60, 4000, 6.44],
-                    "coruwfus": [6, 12, 35, 600, 2.8] // efficiency=6.443299
-				},
-				"water": {
-					"cortide": [45, 60],
-					"corwin": [10, 20],
-					"corsolar": [6, 10, 0, 0, 0.027], // efficiency=0.026667
-                    "coradvsol": [16, 20, 12, 220, 0.220], //efficiency=0.237542
-                    //"corgeo": [4, 8, 16, 300, 0.6],
-                    //"corageo": [0, 1, 16, 1000, 3.0],
-                    "corfus": [4, 6, 35, 600, 2.06],  // efficiency=2.057844
-                    "corafus": [50, 100, 60, 4000, 6.44], // efficiency=6.443299
-					"coruwfus": [50, 100, 35, 600, 2.8]  // efficiency=2.756296
-				}
-			}
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
+			// limit = random(<lower limit>..<upper limit>)
+			//efficiency calculation: engy.cond.score = SQUARE(engy.make) / (cdef->GetCostM() * cdef->GetDef()->GetXSize() * cdef->GetDef()->GetZSize());
+			//higer value => more efficient | e-output * e-output / mcost*x*y
+			"armwin": [30, 60],
+			"armsolar": [12, 14, 0, 0, 0.030],  // efficiency=0.025806 --- increased eff to make it better against wind
+			"armadvsol": [20, 30, 12, 220, 0.200], 	// efficiency=0.237542
+			//"armgeo": [4, 8, 16, 300, 0.6], //eff 0.6
+			"armgmm":[4, 8, 25, 600, 2.2],
+			//"armageo":[0, 1, 35, 1000, 3.0], //eff 3.0
+			"armfus": [3, 4, 50, 900, 1.9],		// efficiency=1.937984
+			"armckfus": [1, 3, 50, 2000, 0.230], // efficiency=2.400266
+			"armafus": [50,100, 70, 4000, 6.44],
+			"armuwfus": [6, 12, 35, 600, 2.8],  // efficiency=6.443299
+			"corwin": [30, 60],
+			"corsolar": [9, 12, 0, 0, 0.060], // efficiency=0.026667
+			"coradvsol": [20, 30, 12, 220, 0.220], //efficiency=0.237542
+			//"corgeo": [4, 8, 16, 300, 0.6], //0.6
+			// "corageo": [0, 1, 35, 1000, 3.0], //eff 3.0
+			"corfus": [4, 6, 50, 600, 2.06],  // efficiency=2.057844
+			"corafus": [50, 100, 60, 4000, 6.44],
+			"coruwfus": [6, 12, 35, 600, 2.8] // efficiency=6.443299
 		},
-		
-		
+		"water": {
+			"armtide": [45, 60],
+			"armwin": [30, 60],
+			"armsolar": [12, 14, 0, 0, 0.030],
+			"armadvsol": [16, 20, 12, 220, 0.200],
+			//"armgeo": [4, 8, 16, 300, 0.6], //0.6
+			"armgmm":[4,8, 25, 600, 2.2],
+			//"armageo": [0, 1, 35, 1000, 3.0], //3.0
+			"armfus": [4, 6, 30, 900, 2.0],
+			"armckfus": [1, 3, 50, 2000, 2.1], // efficiency=2.400266
+			"armafus": [50,100, 70, 4000, 6.44],  // efficiency=6.443299
+			"armuwfus": [50, 100, 35, 600, 2.8],
+			"cortide": [45, 60],
+			"corwin": [10, 20],
+			"corsolar": [6, 10, 0, 0, 0.027], // efficiency=0.026667
+			"coradvsol": [16, 20, 12, 220, 0.220], //efficiency=0.237542
+			//"corgeo": [4, 8, 16, 300, 0.6],
+			//"corageo": [0, 1, 16, 1000, 3.0],
+			"corfus": [4, 6, 35, 600, 2.06],  // efficiency=2.057844
+			"corafus": [50, 100, 60, 4000, 6.44], // efficiency=6.443299
+			"coruwfus": [50, 100, 35, 600, 2.8]  // efficiency=2.756296
+		},
+
 		"factor": [[6.0, 1], [20, 300], [30, 420], [60.0, 3600]], //desired energy factor at a certain time
 		// desired energy rule #1: e-income >= m-income * factor
 		// income factor for energy, time is in seconds

--- a/luarules/configs/BARb/stable/config/medium/economy.json
+++ b/luarules/configs/BARb/stable/config/medium/economy.json
@@ -3,41 +3,29 @@
 "economy": {
 	"energy": {
 		// If land area >= 40% of the map then "land" config used, "water" otherwise
-		"side": {
-			"armada": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
-					// limit = random(<lower limit>..<upper limit>)
-					"armwin": [10, 20],
-					"armsolar": [40, 80, 0, 0, 0.030],
-					"armadvsol": [15, 20, 30, 500, 0.200],
-					"armfus": [2, 4, 60, 1200, 2.000]
-				},
-				"water": {
-					"armtide": [14, 25],
-					"armwin": [10, 20],
-					"armsolar": [1],
-					"armadvsol": [12, 16],
-					"armuwfus": [1, 2]
-				}
-			},
-			"cortex": {
-				"land": {
-					// "<energy_def>": [<lower limit>, <upper limit>]
-					// limit = random(<lower limit>..<upper limit>)
-					"corwin": [10, 20],
-					"corsolar": [40, 80, 0, 0, 0.030],
-					"coradvsol": [12, 16, 30, 500, 0.200],
-					"corfus": [2, 4, 50, 1200, 2.000]
-				},
-				"water": {
-					"cortide": [14, 25],
-					"corwin": [10, 20],
-					"corsolar": [1],
-					"coradvsol": [12, 16],
-					"coruwfus": [1, 2]
-				}
-			}
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>, <m-income>, <e-income>, <efficiency>]
+			// limit = random(<lower limit>..<upper limit>)
+			"armwin": [10, 20],
+			"armsolar": [40, 80, 0, 0, 0.030],
+			"armadvsol": [15, 20, 30, 500, 0.200],
+			"armfus": [2, 4, 60, 1200, 2.000],
+			"corwin": [10, 20],
+			"corsolar": [40, 80, 0, 0, 0.030],
+			"coradvsol": [12, 16, 30, 500, 0.200],
+			"corfus": [2, 4, 50, 1200, 2.000]
+		},
+		"water": {
+			"armtide": [14, 25],
+			"armwin": [10, 20],
+			"armsolar": [1],
+			"armadvsol": [12, 16],
+			"armuwfus": [1, 2],
+			"cortide": [14, 25],
+			"corwin": [10, 20],
+			"corsolar": [1],
+			"coradvsol": [12, 16],
+			"coruwfus": [1, 2]
 		},
 		// income factor for energy, time is in seconds
 		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]

--- a/luarules/configs/BARb/stable/script/define.as
+++ b/luarules/configs/BARb/stable/script/define.as
@@ -6,3 +6,5 @@ const int ASSIGN_TIMEOUT = 5 * MINUTE;
 const int SQUARE_SIZE = 8;
 
 const AIFloat3 RgtVector(1.0f, 0.0f, 0.0f);
+
+const float NEAR_ZERO = 1e-3f;

--- a/luarules/configs/BARb/stable/script/easy/misc/commander.as
+++ b/luarules/configs/BARb/stable/script/easy/misc/commander.as
@@ -40,64 +40,46 @@ class SOpener {
 	array<SO> def;
 }
 
-dictionary@ GetOpenInfo()
+SOpener@ GetOpenInfo()
 {
-	return dictionary = {
-		{Commander::armcom, SOpener({
-			{Factory::armlab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER), SO(RT::SKIRM), SO(RT::BUILDER)})
-			}},
-			{Factory::armalab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::armavp, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::armasy, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::armap, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::AA), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::BOMBER), SO(RT::SCOUT)})
-			}}
-			}, {SO(RT::RAIDER), SO(RT::BUILDER)})
-		},
-		{Commander::corcom, SOpener({
-			{Factory::corlab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER)})
-			}},
-			{Factory::coralab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::ARTY, 2), SO(RT::ASSAULT), SO(RT::BUILDER2), SO(RT::AA)})
-			}},
-			{Factory::coravp, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::ASSAULT), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::corasy, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::corap, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER), SO(RT::AA), SO(RT::RAIDER), SO(RT::BOMBER), SO(RT::SCOUT)})
-			}}
-			}, {SO(RT::BUILDER), SO(RT::SKIRM)})
-		}
-	};
+	return SOpener({
+		{Factory::armlab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER), SO(RT::SKIRM), SO(RT::BUILDER)})
+		}},
+		{Factory::armalab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::armavp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::armasy, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::armap, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::AA), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::BOMBER), SO(RT::SCOUT)})
+		}},
+		{Factory::corlab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER)})
+		}},
+		{Factory::coralab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::ARTY, 2), SO(RT::ASSAULT), SO(RT::BUILDER2), SO(RT::AA)})
+		}},
+		{Factory::coravp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::ASSAULT), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::corasy, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::corap, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER), SO(RT::AA), SO(RT::RAIDER), SO(RT::BOMBER), SO(RT::SCOUT)})
+		}}
+		}, {SO(RT::BUILDER), SO(RT::SKIRM)}
+	);
 }
 
 const array<SO>@ GetOpener(const CCircuitDef@ facDef)
 {
-	dictionary@ openInfo = GetOpenInfo();
-	const CCircuitDef@ commChoice = aiSetupMgr.commChoice;
-	const string commName = commChoice.GetName();
-
-	SOpener@ open;  // null
-	const array<string>@ keys = openInfo.getKeys();
-	for (uint i = 0, l = keys.length(); i < l; ++i)
-		if (commName.findFirst(keys[i]) >= 0) {
-			@open = cast<SOpener>(openInfo[keys[i]]);
-			break;
-		}
-
-	if (open is null)
-		return null;
+	SOpener@ open = GetOpenInfo();
 
 	const string facName = facDef.GetName();
 	array<SQueue>@ queues;

--- a/luarules/configs/BARb/stable/script/hard/main.as
+++ b/luarules/configs/BARb/stable/script/hard/main.as
@@ -8,6 +8,20 @@ namespace Main {
 
 void AiMain()  // Initialize config params
 {
+	for (Id defId = 1, count = ai.GetDefCount(); defId <= count; ++defId) {
+		CCircuitDef@ cdef = ai.GetCircuitDef(defId);
+		if (cdef.costM >= 200.f && !cdef.IsMobile() && aiEconomyMgr.GetEnergyMake(cdef) > 1.f)
+			cdef.AddAttribute(Unit::Attr::BASE.type);  // Build heavy energy at base
+	}
+
+	// Example of user-assigned custom attributes
+	array<string> names = {Factory::armalab, Factory::coralab, Factory::armavp, Factory::coravp,
+		Factory::armaap, Factory::coraap, Factory::armasy, Factory::corasy};
+	for (uint i = 0; i < names.length(); ++i)
+		Factory::userData[ai.GetCircuitDef(names[i]).id].attr |= Factory::Attr::T2;
+	names = {Factory::armshltx, Factory::corgant};
+	for (uint i = 0; i < names.length(); ++i)
+		Factory::userData[ai.GetCircuitDef(names[i]).id].attr |= Factory::Attr::T3;
 }
 
 void AiUpdate()  // SlowUpdate, every 30 frames with initial offset of skirmishAIId

--- a/luarules/configs/BARb/stable/script/hard/manager/economy.as
+++ b/luarules/configs/BARb/stable/script/hard/manager/economy.as
@@ -34,6 +34,8 @@ void AiUpdateEconomy()
 	}
 	// NOTE: Default energy-to-metal conversion TeamRulesParam "mmLevel" = 0.75
 	aiEconomyMgr.isEnergyFull = energy.current > energy.storage * 0.88f;
+
+	aiFactoryMgr.isAssistRequired = (metal.current > metal.storage * 0.2f) && !aiEconomyMgr.isEnergyStalling;
 }
 
 }  // namespace Economy

--- a/luarules/configs/BARb/stable/script/hard/manager/factory.as
+++ b/luarules/configs/BARb/stable/script/hard/manager/factory.as
@@ -6,6 +6,21 @@
 
 namespace Factory {
 
+enum Attr {
+	T1 = 0x0001, T2 = 0x0002, T3 = 0x0004, T4 = 0x0008
+}
+
+class SUserData {
+	SUserData(int a) {
+		attr = a;
+	}
+	SUserData() {}
+	int attr = 0;
+}
+
+// Example of userData per UnitDef
+array<SUserData> userData(ai.GetDefCount() + 1);
+
 string armlab  ("armlab");
 string armalab ("armalab");
 string armvp   ("armvp");
@@ -13,6 +28,7 @@ string armavp  ("armavp");
 string armsy   ("armsy");
 string armasy  ("armasy");
 string armap   ("armap");
+string armaap  ("armaap");
 string armshltx("armshltx");
 string corlab  ("corlab");
 string coralab ("coralab");
@@ -21,6 +37,7 @@ string coravp  ("coravp");
 string corsy   ("corsy");
 string corasy  ("corasy");
 string corap   ("corap");
+string coraap  ("coraap");
 string corgant ("corgant");
 
 float switchLimit = MakeSwitchLimit();
@@ -44,6 +61,14 @@ void AiUnitAdded(CCircuitUnit@ unit, Unit::UseAs usage)
 		return;
 
 	const CCircuitDef@ facDef = unit.circuitDef;
+	if (userData[facDef.id].attr & Attr::T3 != 0) {
+		// if (ai.teamId != ai.GetLeadTeamId()) then this change affects only target selection,
+		// while threatmap still counts "ignored" here units.
+		array<string> spam = {"armpw", "corak", "armflea", "armfav", "corfav"};
+		for (uint i = 0; i < spam.length(); ++i)
+			ai.GetCircuitDef(spam[i]).SetIgnore(true);
+	}
+
 	const array<Opener::SO>@ opener = Opener::GetOpener(facDef);
 	if (opener is null)
 		return;

--- a/luarules/configs/BARb/stable/script/hard/misc/commander.as
+++ b/luarules/configs/BARb/stable/script/hard/misc/commander.as
@@ -40,95 +40,77 @@ class SOpener {
 	array<SO> def;
 }
 
-dictionary@ GetOpenInfo()
+SOpener@ GetOpenInfo()
 {
-	return dictionary = {
-		{Commander::armcom, SOpener({
-			{Factory::armlab, array<SQueue> = {
-				//raider
-				SQueue(0.4f, {SO(RT::BUILDER), SO(RT::SCOUT, 2), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 5), SO(RT::BUILDER), SO(RT::RAIDER)}),
-				//builder
-				SQueue(0.3f, {SO(RT::BUILDER), SO(RT::SCOUT), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER, 3), SO(RT::RAIDER, 3), SO(RT::SUPPORT), SO(RT::RAIDER)}),
-				//standard
-				SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER, 3), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER)})
-			}},
-			{Factory::armvp, array<SQueue> = {
-				//standard
-				SQueue(0.4f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 3), SO(RT::BUILDER), SO(RT::RAIDER)}),
-				//early scout push
-				SQueue(0.3f, {SO(RT::SCOUT, 2), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)}),
-				SQueue(0.3f, {SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER)})
-			}},
-			{Factory::armalab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RIOT), SO(RT::ASSAULT, 2), SO(RT::BUILDER2), SO(RT::ASSAULT), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::AHA, 2), SO(RT::BUILDER2), SO(RT::HEAVY), SO(RT::BUILDER2)})
-			}},
-			{Factory::armavp, array<SQueue> = {
-				SQueue(0.4f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::AHA), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::AHA), SO(RT::BUILDER2)}),
-				SQueue(0.6f, {SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM, 2)})
-			}},
-			{Factory::armshltx, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::RAIDER), SO(RT::RIOT, 2), SO(RT::ARTY, 2), SO(RT::SUPER)})
-			}},
-			{Factory::armsy, array<SQueue> = {
-				SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SUB), SO(RT::SKIRM)})
-			}},
-			{Factory::armasy, array<SQueue> = {
-				SQueue(0.5f, {SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2, 2)})
-			}}
-			}, {SO(RT::BUILDER), SO(RT::RAIDER, 3), SO(RT::BUILDER), SO(RT::RAIDER)})
-		},
-		{Commander::corcom, SOpener({
-			{Factory::corlab, array<SQueue> = {
-				SQueue(0.3f, {SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 4), SO(RT::BUILDER), SO(RT::RAIDER, 2)}),
-				SQueue(0.3f, {SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::RIOT), SO(RT::BUILDER), SO(RT::RAIDER, 2)}),
-				SQueue(0.3f, {SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)})
-			}},
-			{Factory::corvp, array<SQueue> = {
-				//standard
-				SQueue(0.4f, {SO(RT::SCOUT), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER, 2)}),
-				// raider serial production
-				SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 5), SO(RT::BUILDER)}),
-				// scout start
-				//SQueue(0.2f, {SO(RT::SCOUT, 4), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)}),
-				//defensive eco start
-				SQueue(0.2f, {SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)})
-			}},
-			{Factory::coralab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::HEAVY), SO(RT::BUILDER2), SO(RT::ASSAULT, 2), SO(RT::BUILDER2)})
-			}},
-			{Factory::coravp, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::ASSAULT), SO(RT::BUILDER2),SO(RT::HEAVY), SO(RT::BUILDER2, 2)})
-			}},
-			{Factory::corgant, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::RAIDER), SO(RT::ASSAULT), SO(RT::ARTY, 2)})
-			}},
-			{Factory::corsy, array<SQueue> = {
-				SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SUB), SO(RT::SKIRM)})
-			}},
-			{Factory::corasy, array<SQueue> = {
-				SQueue(0.5f, {SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2, 2)})
-			}}
-			}, {SO(RT::BUILDER, 2), SO(RT::SKIRM, 2), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::SUPPORT), SO(RT::RAIDER)})
-		}
-	};
+	return SOpener({
+		{Factory::armlab, array<SQueue> = {
+			//raider
+			SQueue(0.4f, {SO(RT::BUILDER), SO(RT::SCOUT, 2), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 5), SO(RT::BUILDER), SO(RT::RAIDER)}),
+			//builder
+			SQueue(0.3f, {SO(RT::BUILDER), SO(RT::SCOUT), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER, 3), SO(RT::RAIDER, 3), SO(RT::SUPPORT), SO(RT::RAIDER)}),
+			//standard
+			SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER, 3), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER)})
+		}},
+		{Factory::armvp, array<SQueue> = {
+			//standard
+			SQueue(0.4f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 3), SO(RT::BUILDER), SO(RT::RAIDER)}),
+			//early scout push
+			SQueue(0.3f, {SO(RT::SCOUT, 2), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)}),
+			SQueue(0.3f, {SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER)})
+		}},
+		{Factory::armalab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RIOT), SO(RT::ASSAULT, 2), SO(RT::BUILDER2), SO(RT::ASSAULT), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::AHA, 2), SO(RT::BUILDER2), SO(RT::HEAVY), SO(RT::BUILDER2)})
+		}},
+		{Factory::armavp, array<SQueue> = {
+			SQueue(0.4f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::AHA), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::AHA), SO(RT::BUILDER2)}),
+			SQueue(0.6f, {SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM, 2)})
+		}},
+		{Factory::armshltx, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::RAIDER), SO(RT::RIOT, 2), SO(RT::ARTY, 2), SO(RT::SUPER)})
+		}},
+		{Factory::armsy, array<SQueue> = {
+			SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SUB), SO(RT::SKIRM)})
+		}},
+		{Factory::armasy, array<SQueue> = {
+			SQueue(0.5f, {SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2, 2)})
+		}},
+		{Factory::corlab, array<SQueue> = {
+			SQueue(0.3f, {SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 4), SO(RT::BUILDER), SO(RT::RAIDER, 2)}),
+			SQueue(0.3f, {SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::RIOT), SO(RT::BUILDER), SO(RT::RAIDER, 2)}),
+			SQueue(0.3f, {SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)})
+		}},
+		{Factory::corvp, array<SQueue> = {
+			//standard
+			SQueue(0.4f, {SO(RT::SCOUT), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER, 2), SO(RT::BUILDER), SO(RT::RAIDER, 2)}),
+			// raider serial production
+			SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER, 5), SO(RT::BUILDER)}),
+			// scout start
+			//SQueue(0.2f, {SO(RT::SCOUT, 4), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)}),
+			//defensive eco start
+			SQueue(0.2f, {SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::RAIDER)})
+		}},
+		{Factory::coralab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::HEAVY), SO(RT::BUILDER2), SO(RT::ASSAULT, 2), SO(RT::BUILDER2)})
+		}},
+		{Factory::coravp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::ASSAULT), SO(RT::BUILDER2),SO(RT::HEAVY), SO(RT::BUILDER2, 2)})
+		}},
+		{Factory::corgant, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::RAIDER), SO(RT::ASSAULT), SO(RT::ARTY, 2)})
+		}},
+		{Factory::corsy, array<SQueue> = {
+			SQueue(0.3f, {SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::RAIDER), SO(RT::SCOUT), SO(RT::BUILDER), SO(RT::SUB), SO(RT::SKIRM)})
+		}},
+		{Factory::corasy, array<SQueue> = {
+			SQueue(0.5f, {SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2, 2)})
+		}}
+		}, {SO(RT::BUILDER), SO(RT::RAIDER, 3), SO(RT::BUILDER), SO(RT::RAIDER)}
+	);
 }
 
 const array<SO>@ GetOpener(const CCircuitDef@ facDef)
 {
-	dictionary@ openInfo = GetOpenInfo();
-	const CCircuitDef@ commChoice = aiSetupMgr.commChoice;
-	const string commName = commChoice.GetName();
-
-	SOpener@ open;  // null
-	const array<string>@ keys = openInfo.getKeys();
-	for (uint i = 0, l = keys.length(); i < l; ++i)
-		if (commName.findFirst(keys[i]) >= 0) {
-			@open = cast<SOpener>(openInfo[keys[i]]);
-			break;
-		}
-
-	if (open is null)
-		return null;
+	SOpener@ open = GetOpenInfo();
 
 	const string facName = facDef.GetName();
 	array<SQueue>@ queues;

--- a/luarules/configs/BARb/stable/script/medium/misc/commander.as
+++ b/luarules/configs/BARb/stable/script/medium/misc/commander.as
@@ -40,64 +40,46 @@ class SOpener {
 	array<SO> def;
 }
 
-dictionary@ GetOpenInfo()
+SOpener@ GetOpenInfo()
 {
-	return dictionary = {
-		{Commander::armcom, SOpener({
-			{Factory::armlab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER), SO(RT::SKIRM), SO(RT::BUILDER)})
-			}},
-			{Factory::armalab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::armavp, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::armasy, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::armap, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::AA), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::BOMBER), SO(RT::SCOUT)})
-			}}
-			}, {SO(RT::RAIDER), SO(RT::BUILDER)})
-		},
-		{Commander::corcom, SOpener({
-			{Factory::corlab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER)})
-			}},
-			{Factory::coralab, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::ARTY, 2), SO(RT::ASSAULT), SO(RT::BUILDER2), SO(RT::AA)})
-			}},
-			{Factory::coravp, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::ASSAULT), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::corasy, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
-			}},
-			{Factory::corap, array<SQueue> = {
-				SQueue(1.0f, {SO(RT::BUILDER), SO(RT::AA), SO(RT::RAIDER), SO(RT::BOMBER), SO(RT::SCOUT)})
-			}}
-			}, {SO(RT::BUILDER), SO(RT::SKIRM)})
-		}
-	};
+	return SOpener({
+		{Factory::armlab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER), SO(RT::SKIRM), SO(RT::BUILDER)})
+		}},
+		{Factory::armalab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::armavp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::armasy, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::armap, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::AA), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::BOMBER), SO(RT::SCOUT)})
+		}},
+		{Factory::corlab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER)})
+		}},
+		{Factory::coralab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::RAIDER, 3), SO(RT::BUILDER2), SO(RT::ARTY, 2), SO(RT::ASSAULT), SO(RT::BUILDER2), SO(RT::AA)})
+		}},
+		{Factory::coravp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::ASSAULT), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::corasy, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::corap, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER), SO(RT::AA), SO(RT::RAIDER), SO(RT::BOMBER), SO(RT::SCOUT)})
+		}}
+		}, {SO(RT::RAIDER), SO(RT::BUILDER)}
+	);
 }
 
 const array<SO>@ GetOpener(const CCircuitDef@ facDef)
 {
-	dictionary@ openInfo = GetOpenInfo();
-	const CCircuitDef@ commChoice = aiSetupMgr.commChoice;
-	const string commName = commChoice.GetName();
-
-	SOpener@ open;  // null
-	const array<string>@ keys = openInfo.getKeys();
-	for (uint i = 0, l = keys.length(); i < l; ++i)
-		if (commName.findFirst(keys[i]) >= 0) {
-			@open = cast<SOpener>(openInfo[keys[i]]);
-			break;
-		}
-
-	if (open is null)
-		return null;
+	SOpener@ open = GetOpenInfo();
 
 	const string facName = facDef.GetName();
 	array<SQueue>@ queues;

--- a/luarules/configs/BARb/stable/script/unit.as
+++ b/luarules/configs/BARb/stable/script/unit.as
@@ -31,7 +31,7 @@ TypeMask ROLE5    = AiAddRole("missileskirm",    ASSAULT.type);
 TypeMask ROLE6    = AiAddRole("turtle",          ASSAULT.type);
 TypeMask ROLE7    = AiAddRole("role7",           ASSAULT.type);
 TypeMask ROLE8    = AiAddRole("role8",           ASSAULT.type);
-TypeMask ROLE9    = AiAddRole("rezzer",          SUPPORT.type);
+TypeMask REZZER   = AiAddRole("rezzer",          SUPPORT.type);
 TypeMask AHA      = AiAddRole("anti_heavy_ass",  SUPPORT.type);
 TypeMask BUILDER2 = AiAddRole("builderT2",       BUILDER.type);
 }  // namespace Role
@@ -54,6 +54,9 @@ TypeMask ONOFF     = aiAttrMasker.GetTypeMask("onoff");
 TypeMask VAMPIRE   = aiAttrMasker.GetTypeMask("vampire");
 TypeMask RARE      = aiAttrMasker.GetTypeMask("rare");
 TypeMask FENCE     = aiAttrMasker.GetTypeMask("fence");
+TypeMask REARM     = aiAttrMasker.GetTypeMask("rearm");
+TypeMask NO_DGUN   = aiAttrMasker.GetTypeMask("no_dgun");
+TypeMask ANTI_STAT = aiAttrMasker.GetTypeMask("anti_stat");
 }  // namespace Attr
 
 enum UseAs {


### PR DESCRIPTION
Apply only after Recoil update [105.1.1-2510-g054bf16](https://github.com/beyond-all-reason/spring/releases/tag/spring_bar_%7BBAR105%7D105.1.1-2510-g054bf16)

BARb configs update.

### Work done
* `economy->energy` syntax update: replace per-faction energy list by single unified list.
* simplify factory opener lists: shouldn't be blocked by commander choice.

#### Addresses Issue(s)
- https://discord.com/channels/549281623154229250/1047080297042280518/threads/1239834832134213664
- https://discord.com/channels/549281623154229250/1047080297042280518/threads/1234517781865697320

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
