### PR TITLE
Remove pushresistance tags

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -608,14 +608,6 @@ function UnitDef_Post(name, uDef)
 		end
 	end
 
-	-- mass remove push resistance
-	if uDef.pushresistant and uDef.pushresistant == true then
-		uDef.pushresistant = false
-		if not uDef.mass then
-			uDef.mass = 4999
-		end
-	end
-
 	if string.find(name, "raptor") and uDef.health then
 		local raptorHealth = uDef.health
 		uDef.activatewhenbuilt = true

--- a/units/ArmBots/T2/armfboy.lua
+++ b/units/ArmBots/T2/armfboy.lua
@@ -23,7 +23,6 @@ return {
 		movementclass = "HBOT4",
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMFBOY.s3o",
-		pushresistant = true,
 		script = "Units/ARMFBOY.cob",
 		seismicsignature = 0,
 		selfdestructas = "largeExplosionGenericSelfd",

--- a/units/ArmGantry/armbanth.lua
+++ b/units/ArmGantry/armbanth.lua
@@ -28,7 +28,6 @@ return {
 		movementclass = "VBOT5",
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMBANTH.s3o",
-		pushresistant = true,
 		script = "Units/ARMBANTH.cob",
 		seismicsignature = 0,
 		selfdestructas = "banthaSelfd",

--- a/units/ArmGantry/armthor.lua
+++ b/units/ArmGantry/armthor.lua
@@ -27,7 +27,6 @@ return {
 		movementclass = "HTANK5",
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMTHOR.s3o",
-		pushresistant = true,
 		script = "Units/ARMTHOR.cob",
 		seismicsignature = 0,
 		selfdestructas = "explosiont3xxl",

--- a/units/ArmShips/T2/armepoch.lua
+++ b/units/ArmShips/T2/armepoch.lua
@@ -27,7 +27,6 @@ return {
 		movementclass = "BOAT8",
 		movestate = 0,
 		objectname = "Units/ARMEPOCH.s3o",
-		pushresistant = true,
 		radardistance = 1530,
 		radaremitheight = 52,
 		script = "Units/ARMEPOCH.cob",

--- a/units/ArmShips/armtship.lua
+++ b/units/ArmShips/armtship.lua
@@ -25,7 +25,6 @@ return {
 		movementclass = "BOAT5",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMTSHIP.s3o",
-		pushresistant = true,
 		releaseheld = false,
 		script = "Units/ARMTSHIP.cob",
 		seismicsignature = 0,

--- a/units/ArmVehicles/armart.lua
+++ b/units/ArmVehicles/armart.lua
@@ -26,7 +26,6 @@ return {
 		movestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/armart.s3o",
-		pushresistant = true,
 		script = "Units/armart.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd",

--- a/units/CorBots/T2/corsumo.lua
+++ b/units/CorBots/T2/corsumo.lua
@@ -23,7 +23,6 @@ return {
 		movementclass = "HBOT4",
 		nochasecategory = "VTOL",
 		objectname = "Units/CORSUMO.s3o",
-		pushresistant = true,
 		script = "Units/CORSUMO.cob",
 		seismicsignature = 0,
 		selfdestructas = "explosiont3",

--- a/units/CorGantry/corjugg.lua
+++ b/units/CorGantry/corjugg.lua
@@ -25,7 +25,6 @@ return {
 		movementclass = "HBOT5",
 		nochasecategory = "VTOL",
 		objectname = "Units/CORJUGG.s3o",
-		pushresistant = true,
 		script = "Units/CORJUGG.cob",
 		seismicsignature = 0,
 		selfdestructas = "juggernautSelfd",

--- a/units/CorGantry/corkorg.lua
+++ b/units/CorGantry/corkorg.lua
@@ -27,7 +27,6 @@ return {
 		movementclass = "VBOT5",
 		nochasecategory = "VTOL GROUNDSCOUT",
 		objectname = "Units/corkorg.s3o",
-		pushresistant = true,
 		script = "Units/corkorg.cob",
 		seismicsignature = 0,
 		selfdestructas = "korgExplosionSelfd",

--- a/units/CorShips/T2/corblackhy.lua
+++ b/units/CorShips/T2/corblackhy.lua
@@ -26,7 +26,6 @@ return {
 		movementclass = "BOAT8",
 		movestate = 0,
 		objectname = "Units/CORBLACKHY.s3o",
-		pushresistant = true,
 		radardistance = 1510,
 		radaremitheight = 64,
 		script = "Units/CORBLACKHY.cob",

--- a/units/CorShips/cortship.lua
+++ b/units/CorShips/cortship.lua
@@ -25,7 +25,6 @@ return {
 		movementclass = "BOAT5",
 		nochasecategory = "ALL",
 		objectname = "Units/CORTSHIP.s3o",
-		pushresistant = true,
 		releaseheld = false,
 		script = "Units/CORTSHIP.cob",
 		seismicsignature = 0,

--- a/units/CorVehicles/corwolv.lua
+++ b/units/CorVehicles/corwolv.lua
@@ -26,7 +26,6 @@ return {
 		movestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORWOLV.s3o",
-		pushresistant = true,
 		script = "Units/CORWOLV.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd",

--- a/units/Legion/Bots/T2 Bots/leginc.lua
+++ b/units/Legion/Bots/T2 Bots/leginc.lua
@@ -25,7 +25,6 @@ return {
 		movementclass = "HBOT4",
 		nochasecategory = "VTOL",
 		objectname = "Units/leginc.s3o",
-		pushresistant = true,
 		script = "Units/leginc_clean.cob",
 		seismicsignature = 0,
 		selfdestructas = "penetrator",

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl2.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl2.lua
@@ -44,7 +44,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL2.s3o",
-		pushresistant = true,
 		radardistance = 800,
 		radaremitheight = 44,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl3.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl3.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL3.s3o",
-		pushresistant = true,
 		radardistance = 900,
 		radaremitheight = 49,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl4.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl4.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1000,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl5.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl5.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1000,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl6.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl6.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1000,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl7.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl7.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl8.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl8.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Legion EvoCom/legcomlvl9.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl9.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMLVL4.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Legion/Other/Commanders/legcomecon.lua
+++ b/units/Legion/Other/Commanders/legcomecon.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOM.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/Legion/Other/Commanders/legcomoff.lua
+++ b/units/Legion/Other/Commanders/legcomoff.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMOFF.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/Legion/Other/Commanders/legcomt2com.lua
+++ b/units/Legion/Other/Commanders/legcomt2com.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMT2COM.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/Legion/Other/Commanders/legcomt2def.lua
+++ b/units/Legion/Other/Commanders/legcomt2def.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOM.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/Legion/Other/Commanders/legcomt2off.lua
+++ b/units/Legion/Other/Commanders/legcomt2off.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOMOFF.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		radardistancejam = 100,

--- a/units/Legion/T3/leegmech.lua
+++ b/units/Legion/T3/leegmech.lua
@@ -26,7 +26,6 @@ return {
 		movementclass = "HBOT4",
 		nochasecategory = "VTOL",
 		objectname = "Units/LEGMECH.s3o",
-		pushresistant = true,
 		script = "Units/LEGMECH.cob",
 		seismicsignature = 0,
 		selfdestructas = "banthaSelfd",

--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -45,7 +45,6 @@ return {
 		movestate = 0,
 		nochasecategory = "ALL",
 		objectname = "Units/LEGCOM.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/Scavengers/Air/corfblackhyt4.lua
+++ b/units/Scavengers/Air/corfblackhyt4.lua
@@ -31,7 +31,6 @@ return {
 		maxwaterdepth = 15,
 		objectname = "Units/scavboss/corfblackhyt4.s3o",
 		script = "Units/scavboss/corfblackhyt4.cob",
-		pushresistant = true,
 		radardistance = 1510,
 		radaremitheight = 64,
 		seismicsignature = 0,

--- a/units/Scavengers/Boss/armcomboss.lua
+++ b/units/Scavengers/Boss/armcomboss.lua
@@ -42,7 +42,6 @@ return {
 		movementclass = "SCAVCOMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/scavboss/ARMCOMBOSS.s3o",
-		pushresistant = true,
 		radardistance = 2000,
 		radaremitheight = 100,
 		reclaimable = false,

--- a/units/Scavengers/Boss/armscavengerbossv2.lua
+++ b/units/Scavengers/Boss/armscavengerbossv2.lua
@@ -92,7 +92,6 @@ for difficulty, stats in pairs(difficultyParams) do
 		movementclass = "SCAVCOMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/scavboss/armscavengerbossv2.s3o",
-		pushresistant = true,
 		radardistance = 500,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Scavengers/Boss/corcomboss.lua
+++ b/units/Scavengers/Boss/corcomboss.lua
@@ -42,7 +42,6 @@ return {
 		movementclass = "SCAVCOMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/scavboss/CORCOMBOSS.s3o",
-		pushresistant = true,
 		radardistance = 2000,
 		radaremitheight = 100,
 		reclaimable = false,

--- a/units/Scavengers/Boss/scavengerbossv4.lua
+++ b/units/Scavengers/Boss/scavengerbossv4.lua
@@ -94,7 +94,6 @@ for difficulty, stats in pairs(difficultyParams) do
 		movementclass = "SCAVCOMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/scavboss/scavengerbossv4.s3o",
-		pushresistant = true,
 		radardistance = 2000,
 		radaremitheight = 54,
 		reclaimable = false,

--- a/units/Scavengers/Vehicles/armvadert4.lua
+++ b/units/Scavengers/Vehicles/armvadert4.lua
@@ -26,7 +26,6 @@ return {
 		movementclass = "EPICALLTERRAIN",
 		nochasecategory = "VTOL",
 		objectname = "Units/scavboss/armvadert4.s3o",
-		pushresistant = true,
 		script = "Units/scavboss/armvadert4.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",

--- a/units/armcom.lua
+++ b/units/armcom.lua
@@ -42,7 +42,6 @@ return {
 		movestate = 0,
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOM"..(Spring.GetModOptions().xmas and '-XMAS' or '')..".s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/armcomcon.lua
+++ b/units/armcomcon.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOM.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/corcom.lua
+++ b/units/corcom.lua
@@ -42,7 +42,6 @@ return {
 		movestate = 0,
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOM"..(Spring.GetModOptions().xmas and '-XMAS' or '')..".s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/corcomcon.lua
+++ b/units/corcomcon.lua
@@ -41,7 +41,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOM.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl10.lua
+++ b/units/other/evocom/armcomlvl10.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl2.lua
+++ b/units/other/evocom/armcomlvl2.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOM"..(Spring.GetModOptions().xmas and '-XMAS' or '')..".s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl3.lua
+++ b/units/other/evocom/armcomlvl3.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1100,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl4.lua
+++ b/units/other/evocom/armcomlvl4.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1100,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl5.lua
+++ b/units/other/evocom/armcomlvl5.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl6.lua
+++ b/units/other/evocom/armcomlvl6.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl7.lua
+++ b/units/other/evocom/armcomlvl7.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl8.lua
+++ b/units/other/evocom/armcomlvl8.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/armcomlvl9.lua
+++ b/units/other/evocom/armcomlvl9.lua
@@ -47,7 +47,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/ARMCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1200,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl10.lua
+++ b/units/other/evocom/corcomlvl10.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1500,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl2.lua
+++ b/units/other/evocom/corcomlvl2.lua
@@ -45,7 +45,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOM"..(Spring.GetModOptions().xmas and '-XMAS' or '')..".s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl3.lua
+++ b/units/other/evocom/corcomlvl3.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl4.lua
+++ b/units/other/evocom/corcomlvl4.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 700,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl5.lua
+++ b/units/other/evocom/corcomlvl5.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1000,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl6.lua
+++ b/units/other/evocom/corcomlvl6.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1000,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl7.lua
+++ b/units/other/evocom/corcomlvl7.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1000,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl8.lua
+++ b/units/other/evocom/corcomlvl8.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1500,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/evocom/corcomlvl9.lua
+++ b/units/other/evocom/corcomlvl9.lua
@@ -46,7 +46,6 @@ return {
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "ALL",
 		objectname = "Units/CORCOMHILVL.s3o",
-		pushresistant = true,
 		radardistance = 1500,
 		radaremitheight = 40,
 		reclaimable = false,

--- a/units/other/raptors/Miniqueen/raptor_matriarch_acid.lua
+++ b/units/other/raptors/Miniqueen/raptor_matriarch_acid.lua
@@ -37,7 +37,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/raptor_miniqueen_acid.s3o",
-		pushresistant = true,
 		script = "Raptors/raptor_miniqueen.cob",
 		seismicsignature = 0,
 		selfdestructas = "BIGBUG_DEATH_ACID",

--- a/units/other/raptors/Miniqueen/raptor_matriarch_basic.lua
+++ b/units/other/raptors/Miniqueen/raptor_matriarch_basic.lua
@@ -40,7 +40,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/raptor_miniqueen_basic.s3o",
-		pushresistant = true,
 		script = "Raptors/raptor_miniqueen.cob",
 		seismicsignature = 0,
 		selfdestructas = "BUG_DEATH",

--- a/units/other/raptors/Miniqueen/raptor_matriarch_electric.lua
+++ b/units/other/raptors/Miniqueen/raptor_matriarch_electric.lua
@@ -37,7 +37,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/raptor_miniqueen_electric.s3o",
-		pushresistant = true,
 		script = "Raptors/raptor_miniqueen.cob",
 		seismicsignature = 0,
 		selfdestructas = "raptor_empdeath_big",

--- a/units/other/raptors/Miniqueen/raptor_matriarch_fire.lua
+++ b/units/other/raptors/Miniqueen/raptor_matriarch_fire.lua
@@ -40,7 +40,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/raptor_miniqueen_fire.s3o",
-		pushresistant = true,
 		script = "Raptors/raptor_miniqueen.cob",
 		seismicsignature = 0,
 		selfdestructas = "BUG_DEATH",

--- a/units/other/raptors/Miniqueen/raptor_matriarch_healer.lua
+++ b/units/other/raptors/Miniqueen/raptor_matriarch_healer.lua
@@ -40,7 +40,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/raptor_miniqueen_healer.s3o",
-		pushresistant = true,
 		repairable = false,
 		script = "Raptors/raptor_miniqueen.cob",
 		seismicsignature = 0,

--- a/units/other/raptors/Miniqueen/raptor_matriarch_spectre.lua
+++ b/units/other/raptors/Miniqueen/raptor_matriarch_spectre.lua
@@ -45,7 +45,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/raptor_miniqueen_spectre.s3o",
-		pushresistant = true,
 		script = "Raptors/raptor_miniqueen.cob",
 		seismicsignature = 0,
 		selfdestructas = "BUG_DEATH",

--- a/units/other/raptors/Queens/raptor_queen_easy.lua
+++ b/units/other/raptors/Queens/raptor_queen_easy.lua
@@ -43,7 +43,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/epic_raptorq.s3o",
-		pushresistant = true,
 		script = "Raptors/epic_raptorq.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",

--- a/units/other/raptors/Queens/raptor_queen_epic.lua
+++ b/units/other/raptors/Queens/raptor_queen_epic.lua
@@ -43,7 +43,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/epic_raptorq.s3o",
-		pushresistant = true,
 		script = "Raptors/epic_raptorq.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",

--- a/units/other/raptors/Queens/raptor_queen_hard.lua
+++ b/units/other/raptors/Queens/raptor_queen_hard.lua
@@ -43,7 +43,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/epic_raptorq.s3o",
-		pushresistant = true,
 		script = "Raptors/epic_raptorq.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",

--- a/units/other/raptors/Queens/raptor_queen_normal.lua
+++ b/units/other/raptors/Queens/raptor_queen_normal.lua
@@ -43,7 +43,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/epic_raptorq.s3o",
-		pushresistant = true,
 		script = "Raptors/epic_raptorq.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",

--- a/units/other/raptors/Queens/raptor_queen_veryeasy.lua
+++ b/units/other/raptors/Queens/raptor_queen_veryeasy.lua
@@ -42,7 +42,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/epic_raptorq.s3o",
-		pushresistant = true,
 		script = "Raptors/epic_raptorq.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",

--- a/units/other/raptors/Queens/raptor_queen_veryhard.lua
+++ b/units/other/raptors/Queens/raptor_queen_veryhard.lua
@@ -43,7 +43,6 @@ return {
 		noautofire = false,
 		nochasecategory = "VTOL SPACE",
 		objectname = "Raptors/epic_raptorq.s3o",
-		pushresistant = true,
 		script = "Raptors/epic_raptorq.cob",
 		seismicsignature = 0,
 		selfdestructas = "crawl_blastsmlscavboss",


### PR DESCRIPTION
It's currently just being removed in alldefs_post, so it doesn't serve much purpose. If the tag is tested and determined that it works, it's up for re-evaluation for what units should actually have it, anyway.

Pushresistance removal also removed from alldefs_post, so if something is given the tag, now it will actually be applied.
