### PR TITLE
dev_replay_data: Allow forwarding UnitDamage callin for spectators.

### DIFF
--- a/luarules/gadgets/dev_replay_data.lua
+++ b/luarules/gadgets/dev_replay_data.lua
@@ -12,18 +12,37 @@ end
 
 -- put gadget in unsynced space
 if not gadgetHandler:IsSyncedCode() then
-	-- check if game is a replay
-	local IsGameReplay = Spring.IsReplay()
+	-- check if game is a replay or spectating
+	local hooked = true
+	local allowForwarding
+
+	local function hookCallIn(g)
+		-- only do something if it is a replay or spectating
+		allowForwarding = Spring.IsReplay() or Spring.GetSpectatingState()
+		if hooked and not allowForwarding then
+			g.RemoveCallIn("UnitDamaged")
+			hooked = false
+		elseif not hooked and allowForwarding then
+			g.UpdateCallIn("UnitDamaged")
+			hooked = true
+		end
+	end
+
+	function gadget:PlayerChanged(playerID)
+		hookCallIn(self)
+	end
+
+	function gadget:Initialize()
+		hookCallIn(self)
+	end
+
 	-- handle the UnitDamaged callin
 	function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
-		-- only do something if it is a replay
-		if IsGameReplay then	
-			-- send to LuaUI, widget space, the UnitDamaged information
-			if Script.LuaUI("UnitDamagedReplay") then
-				Script.LuaUI.UnitDamagedReplay(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
-			end
-		end	
-	end	
+		-- send to LuaUI, widget space, the UnitDamaged information
+		if Script.LuaUI("UnitDamagedReplay") then
+			Script.LuaUI.UnitDamagedReplay(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+		end
+	end
 end
 
 --[[

--- a/luarules/gadgets/dev_replay_data.lua
+++ b/luarules/gadgets/dev_replay_data.lua
@@ -20,10 +20,10 @@ if not gadgetHandler:IsSyncedCode() then
 		-- only do something if it is a replay or spectating
 		allowForwarding = Spring.IsReplay() or Spring.GetSpectatingState()
 		if hooked and not allowForwarding then
-			g.RemoveCallIn("UnitDamaged")
+			gadgetHandler:RemoveCallIn("UnitDamaged")
 			hooked = false
 		elseif not hooked and allowForwarding then
-			g.UpdateCallIn("UnitDamaged")
+			gadgetHandler:UpdateCallIn("UnitDamaged")
 			hooked = true
 		end
 	end

--- a/luarules/gadgets/dev_replay_data.lua
+++ b/luarules/gadgets/dev_replay_data.lua
@@ -12,12 +12,11 @@ end
 
 -- put gadget in unsynced space
 if not gadgetHandler:IsSyncedCode() then
-	-- check if game is a replay or spectating
 	local hooked = true
 	local allowForwarding
 
-	local function hookCallIn(g)
-		-- only do something if it is a replay or spectating
+	local function hookCallIn()
+		-- check if game is a replay or spectating
 		allowForwarding = Spring.IsReplay() or Spring.GetSpectatingState()
 		if hooked and not allowForwarding then
 			gadgetHandler:RemoveCallIn("UnitDamaged")
@@ -29,11 +28,11 @@ if not gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:PlayerChanged(playerID)
-		hookCallIn(self)
+		hookCallIn()
 	end
 
 	function gadget:Initialize()
-		hookCallIn(self)
+		hookCallIn()
 	end
 
 	-- handle the UnitDamaged callin


### PR DESCRIPTION
### Work done

* Made the dev_replay_data gadget forward UnitDamage callin to widgets also for spectators 
* Also improved the code to make it deregister gadget:UnitDamage callin when not forwarding to save some cycles

#### Addresses Issue(s)
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3634

#### Test steps
- Install widget code embedded in dev_replay_data.lua as widget
- Open a replay
- Check it still works
- Note I can't reproduce inside a real networked game as afaik can't play online with modded version, but I'm confident it should work

### Considerations

* This might not be actually wanted, but I just did it to address the above issue.
* Maybe now the dev_replay_data widget name should be changed since it's not just for replays any more.
* I don't react to GetSpectatingState secondary values, I think that would be the job of widgets receiving this data.
* Could be done at engine itself if you prefer, but engine devs need to approve it then.
* I think it's not necessary to check for replay, since just checking spec should do it as usually if replaying the player is specing too, although if they can unspec at some point it would make some difference. Anyways checking it is no big deal since it only happens on initialization and player change so no biggie.
* Also if replay is checked and it's a replay, technically don't need the PlayerChanged callin registered, but again, that would complicate the code for a very petty gain.