### PR TITLE
SSAO + Bloom rewrite

### DIFF
--- a/luaui/Widgets/Include/LuaShader.lua
+++ b/luaui/Widgets/Include/LuaShader.lua
@@ -312,14 +312,17 @@ local function CheckShaderUpdates(shadersourcecache, delaytime)
 			if vsSrcNew then 
 				vsSrcNew = vsSrcNew:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 				vsSrcNew = vsSrcNew:gsub("//__DEFINES__", shaderDefines)
+				shadersourcecache.vsSrcComplete = vsSrcNew
 			end
 			if fsSrcNew then 
 				fsSrcNew = fsSrcNew:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 				fsSrcNew = fsSrcNew:gsub("//__DEFINES__", shaderDefines)
+				shadersourcecache.fsSrcComplete = fsSrcNew
 			end
 			if gsSrcNew then 
 				gsSrcNew = gsSrcNew:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 				gsSrcNew = gsSrcNew:gsub("//__DEFINES__", shaderDefines)
+				shadersourcecache.gsSrcComplete = gsSrcNew
 			end
 			local reinitshader =  LuaShader(
 				{

--- a/luaui/Widgets/Include/LuaShader.lua
+++ b/luaui/Widgets/Include/LuaShader.lua
@@ -335,8 +335,9 @@ local function CheckShaderUpdates(shadersourcecache, delaytime)
 				shadersourcecache.shaderName
 			)
 			local shaderCompiled = reinitshader:Initialize()
-			
-			Spring.Echo(shadersourcecache.shaderName, " recompiled in ", Spring.DiffTimers(Spring.GetTimer(), compilestarttime, true), "ms at", Spring.GetGameFrame(), "success", shaderCompiled or false)
+			if not shadersourcecache.silent then 
+				Spring.Echo(shadersourcecache.shaderName, " recompiled in ", Spring.DiffTimers(Spring.GetTimer(), compilestarttime, true), "ms at", Spring.GetGameFrame(), "success", shaderCompiled or false)
+			end
 			if shaderCompiled then 
 				reinitshader.ignoreUnkUniform = true
 				return reinitshader

--- a/luaui/Widgets/Include/instancevbotable.lua
+++ b/luaui/Widgets/Include/instancevbotable.lua
@@ -1266,3 +1266,42 @@ function makeSphereVBO(sectorCount, stackCount, radius) -- http://www.songho.ca/
 
 	return sphereVBO, numVerts, sphereIndexVBO, #VBOData
 end
+
+
+function MakeTexRectVAO(minX,minY, maxX, maxY, minU, minV, maxU, maxV)
+	-- Draw with myGL4TexRectVAO:DrawArrays(GL.TRIANGLES)
+	minX,minY,maxX,maxY,minU,minV,maxU,maxV  = minX or -1,minY or -1,maxX or 1, maxY or 1, minU or 0, minV or 0, maxU or 1, maxV or 1
+
+	local myGL4TexRectVAO
+	local rectVBO = gl.GetVBO(GL.ARRAY_BUFFER,false)
+	if rectVBO == nil then return nil end
+
+	--rectVBO:Define(	6,	{{id = 0, name = "position_xy_uv", size = 8}})
+	local z = 0.5
+	local w = 1
+	rectVBO:Define(	6,	{{id = 0, name = "pos", size = 4}})
+	rectVBO:Upload({
+			
+		minX,minY, minU, minV, --bl
+		minX,maxY, minU, maxV, --tr
+		maxX,maxY, maxU, maxV, --tr
+		maxX,maxY, maxU, maxV, --tr
+		maxX,minY, maxU, minV, --br
+		minX,minY, minU, minV, --bl
+			})
+	
+	--[[rectVBO:Upload( {
+		minX,minY,z,w, minU, minV,0,0, --bl
+		minX,maxY,z,w, minU, maxV,0,0, --br
+		maxX,maxY,z,w, maxU, maxV,0,0,--tr
+		maxX,maxY,z,w,maxU, maxV,0,0, --tr
+		maxX,minY,z,w, maxU, minV,0,0, --br
+		minX,minY,z,w, minU, minV,0,0, --bl
+	})
+	]]--
+			
+	myGL4TexRectVAO = gl.GetVAO()
+	if myGL4TexRectVAO == nil then return nil end
+	myGL4TexRectVAO:AttachVertexBuffer(rectVBO)
+	return myGL4TexRectVAO
+end

--- a/luaui/Widgets/Shaders/gaussianBlur.frag.glsl
+++ b/luaui/Widgets/Shaders/gaussianBlur.frag.glsl
@@ -1,37 +1,126 @@
 #version 150 compatibility
 
-uniform sampler2D tex;
+//__DEFINES__
 
-uniform float offsets[###BLUR_HALF_KERNEL_SIZE###];
-uniform float weights[###BLUR_HALF_KERNEL_SIZE###];
+uniform sampler2D tex;
+uniform sampler2D unitStencilTex;
+
+uniform float offsets[BLUR_HALF_KERNEL_SIZE];
+uniform float weights[BLUR_HALF_KERNEL_SIZE];
+
+
+#define NORM2SNORM(value) (value * 2.0 - 1.0)
+#define SNORM2NORM(value) (value * 0.5 + 0.5)
 
 uniform vec2 dir;
+uniform float strengthMult;
 
 uniform vec2 viewPortSize;
-
+#line 1018
 void main(void)
 {
-	vec2 uv = gl_FragCoord.xy / viewPortSize;
-	vec4 acc = texture( tex, uv ) * weights[0];
-	float okCoords;
+	//vec2 uv = gl_FragCoord.xy / viewPortSize;
 
-	for (int i = 1; i < ###BLUR_HALF_KERNEL_SIZE###; ++i) {
-		vec2 uvOff = offsets[i] * dir / viewPortSize;
-		vec2 uvP = uv + uvOff;
-		vec2 uvN = uv - uvOff;
+	vec2 uv = gl_FragCoord.xy / vec2(HSX,HSY);
 
-		float weightP = weights[i];
-		float weightN = weights[i];
 
-		okCoords = float( all(bvec4( greaterThanEqual(uvP, vec2(0.0)), lessThanEqual(uvP, vec2(1.0)) )) );
-		weightP *= okCoords;
+	#if USE_STENCIL == 1 
+		if (texture(unitStencilTex, uv).r < 0.1) {
+			gl_FragColor = vec4(0.0,0.0, 0.0, 1.0);	return;
+		}
+	#endif
 
-		okCoords = float( all(bvec4( greaterThanEqual(uvN, vec2(0.0)), lessThanEqual(uvN, vec2(1.0)) )) );
-		weightN *= okCoords;
+		// Allrighty, this is a completely novel implementation now, that will attempt to use a bilateral weighting!
+		// tex contains normals, alpha contains occlusion
+		// We will weight individual samples by dot-ing them.
+		//new bilateral filter implementation
 
-		acc += texture( tex, uvP ) * weightP;
-		acc += texture( tex, uvN ) * weightN;
-	}
+		// TODO: ground has null vector normals, use that
+		// implement outlier detection too 
+		// MORE GROUND EFFECT! USE UNIFORM KERNEL FOR GROUND!
 
-	gl_FragColor = acc;
+		vec4 texSample = texture( tex, uv );
+		vec3 myNormal = NORM2SNORM(texSample.rgb);
+		myNormal.z = texSample.z;
+
+		float imground =step(dot(myNormal.xy, myNormal.xy), 0.1);
+		
+		float weightSum = weights[0];
+		if (imground > 0.5) {
+			//weightSum = 1.0/(2 * BLUR_HALF_KERNEL_SIZE-1);
+		}
+		float howLit = texSample.a * weightSum;
+		float unWeighted = howLit;
+		float myDistance = myNormal.z; // 1 at full distance, 0 at camera
+		vec2 texelOffset = dir / vec2(HSX,HSY);
+
+		// possibly better L1 cache locality via non expanding stepping?
+		for (int i = 1; i < (BLUR_HALF_KERNEL_SIZE  ); ++i) { // i goes from 1 to BLUR_HALF_KERNEL_SIZE-1
+			vec2 uvOff = offsets[i] * texelOffset ;
+			vec2 uvP = uv + uvOff;
+			vec2 uvN = uv - uvOff;
+
+			float weightP = weights[i];
+			float weightN = weights[i];
+			if (imground > 0.5) {
+				//weightP = 1.0/(2 * BLUR_HALF_KERNEL_SIZE-1);
+				//weightN = 1.0/(2* BLUR_HALF_KERNEL_SIZE-1);
+				//uvP = uv + 2*float(i) *  dir / vec2(HSX,HSY);
+				//uvN = uv - 2*float(i) *  dir / vec2(HSX,HSY);
+			}
+
+
+			vec4 leftSample = texture( tex, uvP );
+			float zclosel = step(abs(myDistance - leftSample.z), ZTHRESHOLD);
+			float dotclosel = smoothstep(MINCOSANGLE, 1.0, dot(myNormal.xy, NORM2SNORM(leftSample.xy)));
+			dotclosel = max(dotclosel, imground);
+			float leftWeight = weightP * dotclosel * zclosel;
+			weightSum += leftWeight;
+			howLit += leftWeight * leftSample.a;
+			unWeighted += weightP * leftSample.a;
+
+			vec4 rightSample = texture( tex, uvN );
+			float zcloser = step(abs(myDistance - rightSample.z), ZTHRESHOLD);
+			float dotcloser = smoothstep(MINCOSANGLE, 1.0, dot(myNormal.xy, NORM2SNORM(rightSample.xy)));
+			dotcloser = max(dotclosel, imground);
+			float rightWeight = weightN * dotcloser * zcloser;
+			weightSum += rightWeight;
+			howLit += rightWeight * rightSample.a;
+			unWeighted += weightP * rightSample.a;
+		}
+
+		howLit = howLit / weightSum;		
+		if (weightSum < (weights[0] + MINSELFWEIGHT) ){
+			howLit = mix(howLit,unWeighted, OUTLIERCORRECTIONFACTOR);
+
+		};
+		//if (imground > 0.5) {howLit = unWeighted;}
+		gl_FragColor = vec4(texSample.rgb, howLit);
+
+		// FINAL MIXDOWN, vert pass last
+		if (dir.y > 0.5) { 
+			if (imground > 0.5) howLit = howLit * howLit;
+			howLit = pow(howLit, BLUR_POWER);
+			howLit = sqrt(howLit * howLit + BLUR_CLAMP);
+			#if DEBUG_BLUR == 1 
+				gl_FragColor.rgba = vec4(howLit);
+			#else
+				gl_FragColor.rgba = vec4(howLit);
+				#if (BRIGHTEN != 0) 
+					if (imground < 0.5) {  // is model fragment
+						float distRatio = SSAO_FADE_DIST_1/(1.0 * SSAO_FADE_DIST_0);
+						float distFactor = 1.0 - smoothstep(0, distRatio, myDistance - distRatio ); // 0 at far distance, 1 at near distance
+
+						float brightenFactor = (BRIGHTEN/255.0) * howLit * distFactor;
+						gl_FragColor.rgb = vec3(brightenFactor);
+					}else{
+						gl_FragColor.rgb = vec3(0);
+
+					}
+				#endif
+				gl_FragColor.rgb *= strengthMult;
+				gl_FragColor.a = 1.0 - ((1.0 - gl_FragColor.a) * strengthMult );
+			#endif
+
+		};
 }

--- a/luaui/Widgets/Shaders/gbuffFuse.frag.glsl
+++ b/luaui/Widgets/Shaders/gbuffFuse.frag.glsl
@@ -1,22 +1,13 @@
 #version 150 compatibility
 
-#define DEPTH_CLIP01 ###DEPTH_CLIP01###
-#define MERGE_MISC ###MERGE_MISC###
+//__DEFINES__
 
 uniform sampler2D modelDepthTex;
 uniform sampler2D mapDepthTex;
-uniform sampler2D modelDiffTex;
 
-uniform sampler2D modelNormalTex;
-uniform sampler2D mapNormalTex;
-
-uniform sampler2D modelMiscTex;
-uniform sampler2D mapMiscTex;
-
-uniform vec2 viewPortSize;
+uniform sampler2D unitStencilTex;
 
 uniform mat4 invProjMatrix;
-uniform mat4 viewMatrix;
 
 #define NORM2SNORM(value) (value * 2.0 - 1.0)
 #define SNORM2NORM(value) (value * 0.5 + 0.5)
@@ -40,10 +31,16 @@ vec4 GetViewPos(vec2 texCoord, float sampledDepth) {
 }
 
 void main() {
-	vec2 uv = gl_FragCoord.xy / viewPortSize;
-
-	float modelAlpha = texture(modelDiffTex, uv, 0).a;
-	float validFragment = step(1.0 / 255.0, modelAlpha); //agressive approach
+	
+	vec2 uv = gl_FragCoord.xy * vec2(1.0/VSX, 1.0/VSY);
+	//vec2 uv = gl_TexCoord[0].xy * vec2(2,-2) + vec2(0,2.0);
+	//gl_FragColor = vec4(uv.xy, 0.0, 1.0); return;
+	#if USE_STENCIL == 1 
+		if (texture(unitStencilTex, uv).r < 0.1) {
+			gl_FragColor = vec4(0,0,0,0) ; 
+			return;
+		}
+	#endif
 
 	float modelDepth = texture(modelDepthTex, uv).r;
 	float mapDepth = texture(mapDepthTex, uv).r;
@@ -53,29 +50,7 @@ void main() {
 
 	vec4 viewPosition = GetViewPos(uv, depth);
 
-	vec3 modelNormal = texture(modelNormalTex, uv).rgb;
-	vec3 mapNormal = texture(mapNormalTex, uv).rgb;
+	if (modelOccludesMap < 0.5) viewPosition.z *= -1.0;
+	gl_FragColor.xyz = viewPosition.xyz;
 
-	vec3 viewNormal = mix(mapNormal, modelNormal, modelOccludesMap);
-	float validNormal = step(0.2, length(viewNormal)); //empty spaces in g-buffer will have vec3(0.0) normals
-
-	viewNormal = NORM2SNORM(viewNormal);
-	viewNormal = normalize(viewNormal);
-	viewNormal = vec3(viewMatrix * vec4(viewNormal, 0.0)); //transform world-->view space
-
-	#if (MERGE_MISC == 1)
-		vec4 modelMiscInfo = texture(modelMiscTex, uv);
-		vec4 mapMiscInfo = texture(mapMiscTex, uv);
-		vec4 miscInfo = mix(mapMiscInfo, modelMiscInfo, modelOccludesMap);
-	#endif
-
-	// MRT output:
-	//[0] = gbuffFuseViewPosTex
-	//[1] = gbuffFuseViewNormalTex
-	//[2] = gbuffFuseMiscTex (conditional to MERGE_MISC == 1)
-	gl_FragData[0].xyz = mix( vec3(0.0), viewPosition.xyz, validFragment);
-	gl_FragData[1].xyz = mix( vec3(0.0), viewNormal.xyz, validNormal * validFragment);
-	#if (MERGE_MISC == 1)
-		gl_FragData[2] = miscInfo;
-	#endif
 }

--- a/luaui/Widgets/Shaders/identity_texrect.vert.glsl
+++ b/luaui/Widgets/Shaders/identity_texrect.vert.glsl
@@ -1,0 +1,7 @@
+#version 150 compatibility
+
+void main() {
+	//gl_Position = gl_Vertex;
+	gl_Position = vec4(gl_Vertex.xy,0,1);
+	gl_TexCoord[0] = gl_MultiTexCoord0;
+}

--- a/luaui/Widgets/gfx_bloom_shader_deferred.lua
+++ b/luaui/Widgets/gfx_bloom_shader_deferred.lua
@@ -21,7 +21,7 @@ end
 
 local version = 1.1
 
-local dbgDraw = 0               -- draw only the bloom-mask? [0 | 1]
+local dbgDraw = 0              -- draw only the bloom-mask? [0 | 1]
 
 local glowAmplifier = 0.85            -- intensity multiplier when filtering a glow source fragment [1, n]
 local blurAmplifier = 1        -- intensity multiplier when applying a blur pass [1, n] (should be set close to 1)
@@ -45,7 +45,7 @@ local presets = {
 	},
 	{
 		quality = 1,
-		blurPasses = 2,
+		blurPasses = 1,
 	},
 }
 
@@ -66,7 +66,12 @@ local brightShader = nil
 local brightTexture1 = nil
 local brightTexture2 = nil
 
+local rectVAO = nil
+
 local combineShader = nil
+
+local luaShaderDir = "LuaUI/Widgets/Include/"
+local LuaShader = VFS.Include(luaShaderDir.."LuaShader.lua")
 
 local glGetSun = gl.GetSun
 
@@ -89,9 +94,6 @@ local brightShaderIllumLoc, brightShaderFragLoc
 local brightShaderTimeLoc
 local blurShaderFragLoc, blurShaderHorizontalLoc
 local combineShaderDebgDrawLoc
-
-local camX, camY, camZ = Spring.GetCameraPosition()
-local camDirX, camDirY, camDirZ = Spring.GetCameraDirection()
 
 local function SetIllumThreshold()
 	local ra, ga, ba = glGetSun("ambient", "unit")
@@ -116,14 +118,33 @@ end
 
 local function MakeBloomShaders()
 	local viewSizeX, viewSizeY = Spring.GetViewGeometry()
-
+	local downscale = presets[preset].quality
 	--Spring.Echo("New bloom init preset:", preset)
 	vsx = math.max(4,viewSizeX); ivsx = 1.0 / vsx --we can do /n here!
 	vsy = math.max(4,viewSizeY); ivsy = 1.0 / vsy
-	qvsx,qvsy = math.floor(vsx/presets[preset].quality), math.floor(vsy/presets[preset].quality)
+	qvsx,qvsy = math.ceil(vsx/downscale), math.ceil(vsy/downscale) -- we ceil to ensure perfect upscaling
 	iqvsx, iqvsy = 1.0 / qvsx, 1.0 / qvsy
+
+	local padx, pady = downscale * qvsx - vsx, downscale * qvsy - vsy
+
+
+	local shaderConfig  = {
+		VSX = vsx,
+		VSY = vsy,
+		HSX = qvsx,
+		HSY = qvsy,
+		IHSX = iqvsx,
+		IHSY = iqvsy,
+		PADX = padx,
+		PADY = pady,
+		DOWNSCALE = downscale,
+	}
+
+	local definesString = LuaShader.CreateShaderDefinesString(shaderConfig)
+
 	glDeleteTexture(brightTexture1 or "")
 	glDeleteTexture(brightTexture2 or "")
+	--Spring.Echo(vsx, vsy, qvsx,qvsy)
 
 	brightTexture1 = glCreateTexture(math.max(1,qvsx), math.max(1,qvsy), {
 		fbo = true,
@@ -151,27 +172,29 @@ local function MakeBloomShaders()
 	end
 
 	combineShader = glCreateShader({
-		fragment = [[
-			#version 150 compatibility
+		fragment = "#version 150 compatibility\n" .. definesString  ..  [[
 			uniform sampler2D texture0;
 			uniform int debugDraw;
 
 			void main(void) {
-				vec4 a = texture2D(texture0, gl_TexCoord[0].st);
+				vec2 subpixel = vec2(IHSX, IHSY) * 0.5; // YES FREAKING HALF-PIXEL BLUR HERE TOO CAUSE WHY NOT?
+				vec4 a = texture2D(texture0, gl_TexCoord[0].st + subpixel);
 				if (debugDraw == 1) {
 					a.a= 1.0;
 				}
 				gl_FragColor = a;
+				//gl_FragColor.rg = gl_TexCoord[0].st; // to debug texture coordinates
 			}
 		]],
 		--while this vertex shader seems to do nothing, it actually does the very important world space to screen space mapping for gl.TexRect!
-		vertex = [[
-			#version 150 compatibility
-			void main(void)
-			{
-				gl_TexCoord[0] = gl_MultiTexCoord0;
-				gl_Position    = gl_Vertex;
-			}
+		vertex = 
+			"#version 150 compatibility\n" .. definesString ..[[
+			void main(void)	{
+				gl_TexCoord[0] = vec4(gl_Vertex.zwzw);
+				#if DOWNSCALE >= 2 
+					gl_TexCoord[0].xy = vec2(gl_TexCoord[0].xy * vec2(DOWNSCALE * HSX, DOWNSCALE * HSY ) /  vec2(VSX, VSY));
+				#endif
+				gl_Position    = vec4(gl_Vertex.xy, 0, 1);	}
 		]],
 		uniformInt = {
 			texture0 = 0,
@@ -180,7 +203,7 @@ local function MakeBloomShaders()
 	})
 
 	if (combineShader == nil) then
-		RemoveMe("[BloomShader::Initialize] combineShader compilation failed"); print(glGetShaderLog()); return
+		RemoveMe("[BloomShader::Initialize] combineShader compilation failed"); Spring.Echo(glGetShaderLog()); return
 	end
 
 	-- How about we do linear sampling instead, using the GPU's built in texture fetching linear blur hardware :)
@@ -189,33 +212,147 @@ local function MakeBloomShaders()
 	 -- TODO:  all this simplification may result in the accumulation of quantizing errors due to the small numbers that get pushed into the BrightTexture
 
 	blurShader = glCreateShader({
-		fragment = "#version 150 compatibility\n"..
-			"#define IQVSX " .. tostring(iqvsx) .. "\n" ..
-			"#define IQVSY " .. tostring(iqvsy) .. "\n" .. [[
+		vertex = [[
+			#version 150 compatibility
+			void main(void)	{
+				gl_TexCoord[0] = vec4(gl_Vertex.zwzw);
+				gl_Position    = vec4(gl_Vertex.xy, 0, 1);	}
+		]],
+		fragment = "#version 150 compatibility\n".. definesString .. [[
 			uniform sampler2D texture0;
 			uniform float fragBlurAmplifier;
 			const float invKernelSum = 0.012;
 			uniform float horizontal;
 			#define inverseRX 1.0
 
+			vec2 quadGetQuadVector(vec2 screenCoords){
+				vec2 quadVector =  fract(floor(screenCoords) * 0.5) * 4.0 - 1.0;
+				vec2 odd_start_mirror = 0.5 * vec2(dFdx(quadVector.x), dFdy(quadVector.y));
+				quadVector = quadVector * odd_start_mirror;
+				return sign(quadVector);
+			}
+			
+			vec3 quadGatherSum3D(vec3 input, vec2 quadVector){
+				vec3 inputadjx = input - dFdx(input) * quadVector.x;
+				vec3 inputadjy = input - dFdy(input) * quadVector.y;
+				vec3 inputdiag = inputadjx - dFdy(inputadjx) * quadVector.y;
+				return (input + inputadjx + inputadjy + inputdiag) * 0.25;
+				//return vec4(
+				//	dot( vec4(input.x, inputadjx.x, inputadjy.x, inputdiag.x), vec4(1.0)),
+				//	dot( vec4(input.y, inputadjx.y, inputadjy.y, inputdiag.y), vec4(1.0)),
+				//	dot( vec4(input.z, inputadjx.z, inputadjy.z, inputdiag.z), vec4(1.0)),
+				//	dot( vec4(input.w, inputadjx.w, inputadjy.w, inputdiag.w), vec4(1.0))
+				//	);
+			}
+
+			#define WF 0.56
+			vec4 selfWeights = vec4(WF*WF, WF*(1.0-WF), WF*(1.0-WF), (1.0-WF)*(1.0-WF)); // F*F, F*(1.0-F), F*(1.0-F), (1-F)*(1-F)
+			vec3 quadGatherSum3DWeighted(vec3 input, vec2 quadVector){
+				vec3 inputadjx = input - dFdx(input) * quadVector.x;
+				vec3 inputadjy = input - dFdy(input) * quadVector.y;
+				vec3 inputdiag = inputadjx - dFdy(inputadjx) * quadVector.y;
+				return vec3(
+					dot( vec4(input.x, inputadjx.x, inputadjy.x, inputdiag.x), vec4(selfWeights)),
+					dot( vec4(input.y, inputadjx.y, inputadjy.y, inputdiag.y), vec4(selfWeights)),
+					dot( vec4(input.z, inputadjx.z, inputadjy.z, inputdiag.z), vec4(selfWeights))
+					);
+			}
+
 			void main(void) {
-				vec2 texCoors = vec2(gl_TexCoord[0]);
-				vec2 subpixel = vec2(IQVSX, IQVSY) * 0.5;
-				vec2 offset = vec2(IQVSX, 0.0);
-				if (horizontal > 0.5) {
-					offset = vec2(0.0, IQVSY);
+				vec2 texCoors = vec2(gl_TexCoord[0]); // These are ideal texel perfect
+				
+				//gl_FragColor = vec4(texture2D(texture0,texCoors).rgb, 1.0);return;
+				vec2 subpixel = vec2(IHSX, IHSY) * 0.5;
+				vec2 offset = vec2(IHSX, 0.0);
+				if (horizontal > 0.5) { // vertical pass
+					offset = vec2(0.0, IHSY);
 					subpixel = -1.0 * subpixel;
 					}
 				vec3 newblur;
 				const float lod = 0.0;
-				newblur   = 6  * texture2D(texture0, texCoors + offset *  6.0 + subpixel, lod).rgb;
-				newblur  += 10 * texture2D(texture0, texCoors + offset *  4.0 + subpixel, lod).rgb;
-				newblur  += 13 * texture2D(texture0, texCoors + offset *  2.0 + subpixel, lod).rgb;
-				newblur  += 20 * texture2D(texture0, texCoors + offset *  0.0 + subpixel, lod).rgb;
-				newblur  += 13 * texture2D(texture0, texCoors + offset * -2.0 + subpixel, lod).rgb;
-				newblur  += 10 * texture2D(texture0, texCoors + offset * -4.0 + subpixel, lod).rgb;
-				newblur  += 6  * texture2D(texture0, texCoors + offset * -6.0 + subpixel, lod).rgb;
+				
+				#if DOWNSCALE >= 2 
+					// old decent method, truly 14 pixel wide kernel in 7 samples
+					newblur   = 6  * texture2D(texture0, texCoors + offset *  6.0 + subpixel, lod).rgb;
+					newblur  += 10 * texture2D(texture0, texCoors + offset *  4.0 + subpixel, lod).rgb;
+					newblur  += 13 * texture2D(texture0, texCoors + offset *  2.0 + subpixel, lod).rgb;
+					newblur  += 20 * texture2D(texture0, texCoors + offset *  0.0 + subpixel, lod).rgb;
+					newblur  += 13 * texture2D(texture0, texCoors + offset * -2.0 + subpixel, lod).rgb;
+					newblur  += 10 * texture2D(texture0, texCoors + offset * -4.0 + subpixel, lod).rgb;
+					newblur  += 6  * texture2D(texture0, texCoors + offset * -6.0 + subpixel, lod).rgb;
+					gl_FragColor = vec4(newblur * invKernelSum * fragBlurAmplifier, 1.0);
+				#else
+					// super high quality path
+					// new awesome method, 32 pixel wide kernel in 5 samples
+					vec2 quadVector = quadGetQuadVector(gl_FragCoord.xy);
+					//https://docs.google.com/spreadsheets/d/15nBdQMMwKzpbxot-BLrCQ_ZraPClJiRKD1pTvH6QGH0/edit?usp=sharing
+					
+					float SelfWeight = 0.202;				
+					vec4 WeightsNearer =  vec4(0.190,0.139,0.080,0.035);
+					vec4 WeightsFurther = vec4(0.168,0.109,0.055,0.022);
+										
+					float SelfOffset = 0.496;				
+					vec4 OffsetsNearer =  vec4(2.488,6.473,10.457,14.442	);
+					vec4 OffsetsFurther = vec4(4.480,8.465,12.449,16.434	);
+					
 
+					vec4 offsets = vec4(2,6,10,12);
+					//vec4 offsets = vec4(1,3,5,7);
+					vec4 weights = vec4(20, 13, 10, 6);
+					float totalWeight = dot(weights , vec4(1.8)) ;
+					subpixel = quadVector * subpixel * vec2( 1, -1);
+					vec3 blurSample = vec3(0.0);
+					float baseweight = SelfWeight;
+					//vec3 baseSample = baseweight * texture2D(texture0, texCoors).rgb;
+
+					vec2 quadCenterUV = texCoors - vec2(1,-1) * quadVector * vec2(IHSX, IHSY) * 0.5;
+
+					//vec3 quadCenterSample = texture2D(texture0, quadCenterUV).rgb;
+					vec3 quadSideSample = vec3(0);
+					// center the UV coords between texel centers:
+					vec2 sideSampleOffset;
+					
+					subpixel = vec2(0.0);
+					if (horizontal > 0.5 ){ 
+						// this means vertical pass
+						// on vertical pass, move X coord towards center
+
+						if (quadVector.x > 0) {
+							weights = WeightsNearer;
+							offsets = OffsetsNearer; 
+						}else{
+							weights = WeightsFurther;
+							offsets = OffsetsFurther; 
+						}
+						sideSampleOffset = vec2( 0.5 * quadVector.x, SelfOffset * quadVector.y ) * offset;
+						offsets *= -1 * quadVector.y;
+						
+					}else{
+						// bail for now
+						//gl_FragColor = vec4(baseSample/baseweight, 1.0); return;
+						if (quadVector.y > 0) {
+							weights = WeightsNearer;
+							offsets = OffsetsNearer; 
+						}else{
+							weights = WeightsFurther;
+							offsets = OffsetsFurther; 
+						}
+						sideSampleOffset = vec2( SelfOffset * quadVector.x, 0.5 * quadVector.y ) * offset;
+						offsets *= -1 * quadVector.x;
+					}
+
+					quadSideSample = SelfWeight * texture2D(texture0, quadCenterUV + sideSampleOffset + subpixel).rgb;
+					
+					blurSample += weights.x * texture2D(texture0, quadCenterUV + offset * offsets.x + subpixel).rgb;
+					blurSample += weights.y * texture2D(texture0, quadCenterUV + offset * offsets.y + subpixel).rgb;
+					blurSample += weights.z * texture2D(texture0, quadCenterUV + offset * offsets.z + subpixel).rgb;
+					blurSample += weights.w * texture2D(texture0, quadCenterUV + offset * offsets.w + subpixel).rgb;
+					
+					vec3 myfriends =  quadGatherSum3D(blurSample , quadVector) ;
+					myfriends =  myfriends + quadGatherSum3DWeighted(quadSideSample, quadVector);
+					
+					gl_FragColor = vec4(myfriends * fragBlurAmplifier * 1.8 , 1.0);
+				#endif
 				/*
 				// OLD CRAPPY METHOD:
 					newblur  = 10 * texture2D(texture0, texCoors + vec2()         ).rgb;
@@ -224,7 +361,6 @@ local function MakeBloomShaders()
 					newblur += 37 * texture2D(texture0, texCoors + vec2( (blursize/3.5) * inverseRX, 0)).rgb;
 					newblur += 10 * texture2D(texture0, texCoors + vec2( blursize * inverseRX, 0)).rgb;
 				*/
-				gl_FragColor = vec4(newblur * invKernelSum * fragBlurAmplifier, 1.0);
 			}
 		]],
 		uniformInt = {
@@ -241,10 +377,14 @@ local function MakeBloomShaders()
 
 
 	brightShader = glCreateShader({
+		vertex = [[
+			#version 150 compatibility
+			void main(void)	{
+				gl_TexCoord[0] = vec4(gl_Vertex.zwzw);
+				gl_Position    = vec4(gl_Vertex.xy, 0, 1);	}
+		]],
 		fragment =
-			"#version 150 compatibility \n" ..
-			"#define IQVSX " .. tostring(iqvsx) .. "\n" ..
-			"#define IQVSY " .. tostring(iqvsy) .. "\n" .. [[
+			"#version 150 compatibility \n" .. definesString  .. [[
 
 			uniform sampler2D modelDiffuseTex;
 			uniform sampler2D modelEmitTex;
@@ -256,27 +396,68 @@ local function MakeBloomShaders()
 			uniform float fragGlowAmplifier;
 			//uniform float ivsx;
 			//uniform float ivsy;
-			//uniform float time;
+			uniform float time;
 
 			void main(void) {
-				vec2 halfpixeloffset = vec2(IQVSX, IQVSY);
-				//float time0 = sin(time*0.01);
-				vec2 texCoors = vec2(gl_TexCoord[0]);
-				float modelDepth = texture2D(modelDepthTex, texCoors).r;
-				float mapDepth = texture2D(mapDepthTex, texCoors).r;
-				float unoccludedModel = float(modelDepth < mapDepth); // this is 1 for a model fragment
+				vec2 halfpixeloffset = vec2(IHSX, IHSY);
+				float time0 = sin(time*0.003);
+				// mega debugging:
+				//if (dot(vec2(1.0), abs(gl_FragCoord.xy - (vec2(HSX,HSY) - 150))) < 40){ gl_FragColor = vec4(1); return;}
+				
+				// Center texture coordinates correctly
+				vec2 texCoors = vec2(gl_TexCoord[0].xy * vec2(VSX, VSY) / vec2(DOWNSCALE * HSX, DOWNSCALE * HSY ));
+				#if DOWNSCALE <= 2
+					float modelDepth = texture2D(modelDepthTex, texCoors).r;
 
-				texCoors +=  halfpixeloffset *  0.25;
+					//Bail early if this is not a model fragment
+					if (modelDepth > 0.9999) {
+						gl_FragColor = 	vec4(0.0, 0.0, 0.0, 1.0);
+						return;
+					}
+					
+		
+					float mapDepth = texture2D(mapDepthTex, texCoors).r;
+					float unoccludedModel = float(modelDepth < mapDepth); // this is 1 for a model fragment
 
-				vec4 color = vec4(texture2D(modelDiffuseTex, texCoors));
-				vec4 colorEmit = texture2D(modelEmitTex, texCoors);
+					//texCoors +=  halfpixeloffset *  0.25 * time0;
 
+					vec4 color = vec4(texture2D(modelDiffuseTex, texCoors));
+					vec4 colorEmit = texture2D(modelEmitTex, texCoors);
 
+				#else
+					// this is for downscale by 3 case
+					vec2 offset = vec2(1.0/VSX, 1.0/VSY) * 0.56;
+					float modelDepth1 = texture2D(modelDepthTex, texCoors + offset).r;
+					float modelDepth2 = texture2D(modelDepthTex, texCoors - offset).r;
+
+					//Bail early if this is not a model fragment
+					if ((modelDepth1 + modelDepth2) > 1.9999) {
+						gl_FragColor = 	vec4(0.0, 0.0, 0.0, 1.0);
+						return;
+					}
+					
+		
+					float mapDepth = texture2D(mapDepthTex, texCoors).r;
+					float unoccludedModel = float((modelDepth1 + modelDepth2) * 0.5 < mapDepth); // this is 1 for a model fragment
+
+					//texCoors +=  halfpixeloffset *  0.25 * time0;
+
+					vec4 color = vec4(texture2D(modelDiffuseTex, texCoors+ offset));
+						 color += vec4(texture2D(modelDiffuseTex, texCoors- offset));
+						 color *= 0.5;
+					vec4 colorEmit = texture2D(modelEmitTex, texCoors+ offset);
+						 colorEmit *=2;
+						 colorEmit += texture2D(modelEmitTex, texCoors- offset);
+
+				#endif
+
+				
 				//Handle transparency in color.a
 				color.rgb = color.rgb * color.a;
 
 				//calculate the resulting color by adding the emit color
 				color.rgb += colorEmit.rgb;
+
 
 				//Make the bloom more sensitive to luminance in green channel
 				float illum = dot(color.rgb, vec3(0.2990, 0.4870, 0.2140)); //adjusted from the real values of  vec3(0.2990, 0.5870, 0.1140)
@@ -284,7 +465,7 @@ local function MakeBloomShaders()
 				// This results in an all 0/1 vector if its over the threshold
 				float illumCond = float(illum > illuminationThreshold) ;
 
-				vec4 brightOutput = vec4(color.rgb * (illum-illuminationThreshold), 1.0) * fragGlowAmplifier * unoccludedModel ;
+				vec4 brightOutput = vec4(color.rgb * (illum-illuminationThreshold) * fragGlowAmplifier * unoccludedModel , 1.0);
 
 				// mix each channel on wether illumCond is 1.0
 				gl_FragColor = mix(
@@ -304,17 +485,18 @@ local function MakeBloomShaders()
 		uniformFloat = {
 			--ivsx = 0,
 			--ivsy = 0,
-			--time = 0,
+			time = 0,
 		}
 	})
 
 	if (brightShader == nil) then
-		RemoveMe("[BloomShader::Initialize] brightShader compilation failed"); print(glGetShaderLog()); return
+		Spring.Echo(glGetShaderLog());
+		RemoveMe("[BloomShader::Initialize] brightShader compilation failed"); return
 	end
 
 	--brightShaderIvsxLoc = glGetUniformLocation(brightShader, "ivsx")
 	--brightShaderIvsyLoc = glGetUniformLocation(brightShader, "ivsy")
-	--brightShaderTimeLoc = glGetUniformLocation(brightShader, "time")
+	brightShaderTimeLoc = glGetUniformLocation(brightShader, "time")
 	brightShaderIllumLoc = glGetUniformLocation(brightShader, "illuminationThreshold")
 	brightShaderFragLoc = glGetUniformLocation(brightShader, "fragGlowAmplifier")
 
@@ -328,6 +510,9 @@ end
 function widget:ViewResize(viewSizeX, viewSizeY)
 	MakeBloomShaders()
 end
+
+local luaShaderDir = "LuaUI/Widgets/Include/"
+VFS.Include(luaShaderDir.."instancevbotable.lua")
 
 function widget:Initialize()
 
@@ -362,6 +547,7 @@ function widget:Initialize()
 	end
 
 	MakeBloomShaders()
+	rectVAO = MakeTexRectVAO()--  -1, -1, 1, 0,   0,0,1, 0.5)
 end
 
 function widget:Shutdown()
@@ -372,6 +558,13 @@ function widget:Shutdown()
 		if combineShader ~= nil then glDeleteShader(combineShader or 0) end
 	end
 	WG['bloomdeferred'] = nil
+end
+
+local function FullScreenQuad()
+	--gl.DepthMask(true)
+	--gl.DepthTest(GL.NOTEQUAL)
+	-- TODO: instead of drawing full screen quads, draw a billboard around every unit
+	rectVAO:DrawArrays(GL.TRIANGLES)
 end
 
 local df = 0
@@ -386,13 +579,14 @@ local function Bloom()
 		--glUniform(   brightShaderIvsxLoc, 0.5/qvsx)
 		--glUniform(   brightShaderIvsyLoc, 0.5/qvsy)
 		local gf = Spring.GetGameFrame()
-		--glUniform(   brightShaderTimeLoc, df)
+		glUniform(   brightShaderTimeLoc, df)
 		glTexture(0, "$model_gbuffer_difftex")
 		glTexture(1, "$model_gbuffer_emittex")
 		glTexture(2, "$model_gbuffer_zvaltex")
 		glTexture(3, "$map_gbuffer_zvaltex")
 
-		glRenderToTexture(brightTexture1, gl.TexRect, -1, 1, 1, -1)
+		--glRenderToTexture(brightTexture1, gl.TexRect, -1, 1, 1, -1)
+		glRenderToTexture(brightTexture1, FullScreenQuad)
 
 		glTexture(0, false)
 		glTexture(1, false)
@@ -408,13 +602,15 @@ local function Bloom()
 					glUniform(blurShaderFragLoc, blurAmplifier)
 					glUniform(blurShaderHorizontalLoc, 0)
 					glTexture(brightTexture1)
-					glRenderToTexture(brightTexture2, gl.TexRect, -1, 1, 1, -1)
+					--glRenderToTexture(brightTexture2, gl.TexRect, -1, 1, 1, -1)
+					glRenderToTexture(brightTexture2, FullScreenQuad)
 					glTexture(false)
 
 					glUniform(blurShaderFragLoc, blurAmplifier)
 					glUniform(blurShaderHorizontalLoc, 1)
 					glTexture(brightTexture2)
-					glRenderToTexture(brightTexture1, gl.TexRect, -1, 1, 1, -1)
+					--glRenderToTexture(brightTexture1, gl.TexRect, -1, 1, 1, -1)
+					glRenderToTexture(brightTexture1, FullScreenQuad)
 					glTexture(false)
 			end
 			glUseShader(0)
@@ -430,7 +626,8 @@ local function Bloom()
 	glUseShader(combineShader)
 		glUniformInt(combineShaderDebgDrawLoc, dbgDraw)
 		glTexture(0, brightTexture1)
-		gl.TexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+		--gl.TexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+		rectVAO:DrawArrays(GL.TRIANGLES)
 		glTexture(0, false)
 	glUseShader(0)
 
@@ -441,7 +638,6 @@ end
 function widget:DrawWorld()
 	Bloom()
 end
-
 
 function widget:GetConfigData()
 	return {

--- a/luaui/Widgets/gfx_glass.lua
+++ b/luaui/Widgets/gfx_glass.lua
@@ -1,0 +1,355 @@
+if gl.CreateShader == nil or Spring.GetSpectatingState() then
+	return
+end
+
+function widget:GetInfo()
+	return {
+		name	  = "Stained Glass",
+		desc	  = "Very psychedelic",
+		author	  = "Beherith",
+		layer	  = 1900,
+		enabled   = true,
+	}
+end
+
+-- Shameless port from https://gist.github.com/martymcmodding/30304c4bffa6e2bd2eb59ff8bb09d135
+
+-----------------------------------------------------------------
+-- Constants
+-----------------------------------------------------------------
+
+-----------------------------------------------------------------
+-- Lua Shortcuts
+-----------------------------------------------------------------
+
+local glTexture		 = gl.Texture
+local glBlending	 = gl.Blending
+
+-----------------------------------------------------------------
+-- File path Constants
+-----------------------------------------------------------------
+
+local luaShaderDir = "LuaUI/Widgets/Include/"
+
+-----------------------------------------------------------------
+-- Shader Sources
+-----------------------------------------------------------------
+
+local vsglass = [[
+#version 330
+// full screen triangle
+
+const vec2 vertices[3] = vec2[3](
+	vec2(-1.0, -1.0),
+	vec2( 3.0, -1.0),
+	vec2(-1.0,  3.0)
+);
+
+
+void main()
+{
+	gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+
+}
+]]
+--https://www.shadertoy.com/view/MdlXWH
+local fsglass = [[
+#version 330
+#line 20058
+
+uniform sampler2D screenCopyTex;
+uniform float sharpness;
+
+vec2 uv;
+vec2 pos;
+
+out vec4 fragColor;
+
+uniform float iTime = 0;
+uniform float strength = 0;
+
+float hash1( float n ) { return fract(sin(n)*43758.5453); }
+vec2  hash2( vec2  p ) { p = vec2( dot(p,vec2(127.1,311.7)), dot(p,vec2(269.5,183.3)) ); return fract(sin(p)*43758.5453); }
+
+vec2 rotate(vec2 p, float a) {
+    float cs = cos(a), sn = sin(a);
+    return (mat3(
+        cs, sn, 0.0,
+        -sn, cs, 0.0,
+        0.0, 0.0, 1.0) * vec3(p,1.0)).xy;
+}
+
+// ratio: 3 = neon, 4 = refracted, 5+ = approximate white
+vec3 physhue2rgb(float hue, float ratio) {
+    return smoothstep(
+        vec3(0.0),vec3(1.0),
+        abs(mod(hue + vec3(0.0,1.0,2.0)*(1.0/ratio),1.0)*2.0-1.0));
+}
+
+vec4 voronoi( in vec2 x, float c, out vec2 rp)
+{
+    vec2 n = floor( x );
+    vec2 f = fract( x );
+
+	vec3 m = vec3( 8.0 );
+	float m2 = 8.0;
+    for( int j=-2; j<=2; j++ )
+    for( int i=-2; i<=2; i++ )
+    {
+        vec2 g = vec2( float(i),float(j) );
+        vec2 o = hash2( n + g );
+
+		// animate
+		float cid = hash1( dot(n+g,vec2(7.0,113.0) ) );
+		if (cid < 0.1)
+        	o = 0.5 + 0.5*abs(mod(c + o,2.0)-1.0);
+
+		vec2 r = g - f + o;
+
+        // triangular
+		vec2 d = vec2( max(abs(r.x)*0.866025+r.y*0.5,-r.y), 
+				        1.0 );
+
+		
+        if( d.x<m.x )
+        {
+			m2 = m.x;
+            m.x = d.x;
+            m.y = cid;
+			m.z = d.y;
+			rp = n + g;
+        }
+		else if( d.x<m2 )
+		{
+			m2 = d.x;
+		}
+
+    }
+    return vec4( m, m2-m.x );
+}
+
+vec4 render_sheet(vec2 p, float fi, float a) {
+	
+	float z = exp(mix(log(32.0), log(0.5), a));
+
+	//p.y = abs(p.y);
+	p.y = -p.y;
+	float tpos = abs(p.x); //max(abs(p.x)*0.866025-p.y*0.5,p.y);
+	p.x = abs(p.x);
+	p = rotate(p, radians(60.0));
+	p.x = abs(p.x);
+	
+	//p = rotate(p, radians(-60.0));
+	//p.x = abs(p.x);
+	
+	vec2 rp;
+	float o = fi*128.0-step(fi,0.2)*a*2.0;
+	vec4 c = voronoi( z*p+o, fi+a*8.0, rp);
+	rp -= o;
+	
+	float pp = 0.6 - (max(abs(rp.x)*0.866025+rp.y*0.5,-rp.y)/4.0); // + fract(fi+c.y);
+	pp = clamp(pp, 0.0, 1.0);
+	
+	float fadein = clamp(a*2.0,0.0,1.0);
+	
+	float rep = 1.0-a-(pp-sin(c.w*40.0)*0.1)*fadein;//;
+	
+	float alpha = clamp((rep-c.w)*16.0, 0.0, 1.0);
+	if (alpha > 0.0) {	
+		float hue = c.w*(1.0+c.y*8.0)
+			+fi+a*9.0*c.y*mix(1.0,8.0,step(fi,0.1))
+			-tpos*1.0;
+		
+		vec3 w = physhue2rgb(hue, 4.0);
+		w.z = 0.5; //sin(iTime)*0.1+0.5;
+		return vec4(w, alpha);
+	}	
+	
+	return vec4(0.0);
+}
+
+vec4 alpha(vec4 a, vec4 b) {
+	a = mix(b, a, a.w);
+	a.w = max(a.w, b.w);
+	return a;
+}
+
+#define STEPS 6
+
+
+void main( )
+{
+	vec2 iResolution = textureSize(screenCopyTex,0).xy;
+    vec2 aspect = vec2(iResolution.x / iResolution.y, 1.0);    
+    vec2 uv = gl_FragCoord.xy / iResolution.xy;
+    vec2 pos = (uv*2.0-1.0)*aspect;
+    
+	vec4 col = vec4(0.0);
+	
+	float s = 1.0/float(STEPS);
+	
+	float t = iTime*0.5;
+	float a = fract(t)*s;
+	t -= fract(t);
+	
+	for (int i = STEPS-1; i >= 0; --i) {
+		float fi = float(i);
+		col = alpha(col, render_sheet(pos, hash1(t-fi), a+fi*s));
+		if (col.w >= 1.0) break;
+	}
+	
+	float blend = sin(iTime)*0.5+0.5;
+	blend = 0.2; //smoothstep(0.0,1.0,blend);
+	
+	vec2 clampuv = clamp(uv + strength * col.xy*blend*0.02, 0, 1);
+	vec3 co = texture(screenCopyTex, clampuv).rgb;
+	col.rgb = mix(co, col.rgb, strength * blend * 0.3);
+
+    fragColor = col;
+	//fragColor.rgb = co;
+	fragColor.a = strength;	
+}
+]]
+
+-----------------------------------------------------------------
+-- Global Variables
+-----------------------------------------------------------------
+
+local LuaShader = VFS.Include(luaShaderDir.."LuaShader.lua")
+
+local screenCopyTex
+local glassShader
+local fullTexQuad
+
+-----------------------------------------------------------------
+-- Local Functions
+-----------------------------------------------------------------
+
+
+-----------------------------------------------------------------
+-- Widget Functions
+-----------------------------------------------------------------
+
+local glasstriggerfeaturedefsids = {}
+for featureDefID, featureDef in pairs(FeatureDefs) do
+	if string.find(featureDef.name, "mushroom", nil, true) then 
+		glasstriggerfeaturedefsids[featureDefID] = true
+	end
+end
+if next(glasstriggerfeaturedefsids) == nil then return end
+
+function widget:Initialize()
+	if gl.CreateShader == nil then
+		Spring.Echo("glass: createshader not supported, removing")
+		widgetHandler:RemoveWidget()
+		return
+	end
+
+	glassShader = LuaShader({
+		vertex = vsglass,
+		fragment = fsglass,
+		uniformInt = {
+			screenCopyTex = 0,
+		},
+		uniformFloat = {
+			iTime = 1,
+			strength = 0,
+		},
+	}, ": Contrast Adaptive Sharpen")
+
+	local shaderCompiled = glassShader:Initialize()
+	if not shaderCompiled then
+			Spring.Echo("Failed to compile Contrast Adaptive Sharpen shader, removing widget")
+			widgetHandler:RemoveWidget()
+			return
+	end
+
+	fullTexQuad = gl.GetVAO()
+	if fullTexQuad == nil then
+		widgetHandler:RemoveWidget() --no fallback for potatoes
+		return
+	end
+
+end
+
+function widget:Shutdown()
+	--gl.DeleteTexture(screenCopyTex)
+	if glassShader then
+		glassShader:Finalize()
+	end
+	if fullTexQuad then
+		fullTexQuad:Delete()
+	end
+end
+
+function widget:PlayerChanged()
+	if Spring.GetSpectatingState() then 
+		widgetHandler:RemoveWidget() 
+	end
+end
+
+
+local gaiaTeamID = Spring.GetGaiaTeamID()
+local myteamid = Spring.GetMyTeamID()
+local effectOn = false
+local effectStart = 0
+
+function widget:FeatureDestroyed(featureID, allyTeam)
+	if allyTeam == gaiaTeamID and glasstriggerfeaturedefsids[Spring.GetFeatureDefID(featureID)] then
+		local fx, fy, fz = Spring.GetFeaturePosition(featureID)
+		local featureHealth = Spring.GetFeatureHealth(featureID)
+		local mr, mm, er, em, rl = Spring.GetFeatureResources(featureID) 
+		Spring.Echo("Reclaiming that was probably not a good idea...", featureHealth, mr, mm, er, em, rl )
+		if featureHealth > 0 and er == 0 then 
+			local unitsnearby = Spring.GetUnitsInCylinder(fx,fz, 170, myteamid)
+			for i, unitID in ipairs(unitsnearby) do 
+				--Spring.Echo("nearby", unitID)
+				local unitDefID = Spring.GetUnitDefID(unitID) 
+				--Spring.Echo("nearby", unitID, UnitDefs[unitDefID].name)
+				if UnitDefs[unitDefID].name == 'armcom' or UnitDefs[unitDefID].name == 'corcom' then
+					if effectOn == false then 
+						effectOn = true
+						effectStart = os.clock()
+						--Spring.Echo("Effect started")
+					end
+				end
+			end
+		end
+	end
+end
+
+function widget:DrawScreenEffects()
+	if effectOn then 
+		--glCopyToTexture(screenCopyTex, 0, 0, vpx, vpy, vsx, vsy)
+		if WG['screencopymanager'] and WG['screencopymanager'].GetScreenCopy then
+			screenCopyTex = WG['screencopymanager'].GetScreenCopy()
+		else
+			--glCopyToTexture(screenCopyTex, 0, 0, vpx, vpy, vsx, vsy)
+			Spring.Echo("Missing Screencopy Manager, exiting",  WG['screencopymanager'] )
+			widgetHandler:RemoveWidget()
+			return false
+		end
+		if screenCopyTex == nil then return end
+
+		local dt = os.clock() - effectStart
+		if dt > 15 then 
+			effectOn = false 
+			widgetHandler:RemoveWidget()
+			return false
+		end
+		local h = 0.33 * dt
+		local strength = h * math.exp(1.0 - h)  -- iq expimpulse, peaking at 3
+
+		
+		glTexture(0, screenCopyTex)
+		glBlending(true)
+		glassShader:Activate()
+		glassShader:SetUniform("iTime", 0.01 * Spring.GetGameFrame())
+		glassShader:SetUniform("strength", strength)
+		fullTexQuad:DrawArrays(GL.TRIANGLES, 3)
+		glassShader:Deactivate()
+		glBlending(true)
+		glTexture(0, false)
+	end
+end
+

--- a/luaui/Widgets/gfx_guishader.lua
+++ b/luaui/Widgets/gfx_guishader.lua
@@ -161,6 +161,13 @@ local function CreateShaders()
 		uniform float ivsx;
 		uniform float ivsy;
 
+		vec2 quadGetQuadVector(vec2 screenCoords){
+			vec2 quadVector =  fract(floor(screenCoords) * 0.5) * 4.0 - 1.0;
+			vec2 odd_start_mirror = 0.5 * vec2(dFdx(quadVector.x), dFdy(quadVector.y));
+			quadVector = quadVector * odd_start_mirror;
+			return sign(quadVector);
+		}
+		
 		void main(void)
 		{
 			vec2 texCoord = vec2(gl_TextureMatrix[0] * gl_TexCoord[0]);
@@ -172,15 +179,36 @@ local function CreateShaders()
 			}else{
 				gl_FragColor = vec4(0.0,0.0,0.0,1.0);
 				vec4 sum = vec4(0.0);
-				vec2 subpixel = vec2(ivsx, ivsy) ;
-				//subpixel *= 0.0;
-				for (int i = -1; i <= 1; ++i) {
-					for (int j = -1; j <= 1; ++j) {
-						vec2 samplingCoords = texCoord + vec2(i, j) * 6.0 * subpixel + subpixel;
-						sum += texture2D(tex0, samplingCoords);
+				#if 0
+					vec2 subpixel = vec2(ivsx, ivsy) ;
+					//subpixel *= 0.0;
+					for (int i = -1; i <= 1; ++i) {
+						for (int j = -1; j <= 1; ++j) {
+							vec2 samplingCoords = texCoord + vec2(i, j) * 6.0 * subpixel + subpixel;
+							sum += texture2D(tex0, samplingCoords);
+						}
 					}
-				}
-				gl_FragColor.rgba = sum/9.0;
+					gl_FragColor.rgba = sum/9.0;
+				#else 
+					//amazingly useless pixel quad message passing for less hammering of membus? 4 lookups instead of 9
+					vec2 quadVector = quadGetQuadVector(gl_FragCoord.xy);
+					vec2 subpixel = vec2(ivsx, ivsy) ;
+					subpixel *= quadVector;
+					//subpixel *= 0.0;
+					for (int i = 0; i <= 1; ++i) {
+						for (int j = 0; j <= 1; ++j) {
+							vec2 samplingCoords = texCoord + vec2(i, j) * 6.0 * subpixel + subpixel;
+							sum += texture2D(tex0, samplingCoords);
+						}
+					}
+
+					vec4 inputadjx = sum - dFdx(sum) * quadVector.x;
+					vec4 inputadjy = sum - dFdy(sum) * quadVector.y;
+					vec4 inputdiag = inputadjx - dFdy(inputadjx) * quadVector.y;
+					sum += inputadjx + inputadjy + inputdiag;
+
+					gl_FragColor.rgba = sum/16.0;
+				#endif
 				//gl_FragColor.rgba = vec4(1.0);
 			}
 		}

--- a/luaui/Widgets/gfx_ssao.lua
+++ b/luaui/Widgets/gfx_ssao.lua
@@ -23,84 +23,166 @@ function widget:GetInfo()
     }
 end
 
+-- pre unitStencilTexture it takes 800 ms per frame
+-- todo: fake more ground ao in blur pass?
+
 -----------------------------------------------------------------
 -- Constants
 -----------------------------------------------------------------
 
 local GL_COLOR_ATTACHMENT0_EXT = 0x8CE0
-local GL_COLOR_ATTACHMENT1_EXT = 0x8CE1
-local GL_COLOR_ATTACHMENT2_EXT = 0x8CE2
-
 local GL_RGB16F = 0x881B
-
-local GL_RGB8_SNORM = 0x8F96
-
 local GL_RGBA8 = 0x8058
 
-local GL_FUNC_ADD = 0x8006
-local GL_FUNC_REVERSE_SUBTRACT = 0x800B
+local glTexture = gl.Texture
 
 -----------------------------------------------------------------
 -- Configuration Constants
 -----------------------------------------------------------------
 
-local SSAO_KERNEL_SIZE = 48 -- how many samples are used for SSAO spatial sampling
-local SSAO_RADIUS = 5 -- world space maximum sampling radius
-local SSAO_MIN = 1.0 -- minimum depth difference between fragment and sample depths to trigger SSAO sample occlusion. Absolute value in world space coords.
-local SSAO_MAX = 1.0 -- maximum depth difference between fragment and sample depths to trigger SSAO sample occlusion. Percentage of SSAO_RADIUS.
-local SSAO_ALPHA_POW = 8.0 -- consider this as SSAO effect strength
+local shaderConfig = {
+	DEPTH_CLIP01 = tostring((Platform.glSupportClipSpaceControl and 1) or 0), -- no idea
+	MERGE_MISC = 0, -- for future material indices based SSAO evaluation, completely dissabled now
+}
 
-local BLUR_HALF_KERNEL_SIZE = 4 -- (BLUR_HALF_KERNEL_SIZE + BLUR_HALF_KERNEL_SIZE + 1) samples are used to perform the blur
-local BLUR_PASSES = 3 -- number of blur passes
-local BLUR_SIGMA = 1.8 -- Gaussian sigma of a single blur pass, other factors like BLUR_HALF_KERNEL_SIZE, BLUR_PASSES and DOWNSAMPLE affect the end result gaussian shape too
+local definesSlidersParamsList = {
+	{name = 'SSAO_FIBONACCI', default = 1, min = 0, max = 1, digits = 0, tooltip = 'Use uniformly distributed rays intead of randomly distributed ones'},
+	{name = 'SSAO_KERNEL_MINZ', default = 0.04, min = 0, max = 0.2, digits = 2, tooltip = 'How close vectors can be to tangent plane'},
+	{name = 'SSAO_RANDOM_LENGTH', default = 0.6, min = 0.2, max = 3, digits = 2, tooltip = 'A power term for the lenghts of the random vectors, small numbers are longer vectors'},
+	{name = 'SSAO_KERNEL_SIZE', default = 32, min = 1, max = 64, digits = 0, tooltip = 'how many samples are used for SSAO spatial sampling'},
+	--{name = 'MINISHADOWS', default = 0, min = 0, max = 1, digits = 0, tooltip = 'Wether to draw a downsampled shadow sampler'},
+	{name = 'SSAO_RADIUS', default = 8, min = 4, max = 16, digits = 1, tooltip = 'world space maximum sampling radius'},
+	{name = 'SSAO_MIN', default = 0.7, min = 0, max = 4, digits = 2, tooltip = 'minimum depth difference between fragment and sample depths to trigger SSAO sample occlusion. Absolute value in world space coords.'},
+	{name = 'SSAO_OCCLUSION_POWER', default = 3, min = 0, max = 16, digits = 1, tooltip = 'how much effect each SSAO sample has'},
+	{name = 'SSAO_FADE_DIST_1', default = 1200, min = 200, max = 3000, digits = 1, tooltip = 'near distance for max SSAO'},
+	{name = 'SSAO_FADE_DIST_0', default = 2400, min = 1000, max = 4000, digits = 1, tooltip = 'far distance for min SSAO'},
+	{name = 'DEBUG_SSAO', default = 0, min = 0, max = 1, digits = 0, tooltip = 'DEBUG_SSAO show the raw samples'},
 
-local DOWNSAMPLE = 2 -- increasing downsapling will reduce GPU RAM occupation (a little bit), increase performace (a little bit), introduce occlusion blockiness
+	
+	{name = 'BRIGHTEN', default = 20, min = 0, max = 255, digits = 0, tooltip = 'Should SSAO Brighten Models, if yes by how much'},
+	{name = 'BLUR_HALF_KERNEL_SIZE', default = 3, min = 1, max = 12, digits = 0, tooltip = 'BLUR_HALF_KERNEL_SIZE*2 - 1 samples for blur'},
+	{name = 'BLUR_SIGMA', default = 3, min = 1, max = 10, digits = 1, tooltip = 'Sigma width of blur filter'},
+	{name = 'MINCOSANGLE', default = -0.15, min = -3, max = 1, digits = 2, tooltip = 'the minimum angle for considering a sample colinear when blurring'},
+	{name = 'ZTHRESHOLD', default = 0.005, min = 0.0, max = 4/255.0, digits = 3, tooltip = 'Should be more than 1.0. Do not touch'},
+	{name = 'MINSELFWEIGHT', default = 0.2, min = 0.0, max = 1, digits = 2, tooltip = 'The minimum additional weight a sample needs to gather to be considered a non-outlier'},
+	{name = 'OUTLIERCORRECTIONFACTOR', default = 0.5, min = 0.0, max = 1, digits = 2, tooltip = 'How strongly to use blurred result instead for outliers'},
+	{name = 'BLUR_POWER', default = 2, min = 1, max = 8, digits = 1, tooltip = 'Post-blur correction factor'},
+	{name = 'BLUR_CLAMP', default = 0.05, min = 0, max = 1, digits = 3, tooltip = 'Limit occlusion post-blur'},
+	{name = 'DEBUG_BLUR', default = 0, min = 0, max = 1, digits = 0, tooltip = 'DEBUG_BLUR show the result of the blur only'},
+	
 
-local MERGE_MISC = true -- for future material indices based SSAO evaluation
-local DEBUG_SSAO = false -- use for debug
+	{name = 'USE_STENCIL', default = 1, min = 0, max = 1, digits = 0, tooltip = 'USE_STENCIL set to zero if you dont wanna'},
+	{name = 'OFFSET', default = 0, min = 0, max = 1, digits = 0, tooltip = 'Set to 2 for half-rez buffers'},
+	{name = 'DOWNSAMPLE', default = 1, min = 1, max = 2, digits = 0, tooltip = 'Set to 2 for half-rez buffers'},
+	{name = 'ENABLE', default = 1, min = 0, max = 1, digits = 0, tooltip = 'Disable the whole SSAO'},
+	{name = 'SLOWFUSE', default = 0, min = 0, max = 1, digits = 0, tooltip = 'Only fuse every 30 frames. DO NOT TOUCH!'},
+	{name = 'NOFUSE', default = 0, min = 0, max = 1, digits = 0, tooltip = 'Dont use the gbuf fuse texture'},
+}
+local function InitShaderDefines()
+	for i, shaderDefine in ipairs(definesSlidersParamsList) do 
+		-- dont overwrite existing, externally defined values with the defaults:
+		if shaderConfig[shaderDefine.name] == nil then 
+			shaderConfig[shaderDefine.name] = shaderDefine.default;
+		end
+	end
+end
+InitShaderDefines()
+
+local function shaderDefinesChangedCallback(name, value, index, oldvalue)
+	--Spring.Echo("shaderDefinesChangedCallback()", name, value, shaderConfig[name])
+	if value ~= oldvalue then 
+		widget:ViewResize()
+	end
+end
+
+local vsx, vsy = Spring.GetViewGeometry()
+
+local shaderDefinedSliders = {
+	windowtitle = "SSAO Defines",
+	name = "SSAOParams",
+	left = vsx - 540, 
+	bottom = 200, 
+	right = vsx - 540 + 250,
+	sliderheight = 20,
+	valuetarget = shaderConfig,
+	sliderParamsList = definesSlidersParamsList,
+	callbackfunc = shaderDefinesChangedCallback
+}
+shaderDefinedSliders.top = shaderDefinedSliders.bottom + shaderDefinedSliders.sliderheight *( #definesSlidersParamsList +3)
+
+local shaderDefinedSlidersLayer, shaderDefinedSlidersWindow
 
 local math_sqrt = math.sqrt
 
+local cusMult = 1.4
 local strengthMult = 1
 
 local initialTonemapA = Spring.GetConfigFloat("tonemapA", 4.75)
 local initialTonemapD = Spring.GetConfigFloat("tonemapD", 0.85)
 local initialTonemapE = Spring.GetConfigFloat("tonemapE", 1.0)
 
-local preset = 2
+local preset = 3
 local presets = {
-	{
-		SSAO_KERNEL_SIZE = 32,
-		DOWNSAMPLE = 3,
-		BLUR_HALF_KERNEL_SIZE = 4,
-		BLUR_PASSES = 2,
-		BLUR_SIGMA = 4,
-		tonemapA = 0.45,
-		tonemapD = -0.25,
-		tonemapE = -0.03,
-	},
-	{
-		SSAO_KERNEL_SIZE = 32,
+	{ -- LOW QUALITY
+		BLUR_CLAMP = 0.16,
+		BLUR_HALF_KERNEL_SIZE = 3,
+		BLUR_POWER = 1.6,
+		BLUR_SIGMA = 2,
+		BRIGHTEN = 30,
 		DOWNSAMPLE = 2,
-		BLUR_HALF_KERNEL_SIZE = 4,
-		BLUR_PASSES = 2,
-		BLUR_SIGMA = 4,
-		tonemapA = 0.45,
-		tonemapD = -0.25,
-		tonemapE = -0.03,
+		MINCOSANGLE = 0.69, 
+		MINSELFWEIGHT = 0.3,
+		NOFUSE = 1, -- at low quality, some vram can be saved 
+		OFFSET = 1,
+		OUTLIERCORRECTIONFACTOR = 0.66,
+		SSAO_FADE_DIST_0 = 2000,
+		SSAO_FADE_DIST_1 = 1000,
+		SSAO_KERNEL_SIZE = 24,
+		SSAO_MIN = 0.69,
+		SSAO_RADIUS = 9,
+		USE_STENCIL = 0, -- There is a non-zero cpu cost of drawing the stencil, and at low resolutions, it doesnt help really
 	},
-	{
-		SSAO_KERNEL_SIZE = 48,
+	{ -- MEDIUM QUALITY
+		BLUR_CLAMP = 0.269,
+		BLUR_HALF_KERNEL_SIZE = 4,
+		BLUR_POWER = 1.6,
+		BLUR_SIGMA = 3,
+		BRIGHTEN = 33,
 		DOWNSAMPLE = 1,
-		BLUR_HALF_KERNEL_SIZE = 6,
-		BLUR_PASSES = 3,
-		BLUR_SIGMA = 6,
-		tonemapA = 0.4,
-		tonemapD = -0.25,
-		tonemapE = -0.025,
+		MINCOSANGLE = 0.70,
+		OUTLIERCORRECTIONFACTOR = 0.16,
+		SSAO_FADE_DIST_0 = 2200,
+		SSAO_FADE_DIST_1 = 1100,	
+		SSAO_KERNEL_SIZE = 32,
+		SSAO_MIN = 0.74,
+		SSAO_RADIUS = 8,
+	},
+	{ -- HIGH QUALITY
+		BLUR_CLAMP = 0.145,
+		BLUR_HALF_KERNEL_SIZE = 4,
+		BLUR_POWER = 1.6,
+		BLUR_SIGMA = 2.9,
+		BRIGHTEN = 30,
+		DOWNSAMPLE = 1,
+		MINCOSANGLE = 0.75,
+		OUTLIERCORRECTIONFACTOR = 0.10,
+		SSAO_FADE_DIST_0 = 3200,
+		SSAO_FADE_DIST_1 = 2000,
+		SSAO_KERNEL_SIZE = 64,
+		SSAO_MIN = 0.71,
+		SSAO_RADIUS = 7,
 	},
 }
 
+local function ActivatePreset(presetID)
+	if presets[presetID] then 
+		for k,v in pairs(presets[presetID]) do 
+			shaderConfig[k] = v
+		end
+	end
+end
+
+ActivatePreset(preset)
 -----------------------------------------------------------------
 -- File path Constants
 -----------------------------------------------------------------
@@ -115,25 +197,30 @@ local luaShaderDir = "LuaUI/Widgets/Include/"
 local LuaShader = VFS.Include(luaShaderDir.."LuaShader.lua")
 
 local vsx, vsy, vpx, vpy
-local firstTime
+local texPaddingX, texPaddingY = 0,0
+
 
 local screenQuadList
 local screenWideList
 
 local gbuffFuseFBO
 local ssaoFBO
-local ssaoBlurFBOs = {}
+local ssaoBlurFBO
 
 local gbuffFuseViewPosTex
-local gbuffFuseViewNormalTex
-local gbuffFuseMiscTex
 local ssaoTex
-local ssaoBlurTexes = {}
+local ssaoBlurTex
 
 local ssaoShader
 local gbuffFuseShader
 local gaussianBlurShader
+local ssaoShaderCache
+local gbuffFuseShaderCache
+local gaussianBlurShaderCache
 
+local unitStencilTexture
+
+local unitStencil = nil
 -----------------------------------------------------------------
 -- Local Functions
 -----------------------------------------------------------------
@@ -161,18 +248,44 @@ local function GetGaussDiscreteWeightsOffsets(sigma, kernelHalfSize, valMult)
 	return weights, offsets
 end
 
+
 --see http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
 local function GetGaussLinearWeightsOffsets(sigma, kernelHalfSize, valMult)
-	local dWeights, dOffsets = GetGaussDiscreteWeightsOffsets(sigma, kernelHalfSize, 1.0)
+	local dWeights, dOffsets = GetGaussDiscreteWeightsOffsets(sigma, (kernelHalfSize-1) * 2 + 1 , 1.0)
+	-- at khs = 4 
+	-- dWeights, {1=0.1112202, 2=0.10779832, 3=0.09815148, 4=0.08395342, 5=0.06745847, 6=0.05092032, 7=0.03610791, }
+	-- dOffsets, {1=0, 2=1, 3=2, 4=3, 5=4, 6=5, 7=6, }
 
 	local weights = {dWeights[1]}
 	local offsets = {dOffsets[1]}
-
-	for i = 1, (kernelHalfSize - 1) / 2 do
-		local newWeight = dWeights[2 * i] + dWeights[2 * i + 1]
+	local totalweights = dWeights[1]
+	
+	-- for 4 this should go to 3
+	for i = 1, kernelHalfSize -1  do -- for khs 4 this goes from 1 to , well 1. 
+		local newWeight = dWeights[2 * i ] + dWeights[2 * i + 1]
 		weights[i + 1] = newWeight * valMult
 		offsets[i + 1] = (dOffsets[2 * i] * dWeights[2 * i] + dOffsets[2 * i + 1] * dWeights[2 * i + 1]) / newWeight
 	end
+
+	for i = 2, kernelHalfSize do 
+		totalweights = totalweights + 2 * weights[i] -- 2x cause symmetric kernel
+	end
+
+	--[[
+	local function tabletostring(t)
+		local res = '{'
+		for k,v in pairs(t) do 
+			res = res .. tostring(k) .. "=" .. tostring(v) .. ', '
+		end
+		return res .. '}'
+	end
+
+	Spring.Echo("GetGaussLinearWeightsOffsets(sigma, kernelHalfSize, valMult)",sigma, kernelHalfSize, valMult, 'total = ', totalweights)
+	Spring.Echo('dWeights',tabletostring(dWeights))
+	Spring.Echo('dOffsets',tabletostring(dOffsets))
+	Spring.Echo('weights',tabletostring(weights)) 
+	Spring.Echo('offsets',tabletostring(offsets))
+	]]--
 	return weights, offsets
 end
 
@@ -194,78 +307,80 @@ end
 local function GetSamplingVectorArray(kernelSize)
 	local result = {}
 	math.randomseed(kernelSize) -- for repeatability
-	for i = 0, kernelSize - 1 do
-		local x, y, z = math.random(), math.random(), math.random() -- [0, 1]^3
+	if shaderConfig.SSAO_FIBONACCI == 1 then
+		local points = {}
+		local phi = math.pi * (math.sqrt(5.) - 1.)--  # golden angle in radians
+		local samples = 2*kernelSize + math.floor((100 * shaderConfig.SSAO_KERNEL_MINZ))
+	
+		for i =0, samples do
+			local y = 1 - (i / (samples - 1)) * 2  -- y goes from 1 to -1
+			local radius = math.sqrt(1 - y * y)  -- radius at y
+	
+			local theta = phi * i  -- golden angle increment
+	
+			local x = math.cos(theta) * radius
+			local z = math.sin(theta) * radius
+			local randlength = math.max(0.2, math.pow(math.random(), shaderConfig.SSAO_RANDOM_LENGTH) )
+			points[i+1] = {x = x * randlength, y = z* randlength,z =  y* randlength} -- note the swizzle of zy
+		end
 
-		x, y = 2.0 * x - 1.0, 2.0 * y - 1.0 -- xy:[-1, 1]^2, z:[0, 1]
+		for i = 0, kernelSize-1 do 
+			result[i] = points[i +1]
+		end
+		return result
 
-		local l = math_sqrt(x * x + y * y + z * z) --norm
-		x, y, z = x / l, y / l, z / l --normalize
+	else
+		for i = 0, kernelSize - 1 do
+			local x, y, z = math.random(), math.random(), math.random() -- [0, 1]^3
 
-		local scale = i / (kernelSize - 1)
-		scale = scale * scale -- shift most samples closer to the origin
-		scale = math.min(math.max(scale, 0.1), 1.0) --clamp
+			x, y = 2.0 * x - 1.0, 2.0 * y - 1.0 -- xy:[-1, 1]^2, z:[0, 1]
+			z = z + shaderConfig.SSAO_KERNEL_MINZ --dont make them fully planar, its wasteful
 
-		x, y, z = x * scale, y * scale, z * scale -- scale
-		result[i] = {x = x, y = y, z = z}
+			local l = math_sqrt(x * x + y * y + z * z) --norm
+			x, y, z = x / l, y / l, z / l --normalize
+
+			local scale = i / (kernelSize - 1)
+			--scale = scale * scale -- shift most samples closer to the origin
+			scale = math.pow(scale, shaderConfig.SSAO_RANDOM_LENGTH)
+			scale = math.min(math.max(scale, 0.2), 1.0) --clamp
+
+			x, y, z = x * scale, y * scale, z * scale -- scale
+			result[i] = {x = x, y = y, z = z}
+		end
+		return result
 	end
-	return result
 end
 
 -----------------------------------------------------------------
 -- Widget Functions
 -----------------------------------------------------------------
 
-function widget:ViewResize()
-	widget:Shutdown()
-	widget:Initialize()
-end
 
-function widget:Initialize()
-	if not gl.CreateShader then -- no shader support, so just remove the widget itself, especially for headless
-		widgetHandler:RemoveWidget()
-		return
-	end
-	WG['ssao'] = {}
-	WG['ssao'].getPreset = function()
-		return preset
-	end
-	WG['ssao'].setPreset = function(value)
-		preset = value
-		widget:Shutdown()
-		widget:Initialize()
-	end
-	WG['ssao'].getStrength = function()
-		return SSAO_ALPHA_POW
-	end
-	WG['ssao'].setStrength = function(value)
-		SSAO_ALPHA_POW = value
-		widget:Shutdown()
-		widget:Initialize()
-	end
-	WG['ssao'].getRadius = function()
-		return SSAO_RADIUS
-	end
-	WG['ssao'].setRadius = function(value)
-		SSAO_RADIUS = value
-		widget:Shutdown()
-		widget:Initialize()
-	end
+local function InitGL()
 	local canContinue = LuaShader.isDeferredShadingEnabled and LuaShader.GetAdvShadingActive()
+	
 	if not canContinue then
 		Spring.Echo(string.format("Error in [%s] widget: %s", widgetName, "Deferred shading is not enabled or advanced shading is not active"))
 	end
 
 	-- make unit lighting brighter to compensate for darkening (also restoring values on Shutdown())
 	if presets[preset].tonemapA then
-		Spring.SetConfigFloat("tonemapA", initialTonemapA + (presets[preset].tonemapA * ((SSAO_ALPHA_POW * strengthMult)/11)))
-		Spring.SetConfigFloat("tonemapD", initialTonemapD + (presets[preset].tonemapD * ((SSAO_ALPHA_POW * strengthMult)/11)))
-		Spring.SetConfigFloat("tonemapE", initialTonemapE + (presets[preset].tonemapE * ((SSAO_ALPHA_POW * strengthMult)/11)))
+		Spring.SetConfigFloat("tonemapA", initialTonemapA + (presets[preset].tonemapA * ((shaderConfig.SSAO_ALPHA_POW * strengthMult)/11)))
+		Spring.SetConfigFloat("tonemapD", initialTonemapD + (presets[preset].tonemapD * ((shaderConfig.SSAO_ALPHA_POW * strengthMult)/11)))
+		Spring.SetConfigFloat("tonemapE", initialTonemapE + (presets[preset].tonemapE * ((shaderConfig.SSAO_ALPHA_POW * strengthMult)/11)))
 		Spring.SendCommands("luarules updatesun")
 	end
 
-	firstTime = true
-	vsx, vsy, vpx, vpy = Spring.GetViewGeometry()
+	vsx, vsy = Spring.GetViewGeometry()
+
+	shaderConfig.VSX = vsx
+	shaderConfig.VSY = vsy
+	shaderConfig.HSX = math.ceil(vsx / shaderConfig.DOWNSAMPLE)
+	shaderConfig.HSY = math.ceil(vsy / shaderConfig.DOWNSAMPLE)
+	shaderConfig.TEXPADDINGX = shaderConfig.DOWNSAMPLE * shaderConfig.HSX - vsx
+	shaderConfig.TEXPADDINGY = shaderConfig.DOWNSAMPLE * shaderConfig.HSY - vsy
+
+	--Spring.Echo("SSAO SIZING",shaderConfig.DOWNSAMPLE, vsx, vsy, shaderConfig.TEXPADDINGX, shaderConfig.TEXPADDINGY)
 
 	local commonTexOpts = {
 		target = GL_TEXTURE_2D,
@@ -277,46 +392,25 @@ function widget:Initialize()
 		wrap_t = GL.CLAMP_TO_EDGE,
 	}
 
-	commonTexOpts.format = GL_RGB16F
-	gbuffFuseViewPosTex = gl.CreateTexture(vsx, vsy, commonTexOpts)
-
-	commonTexOpts.format = GL_RGB8_SNORM
-	gbuffFuseViewNormalTex = gl.CreateTexture(vsx, vsy, commonTexOpts)
-
-	if MERGE_MISC then
-		commonTexOpts.format = GL_RGBA8
-		gbuffFuseMiscTex = gl.CreateTexture(vsx, vsy, commonTexOpts)
+	if shaderConfig.NOFUSE == 0 then
+		commonTexOpts.format = GL_RGB16F
+		gbuffFuseViewPosTex = gl.CreateTexture(vsx, vsy, commonTexOpts) -- at 1080p this is 16MB
+	
+		gbuffFuseFBO = gl.CreateFBO({
+			color0 = gbuffFuseViewPosTex,
+			drawbuffers = {GL_COLOR_ATTACHMENT0_EXT},
+		})
+		if not gl.IsValidFBO(gbuffFuseFBO) then
+			Spring.Echo(string.format("Error in [%s] widget: %s", widgetName, "Invalid gbuffFuseFBO"))
+		end	
 	end
-
+	
 	commonTexOpts.min_filter = GL.LINEAR
 	commonTexOpts.mag_filter = GL.LINEAR
-
 	commonTexOpts.format = GL_RGBA8
-	ssaoTex = gl.CreateTexture(vsx / presets[preset].DOWNSAMPLE, vsy / presets[preset].DOWNSAMPLE, commonTexOpts)
 
-	commonTexOpts.format = GL_RGBA8
-	for i = 1, 2 do
-		ssaoBlurTexes[i] = gl.CreateTexture(vsx / presets[preset].DOWNSAMPLE, vsy / presets[preset].DOWNSAMPLE, commonTexOpts)
-	end
-
-	if MERGE_MISC then
-		gbuffFuseFBO = gl.CreateFBO({
-			color0 = gbuffFuseViewPosTex,
-			color1 = gbuffFuseViewNormalTex,
-			color2 = gbuffFuseMiscTex,
-			drawbuffers = {GL_COLOR_ATTACHMENT0_EXT, GL_COLOR_ATTACHMENT1_EXT, GL_COLOR_ATTACHMENT2_EXT},
-		})
-	else
-		gbuffFuseFBO = gl.CreateFBO({
-			color0 = gbuffFuseViewPosTex,
-			color1 = gbuffFuseViewNormalTex,
-			drawbuffers = {GL_COLOR_ATTACHMENT0_EXT, GL_COLOR_ATTACHMENT1_EXT},
-		})
-	end
-
-	if not gl.IsValidFBO(gbuffFuseFBO) then
-		Spring.Echo(string.format("Error in [%s] widget: %s", widgetName, "Invalid gbuffFuseFBO"))
-	end
+	ssaoTex = gl.CreateTexture(shaderConfig.HSX, shaderConfig.HSY , commonTexOpts)
+	ssaoBlurTex = gl.CreateTexture(shaderConfig.HSX, shaderConfig.HSY, commonTexOpts)
 
 	ssaoFBO = gl.CreateFBO({
 		color0 = ssaoTex,
@@ -326,107 +420,211 @@ function widget:Initialize()
 		Spring.Echo(string.format("Error in [%s] widget: %s", widgetName, "Invalid ssaoFBO"))
 	end
 
-	for i = 1, 2 do
-		ssaoBlurFBOs[i] = gl.CreateFBO({
-			color0 = ssaoBlurTexes[i],
-			drawbuffers = {GL_COLOR_ATTACHMENT0_EXT},
-		})
-		if not gl.IsValidFBO(ssaoBlurFBOs[i]) then
-			Spring.Echo(string.format("Error in [%s] widget: %s", widgetName, string.format("Invalid ssaoBlurFBOs[%d]", i)))
-		end
+	ssaoBlurFBO = gl.CreateFBO({
+		color0 = ssaoBlurTex,
+		drawbuffers = {GL_COLOR_ATTACHMENT0_EXT},
+	})
+	if not gl.IsValidFBO(ssaoBlurFBO) then
+		Spring.Echo(string.format("Error in [%s] widget: %s", widgetName, string.format("Invalid ssaoBlurFBO")))
 	end
 
+	-- ensure stencil is available
+	if shaderConfig.USE_STENCIL == 1 then 
+		unitStencilTexture = WG['unitstencilapi'].GetUnitStencilTexture()
+		shaderConfig.USE_STENCIL = unitStencilTexture and 1 or 0
+	end
 
-	local gbuffFuseShaderVert = VFS.LoadFile(shadersDir.."identity.vert.glsl")
-	local gbuffFuseShaderFrag = VFS.LoadFile(shadersDir.."gbuffFuse.frag.glsl")
-
-	gbuffFuseShaderFrag = gbuffFuseShaderFrag:gsub("###DEPTH_CLIP01###", tostring((Platform.glSupportClipSpaceControl and 1) or 0))
-	gbuffFuseShaderFrag = gbuffFuseShaderFrag:gsub("###MERGE_MISC###", tostring((MERGE_MISC and 1) or 0))
-
-	gbuffFuseShader = LuaShader({
-		vertex = gbuffFuseShaderVert,
-		fragment = gbuffFuseShaderFrag,
+	gbuffFuseShaderCache = {
+		vssrcpath = shadersDir.."identity_texrect.vert.glsl",
+		fssrcpath = shadersDir.."gbuffFuse.frag.glsl",
 		uniformInt = {
-			-- be consistent with gfx_deferred_rendering.lua
-			--	glTexture(0, "$model_gbuffer_normtex")
-			--	glTexture(1, "$model_gbuffer_zvaltex")
-			--	glTexture(2, "$map_gbuffer_normtex")
-			--	glTexture(3, "$map_gbuffer_zvaltex")
+			modelDepthTex = 1,
+			mapDepthTex = 4,
+
+			unitStencilTex = 7,
+		},
+		uniformFloat = {},
+		silent = true, -- suppress compilation messages
+		shaderConfig = shaderConfig,
+		shaderName = widgetName..": G-buffer Fuse",
+	}
+
+	gbuffFuseShader = LuaShader.CheckShaderUpdates(gbuffFuseShaderCache)
+
+	ssaoShaderCache = {
+		vssrcpath = shadersDir.."identity_texrect.vert.glsl",
+		fssrcpath = shadersDir.."ssao.frag.glsl",
+		uniformInt = {
+			viewPosTex = 5,
+			viewNormalTex = 6,
+			miscTex = 2,
+
 			modelNormalTex = 0,
 			modelDepthTex = 1,
-			modelDiffTex = 2,
 			mapNormalTex = 3,
 			mapDepthTex = 4,
 
-			modelMiscTex = 5,
-			mapMiscTex = 6,
+			unitStencilTex = 7,
 		},
 		uniformFloat = {
-			viewPortSize = {vsx, vsy},
 		},
-	}, widgetName..": G-buffer Fuse")
-	gbuffFuseShader:Initialize()
+		silent = true, -- suppress compilation messages
+		shaderConfig = shaderConfig,
+		shaderName = widgetName..": SSAO",
+	}
 
-
-	local ssaoShaderVert = VFS.LoadFile(shadersDir.."identity.vert.glsl")
-	local ssaoShaderFrag = VFS.LoadFile(shadersDir.."ssao.frag.glsl")
-
-	ssaoShaderFrag = ssaoShaderFrag:gsub("###SSAO_KERNEL_SIZE###", tostring(presets[preset].SSAO_KERNEL_SIZE))
-
-	ssaoShaderFrag = ssaoShaderFrag:gsub("###SSAO_RADIUS###", tostring(SSAO_RADIUS))
-	ssaoShaderFrag = ssaoShaderFrag:gsub("###SSAO_MIN###", tostring(SSAO_MIN))
-	ssaoShaderFrag = ssaoShaderFrag:gsub("###SSAO_MAX###", tostring(SSAO_MAX))
-
-	ssaoShaderFrag = ssaoShaderFrag:gsub("###SSAO_ALPHA_POW###", tostring(SSAO_ALPHA_POW * strengthMult))
-	ssaoShaderFrag = ssaoShaderFrag:gsub("###USE_MATERIAL_INDICES###", tostring((MERGE_MISC and 1) or 0))
-
-	ssaoShader = LuaShader({
-		vertex = ssaoShaderVert,
-		fragment = ssaoShaderFrag,
-		uniformInt = {
-			viewPosTex = 0,
-			viewNormalTex = 1,
-			miscTex = 2,
-		},
-		uniformFloat = {
-			viewPortSize = {vsx / presets[preset].DOWNSAMPLE, vsy / presets[preset].DOWNSAMPLE},
-		},
-	}, widgetName..": Processing")
-	ssaoShader:Initialize()
+	ssaoShader = LuaShader.CheckShaderUpdates(ssaoShaderCache)
 
 	ssaoShader:ActivateWith( function()
-		local samplingKernel = GetSamplingVectorArray(presets[preset].SSAO_KERNEL_SIZE)
-		for i = 0, presets[preset].SSAO_KERNEL_SIZE - 1 do
+		local samplingKernel = GetSamplingVectorArray(shaderConfig.SSAO_KERNEL_SIZE)
+		for i = 0, shaderConfig.SSAO_KERNEL_SIZE - 1 do
 			local sv = samplingKernel[i]
-			ssaoShader:SetUniformFloatAlways(string.format("samplingKernel[%d]", i), sv.x, sv.y, sv.z)
+			local success = ssaoShader:SetUniformFloatAlways(string.format("samplingKernel[%d]", i), sv.x, sv.y, sv.z)
+			--Spring.Echo("ssaoShader:SetUniformFloatAlways",success, i, sv.x, sv.y, sv.z)
 		end
+		ssaoShader:SetUniformFloatAlways("testuniform", 1.0)
 	end)
 
 
-	local gaussianBlurVert = VFS.LoadFile(shadersDir.."identity.vert.glsl")
-	local gaussianBlurFrag = VFS.LoadFile(shadersDir.."gaussianBlur.frag.glsl")
-
-	gaussianBlurFrag = gaussianBlurFrag:gsub("###BLUR_HALF_KERNEL_SIZE###", tostring(presets[preset].BLUR_HALF_KERNEL_SIZE))
-
-	gaussianBlurShader = LuaShader({
-		vertex = gaussianBlurVert,
-		fragment = gaussianBlurFrag,
+	gaussianBlurShaderCache = {
+		vssrcpath = shadersDir.."identity_texrect.vert.glsl",
+		fssrcpath = shadersDir.."gaussianBlur.frag.glsl",
 		uniformInt = {
 			tex = 0,
+			unitStencilTex = 7,
 		},
 		uniformFloat = {
-			viewPortSize = {vsx / presets[preset].DOWNSAMPLE, vsy / presets[preset].DOWNSAMPLE},
+			dir = {0,1},
+			strengthMult = 1,
 		},
-	}, widgetName..": Gaussian Blur")
-	gaussianBlurShader:Initialize()
+		silent = true, -- suppress compilation messages
+		shaderConfig = shaderConfig,
+		shaderName = widgetName..": gaussianBlur",
+	}
 
-	local gaussWeights, gaussOffsets = GetGaussLinearWeightsOffsets(presets[preset].BLUR_SIGMA, presets[preset].BLUR_HALF_KERNEL_SIZE, 1.0)
+	gaussianBlurShader = LuaShader.CheckShaderUpdates(gaussianBlurShaderCache)
+
+	local gaussWeights, gaussOffsets = GetGaussLinearWeightsOffsets(shaderConfig.BLUR_SIGMA, shaderConfig.BLUR_HALF_KERNEL_SIZE, 1.0)
 
 	gaussianBlurShader:ActivateWith( function()
 		gaussianBlurShader:SetUniformFloatArrayAlways("weights", gaussWeights)
 		gaussianBlurShader:SetUniformFloatArrayAlways("offsets", gaussOffsets)
 	end)
 
+	-- These are now offset by the half pixel that is needed here due to ceil(vsx/rez)
+	screenQuadList = gl.CreateList(gl.TexRect, -1, -1, 1, 1, 0.0, 0.0, 1.0, 1.0)
+	--screenWideList = gl.CreateList(gl.TexRect, -1, -1, 1000, 1000, 0.0, 0.0,
+	--	1.0 - shaderConfig.TEXPADDINGX/shaderConfig.VSX, 1.0 - shaderConfig.TEXPADDINGY/shaderConfig.VSY)
+	screenWideList = gl.CreateList(function() 
+
+		gl.MatrixMode(GL.MODELVIEW)
+		gl.PushMatrix()
+		gl.LoadIdentity()
+	
+			gl.MatrixMode(GL.PROJECTION)
+			gl.PushMatrix()
+			gl.LoadIdentity()
+	
+
+			gl.TexRect(-1, -1, 1, 1, 0.0, 0.0,
+				1.0 - shaderConfig.TEXPADDINGX/shaderConfig.VSX, 1.0 - shaderConfig.TEXPADDINGY/shaderConfig.VSY)
+			
+			gl.MatrixMode(GL.PROJECTION)
+			gl.PopMatrix()
+	
+		gl.MatrixMode(GL.MODELVIEW)
+		gl.PopMatrix()
+		end
+	)
+
+end
+
+local function CleanGL()
+
+	if screenQuadList then
+		gl.DeleteList(screenQuadList)
+	end
+
+	if screenWideList then
+		gl.DeleteList(screenWideList)
+	end
+
+	gl.DeleteTexture(ssaoTex)
+	if gbuffFuseViewPosTex then gl.DeleteTexture(gbuffFuseViewPosTex) end
+	gl.DeleteTexture(ssaoBlurTex)
+
+
+	gl.DeleteFBO(ssaoFBO)
+	if gbuffFuseFBO then gl.DeleteFBO(gbuffFuseFBO) end
+	gl.DeleteFBO(ssaoBlurFBO)
+
+	ssaoShader:Finalize()
+	gbuffFuseShader:Finalize()
+	gaussianBlurShader:Finalize()
+end
+
+
+function widget:ViewResize()
+	CleanGL()
+	InitGL()
+end
+
+function widget:Initialize()
+	WG['ssao'] = {}
+	WG['ssao'].getPreset = function()
+		return preset
+	end
+	WG['ssao'].setPreset = function(value)
+		preset = value
+		InitShaderDefines()
+		ActivatePreset(preset)
+		CleanGL()
+		InitGL()
+	end
+	WG['ssao'].getStrength = function()
+		return shaderConfig.SSAO_ALPHA_POW
+	end
+	WG['ssao'].setStrength = function(value)
+		shaderConfig.SSAO_ALPHA_POW = value
+		CleanGL()
+		InitGL()
+	end
+	WG['ssao'].getRadius = function()
+		return shaderConfig.SSAO_RADIUS
+	end
+	WG['ssao'].setRadius = function(value)
+		shaderConfig.SSAO_RADIUS = value
+		CleanGL()
+		InitGL()
+	end
+
+	if WG['flowui_gl4']  and WG['flowui_gl4'].forwardslider then 
+		Spring.Echo(" WG[flowui_gl4] detected")	
+			shaderDefinedSlidersLayer, shaderDefinedSlidersWindow = WG['flowui_gl4'].requestWidgetLayer(shaderDefinedSliders) -- this is a window
+			shaderDefinedSliders.parent = shaderDefinedSlidersWindow
+			
+			WG['flowui_gl4'].forwardslider(shaderDefinedSliders)
+	end
+
+	InitGL()
+end
+
+
+local sec = 0
+function widget:Update(dt)
+	sec = sec + dt
+	if sec > 1 then
+		sec = 0
+		if Spring.GetConfigInt("cus", 1) == 1 then
+			if WG.disabledCus then
+				strengthMult = 1
+			else
+				strengthMult = cusMult
+			end
+		else
+			strengthMult = 1
+		end
+	end
 end
 
 function widget:Shutdown()
@@ -438,184 +636,118 @@ function widget:Shutdown()
 		Spring.SetConfigFloat("tonemapE", initialTonemapE)
 		Spring.SendCommands("luarules updatesun")
 	end
+	
+	if shaderDefinedSlidersLayer and shaderDefinedSlidersLayer.Destroy then shaderDefinedSlidersLayer:Destroy() end 
+	--if shaderDefinedSlidersWindow and shaderDefinedSlidersWindow.Destroy then shaderDefinedSlidersWindow:Destroy() end 
 
-	firstTime = nil
-
-	if screenQuadList then
-		gl.DeleteList(screenQuadList)
-	end
-
-	if screenWideList then
-		gl.DeleteList(screenWideList)
-	end
-
-	gl.DeleteTexture(ssaoTex)
-	gl.DeleteTexture(gbuffFuseViewPosTex)
-	gl.DeleteTexture(gbuffFuseViewNormalTex)
-	if MERGE_MISC then
-		gl.DeleteTexture(gbuffFuseMiscTex)
-	end
-
-	for i = 1, 2 do
-		gl.DeleteTexture(ssaoBlurTexes[i])
-	end
-
-	if gl.DeleteFBO then
-		gl.DeleteFBO(ssaoFBO)
-		gl.DeleteFBO(gbuffFuseFBO)
-		for i = 1, 2 do
-			gl.DeleteFBO(ssaoBlurFBOs[i])
-		end
-	end
-
-	if ssaoShader then ssaoShader:Finalize() end
-	if gbuffFuseShader then gbuffFuseShader:Finalize() end
-	if gaussianBlurShader then gaussianBlurShader:Finalize() end
+	CleanGL()
 end
 
-local function DoDrawSSAO(isScreenSpace)
+local function DoDrawSSAO()
 	gl.DepthTest(false)
 	gl.DepthMask(false) --"BK OpenGL state resets", default is already false, could remove
 	gl.Blending(false)
 
-
-	if firstTime then
-		screenQuadList = gl.CreateList(gl.TexRect, -1, -1, 1, 1)
-		if isScreenSpace then
-			screenWideList = gl.CreateList(gl.TexRect, 0, vsy, vsx, 0)
-		else
-			screenWideList = gl.CreateList(gl.TexRect, -1, -1, 1, 1, false, true)
-		end
-		firstTime = false
+	if shaderConfig.USE_STENCIL == 1 and unitStencilTexture then 	
+		unitStencilTexture = WG['unitstencilapi'].GetUnitStencilTexture() -- needs this to notify that we want it next frame too
+		glTexture(7, unitStencilTexture)
 	end
 
+
 	local prevFBO
+	
+	if ((shaderConfig.SLOWFUSE == 0) or Spring.GetDrawFrame()%30==0) and (shaderConfig.NOFUSE ~= 1) then 
 	prevFBO = gl.RawBindFBO(gbuffFuseFBO)
-		gbuffFuseShader:Activate()
+		gbuffFuseShader:Activate() -- ~0.25ms
 
 			gbuffFuseShader:SetUniformMatrix("invProjMatrix", "projectioninverse")
-			gbuffFuseShader:SetUniformMatrix("viewMatrix", "view")
-
-			gl.Texture(0, "$model_gbuffer_normtex")
-			gl.Texture(1, "$model_gbuffer_zvaltex")
-			gl.Texture(2, "$model_gbuffer_difftex")
-			gl.Texture(3, "$map_gbuffer_normtex")
-			gl.Texture(4, "$map_gbuffer_zvaltex")
-
-			if MERGE_MISC then
-				gl.Texture(5, "$model_gbuffer_misctex")
-				gl.Texture(6, "$map_gbuffer_misctex")
-			end
-
+			glTexture(1, "$model_gbuffer_zvaltex")
+			glTexture(4, "$map_gbuffer_zvaltex")
 
 			gl.CallList(screenQuadList) -- gl.TexRect(-1, -1, 1, 1)
-			--gl.TexRect(-1, -1, 1, 1)
+		
+			glTexture(1, false)
+			glTexture(4, false)
 
-			gl.Texture(0, false)
-			gl.Texture(1, false)
-			gl.Texture(2, false)
-			gl.Texture(3, false)
-			gl.Texture(4, false)
-			if MERGE_MISC then
-				gl.Texture(5, false)
-				gl.Texture(6, false)
-			end
 		gbuffFuseShader:Deactivate()
 	--end)
 	gl.RawBindFBO(nil, nil, prevFBO)
+	end
 
 	prevFBO = gl.RawBindFBO(ssaoFBO)
 		gl.Clear(GL.COLOR_BUFFER_BIT, 0, 0, 0, 0)
 		ssaoShader:Activate()
-			ssaoShader:SetUniformMatrix("projMatrix", "projection")
-			local shadowDensity = gl.GetSun("shadowDensity", "unit")
-			ssaoShader:SetUniformFloat("shadowDensity", shadowDensity)
-
-			gl.Texture(0, gbuffFuseViewPosTex)
-			gl.Texture(1, gbuffFuseViewNormalTex)
-			if MERGE_MISC then
-				gl.Texture(2, gbuffFuseMiscTex)
+			if shaderConfig.NOFUSE > 0 then 
+				glTexture(1, "$model_gbuffer_zvaltex")
+				glTexture(4, "$map_gbuffer_zvaltex")
+			else
+				glTexture(5, gbuffFuseViewPosTex)
 			end
-			gl.CallList(screenQuadList) -- gl.TexRect(-1, -1, 1, 1)
-			--gl.TexRect(-1, -1, 1, 1)
+			glTexture(0, "$model_gbuffer_normtex")
 
-			gl.Texture(0, false)
-			gl.Texture(1, false)
-			if MERGE_MISC then
-				gl.Texture(2, false)
-			end
+			gl.CallList(screenQuadList) 
+
+			for i = 0, 6 do glTexture(i,false) end  
 		ssaoShader:Deactivate()
 	gl.RawBindFBO(nil, nil, prevFBO)
 
-	gl.Texture(0, ssaoTex)
+	glTexture(0, ssaoTex)
 
-	for i = 1, presets[preset].BLUR_PASSES do
-		gaussianBlurShader:Activate()
+	if shaderConfig.DEBUG_SSAO == 0 then -- dont debug ssao
+			gaussianBlurShader:Activate()
 
-			gaussianBlurShader:SetUniform("dir", 1.0, 0.0) --horizontal blur
-			prevFBO = gl.RawBindFBO(ssaoBlurFBOs[1])
-			gl.CallList(screenQuadList) -- gl.TexRect(-1, -1, 1, 1)
-			gl.RawBindFBO(nil, nil, prevFBO)
-			gl.Texture(0, ssaoBlurTexes[1])
+				gaussianBlurShader:SetUniform("dir", 1.0, 0.0) --horizontal blur
+				prevFBO = gl.RawBindFBO(ssaoBlurFBO)
+				gl.CallList(screenQuadList) -- gl.TexRect(-1, -1, 1, 1)
+				gl.RawBindFBO(nil, nil, prevFBO)
+				glTexture(0, ssaoBlurTex)
 
-			gaussianBlurShader:SetUniform("dir", 0.0, 1.0) --vertical blur
-			prevFBO = gl.RawBindFBO(ssaoBlurFBOs[2])
-			gl.CallList(screenQuadList) -- gl.TexRect(-1, -1, 1, 1)
-			gl.RawBindFBO(nil, nil, prevFBO)
-			gl.Texture(0, ssaoBlurTexes[2])
+				gaussianBlurShader:SetUniform("strengthMult", shaderConfig.SSAO_ALPHA_POW/ 7.0) --vertical blur
+				gaussianBlurShader:SetUniform("dir", 0.0, 1.0) --vertical blur
+				prevFBO = gl.RawBindFBO(ssaoFBO)
+				gl.CallList(screenQuadList) -- gl.TexRect(-1, -1, 1, 1)
+				gl.RawBindFBO(nil, nil, prevFBO)
+				glTexture(0, ssaoTex)
 
-		gaussianBlurShader:Deactivate()
-	end
-
-
-	if DEBUG_SSAO then
-		gl.Blending(false)
+			gaussianBlurShader:Deactivate()
+		if shaderConfig.DEBUG_BLUR == 1 then
+			gl.Blending(false) -- now blurred tex contains normals
+		else
+			if shaderConfig.BRIGHTEN == 0 then 
+				gl.Blending(GL.ZERO, GL.SRC_ALPHA) -- now blurred tex contains normals
+			else
+			-- at this point, Alpha contains occlusoin, and rgb contains brighten factor
+				gl.Blending(GL.DST_COLOR, GL.SRC_ALPHA) -- now blurred tex contains normals
+			end
+		end
 	else
-		gl.BlendEquation(GL_FUNC_REVERSE_SUBTRACT)
-		--gl.Blending("alpha")
-		gl.Blending(true)
-		gl.BlendFuncSeparate(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ZERO, GL.ONE)
-		--gl.BlendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA) --alpha NO pre-multiply
-		--gl.BlendFunc(GL.ONE, GL.ONE_MINUS_SRC_ALPHA) --alpha pre-multiply
-		--gl.BlendFunc(GL.ZERO, GL.ONE)
+		if shaderConfig.DEBUG_BLUR == 1 then
+			gl.Blending(false) -- now blurred tex contains normals
+		else
+		end
 	end
-
 	-- Already bound
-	--gl.Texture(0, ssaoBlurTexes[1])
+	--glTexture(0, ssaoBlurTexes[1])
 
 	gl.CallList(screenWideList)
 
-	if not DEBUG_SSAO then
-		gl.BlendEquation(GL_FUNC_ADD)
-	end
+	glTexture(0, false)
+	glTexture(1, false)
+	glTexture(2, false)
+	glTexture(3, false)
+	glTexture(4, false)
+	glTexture(5, false)
+	glTexture(6, false)
+	glTexture(7, false)
 
-	gl.Texture(0, false)
-	gl.Texture(1, false)
-	gl.Texture(2, false)
-	gl.Texture(3, false)
-
-
-	gl.Blending("alpha")
-	--gl.DepthMask(true) --"BK OpenGL state resets", already commented out
-	--gl.DepthTest(true) --"BK OpenGL state resets", already commented out
+	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
+	gl.DepthMask(true) --"BK OpenGL state resets", already commented out
+	gl.DepthTest(true) --"BK OpenGL state resets", already commented out
 end
 
 function widget:DrawWorld()
-	gl.MatrixMode(GL.MODELVIEW)
-	gl.PushMatrix()
-	gl.LoadIdentity()
-
-		gl.MatrixMode(GL.PROJECTION)
-		gl.PushMatrix()
-		gl.LoadIdentity()
-
-			DoDrawSSAO(false)
-
-		gl.MatrixMode(GL.PROJECTION)
-		gl.PopMatrix()
-
-	gl.MatrixMode(GL.MODELVIEW)
-	gl.PopMatrix()
+	if shaderConfig.ENABLE == 0 then return end
+	DoDrawSSAO(false)
 
 	if delayedUpdateSun and os.clock() > delayedUpdateSun then
 		Spring.SendCommands("luarules updatesun")
@@ -625,18 +757,33 @@ end
 
 function widget:GetConfigData(data)
 	return {
-		strength = SSAO_ALPHA_POW,
-		radius = SSAO_RADIUS,
+		strength = shaderConfig.SSAO_ALPHA_POW,
+		radius = shaderConfig.SSAO_RADIUS,
 		preset = preset
 	}
 end
 
+local lastfps = Spring.GetFPS()
+function widget:DrawScreen()
+	if shaderDefinedSlidersLayer then 
+		local newfps = Spring.GetFPS()
+		if ssaoShaderCache.updateFlag then 
+			ssaoShaderCache.updateFlag = nil
+			lastfps = newfps
+		end
+		local totaldrawus = (1000/newfps)
+		local lastdelta = (1000/lastfps - 1000/newfps)
+		
+		gl.Text(string.format("SSAO total %.3f ms delta %.3f ms", totaldrawus, lastdelta),  vsx - 600,  20, 16, "do")
+	end
+end
+
 function widget:SetConfigData(data)
 	if data.strength ~= nil then
-		SSAO_ALPHA_POW = data.strength
+		shaderConfig.SSAO_ALPHA_POW = data.strength
 	end
 	if data.radius ~= nil then
-		SSAO_RADIUS = data.radius
+		shaderConfig.SSAO_RADIUS = data.radius
 	end
 	if data.preset ~= nil then
 		preset = data.preset
@@ -644,4 +791,8 @@ function widget:SetConfigData(data)
 			preset = 3
 		end
 	end
+	Spring.Echo("widget:SetConfigData SSAO preset=", preset)
+	InitShaderDefines()
+	ActivatePreset(preset)
+	--widget:ViewResize()
 end

--- a/luaui/Widgets/gfx_unit_stencil_gl4.lua
+++ b/luaui/Widgets/gfx_unit_stencil_gl4.lua
@@ -1,0 +1,417 @@
+function widget:GetInfo()
+	return {
+		name      = "Unit Stencil GL4",
+		desc      = "A fun approach to minimizing the cost of some fun shaders",
+		author    = "Beherith",
+		date      = "2022.03.05",
+		license   = "Lua: GNU GPL, v2 or later, GLSL code: (c) Beherith, mysterme@gmail.com ",
+		layer     = 50,
+		enabled   = true
+	}
+end
+
+-- Key Idea: make a 1/2 or 1/4 sized texture 'stencil buffer' that can be used for units and features.
+-- Draw features first at 0.5, then units at 1.0, clear if no draw happened
+-- Make this shared the same way screencopy texture is shared, via an api
+-- bind and sample this texture if needed for any other method :)
+
+local unitStencilVBO = nil
+local featureStencilVBO = nil -- TODO
+local unitStencilShader = nil
+
+local unitFeatureStencilTex = nil
+
+local unitDimensionsXYZ = {} -- table of unitDefID to max x,y,z dims
+local featureDimensionsXYZ = {} -- table of unitDefID to max x,y,z dims
+-----------------------------------------------------------------
+-- Configuration Constants
+-----------------------------------------------------------------
+local addRadius = 10
+-----------------------------------------------------------------
+-- GL4 Backend Stuff
+
+local luaShaderDir = "LuaUI/Widgets/Include/"
+local LuaShader = VFS.Include(luaShaderDir.."LuaShader.lua")
+VFS.Include(luaShaderDir.."instancevbotable.lua")
+
+local vsSrc =  [[
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+
+#line 5000
+
+layout (location = 0) in vec4 unitModelMinXYZ;
+layout (location = 1) in vec4 unitModelMaxXYZ;
+layout (location = 2) in uvec4 instData;
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+struct SUniformsBuffer {
+    uint composite; //   u8 drawFlag; u8 unused1; u16 id;
+    
+    uint unused2;
+    uint unused3;
+    uint unused4;
+
+    float maxHealth;
+    float health;
+    float unused5;
+    float unused6;
+    
+    vec4 drawPos;
+    vec4 speed;
+    vec4[4] userDefined; //can't use float[16] because float in arrays occupies 4 * float space
+};
+
+layout(std140, binding=1) readonly buffer UniformsBuffer {
+    SUniformsBuffer uni[];
+}; 
+
+#line 10000
+
+uniform float addRadius = 10;
+
+out DataVS {
+	vec4 v_unitModelMinXYZ;
+    vec4 v_unitModelMaxXYZ;
+    vec4 v_centerPos;
+};
+
+void main()
+{
+	gl_Position = cameraViewProj * vec4(uni[instData.y].drawPos.xyz, 1.0); // We transform this vertex into the center of the model
+    v_unitModelMinXYZ = unitModelMinXYZ;
+    v_unitModelMaxXYZ = unitModelMaxXYZ;
+    v_unitModelMaxXYZ.w = 1.0;
+    v_centerPos = vec4(uni[instData.y].drawPos);
+    // TODO: calculate radius in screen-space pixels
+
+    // Make no primitives on stuff outside of screen
+    if (isSphereVisibleXY(vec4(uni[instData.y].drawPos.xyz, 1.0), addRadius + unitModelMaxXYZ.x + unitModelMaxXYZ.z)) 
+    v_unitModelMaxXYZ.w = 0.0; 
+
+    // this checks the drawFlag of wether the unit is actually being drawn 
+    // (this is ==1 when then unit is both visible and drawn as a full model (not icon)) 
+    if ((uni[instData.y].composite & 0x00000003u) < 1u ) 
+    v_unitModelMaxXYZ.w = 0.0; 
+}
+]]
+
+local gsSrc = [[
+#version 330
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+layout(points) in;
+layout(triangle_strip, max_vertices = 12) out;
+#line 20000
+
+uniform float addRadius = 10;
+
+in DataVS {
+	vec4 v_unitModelMinXYZ;
+    vec4 v_unitModelMaxXYZ;
+    vec4 v_centerPos;
+} dataIn[];
+
+mat3 rotY;
+vec4 centerpos;
+
+void offsetVertex4( float x, float y, float z){
+	vec3 primitiveCoords = vec3(x,y,z);
+    primitiveCoords*= 1;
+	vec3 vecnorm = sign(primitiveCoords);
+	gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * ( vec3(addRadius ,0,addRadius)* vecnorm + primitiveCoords ), 1.0);
+	EmitVertex();
+}
+
+#line 22000
+void main(){
+    vec4 Mins =  dataIn[0].v_unitModelMinXYZ;
+    vec4 Maxs =  dataIn[0].v_unitModelMaxXYZ;
+    if (Maxs.w < 0.5) return;
+	centerpos = dataIn[0].v_centerPos;
+
+    vec3 camPos = cameraViewInv[3].xyz ;
+	vec3 camDir = normalize(camPos-centerpos.xyz);
+
+    float s = sin(centerpos.w);
+	float c = cos(centerpos.w);
+
+    rotY =  mat3(
+        c, 0.0, -s,
+        0.0, 1.0, 0.0,
+        s, 0.0, c);
+
+
+    // Draw Top Face
+    offsetVertex4( Mins.x, Maxs.y,  Mins.z);
+    offsetVertex4( Maxs.x, Maxs.y,  Mins.z);
+    offsetVertex4( Mins.x, Maxs.y,  Maxs.z);
+    offsetVertex4( Maxs.x, Maxs.y,  Maxs.z);
+    EndPrimitive();
+    
+    float leftright = (dot(vec3(c, 0, -s), camDir) < 0) ? Mins.x : Maxs.x;
+        offsetVertex4( leftright, Maxs.y,  Mins.z);
+        offsetVertex4( leftright, Maxs.y,  Maxs.z);
+        offsetVertex4( leftright, Mins.y,  Mins.z);
+        offsetVertex4( leftright, Mins.y,  Maxs.z);
+        EndPrimitive();
+
+        
+    float frontback = (dot(vec3(s, 0, c), camDir) > 0) ? Maxs.z : Mins.z;
+        offsetVertex4( Mins.x, Maxs.y,  frontback);
+        offsetVertex4( Maxs.x, Maxs.y,  frontback);
+        offsetVertex4( Mins.x, Mins.y,  frontback);
+        offsetVertex4( Maxs.x, Mins.y,  frontback);
+    
+    EndPrimitive();
+}
+]]
+
+local fsSrc =
+[[
+#version 150 compatibility
+
+uniform float stencilColor = 1.0; // 1 if we are stenciling
+
+void main(void)
+{
+    gl_FragColor = vec4(stencilColor,stencilColor,stencilColor,1.0);
+}
+]]
+
+local function goodbye(reason)
+	Spring.Echo("Unit Stencil GL4 widget exiting with reason: "..reason)
+end
+local resolution = 4
+local vsx, vsy  
+function widget:ViewResize()
+    local GL_R8 = 0x8229
+    vsx, vsy = Spring.GetViewGeometry()
+    if unitFeatureStencilTex then gl.DeleteTexture(unitFeatureStencilTex) end
+    unitFeatureStencilTex = gl.CreateTexture(vsx/resolution, vsy/resolution, {
+		--format = GL.RGBA8,
+        format = GL_R8,
+		fbo = true,
+		min_filter = GL.NEAREST,
+		mag_filter = GL.NEAREST,
+		wrap_s = GL.CLAMP_TO_EDGE,
+		wrap_t = GL.CLAMP_TO_EDGE,
+	})
+end
+
+
+local function InitDrawPrimitiveAtUnit(modifiedShaderConf, DPATname)
+	local engineUniformBufferDefs = LuaShader.GetEngineUniformBufferDefs()
+	vsSrc = vsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+	fsSrc = fsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+	gsSrc = gsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+	local DrawPrimitiveAtUnitShader =  LuaShader(
+		{
+			vertex = vsSrc,
+			fragment = fsSrc,
+			geometry = gsSrc,
+			uniformInt = {
+				--DrawPrimitiveAtUnitTexture = 0;
+			},
+			uniformFloat = {
+				addRadius = 1,
+                stencilColor = 1,
+			},
+		},
+		DPATname .. "Shader GL4"
+	  )
+	local shaderCompiled = DrawPrimitiveAtUnitShader:Initialize()
+	if not shaderCompiled then
+		goodbye("Failed to compile ".. DPATname .." GL4 ")
+		return
+	end
+
+	unitStencilVBO = makeInstanceVBOTable(
+		{
+			{id = 0, name = 'unitModelMinXYZ', size = 4},
+			{id = 1, name = 'unitModelMaxXYZ', size = 4},
+			{id = 2, name = 'instData', size = 4, type = GL.UNSIGNED_INT},
+		},
+		64, -- maxelements
+		DPATname .. "VBO", -- name
+		2  -- unitIDattribID (instData)
+	)
+
+	unitStencilVBO.VAO  = gl.GetVAO()
+	unitStencilVBO.VAO:AttachVertexBuffer(unitStencilVBO.instanceVBO)
+
+    featureStencilVBO = makeInstanceVBOTable(
+		{
+			{id = 0, name = 'unitModelMinXYZ', size = 4},
+			{id = 1, name = 'unitModelMaxXYZ', size = 4},
+			{id = 2, name = 'instData', size = 4, type = GL.UNSIGNED_INT},
+		},
+		64, -- maxelements
+		"featurestencil VBO", -- name
+		2  -- unitIDattribID (instData)
+	)
+    
+	featureStencilVBO.VAO  = gl.GetVAO()
+	featureStencilVBO.VAO:AttachVertexBuffer(featureStencilVBO.instanceVBO)
+    featureStencilVBO.featureIDs = true
+
+	return DrawPrimitiveAtUnitShader
+end
+
+function widget:VisibleUnitAdded(unitID, unitDefID)
+    if unitDimensionsXYZ[unitDefID] == nil then
+        local unitDef = UnitDefs[unitDefID]
+        unitDimensionsXYZ[unitDefID] = {
+            unitDef.model.minx,  math.min(0, unitDef.model.miny), unitDef.model.minz,
+            unitDef.model.maxx,  unitDef.model.maxy, unitDef.model.maxz,
+        }
+        local dimsXYZ  = unitDimensionsXYZ[unitDefID]
+        --Spring.Echo(dimsXYZ[1], dimsXYZ[2], dimsXYZ[3], dimsXYZ[4], dimsXYZ[5], dimsXYZ[6])
+    end
+    local dimsXYZ  = unitDimensionsXYZ[unitDefID]
+	
+	pushElementInstance(
+		unitStencilVBO, -- push into this Instance VBO Table
+		{
+            dimsXYZ[1], dimsXYZ[2], dimsXYZ[3], 0, 
+            dimsXYZ[4], dimsXYZ[5], dimsXYZ[6], 0,
+			0, 0, 0, 0 -- these are just padding zeros, that will get filled in
+		},
+		unitID, -- this is the key inside the VBO TAble,
+		true, -- update existing element
+		nil, -- noupload, dont use unless you know what you are doing
+		unitID -- last one should be UNITID?
+	)
+end
+function widget:VisibleUnitsChanged(extVisibleUnits, extNumVisibleUnits)
+	clearInstanceTable(unitStencilVBO)
+	for unitID, unitDefID in pairs(extVisibleUnits) do
+		widget:VisibleUnitAdded(unitID, unitDefID)
+	end
+end
+
+function widget:VisibleUnitRemoved(unitID)
+	if unitStencilVBO.instanceIDtoIndex[unitID] then
+		popElementInstance(unitStencilVBO, unitID)
+	end
+end
+
+function widget:FeatureCreated(featureID, allyTeam)
+    local featureDefID = Spring.GetFeatureDefID(featureID)
+    --Spring.Echo(featureDefID, featureID)
+
+    if featureDimensionsXYZ[featureDefID] == nil then
+        local featureDef = FeatureDefs[featureDefID]
+        if featureDef.model then 
+            local dimsXYZ = {
+                featureDef.model.minx,  featureDef.model.miny, featureDef.model.minz,
+                featureDef.model.maxx,  featureDef.model.maxy, featureDef.model.maxz,
+            }
+            if (dimsXYZ[4] - dimsXYZ[1]) < 1 then return end -- goddamned geovents
+            featureDimensionsXYZ[featureDefID] =dimsXYZ
+            --Spring.Echo(dimsXYZ[1], dimsXYZ[2], dimsXYZ[3], dimsXYZ[4], dimsXYZ[5], dimsXYZ[6])
+        else
+            return
+        end
+    end
+    local dimsXYZ  = featureDimensionsXYZ[featureDefID]
+	if dimsXYZ == nil then return end
+	pushElementInstance(
+		featureStencilVBO, -- push into this Instance VBO Table
+		{
+            dimsXYZ[1], dimsXYZ[2], dimsXYZ[3], 0, 
+            dimsXYZ[4], dimsXYZ[5], dimsXYZ[6], 0,
+			0, 0, 0, 0 -- these are just padding zeros, that will get filled in
+		},
+		featureID, -- this is the key inside the VBO TAble,
+		true, -- update existing element
+		nil, -- noupload, dont use unless you know what you are doing
+		featureID -- last one should be UNITID?
+	)
+end
+
+function widget:FeatureDestroyed(featureID)
+	if featureStencilVBO.instanceIDtoIndex[featureID] then
+		popElementInstance(featureStencilVBO, featureID)
+	end
+end
+
+local function DrawMe() -- about 0.025 ms
+	if unitStencilVBO.usedElements > 0  or featureStencilVBO.usedElements > 0 then
+        gl.Clear(GL.COLOR_BUFFER_BIT,0,0,0,0)
+		gl.Blending(GL.ONE, GL.ZERO)
+        gl.Culling(false)
+		unitStencilShader:Activate()
+		unitStencilShader:SetUniform("addRadius", addRadius)
+        if featureStencilVBO.usedElements > 0 then
+            unitStencilShader:SetUniform("stencilColor", 0.5)
+            featureStencilVBO.VAO:DrawArrays(GL.POINTS, featureStencilVBO.usedElements)
+        end
+        if unitStencilVBO.usedElements > 0 then 
+            unitStencilShader:SetUniform("stencilColor", 1.0)
+	    	unitStencilVBO.VAO:DrawArrays(GL.POINTS, unitStencilVBO.usedElements)
+        end
+		unitStencilShader:Deactivate()
+		gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
+	end
+end
+
+function widget:DrawWorldPreUnit()
+    --DrawMe()
+end
+
+local stencilRequested = false
+
+function widget:DrawWorld()
+    if stencilRequested then 
+        gl.RenderToTexture(unitFeatureStencilTex, DrawMe)
+        stencilRequested = false
+    end
+end
+
+-- This shows the debug stencil texture
+--[[ 
+function widget:DrawScreen()
+    gl.Color(1,1,1,1)
+    gl.Blending(GL.ONE, GL.ZERO)
+    gl.Texture(unitFeatureStencilTex)
+	gl.TexRect(0, 0, vsx/resolution, vsy/resolution, 0, 0, 1, 1)
+end
+]]--
+
+local function GetUnitStencilTexture()
+    stencilRequested = true
+    return unitFeatureStencilTex
+end
+
+function widget:Initialize()
+	unitStencilShader = InitDrawPrimitiveAtUnit(shaderConfig, "unitStencils")
+    widget:ViewResize()
+
+    WG['unitstencilapi'] = {}
+    WG['unitstencilapi'].GetUnitStencilTexture = GetUnitStencilTexture
+    WG['unitstencilapi'].members = {ok = "yes", vsSrc = vsSrc, gsSrc = gsSrc, fsSrc = fsSrc, unitStencilVBO = unitStencilVBO, featureStencilVBO = featureStencilVBO}
+	widgetHandler:RegisterGlobal('GetUnitStencilTexture', WG['unitstencilapi'].GetUnitStencilTexture)
+
+	if WG['unittrackerapi'] and WG['unittrackerapi'].visibleUnits then
+		local visibleUnits =  WG['unittrackerapi'].visibleUnits
+		for unitID, unitDefID in pairs(visibleUnits) do
+			widget:VisibleUnitAdded(unitID, unitDefID)
+		end
+        for _, featureID in ipairs(Spring.GetAllFeatures()) do
+            widget:FeatureCreated(featureID)
+        end
+	end
+end
+
+function widget:Shutdown()
+	if unitFeatureStencilTex then gl.DeleteTexture(unitFeatureStencilTex) end
+	WG['unitstencilapi'] = nil
+	widgetHandler:DeregisterGlobal('GetUnitStencilTexture')
+end


### PR DESCRIPTION
## SSAO

Greatly reduced the VRAM usage
Architectural changes:

### Unit stencil texture
- All features and units model bounding boxes are rendered onto a downsized texture, that may be requested and reused by any subsequent pass.

### Gbuffer Fusion pass
- Removed merging of misc tex buffers, saving a fullscreen buffers worth of vram and some gpu load
- Removed merging of map and model normals, saving another fullscreen buffer, since these were also queried only once per fragment in ssao shader
- In the gbuffer fusion shader, map model occlusion is indicated by a positive z in viewpos tex
- The entire gbuffer fusion shader can be turned off, directly sampling the map and model depth buffers, this is most useful when rendering ssao to a downsampled target
### SSAO
The ssao shader samples multiple neighbouring texels when downsampling, to reduce shimmer in the downsampled target.
Random hemispherical samples are now generated across a fibonacci sphere for even surface distribution
Outputs are now:
- RG channel is viewpos xy normals, which is output as zero vector for ground fragments
- B channel is relative depth of fragment
- A is occlusion
### Blur
- Blur shader is now designed to work in a single pair of horizontal and vertical passes, and the dir uniform controls wether it - - should perform its final mixdown
- Blur shader has correct offsets and weights
- Compares the neighbouring normals and depths when blurring
- Identifies samples that are outliers with no similar neighbours 
- Blur shader reuses the SSAO texture in its second pass, saving more vram
- During final mixdown, occlusion is packed into alpha, and brightening (inverse occlusion) is passed into rgb

### Compositing
- A different gl blending operation is used, where the ssao alpha darkens the original image, and the ssao color brightens the original.

## Bloom
- Less VRAM usage
- Fixed shimmering on low qualities
- Uses Pixel Quad Message passing to massively reduce the number of passes and texture samples required
- Wider kernels, smoother looks
- Better performance

## CAS
- Uses Pixel Quad Message passing to massively reduce the number of texture samples

## Unit Stencil API
- For early bailing a lot of near-unit shading stuff. Useable on demand. 

Thaks to @rlcevg for every bit of help. Thanks to @icexuick for tuning SSAO. 

## Screenshots
I did not make screenshots of old bloom or old SSAO. Make them if you want to compare them.

### NO BLOOM NO SSAO:
![screen_2024-08-08_18-44-35-979](https://github.com/user-attachments/assets/72f581f1-9571-4e93-a9f1-77228c874cc5)

### SSAO only:
![screen_2024-08-08_18-43-39-215](https://github.com/user-attachments/assets/605ba0dc-6ff6-48ca-8d07-0ac609da32f2)

### Bloom only:
![screen_2024-08-08_18-43-08-197](https://github.com/user-attachments/assets/4cb66cf3-5c0d-435c-90a9-75de5d6c9fd2)

### SSAO + BLOOM:
![screen_2024-08-08_18-43-23-114](https://github.com/user-attachments/assets/5b302330-683b-4a43-a078-bfcff26a529f)

