### PR TITLE
Adding modoption for accurate lasers

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1290,7 +1290,13 @@ function WeaponDef_Post(name, wDef)
 				wDef.mygravity = 0.1667 --150/900
 			end
 		end
-
+		
+		-- Accurate Lasers		
+		if modOptions.accuratelasers then
+			if wDef.weapontype and wDef.weapontype == 'BeamLaser' then
+				wDef.targetmoveerror = nil
+			end
+		end
 
 		----EMP rework
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1179,6 +1179,15 @@ local options = {
         section = "options_experimental",
         def  	= false,
     },
+	
+    {
+        key   	= "accuratelasers",
+        name   	= "Accurate Lasers",
+        desc   	= "Removes inaccuracy vs moving units from all laser weapons as a proposed solution to overpowered scoutspam",
+        type   	= "bool",
+        section = "options_experimental",
+        def  	= false,
+    },
 
     {
         key    	= "experimentallegionfaction",


### PR DESCRIPTION
### Work done
Added modoption for accurate lasers (removing targetmoveerror from all laser weapons) 

#### Addresses Issue(s)
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3462