### PR TITLE
Fix switching among buildmenu and gridmenu.

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -1247,7 +1247,7 @@ end
 
 function widget:Initialize()
 	if widgetHandler:IsWidgetKnown("Grid menu") then
-		widgetHandler:DisableWidget("Grid menu")
+		widgetHandler:DisableWidgetRaw("Grid menu")
 	end
 
 	units.checkGeothermalFeatures()

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1239,6 +1239,10 @@ local function cycleBuilder()
 end
 
 function widget:Initialize()
+	if widgetHandler:IsWidgetKnown("Build menu") then
+		widgetHandler:DisableWidgetRaw("Build menu")
+	end
+
 	myTeamID = Spring.GetMyTeamID()
 	isSpec = Spring.GetSpectatingState()
 	isPregame = Spring.GetGameFrame() == 0 and not isSpec
@@ -1247,10 +1251,6 @@ function widget:Initialize()
 	WG["buildmenu"] = {}
 
 	doUpdateClock = os.clock()
-
-	if widgetHandler:IsWidgetKnown("Build menu") then
-		widgetHandler:DisableWidget("Build menu")
-	end
 
 	units.checkGeothermalFeatures()
 


### PR DESCRIPTION
### Work done

* Fixes problems when switching between grid and buildmenu.

### Explanation

* Both use the same global `WG['buildmenu'] `. It will be set to nil by both on Shutdown and setup with Initialize, so this really needs DisableWidget to run immediately, and before `WG['buildmenu']` is created. Otherwise it will get destroyed either in the middle of Initialize or afterwards by the other widget.
* Seems buildmenu->gridmenu broke with the new queued DisableWidget that will make shutdown run after initialize is done here. Looks like gridmenu->buildmenu was broken since some time (jun-2024 with 30cac26a0947ed9e94dc2fd0656b6e5ae1bbc709),