### PR TITLE
Fix not equal tests

### DIFF
--- a/common/testing/assertions.lua
+++ b/common/testing/assertions.lua
@@ -44,8 +44,75 @@ local function assertTablesEqual(table1, table2, margin, visited, path)
 	end
 end
 
+local depth = 0
 
+-- Assert the given fn returns trueish before seconds.
+--
+-- fn will be called every 'frames' game frames.
+-- errorMsg can be set to customize the error message preface.
+local function assertSuccessBefore(seconds, frames, fn, errorMsg, depthOffset)
+	local iters = math.ceil((seconds*30)/frames)
+	for i=1, iters do
+		-- dangerous to set depth here since fn() can fail.
+		-- no pcall since SyncedProxy and SyncedRun wouldn't work.
+		local res = fn()
+		if res then
+			return
+		end
+		Test.waitFrames(frames)
+	end
+	depthOffset = (depthOffset or 0) + 2 + depth
+	-- Error instead of assert to get a proper error line position
+	error(errorMsg or "assertSuccessBefore: didn't succeed before " .. tostring(seconds) .. " seconds", depthOffset)
+end
+
+
+-- Assert the given function throws an exception
+--
+-- Note it's better to use assertThrowsMessage since otherwise you might be catching an
+-- unexpected error. Still, this is provided for convenience.
+-- Can't be used with SyncedProxy or SyncedRun for now as they don't work inside pcall.
+local function assertThrows(fn, errorMsg, depthOffset)
+	depth = depth + 1
+	local isOk = pcall(fn)
+	depth = depth - 1
+	if isOk then
+		depthOffset = (depthOffset or 0) + 2 + depth
+		error(errorMsg or "assertThrows", depthOffset)
+	end
+end
+
+
+-- Assert the given function throws an exception with a specific error message
+--
+-- Can't be used with SyncedProxy or SyncedRun for now as they don't work inside pcall.
+local function assertThrowsMessage(fn, testMsg, errorMsg, depthOffset)
+	depthOffset = depthOffset or 0
+	depth = depth + 1
+	local isOk, result = pcall(fn)
+	depth = depth - 1
+	depthOffset = (depthOffset or 0) + 2 + depth
+	if isOk then
+		error(errorMsg or "assertThrowsMessage: didn't throw", depthOffset)
+	end
+	if not isOk and not type(result) == "string" then
+		error(errorMsg or "assertThrowsMessage: error was not a string", depthOffset)
+	end
+	-- split "standard" error format
+	-- it's in the form: [string "LuaUI/Widgets/tests/selftests/test_assertions.lua"]:17: error2
+	local match = result
+	local errorIndex = result:match'^%[string "[%p%a%s]*%"]:[%d]+:().*'
+	if errorIndex and errorIndex > 0 then
+		match = result:sub(errorIndex + 1)
+	end
+	if match ~= testMsg then
+		error(errorMsg or "assertThrowsMessage: error was not '" .. tostring(testMsg) .. "': '" .. tostring(match) .. "'", depthOffset)
+	end
+end
 
 return {
 	assertTablesEqual = assertTablesEqual,
+	assertSuccessBefore = assertSuccessBefore,
+	assertThrows = assertThrows,
+	assertThrowsMessage = assertThrowsMessage,
 }

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -288,7 +288,7 @@ if gadgetHandler:IsSyncedCode() then
 		spSetUnitRulesParam(unitID, "targetCoordX", -1)
 		spSetUnitRulesParam(unitID, "targetCoordY", -1)
 		spSetUnitRulesParam(unitID, "targetCoordZ", -1)
-		if unitTargets[unitID] and not keeptrack == true then
+		if unitTargets[unitID] and not keeptrack then
 			SendToUnsynced("targetList", unitID, 0)
 		end
 		unitTargets[unitID] = nil

--- a/luaui/Widgets/Tests/selftests/test_assertions.lua
+++ b/luaui/Widgets/Tests/selftests/test_assertions.lua
@@ -1,0 +1,159 @@
+
+function sanityChecks()
+	-- Just to make sure some standard methods used here work as expected.
+	Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
+	SyncedProxy.Spring.ValidUnitID(20)
+	local res, err = pcall(function()
+		Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
+	end)
+	assert(err ~= "attempt to yield across metamethod/C-call boundary")
+end
+
+function failingTests()
+	-- All of these fail due to error "attempt to yield across metamethod/C-call boundary"
+	-- This is something to do with how the test system is structured.
+	local res, err = pcall(function()
+		SyncedRun(function()
+			Spring.ValidUnitID(20)
+		end)
+	end)
+	assert(err ~= "attempt to yield across metamethod/C-call boundary")
+
+	local res, err = pcall(function()
+		SyncedProxy.Spring.ValidUnitID(20)
+	end)
+	assert(err ~= "attempt to yield across metamethod/C-call boundary")
+
+	local res, bla = pcall(function()
+		Test.waitUntil(function()
+			return true
+		end)
+	end)
+	assert(err ~= "attempt to yield across metamethod/C-call boundary")
+
+	assertThrowsMessage(function()
+		SyncedProxy.Spring.ValidUnitID(20)
+		error("error")
+	end, "error")
+
+	assertThrowsMessage(function()
+		SyncedProxy.Spring.GiveOrderToUnit(20, CMD.FIRE_STATE, {0}, {})
+	end, "[GiveOrderToUnit] invalid unitID")
+
+	assertThrowsMessage(function()
+		assertSuccessBefore(1, 10, function() return false end, "error")
+	end, "error")
+
+	assertThrowsMessage(function()
+		Test.waitUntil(function()
+			error("error")
+		end, 1)
+	end, "error")
+
+	-- this ones can get stuck forever:
+	--Test.waitUntil(function()
+	--	SyncedRun(function()
+	--		Spring.ValidUnitID(20)
+	--	end)
+	--end, 1)
+	--Test.waitUntil(function()
+	--	SyncedProxy.Spring.ValidUnitID(20)
+	--end, 1)
+	--
+end
+
+function failingWhileSucceedingTests()
+	-- these ones are actually failing even when they don't throw exceptions,
+	-- it's because assertThrows is catching the exception, it's just not
+	-- the one we want.
+
+	assertThrows(function()
+		-- this test should fail since ValidUnitID doesn't throw exceptions.
+		SyncedProxy.Spring.ValidUnitID(20)
+	end)
+	assertThrows(function()
+		-- this actually throws an exception, but due to something else.
+		SyncedProxy.Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
+	end)
+end
+
+function testWaitUntil()
+	Test.waitUntil(function()
+		return true
+	end)
+end
+
+function testAssertSuccessBefore()
+	-- test the method succeeding
+	assertSuccessBefore(1, 10, function() return true end)
+	assertSuccessBefore(1, 10, function()
+		-- SyncedProxy works here
+		SyncedProxy.Spring.ValidUnitID(20)
+		return true
+	end)
+	-- test the method never succeeding in the alloted time
+	assertThrowsMessage(function()
+		assertSuccessBefore(1, 10, function() error("error") end)
+	end, "error")
+end
+
+function testAssertThrows()
+	-- test detecting an exception
+	assertThrows(function()
+		error("error")
+	end)
+	-- test detecting an assertion
+	assertThrows(function()
+		assert(false)
+	end)
+	-- test assert throws an error when the function doesn't
+	assertThrows(function()
+		assertThrows(function() return true end)
+	end)
+	assertThrows(function()
+		Spring.ValidUnitID(20)
+		error("error")
+	end)
+end
+
+function testAssertThrowsMessage()
+	-- test throwing a specific message
+	assertThrowsMessage(function()
+		error("error")
+	end, "error")
+	-- test assertion throwing a specific message
+	assertThrowsMessage(function()
+		assert(false, "error")
+	end, "error")
+	-- test if works when the error has brackets
+	assertThrowsMessage(function()
+		error("[error]")
+	end, "[error]")
+	-- test it works when error ends the same as the error
+	assertThrows(function()
+		assertThrowsMessage(function() error("another error") end, "error")
+	end)
+	-- test our splitting method works when the error has the same pattern
+	assertThrowsMessage(function()
+		error('[string "LuaUI/Widgets/tests/selftests/test_assertions.lua"]:17: error2')
+	end, '[string "LuaUI/Widgets/tests/selftests/test_assertions.lua"]:17: error2')
+
+	-- test other methods setting the error message
+	assertThrowsMessage(function()
+		assert(false, "error")
+	end, "error")
+	assertThrowsMessage(function()
+		Spring.ValidUnitID(20)
+		error("error")
+	end, "error")
+end
+
+function test()
+	sanityChecks()
+	testWaitUntil()
+	testAssertThrows()
+	testAssertSuccessBefore()
+	testAssertThrowsMessage()
+	--failingTests()
+	failingWhileSucceedingTests()
+end

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1103,7 +1103,7 @@ local function drawUnitInfo()
 
 	local unitNameColor = tooltipTitleColor
 	if SelectedUnitsCount > 0 then
-		if not displayMode == 'unitdef' or (WG['buildmenu'] and (activeCmdID and activeCmdID < 0 and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
+		if displayMode ~= 'unitdef' or (WG['buildmenu'] and (activeCmdID and activeCmdID < 0 and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
 			unitNameColor = '\255\125\255\125'
 		end
 	end
@@ -1143,7 +1143,7 @@ local function drawUnitInfo()
 	-- custom unit info area
 	customInfoArea = { math_floor(backgroundRect[3] - width - bgpadding), math_floor(backgroundRect[2]), math_floor(backgroundRect[3] - bgpadding), math_floor(backgroundRect[2] + height) }
 
-	if not displayMode == 'unitdef' or not showBuilderBuildlist or not unitDefInfo[displayUnitDefID].buildOptions or (not (WG['buildmenu'] and WG['buildmenu'].hoverID)) then
+	if displayMode ~= 'unitdef' or not showBuilderBuildlist or not unitDefInfo[displayUnitDefID].buildOptions or (not (WG['buildmenu'] and WG['buildmenu'].hoverID)) then
 		RectRound(customInfoArea[1], customInfoArea[2], customInfoArea[3], customInfoArea[4], elementCorner*0.66, 1, 0, 0, 0, { 0.8, 0.8, 0.8, 0.08 }, { 0.8, 0.8, 0.8, 0.15 })
 	end
 

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -26,7 +26,7 @@ end
 if damageStats and damageStats[gameName] and damageStats[gameName].team then
 	local rate = 0
 	for k, v in pairs (damageStats[gameName].team) do
-		if not v == damageStats[gameName].team.games and v.cost and v.killed_cost then
+		if k ~= "games" and v.cost and v.killed_cost then
 			local compRate = v.killed_cost/v.cost
 			if compRate > rate then
 				highestUnitDef = k
@@ -36,7 +36,7 @@ if damageStats and damageStats[gameName] and damageStats[gameName].team then
 	end
 	local scndRate = 0
 	for k, v in pairs (damageStats[gameName].team) do
-		if not v == damageStats[gameName].team.games and v.cost and v.killed_cost then
+		if k ~= "games" and v.cost and v.killed_cost then
 			local compRate = v.killed_cost/v.cost
 			if compRate > scndRate and k ~= highestUnitDef then
 				scndhighestUnitDef = k
@@ -47,7 +47,7 @@ if damageStats and damageStats[gameName] and damageStats[gameName].team then
 	local thirdRate = 0
 	--local thirdhighestUnitDef
 	for k, v in pairs (damageStats[gameName].team) do
-		if not v == damageStats[gameName].team.games and v.cost and v.killed_cost then
+		if k ~= "games" and v.cost and v.killed_cost then
 			local compRate = v.killed_cost/v.cost
 			if compRate > thirdRate and k ~= highestUnitDef and k ~= scndhighestUnitDef then
 				--thirdhighestUnitDef = k


### PR DESCRIPTION
Searched for the lua antipattern of doing `if not x == y`, that results in `if (not x) == y` instead of `if x ~= y`.

Using `grep -r "not [a-z0-9A-Z\.]* *=="`

They would result in the test always being skipped.

**Note:** I suppose the intent was for the test to have some effect, also tried to make sure of the meaning, but more eyes checking to see the result is proper will be good.

Fixing all detected instances in the codebase except the ones related to sockets (camera_joystick.lua and api_unit_tracker_gl4.lua), since those will need a couple more changes to fix socket usage.