### PR TITLE
feat(chain actions): Enabled by default

### DIFF
--- a/luaui/Widgets/cmd_chainactions.lua
+++ b/luaui/Widgets/cmd_chainactions.lua
@@ -26,7 +26,7 @@ function widget:GetInfo()
 		date = "April 2024",
 		license = "GNU GPL, v2 or later",
 		layer = 0,
-		enabled = false,
+		enabled = true,
 		handler = true,
 	}
 end


### PR DESCRIPTION
### Work done

Enables the chain actions widget by default. As I understand there's a recent change that makes this less effective, but it should still work for new users.

The reason for this change is that this widget provides functionality that can fix many issues related to engine actions in keybinding customization, as well as offering extended functionality, at no other cost than a small memory footprint.