### PR TITLE
No Rush Timer: mention minutes

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -214,7 +214,7 @@ local options = {
 
     {
         key    	= "norushtimer",
-        name   	= "No Rush Time",
+        name   	= "No Rush Time".."\255\128\128\128".." [minutes]",
         desc   	= "Set timer in which players cannot get out of their startbox, so you have time to prepare before fighting. PLEASE NOTE: For this to work, the game needs to have set startboxes. It won't work in FFA mode without boxes. Also, it does not affect Scavengers and Raptors.",
         type   	= "number",
         section	= "options_main",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -215,7 +215,11 @@ local options = {
     {
         key    	= "norushtimer",
         name   	= "No Rush Time".."\255\128\128\128".." [minutes]",
-        desc   	= "Set timer in which players cannot get out of their startbox, so you have time to prepare before fighting. PLEASE NOTE: For this to work, the game needs to have set startboxes. It won't work in FFA mode without boxes. Also, it does not affect Scavengers and Raptors.",
+        desc   	= "Set timer in which players cannot get out of their startbox, so you have time to prepare before fighting.\n"..
+			"PLEASE NOTE: For this to work, the game needs to have set startboxes.\n"..
+			-- tabs don't do much in chobby
+			"                          It won't work in FFA mode without boxes.\n"..
+			"                          Also, it does not affect Scavengers and Raptors.",
         type   	= "number",
         section	= "options_main",
         def    	= 0,


### PR DESCRIPTION
# Work Done

The Display Name of the no Rush Timer now includes the word miuntes, not to be confused with seconds, or hours.
*also formated the description so that it doesn't look like spaghetti.

# Addresses: 

https://discord.com/channels/549281623154229250/1310982732779618377/1310982732779618377

# Preview

![image](https://github.com/user-attachments/assets/52840a56-91c7-48ae-bb5f-5e65a26c20ba)
![image](https://github.com/user-attachments/assets/7558ad45-e68f-409b-95a8-394004e986c8)
![image](https://github.com/user-attachments/assets/c651e56a-5249-46a0-9ba8-fc6f8a127235)
