### PR TITLE
feat(blueprint): filter out unbuildable blueprints

### DIFF
--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -724,6 +724,21 @@ local function setActiveBuilders(unitIDs)
 	)
 end
 
+local function getBuildableUnits(blueprint)
+	local buildable = 0
+	local unbuildable = 0
+
+	for _, unit in ipairs(blueprint.units) do
+		if activeBuilderBuildOptions[unit.unitDefID] then
+			buildable = buildable + 1
+		else
+			unbuildable = unbuildable + 1
+		end
+	end
+
+	return buildable, unbuildable
+end
+
 function widget:Initialize()
 	if not gl.CreateShader then
 		-- no shader support, so just remove the widget itself, especially for headless
@@ -747,6 +762,7 @@ function widget:Initialize()
 		getBuildingDimensions = getBuildingDimensions,
 		getBlueprintDimensions = getBlueprintDimensions,
 		getUnitsBounds = getUnitsBounds,
+		getBuildableUnits = getBuildableUnits,
 		snapBlueprint = snapBlueprint,
 		BUILD_MODES = BUILD_MODES,
 		SQUARE_SIZE = SQUARE_SIZE,

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -206,6 +206,8 @@ local selectedBlueprintIndex = nil
 
 local blueprintPlacementActive = false
 
+local lastExplicitlySelectedBlueprintIndex = nil
+
 local state = {
 	---@type Point|nil
 	---non-nil implies that we are dragging
@@ -267,6 +269,30 @@ local function setSelectedBlueprintIndex(index)
 	if blueprintPlacementActive and index ~= nil and index > 0 then
 		Spring.Echo("[Blueprint] selected blueprint #" .. selectedBlueprintIndex)
 	end
+end
+
+local function getNextFilteredBlueprintIndex(startIndex)
+	local newIndex = startIndex or selectedBlueprintIndex
+	for _ = 1, #blueprints do
+		newIndex = nextIndex(newIndex, #blueprints)
+		local buildable = WG["api_blueprint"].getBuildableUnits(blueprints[newIndex])
+		if buildable > 0 then
+			break
+		end
+	end
+	return newIndex
+end
+
+local function getPrevFilteredBlueprintIndex(startIndex)
+	local newIndex = startIndex or selectedBlueprintIndex
+	for _ = 1, #blueprints do
+		newIndex = prevIndex(newIndex, #blueprints)
+		local buildable = WG["api_blueprint"].getBuildableUnits(blueprints[newIndex])
+		if buildable > 0 then
+			break
+		end
+	end
+	return newIndex
 end
 
 local function getMouseWorldPosition(blueprint, x, y)
@@ -467,6 +493,22 @@ local function setBlueprintPlacementActive(active)
 
 	if active then
 		widget:SelectionChanged(Spring.GetSelectedUnits())
+
+		local selectedBlueprint = getSelectedBlueprint()
+		if selectedBlueprint then
+			local buildable = WG["api_blueprint"].getBuildableUnits(selectedBlueprint)
+			if buildable == 0 then
+				local startIndex = nil
+				if lastExplicitlySelectedBlueprintIndex ~= nil then
+					-- this prevents cycling through all blueprints if you
+					-- select different faction constructors repeatedly
+					startIndex = lastExplicitlySelectedBlueprintIndex - 1
+				end
+				setSelectedBlueprintIndex(
+					getNextFilteredBlueprintIndex(startIndex)
+				)
+			end
+		end
 
 		Spring.PlaySoundFile(sounds.activateBlueprint, 0.75, "ui")
 	else
@@ -750,7 +792,8 @@ local function handleBlueprintNextAction()
 		return
 	end
 
-	setSelectedBlueprintIndex(nextIndex(selectedBlueprintIndex, #blueprints))
+	setSelectedBlueprintIndex(getNextFilteredBlueprintIndex())
+	lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 
 	Spring.PlaySoundFile(sounds.selectBlueprint, 0.75, "ui")
 
@@ -767,7 +810,8 @@ local function handleBlueprintPrevAction()
 		return
 	end
 
-	setSelectedBlueprintIndex(prevIndex(selectedBlueprintIndex, #blueprints))
+	setSelectedBlueprintIndex(getPrevFilteredBlueprintIndex())
+	lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 
 	Spring.PlaySoundFile(sounds.selectBlueprint, 0.75, "ui")
 


### PR DESCRIPTION
This change modifies the behavior when activating blueprint placement, and when executing the `blueprint_next` and `blueprint_prev` actions. If the current blueprint is not buildable by the currently selected units, it attempts to find the next one that is. If none are found, it functions as before this change.

This is another approach to the issue addressed by https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3524 . It's possible to use one or both of these.