### PR TITLE
Fix settarget incorrectly calling CallAsTeam with allyTeamID instead of teamID.

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -829,7 +829,7 @@ else	-- UNSYNCED
 		if fullview then
 			drawDecorations()
 		else
-			CallAsTeam(myAllyTeam, drawDecorations)
+			CallAsTeam(myTeam, drawDecorations)
 		end
 	end
 


### PR DESCRIPTION
### Work done

* Fix drawing of player settarget commands by properly passing myTeamID instead of myAllyTeamID to CallAsTeam

### Related issues

* No github issues but we have [this at discord](https://discord.com/channels/549281623154229250/1308503461905825872), also [this](https://discord.com/channels/549281623154229250/1309598770433888316) possibly fixed by this. Also during last week I have some reports of developers not being able to settarget properly (like @SethDGamre and @kroIya), might also be related.

### Remarks

* [In latest improvements of settarget](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3909) CallAsTeam was introduced to properly get radar corrected positions and los for allied settarget commands.
* This can cause the command to not be properly drawn in certain situations.
* It's my fault.