### PR TITLE
Evo com max level modoption

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -278,6 +278,23 @@ function UnitDef_Post(name, uDef)
         		uDef.customparams.childreninheritxp = "DRONE BOTCANNON"
         		uDef.customparams.parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON"
 				end
+				local levelsTable = {}
+				for i = modOptions.evocomlevelcap, 9 do
+					if i <= 10 then -- <- this 10 is because max level of evocom is 10
+						table.insert(levelsTable, i)
+					end
+				end
+				for _, level in ipairs(levelsTable) do
+					local cortexEvocomLevels = "corcomlvl" .. level
+					local armadaEvocomLevels = "armcomlvl" .. level
+					local legionEvocomLevels = "legcomlvl" .. level
+					if cortexEvocomLevels == name or armadaEvocomLevels == name or legionEvocomLevels == name then
+						uDef.customparams.evolution_announcement = nil
+						uDef.customparams.evolution_announcement_size = nil
+						uDef.customparams.evolution_target = nil
+						uDef.customparams.evolution_condition = nil
+					end
+				end
 			end
 		end
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1233,6 +1233,18 @@ local options = {
     },
 
     {
+        key    	= "evocomlevelcap",
+        name   	= "Commander Level Cap",
+        desc   	= "(Range 5 - 10) Changes the Evolving Commanders maximum level",
+        type   	= "number",
+        section	= "options_experimental",
+        def    	= 10,
+        min    	= 5,
+        max    	= 10,
+        step   	= 1,
+    },
+
+    {
 		key		= "forceallunits",
 		name	= "Force Load All Units (For modders/devs)",
 		desc	= "Load all UnitDefs even if ais or options for them aren't enabled",

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -129,7 +129,7 @@ return {
 			workertimeboost = 6,
 			wtboostunittype = "MOBILE",
 			stockpileLimit = 4,
-			inheritxpratemultiplier = 0.5,
+			inheritxpratemultiplier = 0.25,
 			childreninheritxp = "DRONE BOTCANNON",
 			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},

--- a/units/Legion/Legion EvoCom/legcomlvl5.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl5.lua
@@ -131,7 +131,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 0,
-			inheritxpratemultiplier = 0.5,
+			inheritxpratemultiplier = 0.25,
 			childreninheritxp = "DRONE BOTCANNON",
 			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},

--- a/units/Legion/Legion EvoCom/legcomlvl6.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl6.lua
@@ -131,7 +131,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 0,
-			inheritxpratemultiplier = 0.5,
+			inheritxpratemultiplier = 0.25,
 			childreninheritxp = "DRONE BOTCANNON",
 			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},

--- a/units/Legion/Legion EvoCom/legcomlvl7.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl7.lua
@@ -134,7 +134,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 0,
-			inheritxpratemultiplier = 0.5,
+			inheritxpratemultiplier = 0.25,
 			childreninheritxp = "DRONE BOTCANNON",
 			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},

--- a/units/Legion/Legion EvoCom/legcomlvl8.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl8.lua
@@ -134,7 +134,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 0,
-			inheritxpratemultiplier = 0.5,
+			inheritxpratemultiplier = 0.25,
 			childreninheritxp = "DRONE BOTCANNON",
 			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},

--- a/units/Legion/Legion EvoCom/legcomlvl9.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl9.lua
@@ -135,7 +135,7 @@ return {
 			evolution_condition = "timer",
 			evolution_timer = 99999,
 			combatradius = 0,
-			inheritxpratemultiplier = 0.5,
+			inheritxpratemultiplier = 0.25,
 			childreninheritxp = "DRONE BOTCANNON",
 			parentsinheritxp = "MOBILEBUILT DRONE BOTCANNON",
 		},


### PR DESCRIPTION
This adds the option for players to define the maximum level of evocom commanders. It does not affect scavenger spawns, so they'll still spawn _scav commanders up to level 10.