### PR TITLE
Add type annotations to `unit_buildmenu_config.lua`

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "runtime.version": "Lua 5.1"
+  "runtime.version": "Lua 5.1",
+  "completion.requireSeparator": "/",
+  "runtime.path": [
+      "?",
+      "?.lua"
+  ],
+  "runtime.special": {
+      "VFS.Include": "require"
+  }
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -7,6 +7,8 @@
       "?.lua"
   ],
   "runtime.special": {
-      "VFS.Include": "require"
+      "VFS.Include": "require",
+      "include": "require",
+      "shard_include": "require"
   }
 }

--- a/luamocks/SpringLuaApi.lua
+++ b/luamocks/SpringLuaApi.lua
@@ -70,6 +70,7 @@ Engine = {
 }
 
 ---@param path string
+---@return any
 function VFS.Include(path)
     assert(type(path) == "string", "Argument path is of invalid type - expected string");
     return numberMock

--- a/luaui/configs/buildmenu_sorting.lua
+++ b/luaui/configs/buildmenu_sorting.lua
@@ -1,3 +1,4 @@
+---@type table<string, number>
 local unitOrderTable = {
 -- UNITS
 	--CONSTRUCTORS
@@ -769,6 +770,7 @@ local unitOrderTable = {
    ['coratl']         = 260600,
 }
 
+---@type table<string, number>
 local newUnitOrder = {}
 for id, value in pairs(unitOrderTable) do
 	if UnitDefNames[id] then
@@ -776,7 +778,6 @@ for id, value in pairs(unitOrderTable) do
 	end
 end
 unitOrderTable = newUnitOrder
-newUnitOrder = nil
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 	if unitDef.customParams.isscavenger then

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -136,14 +136,14 @@ maxOrder = maxOrder + 1
 -- For units who have the same order value we compare the unit's IDs.
 -- This sort is always stable, as no two units should have the same ID.
 table.sort(unitOrder, function(aID, bID)
-			local aOrder = unitOrderManualOverrideTable[aID] or maxOrder
-			local bOrder = unitOrderManualOverrideTable[bID] or maxOrder
+	local aOrder = unitOrderManualOverrideTable[aID] or maxOrder
+	local bOrder = unitOrderManualOverrideTable[bID] or maxOrder
 
-			if (aOrder == bOrder) then
-			  return aID < bID
-			end
-			return aOrder < bOrder
-		end)
+	if (aOrder == bOrder) then
+		return aID < bID
+	end
+	return aOrder < bOrder
+end)
 
 local minWaterUnitDepth = -11
 
@@ -153,7 +153,6 @@ local minWaterUnitDepth = -11
 ------------------------------------
 
 return {
-
 	unitName = unitName,
 	unitEnergyCost = unitEnergyCost,
 	unitMetalCost = unitMetalCost,

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -18,8 +18,6 @@ local isWaterUnit = {}
 local isGeothermal = {}
 local unitMaxWeaponRange = {}
 
-local showWaterUnits = false
-
 for unitDefID, unitDef in pairs(UnitDefs) do
 
 	unitGroup[unitDefID] = unitDef.customParams.unitgroup
@@ -172,8 +170,6 @@ return {
 
 	minWaterUnitDepth = minWaterUnitDepth,
 	unitOrder = unitOrder,
-
-	showWaterUnits = showWaterUnits,
 
 	checkGeothermalFeatures = checkGeothermalFeatures,
 	restrictGeothermalUnits = restrictGeothermalUnits,

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -147,12 +147,6 @@ table.sort(unitOrder, function(aID, bID)
 			return aOrder < bOrder
 		end)
 
-local voidWater = false
-local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs
-if success and mapinfo then
-	voidWater = mapinfo.voidwater
-end
-
 local minWaterUnitDepth = -11
 
 

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -3,19 +3,18 @@
 --- DateTime: 4/26/2023 8:48 PM
 ---
 
-
-local unitEnergyCost = {}
-local unitMetalCost = {}
-local unitGroup = {}
-local unitRestricted = {}
-local isBuilder = {}
-local isFactory = {}
-local unitIconType = {}
-local isMex = {}
-local isWind = {}
-local isWaterUnit = {}
-local isGeothermal = {}
-local unitMaxWeaponRange = {}
+local unitGroup = {} ---@type table<number, number>
+local unitEnergyCost = {} ---@type table<number, number>
+local unitMetalCost = {} ---@type table<number, number>
+local unitRestricted = {} ---@type table<number, boolean>
+local unitIconType = {} ---@type table<number, number>
+local unitMaxWeaponRange = {} ---@type table<number, number>
+local isFactory = {} ---@type table<number, true>
+local isBuilder = {} ---@type table<number, true>
+local isMex = {} ---@type table<number, true>
+local isWind = {} ---@type table<number, true>
+local isWaterUnit = {} ---@type table<number, true>
+local isGeothermal = {} ---@type table<number, true>
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 
@@ -62,25 +61,29 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
-
+---@param disable boolean
 local function restrictWindUnits(disable)
 	for unitDefID,_ in pairs(isWind) do
 		unitRestricted[unitDefID] = disable
 	end
 end
 
+---@param disable boolean
 local function restrictGeothermalUnits(disable)
 	for unitDefID,_ in pairs(isGeothermal) do
 		unitRestricted[unitDefID] = disable
 	end
 end
 
+---@param disable boolean
 local function restrictWaterUnits(disable)
 	for unitDefID,_ in pairs(isWaterUnit) do
 		unitRestricted[unitDefID] = disable
 	end
 end
 
+---Sets geothermal unit restriction based on the presence of geothermal
+---features.
 local function checkGeothermalFeatures()
 	local hideGeoUnits = true
 	local geoThermalFeatures = {}
@@ -104,10 +107,12 @@ end
 -- UNIT ORDER ----------------------
 ------------------------------------
 
--- At the end of this 'UNIT ORDER' section, unitOrder is an array with unitIDs
--- sorted by their value specified in unitOrderManualOverrideTable. If no
--- value is specified, the unit will be placed at the end of the array.
+---At the end of this 'UNIT ORDER' section, unitOrder is an array with unitIDs
+---sorted by their value specified in unitOrderManualOverrideTable. If no
+---value is specified, the unit will be placed at the end of the array.
+---@type number[]
 local unitOrder = {}
+
 local unitOrderManualOverrideTable = VFS.Include("luaui/configs/buildmenu_sorting.lua")
 
 -- Populate unitOrder with unit IDs.
@@ -144,28 +149,30 @@ table.sort(unitOrder, function(aID, bID)
 	return aOrder < bOrder
 end)
 
-local minWaterUnitDepth = -11
 
-
-------------------------------------
--- /UNIT ORDER ----------------------
-------------------------------------
-
-return {
+local units = {
 	unitEnergyCost = unitEnergyCost,
 	unitMetalCost = unitMetalCost,
 	unitGroup = unitGroup,
 	unitRestricted = unitRestricted,
-	isBuilder = isBuilder,
-	isFactory = isFactory,
 	unitIconType = unitIconType,
-	isMex = isMex,
-	isWind = isWind,
-	isWaterUnit = isWaterUnit,
-	isGeothermal = isGeothermal,
 	unitMaxWeaponRange = unitMaxWeaponRange,
-
-	minWaterUnitDepth = minWaterUnitDepth,
+	---Set of unit IDs that are factories.
+	isFactory = isFactory,
+	---Set of unit IDs that have build options.
+	isBuilder = isBuilder,
+	---Set of unit IDs that require metal.
+	isMex = isMex,
+	---Set of unit IDs that require wind.
+	isWind = isWind,
+	---Set of unit IDs that require water.
+	isWaterUnit = isWaterUnit,
+	---Set of unit IDs that require geothermal.
+	isGeothermal = isGeothermal,
+	minWaterUnitDepth = -11,
+	---An array with unitIDs sorted by their value specified in
+	---`unitOrderManualOverrideTable`. If no value is specified, the unit will be
+	---placed at the end of the array.
 	unitOrder = unitOrder,
 
 	checkGeothermalFeatures = checkGeothermalFeatures,
@@ -173,3 +180,5 @@ return {
 	restrictWindUnits = restrictWindUnits,
 	restrictWaterUnits = restrictWaterUnits,
 }
+
+return units

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -4,7 +4,6 @@
 ---
 
 
-local unitName = {}
 local unitEnergyCost = {}
 local unitMetalCost = {}
 local unitGroup = {}
@@ -153,7 +152,6 @@ local minWaterUnitDepth = -11
 ------------------------------------
 
 return {
-	unitName = unitName,
 	unitEnergyCost = unitEnergyCost,
 	unitMetalCost = unitMetalCost,
 	unitGroup = unitGroup,


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

No functional changes, just adds type annotations for `unit_buildmenu_config.lua` so that error checking can be done via lua language server. I thought I'd open a PR with the change to see if this kind of thing is welcome. It certainly helps a lot in understanding the codebase as newcomer.

I also deleted some obviously dead code—I removed the unused variable `showWaterUnits` and a few lines of cruft that were left over from when it was not always false. This has logic was previously been moved into `gui_buildmenu.lua` and `gui_gridmenu.lua`.

**Note for review**
- Please merge #3919 first, I have rebased this on top of that branch.
- Non-doc cleanup changes have been committed as separate commits explaining what and why. This should ease reviewing.
- I've left the two conversations open for review, but I'm pretty sure they're fine to be resolved without changes.

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Play game using grid menu, behaviour should be unchanged.

### Screenshots:

Now autocomplete is possible (as well as type checks in IDE).

![image](https://github.com/user-attachments/assets/19451f62-0845-48a2-864f-d33bcc8075e8)
