### PR TITLE
feat(cmd_blueprint): add blueprint_select action

### DIFF
--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -267,7 +267,7 @@ local function setSelectedBlueprintIndex(index)
 		WG["api_blueprint"].setActiveBlueprint(nil)
 	end
 
-	if blueprintPlacementActive and index ~= nil and index > 0 then
+	if index ~= nil and index > 0 then
 		Spring.Echo("[Blueprint] selected blueprint #" .. selectedBlueprintIndex)
 	end
 end
@@ -864,6 +864,45 @@ local function handleSpacingAction(_, _, args)
 	end
 end
 
+local function handleBlueprintSelectAction(cmd, optLine, optWords, data, isRepeat, release, actions)
+	local targetIndex = tonumber(optLine)
+
+	local function selectIndex(index)
+		setSelectedBlueprintIndex(index)
+		Spring.SetActiveCommand(
+			Spring.GetCmdDescIndex(CMD_BLUEPRINT_PLACE),
+			1,
+			true,
+			false,
+			false,
+			false,
+			false,
+			false
+		)
+	end
+
+	if targetIndex ~= nil then
+		if targetIndex <= #blueprints then
+			selectIndex(targetIndex)
+			return true
+		else
+			return false
+		end
+	end
+
+	local targetName = optLine
+	if targetName ~= nil then
+		for blueprintIndex, blueprint in ipairs(blueprints) do
+			if blueprint.name == targetName then
+				selectIndex(blueprintIndex)
+				return true
+			end
+		end
+
+		return false
+	end
+end
+
 function widget:MousePress(x, y, button)
 	if button ~= 1 or not blueprintPlacementActive or not getSelectedBlueprint() then
 		return
@@ -1145,6 +1184,7 @@ function widget:Initialize()
 	widgetHandler.actionHandler:AddAction(self, "blueprint_next", handleBlueprintNextAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_prev", handleBlueprintPrevAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_delete", handleBlueprintDeleteAction, nil, "p")
+	widgetHandler.actionHandler:AddAction(self, "blueprint_select", handleBlueprintSelectAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "buildfacing", handleFacingAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "buildspacing", handleSpacingAction, nil, "p")
 
@@ -1171,6 +1211,7 @@ function widget:Shutdown()
 	widgetHandler.actionHandler:RemoveAction(self, "blueprint_next", "p")
 	widgetHandler.actionHandler:RemoveAction(self, "blueprint_prev", "p")
 	widgetHandler.actionHandler:RemoveAction(self, "blueprint_delete", "p")
+	widgetHandler.actionHandler:RemoveAction(self, "blueprint_select", "p")
 	widgetHandler.actionHandler:RemoveAction(self, "buildfacing", "p")
 	widgetHandler.actionHandler:RemoveAction(self, "buildspacing", "p")
 end


### PR DESCRIPTION
This action directly selects a blueprint, either by index or name. It can be bound like this examples:

```
bind           Alt+sc_p  blueprint_select 3 // select index 3
bind           Alt+sc_p  blueprint_select wind // select name "wind"
```

While name works, it also can only be set by modifying blueprints.json by hand.

#### Addresses Issue(s)
- https://discord.com/channels/549281623154229250/1299637201021440094

#### Test steps
- [ ] bind the action; the examples above should be sufficient
- Valid actions
  - [ ] with no unit selected, press the hotkey; the blueprint should be selected but not activated
  - [ ] with a builder selected, and a valid index or name passed, press the hotkey; the blueprint should be selected and the blueprint placement command activated
- Invalid actions
  - [ ] with an invalid index (larger than the number of blueprints) passed, press the hotkey; nothing should happen
  - [ ] with an invalid name (not present in any blueprint; this will almost always be the case) passed, press the hotkey; nothing should happen
