### PR TITLE
PrebakeUnitDefs() fix

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -32,7 +32,7 @@ SaveDefsToCustomParams = false
 -------------------------
 
 function PrebakeUnitDefs()
-	for name, unitDef in pairs(UnitDefs) do
+	for name, uDef in pairs(UnitDefs) do
 		-- UnitDef changes go here
 	end
 end


### PR DESCRIPTION
uDef instead of unitDef, so it uses same syntax as the rest of the file
