### PR TITLE
Scavenger Mist update

### DIFF
--- a/gamedata/scavengers/unitdef_changes.lua
+++ b/gamedata/scavengers/unitdef_changes.lua
@@ -39,7 +39,7 @@ end
 local legionLobberUnitsT1 = "leglob_scav leggob_scav leghades_scav leghelios_scav legsh_scav"
 local legionLobberUnitsT2 = "legcen_scav legkark_scav legbal_scav leggat_scav legrail_scav legbar_scav legmh_scav legner_scav"
 local legionLobberUnitsT3 = "legstr_scav leginfestor_scav legbart_scav legsrail_scav legmrv_scav legfloat_scav"
-local legionLobberUnitsT4 = "leginf_scav legheattank_scav legskirmtank_scav leginc_scav legmed_scav legvroc_scav"
+local legionLobberUnitsT4 = "leginf_scav legheattank_scav legaskirmtank_scav leginc_scav legmed_scav legvroc_scav"
 
 customDefs.armsilo = {
 	weapondefs = {

--- a/luarules/gadgets/unit_explosion_spawner.lua
+++ b/luarules/gadgets/unit_explosion_spawner.lua
@@ -21,6 +21,7 @@ end
 -- spawns_mode = if you have multiple entries, use one of these strings: "random" "random_locked" or "sequential"
 -- spawns_expire = how long before your unit is destroyed in seconds
 -- spawns_ceg = use to spawn an arbitrary ceg in addition to the explosion effect used in the weapondefs. uses Spring.SpawnCEG()
+-- spawns_stun = a number, use it to define how long a unit will be stunned for after landing.
 
 
 local spCreateFeature         = Spring.CreateFeature
@@ -34,6 +35,8 @@ local spGiveOrderToUnit       = Spring.GiveOrderToUnit
 local spSetFeatureDirection   = Spring.SetFeatureDirection
 local spSetUnitRulesParam     = Spring.SetUnitRulesParam
 local spSpawnCEG 			  = Spring.SpawnCEG
+local spGetUnitHealth 		  = Spring.GetUnitHealth
+local spSetUnitHealth		  = Spring.SetUnitHealth
 
 local mapsizeX 				  = Game.mapSizeX
 local mapsizeZ 				  = Game.mapSizeZ
@@ -75,6 +78,7 @@ for weaponDefID = 1, #WeaponDefs do
 			surface = wdcp.spawns_surface,
 			mode = wdcp.spawns_mode,
 			ceg = wdcp.spawns_ceg,
+			stun = wdcp.spawns_stun,
 		}
 		if wdcp.spawn_blocked_by_shield then
 			shieldCollide[weaponDefID] = WeaponDefs[weaponDefID].damages[Game.armorTypes.shield]
@@ -153,6 +157,12 @@ local function SpawnUnit(spawnData)
 				unitID = spCreateUnit(spawnUnitName, spawnData.x, spawnData.y, spawnData.z, 0, spawnData.teamID)
 				if spawnDef.ceg then
 					spSpawnCEG(spawnDef.ceg, spawnData.x, spawnData.y, spawnData.z, 0,0,0)
+				end
+				if spawnDef.stun then
+					local maxHealth = select(2, spGetUnitHealth(unitID))
+					local paralyzeTime = maxHealth + ((maxHealth/30)*spawnDef.stun)
+					spSetUnitHealth(unitID, {paralyze = paralyzeTime })
+					Spring.Echo("Step 4, max health", maxHealth)
 				end
 			end
 			if not unitID then

--- a/luarules/gadgets/unit_explosion_spawner.lua
+++ b/luarules/gadgets/unit_explosion_spawner.lua
@@ -162,7 +162,6 @@ local function SpawnUnit(spawnData)
 					local maxHealth = select(2, spGetUnitHealth(unitID))
 					local paralyzeTime = maxHealth + ((maxHealth/30)*spawnDef.stun)
 					spSetUnitHealth(unitID, {paralyze = paralyzeTime })
-					Spring.Echo("Step 4, max health", maxHealth)
 				end
 			end
 			if not unitID then

--- a/luarules/gadgets/unit_juno_damage.lua
+++ b/luarules/gadgets/unit_juno_damage.lua
@@ -67,6 +67,9 @@ if gadgetHandler:IsSyncedCode() then
 		['raptor_land_kamikaze_emp_t2_v1'] = true,
 		['raptor_land_kamikaze_basic_t4_v1'] = true,
 		['raptor_land_kamikaze_emp_t4_v1'] = true,
+		['scavmist'] = true,
+		['scavmistxl'] = true,
+		['scavmistxxl'] = true,
 	}
 	-- convert unitname -> unitDefID
 	local tokillUnits = {}
@@ -86,6 +89,9 @@ if gadgetHandler:IsSyncedCode() then
 		['raptor_land_kamikaze_emp_t2_v1'] = true,
 		['raptor_land_kamikaze_basic_t4_v1'] = true,
 		['raptor_land_kamikaze_emp_t4_v1'] = true,
+		['scavmist'] = true,
+		['scavmistxl'] = true,
+		['scavmistxxl'] = true,
 	}
 	-- convert unitname -> unitDefID
 	local todenyUnits = {}

--- a/units/Scavengers/Other/scavmists.lua
+++ b/units/Scavengers/Other/scavmists.lua
@@ -194,7 +194,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_surface = "LAND",
 					spawns_mode = "random",
                     spawns_ceg = "scav-spawnexplo",
-					spawns_stun = 2
+					spawns_stun = 1
 				},
 				damage = {
 					default = 0,
@@ -240,7 +240,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_mode = "random",
 					spawns_expire = 60,
                     spawns_ceg = "scav-spawnexplo",
-					spawns_stun = 2
+					spawns_stun = 1
 				},
 				damage = {
 					default = 0,
@@ -286,7 +286,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_surface = "SEA",
 					spawns_mode = "random",
                     spawns_ceg = "scav-spawnexplo",
-					spawns_stun = 2
+					spawns_stun = 1
 				},
 				damage = {
 					default = 0,

--- a/units/Scavengers/Other/scavmists.lua
+++ b/units/Scavengers/Other/scavmists.lua
@@ -194,7 +194,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_surface = "LAND",
 					spawns_mode = "random",
                     spawns_ceg = "scav-spawnexplo",
-					spawns_stun = 3
+					spawns_stun = 2
 				},
 				damage = {
 					default = 0,

--- a/units/Scavengers/Other/scavmists.lua
+++ b/units/Scavengers/Other/scavmists.lua
@@ -194,6 +194,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_surface = "LAND",
 					spawns_mode = "random",
                     spawns_ceg = "scav-spawnexplo",
+					spawns_stun = 3
 				},
 				damage = {
 					default = 0,
@@ -239,6 +240,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_mode = "random",
 					spawns_expire = 60,
                     spawns_ceg = "scav-spawnexplo",
+					spawns_stun = 2
 				},
 				damage = {
 					default = 0,
@@ -284,6 +286,7 @@ for lvl, stats in pairs(lvlParams) do
 					spawns_surface = "SEA",
 					spawns_mode = "random",
                     spawns_ceg = "scav-spawnexplo",
+					spawns_stun = 2
 				},
 				damage = {
 					default = 0,


### PR DESCRIPTION
Just adds entries to the juno gadget to kill scavenger mists. This is desirable to give players an option to advance into mist territory without encountering defensive units/structures (But not for free!)

Also added optional ability to stun units created by unit_explosion_spawner.lua that is used by scavenger mists to have their spawned units not immediately start firing.