### PR TITLE
Unify tidal gen gridkeys across all cons/coms

### DIFF
--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1208,8 +1208,8 @@ local unitGrids = {
 	-- T1 sea con
 	armcs = {
 		{
-			{ "armmex", "armtide", },                         -- mex, tidal
-			{ "armfmkr", "armgeo", },                         -- floating T1 converter, geo
+			{ "armmex",},                                     -- mex
+			{ "armfmkr", "armgeo","", "armtide"},               -- floating T1 converter, geo, tidal
 			{ "armuwes", "armuwms", },                        -- uw e stor, uw m stor
 		},
 		{
@@ -1230,8 +1230,8 @@ local unitGrids = {
 
 	corcs = {
 		{
-			{ "cormex", "cortide", },                         -- mex, tidal
-			{ "corfmkr", "corgeo", },                         -- floating T1 converter, geo
+			{ "cormex",},                                     -- mex
+			{ "corfmkr", "corgeo", "","cortide"},               -- floating T1 converter, geo, tidal
 			{ "coruwes", "coruwms", },                        -- uw e stor, uw m stor
 		},
 		{
@@ -1956,8 +1956,8 @@ local unitGrids = {
 	--naval engineers
 	armmls = {
 		{
-			{ "armmex", "armtide", },                               -- mex, tidal
-			{ },                                                    --
+			{ "armmex", },                                          -- mex
+			{ "","","","armtide"},                                  -- tidal
 			{ },                                                    --
 		},
 		{
@@ -1979,8 +1979,8 @@ local unitGrids = {
 
 	cormls = {
 		{
-			{ "cormex", "cortide", },                              -- mex, tidal
-			{ },                                                   --
+			{ "cormex", },                                         -- mex, 
+			{ "","","","cortide"},                                 -- tidal
 			{ },                                                   --
 		},
 		{

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1208,8 +1208,8 @@ local unitGrids = {
 	-- T1 sea con
 	armcs = {
 		{
-			{ "armmex",},                                     -- mex
-			{ "armfmkr", "armgeo","", "armtide"},               -- floating T1 converter, geo, tidal
+			{ "armmex","","armuwgeo"},                        -- mex, uw geo
+			{ "armfmkr", "armgeo","", "armtide"},             -- floating T1 converter, geo, tidal
 			{ "armuwes", "armuwms", },                        -- uw e stor, uw m stor
 		},
 		{
@@ -1230,8 +1230,8 @@ local unitGrids = {
 
 	corcs = {
 		{
-			{ "cormex",},                                     -- mex
-			{ "corfmkr", "corgeo", "","cortide"},               -- floating T1 converter, geo, tidal
+			{ "cormex","","coruwgeo"},                        -- mex, uw geo
+			{ "corfmkr", "corgeo", "","cortide"},             -- floating T1 converter, geo, tidal
 			{ "coruwes", "coruwms", },                        -- uw e stor, uw m stor
 		},
 		{


### PR DESCRIPTION
Moved Tidals to ZF gridkeys for T1 cons and naval engineers

I suggested this on Discord because of the currently inconsistent experience of it being ZX for two cons but ZF for coms and beavers.  The only downside I see to this is an adjustment period for those who are used to it being split between ZX and ZF today and having to relearn that ZF will work but after that we'll have a consistent single key combination for tidals.


### Work done
Moved Tidal gens to ZF on grid menu for t1 cons and naval engineers
Manually defined underwater geos so they would not shift over (somehow they were in the build menu without being defined?


#### Test steps
- Loaded a skirmish with arm, core, legion and made sure tidals were in the ZF location for all cons/coms

### Screenshots:
![tidalPR](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/174193948/10b5d112-d528-4d14-ae75-025bac272be1)

