### PR TITLE
Spectator HUD: Add custom options

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -907,6 +907,8 @@
 			"armyValue_tooltip": "Army value in metal,\nincl. commander",
 			"defenseValue_title": "Defense Value",
 			"defenseValue_tooltip": "Defense value in metal",
+			"utilityValue_title": "Utility Value",
+			"utilityValue_tooltip": "Utility value in metal",
 			"economyValue_title": "Economy Value",
 			"economyValue_tooltip": "Economy value in metal",
 			"damageDealt_title": "Damage Dealt",
@@ -1621,6 +1623,7 @@
 				"spectator_hud_config_basic": "Basic",
 				"spectator_hud_config_advanced": "Advanced",
 				"spectator_hud_config_expert": "Expert",
+				"spectator_hud_config_custom": "Custom",
 				"startpositionsuggestions": "Start Position Suggestions",
 				"startpositionsuggestions_descr": "Show expert recommended starting locations on the map"
 			}

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -211,6 +211,7 @@ local spectatorHUDConfigOptions = {
 	Spring.I18N('ui.settings.option.spectator_hud_config_basic'),
 	Spring.I18N('ui.settings.option.spectator_hud_config_advanced'),
 	Spring.I18N('ui.settings.option.spectator_hud_config_expert'),
+	Spring.I18N('ui.settings.option.spectator_hud_config_custom'),
 }
 
 local startScript = VFS.LoadFile("_script.txt")
@@ -4270,12 +4271,110 @@ function init()
 		  end,
 		},
 
-		{ id = "spectator_hud_config", group = "ui", category = types.advanced, widget = "Spectator HUD", name = Spring.I18N('ui.settings.option.spectator_hud_config'), type = "select", options = spectatorHUDConfigOptions, value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getConfig ~= nil and WG['spectator_hud'].getConfig()) or 1, description = Spring.I18N('ui.settings.option.spectator_hud_config_descr'),
+		{ id = "spectator_hud_config", group = "ui", category = types.advanced, name = Spring.I18N('ui.settings.option.spectator_hud_config'), type = "select", options = spectatorHUDConfigOptions, value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getConfig ~= nil and WG['spectator_hud'].getConfig()) or 1, description = Spring.I18N('ui.settings.option.spectator_hud_config_descr'),
 			onload = function(i)
 				loadWidgetData("Spectator HUD", "spectator_hud_config", { 'config' })
 			end,
 			onchange = function(i, value)
 				saveOptionValue('Spectator HUD', 'spectator_hud', 'setConfig', { 'config' }, value)
+				init()
+			end,
+		},
+
+		{ id = "spectator_hud_metric_metalIncome", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.metalIncome_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('metalIncome')) or 1, description = Spring.I18N('ui.spectator_hud.metalIncome_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_metalIncome", { 'metricsEnabled', 'metalIncome' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'metalIncome' }, value, { 'metalIncome', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_energyIncome", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.energyIncome_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('energyIncome')) or 1, description = Spring.I18N('ui.spectator_hud.energyIncome_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_energyIncome", { 'metricsEnabled', 'energyIncome' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'energyIncome' }, value, { 'energyIncome', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_buildPower", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.buildPower_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('buildPower')) or 1, description = Spring.I18N('ui.spectator_hud.buildPower_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_buildPower", { 'metricsEnabled', 'buildPower' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'buildPower' }, value, { 'buildPower', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_metalProduced", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.metalProduced_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('metalProduced')) or 1, description = Spring.I18N('ui.spectator_hud.metalProduced_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_metalProduced", { 'metricsEnabled', 'metalProduced' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'metalProduced' }, value, { 'metalProduced', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_energyProduced", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.energyProduced_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('energyProduced')) or 1, description = Spring.I18N('ui.spectator_hud.energyProduced_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_energyProduced", { 'metricsEnabled', 'energyProduced' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'energyProduced' }, value, { 'energyProduced', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_metalExcess", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.metalExcess_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('metalExcess')) or 1, description = Spring.I18N('ui.spectator_hud.metalExcess_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_metalExcess", { 'metricsEnabled', 'metalExcess' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'metalExcess' }, value, { 'metalExcess', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_energyExcess", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.energyExcess_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('energyExcess')) or 1, description = Spring.I18N('ui.spectator_hud.energyExcess_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_energyExcess", { 'metricsEnabled', 'energyExcess' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'energyExcess' }, value, { 'energyExcess', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_armyValue", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.armyValue_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('armyValue')) or 1, description = Spring.I18N('ui.spectator_hud.armyValue_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_armyValue", { 'metricsEnabled', 'armyValue' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'armyValue' }, value, { 'armyValue', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_defenseValue", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.defenseValue_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('defenseValue')) or 1, description = Spring.I18N('ui.spectator_hud.defenseValue_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_defenseValue", { 'metricsEnabled', 'defenseValue' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'defenseValue' }, value, { 'defenseValue', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_utilityValue", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.utilityValue_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('utilityValue')) or 1, description = Spring.I18N('ui.spectator_hud.utilityValue_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_utilityValue", { 'metricsEnabled', 'utilityValue' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'utilityValue' }, value, { 'utilityValue', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_economyValue", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.economyValue_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('economyValue')) or 1, description = Spring.I18N('ui.spectator_hud.economyValue_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_economyValue", { 'metricsEnabled', 'economyValue' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'economyValue' }, value, { 'economyValue', value })
+			end,
+		},
+		{ id = "spectator_hud_metric_damageDealt", group = "ui", category = types.advanced, name = Spring.I18N('ui.spectator_hud.damageDealt_title'), type = "bool", value = (WG['spectator_hud'] ~= nil and WG['spectator_hud'].getMetricEnabled~= nil and WG['spectator_hud'].getMetricEnabled('damageDealt')) or 1, description = Spring.I18N('ui.spectator_hud.damageDealt_tooltip'),
+			onload = function(i)
+				loadWidgetData("Spectator HUD", "spectator_hud_metric_damageDealt", { 'metricsEnabled', 'damageDealt' })
+			end,
+			onchange = function(i, value)
+				saveOptionValue('Spectator HUD', 'spectator_hud', 'setMetricEnabled', { 'metricsEnabled', 'damageDealt' }, value, { 'damageDealt', value })
 			end,
 		},
 
@@ -5657,6 +5756,21 @@ function init()
 		options[getOptionByID('gridmenu_alwaysreturn')] = nil
 		options[getOptionByID('gridmenu_autoselectfirst')] = nil
 		options[getOptionByID('gridmenu_labbuildmode')] = nil
+	end
+
+	if spectatorHUDConfigOptions[options[getOptionByID('spectator_hud_config')].value] ~= Spring.I18N('ui.settings.option.spectator_hud_config_custom') then
+		options[getOptionByID('spectator_hud_metric_metalIncome')] = nil
+		options[getOptionByID('spectator_hud_metric_energyIncome')] = nil
+		options[getOptionByID('spectator_hud_metric_buildPower')] = nil
+		options[getOptionByID('spectator_hud_metric_metalProduced')] = nil
+		options[getOptionByID('spectator_hud_metric_energyProduced')] = nil
+		options[getOptionByID('spectator_hud_metric_metalExcess')] = nil
+		options[getOptionByID('spectator_hud_metric_energyExcess')] = nil
+		options[getOptionByID('spectator_hud_metric_armyValue')] = nil
+		options[getOptionByID('spectator_hud_metric_defenseValue')] = nil
+		options[getOptionByID('spectator_hud_metric_utilityValue')] = nil
+		options[getOptionByID('spectator_hud_metric_economyValue')] = nil
+		options[getOptionByID('spectator_hud_metric_damageDealt')] = nil
 	end
 
 	-- hide English unit names toggle if using English

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -195,7 +195,7 @@ local settings = {
 	statsUpdateFrequency = 2,		 -- every 2nd frame
 
 	widgetScale = 0.8,
-	widgetConfig = 3,
+	widgetConfig = constants.configLevel.basic,
 }
 
 local metricKeys = {

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -150,7 +150,8 @@ local constants = {
 		basic = 1,
 		advanced = 2,
 		expert = 3,
-		unavailable = 4,
+		custom = 4,
+		unavailable = 5,
 	},
 }
 
@@ -196,6 +197,9 @@ local settings = {
 
 	widgetScale = 0.8,
 	widgetConfig = constants.configLevel.basic,
+
+	-- this table is used only when widgetConfig is set to custom
+	metricsEnabled = {},
 }
 
 local metricKeys = {
@@ -236,6 +240,11 @@ local metricsAvailable = {
 	{ key="damageEfficiency", configLevel=constants.configLevel.unavailable, text="D%" },
 }
 local metricsEnabled = {}
+
+-- set defaults before loading values from config
+for _,metric in ipairs(metricsAvailable) do
+	settings.metricsEnabled[metric.key] = metric.configLevel == constants.configLevel.basic
+end
 
 local allyTeamTable = nil
 
@@ -661,7 +670,16 @@ local function buildMetricsEnabled()
 	metricsEnabled = {}
 	local index = 1
 	for _,metric in ipairs(metricsAvailable) do
-		if settings.widgetConfig >= metric.configLevel then
+		local addMetric = false
+		if settings.widgetConfig == constants.configLevel.custom then
+			if settings.metricsEnabled[metric.key] then
+				addMetric = true
+			end
+		elseif settings.widgetConfig >= metric.configLevel then
+			addMetric = true
+		end
+
+		if addMetric then
 			local metricEnabled = table.copy(metric)
 			metricEnabled.id = index
 			metricsEnabled[index] = metricEnabled
@@ -1820,6 +1838,10 @@ local function init()
 		settings.statsUpdateFrequency = 2  -- 15 times a second, same as engine slowUpdate
 		settings.useMovingAverage = true
 		settings.movingAverageWindowSize = 16  -- approx 1 sec
+	elseif settings.widgetConfig == constants.configLevel.custom then
+		settings.statsUpdateFrequency = 2
+		settings.useMovingAverage = true
+		settings.movingAverageWindowSize = 16
 	end
 
 	calculateDimensions()
@@ -1893,6 +1915,14 @@ function widget:Initialize()
 	end
 	WG["spectator_hud"].setConfig = function(value)
 		settings.widgetConfig = value
+		reInit()
+	end
+
+	WG["spectator_hud"].getMetricEnabled = function(metric)
+		return settings.metricsEnabled[metric]
+	end
+	WG["spectator_hud"].setMetricEnabled = function(args)
+		settings.metricsEnabled[args[1]] = args[2]
 		reInit()
 	end
 
@@ -2073,6 +2103,11 @@ function widget:GetConfigData()
 		widgetConfig = settings.widgetConfig,
 	}
 
+	result.metricsEnabled = {}
+	for _,metric in pairs(metricKeys) do
+		result.metricsEnabled[metric] = settings.metricsEnabled[metric]
+	end
+
 	return result
 end
 
@@ -2082,5 +2117,13 @@ function widget:SetConfigData(data)
 	end
 	if data.widgetConfig then
 		settings.widgetConfig = data.widgetConfig
+	end
+
+	if data["metricsEnabled"] then
+		for _,metric in pairs(metricKeys) do
+			if data["metricsEnabled"][metric] then
+				settings.metricsEnabled[metric] = data["metricsEnabled"][metric]
+			end
+		end
 	end
 end

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -223,7 +223,7 @@ local metricKeys = {
 local metricsAvailable = {
 	{ key="metalIncome", configLevel=constants.configLevel.basic, text="M/s" },
 	{ key="reclaimMetalIncome", configLevel=constants.configLevel.unavailable, text="MR" },
-	{ key="energyConversionMetalIncome", configLevel=constants.configLevel.expert, text="EC" },
+	{ key="energyConversionMetalIncome", configLevel=constants.configLevel.unavailable, text="EC" },
 	{ key="energyIncome", configLevel=constants.configLevel.basic, text="E/s" },
 	{ key="reclaimEnergyIncome", configLevel=constants.configLevel.unavailable, text="ER" },
 	{ key="buildPower", configLevel=constants.configLevel.expert, text="BP" },


### PR DESCRIPTION
Add possibility to configure each metric shown by Spectator HUD separately.

#### BEFORE:

![screen_2024-09-10_09-01-21-665](https://github.com/user-attachments/assets/a2359042-eda2-406a-9f54-d51b8278c0e4)

#### AFTER:

![screen_2024-09-10_09-01-30-717](https://github.com/user-attachments/assets/766150f0-7b4d-4e50-b7ea-fd56f6fc197d)