### PR TITLE
feat (shields rework): Allow deactivation of shield units

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -859,6 +859,15 @@ function UnitDef_Post(name, uDef)
 		end
 	end
 
+	-- Shield Rework
+	if modOptions.shieldsrework == true and uDef.weapondefs then
+		for _, weapon in pairs(uDef.weapondefs) do
+			if weapon.shield and weapon.shield.repulser then
+				uDef.onoffable = true
+			end
+		end
+	end
+
 	--- EMP rework
 	if modOptions.emprework == true then
 		if name == "armstil" then

--- a/luamocks/SpringLuaApi.lua
+++ b/luamocks/SpringLuaApi.lua
@@ -1910,6 +1910,10 @@ assert(type(unitID) == "number","Argument unitID is of invalid type - expected n
 return  booleanMock
  end
 
+function Spring.GetUnitIsActive (unitID)
+assert(type(unitID) == "number","Argument unitID is of invalid type - expected number");
+return  booleanMock
+ end
 
 function Spring.SetLastMessagePosition (  x, y, z)
 assert(type(x) == "number","Argument x is of invalid type - expected number");

--- a/luarules/gadgets/lups_shield.lua
+++ b/luarules/gadgets/lups_shield.lua
@@ -228,6 +228,12 @@ local function UpdateVisibility(unitID, unitData, unitVisible, forceUpdate)
 		unitVisible = GetVisibleSearch(ux, uz, unitData.search)
 	end
 
+	local unitIsActive = Spring.GetUnitIsActive(unitID) 
+	if unitIsActive ~= unitData.isActive then
+		forceUpdate = true
+		unitData.isActive = unitIsActive
+	end
+
 	if unitVisible == unitData.unitVisible and not forceUpdate then
 		return
 	end
@@ -237,7 +243,7 @@ local function UpdateVisibility(unitID, unitData, unitVisible, forceUpdate)
 		local fxID = unitData.fxTable[i]
 		local fx = Lups.GetParticles(fxID)
 		if fx then
-			fx.visibleToMyAllyTeam = unitVisible
+			fx.visibleToMyAllyTeam = unitIsActive and unitVisible
 		end
 	end
 end

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -37,6 +37,7 @@ local spGetUnitsInSphere = Spring.GetUnitsInSphere
 local spGetProjectilesInRectangle = Spring.GetProjectilesInRectangle
 local spGetUnitIsStunned = Spring.GetUnitIsStunned
 local spAreTeamsAllied = Spring.AreTeamsAllied
+local spGetUnitIsActive = Spring.GetUnitIsActive
 
 local shieldUnitDefs = {}
 local shieldUnitsData = {}
@@ -216,6 +217,9 @@ function gadget:GameFrame(frame)
 		end
 
 		if frame % 10 == 0 then
+			if not spGetUnitIsActive(shieldUnitID) then
+				spSetUnitShieldState(shieldUnitID, shieldData.shieldWeaponNumber, 0)
+			end
 			if not shieldData.shieldEnabled and shieldData.downtimeReset ~= 0 and shieldData.downtimeReset <= gameSeconds then
 				shieldData.downtimeReset = 0
 				shieldData.shieldEnabled = true


### PR DESCRIPTION
### Work done
Made it possible to deactivate the Plasma Deflector buildings for both factions. This was mostly a simple matter of setting the `onoffable` bool in the unit definition files (corgate.lua and armgate.lua), which enables the on/off toggle, which turns off the shield functionality and the energy usage. However, the shield FX would persist. I resolved that by adding a check on the active status of a unit in the UpdateVisibility function in lups_shield.lua. In order to check the active status of units, I also added a binding for the Spring function GetUnitIsActive to SpringLuaApi.lua -- I'm new to this codebase, so there might have already been a way of doing this, but it seemed like a logical binding to have to me.

#### Addresses Issue
[3453 - Plasma Deflectors cannot be turned off](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3453)

#### Test steps
- [ ] Construct a Plasma Deflector
- [ ] Disable the building
- [ ] Enable the building