### PR TITLE
Make sure ecostats toggling run just once to avoid flickering on player camera toggle.

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -1838,7 +1838,6 @@ local function showEcostats()
 end
 
 local function init()
-	hideEcostats()
 	font = WG['fonts'].getFont()
 
 	viewScreenWidth, viewScreenHeight = Spring.GetViewGeometry()
@@ -1894,7 +1893,6 @@ local function deInit()
 	deleteMetricDisplayLists()
 	deleteKnobVAO()
 	deleteTextures()
-	showEcostats()
 end
 
 local function reInit()
@@ -1953,11 +1951,13 @@ function widget:Initialize()
 
 	checkAndUpdateHaveFullView()
 
+	hideEcostats()
 	init()
 end
 
 function widget:Shutdown()
 	deInit()
+	showEcostats()
 
 	if shader then
 		shader:Finalize()


### PR DESCRIPTION
### Work done
Make sure hideEcostats and showEcostats is only run once to avoid flicker on spectator HUD reInit().

This happens when toggling player view as spec. Also seems to sometimes trigger missing backgrounds for some meter elements on the spectator hud.

The fix fixes the ecostats flicker issue, while possibly fixing the missing backgrounds (at least makes them much more unlikely, not sure where they come from tbh).

#### Test steps
- Open a replay or spec game with 2 ally teams.
- Enable spectator hud
- Select a player and enable their view.
- A fast flicker of ecostats can sometimes be noticed.
- Also sometimes spectator hud will lose background for one of it's areas.

### Screenshots:

Since this is a rapidly changing condition screenshot doesn't do much, but the problem can be observed at the following youtube video: https://www.youtube.com/watch?v=k-ZhX2Vu8CQ.

* At [3:50](https://www.youtube.com/watch?v=k-ZhX2Vu8CQ&t=230s) the flickering can be observed. (better to watch it at 0.25x to be able to note the flicker)

* At [4:27](https://www.youtube.com/watch?v=k-ZhX2Vu8CQ&t=267s) spectator HUD losing background for one of it's meters can be observed (the background actually appears, but dissapears in a few seconds).

#### Notes:

The missing backgrounds issue can be due to something else but this fix seems to make them much more unlikely. I can reproduce missing backgrounds without the fix, but not with it applied.

The missing background itself seemsa bit strange, since it shows but then dissapears in a few seconds after the lua has done it's things... I'm guessing the lua side should not be doing that but not totally sure... maybe further investigation would be warranted, not sure tbh.