### PR TITLE
POC: Chat Filter

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -561,8 +561,20 @@ end
 local energyText = Spring.I18N('ui.topbar.resources.energy'):lower()
 local metalText = Spring.I18N('ui.topbar.resources.metal'):lower()
 
+local function filterBadword(text)
+	badWords = {"retard"}
+
+	for _, badword in ipairs(badWords) do
+		text = string.gsub(text, badword, "****")
+	end
+	
+	return text
+end
+
 local function addChat(gameFrame, lineType, name, text, isLive)
 	if not text or text == '' then return end
+
+	text = filterBadword(text)
 
 	-- determine text typing start time
 	local startTime = clock()


### PR DESCRIPTION
### Context
Currently one of the largest reasons for bans is usage of politically incorrect words against COC. This results in some players feeling restricted in their speech and becoming frustrated with moderation. On moderation's side this creates an increased work load having to ban many people daily for usage of words against COC. As a solution a word filter would help both sides.

### Work done
A brief POC to introduce the idea of filtering words against COC approved by moderation.

### Full Implementation
By default politically incorrect terms would be censored for all new players installing the game. There can be an option to disable the filter in settings. This allows players to use language more freely without feeling oppressed by moderation, while people who do not want to interact with such language will not be exposed to it.

## Absolute No's
A secondary list of absolutely banned words which are deemed by moderation to have no place in the game can be implemented.

## Escaping Filter
If someone attempts to circumvent the filter, algorithms such as Levenshtein's distance can be used to prevent typos/intentional filter circumvention. Possibly the COC could be updated to punish filter bypassing.
