### PR TITLE
Minesweeper Detection Logic Cleaning

### DIFF
--- a/luarules/gadgets/unit_minesweeper_detection.lua
+++ b/luarules/gadgets/unit_minesweeper_detection.lua
@@ -5,11 +5,11 @@ function gadget:GetInfo()
 	return {
 		name = "Minesweeper Detection",
 		desc = "Shows mines around minesweepers",
-		author = "Hornet",
+		author = "Hornet, Cleaning: robert the pie",
 		date = "May 25th, 2024",
 		license = "GNU GPL, v2 or later",
 		layer = 0,
-		enabled = true
+		enabled = true,
 	}
 end
 
@@ -17,189 +17,107 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
-local spMoveCtrlSetAirMoveTypeData = Spring.MoveCtrl.SetAirMoveTypeData
-
-local minesweeperIDs = {}
-local minesweepers = {}
 local minesweeperRanges = {}
+local minesweepers = {}
+
 local mineIDs = {}
-
---Spring.Echo('hornet ms loaded')
-
-local teamList = Spring.GetTeamList()
-local teamIDs = {}
-
 local revealedMines = {}
---Spring.Debug.TableEcho(teamList)
-for i = 1, #teamList do
-    teamIDs[teamList[i]] = teamList[i]
-	revealedMines[teamList[i]] = {}
-	minesweepers[teamList[i]] = {}
-end
---Spring.Debug.TableEcho(teamIDs)
---Spring.Echo('hornet revealedMines')
---Spring.Debug.TableEcho(revealedMines)
-
-
-
 
 for udid, ud in pairs(UnitDefs) do
-	if ud.customParams and ud.customParams.minesweeper then
-		minesweeperIDs[udid] = udid
+	if ud.customParams.minesweeper then
 		minesweeperRanges[udid] = ud.customParams.minesweeper
+	elseif ud.customParams.mine then
+		mineIDs[udid] = true
 	end
+end
+if table.count(minesweeperRanges) <= 0 or table.count(mineIDs) <= 0 then
+	return false
+end
+
+local teamIDs = {}
+for _, teamID in pairs(Spring.GetTeamList()) do
+	local _, _, _, _, _, allyTeam = Spring.GetTeamInfo(teamID)
+	teamIDs[teamID] = allyTeam
+	revealedMines[teamID] = {}
+	minesweepers[teamID] = {}
 end
 
 
-for udid, ud in pairs(UnitDefs) do
-	if ud.customParams and ud.customParams.mine then
-		mineIDs[udid] = udid
-	end
-end
-
---Spring.Echo('hornet poi minesweeperIDs')
---Spring.Debug.TableEcho(minesweeperIDs)
-
---Spring.Echo('hornet mineIDs')
---Spring.Debug.TableEcho(mineIDs)
-
-
-function gadget:Initialize()
-	if table.count(minesweeperIDs) <= 0 then
-		gadgetHandler:RemoveGadget(self)
-	end
-	if table.count(mineIDs) <= 0 then
-		gadgetHandler:RemoveGadget(self)
-	end
-end
-
-
-function gadget:MetaUnitAdded(unitID, unitDefID, unitTeam)
-	--Spring.Echo('hornet poi 79 minesweeperIDs[unitDefID], unitDefID, unitID', minesweeperIDs[unitDefID], unitDefID, unitID)
-	if minesweeperIDs[unitDefID] then
+function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+	if minesweeperRanges[unitDefID] then
 		minesweepers[unitTeam][unitID] = unitDefID
 	end
 end
 
+function gadget:UnitTaken(unitID, UnitDefID, oldTeam, newTeam)
+	if minesweeperRanges[unitDefID] then
+		minesweepers[oldTeam][unitID] = nil
+		minesweepers[newTeam][unitID] = unitDefID
+	end
+end
+
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
-	if minesweepers[unitTeam][unitID] then
+	if minesweeperRanges[unitDefID] and minesweepers[unitTeam][unitID] then
 		minesweepers[unitTeam][unitID] = nil
 	end
 end
 
-function gadget:GameFrame(f)
+local function processesTeamsSweepers(currentTeam)
 	local minesToReveal = {}
-	--generate list of active teams. this is list of mines that team can see
 
-
-	for teamouter in pairs(teamIDs) do
-
-		--if this team's update cycle
-		if (f % 37 + (teamouter*2)) == 1 then
-			for teamprime in pairs(teamIDs) do
-				minesToReveal[teamprime] = {}
-			end
-			
-			--minesToReveal[teamouter] = {}
-
-			--Spring.Echo('hornet minesweepers')
-			--Spring.Debug.TableEcho(minesweepers)
-			--find all minesweepers
-			for miner, minerdef in next, (minesweepers[teamouter] or {}) do
-
-				--Spring.Echo('hornet miner', miner)
-				--Spring.Echo('hornet minerdef', minerdef)
-
-				
-				local minerTeam = Spring.GetUnitTeam(miner)
-				local x, y, z = Spring.GetUnitPosition(miner)
-
-				if x ~= nil and z ~= nil then
-					--bypass 'impossible' bug causing logspam 'sometimes'
-					
-
-
-					local nearUnits = Spring.GetUnitsInCylinder(x, z, minesweeperRanges[minerdef])
-
-					--Spring.Echo('hornet minerTeam', minerTeam)
-					--Spring.Echo('hornet minerdef minesweeperRanges[minerdef]', minerdef, minesweeperRanges[minerdef])
-
-					--Spring.Echo('hornet nearUnits')
-					--Spring.Debug.TableEcho(nearUnits)
-					for _, nearUnit in ipairs(nearUnits) do
-						--Spring.Echo('hornet poi Spring.GetUnitTeam(nearUnit)', Spring.GetUnitTeam(nearUnit))
-						--local mineTeam = Spring.GetUnitTeam(nearUnit)
-						if minerTeam ~= Spring.GetUnitTeam(nearUnit) then
-							local nearUnitDefID = Spring.GetUnitDefID(nearUnit)
-						
-							if mineIDs[nearUnitDefID] then
-								--Spring.Echo('hornet adding  minesToReveal[minerTeam][nearUnit] = nearUnit', minerTeam, nearUnit)
-								minesToReveal[minerTeam][nearUnit] = nearUnit
-							end
-							
-						end
-
-					end
-				else
-					minesweepers[teamouter][miner] = nil
-					--unset , errant entry somehow
-
-				end
-			end
-
-
-		
-
-			for team in pairs(teamIDs) do
-
-				--Spring.Echo('hornet minesToReveal (team)' , team)
-				--Spring.Debug.TableEcho(minesToReveal)
-				for mineToReveal in next, (minesToReveal[team] or {}) do
-					--Spring.Echo('hornet poi2 minesToReveal loop starting, team: ' , team)
-					--Spring.Echo('mineToReveal loop,', mineToReveal)
-					if revealedMines[team][mineToReveal] == nil then
-						--show 
-						--Spring.Echo('revealedMines[team][mineToReveal] = mineToReveal', team, mineToReveal)
-						revealedMines[team][mineToReveal] = mineToReveal
-						Spring.SetUnitLosState(mineToReveal, team, 3) --show in vision and radar
-						Spring.SetUnitLosMask(mineToReveal, team, 3) -- prevent engine from immediately resetting that state
-
+	for sweeper, sweeperDef in pairs(minesweepers[currentTeam])  do
+		local x, y, z = Spring.GetUnitPosition(sweeper)
+		if x and z then
+			local nearUnits = Spring.GetUnitsInCylinder(x, z, minesweeperRanges[sweeperDef])
+			for _, nearUnit in ipairs(nearUnits) do
+				local nearUnitDefID = Spring.GetUnitDefID(nearUnit)
+				if currentTeam ~= Spring.GetUnitTeam(nearUnit) then
+					if mineIDs[nearUnitDefID] then
+						minesToReveal[nearUnit] = true
 					end
 				end
-					
-
-				--Spring.Echo('hornet revealedMines (team)' , team)
-				--Spring.Debug.TableEcho(revealedMines)
-				if next(revealedMines[team]) ~= nil then
-
-					--Spring.Echo('hornet minesToReveal (team)' , team)
-					--Spring.Debug.TableEcho(minesToReveal)
-
-					--if any mines -are- uncloaked that no longer should be, recloak
-					--if table.count(minesToReveal[team]) > 0 then
-					if next(minesToReveal[team]) ~= nil then
-
-						for revealedMine in pairs(revealedMines[team]) do
-							if minesToReveal[team][revealedMine] == nil then
-								--reset this team mask
-								Spring.SetUnitLosMask(revealedMine, team, 0)
-								revealedMines[team][revealedMine] = nil
-							end
-						end
-					else
-						--if empty and previously decloaked not empty, reset all mines
-						for revealedMine in pairs(revealedMines[team]) do
-							Spring.SetUnitLosMask(revealedMine, team, 0)
-							revealedMines[team][revealedMine] = nil
-						end
-					end
-
-				end
-
 			end
-
-		end--end frame check
-
+		end
 	end
 
+	for mineToReveal, _ in pairs(minesToReveal) do
+		if revealedMines[currentTeam][mineToReveal] == nil then
+			revealedMines[currentTeam][mineToReveal] = true
+			--show in vision and radar, and prevent engine from immediately resseting that state
+			Spring.Echo("revleaed", mineToReveal, "to", currentTeam)
+			Spring.SetUnitLosState(mineToReveal, teamIDs[currentTeam], 3)
+			Spring.SetUnitLosMask(mineToReveal, teamIDs[currentTeam], 3)
+		end
+	end
+end
+
+local function processRevealedMines(teamID)
+	for revealedMine, _ in pairs(revealedMines[teamID]) do
+		Spring.SetUnitLosMask(revealedMine, teamID, 0)
+		revealedMines[teamID][revealedMine] = nil
+	end
+end
+
+-- if we have more teams than frames per second we use a slightly slower method
+local GAMESPEED = Game.gameSpeed
+if #teamIDs + 1 >= GAMESPEED then
+	function gadget:GameFrame(f)
+		local loopedFrame = f % GAMESPEED
+		for teamID in pairs(teamIDs) do
+			if teamID % GAMESPEED == loopedFrame then
+				processRevealedMines(teamID)
+				processesTeamsSweepers(teamID)
+			end
+		end
+	end
+else
+	function gadget:GameFrame(f)
+		local currentTeam = f%GAMESPEED
+		if currentTeam > #teamIDs then
+			return
+		end
+
+		processRevealedMines(currentTeam)
+		processesTeamsSweepers(currentTeam)
+	end
 end

--- a/luarules/gadgets/unit_minesweeper_detection.lua
+++ b/luarules/gadgets/unit_minesweeper_detection.lua
@@ -5,7 +5,7 @@ function gadget:GetInfo()
 	return {
 		name = "Minesweeper Detection",
 		desc = "Shows mines around minesweepers",
-		author = "Hornet, Cleaning: robert the pie",
+		author = "Hornet, robert the pie",
 		date = "May 25th, 2024",
 		license = "GNU GPL, v2 or later",
 		layer = 0,
@@ -17,20 +17,27 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
+local spSetUnitLosState		= Spring.SetUnitLosState
+local spSetUnitLosMask		= Spring.SetUnitLosMask
+local spGetUnitPosition		= Spring.GetUnitPosition
+local spGetUnitsInCylinder	= Spring.GetUnitsInCylinder
+local spGetUnitDefID		= Spring.GetUnitDefID
+local spGetUnitTeam			= Spring.GetUnitTeam
+
 local minesweeperRanges = {}
 local minesweepers = {}
 
-local mineIDs = {}
+local mineDefIDs = {}
 local revealedMines = {}
 
-for udid, ud in pairs(UnitDefs) do
-	if ud.customParams.minesweeper then
-		minesweeperRanges[udid] = ud.customParams.minesweeper
-	elseif ud.customParams.mine then
-		mineIDs[udid] = true
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.customParams.minesweeper then
+		minesweeperRanges[unitDefID] = unitDef.customParams.minesweeper
+	elseif unitDef.customParams.mine then
+		mineDefIDs[unitDefID] = true
 	end
 end
-if table.count(minesweeperRanges) <= 0 or table.count(mineIDs) <= 0 then
+if table.count(minesweeperRanges) == 0 or table.count(mineDefIDs) == 0 then
 	return false
 end
 
@@ -42,82 +49,58 @@ for _, teamID in pairs(Spring.GetTeamList()) do
 	minesweepers[teamID] = {}
 end
 
-
-function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+function gadget:MetaUnitAdded(unitID, unitDefID, unitTeam)
 	if minesweeperRanges[unitDefID] then
 		minesweepers[unitTeam][unitID] = unitDefID
 	end
 end
 
-function gadget:UnitTaken(unitID, UnitDefID, oldTeam, newTeam)
-	if minesweeperRanges[unitDefID] then
-		minesweepers[oldTeam][unitID] = nil
-		minesweepers[newTeam][unitID] = unitDefID
-	end
-end
-
-function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
+function gadget:MetaUnitRemoved(unitID, unitDefID, unitTeam)
 	if minesweeperRanges[unitDefID] and minesweepers[unitTeam][unitID] then
 		minesweepers[unitTeam][unitID] = nil
 	end
 end
 
-local function processesTeamsSweepers(currentTeam)
+local function processTeamsSweepers(teamID)
 	local minesToReveal = {}
 
-	for sweeper, sweeperDef in pairs(minesweepers[currentTeam])  do
-		local x, y, z = Spring.GetUnitPosition(sweeper)
+	for sweeper, sweeperDef in pairs(minesweepers[teamID])  do
+		local x, y, z = spGetUnitPosition(sweeper)
 		if x and z then
-			local nearUnits = Spring.GetUnitsInCylinder(x, z, minesweeperRanges[sweeperDef])
+			local nearUnits = spGetUnitsInCylinder(x, z, minesweeperRanges[sweeperDef])
 			for _, nearUnit in ipairs(nearUnits) do
-				local nearUnitDefID = Spring.GetUnitDefID(nearUnit)
-				if currentTeam ~= Spring.GetUnitTeam(nearUnit) then
-					if mineIDs[nearUnitDefID] then
-						minesToReveal[nearUnit] = true
-					end
+				local nearUnitDefID = spGetUnitDefID(nearUnit)
+				if mineDefIDs[nearUnitDefID] and teamID ~= spGetUnitTeam(nearUnit) then
+					minesToReveal[nearUnit] = true
 				end
 			end
 		end
 	end
 
 	for mineToReveal, _ in pairs(minesToReveal) do
-		if revealedMines[currentTeam][mineToReveal] == nil then
-			revealedMines[currentTeam][mineToReveal] = true
+		if revealedMines[teamID][mineToReveal] == nil then
+			revealedMines[teamID][mineToReveal] = true
 			--show in vision and radar, and prevent engine from immediately resseting that state
-			Spring.Echo("revleaed", mineToReveal, "to", currentTeam)
-			Spring.SetUnitLosState(mineToReveal, teamIDs[currentTeam], 3)
-			Spring.SetUnitLosMask(mineToReveal, teamIDs[currentTeam], 3)
+			spSetUnitLosState(mineToReveal, teamIDs[teamID], 3)
+			spSetUnitLosMask(mineToReveal, teamIDs[teamID], 3)
 		end
 	end
 end
 
 local function processRevealedMines(teamID)
 	for revealedMine, _ in pairs(revealedMines[teamID]) do
-		Spring.SetUnitLosMask(revealedMine, teamID, 0)
+		spSetUnitLosMask(revealedMine, teamIDs[teamID], 0)
 		revealedMines[teamID][revealedMine] = nil
 	end
 end
 
--- if we have more teams than frames per second we use a slightly slower method
-local GAMESPEED = Game.gameSpeed
-if #teamIDs + 1 >= GAMESPEED then
-	function gadget:GameFrame(f)
-		local loopedFrame = f % GAMESPEED
-		for teamID in pairs(teamIDs) do
-			if teamID % GAMESPEED == loopedFrame then
-				processRevealedMines(teamID)
-				processesTeamsSweepers(teamID)
-			end
+local processingInterval = Game.gameSpeed
+function gadget:GameFrame(n)
+	local loopedFrame = n % processingInterval
+	for teamID in pairs(teamIDs) do
+		if teamID % processingInterval == loopedFrame then
+			processRevealedMines(teamID)
+			processTeamsSweepers(teamID)
 		end
-	end
-else
-	function gadget:GameFrame(f)
-		local currentTeam = f%GAMESPEED
-		if currentTeam > #teamIDs then
-			return
-		end
-
-		processRevealedMines(currentTeam)
-		processesTeamsSweepers(currentTeam)
 	end
 end

--- a/luarules/gadgets/unit_minesweeper_detection.lua
+++ b/luarules/gadgets/unit_minesweeper_detection.lua
@@ -104,3 +104,13 @@ function gadget:GameFrame(n)
 		end
 	end
 end
+
+function gadget:Initialize()
+	for _, unitID in pairs(Spring.GetAllUnits()) do
+		local unitDefID = Spring.GetUnitDefID(unitID)
+		local unitTeam = Spring.GetUnitTeam(unitID)
+		if minesweeperRanges[unitDefID] then
+			minesweepers[unitTeam][unitID] = unitDefID
+		end
+	end
+end


### PR DESCRIPTION
### Work done
Rewrote some parts of the Minesweeper Detection Gadget to address the following issues:
- Only Team 0's Mine Sweepers could detect mines
- If Mine Sweeperes were traded or captured, the traded units would be tracked for both old and new teams, could crash, at the the time useless, gadget.
It also removes some redundent tables

#### Setup
Add at least 1 inactive AI to your team, as more than team id 0 should be tested
Give mines to an enemy team, and a mine sweeper to an allied AI.
Provide both with a resoruce cheat, as mines need energy to cloak

#### Test steps
- [ ] Mine Sweepers detect mines in radar range of both enemy and gaia factions
- [ ] Mine Sweepers detect for allied team, that means your allies detect for you, you for them, and enemies for each other
- [ ] Mine detection can be lost and can be redetected
- [ ] Mine Sweepers work for the right allied team after being traded or captured
