### PR TITLE
Show selected unit in legacy build menu pre-game

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -746,9 +746,8 @@ function widget:DrawScreen()
 
 	if Spring.GetGameFrame() == 0 and WG['pregame-build'] then
 		activeCmd = WG["pregame-build"] and WG["pregame-build"].getPreGameDefID()
-		activeCmd = activeCmd and -activeCmd
 		if activeCmd then
-			activeCmd = units.unitName[activeCmd]
+			activeCmd = unitName[activeCmd]
 		end
 	else
 		activeCmd = select(4, spGetActiveCommand())

--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -4,7 +4,6 @@
 ---
 
 
-local unitName = {}
 local unitEnergyCost = {}
 local unitMetalCost = {}
 local unitGroup = {}
@@ -163,8 +162,6 @@ local minWaterUnitDepth = -11
 ------------------------------------
 
 return {
-
-	unitName = unitName,
 	unitEnergyCost = unitEnergyCost,
 	unitMetalCost = unitMetalCost,
 	unitGroup = unitGroup,


### PR DESCRIPTION
### Work done

This fixes a bug where the currently selected build option is not highighted in the build menu when placing buildings pre-game.

I found this while investigating use of empty `units.unitName` table (https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3957#issuecomment-2492610116).

This table has been empty since e0f02ae69f68072ae08aeb141a53eddea80259c9, but there is a local table for the same purpose in `gui_buildmenu.lua` that is used instead.

- Use correct lookup table: `units.unitName` is always empty, but there is a table local to this file that can be used.
- Do not invert the def ID, the names are keyed by positive ID.
- Remove table `unitName` from `unit_buildmenu_config.lua` which is now definitely not referenced anywhere.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Play the game with legacy build menu.
- [ ] Observe highlight selection pre-game

### Screenshots
#### BEFORE:
![image](https://github.com/user-attachments/assets/95d6d87e-16e6-4fa7-94e1-51f77e96d23f)
_Mex is not highlighed_

#### AFTER:
![image](https://github.com/user-attachments/assets/75f0b180-6105-41db-9ff9-723f256eb80b)
_Mex is highlighed_
