### PR TITLE
remove the ability to transport naval transports

### DIFF
--- a/units/ArmBuildings/LandUtil/armnanotc.lua
+++ b/units/ArmBuildings/LandUtil/armnanotc.lua
@@ -15,7 +15,7 @@ return {
 		canreclaim = true,
 		canrepeat = false,
 		canstop = true,
-		cantbetransported = false,
+		cantbetransported = true,
 		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "31 32 31",

--- a/units/CorBuildings/LandUtil/cornanotc.lua
+++ b/units/CorBuildings/LandUtil/cornanotc.lua
@@ -15,7 +15,7 @@ return {
 		canreclaim = true,
 		canrepeat = false,
 		canstop = true,
-		cantbetransported = false,
+		cantbetransported = true,
 		category = "ALL NOTSUB NOWEAPON NOTAIR NOTHOVER SURFACE EMPABLE",
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "31 32 31",


### PR DESCRIPTION
Naval nanos cannot be unloaded into water. on top of that there is griefing potential this has been an issue for atleast 3 years now. this bug needs to be removed as there is no good reason to allow players to grief themselves on something that should be working

### work done
changes the transportable tag to prevent players from being able to pick up naval nanos with air transports