### PR TITLE
Tests: Fix deserializing error return value on deserializeFunctionRun/Call.

### DIFF
--- a/common/testing/rpc.lua
+++ b/common/testing/rpc.lua
@@ -134,6 +134,9 @@ function RPC:deserializeFunctionRun(serializedFn)
 
 	local callableFunction = function()
 		local pcallOk, pcallResult = Util.splitFirstElement(Util.pack(pcall(data.fn, localsDictionary)))
+		if not pcallOk then
+			pcallResult = pcallResult[1]
+		end
 		return pcallOk, pcallResult
 	end
 

--- a/common/testing/rpc.lua
+++ b/common/testing/rpc.lua
@@ -91,6 +91,9 @@ function RPC:deserializeFunctionCall(serializedCall, env)
 
 	local callableFunction = function()
 		local pcallOk, pcallResult = Util.splitFirstElement(Util.pack(pcall(fn, unpack(data.args))))
+		if not pcallOk then
+			pcallResult = pcallResult[1]
+		end
 		return pcallOk, pcallResult
 	end
 


### PR DESCRIPTION
### Work done

* Fixes proxy calls deserialization for error values

#### Test steps

* Create a test with an error on SyncedRun or SyncedProxy, see below for snippet
* Run it and you will see it generates an error at formatTestResult, crashing the debug runner

### Explanation

Error value is expected to always be a string, but due to how the pcall return and result are unpacked from deserialization, the error would be set to an array. All downstream code expects error result to be string (not be packed into an extra array at least).

See https://github.com/beyond-all-reason/Beyond-All-Reason/blob/99e58f5e1fb69e2ca0e13be06e2643f22de3c472/common/testing/rpc.lua#L93 and https://github.com/beyond-all-reason/Beyond-All-Reason/blob/99e58f5e1fb69e2ca0e13be06e2643f22de3c472/common/testing/util.lua#L14-L15 second parameter is a table.

(Actually, the error might not be a string, but the problem here is we're creating the array here ourselves with pack, so if pcall returns are `false, "error at foo"`, we would return `false, {"error at foo"}`)

This could also be fixed somewhere downstream in [dbg_synced_proxy.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/99e58f5e1fb69e2ca0e13be06e2643f22de3c472/luarules/gadgets/dbg_synced_proxy.lua#L48), [dbg_test_runner.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/99e58f5e1fb69e2ca0e13be06e2643f22de3c472/luaui/Widgets/dbg_test_runner.lua#L894) or [common/testing/results.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/99e58f5e1fb69e2ca0e13be06e2643f22de3c472/common/testing/results.lua#L65), but imo rpc.lua is the root of the error.

Making the test runner more robust against error not being a string can also be done in addition to this (for example by adding Json.encode inside [common/testing/results.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/99e58f5e1fb69e2ca0e13be06e2643f22de3c472/common/testing/results.lua#L65)), but that's not a problem atm since I don't think spring or BAR have a custom of raising structured errors.

### Snippet

Put this inside test() of any of the available tests, for example test_cmd_stop_selfd.lua and then run as /runtests test_cmd_stop_selfd

```LUA
        local cmdID = CMD.FIRE_STATE
        SyncedRun(function(locals)
                -- bad unitID of 7 will make GiveOrderToUnit fail
                return Spring.GiveOrderToUnit(7, locals.cmdID, {0}, {})
        end)
```

alternatively, to test the deserializeFunctionCall path:

```LUA
SyncedProxy.Spring.GiveOrderToUnit(7, CMD.FIRE_STATE, {0}, 0)
```


### Before

```
[t=00:51:45.521036][f=0000190] [Test Runner] =====RUNNING TESTS=====
[t=00:51:45.920797][f=0000202] Error in GameFrame(): [string "common/testing/results.lua"]:65: attempt to concatenate field 'error' (a table value)
[t=00:51:45.920826][f=0000202] Removed widget: Test Runner
```

### After

```
[t=00:50:31.322872][f=0000293] [Test Runner] =====RUNNING TESTS=====
[t=00:50:31.688588][f=0000304] [Test Runner] ��FAIL����: settarget/test_settarget.lua [10 frames] [333 ms] | [string "LuaUI/Widgets/tests/settarget/test_settarget.lua"]:57: [string "common/testing/helpers.lua"]:44: [GiveOrderToUnit] invalid unitID
[t=00:50:31.688610][f=0000304] [Test Runner] =====TEST RESULTS=====
[t=00:50:31.688620][f=0000304] [Test Runner] ��FAIL����: settarget/test_settarget.lua [10 frames] [333 ms] | [string "LuaUI/Widgets/tests/settarget/test_settarget.lua"]:57: [string "common/testing/helpers.lua"]:44: [GiveOrderToUnit] invalid unitID
```