### PR TITLE
remove unused damagereduction unitdef from armason.lua

### DIFF
--- a/units/ArmBuildings/SeaUtil/armason.lua
+++ b/units/ArmBuildings/SeaUtil/armason.lua
@@ -12,7 +12,6 @@ return {
 		canrepeat = false,
 		category = "ALL UNDERWATER NOTLAND NOTSUB NOWEAPON NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
 		corpse = "DEAD",
-		damagemodifier = 0.46,
 		explodeas = "mediumBuildingexplosiongeneric-uw",
 		footprintx = 4,
 		footprintz = 4,


### PR DESCRIPTION
this is to resolve issue https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2093

the cortex equivalent to the advanced sonar (which isn't even used in any part of the game I'm aware of) doesnt have this damage reduction and there's no way to activate it while using the unit from damage or on/off (disabled). This PR removes it to make the info accurate