### PR TITLE
Enable ecostats just one time for everyone

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -201,6 +201,7 @@ local settings = {
 
 	-- this table is used only when widgetConfig is set to custom
 	metricsEnabled = {},
+	oneTimeEcostatsEnableDone = false,
 }
 
 local metricKeys = {
@@ -1902,6 +1903,11 @@ local function reInit()
 end
 
 function widget:Initialize()
+	-- One time enabling of ecostats since old spectator hud versions would disable ecostats
+	-- and we don't want people not being able to enable it again easily.
+	if not settings.oneTimeEcostatsEnableDone and widgetHandler:IsWidgetKnown("Ecostats") then
+		widgetHandler:EnableWidget("Ecostats")
+	end
 	-- Note: Widget is logically enabled only if there are exactly two teams
 	-- If yes, we will hide ecostats (hide at init() and show at deInit())
 	-- If no, we will do nothing since user might or might not be using ecostats
@@ -2109,6 +2115,7 @@ function widget:GetConfigData()
 	local result = {
 		widgetScale = settings.widgetScale,
 		widgetConfig = settings.widgetConfig,
+		oneTimeEcostatsEnableDone = true,
 	}
 
 	result.metricsEnabled = {}
@@ -2125,6 +2132,9 @@ function widget:SetConfigData(data)
 	end
 	if data.widgetConfig then
 		settings.widgetConfig = data.widgetConfig
+	end
+	if data.oneTimeEcostatsEnableDone then
+		settings.oneTimeEcostatsEnableDone = data.oneTimeEcostatsEnableDone
 	end
 
 	if data["metricsEnabled"] then


### PR DESCRIPTION
### Work done
Make spectator hud perform a one time only enabling of ecostats to avoid users staying with it disabled.

Uses an internal config flag to remember this.

#### Addresses Issue(s)
Previous spectator hud behaviour would in some cases disable ecostats, making it difficult to enable again, it would in some cases enable it again though. With latest changes from #3799 some of them could stay with ecostats disabled.

This pull request makes sure we enable ecostats once for all users, making sure they won't stay with it disabled. It might re-enable it for some people who want it disabled, but those users are the ones who know where F11 is. For others re-enabling it could be very tricky.

