### PR TITLE
Part2 reclaim highlight fields

### DIFF
--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -516,8 +516,8 @@ do
 			local point = knownFeatures[fid]
 			local members = { point }
 			local cluster = { members = members }
-			featureClusters[clusterID] = cluster
 			clusterID = clusterID + 1
+			featureClusters[clusterID] = cluster
 
 			-- Process visited points, like so.
 			point.cid = clusterID

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -242,7 +242,7 @@ do
 		local middle = floor(#points * 0.5)
 		local x, z = points[1].x, points[1].z
 		x, z = x + points[middle].x, z + points[middle].z 
-		x, z = x + points[#points].x, z + points[floor(#points * 0.5)].z
+		x, z = x + points[#points].x, z + points[#points].z
 		x, z = x / 3, z / 3
 
 		-- (1) Cover all points by expanding a quadrilateral to follow these rules:

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -44,7 +44,7 @@ local reclaimColor = {0, 0, 0, 0.16}
 local reclaimEdgeColor = {1, 1, 1, 0.18}
 
 --Update rate, in seconds
-local checkFrequency = 1/3
+local checkFrequency = 1/2
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -474,7 +474,7 @@ do
 			reachDistSq = (reachDistSq ~= nil and reachDistSq <= epsilonSq and reachDistSq) or nil
 			feature.rd = reachDistSq
 		end
-		convexHullTable = {}
+		featureConvexHulls = {}
 	end
 
 	---Distance from a point to its nearest neighbor.
@@ -699,9 +699,10 @@ end
 
 local drawFeatureClusterTextList
 local function DrawFeatureClusterText()
-	for clusterID = 1, #featureClusters do
+	for clusterID = 1, #featureConvexHulls do
 		glPushMatrix()
 
+		local area = featureConvexHulls[clusterID].area
 		local center = featureConvexHulls[clusterID].center
 
 		glTranslate(center.x, center.y, center.z)
@@ -714,7 +715,6 @@ local function DrawFeatureClusterText()
 		end
 
 		local fontSize = fontSizeMin * fontScaling
-		local area = featureConvexHulls[clusterID].area
 		fontSize = sqrt(area) * fontSize / minTextAreaLength
 		fontSize = min(fontSize, fontSizeMax)
 		fontSize = max(fontSize, fontSizeMin)

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -95,10 +95,10 @@ local redrawingNeeded = false
 
 local epsilon = 300
 local epsilonSq = epsilon^2
-local minFeatureMetal = 9 -- armflea reclaim value
+local minFeatureMetal = 9 -- armflea reclaim value, probably
 if UnitDefNames.armflea then
-	local tragic = FeatureDefNames[UnitDefNames.armflea.corpse]
-	minFeatureMetal = max(minFeatureMetal, tragic.metal or 0)
+	local small = FeatureDefNames[UnitDefNames.armflea.corpse]
+	minFeatureMetal = small and small.metal or minFeatureMetal
 end
 local minTextAreaLength = 100
 checkFrequency = math.round(checkFrequency * Game.gameSpeed)

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -1,4 +1,3 @@
-
 function widget:GetInfo()
 	return {
 		name      = "Reclaim Field Highlight",
@@ -14,7 +13,6 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Options
-
 
 --[[----------------------------------------------------------------------------
 	When to show reclaim highlight?
@@ -45,324 +43,22 @@ local fontScaling = 0.45
 local reclaimColor = {0, 0, 0, 0.16}
 local reclaimEdgeColor = {1, 1, 1, 0.18}
 
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
--- Priority Queue
-
-local abs = math.abs
-local min = math.min
-local max = math.max
-local mathHuge = math.huge
-local sqrt = math.sqrt
-
-local insert = table.insert
-local remove = table.remove
-
-local PriorityQueue = {}
-
-function PriorityQueue.new(cmp, initial)
-	local pq = setmetatable({}, {
-		__index = {
-			cmp = cmp or function(a,b) return a < b end,
-			push = function(self, v)
-				insert(self, v)
-				local next = #self
-				local prev = (next-next%2)/2
-				while next > 1 and cmp(self[next], self[prev]) do
-					self[next], self[prev] = self[prev], self[next]
-					next = prev
-					prev = (next-next%2)/2
-				end
-			end,
-			pop = function(self)
-				if #self < 2 then
-					return remove(self)
-				end
-				local root = 1
-				local r = self[root]
-				self[root] = remove(self)
-				local size = #self
-				if size > 1 then
-					local child = 2*root
-					while child <= size do
-						local aBool =   cmp(self[root],self[child]);
-						local bBool =   true;
-						local cBool =   true;
-						if child+1 <= size then
-							bBool =   cmp( self[root],self[child+1]);
-							cBool =   cmp(self[child], self[child+1]);
-						end
-						if aBool and bBool then
-							break;
-						elseif cBool then
-							self[root], self[child] = self[child], self[root]
-							root = child
-						else
-							self[root], self[child+1] = self[child+1], self[root]
-							root = child+1
-						end
-						child = 2*root
-					end
-				end
-				return r
-			end,
-			peek = function(self)
-				return self[1]
-			end,
-		}
-	})
-
-	for _,el in ipairs(initial or {}) do
-		pq:push(el)
-	end
-
-	return pq
-end
-
-
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
--- Optics
-
-local function DistSq(p1, p2)
-	return (p1.x - p2.x)^2 + (p1.z - p2.z)^2
-end
-
-local Optics = {}
-function Optics.new(incPoints, incNeighborMatrix, incMinPoints)
-	local object = setmetatable({}, {
-		__index = {
-			points = incPoints or {},
-			neighborMatrix  = incNeighborMatrix or {},
-			minPoints = incMinPoints,
-
-			pointByfID = {},
-
-			unprocessed = {},
-			ordered = {},
-
-			-- Get ready for a clustering run
-			_Setup = function(self)
-				local points, unprocessed = self.points, self.unprocessed
-
-				for pIdx, point in pairs(points) do
-					point.rd = nil
-					point.cd = nil
-					point.processed = nil
-					unprocessed[point] = true
-					self.pointByfID[point.fID] = point
-				end
-			end,
-
-			-- Distance from a point to its nth neighbor (n = minPoints - 1)
-			_CoreDistance = function(self, point, neighbors)
-				if point.cd then
-					return point.cd
-				end
-
-				if #neighbors >= self.minPoints - 1 then --(minPoints - 1) because point is also part of minPoints
-					local distTable = {}
-					for i = 1, #neighbors do
-						local neighbor = neighbors[i]
-						distTable[#distTable + 1] = DistSq(point, neighbor)
-					end
-					table.sort(distTable)
-
-					point.cd = distTable[self.minPoints - 1] --return (minPoints - 1) farthest distance as CoreDistance
-					return point.cd
-				end
-				return nil
-			end,
-
-			-- Neighbors for a point within eps
-			_Neighbors = function(self, pIdx)
-				local neighbors = {}
-
-				for pIdx2, _ in pairs(self.neighborMatrix[pIdx]) do
-					neighbors[#neighbors + 1] = self.pointByfID[pIdx2]
-				end
-
-				return neighbors
-			end,
-
-			-- Mark a point as processed
-			_Processed = function(self, point)
-				point.processed = true
-				self.unprocessed[point] = nil
-
-				local ordered = self.ordered
-				ordered[#ordered + 1] = point
-			end,
-
-			-- Update seeds if a smaller reachability distance is found
-			_Update = function(self, neighbors, point, seedsPQ)
-				for ni = 1, #neighbors do
-					local n = neighbors[ni]
-					if not n.processed then
-						--Spring.Echo("newRD")
-						local newRd = max(point.cd, DistSq(point, n))
-						if n.rd == nil then
-							n.rd = newRd
-							--this is a bug!!!!
-							seedsPQ:push({newRd, n})
-						elseif newRd < n.rd then
-							--this is a bug!!!!
-							n.rd = newRd
-						end
-					end
-				end
-				--return seedsPQ
-			end,
-
-			-- run the OPTICS algorithm
-			Run = function(self)
-				self:_Setup()
-
-				local unprocessed = self.unprocessed
-				while next(unprocessed) do
-					local point = next(unprocessed)
-
-					-- mark p as processed
-					self:_Processed(point)
-
-					-- find p's neighbors
-					local neighbors = self:_Neighbors(point.fID)
-
-					-- if p has a core_distance, i.e has min_cluster_size - 1 neighbors
-					if self:_CoreDistance(point, neighbors) then
-						--Spring.Echo("if self:_CoreDistance(point, neighbors) then")
-						local seedsPQ = PriorityQueue.new( function(a,b) return a[1] < b[1] end )
-						--seedsPQ = self:_Update(neighbors, point, seedsPQ)
-						self:_Update(neighbors, point, seedsPQ)
-						while seedsPQ:peek() do
-							-- seeds.sort(key=lambda n: n.rd)
-							local n = seedsPQ:pop()[2] --because we don't need priority
-
-							-- mark n as processed
-							self:_Processed(n)
-
-							-- find n's neighbors
-							local nNeighbors = self:_Neighbors(n.fID)
-
-							-- if p has a core_distance...
-							if self:_CoreDistance(n, nNeighbors) then
-								--seedsPQ = self:_Update(nNeighbors, n, seedsPQ)
-								self:_Update(nNeighbors, n, seedsPQ)
-							end
-						end
-					end
-				end
-
-				-- when all points have been processed
-				-- return the ordered list
-				--Spring.Echo("#ordered", #self.ordered)
-				return self.ordered
-			end,
-
-			-- ???
-			Clusterize = function(self, clusterThreshold)
-				local clusters = {}
-				local separators = {}
-
-				local clusterThresholdSq = clusterThreshold^2
-
-				local ordered = self.ordered
-
-				for i = 1, #ordered do
-					local thisP = ordered[i]
-					local thisRD = thisP.rd or mathHuge
-
-					-- use an upper limit to separate the clusters
-
-					if thisRD > clusterThresholdSq then
-						separators[#separators + 1] = i
-					end
-				end
-				separators[#separators + 1] = #ordered + 1
-
-				for j = 1, #separators - 1 do
-					local sepStart = separators[j]
-					local sepEnd = separators[j + 1]
-					--print(sepEnd, sepStart, sepEnd - sepStart, self.minPoints)
-					if sepEnd - sepStart >= self.minPoints then
-						local clPoints = {}
-						for si = sepStart, sepEnd - 1 do
-							clPoints[#clPoints + 1] = ordered[si].fID
-						end
-
-						clusters[#clusters + 1] = {}
-						clusters[#clusters].members = clPoints
-					end
-				end
-				return clusters
-			end,
-		}
-	})
-	return object
-end
-
-
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
--- Convex Hull
-
-local function cross(p, q, r)
-	return (q.z - p.z) * (r.x - q.x)
-		 - (q.x - p.x) * (r.z - q.z)
-end
-
---- JARVIS MARCH
-
---- MONOTONE CHAIN
--- https://gist.githubusercontent.com/sixFingers/ee5c1dce72206edc5a42b3246a52ce2e/raw/b2d51e5236668e5408d24b982eec9c339dc94065/Lua%2520Convex%2520Hull
-
--- Andrew's monotone chain convex hull algorithm
--- https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
--- Direct port from Javascript version
-
-local MonotoneChain
-do
-	local function sortMonotonic(a, b)
-		return (a.x > b.x) or (a.x == b.x and a.z > b.z)
-	end
-
-	MonotoneChain = function (points)
-		local numPoints = #points
-		if numPoints < 3 then return end
-	
-		table.sort(points, sortMonotonic)
-
-		local lower = {}
-		for i = 1, numPoints do
-			while (#lower >= 2 and cross(lower[#lower - 1], lower[#lower], points[i]) <= 0) do
-				table.remove(lower)
-			end
-	
-			table.insert(lower, points[i])
-		end
-	
-		local upper = {}
-		for i = numPoints, 1, -1 do
-			while (#upper >= 2 and cross(upper[#upper - 1], upper[#upper], points[i]) <= 0) do
-				table.remove(upper)
-			end
-	
-			table.insert(upper, points[i])
-		end
-	
-		table.remove(upper)
-		table.remove(lower)
-		for _, point in ipairs(lower) do
-			table.insert(upper, point)
-		end
-		return upper
-	end
-end
-
+--Update rate, in seconds
+local checkFrequency = 1/3
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Speedups
+
+local insert = table.insert
+local remove = table.remove
+
+local abs = math.abs
+local floor = math.floor
+local min = math.min
+local max = math.max
+local sqrt = math.sqrt
+local mathHuge = math.huge
 
 local glBeginEnd = gl.BeginEnd
 local glBlending = gl.Blending
@@ -379,18 +75,12 @@ local glRotate = gl.Rotate
 local glText = gl.Text
 local glTranslate = gl.Translate
 local glVertex = gl.Vertex
-local spGetAllFeatures = Spring.GetAllFeatures
+
 local spGetCameraPosition = Spring.GetCameraPosition
-local spGetFeatureHeight = Spring.GetFeatureHeight
 local spGetFeaturePosition = Spring.GetFeaturePosition
 local spGetFeatureResources = Spring.GetFeatureResources
-local spGetFeatureTeam = Spring.GetFeatureTeam
-local spGetGaiaTeamID = Spring.GetGaiaTeamID
-local spGetGameFrame = Spring.GetGameFrame
-local spGetGroundHeight = Spring.GetGroundHeight
 local spIsGUIHidden = Spring.IsGUIHidden
 local spTraceScreenRay = Spring.TraceScreenRay
-local spValidFeatureID = Spring.ValidFeatureID
 local spGetActiveCommand = Spring.GetActiveCommand
 local spGetActiveCmdDesc = Spring.GetActiveCmdDesc
 local spGetMapDrawMode = Spring.GetMapDrawMode
@@ -402,23 +92,21 @@ local spGetCameraVectors = Spring.GetCameraVectors
 -- Data
 
 local screenx, screeny
-local gaiaTeamId = spGetGaiaTeamID()
-local clusterizingNeeded = false -- Used to check if clusterizing neds to be run, set by FeatureCreated/Removed
+local clusterizingNeeded = false
 local redrawingNeeded = false
 
-local minDistance = 300
-local minSqDistance = minDistance^2
-local minPoints = 2
-local minFeatureMetal = 9 -- Tick
-local E2M = 1 / 70 -- Converter ratio
-local minDim = 100
+local epsilon = 300
+local epsilonSq = epsilon^2
+local minFeatureMetal = 9 -- armflea reclaim value
+if UnitDefNames.armflea then
+	local tragic = FeatureDefNames[UnitDefNames.armflea.corpse]
+	minFeatureMetal = max(minFeatureMetal, tragic.metal or 0)
+end
+local minTextAreaLength = 100
+checkFrequency = math.round(checkFrequency * Game.gameSpeed)
 
-local checkFrequency = 1 * Game.gameSpeed
-
-local drawEnabled = true
+local drawEnabled = false
 local actionActive = false
-local knownFeatures = {}
-
 local reclaimerSelected = false
 local resBotSelected = false
 
@@ -433,6 +121,384 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
+-- Information tables
+local knownFeatures
+local featureClusters
+local featureConvexHulls
+local featureNeighborsMatrix
+local opticsObject
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Priority Queue
+
+local PriorityQueue = {}
+do
+	-- local function less(a, b) return a[1] < b[1] end
+
+	local function push(self, pair)
+		insert(self, pair)
+		local n = #self
+		local p = floor(n * 0.5)
+		while n > 1 and self[n][1] < self[p][1] do
+			self[n], self[p] = self[p], self[n]
+			n = p
+			p = floor(n * 0.5)
+		end
+	end
+
+	local function pop(self)
+		local el = remove(self, 1)
+		if #self > 1 then
+			local root = 1
+			local size = #self
+			local aBool, bBool, cBool
+			if size > 1 then
+				local child = 2*root
+				while child <= size do
+					aBool = self[root][1] < self[child][1]
+					if child+1 <= size then
+						bBool =  self[root][1] < self[child+1][1]
+						cBool = self[child][1] < self[child+1][1]
+					else
+						bBool = true
+						cBool = true
+					end
+					if aBool == true and bBool == true then
+						break;
+					elseif cBool == true then
+						self[root], self[child] = self[child], self[root]
+						root = child
+					else
+						self[root], self[child+1] = self[child+1], self[root]
+						root = child+1
+					end
+					child = 2*root
+				end
+			end
+		end
+		return el
+	end
+
+	local function peek(self)
+		return self[1]
+	end
+
+	function PriorityQueue.new()
+		local pq = setmetatable({}, {
+			__index = {
+				push   = push,
+				pop    = pop,
+				peek   = peek,
+			},
+		})
+		return pq
+	end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Cluster post-processing
+-- Convex hull outlines and text areas
+
+local function GetClusterStats(cluster, members)
+	local metal = 0
+	for j = 1, #members do
+		local feature = members[j]
+		metal = metal + feature.metal
+	end
+	cluster.metal = metal
+end
+
+local GetConvexHull
+do
+	--- MONOTONE CHAIN
+	-- https://gist.githubusercontent.com/sixFingers/ee5c1dce72206edc5a42b3246a52ce2e/raw/b2d51e5236668e5408d24b982eec9c339dc94065/Lua%2520Convex%2520Hull
+
+	-- Andrew's monotone chain convex hull algorithm
+	-- https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+	-- Direct port from Javascript version
+
+	local MonotoneChain
+	do
+		local function sortMonotonic(a, b)
+			return (a.x > b.x) or (a.x == b.x and a.z > b.z)
+		end
+
+		local function cross(p, q, r)
+			return (q.z - p.z) * (r.x - q.x) -
+				(q.x - p.x) * (r.z - q.z)
+		end
+
+		MonotoneChain = function (points)
+			local numPoints = #points
+			if numPoints < 3 then return end
+			table.sort(points, sortMonotonic)
+
+			local lower = {}
+			for i = 1, numPoints do
+				local point = points[i]
+				while (#lower >= 2 and cross(lower[#lower - 1], lower[#lower], point) <= 0) do
+					remove(lower)
+				end
+				insert(lower, point)
+			end
+
+			local upper = {}
+			for i = numPoints, 1, -1 do
+				local point = points[i]
+				while (#upper >= 2 and cross(upper[#upper - 1], upper[#upper], point) <= 0) do
+					remove(upper)
+				end
+				insert(upper, point)
+			end
+
+			remove(upper)
+			remove(lower)
+			for i = 1, #lower do
+				insert(upper, lower[i])
+			end
+			return upper
+		end
+	end
+
+	local function pointArea(points)
+		local totalArea = 0
+		-- Determinant area, triangle form
+		local x1, z1 = points[1].x, points[1].z
+		local x2, z2
+		local x3, z3 = points[2].x, points[2].z
+		for i = 2, #points - 1 do
+			x2 = x3
+			z2 = z3
+			x3 = points[i + 1].x
+			z3 = points[i + 1].z
+			totalArea = totalArea + 0.5 * abs(x1 * (z2 - z3) + x2 * (z3 - z1) + x3 * (z1 - z2))
+		end
+		return totalArea
+	end
+
+	GetConvexHull = function (cluster, clusterID, candidatePoints)
+		-- Not a wasteful copy since we need to remove elements from the table.
+		-- That will be added as part of the pruning step, which is -- TODO
+		local clusterPoints = table.copy(candidatePoints)
+
+		-- TODO perform pruning as described in the article below, if convex hull algo will start to choke out
+		-- http://mindthenerd.blogspot.ru/2012/05/fastest-convex-hull-algorithm-ever.html
+
+		local convexHull
+
+		local hullArea = (#clusterPoints >= 3 and pointArea(clusterPoints)) or 0
+		if hullArea >= 3000 then
+			convexHull = MonotoneChain(clusterPoints)
+		else
+			local xmin, xmax, zmin, zmax = mathHuge, -mathHuge, mathHuge, -mathHuge
+			for j = 1, #clusterPoints do
+				local feature = clusterPoints[j]
+				local x = feature.x
+				local z = feature.z
+				xmin = min(xmin, x)
+				xmax = max(xmax, x)
+				zmin = min(zmin, z)
+				zmax = max(zmax, z)
+			end
+
+			local dx, dz = xmax - xmin, zmax - zmin
+
+			if dx < minTextAreaLength then
+				xmin = xmin - (minTextAreaLength - dx) / 2
+				xmax = xmax + (minTextAreaLength - dx) / 2
+				dx = dx + minTextAreaLength
+			end
+
+			if dz < minTextAreaLength then
+				zmin = zmin - (minTextAreaLength - dz) / 2
+				zmax = zmax + (minTextAreaLength - dz) / 2
+				dz = dz + minTextAreaLength
+			end
+
+			hullArea = dx * dz
+
+			local ymax = clusterPoints[1].y
+			if #clusterPoints == 2 then
+				ymax = max(ymax, clusterPoints[2].y)
+			end
+
+			convexHull = {
+				{x = xmin, y = ymax, z = zmin},
+				{x = xmax, y = ymax, z = zmin},
+				{x = xmax, y = ymax, z = zmax},
+				{x = xmin, y = ymax, z = zmax},
+			}
+		end
+
+		local cx, cz, cy = 0, 0, 0
+		for i = 1, #convexHull do
+			local convexHullPoint = convexHull[i]
+			cx = cx + convexHullPoint.x
+			cz = cz + convexHullPoint.z
+			cy = max(cy, convexHullPoint.y)
+		end
+
+		convexHull.area = hullArea
+		convexHull.center = { x = cx/#convexHull, z = cz/#convexHull, y = cy + 1 }
+
+		featureConvexHulls[clusterID] = convexHull
+	end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- OPTICS clustering
+-- Note @efrec I'm ngl to you this wasn't OPTICS before and very much is not now.
+-- This should have been a total rewrite to reduce confusion over shared details.
+
+local Optics = {}
+do
+	local unprocessed -- Intermediate table for processing points
+
+	---Get ready for a clustering run
+	local function Setup()
+		-- Fully reset cluster processing.
+		unprocessed = {}
+		for fid, feature in pairs(knownFeatures) do
+			unprocessed[fid] = true
+			local reachDistSq = feature.rd
+			reachDistSq = (reachDistSq ~= nil and reachDistSq <= epsilonSq and reachDistSq) or nil
+			feature.rd = reachDistSq
+		end
+		convexHullTable = {}
+	end
+
+	---Distance from a point to its nearest neighbor.
+	local function Reachability(point, neighbors)
+		if point.rd ~= nil and point.rd < epsilonSq then
+			return point.rd
+		end
+		-- This function was changed from its generic implementation because
+		-- the special case where minPoints == 2 has a much faster evaluation.
+		-- Note also that we have to guarantee the epsilon neighbors matrix.
+		local reachDistSq = mathHuge
+		for fid, distSq in pairs(neighbors) do
+			if unprocessed[fid] == nil and distSq < reachDistSq then -- ? not sure about unproc here
+				reachDistSq = distSq
+			end
+		end
+		-- Fine to double-check epsilon here since we remove mathHuge anyway.
+		if reachDistSq <= epsilonSq then
+			point.rd = reachDistSq
+			return reachDistSq
+		end
+	end
+
+	---Update seeds if a smaller reachability distance is found.
+	local function Update(neighbors, point, seedsPQ)
+		-- We maintain the epsilon neighborhoods during callins, now.
+		-- local M_point = featureNeighborsMatrix[point.fid]
+		for fid, distSq in pairs(neighbors) do
+			-- Bugged: Something is causing points to re-process.
+			if unprocessed[fid] == true then
+				unprocessed[fid] = nil -- Bugged: So I'm doing this.
+				local np = knownFeatures[fid]
+				seedsPQ:push({ np.rd, np })
+			end
+		end
+	end
+
+	---Run the OPTICS sequencing step (now identical to a single-link chain algo).
+	---This is combined with the previous Clusterize fn step to produce clusters.
+	---It also leaves no point un-clusterized; solo points form their own cluster.
+	---This has allowed all processing to occur in one place and in a single pass.
+	local function Run()
+		Setup()
+
+		featureClusters = {}
+		local clusterID = 0
+
+		local fid = next(unprocessed)
+		while fid ~= nil do
+			-- Start a new cluster.
+			local point = knownFeatures[fid]
+			local members = { point }
+			local cluster = { members = members }
+			featureClusters[#featureClusters+1] = cluster
+			clusterID = clusterID + 1
+
+			-- Process visited points, like so.
+			point.cid = clusterID
+			unprocessed[fid] = nil
+
+			-- Process immediate neighbors.
+			local neighbors = featureNeighborsMatrix[fid]
+			if neighbors ~= nil and Reachability(point, neighbors) ~= nil then
+				local seedsPQ = PriorityQueue.new()
+				Update(neighbors, point, seedsPQ)
+
+				-- Continue to spread through neighbors
+				-- by moving to the next nearest point.
+				local neighbor = seedsPQ:pop()
+				while neighbor ~= nil do
+					local point = neighbor[2] -- [1] = priority, [2] = point
+					members[#members+1] = point
+
+					point.cid = clusterID
+					unprocessed[point.fid] = nil
+
+					local nextNeighbors = featureNeighborsMatrix[point.fid]
+					if nextNeighbors ~= nil and Reachability(point, nextNeighbors) ~= nil then
+						Update(nextNeighbors, point, seedsPQ)
+					end
+					neighbor = seedsPQ:pop()
+				end
+			end
+
+			fid = next(unprocessed)
+		end
+
+		for ii = 1, clusterID do
+			-- Post-process each cluster.
+			local cluster = featureClusters[ii]
+			GetClusterStats(cluster, cluster.members)
+			GetConvexHull(cluster, ii, cluster.members)
+		end
+	end
+
+	function Optics.new()
+		local object = setmetatable({}, {
+			__index = { Run = Run, }
+		})
+		return object
+	end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Feature Tracking
+
+local function UpdateFeatureReclaim()
+	for fid, fInfo in pairs(knownFeatures) do
+		local metal = spGetFeatureResources(fid)
+		if metal >= minFeatureMetal then
+			if fInfo.metal ~= metal then
+				if fInfo.cid ~= nil then
+					local thisCluster = featureClusters[fInfo.cid]
+					thisCluster.metal = thisCluster.metal - fInfo.metal + metal
+				end
+				fInfo.metal = metal
+			end
+		else
+			knownFeatures[fid] = nil
+			clusterizingNeeded = true
+		end
+	end
+end
+
+local function ClusterizeFeatures()
+	opticsObject:Run()
+	clusterizingNeeded = false
+	redrawingNeeded = true
+end
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- State update
@@ -445,339 +511,52 @@ local function disableHighlight()
 	actionActive = false
 end
 
-local function UpdateDrawEnabled()
-	local ecoView = spGetMapDrawMode() == 'metal'
-
-	if actionActive then return true end
-	if showOption == 1 then return true end
-	if showOption == 2 then return ecoView or ecoView end
-	if showOption == 3 then return reclaimerSelected or ecoView end
-	if showOption == 4 then return resBotSelected or ecoView end
-	if showOption == 5 then
-		local currentCmd = spGetActiveCommand()
-		if currentCmd then
-			local activeCmdDesc = spGetActiveCmdDesc(currentCmd)
-			return (activeCmdDesc and (activeCmdDesc.name == "Reclaim")) or ecoView
-		end
-	end
-	if showOption == 6 then widgetHandler:RemoveWidget() end
-
-	return false
-end
-
-function widget:SelectionChanged(units)
-	local udefID
-	reclaimerSelected = false
-	resBotSelected = false
-	for _, v in pairs(units) do
-		udefID = spGetUnitDefID(v)
-		if canResurrect[udefID] then
-			resBotSelected = true
-			reclaimerSelected = true
-			return
-		elseif canReclaim[udefID] then
-			reclaimerSelected = true
-			return
-		end
-	end
-end
-
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
--- Feature Tracking
-
-local featureNeighborsMatrix = {}
-local featureClusters = {}
-local featureConvexHulls = {}
-
----To update a feature's entire neighborhood, flag it as both added and removed.
-local function UpdateFeatureNeighborsMatrix(fID, added, removed)
-	local fInfo = knownFeatures[fID]
-
-	if removed then
-		for fID2 in pairs(featureNeighborsMatrix[fID]) do
-			featureNeighborsMatrix[fID2][fID] = nil
-			featureNeighborsMatrix[fID][fID2] = nil
-		end
+local UpdateDrawEnabled -- Uses the showOption setting to pick a function call.
+do
+	local function always()
+		return true
 	end
 
-	if added then
-		local fx, fz = fInfo.x, fInfo.z
-		featureNeighborsMatrix[fID] = {}
-		for fID2, fInfo2 in pairs(knownFeatures) do
-			if fID2 ~= fID then --don't include self into featureNeighborsMatrix[][]
-				local sqDist = (fx - fInfo2.x)^2 + (fz - fInfo2.z)^2
-				if sqDist <= minSqDistance then
-					featureNeighborsMatrix[fID][fID2] = true
-					featureNeighborsMatrix[fID2][fID] = true
-				end
-			end
-		end
+	local function onMapDrawMode()
+		-- todo: would be nice to set only when it changes
+		-- todo: eg widget:MapDrawModeChanged(newMode, oldMode)
+		return actionActive == true or spGetMapDrawMode() == 'metal'
 	end
-end
 
-local function UpdateFeatures()
-	for fID, fInfo in pairs(knownFeatures) do
-		-- local metal, _, energy = spGetFeatureResources(fID)
-		-- if includeEnergy then metal = metal + energy * E2M end
-		local metal = spGetFeatureResources(fID)
-		if metal >= minFeatureMetal then
-			-- -- @efrec testing whether this is still needed
-			-- local fx, _, fz = spGetFeaturePosition(fID)
-			-- local fy = spGetGroundHeight(fx, fz)
-			-- if fInfo.x ~= fx or fInfo.y ~= fy or fInfo.z ~= fz then
-			-- 	fInfo.x = fx
-			-- 	fInfo.y = fy
-			-- 	fInfo.z = fz
-			-- 	fInfo.drawAlt = ((fy > 0 and fy) or 0) --+ fInfo.height
-			-- 	UpdateFeatureNeighborsMatrix(fID, true, true)
-			-- end
+	local function onSelectReclaimer()
+		return actionActive == true or reclaimerSelected == true or onMapDrawMode() == true
+	end
 
-			if fInfo.metal ~= metal then
-				if fInfo.clID then
-					local thisCluster = featureClusters[fInfo.clID]
-					thisCluster.metal = thisCluster.metal - fInfo.metal
-					-- Okay but we've already established that it's >= min
-					-- if metal >= minFeatureMetal then
-						thisCluster.metal = thisCluster.metal + metal
-						fInfo.metal = metal
-					-- So this would never execute
-					-- else
-					-- 	UpdateFeatureNeighborsMatrix(fID, false, true)
-					-- 	knownFeatures[fID] = nil
-					-- end
-				end
-			end
+	local function onSelectResurrector()
+		return actionActive == true or resBotSelected == true or onMapDrawMode() == true
+	end
+
+	local function onActiveCommand()
+		if actionActive == true or onMapDrawMode() == true then
+			return true
 		else
-			knownFeatures[fID] = nil
-			clusterizingNeeded = true
-		end
-	end
-
-	for fID, fInfo in pairs(knownFeatures) do
-		if fInfo.isGaia and spValidFeatureID(fID) == false then
-			UpdateFeatureNeighborsMatrix(fID, false, true)
-			fInfo = nil
-			knownFeatures[fID] = nil
-		else
-			fInfo.clID = nil
-		end
-	end
-end
-
-local function ClusterizeFeatures()
-	local pointsTable = {}
-	local unclusteredPoints  = {}
-
-	for fID, fInfo in pairs(knownFeatures) do
-		pointsTable[#pointsTable + 1] = {
-			x = fInfo.x,
-			z = fInfo.z,
-			fID = fID,
-		}
-		unclusteredPoints[fID] = true
-	end
-
-	local opticsObject = Optics.new(pointsTable, featureNeighborsMatrix, minPoints)
-	opticsObject:Run()
-
-	featureClusters = opticsObject:Clusterize(minDistance)
-
-	for i = 1, #featureClusters do
-		local thisCluster = featureClusters[i]		
-		local members = thisCluster.members
-		local xmin, xmax, zmin, zmax = -mathHuge, mathHuge, -mathHuge, mathHuge
-		local metal = 0
-		for j = 1, #members do
-			local fID = members[j]
-			local fInfo = knownFeatures[fID]
-
-			local x = fInfo.x
-			local z = fInfo.z
-			xmin = min(xmin, x)
-			xmax = max(xmax, x)
-			zmin = min(zmin, z)
-			zmax = max(zmax, z)
-
-			metal = metal + fInfo.metal
-			fInfo.clID = i
-			unclusteredPoints[fID] = nil
-		end
-
-		thisCluster.metal = metal
-		thisCluster.xmin = xmin
-		thisCluster.xmax = xmax
-		thisCluster.zmin = zmin
-		thisCluster.zmax = zmax
-	end
-
-	for fID in pairs(unclusteredPoints) do
-		local fInfo = knownFeatures[fID]
-		local thisCluster = {}
-
-		thisCluster.members = { fID }
-		thisCluster.metal = fInfo.metal
-
-		thisCluster.xmin = fInfo.x
-		thisCluster.xmax = fInfo.x
-		thisCluster.zmin = fInfo.z
-		thisCluster.zmax = fInfo.z
-
-		featureClusters[#featureClusters + 1] = thisCluster
-		fInfo.clID = #featureClusters
-	end
-end
-
-local function pointArea(points)
-	local totalArea = 0
-	-- Determinant area, triangle form
-	local x1, z1 = points[1].x, points[1].z
-	local x2, z2
-	local x3, z3 = points[2].x, points[2].z
-	for i = 2, #points - 1 do
-		x2 = x3
-		z2 = z3
-		x3 = points[i + 1].x
-		z3 = points[i + 1].z
-		totalArea = totalArea + 0.5 * abs(x1 * (z2 - z3) + x2 * (z3 - z1) + x3 * (z1 - z2))
-	end
-	return totalArea
-end
-
-local function ClustersToConvexHull()
-	featureConvexHulls = {}
-	for fc = 1, #featureClusters do
-		local clusterPoints = {}
-		local members = featureClusters[fc].members
-
-		for fcm = 1, #members do
-			local fID = members[fcm]
-			clusterPoints[#clusterPoints + 1] = {
-				x = knownFeatures[fID].x,
-				y = knownFeatures[fID].drawAlt,
-				z = knownFeatures[fID].z
-			}
-			--Spring.MarkerAddPoint(knownFeatures[fID].x, 0, knownFeatures[fID].z, string.format("%i(%i)", fc, fcm))
-		end
-
-		--- TODO perform pruning as described in the article below, if convex hull algo will start to choke out
-		-- http://mindthenerd.blogspot.ru/2012/05/fastest-convex-hull-algorithm-ever.html
-
-		local convexHull
-		local hullArea = (#clusterPoints >= 3 and pointArea(clusterPoints)) or nil
-		if hullArea ~= nil and hullArea >= 3000 then
-			--spEcho("#clusterPoints >= 3")
-			--convexHull = ConvexHull.JarvisMarch(clusterPoints)
-			convexHull = MonotoneChain(clusterPoints) --twice faster
-		else
-			--spEcho("not #clusterPoints >= 3")
-			local thisCluster = featureClusters[fc]
-
-			local xmin, xmax, zmin, zmax = thisCluster.xmin, thisCluster.xmax, thisCluster.zmin, thisCluster.zmax
-
-			local dx, dz = xmax - xmin, zmax - zmin
-
-			if dx < minDim then
-				xmin = xmin - (minDim - dx) / 2
-				xmax = xmax + (minDim - dx) / 2
+			local currentCmd = spGetActiveCommand()
+			if currentCmd ~= nil then
+				local activeCmdDesc = spGetActiveCmdDesc(currentCmd)
+				return activeCmdDesc ~= nil and activeCmdDesc.name == "Reclaim"
+			else
+				return false
 			end
-
-			if dz < minDim then
-				zmin = zmin - (minDim - dz) / 2
-				zmax = zmax + (minDim - dz) / 2
-			end
-
-			local height = clusterPoints[1].y
-			if #clusterPoints == 2 then
-				height = max(height, clusterPoints[2].y)
-			end
-
-			convexHull = {
-				{x = xmin, y = height, z = zmin},
-				{x = xmax, y = height, z = zmin},
-				{x = xmax, y = height, z = zmax},
-				{x = xmin, y = height, z = zmax},
-			}
-			hullArea = minDim * minDim
 		end
-
-		local cx, cz, cy = 0, 0, 0
-		for i = 1, #convexHull do
-			local convexHullPoint = convexHull[i]
-			cx = cx + convexHullPoint.x
-			cz = cz + convexHullPoint.z
-			cy = max(cy, convexHullPoint.y)
-		end
-
-		convexHull.area = hullArea
-		convexHull.center = {x = cx/#convexHull, z = cz/#convexHull, y = cy + 1}
-
-		featureConvexHulls[fc] = convexHull
-
---[[
-		for i = 1, #convexHull do
-			Sppring.MarkerAddPoint(convexHull[i].x, convexHull[i].y, convexHull[i].z, string.format("C%i(%i)", fc, i))
-		end
-]]--
-	end
-end
-
-function widget:Initialize()
-	screenx, screeny = widgetHandler:GetViewSizes()
-
-	widgetHandler:AddAction("reclaim_highlight", enableHighlight, nil, "p")
-	widgetHandler:AddAction("reclaim_highlight", disableHighlight, nil, "r")
-
-	WG['reclaimfieldhighlight'] = {}
-	WG['reclaimfieldhighlight'].getShowOption = function()
-		return showOption
-	end
-	WG['reclaimfieldhighlight'].setShowOption = function(value)
-		showOption = value
 	end
 
-	for _, fID in ipairs(spGetAllFeatures()) do
-		widget:FeatureCreated(fID)
-	end
-end
+	local showOptionFunctions = {
+		--[[1]] always,
+		--[[2]] onMapDrawMode,
+		--[[3]] onSelectReclaimer,
+		--[[4]] onSelectResurrector,
+		--[[5]] onActiveCommand,
+		--[[6]] widgetHandler:RemoveWidget(),
+	}
 
-function widget:FeatureCreated(featureID, allyTeamID)
-	-- local metal, _, energy = spGetFeatureResources(fID)
-	-- if includeEnergy then metal = metal + energy * E2M end
-	local metal = spGetFeatureResources(featureID)
-	if (not knownFeatures[featureID]) and (metal >= minFeatureMetal) then
-		local fx, fy, fz = spGetFeaturePosition(featureID)
-		knownFeatures[featureID] = {
-			x = fx,
-			y = fy, -- spGetGroundHeight(fx, fz) -- befrwmrn
-			z = fz,
-			metal = metal,
-			drawAlt = ((fy > 0 and fy) or 0),
-			height = spGetFeatureHeight(featureID),
-			isGaia = (spGetFeatureTeam(featureID) == gaiaTeamId),
-		}
-
-		UpdateFeatureNeighborsMatrix(featureID, true, false)
-		clusterizingNeeded = true
-	end
-end
-
-function widget:FeatureDestroyed(featureID, allyTeamID)
-	if knownFeatures[featureID] then
-		knownFeatures[featureID] = nil
-		clusterizingNeeded = true
-	end
-end
-
-function widget:GetConfigData(data)
-    return {
-        showOption = showOption
-    }
-end
-
-function widget:SetConfigData(data)
-	if data.showOption ~= nil then
-		showOption = data.showOption
+	UpdateDrawEnabled = function ()
+		drawEnabled = showOptionFunctions[showOption]()
+		return drawEnabled
 	end
 end
 
@@ -813,27 +592,27 @@ end
 
 local drawFeatureClusterTextList
 local function DrawFeatureClusterText()
-	for i = 1, #featureConvexHulls do
+	for clusterID = 1, #featureClusters do
 		glPushMatrix()
 
-		local center = featureConvexHulls[i].center
+		local center = featureConvexHulls[clusterID].center
 
 		glTranslate(center.x, center.y, center.z)
 		glRotate(-90, 1, 0, 0)
 
 		-- Rotate text based on camera rotation
-		if camUpVector[1] and camUpVector[3] then
+		if camUpVector[1] ~= nil and camUpVector[3] ~= nil then
 			local rotationAngle = math.atan2(-camUpVector[1], -camUpVector[3]) * (180 / math.pi)
 			glRotate(rotationAngle, 0, 0, 1)
 		end
 
 		local fontSize = fontSizeMin * fontScaling
-		local area = featureConvexHulls[i].area
-		fontSize = sqrt(area) * fontSize / minDim
+		local area = featureConvexHulls[clusterID].area
+		fontSize = sqrt(area) * fontSize / minTextAreaLength
 		fontSize = min(fontSize, fontSizeMax)
 		fontSize = max(fontSize, fontSizeMin)
 
-		local metalText = string.formatSI(featureClusters[i].metal)
+		local metalText = string.formatSI(featureClusters[clusterID].metal)
 
 		glColor(numberColor)
 
@@ -843,38 +622,88 @@ local function DrawFeatureClusterText()
 	end
 end
 
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Widget call-ins
+
+function widget:Initialize()
+	screenx, screeny = widgetHandler:GetViewSizes()
+
+	widgetHandler:AddAction("reclaim_highlight", enableHighlight, nil, "p")
+	widgetHandler:AddAction("reclaim_highlight", disableHighlight, nil, "r")
+
+	WG['reclaimfieldhighlight'] = {}
+	WG['reclaimfieldhighlight'].getShowOption = function()
+		return showOption
+	end
+	WG['reclaimfieldhighlight'].setShowOption = function(value)
+		showOption = value
+	end
+
+	-- Start/restart feature clustering.
+	knownFeatures = {}
+	featureNeighborsMatrix = {}
+	featureClusters = {}
+	featureConvexHulls = {}
+	opticsObject = Optics.new()
+
+	for _, featureID in ipairs(Spring.GetAllFeatures()) do
+		widget:FeatureCreated(featureID)
+	end
+end
+
+function widget:Shutdown()
+	widgetHandler:RemoveAction("reclaim_highlight", "p")
+	widgetHandler:RemoveAction("reclaim_highlight", "r")
+
+	WG['reclaimfieldhighlight'] = nil -- todo: register/deregister, right?
+
+	if drawFeatureConvexHullSolidList ~= nil then
+		glDeleteList(drawFeatureConvexHullSolidList)
+	end
+	if drawFeatureConvexHullEdgeList ~= nil then
+		glDeleteList(drawFeatureConvexHullEdgeList)
+	end
+	if drawFeatureClusterTextList ~= nil then
+		glDeleteList(drawFeatureClusterTextList)
+	end
+end
+
+function widget:GetConfigData(data)
+    return { showOption = showOption }
+end
+
+function widget:SetConfigData(data)
+	if data.showOption ~= nil then
+		showOption = data.showOption
+	end
+end
 
 function widget:Update(dt)
-	drawEnabled = UpdateDrawEnabled()
-	if not drawEnabled then return end
-
-	local cx, cy, cz = spGetCameraPosition()
-
-	local desc, w = spTraceScreenRay(screenx / 2, screeny / 2, true)
-	if desc then
-		local cameraDist = min( 8000, sqrt( (cx-w[1])^2 + (cy-w[2])^2 + (cz-w[3])^2 ) )
-		cameraScale = sqrt((cameraDist / 600)) --number is an "optimal" view distance
-	else
-		cameraScale = 1.0
+	if UpdateDrawEnabled() == true then
+		local cx, cy, cz = spGetCameraPosition()
+		local desc, w = spTraceScreenRay(screenx / 2, screeny / 2, true)
+		if desc ~= nil then
+			local cameraDist = min( 8000, sqrt( (cx-w[1])^2 + (cy-w[2])^2 + (cz-w[3])^2 ) )
+			cameraScale = sqrt((cameraDist / 600)) --number is an "optimal" view distance
+		else
+			cameraScale = 1.0
+		end
 	end
 end
 
 function widget:GameFrame(frame)
-	if not drawEnabled or frame % checkFrequency ~= 0 then
+	if drawEnabled == false or frame % checkFrequency ~= 0 then
 		return
 	end
 
-	local camUpVectorCurrent = spGetCameraVectors().up
-	if drawFeatureClusterTextList == nil or camUpVectorCurrent ~= camUpVector then
-		camUpVector = camUpVectorCurrent
-		if drawFeatureClusterTextList ~= nil then
-			glDeleteList(drawFeatureClusterTextList)
-			drawFeatureClusterTextList = nil
-		end
-		drawFeatureClusterTextList = glCreateList(DrawFeatureClusterText)
+	UpdateFeatureReclaim()
+
+	if clusterizingNeeded == true then
+		ClusterizeFeatures()
 	end
 
-	if redrawingNeeded then
+	if redrawingNeeded == true then
 		if drawFeatureConvexHullSolidList ~= nil then
 			glDeleteList(drawFeatureConvexHullSolidList)
 			drawFeatureConvexHullSolidList = nil
@@ -888,13 +717,95 @@ function widget:GameFrame(frame)
 		redrawingNeeded = false
 	end
 
-	UpdateFeatures()
+	-- Text is always redrawn to rotate it facing the camera.
+	local camUpVectorCurrent = spGetCameraVectors().up
+	if drawFeatureClusterTextList == nil or camUpVectorCurrent ~= camUpVector then
+		camUpVector = camUpVectorCurrent
+		if drawFeatureClusterTextList ~= nil then
+			glDeleteList(drawFeatureClusterTextList)
+			drawFeatureClusterTextList = nil
+		end
+		drawFeatureClusterTextList = glCreateList(DrawFeatureClusterText)
+	end
+end
 
-	if clusterizingNeeded then
-		ClusterizeFeatures()
-		ClustersToConvexHull()
-		clusterizingNeeded = false
-		redrawingNeeded = true
+function widget:FeatureCreated(featureID, allyTeamID)
+	local metal = spGetFeatureResources(featureID)
+	if metal >= minFeatureMetal then
+		local x, y, z = spGetFeaturePosition(featureID)
+
+		local M = featureNeighborsMatrix
+		local M_newFeature = {}
+		local reachDistSq = mathHuge
+		for fid2, feat2 in pairs(knownFeatures) do
+			local distSq = (x - feat2.x)^2 + (z - feat2.z)^2
+			if distSq <= epsilonSq then
+				M[fid2][featureID] = distSq
+				M_newFeature[fid2] = distSq
+				if distSq < reachDistSq then
+					reachDistSq = distSq
+				end
+				if feat2.rd == nil or distSq < feat2.rd then
+					feat2.rd = distSq
+				end
+			end
+		end
+		featureNeighborsMatrix[featureID] = M_newFeature
+
+		knownFeatures[featureID] = {
+			fid   = featureID,
+			metal = metal,
+			rd    = reachDistSq,
+			x     = x,
+			y     = max(0, y), -- spGetGroundHeight(x, z) seems unneeded
+			z     = z,
+		}
+
+		clusterizingNeeded = true
+	end
+end
+
+function widget:FeatureDestroyed(featureID, allyTeamID)
+	if knownFeatures[featureID] ~= nil then
+		knownFeatures[featureID] = nil
+		-- The memory leak from not nilling fNM[fid2][fid1] is nbd.
+		-- But we need to maintain `rd` from Created/Destroyed. So:
+		local neighbors = featureNeighborsMatrix[featureID]
+		featureNeighborsMatrix[featureID] = nil
+		for fid, distSq in pairs(neighbors) do
+			-- Update the reachability of neighbors linked through this point.
+			if knownFeatures[fid].rd == distSq then
+				local nextNeighbors = featureNeighborsMatrix[fid]
+				nextNeighbors[featureID] = nil
+				local reachDistSq = mathHuge
+				for fid2, distSq2 in pairs(nextNeighbors) do
+					if distSq2 < reachDistSq then
+						reachDistSq = distSq2
+					end
+				end
+				knownFeatures[fid].rd = (reachDistSq < epsilonSq and reachDistSq) or nil
+			else
+				featureNeighborsMatrix[fid][featureID] = nil
+			end
+		end
+		clusterizingNeeded = true
+	end
+end
+
+function widget:SelectionChanged(units)
+	local uDefID
+	reclaimerSelected = false
+	resBotSelected = false
+	for _, unitID in pairs(units) do
+		uDefID = spGetUnitDefID(unitID)
+		if canResurrect[uDefID] == true then
+			resBotSelected = true
+			reclaimerSelected = true
+			return
+		elseif canReclaim[uDefID] == true then
+			reclaimerSelected = true
+			return
+		end
 	end
 end
 
@@ -903,7 +814,7 @@ function widget:ViewResize(viewSizeX, viewSizeY)
 end
 
 function widget:DrawWorld()
-	if spIsGUIHidden() or not drawEnabled then
+	if drawEnabled == false or spIsGUIHidden() == true then
 		return
 	end
 
@@ -919,7 +830,7 @@ function widget:DrawWorld()
 end
 
 function widget:DrawWorldPreUnit()
-	if spIsGUIHidden() or not drawEnabled then
+	if drawEnabled == false or spIsGUIHidden() == true then
 		return
 	end
 
@@ -939,16 +850,4 @@ function widget:DrawWorldPreUnit()
 	end
 
 	glDepthTest(true)
-end
-
-function widget:Shutdown()
-	if drawFeatureConvexHullSolidList then
-		glDeleteList(drawFeatureConvexHullSolidList)
-	end
-	if drawFeatureConvexHullEdgeList then
-		glDeleteList(drawFeatureConvexHullEdgeList)
-	end
-	if drawFeatureClusterTextList then
-		glDeleteList(drawFeatureClusterTextList)
-	end
 end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -2,8 +2,8 @@ function widget:GetInfo()
 	return {
 		name      = "Reclaim Field Highlight",
 		desc      = "Highlights clusters of reclaimable material",
-		author    = "ivand, refactored by esainane, edited for BAR by Lexon",
-		date      = "2022",
+		author    = "ivand, refactored by esainane, edited for BAR by Lexon and efrec",
+		date      = "2024",
 		license   = "public",
 		layer     = 1000,
 		enabled   = true
@@ -290,9 +290,6 @@ do
 			for ii = 1, #members do
 				candidatePoints[ii] = members[ii]
 			end
-
-			-- TODO perform pruning as described in the article below, if convex hull algo will start to choke out
-			-- http://mindthenerd.blogspot.ru/2012/05/fastest-convex-hull-algorithm-ever.html
 
 			if #candidatePoints > 30 then
 				-- With uniformly random data, this should prune down to around 20% the original set.

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -516,7 +516,7 @@ do
 			local point = knownFeatures[fid]
 			local members = { point }
 			local cluster = { members = members }
-			featureClusters[#featureClusters+1] = cluster
+			featureClusters[clusterID] = cluster
 			clusterID = clusterID + 1
 
 			-- Process visited points, like so.


### PR DESCRIPTION
### Work done

Refactor of existing clustering algorithm into the same method but without several generalizations used in OPTICS that don't apply to this use case. This is now a basic single-chain reachability clustering method.

The extent of the rewrite puts this in a category that it likely needs testing before merge.

I precondition the candidate points for the convex hull makes hulls build in about the same amount of time no matter how large they are. My testing on 1600 wrecks shows essentially no impact at all from the convex hull step, as a result.

Some better-practices on OOPish code, mostly avoiding a lot of copying.

Cold starts were the topic I wanted to address, where clustering done for the first time creates a large frame hitch. This is, again, only a portion of the way to fixing that problem. The tables used for clustering are built over time so that all O(N^2)-ish work is done in O(N) chunks on each FeatureCreated and O(logN) on FeatureDestroyed. The remaining final clustering step significantly faster as a result.

#### Addresses Issue(s)

This PR could be considered to close #3419 if there are no bugs. The gains are good enough.

This is not an iterative clustering method, still. Maintaining a clustering that is almost-correct over time would be much faster and is a good further goal for the widget for the compsci-inclined.