### PR TITLE
Mygravity for Torpedo Bombers

### DIFF
--- a/units/ArmAircraft/T2/armlance.lua
+++ b/units/ArmAircraft/T2/armlance.lua
@@ -97,6 +97,7 @@ return {
 				flighttime = 4,
 				impulsefactor = 0.123,
 				model = "cortorpedo.s3o",
+				mygravity = 0.1445,
 				name = "Light homing torpedo launcher",
 				noselfdamage = true,
 				range = 650,

--- a/units/CorAircraft/T2/cortitan.lua
+++ b/units/CorAircraft/T2/cortitan.lua
@@ -100,6 +100,7 @@ return {
 				model = "cortorpedo.s3o",
 				name = "Light homing torpedo launcher",
 				noselfdamage = true,
+				mygravity = 0.1445,
 				range = 650,
 				reloadtime = 8,
 				soundhit = "xplodep2",


### PR DESCRIPTION
Torp bombers don't have gravityaffected = true tag, despite being affected by gravity, so they have not been affected by the global weapon gravity defined in alldefs_post.

In other words, their range is inconsistent across maps.

This changes that and sets their gravity to be the same as other gravityaffected weapons, resulting in a range nerf on low-gravity maps.