### PR TITLE
Factory quota fixes

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -1035,7 +1035,7 @@ local function isOnQuotaBuildMode(targetDefID)
 	for _, unitID in ipairs(spGetSelectedUnits()) do
 		local uDefID = spGetUnitDefID(unitID)
 		if units.isFactory[uDefID] and table.contains(unitBuildOptions[uDefID], targetDefID) then
-			return WG.Quotas.isOnQuotaMode(unitID)
+			return WG.Quotas and WG.Quotas.isOnQuotaMode(unitID) 
 		end
 	end
 	return false

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -90,15 +90,15 @@ local function isFactoryUsable(factoryID)
     if not commandQueue then
         return true
     end
-    return commandQueue and( #commandQueue == 0 or not (commandQueue[1].options.alt or (commandQueue[2] and commandQueue[2].options.alt)))
+    return commandQueue and( #commandQueue == 0 or not (commandQueue[1].options.alt or (commandQueue[2] and commandQueue[2].options.alt) or (commandQueue[1].id == CMD.WAIT)))
 end
 
 local function appendToFactoryQueue(factoryID, unitDefID)
-    local currentCmd, targetID = Spring.GetUnitWorkerTask(factoryID)
+    local currentCmdID, targetID = Spring.GetUnitWorkerTask(factoryID)
     local insertPosition = 1
     if targetID then
         local _, _, _, _, buildProgress = Spring.GetUnitHealth(targetID)
-        if buildProgress < maxBuildProg and metalcosts[-currentCmd] and (buildProgress * metalcosts[-currentCmd]) < maxMetal then -- 7.5 % is the most that it is willing to cancel, and maximally 500 metal
+        if buildProgress < maxBuildProg and metalcosts[-currentCmdID] and (buildProgress * metalcosts[-currentCmdID]) < maxMetal then -- 7.5 % is the most that it is willing to cancel, and maximally 500 metal
             insertPosition = 0
         end
     else


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
1. In buildmenu, it is now checked if `WG.Quotas` exists before it calls functions that use it.
2. Factory quotas now respect wait commands as a higher priority.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->
<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
