### PR TITLE
Add autogroups on UnitCreated

### DIFF
--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -281,7 +281,7 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 		finiGroup[unitID] = 1
 	end
 
-	if builtInFrame or immediate or (builtInPlace[unitID] and #Spring.GetCommandQueue(unitID, 1) == 0) then
+	if not immediate and ((builtInPlace[unitID] and #Spring.GetCommandQueue(unitID, 1) == 0) or builtInFrame) then
 		local gr = unit2group[unitDefID]
 		if gr ~= nil and GetUnitGroup(unitID) == nil then
 			SetUnitGroup(unitID, gr)
@@ -310,6 +310,13 @@ function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 
 	if builderID and mobileBuilders[Spring.GetUnitDefID(builderID)] then
 		builtInPlace[unitID] = true
+	end
+
+	if immediate then
+		local gr = unit2group[unitDefID]
+		if gr ~= nil then
+			SetUnitGroup(unitID, gr)
+		end
 	end
 end
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
The autogroup widget adds the control groups on unit creation on immediate mode.

closes #3449

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
