### PR TITLE
camera flip for spring camera isnt full 180 degrees if camera is at 0 rotation

### DIFF
--- a/luaui/Widgets/camera_flip.lua
+++ b/luaui/Widgets/camera_flip.lua
@@ -33,7 +33,7 @@ local function cameraFlipHandler()
 		Spring.SetConfigInt("CamSpringLockCardinalDirections", 0)
 	end
 
-	camState.ry = camState.ry + math.pi
+	camState.ry = camState.ry + math.pi + .01
 	Spring.SetCameraState(camState, 0)
 
 	if previousLock == 1 then

--- a/luaui/Widgets/camera_flip.lua
+++ b/luaui/Widgets/camera_flip.lua
@@ -29,14 +29,19 @@ local function cameraFlipHandler()
 	-- CardinalLock messes up rotation
 	local previousLock = Spring.GetConfigInt("CamSpringLockCardinalDirections")
 
-	if previousLock == 1 then
-		Spring.SetConfigInt("CamSpringLockCardinalDirections", 0)
+	if previousLock == 0 then
+		Spring.SetConfigInt("CamSpringLockCardinalDirections", 1)
 	end
 
-	camState.ry = camState.ry + math.pi + .01
+	if camState.ry > 0 then
+		camState.ry = camState.ry - math.pi - 1 / 3
+	else
+		camState.ry = camState.ry + math.pi + 1 / 3
+	end
+
 	Spring.SetCameraState(camState, 0)
 
-	if previousLock == 1 then
+	if previousLock == 0 then
 		Spring.SetConfigInt("CamSpringLockCardinalDirections", previousLock)
 	end
 

--- a/luaui/Widgets/camera_flip.lua
+++ b/luaui/Widgets/camera_flip.lua
@@ -27,23 +27,19 @@ local function cameraFlipHandler()
 
 	-- camera is spring cam
 	-- CardinalLock messes up rotation
-	local previousLock = Spring.GetConfigInt("CamSpringLockCardinalDirections")
-
-	if previousLock == 0 then
-		Spring.SetConfigInt("CamSpringLockCardinalDirections", 1)
+	local cardinalLock = Spring.GetConfigInt("CamSpringLockCardinalDirections")
+	local lockCorrection = 0
+	if cardinalLock == 1 then
+		lockCorrection = 1/3
 	end
 
 	if camState.ry > 0 then
-		camState.ry = camState.ry - math.pi - 1 / 3
+		camState.ry = camState.ry - math.pi - lockCorrection
 	else
-		camState.ry = camState.ry + math.pi + 1 / 3
+		camState.ry = camState.ry + math.pi + lockCorrection
 	end
 
 	Spring.SetCameraState(camState, 0)
-
-	if previousLock == 0 then
-		Spring.SetConfigInt("CamSpringLockCardinalDirections", previousLock)
-	end
 
 	return true
 end

--- a/luaui/Widgets/camera_flip.lua
+++ b/luaui/Widgets/camera_flip.lua
@@ -30,6 +30,7 @@ local function cameraFlipHandler()
 	local cardinalLock = Spring.GetConfigInt("CamSpringLockCardinalDirections")
 	local lockCorrection = 0
 	if cardinalLock == 1 then
+		-- This value must be larger than the cardinal lock width of 0.2
 		lockCorrection = 1/3
 	end
 


### PR DESCRIPTION
The spring camera has a wonky rotation if flipped after switching to it from overhead camera, this resolves:

![image](https://github.com/beyond-all-reason/Beyond-All-Reason/assets/13026303/e4e306d7-3b2b-4594-b4cb-fe0e5d26a7e1)
