### PR TITLE
Guesstimate Some Tidal Strenth if Missing

### DIFF
--- a/luarules/gadgets/map_waterlevel.lua
+++ b/luarules/gadgets/map_waterlevel.lua
@@ -44,23 +44,16 @@ if gadgetHandler:IsSyncedCode() then
 			local modOptions = Spring.GetModOptions()
 			if modOptions.map_waterlevel ~= 0 then
 				waterlevel = modOptions.map_waterlevel
-				adjustWaterlevel()
 
 				-- adjust tidal strength if previosuly not present and applicable
-				if (modOptions.map_tidal == nil or modOptions.map_tidal == "unchanged") and Spring.GetTidal() == 0 then
-					local initalMinHeight = Spring.GetGroundExtremes()
-					if initalMinHeight > 0 then
-						-- avrage between capped wind speed or 10 if greater (half of basic solar)
-						Spring.SetTidal(
-							math.max(
-								(math.min(Game.windMax, 27) +
-								math.max(Game.windMin, 0) ) / 2,
-								10
-							)
-						)
-					end
+				if (modOptions.map_tidal == nil or modOptions.map_tidal == "unchanged")
+					and Spring.GetTidal() == 0
+					and select(1, Spring.GetGroundExtremes()) > 0
+					then
+						Spring.SetTidal( 15 )
 				end
 
+				adjustWaterlevel()
 			end
 		end
 	end

--- a/luarules/gadgets/map_waterlevel.lua
+++ b/luarules/gadgets/map_waterlevel.lua
@@ -40,9 +40,21 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:Initialize()
-		if Spring.GetGameFrame() == 0 and Spring.GetModOptions().map_waterlevel ~= 0 then
-			waterlevel = Spring.GetModOptions().map_waterlevel
-			adjustWaterlevel()
+		if Spring.GetGameFrame() == 0 then
+			local modOptions = Spring.GetModOptions()
+			if modOptions.map_waterlevel ~= 0 then
+				waterlevel = modOptions.map_waterlevel
+				adjustWaterlevel()
+				if (modOptions.map_tidal == nil or modOptions.map_tidal == "unchanged") and Spring.GetTidal() == 0 then
+					Spring.SetTidal(
+						math.max(
+							(math.min(Game.windMax, 27) +
+							math.max(Game.windMin, 0) ) / 2,
+							10
+						)
+					)
+				end
+			end
 		end
 	end
 

--- a/luarules/gadgets/map_waterlevel.lua
+++ b/luarules/gadgets/map_waterlevel.lua
@@ -45,15 +45,22 @@ if gadgetHandler:IsSyncedCode() then
 			if modOptions.map_waterlevel ~= 0 then
 				waterlevel = modOptions.map_waterlevel
 				adjustWaterlevel()
+
+				-- adjust tidal strength if previosuly not present and applicable
 				if (modOptions.map_tidal == nil or modOptions.map_tidal == "unchanged") and Spring.GetTidal() == 0 then
-					Spring.SetTidal(
-						math.max(
-							(math.min(Game.windMax, 27) +
-							math.max(Game.windMin, 0) ) / 2,
-							10
+					local initalMinHeight = Spring.GetGroundExtremes()
+					if initalMinHeight > 0 then
+						-- avrage between capped wind speed or 10 if greater (half of basic solar)
+						Spring.SetTidal(
+							math.max(
+								(math.min(Game.windMax, 27) +
+								math.max(Game.windMin, 0) ) / 2,
+								10
+							)
 						)
-					)
+					end
 				end
+
 			end
 		end
 	end


### PR DESCRIPTION
### Work done
If
 - waterlevel is changed using the waterlevel option
 - and the map has a map tidal of zero (maps that normally have no water)
 - and the hidden tidal strength modoption isn't set

then water tidal strength is set to 15

#### Setup
Select a map that has no water, such as all that gliters
Set Waterlevel modopion high enough to add water to the map: all that gliters 300ish

#### Test steps
- [ ] Set up a map as exampled above, start game, and witness tidal strength not being zero
