### PR TITLE
Add a mechanism so gadgetHandler reordering api can be used safely.

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -282,11 +282,7 @@ end
 --
 --  array-table reverse iterator
 --
---  all callin handlers use this so that gadgets can
---  RemoveGadget() themselves (during iteration over
---  a callin list) without causing a miscount
---
---  c.f. Array{Insert,Remove}
+--  used to invert layer ordering so draw and events will have inverse ordering
 --
 local function r_ipairs(tbl)
 	local function r_iter(tbl, key)
@@ -328,6 +324,7 @@ local VFSMODE_OVERRIDE = {
 	}
 
 function gadgetHandler:Initialize()
+	gadgetHandler:CreateQueuedReorderFuncs()
 	local syncedHandler = Script.GetSynced()
 
 	local unsortedGadgets = {}
@@ -374,7 +371,7 @@ function gadgetHandler:Initialize()
 
 	-- add the gadgets
 	for _, g in ipairs(unsortedGadgets) do
-		gadgetHandler:InsertGadget(g)
+		gadgetHandler:InsertGadgetRaw(g)
 
 		local gtype = ((syncedHandler and "synced") or "unsynced")
 		local gname = g.ghInfo.name
@@ -382,6 +379,9 @@ function gadgetHandler:Initialize()
 
 		Spring.Log(LOG_SECTION, LOG.INFO, string.format("Loaded %s gadget:  %-18s  <%s>", gtype, gname, gbasename))
 	end
+	-- Since Initialize is run out of the normal callin wrapper, we
+	-- need to reorder explicitly here.
+	gadgetHandler:PerformReorders()
 end
 
 function gadgetHandler:LoadGadget(filename, overridevfsmode)
@@ -669,7 +669,65 @@ local function ArrayRemove(t, g)
 	end
 end
 
-function gadgetHandler:InsertGadget(gadget)
+--------------------------------------------------------------------------------
+--- Safe reordering
+
+-- Since we are traversing lists, some of the gadgetHandler api would be dangerous to use.
+--
+-- We will queue all the dangerous methods to process after callin loop finishes iterating.
+-- The 'real' methods have 'Raw' appended to them, and are unsafe to use unless you know what
+-- you are doing.
+
+local reorderQueue = {}
+local reorderNeeded = false
+local reorderFuncs = {}
+
+function gadgetHandler:CreateQueuedReorderFuncs()
+	-- This will create an array with linked Raw methods so we can find them by index.
+	-- It will also create the gadgetHandler usual api queing the calls.
+	local reorderFuncNames = {'InsertGadget', 'RemoveGadget', 'EnableGadget', 'DisableGadget',
+		'LowerGadget', 'RaiseGadget', 'UpdateGadgetCallIn', 'RemoveGadgetCallIn'}
+	local queueReorder = gadgetHandler.QueueReorder
+
+	for idx, name in ipairs(reorderFuncNames) do
+		-- linked method index
+		reorderFuncs[#reorderFuncs + 1] = gadgetHandler[name .. 'Raw']
+
+		-- gadgetHandler api
+		gadgetHandler[name] = function(s, ...)
+			queueReorder(s, idx, ...)
+		end
+	end
+end
+
+function gadgetHandler:QueueReorder(methodIndex, ...)
+	reorderQueue[#reorderQueue + 1] = {methodIndex, ...}
+	reorderNeeded = true
+end
+
+function gadgetHandler:PerformReorder(methodIndex, ...)
+	reorderFuncs[methodIndex](self, ...)
+end
+
+function gadgetHandler:PerformReorders()
+	-- Reset and store the list so we can support nested reorderings
+	reorderNeeded = false
+	local nextReorder = reorderQueue
+	reorderQueue = {}
+	-- Process the reorder queue
+	for _, elmts in ipairs(nextReorder) do
+		self:PerformReorder(unpack(elmts))
+	end
+	-- Check for further reordering
+	if reorderNeeded then
+		self:PerformReorders()
+	end
+end
+
+--------------------------------------------------------------------------------
+--- Unsafe insert/remove
+
+function gadgetHandler:InsertGadgetRaw(gadget)
 	if gadget == nil then
 		return
 	end
@@ -701,7 +759,7 @@ function gadgetHandler:InsertGadget(gadget)
 	end
 end
 
-function gadgetHandler:RemoveGadget(gadget)
+function gadgetHandler:RemoveGadgetRaw(gadget)
 	if gadget == nil then
 		return
 	end
@@ -742,7 +800,11 @@ function gadgetHandler:UpdateCallIn(name)
 
 		if selffunc ~= nil then
 			_G[name] = function(...)
-				return selffunc(self, ...)
+				local res = selffunc(self, ...)
+				if reorderNeeded then
+					self:PerformReorders()
+				end
+				return res
 			end
 		else
 			Spring.Log(LOG_SECTION, LOG.ERROR, "UpdateCallIn: " .. name .. " is not implemented")
@@ -752,7 +814,7 @@ function gadgetHandler:UpdateCallIn(name)
 	Script.UpdateCallIn(name)
 end
 
-function gadgetHandler:UpdateGadgetCallIn(name, g)
+function gadgetHandler:UpdateGadgetCallInRaw(name, g)
 	local listName = name .. 'List'
 	local ciList = self[listName]
 	if ciList then
@@ -768,7 +830,7 @@ function gadgetHandler:UpdateGadgetCallIn(name, g)
 	end
 end
 
-function gadgetHandler:RemoveGadgetCallIn(name, g)
+function gadgetHandler:RemoveGadgetCallInRaw(name, g)
 	local listName = name .. 'List'
 	local ciList = self[listName]
 	if ciList then
@@ -789,7 +851,7 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-function gadgetHandler:EnableGadget(name)
+function gadgetHandler:EnableGadgetRaw(name)
 	local ki = self.knownGadgets[name]
 	if not ki then
 		Spring.Log(LOG_SECTION, LOG.ERROR, "EnableGadget(), could not find gadget: " .. tostring(name))
@@ -805,12 +867,12 @@ function gadgetHandler:EnableGadget(name)
 		if not w then
 			return false
 		end
-		self:InsertGadget(w)
+		self:InsertGadgetRaw(w)
 	end
 	return true
 end
 
-function gadgetHandler:DisableGadget(name)
+function gadgetHandler:DisableGadgetRaw(name)
 	local ki = self.knownGadgets[name]
 	if not ki then
 		Spring.Log(LOG_SECTION, LOG.ERROR, "DisableGadget(), could not find gadget: " .. tostring(name))
@@ -822,7 +884,7 @@ function gadgetHandler:DisableGadget(name)
 			return false
 		end
 		Spring.Log(LOG_SECTION, LOG.INFO, 'Removed:  ' .. ki.filename)
-		self:RemoveGadget(w)     -- deactivate
+		self:RemoveGadgetRaw(w)     -- deactivate
 		self.orderList[name] = 0 -- disable
 	end
 	return true
@@ -866,7 +928,7 @@ local function FindLowestIndex(t, i, layer)
 	return 1
 end
 
-function gadgetHandler:RaiseGadget(gadget)
+function gadgetHandler:RaiseGadgetRaw(gadget)
 	if gadget == nil then
 		return
 	end
@@ -900,7 +962,7 @@ local function FindHighestIndex(t, i, layer)
 	return (ts + 1)
 end
 
-function gadgetHandler:LowerGadget(gadget)
+function gadgetHandler:LowerGadgetRaw(gadget)
 	if gadget == nil then
 		return
 	end


### PR DESCRIPTION
### Work done

* Create an internal mechanism at gadgets.lua to queue methods with callin list reordering side effects.
* Users of the methods shouldn't notice any difference and this shouldn't break any existing gadgets.

#### Addresses Issue(s)

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3900

### Details

**NOTE** This is changing critical game code so will need some review and testing. I am posting this PR to gather feedback while I can perform some last checks on the operation (like reviewing whether after initialization ordering is still the same for example). Also probably need to add some safeguards against duplicated items in the queue.

This changes all of the following callins:
- InsertGadget, RemoveGadget, EnableGadget, DisableGadget, LowerGadget, RaiseGadget, UpdateGadgetCallIn, RemoveGadgetCallIn

After reviewing the code I think all those methods can cause unsafe reordering of the callin lists (ie the problem is not just InsertGadget and RemoveGadget), while the callers are iterating them, thus can result in skipped calls.

The solution I propose consists in replacing the callins by queued versions, and providing the old api under ..'Raw' name (not to be used directly). The main handler is augmented to call a reordering method (gadgetHandler:PerformReorders) after callin loops, that will process all methods above in order after the loop is finished.

This solution should make all of the above methods safe to use during execution of any handlers. I tried to make it as efficient as possible, so in the general case after every callin loop just a local bool check is introduced before doing any heavy work.

This could result in slightly different behaviour than before in the case a gadget is removing another one before that one executes. I will also study this closely, but that might be more of a problem with widgets.

The solution can be implemented for widgets as well since handling is very similar, but I think gadgets have a higher requirement for robustness so I implemented it here first.

#### Test steps

- Fetch branch and run BAR
