### PR TITLE
unit_target_on_the_move: fix typo

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -819,7 +819,7 @@ else	-- UNSYNCED
 
 	function gadget:DrawWorld()
 		if fullview then
-			drawDecoratons()
+			drawDecorations()
 		else
 			CallAsTeam(myAllyTeam, drawDecorations)
 		end


### PR DESCRIPTION
When spectating a game, BAR spams console log with messages like this:

    [t=00:53:10.098460][f=0012882] Error: [LuaRules::RunCallInTraceback]
    error=2 (LUA_ERRRUN) callin=DrawWorld trace=[Internal Lua error: Call
    failure] [string "LuaRules/Gadgets/unit_target_on_the_move.lua"]:822:
    attempt to call global 'drawDecoratons' (a nil value)

Fix by fixing the typo on affected line (822).