### PR TITLE
Stop sideways shots for Armada Claw and Lightening wall

### DIFF
--- a/units/ArmBuildings/LandDefenceOffence/armclaw.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armclaw.lua
@@ -161,6 +161,7 @@ return {
 		},
 		weapons = {
 			[1] = {
+				burstControlWhenOutOfArc = 2,
 				def = "DCLAW",
 				onlytargetcategory = "SURFACE",
 				fastautoretargeting = true,

--- a/units/Scavengers/Buildings/DefenseOffense/armlwall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/armlwall.lua
@@ -210,6 +210,7 @@ return {
 		},
 		weapons = {
 			[1] = {
+				burstControlWhenOutOfArc = 2,
 				def = "lightning",
 				onlytargetcategory = "SURFACE",
 				fastautoretargeting = true,


### PR DESCRIPTION
this adds burstControlWhenOutOfArc = 2, same as the Razorback and the Thor to prevent sideways lightening blasts. This will make it slightly worse at handling tick spam but shooting sideways always looks silly and buggy. This resolves issue: https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3616