### PR TITLE
Send a LuaRulesMsg message when a player pauses/unpauses the game.

### DIFF
--- a/luarules/gadgets/system_info.lua
+++ b/luarules/gadgets/system_info.lua
@@ -252,5 +252,12 @@ else
 		end
 	end
 
+	function gadget:GamePaused(playerID, isPaused)
+		if playerID == myPlayerID then
+			local msg = string.format("p@u$3:%s", tostring(isPaused))
+			SendLuaRulesMsg(msg)
+		end
+	end
+
 end
 


### PR DESCRIPTION
This will allow a SPADS plugin to detect and log pauses/unpauses, by looking for LUAMSG events in the format `p@u$3:%s` (where `%s` is true/false).

There are no user-visible changes for this PR. Integration testing will require a corresponding update to the SPADS plugins used by BAR, but for coverage purposes it is sufficient to verify that the game can still be paused/unpaused.