### PR TITLE
Add mechanism for sending synced->unsynced map point messages.

### DIFF
--- a/luarules/gadgets/game_map_point.lua
+++ b/luarules/gadgets/game_map_point.lua
@@ -2,7 +2,7 @@
 function gadget:GetInfo()
 	return {
 		name    = "Game Map Point",
-		desc	= 'allow sending map points using the i18n library so everyone can see them in their own language',
+		desc	= 'allow sending synced->unsynced map point messages so they can be further processed by luaui',
 		author	= 'Saurtron',
 		date	= 'Oct 2024',
 		license	= 'GNU GPL, v2 or later',

--- a/luarules/gadgets/game_map_point.lua
+++ b/luarules/gadgets/game_map_point.lua
@@ -1,0 +1,48 @@
+
+function gadget:GetInfo()
+	return {
+		name    = "Game Map Point",
+		desc	= 'allow sending map points using the i18n library so everyone can see them in their own language',
+		author	= 'Saurtron',
+		date	= 'Oct 2024',
+		license	= 'GNU GPL, v2 or later',
+		layer	= 1,
+		enabled	= true
+	}
+end
+
+-- for example usecase see the ping_wheel widget createMapPoint and MapPointEvent methods
+
+local PACKET_HEADER = "mppnt:"
+local PACKET_HEADER_LENGTH = string.len(PACKET_HEADER)
+
+if gadgetHandler:IsSyncedCode() then
+
+	function gadget:RecvLuaMsg(msg, playerID)
+		if string.sub(msg, 1, PACKET_HEADER_LENGTH) ~= PACKET_HEADER then
+			return
+		end
+		SendToUnsynced("sendMapPoint", playerID, string.sub(msg, PACKET_HEADER_LENGTH+1))
+		return true
+	end
+
+else	-- UNSYNCED
+
+	local function sendMapPoint(_, playerID, msg)
+		local name,_,spec,_,playerAllyTeamID = Spring.GetPlayerInfo(playerID)
+		local mySpec = Spring.GetSpectatingState()
+		if playerAllyTeamID == Spring.GetMyAllyTeamID() or mySpec then
+			if Script.LuaUI("MapPointEvent") then
+				Script.LuaUI.MapPointEvent(playerID, msg)
+			end
+		end
+	end
+
+	function gadget:Initialize()
+		gadgetHandler:AddSyncAction("sendMapPoint", sendMapPoint)
+	end
+	function gadget:Shutdown()
+		gadgetHandler:AddSyncAction("sendMapPoint")
+	end
+end
+


### PR DESCRIPTION
### Work done

Added a mechanism to send luarules messages from synced to unsynced allowing for unsynced handling of map points/mapmarkers.

- Uses 'mppnt:{jsondata}' payload and sends to global Script.LuaUI.MapPointEvent.
- Inspired by the mechanism from game_messages.lua since the goal is similar, just translating/enhancing mapmarkers, not just chat messages.

#### Setup
- Place  [gui_ping_wheel.lua](https://raw.githubusercontent.com/saurtron/Beyond-All-Reason/refs/heads/add-ping-wheel-widget/luaui/Widgets/gui_ping_wheel.lua) and [gui_ping_wheel_event.lua](https://raw.githubusercontent.com/saurtron/Beyond-All-Reason/refs/heads/add-ping-wheel-widget/luaui/Widgets/gui_ping_wheel_event.lua) inside luaui/widgets so you have smth using this.

#### Test steps
- Install ping wheel as shown above.
- You can now use alt+w or mouse 4/5 to show it and place a map marker, it will use the new mechanism.

#### Notes
This paves the way for i18n for the marker texts, as well as lua side rendering, or completely skipping engine support and just managing it from lua.

Might be better to use a widget callin instead of global, but did it like this to not overcomplicate for now.

I'm pr'ing this first since then the rest of ping wheel work can be tested with just widgets in luaui/widgets, so no need for custom BAR. This part is needed since otherwise there's no way to send synced message that will result in each client rendering different text on markers (each player will see it in their own language).