### PR TITLE
Move mapmark ping

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2088,7 +2088,6 @@ end
 function widget:MapDrawCmd(playerID, cmdType, x, y, z, a, b, c)
 	if cmdType == 'point' then
 		lastMapmarkCoords = {x,y,z}
-		spPlaySoundFile( sndMapmarkFile, sndMapmarkFileVolume, nil, "ui" )
 	end
 end
 

--- a/luaui/Widgets/snd_mapmark_ping.lua
+++ b/luaui/Widgets/snd_mapmark_ping.lua
@@ -1,0 +1,22 @@
+function widget:GetInfo()
+    return {
+      name = "Mapmark Ping",
+      desc = "Plays a sound when a point mapmark is placed by an allied player.",
+      author = "hihoman23",
+      date = "Jun 2024",
+      license = "GNU GPL, v2 or later",
+      layer = 0,
+      enabled = true
+    }
+end
+
+local mapmarkFile = "sounds/ui/mappoint2.wav"
+local volume = 0.5
+
+local PlaySoundFile = Spring.PlaySoundFile
+
+function widget:MapDrawCmd(playerID, cmdType, x, y, z, a, b, c)
+    if cmdType == "point" then
+        PlaySoundFile( mapmarkFile, volume, x, y, z, nil, nil, nil, "ui")
+    end
+end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
The sound functionality of the pinging(mapmarks of the point type), was handled by the chat widget, which made no sense, so I moved it to its own widget. This also allows for more customizability.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
Ping around a bit

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
