### PR TITLE
fix commandinsert math

### DIFF
--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -176,7 +176,7 @@ function widget:CommandNotify(id, params, options)
       end
     end
     -- check for insert at end of queue if its shortest walk.
-    local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(py-cy)))
+    local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(pz-cz)))
     if dlen < min_dlen then
       --options.meta=nil
       --options.shift=true

--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -166,7 +166,7 @@ function widget:CommandNotify(id, params, options)
       --Spring.Echo("cmd:"..table.tostring(command))
       local px2,py2,pz2 = GetCommandPos(command)
       if px2 and px2>-1 then
-        local dlen = math_sqrt(((px2-cx)*(px2-cx)) + ((py2-cy)*(py2-cy)) + ((pz2-cz)*(pz2-cz))) + math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(pz-cz))) - math_sqrt((((px2-px)*(px2-px)) + ((py2-py)*(py2-py)) + ((py2-py)*(py2-py))))
+        local dlen = math_sqrt(((px2-cx)*(px2-cx)) + ((py2-cy)*(py2-cy)) + ((pz2-cz)*(pz2-cz))) + math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(pz-cz))) - math_sqrt((((px2-px)*(px2-px)) + ((py2-py)*(py2-py)) + ((pz2-pz)*(pz2-pz))))
         --Spring.Echo("dlen "..dlen)
         if dlen < min_dlen then
           min_dlen = dlen
@@ -176,7 +176,7 @@ function widget:CommandNotify(id, params, options)
       end
     end
     -- check for insert at end of queue if its shortest walk.
-    local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(pz-cz)))
+    local dlen = math_sqrt(((px-cx)*(px-cx)) + ((py-cy)*(py-cy)) + ((pz-cz)*(py-cy)))
     if dlen < min_dlen then
       --options.meta=nil
       --options.shift=true


### PR DESCRIPTION
The check to add at end of command queue has incorrect math.

Fix by correcting the math.

#### Test steps

1. Load skirmish against InactiveAI and start game.
1. Use commander to place a command queue of solars along a path from north to south (vertically on screen)
1. Place solars in the middle using `prepend_between` i.e. with `shift`+`space`

Prior to this change the solars are not placed between the solars queued earlier.

After this change the solars are placed between the solars queued earlier.
