### PR TITLE
Spring.Echo: Support echoing tables

### DIFF
--- a/common/springFunctions.lua
+++ b/common/springFunctions.lua
@@ -34,7 +34,6 @@ local debugUtilities = VFS.Include(utilitiesDirectory .. 'debug.lua')
 
 local debugFuncs = {
 	ParamsEcho = debugUtilities.ParamsEcho,
-	TableEcho = debugUtilities.TableEcho,
 	TraceEcho = debugUtilities.TraceEcho,
 	TraceFullEcho = debugUtilities.TraceFullEcho,
 }

--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -58,7 +58,13 @@ if Spring.Echo then
 			end
 		end
 
-		echo(unpack(args, 1, args.n))
+		-- When Spring.Echo is called with a single table parameter, engine will echo "TABLE: {value}",
+		-- where {value} is whatever value happens to be the first value in the table
+		if #tableIndexes == 1 and args.n == 1 then
+			echo("<table>")
+		else
+				echo(unpack(args, 1, args.n))
+		end
 
 		for _, index in ipairs(tableIndexes) do
 			echo(table.toString(args[index], printOptions))

--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -63,7 +63,7 @@ if Spring.Echo then
 		if #tableIndexes == 1 and args.n == 1 then
 			echo("<table>")
 		else
-				echo(unpack(args, 1, args.n))
+			echo(unpack(args, 1, args.n))
 		end
 
 		for _, index in ipairs(tableIndexes) do

--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -44,6 +44,7 @@ end
 
 if Spring.Echo then
 	local echo = Spring.Echo
+	local printOptions = { pretty = true }
 
 	local function multiEcho(...)
 		local args = table.pack(...)
@@ -57,14 +58,10 @@ if Spring.Echo then
 			end
 		end
 
-		if #tableIndexes > 0 and #tableIndexes ~= args.n then
-			Spring.Log("", LOG.WARNING, "Spring.Echo called with mixed table and non-table parameters. Echoing table parameters separately.")
-		end
-
 		echo(unpack(args, 1, args.n))
 
 		for _, index in ipairs(tableIndexes) do
-			Spring.Debug.TableEcho(args[index])
+			echo(table.toString(args[index], printOptions))
 		end
 	end
 

--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -41,3 +41,32 @@ if Spring.GetModOptions then
 		return table.copy(modOptions)
 	end
 end
+
+if Spring.Echo then
+	local echo = Spring.Echo
+
+	local function multiEcho(...)
+		local args = table.pack(...)
+		local tableIndexes = {}
+
+		for index = 1, args.n do
+			local value = args[index]
+
+			if type(value) == 'table' then
+				table.insert(tableIndexes, index)
+			end
+		end
+
+		if #tableIndexes > 0 and #tableIndexes ~= args.n then
+			Spring.Log("", LOG.WARNING, "Spring.Echo called with mixed table and non-table parameters. Echoing table parameters separately.")
+		end
+
+		echo(unpack(args, 1, args.n))
+
+		for _, index in ipairs(tableIndexes) do
+			Spring.Debug.TableEcho(args[index])
+		end
+	end
+
+	Spring.Echo = multiEcho
+end

--- a/common/springUtilities/debug.lua
+++ b/common/springUtilities/debug.lua
@@ -6,30 +6,6 @@ local function paramsEcho(...)
 	return ...
 end
 
-local function tableEcho(data, name, indent, tableChecked)
-	name = name or "TableEcho"
-	indent = indent or ""
-	if (not tableChecked) and type(data) ~= "table" then
-		Spring.Echo(indent .. name, data)
-		return
-	end
-	Spring.Echo(indent .. name .. " = {")
-	local newIndent = indent .. "    "
-	for name, v in pairs(data) do
-		local ty = type(v)
-		if ty == "table" then
-			tableEcho(v, name, newIndent, true)
-		elseif ty == "boolean" then
-			Spring.Echo(newIndent .. name .. " = " .. (v and "true" or "false"))
-		elseif ty == "string" or ty == "number" then
-			Spring.Echo(newIndent .. name .. " = " .. v)
-		else
-			Spring.Echo(newIndent .. name .. " = ", v)
-		end
-	end
-	Spring.Echo(indent .. "},")
-end
-
 local function traceEcho(...)
 	local myargs = {...}
 	local infostr = ""
@@ -144,7 +120,6 @@ end
 
 return {
 	ParamsEcho = paramsEcho,
-	TableEcho = tableEcho,
 	TraceEcho = traceEcho,
 	TraceFullEcho = traceFullEcho,
 }

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -5,6 +5,9 @@ them in `init.lua` (because they're not free to run, so we don't want them to
 run for end users.)
 ]]
 
+-- Lua 5.1 backwards compatibility
+table.pack = table.pack or function(...) return { n = select("#", ...), ... } end
+
 if not table.copy then
 	function table.copy(tbl)
 		local copy = {}

--- a/luarules/gadgets/AILoader.lua
+++ b/luarules/gadgets/AILoader.lua
@@ -78,7 +78,6 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:RecvLuaMsg(msg, playerID)
 		--msg = 'StGiveOrderToSync'..';'..id..';'..cmd..';'..pos..';'..opts..';'..timeout..';'..uname..';'.'StEndGOTS'
-		--Spring.Debug.TableEcho(datas)
 		if string.sub(msg,1,17) ~= 'StGiveOrderToSync' then
 			return
 		end
@@ -103,14 +102,14 @@ if gadgetHandler:IsSyncedCode() then
 
 		pos = string.split(pos,',')
 		if not pos or not pos[1] or pos[1] == '' then
-			Spring.Debug.TableEcho(pos)
+			Spring.Echo(pos)
 			spEcho('warn! invalid POS argument in STAI gotu luarules message')
 			return
 		end
 		if opts ~= 0 then
 			opts = string.split(opts,',')
 			if not opts or not opts[1] or opts[1] == '' then
-				Spring.Debug.TableEcho(opts)
+				Spring.Echo(opts)
 				spEcho('warn! invalid OPTS argument in STAI gotu luarules message')
 				return
 			end
@@ -126,87 +125,6 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 
-
-
-
-
-
-
-
-
-
-
--- 	function gadget:RecvLuaMsg1(msg, playerID)
---
--- 		if string.sub(msg,1,17) == 'StGiveOrderToSync' then
--- 			local id = string.split(msg,"*")
--- 			local cmd = string.split(msg,'_')
--- 			local pos = string.split(msg,':')
--- 			local opts = string.split(msg,';')
--- 			local timeout = string.split(msg,'#')
--- 			local unit = string.split(msg,'!')
--- 			if #id ~= 3 or #cmd ~= 3 or #pos ~= 3 or #opts ~= 3 or #timeout ~= 3 or #unit ~= 3 then
--- 				spEcho('format incomplete',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
--- 				spEcho('recvluamsg',msg)
--- 				spEcho('splitting length',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
--- 				spEcho('GiveOrderToUnit : ')
--- 				spEcho('unit',unit,type(unit))
--- 				spEcho('id',id,type(id))
--- 				spEcho('cmd',cmd,type(cmd))
--- 				spEcho('pos',pos,type(pos))
--- 				spEcho('opts',opts,type(opts))
--- 				spEcho('timeout',timeout,type(timeout))
--- 				Spring.Debug.TableEcho(pos)
--- 				return
--- 			end
--- 			id = id[2]
--- 			cmd = cmd[2]
--- 			pos = pos[2]
--- 			opts = opts[2]
--- 			timeout = timeout[2]
--- 			unit = unit[2]
--- 			if not Spring.ValidUnitID ( id )  then
--- 				Spring.Echo('ST RECEIVEDGOTS ID INVALID','name',unit,'id',id,'cmd',cmd)
--- 				return
--- 			end
--- 			if string.split(pos,',') then
--- 				pos = string.split(pos,',')
--- 				if not pos[1] or pos[1] == '' then
--- 					Spring.Debug.TableEcho(pos)
--- 					spEcho('warn! invalid pos argument in STAI gotu luarules message')
--- 					return
--- 				end
--- 			end
--- 			if string.split(opts,',') then
--- 				opts = string.split(opts,',')
--- 				if not opts[1] or opts[1] == '' then
--- 					Spring.Debug.TableEcho(pos)
--- 					spEcho('warn! invalid opts argument in STAI gotu luarules message')
--- 					return
--- 				end
--- 			end
--- 			if type(timeout) ~= 'table' then--maybe this is not required
--- 				timeout = {timeout}
--- 			end
--- 			if dbg then
--- 				spEcho('recvluamsg',msg)
--- 				spEcho('splitting length',unit,#id,#cmd,#pos,#opts,#timeout,#unit)
--- 				spEcho('GiveOrderToUnit : ')
--- 				spEcho('unit',unit,type(unit))
--- 				spEcho('id',id,type(id))
--- 				spEcho('cmd',cmd,type(cmd))
--- 				spEcho('pos',pos,type(pos))
--- 				spEcho('opts',opts,type(opts))
--- 				spEcho('timeout',timeout,type(timeout))
--- 				Spring.Debug.TableEcho(pos)
--- 			end
--- 			local order = Spring.GiveOrderToUnit(id,cmd,pos,opts,timeout)
--- 			if order ~= true then
--- 				spEcho('order error in STAI unsync to sync give order to unit',msg)
--- 				spEcho('order', order,id,cmd,pos,opts,timeout)
--- 			end
--- 		end
--- 	end
 else
 
 	-- UNSYNCED CODE

--- a/luarules/gadgets/ai/STAI/attackerbst.lua
+++ b/luarules/gadgets/ai/STAI/attackerbst.lua
@@ -135,7 +135,6 @@ function AttackerBST:Advance(pos, perpendicularAttackAngle, reverseAttackAngle)
 -- 		if RAM11-RAM > 0 then Spring.Echo('member advance11',RAM11-RAM) end
 	else
 		self:EchoDebug('adv drit')
--- 		Spring.Debug.TableEcho(self.target)
 		self.target = self.ai.tool:RandomAway2( pos, self.formationDist, nil, perpendicularAttackAngle,self.target)
 -- 			RAM12 = gcinfo()
 -- 	if RAM12-RAM > 0 then Spring.Echo('member advance12',RAM12-RAM) end

--- a/luarules/gadgets/ai/STAI/raidbst.lua
+++ b/luarules/gadgets/ai/STAI/raidbst.lua
@@ -135,7 +135,6 @@ function RaidBST:Advance(pos, perpendicularAttackAngle, reverseAttackAngle)
 -- 		if RAM11-RAM > 0 then Spring.Echo('member advance11',RAM11-RAM) end
 	else
 		self:EchoDebug('adv drit')
--- 		Spring.Debug.TableEcho(self.target)
 		self.target = self.ai.tool:RandomAway2( pos, self.formationDist, nil, perpendicularAttackAngle,self.target)
 -- 			RAM12 = gcinfo()
 -- 	if RAM12-RAM > 0 then Spring.Echo('member advance12',RAM12-RAM) end

--- a/luarules/gadgets/ai_simpleai.lua
+++ b/luarules/gadgets/ai_simpleai.lua
@@ -168,7 +168,6 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
---Spring.Debug.TableEcho(BuildOptions)
 -------- functions
 
 local function SimpleGetClosestMexSpot(x, z)

--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -958,7 +958,7 @@ else	-- UNSYNCED
 			local mapcx = Game.mapSizeX/2
 			local mapcz = Game.mapSizeZ/2
 			local mapcy = Spring.GetGroundHeight(mapcx,mapcz)
-			--Spring.Debug.TableEcho(camState)
+
 			camState["px"] = mapcx
 			camState["py"] = mapcy
 			camState["pz"] = mapcz
@@ -1154,8 +1154,7 @@ else	-- UNSYNCED
 				stats.display = tostring(vsx) ..'x' .. tostring(vsy)
 
 				Spring.Echo("Benchmark Results")
-				Spring.Debug.TableEcho(stats)
-
+				Spring.Echo(stats)
 
 				if Spring.GetMenuName then
 					local message = Json.encode(stats)
@@ -1172,7 +1171,7 @@ else	-- UNSYNCED
 			if Spring.GetModOptions().scenariooptions then
 				--Spring.Echo("Scenario: Spawning on frame", Spring.GetGameFrame())
 				local scenariooptions = string.base64Decode(Spring.GetModOptions().scenariooptions)
-				Spring.Debug.TableEcho(scenariooptions)
+				Spring.Echo(scenariooptions)
 				scenariooptions = Json.decode(scenariooptions)
 				if scenariooptions and scenariooptions.benchmarkcommand then
 					--This is where the magic happens!

--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -1373,9 +1373,6 @@ local function RemoveObjectFromBin(objectID, objectDefID, texKey, shader, flag, 
 					unitDrawBinsFlagShaderTexKey.objectsArray[objectIndex] = objectIDatEnd -- Bring the last objectID here
 					unitDrawBinsFlagShaderTexKey.numobjects = numobjects -1
 				end
-			else
-				--Spring.Echo("Failed to find texKey for", objectID, objectDefID, texKey, shader, flag, uniformBinID)
-				--	Spring.Debug.TableEcho(textures)
 			end
 		else
 			if debugmode then Spring.Echo("Failed to find uniformBinID for", objectID, objectDefID, texKey, shader, flag, uniformBinID) end
@@ -1476,8 +1473,6 @@ local function RemoveObject(objectID, reason) -- we get pos/neg objectID here
 		-- processedFeatures[-1 * objectID] = nil
 		Spring.SetFeatureEngineDrawMask(-1 * objectID, 255)
 	end
-
-	--Spring.Debug.TableEcho(unitDrawBins)
 end
 
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
@@ -1719,33 +1714,6 @@ local function initGL4()
 	initiated = true
 end
 
-local function tableEcho(data, name, indent, tableChecked)
-	name = name or "TableEcho"
-	indent = indent or ""
-	if not tableChecked and type(data) ~= "table" then
-		Spring.Echo(indent .. name, data)
-		return
-	end
-	if type (name) == "table" then
-		name = '<table>'
-	end
-	Spring.Echo(indent .. name .. " = {")
-	local newIndent = indent .. "    "
-	for name, v in pairs(data) do
-		local ty = type(v)
-		if ty == "table" then
-			tableEcho(v, name, newIndent, true)
-		elseif ty == "boolean" then
-			Spring.Echo(newIndent .. name .. " = " .. (v and "true" or "false"))
-		elseif ty == "string" or ty == "number" then
-			Spring.Echo(newIndent .. name .. " = " .. v)
-		else
-			Spring.Echo(newIndent .. name .. " = ", v)
-		end
-	end
-	Spring.Echo(indent .. "},")
-end
-
 local manualReload = false -- Indicates wether the first round of getting units should grab all instead of delta
 
 local function ReloadCUSGL4(optName, line, words, playerID)
@@ -1964,7 +1932,7 @@ function gadget:Initialize()
 end
 
 function gadget:Shutdown()
-	if debugmode then tableEcho(unitDrawBins, 'unitDrawBins') end
+	if debugmode then Spring.Echo(unitDrawBins, 'unitDrawBins') end
 
 	for unitID, _ in pairs(overriddenUnits) do
 		RemoveObject(unitID, "shutdown")

--- a/luarules/gadgets/include/LuaShader.lua
+++ b/luarules/gadgets/include/LuaShader.lua
@@ -236,9 +236,7 @@ vec3 rgb2hsv(vec3 c){
 	local waterAbsorbColorR, waterAbsorbColorG, waterAbsorbColorB = gl.GetWaterRendering("absorb")
 	local waterMinColorR, waterMinColorG, waterMinColorB = gl.GetWaterRendering("minColor")
 	local waterBaseColorR, waterBaseColorG, waterBaseColorB = gl.GetWaterRendering("baseColor")
-	
-	--Spring.Echo(waterAbsorbColorR, waterAbsorbColorG, waterAbsorbColorB)
-	--Spring.Debug.TableEcho(waterAbsorbColor)
+
 	local waterUniforms = 
 [[ 
 #define WATERABSORBCOLOR vec3(%f,%f,%f)

--- a/luarules/gadgets/map_atmosphere_cegs.lua
+++ b/luarules/gadgets/map_atmosphere_cegs.lua
@@ -85,8 +85,7 @@ if not gadgetHandler:IsSyncedCode() then
 			},
 			sunDir = {gl.GetSun("pos")},
 		}
-		--Spring.Echo("GetLightingAndAtmosphere")
-		--Spring.Debug.TableEcho(res)
+
 		return res
 	end
 
@@ -185,8 +184,6 @@ if not gadgetHandler:IsSyncedCode() then
 					end
 				end
 			end
-			--Spring.Echo("endlight =")
-			--Spring.Debug.TableEcho(endlight)
 		end
 		local dt = 300
 		local tstart = 60
@@ -202,7 +199,6 @@ if not gadgetHandler:IsSyncedCode() then
 				MixLightingAndAtmosphere(endlight, initlight, mixfac, mixedlight)
 			end
 			SetLightingAndAtmosphere(mixedlight)
-			--Spring.Debug.TableEcho(mixedlight)
 		end
 
 	end

--- a/luarules/gadgets/map_nightmode.lua
+++ b/luarules/gadgets/map_nightmode.lua
@@ -155,8 +155,7 @@ if not gadgetHandler:IsSyncedCode() then
 			sunDir = {gl.GetSun("pos")},
 			nightFactor = {red = 1, green = 1, blue = 1, shadow = 1, altitude = 1},
 		}
-		--Spring.Echo("GetLightingAndAtmosphere")
-		--Spring.Debug.TableEcho(res)
+
 		return res
 	end	
 	
@@ -352,7 +351,6 @@ if not gadgetHandler:IsSyncedCode() then
 		end
 		
 		Spring.Echo("Expecting /luarules NightMode nightR nightG nightB azimuth altitude shadowfactor")
-		--Spring.Debug.TableEcho(words)
 		local nightR = (words[1] and tonumber(words[1])) or 1
 		local nightG = (words[2] and tonumber(words[2])) or 1
 		local nightB = (words[3] and tonumber(words[3])) or 1
@@ -361,7 +359,7 @@ if not gadgetHandler:IsSyncedCode() then
 		local shadowfactor = (words[6] and tonumber(words[6])) or 1
 		
 		local newNightLight = GetNightLight(nil, { nightR, nightG,nightB,shadowfactor}, azimuth, altitude)
-		Spring.Debug.TableEcho(newNightLight)
+		Spring.Echo(newNightLight)
 		-- If this command is recieved, immediately stop any existing nightModeConfig
 		transitionenabled = false
 		SetLightingAndAtmosphere(newNightLight)
@@ -419,8 +417,6 @@ if not gadgetHandler:IsSyncedCode() then
 		local df = Spring.GetDrawFrame()
 		if df == lastSunChanged then return end
 		lastSunChanged = df
-		--Spring.Echo("gadget:SunChanged",Spring.GetGameFrame())
-		--Spring.Debug.TableEcho(GG.NightFactor)
 	end
 
 	function gadget:Initialize()

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1210,8 +1210,6 @@ if gadgetHandler:IsSyncedCode() then
 	function spawnCreepStructuresWave()
 		tracy.ZoneBeginN("Raptors:spawnCreepStructuresWave")
 		for uName, uSettings in pairs(config.raptorTurrets) do
-			--Spring.Echo(uName)
-			--Spring.Debug.TableEcho(uSettings)
 			if not uSettings.maxQueenAnger then uSettings.maxQueenAnger = uSettings.minQueenAnger + 100 end
 			if uSettings.minQueenAnger <= techAnger and uSettings.maxQueenAnger >= techAnger then
 				local numOfTurrets = (uSettings.spawnedPerWave*(1-config.raptorPerPlayerMultiplier))+(uSettings.spawnedPerWave*config.raptorPerPlayerMultiplier)*SetCount(humanTeams)

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1328,8 +1328,6 @@ if gadgetHandler:IsSyncedCode() then
 
 	function spawnCreepStructuresWave()
 		for uName, uSettings in pairs(config.scavTurrets) do
-			--Spring.Echo(uName)
-			--Spring.Debug.TableEcho(uSettings)
 			if not uSettings.maxBossAnger then uSettings.maxBossAnger = uSettings.minBossAnger + 100 end
 			if uSettings.minBossAnger <= waveParameters.waveTechAnger and uSettings.maxBossAnger >= waveParameters.waveTechAnger then
 				local numOfTurrets = (uSettings.spawnedPerWave*(1-config.scavPerPlayerMultiplier))+(uSettings.spawnedPerWave*config.scavPerPlayerMultiplier)*SetCount(humanTeams)

--- a/luarules/gadgets/unit_airbase.lua
+++ b/luarules/gadgets/unit_airbase.lua
@@ -516,19 +516,9 @@ if gadgetHandler:IsSyncedCode() then
 								local unitDefID = Spring.GetUnitDefID(unitID)
 								if isAirUnit[unitDefID] and uy > Spring.GetGroundHeight(ux,uz)+10 then -- maybe landed planes are "not a flying unit" so lets try checking ground height
 									local moveTypeData = Spring.GetUnitMoveTypeData(unitID)
-									
-									--[[
-									if moveTypeData.aircraftState == nil then 
-										Spring.Echo('SetUnitLandGoal Failure imminent:',unitID, UnitDefs[Spring.GetUnitDefID(unitID)].name)
-										Spring.Echo(unitID)
-										Spring.Debug.TableEcho(moveTypeData)
-										Spring.SendCommands("pause 1")
-									end
-									]]--
-									
+
 									if moveTypeData.aircraftState and moveTypeData.aircraftState ~= "crashing" then --#attempt 12
 										-- crashing aircraft probably dont count as 'flying units', attempt #10 at fixing "not a flying unit"
-										--Spring.Echo('SetUnitLandGoal',unitID, UnitDefs[Spring.GetUnitDefID(unitID)].name)
 										Spring.SetUnitLandGoal(unitID, px, py, pz, radius)	-- sometimes this gives an error: "not a flying unit"
 									end
 

--- a/luarules/gadgets/unit_attributes.lua
+++ b/luarules/gadgets/unit_attributes.lua
@@ -665,7 +665,7 @@ function gadget:GameFrame(f)
 
 
 	if false and f % 50 == 1 then
-		Spring.Debug.TableEcho(unitSlowed)
+		Spring.Echo(unitSlowed)
 	end
 
 end

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -407,8 +407,6 @@ local function SpawnUnit(spawnData)
 					local carrierz
 					dockPointx,dockPointy, dockPointz = Spring.GetUnitPiecePosition(ownerID, dockingpiece)--Spring.GetUnitPieceInfo (ownerID, dockingpieceindex)
 					carrierx,carriery, carrierz = Spring.GetUnitPosition(ownerID)
-					--Spring.Echo(dockingpieceindex)
-					--Spring.Debug.TableEcho(Spring.GetUnitPiecePosition(ownerID, dockingpiece))
 					mcSetPosition(subUnitID, carrierx+dockPointx, carriery+dockPointy, carrierz+dockPointz)
 				end
 				mcDisable(subUnitID)

--- a/luarules/gadgets/unit_custom_weapons_cluster.lua
+++ b/luarules/gadgets/unit_custom_weapons_cluster.lua
@@ -189,16 +189,6 @@ for udid, _ in pairs(UnitDefs) do
     end
 end
 
--- Spring.Debug.TableEcho(
---     {
---         ['Tick bulk']     = unitBulk[ UnitDefNames["armflea"].id  ],
---         ['Pawn bulk']     = unitBulk[ UnitDefNames["armpw"].id    ],
---         ['Gauntlet bulk'] = unitBulk[ UnitDefNames["armguard"].id ],
---         ['Pulsar bulk']   = unitBulk[ UnitDefNames["armanni"].id  ],
---         ['Thor bulk']     = unitBulk[ UnitDefNames["armthor"].id  ],
---     }
--- )
-
 -- Reusable table for reducing garbage
 
 local spawnCache  = {

--- a/luarules/gadgets/unit_onlytargetcategory.lua
+++ b/luarules/gadgets/unit_onlytargetcategory.lua
@@ -28,8 +28,6 @@ for udid, unitDef in pairs(UnitDefs) do
 				if not unitOnlyTargetsCategory[udid] then
 					unitOnlyTargetsCategory[udid] = category
 					if category == 'vtol' then
-						--Spring.Echo(UnitDefs[udid].name, 'has category', category, 'unitDontAttackGround')
-						--Spring.Debug.TableEcho(weapon.onlyTargets)
 						unitDontAttackGround[udid] = true
 					end
 				elseif unitOnlyTargetsCategory[udid] ~= category then	-- multiple different onlytargetcategory used: disregard
@@ -41,28 +39,6 @@ for udid, unitDef in pairs(UnitDefs) do
 		end
 	end
 end
-
---[[
-function gadget:Initialize()
-	Spring.Echo("unitCategories")
-	for udid, categories in pairs(unitCategories) do 
-		Spring.Echo(UnitDefs[udid].name)
-		Spring.Debug.TableEcho(categories)
-	end
-	
-	Spring.Echo("unitOnlyTargetsCategory")
-	for udid, onlycat in pairs(unitOnlyTargetsCategory) do 
-		Spring.Echo(UnitDefs[udid].name,"=", onlycat)
-	end
-	
-	Spring.Echo("unitDontAttackGround")
-	for udid, noground in pairs(unitDontAttackGround) do 
-			Spring.Echo(UnitDefs[udid].name,"=", noground)
-	end
-	
-end
-]]-- 
--- debug output
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if cmdID == CMD.ATTACK

--- a/luarules/gadgets/unit_paralyze_damage_limit.lua
+++ b/luarules/gadgets/unit_paralyze_damage_limit.lua
@@ -65,20 +65,12 @@ end
 
 local spGetUnitHealth = Spring.GetUnitHealth
 
-
---Spring.Echo('hornet debug emp loaded')
---Spring.Debug.TableEcho(unitOhms)
 function gadget:UnitPreDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, projID, aID, aDefID, aTeam)
 
 
     if paralyzer then
---Spring.Debug.TableEcho(isBuilding)
---Spring.Echo('hornet debug here2')
         -- restrict the max paralysis time of mobile units
         if aDefID and uDefID and weaponID and not isBuilding[uDefID] and not excluded[uDefID] then
-		--Spring.Echo('hornet debug emp')
-			
-			
 			local hp, maxHP, currentEmp = spGetUnitHealth(uID)
 			local effectiveHP = Game.paralyzeOnMaxHealth and maxHP or hp
 			local paralyzeDeclineRate = Game.paralyzeDeclineRate
@@ -125,10 +117,7 @@ function gadget:UnitPreDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, 
 			newdamage = math.max(0, math.min(damage, maxEmpDamage - currentEmp))
 			--Spring.Echo('h mh ph wpt old new',hp,maxHP, currentEmp, thismaxtime, damage, newdamage)
 
-			--Spring.Echo(Game.paralyzeDeclineRate)
-			--Spring.Echo(Game.paralyzeOnMaxHealth)
 			damage = newdamage
-			--Spring.Debug.TableEcho(Game)
 			--damage = mh +6 
 			--Spring.Echo('new',h,mh, ph, max_para_damage, max_para_time, damage)
 				

--- a/luarules/gadgets/unit_single_damage_fire.lua
+++ b/luarules/gadgets/unit_single_damage_fire.lua
@@ -70,8 +70,6 @@ function gadget:Initialize()
 			end
 		end
 	end
-	--Spring.Echo('hornet debug wantedweaponlist')
-	--Spring.Debug.TableEcho(wantedWeaponList)
 end
 
 
@@ -90,8 +88,6 @@ for weaponDefID, weaponDef in ipairs(WeaponDefs) do
 		end
 	end
 end
---Spring.Echo('hornet debug degunweapons')
---Spring.Debug.TableEcho(fireballWeapons)
 
 
 

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -86,7 +86,7 @@ if gadgetHandler:IsSyncedCode() then
 			validUnits[unitDefID] = true
 		end
 		local weapons = unitDef.weapons
-		--Spring.Debug.TableEcho(weapons)
+
 		if #weapons > 0 then
 			-- filter this down to only the params that actually get used, weapons is an array full of stuff!
 			unitWeapons[unitDefID] = weapons

--- a/luaui/Widgets/Include/LuaShader.lua
+++ b/luaui/Widgets/Include/LuaShader.lua
@@ -236,9 +236,7 @@ vec3 rgb2hsv(vec3 c){
 	local waterAbsorbColorR, waterAbsorbColorG, waterAbsorbColorB = gl.GetWaterRendering("absorb")
 	local waterMinColorR, waterMinColorG, waterMinColorB = gl.GetWaterRendering("minColor")
 	local waterBaseColorR, waterBaseColorG, waterBaseColorB = gl.GetWaterRendering("baseColor")
-	
-	--Spring.Echo(waterAbsorbColorR, waterAbsorbColorG, waterAbsorbColorB)
-	--Spring.Debug.TableEcho(waterAbsorbColor)
+
 	local waterUniforms = 
 [[ 
 #define WATERABSORBCOLOR vec3(%f,%f,%f)

--- a/luaui/Widgets/Include/instancevbotable.lua
+++ b/luaui/Widgets/Include/instancevbotable.lua
@@ -655,8 +655,7 @@ end
 function uploadAllElements(iT)
 	-- upload all USED elements
 	if iT.usedElements == 0 then return end
-	--Spring.Echo("uploadAllElements", iT.usedElements)
-	--Spring.Debug.TableEcho(iT.indextoUnitID)
+
 	iT.instanceVBO:Upload(iT.instanceData,nil,0, 1, iT.usedElements * iT.instanceStep)
 	iT.dirty = false
 	if iT.indextoUnitID then

--- a/luaui/Widgets/api_chili_draw_gl4.lua
+++ b/luaui/Widgets/api_chili_draw_gl4.lua
@@ -50,7 +50,7 @@ local function makeAtlas()
 	addDirToAtlas(atlasTexture, "luaui/images/chiliskin_gl4", "tech")
 	gl.FinalizeTextureAtlas(atlasTexture)	
 	local texInfo = gl.TextureInfo(atlasTexture ) 
-	--Spring.Debug.TableEcho(texInfo)	
+
 	atlasX = texInfo.xsize -- cool this works
 	atlasY = texInfo.ysize
 	for filepath,_ in pairs(atlassedImagesUVs) do

--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -611,7 +611,7 @@ function widget:TextCommand(command)
 					elseif #data == 0 then
 						Spring.Echo("nil")
 					else
-						Spring.Debug.TableEcho(data)
+						Spring.Echo(data)
 					end
 				else
 					Spring.Echo(data)
@@ -636,7 +636,7 @@ function widget:TextCommand(command)
 					elseif #data == 0 then
 						Spring.Echo("nil")
 					else
-						Spring.Debug.TableEcho(data)
+						Spring.Echo(data)
 					end
 				else
 					Spring.Echo(data)

--- a/luaui/Widgets/camera_joystick.lua
+++ b/luaui/Widgets/camera_joystick.lua
@@ -504,7 +504,6 @@ function widget:Update(dt) -- dt in seconds
 	local cs = spGetCameraState()
 
 	if cs.name == "rot" and joystate.axes then
-		--Spring.Utilities.TableEcho(cs)
 		if joystate[Ybutton[1]][Ybutton[2]] and joystate[Ybutton[1]][Ybutton[2]] == 1 then -- A button dumps debug
 			Spring.Echo(joystatetostr(joystate))
 		end

--- a/luaui/Widgets/flowui_gl4.lua
+++ b/luaui/Widgets/flowui_gl4.lua
@@ -455,7 +455,6 @@ function metaElement:UpdateVBOKeys(keyname, value, delta)
 				Spring.Echo("element not found",self.name, VBO.myName,instanceKey)
 				Spring.Debug.TraceFullEcho()
 			end
-			--Spring.Debug.TableEcho(self.vboCache)
 
 			if delta then
 				local cache = self.vboCache
@@ -465,7 +464,6 @@ function metaElement:UpdateVBOKeys(keyname, value, delta)
 				self.vboCache[self.vbokeys[keyname]] = value
 			end
 			pushElementInstance(VBO,self.vboCache, instanceKey, true)
-			--Spring.Echo("Setting VBO Key", keyname, self.name, 'to',value,'for',instanceKey, #self.vboCache)
 			--todo needs a 'refresh' trigger for the ivbo
 		end
 	end
@@ -1108,7 +1106,7 @@ local function makeSliderList(sliderListConfig)
 		parent = container,
 		MouseEvents = {left = function()
 			Spring.Echo("Exporting Settings")
-			Spring.Debug.TableEcho(valuetarget)
+			Spring.Echo(valuetarget)
 		end},
 		textelements = {{text = "Export "..sliderListConfig.name, fontsize = 16, alignment = 'center'},},
 	})
@@ -2502,7 +2500,6 @@ function widget:DrawScreen()
 	if atlasID == nil then
 		atlasID = WG['flowui_atlas']
 		atlassedImages = WG['flowui_atlassedImages']
-		--Spring.Debug.TableEcho({gl.GetAtlasTexture(atlasID, "unitpics/armcom.dds")})
 	end
 	if elems < 0  then
 		elems = elems+1

--- a/luaui/Widgets/gfx_airjets_gl4.lua
+++ b/luaui/Widgets/gfx_airjets_gl4.lua
@@ -847,26 +847,21 @@ local function Activate(unitID, unitDefID, who, when)
 	local unitEffects = effectDefs[unitDefID]
 	for i = 1, #unitEffects do
 		local effectDef = unitEffects[i]
-		--Spring.Utilities.TableEcho(effectDef)
 		local color = effectDef.color
 		local emitVector = effectDef.emitVector
 		local effectdata = {
 			effectDef.width*0.4,effectDef.length, when,
 			emitVector[1],emitVector[2],emitVector[3],
 			color[1],color[2],color[3],
-			--math.floor(math.random() * 5) ,
 			effectDef.piecenum - 1,
 			0,0,0,0, -- this is needed to keep the lua copy of the vbo the correct size
 
 		}
-		--Spring.Echo("Adding", tostring(unitID).."_"..tostring(effectDef.piecenum))
 		pushElementInstance(jetInstanceVBO,effectdata,tostring(unitID).."_"..tostring(effectDef.piecenum), true, nil, unitID)
 	end
 end
 
 local function Deactivate(unitID, unitDefID, who)
-	--Spring.Echo(Spring.GetGameFrame(),who, "Deactivate(unitID, unitDefID)",unitID, unitDefID)
-
 	activePlanes[unitID] = nil
 
 	inactivePlanes[unitID] = unitDefID

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -820,8 +820,6 @@ local function AddStaticLightsForUnit(unitID, unitDefID, noUpload, reason)
 		end
 		for lightname, lightParams in pairs(unitDefLight) do
 			if lightname ~= 'initComplete' then
-				--Spring.Debug.TraceFullEcho(nil,nil,nil,"AddStaticLightsForUnit")
-				--Spring.Debug.TableEcho(lightParams)
 				local targetVBO = unitLightVBOMap[lightParams.lightType]
 
 				if (not spec) and lightParams.alliedOnly == true and Spring.IsUnitAllied(unitID) == false then return end
@@ -1311,15 +1309,11 @@ local function updateProjectileLights(newgameframe)
 				local weapon, piece = spGetProjectileType(projectileID)
 				if piece then
 					local explosionflags = spGetPieceProjectileParams(projectileID)
-					--if explosionflags and explosionflags%32 > 15 then
-						local gib = gibLight.lightParamTable
-						gib[1] = px
-						gib[2] = py
-						gib[3] = pz
-						AddLight(projectileID, nil, nil, projectilePointLightVBO, gib, noUpload)
-						--Spring.Echo("added gib")
-						--Spring.Debug.TableEcho(gib)
-					--end
+					local gib = gibLight.lightParamTable
+					gib[1] = px
+					gib[2] = py
+					gib[3] = pz
+					AddLight(projectileID, nil, nil, projectilePointLightVBO, gib, noUpload)
 				else
 					local weaponDefID = spGetProjectileDefID ( projectileID )
 					if projectileDefLights[weaponDefID] and ( projectileID % (projectileDefLights[weaponDefID].fraction or 1) == 0 ) then
@@ -1618,13 +1612,11 @@ function widget:Initialize()
 	local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs
 
 	if nightFactor ~= 1 then
-		--Spring.Debug.TableEcho(mapinfo)
 		local nightLightingParams = {}
 		for _,v in ipairs(adjustfornight) do
 			nightLightingParams[v] = mapinfo.lighting[string.lower(v)]
 			if nightLightingParams[v] ~= nil then
 				for k2, v2 in pairs(nightLightingParams[v]) do
-					--Spring.Echo(v,k2,v2)
 					if tonumber(v2) then
 						if string.find(v, 'unit', nil, true) then
 							nightLightingParams[v][k2] = v2 * nightFactor * unitNightFactor

--- a/luaui/Widgets/gfx_lupsgl4_orbs.lua
+++ b/luaui/Widgets/gfx_lupsgl4_orbs.lua
@@ -218,8 +218,6 @@ for unitname, effect in pairs(UnitEffects) do
 				attr[6] = 0 -- precision
 				attr[7] = (opts.isShield and 1) or 0  -- isShield
 				attr[8] = 1 -- technique
-				--Spring.Echo(unitname)
-				--Spring.Debug.TableEcho(opts)
 				
 				attr[ 9], attr[10], attr[11], attr[12] = unpack((opts.colormap1 and opts.colormap1[1]) or {-1,-1,-1,-1})
 				attr[13], attr[14], attr[15], attr[16] = unpack((opts.colormap2 and opts.colormap2[1]) or {-1,-1,-1,-1})

--- a/luaui/Widgets/gui_controller_test.lua
+++ b/luaui/Widgets/gui_controller_test.lua
@@ -25,7 +25,7 @@ function widget:Initialize()
 	end
 
 	Spring.Echo("ControllerTest: Found controllers")
-	Spring.Debug.TableEcho(availableControllers)
+	Spring.Echo(availableControllers)
 
 	-- Find already connected controllers and disconnect if more than 1 already connected
 	for _, controller in pairs(availableControllers) do
@@ -55,7 +55,7 @@ function widget:Update(dt)
 		uiSec = 0
 
 		Spring.Echo("ControllerTest: Controller State")
-		Spring.Debug.TableEcho(Spring.GetControllerState(connectedController))
+		Spring.Echo(Spring.GetControllerState(connectedController))
 	end
 end
 

--- a/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
@@ -212,7 +212,6 @@ function widget:Initialize()
 			
 		elseif FD.customParams then 
 			if  FD.customParams.decalinfo_texfile then 
-				--Spring.Debug.TableEcho(FD.customParams)
 				featureDefIDtoDecalInfo[id] = {
 					texfile = atlassedImages[FD.customParams.decalinfo_texfile],
 					sizex = (tonumber(FD.customParams.decalinfo_sizex) or 5) * 16,

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -763,15 +763,12 @@ local function addBarToFeature(featureID,  barname)
 	if barname == 'featurereclaim' then targetVBO = featureReclaimVBO end
 	if barname == 'featureresurrect' then targetVBO = featureResurrectVBO end
 
-	--Spring.Echo("addBarToFeature", featureID,  barname, featureDefHeights[featureDefID])
 	if targetVBO.instanceIDtoIndex[featureID] then return end -- already exists, bail
 	if featureBars[featureID] == nil then
-		--Spring.Echo("this feature did not exist yet?", FeatureDefs[Spring.GetFeatureDefID(featureID)].name, Spring.GetFeaturePosition(featureID))
 		featureBars[featureID] = 0
 	end
 	featureBars[featureID] = featureBars[featureID] + 1
 
-	--Spring.Debug.TableEcho(bt)
 	pushElementInstance(
 		targetVBO, -- push into this Instance VBO Table
 			{featureDefHeights[featureDefID] + additionalheightaboveunit,  -- height

--- a/luaui/Widgets/gui_infolos.lua
+++ b/luaui/Widgets/gui_infolos.lua
@@ -167,7 +167,6 @@ function widget:Initialize()
 		local texInfo = gl.TextureInfo(tex)
 		shaderConfig[name .. 'XSIZE'] = texInfo.xsize
 		shaderConfig[name .. 'YSIZE'] = texInfo.ysize
-		--Spring.Debug.TableEcho(texInfo)
 	end
 	currentAllyTeam = Spring.GetMyAllyTeamID()
 

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4580,7 +4580,7 @@ function init()
 		{ id = "echocamerastate", group = "dev", category = types.dev, name = Spring.I18N('ui.settings.option.echocamerastate'), type = "bool", value = false, description = Spring.I18N('ui.settings.option.echocamerastate_descr'),
 		  onchange = function(i, value)
 			  options[getOptionByID('echocamerastate')].value = false
-			  Spring.Debug.TableEcho(Spring.GetCameraState())
+			  Spring.Echo(Spring.GetCameraState())
 		  end,
 		},
 

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -127,8 +127,6 @@ local function DistSq(p1, p2)
 	return (p1.x - p2.x)^2 + (p1.z - p2.z)^2
 end
 
-local TableEcho = Spring.Utilities.TableEcho
-
 local Optics = {}
 function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 	local object = setmetatable({}, {
@@ -220,9 +218,7 @@ function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 				self:_Setup()
 
 				local unprocessed = self.unprocessed
-				--TableEcho(unprocessed, "unprocessed")
 				while next(unprocessed) do
-					--TableEcho({item=next(unprocessed)}, "next(unprocessed)")
 					local point = next(unprocessed)
 
 					-- mark p as processed
@@ -230,8 +226,6 @@ function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 
 					-- find p's neighbors
 					local neighbors = self:_Neighbors(point.fID)
-					--TableEcho({point=point, neighbors=neighbors}, "self:_Neighbors(point)")
-					--TableEcho({point=point, neighborsNum=#neighbors}, "self:_Neighbors(point)")
 
 					-- if p has a core_distance, i.e has min_cluster_size - 1 neighbors
 					if self:_CoreDistance(point, neighbors) then
@@ -242,14 +236,12 @@ function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 						while seedsPQ:peek() do
 							-- seeds.sort(key=lambda n: n.rd)
 							local n = seedsPQ:pop()[2] --because we don't need priority
-							--TableEcho({n=n}, "seedsPQ:pop()")
 
 							-- mark n as processed
 							self:_Processed(n)
 
 							-- find n's neighbors
 							local nNeighbors = self:_Neighbors(n.fID)
-							--TableEcho({n=n, nNeighbors=nNeighbors}, "seedsPQ:peek()")
 
 							-- if p has a core_distance...
 							if self:_CoreDistance(n, nNeighbors) then
@@ -263,7 +255,6 @@ function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 				-- when all points have been processed
 				-- return the ordered list
 				--Spring.Echo("#ordered", #self.ordered)
-				--TableEcho({ordered = self.ordered}, "ordered")
 				return self.ordered
 			end,
 
@@ -287,27 +278,21 @@ function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
 					end
 				end
 				separators[#separators + 1] = #ordered + 1
-				--TableEcho(separators,"separators")
 
 				for j = 1, #separators - 1 do
 					local sepStart = separators[j]
 					local sepEnd = separators[j + 1]
 					--print(sepEnd, sepStart, sepEnd - sepStart, self.minPoints)
 					if sepEnd - sepStart >= self.minPoints then
-						--Spring.Echo("sepEnd - sepStart >= self.minPoints")
-						--self.ordered[start:end]
 						local clPoints = {}
 						for si = sepStart, sepEnd - 1 do
 							clPoints[#clPoints + 1] = ordered[si].fID
 						end
-					--	TableEcho({clPoints=clPoints}, "clPoints")
 
 						clusters[#clusters + 1] = {}
 						clusters[#clusters].members = clPoints
-						--Spring.Echo("#clPoints", #clPoints)
 					end
 				end
-				--TableEcho({ordered=ordered}, "clusters")
 				return clusters
 			end,
 		}

--- a/luaui/Widgets/gui_unit_energy_icons.lua
+++ b/luaui/Widgets/gui_unit_energy_icons.lua
@@ -236,10 +236,6 @@ function widget:DrawWorld()
 	if chobbyInterface then return end
 	if Spring.IsGUIHidden() then return end
 
-	--if lastGameFrame % 90 == 0 then
-	--	Spring.Echo("energyicons",energyIconVBO.usedElements)
-	--	Spring.Debug.TableEcho(energyIconVBO.indextoUnitID)
-	--end
 	if energyIconVBO.usedElements > 0 then
 		local disticon = Spring.GetConfigInt("UnitIconDistance", 200) * 27.5 -- iconLength = unitIconDist * unitIconDist * 750.0f;
 		gl.DepthTest(true)

--- a/luaui/Widgets/map_edge_extension2.lua
+++ b/luaui/Widgets/map_edge_extension2.lua
@@ -542,32 +542,19 @@ function widget:DrawWorldPreUnit()
 	gl.DepthTest(false)
 	gl.DepthMask(false)
 	gl.Culling(GL.BACK)
-
-	--Spring.Echo(gl.GetQuery(q))
 end
 
 local lastSunChanged = -1
 function widget:SunChanged() -- Note that map_nightmode.lua gadget has to change sun twice in a single draw frame to update all
 	local df = Spring.GetDrawFrame()
-	--Spring.Echo("widget:SunChanged", df)
+
 	if df == lastSunChanged then return end
 	lastSunChanged = df
 	-- Do the math:
 	if WG['NightFactor'] then
 		nightFactor = (WG['NightFactor'].red + WG['NightFactor'].green + WG['NightFactor'].blue) * 0.33
-		--Spring.Echo("Map edge extension NightFactor", nightFactor)
-		--UpdateShader()
 	end
-	--Spring.Debug.TableEcho(WG['NightFactor'])
 end
-
--- I see no value in this call
---[[
-function widget:DrawWorldRefraction()
-	--DrawWorldFunc()
-end
-]]--
-
 
 function widget:GetConfigData(data)
 	return {

--- a/luaui/Widgets/map_grass_gl4.lua
+++ b/luaui/Widgets/map_grass_gl4.lua
@@ -1584,7 +1584,6 @@ function widget:SunChanged() -- Note that map_nightmode.lua gadget has to change
 		nightFactor[3] = WG['NightFactor'].blue * altitudefactor
 		nightFactor[4] = WG['NightFactor'].shadow
 	end
-	--Spring.Debug.TableEcho(WG['NightFactor'])
 end
 
 -- ahahahah you cant stop me:

--- a/luaui/Widgets/map_lighting_adjuster.lua
+++ b/luaui/Widgets/map_lighting_adjuster.lua
@@ -181,10 +181,9 @@ end
 local lastSunChanged = -1
 function widget:SunChanged() -- Note that map_nightmode.lua gadget has to change sun twice in a single draw frame to update all
 	local df = Spring.GetDrawFrame()
-	--Spring.Echo("widget:SunChanged", df)
+
 	if df == lastSunChanged then return end
 	lastSunChanged = df
-	--Spring.Debug.TableEcho(WG['NightFactor'])
 end
 
 function widget:Shutdown()

--- a/lups/particleclasses/ShieldSphereColor.lua
+++ b/lups/particleclasses/ShieldSphereColor.lua
@@ -215,12 +215,6 @@ function ShieldSphereColorParticle:EndDraw()
 					local hitTable = GG.GetShieldHitPositions(unitID)
 
 					if hitTable then
-						
-						if #hitTable > 0 then
-							--Spring.Debug.TableEcho(hitTable, "hitTable")
-							--Spring.Echo("#hitTable", #hitTable)
-						end
-
 						local hitPointCount = math.min(#hitTable, MAX_POINTS)
 						--Spring.Echo("hitPointCount", hitPointCount)
 						glUniformInt(uniformLocations["impactInfo.count"], hitPointCount)
@@ -228,7 +222,6 @@ function ShieldSphereColorParticle:EndDraw()
 							local hx, hy, hz, aoe = hitTable[i].x, hitTable[i].y, hitTable[i].z, hitTable[i].aoe
 							glUniform(uniformLocations[impactInfoStringTable[i-1]], hx, hy, hz, aoe)
 						end
-
 					end
 				end
 


### PR DESCRIPTION
### Work done

- Override `Spring.Echo` to support echoing tables
- Remove `TableEcho` function, superseded by `table.toString`

This makes debugging less frustrating, where you had to use two functions depending on the data type of the variable you wanted to echo. Tables are first printed as _\<table\>_ in the echo line, then the contents of each table are printed afterwards, in the order they were passed.

#### Test steps
- [ ] Call `Spring.Echo` and pass it a mix of table and non-table parameters. Verify the contents of the table are echoed.

**Note: no special handling for recursive tables has been added, echoing them will still crash your game.**

Note: This work will hopefully be superseded by native engine handling of printing tables, and this code will one day be removed. https://github.com/beyond-all-reason/spring/issues/1613