### PR TITLE
Infer correct types from custom include functions

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "runtime.version": "Lua 5.1"
+  "runtime.version": "Lua 5.1",
+  "completion.requireSeparator": "/",
+  "runtime.path": [
+      "?",
+      "?.lua"
+  ],
+  "runtime.special": {
+      "VFS.Include": "require"
+  }
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -7,6 +7,8 @@
       "?.lua"
   ],
   "runtime.special": {
-      "VFS.Include": "require"
+      "VFS.Include": "require",
+      "include": "require",
+      "shard_include": "require"
   }
 }


### PR DESCRIPTION
### Work done

Configure lua language server to treat `VFS.Include`, `include` and `shard_include` as aliases of `require`, meaning that the correct types are applied to the return value.

Note that this only affects type inference in IDE and does not have any impact on execution.

Suggested by @saurtron here: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3905#issuecomment-2466098324

Approach advised by lua language server contributor here: https://github.com/LuaLS/lua-language-server/issues/2947

#### Test steps
- [ ] Open project in VSCode.
- [ ] Hover the return value from a `VFS.Include` and see that it is correctly typed.

### Screenshots:
#### BEFORE:
![image](https://github.com/user-attachments/assets/59863770-c332-4a59-aa97-4893f125029d)

#### AFTER:
![image](https://github.com/user-attachments/assets/240e8023-bc8f-4e08-884d-906970a77ec0)
