### PR TITLE
Fix command target ID comparison checks for unit vs feature

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -96,9 +96,9 @@ local function auto_repair_routine(unitID,unitDefID)
     end
     if (commandQueue[1] ~= nil and commandQueue[1]["id"] == CMD_REPAIR) then
         -- out of range repair command
-		if (commandQueue[1]["params"][1] > Game.maxUnits) then
-			tx,ty,tz = SpGetFeaturePosition(commandQueue[1]["params"][1]-Game.maxUnits)
-			object_radius = SpGetFeatureRadius(commandQueue[1]["params"][1]-Game.maxUnits)
+		if (commandQueue[1]["params"][1] >= Game.maxUnits) then
+			tx,ty,tz = SpGetFeaturePosition(commandQueue[1]["params"][1] - Game.maxUnits)
+			object_radius = SpGetFeatureRadius(commandQueue[1]["params"][1] - Game.maxUnits)
 		else
 			tx,ty,tz = SpGetUnitPosition(commandQueue[1]["params"][1])
 			object_radius = SpGetUnitRadius(commandQueue[1]["params"][1])
@@ -109,9 +109,9 @@ local function auto_repair_routine(unitID,unitDefID)
     end
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] == CMD_RECLAIM) then
 		-- out of range reclaim command
-		if (commandQueue[1]["params"][1] > Game.maxUnits) then
-			tx,ty,tz = SpGetFeaturePosition(commandQueue[1]["params"][1]-Game.maxUnits)
-			object_radius = SpGetFeatureRadius(commandQueue[1]["params"][1]-Game.maxUnits)
+		if (commandQueue[1]["params"][1] >= Game.maxUnits) then
+			tx,ty,tz = SpGetFeaturePosition(commandQueue[1]["params"][1] - Game.maxUnits)
+			object_radius = SpGetFeatureRadius(commandQueue[1]["params"][1] - Game.maxUnits)
 		else
 			tx,ty,tz = SpGetUnitPosition(commandQueue[1]["params"][1])
 			object_radius = SpGetUnitRadius(commandQueue[1]["params"][1])

--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -102,10 +102,10 @@ end
 --]]
 
 local function GetUnitOrFeaturePosition(id)
-	if id <= Game.maxUnits then
+	if id < Game.maxUnits then
 		return Spring.GetUnitPosition(id)
 	else
-		return Spring.GetFeaturePosition(id-Game.maxUnits)
+		return Spring.GetFeaturePosition(id - Game.maxUnits)
 	end
 end
 

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -205,7 +205,7 @@ local function GetUnitFinalPosition(uID)
 						local pID = params[1]
 						local px, py, pz
 
-						if pID > maxUnits then
+						if pID >= maxUnits then
 							px, py, pz = spGetFeaturePosition(pID - maxUnits)
 						else
 							px, py, pz = spGetUnitPosition(pID)


### PR DESCRIPTION
### Work done
In commands, the target with ID == Game.maxUnits is the feature with ID 0.
https://github.com/beyond-all-reason/spring/blob/7363dbc54b55d309539b92c60245f88afd1f4e4a/rts/Sim/Units/CommandAI/BuilderCAI.cpp#L1005-L1008

This fixes the comparisons using the wrong logic.

#### Test steps
I truly have no idea. These only affect the edge case of the feature with ID 0.