### PR TITLE
gui_metalspots: Avoid rechecking metalspots all the time until gamestart.

### DIFF
--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -36,7 +36,7 @@ if Spring.GetModOptions().unit_restrictions_noextractorDefs then
 	return
 end
 
-local needsInit			= false
+local needsInit			= true
 local showValue			= false
 local metalViewOnly		= false
 

--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -36,7 +36,7 @@ if Spring.GetModOptions().unit_restrictions_noextractorDefs then
 	return
 end
 
-
+local needsInit			= false
 local showValue			= false
 local metalViewOnly		= false
 
@@ -527,8 +527,9 @@ function widget:DrawWorldPreUnit()
 	drawInstanceVBO(spotInstanceVBO)
 	spotShader:Deactivate()
 
-	if Spring.GetGameFrame() == 0 then
+	if needsInit and Spring.GetGameFrame() == 0 then
 		checkMetalspots()
+		needsInit = false
 	end
 
 	gl.Texture(0, false)


### PR DESCRIPTION
### Work done

* Add a simple check to avoid doing checkMetalspots all the time until game start.

- Related to the following issue: https://github.com/beyond-all-reason/Beyond-All-Reason/issues/825

#### Test steps

- Open game with widget debugger open, check high memory load of metalspots until game starts (also somewhat higher cpu usage than normal).

### Considerations

- I don't see that continuous checking at frame 0 serving any purpose and probably the idea was to do it at first frame one time.
- Maybe @Beherith has something to say, but I think this is safe to do, I checked and doesn't seem to affect behaviour.
- Could use a more sophisticated approach for one time init instead of checking all the time inside DrawWorldPreUnit() but this keeps it simple and actually lighter check than before (check of local bool instead of engine method).
