### PR TITLE
Remove unused code for UnitCaptured callin

### DIFF
--- a/luarules/gadgets/game_end.lua
+++ b/luarules/gadgets/game_end.lua
@@ -427,7 +427,6 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 	gadget.UnitGiven = gadget.UnitCreated
-	gadget.UnitCaptured = gadget.UnitCreated
 
 	function gadget:UnitDestroyed(unitID, unitDefID, unitTeamID)
 		if not ignoredTeams[unitTeamID] then

--- a/luarules/gadgets/game_marketplace.lua
+++ b/luarules/gadgets/game_marketplace.lua
@@ -64,7 +64,6 @@ function gadget:UnitFinished(unitID, unitDefID, teamID)
 	end
 end
 gadget.UnitGiven = gadget.UnitFinished
-gadget.UnitCaptured = gadget.UnitFinished
 
 function gadget:Initialize()
 	for ct, unitID in pairs(Spring.GetAllUnits()) do

--- a/luarules/gadgets/unit_stockpile_limit.lua
+++ b/luarules/gadgets/unit_stockpile_limit.lua
@@ -176,13 +176,6 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	function gadget:UnitCaptured(unitID, unitDefID, unitTeam)
-		if canStockpile[unitDefID] then
-			StockpileDesiredTarget[unitID] = isStockpilingUnit[unitDefID] or defaultStockpileLimit
-			UpdateStockpile(unitID, unitDefID)
-		end
-	end
-
 	function gadget:StockpileChanged(unitID, unitDefID, unitTeam)
 		UpdateStockpile(unitID, unitDefID)
 	end


### PR DESCRIPTION
### Work done
Removed code referencing a `UnitCaptured` callin, which does not exist.