### PR TITLE
un-break what I broke, dragon's fury

### DIFF
--- a/units/Scavengers/Buildings/DefenseOffense/armlwall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/armlwall.lua
@@ -210,7 +210,6 @@ return {
 		},
 		weapons = {
 			[1] = {
-				burstControlWhenOutOfArc = 2,
 				def = "lightning",
 				onlytargetcategory = "SURFACE",
 				fastautoretargeting = true,


### PR DESCRIPTION
Turns out, it doesn't have a turret and it does NOT work with burstwhenoutofcontrolarc = 2. I think it's because it doesn't actually turn the turret (because it doesn't have one) so the burst continues at the current unaltered heading of the flare. Given those two things, this change was unnecessary and introduced another bug. Lesson learned, don't Trust The Code (tm)