### PR TITLE
Remove 0.1 energy upkeep from the Cortex T2 Naval Flak Turret

### DIFF
--- a/units/CorBuildings/SeaDefence/corenaa.lua
+++ b/units/CorBuildings/SeaDefence/corenaa.lua
@@ -15,7 +15,6 @@ return {
 		collisionvolumescales = "42 44 42",
 		collisionvolumetype = "CylY",
 		corpse = "DEAD",
-		energyupkeep = 0.1,
 		explodeas = "largeexplosiongeneric",
 		footprintx = 4,
 		footprintz = 4,


### PR DESCRIPTION
While Zecrus has not been notified about this vast buff to Cortex naval AA capability to bring it up to speed with [the equivalent Armada turret](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/77e9e05ce58dc9ae00b00a8811d8713273439e61/units/ArmBuildings/SeaDefence/armfflak.lua), I'm sure the need for one does not need much explaining.

Noticed by Rippsy in https://discord.com/channels/549281623154229250/1249705278400888913/1249705278400888913 .

### Work done

I have removed a line.

#### Test steps
- [ ] `/give corenaa`
- [ ] don't go broke

