### PR TITLE
update evocom evolution - add global_timer method and add more configurable evolution lobby options

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -280,24 +280,28 @@ function UnitDef_Post(name, uDef)
 					uDef.power = ((uDef.metalcost+(uDef.energycost/60))/modOptions.evocomxpmultiplier)
 				end
 				
+				if  name == "armcom" then
+					uDef.customparams.evolution_target = "armcomlvl2"
+					uDef.customparams.inheritxpratemultiplier = 0.5
+					uDef.customparams.childreninheritxp = "TURRET MOBILEBUILT"
+					uDef.customparams.parentsinheritxp = "TURRET MOBILEBUILT"
+					uDef.customparams.evocomlvl = 1
+					elseif name == "corcom" then
+					uDef.customparams.evolution_target = "corcomlvl2"
+					uDef.customparams.evocomlvl = 1
+					elseif name == "legcom" then
+					uDef.customparams.evolution_target = "legcomlvl2"
+					uDef.customparams.evocomlvl = 1
+					end
+
 				if modOptions.evocomlevelupmethod == "dynamic" then
 					uDef.customparams.evolution_condition = "power"
 					uDef.customparams.evolution_power_multiplier = 1			-- Scales the power calculated based on your own combined power. 
 					uDef.customparams.evolution_power_threshold = uDef.customparams.evolution_power_threshold or 10000 --sets threshold for level 1 commanders
 				elseif modOptions.evocomlevelupmethod == "timed" then
-					uDef.customparams.evolution_timer = modOptions.evocomleveluprate*60
-					uDef.customparams.evolution_condition = "timer"
-				end
-
-				if  name == "armcom" then
-				uDef.customparams.evolution_target = "armcomlvl2"
-				uDef.customparams.inheritxpratemultiplier = 0.5
-				uDef.customparams.childreninheritxp = "TURRET MOBILEBUILT"
-				uDef.customparams.parentsinheritxp = "TURRET MOBILEBUILT"
-				elseif name == "corcom" then
-				uDef.customparams.evolution_target = "corcomlvl2"
-				elseif name == "legcom" then
-				uDef.customparams.evolution_target = "legcomlvl2"
+					uDef.customparams.evolution_timer = modOptions.evocomleveluprate*60*uDef.customparams.evocomlvl
+					Spring.Echo("evolution_timer", uDef.customparams.evolution_timer)
+					uDef.customparams.evolution_condition = "timer_global"
 				end
 
 				if comLevel and modOptions.evocomlevelcap <= comLevel then

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -297,10 +297,10 @@ function UnitDef_Post(name, uDef)
 				if modOptions.evocomlevelupmethod == "dynamic" then
 					uDef.customparams.evolution_condition = "power"
 					uDef.customparams.evolution_power_multiplier = 1			-- Scales the power calculated based on your own combined power. 
-					uDef.customparams.evolution_power_threshold = uDef.customparams.evolution_power_threshold or 10000 --sets threshold for level 1 commanders
+					local evolutionPowerThreshold = uDef.customparams.evolution_power_threshold or 10000 --sets threshold for level 1 commanders
+					uDef.customparams.evolution_power_threshold = evolutionPowerThreshold*modOptions.evocomlevelupmultiplier
 				elseif modOptions.evocomlevelupmethod == "timed" then
-					uDef.customparams.evolution_timer = modOptions.evocomleveluprate*60*uDef.customparams.evocomlvl
-					Spring.Echo("evolution_timer", uDef.customparams.evolution_timer)
+					uDef.customparams.evolution_timer = modOptions.evocomleveluptime*60*uDef.customparams.evocomlvl
 					uDef.customparams.evolution_condition = "timer_global"
 				end
 

--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -98,7 +98,7 @@ if gadgetHandler:IsSyncedCode() then
 		-- evolution_announcement_size = 18.5, 		-- Size of the onscreen announcement
 
 		--	-- Has a default value, as indicated, if not chosen:
-		-- evolution_condition = "timer",    		-- condition type for the evolution. "timer", "health", or "power"
+		-- evolution_condition = "timer",    		-- condition type for the evolution. "timer", "timer_global", "health", or "power"
 		-- evolution_timer = 600, 					-- set the timer used for the timer condition. Given in secons from when the unit was created.
 		-- evolution_health_threshold = 0,			-- threshold for triggering the "health" evolution condition.
 		-- evolution_power_threshold = 600,			-- threshold for triggering the "power" evolution condition.
@@ -338,6 +338,18 @@ if gadgetHandler:IsSyncedCode() then
 			for unitID, _ in pairs(evolutionMetaList) do
 				local currentTime =  spGetGameSeconds()
 				if evolutionMetaList[unitID].evolution_condition == "timer" and (currentTime-evolutionMetaList[unitID].timeCreated) >= evolutionMetaList[unitID].evolution_timer then
+					local enemyNearby = spGetUnitNearestEnemy(unitID, evolutionMetaList[unitID].combatRadius)
+					local inCombat = false
+					if enemyNearby then
+						inCombat = true
+						evolutionMetaList[unitID].combatTimer = spGetGameSeconds()
+					end
+
+					if not inCombat and (currentTime-evolutionMetaList[unitID].combatTimer) >= 5 then
+						Evolve(unitID, evolutionMetaList[unitID].evolution_target)
+					end
+				end
+				if evolutionMetaList[unitID].evolution_condition == "timer_global" and currentTime >= evolutionMetaList[unitID].evolution_timer then
 					local enemyNearby = spGetUnitNearestEnemy(unitID, evolutionMetaList[unitID].combatRadius)
 					local inCombat = false
 					if enemyNearby then

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -968,9 +968,20 @@ local options = {
         step   	= 0.1,
     },
 
+    {
+        key    	= "evocomlevelupmultiplier",
+        name   	= "Evolving Commanders - Dynamic Only - Evolution Rate Multiplier.",
+        desc   	= "(Range 0.1x - 3x Multiplier) Adjusts the thresholds at which Dynamic evolutions occur",
+        type   	= "number",
+        section	= "options_extra",
+        def    	= 1,
+        min    	= 0.1,
+        max    	= 3,
+        step   	= 0.1,
+    },
 
     {
-        key    	= "evocomleveluprate",
+        key    	= "evocomleveluptime",
         name   	= "Evolving Commanders - Timed Only - Evolution Timer.",
         desc   	= "(Range 0.1 - 20 Minutes) Rate at which commanders will evolve if Timed method is selected.",
         type   	= "number",


### PR DESCRIPTION
this adds unit_evolution method of timer_global which checks the time threshold against current gameseconds.

switches evocom timed evolution method in lobby options to use this new method.

add adjustable dynamic thresholds to lobby modoptions for evocom