### PR TITLE
Fix infobox for transportable: light/heavy

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -496,11 +496,21 @@ local function drawStats(uDefID, uID)
 	-- Transportable
 	------------------------------------------------------------------------------------
 
-	if transportable and mass > 0 and size > 0 then
-		if mass < 5000 and size < 3 then -- 3 is t1 transport max size
-			DrawText(texts.transportable..':', blue .. texts.transportable_light)
-		elseif mass < 100000 and size < 4 then
-			DrawText(texts.transportable..':', yellow .. texts.transportable_heavy)
+	if Spring.GetModOptions().proposed_unit_reworks == true then
+		if transportable and mass > 0 and size > 0 then
+			if mass < 751 and size < 4 then -- 3 is t1 transport max size
+				DrawText(texts.transportable..':', blue .. texts.transportable_light)
+			elseif mass < 100000 and size < 5 then
+				DrawText(texts.transportable..':', yellow .. texts.transportable_heavy)
+			end
+		end
+	else
+		if transportable and mass > 0 and size > 0 then
+			if mass < 5000 and size < 4 then -- 3 is t1 transport max size
+				DrawText(texts.transportable..':', blue .. texts.transportable_light)
+			elseif mass < 100000 and size < 5 then
+				DrawText(texts.transportable..':', yellow .. texts.transportable_heavy)
+			end
 		end
 	end
 	cY = cY - fontSize


### PR DESCRIPTION
Both for the new transport system, and the legacy one.

It was mistakenly labeling size 3 units as heavy.
