### PR TITLE
New top bar using priority gadget

### DIFF
--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -53,7 +53,7 @@ function gadget:GetInfo()
 	}
 end
 
-local DEBUG = true -- will draw the buildSpeeds above builders. Perf heavy but its debugging only.
+local DEBUG = false -- will draw the buildSpeeds above builders. Perf heavy but its debugging only.
 local VERBOSE = false -- will spam debug into infolog
 local FORWARDUNIFORMS = false -- Needed for future nanospray GL4
 -- Available Info to Widgets:

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -15,54 +15,165 @@
 -- REASON:
 -- AllowUnitBuildStep is damn expensive and is a serious perf hit if it is used for all this.
 
+-- Done: Unify the usage of ruleName, to make it so that high prio = nil or false, low prio = assigned buildspeed
+
+-- TODO: rewrite the whole goddamn thing as a multilevel queue!
+
+--[[
+
+Note to self, there are four outstanding issues with this approach:
+
+	solars and makers cant be built by low-prio cons, would need a medium priority queue
+	During round-robin iteration, units that were previously given resources do not free them.
+	Still creates a non-zero amount of garbage by iterating over every stupid constructor
+	Needs a proper multilevel queue implementation for this to make sense, with proper pop-back instructions, because there are factually 4 priority levels currently:
+
+	High prio cons
+	Low prio Cons building solars or makers
+	low prio cons who are sole builders of a target
+	low prio everyone else.
+
+	Sets UnitUniformBuffers set for nanospray gl4
+
+
+]]--
+
+
+
+
 function gadget:GetInfo()
-    return {
-        name      = 'Builder Priority', 	-- this once was named: Passive Builders v3
-        desc      = 'Builders marked as low priority only use resources after others builder have taken their share',
-        author    = 'BrainDamage, Bluestone',
-		version   = '1.01',
-        date      = '2024',
-        license   = 'GNU GPL, v2 or later',
-        layer     = 0,
-        enabled   = true
-    }
+	return {
+		name	  = 'Builder Priority', 	-- this once was named: Passive Builders v3
+		desc	  = 'Builders marked as low priority only use resources after others builder have taken their share',
+		author	= 'Beherith, Floris',
+		date	  = '2023.12.28',
+		license   = 'GNU GPL, v2 or later',
+		layer	 = 0,
+		enabled   = true
+	}
 end
 
+local DEBUG = true -- will draw the buildSpeeds above builders. Perf heavy but its debugging only.
+local VERBOSE = false -- will spam debug into infolog
+local FORWARDUNIFORMS = false -- Needed for future nanospray GL4
+-- Available Info to Widgets:
+--Number is build speed number, and means low priority, otherwise nil means high
+--Spring.GetUnitRulesParam(unitID, "builderPriorityLow")
+local ruleName = "builderPriorityLow" -- So that non-nil means low prio, and the actual build speed number, nil means high
+
+--TeamRulesParams
+local totalBuildPowerRule = "totalBuildPower" -- total build power of a team
+local highPrioBuildPowerRule = "highPrioBuildPower" -- The total buildpower of constructors set to high priority
+local lowPrioBuildPowerRule = "lowPrioBuildPower"	-- The total buildpower of constructors set to low  priority 
+local highPrioBuildPowerWantedRule = "highPrioBuildPowerWanted" -- The total buildpower of constructors set to high priority that are building things
+local lowPrioBuildPowerWantedRule = "lowPrioBuildPowerWanted"  -- The total buildpower of constructors set to low priority that are building things
+local highPrioBuildPowerAssignedRule = "highPrioBuildPowerAssigned" -- it's actually assigned not used !!!-- The total buildpower of constructors set to high priority that is actually spent on building stuff
+local lowPrioBuildPowerAssignedRule = "lowPrioBuildPowerAssigned" -- it's actually assigned not used !!! The total buildpower of constructors set to low priority that is actually spent on building stuff
+
+local highPrioNeededMetalRule = "highPrioNeededMetal"
+local lowPrioNeededMetalRule = "lowPrioNeededMetal"
+local highPrioNeededEnergyRule = "highPrioNeededEnergy"
+local lowPrioNeededEnergyRule = "lowPrioNeededEnergy"
+
+local lowPrioExpenseMetalRule = "lowPrioExpenseMetal"
+local lowPrioExpenseEnergyRule = "lowPrioExpenseEnergy"
+
+
+local totalNeedEnergyRule = "totalNeedEnergy"   ---xxx
+local totalNeedMetalRule = "totalNeedMetal"
+
+local currentFrame = 0
+local lastUpdatedFrame = 0
+local cicleNumber = 0
 if not gadgetHandler:IsSyncedCode() then
-    return
-end
+	if DEBUG then 
+		
+		local canPassive = {} -- canPassive[unitDefID] = nil / true
+		for unitDefID, unitDef in pairs(UnitDefs) do
+			canPassive[unitDefID] = ((unitDef.canAssist and unitDef.buildSpeed > 0) or #unitDef.buildOptions > 0)
+		end
+		
+		function gadget:DrawWorld()
+			for i, unitID in pairs(Spring.GetAllUnits()) do 
+				if Spring.IsUnitInView(unitID) and canPassive[Spring.GetUnitDefID(unitID)] then  
+					local lowPriority = Spring.GetUnitRulesParam(unitID, ruleName)
+				
+					local x,y,z = Spring.GetUnitPosition(unitID)
+					gl.PushMatrix()
+					gl.Translate(x,y+64, z)
+					
+					gl.Text(((lowPriority and "L:"..tostring(lowPriority)) or "High"),0,0,16,'n')
+					gl.PopMatrix()
 
--- These values are supposedly engine-backed:
-local stallMarginInc = 0.20
+				end
+			end
+		end
+		
+		function gadget:DrawScreen()
+			local myTeam = Spring.GetMyTeamID()
+			local myPrioUpdateRate = Spring.GetTeamRulesParam(myTeam, "builderUpdateInterval")
+			if myPrioUpdateRate then 
+				local vsx, vsy = Spring.GetViewGeometry()
+				gl.Text(string.format("Update Interval = %.2f",myPrioUpdateRate), vsx/2, 16,16)
+			end
+		end
+		
+	end
+	if FORWARDUNIFORMS then 
+		local uniformCache = {0}
+		local function BuildSpeedsChanged(cmdname, countx2, ...)
+			local vararg = {...}
+			for i= 1, countx2, 2 do 
+				uniformCache[1] = vararg[i+1]
+				gl.SetUnitBufferUniforms(vararg[i], uniformCache, 1)
+				--Spring.Echo(vararg[i], vararg[i+1])
+			end
+			
+		end
+		
+		function gadget:Initialize()
+			gadgetHandler:AddSyncAction("BuildSpeedsChanged", BuildSpeedsChanged)
+		end
+
+		function gadget:Shutdown()
+			gadgetHandler:RemoveSyncAction("BuildSpeedsChanged")
+		end
+	end
+
+else
+
+local CMD_PRIORITY = 34571
+
+local stallMarginInc = 0.2 -- 
 local stallMarginSto = 0.01
 
-local passiveCons = {} -- passiveCons[teamID][builderID]
+local buildPowerMinimum = 0.001 -- A small amount of buildpower we allocate to each build target owner to ensure that nanoframes dont vanish 
 
-local buildTargets = {} --the unitIDs of build targets of passive builders
-local buildTargetOwners = {} --each build target has one passive builder that doesn't turn fully off, to stop the building decaying
-
+local passiveCons = {} -- passiveCons[teamID][builderID] = true for passive cons
+local roundRobinIndexTeam = {} -- {teamID = roundRobinIndex}
+local roundRobinLastRoundTeamBuilders = {} -- {teamID = {builderID = true}} -- this is for taking away the resources of previous RR recipients
 local canBuild = {} --builders[teamID][builderID], contains all builders
-local realBuildSpeed = {} --build speed of builderID, as in UnitDefs (contains all builders)
-local currentBuildSpeed = {} --build speed of builderID for current interval, not accounting for buildOwners special speed (contains only passive builders)
 
-local costID = {} -- costID[unitID] (contains all non-finished units)
+local buildTargets = {} --{builtUnitID = builderUnitID} the unitIDs of build targets of passive builders, a -1 here indicates that this build target has Active builders too.
 
-local ruleName = "builderPriority"
+local maxBuildSpeed = {} -- {builderUnitID = buildSpeed} build speed of builderID, as in UnitDefs (contains all builders)
+local currentBuildSpeed = {} -- {builderid = currentBuildSpeed} build speed of builderID for current interval, not accounting for buildOwners special speed (contains only passive builders)
 
--- Translate between array-style and hash-style resource tables.
-local resources = { "metal", "energy" } -- ipairs-able
-resources["metal"] = 1 -- reverse-able
-resources["energy"] = 2
+-- NOTE: Explanation: Instead of using an individual table to store {unitID = {metal, energy, buildtime}}
+-- We are using using a single table, where {unitID = metal, (unitID + energyOffset) = energy, (unitID+buildTimeOffset) = buildtime}
+local costIDOverride = {}
+local energyOffset = Game.maxUnits + 1
+local buildTimeOffset = (Game.maxUnits + 1) * 2 
 
-VFS.Include('luarules/configs/customcmds.h.lua')
-local CMD_PRIORITY = CMD_PRIORITY
+local resTable = {"metal","energy"} -- 1 = metal, 2 = energy
+
 local cmdPassiveDesc = {
-      id      = CMD_PRIORITY,
-      name    = 'priority',
-      action  = 'priority',
-      type    = CMDTYPE.ICON_MODE,
-      tooltip = 'Builder Mode: Low Priority restricts build when stalling on resources',
-      params  = {1, 'Low Prio', 'High Prio'}
+	  id	  = CMD_PRIORITY,
+	  name	= 'priority',
+	  action  = 'priority',
+	  type	= CMDTYPE.ICON_MODE,
+	  tooltip = 'Builder Mode: Low Priority restricts build when stalling on resources',
+	  params  = {1, 'Low Prio', 'High Prio'}, -- cmdParams[1], where 0 == Low Prio, 1 == High prio
 }
 
 local spInsertUnitCmdDesc = Spring.InsertUnitCmdDesc
@@ -77,8 +188,8 @@ local spSetUnitBuildSpeed = Spring.SetUnitBuildSpeed
 local spGetUnitIsBuilding = Spring.GetUnitIsBuilding
 local spValidUnitID = Spring.ValidUnitID
 local spGetTeamInfo = Spring.GetTeamInfo
-local spGetUnitTeam = Spring.GetUnitTeam
 local simSpeed = Game.gameSpeed
+local LOS_ACCESS = {inlos = true}
 
 local max = math.max
 local floor = math.floor
@@ -87,219 +198,535 @@ local updateFrame = {}
 
 local teamList
 local deadTeamList = {}
-local unitBuildSpeed = {}
 local canPassive = {} -- canPassive[unitDefID] = nil / true
-local cost = {} -- cost[unitDefID] = { metal, energy, buildTime }
 
+-- Uses a flattened table as per costIDOverride
+local cost = {} -- cost = {unitDefID = metal, (unitDefID + energyOffset) = energy, (unitDefID+buildTimeOffset) = buildtime}, this is now keyed on integers for better cache
+-- Is there any point in the approximate 100Kb of RAM savings? Probably no 
+
+local unitBuildSpeed = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	-- All builders can have their build speeds changed via lua
-    if unitDef.buildSpeed > 0 then
-        unitBuildSpeed[unitDefID] = unitDef.buildSpeed
-    end
-    -- Units that can only repair, ressurrect, or capture don't have a passive mode (in this gadget)
-	local prioritizes = ((unitDef.canAssist and unitDef.buildSpeed > 0) or #unitDef.buildOptions > 0)
-    canPassive[unitDefID] = prioritizes and true or nil
-	-- Minor speedup for determining total resource drain per frame/interval
-	cost[unitDefID] = { unitDef.metalCost, unitDef.energyCost, unitDef.buildTime }
+	if unitDef.buildSpeed > 0 then
+		unitBuildSpeed[unitDefID] = unitDef.buildSpeed
+	end
+	-- build the list of which unitdef can have low prio mode
+	canPassive[unitDefID] = ((unitDef.canAssist and unitDef.buildSpeed > 0) or #unitDef.buildOptions > 0)
+	-- build a list of the unit costs
+	cost[unitDefID				  ] = unitDef.metalCost
+	cost[unitDefID +	energyOffset] = unitDef.energyCost
+	cost[unitDefID + buildTimeOffset] = unitDef.buildTime
 end
 
 local function updateTeamList()
 	teamList = spGetTeamList()
-end
+	for _, teamID in ipairs(teamList) do
+		passiveCons[teamID] = {} -- passiveCons[teamID][builderID] = true for passive cons
+		roundRobinIndexTeam[teamID] = 1 -- {teamID = roundRobinIndex}
+		roundRobinLastRoundTeamBuilders[teamID] = {} -- {teamID = {builderID = true}} -- this is for taking away the resources of previous RR recipients
+		canBuild[teamID] = {} --builders[teamID][builderID], contains all builders
+		Spring.SetTeamRulesParam(teamID, totalBuildPowerRule, 0)
+		Spring.SetTeamRulesParam(teamID, highPrioBuildPowerRule, 0)
+		Spring.SetTeamRulesParam(teamID, lowPrioBuildPowerRule, 0)
+		Spring.SetTeamRulesParam(teamID, highPrioBuildPowerAssignedRule, 0)
+		Spring.SetTeamRulesParam(teamID, lowPrioBuildPowerAssignedRule, 0)
 
-local isTeamSavingMetal = function(_) return false end
+		Spring.SetTeamRulesParam(teamID, highPrioNeededMetalRule, 0)
+		Spring.SetTeamRulesParam(teamID, lowPrioNeededMetalRule, 0)
+		Spring.SetTeamRulesParam(teamID, highPrioNeededEnergyRule, 0)
+		Spring.SetTeamRulesParam(teamID, lowPrioNeededEnergyRule, 0)
+
+
+		Spring.SetTeamRulesParam(teamID, lowPrioExpenseMetalRule, 0)
+		Spring.SetTeamRulesParam(teamID, lowPrioExpenseEnergyRule, 0)
+
+
+		Spring.SetTeamRulesParam(teamID, totalNeedEnergyRule, 0)
+		Spring.SetTeamRulesParam(teamID, totalNeedMetalRule, 0)
+	end
+end
 
 function gadget:Initialize()
 	updateTeamList()
-
-	for _, teamID in ipairs(teamList) do
-		-- Distribute initial update frames. They will drift on their own afterward.
-		local gameFrame = Spring.GetGameFrame()
-		if not updateFrame[teamID] then
-			updateFrame[teamID] = gameFrame + (teamID % 6)
-		end
-		-- Reset team tracking for constructors and their build priority settings.
-		canBuild[teamID] = canBuild[teamID] or {}
-		passiveCons[teamID] = passiveCons[teamID] or {}
-	end
-
 	for _,unitID in pairs(Spring.GetAllUnits()) do
-        gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID), spGetUnitTeam(unitID))
-		if currentBuildSpeed[unitID] then
-			spSetUnitBuildSpeed(unitID, currentBuildSpeed[unitID]) -- needed for luarules reloads
-		end
-    end
+		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID), Spring.GetUnitTeam(unitID))
+	end
+end
 
-	-- huge apologies for intruding on this gadget, but players have requested ability to put everything on hold to buy t2 as soon as possible (Unit Market)
-	if (Spring.GetModOptions().unit_market) then
-		isTeamSavingMetal = function(teamID)
-			local isAiTeam = select(4,spGetTeamInfo(teamID))
-			if not isAiTeam then
-				return (GG.isTeamSaving and GG.isTeamSaving(teamID)) or false
-			end
-			return false
+local nCBS = 0
+local changedBuildSpeeds = {}
+
+local function MaybeSetWantedBuildSpeed(builderID, wantedSpeed, force)
+	if (currentBuildSpeed[builderID] ~= wantedSpeed) or force then
+		spSetUnitBuildSpeed(builderID, wantedSpeed) -- 100 ns per call
+		spSetUnitRulesParam(builderID, ruleName, wantedSpeed)  -- 300 ns per call
+		currentBuildSpeed[builderID] = wantedSpeed
+		if FORWARDUNIFORMS then 
+			changedBuildSpeeds[nCBS + 1] = builderID
+			changedBuildSpeeds[nCBS + 2] = wantedSpeed
+			nCBS = nCBS + 2
 		end
 	end
 end
+
+local function SetBuilderPriority(builderID, lowPriority)
+	if lowPriority then  -- low prio immediately sets it to 0 buildspeed
+		MaybeSetWantedBuildSpeed(builderID, 0, true)
+	else -- set to high
+		-- clear all our passive status
+		spSetUnitBuildSpeed(builderID, maxBuildSpeed[builderID]) 
+		spSetUnitRulesParam(builderID, ruleName, nil) 
+		currentBuildSpeed[builderID] = maxBuildSpeed[builderID]
+		
+		if FORWARDUNIFORMS then 
+			changedBuildSpeeds[nCBS + 1] = builderID
+			changedBuildSpeeds[nCBS + 2] = maxBuildSpeed[builderID]
+			nCBS = nCBS + 2
+		end
+	end
+end
+
+local function BuildSpeedsChanged()
+	if nCBS > 0 then 
+		-- Note: we are pretty much pushing an entire unpacked table onto sendtounsynced
+		-- the max amound of stuff we can send here is like <8000 elements. 
+		-- todo: actually check that we dont send more, and if we do, then split it into multiple calls.
+		SendToUnsynced("BuildSpeedsChanged", nCBS, unpack(changedBuildSpeeds))
+		changedBuildSpeeds = {}
+		nCBS = 0
+	end
+end
+
+
+local function UDN(unitID) --get unit name
+	return UnitDefs[Spring.GetUnitDefID(unitID)].name
+end
+
 
 function gadget:UnitCreated(unitID, unitDefID, teamID)
-	-- Units use their full build speed, by default.
-    if unitBuildSpeed[unitDefID] then
-        canBuild[teamID][unitID] = true
-        realBuildSpeed[unitID] = unitBuildSpeed[unitDefID] or 0
+	if unitBuildSpeed[unitDefID] then
+		canBuild[teamID][unitID] = true
+		maxBuildSpeed[unitID] = unitBuildSpeed[unitDefID]
+	end
+	if canPassive[unitDefID] then
+		spInsertUnitCmdDesc(unitID, cmdPassiveDesc)
+		local lowPriority = spGetUnitRulesParam(unitID, ruleName) or nil -- non-nil rule means passive
+		passiveCons[teamID][unitID] = lowPriority
+		SetBuilderPriority(unitID, lowPriority)
 
-		-- Only units that can build other units can use passive build priority.
-		if canPassive[unitDefID] then
-			spInsertUnitCmdDesc(unitID, cmdPassiveDesc)
-			passiveCons[teamID][unitID] = (spGetUnitRulesParam(unitID, ruleName) == 1) or nil
-			currentBuildSpeed[unitID] = realBuildSpeed[unitID]
+		if VERBOSE then 
+			Spring.Echo(string.format("UnitID %i of def %s has been set to %s = %s",
+					unitID, UnitDefs[unitDefID].name, ruleName, tostring(passiveCons[teamID][unitID])))
 		end
-    end
-
-    costID[unitID] = cost[unitDefID]
-end
-
-function gadget:UnitFinished(unitID, unitDefID, teamID, builderID)
-    buildTargetOwners[unitID] = nil
-	costID[unitID] = nil
+	end
+	--here we start tracking the unit, that is beeing built until it is finished. We use it to calculate the resources wanted by the constructors
+	costIDOverride[unitID +			   0] = cost[unitDefID]  --  
+	costIDOverride[unitID +	energyOffset] = cost[unitDefID + energyOffset]
+	costIDOverride[unitID + buildTimeOffset] = cost[unitDefID + buildTimeOffset]
 end
 
 function gadget:UnitGiven(unitID, unitDefID, newTeamID, oldTeamID)
-    if passiveCons[oldTeamID] and passiveCons[oldTeamID][unitID] then
-        passiveCons[newTeamID][unitID] = passiveCons[oldTeamID][unitID]
-        passiveCons[oldTeamID][unitID] = nil
-    end
-
-    if canBuild[oldTeamID] and canBuild[oldTeamID][unitID] then
-        canBuild[newTeamID][unitID] = true
-        canBuild[oldTeamID][unitID] = nil
-    end
+	gadget:UnitDestroyed(unitID, unitDefID, oldTeamID)
+	gadget:UnitCreated(unitID, unitDefID, newTeamID)
 end
 
 function gadget:UnitTaken(unitID, unitDefID, oldTeamID, newTeamID)
-    gadget:UnitGiven(unitID, unitDefID, newTeamID, oldTeamID)
+	gadget:UnitGiven(unitID, unitDefID, newTeamID, oldTeamID)
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, teamID)
-    canBuild[teamID][unitID] = nil
+	-- Clear Team stuff
+	canBuild[teamID][unitID] = nil
+	roundRobinLastRoundTeamBuilders[teamID][unitID] = nil
+	passiveCons[teamID][unitID] = nil
+	
+	-- clear unit data
+	maxBuildSpeed[unitID] = nil
+	currentBuildSpeed[unitID] = nil
 
-    passiveCons[teamID][unitID] = nil
-    realBuildSpeed[unitID] = nil
-    currentBuildSpeed[unitID] = nil
-    buildTargetOwners[unitID] = nil
-
-    costID[unitID] = nil
+	costIDOverride[unitID +			   0] = nil
+	costIDOverride[unitID +	energyOffset] = nil
+	costIDOverride[unitID + buildTimeOffset] = nil
 end
 
+function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+	-- as its no longer being built, clear cache of its costs
+	costIDOverride[unitID +			   0] = nil
+	costIDOverride[unitID +	energyOffset] = nil
+	costIDOverride[unitID + buildTimeOffset] = nil
+end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-    -- track which cons are set to passive
-    if cmdID == CMD_PRIORITY and canPassive[unitDefID] then
-        local cmdIdx = spFindUnitCmdDesc(unitID, CMD_PRIORITY)
-        if cmdIdx then
-            local cmdDesc = spGetUnitCmdDescs(unitID, cmdIdx, cmdIdx)[1]
-            cmdDesc.params[1] = cmdParams[1]
-            spEditUnitCmdDesc(unitID, cmdIdx, cmdDesc)
-            spSetUnitRulesParam(unitID,ruleName,cmdParams[1])
-			if cmdParams[1] == 0 then --
-				passiveCons[teamID][unitID] = true
-			elseif realBuildSpeed[unitID] then
-				spSetUnitBuildSpeed(unitID, realBuildSpeed[unitID])
-				currentBuildSpeed[unitID] = realBuildSpeed[unitID]
-				passiveCons[teamID][unitID] = nil
+	-- track which cons are set to passive
+	if cmdID == CMD_PRIORITY and canPassive[unitDefID] then
+		local cmdIdx = spFindUnitCmdDesc(unitID, CMD_PRIORITY)
+		if cmdIdx then
+			local cmdDesc = spGetUnitCmdDescs(unitID, cmdIdx, cmdIdx)[1]
+			cmdDesc.params[1] = cmdParams[1] -- cmdParams[1] where 0 == Low Prio, 1 == High prio
+			spEditUnitCmdDesc(unitID, cmdIdx, cmdDesc)
+			local lowPriority = (cmdParams[1] == 0) -- if the parameter eaquals 0 this will be true
+			
+			SetBuilderPriority(unitID, lowPriority) -- if lowPriority == true the function will set the BP value to 0
+			passiveCons[teamID][unitID] = lowPriority or nil
+			roundRobinLastRoundTeamBuilders[teamID][unitID] = nil -- this is to ensure that mid-update changes carry over
+
+			if VERBOSE then 
+				Spring.Echo(string.format("UnitID %i of def %s has been set to %s = %s (%s)",
+						unitID, UnitDefs[unitDefID].name, ruleName, tostring(passiveCons[teamID][unitID]), tostring(cmdParams[1])))
 			end
-        end
-        return false -- Allowing command causes command queue to be lost if command is unshifted
-    end
-    return true
+		end
+		return false -- Allowing command causes command queue to be lost if command is unshifted
+	end
+	return true
 end
 
 local function UpdatePassiveBuilders(teamID, interval)
-	-- calculate how much expense each passive con would require
-	-- and how much total expense the non-passive cons require
-	local nonPassiveConsTotalExpenseEnergy = 0
-	local nonPassiveConsTotalExpenseMetal = 0
-	local passiveConsExpense = {}
-	local passiveTeamCons = passiveCons[teamID]
+	cicleNumber = cicleNumber + 1
+	if currentFrame ~= lastUpdatedFrame then
+		lastUpdatedFrame = currentFrame
+		cicleNumber = 1
+	end
+	--Spring.Echo("cicleNumber: " ..tostring(cicleNumber))
+	-- calculate how much expense each passive con would require, and how much total expense the non-passive cons require
 
-	for builderID in pairs(canBuild[teamID]) do
-		local builtUnit = spGetUnitIsBuilding(builderID)
-		local targetCosts = (builtUnit and costID[builtUnit]) or nil
-		if builtUnit and targetCosts then
-			local mcost, ecost = targetCosts[1], targetCosts[2]
-			local rate = realBuildSpeed[builderID] / targetCosts[3]
-			-- Add an exception for basic metal converters, which each cost 1 metal.
-			-- Don't stall over something so small and that may be needed to recover.
-			mcost = mcost <= 1 and 0 or mcost * rate
-			ecost = ecost * rate
-			if passiveTeamCons[builderID] then
-				passiveConsExpense[builderID] = { mcost, ecost }
-				if not buildTargets[builtUnit] then
-					buildTargets[builtUnit] = true
-					buildTargetOwners[builderID] = builtUnit
-				end
+
+
+	local passiveConsTeam = passiveCons[teamID]
+	if tracy then tracy.ZoneBeginN("UpdateStart") end 
+	local numPassiveCons = 0
+
+	
+	local passiveExpense = {} -- once again, similar to the costIDOverride we are using a single table with offsets to store two values per unitID
+	local totalBuildPower = 0
+	local highPrioBuildPower = 0
+	local lowPrioBuildPower = 0
+	local highPrioBuildPowerWanted = 0
+	local lowPrioBuildPowerWanted = 0
+	local highPrioBuildPowerAssigned = 0
+	local lowPrioBuildPowerAssigned = 0
+
+	local lowPrioExpenseMetal = 0  
+	local lowPrioExpenseEnergy = 0
+	
+	local highPrioNeededEnergy = 0
+	local highPrioNeededMetal = 0
+
+	local lowPrioNeededEnergy = 0
+	local lowPrioNeededMetal = 0
+
+	local totalNeedEnergy = 0   ---xxx
+	local totalNeedMetal = 0
+
+	
+	-- Dont count solars and mm's as stalling:
+	local midPrioSolarMaker = {} -- builderID to negative metal, positive energy cost
+	-- this is about 800 us
+	if canBuild[teamID] then
+		local canBuildTeam = canBuild[teamID]
+		for builderID in pairs(canBuildTeam) do
+			--Spring.Echo('builderID', builderID)
+			local builtUnit = spGetUnitIsBuilding(builderID)
+			local expenseMetal = builtUnit and costIDOverride[builtUnit] or nil -- sets expenseMetal to the metal cost of the built unit
+			local maxbuildspeed = maxBuildSpeed[builderID]
+			totalBuildPower = totalBuildPower + maxbuildspeed
+			local isPassive = passiveConsTeam[builderID]
+			if isPassive then 
+				lowPrioBuildPower = lowPrioBuildPower + maxbuildspeed
 			else
-				nonPassiveConsTotalExpenseMetal = nonPassiveConsTotalExpenseMetal + mcost
-				nonPassiveConsTotalExpenseEnergy = nonPassiveConsTotalExpenseEnergy + ecost
+				highPrioBuildPower = highPrioBuildPower + maxbuildspeed
 			end
+			
+			if builtUnit and expenseMetal and maxbuildspeed then	-- added check for maxBuildSpeed[builderID] else line below could error (unsure why), probably units that were newly created?
+
+				local expenseEnergy = costIDOverride[builtUnit + energyOffset]
+				local rate = maxbuildspeed / costIDOverride[builtUnit + buildTimeOffset] -- calculates the max fraction of the unit that can be built by the current constructor
+
+				-- TODO: redo solar and basic MM no-stall logic
+				
+				-- metal maker costs 1 metal, don't stall because of that, so we will set the metalExpense to 0 if it is 1 or less
+				expenseMetal = (expenseMetal <=1) and 0 or expenseMetal * rate  -- now we know how much the constructor actually wants to spend
+				totalNeedMetal = totalNeedMetal + expenseMetal --careful is this just the help value? should I add it in the if expenseEnergy == 0 constraint? aswell?
+				-- solar costs 0 energy, don't stall because of that (is this really needed? 0 stays 0)
+				--Spring.Echo ("Energy cost of this project: " ..expenseEnergy)
+				expenseEnergy = (expenseEnergy <=1) and 0 or expenseEnergy * rate
+				--Spring.Echo ("energy needed by con: " ..expenseEnergy)
+				totalNeedEnergy = totalNeedEnergy + expenseEnergy
+				--Spring.Echo ("totalNeedEnergy")
+				--Spring.Echo (totalNeedEnergy)  -----xxx
+
+
+
+				if isPassive then 
+					passiveExpense[builderID] = expenseMetal  -- here it still shows the wanted metal, not the actually spent metal
+					passiveExpense[builderID+ energyOffset] = expenseEnergy
+					numPassiveCons = numPassiveCons + 1
+					lowPrioNeededEnergy = lowPrioNeededEnergy + expenseEnergy
+					lowPrioNeededMetal  = lowPrioNeededMetal  + expenseMetal
+					buildTargets[builtUnit] = builderID 
+					--Spring.Echo ("Passive")
+					
+					if expenseMetal == 0 then
+						midPrioSolarMaker[builderID] = expenseEnergy 
+						--Spring.Echo ("Metal maker is being built")
+					end
+					if expenseEnergy == 0 then 
+						midPrioSolarMaker[builderID] = -1 * expenseMetal
+						--Spring.Echo ("Solar is being built") 
+					end
+					lowPrioBuildPowerWanted = lowPrioBuildPowerWanted + maxbuildspeed
+					
+				else
+					highPrioBuildPowerWanted = highPrioBuildPowerWanted + maxbuildspeed
+					highPrioNeededEnergy = highPrioNeededEnergy + expenseEnergy
+					highPrioNeededMetal  = highPrioNeededMetal  + expenseMetal
+				end
+				
+			end
+			
+			
+		end
+	end
+	local intervalpersimspeed = interval/simSpeed
+	--Spring.Echo("interval per simSpeed: " .. tostring(intervalpersimspeed))
+	if tracy then tracy.ZoneEnd() end 
+
+	-- calculate how much expense passive cons will be allowed, this can be negative
+	local passiveEnergyLeft, passiveMetalLeft
+
+	for _,resName in pairs(resTable) do
+		--Spring.Echo ("Checking: "  ..tostring (resName))
+		local currentLevel, storage, pull, income, expense, share, sent, received = spGetTeamResources(teamID, resName)
+		storage = storage * share -- consider capacity only up to the share slider
+		--Spring.Echo("Resource: " .. resName .. ", Current Level: " .. tostring(currentLevel) ..", storage "  .. tostring(storage).. ", Income: " .. tostring(income) .. ", Expense: " .. tostring(expense) ..", pull: " .. tostring(pull)  ..", highPrioNeededEnergy: " ..tostring(highPrioNeededEnergy))
+		local reservedExpense = (resName == 'energy' and highPrioNeededEnergy or highPrioNeededMetal) -- we don't want to touch this part of expense
+		if resName == 'energy' then
+			passiveEnergyLeft = currentLevel - max(income * stallMarginInc, storage * stallMarginSto) - 1 + (income - reservedExpense + received - sent) * intervalpersimspeed --amount of res available to assign to passive builders (in next interval); leave a tiny bit left over to avoid engines own "stall mode"
+			--Spring.Echo("Formula: passiveEnergyLeft = currentLevel - max(income * stallMarginInc, storage * stallMarginSto) - 1 + (income - reservedExpense + received - sent) * intervalpersimspeed")
+			local test = max(income * stallMarginInc, storage * stallMarginSto)
+			--Spring.Echo(" max(income * stallMarginInc, storage * stallMarginSto) "  ..test)
+			--Spring.Echo("Numbers: passiveEnergyLeft = " .. tostring(currentLevel) .. " - max(" .. tostring(income) .. " * " .. tostring(stallMarginInc) .. ", " .. tostring(storage) .. " * " .. tostring(stallMarginSto) .. ") - 1 + (" .. tostring(income) .. " - " .. tostring(reservedExpense) .. " + " .. tostring(received) .. " - " .. tostring(sent) .. ")" ..tostring(intervalpersimspeed))
+			--Spring.Echo("Passive Energy Left: " .. tostring(passiveEnergyLeft))
+			local actualPassiveEnergyLeft = currentLevel + ( 0 - max(income * stallMarginInc, storage * stallMarginSto) + (income - reservedExpense + received)) * intervalpersimspeed
+			--Spring.Echo("actualPassiveEnergyLeft: " .. tostring(actualPassiveEnergyLeft))
+			--passiveEnergyLeft = actualPassiveEnergyLeft
+		else
+			passiveMetalLeft =  currentLevel - max(income * stallMarginInc, storage * stallMarginSto) - 1 + (income - reservedExpense + received - sent) -- * intervalpersimspeed is not needed --amount of res available to assign to passive builders (in next interval); leave a tiny bit left over to avoid engines own "stall mode"
+			--Spring.Echo("Formula: passiveMetalLeft = currentLevel - max(income * stallMarginInc, storage * stallMarginSto) - 1 + (income - reservedExpense + received - sent)")
+			--Spring.Echo("Numbers: passiveMetalLeft = " .. tostring(currentLevel) .. " - max(" .. tostring(income) .. " * " .. tostring(stallMarginInc) .. ", " .. tostring(storage) .. " * " .. tostring(stallMarginSto) .. ") - 1 + (" .. tostring(income) .. " - " .. tostring(reservedExpense) .. " + " .. tostring(received) .. " - " .. tostring(sent) .. ")")
+			--Spring.Echo("Passive Metal Left: " .. tostring(passiveMetalLeft))
 		end
 	end
 
-	-- calculate how much expense passive cons will be allowed
-	local teamStallingEnergy, teamStallingMetal
-	local cur, stor, inc, share, sent, rec, _
+	local passiveMetalStart = passiveMetalLeft
+	local passiveEnergyStart = passiveEnergyLeft
 
-	cur, stor, _, inc, _, share, sent, rec = spGetTeamResources(teamID, "metal")
-	-- consider capacity only up to the share slider
-	stor = stor * share
-	-- amount of res available to assign to passive builders (in next interval)
-	-- leave a tiny bit left over to avoid engines own "stall mode"
-	teamStallingMetal = cur - max(inc*stallMarginInc, stor*stallMarginSto) - 1 + (interval)*(nonPassiveConsTotalExpenseMetal+inc+rec-sent)/simSpeed
+	--Spring.Echo("Starting Passive Metal: " .. tostring(passiveMetalStart) .. ", Starting Passive Energy: " .. tostring(passiveEnergyStart))
 
-	cur, stor, _, inc, _, share, sent, rec = spGetTeamResources(teamID, "energy")
-	stor = stor * share
-	teamStallingEnergy = cur - max(inc*stallMarginInc, stor*stallMarginSto) - 1 + (interval)*(nonPassiveConsTotalExpenseEnergy+inc+rec-sent)/simSpeed
 
-	-- work through passive cons allocating as much expense as we have left
-	for builderID in pairs(passiveTeamCons) do
-		-- find out if we have used up all the expense available to passive builders yet
-		local wouldStall = false
-		local conExpense = passiveConsExpense[builderID]
-		if conExpense then
-			local passivePullMetal = conExpense[1] * (interval / simSpeed)
-			local passivePullEnergy = conExpense[2] * (interval / simSpeed)
-			local newPullMetal = teamStallingMetal - passivePullMetal
-			local newPullEnergy = teamStallingEnergy - passivePullEnergy
-			if passivePullMetal > 0 or passivePullEnergy > 0 then
-				-- Changed: Stalling in one resource stalls in the other.
-				if newPullMetal <= 0 or newPullEnergy <= 0 then
-					wouldStall = true
-				else
-					teamStallingMetal = newPullMetal
-					teamStallingEnergy = newPullEnergy
+
+	---								local currentlyUsedBP = (Spring.GetUnitCurrentBuildPower(builderID) or 0) * maxBuildSpeed[builderID]
+	---								Spring.Echo('Spring.GetUnitCurrentBuildPower(builderID)', Spring.GetUnitCurrentBuildPower(builderID))
+
+	local havePassiveResourcesLeft = (passiveEnergyLeft > 0) and (passiveMetalLeft > 0 )
+	if havePassiveResourcesLeft then 
+		--Spring.Echo("Sufficient passive resources left.")
+		--local currentlyUsedBP = (Spring.GetUnitCurrentBuildPower(builderID) or 0) * highPrioBuildPowerWanted
+		--Spring.Echo('currentlyUsedBP', currentlyUsedBP)
+		--Spring.Echo('highPrioBuildPowerWanted', highPrioBuildPowerWanted)
+		highPrioBuildPowerAssigned = highPrioBuildPowerWanted
+	else
+		--Spring.Echo("Insufficient passive resources. Calculating high priority build power used.")
+		highPrioNeededMetal = math.max(highPrioNeededMetal, 1)
+		-- Sicherstellen, dass die benötigte Hochprioritäts-Energie mindestens 1 ist
+		highPrioNeededEnergy = math.max(highPrioNeededEnergy, 1)
+		--Spring.Echo("Ensuring minimum high priority needed energy is 1, Actual High Priority Needed Energy: " .. tostring(highPrioNeededEnergy))
+
+		-- Berechnen des Hochprioritäts-Metallverbrauchsverhältnisses
+		local highPrioMetalSpend = (highPrioNeededMetal + math.min(0, passiveMetalLeft)) / highPrioNeededMetal
+		--Spring.Echo("Calculated High Priority Metal Spend Ratio: " .. tostring(highPrioMetalSpend) .. ", High Priority Needed Metal: " .. tostring(highPrioNeededMetal) .. ", Passive Metal Left: " .. tostring(passiveMetalLeft))
+
+		-- Berechnen des Hochprioritäts-Energieverbrauchsverhältnisses
+		local highPrioEnergySpend = (highPrioNeededEnergy + math.min(0, passiveEnergyLeft)) / highPrioNeededEnergy
+		--Spring.Echo("Calculated High Priority Energy Spend Ratio: " .. tostring(highPrioEnergySpend) .. ", High Priority Needed Energy: " .. tostring(highPrioNeededEnergy) .. ", Passive Energy Left: " .. tostring(passiveEnergyLeft))
+
+		-- Berechnen des Hochprioritäts-Metallverbrauchsverhältnisses 1
+		local highPrioMetalSpend1 = (highPrioNeededMetal + passiveMetalLeft) / highPrioNeededMetal
+		--Spring.Echo("Calculated High Priority Metal Spend Ratio 1: " .. tostring(highPrioMetalSpend1) .. ", High Priority Needed Metal: " .. tostring(highPrioNeededMetal) .. ", Passive Metal Left: " .. tostring(passiveMetalLeft))
+
+		-- Ausgabe der verwendeten Hochprioritäts-Baukraft
+		--Spring.Echo("High Priority Build Power Used: " .. tostring(highPrioBuildPowerAssigned))
+
+		-- Berechnung und Ausgabe der tatsächlich verwendeten Hochprioritäts-Baukraft
+		highPrioBuildPowerAssigned = highPrioBuildPowerWanted * math.min(highPrioMetalSpend, highPrioEnergySpend)
+		--Spring.Echo("High Priority Build Power Used: " .. tostring(highPrioBuildPowerAssigned) .. ", High Priority Build Power Wanted: " .. tostring(highPrioBuildPowerWanted) .. ", Min(High Priority Metal Spend, High Priority Energy Spend): " .. tostring(math.min(highPrioMetalSpend, highPrioEnergySpend)))
+
+
+	end
+
+	
+	
+	-- Allow passive cons to build solars and makers as a medium priority
+	for builderID, costtype in pairs(midPrioSolarMaker) do 
+		if costtype < 0 then -- metal
+			if (passiveMetalLeft > -1 * costtype) then 
+				passiveMetalLeft = passiveMetalLeft + costtype
+				MaybeSetWantedBuildSpeed(builderID, maxBuildSpeed[builderID])
+				lowPrioBuildPowerAssigned = lowPrioBuildPowerAssigned + maxBuildSpeed[builderID]
+				lowPrioExpenseMetal = lowPrioExpenseMetal - costtype
+			else
+				midPrioSolarMaker[builderID] = nil -- remove them if we cant give them resources here
+			end
+		else -- energy
+			if (passiveEnergyLeft > costtype) then
+				passiveEnergyLeft = passiveEnergyLeft - costtype
+				MaybeSetWantedBuildSpeed(builderID, maxBuildSpeed[builderID])
+				lowPrioBuildPowerAssigned = lowPrioBuildPowerAssigned + maxBuildSpeed[builderID]
+				lowPrioExpenseEnergy = lowPrioExpenseEnergy + costtype
+			else
+				midPrioSolarMaker[builderID] = nil	-- remove them if we cant give them resources here
+			end
+		end
+	end
+	
+	-- Take away the resources allocated in a round-robin way in the previous pass:
+	local previousRoundRobinBuilders = 	roundRobinLastRoundTeamBuilders[teamID] 
+	for builderID, _ in pairs(previousRoundRobinBuilders) do 
+		MaybeSetWantedBuildSpeed(builderID, 0)
+		previousRoundRobinBuilders[builderID] = nil
+	end
+	
+	-- !!!!!! Important Explanation !!!!!
+	-- Iterating over a hash table has a random, but fixed order
+	-- If we just iterated over passive cons once, naively, then the first cons would always get the leftover resources
+	-- We want to do a round-robin of leftover resources distribution, where all cons approximately evenly get resources
+	-- We also want to minimize buildspeed changes, so the trivial solution of assigning fractional buildpower to all is undesired. 
+	-- Thus we need to store which index of hash table we doled out the last leftovers in the previous pass.
+	-- Then we need to iterate over passive cons twice
+	-- This is done in two passes around the pairs(passiveConsTeam), 
+		-- First Pass: we ignore the first roundRobinIndex units, and if there are still resources left over, we start a second pass
+		-- Second Pass: then in second pass ignore the last roundRobinIndex units. 
+		
+	local roundRobinIndex = roundRobinIndexTeam[teamID] or 1 -- this stores the first unit that _should_ get res
+	havePassiveResourcesLeft = (passiveEnergyLeft > 0) and (passiveMetalLeft > 0 )
+
+	if havePassiveResourcesLeft then 
+		-- on the first pass, ignore everything < roundRobinLimit
+		-- on the second pass, ignore everything >= roundRobinLimit
+		local roundRobinLimit = roundRobinIndex
+		
+		for j=1, 2 do
+			local i = 0
+			local firstpass = (j == 1) 
+			for builderID in pairs(passiveConsTeam) do 
+				i = i + 1
+				if (firstpass and i >= roundRobinLimit) or ((not firstpass) and i < roundRobinLimit) then
+				----- can I just look at the resources: current, pull (including share), income (including share) if current smol and pull similar to income then stall
+				----- if stall take the resources of one high prio builder to know the percentage
+				--if i >= roundRobinIndex then  
+					if passiveExpense[builderID] and not midPrioSolarMaker[builderID] then -- this builder is actually building, and wasnt given resources for solar or maker
+						local wantedBuildSpeed = 0 -- init at zero buildspeed
+						if havePassiveResourcesLeft then 
+							-- we still have res, so try to pull it
+							local passivePullEnergy = passiveExpense[builderID + energyOffset] * intervalpersimspeed
+							local passivePullMetal  = passiveExpense[builderID] * intervalpersimspeed
+							roundRobinIndex = i -- So the next time we run around this exact table, we should give this con some res
+							if passiveEnergyLeft < passivePullEnergy or passiveMetalLeft < passivePullMetal then 
+								-- we ran out, time to save our roundrobin index, and bail
+								havePassiveResourcesLeft = false 
+								if VERBOSE then Spring.Echo(string.format("Ran out for %d at %i, RRI =%d, j=%d",builderID, i, roundRobinIndex, j)) end 
+								break
+							else
+								-- Yes we still have resources
+								wantedBuildSpeed = maxBuildSpeed[builderID]
+								passiveEnergyLeft = passiveEnergyLeft - passivePullEnergy
+								passiveMetalLeft  = passiveMetalLeft  - passivePullMetal
+								previousRoundRobinBuilders[builderID] = true
+								if VERBOSE then Spring.Echo(string.format("Had Some for %d at %i, RRI =%d, j=%d",builderID, i, roundRobinIndex, j)) end 
+							end
+						end
+						MaybeSetWantedBuildSpeed(builderID, wantedBuildSpeed)
+						lowPrioBuildPowerAssigned = lowPrioBuildPowerAssigned + wantedBuildSpeed
+						--Spring.Echo('lowPrioExpenseMetal ', lowPrioExpenseMetal)
+						--Spring.Echo('+ passiveExpense ', passiveExpense[builderID])
+						lowPrioExpenseMetal = lowPrioExpenseMetal + passiveExpense[builderID]
+						--Spring.Echo('=  ', lowPrioExpenseMetal)
+						lowPrioExpenseEnergy = lowPrioExpenseEnergy + passiveExpense[builderID + energyOffset]
+					end
+				end
+			end
+			if (not havePassiveResourcesLeft) or (not firstpass) then 
+				-- Either ran out of resources, or on our second pass
+				roundRobinIndexTeam[teamID] = roundRobinIndex
+				break 
+			else
+				-- We still have resources left over after completing the first pass, so do a second pass too 
+				if firstpass then 
+					roundRobinIndex = 1
 				end
 			end
 		end
+	else
+	-- Special case, we are completely and totally stalled, no resources left for passive builders. 
 
-		-- turn this passive builder on/off as appropriate
-		local wantedBuildSpeed = wouldStall and 0 or realBuildSpeed[builderID]
-		if currentBuildSpeed[builderID] ~= wantedBuildSpeed then
-			spSetUnitBuildSpeed(builderID, wantedBuildSpeed)
-			currentBuildSpeed[builderID] = wantedBuildSpeed
+		for builderID in pairs(passiveConsTeam) do 
+			if passiveExpense[builderID] and not midPrioSolarMaker[builderID] then  
+				MaybeSetWantedBuildSpeed(builderID, 0)
+			end
+		end	
+	end
+	
+	-- override buildTarget builders build speeds for a single frame; let them build at a tiny rate to prevent nanoframes from possibly decaying (yes this is confirmed to happen)
+	-- dont remove the resources given to a builder in a round-robin fashion just because they are build target owners
+	-- and take them off the buildTargets queue!
+	for buildTargetID, builderUnitID in pairs(buildTargets) do 
+		-- if owner is passive, then give it a bit of BP
+		-- This ensures that we at least build each unit a tiny bit.
+		if currentBuildSpeed[builderUnitID] < buildPowerMinimum then 
+			-- This builderUnitID has been assigned as passive with no resources, so give it a little bit
+			MaybeSetWantedBuildSpeed(builderUnitID, buildPowerMinimum)
+		else
+			-- this builderUnitID has been assigned greater than 0 resources in the round robin pass, so remove it from the next frames clear pass
+			buildTargets[buildTargetID] = nil
 		end
+	end 
+	
+	
+	Spring.SetTeamRulesParam(teamID, totalBuildPowerRule, totalBuildPower)
+	Spring.SetTeamRulesParam(teamID, highPrioBuildPowerRule, highPrioBuildPower)
+	Spring.SetTeamRulesParam(teamID, lowPrioBuildPowerRule, lowPrioBuildPower)
+	Spring.SetTeamRulesParam(teamID, highPrioBuildPowerWantedRule, highPrioBuildPowerWanted)
+	Spring.SetTeamRulesParam(teamID, lowPrioBuildPowerWantedRule, lowPrioBuildPowerWanted)
+	Spring.SetTeamRulesParam(teamID, highPrioBuildPowerAssignedRule, highPrioBuildPowerAssigned)
+	Spring.SetTeamRulesParam(teamID, lowPrioBuildPowerAssignedRule, lowPrioBuildPowerAssigned)
 
-		-- override buildTargetOwners build speeds for a single frame;
-		-- let them build at a tiny rate to prevent nanoframes from possibly decaying
-		if (buildTargetOwners[builderID] and currentBuildSpeed[builderID] == 0) then
-			spSetUnitBuildSpeed(builderID, 0.001) --(*)
-		end
+	Spring.SetTeamRulesParam(teamID, highPrioNeededMetalRule, highPrioNeededMetal)
+	Spring.SetTeamRulesParam(teamID, lowPrioNeededMetalRule, lowPrioNeededMetal)
+	Spring.SetTeamRulesParam(teamID, highPrioNeededEnergyRule, highPrioNeededEnergy)
+	Spring.SetTeamRulesParam(teamID, lowPrioNeededEnergyRule, lowPrioNeededEnergy)
+
+	
+	Spring.SetTeamRulesParam(teamID, lowPrioExpenseMetalRule, lowPrioExpenseMetal)
+	Spring.SetTeamRulesParam(teamID, lowPrioExpenseEnergyRule, lowPrioExpenseEnergy)
+	
+
+	Spring.SetTeamRulesParam(teamID, totalNeedEnergyRule, totalNeedEnergy)
+	Spring.SetTeamRulesParam(teamID, totalNeedMetalRule, totalNeedMetal)
+	
+	if VERBOSE then 
+		Spring.Echo(string.format("%d Pstart = %.1f/%.0f Pleft = %.1f/%.0f RRI=%d #passive=%d Stalled=%d", 
+			Spring.GetGameFrame(),
+			passiveMetalStart, passiveEnergyStart,
+			passiveMetalLeft, passiveEnergyLeft, 
+			roundRobinIndex, 
+			numPassiveCons,
+			havePassiveResourcesLeft and 0 or 1
+			)
+		)
 	end
 end
 
-
 local function GetUpdateInterval(teamID)
 	local maxInterval = 1
-	for _, resName in ipairs(resources) do
+	for _,resName in pairs(resTable) do
 		local _, stor, _, inc = spGetTeamResources(teamID, resName)
 		local resMaxInterval
 		if inc > 0 then
@@ -312,31 +739,9 @@ local function GetUpdateInterval(teamID)
 		end
 	end
 	if maxInterval > 6 then maxInterval = 6 end
+	--Spring.Echo("interval: "..maxInterval)
+	Spring.SetTeamRulesParam(teamID, "builderUpdateInterval", maxInterval)
 	return maxInterval
-end
-
-function gadget:GameFrame(n)
-    for builderID, builtUnit in pairs(buildTargetOwners) do
-        if spValidUnitID(builderID) and spGetUnitIsBuilding(builderID) == builtUnit then
-			local teamID = spGetUnitTeam(builderID)
-			if not isTeamSavingMetal(teamID) then
-            	spSetUnitBuildSpeed(builderID, currentBuildSpeed[builderID])
-			end
-        end
-    end
-	buildTargetOwners = {}
-    buildTargets = {}
-
-	for i=1, #teamList do
-		local teamID = teamList[i]
-		if not deadTeamList[teamID] and not isTeamSavingMetal(teamID) then
-			if n >= updateFrame[teamID] then
-				local interval = GetUpdateInterval(teamID)
-				UpdatePassiveBuilders(teamID, interval)
-				updateFrame[teamID] = n + interval
-			end
-		end
-    end
 end
 
 function gadget:TeamDied(teamID)
@@ -345,4 +750,38 @@ end
 
 function gadget:TeamChanged(teamID)
 	updateTeamList()
+end
+
+function gadget:GameFrame(n)
+	currentFrame = n
+	--Spring.Echo ("Current Frame:" .. tostring(currentFrame))
+	-- During the previous UpdatePassiveBuilders, we set build target owners to buildPowerMinimum so that the nanoframes dont die
+	-- Now we can set their buildpower to what we wanted instead of buildPowerMinimum we had for 1 frame.
+	for builtUnit, builderID in pairs(buildTargets) do
+		if spValidUnitID(builderID) and spGetUnitIsBuilding(builderID) == builtUnit then
+			MaybeSetWantedBuildSpeed(builderID, 0)
+
+		end
+	end
+	
+	buildTargets = (next(buildTargets) and {}) or buildTargets -- check if table is empty and if not reallocate it!
+	
+	for i=1, #teamList do
+		local teamID = teamList[i]
+		if not deadTeamList[teamID] then -- isnt dead
+			if n == updateFrame[teamID] then
+				--Spring.Echo("updating Team: " ..tostring (teamID))
+				local interval = GetUpdateInterval(teamID)
+				UpdatePassiveBuilders(teamID, interval)
+				updateFrame[teamID] = n + interval
+			elseif not updateFrame[teamID] or updateFrame[teamID] < n then
+				updateFrame[teamID] = n + GetUpdateInterval(teamID)
+			end
+		end
+	end
+	if FORWARDUNIFORMS then 
+		BuildSpeedsChanged()
+	end
+end
+
 end

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1,4 +1,4 @@
-local versionString = "version 0.3.01, modified 2024-09-01"
+local versionString = "version 0.3.02, modified 2024-09-01"
 function widget:GetInfo()
 	return {
 		name = "Top Bar with Buildpower 0.3.02",
@@ -532,57 +532,6 @@ local function RectQuad(px, py, sx, sy, offset)
 	gl.TexCoord(offset, offset)
 	gl.Vertex(px, sy, 0)
 end
-
-local function ChamferedRectQuad(px, py, sx, sy, chamferSize)
-		gl.BeginEnd(GL.QUADS, function()
-		gl.Vertex(px + chamferSize, py)	-- Bottom chamfers
-		gl.Vertex(sx - chamferSize, py)
-		gl.Vertex(sx, py + chamferSize)
-		gl.Vertex(px, py + chamferSize)
-
-		gl.Vertex(px, py + chamferSize) --square
-		gl.Vertex(sx, py + chamferSize)
-		gl.Vertex(sx, sy)
-		gl.Vertex(px, sy)
-	end)
-end
-
-local function DrawPartialRing(cx, cy, r, startAngle, endAngle, segments, thickness, color)
-	gl.Color(color[1], color[2], color[3], color[4]) --RGB opac
-	local function drawCircleCap(radius, thickness, angle, flip)
-		local capRadius = thickness / 2
-		local capCenterX = cx + (radius + capRadius) * math.cos(angle)
-		local capCenterY = cy + (radius + capRadius) * math.sin(angle)
-		local angleStep = math.pi / segments
-		gl.BeginEnd(GL.TRIANGLE_FAN, function()
-			gl.Vertex(capCenterX, capCenterY) -- mid point cap
-			for i = 0, segments do
-				local a = angle + math.pi / 2 + (i * angleStep) * (flip and -1 or 1) - (math.pi / 2)
-				local x = capCenterX + capRadius * math.cos(a)
-				local y = capCenterY + capRadius * math.sin(a)
-				gl.Vertex(x, y)
-			end
-		end)
-	end
-	local function drawRingBody() -- draw ring
-		local angleStep = (endAngle - startAngle) / segments
-		gl.BeginEnd(GL.QUAD_STRIP, function()
-			for i = 0, segments do
-				local angle = startAngle + i * angleStep
-				local x1 = cx + r * math.cos(angle)
-				local y1 = cy + r * math.sin(angle)
-				local x2 = cx + (r + thickness) * math.cos(angle)
-				local y2 = cy + (r + thickness) * math.sin(angle)
-				gl.Vertex(x1, y1)
-				gl.Vertex(x2, y2)
-			end
-		end)
-	end
-	drawRingBody() -- main body
-	drawCircleCap(r, thickness, startAngle, false)  -- start cap	
-	drawCircleCap(r, thickness, endAngle, true)    -- mirrowed end cap
-end
-
 
 local function DrawRect(px, py, sx, sy, zoom)
 	gl.BeginEnd(GL.QUADS, RectQuad, px, py, sx, sy, zoom)
@@ -2545,48 +2494,6 @@ local function drawResBars() --hadles the blinking
 end
 
 function widget:DrawScreen()
-		-- Rumble
-		if BP[3] and BP[4] and BP[5] then  --ql
-			local startDeg = -108 -- Example in degrees (-0.3 * 360)
-			local startAngle = math.rad(startDeg) -- Convert degrees to radians
-		
-			local maxDeg = 230
-	
-			local endDegMax = startDeg - (1 * maxDeg)
-			local endAngleMax = math.rad(endDegMax)
-			
-			local progress1 = BP[3]/BP[4]
-			local endDeg = startDeg - (progress1 * maxDeg)
-			local endAngle = math.rad(endDeg)
-			
-			local progress2 = BP[5]/BP[4]
-			local endDeg2 = startDeg - (progress2 * maxDeg) 
-			local endAngle2 = math.rad(endDeg2)
-	
-	
-		
-			local segments = 50
-			local thickness = 10
-	
-			local color = {0.3, 0.3, 0, 1} 
-			DrawPartialRing(300, 300, 50, startAngle, endAngleMax, segments, thickness, color)  -- Rumble use this to actually draw it -- Background
-			local color = {0.04, 0.6, 0.7, 1} 
-			DrawPartialRing(300, 300, 50, startAngle, endAngle, segments, thickness, color)  -- Rumble use this to actually draw it -- second biggest
-	
-			local color = {0.125, 1, 1, 1} 
-			DrawPartialRing(300, 300, 50, startAngle, endAngle2, segments, thickness, color)  -- Rumble use this to actually draw it -- smallest
-			-- Rumble
-			local px, py = 500, 500 -- Bottom-left corner --left --bottom
-			local sx, sy = 700, 600 -- Top-right corner --right -- top
-			local chamferSize = 20  -- Size of the chamfer
-	
-		
-		--gl.BeginEnd(GL.QUADS, function()	-- Rumble use this to actually draw it
-	
-		--	ChamferedRectQuad(px, py, sx, sy, chamferSize)
-		--end)
-		end
-	
 
 
 	drawResBars()

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1,6 +1,6 @@
 function widget:GetInfo()
 	return {
-		name = "Top Bar a with Buildpower",
+		name = "Top Bar with Buildpower",
 		desc = "Shows resources, buildpower, wind speed, commander counter, and various options.",
 		author = "Floris, Robert82",
 		date = "Sep, 2024",
@@ -24,7 +24,7 @@ local config = {
 	debugTooltip = true,
 	-- Show markers on the buildpower bar that indicate how much buildpower our metal and energy income could support.
 	drawBPIndicators = true,
-	drawBPWindRangeIndicators = false,
+	drawBPWindRangeIndicators = true,
 
 	barScale = 1,
 	barWidth = 1,
@@ -246,17 +246,19 @@ cacheDataBase['usedBPEnergyExpense'] = 0
 cacheDataBase['realWindStrength'] = 0
 
 local unitsPerFrame = 30 --limit processed units per frame to improve performance
-local trackedNum = 0
 
 ---------------------------  tracking  --------------------------
 
-local trackedBuilders = {} -- stores units of the player and their BP
+local trackedBuilders = {} -- important infos of units of the player
+local trackedProjects = {}
+local builderDefs = {} -- store unitDefs in here
 
--- Keep track of wind generators
-local trackedWinds = {}
-local numWindTurbines = 0
+local trackedWinds = {} -- Keep track of wind generators
+local windGenDefs = {} -- store unitDefs in here
+local multiplicatorWindTurbines = 0
 
 local unitCostData = {} --data of all units regarding the building costs, M/BP and E/BP
+
 local stalling = {}
 stalling['lowPrioEnergy'] = 0 -- totalStallingM = 0
 stalling['lowPrioMetal'] = 0 --totalStallingE = 0
@@ -1025,6 +1027,88 @@ function showBuildpowerAlert(resourceArea, text, fontSize, lowlightColor, highli
 	return offset + textWidth
 end
 
+local function updateBPIndicatorPos()---yyy
+    local res = 'BP'
+	dlistResbar[res][2] = glCreateList(function()
+		if resbarDrawinfo[res].barArea then
+			if config.drawBPIndicators then
+				local barArea = resbarDrawinfo[res].barArea
+				local barWidth = barArea[3] - barArea[1]
+				local barHeight = barArea[4] - barArea[2]
+				local shareSliderWidth = resbarDrawinfo[res].shareSliderWidth or (barHeight + math_floor(barHeight / 1.55) * 2)
+				local indicatorPosM = BP['mSliderPosition']
+				local indicatorPosE = BP['eSliderPosition']
+				local indicatorAreaMultiplyerM = playerStallingMetal and 1.4 or 1
+				local indicatorAreaMultiplyerE = playerStallingEnergy and 1.4 or 1
+				local indicatorH = barHeight
+				local barIntrusion = barHeight * 0.4
+				local indicatorW = indicatorH * 1.2
+				local cornerSize = indicatorH / 2
+				local metalIndicatorHalfWidth = indicatorW * indicatorAreaMultiplyerM / 2
+				local energyIndicatorHalfWidth = indicatorW * indicatorAreaMultiplyerE / 2
+				-- Indikator für die METALL-unterstützte BP (untere Kante)
+				if indicatorPosM then
+					local x1 = barArea[1] + (indicatorPosM * barWidth) - metalIndicatorHalfWidth
+					local y1 = barArea[2] + (barIntrusion - indicatorH * indicatorAreaMultiplyerM)
+					local x2 = barArea[1] + (indicatorPosM * barWidth) + metalIndicatorHalfWidth
+					local y2 = barArea[2] + barIntrusion
+					-- Berechnung des maximal zulässigen Eckenradius
+					local maxCornerRadius = math_min((x2 - x1) / 2, (y2 - y1) / 2)
+					local cornerRadius = cornerSize * indicatorAreaMultiplyerM
+					if cornerRadius > maxCornerRadius then
+						cornerRadius = maxCornerRadius
+					end
+					-- Optionale Rundung der Werte
+					x1 = math_floor(x1 + 0.5)
+					y1 = math_floor(y1 + 0.5)
+					x2 = math_floor(x2 + 0.5)
+					y2 = math_floor(y2 + 0.5)
+					-- Keine Rundung des Eckenradius oder Rundung nach unten
+					cornerRadius = math_floor(cornerRadius)
+					RectRound(
+						x1, y1, x2, y2,
+						cornerRadius,
+						1, 1, 0, 0,
+						{ 0.6, 0.6, 0.6, 1 },
+						{ 1, 1, 1, 1 }
+					)
+				end
+
+				-- Indikator für die ENERGIE-unterstützte BP (obere Kante)
+				if indicatorPosE then
+					-- Bereichsindikator basierend auf Windbedingungen
+					if config.drawBPWindRangeIndicators and multiplicatorWindTurbines > 0 and BP['eSliderPosition_minWind'] and BP['eSliderPosition_maxWind'] then
+						RectRound(
+							barArea[1] + (BP['eSliderPosition_minWind'] * barWidth) - energyIndicatorHalfWidth,
+							barArea[4] + barIntrusion,
+							barArea[1] + (BP['eSliderPosition_maxWind'] * barWidth) + energyIndicatorHalfWidth,
+							barArea[4] - barIntrusion + indicatorH,
+							(indicatorH * 1 - 2 * barIntrusion) / 2,
+							0, 0, 0, 0,
+							{ 0.8, 0.8, 0.0, 1 },
+							{ 0.4, 0.4, 0.0, 1 }
+						)
+					end
+
+					RectRound(
+						barArea[1] + (indicatorPosE * barWidth) - energyIndicatorHalfWidth,
+						barArea[4] - barIntrusion,
+						barArea[1] + (indicatorPosE * barWidth) + energyIndicatorHalfWidth,
+						barArea[4] - barIntrusion + indicatorH * indicatorAreaMultiplyerE,
+						cornerSize * indicatorAreaMultiplyerE,
+						0, 0, 1, 1,
+						{ 0.8, 0.8, 0.0, 1 },
+						{ 1, 1, 0.2, 1 }
+					)
+				end
+			end
+		end
+	end)
+end
+
+
+
+
 local function updateResbar(res)  --decides where and what is drawn
 	local area = resbarArea[res]
 
@@ -1169,94 +1253,27 @@ local function updateResbar(res)  --decides where and what is drawn
 			UiSliderKnob(math_floor(conversionIndicatorArea[1]+((conversionIndicatorArea[3]-conversionIndicatorArea[1])/2)), math_floor(conversionIndicatorArea[2]+((conversionIndicatorArea[4]-conversionIndicatorArea[2])/2)), math_floor((conversionIndicatorArea[3]-conversionIndicatorArea[1])/2), { 0.95, 0.95, 0.7, 1 })
 		
 		end
-		
-		for i = 1, 1 do --show usefulBPFactor
-			if res == 'BP' and config.drawBPIndicators then
-				local texWidth = 1.0 * shareSliderWidth
-				local texHeight = math_floor( shareSliderWidth / 2 ) - 1
-				local indicatorPosM = BP['mSliderPosition']
-				local indicatorPosE = BP['eSliderPosition']
-				local indicatorAreaMultiplyerM = 1
-				local indicatorAreaMultiplyerE = 1
-
-				if playerStallingMetal == true then
-					indicatorAreaMultiplyerM = 1.4
-				end
-				if playerStallingEnergy == true then
-					indicatorAreaMultiplyerE = 1.4
-				end
-
-				local indicatorH = barHeight -- how tall are the metal-supported-BP and energy-supported-BP indicators?
-				local barIntrusion = barHeight * 0.4 -- how much of the BP bar can be obscured (vertically) by one of these indicators?
-				local indicatorW = indicatorH * 1.2 -- 1.0 would bring the indicator to a perfect point, sort of like a home plate in baseball, but 1.2 gives a little extra softness and visual weight
-				local cornerSize = indicatorH / 2
-				local metalIndicatorHalfWidth = indicatorW * indicatorAreaMultiplyerM / 2
-				local energyIndicatorHalfWidth = indicatorW * indicatorAreaMultiplyerE / 2
-
-				-- Indicator for buildpower that current METAL income can support. This is shown along the BOTTOM edge of the BP bar.
-				if indicatorPosM ~= nil then
-					RectRound(
-						barArea[1] + (indicatorPosM * barWidth) - metalIndicatorHalfWidth, -- left
-						barArea[2] + (barIntrusion - indicatorH * indicatorAreaMultiplyerM), -- bottom of the bar, plus an intrusion upward, minus the indicator's height
-						barArea[1] + (indicatorPosM * barWidth) + metalIndicatorHalfWidth, -- right
-						barArea[2] + barIntrusion, -- bottom of the bar, plus an intrusion upward
-						cornerSize * indicatorAreaMultiplyerM,
-						1, 1, 0, 0, -- round TopLeft, TopRight, but not BottomRight, BottomLeft (so it looks like it's pointing upward)
-						{ 0.6, 0.6, 0.6, 1 }, -- lowlight color (RGBA)
-						{ 1,   1,   1,   1 }) -- highlight color (RGBA)
-				end
-
-				if indicatorPosE ~= nil then
-					-- Indicator for the range of buildpower that energy COULD support if the wind changes.
-					if config.drawBPWindRangeIndicators and numWindTurbines > 0 and BP['eSliderPosition_minWind'] ~= nil and BP['eSliderPosition_maxWind'] ~= nil then
-						-- Draw a thin rectangle showing the possible positions of the E-supported BP slider based on min and max wind conditions.
-						RectRound(
-							barArea[1] + (BP['eSliderPosition_minWind'] * barWidth) - energyIndicatorHalfWidth, -- left
-							barArea[4] + barIntrusion, -- top of the bar, plus an intrusion upward
-							barArea[1] + (BP['eSliderPosition_maxWind'] * barWidth) + energyIndicatorHalfWidth, -- right
-							barArea[4] - barIntrusion + indicatorH, -- to the top of the E indicator assuming no multiplier
-							(indicatorH * 1 - 2 * barIntrusion) / 2, -- corner size
-							0, 0, 0, 0, -- don't round any corners
-							{ 0.8, 0.8, 0.0, 1 }, -- lowlight color (RGBA)
-							{ 0.4, 0.4, 0.0, 1 }) -- highlight color (RGBA)
-					end
-
-					-- Indicator for buildpower that current ENERGY income can support. This is shown along the TOP edge of the BP bar.
-					RectRound(
-						barArea[1] + (indicatorPosE * barWidth) - energyIndicatorHalfWidth, -- left
-						barArea[4] - barIntrusion, -- top of the bar, minus an intrusion downward
-						barArea[1] + (indicatorPosE * barWidth) + energyIndicatorHalfWidth, -- right
-						barArea[4] - barIntrusion + indicatorH * indicatorAreaMultiplyerE, -- top of the bar, minus an intrusion downward, plus the indicator's height
-						cornerSize * indicatorAreaMultiplyerE,
-						0, 0, 1, 1, -- don't round TopLeft, TopRight but round BottomRight, BottomLeft (so it looks like it's pointing downward)
-						{0.8, 0.8, 0.0, 1}, -- lowlight color (RGBA)
-						{ 1, 1, 0.2, 1 }) -- highlight color (RGBA)
-				end
-			end
-		end
 		-- Share slider
 		if not isSingle then
-			if res ~= 'BP' then
-				if res == 'energy' then
-					eneryOverflowLevel = r[res][6]
-				else
-					metalOverflowLevel = r[res][6]
-				end
-				local value = r[res][6]
-				if draggingShareIndicator and draggingShareIndicatorValue[res] ~= nil then
-					value = draggingShareIndicatorValue[res]
-				else
-					draggingShareIndicatorValue[res] = value
-				end
-				shareIndicatorArea[res] = { math_floor(barArea[1] + (value * barWidth) - (shareSliderWidth / 2)), math_floor(barArea[2] - sliderHeightAdd), math_floor(barArea[1] + (value * barWidth) + (shareSliderWidth / 2)), math_floor(barArea[4] + sliderHeightAdd) }
-				local cornerSize
-				if not showQuitscreen and resbarHover ~= nil and resbarHover == res then
-					cornerSize = 2 * widgetScale
-				else
-					cornerSize = 1.33 * widgetScale
-				end
-				UiSliderKnob(math_floor(shareIndicatorArea[res][1]+((shareIndicatorArea[res][3]-shareIndicatorArea[res][1])/2)), math_floor(shareIndicatorArea[res][2]+((shareIndicatorArea[res][4]-shareIndicatorArea[res][2])/2)), math_floor((shareIndicatorArea[res][3]-shareIndicatorArea[res][1])/2), { 0.85, 0, 0, 1 })
+			if res == 'energy' then
+				eneryOverflowLevel = r[res][6]
+			else
+				metalOverflowLevel = r[res][6]
 			end
+			local value = r[res][6]
+			if draggingShareIndicator and draggingShareIndicatorValue[res] ~= nil then
+				value = draggingShareIndicatorValue[res]
+			else
+				draggingShareIndicatorValue[res] = value
+			end
+			shareIndicatorArea[res] = { math_floor(barArea[1] + (value * barWidth) - (shareSliderWidth / 2)), math_floor(barArea[2] - sliderHeightAdd), math_floor(barArea[1] + (value * barWidth) + (shareSliderWidth / 2)), math_floor(barArea[4] + sliderHeightAdd) }
+			local cornerSize
+			if not showQuitscreen and resbarHover ~= nil and resbarHover == res then
+				cornerSize = 2 * widgetScale
+			else
+				cornerSize = 1.33 * widgetScale
+			end
+			UiSliderKnob(math_floor(shareIndicatorArea[res][1]+((shareIndicatorArea[res][3]-shareIndicatorArea[res][1])/2)), math_floor(shareIndicatorArea[res][2]+((shareIndicatorArea[res][4]-shareIndicatorArea[res][2])/2)), math_floor((shareIndicatorArea[res][3]-shareIndicatorArea[res][1])/2), { 0.85, 0, 0, 1 })
 		end
 	end)
 
@@ -1306,7 +1323,8 @@ local function updateResbar(res)  --decides where and what is drawn
 				.. highlightColor .. formattedAssigned .. textColor .. " is assigned to tasks or moving to jobs (dark green bar).\n"
 				.. highlightColor .. formattedActive .. textColor .. " is currently active and being used (green bar). This is the number shown.\n"
 				.. highlightColor .. formattedIdle .. textColor .. " is idle with no BP tasks (red part)."
-		
+
+
 			if config.drawBPIndicators and BP['mSliderPosition'] ~= nil and BP['eSliderPosition'] ~= nil then
 				bpTooltipText = bpTooltipText .. "\n\n"
 					.. textColor .. "The grey and yellow indicators show you that, if all BP were fully engaged:\n"
@@ -1353,7 +1371,7 @@ local function updateResbar(res)  --decides where and what is drawn
 					.. float_to_s(r['metal'][5]) .. " / " .. float_to_s(r['energy'][5]) .. " metal/energy expense, \n"
 					.. float_to_s(BP['metalExpensePerBP']) .. " / " .. float_to_s(BP['energyExpensePerBP']) .. " M/E expense per BP, \n"
 					.. float_to_s(r['energy'][4]) .." E income\n"
-					.. float_to_s(numWindTurbines) .." wind generators\n"
+					.. float_to_s(multiplicatorWindTurbines) .." wind generators\n"
 					.. "\nprojections:\n"
 					.. float_to_s(eIncomeNoWind) .." E income without wind\n"
 					.. float_to_s(BP['metalExpenseIfAllBPUsed']) .. " M spent if all BP is used, \n"
@@ -1687,42 +1705,36 @@ function widget:GameStart()
 	init()
 end
 
+local builderList = {}
+local currentBuilderIndex = 1
+
+local function RefreshBuilderList()
+    builderList = {}
+    for unitID, builderData in pairs(trackedBuilders) do
+        table.insert(builderList, {unitID = unitID, data = builderData})
+    end
+    currentBuilderIndex = 1
+end
+
 function widget:GameFrame(n)
 	gameFrame = n
-	--spec = spGetSpectatingState()
-
 	local bladeSpeedMultiplier = 0.2
 	windRotation = windRotation + (currentWind * bladeSpeedMultiplier)
-	-- If we're supposed to draw the buildpower bar, do some calculations.
 	if config.drawBPBar then -- calculations for the exact metal and energy draw value
-		-- Log initial cache values
 		local cacheTotalReservedBP = 0
 		local cacheTotallyUsedBP = 0
 
 		local usedBPMetalExpense = 0
 		local usedBPEnergyExpense = 0
-		local buildingBP = 0 -- how much BP is actively building, regardless of how stalled it is?
-
-
-		--Spring.Echo("Starting trackedBuilders loop")
-
-		if not builderCoroutine or coroutine.status(builderCoroutine) == "dead" then -- init builderCoroutine
-			builderCoroutine = coroutine.create(function()
-				for unitID, currentlyInspectedBuilder in pairs(trackedBuilders) do
-					coroutine.yield(unitID, currentlyInspectedBuilder)
-				end
-			end)
-		end
-
-		for i = 1, unitsPerFrame do -- use builderCoroutine, to work though builders
-			local success, unitID, currentlyInspectedBuilder = coroutine.resume(builderCoroutine)
-			if not success or not unitID then
+		local buildingBP = 0
+		for i = 1, 100 do
+			if currentBuilderIndex > #builderList then
 				break
 			end
-			local currentUnitBP, unitIsBuilt, unitDefID, unitTeamID = unpack(currentlyInspectedBuilder)
-			local unitExists, foundActivity, firstTime = findBPCommand(unitID, unitDefID, {CMD.REPAIR, CMD.RECLAIM, CMD.CAPTURE, CMD.GUARD})
-			--Spring.Echo("Unit exists: " .. tostring(unitExists) .. ", foundActivity: " .. tostring(foundActivity) ..", firstTime: " .. tostring(firstTime) .. ", builtUnitDefID: " .. tostring(builtUnitDefID))
-
+			local builder = builderList[currentBuilderIndex]
+			currentBuilderIndex = currentBuilderIndex + 1
+			local currentUnitBP, unitIsBuilt, unitDefID, unitTeamID= unpack(currentlyInspectedBuilder)
+			local unitExists, foundActivity, firstTime, builtUnitDefID = findBPCommand(unitID, unitDefID, {CMD.REPAIR, CMD.RECLAIM, CMD.CAPTURE, CMD.GUARD})
 			if not unitExists then
 				--Spring.Echo("Unit no longer exists, untracking unitID: " .. unitID)	
 				UntrackUnit(unitID)
@@ -1732,8 +1744,7 @@ function widget:GameFrame(n)
 				cacheTotalReservedBP = cacheTotalReservedBP + currentUnitBP
 				if firstTime == 1 then  -- it could use resources
 					local builtUnitID = spGetUnitIsBuilding(unitID)
-					if builtUnitID then -- is it in place?
-						local builtUnitDefID = spGetUnitDefID(builtUnitID)
+					if builtUnitID and builtUnitDefID then -- is it in place?
 						local _, currentlyUsedM, _, currentlyUsedE = spGetUnitResources(unitID)
 						usedBPMetalExpense = usedBPMetalExpense + currentlyUsedM
 						usedBPEnergyExpense = usedBPEnergyExpense + currentlyUsedE -- A builder may be cloaked, but not while it's building
@@ -1751,7 +1762,7 @@ function widget:GameFrame(n)
 		cacheDataBase['usedBPMetalExpense'] = cacheDataBase['usedBPMetalExpense'] + usedBPMetalExpense
 		cacheDataBase['usedBPEnergyExpense'] = cacheDataBase['usedBPEnergyExpense'] + usedBPEnergyExpense
 
-		if not builderCoroutine or coroutine.status(builderCoroutine) == "dead" then	-- If every builder was checked store it in BP
+		if currentBuilderIndex > #builderList then
 			BP['reservedBP_instant'] = cacheDataBase['reservedBP_instant']
 			BP['usedBP_instant'] = cacheDataBase['usedBP_instant']
 			BP['usedBPMetalExpense'] = cacheDataBase['usedBPMetalExpense']  --xxx extern for tooltip only
@@ -1766,70 +1777,66 @@ function widget:GameFrame(n)
 		end
 
 
+		if BP['usedBP_instant'] >= 1 then
+			-- We only need to calculate this if at least one builder is building.
+			BP['metalExpensePerBP'] = BP['usedBPMetalExpense'] / BP['usedBP_instant']
+			BP['energyExpensePerBP'] = BP['usedBPEnergyExpense'] / BP['usedBP_instant']
+			local totalBP = BP[4]
+			local energyExpense = r['energy'][5]
+			local metalExpense = r['metal'][5]
+			local metalExpenseMinusBuilders_instant  = metalExpense - BP['usedBPMetalExpense']
+			local energyExpenseMinusBuilders_instant = energyExpense - BP['usedBPEnergyExpense']
+			local metalExpenseMinusBuilders = addValueAndGetWeightedAverage(BP['history_nonBuilderMetalExpense'], metalExpenseMinusBuilders_instant, 1)
+			local energyExpenseMinusBuilders = addValueAndGetWeightedAverage(BP['history_nonBuilderEnergyExpense'], energyExpenseMinusBuilders_instant, 1)
+			BP['nonBPMetalExpense'] = metalExpenseMinusBuilders --xxx extern for tooltip only
+			BP['nonBPEnergyExpense'] = energyExpenseMinusBuilders --xxx extern for tooltip only
+			BP['metalExpenseIfAllBPUsed'] = metalExpenseMinusBuilders + BP['metalExpensePerBP'] * totalBP --xxx extern for tooltip only
+			BP['energyExpenseIfAllBPUsed'] = energyExpenseMinusBuilders + BP['energyExpensePerBP'] * totalBP --xxx extern for tooltip only
 
-		if n %3 == 0 then
-			if BP['usedBP_instant'] >= 1 then
-				-- We only need to calculate this if at least one builder is building.
-				BP['metalExpensePerBP'] = BP['usedBPMetalExpense'] / BP['usedBP_instant']
-				BP['energyExpensePerBP'] = BP['usedBPEnergyExpense'] / BP['usedBP_instant']
-				local totalBP = BP[4]
-				local energyExpense = r['energy'][5]
-				local metalExpense = r['metal'][5]
-				local metalExpenseMinusBuilders_instant  = metalExpense - BP['usedBPMetalExpense']
-				local energyExpenseMinusBuilders_instant = energyExpense - BP['usedBPEnergyExpense']
-				local metalExpenseMinusBuilders = addValueAndGetWeightedAverage(BP['history_nonBuilderMetalExpense'], metalExpenseMinusBuilders_instant, 1)
-				local energyExpenseMinusBuilders = addValueAndGetWeightedAverage(BP['history_nonBuilderEnergyExpense'], energyExpenseMinusBuilders_instant, 1)
-				BP['nonBPMetalExpense'] = metalExpenseMinusBuilders --xxx extern for tooltip only
-				BP['nonBPEnergyExpense'] = energyExpenseMinusBuilders --xxx extern for tooltip only
-				BP['metalExpenseIfAllBPUsed'] = metalExpenseMinusBuilders + BP['metalExpensePerBP'] * totalBP --xxx extern for tooltip only
-				BP['energyExpenseIfAllBPUsed'] = energyExpenseMinusBuilders + BP['energyExpensePerBP'] * totalBP --xxx extern for tooltip only
-
-				local metalIncome = r['metal'][4]
-				local energyIncome = r['energy'][4]
-				-- Assume our eco supports full BP until we calculate otherwise.
-				--local bpRatioSupportedByMIncome = 1 -- what proportion of our total BP can be supported by our metal income?
-				local bpRatioSupportedByEIncome = 1 -- what proportion of our total BP can be supported by our energy income?
-				local metalSupportedBP = metalIncome / BP['metalExpenseIfAllBPUsed'] * totalBP 
-				local bpRatioSupportedByMIncome = math_max(0, math_min(metalSupportedBP / totalBP, 1))
-				
-				if BP['energyExpensePerBP'] > 0 then
-					local energySupportedBP = energyIncome / BP['energyExpenseIfAllBPUsed'] * totalBP --ql
-					bpRatioSupportedByEIncome = math_max(0, math_min(energySupportedBP / totalBP, 1))
-				end
-				-- Weighted average of slider positions. If weight (BP['usedBP_instant']) is 0 the table won't be altered at all.
-				BP['mSliderPosition'] = addValueAndGetWeightedAverage(BP['history_mSliderPosition'], bpRatioSupportedByMIncome, BP['usedBP_instant'])
-				BP['eSliderPosition'] = addValueAndGetWeightedAverage(BP['history_eSliderPosition'], bpRatioSupportedByEIncome, BP['usedBP_instant'])
-				
-				
-				if config.drawBPWindRangeIndicators then
-				Spring.Echo('drawBPWindRangeIndicators')
-					local realWindStrength = 0
-					for unitID in pairs(trackedWinds) do
-						local _, _, energyMake, _ = spGetUnitResources(unitID)
-						if energyMake ~= nil then
-							realWindStrength = energyMake
-							break
-						end
-					end
-					cacheDataBase['realWindStrength'] = 0
-					BP['energyIncomeNoWind'] = energyIncome - numWindTurbines * realWindStrength
-					eSupportedBP_minWind = (BP['energyIncomeNoWind'] - energyExpenseMinusBuilders) / BP['energyExpensePerBP'] -- is that what we want? e converters exist...
-					local bpRatioSupportedByEIncome_minWind = math_max(0, math_min(eSupportedBP_minWind / totalBP, 1))
-
-					maxEPerWindGenerator = math_min(25, Game.windMax)
-					eSupportedBP_maxWind = (BP['energyIncomeNoWind'] + numWindTurbines * maxEPerWindGenerator - energyExpenseMinusBuilders) / BP['energyExpensePerBP']
-					local bpRatioSupportedByEIncome_maxWind = math_max(0, math_min(eSupportedBP_maxWind / totalBP, 1))
-					BP['eSliderPosition_minWind'] = addValueAndGetWeightedAverage(BP['history_eSliderPosition_minWind'], bpRatioSupportedByEIncome_minWind, BP['usedBP_instant'])
-					BP['eSliderPosition_maxWind'] = addValueAndGetWeightedAverage(BP['history_eSliderPosition_maxWind'], bpRatioSupportedByEIncome_maxWind, BP['usedBP_instant'])
-					--BP['eSliderPosition_minWind'] = bpRatioSupportedByEIncome_minWind * BP[5] / BP[4]
-					--BP['eSliderPosition_maxWind'] = bpRatioSupportedByEIncome_maxWind * BP[5] / BP[4]
-				end
-			else
-				BP['eSliderPosition_minWind'] = 1
-				BP['eSliderPosition_maxWind'] = 1
-				BP['mSliderPosition'] = nil
-				BP['eSliderPosition'] = nil
+			local metalIncome = r['metal'][4]
+			local energyIncome = r['energy'][4]
+			-- Assume our eco supports full BP until we calculate otherwise.
+			--local bpRatioSupportedByMIncome = 1 -- what proportion of our total BP can be supported by our metal income?
+			local bpRatioSupportedByEIncome = 1 -- what proportion of our total BP can be supported by our energy income?
+			local metalSupportedBP = metalIncome / BP['metalExpenseIfAllBPUsed'] * totalBP 
+			local bpRatioSupportedByMIncome = math_max(0, math_min(metalSupportedBP / totalBP, 1))
+			
+			if BP['energyExpensePerBP'] > 0 then
+				local energySupportedBP = energyIncome / BP['energyExpenseIfAllBPUsed'] * totalBP --ql
+				bpRatioSupportedByEIncome = math_max(0, math_min(energySupportedBP / totalBP, 1))
 			end
+			-- Weighted average of slider positions. If weight (BP['usedBP_instant']) is 0 the table won't be altered at all.
+			BP['mSliderPosition'] = addValueAndGetWeightedAverage(BP['history_mSliderPosition'], bpRatioSupportedByMIncome, BP['usedBP_instant'])
+			BP['eSliderPosition'] = addValueAndGetWeightedAverage(BP['history_eSliderPosition'], bpRatioSupportedByEIncome, BP['usedBP_instant'])
+			
+			
+			if config.drawBPWindRangeIndicators then
+				local realWindStrength = 0
+				for unitID in pairs(trackedWinds) do
+					local _, _, energyMake, _ = spGetUnitResources(unitID)
+					if energyMake ~= nil then
+						realWindStrength = energyMake
+						break
+					end
+				end
+				cacheDataBase['realWindStrength'] = 0
+				BP['energyIncomeNoWind'] = energyIncome - multiplicatorWindTurbines * realWindStrength
+				eSupportedBP_minWind = (BP['energyIncomeNoWind'] - energyExpenseMinusBuilders) / BP['energyExpensePerBP'] -- is that what we want? e converters exist...
+				local bpRatioSupportedByEIncome_minWind = math_max(0, math_min(eSupportedBP_minWind / totalBP, 1))
+
+				maxEPerWindGenerator = math_min(25, Game.windMax)
+				eSupportedBP_maxWind = (BP['energyIncomeNoWind'] + multiplicatorWindTurbines * maxEPerWindGenerator - energyExpenseMinusBuilders) / BP['energyExpensePerBP']
+				local bpRatioSupportedByEIncome_maxWind = math_max(0, math_min(eSupportedBP_maxWind / totalBP, 1))
+				BP['eSliderPosition_minWind'] = addValueAndGetWeightedAverage(BP['history_eSliderPosition_minWind'], bpRatioSupportedByEIncome_minWind, BP['usedBP_instant'])
+				BP['eSliderPosition_maxWind'] = addValueAndGetWeightedAverage(BP['history_eSliderPosition_maxWind'], bpRatioSupportedByEIncome_maxWind, BP['usedBP_instant'])
+				--BP['eSliderPosition_minWind'] = bpRatioSupportedByEIncome_minWind * BP[5] / BP[4]
+				--BP['eSliderPosition_maxWind'] = bpRatioSupportedByEIncome_maxWind * BP[5] / BP[4]
+			end
+		else
+			BP['eSliderPosition_minWind'] = 1
+			BP['eSliderPosition_maxWind'] = 1
+			BP['mSliderPosition'] = nil
+			BP['eSliderPosition'] = nil
 		end
 		local lowPrioNeededEnergy = Spring.GetTeamRulesParam(myTeamID, "lowPrioNeededEnergy") 
 		local lowPrioExpenseEnergy = Spring.GetTeamRulesParam(myTeamID, "lowPrioExpenseEnergy")
@@ -1839,8 +1846,8 @@ function widget:GameFrame(n)
 			stalling['lowPrioEnergy'] = lowPrioNeededEnergy + lowPrioExpenseEnergy
 			stalling['lowPrioMetal'] = lowPrioNeededMetal + lowPrioExpenseMetal
 		end
-		updateResbar('BP')
 	end
+	updateBPIndicatorPos()
 end
 
 local function updateAllyTeamOverflowing()
@@ -1948,7 +1955,7 @@ function widget:Update(dt)
 	end
 
 	sec = sec + dt
-	if sec > 0.033 then
+	if sec > 0.1 then
 		sec = 0
 		r = { metal = { spGetTeamResources(myTeamID, 'metal') }, energy = { spGetTeamResources(myTeamID, 'energy') }, BP = BP }
 		if not spec and not showQuitscreen then
@@ -2765,17 +2772,7 @@ function widget:Initialize()
 	Spring.SendCommands("resbar 0")
 
 	InitAdditionalValues()
-	for unitDefID, unitDef in pairs(UnitDefs) do -- fill unitCostData this is needed for exact calculations
-		local energy = unitDef.energyCost
-		unitCostData[unitDefID] = {
-			buildTime = unitDef.buildTime, 
-			energy = unitDef.energyCost, 
-			metal = unitDef.metalCost, 
-			EperBP = unitDef.energyCost/unitDef.buildTime, 
-			MperBP = unitDef.metalCost/unitDef.buildTime
-		}
-		local unitName = UnitDefs[unitDefID].name
-	end
+
 	-- determine if we want to show comcounter
 	local allteams = Spring.GetTeamList()
 	local teamN = table.maxn(allteams) - 1               --remove gaia
@@ -2902,85 +2899,116 @@ function widget:Shutdown()
 	WG['topbar'] = nil
 end
 
+
 function findBPCommand(unitID, unitDefID, cmdList)
-	local unitExists = false
-	local activityFound = nil
-	local firstTime = nil
-	local unitDef = UnitDefs[unitDefID]
-	if UnitDefs[unitDefID].isFactory then
-		commands = Spring.GetFactoryCommands(unitID, 1)
-	else
-		commands = Spring.GetUnitCommands(unitID, -1)
-	end
-	if commands then
-		unitExists = true
-	end
-	if unitDef.isFactory == true then
-		if #commands > 0 then
-			firstTime = 1
-			activityFound = true
-			return unitExists, activityFound, firstTime
-		end
-	end
-	for i = 1, #commands do
-		for _, relevantCMD in ipairs(cmdList) do
-			if commands[i].id == relevantCMD or commands[i].id < 0 then
-				firstTime = i
-				activityFound = true
-			return unitExists, activityFound, firstTime
-			end
-		end
-	end
-	return unitExists, activityFound, firstTime
+    local unitExists = false
+    local activityFound = nil
+    local firstTime = nil
+    local builtUnitDefID = nil
+    local builderInfo = builderDefs[unitDefID]
+
+    if builderInfo then
+        local commands
+        if builderInfo.isFactory then
+            commands = Spring.GetFactoryCommands(unitID, 1)
+        else
+            commands = Spring.GetUnitCommands(unitID, -1)
+        end
+        if commands and #commands > 0 then
+            unitExists = true
+            -- Erstelle ein Lookup-Table für cmdList
+            local cmdSet = {}
+            for _, cmdID in ipairs(cmdList) do
+                cmdSet[cmdID] = true
+            end
+
+            -- Spezielle Behandlung für Fabriken
+            if builderInfo.isFactory then
+                firstTime = 1
+                activityFound = true
+                return unitExists, activityFound, firstTime
+            end
+
+            for i = 1, #commands do
+                local cmdID = commands[i].id
+                if cmdSet[cmdID] or cmdID < 0 then
+                    firstTime = i
+                    activityFound = true
+                    if cmdID < 0 then
+                        builtUnitDefID = -cmdID
+                    end
+                    return unitExists, activityFound, firstTime, builtUnitDefID
+                end
+            end
+        end
+    end
+    return unitExists, activityFound, firstTime, builtUnitDefID
 end
+
+
 
 function TrackUnit(unitID, unitDefID, unitTeam) --needed for exact calculations
 	if (myTeamID == unitTeam) then
-		local unitDef = UnitDefs[unitDefID]
-		local _, _, _, _, build = Spring.GetUnitHealth(unitID) --is it finished?
-		local isBuilt = build >= 1
-		if isBuilt and unitDef then
-			if unitDef.buildSpeed and unitDef.buildSpeed > 0 and unitDef.canAssist or UnitDefs[unitDefID].isFactory then
-				trackedNum = trackedNum + 1
-				if not trackedBuilders[unitID] then				-- We may have already tracked this unit when it started being built. No need to add its BP again.
-					BP[4] = BP[4] + unitDef.buildSpeed -- BP[4] ^= totalAvailableBP
-				end
-				trackedBuilders[unitID] = { unitDef.buildSpeed, isBuilt, unitDefID, unitTeam }
-			elseif unitDef.name == "armwin" or unitDef.name == "corwin" then -- wind generator
+		local _, _, _, _, build = Spring.GetUnitHealth(unitID) 
+		local isBuilt = build >= 1 --is it finished?
+		if isBuilt then
+			local builderInfo = builderDefs[unitDefID] -- Get builder info from the pre-filled table
+			if builderInfo and not trackedBuilders[unitID] then
+				BP[4] = BP[4] + builderInfo.buildSpeed -- BP[4] is totalAvailableBP
+				trackedBuilders[unitID] = { builderInfo.buildSpeed, isBuilt, unitDefID, unitTeam, nil}
+			end
+			local energyMultiplier = windGenDefs[unitDefID] -- Get energyMultiplier info from the pre-filled table
+			if energyMultiplier and not trackedWinds[unitID] then
 				trackedWinds[unitID] = 1
-				numWindTurbines = numWindTurbines + 1
+				multiplicatorWindTurbines = multiplicatorWindTurbines + energyMultiplier
 			end
 		end
 	end
 end
 
 function UntrackUnit(unitID, unitDefID, unitTeam) -- needed for exact calculations
-	local unitDef = UnitDefs[unitDefID]
-	if (myTeamID == unitTeam) and unitDef then
-		if trackedBuilders[unitID] then
-			if unitDef.buildSpeed and unitDef.buildSpeed > 0 and unitDef.canAssist or UnitDefs[unitDefID].isFactory then
-			trackedNum = trackedNum - 1
-				BP[4] = BP[4] - trackedBuilders[unitID][1] -- BP[4] ^= totalAvailableBP
-			end
-		end
-		if trackedBuilders[unitID] then
-			 trackedBuilders[unitID] = nil
-		end
-		if trackedWinds[unitID] then
+	if (myTeamID == unitTeam) then
+        if trackedBuilders[unitID] then
+            local builderInfo = builderDefs[unitDefID] -- Get builder info from the pre-filled table
+            if builderInfo then
+                BP[4] = math.max(0, BP[4] - builderInfo.buildSpeed) -- Prevent negative BP[4]
+            end
+            trackedBuilders[unitID] = nil -- Remove from tracked builders
+        end
+		local energyMultiplier = windGenDefs[unitDefID]
+		if energyMultiplier then
 			trackedWinds[unitID] = nil
-			numWindTurbines = numWindTurbines - 1
+			multiplicatorWindTurbines = multiplicatorWindTurbines - energyMultiplier
 		end
 	end
 end
 
 function InitAdditionalValues()
-	BP[4] = 0
-	trackedNum = 0
-	trackedBuilders = {}
+	BP[4] = 0	
 	trackedWinds = {}
-	numWindTurbines = 0
+	multiplicatorWindTurbines = 0
+	trackedBuilders = {}
 
+	for unitDefID, unitDef in pairs(UnitDefs) do -- fill unitCostData this is needed for exact calculations
+		local energy = unitDef.energyCost
+		unitCostData[unitDefID] = {
+			buildTime = unitDef.buildTime, 
+			energy = unitDef.energyCost, 
+			metal = unitDef.metalCost, 
+			EperBP = unitDef.energyCost/unitDef.buildTime, 
+			MperBP = unitDef.metalCost/unitDef.buildTime
+		}
+		if unitDef.windGenerator and unitDef.windGenerator > 0 then -- Populate the windGenDefs
+			windGenDefs[unitDefID] = (unitDef.customParams and unitDef.customParams.energymultiplier) or 1
+		end
+		if unitDef.buildSpeed and unitDef.buildSpeed > 0 and unitDef.canAssist or UnitDefs[unitDefID].isFactory then -- Populate the builderDefs table
+			builderDefs[unitDefID]= {
+				buildSpeed = unitDef.buildSpeed,
+				isFactory = UnitDefs[unitDefID].isFactory
+			}
+		end
+	end
 	for _, unitID in pairs(Spring.GetTeamUnits(myTeamID)) do  -- needed for exact calculations
-		TrackUnit(unitID, Spring.GetUnitDefID(unitID), myTeamID)
+		TrackUnit(unitID, spGetUnitDefID(unitID), myTeamID)
 	end
 end

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -881,6 +881,7 @@ local function updateResbarText(res)
 	end
 
 	-- Add stalling M/E for any low-priority builders
+
 	if res == 'metal' then
 		r[res][3] = r[res][3] + stalling['lowPrioMetal'] 
 	elseif res == 'energy' then
@@ -1965,9 +1966,13 @@ function widget:GameFrame(n)
 		cacheDataBase[6] = 0
 		cacheDataBase[7] = 0
 	end
+	local lowPrioNeededEnergy = Spring.GetTeamRulesParam(myTeamID, "lowPrioNeededEnergy") 
+	local lowPrioExpenseEnergy = Spring.GetTeamRulesParam(myTeamID, "lowPrioExpenseEnergy")
+	local lowPrioNeededMetal = Spring.GetTeamRulesParam(myTeamID, "lowPrioNeededMetal")
+	local lowPrioExpenseMetal = Spring.GetTeamRulesParam(myTeamID, "lowPrioExpenseMetal")
 	if lowPrioNeededEnergy and lowPrioExpenseEnergy and lowPrioNeededMetal and lowPrioExpenseMetal then
-		stalling['lowPrioEnergy'] = Spring.GetTeamRulesParam(myTeamID, "lowPrioNeededEnergy") + Spring.GetTeamRulesParam(myTeamID, "lowPrioExpenseEnergy")
-		stalling['lowPrioMetal'] = Spring.GetTeamRulesParam(myTeamID, "lowPrioNeededMetal") + Spring.GetTeamRulesParam(myTeamID, "lowPrioExpenseMetal")
+		stalling['lowPrioEnergy'] = lowPrioNeededEnergy + lowPrioExpenseEnergy
+		stalling['lowPrioMetal'] = lowPrioNeededMetal + lowPrioExpenseMetal
 	end 
 end
 

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -2,7 +2,7 @@ function widget:GetInfo()
 	return {
 		name = "Top Bar with Buildpower",
 		desc = "Shows resources, buildpower, wind speed, commander counter, and various options.",
-		author = "Floris, Robert82 and McDoodle ",
+		author = "Floris, Robert82",
 		date = "Feb, 2017",
 		license = "GNU GPL, v2 or later", 
 		layer = -99980,
@@ -527,57 +527,6 @@ local function RectQuad(px, py, sx, sy, offset)
 	gl.TexCoord(offset, offset)
 	gl.Vertex(px, sy, 0)
 end
-
-local function ChamferedRectQuad(px, py, sx, sy, chamferSize)
-		gl.BeginEnd(GL.QUADS, function()
-		gl.Vertex(px + chamferSize, py)	-- Bottom chamfers
-		gl.Vertex(sx - chamferSize, py)
-		gl.Vertex(sx, py + chamferSize)
-		gl.Vertex(px, py + chamferSize)
-
-		gl.Vertex(px, py + chamferSize) --square
-		gl.Vertex(sx, py + chamferSize)
-		gl.Vertex(sx, sy)
-		gl.Vertex(px, sy)
-	end)
-end
-
-local function DrawPartialRing(cx, cy, r, startAngle, endAngle, segments, thickness, color)
-	gl.Color(color[1], color[2], color[3], color[4]) --RGB opac
-	local function drawCircleCap(radius, thickness, angle, flip)
-		local capRadius = thickness / 2
-		local capCenterX = cx + (radius + capRadius) * math.cos(angle)
-		local capCenterY = cy + (radius + capRadius) * math.sin(angle)
-		local angleStep = math.pi / segments
-		gl.BeginEnd(GL.TRIANGLE_FAN, function()
-			gl.Vertex(capCenterX, capCenterY) -- mid point cap
-			for i = 0, segments do
-				local a = angle + math.pi / 2 + (i * angleStep) * (flip and -1 or 1) - (math.pi / 2)
-				local x = capCenterX + capRadius * math.cos(a)
-				local y = capCenterY + capRadius * math.sin(a)
-				gl.Vertex(x, y)
-			end
-		end)
-	end
-	local function drawRingBody() -- draw ring
-		local angleStep = (endAngle - startAngle) / segments
-		gl.BeginEnd(GL.QUAD_STRIP, function()
-			for i = 0, segments do
-				local angle = startAngle + i * angleStep
-				local x1 = cx + r * math.cos(angle)
-				local y1 = cy + r * math.sin(angle)
-				local x2 = cx + (r + thickness) * math.cos(angle)
-				local y2 = cy + (r + thickness) * math.sin(angle)
-				gl.Vertex(x1, y1)
-				gl.Vertex(x2, y2)
-			end
-		end)
-	end
-	drawRingBody() -- main body
-	drawCircleCap(r, thickness, startAngle, false)  -- start cap	
-	drawCircleCap(r, thickness, endAngle, true)    -- mirrowed end cap
-end
-
 
 local function DrawRect(px, py, sx, sy, zoom)
 	gl.BeginEnd(GL.QUADS, RectQuad, px, py, sx, sy, zoom)
@@ -2541,50 +2490,6 @@ local function drawResBars() --hadles the blinking
 end
 
 function widget:DrawScreen()
-		-- Rumble
-		if BP[3] and BP[4] and BP[5] then  --ql
-			local startDeg = -108 -- Example in degrees (-0.3 * 360)
-			local startAngle = math.rad(startDeg) -- Convert degrees to radians
-		
-			local maxDeg = 230
-	
-			local endDegMax = startDeg - (1 * maxDeg)
-			local endAngleMax = math.rad(endDegMax)
-			
-			local progress1 = BP[3]/BP[4]
-			local endDeg = startDeg - (progress1 * maxDeg)
-			local endAngle = math.rad(endDeg)
-			
-			local progress2 = BP[5]/BP[4]
-			local endDeg2 = startDeg - (progress2 * maxDeg) 
-			local endAngle2 = math.rad(endDeg2)
-	
-	
-		
-			local segments = 50
-			local thickness = 10
-	
-			local color = {0.3, 0.3, 0, 1} 
-			DrawPartialRing(300, 300, 50, startAngle, endAngleMax, segments, thickness, color)  -- Rumble use this to actually draw it -- Background
-			local color = {0.04, 0.6, 0.7, 1} 
-			DrawPartialRing(300, 300, 50, startAngle, endAngle, segments, thickness, color)  -- Rumble use this to actually draw it -- second biggest
-	
-			local color = {0.125, 1, 1, 1} 
-			DrawPartialRing(300, 300, 50, startAngle, endAngle2, segments, thickness, color)  -- Rumble use this to actually draw it -- smallest
-			-- Rumble
-			local px, py = 500, 500 -- Bottom-left corner --left --bottom
-			local sx, sy = 700, 600 -- Top-right corner --right -- top
-			local chamferSize = 20  -- Size of the chamfer
-	
-		
-		--gl.BeginEnd(GL.QUADS, function()	-- Rumble use this to actually draw it
-	
-		--	ChamferedRectQuad(px, py, sx, sy, chamferSize)
-		--end)
-		end
-	
-
-
 	drawResBars()
 
 	local now = os.clock()


### PR DESCRIPTION
### Work done
A running version of the New Top Bar.
It shows an additional bar for BP.
It shows the % of BP that is actually used and spending resources and it shows how much of your BP has orders that are related to use BP like guard and repair.
This bar includes indicators that show you how much of your BP can be supplied with your energy income and metal income. This is indicated by moving sliders.
Additionally there is a possibility to actually see the wind risk. This is indicated by a yellow line next to the BP bar. It will all make sense when you see it :)


### ToDo
It still has unused variables in the gadget.
Still needs work if in game scaling is needed
Improve addWeightedValue
Use getwind instead of Energy from s random windgen.
Use minWind for windrisk
Use maxwind instead of Spring.WindMax
Seperate stalling['lowPrioEnergy'] and n %6
Local usedBP_instant = BP['usedBP_instant']
Try to use old slider pos and delete 20 lines