### PR TITLE
Add a nil check to shift queue logic in unit_immobile_builder.lua

### DIFF
--- a/luaui/Widgets/unit_immobile_builder.lua
+++ b/luaui/Widgets/unit_immobile_builder.lua
@@ -134,7 +134,7 @@ function widget:UnitCommand(unitID, unitDefID, _, cmdID, _, cmdOpts)
 	if isImmobileBuilder[unitDefID] and cmdOpts.shift and cmdID ~= CMD_FIGHT then
 		local commandQueue = spGetCommandQueue(unitID, -1)
 		local lastCommand = commandQueue[#commandQueue]
-		if lastCommand.id == CMD_FIGHT then
+		if lastCommand and lastCommand.id == CMD_FIGHT then
 			spGiveOrderToUnit(unitID, CMD.REMOVE, { lastCommand.tag }, 0)
 		end
 	end


### PR DESCRIPTION
It shouldn't be removing the last command if there are no commands anyway?

Addresses https://discord.com/channels/549281623154229250/1293572198682071193

