### PR TITLE
spectator_hud: move to layer 2

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author = "CMDR*Zod",
 		date = "2024",
 		license = "GNU GPL v3 (or later)",
-		layer = 1,
+		layer = 2,
 		handler = true,
 		enabled = false
 	}

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author = "CMDR*Zod",
 		date = "2024",
 		license = "GNU GPL v3 (or later)",
-		layer = 2,
+		layer = 2, -- after eco stats widget which is on layer 1; see Initialize()
 		handler = true,
 		enabled = false
 	}


### PR DESCRIPTION
Spectator HUD enables/disables ecostats depending on the amount of ally teams in the game. If there are exactly two teams (in addition to Gaia), then Spectator HUD is enabled. If there are not exactly two teams, i.e. it's an FFA game, then Ecostats is enabled.

However, this logic requires we make sure the Initialize() of Spectator HUD runs after Ecostats. If the widgets are in the same layer or Spectator HUD is on an earlier layer, both Spectator HUD and Ecostats are enabled at the same time after loading a FFA game.