### PR TITLE
Fix spectator hud conflicts with ecostats.

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -62,6 +62,7 @@ local gaiaID = Spring.GetGaiaTeamID()
 local gaiaAllyID = select(6, Spring.GetTeamInfo(gaiaID, false))
 
 local widgetEnabled = nil
+local ecostatsWidget = nil
 
 local haveFullView = false
 
@@ -1820,7 +1821,23 @@ local function initGL4()
 	return shaderCompiled
 end
 
+local function hideEcostats()
+	if widgetEnabled and widgetHandler:IsWidgetKnown("Ecostats") then
+		ecostatsWidget = widgetHandler:FindWidget("Ecostats")
+		if (not ecostatsWidget) then return end
+		widgetHandler:RemoveWidget(ecostatsWidget)
+	end
+end
+
+local function showEcostats()
+	if ecostatsWidget then
+		widgetHandler:InsertWidget(ecostatsWidget)
+		ecostatsWidget = nil
+	end
+end
+
 local function init()
+	hideEcostats()
 	font = WG['fonts'].getFont()
 
 	viewScreenWidth, viewScreenHeight = Spring.GetViewGeometry()
@@ -1876,6 +1893,7 @@ local function deInit()
 	deleteMetricDisplayLists()
 	deleteKnobVAO()
 	deleteTextures()
+	showEcostats()
 end
 
 local function reInit()
@@ -1885,20 +1903,10 @@ end
 
 function widget:Initialize()
 	-- Note: Widget is logically enabled only if there are exactly two teams
-	-- If yes, we disable ecostats
-	-- If no, we enable ecostats
-	-- TODO: What if user doesn't want to have Ecostats?
+	-- If yes, we will hide ecostats (hide at init() and show at deInit())
+	-- If no, we will do nothing since user might or might not be using ecostats
 	widgetEnabled = getAmountOfAllyTeams() == 2
-	if widgetEnabled then
-		if widgetHandler:IsWidgetKnown("Ecostats") then
-			widgetHandler:DisableWidget("Ecostats")
-		end
-	else
-		if widgetHandler:IsWidgetKnown("Ecostats") then
-			widgetHandler:EnableWidget("Ecostats")
-		end
-		return
-	end
+	if not widgetEnabled then return end
 
 	WG["spectator_hud"] = {}
 


### PR DESCRIPTION
### Work done

Changes behavior of spectator hud to show/hide ecostats instead of plain disabling it so it should work intuitively in all situations.

(Still respects the intended behavior where if both are enabled each will show in different matches depending on the amount of allyteams).

The only problem is people with ecostats disabled because of the issues mentioned in #3800, will still have it disabled until they enable through F11 but for new users behavior should be good. Don't see how we can fix this for old users, other than one time forcing ecostats enablefor everyone... maybe this could be achieved through some flag internally to remember we already did it, but didn't want to over complicate the solution for now, also not sure it's viable but I guess yes.

Another side effect is, when spectator hud is enabled ecostats can't be disabled through F11. User has to start the match with spectator hud disabled, This can be a bit inconvenient but at least it's not breaking behaviour.

**note**: new to the code base so pls review changes since I'm not sure the technique used to hide and show the widget is the best, although afaics it is.

#### Addresses Issue(s)

#3800

#### Test steps

See issue above