### PR TITLE
hide shields rework modooption

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1249,6 +1249,7 @@ local options = {
         name   	= "Shields Rework",
         desc   	= "Shields block all projectiles. Overkill damage is blocked once before reaching 0% charge. Shields are disabled for a few seconds upon reaching 0%.",
         type   	= "bool",
+        hidden 	= true,
         section = "options_experimental",
         def  	= false,
     },


### PR DESCRIPTION
This is no longer in allignement with the design principals of the game design document. It should be hidden until the re-rework has been executed.