### PR TITLE
Gridmenu: fix alt queue

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2442,21 +2442,21 @@ function widget:UnitCommand(unitID, _, _, cmdID, _, cmdParams)
 end
 
 -- update queue number
--- UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)
-function widget:UnitFromFactory(_, unitDefID, _, factoryID)
+-- UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, options, cmdTag)
+function widget:UnitCmdDone(unitID, _, _, cmdID, _, options)
 	-- if factory is not current active builder return
-	if factoryID ~= activeBuilderID then
+	if unitID ~= activeBuilderID then
 		return
 	end
 
-	-- If factory is in repeat, queue does not change
-	local factoryRepeat = select(4, Spring.GetUnitStates(factoryID, false, true))
+	-- If factory is in repeat, queue does not change, except if it is alt-queued
+	local factoryRepeat = select(4, Spring.GetUnitStates(unitID, false, true))
 
-	if factoryRepeat then
+	if factoryRepeat and not options.alt then
 		return
 	end
 
-	updateQueueNr(unitDefID, -1)
+	updateQueueNr(-cmdID, -1)
 end
 
 -- PERF: Fix convoluted setActiveBuilder and multiple calls to getselectedsorted


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Grid menu used `widget:UnitFromFactory()` to reduce the units queued number by 1. This wouldn't happen when the factory was on repeat, even if the unit was queued with alt. This is changed to `widget:UnitCmdDone()` so that the widget can see the command options to see if a unit was queued with alt, to reduce the factory count by 1.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- Have a factory on repeat, queue a unit with alt, wait until it finishes. 
    - In this version, the queue number goes down by 1.
    - In the old version, the queue number stayed the same until the factory is reselected.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
