### PR TITLE
Spectator HUD: Increase fontsize

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -995,28 +995,6 @@ local function updateStats()
 	regenerateTextTextures = true
 end
 
-local function drawMetricKnobText(left, bottom, right, top, text)
-	-- note: call this function within a font:Begin() - font:End() block
-
-	local knobTextAreaWidth = right - left - 2 * knobDimensions.outline
-	local fontSizeSmaller = knobDimensions.fontSize
-	local textWidth = font:GetTextWidth(text)
-	while textWidth * fontSizeSmaller > knobTextAreaWidth do
-		fontSizeSmaller = fontSizeSmaller - 1
-	end
-
-	--font:Begin()
-	--	  font:SetTextColor(textColorWhite)
-		font:Print(
-			text,
-			mathfloor((right + left) / 2),
-			mathfloor((top + bottom) / 2),
-			fontSizeSmaller,
-			'cvO'
-		)
-	--font:End()
-end
-
 local colorKnobMiddleGrey = { 0.5, 0.5, 0.5, 1 }
 local function drawMetricBar(left, bottom, right, top, indexLeft, indexRight, metricIndex, mouseOver)
 	local valueLeft = teamStats[metricIndex].aggregates[indexLeft]

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -164,7 +164,7 @@ local defaults = {
 	},
 
 	metricDimensions = {
-		height = 70,
+		height = 80,
 		-- width is same as widget width
 	},
 
@@ -175,7 +175,7 @@ local defaults = {
 	},
 
 	knobDimensions = {
-		fontSize = 32,
+		fontSize = 44,
 
 		cornerSize = 8,
 		outline = 4,


### PR DESCRIPTION
Users with resolutions in the lower end such as 1080p have reported the
numbers on the knobs are small and hard to read. Increase the fontsize
by increasing both the height of the metric bars and the fontsize
itself.

Current version:

![spectator_hud_1080p_old](https://github.com/user-attachments/assets/b97d5f6d-8d69-4ad2-a65b-9fb5bd2f3661)

Version in this pull request:

![spectator_hud_1080p_new](https://github.com/user-attachments/assets/5c3d4034-6d6e-4746-8110-58c9c66f9410)

Both screenshots are generated with 1080p.