### PR TITLE
feat(blueprint): swap blueprints to selected con faction when possible

### DIFF
--- a/luaui/Widgets/api_unit_swap.lua
+++ b/luaui/Widgets/api_unit_swap.lua
@@ -1,0 +1,305 @@
+function widget:GetInfo()
+	return {
+		name = "Unit Swap API",
+		desc = "-",
+		license = "GNU GPL, v2 or later",
+		layer = -1,
+		enabled = true
+	}
+end
+
+---Creates a simple enum-like table, where for each entry, the key and value are the same. This allows syntax like
+---ENUM.OPTION_ONE, while also having the value "OPTION_ONE" for serialization or printing.
+---@param ... table a list of entries for the enum
+---@return table
+local function enum(...)
+	local args = { ... }
+	local result = {}
+	for _, v in ipairs(args) do
+		result[v] = v
+	end
+	return result
+end
+
+local factions = enum("arm", "cor", "leg")
+local terrains = enum("ground", "water")
+
+local function isFactionEnabled(faction)
+	if faction == factions.leg then
+		return Spring.GetModOptions().experimentallegionfaction or false
+	else
+		return true
+	end
+end
+
+local factionSwapNames = {
+	-- economy
+	{ [factions.arm] = "armmstor", [factions.cor] = "cormstor", [factions.leg] = "legmstor" },
+	{ [factions.arm] = "armestor", [factions.cor] = "corestor", [factions.leg] = "corestor" },
+
+	{ [factions.arm] = "armmakr", [factions.cor] = "cormakr", [factions.leg] = "legeconv" },
+	--todo: geo
+
+	{ [factions.arm] = "armmex", [factions.cor] = "cormex", [factions.leg] = "legmex" },
+	{ [factions.arm] = "armsolar", [factions.cor] = "corsolar", [factions.leg] = "legsolar" },
+	{ [factions.arm] = "armwin", [factions.cor] = "corwin", [factions.leg] = "legwin" },
+	{ [factions.arm] = "armadvsol", [factions.cor] = "coradvsol", [factions.leg] = "legadvsol" },
+
+	{ [factions.arm] = "armuwes", [factions.cor] = "coruwes", [factions.leg] = "coruwes" },
+	{ [factions.arm] = "armuwms", [factions.cor] = "coruwms", [factions.leg] = "coruwms" },
+
+	{ [factions.arm] = "armfmkr", [factions.cor] = "corfmkr", [factions.leg] = "corfmkr" },
+
+	{ [factions.arm] = "armtide", [factions.cor] = "cortide", [factions.leg] = "legtide" },
+
+	-- combat
+	{ [factions.arm] = "armdl", [factions.cor] = "cordl", [factions.leg] = "cordl" },
+	{ [factions.arm] = "armguard", [factions.cor] = "corpun", [factions.leg] = "legcluster" },
+	{ [factions.arm] = "armfhlt", [factions.cor] = "corfhlt", [factions.leg] = "corfhlt" },
+
+	{ [factions.arm] = "armrl", [factions.cor] = "corrl", [factions.leg] = "legrl" },
+	{ [factions.arm] = "armferret", [factions.cor] = "cormadsam", [factions.leg] = "legrhapsis" },
+	{ [factions.arm] = "armcir", [factions.cor] = "corerad", [factions.leg] = "leglupara" },
+	{ [factions.arm] = "armfrt", [factions.cor] = "corfrt", [factions.leg] = "corfrt" },
+
+	{ [factions.arm] = "armllt", [factions.cor] = "corllt", [factions.leg] = "leglht" },
+	{ [factions.arm] = "armbeamer", [factions.cor] = "corhllt" },
+	{ [factions.arm] = "armhlt", [factions.cor] = "corhlt", [factions.leg] = "legmg" },
+	{ [factions.arm] = "armclaw", [factions.cor] = "cormaw", [factions.leg] = "legdtr" },
+	{ [factions.arm] = "armtl", [factions.cor] = "cortl", [factions.leg] = "cortl" },
+
+	-- utility
+	{ [factions.arm] = "armjuno", [factions.cor] = "corjuno", [factions.leg] = "corjuno" },
+
+	{ [factions.arm] = "armasp", [factions.cor] = "corasp", [factions.leg] = "corasp" },
+	{ [factions.arm] = "armfrad", [factions.cor] = "corfrad", [factions.leg] = "corfrad" },
+	{ [factions.arm] = "armfdrag", [factions.cor] = "corfdrag", [factions.leg] = "corfdrag" },
+
+	{ [factions.arm] = "armrad", [factions.cor] = "corrad", [factions.leg] = "legrad" },
+	{ [factions.arm] = "armeyes", [factions.cor] = "coreyes", [factions.leg] = "coreyes" },
+	{ [factions.arm] = "armdrag", [factions.cor] = "cordrag", [factions.leg] = "legdrag" },
+	{ [factions.arm] = "armjamt", [factions.cor] = "corjamt", [factions.leg] = "legjam" },
+
+	-- build
+	{ [factions.arm] = "armhp", [factions.cor] = "corhp", [factions.leg] = "leghp" },
+	{ [factions.arm] = "armfhp", [factions.cor] = "corfhp", [factions.leg] = "legfhp" },
+
+	{ [factions.arm] = "armnanotc", [factions.cor] = "cornanotc", [factions.leg] = "cornanotc" },
+
+	{ [factions.arm] = "armlab", [factions.cor] = "corlab", [factions.leg] = "leglab" },
+	{ [factions.arm] = "armvp", [factions.cor] = "corvp", [factions.leg] = "legvp" },
+	{ [factions.arm] = "armap", [factions.cor] = "corap", [factions.leg] = "legap" },
+	{ [factions.arm] = "armsy", [factions.cor] = "corsy", [factions.leg] = "corsy" },
+
+	{ [factions.arm] = "armamsub", [factions.cor] = "coramsub", [factions.leg] = "coramsub" },
+	{ [factions.arm] = "armplat", [factions.cor] = "corplat", [factions.leg] = "corplat" },
+
+	{ [factions.arm] = "armalab", [factions.cor] = "coralab", [factions.leg] = "legalab" },
+	{ [factions.arm] = "armavp", [factions.cor] = "coravp", [factions.leg] = "legavp" },
+	{ [factions.arm] = "armaap", [factions.cor] = "coraap", [factions.leg] = "legaap" },
+	{ [factions.arm] = "armasy", [factions.cor] = "corasy", [factions.leg] = "corasy" },
+
+	-- extra
+
+	{ [factions.arm] = "armsonar", [factions.cor] = "corsonar" },
+	{ [factions.arm] = "armptl", [factions.cor] = "corptl", [factions.leg] = "legptl" },
+
+}
+
+local terrainSwapNames = {
+	{ [terrains.ground] = "armmakr", [terrains.water] = "armfmkr" },
+	{ [terrains.ground] = "cormakr", [terrains.water] = "corfmkr" },
+	{ [terrains.ground] = "armdrag", [terrains.water] = "armfdrag" },
+	{ [terrains.ground] = "cordrag", [terrains.water] = "corfdrag" },
+	{ [terrains.ground] = "armmstor", [terrains.water] = "armuwms" },
+	{ [terrains.ground] = "armestor", [terrains.water] = "armuwes" },
+	{ [terrains.ground] = "cormstor", [terrains.water] = "coruwms" },
+	{ [terrains.ground] = "corestor", [terrains.water] = "coruwes" },
+	{ [terrains.ground] = "armrl", [terrains.water] = "armfrt" },
+	{ [terrains.ground] = "corrl", [terrains.water] = "corfrt" },
+	{ [terrains.ground] = "armhp", [terrains.water] = "armfhp" },
+	{ [terrains.ground] = "corhp", [terrains.water] = "corfhp" },
+	{ [terrains.ground] = "armrad", [terrains.water] = "armfrad" },
+	{ [terrains.ground] = "corrad", [terrains.water] = "corfrad" },
+	{ [terrains.ground] = "armhlt", [terrains.water] = "armfhlt" },
+	{ [terrains.ground] = "corhlt", [terrains.water] = "corfhlt" },
+	{ [terrains.ground] = "armtarg", [terrains.water] = "armfatf" },
+	{ [terrains.ground] = "cortarg", [terrains.water] = "corfatf" },
+	{ [terrains.ground] = "armmmkr", [terrains.water] = "armuwmmm" },
+	{ [terrains.ground] = "cormmkr", [terrains.water] = "coruwmmm" },
+	{ [terrains.ground] = "armfus", [terrains.water] = "armuwfus" },
+	{ [terrains.ground] = "corfus", [terrains.water] = "coruwfus" },
+	{ [terrains.ground] = "armflak", [terrains.water] = "armfflak" },
+	{ [terrains.ground] = "corflak", [terrains.water] = "corenaa" },
+	{ [terrains.ground] = "armmoho", [terrains.water] = "armuwmme" },
+	{ [terrains.ground] = "cormoho", [terrains.water] = "coruwmme" },
+	{ [terrains.ground] = "armsolar", [terrains.water] = "armtide" },
+	{ [terrains.ground] = "corsolar", [terrains.water] = "cortide" },
+	{ [terrains.ground] = "armlab", [terrains.water] = "armsy" },
+	{ [terrains.ground] = "corlab", [terrains.water] = "corsy" },
+	{ [terrains.ground] = "armllt", [terrains.water] = "armtl" },
+	{ [terrains.ground] = "corllt", [terrains.water] = "cortl" },
+	{ [terrains.ground] = "armnanotc", [terrains.water] = "armnanotcplat" },
+	{ [terrains.ground] = "cornanotc", [terrains.water] = "cornanotcplat" },
+	{ [terrains.ground] = "armvp", [terrains.water] = "armamsub" },
+	{ [terrains.ground] = "corvp", [terrains.water] = "coramsub" },
+	{ [terrains.ground] = "armap", [terrains.water] = "armplat" },
+	{ [terrains.ground] = "corap", [terrains.water] = "corplat" },
+	{ [terrains.ground] = "armasp", [terrains.water] = "armfasp" },
+	{ [terrains.ground] = "corasp", [terrains.water] = "corfasp" },
+	{ [terrains.ground] = "armgeo", [terrains.water] = "armuwgeo" },
+	{ [terrains.ground] = "armageo", [terrains.water] = "armuwageo" },
+	{ [terrains.ground] = "corgeo", [terrains.water] = "coruwgeo" },
+	{ [terrains.ground] = "corageo", [terrains.water] = "coruwageo" },
+	--{ [terrains.ground] = "armllt", [terrains.water] = "armptl" },
+	--{ [terrains.ground] = "corllt", [terrains.water] = "corptl" },
+	{ [terrains.ground] = "leghp", [terrains.water] = "legfhp" },
+	{ [terrains.ground] = "leglht", [terrains.water] = "legtl" },
+	{ [terrains.ground] = "leghive", [terrains.water] = "legfhive" },
+	{ [terrains.ground] = "legvp", [terrains.water] = "legamsub" },
+}
+
+local factionBuildableUnits = {}
+
+local factionSwapIDs = {}
+local terrainSwapIDs = {}
+
+local factionSwapMap = {}
+local terrainSwapMap = {}
+
+local function traverseBuildOptions(unitDefID, visited)
+	visited = visited or {}
+
+	for _, buildUnitDefID in ipairs(UnitDefs[unitDefID].buildOptions) do
+		if not visited[buildUnitDefID] then
+			visited[buildUnitDefID] = true
+			traverseBuildOptions(buildUnitDefID, visited)
+		end
+	end
+
+	return visited
+end
+
+local function initializeFactionUnits()
+	local startUnits = {
+		[factions.cor] = UnitDefNames.corcom.id,
+		[factions.arm] = UnitDefNames.armcom.id,
+	}
+	if isFactionEnabled(factions.leg) then
+		startUnits[factions.leg] = UnitDefNames.legcom.id
+	end
+
+	for faction, startUnitDefID in pairs(startUnits) do
+		factionBuildableUnits[faction] = traverseBuildOptions(startUnitDefID)
+	end
+end
+
+local function initializeFactionSwapIDs()
+	factionSwapIDs = table.map(factionSwapNames, function(group)
+		return table.map(group, function(unitDefName, faction)
+			if not isFactionEnabled(faction) then
+				return nil
+			end
+
+			local unitDef = UnitDefNames[unitDefName]
+			if unitDef then
+				return unitDef.id
+			else
+				Spring.Echo("Could not find unit for faction swap: " .. unitDefName)
+				return nil
+			end
+		end)
+	end)
+end
+
+local function initializeTerrainSwapIDs()
+	terrainSwapIDs = table.map(terrainSwapNames, function(group)
+		return table.map(group, function(unitDefName)
+			local unitDef = UnitDefNames[unitDefName]
+			if unitDef then
+				return unitDef.id
+			else
+				Spring.Echo("Could not find unit for terrain swap: " .. unitDefName)
+			end
+		end)
+	end)
+end
+
+local function initializeFactionSwapMap()
+	for groupIndex, group in ipairs(factionSwapIDs) do
+		for _, unitDefID in pairs(group) do
+			if factionSwapMap[unitDefID] ~= nil and factionSwapMap[unitDefID] ~= group then
+				Spring.Echo("Faction swap collision detected: " .. UnitDefs[unitDefID].name .. " " .. table.toString(factionSwapNames[groupIndex]))
+				Spring.Echo("--old group", table.toString(factionSwapMap[unitDefID]))
+				Spring.Echo("--new group", table.toString(group))
+			end
+			factionSwapMap[unitDefID] = group
+		end
+	end
+end
+
+local function initializeTerrainSwapMap()
+	for groupIndex, group in ipairs(terrainSwapIDs) do
+		for _, unitDefID in pairs(group) do
+			if terrainSwapMap[unitDefID] ~= nil and terrainSwapMap[unitDefID] ~= group then
+				Spring.Echo("Terrain swap collision detected: " .. UnitDefs[unitDefID].name .. " " .. table.toString(terrainSwapNames[groupIndex]))
+				Spring.Echo("--old group", table.toString(terrainSwapMap[unitDefID]))
+				Spring.Echo("--new group", table.toString(group))
+			end
+			terrainSwapMap[unitDefID] = group
+		end
+	end
+end
+
+-- API
+
+local function swapFaction(unitDefID, faction)
+	local group = factionSwapMap[unitDefID]
+	if group ~= nil then
+		return group[faction]
+	end
+end
+
+local function swapTerrain(unitDefID, terrain)
+	local group = terrainSwapMap[unitDefID]
+	if group ~= nil then
+		return group[terrain]
+	end
+end
+
+local function isUnitBuildableByFaction(unitDefID, faction)
+	return factionBuildableUnits[faction] and factionBuildableUnits[faction][unitDefID] ~= nil
+end
+
+local function getEnabledFactions()
+	local result = {}
+	for faction in pairs(factions) do
+		if isFactionEnabled(faction) then
+			result[faction] = faction
+		end
+	end
+	return result
+end
+
+function widget:Initialize()
+	initializeFactionUnits()
+
+	initializeFactionSwapIDs()
+	initializeTerrainSwapIDs()
+
+	initializeFactionSwapMap()
+	initializeTerrainSwapMap()
+
+	WG["api_unit_swap"] = {
+		factions = factions,
+		terrains = terrains,
+		swapFaction = swapFaction,
+		swapTerrain = swapTerrain,
+		isUnitBuildableByFaction = isUnitBuildableByFaction,
+		getEnabledFactions = getEnabledFactions,
+	}
+end
+
+function widget:Shutdown()
+	WG["api_unit_swap"] = nil
+end

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -202,6 +202,9 @@ local BLUEPRINT_FILE_PATH = "LuaUI/config/blueprints.json"
 ---@type Blueprint[]
 local blueprints = {}
 
+---@type Blueprint[]
+local blueprintsFactionSwapped = {}
+
 local selectedBlueprintIndex = nil
 
 local blueprintPlacementActive = false
@@ -253,8 +256,20 @@ for builderUnitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
+local trySwapFaction = nil
+
 local function getSelectedBlueprint()
 	return blueprints[selectedBlueprintIndex]
+end
+
+local function getEffectiveBlueprint()
+	local bp = getSelectedBlueprint()
+	local swapped = false
+	if trySwapFaction and blueprintsFactionSwapped[bp][trySwapFaction] then
+		bp = blueprintsFactionSwapped[bp][trySwapFaction]
+		swapped = true
+	end
+	return bp, swapped
 end
 
 local function setSelectedBlueprintIndex(index)
@@ -316,6 +331,61 @@ local function determineBuildModeArgs(mode, startPosition, endPosition, targetID
 	end
 end
 
+local function createFactionSwaps(bp)
+	if not WG["api_unit_swap"] then
+		return {}
+	end
+
+	local swap = WG["api_unit_swap"]
+	local result = {}
+
+	local function trySwap(unitDefID, faction)
+		local swapUnitDefID = swap.swapFaction(unitDefID, faction)
+
+		if swapUnitDefID then
+			local xSizeOld, zSizeOld = WG["api_blueprint"].getBuildingDimensions(unitDefID, 0)
+			local xSizeNew, zSizeNew = WG["api_blueprint"].getBuildingDimensions(swapUnitDefID, 0)
+
+			if xSizeOld == xSizeNew and zSizeOld == zSizeNew then
+				return swapUnitDefID
+			end
+		end
+
+		return nil
+	end
+
+	for faction in pairs(swap.getEnabledFactions()) do
+		local swapped = {}
+		local atLeastOneSwap = false
+		for i, u in ipairs(bp.units) do
+			if swap.isUnitBuildableByFaction(u.unitDefID, faction) then
+				swapped[i] = u
+			else
+				local swapUnitDefID = trySwap(u.unitDefID, faction)
+
+				if swapUnitDefID then
+					swapped[i] = table.copy(u)
+					swapped[i].unitDefID = swapUnitDefID
+					if swapUnitDefID ~= u.unitDefID then
+						atLeastOneSwap = true
+					end
+				else
+					swapped = nil
+					break
+				end
+			end
+		end
+
+		if swapped and atLeastOneSwap then
+			local newBP = table.copy(bp)
+			newBP.units = swapped
+			result[faction] = newBP
+		end
+	end
+
+	return result
+end
+
 local function postProcessBlueprint(bp)
 	-- precompute some useful information
 	bp.dimensions = pack(WG["api_blueprint"].getBlueprintDimensions(bp))
@@ -333,6 +403,8 @@ local function postProcessBlueprint(bp)
 			return math.min(w, h)
 		end
 	end, nil)
+
+	blueprintsFactionSwapped[bp] = {}
 end
 
 local function createBlueprint(unitIDs, ordered)
@@ -567,9 +639,10 @@ function widget:Update(dt)
 	if blueprint ~= state.blueprint or blueprint.dirty then
 		blueprintChanged = true
 		state.blueprint = blueprint
+		blueprintsFactionSwapped[blueprint] = createFactionSwaps(blueprint)
 		blueprint.dirty = false
 
-		WG["api_blueprint"].setActiveBlueprint(blueprint)
+		WG["api_blueprint"].setActiveBlueprint(getEffectiveBlueprint())
 		updateBuildingGridState(true, blueprint)
 	end
 
@@ -625,10 +698,14 @@ function widget:Update(dt)
 	end
 end
 
-local drawCursorText = glListCache(function(index)
+local drawCursorText = glListCache(function(index, faction)
 	local text
 	if index then
 		text = "\255\220\220\240Blueprint #" .. tostring(index)
+
+		if faction then
+			text = text .. " (" .. Spring.I18N("units.factions." .. faction) .. ")"
+		end
 	else
 		text = "\255\240\220\220No Blueprints"
 	end
@@ -685,9 +762,21 @@ function widget:DrawScreenEffects()
 	gl.PushMatrix()
 
 	gl.Translate(x, y, 0)
-	drawCursorText(selectedBlueprintIndex)
+
+	local faction
+	local _, drawFaction = getEffectiveBlueprint()
+	if drawFaction then
+		faction = trySwapFaction
+	end
+
+	drawCursorText(selectedBlueprintIndex, faction)
 
 	gl.PopMatrix()
+end
+
+local function getUnitFactionByUnitID(unitID)
+	local unitDefName = UnitDefs[Spring.GetUnitDefID(unitID)].name
+	return string.sub(unitDefName, 1, 3)
 end
 
 function widget:SelectionChanged(selection)
@@ -699,6 +788,18 @@ function widget:SelectionChanged(selection)
 				return blueprintCommandableUnitDefs[Spring.GetUnitDefID(unitID)]
 			end
 		)
+
+		local builderFactions = table.reduce(builders, function(acc, unitID)
+			acc[getUnitFactionByUnitID(unitID)] = true
+			return acc
+		end, {})
+
+		if table.count(builderFactions) == 1 then
+			local faction = next(builderFactions)
+			trySwapFaction = faction
+		else
+			trySwapFaction = nil
+		end
 
 		WG["api_blueprint"].setActiveBuilders(builders)
 	end
@@ -921,7 +1022,7 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	if cmdID == CMD_BLUEPRINT_CREATE then
 		handleBlueprintCreateAction()
 	elseif cmdID == CMD_BLUEPRINT_PLACE then
-		local selectedBlueprint = getSelectedBlueprint()
+		local selectedBlueprint = getEffectiveBlueprint()
 
 		if not selectedBlueprint then
 			Spring.Echo("[Blueprint] no active blueprints")


### PR DESCRIPTION
There are two components to this PR:

#### api_unit_swap.lua (new) - An API for getting equivalent units
This currently supports:
* swapping between factions (for example: armwin, corwin, legwin)
* swapping between terrains (for example: armmakr, armfmkr)

Generally this will be used by calling `swapFaction(unitDefID, faction)`
or `swapTerrain(unitDefID, terrain)`.

Factions and terrains should be referred to using the enums shared by
this widget: `factions` and `terrains`.

#### cmd_blueprint.lua (updated) - use the above API to swap blueprints to the relevant faction when possible

### Notes

* This is not completed yet:
  * The blueprint component should get some more testing
  * There are a lot of missing swap groups. I added a bunch, but it's pretty tedious work

Once this is merged, we can work on refactoring `gui_pregame_build.lua` and `cmd_context_build.lua` to use this API. Looking at their code, this will probably not be trivial.