### PR TITLE
Add a new mapmetadata modoptions section.

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1393,6 +1393,41 @@ local options = {
 
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    -- Map Metadata options
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    --
+    -- The modoptions below are intended to be set automatically by lobby/spads based on the selected
+    -- map name. They are used for a dynamic map configuration where the configruation values are not
+    -- tied to either game version or reside inside of the map file, allowing for independent distribution
+    -- from the maps metadata source of truth: https://github.com/beyond-all-reason/maps-metadata
+    {
+        key     = "mapmetadata",
+        name    = "MapMetadata",
+        desc    = "mapmetadata tab that should be hidden by chobby",
+        hidden  = true,
+        type    = "section",
+    },
+    {
+        key     = "sub_header",
+        name    = "Hidden map metadata options that are supposed to be set automatically by lobby/spads based on the map name.",
+        desc    = "",
+        section = "mapmetadata",
+        type    = "subheader",
+        hidden  = true,
+        def     = true,
+    },
+    {
+        key     = "mapmetadata_startpos",
+        name    = "Map Metadata: StartPos",
+        desc    = "StatPos configuration. Format is: base64url(zlib(json))",
+        hidden  = true,
+        section = "mapmetadata",
+        type    = "string",
+        def     = "",
+    },
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     -- Cheats
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1420,7 +1420,7 @@ local options = {
     {
         key     = "mapmetadata_startpos",
         name    = "Map Metadata: StartPos",
-        desc    = "StatPos configuration. Format is: base64url(zlib(json))",
+        desc    = "StartPos configuration. Format is: base64url(zlib(json))",
         hidden  = true,
         section = "mapmetadata",
         type    = "string",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1404,7 +1404,7 @@ local options = {
     {
         key     = "mapmetadata",
         name    = "MapMetadata",
-        desc    = "mapmetadata tab that should be hidden by chobby",
+        desc    = "mapmetadata tab that should be hidden by chobby, which would have ideally been achieved by just not listing it and the following options here in the first place, but then SPADS refuses to set the modoption",
         hidden  = true,
         type    = "section",
     },


### PR DESCRIPTION
The map metadata mod options will be set automatically by lobby client or spads based on the selected map name. They are a way of injecting more dynamic map metadata information that is independent from both map file and game version.

The first use case will be the startpos suggestions widget.