### PR TITLE
Idle builder icons ignore non-completed units

### DIFF
--- a/luaui/Widgets/gui_unit_idlebuilder_icons.lua
+++ b/luaui/Widgets/gui_unit_idlebuilder_icons.lua
@@ -115,7 +115,7 @@ local function updateIcon(unitID, unitDefID, gf)
 	else
 		if not (unitConf[unitDefID][3] and spGetFactoryCommands(unitID, 1)[1] or spGetCommandQueue(unitID, 1)[1]) then
 			if iconVBO.instanceIDtoIndex[unitID] == nil then -- not already being drawn
-				if Spring.ValidUnitID(unitID) and not Spring.GetUnitIsDead(unitID) then
+				if Spring.ValidUnitID(unitID) and not Spring.GetUnitIsDead(unitID) and not Spring.GetUnitIsBeingBuilt(unitID) then
 					if not idleUnitList[unitID] then
 						idleUnitList[unitID] = os.clock()
 					elseif idleUnitList[unitID] < os.clock() - idleUnitDelay then


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
The `zzz`s won't show if a unit isn't fully built.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
Build a factory with the commander, without the changes the `zzz`s appear after some time(while the factory isn't fully built), with the changes it will only appear after the factory is built(given that it is idle)

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
