### PR TITLE
settarget: Add target icons, fix radar dot targeting and fix for circle selection glitch.

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -652,8 +652,6 @@ else	-- UNSYNCED
 	local spGetSpectatingState = Spring.GetSpectatingState
 	local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
 	local spGetUnitTeam = Spring.GetUnitTeam
-	local spGetUnitPosErrorParams = Spring.GetUnitPosErrorParams
-	local spGetRadarErrorParams = Spring.GetRadarErrorParams
 
 	local myAllyTeam = spGetMyAllyTeamID()
 	local myTeam = spGetMyTeamID()

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -682,6 +682,12 @@ else	-- UNSYNCED
 
 	end
 
+	function gadget:PlayerChanged(playerID)
+		myAllyTeam = spGetMyAllyTeamID()
+		myTeam = spGetMyTeamID()
+		_, fullview = spGetSpectatingState()
+	end
+
 	function gadget:Shutdown()
 		gadgetHandler:RemoveChatAction("targetdrawteam")
 		gadgetHandler:RemoveChatAction("targetdrawunit")


### PR DESCRIPTION
### Work done

- Fix settarget targeting radar dots.
- Add target icons to settargeted units.
- Fix circle non-shift selection when an invalid unit is first in command.
- Add PlayerChanged callin so unsynced gadget works when switching player.

#### Related Issues

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1167
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1402

Note I don't think this addresses the first issue, but I was investigating that one and discovered other issues. I haven't been able to reproduce the original issue so not sure if this fix addresses that, likely not but would be good to test and find a way to reproduce. It might be the case now it works or at least shows the icons.

Issue #1402 should be fixed by this.


Also, https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1488#issuecomment-2455599388 is related, but for now I'm conforming to the same selection behaviour (and bugs) as attack command until that one is fixed for consistency.

#### Test steps

- Open game.
- Set a unit at the left side of a group of enemy units.
- Set target on some of the enemy units at rightmost position using settarget circle (or just shift click).
- Try to set target again with non-shift circle, on just a few of the letfmost enemy units, but ensure the area also comprises some ally unit.
- Instead of selecting just the enemy units in the circle, they are appended to settarget previous group.
- Action icon is not shown on enemy units, just lines between them.

With this PR the selection will behave properly, and also icons will show.

- Open game
- Set Target on radar items (or items that later go into radar view or out of view)

With this PR target command should behave properly regarding LOS and radar dots.


#### Considerations

- I tested myself but would be good someone else tests the fix to see it works for them.
- I'm rendering the icons with engine facilities, the method seems to be light enough but you might want to consider this. I tested and with 1500 units settarget seems to work faster than move command even with this (at least sending the command, I guess because of pathing being more expensive), I could have all 1500 units with settarget and move and still reach 60fps on my machine. Giving commands does produce a lag but I'm not addressing that here. Test machine is 4th gen i7 with nvidia 1080.
- I'm caching and filtering to ensure if all units have the same target it won't send so many Icons to engine, but I did test with all separate points as well. I'm unsure if the cache is really needed but I didn't see the engine avoiding render of the same icon in the same place many times so preferred to avoid sending.
- It's likely the settarget gadget has more bugs and space for improvement, but imo these simple fixes here already provide a lot of value.
- Note: afaics, for radar dots, before it would not be drawing the targeted items properly, but actually setting target on them.

### Screenshots:

(note in these videos I'm not using shift with the circle selection even if the "before" video looks like it, it's because of the bug)

#### BEFORE:

![soutput2](https://github.com/user-attachments/assets/7050085f-80b0-4744-a551-ecedaac818b0)


#### AFTER:

Note the after video doesn't conform to the test procedure, but shows the error doesn't exist since after having a selection and doing another non-shift selection with an ally unit included the selection is reset and updated instead of just appended like before. (I can make another video but it's very cumbersome XD)

![soutput](https://github.com/user-attachments/assets/b54f6341-ebf6-4950-a4bc-204bc81e9897)

Radar dot targeting:

![radardots](https://github.com/user-attachments/assets/c7f753be-088f-4ae7-a074-d21baa7bbc2f)
