### PR TITLE
More accurate decaying time

### DIFF
--- a/luaui/Widgets/gui_build_eta.lua
+++ b/luaui/Widgets/gui_build_eta.lua
@@ -126,9 +126,9 @@ function widget:Update(dt)
 							bi.timeLeft = (1 - buildProgress) / rate
 						end
 					elseif rate < 0 then
-						local newTime = buildProgress / rate
+						local newTime = buildProgress / bi.rate -- use smooth rate
 						if bi.timeLeft and bi.timeLeft < 0 then
-							bi.timeLeft = ((1 - tf) * bi.timeLeft) + (tf * newTime)
+							bi.timeLeft = newTime -- we don't need to smoothen the time if the rate is smooth
 						else
 							bi.timeLeft = buildProgress / rate
 						end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
The decaying time doesn't use the time that is smoothed out (the way that the smoothing works is that the smoother it is, the more it lags behind), instead it uses the rate of change that is smoothed out, which seems to be accurate and smoother at the same time, so a win-win.
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Closes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3225

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Build a factory with the commander and then stop building it before it finishes.
You should see that the decaying time is accurate, and it also doesn't jump around.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
