### PR TITLE
Evocom dgun hotfix

### DIFF
--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -166,10 +166,17 @@ function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shie
 
 		local gameframe = spGetGameFrame()
 
-		if not modOptions.shieldsrework and hitX > 0 and lastShieldFrameCheck[shieldCarrierUnitID] ~= gameframe then
-			shieldPower = math.max(shieldPower - damage, 0)
-			spSetUnitShieldState(shieldCarrierUnitID, shieldEmitterWeaponNum, shieldEnabledState, shieldPower)
-			lastShieldFrameCheck[shieldCarrierUnitID] = gameframe
+		if not modOptions.shieldsrework then
+			local damageCooldownFrames = 10
+			if shieldPower < damage then return false end
+
+			lastShieldFrameCheck[shieldCarrierUnitID] = lastShieldFrameCheck[shieldCarrierUnitID] or gameframe
+
+			if hitX > 0 and lastShieldFrameCheck[shieldCarrierUnitID] <= gameframe then
+				shieldPower = math.max(shieldPower - damage, 0)
+				spSetUnitShieldState(shieldCarrierUnitID, shieldEmitterWeaponNum, shieldEnabledState, shieldPower)
+				lastShieldFrameCheck[shieldCarrierUnitID] = gameframe + damageCooldownFrames
+			end
 		end
 
 		-- Engine does not provide a way for shields to stop DGun projectiles, they will impact once and carry on through,

--- a/units/other/evocom/corcomlvl10.lua
+++ b/units/other/evocom/corcomlvl10.lua
@@ -399,7 +399,7 @@ return {
 						alpha = 0.17,
 						armortype = "shields",
 						force = 2.5,
-						intercepttype = 11111,
+						intercepttype = 8191,
 						power = 30000,
 						powerregen = 500,
 						powerregenenergy = 100,

--- a/units/other/evocom/corcomlvl2.lua
+++ b/units/other/evocom/corcomlvl2.lua
@@ -343,7 +343,7 @@ return {
 					alpha = 0.17,
 					armortype = "shields",
 					force = 2.5,
-					intercepttype = 11111,
+					intercepttype = 8191,
 					power = 1000,
 					powerregen = 33,
 					powerregenenergy = 6.6,

--- a/units/other/evocom/corcomlvl3.lua
+++ b/units/other/evocom/corcomlvl3.lua
@@ -393,7 +393,7 @@ return {
 					alpha = 0.17,
 					armortype = "shields",
 					force = 2.5,
-					intercepttype = 11111,
+					intercepttype = 8191,
 					power = 3300,
 					powerregen = 75,
 					powerregenenergy = 15,

--- a/units/other/evocom/corcomlvl4.lua
+++ b/units/other/evocom/corcomlvl4.lua
@@ -392,7 +392,7 @@ return {
 					alpha = 0.17,
 					armortype = "shields",
 					force = 2.5,
-					intercepttype = 11111,
+					intercepttype = 8191,
 					power = 5500,
 					powerregen = 125,
 					powerregenenergy = 25,

--- a/units/other/evocom/corcomlvl5.lua
+++ b/units/other/evocom/corcomlvl5.lua
@@ -395,7 +395,7 @@ return {
 					alpha = 0.17,
 					armortype = "shields",
 					force = 2.5,
-					intercepttype = 11111,
+					intercepttype = 8191,
 					power = 7000,
 					powerregen = 200,
 					powerregenenergy = 40,

--- a/units/other/evocom/corcomlvl6.lua
+++ b/units/other/evocom/corcomlvl6.lua
@@ -399,7 +399,7 @@ return {
 					alpha = 0.17,
 					armortype = "shields",
 					force = 2.5,
-					intercepttype = 11111,
+					intercepttype = 8191,
 					power = 10000,
 					powerregen = 250,
 					powerregenenergy = 50,

--- a/units/other/evocom/corcomlvl7.lua
+++ b/units/other/evocom/corcomlvl7.lua
@@ -400,7 +400,7 @@ return {
 					alpha = 0.17,
 					armortype = "shields",
 					force = 2.5,
-					intercepttype = 11111,
+					intercepttype = 8191,
 					power = 13000,
 					powerregen = 308,
 					powerregenenergy = 61,

--- a/units/other/evocom/corcomlvl8.lua
+++ b/units/other/evocom/corcomlvl8.lua
@@ -407,7 +407,7 @@ return {
 						alpha = 0.17,
 						armortype = "shields",
 						force = 2.5,
-						intercepttype = 11111,
+						intercepttype = 8191,
 						power = 17000,
 						powerregen = 366,
 						powerregenenergy = 72,

--- a/units/other/evocom/corcomlvl9.lua
+++ b/units/other/evocom/corcomlvl9.lua
@@ -406,7 +406,7 @@ return {
 						alpha = 0.17,
 						armortype = "shields",
 						force = 2.5,
-						intercepttype = 11111,
+						intercepttype = 8191,
 						power = 23000,
 						powerregen = 424,
 						powerregenenergy = 84,


### PR DESCRIPTION
Oversight on my part. Outside of the shield rework, dgun projectiles keep moving back so long as there's shield charge means the dgun can never actually hit the cortex commander. This PR fixes that and also assigns correct bitmasks to the cortex commander.