### PR TITLE
Transifex merge action no longer runs against all pull requests

### DIFF
--- a/.github/workflows/transifex_merge.yml
+++ b/.github/workflows/transifex_merge.yml
@@ -13,10 +13,11 @@ name: Translations set merge target to master
 on:
   pull_request:
     types: [opened, synchronize]
+    branches:
+      - 'transifex-synchronization-source'
 
 jobs:
   auto_change_base_branch:
-    if: ${{ github.base_ref == 'transifex-synchronization-source' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Work done
The action to auto-change the merge target branch for Transifex pull requests was running against all pull requests. It now only runs against pull requests created targeting the `transifex-synchronization-source` branch.