### PR TITLE
feat(cmd_blueprint): add filtering for unbuildable blueprints

### DIFF
--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_filter.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_filter.lua
@@ -1,0 +1,109 @@
+local widgetName = "Blueprint"
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	assert(widgetHandler.knownWidgets[widgetName] ~= nil)
+
+	Test.clearMap()
+
+	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
+	if initialWidgetActive then
+		widgetHandler:DisableWidget(widgetName)
+	end
+	widgetHandler:EnableWidget(widgetName, true)
+
+	initialCameraState = Spring.GetCameraState()
+
+	Spring.SetCameraState({
+		mode = 5,
+	})
+end
+
+function cleanup()
+	Test.clearMap()
+
+	widgetHandler:DisableWidget(widgetName)
+	if initialWidgetActive then
+		widgetHandler:EnableWidget(widgetName, false)
+	end
+
+	Spring.SetCameraState(initialCameraState)
+end
+
+local delay = 5
+function test()
+	VFS.Include("luarules/configs/customcmds.h.lua")
+
+	widget = widgetHandler:FindWidget(widgetName)
+	assert(widget)
+
+	mock_saveBlueprintsToFile = Test.mock(widget, "saveBlueprintsToFile")
+
+	-- load test blueprints
+	widget.BLUEPRINT_FILE_PATH = "LuaUI/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_filter_blueprints.json"
+	widget.loadBlueprintsFromFile()
+
+	Test.clearMap()
+
+	local builderUnitDefName = "armck"
+
+	local myTeamID = Spring.GetMyTeamID()
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+	local facing = 1
+
+	local builderUnitID = SyncedRun(function(locals)
+		return Spring.CreateUnit(
+			locals.builderUnitDefName,
+			locals.x,
+			locals.y,
+			locals.z,
+			locals.facing,
+			locals.myTeamID
+		)
+	end)
+
+	Spring.SelectUnit(builderUnitID)
+
+	Test.waitFrames(delay)
+
+	Spring.SetActiveCommand(
+		Spring.GetCmdDescIndex(CMD_BLUEPRINT_PLACE),
+		1,
+		true,
+		false,
+		false,
+		false,
+		false,
+		false
+	)
+
+	Test.waitFrames(delay)
+
+	assert(widget.blueprintPlacementActive)
+
+	-- make sure we skipped the blueprint #1, which is invalid
+	assert(widget.selectedBlueprintIndex == 2, widget.selectedBlueprintIndex)
+
+	-- make sure we skipped blueprint #3, which is cortex and unbuildable by armada
+	widget.handleBlueprintNextAction()
+	assert(widget.selectedBlueprintIndex == 4, widget.selectedBlueprintIndex)
+
+	-- make sure we rotate to the next valid blueprint, #2
+	widget.handleBlueprintDeleteAction()
+	assert(widget.selectedBlueprintIndex == 2, widget.selectedBlueprintIndex)
+
+	-- reset blueprints
+	widget.loadBlueprintsFromFile()
+
+	-- make sure we rotate to the next valid blueprint, #3 (which shifted from #4)
+	widget.handleBlueprintDeleteAction()
+	assert(widget.selectedBlueprintIndex == 3, widget.selectedBlueprintIndex)
+
+	-- make sure we rotate to the next valid blueprint, nil
+	widget.handleBlueprintDeleteAction()
+	assert(widget.selectedBlueprintIndex == nil, widget.selectedBlueprintIndex)
+end

--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_filter.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_filter.lua
@@ -9,11 +9,7 @@ function setup()
 
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
-	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widget = Test.prepareWidget(widgetName)
 
 	initialCameraState = Spring.GetCameraState()
 
@@ -25,11 +21,6 @@ end
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
-	end
-
 	Spring.SetCameraState(initialCameraState)
 end
 
@@ -37,13 +28,12 @@ local delay = 5
 function test()
 	VFS.Include("luarules/configs/customcmds.h.lua")
 
-	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 
 	mock_saveBlueprintsToFile = Test.mock(widget, "saveBlueprintsToFile")
 
 	-- load test blueprints
-	widget.BLUEPRINT_FILE_PATH = "LuaUI/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_filter_blueprints.json"
+	widget.BLUEPRINT_FILE_PATH = "LuaUI/Tests/cmd_blueprint/test_cmd_blueprint_filter_blueprints.json"
 	widget.loadBlueprintsFromFile()
 
 	Test.clearMap()

--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_filter_blueprints.json
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_filter_blueprints.json
@@ -1,0 +1,61 @@
+{
+  "savedBlueprints": [
+    {
+      "ordered": true,
+      "name": "",
+      "spacing": 0,
+      "facing": 0,
+      "units": [
+        {
+          "unitName": "INVALID",
+          "facing": 0,
+          "position": [0, 0, 0]
+        }
+      ]
+    },
+    {
+      "ordered": true,
+      "name": "",
+      "spacing": 0,
+      "facing": 0,
+      "units": [
+        {
+          "unitName": "armwin",
+          "facing": 0,
+          "position": [0, 0, 0]
+        }
+      ]
+    },
+    {
+      "ordered": true,
+      "name": "",
+      "spacing": 0,
+      "facing": 0,
+      "units": [
+        {
+          "unitName": "corwin",
+          "facing": 0,
+          "position": [0, 0, 0]
+        }
+      ]
+    },
+    {
+      "ordered": true,
+      "name": "",
+      "spacing": 0,
+      "facing": 0,
+      "units": [
+        {
+          "unitName": "armwin",
+          "facing": 0,
+          "position": [-24, 0, 0]
+        },
+        {
+          "unitName": "corwin",
+          "facing": 0,
+          "position": [24, 0, 0]
+        }
+      ]
+    }
+  ]
+}

--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
@@ -34,9 +34,8 @@ function test()
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 
-	while #(widget.blueprints) > 0 do
-		widget.deleteBlueprint(1)
-	end
+	widget.blueprints = {}
+	widget.setSelectedBlueprintIndex(nil)
 
 	local blueprintUnitDefName = "armsolar"
 	local builderUnitDefName = "armck"

--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -33,9 +33,8 @@ function test()
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 
-	while #(widget.blueprints) > 0 do
-		widget.deleteBlueprint(1)
-	end
+	widget.blueprints = {}
+	widget.setSelectedBlueprintIndex(nil)
 
 	local blueprintUnitDefName = "armsolar"
 	local builderUnitDefName = "armck"

--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -728,6 +728,21 @@ local function setActiveBuilders(unitIDs)
 	)
 end
 
+local function getBuildableUnits(blueprint)
+	local buildable = 0
+	local unbuildable = 0
+
+	for _, unit in ipairs(blueprint.units) do
+		if activeBuilderBuildOptions[unit.unitDefID] then
+			buildable = buildable + 1
+		else
+			unbuildable = unbuildable + 1
+		end
+	end
+
+	return buildable, unbuildable
+end
+
 function widget:Initialize()
 	if not gl.CreateShader then
 		-- no shader support, so just remove the widget itself, especially for headless
@@ -751,6 +766,7 @@ function widget:Initialize()
 		getBuildingDimensions = getBuildingDimensions,
 		getBlueprintDimensions = getBlueprintDimensions,
 		getUnitsBounds = getUnitsBounds,
+		getBuildableUnits = getBuildableUnits,
 		snapBlueprint = snapBlueprint,
 		BUILD_MODES = BUILD_MODES,
 		SQUARE_SIZE = SQUARE_SIZE,

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -294,36 +294,21 @@ local function isValidBlueprint(blueprint)
 	return true
 end
 
-local function getNextFilteredBlueprintIndex(startIndex, checkStart)
-	local newIndex = startIndex or selectedBlueprintIndex or 1
-	local foundValid = isValidBlueprint(blueprints[newIndex])
-
-	if foundValid and checkStart then
-		return newIndex
-	end
+local function getNextFilteredBlueprintIndex(startIndex)
+	local newIndex = startIndex or selectedBlueprintIndex or 0
 
 	for _ = 1, #blueprints do
 		newIndex = nextIndex(newIndex, #blueprints)
 		if isValidBlueprint(blueprints[newIndex]) then
-			foundValid = true
-			break
+			return newIndex
 		end
 	end
 
-	if foundValid then
-		return newIndex
-	else
-		return nil
-	end
+	return nil
 end
 
-local function getPrevFilteredBlueprintIndex(startIndex, checkStart)
-	local newIndex = startIndex or selectedBlueprintIndex or 1
-	local foundValid = isValidBlueprint(blueprints[newIndex])
-
-	if foundValid and checkStart then
-		return newIndex
-	end
+local function getPrevFilteredBlueprintIndex(startIndex)
+	local newIndex = startIndex or selectedBlueprintIndex or 0
 
 	for _ = 1, #blueprints do
 		newIndex = prevIndex(newIndex, #blueprints)

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -1066,16 +1066,12 @@ local function deserializeBlueprint(serializedBlueprint)
 end
 
 local function loadBlueprintsFromFile()
-	local file = io.open(BLUEPRINT_FILE_PATH, "r")
+	local content = VFS.LoadFile(BLUEPRINT_FILE_PATH)
 
-	if not file then
-		Spring.Echo("Failed to open blueprints file for reading: " .. BLUEPRINT_FILE_PATH)
+	if not content then
+		Spring.Echo("Failed to read blueprints file: " .. BLUEPRINT_FILE_PATH)
 		return
 	end
-
-	local content = file:read("*all")
-
-	file:close()
 
 	local decoded = Json.decode(content)
 

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -490,6 +490,7 @@ local function deleteBlueprint(index)
 	elseif index < selectedBlueprintIndex then
 		-- keep the same blueprint selected
 		setSelectedBlueprintIndex(selectedBlueprintIndex - 1)
+		lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 	end
 end
 

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -467,7 +467,7 @@ local function deleteBlueprint(index)
 			getPrevFilteredBlueprintIndex(selectedBlueprintIndex)
 		)
 		lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
-	elseif index < selectedBlueprintIndex then
+	else -- index < selectedBlueprintIndex
 		-- keep the same blueprint selected
 		setSelectedBlueprintIndex(selectedBlueprintIndex - 1)
 		lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -328,16 +328,11 @@ local function getPrevFilteredBlueprintIndex(startIndex, checkStart)
 	for _ = 1, #blueprints do
 		newIndex = prevIndex(newIndex, #blueprints)
 		if isValidBlueprint(blueprints[newIndex]) then
-			foundValid = true
-			break
+			return newIndex
 		end
 	end
 
-	if foundValid then
-		return newIndex
-	else
-		return nil
-	end
+	return nil
 end
 
 local function getMouseWorldPosition(blueprint, x, y)

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -208,6 +208,8 @@ local selectedBlueprintIndex = nil
 
 local blueprintPlacementActive = false
 
+local lastExplicitlySelectedBlueprintIndex = nil
+
 local state = {
 	---@type Point|nil
 	---non-nil implies that we are dragging
@@ -271,6 +273,70 @@ local function setSelectedBlueprintIndex(index)
 
 	if blueprintPlacementActive and index ~= nil and index > 0 then
 		Spring.Echo("[Blueprint] selected blueprint #" .. selectedBlueprintIndex)
+	end
+end
+
+local function isValidBlueprint(blueprint)
+	if blueprint == nil then
+		return false
+	end
+
+	if blueprint.hasInvalidUnits then
+		return false
+	end
+
+	local buildable, unbuildable = WG["api_blueprint"].getBuildableUnits(blueprint)
+
+	if buildable == 0 then
+		return false
+	end
+
+	return true
+end
+
+local function getNextFilteredBlueprintIndex(startIndex, checkStart)
+	local newIndex = startIndex or selectedBlueprintIndex or 1
+	local foundValid = isValidBlueprint(blueprints[newIndex])
+
+	if foundValid and checkStart then
+		return newIndex
+	end
+
+	for _ = 1, #blueprints do
+		newIndex = nextIndex(newIndex, #blueprints)
+		if isValidBlueprint(blueprints[newIndex]) then
+			foundValid = true
+			break
+		end
+	end
+
+	if foundValid then
+		return newIndex
+	else
+		return nil
+	end
+end
+
+local function getPrevFilteredBlueprintIndex(startIndex, checkStart)
+	local newIndex = startIndex or selectedBlueprintIndex or 1
+	local foundValid = isValidBlueprint(blueprints[newIndex])
+
+	if foundValid and checkStart then
+		return newIndex
+	end
+
+	for _ = 1, #blueprints do
+		newIndex = prevIndex(newIndex, #blueprints)
+		if isValidBlueprint(blueprints[newIndex]) then
+			foundValid = true
+			break
+		end
+	end
+
+	if foundValid then
+		return newIndex
+	else
+		return nil
 	end
 end
 
@@ -413,9 +479,16 @@ local function deleteBlueprint(index)
 
 	if #blueprints == 0 then
 		setSelectedBlueprintIndex(nil)
-	elseif selectedBlueprintIndex > #blueprints then
-		setSelectedBlueprintIndex(selectedBlueprintIndex - 1)
+	elseif index > selectedBlueprintIndex then
+		-- no need to do anything
+	elseif index == selectedBlueprintIndex then
+		-- find the closest valid blueprint, searching backwards
+		setSelectedBlueprintIndex(
+			getPrevFilteredBlueprintIndex(selectedBlueprintIndex)
+		)
+		lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 	elseif index < selectedBlueprintIndex then
+		-- keep the same blueprint selected
 		setSelectedBlueprintIndex(selectedBlueprintIndex - 1)
 	end
 end
@@ -706,6 +779,19 @@ function widget:SelectionChanged(selection)
 		)
 
 		WG["api_blueprint"].setActiveBuilders(builders)
+
+		local selectedBlueprint = getSelectedBlueprint()
+		if not selectedBlueprint or not isValidBlueprint(selectedBlueprint) then
+			local startIndex = nil
+			if lastExplicitlySelectedBlueprintIndex ~= nil then
+				-- this prevents cycling through all blueprints if you
+				-- select different faction constructors repeatedly
+				startIndex = lastExplicitlySelectedBlueprintIndex - 1
+			end
+			setSelectedBlueprintIndex(
+				getNextFilteredBlueprintIndex(startIndex)
+			)
+		end
 	end
 
 	-- track selection order (skip if we're still box selecting)
@@ -755,7 +841,8 @@ local function handleBlueprintNextAction()
 		return
 	end
 
-	setSelectedBlueprintIndex(nextIndex(selectedBlueprintIndex, #blueprints))
+	setSelectedBlueprintIndex(getNextFilteredBlueprintIndex())
+	lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 
 	Spring.PlaySoundFile(sounds.selectBlueprint, 0.75, "ui")
 
@@ -772,7 +859,8 @@ local function handleBlueprintPrevAction()
 		return
 	end
 
-	setSelectedBlueprintIndex(prevIndex(selectedBlueprintIndex, #blueprints))
+	setSelectedBlueprintIndex(getPrevFilteredBlueprintIndex())
+	lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 
 	Spring.PlaySoundFile(sounds.selectBlueprint, 0.75, "ui")
 
@@ -1029,9 +1117,15 @@ end
 -- saving/loading
 -- ==============
 
+local serializedInvalidBlueprints = {}
+
 ---@param blueprint Blueprint
 ---@return SerializedBlueprint
 local function serializeBlueprint(blueprint)
+	if serializedInvalidBlueprints[blueprint] ~= nil then
+		return serializedInvalidBlueprints[blueprint]
+	end
+
 	return {
 		name = blueprint.name,
 		spacing = blueprint.spacing,
@@ -1051,16 +1145,28 @@ end
 ---@return Blueprint
 local function deserializeBlueprint(serializedBlueprint)
 	local result = table.copy(serializedBlueprint)
+	result.hasInvalidUnits = false
 	result.units = table.map(serializedBlueprint.units, function(serializedBlueprintUnit)
-		return {
+		local unit = {
 			blueprintUnitID = nextBlueprintUnitID(),
-			unitDefID = UnitDefNames[serializedBlueprintUnit.unitName].id,
 			position = serializedBlueprintUnit.position,
 			facing = serializedBlueprintUnit.facing
 		}
+
+		if UnitDefNames[serializedBlueprintUnit.unitName] then
+			unit.unitDefID = UnitDefNames[serializedBlueprintUnit.unitName].id
+		else
+			result.hasInvalidUnits = true
+		end
+
+		return unit
 	end)
 
-	postProcessBlueprint(result)
+	if not result.hasInvalidUnits then
+		postProcessBlueprint(result)
+	else
+		serializedInvalidBlueprints[result] = serializedBlueprint
+	end
 
 	return result
 end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -144,7 +144,7 @@ local function findTestFiles(directory, patterns, rootDirectory, result)
 		result = {}
 	end
 
-	for _, filename in ipairs(VFS.DirList(directory, "*", VFS.RAW_FIRST)) do
+	for _, filename in ipairs(VFS.DirList(directory, "*.lua", VFS.RAW_FIRST)) do
 		local relativePath = string.sub(filename, string.len(rootDirectory) + 1)
 		local withoutExtension = Util.removeFileExtension(relativePath)
 		if patterns == nil or #patterns == 0 or matchesPatterns(withoutExtension, patterns) then


### PR DESCRIPTION
### Work done
This filters out any blueprints that the currently selected builders
cannot build any part of.

This also adds a check when loading blueprints, so that unloaded units,
such as legion units, do not crash the widget. Instead, blueprints with
unloaded units are saved in serialized form, filtered out of the UI, and
then written as they were when saving.

These two are combined since handling unloaded units requires
filtering anyways.

Note that the test runner change is required for the included test.

#### Addresses Issue(s)
Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3684

#### Test steps
- Run included test (`/runtests blueprint_filter` while in a single-player game)
- Unbuildable units
  - Create a blueprint with only T1 Armada units in it
  - Select a Cortex T1 constructor, and attempt to select a blueprint. The Armada-only blueprint should be skipped when selecting blueprints (but still occupy a numbered spot).
- Unloaded units
  - Create an appropriately configured game, and then create a blueprint that includes legion units (or other non-standard units), and leave the game.
  - Create a new game with default settings, and attempt to select a blueprint. Blueprints with invalid units should be skipped when selecting blueprints (but still occupy a numbered spot).