### PR TITLE
SpringLuaApi Updates

### DIFF
--- a/luamocks/SpringLuaApi.lua
+++ b/luamocks/SpringLuaApi.lua
@@ -1847,9 +1847,9 @@ assert(type(teamID) == "number","Argument teamID is of invalid type - expected n
 return  numberMock
  end
 
-function Spring.GetUnitsInRectangle (  xmin, teamID, zmin, zmax, xmax)
+function Spring.GetUnitsInRectangle (  xmin, zmin, xmax, zmax, teamID)
 assert(type(xmin) == "number","Argument xmin, is of invalid type - expected number");
-assert(type(teamID) == "number","Argument teamID] is of invalid type - expected number");
+assert(type(teamID) == "number","Argument teamID is of invalid type - expected number");
 assert(type(zmin) == "number","Argument zmin, is of invalid type - expected number");
 assert(type(zmax) == "number","Argument zmax is of invalid type - expected number");
 assert(type(xmax) == "number","Argument xmax, is of invalid type - expected number");
@@ -1864,7 +1864,7 @@ function Spring.GetUnitsInSphere (  radius, y, z, teamID, x)
 assert(type(radius) == "number","Argument radius is of invalid type - expected number");
 assert(type(y) == "number","Argument y, is of invalid type - expected number");
 assert(type(z) == "number","Argument z, is of invalid type - expected number");
-assert(type(teamID) == "number","Argument teamID] is of invalid type - expected number");
+assert(type(teamID) == "number","Argument teamID is of invalid type - expected number");
 assert(type(x) == "number","Argument x, is of invalid type - expected number");
 return  tableMock
  end
@@ -1873,7 +1873,7 @@ function Spring.GetUnitsInCylinder (x, z, radius, teamID)
     assert(type(x) == "number","Argument x, is of invalid type - expected number");
     assert(type(z) == "number","Argument z, is of invalid type - expected number");
     assert(type(radius) == "number","Argument radius is of invalid type - expected number");
-    assert(type(teamID) == "number","Argument teamID] is of invalid type - expected number");
+    assert(type(teamID) == "number","Argument teamID is of invalid type - expected number");
 return  tableMock
 end
 

--- a/luamocks/SpringLuaApi.lua
+++ b/luamocks/SpringLuaApi.lua
@@ -1853,11 +1853,11 @@ assert(type(teamID) == "number","Argument teamID] is of invalid type - expected 
 assert(type(zmin) == "number","Argument zmin, is of invalid type - expected number");
 assert(type(zmax) == "number","Argument zmax is of invalid type - expected number");
 assert(type(xmax) == "number","Argument xmax, is of invalid type - expected number");
-return  numberMock
+return  tableMock
  end
 
 function Spring.GetUnitsInBox ( )
-return  numberMock
+return  tableMock
  end
 
 function Spring.GetUnitsInSphere (  radius, y, z, teamID, x)
@@ -1866,7 +1866,7 @@ assert(type(y) == "number","Argument y, is of invalid type - expected number");
 assert(type(z) == "number","Argument z, is of invalid type - expected number");
 assert(type(teamID) == "number","Argument teamID] is of invalid type - expected number");
 assert(type(x) == "number","Argument x, is of invalid type - expected number");
-return  numberMock
+return  tableMock
  end
 
 function Spring.GetUnitsInCylinder (x, z, radius, teamID)
@@ -1874,11 +1874,11 @@ function Spring.GetUnitsInCylinder (x, z, radius, teamID)
     assert(type(z) == "number","Argument z, is of invalid type - expected number");
     assert(type(radius) == "number","Argument radius is of invalid type - expected number");
     assert(type(teamID) == "number","Argument teamID] is of invalid type - expected number");
-return  numberMock
+return  tableMock
 end
 
 function Spring.GetUnitsInPlanes ( )
-return  numberMock
+return  tableMock
  end
 
 function Spring.GetUnitNearestAlly (  range, unitID)


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Spatial unit queries now "return" a table value, instead of a number one(I hope I did that correctly), the argument order for `Spring.GetUnitsInRectangle` is fixed and a typo is also fixed.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
