### PR TITLE
Modoptions: move and patch new tax options

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -16,7 +16,9 @@ end
 if not gadgetHandler:IsSyncedCode() then
 	return false
 end
-if not Spring.GetModOptions().disable_assist_ally_construction then
+if	not (Spring.GetModOptions().disable_assist_ally_construction
+	-- tax force enables this
+	or (Spring.GetModOptions().tax_resource_sharing_amount or 0) ~= 0) then
 	return false
 end
 

--- a/luarules/gadgets/game_disable_unit_sharing.lua
+++ b/luarules/gadgets/game_disable_unit_sharing.lua
@@ -16,7 +16,12 @@ end
 if not gadgetHandler:IsSyncedCode() then
 	return false
 end
-if not Spring.GetModOptions().disable_unit_sharing then
+
+if not (Spring.GetModOptions().disable_unit_sharing
+	-- tax force enables this
+	or (Spring.GetModOptions().tax_resource_sharing_amount or 0) ~= 0)
+	-- unit market handles the restriction instead if enabled so that selling still works
+	or Spring.GetModOptions().unit_market then
 	return false
 end
 

--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -75,10 +75,8 @@ function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
 end
 
 
-	
--- Disallow reclaiming allied units for metal
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
-
+	-- Disallow reclaiming allied units for metal
 	if (cmdID == CMD.RECLAIM and #cmdParams >= 1) then
 		local targetID = cmdParams[1]
 		local targetTeam
@@ -89,20 +87,15 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 		if unitTeam ~= targetTeam and Spring.AreTeamsAllied(unitTeam, targetTeam) then
 			return false
 		end
-	end
-	return true
-end
-
--- Also block guarding allied units that can reclaim
-function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
-	if (cmdID == CMD.GUARD) then
+	-- Also block guarding allied units that can reclaim
+	elseif (cmdID == CMD.GUARD) then
 		local targetID = cmdParams[1]
 		local targetTeam = Spring.GetUnitTeam(targetID)
 		local targetUnitDef = UnitDefs[Spring.GetUnitDefID(targetID)]
 
 		if (unitTeam ~= Spring.GetUnitTeam(targetID)) and Spring.AreTeamsAllied(unitTeam, targetTeam) then
 			-- Labs are considered able to reclaim. In practice you will always use this modoption with "disable_assist_ally_construction", so disallowing guard labs here is fine
-			if targetUnitDef.canReclaim then 
+			if targetUnitDef.canReclaim then
 				return false
 			end
 		end

--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -16,7 +16,7 @@ end
 if not gadgetHandler:IsSyncedCode() then
 	return false
 end
-if not Spring.GetModOptions().tax_resource_sharing_and_prevent_some_reclaim_loopholes then
+if Spring.GetModOptions().tax_resource_sharing_amount == 0 then
 	return false
 end
 
@@ -24,6 +24,8 @@ local spIsCheatingEnabled = Spring.IsCheatingEnabled
 local spGetTeamUnitCount = Spring.GetTeamUnitCount
 
 local gameMaxUnits = math.min(Spring.GetModOptions().maxunits, math.floor(32000 / #Spring.GetTeamList()))
+
+local sharingTax = Spring.GetModOptions().tax_resource_sharing_amount
 
 ----------------------------------------------------------------
 -- Callins
@@ -52,11 +54,10 @@ function gadget:AllowResourceTransfer(senderTeamId, receiverTeamId, resourceType
 	-- rShare is the share slider setting, don't exceed their share slider max when sharing
 	local maxShare = rStor * rShare - rCur
 
-	local sharingTax = Spring.GetModOptions().tax_resource_sharing_amount 
 	local taxedAmount = math.min((1-sharingTax)*amount, maxShare)
 	local totalAmount = taxedAmount / (1-sharingTax)
-	local transferTax = totalAmount * sharingTax	
-	
+	local transferTax = totalAmount * sharingTax
+
 	Spring.SetTeamResource(receiverTeamId, resourceName, rCur+taxedAmount)
 	local sCur, _, _, _, _, _ = Spring.GetTeamResources(senderTeamId, resourceName)
 	Spring.SetTeamResource(senderTeamId, resourceName, sCur-totalAmount)

--- a/luarules/gadgets/game_unit_market.lua
+++ b/luarules/gadgets/game_unit_market.lua
@@ -189,7 +189,7 @@ local function tryToBuyUnit(unitID, msgFromTeamID)
     UnitSoldBroadcast(unitID, price, old_ownerTeamID, msgFromTeamID)
 end
 
-if true then
+if disable_unit_sharing then
     function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
         if(capture) then
             return true

--- a/luarules/gadgets/game_unit_market.lua
+++ b/luarules/gadgets/game_unit_market.lua
@@ -149,6 +149,12 @@ local function offerUnitForSale(unitID, sale_price, msgFromTeamID)
     end
 end
 
+local disable_unit_sharing = (
+    Spring.GetModOptions().disable_unit_sharing
+ or (Spring.GetModOptions().tax_resource_sharing_amount or 0) ~= 0)
+and Spring.GetModOptions().unit_market
+local saleWhitelist = {}
+
 local function tryToBuyUnit(unitID, msgFromTeamID)
     if not unitID or unitsForSale[unitID] == nil or unitsForSale[unitID] == 0 then return end
     local unitDefID = spGetUnitDefID(unitID)
@@ -171,12 +177,29 @@ local function tryToBuyUnit(unitID, msgFromTeamID)
 
     if (current < price) then return end
 
+    if disable_unit_sharing then
+        saleWhitelist[unitID] = true
+    end
+
     TransferUnit(unitID, msgFromTeamID)
     if msgFromTeamID ~= old_ownerTeamID and price > 0 then -- don't send resources to yourself
         ShareTeamResource(msgFromTeamID, old_ownerTeamID, "metal", price)
     end
     setNotForSale(unitID)
     UnitSoldBroadcast(unitID, price, old_ownerTeamID, msgFromTeamID)
+end
+
+if true then
+    function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
+        if(capture) then
+            return true
+        end
+        if saleWhitelist[unitID] then
+            saleWhitelist[unitID] = nil
+            return true
+        end
+        return false
+    end
 end
 
 -- this takes control and makes all cons stop using metal, we remove all limits on a) shutdown b) storage getting full c) widget crash - should be safe enough

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -162,63 +162,6 @@ local options = {
     },
 
     {
-        key 	= "unit_market",
-        name 	= "Unit Market",
-        desc 	= "Allow players to trade units. (Select unit, press 'For Sale' in order window or say /sell_unit in chat to mark the unit for sale. Double-click to buy from allies. T2cons show up in shop window!)",
-        type   	= "bool",
-        def    	= false,
-        section = "options_main",
-		lock	= {"disable_unit_sharing"},
-		unlock	= {"disable_unit_sharing_locked"},
-    },
-	{
-		key		= "unit_market_locked",
-		name	= "\255\128\128\128".."Unit Market                                             [Disable Unit Sharing]",
-		type	= "subheader",
-		section = "options_main",
-	},
-
-	{
-		key		= "disable_unit_sharing",
-		name	= "Disable Unit Sharing",
-		desc	= "Disable sharing units and structures to allies",
-		type	= "bool",
-		section	= "options_main",
-		def		= false,
-		lock	= {"unit_market"},
-		unlock	= {"unit_market_locked"},
-	},
-	{
-		key		= "disable_unit_sharing_locked",
-		name	= "\255\128\128\128".."Disable Unit Sharing                              [Unit Market]",
-		type	= "subheader",
-		section	= "options_main",
-	},
-	{
-		key		= "disable_assist_ally_construction",
-		name	= "Disable Assist Ally Construction",
-		desc	= "Disables assisting allied blueprints and labs.",
-		type	= "bool",
-		section	= "options_main",
-		def		=  false,
-	},
-	{
-		key		= "tax_resource_sharing_amount",
-		name	= "Resource Sharing Tax",
-		desc	=	"Taxes resource sharing".."\255\128\128\128".." and overflow (engine TODO:)\n"..
-					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)\n"..
-					"*Disables: Reclaiming of Allied Units\n"..
-					"*Recommended: [Disable Unit Sharing] and [Disable Assist Ally Construction] to prevent loopholes",
-		type	= "number",
-		def		= 0,
-		min		= 0,
-		max		= 0.99,
-		step	= 0.01,
-		section	= "options_main",
-		column	= 1,
-	},
-
-    {
         key		= "transportenemy",
         name	= "Enemy Transporting",
         desc	= "Toggle which enemy units you can kidnap with an air transport",
@@ -231,7 +174,6 @@ local options = {
             { key= "none", 		name= "Disallow All", 		desc= "No enemy units can be napped" },
         }
     },
-
 
     {
         key     = "teamffa_start_boxes_shuffle",
@@ -281,6 +223,76 @@ local options = {
         max    	= 30,
         step   	= 1,
     },
+
+	{
+		key		= "sub_header",
+		section	= "options_main",
+		type	= "separator",
+	},
+	{
+		key		= "sub_header",
+		name	= "-- Sharing and Taxes",
+		section	= "options_main",
+		type	= "subheader",
+		def		=  true,
+	},
+	{
+		key		= "tax_resource_sharing_amount",
+		name	= "Resource Sharing Tax",
+		desc	=	"Taxes resource sharing".."\255\128\128\128".." and overflow (engine TODO:)\n"..
+					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)\n"..
+					"*Disables: Reclaiming of Allied Units\n"..
+					"*Recommended: [Disable Unit Sharing] and [Disable Assist Ally Construction] to prevent loopholes",
+		type	= "number",
+		def		= 0,
+		min		= 0,
+		max		= 0.99,
+		step	= 0.01,
+		section	= "options_main",
+		column	= 1,
+		lock	= {"disable_unit_sharing","disable_assist_ally_construction"},
+		unlock	= {"disable_unit_sharing_forced","disable_assist_ally_construction_forced"},
+	},
+	{
+		key		= "disable_unit_sharing",
+		name	= "Disable Unit Sharing",
+		desc	= "Disable sharing units and structures to allies",
+		type	= "bool",
+		section	= "options_main",
+		def		= false,
+	},
+	{
+		key		= "disable_assist_ally_construction",
+		name	= "Disable Assist Ally Construction",
+		desc	= "Disables assisting allied blueprints and labs.",
+		type	= "bool",
+		section	= "options_main",
+		def		=  false,
+		column	= 1.76,
+	},
+	{	key = "tax_padding", name = "", type = "subheader", section = "options_main", column = -3, },
+	{
+		key		= "disable_unit_sharing_forced",
+		name	= "\255\252\191\76".."Disable Unit Sharing                              [Forced ON]",
+		type	= "subheader",
+		section	= "options_main",
+	},
+	{
+		key		= "disable_assist_ally_construction_forced",
+		name	= "\255\252\191\76".."Disable Assist Ally Construction           [Forced ON]",
+		type	= "subheader",
+		section	= "options_main",
+		column	= 1.76,
+	},
+	{
+		key		= "unit_market",
+		name	= "Unit Market",
+		desc	= "Allow players to trade units. (Select unit, press 'For Sale' in order window or say /sell_unit in chat to mark the unit for sale. Double-click to buy from allies. T2cons show up in shop window!)",
+		type	= "bool",
+		def		= false,
+		section	= "options_main",
+	},
+
 
     {
         key     = "sub_header",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -168,7 +168,55 @@ local options = {
         type   	= "bool",
         def    	= false,
         section = "options_main",
+		lock	= {"disable_unit_sharing"},
+		unlock	= {"disable_unit_sharing_locked"},
     },
+	{
+		key		= "unit_market_locked",
+		name	= "\255\128\128\128".."Unit Market                                             [Disable Unit Sharing]",
+		type	= "subheader",
+		section = "options_main",
+	},
+
+	{
+		key		= "disable_unit_sharing",
+		name	= "Disable Unit Sharing",
+		desc	= "Disable sharing units and structures to allies",
+		type	= "bool",
+		section	= "options_main",
+		def		= false,
+		lock	= {"unit_market"},
+		unlock	= {"unit_market_locked"},
+	},
+	{
+		key		= "disable_unit_sharing_locked",
+		name	= "\255\128\128\128".."Disable Unit Sharing                              [Unit Market]",
+		type	= "subheader",
+		section	= "options_main",
+	},
+	{
+		key		= "disable_assist_ally_construction",
+		name	= "Disable Assist Ally Construction",
+		desc	= "Disables assisting allied blueprints and labs.",
+		type	= "bool",
+		section	= "options_main",
+		def		=  false,
+	},
+	{
+		key		= "tax_resource_sharing_amount",
+		name	= "Resource Sharing Tax",
+		desc	=	"Taxes resource sharing".."\255\128\128\128".." and overflow (engine TODO:)\n"..
+					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)\n"..
+					"*Disables: Reclaiming of Allied Units\n"..
+					"*Recommended: [Disable Unit Sharing] and [Disable Assist Ally Construction] to prevent loopholes",
+		type	= "number",
+		def		= 0,
+		min		= 0,
+		max		= 0.99,
+		step	= 0.01,
+		section	= "options_main",
+		column	= 1,
+	},
 
     {
         key		= "transportenemy",
@@ -378,42 +426,7 @@ local options = {
         def    	= false,
         column  = 1.66,
     },
-    
-    {
-		key			="disable_unit_sharing",
-		name   		="Disable Unit Sharing",
-		desc   		="Disable sharing units and structures to allies",
-		type   		="bool",
-		section		="restrictions",
-		def    		= false,
-	},
-	{
-		key			="disable_assist_ally_construction",
-		name   		="Disable Assist Ally Construction",
-		desc   		="Disables assisting an allied blueprint or lab.",
-		type   		="bool",
-		section		="restrictions",
-		def    		= false,
-	},
-	{
-		key			="tax_resource_sharing_and_prevent_some_reclaim_loopholes",
-		name   		="Tax Resource Sharing",
-		desc   		="Taxes resource sharing and overflow (engine TODO), and disables reclaiming allied units for metal. If using, should also select 'Disable Unit Sharing' and 'Disable Assist Ally Construction'",
-		type   		= "bool",
-		section		="restrictions",
-		def    		= false,
-	},
-	{
-		key    = "tax_resource_sharing_amount",
-		name   = "Resource Sharing Tax Amount",
-		desc   = "(Range: 0 - 0.99). What portion of shared resources (including overflow) will consumed as transfer tax.",
-		type   = "number",
-		def    = 0.4,
-		min    = 0,
-		max    = 0.99,
-		step   = 0.01,
-		section= "restrictions",
-	},
+
 
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -241,8 +241,7 @@ local options = {
 		name	= "Resource Sharing Tax",
 		desc	=	"Taxes resource sharing".."\255\128\128\128".." and overflow (engine TODO:)\n"..
 					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)\n"..
-					"*Disables: Reclaiming of Allied Units\n"..
-					"*Recommended: [Disable Unit Sharing] and [Disable Assist Ally Construction] to prevent loopholes",
+					"*Disables: Reclaiming of Allied Units, [Unit Sharing] and [Assisting Ally Construction] to prevent loopholes",
 		type	= "number",
 		def		= 0,
 		min		= 0,

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -272,16 +272,19 @@ local options = {
 	{	key = "tax_padding", name = "", type = "subheader", section = "options_main", column = -3, },
 	{
 		key		= "disable_unit_sharing_forced",
-		name	= "\255\252\191\76".."Disable Unit Sharing                              [Forced ON]",
+		--name	= "\255\252\191\76".."Disable Unit Sharing                              [Forced ON]",
+		name	= "\255\252\191\76".."Disable Unit Sharing                                                             Disable Assist Ally Construction",
 		type	= "subheader",
 		section	= "options_main",
 	},
 	{
 		key		= "disable_assist_ally_construction_forced",
-		name	= "\255\252\191\76".."Disable Assist Ally Construction           [Forced ON]",
+		--name	= "\255\252\191\76".."Disable Assist Ally Construction           [Forced ON]",
+		name	= "\255\252\191\76".."[■]                                                                          [■]",
 		type	= "subheader",
 		section	= "options_main",
-		column	= 1.76,
+		column	= 1.505,
+		font	= 4,
 	},
 	{
 		key		= "unit_market",


### PR DESCRIPTION
### TODO
Blocker: https://github.com/beyond-all-reason/BYAR-Chobby/pull/781
- [x] Make `Disable Unit Sharing` and `Unit Market` **Compatible**
- [x] Make Enabling the Tax Force enables `Disable Unit Sharing` and `Disable Assist Ally Construction`

### Work done
Squishes the enable tax and tax value into 1 value, set to zero to disable instead
Fixes two instaces of allow command in the tax gadget
Moves the new modoptions out of the removed Restrictions tab into a new subsection under the current Main tab
Makes the Unit Market Selling/Buying work when Unit Sharing is disabled, via deligating the restriction to the market gadget when both are enabled.
Makes the Tax option Force enables `Disable Unit Sharing` and `Disable Assist Ally Construction`

#### Test steps
- [ ] Having Tax enabled now prevents the reclaim of allied units.
- [ ] Tax enabled still prevents the guarding of allied reclaimers
- [ ] Enabling the Tax Force enables `Disable Unit Sharing` and `Disable Assist Ally Construction`

### Screenshots:
![image](https://github.com/user-attachments/assets/07af36ee-f2e0-4f00-8780-ef71ca301605)
![image](https://github.com/user-attachments/assets/a716550c-eb61-4eda-af41-3c11cbd8b307)