### PR TITLE
Reclaim highlight perf and slow update

### DIFF
--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -33,7 +33,7 @@ local showOption = 3
 ]]
 
 --If true energy reclaim will be converted into metal (1 / 70) and added to the reclaim field value
-local includeEnergy = false
+-- local includeEnergy = false
 
 --Metal value font
 local numberColor = {1, 1, 1, 0.75}
@@ -519,9 +519,9 @@ end
 
 local function UpdateFeatures()
 	for fID, fInfo in pairs(knownFeatures) do
-		local metal, _, energy = spGetFeatureResources(fID)
-
-		if includeEnergy then metal = metal + energy * E2M end
+		-- local metal, _, energy = spGetFeatureResources(fID)
+		-- if includeEnergy then metal = metal + energy * E2M end
+		local metal = spGetFeatureResources(fID)
 		if metal >= minFeatureMetal then
 			-- -- @efrec testing whether this is still needed
 			-- local fx, _, fz = spGetFeaturePosition(fID)
@@ -538,13 +538,15 @@ local function UpdateFeatures()
 				if fInfo.clID then
 					local thisCluster = featureClusters[fInfo.clID]
 					thisCluster.metal = thisCluster.metal - fInfo.metal
-					if metal >= minFeatureMetal then
+					-- Okay but we've already established that it's >= min
+					-- if metal >= minFeatureMetal then
 						thisCluster.metal = thisCluster.metal + metal
 						fInfo.metal = metal
-					else
-						UpdateFeatureNeighborsMatrix(fID, false, true)
-						knownFeatures[fID] = nil
-					end
+					-- So this would never execute
+					-- else
+					-- 	UpdateFeatureNeighborsMatrix(fID, false, true)
+					-- 	knownFeatures[fID] = nil
+					-- end
 				end
 			end
 		else

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -633,7 +633,7 @@ local function lineCheck(points)
 	local x3, z3 = points[2].x, points[2].z
 
 	for i = 2, #points - 1 do
-		-- Triangular determinant form for polygon area (I think, blame efrec ig)
+		-- Triangular determinant form for polygon area
 		-- Can be extended by parts to program this sum faster, if needed
 		x2 = x3
 		z2 = z3

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -627,26 +627,20 @@ local function lineCheck(points)
 	local totalArea = 0
 	local pt1 = points[1]
 	-- local x1, z1, x2, z2, pt2, pt3 -- heron, exterior
-	local x, z, x2, z2, x3, z3 -- triangle determinant
+	local x, z = pt1.x, pt1.z
+	local x2, z2, x3, z3 -- triangle determinant
 
 	for i = 2, #points - 1 do
+		-- Triangular determinant form for polygon area (I think, blame efrec ig)
+		-- Can be extended by parts to program this sum faster, if needed
 		pt2 = pt3 or points[i]
 		pt3 = points[i + 1]
-		
+
 		x1 = x2 or pt2.x - pt1.x
 		z1 = z2 or pt2.z - pt1.z
 		x2 = pt3.x - pt1.x
 		z2 = pt3.z - pt1.z
 
-		-- -- Heron formula to get triangle area
-		-- local a = sqrt((pt2.x - pt1.x)^2 + (pt2.z - pt1.z)^2)
-		-- local b = sqrt((pt3.x - pt2.x)^2 + (pt3.z - pt2.z)^2)
-		-- local c = sqrt((pt3.x - pt1.x)^2 + (pt3.z - pt1.z)^2)
-		-- local p = (a + b + c)/2 -- Half perimeter
-		-- local triangleArea = sqrt(p * (p - a) * (p - b) * (p - c))
-
-		-- Triangular determinant form for polygon area (I think, blame efrec ig)
-		-- Can be extended by parts to program this sum faster, if needed
 		totalArea = totalArea + 0.5 * x * (z1 - z2) + x1 * (z2 - z) + x2 * (z - z1)
 	end
 

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -413,7 +413,7 @@ local minFeatureMetal = 9 -- Tick
 local E2M = 1 / 70 -- Converter ratio
 local minDim = 100
 
-local checkFrequency = 3 * Game.gameSpeed
+local checkFrequency = 2 * Game.gameSpeed
 
 local drawEnabled = true
 local actionActive = false

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -335,7 +335,7 @@ do
 		local lower = {}
 		for i = 1, numPoints do
 			while (#lower >= 2 and cross(lower[#lower - 1], lower[#lower], points[i]) <= 0) do
-				table.remove(lower, #lower)
+				table.remove(lower)
 			end
 	
 			table.insert(lower, points[i])
@@ -344,14 +344,14 @@ do
 		local upper = {}
 		for i = numPoints, 1, -1 do
 			while (#upper >= 2 and cross(upper[#upper - 1], upper[#upper], points[i]) <= 0) do
-				table.remove(upper, #upper)
+				table.remove(upper)
 			end
 	
 			table.insert(upper, points[i])
 		end
 	
-		table.remove(upper, #upper)
-		table.remove(lower, #lower)
+		table.remove(upper)
+		table.remove(lower)
 		for _, point in ipairs(lower) do
 			table.insert(upper, point)
 		end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -583,22 +583,20 @@ local function ClusterizeFeatures()
 	featureClusters = opticsObject:Clusterize(minDistance)
 
 	for i = 1, #featureClusters do
-		local thisCluster = featureClusters[i]
-
-		thisCluster.xmin = mathHuge
-		thisCluster.xmax = -mathHuge
-		thisCluster.zmin = mathHuge
-		thisCluster.zmax = -mathHuge
-
+		local thisCluster = featureClusters[i]		
+		local members = thisCluster.members
+		local xmin, xmax, zmin, zmax = -mathHuge, mathHuge, -mathHuge, mathHuge
 		local metal = 0
-		for j = 1, #thisCluster.members do
-			local fID = thisCluster.members[j]
+		for j = 1, #members do
+			local fID = members[j]
 			local fInfo = knownFeatures[fID]
 
-			thisCluster.xmin = min(thisCluster.xmin, fInfo.x)
-			thisCluster.xmax = max(thisCluster.xmax, fInfo.x)
-			thisCluster.zmin = min(thisCluster.zmin, fInfo.z)
-			thisCluster.zmax = max(thisCluster.zmax, fInfo.z)
+			local x = fInfo.x
+			local z = fInfo.z
+			xmin = min(xmin, x)
+			xmax = max(xmax, x)
+			zmin = min(zmin, z)
+			zmax = max(zmax, z)
 
 			metal = metal + fInfo.metal
 			fInfo.clID = i
@@ -606,6 +604,10 @@ local function ClusterizeFeatures()
 		end
 
 		thisCluster.metal = metal
+		thisCluster.xmin = xmin
+		thisCluster.xmax = xmax
+		thisCluster.zmin = zmin
+		thisCluster.zmax = zmax
 	end
 
 	for fID in pairs(unclusteredPoints) do
@@ -628,7 +630,7 @@ end
 local function pointArea(points)
 	-- Determinant area, point form
 	local n = #points
-	local totalArea = totalArea + points[1].x * (points[n].z - points[2].z)
+	local totalArea = points[1].x * (points[n].z - points[2].z)
 	for i = 2, n-1 do
 		totalArea = totalArea + points[i].x * (points[i-1].z - points[i+1].z)
 	end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -412,7 +412,7 @@ local minFeatureMetal = 9 -- Tick
 local E2M = 1 / 70 -- Converter ratio
 local minDim = 100
 
-local checkFrequency = 30
+local checkFrequency = 3 * Game.gameSpeed
 
 local drawEnabled = true
 local actionActive = false
@@ -876,8 +876,7 @@ function widget:Update(dt)
 end
 
 function widget:GameFrame(frame)
-	local frameMod = frame % checkFrequency
-	if not drawEnabled or frameMod ~= 0 then
+	if not drawEnabled or frame % checkFrequency ~= 0 then
 		return
 	end
 

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -33,7 +33,7 @@ local showOption = 3
 ]]
 
 --If true energy reclaim will be converted into metal (1 / 70) and added to the reclaim field value
-local includeEnergy = false
+-- local includeEnergy = false
 
 --Metal value font
 local numberColor = {1, 1, 1, 0.75}
@@ -518,34 +518,13 @@ end
 
 local function UpdateFeatures()
 	for fID, fInfo in pairs(knownFeatures) do
-		local metal, _, energy = spGetFeatureResources(fID)
-
-		if includeEnergy then metal = metal + energy * E2M end
-		if metal >= minFeatureMetal then
-			-- -- @efrec testing whether this is still needed
-			-- local fx, _, fz = spGetFeaturePosition(fID)
-			-- local fy = spGetGroundHeight(fx, fz)
-			-- if fInfo.x ~= fx or fInfo.y ~= fy or fInfo.z ~= fz then
-			-- 	fInfo.x = fx
-			-- 	fInfo.y = fy
-			-- 	fInfo.z = fz
-			-- 	fInfo.drawAlt = ((fy > 0 and fy) or 0) --+ fInfo.height
-			-- 	UpdateFeatureNeighborsMatrix(fID, true, true)
-			-- end
-
-			if fInfo.metal ~= metal then
-				if fInfo.clID then
-					local thisCluster = featureClusters[fInfo.clID]
-					thisCluster.metal = thisCluster.metal - fInfo.metal
-					if metal >= minFeatureMetal then
-						thisCluster.metal = thisCluster.metal + metal
-						fInfo.metal = metal
-					else
-						UpdateFeatureNeighborsMatrix(fID, false, true)
-						knownFeatures[fID] = nil
-					end
-				end
-			end
+		-- local metal, _, energy = spGetFeatureResources(fID)
+		-- if includeEnergy then metal = metal + energy * E2M end
+		local metal = spGetFeatureResources(fID)
+		if metal >= minFeatureMetal and metal ~= fInfo.metal and fInfo.clID then
+			local thisCluster = featureClusters[fInfo.clID]
+			thisCluster.metal = thisCluster.metal - fInfo.metal + metal
+			fInfo.metal = metal
 		else
 			knownFeatures[fID] = nil
 			clusterizingNeeded = true
@@ -555,7 +534,6 @@ local function UpdateFeatures()
 	for fID, fInfo in pairs(knownFeatures) do
 		if fInfo.isGaia and spValidFeatureID(fID) == false then
 			UpdateFeatureNeighborsMatrix(fID, false, true)
-			fInfo = nil
 			knownFeatures[fID] = nil
 		else
 			fInfo.clID = nil
@@ -582,22 +560,20 @@ local function ClusterizeFeatures()
 	featureClusters = opticsObject:Clusterize(minDistance)
 
 	for i = 1, #featureClusters do
-		local thisCluster = featureClusters[i]
-
-		thisCluster.xmin = mathHuge
-		thisCluster.xmax = -mathHuge
-		thisCluster.zmin = mathHuge
-		thisCluster.zmax = -mathHuge
-
+		local thisCluster = featureClusters[i]		
+		local members = thisCluster.members
+		local xmin, xmax, zmin, zmax = -mathHuge, mathHuge, -mathHuge, mathHuge
 		local metal = 0
-		for j = 1, #thisCluster.members do
-			local fID = thisCluster.members[j]
+		for j = 1, #members do
+			local fID = members[j]
 			local fInfo = knownFeatures[fID]
 
-			thisCluster.xmin = min(thisCluster.xmin, fInfo.x)
-			thisCluster.xmax = max(thisCluster.xmax, fInfo.x)
-			thisCluster.zmin = min(thisCluster.zmin, fInfo.z)
-			thisCluster.zmax = max(thisCluster.zmax, fInfo.z)
+			local x = fInfo.x
+			local z = fInfo.z
+			xmin = min(xmin, x)
+			xmax = max(xmax, x)
+			zmin = min(zmin, z)
+			zmax = max(zmax, z)
 
 			metal = metal + fInfo.metal
 			fInfo.clID = i
@@ -605,6 +581,10 @@ local function ClusterizeFeatures()
 		end
 
 		thisCluster.metal = metal
+		thisCluster.xmin = xmin
+		thisCluster.xmax = xmax
+		thisCluster.zmin = zmin
+		thisCluster.zmax = zmax
 	end
 
 	for fID in pairs(unclusteredPoints) do
@@ -757,10 +737,9 @@ function widget:Initialize()
 end
 
 function widget:FeatureCreated(featureID, allyTeamID)
-	local metal, _, energy = spGetFeatureResources(featureID)
-
-	if includeEnergy then metal = metal + energy * E2M end
-
+	-- local metal, _, energy = spGetFeatureResources(fID)
+	-- if includeEnergy then metal = metal + energy * E2M end
+	local metal = spGetFeatureResources(fID)
 	if (not knownFeatures[featureID]) and (metal >= minFeatureMetal) then
 		local fx, fy, fz = spGetFeaturePosition(featureID)
 		knownFeatures[featureID] = {

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -49,6 +49,7 @@ local reclaimEdgeColor = {1, 1, 1, 0.18}
 --------------------------------------------------------------------------------
 -- Priority Queue
 
+local abs = math.abs
 local min = math.min
 local max = math.max
 local mathHuge = math.huge
@@ -625,23 +626,22 @@ end
 
 local function lineCheck(points)
 	local totalArea = 0
+
 	local pt1 = points[1]
-	-- local x1, z1, x2, z2, pt2, pt3 -- heron, exterior
-	local x, z = pt1.x, pt1.z
-	local x2, z2, x3, z3 -- triangle determinant
+	local x1, z1 = pt1.x, pt1.z
+	local x2, z2
+	local x3, z3 = points[2].x, points[2].z
 
 	for i = 2, #points - 1 do
 		-- Triangular determinant form for polygon area (I think, blame efrec ig)
 		-- Can be extended by parts to program this sum faster, if needed
-		pt2 = pt3 or points[i]
-		pt3 = points[i + 1]
+		x2 = x3
+		z2 = z3
+		x3 = points[i + 1].x
+		z3 = points[i + 1].z
 
-		x1 = x2 or pt2.x - pt1.x
-		z1 = z2 or pt2.z - pt1.z
-		x2 = pt3.x - pt1.x
-		z2 = pt3.z - pt1.z
-
-		totalArea = totalArea + 0.5 * x * (z1 - z2) + x1 * (z2 - z) + x2 * (z - z1)
+		-- Using shoelace formula:
+		totalArea = totalArea + 0.5 * abs(x1 * (z2 - z3) + x2 * (z3 - z1) + x3 * (z1 - z2))
 	end
 
 	return totalArea >= 3000

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -711,17 +711,17 @@ local function ClustersToConvexHull()
 
 		local totalArea = 0
 		local pt1 = convexHull[1]
+		local x1, z1 = pt1.x, pt1.z
+		local x2, z2
+		local x3, z3 = convexHull[2].x, convexHull[2].z
 		for i = 2, #convexHull - 1 do
-			local pt2 = convexHull[i]
-			local pt3 = convexHull[i + 1]
-			--Heron formula to get triangle area
-			local a = sqrt((pt2.x - pt1.x)^2 + (pt2.z - pt1.z)^2)
-			local b = sqrt((pt3.x - pt2.x)^2 + (pt3.z - pt2.z)^2)
-			local c = sqrt((pt3.x - pt1.x)^2 + (pt3.z - pt1.z)^2)
-			local p = (a + b + c)/2 --half perimeter
-
-			local triangleArea = sqrt(p * (p - a) * (p - b) * (p - c))
-			totalArea = totalArea + triangleArea
+			-- Triangular determinant form for polygon area
+			x2 = x3
+			z2 = z3
+			x3 = points[i + 1].x
+			z3 = points[i + 1].z
+			-- Using shoelace formula:
+			totalArea = totalArea + 0.5 * abs(x1 * (z2 - z3) + x2 * (z3 - z1) + x3 * (z1 - z2))
 		end
 
 		convexHull.area = totalArea


### PR DESCRIPTION
### Work done

- Use determinant area/shoelace formula for area enclosed by three points, much more efficient than Heron's formula
- Other more minor changes for perf
- Suppressed check for features moving in x, z
- Increase the time between updates to around 3 seconds

#### Addresses Issue(s)

- Partly resolves #3419. This pr focused on making calcs less expensive to perform. It would take more work to make clusters update independently instead the one map-wide update.