### PR TITLE
Better reclaim highlights for raptor eggs, falling wrecks

### DIFF
--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -723,6 +723,8 @@ function widget:Initialize()
 	for _, featureID in ipairs(Spring.GetAllFeatures()) do
 		widget:FeatureCreated(featureID)
 	end
+
+	camUpVector = spGetCameraVectors().up
 end
 
 function widget:Shutdown()


### PR DESCRIPTION
### Work done

I played a raptors game and noticed the raptor eggs spawn above the unit's base position (+20). They also go flying, roll around, etc. so the widget wasn't tracking these well.

I separated tracking of moving features on creation, and wait until they stop moving to add them to the reclaim highlights. This is more lightweight and seems a little better than updating the positions of all features, though it means there can be some positional error still.

While looking over the widget again, there was leftover, unnecessary code. Most lines changed are removed nil checks and decreased indents. The CPU time was concentrated in rotating the camera and redrawing text, also, so I removed some unnecessary redraws. Should be improved all-around but especially when there aren't updates of any kind.


#### AFTER:

https://github.com/user-attachments/assets/d90dbbf2-dbfd-43f3-91dd-11f2d83e3d15