### PR TITLE
Add a ClearMapMarks callin so widgets can better react to clearmapmark action.

### DIFF
--- a/luaui/Widgets/gui_clearmapmarks.lua
+++ b/luaui/Widgets/gui_clearmapmarks.lua
@@ -134,8 +134,8 @@ function widget:MouseRelease(mx, my, mb)
 	if mb == 1 and math_isInRect(mx, my, xPos-usedImgSize, yPos, xPos, yPos+usedImgSize) then
 		Spring.SendCommands({"clearmapmarks"})
 		updatePosition(true)
-		if WG['autoeraser'] and WG['autoeraser'].clearedMapmarks then
-			WG['autoeraser'].clearedMapmarks()
+		if Script.LuaUI('ClearMapMarks') then
+			Script.LuaUI.ClearMapMarks()
 		end
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
 		if ctrl then

--- a/luaui/Widgets/gui_mapmarks_fx.lua
+++ b/luaui/Widgets/gui_mapmarks_fx.lua
@@ -164,6 +164,9 @@ function widget:RecvLuaMsg(msg, playerID)
 	end
 end
 
+function widget:ClearMapMarks()
+	commands = {}
+end
 
 function widget:DrawWorldPreUnit()
 	if chobbyInterface then return end

--- a/luaui/Widgets/gui_point_tracker.lua
+++ b/luaui/Widgets/gui_point_tracker.lua
@@ -307,3 +307,7 @@ function widget:DrawInMiniMap(sx, sy)
   gl.ClipDistance ( 3, false)
   DrawMapMarksWorld(1)
 end
+
+function widget:ClearMapMarks()
+	ClearPoints()
+end

--- a/luaui/Widgets/map_auto_mapmark_eraser.lua
+++ b/luaui/Widgets/map_auto_mapmark_eraser.lua
@@ -26,10 +26,6 @@ function widget:Initialize()
 	WG['autoeraser'].getRecentlyErased = function(value)	-- so mapmarks fx widget can call this and wont activate on auto erasing
 		return recentlyErased
 	end
-	WG['autoeraser'].clearedMapmarks = function()	-- so mapmarks fx widget can call this and wont activate on auto erasing
-		pointsToErase = {}
-		recentlyErased = {}
-	end
 end
 
 function widget:MapDrawCmd(playerID, cmdType, px, py, pz, arg1, arg2, arg3, arg4) -- cmdType can be 'erase', 'point', or 'line', arg1 is the text or line length(?)
@@ -81,4 +77,9 @@ function widget:SetConfigData(data)
 	if data.pointsToErase ~= nil and Spring.GetGameFrame() > 0 then
 		pointsToErase = data.pointsToErase
 	end
+end
+
+function widget:ClearMapMarks()
+	pointsToErase = {}
+	recentlyErased = {}
 end

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -207,6 +207,7 @@ local callInLists = {
 	'VisibleExplosion',
 	'Barrelfire',
 	'CrashingAircraft',
+	'ClearMapMarks',
 
 	-- these use mouseOwner instead of lists
 	--  'MouseMove',
@@ -2010,6 +2011,15 @@ function widgetHandler:MapDrawCmd(playerID, cmdType, px, py, pz, ...)
 	return retval
 end
 
+function widgetHandler:ClearMapMarks()
+	tracy.ZoneBeginN("W:ClearMapMarks")
+	for _, w in ipairs(self.ClearMapMarksList) do
+		w:ClearMapMarks()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
 function widgetHandler:GameSetup(state, ready, playerStates)
 	tracy.ZoneBeginN("W:GameSetup")
 	for _, w in ipairs(self.GameSetupList) do
@@ -2435,6 +2445,7 @@ function widgetHandler:CrashingAircraft(unitID, unitDefID, unitTeam)
 	tracy.ZoneEnd()
 	return
 end
+
 
 --------------------------------------------------------------------------------
 --

--- a/luaui/callins.lua
+++ b/luaui/callins.lua
@@ -142,6 +142,7 @@ CallInsList = {
 	"VisibleExplosion",
 	"Barrelfire",
 	"CrashingAircraft",
+	"ClearMapMarks",
 }
 
 CallInsMap = {}


### PR DESCRIPTION
### Work done

Add a ClearMapMarks callin so widgets can better react to clearmapmark action.

- Adds support for gui_mapmarks_fx, gui_clearmapmarks and map_auto_mapmark_eraser widgets.
- Fixes gui_mapmarks_fx and gui_point_tracker not clearing fx when mapmarks are cleared.
- Removes ad-hoc mechanism from map_auto_mapmark_eraser in favour of the new mechanism.

#### Test steps
- Place a map mark.
- Notice the mapmark fx (an animated circle) and the point tracker.
- Click on clearmapmarks below the advanced player list.
- Mapmark fx and point tracker is cleared.

#### Notes

While not strictly needed this will help in coordinating different widgets 'enhancing' map marks, like gui_point_tracker.lua and gui_mapmarks_fx.lua. Otherwise ad-hoc mechanism is needed like the one used atm at gui_clearmapmarks and map_auto_mapmark_eraser.

At the moment this won't react to commands run from a different mechanism, like writing /clearmapmarks at console. Not sure if there's a better way to handle this, like adding a handler to engine, or just adding some ad-hoc code to gui_chat to trigger the new handler can fix this too. 

#### Before

This is how it looks now after clearing markers (mapmark fx and point tracker still there):

![uncleared2](https://github.com/user-attachments/assets/af7d36fb-c3e1-4a32-9191-635db3a10eeb)


