### PR TITLE
Fix crash with buildunit when binded units doesn't exist in pregame gui_buildmenu.lua

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -1096,9 +1096,11 @@ local function buildUnitHandler(_, _, _, data)
 		if string.sub(keybind.command, 1, 10) == 'buildunit_' then
 			local uDefName = string.sub(keybind.command, 11)
 			local uDef = UnitDefNames[uDefName]
-			if comBuildOptions[unitName[startDefID]][uDef.id] and not units.unitRestricted[uDef.id] then
-				table.insert(buildCycle, uDef.id)
-			end
+	        if uDef then -- prevents crashing when trying to access unloaded units (legion)
+	            if comBuildOptions[unitName[startDefID]][uDef.id] and not units.unitRestricted[uDef.id] then
+	                table.insert(buildCycle, uDef.id)
+	            end
+        	end
 		end
 	end
 


### PR DESCRIPTION
When having binds for legion (legmoho), when legion isn't loaded that isn't put into UnitDefNames, causing it to crash.

Adding null check and only running when we have a uDef fixes the crashing issue

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Added Null Check, before reading uDef.id
-->

<!-- If relevant
#### Setup
Legacy hotkeys, Pregame mode
-->

