### PR TITLE
Remove Commando detected notification

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -138,7 +138,6 @@ local unitsOfInterestNames = {
 	armbanth = 'TitanDetected',
 	armepoch = 'FlagshipDetected',
 	corblackhy = 'FlagshipDetected',
-	cormando = 'CommandoDetected',
 	armthovr = 'TransportDetected',
 	corthovr = 'TransportDetected',
 	corintr = 'TransportDetected',


### PR DESCRIPTION
Commando notification was previously removed after GDT approval but somehow snuck back in.