### PR TITLE
Fix JSON syntan error in German interface.json

### DIFF
--- a/language/de/interface.json
+++ b/language/de/interface.json
@@ -229,7 +229,7 @@
 			"customOnOff": {
 				"lowTrajectory": "Direktes Feuer",
 				"highTrajectory": "Indirektes Feuer",
-				"trajectory_tooltip": "Schaltet den Artillerie-Abschusswinkel zwischen flacher und steiler Flugbahn um",
+				"trajectory_tooltip": "Schaltet den Artillerie-Abschusswinkel zwischen flacher und steiler Flugbahn um"
 			}
 		},
 		"idleBuilders": {


### PR DESCRIPTION
### Work done
Fix JSON syntax error in interface.json. While this does not break I18N inside the game, it breaks the Transifex integration picking up changes to the file.