### PR TITLE
Add Test.prepareWidget and Test.restoreWidget to simplify common test initializations

### DIFF
--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
@@ -9,13 +9,8 @@ function setup()
 
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidgetRaw(widgetName)
-	end
-	widgetHandler:EnableWidgetRaw(widgetName, true)
+	widget = Test.prepareWidget(widgetName)
 
-	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 	mock_saveBlueprintsToFile = Test.mock(widget, "saveBlueprintsToFile")
 
@@ -28,11 +23,6 @@ end
 
 function cleanup()
 	Test.clearMap()
-
-	widgetHandler:DisableWidgetRaw(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidgetRaw(widgetName, false)
-	end
 
 	Spring.SetCameraState(initialCameraState)
 end

--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -9,14 +9,8 @@ function setup()
 
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidgetRaw(widgetName)
-	end
-	widgetHandler:EnableWidgetRaw(widgetName, true)
+	widget = Test.prepareWidget(widgetName)
 
-	widget = widgetHandler:FindWidget(widgetName)
-	assert(widget)
 	mock_saveBlueprintsToFile = Test.mock(widget, "saveBlueprintsToFile")
 
 	initialCameraState = Spring.GetCameraState()
@@ -28,11 +22,6 @@ end
 
 function cleanup()
 	Test.clearMap()
-
-	widgetHandler:DisableWidgetRaw(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidgetRaw(widgetName, false)
-	end
 
 	Spring.SetCameraState(initialCameraState)
 end

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
@@ -7,20 +7,11 @@ end
 function setup()
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidgetRaw(widgetName)
-	end
-	widgetHandler:EnableWidgetRaw(widgetName, true)
+	Test.prepareWidget(widgetName)
 end
 
 function cleanup()
 	Test.clearMap()
-
-	widgetHandler:DisableWidgetRaw(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidgetRaw(widgetName, false)
-	end
 end
 
 function test()

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
@@ -7,20 +7,11 @@ end
 function setup()
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidgetRaw(widgetName)
-	end
-	widgetHandler:EnableWidgetRaw(widgetName, true)
+	Test.prepareWidget(widgetName)
 end
 
 function cleanup()
 	Test.clearMap()
-
-	widgetHandler:DisableWidgetRaw(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidgetRaw(widgetName, false)
-	end
 end
 
 function test()

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
@@ -7,20 +7,11 @@ end
 function setup()
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidgetRaw(widgetName)
-	end
-	widgetHandler:EnableWidgetRaw(widgetName, true)
+	Test.prepareWidget(widgetName)
 end
 
 function cleanup()
 	Test.clearMap()
-
-	widgetHandler:DisableWidgetRaw(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidgetRaw(widgetName, false)
-	end
 end
 
 function test()

--- a/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
+++ b/luaui/Widgets/TestsExamples/gui_battle_resource_tracker/test_gui_battle_resource_tracker.lua
@@ -9,20 +9,11 @@ function setup()
 
 	Test.clearMap()
 
-	initialWidgetActive = widgetHandler.knownWidgets[widgetName].active
-	if initialWidgetActive then
-		widgetHandler:DisableWidgetRaw(widgetName)
-	end
-	widgetHandler:EnableWidgetRaw(widgetName, true)
+	Test.prepareWidget(widgetName)
 end
 
 function cleanup()
 	Test.clearMap()
-
-	widgetHandler:DisableWidgetRaw(widgetName)
-	if initialWidgetActive then
-		widgetHandler:EnableWidgetRaw(widgetName, false)
-	end
 end
 
 function test()


### PR DESCRIPTION
### Work done

* Introduce Test.prepareWidget and Test.restoreWidget to simplify common test initializations

### Explanation

While working on the [safe-reordering-widgets](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3941) PR noticed a few widget tests calling EnableWidget and EnableWidget, all doing the same thing, namely remembering if the widget was enabled, then disabling and re-enabling it with locals access. On cleanup they will restore the previous enabled store and reenable without locals access if needed.

This PR introduces two methods and needed mechanism inside dbg_test_runner.lua to avoid all the copy paste among tests, also hiding some implementation details from them. Also makes the restoring after the test automatic for tests that did call prepareWidget.