### PR TITLE
Updated arm bot lab and core shipyard to have exit only yardmaps

### DIFF
--- a/units/ArmBuildings/LandFactories/armlab.lua
+++ b/units/ArmBuildings/LandFactories/armlab.lua
@@ -31,7 +31,7 @@ return {
 		sightdistance = 290,
 		terraformspeed = 500,
 		workertime = 100,
-		yardmap = "oooooooooooooooooocccccccccccccccccc",
+		yardmap = "oooooooooooooooooeeeeeeeeeeeeeeeeee",
 		buildoptions = {
 			[1] = "armck",
 			[2] = "armpw",

--- a/units/CorBuildings/SeaFactories/corsy.lua
+++ b/units/CorBuildings/SeaFactories/corsy.lua
@@ -30,7 +30,7 @@ return {
 		terraformspeed = 500,
 		waterline = 1,
 		workertime = 165,
-		yardmap = "oyyyyyyoyccccccyyccccccyyccccccyyccccccyyccccccyyccccccyoyyyyyyo",
+		yardmap = "oeeeeeeoeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeoeeeeeeo",
 		buildoptions = {
 			[1] = "corcs",
 			[2] = "correcl",


### PR DESCRIPTION
### Work done
Updated corsy and armlab to have exit only buildplates, which should prevent hitbox exploits. Other labs could potentially benefit later, I'm just doing a couple as a test first.

Dolphins and supports cheesing into docks and becoming unshootable is a common 'hack' addressed by this.

https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3457 for one recent example of botlab issues.
