### PR TITLE
suspend unit_collision_damage_behavior

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -68,7 +68,7 @@ local modrules = {
 	},
 
 	movement = {
-		allowUnitCollisionDamage = true,	-- default: true if using QTPFS pathfinder.  Do unit-unit (skidding) collisions cause damage?
+		allowUnitCollisionDamage = false,	-- default: true if using QTPFS pathfinder.  Do unit-unit (skidding) collisions cause damage?
 		allowUnitCollisionOverlap = false,	-- can mobile units collision volumes overlap one another? Allows unit movement like this (video http://www.youtube.com/watch?v=mRtePUdVk2o ) at the cost of more 'clumping'.
 		allowCrushingAlliedUnits = true,	-- default: false.  Can allied ground units crush each other during collisions? Units still have to be explicitly set as crushable using the crushable parameter of Spring.SetUnitBlocking.
 		allowGroundUnitGravity = false,		-- default: true.   Allows fast moving mobile units to 'catch air' as they move over terrain.

--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -6,7 +6,7 @@ function gadget:GetInfo()
 		date = "2024.8.29",
 		license = "GNU GPL, v2 or later",
 		layer = 0,
-		enabled = true
+		enabled = false
 	}
 end
 


### PR DESCRIPTION
suspends collision damage gadget and modrule until bomber bug is fixed and especially until after fight night finals is finished