### PR TITLE
add gravity standardization exemption list to alldefs_post

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1377,9 +1377,23 @@ function WeaponDef_Post(name, wDef)
 
 	if not SaveDefsToCustomParams then
 		-------------- EXPERIMENTAL MODOPTIONS
+		
 		-- Standard Gravity
+		local gravityOverwriteExemptions = { --add the name of the weapons (or just the name of the unit followed by _ ) to this table to exempt from gravity standardization.
+			'cormship_', 'armmship_'
+		}
 		if wDef.gravityaffected == "true" and wDef.mygravity == nil then
-			wDef.mygravity = 0.1445
+			local isExempt = false
+
+			for _, exemption in ipairs(gravityOverwriteExemptions) do
+				if string.find(name, exemption) then
+					isExempt = true
+					break
+				end
+			end
+			if not isExempt then
+				wDef.mygravity = 0.1445
+			end
 		end
 		
 		-- Accurate Lasers		


### PR DESCRIPTION
Added infrustructure for gravity standardization exemptions for ease of maintainance later. Entries in this list should be put here as bugs are found until they can be individually assigned a mygravity value in their weapondefs.