### PR TITLE
Fix instances of 'if not x == y'.

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -288,7 +288,7 @@ if gadgetHandler:IsSyncedCode() then
 		spSetUnitRulesParam(unitID, "targetCoordX", -1)
 		spSetUnitRulesParam(unitID, "targetCoordY", -1)
 		spSetUnitRulesParam(unitID, "targetCoordZ", -1)
-		if unitTargets[unitID] and not keeptrack == true then
+		if unitTargets[unitID] and not keeptrack then
 			SendToUnsynced("targetList", unitID, 0)
 		end
 		unitTargets[unitID] = nil

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1103,7 +1103,7 @@ local function drawUnitInfo()
 
 	local unitNameColor = tooltipTitleColor
 	if SelectedUnitsCount > 0 then
-		if not displayMode == 'unitdef' or (WG['buildmenu'] and (activeCmdID and activeCmdID < 0 and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
+		if displayMode ~= 'unitdef' or (WG['buildmenu'] and (activeCmdID and activeCmdID < 0 and (not WG['buildmenu'].hoverID or (-activeCmdID == WG['buildmenu'].hoverID)))) then
 			unitNameColor = '\255\125\255\125'
 		end
 	end
@@ -1143,7 +1143,7 @@ local function drawUnitInfo()
 	-- custom unit info area
 	customInfoArea = { math_floor(backgroundRect[3] - width - bgpadding), math_floor(backgroundRect[2]), math_floor(backgroundRect[3] - bgpadding), math_floor(backgroundRect[2] + height) }
 
-	if not displayMode == 'unitdef' or not showBuilderBuildlist or not unitDefInfo[displayUnitDefID].buildOptions or (not (WG['buildmenu'] and WG['buildmenu'].hoverID)) then
+	if displayMode ~= 'unitdef' or not showBuilderBuildlist or not unitDefInfo[displayUnitDefID].buildOptions or (not (WG['buildmenu'] and WG['buildmenu'].hoverID)) then
 		RectRound(customInfoArea[1], customInfoArea[2], customInfoArea[3], customInfoArea[4], elementCorner*0.66, 1, 0, 0, 0, { 0.8, 0.8, 0.8, 0.08 }, { 0.8, 0.8, 0.8, 0.15 })
 	end
 

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -26,7 +26,7 @@ end
 if damageStats and damageStats[gameName] and damageStats[gameName].team then
 	local rate = 0
 	for k, v in pairs (damageStats[gameName].team) do
-		if not v == damageStats[gameName].team.games and v.cost and v.killed_cost then
+		if k ~= "games" and v.cost and v.killed_cost then
 			local compRate = v.killed_cost/v.cost
 			if compRate > rate then
 				highestUnitDef = k
@@ -36,7 +36,7 @@ if damageStats and damageStats[gameName] and damageStats[gameName].team then
 	end
 	local scndRate = 0
 	for k, v in pairs (damageStats[gameName].team) do
-		if not v == damageStats[gameName].team.games and v.cost and v.killed_cost then
+		if k ~= "games" and v.cost and v.killed_cost then
 			local compRate = v.killed_cost/v.cost
 			if compRate > scndRate and k ~= highestUnitDef then
 				scndhighestUnitDef = k
@@ -47,7 +47,7 @@ if damageStats and damageStats[gameName] and damageStats[gameName].team then
 	local thirdRate = 0
 	--local thirdhighestUnitDef
 	for k, v in pairs (damageStats[gameName].team) do
-		if not v == damageStats[gameName].team.games and v.cost and v.killed_cost then
+		if k ~= "games" and v.cost and v.killed_cost then
 			local compRate = v.killed_cost/v.cost
 			if compRate > thirdRate and k ~= highestUnitDef and k ~= scndhighestUnitDef then
 				--thirdhighestUnitDef = k


### PR DESCRIPTION
Searched for the lua antipattern of doing `if not x == y`, that results in `if (not x) == y` instead of `if x ~= y`.

Using `grep -r "not [a-z0-9A-Z\.]* *=="`

They would result in the test always being skipped.

* Affect unit_target_on_the_move, aka settarget. The results of the fix **need to be tested well**.
  * As far as I can see this was doing inverse logic, but not sure yet about the effects, it's for keeping the unsynced information untouched in cases where targeting gets paused. When inverse it will keep the info in a lot of other situations where is shouldn't but it could not affect much due to code redundancy.
* gui_info: Some instances of slightly different style when not in unitdef mode
  * can't really see the difference it's supposed to make the rounded area at the unit extra info area show sometimes
* gui_unit_stats: Not setting scndhighestUnitDef and rate/scndRate/thirdRate properly
  * totally useless part of the code

**Note:** I suppose the intent was for the tests to have some effect, also tried to make sure of the meaning, but more eyes checking to see the result is proper will be good.

Fixing all detected instances in the codebase except the ones related to sockets (camera_joystick.lua and api_unit_tracker_gl4.lua), since those will need a couple more changes to fix socket usage. Those get changed at https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3981