### PR TITLE
Remove all echoes from scav_spawn_defs.lua

### DIFF
--- a/luarules/configs/scav_spawn_defs.lua
+++ b/luarules/configs/scav_spawn_defs.lua
@@ -207,9 +207,6 @@ local tierConfiguration = { -- Double maxSquadSize for special squads
 --	[6] = {minAnger = 61 + teamAngerEasementFB, maxAnger = 70 + teamAngerEasementFB},
 --	[7] = {minAnger = 71 + teamAngerEasementFB, maxAnger = 80 + teamAngerEasementFB},
 --}
--- for index, entry in pairs(fBusterConfig) do
---     Spring.Echo("Entry " .. index .. ": minAnger = " .. entry.minAnger .. ", maxAnger = " .. entry.maxAnger)
--- end
 
 ----------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------
@@ -1317,9 +1314,6 @@ for tier, _ in pairs(Turrets) do
 		(not ( Spring.GetModOptions().unit_restrictions_noair and turretInfo.type == "antiair")) and
 		(not ( Spring.GetModOptions().unit_restrictions_nonukes and turretInfo.type == "nuke")) and
 		(not (Spring.GetModOptions().unit_restrictions_nolrpc and turretInfo.type == "lrpc")) then
-			-- Spring.Echo("---")
-			-- Spring.Echo(turret)
-			-- Spring.Echo(UnitDefs[UnitDefNames[turret].id].name)
 			scavTurrets[turret] = {
 				minBossAnger = tierConfiguration[tier].minAnger,
 				spawnedPerWave = turretInfo.spawnedPerWave or 1,
@@ -1727,7 +1721,6 @@ local function addNewSquad(squadParams) -- params: {type = "basic", minAnger = 0
 		if not squadParams.maxAnger then squadParams.maxAnger = squadParams.minAnger + 100 end -- Eliminate squads 100% after they're introduced by default, can be overwritten
 		if squadParams.maxAnger >= 1000 then squadParams.maxAnger = 1000 end -- basically infinite, anger caps at 999
 		if not squadParams.weight then squadParams.weight = 1 end
-		Spring.Echo(squadParams)
 		for _ = 1,squadParams.weight do
 			table.insert(squadSpawnOptionsTable[squadParams.type], {minAnger = squadParams.minAnger, maxAnger = squadParams.maxAnger, units = squadParams.units, weight = squadParams.weight})
 		end
@@ -1742,7 +1735,6 @@ for tier, _ in pairs(LandUnitsList.Raid) do
 	for unitName, _ in pairs(LandUnitsList.Raid[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = LandUnitsList.Raid[tier][unitName]
-			-- Spring.Echo(unitName)
 			addNewSquad({ type = "basicLand", minAnger = tierConfiguration[tier].minAnger, units = { tierConfiguration[tier].maxSquadSize .. " " .. unitName}, weight = unitWeight, maxAnger = tierConfiguration[tier].maxAnger })
 			addNewSquad({ type = "specialLand", minAnger = tierConfiguration[tier].minAnger, units = { tierConfiguration[tier].maxSquadSize*2 .. " " .. unitName}, weight = unitWeight, maxAnger = tierConfiguration[tier].maxAnger })
 		end
@@ -1753,7 +1745,6 @@ for tier, _ in pairs(LandUnitsList.Assault) do
 	for unitName, _ in pairs(LandUnitsList.Assault[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = LandUnitsList.Assault[tier][unitName]
-			-- Spring.Echo(unitName)
 			if not scavBehaviours.BERSERK[UnitDefNames[unitName].id] then
 				scavBehaviours.BERSERK[UnitDefNames[unitName].id] = {distance = 2000, chance = 0.01}
 			end
@@ -1767,7 +1758,6 @@ for tier, _ in pairs(LandUnitsList.Support) do
 	for unitName, _ in pairs(LandUnitsList.Support[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = LandUnitsList.Support[tier][unitName]
-			-- Spring.Echo(unitName)
 			if not scavBehaviours.SKIRMISH[UnitDefNames[unitName].id] then
 				scavBehaviours.SKIRMISH[UnitDefNames[unitName].id] = {distance = 500, chance = 0.1}
 				scavBehaviours.COWARD[UnitDefNames[unitName].id] = {distance = 500, chance = 0.75}
@@ -1783,7 +1773,6 @@ for tier, _ in pairs(LandUnitsList.Healer) do
 	for unitName, _ in pairs(LandUnitsList.Healer[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = LandUnitsList.Healer[tier][unitName]
-			-- Spring.Echo(unitName)
 			if not scavBehaviours.HEALER[UnitDefNames[unitName].id] then
 				scavBehaviours.HEALER[UnitDefNames[unitName].id] = true
 				if not scavBehaviours.SKIRMISH[UnitDefNames[unitName].id] then
@@ -1804,7 +1793,6 @@ for tier, _ in pairs(SeaUnitsList.Raid) do
 	for unitName, _ in pairs(SeaUnitsList.Raid[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = SeaUnitsList.Raid[tier][unitName]
-			-- Spring.Echo(unitName)
 			addNewSquad({ type = "basicSea", minAnger = tierConfiguration[tier].minAnger, units = { math.ceil(tierConfiguration[tier].maxSquadSize*0.25) .. " " .. unitName}, weight = unitWeight, maxAnger = tierConfiguration[tier].maxAnger })
 			addNewSquad({ type = "specialSea", minAnger = tierConfiguration[tier].minAnger, units = { math.ceil(tierConfiguration[tier].maxSquadSize*0.5) .. " " .. unitName}, weight = unitWeight, maxAnger = tierConfiguration[tier].maxAnger })
 		end
@@ -1815,7 +1803,6 @@ for tier, _ in pairs(SeaUnitsList.Assault) do
 	for unitName, _ in pairs(SeaUnitsList.Assault[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = SeaUnitsList.Assault[tier][unitName]
-			-- Spring.Echo(unitName)
 			if not scavBehaviours.BERSERK[UnitDefNames[unitName].id] then
 				scavBehaviours.BERSERK[UnitDefNames[unitName].id] = {distance = 2000, chance = 0.01}
 			end
@@ -1829,7 +1816,6 @@ for tier, _ in pairs(SeaUnitsList.Support) do
 	for unitName, _ in pairs(SeaUnitsList.Support[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = SeaUnitsList.Support[tier][unitName]
-			-- Spring.Echo(unitName)
 			if not scavBehaviours.SKIRMISH[UnitDefNames[unitName].id] then
 				scavBehaviours.SKIRMISH[UnitDefNames[unitName].id] = {distance = 500, chance = 0.1}
 				scavBehaviours.COWARD[UnitDefNames[unitName].id] = {distance = 500, chance = 0.75}
@@ -1845,7 +1831,6 @@ for tier, _ in pairs(SeaUnitsList.Healer) do
 	for unitName, _ in pairs(SeaUnitsList.Healer[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = SeaUnitsList.Healer[tier][unitName]
-			-- Spring.Echo(unitName)
 			if not scavBehaviours.HEALER[UnitDefNames[unitName].id] then
 				scavBehaviours.HEALER[UnitDefNames[unitName].id] = true
 				if not scavBehaviours.SKIRMISH[UnitDefNames[unitName].id] then
@@ -1866,7 +1851,6 @@ for tier, _ in pairs(AirUnitsList.Land) do
 	for unitName, _ in pairs(AirUnitsList.Land[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = AirUnitsList.Land[tier][unitName]
-			-- Spring.Echo(unitName)
 			addNewSquad({ type = "basicAirLand", minAnger = tierConfiguration[tier].minAnger, units = { tierConfiguration[tier].maxSquadSize .. " " .. unitName}, weight = unitWeight, maxAnger = 1000 })
 			addNewSquad({ type = "specialAirLand", minAnger = tierConfiguration[tier].minAnger, units = { tierConfiguration[tier].maxSquadSize*2 .. " " .. unitName}, weight = unitWeight, maxAnger = 1000 })
 		end
@@ -1877,7 +1861,6 @@ for tier, _ in pairs(AirUnitsList.Sea) do
 	for unitName, _ in pairs(AirUnitsList.Sea[tier]) do
 		if UnitDefNames[unitName] then
 			local unitWeight = AirUnitsList.Sea[tier][unitName]
-			-- Spring.Echo(unitName)
 			addNewSquad({ type = "basicAirSea", minAnger = tierConfiguration[tier].minAnger, units = { tierConfiguration[tier].maxSquadSize .. " " .. unitName}, weight = unitWeight, maxAnger = 1000 })
 			addNewSquad({ type = "specialAirSea", minAnger = tierConfiguration[tier].minAnger, units = { tierConfiguration[tier].maxSquadSize*2 .. " " .. unitName}, weight = unitWeight, maxAnger = 1000 })
 		end


### PR DESCRIPTION
```[2024-09-01 19:00:18.205] [info]  [t=00:11:46.305618][f=-000001] <table>
[t=00:11:46.305664][f=-000001] {
  maxAnger=500,
  minAnger=60,
  type="basicLand",
  units={
    "4 corakt4_scav",
  },
  weight=3,
}
[t=00:11:46.305686][f=-000001] <table>
[t=00:11:46.305709][f=-000001] {
  maxAnger=500,
  minAnger=60,
  type="specialLand",
  units={
    "8 corakt4_scav",
  },
  weight=3,
}
[t=00:11:46.305719][f=-000001] <table>
[t=00:11:46.305741][f=-000001] {
  maxAnger=500,
  minAnger=60,
  type="basicLand",
  units={
    "4 armpwt4_scav",
  },
  weight=3,
}
[t=00:11:46.305750][f=-000001] <table>

[2024-09-01 19:00:18.206] [info]  [t=00:11:46.305771][f=-000001] {
  maxAnger=500,
  minAnger=60,
  type="specialLand",
  units={
    "8 armpwt4_scav",
  },
  weight=3,
}
[t=00:11:46.305783][f=-000001] <table>
[t=00:11:46.305802][f=-000001] {
  maxAnger=500,
  minAnger=60,
  type="basicLand",
  units={
    "4 armmar_scav",
  },
  weight=4,
}
[t=00:11:46.305812][f=-000001] <table>
[t=00:11:46.305831][f=-000001] {
  maxAnger=500,
  minAnger=60,
  type="specialLand",
  units={
    "8 armmar_scav",
  },
  weight=4,
}
[t=00:11:46.305841][f=-000001] <table>
[t=00:11:46.305865][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="basicLand",
  units={
    "12 leggob_scav",
  },
  weight=4,
}
[t=00:11:46.305876][f=-000001] <table>
[t=00:11:46.305896][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="specialLand",
  units={
    "24 leggob_scav",
  },
  weight=4,
}
[t=00:11:46.305906][f=-000001] <table>
[t=00:11:46.305924][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="basicLand",
  units={
    "12 corsh_scav",
  },
  weight=3,
}
[t=00:11:46.305932][f=-000001] <table>
[t=00:11:46.305958][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="specialLand",
  units={
    "24 corsh_scav",
  },
  weight=3,
}
[t=00:11:46.305968][f=-000001] <table>
[t=00:11:46.305987][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="basicLand",
  units={
    "12 armpw_scav",
  },
  weight=4,
}
[t=00:11:46.305995][f=-000001] <table>
[t=00:11:46.306015][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="specialLand",
  units={
    "24 armpw_scav",
  },
  weight=4,
}
[t=00:11:46.306025][f=-000001] <table>
[t=00:11:46.306048][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="basicLand",
  units={
    "12 leghades_scav",
  },
  weight=4,
}
[t=00:11:46.306057][f=-000001] <table>
[t=00:11:46.306077][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="specialLand",
  units={
    "24 leghades_scav",
  },
  weight=4,
}
[t=00:11:46.306086][f=-000001] <table>
[t=00:11:46.306107][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="basicLand",
  units={
    "12 armfav_scav",
  },
  weight=3,
}
[t=00:11:46.306116][f=-000001] <table>
[t=00:11:46.306138][f=-000001] {
  maxAnger=65,
  minAnger=10,
  type="specialLand",
  units={
    "24 armfav_scav",
  },
  weight=3,
}
```

Echoes of min and max anger are polluting logs for every unit when scavs are enabled. This PR removes them all, commented out or not.