### PR TITLE
Fix idle builder icons for factories

### DIFF
--- a/luaui/Widgets/gui_unit_idlebuilder_icons.lua
+++ b/luaui/Widgets/gui_unit_idlebuilder_icons.lua
@@ -23,7 +23,7 @@ local teamList = {} -- {team1, team2, team3....}
 local idleUnitList = {}
 
 local spGetCommandQueue = Spring.GetCommandQueue
-local spGetFactoryCommands = Spring.GetFactoryCommands
+local spGetFactoryCounts = Spring.GetFactoryCounts
 local spGetUnitTeam = Spring.GetUnitTeam
 local spec, fullview = Spring.GetSpectatingState()
 local myTeamID = Spring.GetMyTeamID()
@@ -111,8 +111,19 @@ function widget:Initialize()
 	end
 end
 
+local function isFactoryQueueEmpty(unitID)
+	local counts = spGetFactoryCounts(unitID, 1, false)
+	if not counts then return false end
+	for uDefID, count in pairs(counts) do
+		if count ~= 0 then
+			return false
+		end
+	end
+	return true
+end
+
 local function updateIcon(unitID, unitDefID, gf)
-	if not (unitConf[unitDefID][3] and spGetFactoryCommands(unitID, 1)[1] or spGetCommandQueue(unitID, 1)[1]) then
+	if (unitConf[unitDefID][3] and isFactoryQueueEmpty(unitID)) or not spGetCommandQueue(unitID, 1)[1] then
 		if iconVBO.instanceIDtoIndex[unitID] == nil then -- not already being drawn
 			if spValidUnitID(unitID) and not spGetUnitIsDead(unitID) and not spGetUnitIsBeingBuilt(unitID) then
 				if not idleUnitList[unitID] then


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Fixes the issue in #3271 , which is also explained there.

Closes #3271 

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- Get an idle factory, and give it a move command. Before, the _zzz_ s disappeared. Now it doesn't disappear if the factory isn't producing any units.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
