### PR TITLE
patchup Disable Tech 1.5 modoption to include Tiers 2 and 3

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -78,8 +78,7 @@ end
 function UnitDef_Post(name, uDef)
 	local modOptions = Spring.GetModOptions()
 
-	local isScav = string.sub(name, -5, -1) == "_scav"
-	local basename = isScav and string.sub(name, 1, -6) or name
+	local basename = uDef.customparams.fromunit or name
 
 	if not uDef.icontype then
 		uDef.icontype = name
@@ -173,25 +172,29 @@ function UnitDef_Post(name, uDef)
 		end
 
 		if modOptions.unit_restrictions_notech15 then
-			-- Tech 1.5 is a semi offical thing, modoption ported from teiserver meme commands
-			local tech15 = {
-				corhp		= true,
-				corfhp		= true,
-				corplat		= true,
-				coramsub	= true,
-
-				armhp		= true,
-				armfhp		= true,
-				armplat		= true,
-				armamsub	= true,
-
-				leghp		= true,
-				legfhp		= true,
-				legplat		= true,
-				legamsub	= true,
-			}
-			if tech15[basename] then
+			if tonumber(uDef.customparams.techlevel) == 2 or tonumber(uDef.customparams.techlevel) == 3 then
 				uDef.maxthisunit = 0
+			else
+				-- Tech 1.5 is a semi offical thing, modoption ported from teiserver meme commands
+				local tech15 = {
+					corhp		= true,
+					corfhp		= true,
+					corplat		= true,
+					coramsub	= true,
+
+					armhp		= true,
+					armfhp		= true,
+					armplat		= true,
+					armamsub	= true,
+
+					leghp		= true,
+					legfhp		= true,
+					legplat		= true,
+					legamsub	= true,
+				}
+				if tech15[basename] then
+					uDef.maxthisunit = 0
+				end
 			end
 		end
 

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -159,17 +159,6 @@ function UnitDef_Post(name, uDef)
 		if not uDef.customparams.subfolder then
 			uDef.customparams.subfolder = "none"
 		end
-		if modOptions.unit_restrictions_notech2 then
-			if tonumber(uDef.customparams.techlevel) == 2 or tonumber(uDef.customparams.techlevel) == 3 then
-				uDef.maxthisunit = 0
-			end
-		end
-
-		if modOptions.unit_restrictions_notech3 then
-			if tonumber(uDef.customparams.techlevel) == 3 then
-				uDef.maxthisunit = 0
-			end
-		end
 
 		if modOptions.unit_restrictions_notech15 then
 			if tonumber(uDef.customparams.techlevel) == 2 or tonumber(uDef.customparams.techlevel) == 3 then
@@ -195,6 +184,14 @@ function UnitDef_Post(name, uDef)
 				if tech15[basename] then
 					uDef.maxthisunit = 0
 				end
+			end
+		elseif modOptions.unit_restrictions_notech2 then
+			if tonumber(uDef.customparams.techlevel) == 2 or tonumber(uDef.customparams.techlevel) == 3 then
+				uDef.maxthisunit = 0
+			end
+		elseif modOptions.unit_restrictions_notech3 then
+			if tonumber(uDef.customparams.techlevel) == 3 then
+				uDef.maxthisunit = 0
 			end
 		end
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -507,6 +507,14 @@ local options = {
         def     =  true,
     },
 
+	{
+		key		= "sub_header",
+		name	= "To Play Add a Raptors AI to the enemy Team: [Add AI]; [RaptorsAI]",
+		desc	= "",
+		section	= "raptor_defense_options",
+		type	= "subheader",
+	},
+
     {
         key     = "sub_header",
         section = "raptor_defense_options",
@@ -656,6 +664,15 @@ local options = {
         type    = "subheader",
         def     =  true,
     },
+
+	{
+		key		= "sub_header",
+		name	= "To Play Add a Scavangers AI to the enemy Team: [Add AI]; [ScavangersAI]",
+		desc	= "",
+		section	= "scav_defense_options",
+		type	= "subheader",
+	},
+
 
     {
         key     = "sub_header",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -270,21 +270,27 @@ local options = {
 	{
 		key		= "unit_restrictions_notech15",
 		name	= "Disable Tech 1.5",
-		desc	= "Disables: Sea Plane Labs, Hovercraft labs, and Amphibious labs. (Considered Tier 1.5)",
+		desc	= "Disables Tech 1.5 and up: T1.5: Sea Plane Labs, Hovercraft labs, and Amphibious labs.",
 		type	= "bool",
 		section	= "options_main",
 		def		= false,
 		column	= 1,
+		bitmask	= 1,
+		lock	= {"unit_restrictions_notech2", "unit_restrictions_notech3", "buffer_t4"},
+		unlock	= {"buffer_t2", "buffer_t3",},
 	},
 
     {
         key    	= "unit_restrictions_notech2",
         name   	= "Disable Tech 2",
-        desc   	= "Disable Tech 2",
+        desc   	= "Disable Tech 2 and up",
         type   	= "bool",
         section	= "options_main",
         def    	= false,
         column  = 1.66,
+		bitmask	= 2,
+		lock	= {"unit_restrictions_notech3"},
+		unlock	= {"buffer_t4",},
     },
 
     {
@@ -296,6 +302,10 @@ local options = {
         def    	= false,
         column  = 2.33,
     },
+
+	{	key = "buffer_t2", type = "subheader", name = "", section = "options_main",},
+	{	key = "buffer_t3", type = "subheader", name = "\255\128\128\128Disable Tech 2 [Tech 1.5]                                          Disable Tech 3 [Tech 2]", section = "options_main", column  = -1.66, },
+	{	key = "buffer_t4", type = "subheader", name = "\255\128\128\128Disable Tech 3 [Tech 2]", section	= "options_main", column  = -2.33,},
 
     {
         key    	= "unit_restrictions_noair",


### PR DESCRIPTION
### Work done
Disable Tech 1.5 now also checks the Tech tiers above it
To match the behaviour of disabling Tech 2 disabling Tech 3

#### Test steps
- [ ] Disable Tech 1.5 modoption now also disables Tech 2 and 3


### Screenshots:
UI element adjustment:
![temp477](https://github.com/user-attachments/assets/5cc7cb58-c67e-4c50-90b9-2303489b77b1)
<!-- If relevant
#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
