### PR TITLE
gridmenu: move stopproduction key

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -36,8 +36,8 @@ bind         Shift+sc_e  reclaim
 bind               sc_f  fight
 bind         Shift+sc_f  fight
 bind           Alt+sc_f  forcestart
-bind               sc_g  stopproduction
-bind         Shift+sc_g  stopproduction
+bind           Alt+sc_g  stopproduction
+bind     Alt+Shift+sc_g  stopproduction
 bind               sc_g  stop
 bind         Shift+sc_g  stop
 bind               sc_h  patrol


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
In the grid keys, I moved the key for `stopproduction` to `alt+sc_g` instead of `sc_g`, so `stop` can still be issued to factories with `sc_g`, and because of what was said [here](https://discord.com/channels/549281623154229250/724293659809284137/1287392528462647370).

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->


<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
