### PR TITLE
Syntax errors

### DIFF
--- a/gamedata/icontypes.lua
+++ b/gamedata/icontypes.lua
@@ -3179,7 +3179,7 @@ for name, params in pairs(icontypes) do
 	newIcontypes[name] = params
 	newIcontypes[name..'_scav'] = { size = params.size or 1 }
 	if params.bitmap then
-		newIcontypes[name..'_scav'].bitmap = params.bitmap:gsub('\/', '\/inverted\/')
+		newIcontypes[name..'_scav'].bitmap = params.bitmap:gsub('/', '/inverted/')
 	end
 end
 

--- a/luamocks/SpringLuaApi.lua
+++ b/luamocks/SpringLuaApi.lua
@@ -1082,7 +1082,6 @@ function Spring.SetLandUnitGoal(unitID, goalX, goalY, goalZ, goalRadius)
 end
 
 unitdefs = Spring.CreateUnit('number UnitDefID')
-unitdefs.
 
 ---@param unitID number
 ---@return nil

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2093,7 +2093,7 @@ function widget:MapDrawCmd(playerID, cmdType, x, y, z, a, b, c)
 end
 
 function widget:AddConsoleLine(lines, priority)
-	lines = lines:match('^\\[f=[0-9]+\\] (.*)$') or lines
+	lines = lines:match('^%[f=[0-9]+%] (.*)$') or lines
 	for line in lines:gmatch("[^\n]+") do
 		processAddConsoleLine(spGetGameFrame(), line, true)
 	end

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2093,7 +2093,7 @@ function widget:MapDrawCmd(playerID, cmdType, x, y, z, a, b, c)
 end
 
 function widget:AddConsoleLine(lines, priority)
-	lines = lines:match('^\[f=[0-9]+\] (.*)$') or lines
+	lines = lines:match('^\\[f=[0-9]+\\] (.*)$') or lines
 	for line in lines:gmatch("[^\n]+") do
 		processAddConsoleLine(spGetGameFrame(), line, true)
 	end

--- a/luaui/Widgets/gui_gameinfo.lua
+++ b/luaui/Widgets/gui_gameinfo.lua
@@ -84,9 +84,9 @@ local function stringifyDefTable(t, path, pathAddition)
 	end
 	for k, v in pairs(t) do
 		if type(v) == "table" then
-			text = text .. '\n' .. valuegreycolor .. depthSpacing .. tostring(k) .. ' = \{'
+			text = text .. '\n' .. valuegreycolor .. depthSpacing .. tostring(k) .. ' = {'
 			text = text .. stringifyDefTable(v, path, k)
-			text = text .. '\n' .. valuegreycolor .. depthSpacing .. '\}'
+			text = text .. '\n' .. valuegreycolor .. depthSpacing .. '}'
 		else
 			text = text .. '\n' .. valuegreycolor .. depthSpacing .. tostring(k) .. ' = ' .. tostring(v)
 		end
@@ -109,9 +109,9 @@ for key, value in pairs(modoptions) do
 					local text = ''
 					for name, ud in pairs(tweaks) do
 						if UnitDefNames[name] then
-							text = text .. '\n' .. valuecolor.. name..valuegreycolor..' = \{'
+							text = text .. '\n' .. valuecolor.. name..valuegreycolor..' = {'
 							text = text..stringifyDefTable(ud, {}, name)
-							text = text .. '\n' .. '\}'
+							text = text .. '\n' .. '}'
 						end
 					end
 					changedModoptions[key] = text

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -6132,7 +6132,6 @@ function init()
 		local filteredOptions = {}
 		for i, option in pairs(options) do
 			if option.name and option.name ~= '' and option.type and option.type ~= 'label' then
-				--local name = string.gsub(option.name, "(\\[0-9]+)+", "")
 				local name = string.gsub(option.name, widgetOptionColor, "")
 				name = string.gsub(name, "  ", " ")
 				if string.find(string.lower(name), string.lower(inputText), nil, true) then

--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -392,7 +392,7 @@ function widget:AddConsoleLine(lines, priority)
 
 	if not WG['rejoin'] or not WG['rejoin'].showingRejoining() then
 
-		lines = lines:match('^\\[f=[0-9]+\\] (.*)$') or lines
+		lines = lines:match('^%[f=[0-9]+%] (.*)$') or lines
 		for line in lines:gmatch("[^\n]+") do
 
 			-- system message

--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -392,7 +392,7 @@ function widget:AddConsoleLine(lines, priority)
 
 	if not WG['rejoin'] or not WG['rejoin'].showingRejoining() then
 
-		lines = lines:match('^\[f=[0-9]+\] (.*)$') or lines
+		lines = lines:match('^\\[f=[0-9]+\\] (.*)$') or lines
 		for line in lines:gmatch("[^\n]+") do
 
 			-- system message


### PR DESCRIPTION
### Work done
Fix Lua syntax errors from invalid escape sequences. See https://www.lua.org/manual/5.1/manual.html#2.1 for list of valid escape sequences. These were mainly in regexes, in which they _are_ valid escape sequences, but as Lua strings they need to escape their backslashes.

Also removed erroneous line in SpringLuaApi.lua.

#### Test steps
- [ ] [Linux] Check Scavengers have properly inverted straticons, 
- [ ] Check commands in chat console are parsed properly
- [ ] Check game info widget opens isn't broken, content isn't missing
- [ ] Test multiplayer voting interface works
