### PR TITLE
Proposed unit reworks, EMP-related things

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -845,12 +845,41 @@ function UnitDef_Post(name, uDef)
 	if modOptions.proposed_unit_reworks == true then
 		if name == "corbw" then
 			uDef.weapondefs.bladewing_lyzer.damage.default = 600
+			uDef.weapons[1].onlytargetcategory = "SURFACE"
 		end
 		if name == "armdfly" then
 			uDef.weapondefs.armdfly_paralyzer.damage.default = 10500
 			uDef.weapondefs.armdfly_paralyzer.paralyzetime = 6
 			uDef.weapondefs.armdfly_paralyzer.beamtime = 0.2
+			uDef.weapons[1].onlytargetcategory = "SURFACE"
 		end
+		if name == "armspid" then
+			uDef.weapons[1].onlytargetcategory = "SURFACE"
+		end
+		if name == "corgator" then
+			uDef.weapondefs.gator_laserx.damage.vtol = 14
+		end
+		if name == "corak" then
+			uDef.weapondefs.gator_laser.damage.vtol = 7
+		end
+		if name == "armpw" then
+			uDef.weapondefs.emg.damage.vtol = 3
+		end
+		if name == "armsh" then
+			uDef.weapondefs.armsh_weapon.damage.vtol = 7
+		end
+		if name == "corsh" then
+			uDef.weapondefs.armsh_weapon.damage.vtol = 7
+		end
+		if uDef.customparams.paralyzemultiplier then
+			if uDef.customparams.paralyzemultiplier < 0.03 then
+				uDef.customparams.paralyzemultiplier = 0
+			elseif uDef.customparams.paralyzemultiplier < 0.5 then
+				uDef.customparams.paralyzemultiplier = 0.2
+			else
+				uDef.customparams.paralyzemultiplier = 1
+			end
+		end	
 	end
 
 	--Lategame Rebalance


### PR DESCRIPTION
EMP weapons no longer shoot air

Light units deal similar damage to air as blitzes did (they rarely get to shoot other air units unless landed)

Paralyzemultipliers standardised, <3% becomes immune, 3-49% becomes 20%, 50+% becomes non-resistant. Lower resistance on some units balanced by lowered Shuri/Abductor damages.

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Write the steps needed to test out the changes. Include the expected result.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
