### PR TITLE
Safe widgets reordering api

### DIFF
--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
@@ -11,9 +11,9 @@ function setup()
 
 	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
 	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
+		widgetHandler:DisableWidgetRaw(widgetName)
 	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widgetHandler:EnableWidgetRaw(widgetName, true)
 
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
@@ -29,9 +29,9 @@ end
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
+	widgetHandler:DisableWidgetRaw(widgetName)
 	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
+		widgetHandler:EnableWidgetRaw(widgetName, false)
 	end
 
 	Spring.SetCameraState(initialCameraState)

--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -11,9 +11,9 @@ function setup()
 
 	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
 	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
+		widgetHandler:DisableWidgetRaw(widgetName)
 	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widgetHandler:EnableWidgetRaw(widgetName, true)
 
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
@@ -29,9 +29,9 @@ end
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
+	widgetHandler:DisableWidgetRaw(widgetName)
 	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
+		widgetHandler:EnableWidgetRaw(widgetName, false)
 	end
 
 	Spring.SetCameraState(initialCameraState)

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
@@ -9,17 +9,17 @@ function setup()
 
 	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
 	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
+		widgetHandler:DisableWidgetRaw(widgetName)
 	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widgetHandler:EnableWidgetRaw(widgetName, true)
 end
 
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
+	widgetHandler:DisableWidgetRaw(widgetName)
 	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
+		widgetHandler:EnableWidgetRaw(widgetName, false)
 	end
 end
 

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
@@ -9,17 +9,17 @@ function setup()
 
 	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
 	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
+		widgetHandler:DisableWidgetRaw(widgetName)
 	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widgetHandler:EnableWidgetRaw(widgetName, true)
 end
 
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
+	widgetHandler:DisableWidgetRaw(widgetName)
 	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
+		widgetHandler:EnableWidgetRaw(widgetName, false)
 	end
 end
 

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
@@ -9,17 +9,17 @@ function setup()
 
 	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
 	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
+		widgetHandler:DisableWidgetRaw(widgetName)
 	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widgetHandler:EnableWidgetRaw(widgetName, true)
 end
 
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
+	widgetHandler:DisableWidgetRaw(widgetName)
 	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
+		widgetHandler:EnableWidgetRaw(widgetName, false)
 	end
 end
 

--- a/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
+++ b/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
@@ -11,17 +11,17 @@ function setup()
 
 	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
 	if initialWidgetActive then
-		widgetHandler:DisableWidget(widgetName)
+		widgetHandler:DisableWidgetRaw(widgetName)
 	end
-	widgetHandler:EnableWidget(widgetName, true)
+	widgetHandler:EnableWidgetRaw(widgetName, true)
 end
 
 function cleanup()
 	Test.clearMap()
 
-	widgetHandler:DisableWidget(widgetName)
+	widgetHandler:DisableWidgetRaw(widgetName)
 	if initialWidgetActive then
-		widgetHandler:EnableWidget(widgetName, false)
+		widgetHandler:EnableWidgetRaw(widgetName, false)
 	end
 end
 

--- a/luaui/Widgets/dbg_widget_profiler.lua
+++ b/luaui/Widgets/dbg_widget_profiler.lua
@@ -213,8 +213,8 @@ local function StartHook()
 	Spring.Echo("hooked all callins")
 
 	--// hook the UpdateCallin function
-	oldUpdateWidgetCallIn = wh.UpdateWidgetCallIn
-	wh.UpdateWidgetCallIn = function(self, name, w)
+	oldUpdateWidgetCallIn = wh.UpdateWidgetCallInRaw
+	wh.UpdateWidgetCallInRaw = function(self, name, w)
 		local listName = name .. 'List'
 		local ciList = self[listName]
 		if ciList then
@@ -236,8 +236,8 @@ local function StartHook()
 	Spring.Echo("hooked UpdateCallin")
 
 	--// hook the InsertWidget function
-	oldInsertWidget = wh.InsertWidget
-	widgetHandler.InsertWidget = function(self, widget)
+	oldInsertWidget = wh.InsertWidgetRaw
+	widgetHandler.InsertWidgetRaw = function(self, widget)
 		if widget == nil then
 			return
 		end
@@ -283,9 +283,9 @@ local function StopHook()
 	Spring.Echo("unhooked all callins")
 
 	--// unhook the UpdateCallin and InsertWidget functions
-	wh.UpdateWidgetCallIn = oldUpdateWidgetCallIn
+	wh.UpdateWidgetCallInRaw = oldUpdateWidgetCallIn
 	Spring.Echo("unhooked UpdateCallin")
-	wh.InsertWidget = oldInsertWidget
+	wh.InsertWidgetRaw = oldInsertWidget
 	Spring.Echo("unhooked InsertWidget")
 end
 

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -314,7 +314,7 @@ local zipOnly = {
 
 function widgetHandler:Initialize()
 	widgetHandler:CreateQueuedReorderFuncs()
-	widgetHandler:HookReorderPostMethods()
+	widgetHandler:HookReorderSpecialFuncs()
 	self:LoadConfigData()
 
 	-- do we allow userland widgets?
@@ -824,7 +824,7 @@ local reorderNeeded = false
 local reorderFuncs = {}
 local callinDepth = 0
 
-function widgetHandler:HookReorderPostMethods()
+function widgetHandler:HookReorderSpecialFuncs()
 	-- Methods that need manual PerformReorders calls because of not
 	-- being wrapped by UpdateCallIns.
 	self:HookReorderPost('DrawScreen', true)
@@ -837,6 +837,8 @@ end
 function widgetHandler:HookReorderPost(name, topMethod)
 	-- Add callinDepth updating and PerformReorders to methods not getting it through UpdateCallIns.
 	-- Can only be used for methods returning just one result.
+	-- We define some methods to be topMethod, those will hard set the callinDepth as a consistency
+	-- measure.
 	local func = self[name]
 	if not func or not type(func) == 'function' then
 		Spring.Log("barwidgets.lua", LOG.WARNING, name .. " does not exist or isn't a function")

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -895,6 +895,10 @@ function widgetHandler:PerformReorders()
 	for _, elmts in ipairs(nextReorder) do
 		self:PerformReorder(unpack(elmts))
 	end
+	-- Check for further reordering
+	if reorderNeeded then
+		self:PerformReorders()
+	end
 end
 
 --------------------------------------------------------------------------------

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -313,6 +313,7 @@ local zipOnly = {
 }
 
 function widgetHandler:Initialize()
+	widgetHandler:CreateQueuedReorderFuncs()
 	self:LoadConfigData()
 
 	-- do we allow userland widgets?
@@ -387,8 +388,12 @@ function widgetHandler:Initialize()
 		local source = self.knownWidgets[name].fromZip and "mod: " or "user:"
 		Spring.Echo(string.format("Loading widget from %s  %-18s  <%s> ...", source, name, basename))
 		Yield()
-		widgetHandler:InsertWidget(w)
+		widgetHandler:InsertWidgetRaw(w)
 	end
+
+	-- Since Initialize is run out of the normal callin wrapper by InsertWidget,
+	-- we, need to reorder explicitly here.
+	widgetHandler:PerformReorders()
 
 	-- save the active widgets, and their ordering
 	self:SaveConfigData()
@@ -804,7 +809,63 @@ local function ArrayRemove(t, w)
 	end
 end
 
-function widgetHandler:InsertWidget(widget)
+--------------------------------------------------------------------------------
+--- Safe reordering
+
+-- Since we are traversing lists, some of the widgetHandler api would be dangerous to use.
+--
+-- We will queue all the dangerous methods to process after callin loop finishes iterating.
+-- The 'real' methods have 'Raw' appended to them, and are unsafe to use unless you know what
+-- you are doing.
+
+local reorderQueue = {}
+local reorderNeeded = false
+local reorderFuncs = {}
+local callinDepth = 0
+
+function widgetHandler:CreateQueuedReorderFuncs()
+	-- This will create an array with linked Raw methods so we can find them by index.
+	-- It will also create the widgetHandler usual api queing the calls.
+	local reorderFuncNames = {'InsertWidget', 'RemoveWidget', 'EnableWidget', 'DisableWidget',
+		'ToggleWidget', 'LowerWidget', 'RaiseWidget', 'UpdateWidgetCallIn', 'RemoveWidgetCallIn'}
+	local queueReorder = widgetHandler.QueueReorder
+
+	for idx, name in ipairs(reorderFuncNames) do
+		-- linked method index
+		reorderFuncs[#reorderFuncs + 1] = widgetHandler[name .. 'Raw']
+
+		-- widgetHandler api
+		widgetHandler[name] = function(s, ...)
+			queueReorder(s, idx, ...)
+		end
+	end
+end
+
+function widgetHandler:QueueReorder(methodIndex, ...)
+	reorderQueue[#reorderQueue + 1] = {methodIndex, ...}
+	reorderNeeded = true
+end
+
+function widgetHandler:PerformReorder(methodIndex, ...)
+	reorderFuncs[methodIndex](self, ...)
+end
+
+function widgetHandler:PerformReorders()
+	-- Reset and store the list so we can support nested reorderings
+	reorderNeeded = false
+	local nextReorder = reorderQueue
+	reorderQueue = {}
+	-- Process the reorder queue
+	for _, elmts in ipairs(nextReorder) do
+		self:PerformReorder(unpack(elmts))
+	end
+end
+
+--------------------------------------------------------------------------------
+--- Unsafe insert/remove
+
+
+function widgetHandler:InsertWidgetRaw(widget)
 	if widget == nil then
 		return
 	end
@@ -825,7 +886,7 @@ function widgetHandler:InsertWidget(widget)
 	end
 end
 
-function widgetHandler:RemoveWidget(widget)
+function widgetHandler:RemoveWidgetRaw(widget)
 	if widget == nil or widget.whInfo == nil then
 		return
 	end
@@ -862,7 +923,16 @@ function widgetHandler:UpdateCallIn(name)
 		-- always assign these call-ins
 		local selffunc = self[name]
 		_G[name] = function(...)
-			return selffunc(self, ...)
+			callinDepth = callinDepth + 1
+
+			local res = selffunc(self, ...)
+
+			callinDepth = callinDepth - 1
+
+			if reorderNeeded and callinDepth == 0 then
+				self:PerformReorders()
+			end
+			return res
 		end
 	else
 		_G[name] = nil
@@ -870,7 +940,7 @@ function widgetHandler:UpdateCallIn(name)
 	Script.UpdateCallIn(name)
 end
 
-function widgetHandler:UpdateWidgetCallIn(name, w)
+function widgetHandler:UpdateWidgetCallInRaw(name, w)
 	local listName = name .. 'List'
 	local ciList = self[listName]
 	if ciList then
@@ -886,7 +956,7 @@ function widgetHandler:UpdateWidgetCallIn(name, w)
 	end
 end
 
-function widgetHandler:RemoveWidgetCallIn(name, w)
+function widgetHandler:RemoveWidgetCallInRaw(name, w)
 	local listName = name .. 'List'
 	local ciList = self[listName]
 	if ciList then
@@ -909,7 +979,7 @@ function widgetHandler:IsWidgetKnown(name)
 	return self.knownWidgets[name] and true or false
 end
 
-function widgetHandler:EnableWidget(name, enableLocalsAccess)
+function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess)
 	local ki = self.knownWidgets[name]
 	if not ki then
 		Spring.Echo("EnableWidget(), could not find widget: " .. tostring(name))
@@ -925,13 +995,13 @@ function widgetHandler:EnableWidget(name, enableLocalsAccess)
 		if not w then
 			return false
 		end
-		self:InsertWidget(w)
+		self:InsertWidgetRaw(w)
 		self:SaveConfigData()
 	end
 	return true
 end
 
-function widgetHandler:DisableWidget(name)
+function widgetHandler:DisableWidgetRaw(name)
 	local ki = self.knownWidgets[name]
 	if not ki then
 		Spring.Echo("DisableWidget(), could not find widget: " .. tostring(name))
@@ -943,23 +1013,23 @@ function widgetHandler:DisableWidget(name)
 			return false
 		end
 		Spring.Echo('Removed:  ' .. ki.filename)
-		self:RemoveWidget(w)     -- deactivate
+		self:RemoveWidgetRaw(w)     -- deactivate
 		self.orderList[name] = 0 -- disable
 		self:SaveConfigData()
 	end
 	return true
 end
 
-function widgetHandler:ToggleWidget(name)
+function widgetHandler:ToggleWidgetRaw(name)
 	local ki = self.knownWidgets[name]
 	if not ki then
 		Spring.Echo("ToggleWidget(), could not find widget: " .. tostring(name))
 		return
 	end
 	if ki.active then
-		return self:DisableWidget(name)
+		return self:DisableWidgetRaw(name)
 	elseif self.orderList[name] <= 0 then
-		return self:EnableWidget(name)
+		return self:EnableWidgetRaw(name)
 	else
 		-- the widget is not active, but enabled; disable it
 		self.orderList[name] = 0
@@ -989,7 +1059,7 @@ local function FindLowestIndex(t, i, layer)
 	return 1
 end
 
-function widgetHandler:RaiseWidget(widget)
+function widgetHandler:RaiseWidgetRaw(widget)
 	if widget == nil then
 		return
 	end
@@ -1023,7 +1093,7 @@ local function FindHighestIndex(t, i, layer)
 	return ts
 end
 
-function widgetHandler:LowerWidget(widget)
+function widgetHandler:LowerWidgetRaw(widget)
 	if widget == nil then
 		return
 	end
@@ -1160,6 +1230,8 @@ end
 
 function widgetHandler:Update()
 
+	-- always top level so just set callinDepth to 1
+	callinDepth = 1
 	if collectgarbage("count") > 1200000 then
 		Spring.Echo("Warning: Emergency garbage collection due to exceeding 1.2GB LuaRAM")
 		collectgarbage("collect")
@@ -1174,11 +1246,16 @@ function widgetHandler:Update()
 		w:Update(deltaTime)
 		tracy.ZoneEnd()
 	end
+	-- Update is not wrapped through UpdateCallIn, so needs manual calling
+	-- of PerformReorders, also since it should never be called nested
+	-- we reset callinDepth here as a consistency measure.
+	callinDepth = 0
+	self:PerformReorders()
 	tracy.ZoneEnd()
 	return
 end
 
-function widgetHandler:ConfigureLayout(command)
+function widgetHandler:ConfigureLayoutRaw(command)
 
 	if command == 'reconf' then
 		self:SendConfigData()
@@ -1190,17 +1267,17 @@ function widgetHandler:ConfigureLayout(command)
 			end
 		end
 		local sw = self:LoadWidget(LUAUI_DIRNAME .. SELECTOR_BASENAME, true) -- load the game's included widget_selector.lua, instead of the default selector.lua
-		self:InsertWidget(sw)
-		self:RaiseWidget(sw)
+		self:InsertWidgetRaw(sw)
+		self:RaiseWidgetRaw(sw)
 		return true
 	elseif string.find(command, 'togglewidget') == 1 then
-		self:ToggleWidget(string.sub(command, 14))
+		self:ToggleWidgetRaw(string.sub(command, 14))
 		return true
 	elseif string.find(command, 'enablewidget') == 1 then
-		self:EnableWidget(string.sub(command, 14))
+		self:EnableWidgetRaw(string.sub(command, 14))
 		return true
 	elseif string.find(command, 'disablewidget') == 1 then
-		self:DisableWidget(string.sub(command, 15))
+		self:DisableWidgetRaw(string.sub(command, 15))
 		return true
 	end
 
@@ -1214,6 +1291,14 @@ function widgetHandler:ConfigureLayout(command)
 		end
 	end
 	return false
+end
+
+function widgetHandler:ConfigureLayout(command)
+	res = self:ConfigureLayoutRaw(command)
+	if reorderNeeded then
+		self:PerformReorders()
+	end
+	return res
 end
 
 function widgetHandler:CommandNotify(id, params, options)
@@ -1308,6 +1393,8 @@ end
 
 
 function widgetHandler:DrawScreen()
+	-- always top level so just set callinDepth to 1
+	callinDepth = 1
 	if (not Spring.GetSpectatingState()) and anonymousMode ~= "disabled" then
 		Spring.SendCommands("info 0")
 	end
@@ -1325,6 +1412,11 @@ function widgetHandler:DrawScreen()
 			tracy.ZoneEnd()
 		end
 	end
+	-- DrawScreen is not wrapped through UpdateCallIn, so needs manual calling
+	-- of PerformReorders, also since it should never be called nested
+	-- we reset callinDepth here as a consistency measure.
+	callinDepth = 0
+	self:PerformReorders()
 	tracy.ZoneEnd()
 	return
 end


### PR DESCRIPTION
### Work done

* Create an internal mechanism at widgetHandler to queue methods with callin list reordering side effects.
  * Doesn't change the widget facing api, but related methods will now be queued after the callin loop.
  * Most widgets shouldn't notice any difference and this shouldn't break any existing widgets (see below for an exception though).
* Affected methods: InsertWidget, RemoveWidget, EnableWidget, DisableWidget, ToggleWidget, LowerWidget, RaiseWidget, UpdateWidgetCallIn, RemoveWidgetCallIn (they all should become safe to use with this PR).
* It does affect tests since those usually need immediate enabling/disabling (see below for related proposal). I adapted the current ones in master in this PR so they still work.
* Adapted widget profiler too, since it needs to hook the real UpdateWidgetCallIn and InsertWidget (now with 'Raw' appendix).

#### Addresses Issue(s)

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3900

### Discussion

* Same idea as: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3907 (this is the second part of the same effort).
* As commented above, this affects a number of tests using EnableWidget and DisableWidget directly, also some in PRs.
  * I noticed all of them use these just for a common idiom of enabling the test widget with locals and then restoring common state.
  * I propose augmenting Test api with two methods, to simplify test code and also better hide implementation details: [see this commit](https://github.com/saurtron/Beyond-All-Reason/commit/58cdea518f8dbf5c62818e44202c40b3a5f37eeb).
  * Haven't added that in this PR since it's out of scope, still I think it's worthy for a future PR (can add that to this PR if you want though since it's kind of related).
  * Other options for tests could be call PerformReorders at certain places, but I don't think this will work very well since it can be too late for the test code so not a general solution.
  * Another option would be to give them a widgetHandler proxy with immediate calls, but this can be fragile since they can run into queued side effects from other methods.
  * All in all, I think test writers will need to be aware of the queueing and either call PerformReorders themselves when needed or directly use Raw methods depending on the situation. I'm all for documenting this but not sure where.
* The following methods have special handling too: ConfigureLayout, DrawScreen, Update, MouseMove, MouseRelease, since they don't get wrapped like other callins and/or have special reordering side effects.

#### Test steps
- Checkout branch
- See everything still works

Additionally, the following snippet can be used for testing at least default ordering and enabled widgets after initialization doesn't change with this PR:

```LUA
       Spring.Echo("ORDERING")
       for _, w in pairs(self.widgets) do
               Spring.Echo(w.whInfo.basename, w.whInfo.layer)
       end
       Spring.Echo("END ORDERING")
       Spring.Echo("DrawScreen")
       for _, w in pairs(self.DrawScreenList) do
               Spring.Echo(w.whInfo.basename, w.whInfo.layer)
       end
       Spring.Echo("END ORDERING")
```

1. Add snippet at the end of widgetHandler:Initialize, both for _master_ and _safe-ordering-widgets_ branches:

2. Manually cut everything not between ORDERING and second END ORDERING at infolog.txt. Save in two txt files file1.txt and file2.txt, each for the run with each branch.

3. Run cut -d' ' -f2- file1.txt > f1.txt and cut -d' ' -f2- file2.txt > f2.txt to remove the timestamps.

4. diff f1.txt f2.txt -> yields empty result

Sample resulting files: [f1.txt](https://github.com/user-attachments/files/17818113/f1.txt), [f2.txt](https://github.com/user-attachments/files/17818114/f2.txt) (yes they look like the same file)


