### PR TITLE
Select com reapplies if only 1 com

### DIFF
--- a/luaui/Widgets/cmd_comselect.lua
+++ b/luaui/Widgets/cmd_comselect.lua
@@ -59,12 +59,18 @@ local function handleSelectComm(_, _, args)
 	local units = {}
 	local teamUnits = Spring.GetTeamUnitsByDefs(myTeamID, commanderDefIDsList)
 	for _, unitID in ipairs(teamUnits) do
-		if not selectedUnits[unitID] or #teamUnits == 1 then
+		if not selectedUnits[unitID] then
 			table.insert(units, unitID)
 		end
 	end
 
 	local unitCount = #units
+
+	-- if all comms are already selected, any of them becomes fair game
+	if unitCount == 0 then
+			units = teamUnits
+			unitCount = #units
+		end
 
 	-- If no comms to select, nothing to do
 	if unitCount < 1 then

--- a/luaui/Widgets/cmd_comselect.lua
+++ b/luaui/Widgets/cmd_comselect.lua
@@ -68,9 +68,9 @@ local function handleSelectComm(_, _, args)
 
 	-- if all comms are already selected, any of them becomes fair game
 	if unitCount == 0 then
-			units = teamUnits
-			unitCount = #units
-		end
+		units = teamUnits
+		unitCount = #units
+	end
 
 	-- If no comms to select, nothing to do
 	if unitCount < 1 then

--- a/luaui/Widgets/cmd_comselect.lua
+++ b/luaui/Widgets/cmd_comselect.lua
@@ -59,7 +59,7 @@ local function handleSelectComm(_, _, args)
 	local units = {}
 	local teamUnits = Spring.GetTeamUnitsByDefs(myTeamID, commanderDefIDsList)
 	for _, unitID in ipairs(teamUnits) do
-		if not selectedUnits[unitID] then
+		if not selectedUnits[unitID] or #teamUnits == 1 then
 			table.insert(units, unitID)
 		end
 	end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->
### Context
Previously when using select commander hot key it would always focus the camera on the commander. Recently it stopped working if you only have 1 commander. If your 1 commander is selected it does not focus the cam on it when using selectCom.

### Work done
Updated logic to allow reselecting singular commanders.
If you only have 1 commander it will be added to the list of selectable commanders, as a result it is reselected and focused.


#### Test steps
Tested in dev with 1 commander and multiple. Successfully swaps to different commanders with comSelect and always centers if only 1 com, even if it is currently selected.
