### PR TITLE
legion context build

### DIFF
--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -81,6 +81,35 @@ local unitlist = {
 	{'corllt', 'corptl'},
 }
 
+
+
+local legionUnitlist = {
+	--{'cormakr','corfmkr'},
+	--{'cordrag','corfdrag'},
+	--{'cormstor', 'coruwms'},
+	--{'corestor', 'coruwes'},
+	{'legrl','corfrt'},
+	{'leghp','legfhp'},
+	{'legrad','corfrad'},
+	{'legmg','corfhlt'},
+	--{'cortarg','corfatf'},
+	--{'cormmkr','coruwmmm'},
+	--{'corfus','coruwfus'},
+	--{'corflak','corenaa'},
+	--{'cormoho','coruwmme'},--does this combo actually manifest on anything...?
+	{'legsolar','cortide'},
+	{'leglab','corsy'},--soon(tm)
+	{'leglht','cortl'},--these seem fussy, reason currently unknown
+	{'leglht', 'corptl'},
+	--{'cornanotc','cornanotcplat'},
+	{'legvp','legamsub'},
+	--{'corap','corplat'},
+	--{'corasp','corfasp'},
+	--{'corgeo','coruwgeo'},
+	--{'corageo','coruwageo'},
+}
+
+
 local ptlCons = {
 	['armbeaver'] = true,
 	['cormuskrat'] = true,
@@ -256,6 +285,14 @@ function widget:Initialize()
 	if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
 		maybeRemoveSelf()
 	end
+	
+	if Spring.GetModOptions().experimentallegionfaction then	
+		for _,v in ipairs(legionUnitlist) do 
+			table.insert(unitlist, v)
+		end
+	end
+
+	
 	local uDefNames = UnitDefNames
 	for _,unitNames in ipairs(unitlist) do
 		for i, unitName in ipairs(unitNames) do


### PR DESCRIPTION
### Work done
Added Legion subset to context build, which now only runs when Legion enabled. It can't use the main list as it will crash on games without Legion loaded.

#### Test steps
Test with Legion enabled, spawn legotter, legcom, etc, test that water/land analogues work as expected.

Sanity test without Legion enabled, verify script unbroken (nothing would swap at all if it were)


Known issue with leghlt/cor(p)tl swapping, cause unknown, time elusive so filing as 'known issue' to be dealth with when possible. The buildlist is patchy already so it's not a huge issue, and state is vastly better than current 'everything not swapping'.