### PR TITLE
Add docs and type annotations to `unit_buildmenu_config.lua`

### DIFF
--- a/luaui/configs/buildmenu_sorting.lua
+++ b/luaui/configs/buildmenu_sorting.lua
@@ -776,7 +776,6 @@ for id, value in pairs(unitOrderTable) do
 	end
 end
 unitOrderTable = newUnitOrder
-newUnitOrder = nil
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 	if unitDef.customParams.isscavenger then

--- a/luaui/configs/buildmenu_sorting.lua
+++ b/luaui/configs/buildmenu_sorting.lua
@@ -1,3 +1,4 @@
+---@type table<string, number>
 local unitOrderTable = {
 -- UNITS
 	--CONSTRUCTORS
@@ -769,6 +770,7 @@ local unitOrderTable = {
    ['coratl']         = 260600,
 }
 
+---@type table<string, number>
 local newUnitOrder = {}
 for id, value in pairs(unitOrderTable) do
 	if UnitDefNames[id] then

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -4,19 +4,19 @@
 ---
 
 
-local unitEnergyCost = {}
-local unitMetalCost = {}
-local unitGroup = {}
-local unitRestricted = {}
-local manualUnitRestricted = {}
-local isBuilder = {}
-local isFactory = {}
-local unitIconType = {}
-local isMex = {}
-local isWind = {}
-local isWaterUnit = {}
-local isGeothermal = {}
-local unitMaxWeaponRange = {}
+local unitEnergyCost = {} ---@type table<number, number>
+local unitMetalCost = {} ---@type table<number, number>
+local unitGroup = {} ---@type table<number, number>
+local unitRestricted = {} ---@type table<number, true>
+local manualUnitRestricted = {} ---@type table<number, true>
+local isBuilder = {} ---@type table<number, true>
+local isFactory = {} ---@type table<number, true>
+local unitIconType = {} ---@type table<number, number>
+local isMex = {} ---@type table<number, true>
+local isWind = {} ---@type table<number, true>
+local isWaterUnit = {} ---@type table<number, true>
+local isGeothermal = {} ---@type table<number, true>
+local unitMaxWeaponRange = {} ---@type table<number, number>
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 
@@ -64,25 +64,29 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
-
+---@param disable boolean
 local function restrictWindUnits(disable)
 	for unitDefID,_ in pairs(isWind) do
 		unitRestricted[unitDefID] = manualUnitRestricted[unitDefID] or disable
 	end
 end
 
+---@param disable boolean
 local function restrictGeothermalUnits(disable)
 	for unitDefID,_ in pairs(isGeothermal) do
 		unitRestricted[unitDefID] = manualUnitRestricted[unitDefID] or disable
 	end
 end
 
+---@param disable boolean
 local function restrictWaterUnits(disable)
 	for unitDefID,_ in pairs(isWaterUnit) do
 		unitRestricted[unitDefID] = manualUnitRestricted[unitDefID] or disable
 	end
 end
 
+---Sets geothermal unit restriction based on the presence of geothermal
+---features.
 local function checkGeothermalFeatures()
 	local hideGeoUnits = true
 	local geoThermalFeatures = {}
@@ -106,10 +110,12 @@ end
 -- UNIT ORDER ----------------------
 ------------------------------------
 
--- At the end of this 'UNIT ORDER' section, unitOrder is an array with unitIDs
--- sorted by their value specified in unitOrderManualOverrideTable. If no
--- value is specified, the unit will be placed at the end of the array.
+---At the end of this 'UNIT ORDER' section, unitOrder is an array with unitIDs
+---sorted by their value specified in unitOrderManualOverrideTable. If no
+---value is specified, the unit will be placed at the end of the array.
+---@type number[]
 local unitOrder = {}
+
 local unitOrderManualOverrideTable = VFS.Include("luaui/configs/buildmenu_sorting.lua")
 
 -- Populate unitOrder with unit IDs.
@@ -146,28 +152,30 @@ table.sort(unitOrder, function(aID, bID)
 	return aOrder < bOrder
 end)
 
-local minWaterUnitDepth = -11
 
-
-------------------------------------
--- /UNIT ORDER ----------------------
-------------------------------------
-
-return {
+local units = {
 	unitEnergyCost = unitEnergyCost,
 	unitMetalCost = unitMetalCost,
 	unitGroup = unitGroup,
 	unitRestricted = unitRestricted,
-	isBuilder = isBuilder,
-	isFactory = isFactory,
 	unitIconType = unitIconType,
-	isMex = isMex,
-	isWind = isWind,
-	isWaterUnit = isWaterUnit,
-	isGeothermal = isGeothermal,
 	unitMaxWeaponRange = unitMaxWeaponRange,
-
-	minWaterUnitDepth = minWaterUnitDepth,
+	---Set of unit IDs that are factories.
+	isFactory = isFactory,
+	---Set of unit IDs that have build options.
+	isBuilder = isBuilder,
+	---Set of unit IDs that require metal.
+	isMex = isMex,
+	---Set of unit IDs that require wind.
+	isWind = isWind,
+	---Set of unit IDs that require water.
+	isWaterUnit = isWaterUnit,
+	---Set of unit IDs that require geothermal.
+	isGeothermal = isGeothermal,
+	minWaterUnitDepth = -11,
+	---An array with unitIDs sorted by their value specified in
+	---`unitOrderManualOverrideTable`. If no value is specified, the unit will be
+	---placed at the end of the array.
 	unitOrder = unitOrder,
 
 	checkGeothermalFeatures = checkGeothermalFeatures,
@@ -175,3 +183,5 @@ return {
 	restrictWindUnits = restrictWindUnits,
 	restrictWaterUnits = restrictWaterUnits,
 }
+
+return units

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -137,14 +137,14 @@ maxOrder = maxOrder + 1
 -- For units who have the same order value we compare the unit's IDs.
 -- This sort is always stable, as no two units should have the same ID.
 table.sort(unitOrder, function(aID, bID)
-			local aOrder = unitOrderManualOverrideTable[aID] or maxOrder
-			local bOrder = unitOrderManualOverrideTable[bID] or maxOrder
+	local aOrder = unitOrderManualOverrideTable[aID] or maxOrder
+	local bOrder = unitOrderManualOverrideTable[bID] or maxOrder
 
-			if (aOrder == bOrder) then
-			  return aID < bID
-			end
-			return aOrder < bOrder
-		end)
+	if (aOrder == bOrder) then
+		return aID < bID
+	end
+	return aOrder < bOrder
+end)
 
 local minWaterUnitDepth = -11
 

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -18,8 +18,6 @@ local isWaterUnit = {}
 local isGeothermal = {}
 local unitMaxWeaponRange = {}
 
-local showWaterUnits = false
-
 for unitDefID, unitDef in pairs(UnitDefs) do
 
 	unitGroup[unitDefID] = unitDef.customParams.unitgroup
@@ -171,8 +169,6 @@ return {
 
 	minWaterUnitDepth = minWaterUnitDepth,
 	unitOrder = unitOrder,
-
-	showWaterUnits = showWaterUnits,
 
 	checkGeothermalFeatures = checkGeothermalFeatures,
 	restrictGeothermalUnits = restrictGeothermalUnits,

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -148,12 +148,6 @@ table.sort(unitOrder, function(aID, bID)
 			return aOrder < bOrder
 		end)
 
-local voidWater = false
-local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs
-if success and mapinfo then
-	voidWater = mapinfo.voidwater
-end
-
 local minWaterUnitDepth = -11
 
 


### PR DESCRIPTION
### Work done

> [!IMPORTANT]
> Includes changes from #3935, please review and merge that PR first.

Adds lua language server docs and type annotations to `unit_buildmenu_config.lua`.

This PR replaces #3905 which was rejected for including code cleanup and documentation changes in one PR.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
No functional changes

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
