### PR TITLE
(fix) Prevent unnecessary stall of low prio builders

### DIFF
--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -271,8 +271,8 @@ local function UpdatePassiveBuilders(teamID, interval)
 			local newPullMetal = teamStallingMetal - passivePullMetal
 			local newPullEnergy = teamStallingEnergy - passivePullEnergy
 			if passivePullMetal > 0 or passivePullEnergy > 0 then
-				-- Changed: Stalling in one resource stalls in the other.
-				if newPullMetal <= 0 or newPullEnergy <= 0 then
+				-- Stalling in one resource stalls in the other (if both resource types are used)
+				if (newPullMetal <= 0 and passivePullMetal > 0) or (newPullEnergy <= 0 and passivePullEnergy > 0) then
 					wouldStall = true
 				else
 					teamStallingMetal = newPullMetal


### PR DESCRIPTION
### Work done
Changes unit_builder_priority.lua gadget so it no longer disables low priority builder if they are stalling on 1 resource but this resource is not used by them.
Most famously it allows low prio builders to build solars while stalling on energy


#### Setup
The bug occurs only when you have big storage with relatively low income. So in order to test it you have to:
1. add multiple energy storages
2. drain your whole energy by building something with high prio builders
3. try to build solars with low prio builder


### Screenshots:

#### BEFORE:
https://github.com/user-attachments/assets/1ce213ee-0f74-4af0-a05e-02ce3ff4c3e9

#### AFTER:
https://github.com/user-attachments/assets/ebb60b20-5ccf-4c34-b07d-18d845e449fe



