### PR TITLE
How to play raptors/scavs in adv options

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -497,6 +497,14 @@ local options = {
         def     =  true,
     },
 
+	{
+		key		= "sub_header",
+		name	= "To Play Add a Raptors AI to the enemy Team: [Add AI], [RaptorsDefense AI]",
+		desc	= "",
+		section	= "raptor_defense_options",
+		type	= "subheader",
+	},
+
     {
         key     = "sub_header",
         section = "raptor_defense_options",
@@ -646,6 +654,15 @@ local options = {
         type    = "subheader",
         def     =  true,
     },
+
+	{
+		key		= "sub_header",
+		name	= "To Play Add a Scavangers AI to the enemy Team: [Add AI], [ScavengersDefense AI]",
+		desc	= "",
+		section	= "scav_defense_options",
+		type	= "subheader",
+	},
+
 
     {
         key     = "sub_header",


### PR DESCRIPTION
### Work done
Adds some text to adv options to explain how to enable scav or raptors PvE gamemodes.
It does this via adding a subheader to both tabs, containing the following:
> To Play Add a Raptors AI to the enemy Team: [Add AI], [RaptorsDefense AI]
> To Play Add a Scavangers AI to the enemy Team: [Add AI], [ScavengersDefense AI]

#### Addresses Issue
https://discord.com/channels/549281623154229250/1286215225699471411/1286570433625325568

### Screenshots:
![image](https://github.com/user-attachments/assets/186e2a0d-1ef7-4a1d-9135-315627c2d784)
![image](https://github.com/user-attachments/assets/3f309b35-98d4-4484-9e72-f85e2b33308e)
