### PR TITLE
Fix socket usage inside api_unit_tracker_gl4 and camera_joystick.

### DIFF
--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -726,13 +726,13 @@ function widget:GameStart()
 
 		local client=socket.tcp()
 		local res, err = client:connect("server4.beyondallreason.info", 8200)
-		if not res and not res=="timeout" then
+		if not res and err ~= "timeout" then
 			--Spring.Echo("Failure",res,err)
 		else
 			local message = "c.telemetry.log_client_event lobby:info " .. string.base64Encode(Json.encode(pnl)).." ZGVhZGJlZWZkZWFkYmVlZmRlYWRiZWVmZGVhZGJlZWY=\n"
 			client:send(message)
 		end
-		if client ~= nil then client:close() end
+		client:close()
 	end
 	--local succes, res = pcall(LobbyInfo)
 end

--- a/luaui/Widgets/camera_joystick.lua
+++ b/luaui/Widgets/camera_joystick.lua
@@ -313,7 +313,8 @@ local function SocketConnect(host, port)
 	client=socket.tcp()
 	client:settimeout(0)
 	res, err = client:connect(host, port)
-	if not res and not res=="timeout" then
+	if not res and err ~= "timeout" then
+		client:close()
 		Spring.Echo("Unable to connect to joystick server: ",res, err, "Restart widget after server is started")
 		return false
 	end
@@ -357,6 +358,8 @@ function widget:Initialize()
 	local connected = SocketConnect(host, port)
 	if connected then
 		Spring.SetConfigInt("RotOverheadClampMap",0)
+	else
+		widgetHandler:RemoveWidget()
 	end
 end
 


### PR DESCRIPTION
### Work done

- Fix slightly incorrect socket usage inside api_unit_tracker_gl4 and camera_joystick.
- Also make camera_joystick remove itself when it can't connect.

### More details
- Real errors were not being properly handled because of `if not res and err ~= "timeout" then` test.
- camera_joystick not releasing its socket
- Removing itself at camera_joystick is not critical, but will save some processing for whoever casually enables it, seems the right thing to do.