### PR TITLE
Move gui_point_tracker below gui elements

### DIFF
--- a/luaui/Widgets/gui_point_tracker.lua
+++ b/luaui/Widgets/gui_point_tracker.lua
@@ -6,7 +6,7 @@ function widget:GetInfo()
 		author = "Beherith",
 		date = "20211020",
 		license = "GNU GPL, v2 or later",
-		layer = 0,
+		layer = 20,
 		enabled = true
 	}
 end

--- a/luaui/Widgets/gui_point_tracker.lua
+++ b/luaui/Widgets/gui_point_tracker.lua
@@ -6,7 +6,7 @@ function widget:GetInfo()
 		author = "Beherith",
 		date = "20211020",
 		license = "GNU GPL, v2 or later",
-		layer = 20,
+		layer = 20, -- below most GUI elements, which generally go up to 10
 		enabled = true
 	}
 end


### PR DESCRIPTION
### Work done

- Moved gui_point_tracker to layer 20 (was layer 0).
- Fixes the tracker showing above many gui elements

### More information

The point tracker currently shows above gui elements like the ordermenu, chat, spectator hud, ecostats, idlebuilders, unitgroups.

Moved it to layer 20: Right now (I think) the highest layer gui widget is gui_replaybuttons at 10. Wanted to leave some layers between so other widgets can show above point_tracker but below gui.

**Could go up to layer 100 or 500**, I don't think there's anything between 10 and 1010, but didn't want to go too far for now. It might be good since right now everything is so packed in layers [-1]->[2] there's hardly much space for maneuver.

For reference, widgets per layer above 0 and below 20:

* 1: gui_buildbar, gui_chat, gui_ecostats, gui_info, gui_ordermenu, gui_pregame_build, gui_unitgroups
* 2: gui_gameinfo, gui_idle_builders, gui_spectator_hud
* 10: gui_replaybuttons

I don't think there can be unintended side effects, but need to keep in mind point_tracker also draws inside minimap so this could make the tracker below something else there too.

From the above list I think the only one will be gui_buildbar, that just shows info at minimap when hovering it, so probably better this way too.

### Screenshots:

#### BEFORE:

![points_above](https://github.com/user-attachments/assets/48130b61-7945-43ff-8747-61cfcac9651a)

#### AFTER:

![points_below](https://github.com/user-attachments/assets/e4949881-26d5-4148-a380-a64d38c96362)
