### PR TITLE
Allow indexing players by accountid inside unit_hats gadget.

### DIFF
--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -116,12 +116,9 @@ function gadget:GameFrame(gf)
 		for _, playerID in ipairs(Spring.GetPlayerList()) do
 
 			local accountID = false
-			local playerInfo = { Spring.GetPlayerInfo(playerID, true) }
-			local playerName = playerInfo[1]
-			local spec = playerInfo[3]
-			local teamID = playerInfo[4]
-			if playerInfo[11] and playerInfo[11].accountid then
-				accountID = tonumber(playerInfo[11].accountid)
+			local playerName, _, spec, teamID, _, _, _, _, _, _, accountInfo = Spring.GetPlayerInfo(playerID, true)
+			if accountInfo and accountInfo.accountid then
+				accountID = tonumber(accountInfo.accountid)
 			end
 
 			if not spec then

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -116,7 +116,7 @@ function gadget:GameFrame(gf)
 		for _, playerID in ipairs(Spring.GetPlayerList()) do
 
 			local accountID = false
-			local playerName, _, spec, teamID, _, _, _, _, _, _, accountInfo = Spring.GetPlayerInfo(playerID, true)
+			local playerName, _, spec, teamID, _, _, _, _, _, _, accountInfo = Spring.GetPlayerInfo(playerID, false)
 			if accountInfo and accountInfo.accountid then
 				accountID = tonumber(accountInfo.accountid)
 			end

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -79,7 +79,7 @@ local champion = { --   Fight Night 1v1 winner
  local vikings = {
 	[59340] = true,  -- [HELO]Austin
 	[3913] = true,   -- [teh]Teddy
-	["MightySheep"] = true,
+	[7137] = true,	-- MightySheep
 	[54088] = true,  -- Lostdeadman
 	[123900] = true, -- Narnuk
 	[38971] = true,  -- Yanami
@@ -89,13 +89,12 @@ local kings = {
 	[38971] = true,  -- Yanami
 }
 local goldMedals = {	 -- Nation Wars winners
-	["Nezah"] = true,
+	[87571] = true,	-- Nezah
 	[63960] = true,  -- [waa]Delfea
 	[44807] = true,  -- [waa]Eural
 	[59916] = true,  -- Kuchy
 	[119832] = true, -- Darkclone
 	[2220] = true,   -- "[200IQ]DrSmashy"
-
 }
 local silverMedals = {
 }

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -69,32 +69,32 @@ local unitDefCanWearHats = {
 	unitDefCanWearHats[UnitDefNames.legcomlvl4.id] = true
  end
  local legchamps = { -- Legion Fight Night winner(s)
-	["[DmE]Wraxell"] = true,
-	["[pretor]"] = true,
+	[144092] = true, -- [DmE]Wraxell
+	[42178] = true,  -- [pretor]
 	[119539] = true, -- [Stud]Lovish
 }
 local champion = { --   Fight Night 1v1 winner
-	["[DmE]FlyingDuck"] = true,
+	[139738] = true, -- [DmE]FlyingDuck
 }
  local vikings = {
-	["[HELO]Austin"] = true,
-	["[teh]Teddy"] = true,
+	[59340] = true,  -- [HELO]Austin
+	[3913] = true,   -- [teh]Teddy
 	["MightySheep"] = true,
-	["Lostdeadman"] = true,
-	["Narnuk"] = true,
-	["Yanami"] = true,
-	["HellsHound"] = true,
+	[54088] = true,  -- Lostdeadman
+	[123900] = true, -- Narnuk
+	[38971] = true,  -- Yanami
+	[5467] = true,   -- HellsHound
 }
 local kings = {
-	["Yanami"] = true,
+	[38971"Yanami"] = true,
 }
-local goldMedals = {	-- Nation Wars winners
+local goldMedals = {	 -- Nation Wars winners
 	["Nezah"] = true,
-	["[waa]Delfea"] = true,
-	["[waa]Eural"] = true,
-	["Kuchy"] = true,
-	["Darkclone"] = true,
-	["[200IQ]DrSmashy"] = true,
+	[63960] = true,  -- [waa]Delfea
+	[44807] = true,  -- [waa]Eural
+	[59916] = true,  -- Kuchy
+	[119832] = true, -- Darkclone
+	[2220] = true,   -- "[200IQ]DrSmashy"
 
 }
 local silverMedals = {

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -71,7 +71,7 @@ local unitDefCanWearHats = {
  local legchamps = { -- Legion Fight Night winner(s)
 	["[DmE]Wraxell"] = true,
 	["[pretor]"] = true,
-	["[Stud]Lovish"] = true, 
+	[119539] = true, -- [Stud]Lovish
 }
 local champion = { --   Fight Night 1v1 winner
 	["[DmE]FlyingDuck"] = true,
@@ -104,11 +104,25 @@ local bronzeMedals = {
 local uniques = {--playername, hat ident, CaSe MaTtErS
 }
 
+local function MatchPlayer(gadgets, name, accountID)
+	if gadgets[name] or (accountID and gadgets[accountID]) then
+		return true
+	end
+	return false
+end
+
 function gadget:GameFrame(gf)
 	if gf == 90 then
 		for _, playerID in ipairs(Spring.GetPlayerList()) do
 
-			local playerName, _, spec, teamID = Spring.GetPlayerInfo(playerID, false)
+			local accountID = false
+			local playerInfo = { Spring.GetPlayerInfo(playerID, true) }
+			local playerName = playerInfo[1]
+			local spec = playerInfo[3]
+			local teamID = playerInfo[4]
+			if playerInfo[11] and playerInfo[11].accountid then
+				accountID = tonumber(playerInfo[11].accountid)
+			end
 
 			if not spec then
 				local units = Spring.GetTeamUnits(teamID)
@@ -119,19 +133,19 @@ function gadget:GameFrame(gf)
 
 					if unitDefCanWearHats[unitDefID] then
             
-						if legchamps[playerName] and UnitDefNames['cor_hat_legfn'] then
+						if MatchPlayer(legchamps, playerName, accountID) and UnitDefNames['cor_hat_legfn'] then
 							local hatDefID = UnitDefNames['cor_hat_legfn'].id
 							local unitID = Spring.CreateUnit(hatDefID, unitPosX, unitPosY, unitPosZ, 0, teamID)
 							gadget:UnitGiven(unitID, hatDefID, teamID)
 						end
 
-						if champion[playerName] and UnitDefNames['cor_hat_fightnight'] then
+						if MatchPlayer(champion, playerName, accountID) and UnitDefNames['cor_hat_fightnight'] then
 							local hatDefID = UnitDefNames['cor_hat_fightnight'].id
 							local unitID = Spring.CreateUnit(hatDefID, unitPosX, unitPosY, unitPosZ, 0, teamID)
 							gadget:UnitGiven(unitID, hatDefID, teamID)
 						end
 
-						if vikings[playerName] and UnitDefNames['cor_hat_viking'] then
+						if MatchPlayer(vikings, playerName, accountID) and UnitDefNames['cor_hat_viking'] then
 							local hatDefID = UnitDefNames['cor_hat_viking'].id
 							local unitID = Spring.CreateUnit(hatDefID, unitPosX, unitPosY, unitPosZ, 0, teamID)
 							gadget:UnitGiven(unitID, hatDefID, teamID)
@@ -160,16 +174,16 @@ function gadget:GameFrame(gf)
 								end
 							end
 						else
-							if kings[playerName] and Spring.GetCOBScriptID(unitID, 'ShowCrown') then
+							if MatchPlayer(kings, playerName, accountID) and Spring.GetCOBScriptID(unitID, 'ShowCrown') then
 								Spring.CallCOBScript(unitID, "ShowCrown", 0)
 							end
-							if goldMedals[playerName] and Spring.GetCOBScriptID(unitID, 'ShowMedalGold') then
+							if MatchPlayer(goldMedals, playerName, accountID) and Spring.GetCOBScriptID(unitID, 'ShowMedalGold') then
 								Spring.CallCOBScript(unitID, "ShowMedalGold", 0)
 							end
-							if silverMedals[playerName] and Spring.GetCOBScriptID(unitID, 'ShowMedalSilver') then
+							if MatchPlayer(silverMedals, playerName, accountID) and Spring.GetCOBScriptID(unitID, 'ShowMedalSilver') then
 								Spring.CallCOBScript(unitID, "ShowMedalSilver", 0)
 							end
-							if bronzeMedals[playerName] and Spring.GetCOBScriptID(unitID, 'ShowMedalBronze') then
+							if MatchPlayer(bronzeMedals, playerName, accountID) and Spring.GetCOBScriptID(unitID, 'ShowMedalBronze') then
 								Spring.CallCOBScript(unitID, "ShowMedalBronze", 0)
 							end
 						end

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -104,8 +104,8 @@ local bronzeMedals = {
 local uniques = {--playername, hat ident, CaSe MaTtErS
 }
 
-local function MatchPlayer(gadgets, name, accountID)
-	if gadgets[name] or (accountID and gadgets[accountID]) then
+local function MatchPlayer(awardees, name, accountID)
+	if awardees[name] or (accountID and awardees[accountID]) then
 		return true
 	end
 	return false

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -86,7 +86,7 @@ local champion = { --   Fight Night 1v1 winner
 	[5467] = true,   -- HellsHound
 }
 local kings = {
-	[38971"Yanami"] = true,
+	[38971] = true,  -- Yanami
 }
 local goldMedals = {	 -- Nation Wars winners
 	["Nezah"] = true,


### PR DESCRIPTION
### Work done

Make trophies indexable by accountid instead of just user name.

I believe indexing by name means the trophy will be lost when user changes name, also it could be coopted by someone else by taking an old name with trophies.

## Test steps

Actually don't know how to test it. I did test some of the code inside a custom widget with replays, but when working with a modified BAR I can't run the replays so don't know how test the gadget.

## Notes

Alternative implementation to https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3821 we just did it in parallel so I don't claim nothing special do as you want with this.

This doesn't account for the unique trophies. Also maybe changing the underlying structure could be better, but I went with a simple allow numbers inside tables and those will be interpreted as account ids.

I did include most accountids, but maybe they have to be reviewed to make sure I didn't mess up the lookups. Also I couldn't find ids for a couple names, probably because they already changed names. -- **update:** all accountids included (thx Floris) and reviewed now, pretty sure they're ok but someone may want to review again.

I think the custom of having a comment with the player name is the way, unless we chose to change the data structure so it can hold both player name and id (maybe change true value with the name or a dict could work).
