### PR TITLE
Make internal list in unit_preaim.lua into customparams

### DIFF
--- a/luarules/gadgets/unit_preaim.lua
+++ b/luarules/gadgets/unit_preaim.lua
@@ -31,48 +31,11 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 					local weaponDefID = weapons[i].weaponDef
 					isPreaimUnit[unitDefID][i] = weaponDefID
 					weaponRange[weaponDefID] = WeaponDefs[weaponDefID].range
-				else
-					Spring.Echo("PreAim Exemption: ".. unitDef.name, i, isPreaimUnit[unitDefID])
 				end
 			end
 		end
 	end
 end
-
--- local exludedUnitsNames = {    -- exclude auto target range boost for popup units
-	--['armclaw'] = true,
-	--['armpb'] = true,
-	--['armamb'] = true,
-	--['cormaw'] = true,
-	--['corvipe'] = true,
-	--['corpun'] = true,
-	--cormexp
-	--['corexp'] = true,
-	--['corllt'] = true,
-	--corhlllt
-	--['corhllt'] = true,
-	--['armllt'] = true,
---	['leginc'] = true,
--- leglht
---legdtr
---legbombard
---armshockwave
--- }
--- -- convert unitname -> unitDefID + add scavengers
--- --local exludedUnits = {}
--- --for name, params in pairs(exludedUnitsNames) do
--- --	if UnitDefNames[name] then
--- --		exludedUnits[UnitDefNames[name].id] = params
--- --		if UnitDefNames[name..'_scav'] then
--- --			exludedUnits[UnitDefNames[name..'_scav'].id] = params
--- 		end
--- 	end
--- end
--- exludedUnitsNames = nil
-
--- for key, value in pairs(exludedUnits) do
--- 	isPreaimUnit[key] = nil
--- end
 
 function gadget:UnitCreated(unitID, unitDefID)
 	if isPreaimUnit[unitDefID] then

--- a/luarules/gadgets/unit_preaim.lua
+++ b/luarules/gadgets/unit_preaim.lua
@@ -14,58 +14,65 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
---use customparams.exclude_preaim = true, to exclude units from being able to pre-aim at targets almost within firing range.
+--use weaponDef.customparams.exclude_preaim = true to exclude units from being able to pre-aim at targets almost within firing range.
 --this is a good idea for pop-up turrets so they don't prematurely reveal themselves.
 --also when proximityPriority is heavily biased toward far targets
 
 local weaponRange = {}
 local isPreaimUnit = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	if not unitDef.canFly and not unitDef.customParams.exclude_preaim then
+	if not unitDef.canFly then
 		local weapons = unitDef.weapons
 		if #weapons > 0 then
 			for i=1, #weapons do
 				if not WeaponDefs[weapons[i].weaponDef].customParams.exclude_preaim then
-					if not isPreaimUnit[unitDefID] then
-						isPreaimUnit[unitDefID] = {}
-					end
+					isPreaimUnit[unitDefID] = isPreaimUnit[unitDefID] or {}
+
 					local weaponDefID = weapons[i].weaponDef
 					isPreaimUnit[unitDefID][i] = weaponDefID
 					weaponRange[weaponDefID] = WeaponDefs[weaponDefID].range
+				else
+					Spring.Echo("PreAim Exemption: ".. unitDef.name, i, isPreaimUnit[unitDefID])
 				end
 			end
 		end
 	end
 end
 
-local exludedUnitsNames = {    -- exclude auto target range boost for popup units
-	['armclaw'] = true,
-	['armpb'] = true,
-	['armamb'] = true,
-	['cormaw'] = true,
-	['corvipe'] = true,
-	['corpun'] = true,
-	['corexp'] = true,
-	['corllt'] = true,
-	['corhllt'] = true,
-	['armllt'] = true,
-	['leginc'] = true,
-}
--- convert unitname -> unitDefID + add scavengers
-local exludedUnits = {}
-for name, params in pairs(exludedUnitsNames) do
-	if UnitDefNames[name] then
-		exludedUnits[UnitDefNames[name].id] = params
-		if UnitDefNames[name..'_scav'] then
-			exludedUnits[UnitDefNames[name..'_scav'].id] = params
-		end
-	end
-end
-exludedUnitsNames = nil
+-- local exludedUnitsNames = {    -- exclude auto target range boost for popup units
+	--['armclaw'] = true,
+	--['armpb'] = true,
+	--['armamb'] = true,
+	--['cormaw'] = true,
+	--['corvipe'] = true,
+	--['corpun'] = true,
+	--cormexp
+	--['corexp'] = true,
+	--['corllt'] = true,
+	--corhlllt
+	--['corhllt'] = true,
+	--['armllt'] = true,
+--	['leginc'] = true,
+-- leglht
+--legdtr
+--legbombard
+--armshockwave
+-- }
+-- -- convert unitname -> unitDefID + add scavengers
+-- --local exludedUnits = {}
+-- --for name, params in pairs(exludedUnitsNames) do
+-- --	if UnitDefNames[name] then
+-- --		exludedUnits[UnitDefNames[name].id] = params
+-- --		if UnitDefNames[name..'_scav'] then
+-- --			exludedUnits[UnitDefNames[name..'_scav'].id] = params
+-- 		end
+-- 	end
+-- end
+-- exludedUnitsNames = nil
 
-for k, v in pairs(exludedUnits) do
-	isPreaimUnit[k] = nil
-end
+-- for key, value in pairs(exludedUnits) do
+-- 	isPreaimUnit[key] = nil
+-- end
 
 function gadget:UnitCreated(unitID, unitDefID)
 	if isPreaimUnit[unitDefID] then

--- a/luarules/gadgets/unit_preaim.lua
+++ b/luarules/gadgets/unit_preaim.lua
@@ -14,19 +14,25 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
+--use customparams.exclude_preaim = true, to exclude units from being able to pre-aim at targets almost within firing range.
+--this is a good idea for pop-up turrets so they don't prematurely reveal themselves.
+--also when proximityPriority is heavily biased toward far targets
+
 local weaponRange = {}
 local isPreaimUnit = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	if not unitDef.canFly then
+	if not unitDef.canFly and not unitDef.customParams.exclude_preaim then
 		local weapons = unitDef.weapons
 		if #weapons > 0 then
 			for i=1, #weapons do
-				if not isPreaimUnit[unitDefID] then
-					isPreaimUnit[unitDefID] = {}
+				if not WeaponDefs[weapons[i].weaponDef].customParams.exclude_preaim then
+					if not isPreaimUnit[unitDefID] then
+						isPreaimUnit[unitDefID] = {}
+					end
+					local weaponDefID = weapons[i].weaponDef
+					isPreaimUnit[unitDefID][i] = weaponDefID
+					weaponRange[weaponDefID] = WeaponDefs[weaponDefID].range
 				end
-				local weaponDefID = weapons[i].weaponDef
-				isPreaimUnit[unitDefID][i] = weaponDefID
-				weaponRange[weaponDefID] = WeaponDefs[weaponDefID].range
 			end
 		end
 	end

--- a/units/ArmBuildings/LandDefenceOffence/armamb.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armamb.lua
@@ -139,6 +139,9 @@ return {
 					subs = 150,
 					vtol = 90,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			armamb_gun_high = {
 				accuracy = 400,
@@ -169,6 +172,9 @@ return {
 					subs = 150,
 					vtol = 90,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/ArmBuildings/LandDefenceOffence/armclaw.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armclaw.lua
@@ -145,6 +145,7 @@ return {
 				weapontype = "LightningCannon",
 				weaponvelocity = 450,
 				customparams = {
+					exclude_preaim = true,
 					spark_ceg = "genericshellexplosion-splash-lightning",
 					spark_forkdamage = "0.33",
 					spark_maxunits = "2",

--- a/units/ArmBuildings/LandDefenceOffence/armguard.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armguard.lua
@@ -132,6 +132,9 @@ return {
 					subs = 150,
 					vtol = 90,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			plasma_high = {
 				accuracy = 75,
@@ -162,6 +165,9 @@ return {
 					subs = 150,
 					vtol = 90,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/ArmBuildings/LandDefenceOffence/armllt.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armllt.lua
@@ -138,6 +138,9 @@ return {
 					subs = 5,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/ArmBuildings/LandDefenceOffence/armpb.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armpb.lua
@@ -137,6 +137,9 @@ return {
 					subs = 300,
 					vtol = 26,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
@@ -159,6 +159,9 @@ return {
 					default = 800,
 					vtol = 0,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/ArmGantry/armvang.lua
+++ b/units/ArmGantry/armvang.lua
@@ -43,7 +43,6 @@ return {
 			subfolder = "ArmGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmGantry/armvang.lua
+++ b/units/ArmGantry/armvang.lua
@@ -43,6 +43,7 @@ return {
 			subfolder = "ArmGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
+			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {
@@ -141,6 +142,9 @@ return {
 					shields = 765,
 					subs = 500,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			shocker_low = {
 				areaofeffect = 192,
@@ -175,6 +179,9 @@ return {
 					shields = 765,
 					subs = 500,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/corexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/corexp.lua
@@ -148,6 +148,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/corhllt.lua
+++ b/units/CorBuildings/LandDefenceOffence/corhllt.lua
@@ -137,6 +137,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			hllt_top = {
 				areaofeffect = 12,
@@ -174,6 +177,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/corllt.lua
+++ b/units/CorBuildings/LandDefenceOffence/corllt.lua
@@ -138,6 +138,9 @@ return {
 					subs = 5,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/cormaw.lua
+++ b/units/CorBuildings/LandDefenceOffence/cormaw.lua
@@ -157,6 +157,9 @@ return {
 					default = 22,
 					subs = 5.5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/cormexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/cormexp.lua
@@ -143,6 +143,9 @@ return {
 					default = 260,
 					vtol = 45,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			corsumo_weapon = {
 				areaofeffect = 12,
@@ -178,6 +181,9 @@ return {
 					default = 215,
 					vtol = 50,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/corpun.lua
+++ b/units/CorBuildings/LandDefenceOffence/corpun.lua
@@ -40,6 +40,7 @@ return {
 			subfolder = "CorBuildings/LandDefenceOffence",
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
+			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {
@@ -133,6 +134,9 @@ return {
 					subs = 90,
 					vtol = 95,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			plasma_high = {
 				accuracy = 75,
@@ -163,6 +167,9 @@ return {
 					subs = 95,
 					vtol = 95,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/corpun.lua
+++ b/units/CorBuildings/LandDefenceOffence/corpun.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "CorBuildings/LandDefenceOffence",
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/cortoast.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortoast.lua
@@ -138,6 +138,9 @@ return {
 					subs = 90,
 					vtol = 90,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			cortoast_gun_high = {
 				accuracy = 450,
@@ -170,6 +173,9 @@ return {
 					subs = 90,
 					vtol = 90,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/CorBuildings/LandDefenceOffence/corvipe.lua
+++ b/units/CorBuildings/LandDefenceOffence/corvipe.lua
@@ -145,6 +145,9 @@ return {
 					subs = 5,
 					vtol = 26,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/Legion/Bots/T2 Bots/leginc.lua
+++ b/units/Legion/Bots/T2 Bots/leginc.lua
@@ -141,6 +141,7 @@ return {
 					vtol = 11,
 				},
 				customparams = {
+					exclude_preaim = true,
 					--sweepfire=0.4,--multiplier for displayed dps during the 'bonus' sweepfire stage, needed for DPS calcs
 				}
 

--- a/units/Legion/Defenses/legacluster.lua
+++ b/units/Legion/Defenses/legacluster.lua
@@ -198,7 +198,7 @@ return {
 				customparams = {
 					cluster = true,
 					exclude_preaim = true,
-					number = 6,
+					number = 8,
 				},
 				damage = {
 					default = 250,

--- a/units/Legion/Defenses/legacluster.lua
+++ b/units/Legion/Defenses/legacluster.lua
@@ -41,7 +41,6 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			onoffname = "trajectory",
 			subfolder = "Legion/Defenses",
-			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Defenses/legacluster.lua
+++ b/units/Legion/Defenses/legacluster.lua
@@ -41,6 +41,7 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			onoffname = "trajectory",
 			subfolder = "Legion/Defenses",
+			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {
@@ -134,6 +135,7 @@ return {
 				weaponvelocity = 450,
 				customparams = {
 					cluster = true,
+					exclude_preaim = true,
 					number = 6,
 				},
 				damage = {
@@ -196,7 +198,8 @@ return {
 				weaponvelocity = 450,
 				customparams = {
 					cluster = true,
-					number = 8,
+					exclude_preaim = true,
+					number = 6,
 				},
 				damage = {
 					default = 250,

--- a/units/Legion/Defenses/legbombard.lua
+++ b/units/Legion/Defenses/legbombard.lua
@@ -185,6 +185,9 @@ return {
 					default = 375,
 					subs = 300,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/Legion/Defenses/legcluster.lua
+++ b/units/Legion/Defenses/legcluster.lua
@@ -40,6 +40,7 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			onoffname = "trajectory",
 			subfolder = "CorBuildings/LandDefenceOffence",
+			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {
@@ -130,6 +131,7 @@ return {
 				weaponvelocity = 450,
 				customparams = {
 					cluster = true,
+					exclude_preaim = true,
 					number = 3,
 				},
 				damage = {
@@ -191,7 +193,8 @@ return {
 				weaponvelocity = 450,
 				customparams = {
 					cluster = true,
-					number = 6,
+					exclude_preaim = true,
+					number = 3,
 				},
 				damage = {
 					default = 200,

--- a/units/Legion/Defenses/legcluster.lua
+++ b/units/Legion/Defenses/legcluster.lua
@@ -40,7 +40,6 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			onoffname = "trajectory",
 			subfolder = "CorBuildings/LandDefenceOffence",
-			smart_weapon_select_priority = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Defenses/legcluster.lua
+++ b/units/Legion/Defenses/legcluster.lua
@@ -193,7 +193,7 @@ return {
 				customparams = {
 					cluster = true,
 					exclude_preaim = true,
-					number = 3,
+					number = 6,
 				},
 				damage = {
 					default = 200,

--- a/units/Legion/Defenses/legdtr.lua
+++ b/units/Legion/Defenses/legdtr.lua
@@ -147,6 +147,9 @@ return {
 					subs = 90,
 					vtol = 35,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/Legion/Defenses/leglht.lua
+++ b/units/Legion/Defenses/leglht.lua
@@ -144,6 +144,9 @@ return {
 					default = 200,
 					vtol = 25,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/Scavengers/Buildings/DefenseOffense/armlwall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/armlwall.lua
@@ -148,6 +148,7 @@ return {
 				weapontype = "LightningCannon",
 				weaponvelocity = 400,
 				customparams = {
+					exclude_preaim = true,
 					spark_ceg = "genericshellexplosion-splash-lightning",
 					spark_forkdamage = "0.3", --was 0.5
 					spark_maxunits = "3", --2x armclaw

--- a/units/Scavengers/Buildings/DefenseOffense/corhllllt.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corhllllt.lua
@@ -138,6 +138,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			hllt_2 = {
 				areaofeffect = 12,
@@ -175,6 +178,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			hllt_3 = {
 				areaofeffect = 12,
@@ -212,6 +218,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 			hllt_4 = {
 				areaofeffect = 12,
@@ -249,6 +258,9 @@ return {
 					default = 75,
 					vtol = 5,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {

--- a/units/Scavengers/Buildings/DefenseOffense/cormwall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/cormwall.lua
@@ -207,6 +207,9 @@ return {
 				damage = {
 					default = 450,
 				},
+				customparams = {
+					exclude_preaim = true
+				}
 			},
 		},
 		weapons = {


### PR DESCRIPTION
this gadget has an internal list which defines the engine behavior of  unit pre-aiming. This is important for weapons with very high negative and positive proximitypriority values and to prevent popups from prematurely revealing themselves when they can't actually fire. It also is important for my smart select project here https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3720/files to prevent bad aiming state conflicts.

This is a very little known about gadget. Making its exemptions a customparam will advertise for it and help reduce unexplainable aiming anomalies.

I echo'd my logic to make sure units I gave the customparams to be it in their unitdef.customparams or weapondef.customparams were excluded correctly. All existing exclusions (and inclusions) will remain untouched in this pull request.