### PR TITLE
spectator_hud: fix resolution change

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -1825,6 +1825,8 @@ local function initGL4()
 end
 
 local function init()
+	font = WG['fonts'].getFont()
+
 	viewScreenWidth, viewScreenHeight = Spring.GetViewGeometry()
 
 	buildMetricsEnabled()
@@ -1928,8 +1930,6 @@ function widget:Initialize()
 	end
 
 	checkAndUpdateHaveFullView()
-
-	font = WG['fonts'].getFont()
 
 	init()
 end


### PR DESCRIPTION
Spectator HUD has the callin for resolution change (ViewResize) correctly. However, the reInit() that is called never ends (re)getting the font. Therefore, after a resolution change, the widget crashes:

    Error in DrawGenesis(): [string "LuaUI/Widgets/gui_spectator_hud.lua"]:1252: attempt to use a deleted font

Fix by moving font (re)initialization from Initialize() to init().