### PR TITLE
Make unittweaks unitrestricted=0 disable naval, winds and geos properly on build menus.

### DIFF
--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -9,6 +9,7 @@ local unitEnergyCost = {}
 local unitMetalCost = {}
 local unitGroup = {}
 local unitRestricted = {}
+local manualUnitRestricted = {}
 local isBuilder = {}
 local isFactory = {}
 local unitIconType = {}
@@ -46,6 +47,7 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 
 	if unitDef.maxThisUnit == 0 then
 		unitRestricted[unitDefID] = true
+		manualUnitRestricted[unitDefID] = true
 	end
 
 	if unitDef.buildSpeed > 0 and unitDef.buildOptions[1] then
@@ -68,19 +70,19 @@ end
 
 local function restrictWindUnits(disable)
 	for unitDefID,_ in pairs(isWind) do
-		unitRestricted[unitDefID] = disable
+		unitRestricted[unitDefID] = manualUnitRestricted[unitDefID] or disable
 	end
 end
 
 local function restrictGeothermalUnits(disable)
 	for unitDefID,_ in pairs(isGeothermal) do
-		unitRestricted[unitDefID] = disable
+		unitRestricted[unitDefID] = manualUnitRestricted[unitDefID] or disable
 	end
 end
 
 local function restrictWaterUnits(disable)
 	for unitDefID,_ in pairs(isWaterUnit) do
-		unitRestricted[unitDefID] = disable
+		unitRestricted[unitDefID] = manualUnitRestricted[unitDefID] or disable
 	end
 end
 


### PR DESCRIPTION
### Work done

- Add logic so manual disabling of naval units, winds and geos through unitrestricted=0 will work properly on build menus.

#### Addresses Issue(s)

- fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3790

#### Test steps

- You can add the following tweakunits: e2FybXN5PXt1bml0cmVzdHJpY3RlZCA9IDB9LGFybWZocD17dW5pdHJlc3RyaWN0ZWQgPSAwfX0K
- Does `{armsy={unitrestricted = 0},armfhp={unitrestricted = 0}}`
- Check the factories are indeed disabled with PR.

### Remarks

- The issue is menus logic to enable/disable wind, water and geos is conflicting with the unittweaks.
- I noticed some other issues here:
  - duplicate code among gridmenu and buildmenu
  - water enabled test being done incorrectly (doesn't follow modrules properly and used limit is also likely wrong)
  - menu doesn't activate water units first time correctly until page is changed (needs a refresh), not an issue for this PR but you may have noticed torpedo launcher on first page always showing disabled initially even if map has water.
  - I think it's better to do a different PR to fix those, https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3935 will generate conflicts since some of the common code for water stuff needs to go there.
  - Everything is easy fix though.

### Screenshots:

If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:

![disabled-before](https://github.com/user-attachments/assets/0d5ad2ba-c78f-4ca8-8ebd-645037c80250)


#### AFTER:

![disabled-after](https://github.com/user-attachments/assets/a78fe944-e353-45a9-a1e1-d2eec4e7099c)
