### PR TITLE
Scavenger Cloud Resurrect

### DIFF
--- a/gamedata/scavengers/unitdef_changes.lua
+++ b/gamedata/scavengers/unitdef_changes.lua
@@ -324,9 +324,11 @@ customDefs.correcl = {
 customDefs.legkam = {
 	weapondefs = {
 		martyrbomb = {
-			spawns_name = "cormine1",
-			spawns_surface = "LAND",
-			spawns_expire = 99999,
+			customparams = {
+				spawns_name = "cormine1_scav",
+				spawns_surface = "LAND",
+				spawns_expire = 99999,
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Scavenger Cloud can now resurrect (or destroy) features. Any resurrect-able wreck will be resurrected, and any non-resurrect-able feature (like tree, or unit debris) will be slowly damaged and destroyed.
- Fixed legion kamikaze plane to drop mines as intended in previous update.