### PR TITLE
Updating documentation for Collisionvolumes.lua

### DIFF
--- a/luarules/configs/collisionvolumes.lua
+++ b/luarules/configs/collisionvolumes.lua
@@ -46,6 +46,12 @@ Spring.SetUnitPieceCollisionVolumeData ( number unitID, number pieceIndex, boole
 		....               -- All undefined pieces will be treated as disabled for collision detection
 	}
 	dynamicPieceCollisionVolume["cor_viper"] = {	--same as with pieceCollisionVolume only uses "on" and "off" tables
+	
+	Warning 
+	Ensure that buildings/units do not have a unitdeff hitbox defined
+	It will break certain units being able to damage the relevant building/unit
+	this is possibly a bug but not sure
+
 		on = {
 			["0"]={true,51,12,53,0,4,0,2,0},
 			["5"]={true,25,66,25,0,-14,0,1,1},
@@ -76,7 +82,7 @@ local unitCollisionVolume = {}			--dynamic collision volume definitions
 local pieceCollisionVolume = {}			--per piece collision volume definitions
 local dynamicPieceCollisionVolume = {}	--dynamic per piece collision volume definitions
 
--- number of times this table had to be touched since 2022 ~22
+-- number of times this table had to be touched since 2022 ~45
 -- increase this number eachtime this table gets touched
 
 dynamicPieceCollisionVolume['cormaw'] = {


### PR DESCRIPTION
Added warning for adding units with `dynamicPieceCollisionVolume` to check for and remove any unitdeff hitbox for any and all applied units