### PR TITLE
Fix toplevel gadget callins returning several parameters.

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -99,6 +99,14 @@ gadgetHandler = {
 }
 
 
+-- top level callins returning several values need to be wrapped
+-- in a special way.
+local multiReturnTopCallins = {
+	"GameSetup",
+	"AllowWeaponTarget",
+	"UnitPreDamaged",
+	"FeaturePreDamaged",
+}
 
 -- these call-ins are set to 'nil' if not used
 -- they are setup in UpdateCallIns()
@@ -812,17 +820,35 @@ function gadgetHandler:UpdateCallIn(name)
 		local selffunc = self[name]
 
 		if selffunc ~= nil then
-			_G[name] = function(...)
-				callinDepth = callinDepth + 1
+			local noUnpack = true
+			if table.contains(multiReturnTopCallins, name) then
+				noUnpack = false
+			end
 
-				local res = selffunc(self, ...)
-
+			local postOps = function()
 				callinDepth = callinDepth - 1
 				if reorderNeeded and callinDepth == 0 then
 					self:PerformReorders()
 				end
+			end
 
-				return res
+			if noUnpack then
+				_G[name] = function(...)
+					callinDepth = callinDepth + 1
+
+					local res = selffunc(self, ...)
+					postOps()
+					return res
+				end
+			else
+				-- methods returning several values need them unpacked
+				_G[name] = function(...)
+					callinDepth = callinDepth + 1
+
+					local res = {selffunc(self, ...)}
+					postOps()
+					return unpack(res)
+				end
 			end
 		else
 			Spring.Log(LOG_SECTION, LOG.ERROR, "UpdateCallIn: " .. name .. " is not implemented")


### PR DESCRIPTION
### Work done

- Fix wrapping of top level callins returning several parameters.
- Affected methods: GameSetup, AllowWeaponTarget, UnitPreDamaged, FeaturePreDamaged

### Explanation

- It's a critical fix
- Looks like I introduced a bug at https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3907
- Sorry about that :P

### Likely affected gadgets:

- GameSetup: none, still it can be affecting some engine calls since it will always return newReady nil
- AllowWeaponTarget (affects returned priority): unit_aa_targeting_priority
- UnitPreDamaged (affects impulse only): unit_combomb_full_damage, unit_dgun_behaviour, engine_hotfixes, unit_paralyze_damage_multiplier, map_lava, unit_paralyze_on_off, unit_collision_damage_behavior, unit_timeslow, unit_objectify, unit_evolution, unit_commando_watch, unit_shield_behaviour, unit_single_damage_fire, unit_lightning_splash_dmg, mo_preventcombomb, scav_spawner_defense, unit_no_land_damage
- FeaturePreDamaged (affects impulse only): gfx_tree_feller