### PR TITLE
feat(buildsplit): Unhardcode build split modifier

### DIFF
--- a/luaui/Widgets/cmd_buildsplit.lua
+++ b/luaui/Widgets/cmd_buildsplit.lua
@@ -1,23 +1,23 @@
 function widget:GetInfo()
 	return {
-		name      = "Build Split",
-		desc      = "Splits builds over cons, and vice versa (use shift+space to activate)",
-		author    = "Niobium",
-		version   = "v1.0",
-		date      = "Jan 11, 2009",
-		license   = "GNU GPL, v2 or later",
-		layer     = 0,
-		enabled = true
+		name = "Build Split",
+		desc = "Splits builds over cons, and vice versa (use shift+space to activate)",
+		author = "Niobium",
+		version = "v1.0",
+		date = "Jan 11, 2009",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
 	}
 end
 
 local floor = math.floor
-local spGetSpecState = Spring.GetSpectatingState
 local spTestBuildOrder = Spring.TestBuildOrder
 local spGetSelUnitCount = Spring.GetSelectedUnitsCount
 local spGetSelUnitsSorted = Spring.GetSelectedUnitsSorted
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGiveOrderToUnitArray = Spring.GiveOrderToUnitArray
+local activeModifier = false
 
 local unitBuildOptions = {}
 for udefID, def in ipairs(UnitDefs) do
@@ -30,39 +30,54 @@ local buildID = 0
 local buildLocs = {}
 local buildCount = 0
 
-local gameStarted
+local gameStarted = false
+local isSpec = false
 
 local function maybeRemoveSelf()
-    if Spring.GetSpectatingState() and (Spring.GetGameFrame() > 0 or gameStarted) then
-        widgetHandler:RemoveWidget()
-    end
+	if isSpec then
+		widgetHandler:RemoveWidget()
+
+		return true
+	end
 end
 
 function widget:GameStart()
-    gameStarted = true
-    maybeRemoveSelf()
+	gameStarted = true
 end
 
-function widget:PlayerChanged(playerID)
-    maybeRemoveSelf()
+function widget:PlayerChanged()
+	isSpec = Spring.GetSpectatingState()
+	maybeRemoveSelf()
+end
+
+local function handleSetModifier(_, _, _, data)
+	data = data or {}
+	activeModifier = data[1]
 end
 
 function widget:Initialize()
-    if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
-        maybeRemoveSelf()
-    end
+	gameStarted = Spring.GetGameFrame() > 0
+	isSpec = Spring.GetSpectatingState()
+
+	if maybeRemoveSelf() then
+		return
+	end
+
+	widgetHandler:AddAction("buildsplit", handleSetModifier, { true }, "p")
+	widgetHandler:AddAction("buildsplit", handleSetModifier, { false }, "r")
 end
 
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts) -- 3 of 3 parameters
-	if not (cmdID < 0 and cmdOpts.shift and cmdOpts.meta) then return false end -- Note: All multibuilds require shift
-	if spGetSelUnitCount() < 2 then return false end
+	if not (cmdID < 0 and cmdOpts.shift and activeModifier) then
+		return false
+	end -- Note: All multibuilds require shift
+
+	if spGetSelUnitCount() < 2 then
+		return false
+	end
 
 	--if #cmdParams < 4 then return false end -- Probably not possible, commented for now
-	if spTestBuildOrder(-cmdID, cmdParams[1], cmdParams[2], cmdParams[3], cmdParams[4]) == 0 then return false end
-
-	local areSpec = spGetSpecState()
-	if areSpec then
-		widgetHandler:RemoveWidget()
+	if spTestBuildOrder(-cmdID, cmdParams[1], cmdParams[2], cmdParams[3], cmdParams[4]) == 0 then
 		return false
 	end
 
@@ -74,7 +89,13 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts) -- 3 of 3 parameters
 end
 
 function widget:Update()
-	if buildCount == 0 then return end
+	if buildCount == 0 then
+		return
+	end
+
+	if not gameStarted then
+		return
+	end
 
 	local selUnits = spGetSelUnitsSorted()
 
@@ -83,9 +104,9 @@ function widget:Update()
 	for uDefID, uIDs in pairs(selUnits) do
 		local uBuilds = unitBuildOptions[uDefID]
 		if uBuilds then
-			for bi=1, #uBuilds do
+			for bi = 1, #uBuilds do
 				if uBuilds[bi] == buildID then
-					for ui=1, #uIDs do
+					for ui = 1, #uIDs do
 						builderCount = builderCount + 1
 						builders[builderCount] = uIDs[ui]
 					end
@@ -99,14 +120,14 @@ function widget:Update()
 		local ratio = floor(buildCount / builderCount)
 		local excess = buildCount - builderCount * ratio -- == buildCount % builderCount
 		local buildingInd = 0
-		for bi=1, builderCount do
-			for r=1, ratio do
+		for bi = 1, builderCount do
+			for _ = 1, ratio do
 				buildingInd = buildingInd + 1
-				spGiveOrderToUnit(builders[bi], -buildID, buildLocs[buildingInd], {"shift"})
+				spGiveOrderToUnit(builders[bi], -buildID, buildLocs[buildingInd], { "shift" })
 			end
 			if bi <= excess then
 				buildingInd = buildingInd + 1
-				spGiveOrderToUnit(builders[bi], -buildID, buildLocs[buildingInd], {"shift"})
+				spGiveOrderToUnit(builders[bi], -buildID, buildLocs[buildingInd], { "shift" })
 			end
 		end
 	else
@@ -114,10 +135,10 @@ function widget:Update()
 		local excess = builderCount - buildCount * ratio -- == builderCount % buildCount
 		local builderInd = 0
 
-		for bi=1, buildCount do
+		for bi = 1, buildCount do
 			local setUnits = {}
 			local setCount = 0
-			for r=1, ratio do
+			for _ = 1, ratio do
 				builderInd = builderInd + 1
 				setCount = setCount + 1
 				setUnits[setCount] = builders[builderInd]
@@ -128,7 +149,7 @@ function widget:Update()
 				setUnits[setCount] = builders[builderInd]
 			end
 
-			spGiveOrderToUnitArray(setUnits, -buildID, buildLocs[bi], {"shift"})
+			spGiveOrderToUnitArray(setUnits, -buildID, buildLocs[bi], { "shift" })
 		end
 	end
 

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -23,6 +23,8 @@ bind          Any+space  selectloop         // activate select shape | Loop Sele
 bind           Any+ctrl  selectloop_invert  // select units not present in current selection modifier | Loop Select Widget
 bind          Any+shift  selectloop_add     // add to selection modifier | Loop Select Widget
 
+bind          Any+space  buildsplit         // activate build split mode (distribute orders between selected builders) | Build Split Widget
+
 // commandinsert keys
 bind          Any+space  commandinsert prepend_between // prepend command into the queue between 2 commands close to cursor
 // bind          Any+space  commandinsert prepend_queue // prepend command into a separate prepend queue until key released


### PR DESCRIPTION


### Work done
Remove the meta modifier check on CommandNotify to an action assigned modifier.

#### Test steps
- [ ] `/cheat`
- [ ] `/give 10 armcv`
- [ ] Select all 10 workers
- [ ] Assign buildunit_armwind as active command (select wind)
- [ ] Hold Alt+shift+space and drag a multiple wind build order
- [ ] Verify orders are distributed between workers

### Remarks

Notice how buildsplits implementation relies on CommandNotify + Update, this is not a good architectural decision as it can not infer whether we are splitting builds assigned by the user or by another widget, i.e. all build orders are split as long as space is being pressed. Notice in previous implementation an external widget could assign an order without meta and this problem would not occur (although still occurred is meta was assigned anyway).

The proper implementation, although uglier, would be to assign the commands on mouserelease and activecommand < 0. We don't fix this here, merge at own risk.