### PR TITLE
Send out a LuaMsg to Chobby when creating a new save

### DIFF
--- a/luaui/Widgets/gui_savegame.lua
+++ b/luaui/Widgets/gui_savegame.lua
@@ -209,6 +209,10 @@ function widget:TextCommand(msg)
 		Spring.Echo("Trying to save:", msg)
 		local savefilename = string.sub(msg, 10)
 		SaveGame(savefilename, savefilename, true)
+
+		if Spring.GetMenuName and string.find(string.lower(Spring.GetMenuName()), 'chobby') ~= nil then
+			Spring.SendLuaMenuMsg("addNewSaveGame")
+		end
 	end
 end
 

--- a/luaui/Widgets/gui_savegame.lua
+++ b/luaui/Widgets/gui_savegame.lua
@@ -211,7 +211,7 @@ function widget:TextCommand(msg)
 		SaveGame(savefilename, savefilename, true)
 
 		if Spring.GetMenuName and string.find(string.lower(Spring.GetMenuName()), 'chobby') ~= nil then
-			Spring.SendLuaMenuMsg("addNewSaveGame")
+			Spring.SendLuaMenuMsg("gameSaved")
 		end
 	end
 end


### PR DESCRIPTION
### Work done
This PR adds a new LuaMenuMsg called "addNewSaveGame" that will trigger an automatic refresh of the Saved Games menu in lobby.


#### Addresses Issue(s)
https://github.com/beyond-all-reason/BYAR-Chobby/issues/691

#### Related PR
https://github.com/beyond-all-reason/BYAR-Chobby/pull/825

#### Setup
Update to latest alpha of Chobby.

#### Test steps
Navigate to Load Game menu and observe the newly added Refresh button. Navigate to Skirmish and start a game on latest mainline build of the BAR game (not dev copy). Save the game. Now leave the game, navigate back to the Load Game menu and load the game you just saved. When the game has loaded again, create another save and navigate back to lobby. Observe how the new save has not appeared and you need to press "Refresh" to get it to appear.

Repeat all above steps but this time create your saved game from a dev copy of the game containing the change in this PR. You should now observe that creating more saved games after loading a save will appear without any manual refresh button pushing.

The end result is that saved games created from game versions after this change will trigger refresh, but older saves created from game versions before this change will need a manual refresh to appear.

