### PR TITLE
Commander respawn hotfix 2

### DIFF
--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -192,8 +192,11 @@ if gadgetHandler:IsSyncedCode() then
 					local oldeffigyID = respawnMetaList[vipID].effigyID
 					
 					respawnMetaList[vipID].effigyID = unitID
+					local oldEffigyBuildProgress = select(5, spGetUnitHealth(oldeffigyID))
 					if oldeffigyID then
 						spDestroyUnit(oldeffigyID, false, true)
+					end
+					if oldEffigyBuildProgress == 1 then
 						Spring.SetUnitCosts(unitID, {buildTime = 1, metalCost = 1, energyCost = 1})
 					end
 					return

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1214,7 +1214,7 @@ local options = {
         name 	= "Commander Respawning",
         desc   	= "Commanders can build one Effigy. The first one is free. When the commander dies, the Effigy is sacrificed in its place.",
         type 	= "list",
-        def 	= "dynamic",
+        def 	= "evocom",
         section = "options_experimental",
         items 	= {
             { key = "evocom", 	name = "Evolving Commanders Only" },


### PR DESCRIPTION
Fixed a bug where if you started building an effigy, stopped, then tried to build another you'd insta-build it for free.

Set default to run respawning with Evolving Commanders by default