### PR TITLE
Deferred map edge extension rendering

### DIFF
--- a/luaintro/springconfig.lua
+++ b/luaintro/springconfig.lua
@@ -71,6 +71,9 @@ Spring.SetConfigInt("MaxDynamicModelLights", 0)
 Spring.SetConfigInt("AllowDeferredMapRendering", 1)
 Spring.SetConfigInt("AllowDeferredModelRendering", 1)
 
+-- Enables the DrawGroundDeferred event, which is needed for deferred map edge rendering
+Spring.SetConfigInt("AllowDrawMapDeferredEvents", 1)
+
 -- Disable LoadingMT because: crashes on load, but fixed in 105.1.1-1422, redisable in 105.1.1-1432
 --Spring.SetConfigInt("LoadingMT", 0)
 

--- a/luaui/Widgets/map_edge_extension2.lua
+++ b/luaui/Widgets/map_edge_extension2.lua
@@ -575,6 +575,9 @@ end
 ]]--
 
 function widget:DrawGroundDeferred()
+	if #mirrorParams == 0 then
+		return
+	end
 	--if true then return end
 	--Spring.Echo('widget:DrawGroundDeferred')
 		--local q = gl.CreateQuery()

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -139,6 +139,7 @@ local flexCallIns = {
 	'StockpileChanged',
 	'SelectionChanged',
 	'DrawGenesis',
+	'DrawGroundDeferred',
 	'DrawWorld',
 	'DrawWorldPreUnit',
 	'DrawPreDecals',
@@ -1331,6 +1332,15 @@ function widgetHandler:DrawGenesis()
 	tracy.ZoneBeginN("W:DrawGenesis")
 	for _, w in r_ipairs(self.DrawGenesisList) do
 		w:DrawGenesis()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function widgetHandler:DrawGroundDeferred()
+	tracy.ZoneBeginN("W:DrawGroundDeferred")
+	for _, w in r_ipairs(self.DrawGroundDeferredList) do
+		w:DrawGroundDeferred()
 	end
 	tracy.ZoneEnd()
 	return


### PR DESCRIPTION
**NOW IS A GOOD TIME FOR ANY FURTHER REQUESTS FOR HOW MAP EDGE SHOULD LOOK!**

### Work done
- map_edge_extension now correctly write to the deferred depth, diffuse and normal buffers. 
- The spec, emit, and misc buffers are not written to
- This allows downstream deferred passes to not have artifacts on map edges (lights, fog, etc)
- Fixed some edge cases


#### Test steps
- [ ] Should look identical, but you can see the new filled deferred buffers in the deferred buffer visualizer widget

### Screenshots:
- [ ] Should be nigh identical

### Notes:
- [ ] The alpha blending looks pretty shitty. See https://github.com/beyond-all-reason/spring/issues/489 