### PR TITLE
Only allow builders to guard out of map

### DIFF
--- a/luarules/gadgets/unit_prevent_aircraft_hax.lua
+++ b/luarules/gadgets/unit_prevent_aircraft_hax.lua
@@ -24,17 +24,25 @@ local mapZ = Game.mapSizeZ
 local allMobileUnits = {}
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitDefID = Spring.GetUnitDefID
+local spValidUnitID = Spring.ValidUnitID
 local CMD_STOP = CMD.STOP
+local CMD_GUARD = CMD.GUARD
 
 local isMobileUnit = {}
+local isBuilder = {}
 for unitDefID, udef in pairs(UnitDefs) do
 	if not (udef.isBuilding or udef.speed == 0) then
 		isMobileUnit[unitDefID] = true
+	end
+	if udef.isBuilder and (udef.buildSpeed and udef.buildSpeed > 0) and (udef.buildDistance and udef.buildDistance > 0) then
+		isBuilder[unitDefID] = true
 	end
 end
 
 function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD_STOP)
+	gadgetHandler:RegisterAllowCommand(CMD_GUARD)
 	for _, unitID in pairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID), spGetUnitTeam(unitID))
 	end
@@ -76,12 +84,25 @@ function gadget:GameFrame(f)
 	end
 end
 
+local function isInsideMap(unitID)
+	local x,_,z = spGetUnitPosition(unitID)
+	if z < 0 or x < 0 or z > mapZ or x > mapX then
+		return false
+	end
+	return true
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, fromSynced, fromLua)
-	-- accepts: CMD_STOP
-	if isMobileUnit[unitDefID] then
-		local x,_,z = Spring.GetUnitPosition(unitID)
-		if z < 0 or x < 0 or z > mapZ or x > mapX then
-			return false
+	if cmdID == CMD_STOP and isMobileUnit[unitDefID] then
+		return isInsideMap(unitID)
+	elseif cmdID == CMD_GUARD then
+		-- To guard out of map both units must be builders
+		local guardeeID = cmdParams[1]
+		if guardeeID and spValidUnitID(guardeeID) and not isInsideMap(guardeeID) then
+			local guardeeUnitDefID = spGetUnitDefID(guardeeID)
+			if not (isBuilder[unitDefID] and isBuilder[guardeeUnitDefID]) then
+				return false
+			end
 		end
 	end
 	return true

--- a/luarules/gadgets/unit_prevent_aircraft_hax.lua
+++ b/luarules/gadgets/unit_prevent_aircraft_hax.lua
@@ -26,6 +26,7 @@ local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitTeam = Spring.GetUnitTeam
 local spGetUnitDefID = Spring.GetUnitDefID
 local spValidUnitID = Spring.ValidUnitID
+local spIsPosInMap = Spring.IsPosInMap
 local CMD_STOP = CMD.STOP
 local CMD_GUARD = CMD.GUARD
 
@@ -86,10 +87,7 @@ end
 
 local function isInsideMap(unitID)
 	local x,_,z = spGetUnitPosition(unitID)
-	if z < 0 or x < 0 or z > mapZ or x > mapX then
-		return false
-	end
-	return true
+	return spIsPosInMap(x, z)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, fromSynced, fromLua)


### PR DESCRIPTION
### Work done

* Add rule to only allow builders to guard other units out of map.

#### Addresses Issue(s)

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/763

This doesn't fix the issue directly, but once engine version with [out of map leniency](https://github.com/beyond-all-reason/spring/pull/1769) hits it will be fixed, this PR addresses concerns at the issue of avoiding aircraft guard hacks out of map.

[out of map leniency](https://github.com/beyond-all-reason/spring/pull/1769) is **removing restrictions** on out of map guard and attack (except for ground attack).

#### Test steps

- Make an aircraft builder build something close to the edge.
- Wait until it's out of map.
- Set some other unit, like another air con to guard it.

### Remarks

* This goes in unit_prevent_aircraft_hax.lua. It does affect other units since for example construction turrets can help airplanes too. It's all about preventing aircraft hacks so I think it's ok.
* This only will really have an effect with latest engine version, but it won't hurt if run with an older (like current) version, it will just enforce something the engine is also enforcing itself.