### PR TITLE
collision gadget hotfix

### DIFF
--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -108,7 +108,7 @@ local function massToHealthRatioMultiplier(unitID, unitDefID)
 	local health, maxHealth = spGetUnitHealth(unitID)
 	if maxHealth then
 		local massToMaxHealthMultiplier = (maxHealth / unitMasses[unitDefID]) * fallDamageMultipliers[unitDefID]
-		return massToMaxHealthMultiplier
+		return massToMaxHealthMultiplier, health
 	else
 		return fallDamageMultipliers[unitDefID], health
 	end
@@ -137,9 +137,9 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 		unitInertiaCheckFlags[unitID] = gameFrame + velocityWatchFrames
 		return damage, impulseMultiplier
 	elseif (weaponDefID == groundCollisionDefID or weaponDefID == objectCollisionDefID) and not transportedUnits[unitID] and isValidCollisionDirection(unitID) then
-			local healthRatioMultiplier, health = massToHealthRatioMultiplier(unitID, unitDefID)
-			damage = preventOverkillDamage(unitID, damage, health, healthRatioMultiplier)
-			return damage, 0
+		local healthRatioMultiplier, health = massToHealthRatioMultiplier(unitID, unitDefID)
+		damage = preventOverkillDamage(unitID, damage, health, healthRatioMultiplier)
+		return damage, 0
 	else
 		return damage
 	end


### PR DESCRIPTION
hotfix for collision behavior. Changes the logic in unitPreDamaged to eliminate a potential bug that hasn't been discovered yet.

Also makes it so that units that fall to their deaths always spawn a feature by using Spring.DestroyUnit when damage is sufficient

I tested transport selfD drop (working as expected) and ran it through a couple BARb games with impulse cranked way up and everything works with no errors that I saw.