### PR TITLE
Update gui_sensor_ranges_radar_preview.lua

### DIFF
--- a/luaui/Widgets/gui_sensor_ranges_radar_preview.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar_preview.lua
@@ -20,6 +20,7 @@ local largeradarrange = 3500	-- updates to 'armarad' value
 
 local cmdidtoradarsize = {}
 local radaremitheight = {}
+local radarYOffset = 50			-- amount added to vertical height of overlay to more closely reflect engine radarLOS
 
 -- Globals
 local mousepos = { 0, 0, 0 }
@@ -44,40 +45,15 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 		smallradarrange = unitDef.radarDistance
 	end
 
-	if unitDef.name == 'armrad' then
-		cmdidtoradarsize[-1 * unitDefID] = "small"
-		radaremitheight[-1 * unitDefID] = 66
-		--[[Spring.Echo(unitDef.radarHeight) -- DOES NOT WORK NEITHER OF THEM
-		Spring.Echo(unitDef.radarEmitHeight)
-		Spring.Echo(unitDef.radaremitheight)
-		Spring.Echo(unitDef.radarDistance)
-		for k,v in pairs(unitDef) do
-			Spring.Echo(k,v)
-		end]]--
-	end
-	if unitDef.name == 'armfrad' then
-		cmdidtoradarsize[-1 * unitDefID] = "small"
-		radaremitheight[-1 * unitDefID] = 52
-	end
-	if unitDef.name == 'corrad' then
-		cmdidtoradarsize[-1 * unitDefID] = "small"
-		radaremitheight[-1 * unitDefID] = 72
-	end
-	if unitDef.name == 'legrad' then
-		cmdidtoradarsize[-1 * unitDefID] = "small"
-		radaremitheight[-1 * unitDefID] = 72
-	end
-	if unitDef.name == 'corfrad' then
-		cmdidtoradarsize[-1 * unitDefID] = "small"
-		radaremitheight[-1 * unitDefID] = 72
-	end
-	if unitDef.name == 'corarad' then
-		cmdidtoradarsize[-1 * unitDefID] = "large"
-		radaremitheight[-1 * unitDefID] = 87
-	end
-	if unitDef.name == 'armarad' then
-		cmdidtoradarsize[-1 * unitDefID] = "large"
-		radaremitheight[-1 * unitDefID] = 66
+	if unitDef.radarDistance > 2000 then
+		radaremitheight[-1 * unitDefID] = unitDef.radarEmitHeight + radarYOffset
+
+		if unitDef.radarDistance == smallradarrange then
+			cmdidtoradarsize[-1 * unitDefID] = "small"
+		end
+		if unitDef.radarDistance == largeradarrange then
+			cmdidtoradarsize[-1 * unitDefID] = "large"
+		end
 	end
 end
 
@@ -94,7 +70,7 @@ local shaderSourceCache = {
 			},
 		uniformFloat = {
 			radarcenter_range = { 2000, 100, 2000, 2000 },
-			resolution = { 64 },
+			resolution = { 128 },
 		  },
 		shaderConfig = shaderConfig,
 	}
@@ -203,4 +179,3 @@ function widget:DrawWorld()
 	gl.Culling(false)
 	gl.DepthTest(true)
 end
-


### PR DESCRIPTION
This updates the radar preview widget overlay to be closer to the actual radar result in game, it is still sadly not an exact match but it is less bad.

### Work done
* Added variable and set to 50elmos additional height for radar preview overlay calcs (not actual unit radar emitheight)
* Refactored the unit filter to remove hardcoded values and be dynamic based on radarDistance for `armrad` and `armarad` units
* Increased resolution of from 64 to 128

#### Test steps
- Disable `LOS colors` widget - so you can see engine radar coverage in blue
- Load into Comet Catcher remake 1.8
- Place armrad or armarad in crater as shown below and compare overlay to results

#### Preview before:
![screen_2024-11-12_13-49-05-108](https://github.com/user-attachments/assets/acfb7599-0e13-4980-98a3-9c801fbe92f5)

Engine + current preview
![screen_2024-11-12_13-48-42-788](https://github.com/user-attachments/assets/1877ccbe-2de7-4508-be29-ce368ba32e85)

#### Preview after:
![screen_2024-11-12_13-49-22-583](https://github.com/user-attachments/assets/5ad2260f-f86a-4bad-9e65-0d301403c8d4)

Engine + new preview
![screen_2024-11-12_13-51-02-462](https://github.com/user-attachments/assets/f64fd5ac-fc9e-47a2-9a09-ad5873ee1dda)

Discord thread and post with more images/details: https://discord.com/channels/549281623154229250/1159283560071573606/1305893249210253394