### PR TITLE
fix(gridmenu,info): A few minor cases

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -919,9 +919,22 @@ local function setCurrentCategory(category)
 	updateCategories(categories)
 	refreshCommands()
 
+	-- handle selecting first option when switching category
 	if changedCategory and autoSelectFirst and activeBuilder then
-		local firstCellCmdOpt = gridOpts[1 + (currentPage - 1) * cellCount]
-		local firstCmd = firstCellCmdOpt and firstCellCmdOpt.id
+		local offset = (currentPage - 1) * cellCount
+
+		local firstCmd
+
+		-- Get first available cell command
+		for i = offset + 1, offset + cellCount do
+			local cellCmdOpt = gridOpts[i]
+			local cellCmd = cellCmdOpt and cellCmdOpt.id
+
+			if cellCmd and not units.unitRestricted[-cellCmd] then
+				firstCmd = cellCmd
+				break
+			end
+		end
 
 		if not firstCmd then
 			return

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -900,7 +900,7 @@ end
 
 local function pickBlueprint(uDefID)
 	local isRepeatMex = unitMetal_extractor[uDefID] and -uDefID == activeCmd
-	local cmd = isRepeatMex and "areamex" or spGetCmdDescIndex(-uDefID)
+	local cmd = (WG["areamex"] and isRepeatMex and "areamex") or spGetCmdDescIndex(-uDefID)
 	if isRepeatMex then
 		WG["areamex"].setAreaMexType(-uDefID)
 	end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -901,7 +901,7 @@ end
 local function pickBlueprint(uDefID)
 	local isRepeatMex = unitMetal_extractor[uDefID] and -uDefID == activeCmd
 	local cmd = (WG["areamex"] and isRepeatMex and "areamex") or spGetCmdDescIndex(-uDefID)
-	if isRepeatMex then
+	if isRepeatMex and WG["areamex"] then
 		WG["areamex"].setAreaMexType(-uDefID)
 	end
 	setActiveCommand(cmd)

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1156,6 +1156,9 @@ function widget:Initialize()
 	isSpec = Spring.GetSpectatingState()
 	isPregame = Spring.GetGameFrame() == 0 and not isSpec
 
+	WG["gridmenu"] = {}
+	WG["buildmenu"] = {}
+
 	doUpdateClock = os.clock()
 
 	if widgetHandler:IsWidgetKnown("Build menu") then
@@ -1196,7 +1199,6 @@ function widget:Initialize()
 		widget:SelectionChanged(Spring.GetSelectedUnits())
 	end
 
-	WG["gridmenu"] = {}
 	WG["gridmenu"].getAlwaysReturn = function()
 		return alwaysReturn
 	end
@@ -1223,7 +1225,6 @@ function widget:Initialize()
 		clearCategory()
 	end
 
-	WG["buildmenu"] = {}
 	WG["buildmenu"].getGroups = function()
 		return groups, units.unitGroup
 	end
@@ -2439,6 +2440,8 @@ function widget:SelectionChanged(newSel)
 		-- If no selection, we still have to draw empty cells
 		if alwaysShow then
 			refreshCommands()
+		else
+			WG["buildmenu"].hoverID = nil
 		end
 
 		return
@@ -2460,6 +2463,13 @@ function widget:SelectionChanged(newSel)
 
 	-- if no builders are selected, there's nothing to do
 	if selectedBuildersCount == 0 then
+		-- If no selection, we still have to draw empty cells
+		if alwaysShow then
+			refreshCommands()
+		else
+			WG["buildmenu"].hoverID = nil
+		end
+
 		return
 	end
 

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -22,6 +22,7 @@ local clickCellZoom = 0.065 * zoomMult
 local hoverCellZoom = 0.03 * zoomMult
 local showBuilderBuildlist = true
 local displayMapPosition = false
+local activeCmdID
 
 local emptyInfo = false
 local showEngineTooltip = false		-- straight up display old engine delivered text
@@ -326,7 +327,7 @@ local function refreshUnitInfo()
 				elseif
 					unitDef.customParams.isevocom  or -- use primary weapon for evolving commanders
 					unitDef.name == 'armcom'       or -- ignore underwater secondary
-					unitDef.name == 'corcom'       or 
+					unitDef.name == 'corcom'       or
 					unitDef.name == 'legcom'       or
 					unitDef.name == 'corkarg'      or -- ignore secondary weapons, kick
 					unitDef.name == 'armguard'     or -- ignore high-trajectory modes
@@ -410,8 +411,8 @@ local function refreshUnitInfo()
 					setEnergyAndMetalCosts(weaponDef)
 
 					if weaponDef.paralyzer ~= true then
-					
-					
+
+
 						if weaponDef.customParams then
 
 							if weaponDef.customParams.sweepfire then
@@ -1111,7 +1112,7 @@ local function drawUnitInfo()
 
 	local unitNameColor = tooltipTitleColor
 	if SelectedUnitsCount > 0 then
-		if not displayMode == 'unitdef' or (WG['buildmenu'] and (WG['buildmenu'].selectedID and (not WG['buildmenu'].hoverID or (WG['buildmenu'].selectedID == WG['buildmenu'].hoverID)))) then
+		if not displayMode == 'unitdef' or (WG['buildmenu'] and (activeCmdID and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
 			unitNameColor = '\255\125\255\125'
 		end
 	end
@@ -2026,12 +2027,12 @@ function checkChanges()
 	displayUnitID = nil
 	displayUnitDefID = nil
 
-	local activeCmdID = select(2, Spring.GetActiveCommand())
+	activeCmdID = select(2, Spring.GetActiveCommand())
 
 	-- buildmenu unitdef
-	if WG['buildmenu'] and (WG['buildmenu'].hoverID or WG['buildmenu'].selectedID) then
+	if WG['buildmenu'] and WG['buildmenu'].hoverID then
 		displayMode = 'unitdef'
-		displayUnitDefID = WG['buildmenu'].hoverID or WG['buildmenu'].selectedID
+		displayUnitDefID = WG['buildmenu'].hoverID
 
 	elseif activeCmdID and activeCmdID < 0 then
 		displayMode = 'unitdef'

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1112,7 +1112,7 @@ local function drawUnitInfo()
 
 	local unitNameColor = tooltipTitleColor
 	if SelectedUnitsCount > 0 then
-		if not displayMode == 'unitdef' or (WG['buildmenu'] and (activeCmdID and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
+		if not displayMode == 'unitdef' or (WG['buildmenu'] and (activeCmdID and activeCmdID < 0 and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
 			unitNameColor = '\255\125\255\125'
 		end
 	end


### PR DESCRIPTION
This PR is composed of 5 small changes, 4 fixes and one feature improvement:

- [feat(gridmenu): Select first item available](https://github.com/beyond-all-reason/Beyond-All-Reason/commit/610b9b2395a91880a777b961190a84369d5250cb)

    Instead of first in the list, if it's not available pick the next
available when autoselecting on category switch

- [fix(info): Fix special activecmd coloring](https://github.com/beyond-all-reason/Beyond-All-Reason/commit/8ce19cb5a4d9caf36ff75142dac782b46530be8f)

    It was never being successful since exposed selectedID does not exist by
buildmenu. Instead we use the activecmd, which should have been used in
the first place.

- [fix(gridmenu): Stale gui_info](https://github.com/beyond-all-reason/Beyond-All-Reason/commit/58c9e3fc8b3154b4c56b8fb3496a10a2f0e814c3)

    Info panel would get stale when hovering a cell and switching selection
without moving the mouse to a non constructor unit (e.g. control group)

- [fix(gridmenu): Defensively check areamex widget](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3227/commits/40af666e5d658edb217035b55a7ff281886243fc)
[40af666](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3227/commits/40af666e5d658edb217035b55a7ff281886243fc)

    If areamex broke, gridmenu should not break
    
- [fix(info): Not showing pregame build selection](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3227/commits/2ec3eb0a05e4473a8ceffd2295b0aa805dc0ed1e)