### PR TITLE
Teiserver meme cleanup

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -78,6 +78,9 @@ end
 function UnitDef_Post(name, uDef)
 	local modOptions = Spring.GetModOptions()
 
+	local isScav = string.sub(name, -5, -1) == "_scav"
+	local basename = isScav and string.sub(name, 1, -6) or name
+
 	if not uDef.icontype then
 		uDef.icontype = name
 	end
@@ -186,21 +189,8 @@ function UnitDef_Post(name, uDef)
 				legfhp		= true,
 				legplat		= true,
 				legamsub	= true,
-
-				corhp_scav		= true,
-				corfhp_scav		= true,
-				corplat_scav	= true,
-				coramsub_scav	= true,
-				armhp_scav		= true,
-				armfhp_scav		= true,
-				armplat_scav	= true,
-				armamsub_scav	= true,
-				leghp_scav		= true,
-				legfhp_scav		= true,
-				legplat_scav	= true,
-				legamsub_scav	= true,
 			}
-			if tech15[name] then
+			if tech15[basename] then
 				uDef.maxthisunit = 0
 			end
 		end
@@ -254,7 +244,7 @@ function UnitDef_Post(name, uDef)
 		end
 
 		if modOptions.unit_restrictions_nofusion then
-			if name == "armdf" or name == "armdf_scav" or string.sub(name, string.len(name) - 2) == "fus" then
+			if basename == "armdf" or string.sub(basename, -3) == "fus" then
 				uDef.maxthisunit = 0
 			end
 		end

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -169,6 +169,42 @@ function UnitDef_Post(name, uDef)
 			end
 		end
 
+		if modOptions.unit_restrictions_notech15 then
+			-- Tech 1.5 is a semi offical thing, modoption ported from teiserver meme commands
+			local tech15 = {
+				corhp		= true,
+				corfhp		= true,
+				corplat		= true,
+				coramsub	= true,
+
+				armhp		= true,
+				armfhp		= true,
+				armplat		= true,
+				armamsub	= true,
+
+				leghp		= true,
+				legfhp		= true,
+				legplat		= true,
+				legamsub	= true,
+
+				corhp_scav		= true,
+				corfhp_scav		= true,
+				corplat_scav	= true,
+				coramsub_scav	= true,
+				armhp_scav		= true,
+				armfhp_scav		= true,
+				armplat_scav	= true,
+				armamsub_scav	= true,
+				leghp_scav		= true,
+				legfhp_scav		= true,
+				legplat_scav	= true,
+				legamsub_scav	= true,
+			}
+			if tech15[name] then
+				uDef.maxthisunit = 0
+			end
+		end
+
 		if modOptions.unit_restrictions_noair then
 			if string.find(uDef.customparams.subfolder, "Aircraft") then
 				uDef.maxthisunit = 0
@@ -217,6 +253,12 @@ function UnitDef_Post(name, uDef)
 			end
 		end
 
+		if modOptions.unit_restrictions_nofusion then
+			if name == "armdf" or name == "armdf_scav" or string.sub(name, string.len(name) - 2) == "fus" then
+				uDef.maxthisunit = 0
+			end
+		end
+
 		if modOptions.unit_restrictions_nonukes then
 			local Nukes = {
 				armamd = true,
@@ -238,6 +280,40 @@ function UnitDef_Post(name, uDef)
 			}
 			if Nukes[name] then
 				uDef.maxthisunit = 0
+			end
+		end
+
+		if modOptions.unit_restrictions_nodefence then
+			local whitelist = {
+				armllt	= true,
+				armrl	= true,
+				armfrt	= true,
+				armtl	= true,
+
+				corllt	= true,
+				corrl	= true,
+				cortl	= true,
+				corfrt	= true,
+
+				leglht	= true,
+				legrl	= true,
+				--sea tl= true,
+				--sea aa= true,
+			}
+			-- "defense" or "defence", as legion doesn't fully follow past conventions
+			if not whitelist[name] and string.find(string.lower(uDef.customparams.subfolder), "defen") then
+				uDef.maxthisunit = 0
+			end
+		end
+
+		if modOptions.unit_restrictions_noantinuke then
+			if uDef.weapondefs then
+				for _, weapon in pairs(uDef.weapondefs) do
+					if weapon.interceptor and weapon.interceptor == 1 then
+						uDef.maxthisunit = 0
+						break
+					end
+				end
 			end
 		end
 

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -65,44 +65,6 @@ if gadgetHandler:IsSyncedCode() then
 	GG.teamStartPoints = teamStartPoints
 	local startPointTable = {}
 
-	---------------------------------------------------------------------------------------------------
-	-- the faction limiter attemtps to group strings seperated by comma and turn any faction names it finds in that into a team limiter.
-	-- any groups that are not found to have a valid faction do not expand the pool.
-	-- if the pool is insufficent for the number of teams, then the list is read looping back from the start
-	local factionStrings = include("gamedata/sidedata.lua")
-	if Spring.GetModOptions().experimentallegionfaction then
-		factionStrings[#factionStrings + 1] = {
-			name = "Legion",
-			startunit = 'legcom'
-		}
-	end
-	for _,factionData in pairs(factionStrings) do
-		factionData.name = string.lower(factionData.name)
-	end
-	local faction_limiter = Spring.GetModOptions().faction_limiter
-	local faction_limiter_valid = false
-	local faction_limited_options = {}
-	if faction_limiter then
-		faction_limiter = string.lower(faction_limiter)
-		local teamGroupID = 1
-		local teamLists = string.split(faction_limiter, ',')
-		for i = 1, #teamLists do
-			local team = teamLists[i]
-			for _, faction in pairs(factionStrings) do
-				if string.find(team, faction.name) then
-					if faction_limited_options[teamGroupID] == nil then
-						faction_limited_options[teamGroupID] = {}
-					end
-					faction_limited_options[teamGroupID][UnitDefNames[faction.startunit].id] = true
-					faction_limiter_valid = true
-				end
-			end
-			if faction_limited_options[teamGroupID] ~= nil then
-				teamGroupID = teamGroupID + 1
-			end
-		end
-	end
-
 	----------------------------------------------------------------
 	-- Start Point Guesser
 	----------------------------------------------------------------
@@ -138,28 +100,10 @@ if gadgetHandler:IsSyncedCode() then
 				-- set & broadcast (current) start unit
 				local _, _, _, _, teamSide, teamAllyID = spGetTeamInfo(teamID, false)
 				local comDefID = armcomDefID
-				-- we try to give you your faction, if we can't, we find the first available faction, loops around if the list isn't long enough to include current team
-				if faction_limiter_valid then
-					if teamSide == 'cortex' and faction_limited_options[ teamAllyID % #faction_limited_options + 1][corcomDefID] then
-						comDefID = corcomDefID
-					elseif teamSide == 'legion' and faction_limited_options[ teamAllyID % #faction_limited_options + 1][legcomDefID] then
-						comDefID = legcomDefID
-					elseif faction_limited_options[teamAllyID % #faction_limited_options + 1][armcomDefID] ~= true then
-						if faction_limited_options[ teamAllyID % #faction_limited_options + 1][corcomDefID] then
-							comDefID = corcomDefID
-						elseif faction_limited_options[teamAllyID % #faction_limited_options + 1][legcomDefID] then
-							comDefID = legcomDefID
-						else
-							Spring.Echo("gadget/game_initial_spawn - how did we get here?")
-						end
-					end
-				-- otherwise default behaviour
-				else
-					if teamSide == 'cortex' then
-						comDefID = corcomDefID
-					elseif teamSide == 'legion' then
-						comDefID = legcomDefID
-					end
+				if teamSide == 'cortex' then
+					comDefID = corcomDefID
+				elseif teamSide == 'legion' then
+					comDefID = legcomDefID
 				end
 				spSetTeamRulesParam(teamID, startUnitParamName, comDefID, { allied = true, public = false })
 				teams[teamID] = teamAllyID
@@ -204,7 +148,7 @@ if gadgetHandler:IsSyncedCode() then
 			startUnit = tonumber(msg:match(changeStartUnitRegex))
 		end
 		local _, _, playerIsSpec, playerTeam, allyTeamID = spGetPlayerInfo(playerID, false)
-		if startUnit and ((validStartUnits[startUnit] and faction_limiter_valid == false) or (faction_limited_options[ allyTeamID % #faction_limited_options + 1][startUnit] and faction_limiter_valid == true)) then
+		if startUnit and validStartUnits[startUnit] then
 			if not playerIsSpec then
 				playerStartingUnits[playerID] = startUnit
 				spSetTeamRulesParam(playerTeam, startUnitParamName, startUnit, { allied = true, public = false }) -- visible to allies only, set visible to all on GameStart

--- a/luarules/gadgets/gfx_raptor_scum_gl4.lua
+++ b/luarules/gadgets/gfx_raptor_scum_gl4.lua
@@ -116,7 +116,6 @@ if gadgetHandler:IsSyncedCode() then
 		for unitDefID, unitDef in pairs(UnitDefs) do
 			if unitDef.customParams.isscavenger and (not unitDef.canMove) and (not string.find(unitDef.name, "lootbox")) and not scumSpawnerIDs[unitDefID] and (not unitDef.customParams.objectify) and (not unitDef.canCloak) and not scumSpawnerExclusions[unitDef.name]then
 				scumSpawnerIDs[unitDefID] = {radius = 600, growthrate = 1.2}
-				Spring.Echo(unitDef.name, "radius", scumSpawnerIDs[unitDefID].radius)
 			end
 		end
 

--- a/luarules/gadgets/pve_builder_controller.lua
+++ b/luarules/gadgets/pve_builder_controller.lua
@@ -52,7 +52,6 @@ for unitDefID, data in pairs(UnitDefs) do
             unitDefName = data.name,
             isFactory = data.isFactory,
         }
-        Spring.Echo(data.name, data.isFactory)
 	end
 end
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -32,7 +32,7 @@ local options = {
 
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    -- Restrictions
+    -- Main + Restrictions
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     {
@@ -267,6 +267,16 @@ local options = {
 		def 	= false,
 	},
 
+	{
+		key		= "unit_restrictions_notech15",
+		name	= "Disable Tech 1.5",
+		desc	= "Disables: Sea Plane Labs, Hovercraft labs, and Amphibious labs. (Considered Tier 1.5)",
+		type	= "bool",
+		section	= "options_main",
+		def		= false,
+		column	= 1,
+	},
+
     {
         key    	= "unit_restrictions_notech2",
         name   	= "Disable Tech 2",
@@ -274,7 +284,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
-        column  = 1,
+        column  = 1.66,
     },
 
     {
@@ -284,7 +294,7 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
-        column  = 1.66,
+        column  = 2.33,
     },
 
     {
@@ -296,6 +306,16 @@ local options = {
         def    	= false,
         column  = 1,
     },
+
+	{
+		key		= "unit_restrictions_nodefence",
+		name	= "Disable Defences",
+		desc	= "Disables Defensive Structures, apart from basic LLTs and basic AA",
+		type	= "bool",
+		section	= "options_main",
+		def		= false,
+		column	= 1.66,
+	},
 
     {
         key    	= "unit_restrictions_noextractors",
@@ -317,15 +337,15 @@ local options = {
         column  = 1.66,
     },
 
-    {
-        key    	= "unit_restrictions_nonukes",
-        name   	= "Disable Nuclear Missiles",
-        desc   	= "Disable Nuclear Missiles",
-        type   	= "bool",
-        section	= "options_main",
-        def    	= false,
-        column  = 1,
-    },
+	{
+		key		= "unit_restrictions_nofusion",
+		name	= "Disable Fusion Generators",
+		desc	= "Disables Normal and Advanced Fusion Energy Generators",
+		type	= "bool",
+		section	= "options_main",
+		def		= false,
+		column	= 2.33,
+	},
 
     {
         key    	= "unit_restrictions_notacnukes",
@@ -334,8 +354,28 @@ local options = {
         type   	= "bool",
         section	= "options_main",
         def    	= false,
+        column  = 1,
+    },
+
+    {
+        key    	= "unit_restrictions_nonukes",
+        name   	= "Disable Nuclear Missiles",
+        desc   	= "Disable Nuclear Missiles",
+        type   	= "bool",
+        section	= "options_main",
+        def    	= false,
         column  = 1.66,
     },
+
+	{
+		key		= "unit_restrictions_noantinuke",
+		name	= "Disable Anti-Nuke Defence",
+		desc	= "Disables Nuke Interceptor Units and Structures.",
+		type	= "bool",
+		section	= "options_main",
+		def		= false,
+		column	= 2.33,
+	},
 
     {
         key    	= "unit_restrictions_nolrpc",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1182,16 +1182,6 @@ local options = {
     },
 
     {
-        key    	= "faction_limiter",
-        name   	= "Team Faction Limiter",
-        desc   	= "Limit which faction a team may play. Format; list factions, seperating teams by a comma, e.g. \"armada cortex, legion\" = cor/arm vs legion.",
-        type   	= "string",
-        section	= "options_experimental",
-        def		= "",
-		hidden	= true,
-    },
-
-    {
         key 	= "skyshift",
         name 	= "Skyshift: Air Rework",
         desc 	= "A complete overhaul of air units and mechanics",


### PR DESCRIPTION
### Work done
Ported some of the Meme command options stored in the teiserver into actual modoptions for ease of maintanance.
PR to cleanup the meme commands: https://github.com/beyond-all-reason/teiserver/pull/476
- Disable Tech 1,5:
Part of the Orginal memes command list
Considered tier 1.5 by some, is added to replace the hard t1 meme option via using disable tier 1.5, tier 2, and tier 3
- Disable Fusion:
From the orginal meme command pool, disables all fusions via roguh 
- Disable Defences
Part of the Orginal memes command list
Basic defence structures are preserved, the orginal kept LLTS to help deal with tick rushes
- Disable Anti-Nuke
Meme command Deathmatch removes all antinuke defences. Added to modoptions, not removed from memes

Also removes the faction locker modoptions.

### Known Issues
Grid Menu Sea build options do not apear grayed out when disabled, past issue, not part of this pr.

#### Test steps
- [ ] Disable Fusion: disables normal, advanced, decoy and cloak fusions for all 3 factions
- [ ] Disable Defences: disables all but the basic defences
- [ ] Disable Tech 1.5: disables amphibious lab, sea plane lab, and hover labs
- [ ] Disable Anti-Nuke: disables all stationary and mobile nuke defeces.
