### PR TITLE
gui_game_type_info: Add 'builders' deathmode and small fix.

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -513,6 +513,7 @@
 		"gametypeInfo": {
 			"killAllUnits": "Kill all enemy units",
 			"killAllCommanders": "Kill all enemy Commanders",
+			"killAllBuilders": "Kill all enemy builders",
 			"commandersSurviveDgun": "Commanders survive D-Guns and commander explosions",
 			"victoryCondition": "Victory condition",
 			"owncomends": "Losing your commander = losing control of your units / resigning"

--- a/luaui/Widgets/gui_game_type_info.lua
+++ b/luaui/Widgets/gui_game_type_info.lua
@@ -63,7 +63,8 @@ end
 
 function widget:Initialize()
 	if Spring.GetModOptions().deathmode == "neverend" then
-		WidgetHandler:RemoveWidget() return
+		widgetHandler:RemoveWidget()
+		return
 	end
 
 	messages[1] = {}

--- a/luaui/Widgets/gui_game_type_info.lua
+++ b/luaui/Widgets/gui_game_type_info.lua
@@ -79,13 +79,20 @@ function widget:Initialize()
 end
 
 function widget:LanguageChanged()
-	if Spring.GetModOptions().deathmode == "killall" then
-		messages[1].str = "\255\255\255\255" .. Spring.I18N('ui.gametypeInfo.victoryCondition') .. ": " .. Spring.I18N('ui.gametypeInfo.killAllUnits')
+	local key
+	local deathmode = Spring.GetModOptions().deathmode
+
+	if deathmode == "killall" then
+		key = 'killAllUnits'
+	elseif deathmode == "builders" then
+		key = 'killAllBuilders'
 	else
-		messages[1].str = "\255\255\255\255" .. Spring.I18N('ui.gametypeInfo.victoryCondition') .. ": " .. Spring.I18N('ui.gametypeInfo.killAllCommanders')
+		key = 'killAllCommanders'
 	end
 
-	if Spring.GetModOptions().deathmode == "own_com" then
+	messages[1].str = "\255\255\255\255" .. Spring.I18N('ui.gametypeInfo.victoryCondition') .. ": " .. Spring.I18N('ui.gametypeInfo.' .. key)
+
+	if deathmode == "own_com" then
 		messages[3].str = "\255\255\150\150" .. Spring.I18N('ui.gametypeInfo.owncomends')
 	end
 end


### PR DESCRIPTION
### Work done

- Fix widgetHandler misstype on 'neverend' deathmode.
- Add specific message for 'builders' deathmode.

"Came for the lua error, stayed for the missing deathmode."

#### Setup

1. Checkout branch as BAR.sdd

#### Test steps

1. Start skirmish on neverend mode.
2. Check infolog.txt: without fix there's an error, otherwise it's ok.

1. Start skirmish on builders mode.
2. See onscreen victory condition description is wrong without this PR.

#### BEFORE:

![killcoms](https://github.com/user-attachments/assets/f285012b-5ed0-43c9-98d5-c1cac62c84bc)


#### AFTER:

![killbuilders](https://github.com/user-attachments/assets/a0cf3427-c63b-4714-bbe1-f3ca7c1b3030)

#### Builders or Constructors?

I'm using `builders` here, although `constructors` could also be used. Not sure what's best. I see both terms being used in the game. Anyways this can be updated any time from the language files so no biggie.

Also, this could rephrased to clarify whether it means builder units and buildings, also are units who can do any sort of worker tasks included too?. I'm not even sure. Anyways probably not a big issue and current phrasing is still better than saying kill all commanders when it's builders in general.