### PR TITLE
refactor(blueprint): set layer to 1, to allow other keybinds priority

### DIFF
--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -3,7 +3,7 @@ function widget:GetInfo()
 		name = "Blueprint",
 		desc = "Saves and queues groups of unit blueprints",
 		license = "GNU GPL, v2 or later",
-		layer = 1,
+		layer = 1, -- after gridmenu(0), to let factories use alt+xyz hotkeys
 		enabled = true,
 		handler = true,
 	}

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -3,7 +3,7 @@ function widget:GetInfo()
 		name = "Blueprint",
 		desc = "Saves and queues groups of unit blueprints",
 		license = "GNU GPL, v2 or later",
-		layer = 0,
+		layer = 1,
 		enabled = true,
 		handler = true,
 	}


### PR DESCRIPTION
This allows things like adding `bind  Alt+sc_c gridmenu_key 1 3` before blueprint binds, so that, when using grid menu, alt+build on a factory builds a unit instead of creating a blueprint.

See https://discord.com/channels/549281623154229250/1281544470923448430 for some context