### PR TITLE
cus_gl4: check unit validity before asking about the unit

### DIFF
--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -1543,7 +1543,7 @@ local function ProcessUnits(units, drawFlags, reason)
 		else
 			--Spring.Echo("ProcessUnit", unitID, drawFlag)
 			if overriddenUnits[unitID] == nil then --object was not seen
-				if (not spGetUnitIsCloaked(unitID)) and Spring.ValidUnitID(unitID) then
+				if Spring.ValidUnitID(unitID) and (not spGetUnitIsCloaked(unitID)) then
 					uniformcache[1] = 0
 					gl.SetUnitBufferUniforms(unitID, uniformcache, 12) -- cloak
 				end


### PR DESCRIPTION
No use checking validity after already having passed potentially invalid data to a function that could blow up on invalid data.

AFAIK the current implementation of `Spring.GetUnitIsCloaked` shouldn't blow up but maybe it's good to avoid spreading bad patterns regardless.