### PR TITLE
Fix energyupkeep usage

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1259,8 +1259,8 @@ function UnitDef_Post(name, uDef)
 			uDef.energystorage = uDef.energystorage * x
 		end
 	end
-	if name == "armsolar" or name == "corsolar" or name == "legsolar" then
-		-- special case (but why?)
+	if uDef.energyupkeep and uDef.energyupkeep < 0 then
+		-- units with negative upkeep means they produce energy when "on".
 		local x = modOptions.multiplier_energyproduction * modOptions.multiplier_resourceincome
 		uDef.energyupkeep = uDef.energyupkeep * x
 		if uDef.energystorage then

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1259,14 +1259,6 @@ function UnitDef_Post(name, uDef)
 			uDef.energystorage = uDef.energystorage * x
 		end
 	end
-	if name == "armsolar" or name == "corsolar" or name == "legsolar" then
-		-- special case (but why?)
-		local x = modOptions.multiplier_energyproduction * modOptions.multiplier_resourceincome
-		uDef.energyupkeep = uDef.energyupkeep * x
-		if uDef.energystorage then
-			uDef.energystorage = uDef.energystorage * x
-		end
-	end
 
 	-- Energy Conversion Multiplier
 	if uDef.customparams.energyconv_capacity and uDef.customparams.energyconv_efficiency then

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1259,6 +1259,14 @@ function UnitDef_Post(name, uDef)
 			uDef.energystorage = uDef.energystorage * x
 		end
 	end
+	if name == "armsolar" or name == "corsolar" or name == "legsolar" then
+		-- special case (but why?)
+		local x = modOptions.multiplier_energyproduction * modOptions.multiplier_resourceincome
+		uDef.energyupkeep = uDef.energyupkeep * x
+		if uDef.energystorage then
+			uDef.energystorage = uDef.energystorage * x
+		end
+	end
 
 	-- Energy Conversion Multiplier
 	if uDef.customparams.energyconv_capacity and uDef.customparams.energyconv_efficiency then

--- a/units/ArmBots/T2/armack.lua
+++ b/units/ArmBots/T2/armack.lua
@@ -12,7 +12,6 @@ return {
 		energycost = 6900,
 		energymake = 14,
 		energystorage = 100,
-		energyupkeep = 14,
 		explodeas = "mediumexplosiongeneric-builder",
 		footprintx = 2,
 		footprintz = 2,

--- a/units/ArmBuildings/LandEconomy/armsolar.lua
+++ b/units/ArmBuildings/LandEconomy/armsolar.lua
@@ -12,6 +12,7 @@ return {
 		damagemodifier = 0.5,
 		energycost = 0,
 		energystorage = 50,
+		-- negative energyupkeep means it's conditional so when unit is off won't produce
 		energyupkeep = -20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,

--- a/units/ArmBuildings/LandEconomy/armsolar.lua
+++ b/units/ArmBuildings/LandEconomy/armsolar.lua
@@ -12,7 +12,7 @@ return {
 		damagemodifier = 0.5,
 		energycost = 0,
 		energystorage = 50,
-		energyupkeep = -20,
+		energymake = 20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,
 		footprintz = 5,

--- a/units/ArmBuildings/LandEconomy/armsolar.lua
+++ b/units/ArmBuildings/LandEconomy/armsolar.lua
@@ -12,7 +12,7 @@ return {
 		damagemodifier = 0.5,
 		energycost = 0,
 		energystorage = 50,
-		energymake = 20,
+		energyupkeep = -20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,
 		footprintz = 5,

--- a/units/ArmBuildings/LandUtil/armnanotc.lua
+++ b/units/ArmBuildings/LandUtil/armnanotc.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "31 32 31",
 		collisionvolumetype = "CylY",
 		energycost = 3200,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		footprintx = 3,
 		footprintz = 3,

--- a/units/ArmBuildings/LandUtil/armnanotct2.lua
+++ b/units/ArmBuildings/LandUtil/armnanotct2.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "46 80 46",
 		collisionvolumetype = "CylY",
 		energycost = 12800,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		footprintx = 4,
 		footprintz = 4,

--- a/units/ArmBuildings/SeaUtil/armnanotc2plat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotc2plat.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "46 80 46",
 		collisionvolumetype = "CylY",
 		energycost = 12800,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		floater = true,
 		footprintx = 4,

--- a/units/ArmBuildings/SeaUtil/armnanotcplat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotcplat.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "31 50 31",
 		collisionvolumetype = "CylY",
 		energycost = 2600,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		floater = true,
 		footprintx = 3,

--- a/units/ArmShips/T2/armacsub.lua
+++ b/units/ArmShips/T2/armacsub.lua
@@ -12,7 +12,6 @@ return {
 		energycost = 9000,
 		energymake = 30,
 		energystorage = 150,
-		energyupkeep = 30,
 		explodeas = "smallExplosionGeneric-uw",
 		footprintx = 4,
 		footprintz = 4,

--- a/units/CorBuildings/LandDefenceOffence/cormadsam.lua
+++ b/units/CorBuildings/LandDefenceOffence/cormadsam.lua
@@ -10,7 +10,6 @@ return {
 		collisionvolumetype = "CylY",
 		corpse = "DEAD",
 		energycost = 6100,
-		energyupkeep = 5,
 		explodeas = "mediumBuildingexplosiongeneric",
 		footprintx = 3,
 		footprintz = 3,

--- a/units/CorBuildings/LandEconomy/corsolar.lua
+++ b/units/CorBuildings/LandEconomy/corsolar.lua
@@ -12,6 +12,7 @@ return {
 		damagemodifier = 0.5,
 		energycost = 0,
 		energystorage = 50,
+		-- negative energyupkeep means it's conditional so when unit is off won't produce
 		energyupkeep = -20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,

--- a/units/CorBuildings/LandEconomy/corsolar.lua
+++ b/units/CorBuildings/LandEconomy/corsolar.lua
@@ -12,7 +12,7 @@ return {
 		damagemodifier = 0.5,
 		energycost = 0,
 		energystorage = 50,
-		energyupkeep = -20,
+		energymake = 20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,
 		footprintz = 5,

--- a/units/CorBuildings/LandEconomy/corsolar.lua
+++ b/units/CorBuildings/LandEconomy/corsolar.lua
@@ -12,7 +12,7 @@ return {
 		damagemodifier = 0.5,
 		energycost = 0,
 		energystorage = 50,
-		energymake = 20,
+		energyupkeep = -20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,
 		footprintz = 5,

--- a/units/CorBuildings/LandUtil/cornanotc.lua
+++ b/units/CorBuildings/LandUtil/cornanotc.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "31 32 31",
 		collisionvolumetype = "CylY",
 		energycost = 3200,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		footprintx = 3,
 		footprintz = 3,

--- a/units/CorBuildings/LandUtil/cornanotct2.lua
+++ b/units/CorBuildings/LandUtil/cornanotct2.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "46 80 46",
 		collisionvolumetype = "CylY",
 		energycost = 12800,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		footprintx = 4,
 		footprintz = 4,

--- a/units/CorBuildings/SeaUtil/cornanotc2plat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotc2plat.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "46 80 46",
 		collisionvolumetype = "CylY",
 		energycost = 12800,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		floater = true,
 		footprintx = 4,

--- a/units/CorBuildings/SeaUtil/cornanotcplat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotcplat.lua
@@ -16,7 +16,6 @@ return {
 		collisionvolumescales = "31 50 31",
 		collisionvolumetype = "CylY",
 		energycost = 2600,
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		floater = true,
 		footprintx = 3,

--- a/units/Legion/Economy/legmex.lua
+++ b/units/Legion/Economy/legmex.lua
@@ -15,6 +15,7 @@ return {
 		collisionvolumescales = "48 30 48",
 		collisionvolumetype = "CylY",
 		corpse = "DEAD",
+		-- negative energyupkeep means it's conditional so when unit is off won't produce
 		energyupkeep = -7,
 		explodeas = "smallBuildingexplosiongeneric",
 		extractsmetal = 0.0008,

--- a/units/Legion/Economy/legsolar.lua
+++ b/units/Legion/Economy/legsolar.lua
@@ -15,6 +15,7 @@ return {
 		corpse = "DEAD",
 		damagemodifier = 0.5,
 		energystorage = 50,
+		-- negative energyupkeep means it's conditional so when unit is off won't produce
 		energyupkeep = -20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,

--- a/units/Legion/Economy/legsolar.lua
+++ b/units/Legion/Economy/legsolar.lua
@@ -15,7 +15,7 @@ return {
 		corpse = "DEAD",
 		damagemodifier = 0.5,
 		energystorage = 50,
-		energymake = 20,
+		energyupkeep = -20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,
 		footprintz = 5,

--- a/units/Legion/Economy/legsolar.lua
+++ b/units/Legion/Economy/legsolar.lua
@@ -15,7 +15,7 @@ return {
 		corpse = "DEAD",
 		damagemodifier = 0.5,
 		energystorage = 50,
-		energyupkeep = -20,
+		energymake = 20,
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 5,
 		footprintz = 5,

--- a/units/Legion/Utilities/cornanotc2plat.lua
+++ b/units/Legion/Utilities/cornanotc2plat.lua
@@ -19,7 +19,6 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "46 80 46",
 		collisionvolumetype = "CylY",
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		floater = true,
 		footprintx = 4,

--- a/units/Legion/Utilities/legnanotc.lua
+++ b/units/Legion/Utilities/legnanotc.lua
@@ -19,7 +19,6 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "31 32 31",
 		collisionvolumetype = "CylY",
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		footprintx = 3,
 		footprintz = 3,

--- a/units/Legion/Utilities/legnanotcplat.lua
+++ b/units/Legion/Utilities/legnanotcplat.lua
@@ -19,7 +19,6 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "31 50 31",
 		collisionvolumetype = "CylY",
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		floater = true,
 		footprintx = 3,

--- a/units/Legion/Utilities/legnanotct2.lua
+++ b/units/Legion/Utilities/legnanotct2.lua
@@ -19,7 +19,6 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "46 80 46",
 		collisionvolumetype = "CylY",
-		energyupkeep = 30,
 		explodeas = "nanoboom",
 		footprintx = 4,
 		footprintz = 4,


### PR DESCRIPTION
### Work done

- Remove energyupkeep for units not really having it:
  - All construction turrets (including experimental? t2 ones).
  - armack (adv con bot), armacsub (adv con sub), and cormadsam (sam battery).
- Switch basic solars from energyupkeep to energymake.

#### Addresses Issue(s)

* Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3917

### Remarks

- Not sure why these units have energyupkeep, for what I could fathom this serves no purpose.
- Same for basic solars, these had negative energyupkeep instead of energymake, plus a special case at alldefs_post.lua to handle enhancing that (the special case would crash if energyupkeep was removed, maybe that was why it was like this?).
- **I might be wrong** about the changes, but I think the PR can be good in sparking some discussion if that's the case and maybe finding appropriate fixes for any issues that arise.
- I just didn't touch legmex negative upkeep. That can probably be changed to energymake too, but I couldn't test it right now so didn't want to mess with it.
- I tested a few things in-game and couldn't find any behaviour changes from changing these.