### PR TITLE
Reclaim pt3, changing size and position less

### DIFF
--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -207,6 +207,7 @@ do
 			metal = metal + points[j].metal
 		end
 		cluster.metal = metal
+		cluster.text = string.formatSI(metal)
 	end
 
 	local function getClusterDimensions(cluster, points)
@@ -431,7 +432,10 @@ do
 		end
 
 		featureConvexHulls[clusterID] = convexHull
+
 		cluster.area = hullArea
+		local areaSize = max(0, min(1, (hullArea - areaTextMin) / areaTextRange))
+		cluster.font = fontSizeMin + (fontSizeMax - fontSizeMin) * areaSize
 	end
 end
 
@@ -592,6 +596,10 @@ local function UpdateFeatureReclaim()
 			clusterizingNeeded = true
 		end
 	end
+
+	for ii = 1, #featureClusters do
+		featureClusters[ii].text = string.formatSI(featureClusters[ii].metal)
+	end
 end
 
 local function ClusterizeFeatures()
@@ -695,20 +703,17 @@ local drawFeatureClusterTextList
 local function DrawFeatureClusterText()
 	if camUpVector[1] ~= nil and camUpVector[3] ~= nil then
 		local cameraFacing = math.atan2(-camUpVector[1], -camUpVector[3]) * (180 / math.pi)
-
 		for clusterID = 1, #featureClusters do
+			local center = featureClusters[clusterID].center
+			
 			glPushMatrix()
 
-			local center = featureClusters[clusterID].center
 			glTranslate(center.x, center.y, center.z)
 			glRotate(-90, 1, 0, 0)
 			glRotate(cameraFacing, 0, 0, 1)
 
-			local metalText = string.formatSI(featureClusters[clusterID].metal)
-			local areaSize = (max(0, featureClusters[clusterID].area - areaTextMin) / areaTextRange)
-			local fontSize = fontSizeMin + (fontSizeMax - fontSizeMin) * min(1, areaSize)
 			glColor(numberColor)
-			glText(metalText, 0, 0, fontSize, "cv") --cvo for outline
+			glText(featureClusters[clusterID].text, 0, 0, featureClusters[clusterID].font, "cv") --cvo for outline
 
 			glPopMatrix()
 		end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -103,7 +103,7 @@ checkFrequency = math.round(checkFrequency * Game.gameSpeed)
 
 local minTextAreaLength = (epsilon / 2 + fontSizeMin) / 2
 local areaTextMin = 3000
-local areaTextRange = (minTextAreaLength * (fontSizeMax / fontSizeMin) ^ 1.08) ^ 2 - areaTextMin
+local areaTextRange = (1.75 * minTextAreaLength * (fontSizeMax / fontSizeMin)) ^ 2 - areaTextMin
 
 local drawEnabled = false
 local actionActive = false
@@ -225,7 +225,7 @@ do
 		-- The average of vertices is a very unstable estimate of the centroid.
 		-- The bounds change slowly, so we can use them to stabilize our guess:
 		cx, cz = cx / #points, cz / #points
-		cx, cz = (xmin + 3 * cx + xmax) / 5, (zmin + 3 * cz + zmax) / 5
+		cx, cz = (xmin + 2 * cx + xmax) / 4, (zmin + 2 * cz + zmax) / 4
 		cluster.center = { x = cx, y = max(0, spGetGroundHeight(cx, cz)) + 2, z = cz }
 
 		-- I keep shuffling this around to different places. Just do it here:

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -807,10 +807,6 @@ function widget:GameFrame(frame)
 	end
 
 	if redrawingNeeded == true then
-		if drawFeatureClusterTextList ~= nil then
-			glDeleteList(drawFeatureClusterTextList)
-			drawFeatureClusterTextList = nil
-		end
 		if drawFeatureConvexHullSolidList ~= nil then
 			glDeleteList(drawFeatureConvexHullSolidList)
 			drawFeatureConvexHullSolidList = nil
@@ -825,17 +821,12 @@ function widget:GameFrame(frame)
 	end
 
 	-- Text is always redrawn to rotate it facing the camera.
-	local camUpVectorCurrent = spGetCameraVectors().up
-	if drawFeatureClusterTextList == nil or
-		camUpVectorCurrent[1] ~= camUpVector[1] or camUpVectorCurrent[2] ~= camUpVector[2]
-	then
-		camUpVector = camUpVectorCurrent
-		if drawFeatureClusterTextList ~= nil then
-			glDeleteList(drawFeatureClusterTextList)
-			drawFeatureClusterTextList = nil
-		end
-		drawFeatureClusterTextList = glCreateList(DrawFeatureClusterText)
+	camUpVector = spGetCameraVectors().up
+	if drawFeatureClusterTextList ~= nil then
+		glDeleteList(drawFeatureClusterTextList)
+		drawFeatureClusterTextList = nil
 	end
+	drawFeatureClusterTextList = glCreateList(DrawFeatureClusterText)
 end
 
 function widget:FeatureCreated(featureID, allyTeamID)

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -781,8 +781,8 @@ function widget:Update(dt)
 		local cx, cy, cz = spGetCameraPosition()
 		local desc, w = spTraceScreenRay(screenx / 2, screeny / 2, true)
 		if desc ~= nil then
-			local cameraDist = min( 8000, sqrt( (cx-w[1])^2 + (cy-w[2])^2 + (cz-w[3])^2 ) )
-			cameraScale = sqrt((cameraDist / 600)) --number is an "optimal" view distance
+			local cameraDist = min(64000000, (cx-w[1])^2 + (cy-w[2])^2 + (cz-w[3])^2)
+			cameraScale = sqrt(sqrt(cameraDist) / 600) --number is an "optimal" view distance
 		else
 			cameraScale = 1.0
 		end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -33,7 +33,7 @@ local showOption = 3
 --Metal value font
 local numberColor = {1, 1, 1, 0.75}
 local fontSizeMin = 30
-local fontSizeMax = 140
+local fontSizeMax = 180
 
 --Field color
 local reclaimColor = {0, 0, 0, 0.16}
@@ -103,7 +103,7 @@ checkFrequency = math.round(checkFrequency * Game.gameSpeed)
 
 local minTextAreaLength = (epsilon / 2 + fontSizeMin) / 2
 local areaTextMin = 3000
-local areaTextRange = (minTextAreaLength * (fontSizeMax / fontSizeMin)) ^ 2 - areaTextMin
+local areaTextRange = (minTextAreaLength * (fontSizeMax / fontSizeMin) ^ 1.08) ^ 2 - areaTextMin
 
 local drawEnabled = false
 local actionActive = false
@@ -434,7 +434,7 @@ do
 		featureConvexHulls[clusterID] = convexHull
 
 		cluster.area = hullArea
-		local areaSize = max(0, min(1, (hullArea - areaTextMin) / areaTextRange))
+		local areaSize = max(0, min(1, (hullArea - 2 * areaTextMin) / areaTextRange))
 		cluster.font = fontSizeMin + (fontSizeMax - fontSizeMin) * areaSize
 	end
 end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -32,8 +32,8 @@ local showOption = 3
 
 --Metal value font
 local numberColor = {1, 1, 1, 0.75}
-local fontSizeMin = 40
-local fontSizeMax = 160
+local fontSizeMin = 30
+local fontSizeMax = 140
 
 --Field color
 local reclaimColor = {0, 0, 0, 0.16}
@@ -99,9 +99,11 @@ if UnitDefNames.armflea then
 	local small = FeatureDefNames[UnitDefNames.armflea.corpse]
 	minFeatureMetal = small and small.metal or minFeatureMetal
 end
-local minTextAreaLength = epsilon / 2
-local maxTextAreaLength = 4 * minTextAreaLength * fontSizeMax / fontSizeMin
 checkFrequency = math.round(checkFrequency * Game.gameSpeed)
+
+local minTextAreaLength = (epsilon / 2 + fontSizeMin) / 2
+local areaTextMin = 3000
+local areaTextRange = (minTextAreaLength * (fontSizeMax / fontSizeMin)) ^ 2 - areaTextMin
 
 local drawEnabled = false
 local actionActive = false
@@ -696,9 +698,8 @@ local function DrawFeatureClusterText()
 			glRotate(cameraFacing, 0, 0, 1)
 
 			local metalText = string.formatSI(featureClusters[clusterID].metal)
-			local fontSize = fontSizeMin + (fontSizeMax - fontSizeMin) *
-				max(0, min(1,
-					sqrt(featureClusters[clusterID].area / maxTextAreaLength / maxTextAreaLength) - 1))
+			local areaSize = (max(0, featureClusters[clusterID].area - areaTextMin) / areaTextRange)
+			local fontSize = fontSizeMin + (fontSizeMax - fontSizeMin) * min(1, areaSize)
 			glColor(numberColor)
 			glText(metalText, 0, 0, fontSize, "cv") --cvo for outline
 

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -807,7 +807,10 @@ function widget:GameFrame(frame)
 	end
 
 	if redrawingNeeded == true then
-		drawFeatureClusterTextList = nil
+		if drawFeatureClusterTextList ~= nil then
+			glDeleteList(drawFeatureClusterTextList)
+			drawFeatureClusterTextList = nil
+		end
 		if drawFeatureConvexHullSolidList ~= nil then
 			glDeleteList(drawFeatureConvexHullSolidList)
 			drawFeatureConvexHullSolidList = nil


### PR DESCRIPTION
### Work done

Slightly faster again, and I scaled font sizes between an explicit min and max area size and adjusted how much the bounds of the reclaim area shift the text position. I think this is my finishing touch.

The purpose was to decrease the amount that each change to a reclaim field can alter its appearance. My previous try was half-baked, just part of making other changes. The small trick here is that smaller areas can change more quickly, so need more gradual change in font size to minimize the visual differences between changes.

I also removed a scaling coefficient that was adjusting font sizes but not used e.g. to downscale the text or anything. The net font sizes are a little different as a result -- similar at the bottom end but I think larger at the top end. That could be adjusted.