### PR TITLE
Transifex merge action bypass branch protection rules, allow manual triggering

### DIFF
--- a/.github/workflows/transifex_merge_translations.yml
+++ b/.github/workflows/transifex_merge_translations.yml
@@ -4,6 +4,7 @@
 name: Translations merge to master
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches:
@@ -11,13 +12,14 @@ on:
 
 jobs:
   merge-translations:
-    if: github.event.pull_request.user.login == 'transifex-integration[bot]' && github.event.pull_request.merged == true
+    if: (github.event.pull_request.user.login == 'transifex-integration[bot]' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
         uses: actions/checkout@v4
         with:
           ref: master
+          ssh-key: ${{ secrets.ACTION_RUNNER_PRIVATE }}
 
       - name: Setup Git User
         run: |


### PR DESCRIPTION
This allows the Github action that merges translations to master to bypass branch protection rules, as it is pushing directly rather than creating a pull request. It also allows manually triggering the action, in case that is required.

Credit goes to @p2004a, big thanks for your help.

Note that the rebase from master job will need to be run after merging, to get these changes on the `transifex-synchronization-source` branch, which is where the merge action runs.

### **The secret still needs to be created by a repository admin, so currently the action will not work.**