### PR TITLE
fix widget:gui_pregame_build.lua

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -382,6 +382,9 @@ function widget:MousePress(mx, my, button)
 		end
 	elseif button == 1 and #buildQueue > 0 then -- avoid clashing first building and commander position
 		local _, pos = Spring.TraceScreenRay(mx, my, true, false, false, isUnderwater(startDefID))
+		if not pos then
+			return
+		end
 		local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, pos[1], pos[2], pos[3])
 
 		if DoBuildingsClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1]) then


### PR DESCRIPTION
Stop the widget from crashing when clicking off screen and getting a nil value for pos on line 384.

Error: [t=00:01:22.965690][f=-000001] Error in MousePress(): [string "LuaUI/Widgets/gui_pregame_build.lua"]:385: attempt to index local 'pos' (a nil value)

Fix: return if pos is nil