### PR TITLE
armah changed movement class from hover2 to hover3

### DIFF
--- a/units/ArmHovercraft/armah.lua
+++ b/units/ArmHovercraft/armah.lua
@@ -22,7 +22,7 @@ return {
 		maxslope = 16,
 		speed = 88.5,
 		maxwaterdepth = 0,
-		movementclass = "HOVER2",
+		movementclass = "HOVER3",
 		movestate = 0,
 		nochasecategory = "NOTAIR",
 		objectname = "Units/ARMAH.s3o",


### PR DESCRIPTION
### work done
made the armah use hover3 instead of hover2 
hover2 is meant for small hover units like the raiders not for something the size of a meduim tank