### PR TITLE
Bugfix: Fix interface.json syntax error

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -281,7 +281,7 @@
 				"lowTrajectory": "Low Trajectory",
 				"highTrajectory": "High Trajectory",
 				"trajectory_tooltip": "Switch artillery firing angle between low and high trajectory",
-				"gauss_tooltip": "Switches between Gauss Cannon and Heavy Plasma Cannon",
+				"gauss_tooltip": "Switches between Gauss Cannon and Heavy Plasma Cannon"
 			}
 		},
 		"idleBuilders": {


### PR DESCRIPTION
### Work done
Fix JSON syntax error in interface.json. While this does not break I18N inside the game, it breaks the Transifex integration picking up changes to the file.