### PR TITLE
adding sc_n (command_skip_current) and ctrl+sc_n command_cancel_last to legacy keybinds

### DIFF
--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -56,6 +56,8 @@ bind sc_l loadunits
 bind Shift+sc_l loadunits
 bind sc_m move
 bind Shift+sc_m move
+bind sc_n  command_skip_current
+bind Ctrl+sc_n  command_cancel_last
 bind sc_p patrol
 bind Shift+sc_p patrol
 bind sc_q,sc_q drawlabel // double hit Q for drawlabel, these are only present due to legacy. Should be deprecated at some point

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -61,6 +61,8 @@ bind sc_l loadunits
 bind Shift+sc_l loadunits
 bind sc_m move
 bind Shift+sc_m move
+bind sc_n command_skip_current
+bind Ctrl+sc_n command_cancel_last
 bind sc_p patrol
 bind Shift+sc_p patrol
 bind sc_q,sc_q drawlabel // double hit Q for drawlabel


### PR DESCRIPTION
One very useful thing that the grid menu has are the command skip keys that are unavailabe in legacy. Adding those would be awesome.

I have added those 2 new commands to the legacy binds, is this binds are currently unused in legacy.

I personally dislike grid keybinds but i really like these 2 shortcuts and other will like them to i guess.

Todo: Someone should update the graphics for the keybind menu ingame.