### PR TITLE
Explicitly define unitdef.waterline for naval constructions turrets

### DIFF
--- a/units/ArmBuildings/SeaUtil/armnanotc2plat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotc2plat.lua
@@ -41,6 +41,7 @@ return {
 		terraformspeed = 3000,
 		turnrate = 1,
 		upright = true,
+		waterline = 0,
 		workertime = 600,
 		customparams = {
 			usebuildinggrounddecal = true,

--- a/units/ArmBuildings/SeaUtil/armnanotcplat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotcplat.lua
@@ -41,6 +41,7 @@ return {
 		terraformspeed = 1000,
 		turnrate = 1,
 		upright = true,
+		waterline = 0,
 		workertime = 200,
 		customparams = {
 			usebuildinggrounddecal = false,

--- a/units/CorBuildings/SeaUtil/cornanotc2plat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotc2plat.lua
@@ -41,6 +41,7 @@ return {
 		terraformspeed = 3000,
 		turnrate = 1,
 		upright = true,
+		waterline = 0,
 		workertime = 600,
 		customparams = {
 			usebuildinggrounddecal = true,

--- a/units/CorBuildings/SeaUtil/cornanotcplat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotcplat.lua
@@ -41,6 +41,7 @@ return {
 		terraformspeed = 1000,
 		turnrate = 1,
 		upright = true,
+		waterline = 0,
 		workertime = 200,
 		customparams = {
 			usebuildinggrounddecal = false,

--- a/units/Legion/Utilities/cornanotc2plat.lua
+++ b/units/Legion/Utilities/cornanotc2plat.lua
@@ -41,6 +41,7 @@ return {
 		terraformspeed = 3000,
 		turnrate = 1,
 		upright = true,
+		waterline = 0,
 		workertime = 600,
 		customparams = {
 			usebuildinggrounddecal = true,

--- a/units/Legion/Utilities/legnanotcplat.lua
+++ b/units/Legion/Utilities/legnanotcplat.lua
@@ -41,6 +41,7 @@ return {
 		terraformspeed = 1000,
 		turnrate = 1,
 		upright = true,
+		waterline = 0,
 		workertime = 200,
 		customparams = {
 			usebuildinggrounddecal = false,


### PR DESCRIPTION
Unlike other surface naval units, naval construction turrets did not have their waterline explicitly defined.
This led to them being misidentified as underwater by the targeting category assigner.

Tested in skirmish, naval construction turrets now function correctly.