### PR TITLE
AllowCommand per cmdId registration

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1399,7 +1399,7 @@ end
 
 function gadgetHandler:AllowCommand(unitID, unitDefID, unitTeam,
 									cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	local cmdKey = cmdID and cmdID or CMD_NIL
+	local cmdKey = cmdID or CMD_NIL
 	if not allowCommandList[cmdKey] then cmdKey = CMD_ANY end
 
 	tracy.ZoneBeginN("G:AllowCommand")

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1264,6 +1264,7 @@ local CMD_NIL = CMD.NIL
 local allowCommandList = {[CMD_ANY] = {}}
 
 function gadgetHandler:ReorderAllowCommands(gadget, f)
+	if not gadget.AllowCommand then return true end
 	for _, list in pairs(allowCommandList) do
 		f(list, true, gadget)
 	end

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1399,7 +1399,7 @@ end
 function gadgetHandler:AllowCommand(unitID, unitDefID, unitTeam,
 									cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	local cmdKey = cmdID and cmdID or CMD_NIL
-	if not allowCommandList[cmdKey] then return true end
+	if not allowCommandList[cmdKey] then cmdKey = CMD_ANY end
 
 	tracy.ZoneBeginN("G:AllowCommand")
 	for _, g in ipairs(allowCommandList[cmdKey]) do

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -537,6 +537,12 @@ function gadgetHandler:NewGadget()
 	gh.RemoveChatAction = function(_, cmd)
 		return actionHandler.RemoveChatAction(gadget, cmd)
 	end
+	gh.RegisterAllowCommand = function(_, cmdID)
+		return self:RegisterAllowCommand(gadget, cmdID)
+	end
+	gh.DeregisterAllowCommands = function(_)
+		return self:DeregisterAllowCommands(gadget)
+	end
 
 	if not IsSyncedCode() then
 		gh.AddSyncAction = function(_, cmd, func, help)
@@ -694,6 +700,10 @@ function gadgetHandler:InsertGadget(gadget)
 	end
 	self:UpdateCallIns()
 
+	if gadget.AllowCommand and not self:HasAllowCommands(gadget) then
+		Spring.Log('AllowCommand', LOG.WARNING, "<" .. gadget.ghInfo.basename .. "> AllowCommand defined but didn't register any commands!")
+	end
+
 	if kbytes then
 		collectgarbage("collect")
 		collectgarbage("collect")
@@ -718,6 +728,7 @@ function gadgetHandler:RemoveGadget(gadget)
 	for _, listname in ipairs(callInLists) do
 		ArrayRemove(self[listname .. 'List'], gadget)
 	end
+	self:DeregisterAllowCommands(gadget)
 
 	for id, g in pairs(self.CMDIDs) do
 		if g == gadget then
@@ -1241,6 +1252,65 @@ function gadgetHandler:PlayerRemoved(playerID, reason)
 	return
 end
 
+--------------------------------------------------------------------------------
+--
+--  AllowCommand subscription
+--
+
+local CMD_ANY = CMD.ANY
+local CMD_NIL = CMD.NIL
+local allowCommandList = {[CMD_ANY] = {}}
+
+function gadgetHandler:HasAllowCommands(gadget)
+	for _, list in pairs(allowCommandList) do
+		for _, g in ipairs(list) do
+			if g == gadget then
+				return true
+			end
+		end
+	end
+end
+
+function gadgetHandler:DeregisterAllowCommands(gadget)
+	for _, list in pairs(allowCommandList) do
+		ArrayRemove(list, gadget)
+	end
+end
+
+function gadgetHandler:RegisterAllowCommand(gadget, cmdID)
+	-- cmdID accepts CMD.ANY and CMD.NIL in addition to usual cmdIDs
+	-- CMD.ANY subscribes to any command
+	Spring.Log('AllowCommand', LOG.INFO, "<" .. gadget.ghInfo.basename .. "> Register "..tostring(cmdID))
+	if cmdID == nil then
+		-- use CMD.NIL instead
+		Spring.Log('AllowCommand', LOG.ERROR, "<" .. gadget.ghInfo.basename .. "> Invalid cmdID "..tostring(cmdID))
+		return
+	end
+	if not gadget.AllowCommand then
+		Spring.Log('AllowCommand', LOG.ERROR, "<" .. gadget.ghInfo.basename .. "> No callin method")
+		return
+	end
+	cmdList = allowCommandList[cmdID]
+	-- create list if needed
+	if not cmdList then
+		cmdList = {}
+		allowCommandList[cmdID] = cmdList
+		-- on a new list, register all known CMD.ANY commands
+		if cmdID ~= CMD_ANY then
+			for _, g in ipairs(allowCommandList[CMD_ANY]) do
+				ArrayInsert(cmdList, true, g)
+			end
+		end
+	end
+	-- insert into the list
+	ArrayInsert(cmdList, true, gadget)
+	-- if it's a CMD.ANY registration, insert into all lists
+	if cmdID == CMD_ANY then
+		for _, list in pairs(allowCommandList) do
+			ArrayInsert(list, true, gadget)
+		end
+	end
+end
 
 --------------------------------------------------------------------------------
 --
@@ -1319,13 +1389,18 @@ end
 
 function gadgetHandler:AllowCommand(unitID, unitDefID, unitTeam,
 									cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if not allowCommandList[cmdID] then return true end
+	local cmdKey = cmdID and cmdID or CMD_NIL
 
 	tracy.ZoneBeginN("G:AllowCommand")
-	for _, g in ipairs(self.AllowCommandList) do
+	for _, g in ipairs(allowCommandList[cmdKey]) do
+		--tracy.ZoneBeginN("G:AllowCommand:"..g.ghInfo.name)
 		if not g:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua) then
+			--tracy.ZoneEnd()
 			tracy.ZoneEnd()
 			return false
 		end
+		--tracy.ZoneEnd()
 	end
 	tracy.ZoneEnd()
 	return true

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -899,6 +899,7 @@ function gadgetHandler:RaiseGadget(gadget)
 	for _, listname in ipairs(callInLists) do
 		Raise(self[listname .. 'List'], gadget[listname], gadget)
 	end
+	self:ReorderAllowCommands(gadget, Raise)
 end
 
 local function FindHighestIndex(t, i, layer)
@@ -933,6 +934,7 @@ function gadgetHandler:LowerGadget(gadget)
 	for _, listname in ipairs(callInLists) do
 		Lower(self[listname .. 'List'], gadget[listname], gadget)
 	end
+	self:ReorderAllowCommands(gadget, Lower)
 end
 
 function gadgetHandler:FindGadget(name)
@@ -1260,6 +1262,12 @@ end
 local CMD_ANY = CMD.ANY
 local CMD_NIL = CMD.NIL
 local allowCommandList = {[CMD_ANY] = {}}
+
+function gadgetHandler:ReorderAllowCommands(gadget, f)
+	for _, list in pairs(allowCommandList) do
+		f(list, true, gadget)
+	end
+end
 
 function gadgetHandler:HasAllowCommands(gadget)
 	for _, list in pairs(allowCommandList) do

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -701,7 +701,8 @@ function gadgetHandler:InsertGadget(gadget)
 	self:UpdateCallIns()
 
 	if gadget.AllowCommand and not self:HasAllowCommands(gadget) then
-		Spring.Log('AllowCommand', LOG.WARNING, "<" .. gadget.ghInfo.basename .. "> AllowCommand defined but didn't register any commands!")
+		Spring.Log('AllowCommand', LOG.WARNING, "<" .. gadget.ghInfo.basename .. "> AllowCommand defined but didn't register any commands. Autoregistering for all commands!")
+		self:RegisterAllowCommand(gadget, CMD.ANY)
 	end
 
 	if kbytes then

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1389,8 +1389,8 @@ end
 
 function gadgetHandler:AllowCommand(unitID, unitDefID, unitTeam,
 									cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if not allowCommandList[cmdID] then return true end
 	local cmdKey = cmdID and cmdID or CMD_NIL
+	if not allowCommandList[cmdKey] then return true end
 
 	tracy.ZoneBeginN("G:AllowCommand")
 	for _, g in ipairs(allowCommandList[cmdKey]) do

--- a/luarules/gadgets/cmd_factory_stop_production.lua
+++ b/luarules/gadgets/cmd_factory_stop_production.lua
@@ -115,6 +115,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:Initialize()
 		gadgetHandler:RegisterCMDID(CMD_STOP_PRODUCTION)
+		gadgetHandler:RegisterAllowCommand(CMD_STOP_PRODUCTION)
 		for _, unitID in pairs(Spring.GetAllUnits()) do
 			gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
 		end

--- a/luarules/gadgets/cmd_factory_stop_production.lua
+++ b/luarules/gadgets/cmd_factory_stop_production.lua
@@ -81,7 +81,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
-		if (cmdID ~= CMD_STOP_PRODUCTION) or not isFactory[unitDefID] then
+		if not isFactory[unitDefID] then
 			return true
 		end
 

--- a/luarules/gadgets/cmd_manual_launch.lua
+++ b/luarules/gadgets/cmd_manual_launch.lua
@@ -36,7 +36,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		cmdParams[2] = CMD.MANUALFIRE
 		Spring.GiveOrderToUnit(unitID, CMD.INSERT, cmdParams, cmdOptions.coded)
 		return false
-	else
+	elseif cmdID == CMD_MANUAL_LAUNCH then
 		Spring.GiveOrderToUnit(unitID, CMD.MANUALFIRE, cmdParams, cmdOptions.coded)
 		return false
 	end

--- a/luarules/gadgets/cmd_manual_launch.lua
+++ b/luarules/gadgets/cmd_manual_launch.lua
@@ -36,9 +36,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		cmdParams[2] = CMD.MANUALFIRE
 		Spring.GiveOrderToUnit(unitID, CMD.INSERT, cmdParams, cmdOptions.coded)
 		return false
-	end
-
-	if cmdID == CMD_MANUAL_LAUNCH then
+	else
 		Spring.GiveOrderToUnit(unitID, CMD.MANUALFIRE, cmdParams, cmdOptions.coded)
 		return false
 	end
@@ -56,4 +54,6 @@ end
 
 function gadget:Initialize()
 	gadgetHandler:RegisterCMDID(CMD_MANUAL_LAUNCH)
+	gadgetHandler:RegisterAllowCommand(CMD.INSERT)
+	gadgetHandler:RegisterAllowCommand(CMD_MANUAL_LAUNCH)
 end

--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -27,6 +27,7 @@ end
 local metalSpotsList
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
 	local isMetalMap = GG["resource_spot_finder"].isMetalMap
 	if isMetalMap then
 		Spring.Log(gadget:GetInfo().name, LOG.INFO, "Metal map detected, removing self")

--- a/luarules/gadgets/cmd_paused_is_paused.lua
+++ b/luarules/gadgets/cmd_paused_is_paused.lua
@@ -31,3 +31,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		return true
 	end
 end
+
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
+end

--- a/luarules/gadgets/cmd_remove_stop.lua
+++ b/luarules/gadgets/cmd_remove_stop.lua
@@ -42,7 +42,8 @@ function gadget:AllowCommand_GetWantedUnitDefID()
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if (cmdID == CMD_STOP and stopRemoveDefs[unitDefID]) then
+	-- accepts: CMD.STOP
+	if stopRemoveDefs[unitDefID] then
 		return false
 	end
 	return true
@@ -60,6 +61,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_STOP)
 	-- load active units
 	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		local unitDefID = Spring.GetUnitDefID(unitID)

--- a/luarules/gadgets/cmd_remove_wait.lua
+++ b/luarules/gadgets/cmd_remove_wait.lua
@@ -42,7 +42,8 @@ function gadget:AllowCommand_GetWantedUnitDefID()
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if (cmdID == CMD_WAIT and waitRemoveDefs[unitDefID]) then
+	-- accepts: CMD.WAIT
+	if waitRemoveDefs[unitDefID] then
 		return false
 	end
 	return true
@@ -60,6 +61,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_WAIT)
 	-- load active units
 	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		local unitDefID = Spring.GetUnitDefID(unitID)

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -208,6 +208,7 @@ end
 local mapConfig
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
 	local allUnits = Spring.GetAllUnits()
 	for _, unitID in pairs(allUnits) do
 		local unitDefID = GetUnitDefID(unitID)
@@ -577,11 +578,10 @@ end
 
 --http://springrts.com/phpbb/viewtopic.php?f=23&t=30109
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if cmdID and cmdID == CMD.ATTACK then
-		if cmdParams and #cmdParams == 1 then
-			if critterUnits[cmdParams[1]] ~= nil then
-				return false
-			end
+	-- accepts: CMD.ATTACK
+	if cmdParams and #cmdParams == 1 then
+		if critterUnits[cmdParams[1]] ~= nil then
+			return false
 		end
 	end
 	return true

--- a/luarules/gadgets/game_apm_broadcast.lua
+++ b/luarules/gadgets/game_apm_broadcast.lua
@@ -37,6 +37,8 @@ if gadgetHandler:IsSyncedCode() then
 	function gadget:Initialize()
 		GG['apm'] = {}
 		GG['apm'].addSkipOrder = addSkipOrder
+
+		gadgetHandler:RegisterAllowCommand(CMD.ANY)
 	end
 
 	function gadget:UnitFinished(unitID, unitDefID, teamID, builderID)

--- a/luarules/gadgets/game_no_rush_mode.lua
+++ b/luarules/gadgets/game_no_rush_mode.lua
@@ -66,6 +66,9 @@ end
 
 
 if gadgetHandler:IsSyncedCode() then
+	function gadget:Initialize()
+		gadgetHandler:RegisterAllowCommand(CMD.ANY)
+	end
 	function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
 		local allowed = true
 		local frame = Spring.GetGameFrame()

--- a/luarules/gadgets/game_selfd_resign.lua
+++ b/luarules/gadgets/game_selfd_resign.lua
@@ -48,6 +48,10 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	function gadget:Initialize()
+		gadgetHandler:RegisterAllowCommand(CMD_SELFD)
+	end
+
 	function gadget:GameFrame(n)
 		if n % 15 == 1 then
 			for teamID, _ in pairs(selfdCheckTeamUnits) do
@@ -95,7 +99,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-		if cmdID == CMD_SELFD and teamID ~= gaiaTeamID then
+		if teamID ~= gaiaTeamID then
 			selfdCheckTeamUnits[teamID] = true
 		end
 		return true

--- a/luarules/gadgets/game_unit_market.lua
+++ b/luarules/gadgets/game_unit_market.lua
@@ -320,13 +320,12 @@ function gadget:UnitFinished(unitID, unitDefID, teamID, builderID)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if (cmdID == CMD_SELL_UNIT) then
+	-- accepts: CMD_SELL_UNIT
         local unitDef = UnitDefs[unitDefID]
         if unitDef then
             local price = unitDef.metalCost
             setUnitOnSale(unitID, price, true)
         end
-	end
 	return true
 end
 
@@ -335,6 +334,7 @@ local function isTeamSaving(teamID)
 end
 
 function gadget:Initialize()
+    gadgetHandler:RegisterAllowCommand(CMD_SELL_UNIT)
     local teamList = spGetTeamList()
 	for _, teamID in ipairs(teamList) do
         TeamIsSaving[teamID] = false

--- a/luarules/gadgets/game_unit_market.lua
+++ b/luarules/gadgets/game_unit_market.lua
@@ -321,11 +321,11 @@ end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	-- accepts: CMD_SELL_UNIT
-        local unitDef = UnitDefs[unitDefID]
-        if unitDef then
-            local price = unitDef.metalCost
-            setUnitOnSale(unitID, price, true)
-        end
+	local unitDef = UnitDefs[unitDefID]
+	if unitDef then
+		local price = unitDef.metalCost
+		setUnitOnSale(unitID, price, true)
+	end
 	return true
 end
 

--- a/luarules/gadgets/unit_air_plants.lua
+++ b/luarules/gadgets/unit_air_plants.lua
@@ -103,8 +103,13 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 	end
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(34569) -- LandAt
+	gadgetHandler:RegisterAllowCommand(34570) -- AirRepair
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if (cmdID == 34569 or cmdID == 34570) and isAirplant[unitDefID] and plantList[unitID] then
+	if isAirplant[unitDefID] and plantList[unitID] then
 		if cmdID == 34569 then
 			local cmdDescID = FindUnitCmdDesc(unitID, 34569)
 			landCmd.params[1] = cmdParams[1]

--- a/luarules/gadgets/unit_airunitsturnradius.lua
+++ b/luarules/gadgets/unit_airunitsturnradius.lua
@@ -44,6 +44,7 @@ end
 isBomb = nil
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
 	for ct, unitID in pairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
 	end

--- a/luarules/gadgets/unit_areaattack.lua
+++ b/luarules/gadgets/unit_areaattack.lua
@@ -56,14 +56,11 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-		if cmdID == CMD_AREAATTACK then
-			if canAreaAttack[unitDefID] then
-				return true
-			else
-				return false
-			end
-		else
+		-- accepts: CMD_AREAATTACK
+		if canAreaAttack[unitDefID] then
 			return true
+		else
+			return false
 		end
 	end
 
@@ -90,6 +87,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:Initialize()
 		gadgetHandler:RegisterCMDID(CMD_AREAATTACK)
+		gadgetHandler:RegisterAllowCommand(CMD_AREAATTACK)
 	end
 
 else	-- UNSYNCED

--- a/luarules/gadgets/unit_attributes.lua
+++ b/luarules/gadgets/unit_attributes.lua
@@ -648,6 +648,7 @@ local function SetAllowUnitCoast(unitID, allowed)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.SET_WANTED_MAX_SPEED)
 	GG.UpdateUnitAttributes = UpdateUnitAttributes
 	GG.SetAllowUnitCoast = SetAllowUnitCoast
 
@@ -683,7 +684,8 @@ function gadget:AllowCommand_GetWantedUnitDefID()
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if (cmdID == 70 and unitSlowed[unitID]) then
+	-- accepts: SET_WANTED_MAX_SPEED
+	if unitSlowed[unitID] then
 		return false
 	else
 		return true

--- a/luarules/gadgets/unit_attributes.lua
+++ b/luarules/gadgets/unit_attributes.lua
@@ -648,7 +648,7 @@ local function SetAllowUnitCoast(unitID, allowed)
 end
 
 function gadget:Initialize()
-	gadgetHandler:RegisterAllowCommand(CMD.SET_WANTED_MAX_SPEED)
+	gadgetHandler:RegisterAllowCommand(70)
 	GG.UpdateUnitAttributes = UpdateUnitAttributes
 	GG.SetAllowUnitCoast = SetAllowUnitCoast
 
@@ -684,7 +684,7 @@ function gadget:AllowCommand_GetWantedUnitDefID()
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	-- accepts: SET_WANTED_MAX_SPEED
+	-- accepts: 70 (SET_WANTED_MAX_SPEED, but not registered anywhere)
 	if unitSlowed[unitID] then
 		return false
 	else

--- a/luarules/gadgets/unit_block_fake_geo.lua
+++ b/luarules/gadgets/unit_block_fake_geo.lua
@@ -27,6 +27,10 @@ local function isNearGeo(x, z)
 	return false
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
+end
+
 local CMD_INSERT = CMD.INSERT
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
 	if cmdID == CMD_INSERT then

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -110,6 +110,7 @@ end
 local isTeamSavingMetal = function(_) return false end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_PRIORITY)
 	updateTeamList()
 
 	for _, teamID in ipairs(teamList) do
@@ -193,8 +194,9 @@ end
 
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+    -- accepts CMD_PRIORITY
     -- track which cons are set to passive
-    if cmdID == CMD_PRIORITY and canPassive[unitDefID] then
+    if canPassive[unitDefID] then
         local cmdIdx = spFindUnitCmdDesc(unitID, CMD_PRIORITY)
         if cmdIdx then
             local cmdDesc = spGetUnitCmdDescs(unitID, cmdIdx, cmdIdx)[1]

--- a/luarules/gadgets/unit_capture_only_enemy.lua
+++ b/luarules/gadgets/unit_capture_only_enemy.lua
@@ -17,8 +17,13 @@ end
 local CMD_CAPTURE = CMD.CAPTURE
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD_CAPTURE and Spring.GetUnitAllyTeam(unitID) == Spring.GetUnitAllyTeam(cmdParams[1]) and not select(4, Spring.GetTeamInfo(Spring.GetUnitTeam(cmdParams[1]))) and not Spring.GetTeamLuaAI(Spring.GetUnitTeam(cmdParams[1])) then
+	-- accepts: CMD.CAPTURE
+	if Spring.GetUnitAllyTeam(unitID) == Spring.GetUnitAllyTeam(cmdParams[1]) and not select(4, Spring.GetTeamInfo(Spring.GetUnitTeam(cmdParams[1]))) and not Spring.GetTeamLuaAI(Spring.GetUnitTeam(cmdParams[1])) then
 		return false
 	end
 	return true
+end
+
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_CAPTURE)
 end

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -738,7 +738,8 @@ end
 
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if (cmdID == 31200) and carrierMetaList[unitID] then
+	-- accepts: 31200 (spawning)
+	if carrierMetaList[unitID] then
 		local cmdDescID = FindUnitCmdDesc(unitID, 31200)
 		spawnCmd.params[1] = cmdParams[1]
 		EditUnitCmdDesc(unitID, cmdDescID, spawnCmd)
@@ -1487,6 +1488,7 @@ function gadget:GameFrame(f)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(31200) -- Spawning
 	local allUnits = Spring.GetAllUnits()
 	for i = 1, #allUnits do
 		local unitID = allUnits[i]

--- a/luarules/gadgets/unit_cloak.lua
+++ b/luarules/gadgets/unit_cloak.lua
@@ -206,10 +206,9 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 			SetWantedCloaked(unitID, cmdParams[1])
 		end
 		return true
-	elseif cmdID == CMD_CLOAK then
+	else -- cmdID == CMD_CLOAK
 		return false
 	end
-	return true
 end
 
 function gadget:UnitCreated(unitID, unitDefID)
@@ -228,6 +227,8 @@ function gadget:UnitCreated(unitID, unitDefID)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_CLOAK)
+	gadgetHandler:RegisterAllowCommand(CMD_WANT_CLOAK)
 	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, spGetUnitDefID(unitID))
 	end

--- a/luarules/gadgets/unit_death_animations.lua
+++ b/luarules/gadgets/unit_death_animations.lua
@@ -49,6 +49,10 @@ local MoveCtrlDisable 	= Spring.MoveCtrl.Disable
 local MoveCtrlSetVelocity = Spring.MoveCtrl.SetVelocity
 local CMD_STOP = CMD.STOP
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
+end
+
 function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
 	if hasDeathAnim[unitDefID] then
 		--Spring.Echo("gadget:UnitDestroyed",unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)

--- a/luarules/gadgets/unit_factory_guard.lua
+++ b/luarules/gadgets/unit_factory_guard.lua
@@ -73,7 +73,8 @@ end
 
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD_FACTORY_GUARD and isFactory[unitDefID] then
+	--accepts: CMD_FACTORY_GUARD
+	if isFactory[unitDefID] then
 		setFactoryGuardState(unitID, cmdParams[1])
 		return false  -- command was used
 	end
@@ -174,6 +175,7 @@ function gadget:UnitCreated(unitID, unitDefID, _)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_FACTORY_GUARD)
 	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
 	end

--- a/luarules/gadgets/unit_factory_quota.lua
+++ b/luarules/gadgets/unit_factory_quota.lua
@@ -32,7 +32,8 @@ local factoryQuotaCmdDesc = {
 }
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD_QUOTA_BUILD_TOGGLE and isFactory[unitDefID] then
+	-- accepts: CMD_QUOTA_BUILD_TOGGLE
+	if isFactory[unitDefID] then
         local cmdDescID = Spring.FindUnitCmdDesc(unitID, CMD_QUOTA_BUILD_TOGGLE)
         if cmdDescID then
             factoryQuotaCmdDesc.params[1] = cmdParams[1]
@@ -51,6 +52,7 @@ function gadget:UnitCreated(unitID, unitDefID, _)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_QUOTA_BUILD_TOGGLE)
 	for _, unitID in ipairs(Spring.GetAllUnits()) do -- handle /luarules reload
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
 	end

--- a/luarules/gadgets/unit_hound_weapon_toggle.lua
+++ b/luarules/gadgets/unit_hound_weapon_toggle.lua
@@ -52,7 +52,8 @@ local function setHoundWeaponState(unitID, state)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD_HOUND_WEAPON_TOGGLE and isHound[unitDefID] then
+	-- accepts: CMD_HOUND_WEAPON_TOGGLE
+	if isHound[unitDefID] then
 		setHoundWeaponState(unitID, cmdParams[1])
 		return false  -- command was used
 	end
@@ -72,6 +73,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_HOUND_WEAPON_TOGGLE)
 	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
 	end

--- a/luarules/gadgets/unit_instant_self_destruct.lua
+++ b/luarules/gadgets/unit_instant_self_destruct.lua
@@ -49,7 +49,8 @@ local function QueueUnitDestruction(unitID, skipChecks)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD_SELFD and selfddefs[unitDefID] and cmdOptions.coded == 0 then
+	-- accepts: CMD.SELFD
+	if selfddefs[unitDefID] and cmdOptions.coded == 0 then
 		QueueUnitDestruction(unitID)
 	end
 	return true
@@ -65,5 +66,6 @@ function gadget:GameFrame(n)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_SELFD)
 	GG.QueueUnitDestruction = QueueUnitDestruction
 end

--- a/luarules/gadgets/unit_morph.lua
+++ b/luarules/gadgets/unit_morph.lua
@@ -716,6 +716,19 @@ end
     -- end
   end
 
+local function RegisterAllowCommands()
+  -- CMD_EZ_MORPH, CMD.STOP, CMD.ONOFF, CMD.SELFD, CMD_MORPH->CMD_MORPH+MAX_MORPH-1, CMD_STOP_MORPH+MAX_MORPH-1
+  -- careful MAX_MORPH increases during Initialize
+  gadgetHandler:RegisterAllowCommand(CMD_EZ_MORPH)
+  gadgetHandler:RegisterAllowCommand(CMD.STOP)
+  gadgetHandler:RegisterAllowCommand(CMD.ONOFF)
+  gadgetHandler:RegisterAllowCommand(CMD.SELFD)
+  for number = 0, MAX_MORPH-1 do
+    gadgetHandler:RegisterAllowCommand(CMD_MORPH+number)
+    gadgetHandler:RegisterAllowCommand(CMD_STOP_MORPH+number)
+  end
+
+end
 
 function gadget:Initialize()
   --// RankApi linking
@@ -754,6 +767,7 @@ function gadget:Initialize()
     gadgetHandler:RegisterCMDID(CMD_MORPH + number)
     gadgetHandler:RegisterCMDID(CMD_MORPH_STOP + number)
   end
+  RegisterAllowCommands()
 
   local allUnits = Spring.GetAllUnits()
   for i = 1, #allUnits do

--- a/luarules/gadgets/unit_onlytargetcategory.lua
+++ b/luarules/gadgets/unit_onlytargetcategory.lua
@@ -40,15 +40,19 @@ for udid, unitDef in pairs(UnitDefs) do
 	end
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if cmdID == CMD.ATTACK
-	and cmdParams[2] == nil
+	-- accepts: CMD.ATTACK
+	if cmdParams[2] == nil
 	and unitOnlyTargetsCategory[unitDefID]
 	and type(cmdParams[1]) == 'number'
 	and not (unitCategories[Spring.GetUnitDefID(cmdParams[1])] and unitCategories[Spring.GetUnitDefID(cmdParams[1])][unitOnlyTargetsCategory[unitDefID]]) then
 		return false
 	else
-		if cmdID == CMD.ATTACK and cmdParams[2] and unitDontAttackGround[unitDefID] then
+		if cmdParams[2] and unitDontAttackGround[unitDefID] then
 			return false
 		else
 			return true

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -24,9 +24,13 @@ for udid, unitDef in pairs(UnitDefs) do
 	end
 end
 
+function gadget:Initialize()
+    gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if cmdID == CMD.ATTACK
-	and empUnits[unitDefID]
+	-- accepts: CMD.ATTACK
+	if empUnits[unitDefID]
 	and cmdParams[2] == nil
 	and type(cmdParams[1]) == 'number'
 	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])] ~= nil then

--- a/luarules/gadgets/unit_prevent_aircraft_hax.lua
+++ b/luarules/gadgets/unit_prevent_aircraft_hax.lua
@@ -34,6 +34,7 @@ for unitDefID, udef in pairs(UnitDefs) do
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_STOP)
 	for _, unitID in pairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID), spGetUnitTeam(unitID))
 	end
@@ -76,7 +77,8 @@ function gadget:GameFrame(f)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, fromSynced, fromLua)
-	if cmdID == CMD_STOP and isMobileUnit[unitDefID] then
+	-- accepts: CMD_STOP
+	if isMobileUnit[unitDefID] then
 		local x,_,z = Spring.GetUnitPosition(unitID)
 		if z < 0 or x < 0 or z > mapZ or x > mapX then
 			return false

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -30,13 +30,14 @@ if gadgetHandler:IsSyncedCode() then
     local GetUnitIsCloaked = Spring.GetUnitIsCloaked
 
     function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams)
-        if (cmdID == CMD.RECLAIM) and (#cmdParams == 1) and GetUnitIsCloaked(cmdParams[1]) and (GetUnitAllyTeam(unitID) ~= GetUnitAllyTeam(cmdParams[1])) and not IsUnitInRadar(cmdParams[1], GetUnitAllyTeam(unitID)) then
+        if (#cmdParams == 1) and GetUnitIsCloaked(cmdParams[1]) and (GetUnitAllyTeam(unitID) ~= GetUnitAllyTeam(cmdParams[1])) and not IsUnitInRadar(cmdParams[1], GetUnitAllyTeam(unitID)) then
             return false
         end
         return true
     end
 
     function gadget:AllowUnitCloak(unitID) -- cancel reclaim commands
+        -- accepts: CMD.RECLAIM
         if (cloakedUnits[unitID]) and (not checkedUnits[unitID]) then  -- only needs to be checked when the unit barely is cloaked
             checkedUnits[unitID] = true
             local x, y, z = GetUnitPosition(unitID)
@@ -71,6 +72,7 @@ if gadgetHandler:IsSyncedCode() then
     end
 
     function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.RECLAIM)
         for unitDefID, unitDef in pairs(UnitDefs) do
             if unitDef.canReclaim then
                 canReclaim[unitDefID] = unitDef.buildDistance or 0

--- a/luarules/gadgets/unit_prevent_load_hax.lua
+++ b/luarules/gadgets/unit_prevent_load_hax.lua
@@ -36,6 +36,12 @@ local CMD_REMOVE = CMD.REMOVE
 
 local watchList = {}
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_INSERT)
+	gadgetHandler:RegisterAllowCommand(CMD_REMOVE)
+	gadgetHandler:RegisterAllowCommand(CMD_LOAD_UNITS)
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
   if fromSynced then return true end
   if (cmdID == CMD_INSERT) then

--- a/luarules/gadgets/unit_prevent_nanoframe_blocking_hax.lua
+++ b/luarules/gadgets/unit_prevent_nanoframe_blocking_hax.lua
@@ -102,7 +102,8 @@ end
 
 -- make it not manually or accidentally targetable
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD_ATTACK and not cmdParams[2] and newNanoFrameNeutralState[cmdParams[1]] ~= nil then
+	-- accepts: CMD.ATTACK
+	if not cmdParams[2] and newNanoFrameNeutralState[cmdParams[1]] ~= nil then
 		return false
 	else
 		return true
@@ -117,6 +118,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, builderID)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_ATTACK)
 	-- handle luarules reload
 	local units = Spring.GetAllUnits()
 	for _,unitID in ipairs(units) do

--- a/luarules/gadgets/unit_prevent_range_hax.lua
+++ b/luarules/gadgets/unit_prevent_range_hax.lua
@@ -19,6 +19,11 @@ local spGetGroundHeight = Spring.GetGroundHeight
 local CMD_ATTACK = CMD.ATTACK
 local CMD_INSERT = CMD.INSERT
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_INSERT)
+	gadgetHandler:RegisterAllowCommand(CMD_ATTACK)
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if fromSynced then
 		return true

--- a/luarules/gadgets/unit_prevent_strange_orders.lua
+++ b/luarules/gadgets/unit_prevent_strange_orders.lua
@@ -17,11 +17,14 @@ end
 local CMD_INSERT = CMD.INSERT
 local CMD_REMOVE = CMD.REMOVE
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_INSERT)
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if cmdID == CMD_INSERT then
-		if CMD_REMOVE == cmdParams[2] or CMD_INSERT == cmdParams[2] then
-			return false
-		end
+	-- accepts: CMD.INSERT
+	if CMD_REMOVE == cmdParams[2] or CMD_INSERT == cmdParams[2] then
+		return false
 	end
 	return true
 end

--- a/luarules/gadgets/unit_stockpile_limit.lua
+++ b/luarules/gadgets/unit_stockpile_limit.lua
@@ -213,6 +213,8 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:Initialize()
+		gadgetHandler:RegisterAllowCommand(CMD_STOCKPILE)
+		gadgetHandler:RegisterAllowCommand(CMD_INSERT)
 		local units = Spring.GetAllUnits()
 		for i = 1, #units do
 			local unitDefID = Spring.GetUnitDefID(units[i])

--- a/luarules/gadgets/unit_stun_control.lua
+++ b/luarules/gadgets/unit_stun_control.lua
@@ -25,9 +25,13 @@ end
 
 local CMD_ONOFF = CMD.ONOFF
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_ONOFF)
+end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if (cmdID == CMD_ONOFF) and Spring.GetUnitIsStunned(unitID) then
+	-- accepts: CMD.ONOFF
+	if Spring.GetUnitIsStunned(unitID) then
 		return false
 	else
 		return true

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -326,6 +326,14 @@ if gadgetHandler:IsSyncedCode() then
 		gadgetHandler:RegisterCMDID(CMD_UNIT_CANCEL_TARGET)
 		gadgetHandler:RegisterCMDID(CMD_UNIT_SET_TARGET_RECTANGLE)
 		gadgetHandler:RegisterCMDID(CMD_UNIT_SET_TARGET_NO_GROUND)
+		-- register allowcommand callin
+		gadgetHandler:RegisterAllowCommand(CMD_STOP)
+		gadgetHandler:RegisterAllowCommand(CMD_DGUN)
+		gadgetHandler:RegisterAllowCommand(CMD.INSERT)
+		gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET_NO_GROUND)
+		gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET)
+		gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET_RECTANGLE)
+		gadgetHandler:RegisterAllowCommand(CMD_UNIT_CANCEL_TARGET)
 
 		-- load active units
 		for _, unitID in pairs(Spring.GetAllUnits()) do

--- a/luarules/gadgets/unit_transportable_nanos.lua
+++ b/luarules/gadgets/unit_transportable_nanos.lua
@@ -64,6 +64,11 @@ end
 
 local watchList = {}
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_LOAD_UNITS)
+	gadgetHandler:RegisterAllowCommand(CMD_UNLOAD_UNITS)
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if cmdID == CMD_LOAD_UNITS then
 		if #cmdParams==1 then -- if unit is target
@@ -73,8 +78,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		end
 		--if Spring.ValidUnit(cmdParams[1]) then
 		--end
-	end
-	if cmdID == CMD_UNLOAD_UNITS then
+	else -- CMD_UNLOAD_UNITS
 		if GetUnitIsTransporting(unitID) then
 			local intrans=GetUnitIsTransporting(unitID)
 			if #intrans>=1 then

--- a/luarules/gadgets/unit_transportee_hider.lua
+++ b/luarules/gadgets/unit_transportee_hider.lua
@@ -42,10 +42,9 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	if cmdID == CMD_LOAD_ONTO then
-		local transportID = cmdParams[1]
-		toBeLoaded[unitID] = transportID
-	end
+	-- accepts: CMD.LOAD_ONTO
+	local transportID = cmdParams[1]
+	toBeLoaded[unitID] = transportID
 	return true
 end
 
@@ -61,6 +60,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_LOAD_ONTO)
 	local allUnits = Spring.GetAllUnits()
 	for _, unitID in ipairs(allUnits) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID), Spring.GetUnitTeam(unitID))

--- a/luarules/gadgets/unit_wanted_speed.lua
+++ b/luarules/gadgets/unit_wanted_speed.lua
@@ -160,6 +160,10 @@ local function MaintainWantedSpeed(unitID)
 	end
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
+end
+
 -------------------------------------------------------------------------------------
 -------------------------------------------------------------------------------------
 -- Command Handling

--- a/luarules/gadgets/unit_xmas.lua
+++ b/luarules/gadgets/unit_xmas.lua
@@ -328,6 +328,10 @@ function gadget:UnitGiven(unitID, unitDefID, unitTeam)
 	end
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.ANY)
+end
+
 -- prevents area targetting xmasballs
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if decorationUdefIDs[unitDefID] then

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -129,4 +129,5 @@ if (System == nil) then
 	}
 
 	System.CMD.ANY = 'a'
+	System.CMD.NIL = 'n'
 end

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -127,4 +127,6 @@ if (System == nil) then
 
 		_VERSION       = _VERSION
 	}
+
+	System.CMD.ANY = 'a'
 end


### PR DESCRIPTION
### Work done

* Introduce a mechanism to register AllowCommand per cmdID.
* Implement this mechanism for all current gadgets using AllowCommand (~40).

### Details

* This greatly reduces the amount of callins called for every AllowCommand.
* Allows blanket subscription through CMD.ANY
* Warns about AllowCommand defined but not subscribed, also when trying to subscribe but not having AllowCommand.
* Automatic subscription for gadgets defining AllowCommand but no RegisterAllowCommand calls on init.
* Maintains the same callin ordering as always (including RaiseGadget and LowerGadget support)
* Only for gadgets for now since doesn't seem widgets implement this generally
* Api: `gh:RegisterAllowCommand(g, cmdId)` and `gadget.gh:RegisterAllowCommand(cmdId)`
* Also provided `DeregisterAllowCommands` (gh and gadget.gh) and `HasAllowCommands`, `ReorderAllowCommands`   (only gh), mostly for internal handling
* 20us vs 55us (median and mode) per AllowCommand callin at game start
* This can also allow further optimizing by double checking the gadgets with 'ANY' filter (I think some may not need it).

#### Addresses Issue(s)

 * https://github.com/beyond-all-reason/Beyond-All-Reason/issues/431

#### Test steps

* Try bar and check everything still works

### Considerations

* Might want to do a different api for this, it's open to discussion of course.
* **Needs through review and testing** ofc, since I'm touching many gadgets.
* Where best to hook CMD.ANY ? (currently at luarules/system.lua).
* I'm handling the case where cmdId is nil, but not sure this is needed (critters gadget was checking for this for some reason).
* Can implement more explicit INSERT handling too, at the moment INSERT is managed as a top level command, means you register to INSERT and then check params[2]. Could do api like RegisterAllowCommand(cmdId, handleInsert), so we could allow easy insert registration and also faster callin for INSERT+CMD pattern. Would probably do it through `"i"..cmdID` filter.
* There are some other similar situations, like:
  * For each callin I'm listing gadgets and widgets implementing it, and in parenthesis the likely number of accepted commands by that module. 
  * Callins having many gadgets with numbers in parenthesis most likely to benefit (currently doesn't look like they would benefit much in general, since the proportion of 'any' is big).
  1. CommandFallback:
     * gadgets: unit_airbase (2), unit_morph (~10), unit_areaattack (1)
  2. UnitCmdDone
     * gadgets: unit_airbase (1), unit_reverse_move (any), unit_carrier_spawner (2), unit_target_on_the_move (any?)
     * widgets: unit_load_own_moving (any), gui_gridmenu (any), gui_selfd_icons (any?)
  3. UnitCommand:
     * gadgets: unit_airbase (any), cmd_alliance_break (5), gui_soundeffects (any), unit_reverse_move (any), unit_carrier_spawner (3), cmd_undo (any?)
     * widgets: gui_attackrange_gl4 (1), unit_cloak_firestate (1), unit_load_own_moving (any), gui_buildmenu (any), unit_immobile_builder (any), cmd_stop_selfd (1), gfx_showbuilderqueue (any), snd_notifications (any), gui_gridmenu (any), cmd_guard_remove (any), gui_selfd_icons (1), gui_commands_fx (any), gui_ordermenu (any?)
* For now I'm providing this implementation as a (fully functional) request for comments draft, this way we can see how to move forward.
* Implementing all of the above callins in one PR can be cumbersome, but I can provide an initial PR supporting AllowCommand subscription, but with a more generic implementation that would easily allow adding other filtered callins later.
* Engine can probably make it even better by providing native ways to subscribe filtered callins. Still, for now this is already an improvement. (or maybe not better by engine, since we would trade somewhat faster loop for more calls from c++ into lua which might be more cumbersome).

