### PR TITLE
Scav and Raptor Small Tweaks

### DIFF
--- a/luarules/configs/scav_spawn_defs.lua
+++ b/luarules/configs/scav_spawn_defs.lua
@@ -184,7 +184,7 @@ local tierConfiguration = { -- Double maxSquadSize for special squads
 	[4] = {minAnger = 35, maxAnger = 200, 	maxSquadSize = 10},
 	[5] = {minAnger = 45, maxAnger = 350, 	maxSquadSize = 8},
 	[6] = {minAnger = 60, maxAnger = 500, 	maxSquadSize = 5},
-	[7] = {minAnger = 80, maxAnger = 1000, 	maxSquadSize = 3},
+	[7] = {minAnger = 70, maxAnger = 1000, 	maxSquadSize = 3},
 }
 
 --local teamAngerEasementFB = 16
@@ -295,7 +295,7 @@ local LandUnitsList = {
 			--Cortex
 			["corakt4_scav"] = 3,
 			--Legion
-			["leggobt3_scav"] = 3,
+			
 			--N/A
 		},
 		[7] = {
@@ -482,6 +482,7 @@ local LandUnitsList = {
 			["corcat_scav"] = 2,
 			["cormabm_scav"] = 2,
 			--Legion
+			["leggobt3_scav"] = 3,
 		},
 		[7] = {
 			--Armada

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1649,7 +1649,7 @@ if gadgetHandler:IsSyncedCode() then
 				spawnQueue = {}
 				raptorEvent("queen") -- notify unsynced about queen spawn
 				_, queenMaxHP = GetUnitHealth(queenID)
-				Spring.SetUnitHealth(queenID, queenMaxHP*(techAnger*0.01))
+				Spring.SetUnitHealth(queenID, math.max(queenMaxHP*(techAnger*0.01), queenMaxHP*0.2))
 				SetUnitExperience(queenID, 0)
 				timeOfLastWave = t
 				for burrowID, _ in pairs(burrows) do

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1842,7 +1842,7 @@ if gadgetHandler:IsSyncedCode() then
 				spawnQueue = {}
 				scavEvent("boss") -- notify unsynced about boss spawn
 				_, bossMaxHP = GetUnitHealth(bossID)
-				Spring.SetUnitHealth(bossID, bossMaxHP*(techAnger*0.01))
+				Spring.SetUnitHealth(bossID, math.max(bossMaxHP*(techAnger*0.01), bossMaxHP*0.2))
 				SetUnitExperience(bossID, 0)
 				timeOfLastWave = t
 				burrows[bossID] = {


### PR DESCRIPTION
- Moved Epic Goblin from Raiders to Supporters in Scav list
- Boss/Queen now spawns with minimum of 20% Health, to prevent instant deaths in Endless.