### PR TITLE
A bunch of Scavenger updates

### DIFF
--- a/luarules/configs/scav_spawn_defs.lua
+++ b/luarules/configs/scav_spawn_defs.lua
@@ -997,6 +997,25 @@ local Turrets = {
 		["cormakr_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 1},
 		["armfmkr_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.1, maxExisting = 1},
 		["corfmkr_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.1, maxExisting = 1},
+		--Factories
+		["armlab_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armvp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armap_scav"] = {type = "antiair", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armhp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["corlab_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["corvp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["corap_scav"] = {type = "antiair", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["corhp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["leglab_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["legvp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["legap_scav"] = {type = "antiair", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["leghp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armfhp_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["armsy_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["corfhp_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["corsy_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["legfhp_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["legsy_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
 	},
 	[3] = {
 		["armbeamer_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 5},
@@ -1075,6 +1094,24 @@ local Turrets = {
 		["cormmkr_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 1},
 		["armuwmmm_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.1, maxExisting = 1},
 		["coruwmmm_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.1, maxExisting = 1},
+		-- Factories
+		["armalab_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armavp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armaap_scav"] = {type = "antiair", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["coralab_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["coravp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["coraap_scav"] = {type = "antiair", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["legalab_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["legavp_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["legaap_scav"] = {type = "antiair", surface = "land", spawnedPerWave = 0.05, maxExisting = 1},
+		["armamsub_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["armasy_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["armplat_scav"] = {type = "antiair", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["coramsub_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["corasy_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["corplat_scav"] = {type = "antiair", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["legamsub_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
+		["legasy_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.05, maxExisting = 1},
 	},
 	[5] = {
 		-- T2 popup arty
@@ -1114,6 +1151,12 @@ local Turrets = {
 		--Eco
 		["armafus_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 5},
 		["corafus_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 5},
+		--Factories
+		["armshltx_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 1},
+		["corgant_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 1},
+		["leggant_scav"] = {type = "normal", surface = "land", spawnedPerWave = 0.1, maxExisting = 1},
+		["armshltxuw_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.1, maxExisting = 1},
+		["corgantuw_scav"] = {type = "normal", surface = "sea", spawnedPerWave = 0.1, maxExisting = 1},
 	},
 	[7] = {
 		--Epic Bulwark and Pulsar/rag/cal

--- a/luarules/gadgets/pve_areahealers.lua
+++ b/luarules/gadgets/pve_areahealers.lua
@@ -23,6 +23,24 @@ else
 	return false
 end
 
+local scavengerAITeamID = 999
+local raptorsAITeamID = 999
+local teams = Spring.GetTeamList()
+for i = 1, #teams do
+	local luaAI = Spring.GetTeamLuaAI(teams[i])
+	if luaAI and luaAI ~= "" and string.sub(luaAI, 1, 12) == 'ScavengersAI' then
+		scavengerAITeamID = i - 1
+		break
+	end
+end
+for i = 1, #teams do
+	local luaAI = Spring.GetTeamLuaAI(teams[i])
+	if luaAI and luaAI ~= "" and string.sub(luaAI, 1, 12) == 'RaptorsAI' then
+		raptorsAITeamID = i - 1
+		break
+	end
+end
+
 local aliveHealers = {}
 local healersTable = {}
 if Spring.Utilities.Gametype.IsRaptors() then
@@ -84,7 +102,7 @@ end
 
 function gadget:GameFrame(frame)
     for unitID, statsTable in pairs(aliveHealers) do
-        if unitID%30 == frame%30 then
+        if unitID%30 == frame%30 and (Spring.GetUnitTeam(unitID) == scavengerAITeamID or Spring.GetUnitTeam(unitID) == raptorsAITeamID) then
             --Spring.Echo("Alive Healer ID", unitID, UnitDefs[Spring.GetUnitDefID(unitID)].name)
             local x,y,z = Spring.GetUnitPosition(unitID)
             local surroundingUnits = Spring.GetUnitsInSphere(x, y, z, statsTable.healingrange)

--- a/luarules/gadgets/pve_builder_controller.lua
+++ b/luarules/gadgets/pve_builder_controller.lua
@@ -50,7 +50,9 @@ for unitDefID, data in pairs(UnitDefs) do
             buildOptions = data.buildOptions,
             unitDefID = unitDefID,
             unitDefName = data.name,
+            isFactory = data.isFactory,
         }
+        Spring.Echo(data.name, data.isFactory)
 	end
 end
 
@@ -74,14 +76,14 @@ function gadget:GameFrame(frame)
     if frame > lastTurretFrame + 300 then
         if frame%30 == 9 then
             for unitID, data in pairs(aliveBuilders) do
-                if Spring.GetUnitNearestEnemy(unitID, data.range*5, true) and math.random(0,30) == 0 then
+                if (Spring.GetUnitNearestEnemy(unitID, data.range*5, true) and math.random(0,30) == 0) or (data.isFactory) then
                     --Spring.Echo(data.unitDefName, "NearestEnemyInRange")
-                    if (Spring.GetUnitCommands(unitID, -1)[1] and Spring.GetUnitCommands(unitID, -1)[1].id > 0 and Spring.GetUnitCommands(unitID, -1)[1].id ~= CMD.REPAIR) or not (Spring.GetUnitCommands(unitID, -1)[1]) then
+                    if (data.isFactory and #Spring.GetFullBuildQueue(unitID, 0) < 5) or ((not data.isFactory) and (Spring.GetUnitCommands(unitID, -1)[1] and Spring.GetUnitCommands(unitID, -1)[1].id > 0 and Spring.GetUnitCommands(unitID, -1)[1].id ~= CMD.REPAIR) or not (Spring.GetUnitCommands(unitID, -1)[1])) then
                         --Spring.Echo(data.unitDefName, "Isn't building anything")
                         local turretOptions = {}
                         for buildOptionIndex, buildOptionID in pairs(data.buildOptions) do
                             --Spring.Echo("buildOptionID", buildOptionID, UnitDefs[buildOptionID].name)
-                            if buildOptionID and UnitDefs[buildOptionID].weapons and #UnitDefs[buildOptionID].weapons > 0 then
+                            if buildOptionID and ((UnitDefs[buildOptionID].weapons and #UnitDefs[buildOptionID].weapons > 0) or (math.random(1,10) == 1 and UnitDefs[buildOptionID].isFactory)) then
                                 turretOptions[#turretOptions+1] = buildOptionID
                                 --Spring.Echo(data.unitDefName, UnitDefs[buildOptionID].name, "Is a turret")
                             end
@@ -90,8 +92,14 @@ function gadget:GameFrame(frame)
                             local turret = turretOptions[math.random(1, #turretOptions)]
                             local x,y,z = Spring.GetUnitPosition(unitID)
                             Spring.GiveOrderToUnit(unitID, -turret, {x+math.random(-data.range, data.range), y, z+math.random(-data.range, data.range)}, {})
-                            lastTurretFrame = frame
-                            break
+                            if data.isFactory then
+                                for i = 1,math.random(1,5) do
+                                    Spring.GiveOrderToUnit(unitID, -turret, {x+math.random(-data.range, data.range), y, z+math.random(-data.range, data.range)}, {})
+                                end
+                            else
+                                lastTurretFrame = frame
+                                break
+                            end
                         end
                     end
                 end

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1796,17 +1796,17 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			if t < config.gracePeriod then
 				queenAnger = 0
-				minBurrows = 4*(t/config.gracePeriod)
+				minBurrows = 8*(t/config.gracePeriod)
 			else
 				if not queenID then
 					queenAnger = math.max(math.ceil(math.min((t - config.gracePeriod) / (queenTime - config.gracePeriod) * 100) + queenAngerAggressionLevel, 100), 0)
-					minBurrows = 4
+					minBurrows = 8
 					if burrowCount <= 2 then
 						playerAggression = playerAggression + 1
 					end
 				else
 					queenAnger = 100
-					minBurrows = 4
+					minBurrows = 8
 				end
 				queenAngerAggressionLevel = queenAngerAggressionLevel + ((playerAggression*0.01)/(config.queenTime/3600)) + playerAggressionEcoValue
 				SetGameRulesParam("RaptorQueenAngerGain_Aggression", (playerAggression*0.01)/(config.queenTime/3600))

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1282,7 +1282,11 @@ if gadgetHandler:IsSyncedCode() then
 								local turretUnitID, spawnPosX, spawnPosY, spawnPosZ = spawnCreepStructure(uName, uSettings, footprintAvg+32)
 								if turretUnitID then
 									setScavXP(turretUnitID)
-									Spring.GiveOrderToUnit(turretUnitID, CMD.PATROL, {spawnPosX + mRandom(-128,128), spawnPosY, spawnPosZ + mRandom(-128,128)}, {"meta"})
+									if UnitDefNames[uName].isFactory then
+										Spring.GiveOrderToUnit(turretUnitID, CMD.FIGHT, {spawnPosX + mRandom(-256,256), spawnPosY, spawnPosZ + mRandom(-256,256)}, {"meta"})
+									else
+										Spring.GiveOrderToUnit(turretUnitID, CMD.PATROL, {spawnPosX + mRandom(-128,128), spawnPosY, spawnPosZ + mRandom(-128,128)}, {"meta"})
+									end
 								end
 							until turretUnitID or attempts > 10
 						end
@@ -1678,17 +1682,17 @@ if gadgetHandler:IsSyncedCode() then
 			techAnger = math.max(math.ceil(math.min((t - config.gracePeriod) / ((bossTime/Spring.GetModOptions().scav_bosstimemult) - config.gracePeriod) * 100), 999), 0) + math.floor(HumanTechLevelPenalty*100)
 			if t < config.gracePeriod then
 				bossAnger = 0
-				minBurrows = 4*(t/config.gracePeriod)
+				minBurrows = 8*(t/config.gracePeriod)
 			else
 				if not bossID then
 					bossAnger = math.max(math.ceil(math.min((t - config.gracePeriod) / (bossTime - config.gracePeriod) * 100) + bossAngerAggressionLevel, 100), 0)
-					minBurrows = 4
+					minBurrows = 8
 					if burrowCount <= 2 then
 						playerAggression = playerAggression + 1
 					end
 				else
 					bossAnger = 100
-					minBurrows = 4
+					minBurrows = 8
 				end
 				bossAngerAggressionLevel = bossAngerAggressionLevel + ((playerAggression*0.01)/(config.bossTime/3600)) + playerAggressionEcoValue
 				SetGameRulesParam("ScavBossAngerGain_Aggression", (playerAggression*0.01)/(config.bossTime/3600))


### PR DESCRIPTION
- Added Factories to the list of turret spawns, and also as options for scav builders, alongside a new behaviour that keeps them pumping out units.

- Area Healing is now disabled for player controlled Scav units to prevent issues with reclaiming, and to make them less overpowered.

- Increased amount of desired spawners from 4 to 8. It's still 2 that triggers boss rush.