### PR TITLE
Mission API: Add victory and defeat actions

### DIFF
--- a/luarules/mission_api/actions.lua
+++ b/luarules/mission_api/actions.lua
@@ -1,5 +1,6 @@
 --============================================================--
 
+local unpack = unpack or table.unpack -- lua 5.2 compat
 local trackedUnits = GG['MissionAPI'].TrackedUnits
 local triggers = GG['MissionAPI'].Triggers
 local actionsDefs = VFS.Include('luarules/mission_api/types.lua')
@@ -48,7 +49,7 @@ local function spawnUnits(name, unitDefName, quantity, position, facing, constru
 	--if not trackedUnits[name] then trackedUnits[name] = {} end
 
 	for i = 1, quantity do
-	local	unitID = Spring.CreateUnit(unitDefName, position.x, position.y, position.z, facing.value, 0, construction)
+		local unitID = Spring.CreateUnit(unitDefName, position.x, position.y, position.z, facing.value, 0, construction)
 
 		--if unitID and name then
 		--	trackedUnits[name][#trackedUnits[name] + 1] = unitID
@@ -99,6 +100,43 @@ end
 
 --============================================================--
 
+-- Win Condition
+
+--============================================================--
+
+local function getAllyTeamsHavingPlayers()
+	local allyTeamsHavingPlayers = {}
+	for _, playerID in pairs(Spring.GetPlayerList()) do
+		local _, _, spec, _, allyTeamID = Spring.GetPlayerInfo(playerID, false)
+		if not spec and not allyTeamsHavingPlayers[allyTeamID] then
+			allyTeamsHavingPlayers[allyTeamID] = allyTeamID
+		end
+	end
+	return allyTeamsHavingPlayers
+end
+
+----------------------------------------------------------------
+
+local function victory()
+	Spring.GameOver({ unpack(getAllyTeamsHavingPlayers()) })
+end
+
+----------------------------------------------------------------
+
+local function defeat()
+	local allyTeamsHavingPlayers = getAllyTeamsHavingPlayers()
+	local allAllyTeamIDs = Spring.GetAllyTeamList()
+	local allyTeamsWithoutPlayers = {}
+	for _, allyTeamID in pairs(allAllyTeamIDs) do
+		if not allyTeamsHavingPlayers[allyTeamID] then
+			allyTeamsWithoutPlayers[allyTeamID] = allyTeamID
+		end
+	end
+	Spring.GameOver({ unpack(allyTeamsWithoutPlayers) })
+end
+
+--============================================================--
+
 -- Custom
 
 --============================================================--
@@ -133,6 +171,8 @@ return {
 	SendMessage = sendMessage,
 
 	-- Win Condition
+	Victory = victory,
+	Defeat = defeat,
 
 	-- Custom
 	Custom = custom,

--- a/luarules/mission_api/actions.lua
+++ b/luarules/mission_api/actions.lua
@@ -1,6 +1,5 @@
 --============================================================--
 
-local unpack = unpack or table.unpack -- lua 5.2 compat
 local trackedUnits = GG['MissionAPI'].TrackedUnits
 local triggers = GG['MissionAPI'].Triggers
 local actionsDefs = VFS.Include('luarules/mission_api/types.lua')
@@ -104,31 +103,31 @@ end
 
 --============================================================--
 
-local function getAllyTeamsHavingPlayers()
-	local allyTeamsHavingPlayers = {}
+local function getHumanAllyTeams()
+	local humanAllyTeams = {}
 	for _, playerID in pairs(Spring.GetPlayerList()) do
 		local _, _, spec, _, allyTeamID = Spring.GetPlayerInfo(playerID, false)
-		if not spec and not allyTeamsHavingPlayers[allyTeamID] then
-			allyTeamsHavingPlayers[allyTeamID] = allyTeamID
+		if not spec and not humanAllyTeams[allyTeamID] then
+			humanAllyTeams[allyTeamID] = allyTeamID
 		end
 	end
-	return allyTeamsHavingPlayers
+	return humanAllyTeams
 end
 
 ----------------------------------------------------------------
 
 local function victory()
-	Spring.GameOver({ unpack(getAllyTeamsHavingPlayers()) })
+	Spring.GameOver({ unpack(getHumanAllyTeams()) })
 end
 
 ----------------------------------------------------------------
 
 local function defeat()
-	local allyTeamsHavingPlayers = getAllyTeamsHavingPlayers()
+	local allyTeamsWithPlayers = getHumanAllyTeams()
 	local allAllyTeamIDs = Spring.GetAllyTeamList()
 	local allyTeamsWithoutPlayers = {}
 	for _, allyTeamID in pairs(allAllyTeamIDs) do
-		if not allyTeamsHavingPlayers[allyTeamID] then
+		if not allyTeamsWithPlayers[allyTeamID] then
 			allyTeamsWithoutPlayers[allyTeamID] = allyTeamID
 		end
 	end

--- a/luarules/mission_api/actions_dispatcher.lua
+++ b/luarules/mission_api/actions_dispatcher.lua
@@ -5,6 +5,7 @@ local types = GG['MissionAPI'].ActionTypes
 local actions = GG['MissionAPI'].Actions
 
 local typeMapping = {
+-- Since the names are all the same, could we ditch this mapping and do it dynamically intead?
 	[types.EnableTrigger] = actionFunctions.EnableTrigger,
 	[types.DisableTrigger] = actionFunctions.DisableTrigger,
 	[types.IssueOrders] = actionFunctions.IssueOrders,
@@ -19,7 +20,7 @@ local typeMapping = {
 	-- [types.SpawnWeapons] = ,
 	-- [types.SpawnEffects] = ,
 	[types.TransferUnits] = actionFunctions.TransferUnits,
-	[types.SpawnExplosion] = actionFunctions.SpawnUnits,
+	[types.SpawnExplosion] = actionFunctions.SpawnExplosion,
 	-- [types.RevealLOS] = ,
 	-- [types.UnrevealLOS] = ,
 	-- [types.AlterMapZones] = ,
@@ -29,8 +30,8 @@ local typeMapping = {
 	-- [types.Unpause] = ,
 	-- [types.PlayMedia] = ,
 	[types.SendMessage] = actionFunctions.SendMessage,
-	-- [types.Victory] = ,
-	-- [types.Defeat] = ,
+	[types.Victory] = actionFunctions.Victory,
+	[types.Defeat] = actionFunctions.Defeat,
 }
 
 -- unpack() does not handle optional parameters, as it cannot pass a value as nil

--- a/singleplayer/test_mission.lua
+++ b/singleplayer/test_mission.lua
@@ -37,6 +37,17 @@ local triggers = {
 		},
 		actions = { 'despawnHero' },
 	},]]--
+
+	gameEnd = {
+		type = triggerTypes.TimeElapsed,
+		settings = {
+			repeating = false,
+		},
+		parameters = {
+			gameFrame = 210,
+		},
+		actions = { 'gameEnd' },
+	},
 }
 
 local actions = {
@@ -64,6 +75,10 @@ local actions = {
 			name = 'hero',
 		},
 	},--]]
+
+	gameEnd = {
+		type = actionTypes.Defeat,
+	},
 }
 
 return {

--- a/singleplayer/test_mission.lua
+++ b/singleplayer/test_mission.lua
@@ -40,9 +40,6 @@ local triggers = {
 
 	gameEnd = {
 		type = triggerTypes.TimeElapsed,
-		settings = {
-			repeating = false,
-		},
 		parameters = {
 			gameFrame = 210,
 		},


### PR DESCRIPTION

### Work done
Added Actions for victory and defeat.
They grant victory to all ally teams having (no) players, respectively.

#### Test steps
- [ ] Run the test mission and wait 7 seconds.
