### PR TITLE
feat(tablefunctions): let table.map callback modify keys

### DIFF
--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -310,14 +310,15 @@ end
 
 if not table.map then
 	--- Applies a function to all elements of a table and returns a new table with the results.
-	---@generic K, V, R
+	---@generic K, V, RV, RK
 	---@param tbl table<K, V> The input table.
-	---@param callback fun(value: V, key: K, tbl: table<K, V>): R The function to apply to each element. It receives three arguments: the element's value, its key, and the original table.
-	---@return R[] A new table containing the results of applying the callback to each element.
+	---@param callback fun(value: V, key: K, tbl: table<K, V>): RV, RK The function to apply to each element. It receives three arguments: the element's value, its key, and the original table. It should return the new value, and optionally, a new key.
+	---@return table<RK, RV> A new table containing the results of applying the callback to each element.
 	function table.map(tbl, callback)
 		local result = {}
 		for k, v in pairs(tbl) do
-			result[k] = callback(v, k, tbl)
+			local mv, mk = callback(v, k, tbl)
+			result[mk ~= nil and mk or k] = mv
 		end
 		return result
 	end


### PR DESCRIPTION
If the callback passes a second return value, that will be used as the new key. The caller is responsible for avoiding collisions.

Addresses https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3470