### PR TITLE
Add another VBO for selected aircraft to draw them after water

### DIFF
--- a/luaui/Widgets/Include/DrawPrimitiveAtUnit.lua
+++ b/luaui/Widgets/Include/DrawPrimitiveAtUnit.lua
@@ -19,7 +19,8 @@ local shaderConfig = {
 	BILLBOARD = 0, -- 1 if you want camera facing billboards, 0 is flat on ground
 	POST_ANIM = " ", -- what you want to do in the animation post function (glsl snippet, see shader source)
 	POST_VERTEX = "v_color = v_color;", -- noop
-	POST_GEOMETRY = "gl_Position.z = (gl_Position.z) - 256.0 / (gl_Position.w);",	--"g_uv.zw = dataIn[0].v_parameters.xy;", -- noop
+	ZPULL = 256.0, -- how much to pull the z (depth) value towards the camera , 256 is about 16 elmos
+	POST_GEOMETRY = "",	--"g_uv.zw = dataIn[0].v_parameters.xy;", -- noop
 	POST_SHADING = "fragColor.rgba = fragColor.rgba;", -- noop
 	MAXVERTICES = 64, -- The max number of vertices we can emit, make sure this is consistent with what you are trying to draw (tris 3, quads 4, corneredrect 8, circle 64
 	USE_CIRCLES = 1, -- set to nil if you dont want circles

--- a/luaui/Widgets/Include/DrawPrimitiveAtUnit.lua
+++ b/luaui/Widgets/Include/DrawPrimitiveAtUnit.lua
@@ -64,7 +64,7 @@ local function InitDrawPrimitiveAtUnit(shaderConfig, DPATname)
 	
 	shaderSourceCache.shaderName = DPATname .. "Shader GL4"
 	
-	DrawPrimitiveAtUnitShader =  LuaShader.CheckShaderUpdates(shaderSourceCache)
+	DrawPrimitiveAtUnitShader =  LuaShader.CheckShaderUpdates(shaderSourceCache) or DrawPrimitiveAtUnitShader
 
 	if not DrawPrimitiveAtUnitShader then 
 		Spring.Echo("Failed to compile shader for ", DPATname)

--- a/luaui/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
+++ b/luaui/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
@@ -49,6 +49,12 @@ void offsetVertex4(float x, float y, float z, float u, float v, float addRadiusC
 	vec3 vecnorm = normalize(primitiveCoords);
 	PRE_OFFSET
 	gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * (addRadius * addRadiusCorr * vecnorm + primitiveCoords ), 1.0);
+	#ifdef ZPULL
+		// Note that this is a hack that can be used to make sure that the geometry is drawn in front of the unit
+		// or behind the unit. Positive values will draw the geometry in front of the unit, negative values will draw
+		// the value is approximately elmos squared, so 512 is 16 elmos
+		gl_Position.z = (gl_Position.z) - ZPULL / (gl_Position.w); // send 16 elmos forward in depth buffer
+	#endif 
 	g_uv.zw = dataIn[0].v_parameters.zw;
 	POST_GEOMETRY
 	EmitVertex();

--- a/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
@@ -232,7 +232,7 @@ function widget:Initialize()
 	shaderConfig.CLIPTOLERANCE = 1.2
 	-- MATCH CUS position as seed to sin, then pass it through geoshader into fragshader
 	--shaderConfig.POST_VERTEX = "v_parameters.w = max(-0.2, sin(timeInfo.x * 2.0/30.0 + (v_centerpos.x + v_centerpos.z) * 0.1)) + 0.2; // match CUS glow rate"
-	shaderConfig.POST_GEOMETRY = " gl_Position.z = (gl_Position.z) - 512.0 / (gl_Position.w); // send 16 elmos forward in depth buffer"
+	shaderConfig.ZPULL = 512.0 -- send 16 elmos forward in depth buffer"
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(texcolor.rgb, pow(texcolor.a,0.5) * g_uv.z);"
 	shaderConfig.MAXVERTICES = 4
 	shaderConfig.USE_CIRCLES = nil

--- a/luaui/Widgets/gui_ground_ao_plates_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_gl4.lua
@@ -118,7 +118,8 @@ function widget:Initialize()
 	shaderConfig.ANIMATION = 0
 	-- MATCH CUS position as seed to sin, then pass it through geoshader into fragshader
 	shaderConfig.POST_VERTEX = "v_parameters.w = max(-0.2, sin((timeInfo.x + timeInfo.w) * 2.0/30.0 + float(UNITID) * 0.1)) + 0.2; // match CUS glow rate"
-	shaderConfig.POST_GEOMETRY = "g_uv.w = dataIn[0].v_parameters.w; gl_Position.z = (gl_Position.z) - 512.0 / (gl_Position.w); // send 16 elmos forward in depth buffer"
+	shaderConfig.ZPULL = 512.0 -- send 16 elmos forward in depth buffer"
+	shaderConfig.POST_GEOMETRY = "g_uv.w = dataIn[0].v_parameters.w;" -- pass the glow rate to the frag shader
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(texcolor.rgb* (1.0 + g_uv.w), texcolor.a * g_uv.z);"
 	shaderConfig.MAXVERTICES = 4
 	shaderConfig.USE_CIRCLES = nil

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -22,6 +22,9 @@ local mouseoverHighlight = true
 ---- GL4 Backend Stuff----
 local selectionVBOGround = nil
 local selectionVBOAir = nil
+
+local mapHasWater = (Spring.GetGroundExtremes() < 0)
+
 local selectShader = nil
 local luaShaderDir = "LuaUI/Widgets/Include/"
 
@@ -165,8 +168,10 @@ local function DrawSelections(selectionVBO, isAir)
 	end
 end
 
-function widget:DrawWorld()
-	DrawSelections(selectionVBOAir, true)
+if mapHasWater then
+	function widget:DrawWorld()
+		DrawSelections(selectionVBOAir, true)
+	end
 end
 
 function widget:DrawWorldPreUnit()
@@ -300,7 +305,11 @@ local function init()
 	shaderConfig.HEIGHTOFFSET = 4
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(mix(g_color.rgb * texcolor.rgb + addRadius, vec3(1.0), "..(1-teamcolorOpacity)..") , texcolor.a * TRANSPARENCY + addRadius);"
 	selectionVBOGround, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsGround")
-	selectionVBOAir = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsAir")
+	if mapHasWater then 
+		selectionVBOAir = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsAir")
+	else
+		selectionVBOAir = selectionVBOGround
+	end
 	ClearLastMouseOver()
 	if selectionVBOGround == nil then
 		widgetHandler:RemoveWidget()

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -20,7 +20,8 @@ local selectionHighlight = true
 local mouseoverHighlight = true
 
 ---- GL4 Backend Stuff----
-local selectionVBO = nil
+local selectionVBOGround = nil
+local selectionVBOAir = nil
 local selectShader = nil
 local luaShaderDir = "LuaUI/Widgets/Include/"
 
@@ -103,7 +104,7 @@ local function AddPrimitiveAtUnit(unitID)
 	end
 	--Spring.Echo(unitID,radius,radius, Spring.GetUnitTeam(unitID), numvertices, 1, gf)
 	pushElementInstance(
-		selectionVBO, -- push into this Instance VBO Table
+		(unitCanFly[unitDefID] and selectionVBOAir) or selectionVBOGround, -- push into this Instance VBO Table
 		{
 			length, width, cornersize, additionalheight,  -- lengthwidthcornerheight
 			unitTeam[unitID], -- teamID
@@ -119,9 +120,8 @@ local function AddPrimitiveAtUnit(unitID)
 	)
 end
 
-local drawFrame = 0
-function widget:DrawWorldPreUnit()
-	drawFrame = drawFrame + 1
+
+local function DrawSelections(selectionVBO, isAir)
 	if selectionVBO.usedElements > 0 then
 		if hasBadCulling then
 			gl.Culling(false)
@@ -131,7 +131,7 @@ function widget:DrawWorldPreUnit()
 		selectShader:Activate()
 		selectShader:SetUniform("iconDistance", 99999) -- pass
 		glStencilTest(true) --https://learnopengl.com/Advanced-OpenGL/Stencil-testing
-		glDepthTest(true)
+		glDepthTest(true) -- One really interesting thing is that the depth test does not seem to be obeyed within DrawWorldPreUnit
 		glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE) -- Set The Stencil Buffer To 1 Where Draw Any Polygon		this to the shader
 		glClear(GL_STENCIL_BUFFER_BIT ) -- set stencil buffer to 0
 
@@ -165,7 +165,19 @@ function widget:DrawWorldPreUnit()
 	end
 end
 
+function widget:DrawWorld()
+	DrawSelections(selectionVBOAir, true)
+end
+
+function widget:DrawWorldPreUnit()
+	DrawSelections(selectionVBOGround, false)
+end
+
 local function RemovePrimitive(unitID)
+	local selectionVBO
+	if selectionVBOGround.instanceIDtoIndex[unitID] then selectionVBO =  selectionVBOGround end
+	if selectionVBOAir.instanceIDtoIndex[unitID] then selectionVBO =  selectionVBOAir end
+
 	if selectionVBO.instanceIDtoIndex[unitID] then
 		if selectionHighlight then
 			unitBufferUniformCache[1] = 0
@@ -287,9 +299,14 @@ local function init()
 	shaderConfig.TEAMCOLORIZATION = teamcolorOpacity	-- not implemented, doing it via POST_SHADING below instead
 	shaderConfig.HEIGHTOFFSET = 4
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(mix(g_color.rgb * texcolor.rgb + addRadius, vec3(1.0), "..(1-teamcolorOpacity)..") , texcolor.a * TRANSPARENCY + addRadius);"
-	selectionVBO, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnits")
+	selectionVBOGround, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsGround")
+	selectionVBOAir = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsAir")
 	ClearLastMouseOver()
-	if selectionVBO == nil then
+	if selectionVBOGround == nil then
+		widgetHandler:RemoveWidget()
+		return false
+	end
+	if selectionVBOAir == nil then
 		widgetHandler:RemoveWidget()
 		return false
 	end

--- a/luaui/Widgets/gui_unit_energy_icons.lua
+++ b/luaui/Widgets/gui_unit_energy_icons.lua
@@ -104,7 +104,7 @@ local function initGL4()
 	shaderConfig.BREATHESIZE = 0.1
   -- MATCH CUS position as seed to sin, then pass it through geoshader into fragshader
 	--shaderConfig.POST_VERTEX = "v_parameters.w = max(-0.2, sin(timeInfo.x * 2.0/30.0 + (v_centerpos.x + v_centerpos.z) * 0.1)) + 0.2; // match CUS glow rate"
-	shaderConfig.POST_GEOMETRY = " gl_Position.z = (gl_Position.z) - 512.0 / (gl_Position.w); // send 16 elmos forward in depth buffer"
+	shaderConfig.ZPULL = 512.0 -- send 32 elmos forward in depth buffer"
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(texcolor.rgb, texcolor.a * g_uv.z);"
 	shaderConfig.MAXVERTICES = 4
 	shaderConfig.USE_CIRCLES = nil

--- a/luaui/Widgets/gui_unit_idlebuilder_icons.lua
+++ b/luaui/Widgets/gui_unit_idlebuilder_icons.lua
@@ -62,7 +62,7 @@ local function initGL4()
 	shaderConfig.BREATHESIZE = 0--0.1
   -- MATCH CUS position as seed to sin, then pass it through geoshader into fragshader
 	--shaderConfig.POST_VERTEX = "v_parameters.w = max(-0.2, sin(timeInfo.x * 2.0/30.0 + (v_centerpos.x + v_centerpos.z) * 0.1)) + 0.2; // match CUS glow rate"
-	shaderConfig.POST_GEOMETRY = " gl_Position.z = (gl_Position.z) - 512.0 / (gl_Position.w); // send 16 elmos forward in depth buffer"
+	shaderConfig.ZPULL = 512.0 -- send 16 elmos forward in depth buffer"
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(texcolor.rgb, texcolor.a * g_uv.z);"
 	shaderConfig.MAXVERTICES = 4
 	shaderConfig.USE_CIRCLES = nil


### PR DESCRIPTION
### Work done

Aircraft, due to often being much higher up in Z, are now drawn in DrawWorld instead of DrawWorldPreUnit to prevent water distortion from affecting them. Note that this causes subtle other rendering problems later, but meh.

#### BEFORE:

#### AFTER:
![image](https://github.com/user-attachments/assets/fb012937-c820-4cb8-8f2d-b0c0c155fd87)

@bcdrme pls