### PR TITLE
Commander Respawning Hotfix 1

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1214,7 +1214,7 @@ local options = {
         name 	= "Commander Respawning",
         desc   	= "Commanders can build one Effigy. The first one is free. When the commander dies, the Effigy is sacrificed in its place.",
         type 	= "list",
-        def 	= "dynamic",
+        def 	= "evocom",
         section = "options_experimental",
         items 	= {
             { key = "evocom", 	name = "Evolving Commanders Only" },

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1214,7 +1214,7 @@ local options = {
         name 	= "Commander Respawning",
         desc   	= "Commanders can build one Effigy. The first one is free. When the commander dies, the Effigy is sacrificed in its place.",
         type 	= "list",
-        def 	= "evocom",
+        def 	= "disabled",
         section = "options_experimental",
         items 	= {
             { key = "evocom", 	name = "Evolving Commanders Only" },

--- a/units/other/evocom/comeffigy.lua
+++ b/units/other/evocom/comeffigy.lua
@@ -44,6 +44,7 @@ for lvl, stats in pairs(lvlParams) do
 		buildtime = 1500,
 		cancloak = true,
 		canmove = false,
+		canselfdestruct = false,
 		capturable = false,
 		category = "ALL WEAPON COMMANDER NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE CANBEUW EMPABLE",
 		cloakcost = 0,


### PR DESCRIPTION
Hi. This disables ability to self destruct effigy's by accident ( and also creating free metal >.>)

it also fixes modoption mistake where the default option wasn't a viable option. Forgot to replace the string.