### PR TITLE
luaui: add config toggle to display English unit names when using another locale

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1567,6 +1567,7 @@
 				"green": "green",
 				"blue": "blue",
 				"language": "Language",
+				"language_english_unit_names": "Display unit names in English",
 				"reclaimfieldhighlight": "Reclaim Field Highlight",
 				"reclaimfieldhighlight_descr": "Highlights clusters of reclaimable metal",
 				"reclaimfieldhighlight_always": "Always enabled",

--- a/language/fr/interface.json
+++ b/language/fr/interface.json
@@ -1492,6 +1492,7 @@
 				"green": "vert",
 				"blue": "bleu",
 				"language": "Langage",
+				"language_english_unit_names": "Afficher noms d'unités en anglais",
 				"reclaimfieldhighlight": "Surbrillance des épaves",
 				"reclaimfieldhighlight_descr": "Permet d'automatiquement mettre en valeur les concentrations d'épaves recyclables.",
 				"reclaimfieldhighlight_always": "Toujours actif",

--- a/luaui/Widgets/gui_language.lua
+++ b/luaui/Widgets/gui_language.lua
@@ -39,6 +39,14 @@ function widget:Initialize()
 			Script.LuaUI.LanguageChanged()
 		end
 	end
+
+	WG['language'].setEnglishUnitNames = function(value)
+		Spring.SetConfigInt("language_english_unit_names", value and 1 or 0)
+
+		if Script.LuaUI('LanguageChanged') then
+			Script.LuaUI.LanguageChanged()
+		end
+	end
 end
 
 function widget:Shutdown()

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3241,6 +3241,11 @@ function init()
 				end
 			end
 		},
+		{ id = "language_english_unit_names", group = "ui", category = types.basic, name = Spring.I18N('ui.settings.option.language_english_unit_names'), type = "bool", value = (Spring.GetConfigInt("language_english_unit_names", 1) == 1),
+			onchange = function(i, value)
+				WG['language'].setEnglishUnitNames(value)
+			end,
+		},
 		{ id = "uiscale", group = "ui", category = types.basic, name = Spring.I18N('ui.settings.option.interface') .. widgetOptionColor .. "  " .. Spring.I18N('ui.settings.option.uiscale'), type = "slider", min = 0.8, max = 1.3, step = 0.01, value = Spring.GetConfigFloat("ui_scale", 1), description = '',
 		  onload = function(i)
 		  end,
@@ -5594,6 +5599,10 @@ function init()
 		options[getOptionByID('gridmenu_labbuildmode')] = nil
 	end
 
+	-- hide English unit names toggle if using English
+	if Spring.I18N.getLocale() == 'en' then
+		options[getOptionByID('language_english_unit_names')] = nil
+	end
 
 	-- add fonts
 	if getOptionByID('font') then

--- a/modules/i18n/i18nlib/i18n/init.lua
+++ b/modules/i18n/i18nlib/i18n/init.lua
@@ -135,6 +135,11 @@ function i18n.translate(key, data)
   data = data or {}
   local usedLocale = data.locale or locale
 
+  -- if user elected to use English unit names, force `en` locale when translating a unit name
+  if (Spring.GetConfigInt("language_english_unit_names", 1) == 1) and key:sub(1, #'units.names.') == 'units.names.' then
+    usedLocale = "en"
+  end
+
   local fallbacks = variants.fallbacks(usedLocale, fallbackLocale)
   for i=1, #fallbacks do
     local fallback = fallbacks[i]


### PR DESCRIPTION
Rationale: in 12b069648f7ff93e8f50d23bc73fccfd19297931, we introduced a new config option to allow using the French language, as the first non-English language available on BAR.

A common feedback from French users is that unit names being also translated is more harmful than helpful especially in PvP contexts. This was also previously mentioned as a probable hindrance as part of the internal discussions around opening up i18n translations on BAR.

This commit introduces an optional config toggle that only displays when selecting a non-English locale, allowing to display English unit names while still translating everything else.

We elected to have this toggle set to "On" by default because most users reported their intent to have this enabled, including PvE players (because they still wish to take part in community discussions and stick to a common vocabulary, even when they don't want to partake in PvP).