### PR TITLE
Removed hardcoded units from anti-ranges widget, check unitDefs for coverage range instead

### DIFF
--- a/luaui/Widgets/gui_anti_ranges.lua
+++ b/luaui/Widgets/gui_anti_ranges.lua
@@ -6,7 +6,7 @@ function widget:GetInfo()
         author    = "[teh]decay, Floris",
         date      = "25 january 2015",
         license   = "GNU GPL, v2 or later",
-        version   = 3,
+        version   = 4,
         layer     = 5,
         enabled   = true
     }
@@ -17,6 +17,7 @@ end
 --Changelog
 -- v2 [teh]decay:  Add water antinukes
 -- v3 Floris:  added normal anti, changed widget name, optional glow, optional fadeout on closeup, changed line thickness and opacity, empty anti uses different color
+-- v4 grotful: Removed hardcoded unit lists, added function to find anti-nuke units in unitDefs
 
 
 --------------------------------------------------------------------------------
@@ -46,15 +47,6 @@ local fadeStartDistance			= 3500
 -- Speedups
 --------------------------------------------------------------------------------
 
-local arm_anti					= UnitDefNames.armamd.id
-local arm_mobile_anti			= UnitDefNames.armscab.id
-local arm_mobile_anti_water		= UnitDefNames.armcarry.id
-local arm_mobile_anti_water_2	= UnitDefNames.armantiship.id
-local cor_anti					= UnitDefNames.corfmd.id
-local cor_mobile_anti			= UnitDefNames.cormabm.id
-local cor_mobile_anti_water		= UnitDefNames.corcarry.id
-local cor_mobile_anti_water_2	= UnitDefNames.corantiship.id
-
 local glColor					= gl.Color
 local glDepthTest				= gl.DepthTest
 local glLineWidth				= gl.LineWidth
@@ -70,19 +62,33 @@ local GetUnitIsStunned     		= Spring.GetUnitIsStunned
 
 local antiInLos					= {}
 local antiOutLos				= {}
-
-local coverageRangeArmStatic	= WeaponDefs[UnitDefNames.armamd.weapons[1].weaponDef].coverageRange
-local coverageRangeCoreStatic	= WeaponDefs[UnitDefNames.corfmd.weapons[1].weaponDef].coverageRange
-local coverageRangeArm			= WeaponDefs[UnitDefNames.armscab.weapons[1].weaponDef].coverageRange
-local coverageRangeCore			= WeaponDefs[UnitDefNames.cormabm.weapons[1].weaponDef].coverageRange
-local coverageRangeArmWater		= WeaponDefs[UnitDefNames.armcarry.weapons[1].weaponDef].coverageRange
-local coverageRangeCoreWater	= WeaponDefs[UnitDefNames.corcarry.weapons[1].weaponDef].coverageRange
-local coverageRangeArmWater2	= WeaponDefs[UnitDefNames.armantiship.weapons[1].weaponDef].coverageRange
-local coverageRangeCoreWater2	= WeaponDefs[UnitDefNames.corantiship.weapons[1].weaponDef].coverageRange
+local antiNukeDefs              = {}
 
 local diag = math.diag
 
 local chobbyInterface
+
+--------------------------------------------------------------------------------
+-- Initialization
+--------------------------------------------------------------------------------
+
+function widget:Initialize()
+    identifyAntiNukeUnits()  -- Pre-process unit definitions
+    checkAllUnits()
+end
+
+function identifyAntiNukeUnits()
+    for unitDefID, unitDef in pairs(UnitDefs) do
+        local weapons = unitDef.weapons
+        for i=1, #weapons do
+            local weaponDef = WeaponDefs[weapons[i].weaponDef]
+            if weaponDef and weaponDef.coverageRange and weaponDef.coverageRange > 0 then
+                antiNukeDefs[unitDefID] = weaponDef.coverageRange
+                break  -- No need to check further weapons for this unit
+            end
+        end
+    end
+end
 
 --------------------------------------------------------------------------------
 -- Callins
@@ -186,29 +192,11 @@ function drawCircle(uID, coverageRange, x, y, z, camX, camY, camZ)
 end
 
 function processVisibleUnit(unitID)
-    local unitDefId = spGetUnitDefID(unitID);
-    if unitDefId == arm_anti or unitDefId == cor_anti or unitDefId == arm_mobile_anti or unitDefId == cor_mobile_anti
-            or unitDefId == arm_mobile_anti_water or unitDefId == cor_mobile_anti_water or unitDefId == arm_mobile_anti_water_2 or unitDefId == cor_mobile_anti_water_2 then
+    local unitDefID = spGetUnitDefID(unitID)
+    local coverageRange = antiNukeDefs[unitDefID]
+    if coverageRange then
         local x, y, z = spGetUnitPosition(unitID)
-        local pos = {x,y,z}
-
-        if unitDefId == arm_mobile_anti then
-            pos[4] = coverageRangeArm
-        elseif unitDefId == arm_anti then
-            pos[4] = coverageRangeArmStatic
-        elseif unitDefId == cor_anti then
-            pos[4] = coverageRangeCoreStatic
-        elseif unitDefId == arm_mobile_anti_water then
-            pos[4] = coverageRangeArmWater
-		elseif unitDefId == arm_mobile_anti_water_2 then
-            pos[4] = coverageRangeArmWater2
-		elseif unitDefId == cor_mobile_anti_water_2 then
-            pos[4] = coverageRangeCoreWater2
-        elseif unitDefId == cor_mobile_anti then
-            pos[4] = coverageRangeCore
-        else
-            pos[4] = coverageRangeCoreWater
-        end
+        local pos = { x, y, z, coverageRange }
 
         antiInLos[unitID] = pos
         antiOutLos[unitID] = nil
@@ -216,24 +204,16 @@ function processVisibleUnit(unitID)
 end
 
 function widget:UnitLeftLos(unitID)
-    local unitDefId = spGetUnitDefID(unitID);
-    if unitDefId == arm_anti or unitDefId == cor_anti or unitDefId == arm_mobile_anti or unitDefId == cor_mobile_anti or unitDefId == arm_mobile_anti_water or unitDefId == cor_mobile_anti_water or unitDefId == arm_mobile_anti_water_2 or unitDefId == cor_mobile_anti_water_2 then
+    local unitDefID = spGetUnitDefID(unitID)
+    local coverageRange = antiNukeDefs[unitDefID]
+    if coverageRange then
         local x, y, z = spGetUnitPosition(unitID)
-        local pos = {(x or antiInLos[unitID][1]), (y or antiInLos[unitID][2]), (z or antiInLos[unitID][3])}
-
-        if unitDefId == arm_mobile_anti then
-            pos[4] = coverageRangeArm
-        elseif unitDefId == arm_mobile_anti_water then
-            pos[4] = coverageRangeArmWater
-		elseif unitDefId == arm_mobile_anti_water_2 then
-            pos[4] = coverageRangeArmWater2
-		elseif unitDefId == cor_mobile_anti_water_2 then
-            pos[4] = coverageRangeCoreWater2
-        elseif unitDefId == cor_mobile_anti then
-            pos[4] = coverageRangeCore
-        else
-            pos[4] = coverageRangeCoreWater
-        end
+        local pos = {
+            (x or antiInLos[unitID][1]),
+            (y or antiInLos[unitID][2]),
+            (z or antiInLos[unitID][3]),
+            coverageRange
+        }
 
         antiOutLos[unitID] = pos
         antiInLos[unitID] = nil
@@ -260,14 +240,9 @@ function widget:GameFrame(n)
     end
 end
 
-function widget:Initialize()
-	checkAllUnits()
-end
-
 function widget:PlayerChanged(playerID)
 	checkAllUnits()
 end
-
 
 function checkAllUnits()
 	antiInLos				= {}


### PR DESCRIPTION
This update replaces the hardcoded list of anti-nuke units with a dynamic method that automatically identifies units based on their weapon definitions.

The identifyAntiNukeUnits function iterates over all units and checks their weapon configurations to determine if they have a valid coverage range. If a unit has a weapon with a coverage range greater than zero, it is added to the anti-nuke units list. This approach improves maintainability by eliminating the need for manual updates whenever new units are added and should support units added through tweakdefs.