### PR TITLE
No Rush mode: Handle insert command

### DIFF
--- a/luarules/gadgets/game_no_rush_mode.lua
+++ b/luarules/gadgets/game_no_rush_mode.lua
@@ -73,16 +73,20 @@ if gadgetHandler:IsSyncedCode() then
 		if frame < norushtimer and (not TeamIDsToExclude[unitTeam]) then
 			local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(unitTeam)
 			if cmdID == CMD.INSERT then
+			  -- CMD.INSERT wraps another command, so we need to extract it
 			  cmdID = cmdParams[2]
-			  local s = #cmdParams == 7 and 4 or 3
-			  local e = #cmdParams
-			  for i = 1, s do
-				cmdParams[i] = cmdParams[i + 3]
+			  -- Area commands have an extra radius parameter, so they shift by 4 instead of 3
+			  local isAreaCommand = (#cmdParams == 7)
+			  local paramCountToShift = isAreaCommand and 4 or 3
+			  -- Shift the parameters to remove the CMD.INSERT wrapper and match normal command format
+			  for i = 1, paramCountToShift do
+			    cmdParams[i] = cmdParams[i + 3]
 			  end
-			  for i = s + 1, e do
-				cmdParams[i] = nil
+			  -- Clear any unused parameters after the shift
+			  for i = paramCountToShift + 1, #cmdParams do
+			    cmdParams[i] = nil
 			  end
-			end		
+			end
 			if cmdID < 0 then
 				if cmdParams[1] and cmdParams[2] and cmdParams[3] then
 					if not positionCheckLibrary.StartboxCheck(cmdParams[1], cmdParams[2], cmdParams[3], allyTeamID) then

--- a/luarules/gadgets/game_no_rush_mode.lua
+++ b/luarules/gadgets/game_no_rush_mode.lua
@@ -72,6 +72,17 @@ if gadgetHandler:IsSyncedCode() then
 
 		if frame < norushtimer and (not TeamIDsToExclude[unitTeam]) then
 			local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(unitTeam)
+			if cmdID == CMD.INSERT then
+			  cmdID = cmdParams[2]
+			  local s = #cmdParams == 7 and 4 or 3
+			  local e = #cmdParams
+			  for i = 1, s do
+				cmdParams[i] = cmdParams[i + 3]
+			  end
+			  for i = s + 1, e do
+				cmdParams[i] = nil
+			  end
+			end		
 			if cmdID < 0 then
 				if cmdParams[1] and cmdParams[2] and cmdParams[3] then
 					if not positionCheckLibrary.StartboxCheck(cmdParams[1], cmdParams[2], cmdParams[3], allyTeamID) then

--- a/luarules/gadgets/game_no_rush_mode.lua
+++ b/luarules/gadgets/game_no_rush_mode.lua
@@ -76,8 +76,7 @@ if gadgetHandler:IsSyncedCode() then
 			  -- CMD.INSERT wraps another command, so we need to extract it
 			  cmdID = cmdParams[2]
 			  -- Area commands have an extra radius parameter, so they shift by 4 instead of 3
-			  local isAreaCommand = (#cmdParams == 7)
-			  local paramCountToShift = isAreaCommand and 4 or 3
+			  local paramCountToShift = #cmdParams - 3
 			  -- Shift the parameters to remove the CMD.INSERT wrapper and match normal command format
 			  for i = 1, paramCountToShift do
 			    cmdParams[i] = cmdParams[i + 3]


### PR DESCRIPTION
The game_no_rush_mode.lua gadget blocks commands outside of a players startbox, but does not currently handle CMD.INSERT

This update adds logic to reformat insert commands into normal commands so the gadget correctly handles them.