### PR TITLE
Fix: Stun and then finish Storage double-removing.

### DIFF
--- a/luarules/gadgets/unit_stun_storage.lua
+++ b/luarules/gadgets/unit_stun_storage.lua
@@ -79,8 +79,8 @@ end
 function gadget:UnitDamaged(unitID, unitDefID, teamID, damage, paralyzer)
 	-- when freshly EMP'd: reduce total storage
 	if paralyzer and storageDefs[unitDefID] and not paralyzedUnits[unitID] then
-		local _, maxHealth, paralyzeDamage, _, _ = Spring.GetUnitHealth(unitID)
-		if paralyzeDamage + damage > maxHealth then
+		local _, maxHealth, paralyzeDamage, _, buildProgress = Spring.GetUnitHealth(unitID)
+		if buildProgress == 1 and paralyzeDamage + damage > maxHealth then
 			if not isCommander[unitDefID] or Spring.GetGameFrame() > 150 then	-- workaround to prevent commander-gate paralyze effect to rob you of half your starting resources
 				reduceStorage(unitID, unitDefID, teamID)
 			end


### PR DESCRIPTION
### Work done
Check if a storage is in progress as to not remove it's not yet contributed storage from the total.
The code already accounted for a unit being finished while stunned.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

#### Test steps
- [ ] Stun an in progress storage unit, and finish it before the emp expires. No longer double removes storage.

