### PR TITLE
Update unit_respawning.lua

### DIFF
--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -104,7 +104,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-    function ReturnToBase(unitID)
+    function ReturnToBase(unitID, friendlyFire)
 		local x,y,z = spGetUnitPosition(unitID) -- usefull if you want to spawn explosions or other effects where you were.
 		local team = spGetUnitTeam(unitID)
 
@@ -121,7 +121,11 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			if respawnMetaList[unitID].destructive_respawn then
-				spDestroyUnit(respawnMetaList[unitID].effigyID, false, false)
+			    if friendlyFire then
+			        spDestroyUnit(respawnMetaList[unitID].effigyID, false, true)
+			    else
+				    spDestroyUnit(respawnMetaList[unitID].effigyID, false, false)
+				end
 				respawnMetaList[unitID].effigyID = nil
 			end
 			local stunDuration = maxHealth + (100*respawnMetaList[unitID].minimum_respawn_stun) + (diag((x-ex), (z-ez))*respawnMetaList[unitID].distance_stun_multiplier)
@@ -190,6 +194,7 @@ if gadgetHandler:IsSyncedCode() then
 					respawnMetaList[vipID].effigyID = unitID
 					if oldeffigyID then
 						spDestroyUnit(oldeffigyID, false, true)
+						Spring.SetUnitCosts(unitID, {buildTime = 1, metalCost = 1, energyCost = 1})
 					end
 					return
 				end
@@ -237,7 +242,12 @@ if gadgetHandler:IsSyncedCode() then
 				if respawnMetaList[unitID].effigyID and (h-damage) <= respawnMetaList[unitID].respawn_health_threshold and (currentTime-respawnMetaList[unitID].respawnTimer) >= 5 then
 					local effigyBuildProgress = select(5, spGetUnitHealth(respawnMetaList[unitID].effigyID))
 					if effigyBuildProgress == 1 then
-						ReturnToBase(unitID)
+					    local friendlyFire = Spring.AreTeamsAllied(unitTeam, attackerTeam)
+					    local enemyNearby = spGetUnitNearestEnemy(unitID, 1000)
+					    if friendlyFire and enemyNearby then
+					        friendlyFire = false
+					    end
+						ReturnToBase(unitID, friendlyFire)
 						respawnMetaList[unitID].respawnTimer = spGetGameSeconds()
 						return 0, 0
 					end


### PR DESCRIPTION
Removed cost and build time for a new effigy if you already have one.


Added a friendly fire check to disable effigy wreck if killed by friendly fire.
