### PR TITLE
Air Rework update

### DIFF
--- a/unitbasedefs/air_rework_defs.lua
+++ b/unitbasedefs/air_rework_defs.lua
@@ -4,24 +4,24 @@ local function airReworkTweaks(name, uDef)
 		uDef.energycost = 7600
 		uDef.buildtime = uDef.buildtime * 1.35
 		uDef.maxaileron = 0.02
-		uDef.maxacc = 0.55
-		uDef.maxdec = 0.075
+		uDef.maxacc = 0.21
+		--uDef.maxdec = 0.075
 		uDef.speed = 250
-		uDef.maxrudder = 0.015
+		uDef.maxrudder = 0.014
 		uDef.maxbank = 0.65
-		uDef.health = 730
+		uDef.health = 740
 		uDef.sightdistance = 550
-		uDef.cruisealtitude = 220
+		uDef.cruisealtitude = 240
 		uDef.weapondefs.armvtol_advmissile.proximitypriority = 0
-		uDef.weapondefs.armvtol_advmissile.areaofeffect = 64
+		uDef.weapondefs.armvtol_advmissile.areaofeffect = 45
 		uDef.weapondefs.armvtol_advmissile.impactonly = 0
-		uDef.weapondefs.armvtol_advmissile.flighttime = 2.7
-		uDef.weapondefs.armvtol_advmissile.range = 1430
-		uDef.weapondefs.armvtol_advmissile.reloadtime = 6
-		uDef.weapondefs.armvtol_advmissile.startvelocity = 120
-		uDef.weapondefs.armvtol_advmissile.tolerance = 16500
-		uDef.weapondefs.armvtol_advmissile.turnrate = 26000
-		uDef.weapondefs.armvtol_advmissile.weaponacceleration = 350
+		uDef.weapondefs.armvtol_advmissile.flighttime = 2.3
+		uDef.weapondefs.armvtol_advmissile.range = 780
+		uDef.weapondefs.armvtol_advmissile.reloadtime = 3.2
+		uDef.weapondefs.armvtol_advmissile.startvelocity = 100
+		uDef.weapondefs.armvtol_advmissile.tolerance = 100000
+		uDef.weapondefs.armvtol_advmissile.turnrate = 37000
+		uDef.weapondefs.armvtol_advmissile.weaponacceleration = 310
 		uDef.weapondefs.armvtol_advmissile.smoketrail = true
 		uDef.weapondefs.armvtol_advmissile.smokePeriod = 12
 		uDef.weapondefs.armvtol_advmissile.smoketime = 24
@@ -30,7 +30,7 @@ local function airReworkTweaks(name, uDef)
 		uDef.weapondefs.armvtol_advmissile.explosiongenerator = "custom:genericshellexplosion-medium-bomb"
 		uDef.weapondefs.armvtol_advmissile.damage = {
 			default = 1,
-			vtol = 550,
+			vtol = 500,
 		}
 	end
 	if name == "armfig" then
@@ -38,47 +38,47 @@ local function airReworkTweaks(name, uDef)
 		uDef.energycost = 4500
 		uDef.buildtime = 5000
 		uDef.speed = 207
-		uDef.maxacc = 0.36
+		uDef.maxacc = 0.2
 		uDef.maxrudder = 0.013
 		uDef.maxbank = 0.65
-		uDef.health = 290
+		uDef.health = 460
 		uDef.sightdistance = 460
-		uDef.cruisealtitude = 110
-		uDef.weapondefs.armvtol_missile.explosiongenerator = "custom:genericshellexplosion-tiny"
-		uDef.weapondefs.armvtol_missile.smokePeriod = 8
-		uDef.weapondefs.armvtol_missile.smoketime = 14
-		uDef.weapondefs.armvtol_missile.smokesize = 5.0
-		uDef.weapondefs.armvtol_missile.smokecolor = 0.66
-		uDef.weapondefs.armvtol_missile.cegtag = "missiletrailtiny"
+		uDef.cruisealtitude = 160
+		--uDef.weapondefs.armvtol_missile.explosiongenerator = "custom:genericshellexplosion-tiny"
+		--uDef.weapondefs.armvtol_missile.smokePeriod = 8
+		--uDef.weapondefs.armvtol_missile.smoketime = 14
+		--uDef.weapondefs.armvtol_missile.smokesize = 5.0
+		--uDef.weapondefs.armvtol_missile.smokecolor = 0.66
+		--uDef.weapondefs.armvtol_missile.cegtag = "missiletrailtiny"
 		uDef.weapondefs.armvtol_missile.proximitypriority = 0
 		uDef.weapondefs.armvtol_missile.flighttime = 1.7
-		uDef.weapondefs.armvtol_missile.range = 530
-		uDef.weapondefs.armvtol_missile.reloadtime = 3
+		uDef.weapondefs.armvtol_missile.range = 550
+		uDef.weapondefs.armvtol_missile.reloadtime = 1.3
 		uDef.weapondefs.armvtol_missile.startvelocity = 110
 		uDef.weapondefs.armvtol_missile.tolerance = 10000
 		uDef.weapondefs.armvtol_missile.turnrate = 23000
-		uDef.weapondefs.armvtol_missile.name = "Light guided a2a/a2g missile launcher"
+		--uDef.weapondefs.armvtol_missile.name = "Light guided a2a/a2g missile launcher"
 		uDef.weapondefs.armvtol_missile.weaponacceleration = 350
-		uDef.weapondefs.armvtol_missile.canattackground = true
+		--uDef.weapondefs.armvtol_missile.canattackground = true
 		uDef.weapondefs.armvtol_missile.damage = {
-			default = 64,
+			--default = 64,
 			vtol = 200,
 		}
-		uDef.weapons[1].onlytargetcategory = "NOTSUB"
+		--uDef.weapons[1].onlytargetcategory = "NOTSUB"
 	end
 	if name == "armsfig2" then
 		uDef.metalcost = 450
 		uDef.energycost = 6500
 		uDef.buildtime = 10000
 		uDef.speed = 165
-		uDef.maxacc = 0.8
-		uDef.maxrudder = 0.02
-		uDef.maxbank = 0.15
+		uDef.maxacc = 0.2
+		uDef.maxrudder = 0.016
+		uDef.maxbank = 0.5
 		--uDef.maxpitch = 0.02
 		--uDef.maxelevator = 0.02
-		uDef.health = 2250
+		uDef.health = 2700
 		uDef.sightdistance = 460
-		uDef.cruisealtitude = 110
+		uDef.cruisealtitude = 160
 		--uDef.turnradius = 128
 		uDef.weapondefs.armsfig_weapon.proximitypriority = 0
 		uDef.weapondefs.armsfig_weapon.flighttime = 1.4
@@ -90,11 +90,11 @@ local function airReworkTweaks(name, uDef)
 		uDef.weapondefs.armsfig_weapon.smoketime = 48
 		uDef.weapondefs.armsfig_weapon.smokesize = 10
 		uDef.weapondefs.armsfig_weapon.smoketrail = true
-		uDef.weapondefs.armsfig_weapon.areaofeffect = 200
+		uDef.weapondefs.armsfig_weapon.areaofeffect = 245
 		uDef.weapondefs.armsfig_weapon.reloadtime = 3
 		uDef.weapondefs.armsfig_weapon.startvelocity = 180
 		uDef.weapondefs.armsfig_weapon.tolerance = 1000
-		uDef.weapondefs.armsfig_weapon.turnrate = 4000
+		uDef.weapondefs.armsfig_weapon.turnrate = 3600
 		uDef.weapondefs.armsfig_weapon.weaponacceleration = 450
 		uDef.weapondefs.armsfig_weapon.weaponvelocity = 1000
 		uDef.weapondefs.armsfig_weapon.wobble = 5
@@ -109,24 +109,24 @@ local function airReworkTweaks(name, uDef)
 		uDef.energycost = 7300
 		uDef.buildtime = uDef.buildtime * 1.35
 		uDef.maxaileron = 0.02
-		uDef.maxacc = 0.78
-		uDef.maxdec = 0.11
+		uDef.maxacc = 0.21
+		uDef.maxdec = 0.075
 		uDef.speed = 275
-		uDef.maxrudder = 0.018
+		uDef.maxrudder = 0.014
 		uDef.maxbank = 0.65
-		uDef.health = 600
+		uDef.health = 580
 		uDef.sightdistance = 550
-		uDef.cruisealtitude = 220
+		uDef.cruisealtitude = 240
 		uDef.weapondefs.corvtol_advmissile.impactonly = 0
 		uDef.weapondefs.corvtol_advmissile.proximitypriority = 0
-		uDef.weapondefs.corvtol_advmissile.areaofeffect = 52
+		uDef.weapondefs.corvtol_advmissile.areaofeffect = 32
 		uDef.weapondefs.corvtol_advmissile.flighttime = 2.2
-		uDef.weapondefs.corvtol_advmissile.range = 850
-		uDef.weapondefs.corvtol_advmissile.reloadtime = 2
-		uDef.weapondefs.corvtol_advmissile.startvelocity = 170
-		uDef.weapondefs.corvtol_advmissile.tolerance = 15500
-		uDef.weapondefs.corvtol_advmissile.turnrate = 27000
-		uDef.weapondefs.corvtol_advmissile.weaponacceleration = 350
+		uDef.weapondefs.corvtol_advmissile.range = 710
+		uDef.weapondefs.corvtol_advmissile.reloadtime = 1.7
+		uDef.weapondefs.corvtol_advmissile.startvelocity = 100
+		uDef.weapondefs.corvtol_advmissile.tolerance = 100000
+		uDef.weapondefs.corvtol_advmissile.turnrate = 37000
+		uDef.weapondefs.corvtol_advmissile.weaponacceleration = 310
 		uDef.weapondefs.corvtol_advmissile.smoketrail = true
 		uDef.weapondefs.corvtol_advmissile.smokePeriod = 12
 		uDef.weapondefs.corvtol_advmissile.smoketime = 24
@@ -135,7 +135,7 @@ local function airReworkTweaks(name, uDef)
 		uDef.weapondefs.corvtol_advmissile.explosiongenerator = "custom:genericshellexplosion-medium-bomb"
 		uDef.weapondefs.corvtol_advmissile.damage = {
 			default = 1,
-			vtol = 340,
+			vtol = 300,
 		}
 	end
 	if name == "corveng" then
@@ -143,52 +143,52 @@ local function airReworkTweaks(name, uDef)
 		uDef.energycost = 4500
 		uDef.buildtime = 5000
 		uDef.speed = 207
-		uDef.maxacc = 0.36
+		uDef.maxacc = 0.2
 		uDef.maxrudder = 0.013
 		uDef.maxbank = 0.65
-		uDef.health = 290
+		uDef.health = 460
 		uDef.sightdistance = 460
-		uDef.cruisealtitude = 110
-		uDef.weapondefs.corvtol_missile.explosiongenerator = "custom:genericshellexplosion-tiny"
-		uDef.weapondefs.corvtol_missile.smokePeriod = 8
-		uDef.weapondefs.corvtol_missile.smoketime = 14
-		uDef.weapondefs.corvtol_missile.smokesize = 5.0
-		uDef.weapondefs.corvtol_missile.smokecolor = 0.66
-		uDef.weapondefs.corvtol_missile.cegtag = "missiletrailtiny"
+		uDef.cruisealtitude = 160
+		--uDef.weapondefs.corvtol_missile.explosiongenerator = "custom:genericshellexplosion-tiny"
+		--uDef.weapondefs.corvtol_missile.smokePeriod = 8
+		--uDef.weapondefs.corvtol_missile.smoketime = 14
+		--uDef.weapondefs.corvtol_missile.smokesize = 5.0
+		--uDef.weapondefs.corvtol_missile.smokecolor = 0.66
+		--uDef.weapondefs.corvtol_missile.cegtag = "missiletrailtiny"
 		uDef.weapondefs.corvtol_missile.proximitypriority = 0
 		uDef.weapondefs.corvtol_missile.flighttime = 1.7
-		uDef.weapondefs.corvtol_missile.range = 530
-		uDef.weapondefs.corvtol_missile.reloadtime = 3
+		uDef.weapondefs.corvtol_missile.range = 550
+		uDef.weapondefs.corvtol_missile.reloadtime = 1.3
 		uDef.weapondefs.corvtol_missile.startvelocity = 110
 		uDef.weapondefs.corvtol_missile.tolerance = 10000
 		uDef.weapondefs.corvtol_missile.turnrate = 23000
 		uDef.weapondefs.corvtol_missile.weaponacceleration = 350
-		uDef.weapondefs.corvtol_missile.canattackground = true
-		uDef.weapondefs.corvtol_missile.name = "Light guided a2a/a2g missile launcher"
+		--uDef.weapondefs.corvtol_missile.canattackground = true
+		--uDef.weapondefs.corvtol_missile.name = "Light guided a2a/a2g missile launcher"
 		uDef.weapondefs.corvtol_missile.damage = {
-			default = 64,
+			--default = 64,
 			vtol = 200,
 		}
-		uDef.weapons[1].onlytargetcategory = "NOTSUB"
+		--uDef.weapons[1].onlytargetcategory = "NOTSUB"
 	end
 	if name == "corsfig2" then
 		uDef.metalcost = 520
 		uDef.energycost = 8000
 		uDef.buildtime = 11000
 		uDef.speed = 155
-		uDef.maxacc = 0.8
-		uDef.maxrudder = 0.025
-		uDef.maxbank = 0.15
+		uDef.maxacc = 0.2
+		uDef.maxrudder = 0.016
+		uDef.maxbank = 0.5
 		--uDef.maxpitch = 0.02
 		--uDef.maxelevator = 0.02
-		uDef.health = 2450
+		uDef.health = 3000
 		uDef.sightdistance = 460
-		uDef.cruisealtitude = 110
+		uDef.cruisealtitude = 160
 		uDef.turnradius = 128
 		uDef.weapondefs.corsfig_weapon.proximitypriority = -1
 		uDef.weapondefs.corsfig_weapon.flighttime = 1.7
 		uDef.weapondefs.corsfig_weapon.range = 680
-		uDef.weapondefs.corsfig_weapon.areaofeffect = 200
+		uDef.weapondefs.corsfig_weapon.areaofeffect = 220
 		uDef.weapondefs.corsfig_weapon.edgeeffectiveness = 0.55
 		uDef.weapondefs.corsfig_weapon.reloadtime = 6.1
 		uDef.weapondefs.corsfig_weapon.startvelocity = 100
@@ -224,39 +224,41 @@ local function airReworkTweaks(name, uDef)
 	if name == "armawac" then
 		uDef.metalcost = uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15 - (uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15) % 1
 		uDef.speed = uDef.speed * 0.76
-		uDef.maxrudder = 0.017
+		uDef.maxrudder = 0.015
 		uDef.maxbank = 0.66
 		uDef.health = 1040
 		uDef.maxacc = 0.4
-		uDef.cruisealtitude = 250
+		uDef.maxdec = 0.01
+		uDef.cruisealtitude = 270
 	end
 	if name == "armpeep" then
 		uDef.metalcost = uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15 - (uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15) % 1
 		uDef.health = 133
 		uDef.speed = uDef.speed * 0.76
-		uDef.maxrudder = 0.024
+		uDef.maxrudder = 0.017
 		uDef.maxbank = 0.66
 		uDef.maxacc = 0.4
-		uDef.cruisealtitude = 150
+		uDef.cruisealtitude = 170
 		uDef.sightdistance = uDef.sightdistance * 1.2
 	end
 	if name == "corawac" then
 		uDef.metalcost = uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15 - (uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15) % 1
 		uDef.speed = uDef.speed * 0.76
-		uDef.maxrudder = 0.017
+		uDef.maxrudder = 0.015
 		uDef.maxbank = 0.66
 		uDef.health = 1140
 		uDef.maxacc = 0.4
-		uDef.cruisealtitude = 250
+		uDef.maxdec = 0.01
+		uDef.cruisealtitude = 270
 	end
 	if name == "corfink" then
 		uDef.metalcost = uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15 - (uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15) % 1
 		uDef.health = 150
 		uDef.speed = uDef.speed * 0.76
-		uDef.maxrudder = 0.024
+		uDef.maxrudder = 0.017
 		uDef.maxbank = 0.66
 		uDef.maxacc = 0.4
-		uDef.cruisealtitude = 150
+		uDef.cruisealtitude = 170
 		uDef.sightdistance = uDef.sightdistance * 1.2
 	end
 	if name == "corhunt" then
@@ -265,7 +267,8 @@ local function airReworkTweaks(name, uDef)
 		uDef.maxrudder = 0.015
 		uDef.maxbank = 0.66
 		uDef.maxacc = 0.4
-		uDef.cruisealtitude = 220
+		uDef.maxdec = 0.01
+		uDef.cruisealtitude = 240
 	end
 	if name == "armsehak" then
 		uDef.metalcost = uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15 - (uDef.metalcost * 1.15 + uDef.energycost / 70 * 0.15) % 1
@@ -273,13 +276,13 @@ local function airReworkTweaks(name, uDef)
 		uDef.maxrudder = 0.015
 		uDef.maxbank = 0.66
 		uDef.maxacc = 0.4
-		uDef.cruisealtitude = 220
+		uDef.maxdec = 0.01
+		uDef.cruisealtitude = 240
 	end
 	if name == "armatlas" or name == "corvalk" then
 		uDef.health = uDef.health * 1.6
 		uDef.speed = uDef.speed * 0.75
 		uDef.turnrate = uDef.turnrate * 1.5
-		uDef.cruisealtitude = 100
 		uDef.buildtime = uDef.buildtime * 0.8
 	end
 	if name == "armbrawl" or name == "armkam" or name == "armdfly" or name == "corseah" or name == "corape" then
@@ -288,6 +291,16 @@ local function airReworkTweaks(name, uDef)
 		uDef.turnrate = uDef.turnrate * 1.5
 		uDef.cruisealtitude = 100
 		uDef.buildtime = uDef.buildtime * 0.8
+	end
+	if name == "armdfly" then
+		uDef.speed = uDef.speed * 0.85
+		uDef.health = uDef.health * 1.2
+		uDef.turnrate = uDef.turnrate * 1.5
+	end
+	if name == "corseah" then
+		uDef.speed = uDef.speed * 0.85
+		uDef.health = uDef.health * 1.4
+		uDef.turnrate = uDef.turnrate * 1.5
 	end
 	if name == "armkam" then
 		uDef.weapondefs.med_emg.burstrate = 0.08
@@ -299,15 +312,13 @@ local function airReworkTweaks(name, uDef)
 		default = 20,
 		}
 	end
-	if name == "corcrw" or name == "corcrwh" then
-		uDef.health = uDef.health * 1.5
+	if name == "corcrwh" then
+		uDef.health = uDef.health * 1.3
 		uDef.speed = uDef.speed * 0.75
 		--uDef.turnrate = uDef.turnrate * 1.5
-		uDef.cruisealtitude = 80
 	end
 	if name == "corbw" then
-		uDef.health = 100
-		uDef.speed = 210
+		uDef.speed = uDef.speed * 0.85
 		uDef.cruisealtitude = 80
 	end
 	if name == "armseap" or name == "corseap" then
@@ -351,7 +362,7 @@ local function airReworkTweaks(name, uDef)
 		}
 	end
 	if name == "armblade" then
-		--uDef.health = uDef.health * 1.3
+		uDef.health = uDef.health * 1.1
 		--uDef.speed = uDef.speed * 0.85
 		uDef.turnrate = uDef.turnrate * 2
 		uDef.cruisealtitude = 100
@@ -376,38 +387,42 @@ local function airReworkTweaks(name, uDef)
 		uDef.energycost = uDef.energycost * 1.2
 		uDef.metalcost = uDef.metalcost * 1.2 - (uDef.metalcost * 1.2) % 1
 		uDef.speed = uDef.speed * 0.73
-		uDef.maxacc = uDef.maxacc * 1.3
+		uDef.maxacc = math.max(uDef.maxacc * 1.3, 0.13)
 		uDef.maxbank = 0.65
+		uDef.maxdec = 0.013
 		uDef.maxrudder = uDef.maxrudder * 2.2
 		uDef.health = uDef.health * 1.6
 		uDef.sightdistance = 550
-		uDef.cruisealtitude = 180
+		uDef.cruisealtitude = 200
 	end
+
 	if name == "corhurc" then
-		uDef.metalcost = uDef.metalcost * 1.3 + uDef.energycost / 70 * 0.3 - (uDef.metalcost * 1.3 + uDef.energycost / 70 * 0.3) % 1
+		uDef.metalcost = uDef.metalcost * 2
 		uDef.energycost = uDef.energycost * 1.2
-		uDef.metalcost = uDef.metalcost * 1.2 - (uDef.metalcost * 1.2) % 1
 		uDef.speed = uDef.speed * 0.62
 		uDef.maxbank = 0.5
+		uDef.maxacc = uDef.maxacc * 1.3
 		uDef.maxrudder = uDef.maxrudder * 2
 		uDef.maxaileron = uDef.maxaileron * 0.7
 		uDef.health = uDef.health * 2.3
 		uDef.sightdistance = 520
+		uDef.cruisealtitude = 240
 		uDef.weapondefs.coradvbomb.burstrate = 0.26
 		uDef.weapondefs.coradvbomb.damage = {
 			default = 500
 		}
 	end
 	if name == "armpnix" then
-		uDef.metalcost = uDef.metalcost * 1.3 + uDef.energycost / 70 * 0.3 - (uDef.metalcost * 1.3 + uDef.energycost / 70 * 0.3) % 1
+		uDef.metalcost = uDef.metalcost * 2
 		uDef.energycost = uDef.energycost * 1.2
-		uDef.metalcost = uDef.metalcost * 1.2 - (uDef.metalcost * 1.2) % 1
 		uDef.speed = uDef.speed * 0.62
 		uDef.maxbank = 0.5
+		uDef.maxacc = uDef.maxacc * 1.3
 		uDef.maxrudder = uDef.maxrudder * 2
 		uDef.maxaileron = uDef.maxaileron * 0.7
 		uDef.health = uDef.health * 2.3
 		uDef.sightdistance = 520
+		uDef.cruisealtitude = 240
 		uDef.weapondefs.armadvbomb.burstrate = 0.35
 		uDef.weapondefs.armadvbomb.burst = 6
 		uDef.weapondefs.armadvbomb.areaofeffect = 220
@@ -418,12 +433,14 @@ local function airReworkTweaks(name, uDef)
 		uDef.metalcost = uDef.metalcost * 1.2 - (uDef.metalcost * 1.2) % 1
 		uDef.speed = uDef.speed * 0.85
 		uDef.maxacc = 0.35
-		uDef.maxdec = 0.045
+		uDef.maxdec = 0.035
 		uDef.maxbank = 0.68
 		uDef.maxrudder = uDef.maxrudder * 2.5
 		uDef.health = uDef.health * 1.4
+		uDef.maxdec = 0.014
 		uDef.sightdistance = 720
-		uDef.cruisealtitude = 180
+		uDef.cruisealtitude = 200
+		uDef.stealth = true
 	end
 	if name == "armaap" then
 		local numBuildoptions = #uDef.buildoptions
@@ -470,6 +487,7 @@ local function airReworkTweaks(name, uDef)
 		uDef.weapondefs.ferret_missile.weaponvelocity = 1100
 		uDef.metalcost = uDef.metalcost * 0.7
 		uDef.energycost = uDef.energycost * 0.7
+		uDef.health = 1000
 	end
 	if name == "cormadsam" then
 		uDef.weapondefs.madsam_missile.areaofeffect = 48
@@ -478,6 +496,7 @@ local function airReworkTweaks(name, uDef)
 		uDef.weapondefs.madsam_missile.weaponvelocity = 1100
 		uDef.metalcost = uDef.metalcost * 0.7 - 0.5
 		uDef.energycost = uDef.energycost * 0.7
+		uDef.health = 2000
 	end
 	if name == "armmercury" then
 		uDef.weapondefs.arm_advsam.startvelocity = 140
@@ -569,12 +588,10 @@ local function airReworkTweaks(name, uDef)
 	if name == "armsam" then
 		uDef.weapondefs.armtruck_missile.startvelocity = 135
 		uDef.weapondefs.armtruck_missile.weaponacceleration = 230
-		uDef.weapondefs.armtruck_missile.damage.vtol = 200
 	end
 	if name == "cormist" then
 		uDef.weapondefs.cortruck_missile.startvelocity = 135
 		uDef.weapondefs.cortruck_missile.weaponacceleration = 230
-		uDef.weapondefs.cortruck_missile.damage.vtol = 150
 	end
 	if name == "corpt" then
 		uDef.weapondefs.cortruck_missile.startvelocity = 135
@@ -618,6 +635,9 @@ local function airReworkTweaks(name, uDef)
 		uDef.weapondefs.ga2.weaponacceleration = 230
 		uDef.weapondefs.ga2.flighttime = 2.5
 		uDef.weapondefs.mobileflak.weaponvelocity = 1000
+	end
+	if uDef.sightdistance then
+		uDef.airsightdistance = uDef.sightdistance * 1.3
 	end
 
 	return uDef


### PR DESCRIPTION
T1 fighter
AA only, 460 HP, reloadtime 1.3s

T2 fighter
Reduced ranges and reloadtimes, fast turning missile allows them to shoot backwards

Heavy fighter
Increased HP, AoE

T2 strategic bombers
M cost increased

T2/seaplane bombers
Stealth added

Unit maneuvering tweaks, more inertia for many units Fixed-wing aircraft flight altitudes increased - less likely to get hit by non-aa weapons Air-LoS of all units is 130% of their normal LoS (Was 150% for most). Makes spotting a factor in air battles, and buffs stealth planes.

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Write the steps needed to test out the changes. Include the expected result.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
