### PR TITLE
Startspot Suggestions: Refactor I18N code to avoid duplicated translation entries

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1629,7 +1629,7 @@
 			"tutorial": "Recommended start positions and roles are indicated within the circles.\n\nTo disable this, check the Settings window for \"Start Position Suggestions\".",
 			"roles": {
 				"front": {
-					"title": "Frontline",
+					"title": "Front",
 					"description": "Build ground units and bring your Commander forward to secure a strong central position, taking metal spots along the way."
 				},
 				"tech": {
@@ -1644,34 +1644,14 @@
 					"title": "Sea",
 					"description": "Build navy units and secure a strong position on the map. Later, build amphibious or air units to invade enemies on land."
 				},
-				"air/front": {
-					"title": "Air/Front",
-					"description": "Scout enemy players, distribute transports to allies, fight for air dominance, bomb enemy bases, and help defend against raids.\n\nand/or\n\nBuild ground units early and bring your commander forward to secure a strong central position, taking metal spots along the way."
-				},
-				"air/sea": {
-					"title": "Air/Sea",
-					"description": "Scout enemy players, distribute transports to allies, fight for air dominance, bomb enemy bases, and help defend against raids.\n\nand/or\n\nBuild navy units early and secure a strong position on the map. Later on, consider building amphibious or air units to invade enemies on land."
-				},
-				"air/tech": {
-					"title": "Air/Tech",
-					"description": "Scout enemy players, distribute transports to allies, fight for air dominance, bomb enemy bases, and help defend against raids.\n\nand/or\n\nFocus on early economy to support building a Tier 2 factory, in order to distribute Tier 2 constructors to the team, and attack with high tier units."
-				},
-				"front/sea": {
-					"title": "Front/Sea",
-					"description": "Build ground units early and bring your commander forward to secure a strong central position, taking metal spots along the way.\n\nand/or\n\nBuild navy units early and secure a strong position on the map. Later on, consider building amphibious or air units to invade enemies on land."
-				},
-				"front/tech": {
-					"title": "Front/Tech",
-					"description": "Build ground units early and bring your commander forward to secure a strong central position, taking metal spots along the way.\n\nand/or\n\nFocus on early economy to support building a Tier 2 factory, in order to distribute Tier 2 constructors to the team, and attack with high tier units."
-				},
-				"sea/tech": {
-					"title": "Sea/Tech",
-					"description": "Build navy units early and secure a strong position on the map. Later on, consider building amphibious or air units to invade enemies on land.\n\nand/or\n\nFocus on early economy to support building a Tier 2 factory, in order to distribute Tier 2 constructors to the team, and attack with high tier units."
-				},
 				"baseCenter": {
 					"title": "Base Center",
 					"description": "Move your Commander here shortly after spawning. Build your first factory in this area."
 				}
+			},
+			"multiRole": {
+				"title": "%{role1}/%{role2}",
+				"description": "%{role1}\n\nand/or\n\n%{role2}"
 			}
 		}
 	}

--- a/luaui/Widgets/map_start_position_suggestions.lua
+++ b/luaui/Widgets/map_start_position_suggestions.lua
@@ -453,6 +453,26 @@ local drawAllStartLocationsCircles = glListCache(function()
 	end
 end)
 
+local function getCaptions(role)
+	local title, description
+	local roles = role:split("/")
+
+	if #roles == 1 then
+		title = Spring.I18N("ui.startPositionSuggestions.roles." .. roles[1] .. ".title")
+		description = Spring.I18N("ui.startPositionSuggestions.roles." .. roles[1] .. ".description")
+	elseif #roles > 1 then
+		local title1 = Spring.I18N("ui.startPositionSuggestions.roles." .. roles[1] .. ".title")
+		local title2 = Spring.I18N("ui.startPositionSuggestions.roles." .. roles[2] .. ".title")
+		title = Spring.I18N("ui.startPositionSuggestions.multiRole.title", { role1 = title1, role2 = title2})
+
+		local description1 = Spring.I18N("ui.startPositionSuggestions.roles." .. roles[1] .. ".description")
+		local description2 = Spring.I18N("ui.startPositionSuggestions.roles." .. roles[2] .. ".description")
+		description = Spring.I18N("ui.startPositionSuggestions.multiRole.description", { role1 = description1, role2 = description2})
+	end
+
+	return { title = title, description = description }
+end
+
 local function drawAllStartLocationsText()
 	if startPositions == nil then
 		return
@@ -483,7 +503,7 @@ local function drawAllStartLocationsText()
 			if showRole then
 				font:SetTextColor(config.roleTextColor)
 				font:Print(
-					Spring.I18N("ui.startPositionSuggestions.roles." .. position.role .. ".title"),
+					getCaptions(position.role).title,
 					0,
 					0,
 					config.roleTextSize,
@@ -569,12 +589,12 @@ local function drawTooltip()
 	WG["tooltip"].ShowTooltip(
 		"startPositionTooltip",
 		wrapText(
-			Spring.I18N("ui.startPositionSuggestions.roles." .. tooltipKey .. ".description"),
+			getCaptions(tooltipKey).description,
 			config.tooltipMaxWidthChars
 		),
 		x + xOffset,
 		y + yOffset,
-		Spring.I18N("ui.startPositionSuggestions.roles." .. tooltipKey .. ".title")
+		getCaptions(tooltipKey).title
 	)
 end
 


### PR DESCRIPTION
### Work done
Refactored I18N code in startspot suggestions widget so that multirole suggestions now concatenate other translation entries, rather than duplicating the entries.

#### Test steps
- [ ] Start a game with a startspot has multiple roles, verify that no change from previous behaviour