### PR TITLE
Fix lavaconfig error

### DIFF
--- a/luarules/configs/lavaConfig.lua
+++ b/luarules/configs/lavaConfig.lua
@@ -463,7 +463,9 @@ elseif Game.waterDamage > 0 and (not voidWaterMap) then -- Waterdamagemaps - kee
 elseif Spring.GetModOptions().map_waterislava and (not voidWaterMap) then
 	lavaMap = true
 	lavaLevel = 4 
-	addTideRhym (4, 0.05, 5*6000)
+	if isLavaGadget and isLavaGadget == "synced" then
+		addTideRhym (4, 0.05, 5*6000)
+	end
 end
 
 


### PR DESCRIPTION
```[2024-11-15 21:15:40.160] [info]  [t=03:05:25.015031][f=-000001] Error in Initialize(): [LuaVFS::Include(synced=false)][pcall] file=luarules/configs/lavaConfig.lua error=2 ([string "luarules/configs/lavaConfig.lua"]:466: attempt to call global 'addTideRhym' (a nil value)) ptop=1 cenv=false vfsmode=rMmeb```

This adds the same wrapping to the addTimeRhym call on this line that all of the other configs have.

[spring-launcher-20241115T171012.log](https://github.com/user-attachments/files/17788020/spring-launcher-20241115T171012.log)
