### PR TITLE
handle LOS in lua gadget to allow Spring.SetFeatureAlwaysVisible to work

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -86,7 +86,7 @@ local modrules = {
 	},
 
 	featureLOS = {
-		featureVisibility = 3, -- Can be 0 - no default LOS for features, 1 - Gaia features always visible, 2 - allyteam & Gaia features always visible, or 3 - all features always visible.
+		featureVisibility = 0, -- Can be 0 - no default LOS for features, 1 - Gaia features always visible, 2 - allyteam & Gaia features always visible, or 3 - all features always visible.
 	},
 
 	system = {

--- a/luarules/gadgets/feature_visibility_behavior.lua
+++ b/luarules/gadgets/feature_visibility_behavior.lua
@@ -1,0 +1,31 @@
+if not gadgetHandler:IsSyncedCode() then return end
+
+function gadget:GetInfo()
+	return {
+		name    = "Feature Visibility Behavior",
+		desc    = "Handles feature visibility",
+        author  = "SethDGamre",
+        date    = "September 2024",
+		license = "Public domain",
+		layer = -101, --this must happen before ai_ruins.lua
+		enabled = true
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then return false end
+
+local wreckFeatureDefID = {}
+for id, fDef in pairs(FeatureDefs) do
+	if fDef.customParams and fDef.customParams.fromunit then
+		wreckFeatureDefID[id] = true
+    end
+end
+
+function gadget:FeatureCreated (featureID)
+    local featureDefID = Spring.GetFeatureDefID(featureID)
+    if wreckFeatureDefID[featureDefID] then
+        Spring.SetFeatureAlwaysVisible(featureID, false)
+    else
+        Spring.SetFeatureAlwaysVisible(featureID, true)
+    end
+end


### PR DESCRIPTION
Currently in modrules.lua featureVisibility is set to 3 for "all features always visible."

this overwrites the function Spring.SetFeatureAlwaysVisible which means that you cannot hide features arbitrarily in gadgets. This is an issue for the following reasons:

1. Scavengers mode design goal of ruins being ruins is not possible without this function.
2. this will be problematic for campaign development when features are to be shown/hidden at desired times.
3. there's an ongoing discussion about hiding commander wrecks to prevent cheeky, cheesy plays relying on unearned unscouted metagame knowledge of wreck locations.

Currently, this PR recreates old behavior through lua just to enable the function. Feature tracking widgets that rely on the FeatureCreated() callin glitch out when  the feature is hidden due to LOS stuff so this will need to be addressed on a per gadget basis as this moves forward.