### PR TITLE
improve shift queueing for nanos

### DIFF
--- a/luaui/Widgets/unit_immobile_builder.lua
+++ b/luaui/Widgets/unit_immobile_builder.lua
@@ -32,8 +32,8 @@ local spGetTeamUnits		= Spring.GetTeamUnits
 local spGetUnitDefID		= Spring.GetUnitDefID
 local spGetUnitPosition		= Spring.GetUnitPosition
 local spGiveOrderToUnit		= Spring.GiveOrderToUnit
+local spGetCommandQueue     = Spring.GetCommandQueue
 local spGetSpectatingState	= Spring.GetSpectatingState
-local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 
 local hmsx = Game.mapSizeX/2
 local hmsz = Game.mapSizeZ/2
@@ -132,9 +132,10 @@ end
 
 function widget:UnitCommand(unitID, unitDefID, _, cmdID, _, cmdOpts)
 	if isImmobileBuilder[unitDefID] and cmdOpts.shift and cmdID ~= CMD_FIGHT then
-		local firstCmdID, _, cmdTag = spGetUnitCurrentCommand(unitID, 1)
-		if firstCmdID == CMD_FIGHT then
-			spGiveOrderToUnit(unitID, CMD.REMOVE, { cmdTag }, 0)
+		local commandQueue = spGetCommandQueue(unitID, -1)
+		local lastCommand = commandQueue[#commandQueue]
+		if lastCommand.id == CMD_FIGHT then
+			spGiveOrderToUnit(unitID, CMD.REMOVE, { lastCommand.tag }, 0)
 		end
 	end
 end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
If there is a fight command at the end of the nano's command queue, it will cancel the fight command once something has been queued with shift, because the fight command will never be completed. Once the nano is idle again, the fight command will get reissued like normal.

closes #744 , and does what #2421 intended to do
Edit: also closes #681
<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->
<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
