### PR TITLE
Update legacy 60% / gridkeys 60% properly to selectcomm

### DIFF
--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -122,7 +122,8 @@ bind          meta+sc_q  drawinmap
 
 bind          Ctrl+sc_e  select AllMap++_ClearSelection_SelectAll+
 bind           Ctrl+tab  select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
-bind                tab  selectcomm
+bind          Shift+tab  selectcomm append
+bind                tab  selectcomm focus
 bind               sc_q  select Visible+_InPrevSel+_ClearSelection_SelectAll+
 bind          Ctrl+sc_q  select PrevSelection++_ClearSelection_SelectPart_50+
 bind          Ctrl+sc_w  select AllMap+_InPrevSel+_ClearSelection_SelectAll+

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -107,7 +107,6 @@ bind Alt+enter fullscreen
 
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
-bind Shift+Ctrl+sc_c selectcomm append
 bind Ctrl+sc_c  selectcomm focus
 bind Ctrl+sc_v select AllMap+_Not_Builder_Not_Commander_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_w select AllMap+_Not_Aircraft_Weapons+_ClearSelection_SelectAll+

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -107,7 +107,8 @@ bind Alt+enter fullscreen
 
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
-bind Ctrl+sc_c selectcomm
+bind Shift+tab  selectcomm append
+bind tab  selectcomm focus
 bind Ctrl+sc_v select AllMap+_Not_Builder_Not_Commander_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_w select AllMap+_Not_Aircraft_Weapons+_ClearSelection_SelectAll+
 bind Ctrl+sc_x select AllMap+_InPrevSel_Not_InHotkeyGroup+_SelectAll+

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -107,7 +107,7 @@ bind Alt+enter fullscreen
 
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
-bind Ctrl+sc_c  selectcomm focus
+bind Ctrl+sc_c selectcomm focus
 bind Ctrl+sc_v select AllMap+_Not_Builder_Not_Commander_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_w select AllMap+_Not_Aircraft_Weapons+_ClearSelection_SelectAll+
 bind Ctrl+sc_x select AllMap+_InPrevSel_Not_InHotkeyGroup+_SelectAll+

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -107,8 +107,8 @@ bind Alt+enter fullscreen
 
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
-bind Shift+tab  selectcomm append
-bind tab  selectcomm focus
+bind Shift+Ctrl+sc_c selectcomm append
+bind Ctrl+sc_c  selectcomm focus
 bind Ctrl+sc_v select AllMap+_Not_Builder_Not_Commander_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_w select AllMap+_Not_Aircraft_Weapons+_ClearSelection_SelectAll+
 bind Ctrl+sc_x select AllMap+_InPrevSel_Not_InHotkeyGroup+_SelectAll+


### PR DESCRIPTION
The old janky comm selection bind was recently changed with the addition of the selectcomm keybind action. The 60% keybinds seems to not have been updated properly after an update to selectcomm. 

#### Addresses Issue(s)
Tab / ctrl-c not focusing on comm after selection on 60% keybinds. That's how it used to work before selectcomm update afaik, and also how it works in grid / legacy 100% binds now.

In addition, gridkeys 60% can append comm to current selection with shift-tab, like on gridkeys 100%. That bind is not in Legacy keys 100%, so I didn't add it to the 60% version.