### PR TITLE
More Ruin Tweaks

### DIFF
--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -211,6 +211,39 @@ local function randomlyMirrorBlueprint(mirrored, direction, unitFacing)
 	end
 end
 
+
+function getNearestBlocker(x, z)
+	local lowestDist = math.huge
+	local metalSpots = GG["resource_spot_finder"] and GG["resource_spot_finder"].metalSpotsList or nil
+	if metalSpots then
+		for i = 1, #metalSpots do
+			local spot = metalSpots[i]
+            if spot then
+			    local dx, dz = x - spot.x, z - spot.z
+			    local dist = dx * dx + dz * dz
+			    if dist < lowestDist then
+			    	lowestDist = dist
+			    end
+            end
+		end
+    end
+	local geoSpots = GG["resource_spot_finder"] and GG["resource_spot_finder"].geoSpotsList or nil
+	if geoSpots then
+		for i = 1, #geoSpots do
+			local spot = geoSpots[i]
+            if spot then
+			    local dx, dz = x - spot.x, z - spot.z
+			    local dist = dx * dx + dz * dz
+			    if dist < lowestDist then
+			    	lowestDist = dist
+			    end
+            end
+		end
+    end
+	Spring.Echo(lowestDist, math.sqrt(lowestDist))
+    return math.sqrt(lowestDist)
+end
+
 local function spawnRuin(ruin, posx, posy, posz, blueprintTierLevel)
 	local swapXandY, flipX, flipZ, rotation = randomlyRotateBlueprint()
 	local mirrored, mirroredDirection, xOffset, zOffset
@@ -244,7 +277,7 @@ local function spawnRuin(ruin, posx, posy, posz, blueprintTierLevel)
 				local posy = Spring.GetGroundHeight(posx + (xOffset*flipX*mirrorX), posz + (zOffset*flipZ*mirrorZ))
 				local unit = Spring.CreateUnit(UnitDefNames[nonscavname].id, posx + (xOffset*flipX*mirrorX), posy, posz + (zOffset*flipZ*mirrorZ), (building.direction+rotation+mirrorRotation)%4, GaiaTeamID)
 				if unit then
-					Spring.SpawnCEG("scav-spawnexplo", posx + (xOffset*flipX*mirrorX), posy, posz + (zOffset*flipZ*mirrorZ), 0,0,0)
+					--Spring.SpawnCEG("scav-spawnexplo", posx + (xOffset*flipX*mirrorX), posy, posz + (zOffset*flipZ*mirrorZ), 0,0,0)
 					local radarRange = UnitDefs[building.unitDefID].radarDistance
 					local canMove = UnitDefs[building.unitDefID].canMove
 					local speed = UnitDefs[building.unitDefID].speed
@@ -275,6 +308,7 @@ local function spawnRuin(ruin, posx, posy, posz, blueprintTierLevel)
 	mirroredDirection = nil
 end
 
+local SpawnedMexes = {}
 local function SpawnMexes(mexSpots)
 	for i = 1,#mexSpots do
 		if math.random(0,1) == 0 then
@@ -289,7 +323,7 @@ local function SpawnMexes(mexSpots)
 				mexesList = seaMexesList
 			end
 
-			local radius = 64
+			local radius = 32
 			local canBuildHere = positionCheckLibrary.VisibilityCheckEnemy(posx, posy, posz, radius, GaiaAllyTeamID, true, true, true)
 						and positionCheckLibrary.MapEdgeCheck(posx, posy, posz, radius)
 						and positionCheckLibrary.OccupancyCheck(posx, posy, posz, radius)
@@ -304,48 +338,17 @@ local function SpawnMexes(mexSpots)
 			if canBuildHere then
 				local mex = mexesList[math.random(1,#mexesList)]
 				local unit = Spring.CreateUnit(UnitDefNames[mex].id, posx, posy, posz, math.random(0,3), GaiaTeamID)
-				Spring.SpawnCEG("scav-spawnexplo", posx, posy, posz, 0,0,0)
+				--Spring.SpawnCEG("scav-spawnexplo", posx, posy, posz, 0,0,0)
 				Spring.SetUnitNeutral(unit, true)
 				Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, {1}, 0)
 				Spring.GiveOrderToUnit(unit, CMD.MOVE_STATE, {0}, 0)
-
-				for i = 1,5 do
-					local posx2 = spot.x+math.random(-256,256)
-					local posz2 = spot.z+math.random(-256,256)
-					local posy2 = Spring.GetGroundHeight(posx2, posz2)
-					local defencesList
-					if posy2 > 0 then
-						defencesList = landDefences
-					else
-						defencesList = seaDefences
-					end
-				
-					local radius = 128
-					local canBuildHere = positionCheckLibrary.VisibilityCheckEnemy(posx2, posy2, posz2, radius, GaiaAllyTeamID, true, true, true)
-								and positionCheckLibrary.MapEdgeCheck(posx2, posy2, posz2, radius)
-								and positionCheckLibrary.OccupancyCheck(posx2, posy2, posz2, radius)
-								and positionCheckLibrary.FlatAreaCheck(posx2, posy2, posz2, radius)
-				
-					if posy2 > 0 then
-						canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx2, posy2, posz2, radius)
-					elseif posy2 <= 0 then
-						canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx2, posy2, posz2, radius, true)
-					end
-				
-					if canBuildHere then
-						local defence = defencesList[math.random(1,#defencesList)]
-						local unit = Spring.CreateUnit(UnitDefNames[defence].id, posx2, posy2, posz2, math.random(0,3), GaiaTeamID)
-						Spring.SpawnCEG("scav-spawnexplo", posx2, posy2, posz2, 0,0,0)
-						Spring.SetUnitNeutral(unit, true)
-						Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, {1}, 0)
-						Spring.GiveOrderToUnit(unit, CMD.MOVE_STATE, {0}, 0)
-					end
-				end
+				SpawnedMexes[i] = math.random(2,10)
 			end
 		end
 	end
 end
 
+local SpawnedGeos = {}
 local function SpawnGeos(geoSpots)
 	for i = 1,#geoSpots do
 		if math.random(0,1) == 0 then
@@ -360,7 +363,7 @@ local function SpawnGeos(geoSpots)
 				geosList = seaGeosList
 			end
 
-			local radius = 64
+			local radius = 32
 			local canBuildHere = positionCheckLibrary.VisibilityCheckEnemy(posx, posy, posz, radius, GaiaAllyTeamID, true, true, true)
 						and positionCheckLibrary.MapEdgeCheck(posx, posy, posz, radius)
 						and positionCheckLibrary.OccupancyCheck(posx, posy, posz, radius)
@@ -375,12 +378,23 @@ local function SpawnGeos(geoSpots)
 			if canBuildHere then
 				local geo = geosList[math.random(1,#geosList)]
 				local unit = Spring.CreateUnit(UnitDefNames[geo].id, posx, posy, posz, math.random(0,3), GaiaTeamID)
-				Spring.SpawnCEG("scav-spawnexplo", posx, posy, posz, 0,0,0)
+				--Spring.SpawnCEG("scav-spawnexplo", posx, posy, posz, 0,0,0)
 				Spring.SetUnitNeutral(unit, true)
 				Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, {1}, 0)
 				Spring.GiveOrderToUnit(unit, CMD.MOVE_STATE, {0}, 0)
+				SpawnedGeos[i] = math.random(5,20)
+			end
+		end
+	end
+end
 
-				for i = 1,10 do
+local function SpawnMexGeoRandomStructures()
+	local mexSpots = GG["resource_spot_finder"] and GG["resource_spot_finder"].metalSpotsList or nil
+	if mexSpots and #mexSpots > 5 then
+		for i = 1,#mexSpots do
+			if SpawnedMexes[i] then
+				local spot = mexSpots[i]
+				for j = 1,SpawnedMexes[i] do
 					local posx2 = spot.x+math.random(-512,512)
 					local posz2 = spot.z+math.random(-512,512)
 					local posy2 = Spring.GetGroundHeight(posx2, posz2)
@@ -402,11 +416,60 @@ local function SpawnGeos(geoSpots)
 					elseif posy2 <= 0 then
 						canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx2, posy2, posz2, radius, true)
 					end
+
+					if canBuildHere and getNearestBlocker(posx2, posz2) < radius then
+						canBuildHere = false
+					end
 				
 					if canBuildHere then
 						local defence = defencesList[math.random(1,#defencesList)]
 						local unit = Spring.CreateUnit(UnitDefNames[defence].id, posx2, posy2, posz2, math.random(0,3), GaiaTeamID)
-						Spring.SpawnCEG("scav-spawnexplo", posx2, posy2, posz2, 0,0,0)
+						--Spring.SpawnCEG("scav-spawnexplo", posx2, posy2, posz2, 0,0,0)
+						Spring.SetUnitNeutral(unit, true)
+						Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, {1}, 0)
+						Spring.GiveOrderToUnit(unit, CMD.MOVE_STATE, {0}, 0)
+					end
+				end
+			end
+		end
+	end
+
+	local geoSpots = GG["resource_spot_finder"] and GG["resource_spot_finder"].geoSpotsList or nil
+	if geoSpots and #geoSpots >= 1 then
+		for i = 1,#geoSpots do
+			if SpawnedGeos[i] then
+				local spot = geoSpots[i]
+				for j = 1,SpawnedGeos[i] do
+					local posx2 = spot.x+math.random(-1024,1024)
+					local posz2 = spot.z+math.random(-1024,1024)
+					local posy2 = Spring.GetGroundHeight(posx2, posz2)
+					local defencesList
+					if posy2 > 0 then
+						defencesList = landDefences
+					else
+						defencesList = seaDefences
+					end
+				
+					local radius = 128
+					local canBuildHere = positionCheckLibrary.VisibilityCheckEnemy(posx2, posy2, posz2, radius, GaiaAllyTeamID, true, true, true)
+								and positionCheckLibrary.MapEdgeCheck(posx2, posy2, posz2, radius)
+								and positionCheckLibrary.OccupancyCheck(posx2, posy2, posz2, radius)
+								and positionCheckLibrary.FlatAreaCheck(posx2, posy2, posz2, radius)
+				
+					if posy2 > 0 then
+						canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx2, posy2, posz2, radius)
+					elseif posy2 <= 0 then
+						canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx2, posy2, posz2, radius, true)
+					end
+					
+					if canBuildHere and getNearestBlocker(posx2, posz2) < radius then
+						canBuildHere = false
+					end
+				
+					if canBuildHere then
+						local defence = defencesList[math.random(1,#defencesList)]
+						local unit = Spring.CreateUnit(UnitDefNames[defence].id, posx2, posy2, posz2, math.random(0,3), GaiaTeamID)
+						--Spring.SpawnCEG("scav-spawnexplo", posx2, posy2, posz2, 0,0,0)
 						Spring.SetUnitNeutral(unit, true)
 						Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, {1}, 0)
 						Spring.GiveOrderToUnit(unit, CMD.MOVE_STATE, {0}, 0)
@@ -419,18 +482,22 @@ end
 
 function gadget:GameFrame(n)
 
-	if n == spawnCutoffFrame+30 then
+	if n == 15 then
 		local mexSpots = GG["resource_spot_finder"] and GG["resource_spot_finder"].metalSpotsList or nil
 		if mexSpots and #mexSpots > 5 then
 			SpawnMexes(mexSpots)
 		end
 	end
 
-	if n == spawnCutoffFrame+60 then
+	if n == 30 then
 		local geoSpots = GG["resource_spot_finder"] and GG["resource_spot_finder"].geoSpotsList or nil
 		if geoSpots and #geoSpots >= 1 then
 			SpawnGeos(geoSpots)
 		end
+	end
+
+	if n == spawnCutoffFrame then
+		SpawnMexGeoRandomStructures()
 	end
 
 	if n < (10/ruinDensityMultiplier) or n%(10/ruinDensityMultiplier) ~= 0 or n > spawnCutoffFrame+5 then
@@ -490,6 +557,10 @@ function gadget:GameFrame(n)
 				canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx, posy, posz, radius)
 			elseif posy <= 0 then
 				canBuildHere = canBuildHere and positionCheckLibrary.SurfaceCheck(posx, posy, posz, radius, true)
+			end
+
+			if canBuildHere and getNearestBlocker(posx, posz) < radius*1.5 then
+				canBuildHere = false
 			end
 
 			if canBuildHere then


### PR DESCRIPTION
- All ruins that are not metal extractors or geothermals, are now avoiding spawning on metal extractors and geo spots.
- Metal Extractor and Geo ruins now spawn first
- Extra turret ruins are now spawning last, instead of together with metal extractors, allowing for more metal/geo extractors to spawn, as well as leaving more space for blueprint ruins.