### PR TITLE
Modoptions Panel Update

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -8,7 +8,7 @@
 --  name:     the displayed name
 --  desc:     the description (could be used as a tooltip)
 --  hint:     greyed out text that appears in input field when empty
---  type:     the option type ('list','string','number','bool')
+--  type:     the option type ('list','string','number','bool',`subheader`,`seperator`)
 --  def:      the default value
 --  min:      minimum value for number options
 --  max:      maximum value for number options
@@ -17,7 +17,16 @@
 --  items:    array of item strings for list options
 --  section:  so lobbies can order options in categories/panels
 --  scope:    'all', 'player', 'team', 'allyteam'      <<< not supported yet >>>
---
+--  collumn:  moves the option 1 row up if value is greater than the preivous row's one, default: 1
+--         |  negative value forces new row, absolute value is used
+--         |  zero moves to the left, 1 is default, 2 is half way to the right
+--         |  recommened values: for 2 columns: 1 and 2, for 3 columns 1, 1.66, and 2.33
+--  
+--  lock:     if type is bool: hides the table of keys when set to TRUE     <<< can not hide seperators >>>
+--      |     if type is list: add under each item what it should SHOW when set to
+--  unlock:   if type is bool: hides the table of keys when set to FALSE    <<< can not hide seperators >>>
+--        |   if type is list: add under each item what it should HIDE when set to
+--  bitmask:  int (1|2|4|8...etc), for when multiple options can hide an item
 
 local options = {
 
@@ -45,11 +54,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_main",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -82,11 +88,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_main",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -233,11 +236,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_main",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -251,7 +251,7 @@ local options = {
 
     {
 		key 	= "no_comtrans",
-		name 	= "T1 transports cant load commanders",
+		name 	= "T1 Transports Can't Load Coms",
 		desc 	= "Commanders will be too heavy for tech 1 transports to carry. (Tech 2 transports can still carry)",
 		type 	= "bool",
 		section = "options_main",
@@ -274,6 +274,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1,
     },
 
     {
@@ -283,6 +284,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1.66,
     },
 
     {
@@ -292,6 +294,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1,
     },
 
     {
@@ -301,6 +304,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1,
     },
 
     {
@@ -310,6 +314,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1.66,
     },
 
     {
@@ -319,33 +324,37 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1,
     },
 
     {
         key    	= "unit_restrictions_notacnukes",
-        name   	= "Disable Tactical Nukes and EMPs",
-        desc   	= "Disable Tactical Nukes and EMPs",
+        name   	= "Disable Tactical Missiles/EMPs",
+        desc   	= "Disables Cortex Tactical Missile Launcher and Armada EMP Missile Launcher",
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1.66,
     },
 
     {
         key    	= "unit_restrictions_nolrpc",
-        name   	= "Disable Long Range Artilery (LRPC) structures",
-        desc   	= "Disable Long Range Artilery (LRPC) structures",
+        name   	= "Disable Long Range Artilery (LRPC)",
+        desc   	= "Disable Long Range Plasma Artilery (LRPC) structures",
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1,
     },
 
     {
         key    	= "unit_restrictions_noendgamelrpc",
-        name   	= "Disable Endgame Long Range Artilery (LRPC) structures (AKA lolcannons)",
-        desc   	= "Disable Endgame Long Range Artilery (LRPC) structures (AKA lolcannons)",
+        name   	= "Disable Endgame Artilery (LRPC)",
+        desc   	= "Disable Endgame Long Range Plasma Artilery (LRPC) structures (AKA lolcannons)",
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1.66,
     },
 
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -450,11 +459,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "raptor_defense_options",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -476,11 +482,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "raptor_defense_options",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -508,11 +511,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "raptor_defense_options",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -609,11 +609,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "scav_defense_options",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -635,11 +632,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "scav_defense_options",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -667,11 +661,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "scav_defense_options",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -745,11 +736,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     --{
@@ -794,12 +782,10 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
+
 
     {
         key 	= "map_waterlevel",
@@ -824,12 +810,10 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
+
 
     {
         key 	= "ruins",
@@ -839,9 +823,9 @@ local options = {
         def 	= "scav_only",
         section = "options_extra",
         items 	= {
-            { key = "enabled", 		name = "Enabled" },
-            { key = "scav_only", 	name = "Enabled for Scavengers only" },
-            { key = "disabled", 	name = "Disabled" },
+            { key = "enabled", 		name = "Enabled", unlock = {"ruins_density", "ruins_only_t1"} },
+            { key = "scav_only", 	name = "Enabled for Scavengers only", unlock = {"ruins_density", "ruins_only_t1"} },
+            { key = "disabled", 	name = "Disabled", lock = {"ruins_density", "ruins_only_t1"} },
         }
     },
 
@@ -879,12 +863,10 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
+
 
     {
         key 	= "lootboxes",
@@ -894,9 +876,9 @@ local options = {
         def 	= "scav_only",
         section = "options_extra",
         items 	= {
-            { key = "enabled", 		name = "Enabled" },
-            { key = "scav_only", 	name = "Enabled for Scavengers only" },
-            { key = "disabled", 	name = "Disabled" },
+            { key = "enabled", 		name = "Enabled", unlock = {"lootboxes_density"} },
+            { key = "scav_only", 	name = "Enabled for Scavengers only", unlock = {"lootboxes_density"} },
+            { key = "disabled", 	name = "Disabled", lock = {"lootboxes_density"} },
         }
     },
 
@@ -915,62 +897,39 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
+
 
     {
         key 	= "evocom",
-        name 	= "Evolving Commanders Enabled",
+        name 	= "Evolving Commanders",
         desc   	= "Commanders evolve, gaining new weapons and abilities.",
         type 	= "bool",
         def 	= false,
         section = "options_extra",
+        unlock  = {"evocomlevelupmethod","evocomlevelcap","evocomxpmultiplier", "evocomleveluptime", "evocomlevelupmultiplier"},
+        --lock    = {"buffer_fix"},
     },
 
     {
         key 	= "evocomlevelupmethod",
-        name 	= "Evolving Commanders: Leveling Method",
+        name 	= "EvoCom: Leveling Method",
         desc   	= "Dynamic: Commanders evolve to keep up with the highest power player. Timed: Static Evolution Rate",
         type 	= "list",
         def 	= "dynamic",
         section = "options_extra",
         items 	= {
-            { key = "dynamic", 	name = "Dynamic" },
-            { key = "timed", name = "Timed" },
+            { key = "dynamic", 	name = "Dynamic"},
+            { key = "timed", name = "Timed"},
         }
     },
 
-    {
-        key    	= "evocomlevelcap",
-        name   	= "Evolving Commanders: Max Level",
-        desc   	= "(Range 2 - 10) Changes the Evolving Commanders maximum level",
-        type   	= "number",
-        section	= "options_extra",
-        def    	= 10,
-        min    	= 2,
-        max    	= 10,
-        step   	= 1,
-    },
-
-    {
-        key    	= "evocomxpmultiplier",
-        name   	= "Evolving Commanders: Commander XP Multiplier - Does not affect leveling!",
-        desc   	= "(Range 0.1 - 10) Changes the rate at which Evolving Commanders gain Experience.",
-        type   	= "number",
-        section	= "options_extra",
-        def    	= 1,
-        min    	= 0.1,
-        max    	= 10,
-        step   	= 0.1,
-    },
 
     {
         key    	= "evocomlevelupmultiplier",
-        name   	= "Evolving Commanders - Dynamic Only - Evolution Rate Multiplier.",
+        name   	= "EvoCom (Dynamic): Evolution Mult.",
         desc   	= "(Range 0.1x - 3x Multiplier) Adjusts the thresholds at which Dynamic evolutions occur",
         type   	= "number",
         section	= "options_extra",
@@ -982,7 +941,7 @@ local options = {
 
     {
         key    	= "evocomleveluptime",
-        name   	= "Evolving Commanders - Timed Only - Evolution Timer.",
+        name   	= "EvoCom (Timed): Evolution Time ",
         desc   	= "(Range 0.1 - 20 Minutes) Rate at which commanders will evolve if Timed method is selected.",
         type   	= "number",
         section	= "options_extra",
@@ -993,13 +952,35 @@ local options = {
     },
 
     {
-        key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
-        section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        key    	= "evocomlevelcap",
+        name   	= "EvoCom: Max Level",
+        desc   	= "(Range 2 - 10) Changes the Evolving Commanders maximum level",
+        type   	= "number",
+        section	= "options_extra",
+        def    	= 10,
+        min    	= 2,
+        max    	= 10,
+        step   	= 1,
     },
+
+    {
+        key    	= "evocomxpmultiplier",
+        name   	= "EvoCom: Commander XP Multiplier",
+        desc   	= "(Range 0.1 - 10) Does not affect leveling! Changes the rate at which Evolving Commanders gain Experience.",
+        type   	= "number",
+        section	= "options_extra",
+        def    	= 1,
+        min    	= 0.1,
+        max    	= 10,
+        step   	= 0.1,
+    },
+
+    {
+        key     = "sub_header",
+        section = "options_extra",
+        type    = "separator",
+    },
+
 
     {
         key 	= "comrespawn",
@@ -1017,28 +998,26 @@ local options = {
  
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
-    {
-        key 	= "assistdronesenabled",
-        name 	= "Commander Drones Enabled",
+
+    { 
+        key 	= "assistdronesenabled", -- TODO, turn this into booleam modoption
+        name 	= "Commander Drones",
         type 	= "list",
         def 	= "disabled",
         section = "options_extra",
         items 	= {
-            { key = "enabled", 	name = "Enabled" },
-            { key = "disabled", name = "Disabled" },
+            { key = "enabled", 	name = "Enabled", unlock = {"assistdronesbuildpowermultiplier", "assistdronescount", "assistdronesair"} },
+            { key = "disabled", name = "Disabled", lock = {"assistdronesbuildpowermultiplier", "assistdronescount", "assistdronesair"} },
         }
     },
 
     {
         key    	= "assistdronesbuildpowermultiplier",
-        name   	= "Commander Drones: Buildpower Multiplier",
+        name   	= "ComDrones: Buildpower Multiplier",
         desc   	= "(Range 0.5 - 5). How much buildpower commander drones should have",
         type   	= "number",
         section	= "options_extra",
@@ -1050,7 +1029,7 @@ local options = {
 
     {
         key    	= "assistdronescount",
-        name   	= "Commander Drones: Count",
+        name   	= "ComDrones: Count",
         desc   	= "How many assist drones per commander should be spawned",
         type   	= "number",
         section	= "options_extra",
@@ -1062,7 +1041,7 @@ local options = {
 
     {
         key    	= "assistdronesair",
-        name   	= "Commander Drones: Use Air Drones",
+        name   	= "ComDrones: Use Air Drones",
         desc   	= "Switch between aircraft drones and amphibious vehicle drones.",
         type   	= "bool",
         def    	= true,
@@ -1071,28 +1050,26 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_extra",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
+
     {
-        key 	= "commanderbuildersenabled",
-        name 	= "Base Builder Turret Enabled",
+        key 	= "commanderbuildersenabled", -- TODO, turn this into boolean modoption
+        name 	= "Base Builder Turret",
         type 	= "list",
         def 	= "disabled",
         section = "options_extra",
         items 	= {
-            { key = "enabled", 	name = "Enabled" },
-            { key = "disabled", name = "Disabled" },
+            { key = "enabled", 	name = "Enabled", unlock = {"commanderbuildersrange", "commanderbuildersbuildpower"} },
+            { key = "disabled", name = "Disabled", lock = {"commanderbuildersrange", "commanderbuildersbuildpower"} },
         }
     },
 
     {
         key    	= "commanderbuildersrange",
-        name   	= "Base Builder Turret: Buildrange",
+        name   	= "Base Builder Turret: Range",
         desc   	= "(Range 500 - 2000).",
         type   	= "number",
         section	= "options_extra",
@@ -1149,11 +1126,8 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_experimental",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
@@ -1432,16 +1406,13 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_cheats",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
         key     = "sub_header",
-        name    = "-- Resources",
+        name    = "-- Starting Resources",
         desc    = "",
         section = "options_cheats",
         type    = "subheader",
@@ -1497,8 +1468,23 @@ local options = {
     },
 
     {
+        key     = "sub_header",
+        section = "options_cheats",
+        type    = "separator",
+    },
+
+    {
+        key     = "sub_header",
+        name    = "-- Resource Multipliers",
+        desc    = "",
+        section = "options_cheats",
+        type    = "subheader",
+        def     =  true,
+    },
+
+    {
         key		= "multiplier_resourceincome",
-        name	= "Overall Resource Income Multiplier",
+        name	= "Overall Resource Income",
         desc	= "(Range 0.1 - 10). Stacks up with the three options below.",
         type	= "number",
         section = "options_cheats",
@@ -1510,7 +1496,7 @@ local options = {
 
     {
         key		= "multiplier_metalextraction",
-        name	= "Metal Extraction Multiplier ",
+        name	= "Metal Extraction ",
         desc	= "(Range 0.1 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1522,7 +1508,7 @@ local options = {
 
     {
         key		= "multiplier_energyconversion",
-        name	= "Energy Conversion Efficiency Multiplier ",
+        name	= "Energy Conversion Efficiency",
         desc	= "(Range 0.1 - 2). lower means you get less metal per energy converted",
         type	= "number",
         section = "options_cheats",
@@ -1534,7 +1520,7 @@ local options = {
 
     {
         key 	= "multiplier_energyproduction",
-        name 	= "Energy Production Multiplier",
+        name 	= "Energy Production",
         desc 	= "(Range 0.1 - 10).",
         type 	= "number",
         section = "options_cheats",
@@ -1546,16 +1532,13 @@ local options = {
 
     {
         key     = "sub_header",
-        name    = "----------------------------------------------------------------------------------------------------------------------------------------",
-        desc    = "",
         section = "options_cheats",
-        type    = "subheader",
-        def     =  true,
+        type    = "separator",
     },
 
     {
         key     = "cheatsdescription7",
-        name    = "-- Unit Parameters",
+        name    = "-- Unit Parameter Multipliers",
         desc    = "",
         section = "options_cheats",
         type    = "subheader",
@@ -1564,7 +1547,7 @@ local options = {
 
     {
         key		= "multiplier_maxvelocity",
-        name	= "Unit Max Velocity Multiplier",
+        name	= "Unit Max Velocity",
         desc	= "(Range 0.1 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1576,7 +1559,7 @@ local options = {
 
     {
         key	= "multiplier_turnrate",
-        name	= "Unit Turn Rate Multiplier",
+        name	= "Unit Turn Rate",
         desc	= "(Range 0.1 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1588,7 +1571,7 @@ local options = {
 
     {
         key		= "multiplier_builddistance",
-        name	= "Build Range Multiplier ",
+        name	= "Build Range",
         desc	= "(Range 0.5 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1600,7 +1583,7 @@ local options = {
 
     {
         key		= "multiplier_buildpower",
-        name	= "Build Power Multiplier",
+        name	= "Build Power",
         desc	= "(Range 0.1 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1612,7 +1595,7 @@ local options = {
 
     {
         key		= "multiplier_losrange",
-        name	= "Vision Range Multiplier",
+        name	= "Vision Range",
         desc	= "(Range 0.5 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1624,7 +1607,7 @@ local options = {
 
     {
         key		= "multiplier_radarrange",
-        name	= "Radar And Sonar Range Multiplier",
+        name	= "Radar And Sonar Range",
         desc	= "(Range 0.5 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1636,7 +1619,7 @@ local options = {
 
     {
         key		= "multiplier_weaponrange",
-        name	= "Weapon Range Multiplier",
+        name	= "Weapon Range",
         desc	= "(Range 0.5 - 10).",
         type	= "number",
         section = "options_cheats",
@@ -1648,7 +1631,7 @@ local options = {
 
     {
         key		= "multiplier_weapondamage",
-        name	= "Weapon Damage Multiplier ",
+        name	= "Weapon Damage",
         desc	= "(Range 0.1 - 10). Also affects unit death explosions.",
         type	= "number",
         section = "options_cheats",
@@ -1660,7 +1643,7 @@ local options = {
 
     {
         key		= "multiplier_shieldpower",
-        name	= "Shield Power Multiplier",
+        name	= "Shield Power",
         desc	= "(Range 0.1 - 10)",
         type	= "number",
         section = "options_cheats",
@@ -1668,6 +1651,21 @@ local options = {
         min		= 0.1,
         max		= 10,
         step	= 0.1,
+    },
+
+    {
+        key     = "sub_header",
+        section = "options_cheats",
+        type    = "separator",
+    },
+
+    {
+        key     = "cheatsdescription7",
+        name    = "-- Other",
+        desc    = "",
+        section = "options_cheats",
+        type    = "subheader",
+        def     =  true,
     },
 
     {
@@ -1707,7 +1705,7 @@ local options = {
 
     {
 		key		= "forceallunits",
-		name	= "Force Load All Units (For modders/devs)",
+		name	= "Force Load All Units (Dev/Modding)",
 		desc	= "Load all UnitDefs even if ais or options for them aren't enabled",
 		section = "options_cheats",
 		type	= "bool",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -909,6 +909,7 @@ local options = {
         type 	= "bool",
         def 	= false,
         section = "options_extra",
+        bitmask = 1,
         unlock  = {"evocomlevelupmethod","evocomlevelcap","evocomxpmultiplier", "evocomleveluptime", "evocomlevelupmultiplier"},
         --lock    = {"buffer_fix"},
     },
@@ -920,16 +921,17 @@ local options = {
         type 	= "list",
         def 	= "dynamic",
         section = "options_extra",
+        bitmask = 2,
         items 	= {
-            { key = "dynamic", 	name = "Dynamic"},
-            { key = "timed", name = "Timed"},
+            { key = "dynamic", 	name = "Dynamic", lock = {"evocomleveluptime"}, unlock = {"evocomlevelupmultiplier"}},
+            { key = "timed", name = "Timed", lock = {"evocomlevelupmultiplier"}, unlock = {"evocomleveluptime"}},
         }
     },
 
 
     {
         key    	= "evocomlevelupmultiplier",
-        name   	= "EvoCom (Dynamic): Evolution Mult.",
+        name   	= "EvoCom: Evolution Mult.",
         desc   	= "(Range 0.1x - 3x Multiplier) Adjusts the thresholds at which Dynamic evolutions occur",
         type   	= "number",
         section	= "options_extra",
@@ -941,7 +943,7 @@ local options = {
 
     {
         key    	= "evocomleveluptime",
-        name   	= "EvoCom (Timed): Evolution Time ",
+        name   	= "EvoCom: Evolution Time ",
         desc   	= "(Range 0.1 - 20 Minutes) Rate at which commanders will evolve if Timed method is selected.",
         type   	= "number",
         section	= "options_extra",


### PR DESCRIPTION
Thanks @robertthepie
Depends on https://github.com/beyond-all-reason/BYAR-Chobby/pull/750
- Modoptions toggles are now on the right of the label, instead of left.
- Modoptions can now be shifted into columns, allowing to put multiple options side by side.
- Modoptions can now be hidden/revealed based on state of other modoptions - Currently used in the Extra tab
- Added new separators
- Changed/Shortened some names to fit new formatting
https://github.com/user-attachments/assets/af9e41ba-82bd-4c8b-8af3-22b94b2b4b8b


Known Issues:
- Whole combobox turns red if you change modoption to non-default, apply, and then return back to the options to change it again.
- Red "Changed" Label is shifted down by 1 pixel for some reason
https://github.com/user-attachments/assets/9f9ac32f-b7c9-4d11-a8a2-b054799798a6

