### PR TITLE
Scav Balancing Tweaks

### DIFF
--- a/luarules/gadgets/pve_supply_drops.lua
+++ b/luarules/gadgets/pve_supply_drops.lua
@@ -102,7 +102,7 @@ elseif lootboxesDensity == "normal" then
 	lootboxDensityMultiplier = 1
 end
 
-local SpawnChance = math.ceil(15/lootboxDensityMultiplier)
+local SpawnChance = math.ceil((150/lootboxDensityMultiplier)/(#teams-1))
 
 if scavengersAIEnabled then
 	spGaiaTeam = scavengerAITeamID
@@ -125,11 +125,11 @@ local nearbyCaptureLibrary = VFS.Include("luarules/utilities/damgam_lib/nearby_c
 -- callins
 
 local function SpawnLootbox(posx, posy, posz)
-	if math.random() < math.min(0.8, aliveLootboxesCountT3*0.05) then
+	if math.random() < math.min(0.8, (aliveLootboxesCountT3*0.4)/(#teams-1)) then
 		lootboxToSpawn = lootboxesListT4[math_random(1,#lootboxesListT4)]
-	elseif math.random() < math.min(0.8, aliveLootboxesCountT2*0.05) then
+	elseif math.random() < math.min(0.8, (aliveLootboxesCountT2*0.4)/(#teams-1)) then
 		lootboxToSpawn = lootboxesListT3[math_random(1,#lootboxesListT3)]
-	elseif math.random() < math.min(0.8, aliveLootboxesCountT1*0.05) then
+	elseif math.random() < math.min(0.8, (aliveLootboxesCountT1*0.4)/(#teams-1)) then
 		lootboxToSpawn = lootboxesListT2[math_random(1,#lootboxesListT2)]
 	else
 		lootboxToSpawn = lootboxesListT1[math_random(1,#lootboxesListT1)]
@@ -141,7 +141,6 @@ local function SpawnLootbox(posx, posy, posz)
 		spCreateUnit("lootdroppod_gold", posx, posy, posz, math_random(0,3), spGaiaTeam)
 	end
 	if spawnedUnit then
-
 		Spring.SetUnitNeutral(spawnedUnit, true)
 		Spring.SetUnitAlwaysVisible(spawnedUnit, true)
 	end

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1847,7 +1847,7 @@ if gadgetHandler:IsSyncedCode() then
 				if unitID%4 == captureRuns then
 					local ux, uy, uz = Spring.GetUnitPosition(unitID)
 					local captureLevel = select(4, Spring.GetUnitHealth(unitID))
-					local captureProgress = 0.01667 * (15/math.ceil(math.sqrt(math.sqrt(UnitDefs[Spring.GetUnitDefID(unitID)].health)))) * math.max(0.1, (techAnger/100)) -- really wack formula that i really don't want to explain. All you need to know is that we take Behemoth 335000 health as the baseline of taking about 1 minute to capture at 100% tech anger.
+					local captureProgress = 0.003 * (20/math.ceil(math.sqrt(math.sqrt(Spring.GetUnitHealth(unitID))))) * math.max(0.1, (techAnger/100)) -- really wack formula that i really don't want to explain.
 					if Spring.GetUnitTeam(unitID) ~= scavTeamID and GG.IsPosInRaptorScum(ux, uy, uz) then
 						if captureLevel+captureProgress >= 0.99 then
 							Spring.TransferUnit(unitID, scavTeamID, false)

--- a/units/Scavengers/Boss/scavengerbossv4.lua
+++ b/units/Scavengers/Boss/scavengerbossv4.lua
@@ -7,8 +7,8 @@ end
 local baseValues = { --format: {value, multiplier}
 
 	--health related
-	autoHeal = { 10, 1.15 },
-	health = { 650000, 1.15 },
+	autoHeal = { 10 * playerCountScale, 1.15 },
+	health = { math.min(800000 * playerCountScale, 10000000), 1.15 },
 
 	--DPS related
 	botCannonProjectiles = { 3 * playerCountScale, 1.15 },


### PR DESCRIPTION
- Lootbox spawn rate and level now scales with number of players.
- Scavenger Cloud now captures based on current unit health, while also the baseline capturing rate has been nerfed very significantly.
- Scavenger Boss health now scales with number of players.
