### PR TITLE
Fix LowerGadget and LowerWidget.

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -897,7 +897,7 @@ local function FindHighestIndex(t, i, layer)
 			return (x - 1)
 		end
 	end
-	return (ts + 1)
+	return ts
 end
 
 function gadgetHandler:LowerGadget(gadget)
@@ -914,7 +914,7 @@ function gadgetHandler:LowerGadget(gadget)
 		end
 		local n = FindHighestIndex(t, i, w.ghInfo.layer)
 		if n and n > i then
-			table.insert(t, n, w)
+			table.insert(t, n+1, w)
 			table.remove(t, i)
 		end
 	end

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1020,7 +1020,7 @@ local function FindHighestIndex(t, i, layer)
 			return (x - 1)
 		end
 	end
-	return (ts + 1)
+	return ts
 end
 
 function widgetHandler:LowerWidget(widget)
@@ -1037,7 +1037,7 @@ function widgetHandler:LowerWidget(widget)
 		end
 		local n = FindHighestIndex(t, i, w.whInfo.layer)
 		if n and n > i then
-			table.insert(t, n, w)
+			table.insert(t, n+1, w)
 			table.remove(t, i)
 		end
 	end


### PR DESCRIPTION
### Work done

* Fix LowerGadget and LowerWidget.
* Fix FindHighestIndex "no find" result.

### Test steps

Tricky to test (see below for a snippet you can use). But I can explain the simple fix:

1. FindHighestIndex gets us the highest index in the list with a given layer.
2. LowerGadget is inserting into such index with table.insert, but that moves the item there up. We actually want to be in that position.
3. Thus need to insert into n+1 instead of n as it's doing now, that way we will be at the end of the layer group as intended.
4. Also, FindHighestIndex is returning length+1 if not finding nothing. That's inconsistent with returning the highest index, also it's not going to work when we insert into n+1 if we already +1 it.

### Other details

* This isn't used much atm, or at all, so no wonder nobody noticed. I noticed when testing #3899 behaviour with Raise and Lower.

### Appendix: snippet for testing

You can place the following at the end of gadgetHandler:Initialize():

```LUA
       Spring.Echo("LISTING")
       local ggg
       for _, g in pairs(self.gadgets) do
               if g.ghInfo.basename == 'unit_hats.lua' then ggg = g end
               Spring.Echo(g.ghInfo.basename, g.ghInfo.layer)
       end
       Spring.Echo("LOWER UNIT_HATS")
       gadgetHandler:LowerGadget(ggg)
       Spring.Echo("LISTING2")
       for _, g in pairs(self.gadgets) do
               Spring.Echo(g.ghInfo.basename, g.ghInfo.layer)
       end
       Spring.Echo("RAISE UNIT_HATS")
       gadgetHandler:RaiseGadget(ggg)
       Spring.Echo("LISTING3")
       for _, g in pairs(self.gadgets) do
               Spring.Echo(g.ghInfo.basename, g.ghInfo.layer)
       end
```

As unit_hats.lua is in the middle of the 1000 layer group. You can see without the fix after "LOWER UNIT HATS" it fails to go to the bottom of it's layer. RAISE works well though.



Output without fix:

```
LISTING
(...)
[t=00:00:27.504065][f=-000001] unit_crashing_aircraft.lua, 1000
[t=00:00:27.504073][f=-000001] unit_death_animations.lua, 1000
[t=00:00:27.504082][f=-000001] unit_hats.lua, 1000
[t=00:00:27.504092][f=-000001] unit_sinking_ship.lua, 1000
(...)
LOWER UNIT_HATS
(...)
[t=00:00:27.506183][f=-000001] unit_crashing_aircraft.lua, 1000
[t=00:00:27.506192][f=-000001] unit_death_animations.lua, 1000
[t=00:00:27.506202][f=-000001] unit_hats.lua, 1000 <-- didn't move to the bottom!
[t=00:00:27.506213][f=-000001] unit_sinking_ship.lua, 1000
(...)
RAISE UNIT_HATS
(...)
[t=00:00:27.508307][f=-000001] unit_hats.lua, 1000
[t=00:00:27.508316][f=-000001] unit_crashing_aircraft.lua, 1000
[t=00:00:27.508325][f=-000001] unit_death_animations.lua, 1000
[t=00:00:27.508334][f=-000001] unit_sinking_ship.lua, 1000
(...)
```

Output with fix:

```
LISTING
(...)
[t=00:00:21.285360][f=-000001] unit_crashing_aircraft.lua, 1000
[t=00:00:21.285371][f=-000001] unit_death_animations.lua, 1000
[t=00:00:21.285382][f=-000001] unit_hats.lua, 1000
[t=00:00:21.285394][f=-000001] unit_sinking_ship.lua, 1000
(...)
LOWER UNIT_HATS
(...)
[t=00:00:21.287849][f=-000001] unit_crashing_aircraft.lua, 1000
[t=00:00:21.287859][f=-000001] unit_death_animations.lua, 1000
[t=00:00:21.287870][f=-000001] unit_sinking_ship.lua, 1000
[t=00:00:21.287881][f=-000001] unit_hats.lua, 1000
(...)
RAISE UNIT_HATS
(...)
[t=00:00:21.290389][f=-000001] unit_hats.lua, 1000
[t=00:00:21.290399][f=-000001] unit_crashing_aircraft.lua, 1000
[t=00:00:21.290410][f=-000001] unit_death_animations.lua, 1000
[t=00:00:21.290419][f=-000001] unit_sinking_ship.lua, 1000
(...)
```

I also tested top and bottom of the list reordering, but that's even trickier since there's no group of same layer gadgets there, I had to change layer of a few gadgets for that. It shows there's a problem indeed when FindHighestIndex returns length+1.