### PR TITLE
Update broken AllowWeaponTargetCheck in gadgets.lua

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1662,13 +1662,20 @@ function gadgetHandler:TerraformComplete(unitID, unitDefID, unitTeam,
 end
 
 function gadgetHandler:AllowWeaponTargetCheck(attackerID, attackerWeaponNum, attackerWeaponDefID)
-	for _, g in ipairs(self.AllowWeaponTargetCheckList) do
-		if not g:AllowWeaponTargetCheck(attackerID, attackerWeaponNum, attackerWeaponDefID) then
-			return false
+local ignore = true
+for _, g in ipairs(self.AllowWeaponTargetCheckList) do
+	local allowCheck, ignoreCheck = g:AllowWeaponTargetCheck(attackerID, attackerWeaponNum, attackerWeaponDefID)
+	if not ignoreCheck then
+		ignore = false
+		if not allowCheck then
+			return 0
 		end
 	end
-	return true
 end
+
+return ((ignore and -1) or 1)
+end
+
 
 function gadgetHandler:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
 	local allowed = true


### PR DESCRIPTION
An engine change made years ago broke this unused call-in. This PR fixes it by copy/pasting over the relevant snippet of code from gadgets.lua 
![image](https://github.com/user-attachments/assets/b8ebd3d8-4173-4100-9e6f-d951cab947c1)
@saurtron for your viewing pleasure. Sometimes github messes up the formatting.

this was pulled out of another PR of mine where I ended up not using it for performance reasons. This will be important when lua-based target prioritization is implemented.