### PR TITLE
Fix a number of ecostats and spectator_hud toggling issues.

### DIFF
--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -285,6 +285,7 @@ local function processScaling()
 	cW = math.floor(cW * sizeMultiplier)
 	textsize = math.floor(textsize * sizeMultiplier)
 	borderPadding = math.floor(borderPadding * sizeMultiplier)
+	widgetHeight = getNbTeams() * tH + (2 * sizeMultiplier)
 end
 
 local function getTeamProduction(teamID)
@@ -452,7 +453,6 @@ local function Init()
 	Button = {}
 
 	right = widgetPosX / vsx > 0.5
-	widgetHeight = getNbTeams() * tH + (2 * sizeMultiplier)
 
 	allyData = {}
 	for _, allyID in ipairs(Spring.GetAllyTeamList()) do
@@ -534,8 +534,8 @@ function widget:Initialize()
 		cfgResText = value
 	end
 
-	widget:ViewResize()
 	Init()
+	widget:ViewResize()
 end
 
 local function removeGuiShaderRects()
@@ -1338,7 +1338,7 @@ function widget:DrawScreen()
 	gl.PopMatrix()
 
 	local mx, my, mb = Spring.GetMouseState()
-	widgetHeight = getNbTeams() * tH + (2 * sizeMultiplier)    -- not sure why i have to redefine this again, height was just 2 px
+
 	if math_isInRect(mx, my, widgetPosX, widgetPosY, widgetPosX + widgetWidth, widgetPosY + widgetHeight) then
 		Spring.SetMouseCursor('cursornormal')
 	end

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -62,7 +62,7 @@ local gaiaID = Spring.GetGaiaTeamID()
 local gaiaAllyID = select(6, Spring.GetTeamInfo(gaiaID, false))
 
 local widgetEnabled = nil
-local ecostatsWidget = nil
+local ecostatsHidden = false
 
 local haveFullView = false
 
@@ -86,6 +86,7 @@ local regenerateTextTextures = true
 local titleTexture = nil
 local titleTextureDone = false
 local statsTexture = nil
+local updateNow = false
 
 local knobVertexShaderSource = [[
 #version 420
@@ -1710,10 +1711,10 @@ end
 
 local function addMiddleKnobs()
 	for metricIndex,_ in ipairs(metricsEnabled) do
-		local bottom = widgetDimensions.top - metricIndex * metricDimensions.height
+		local bottom = widgetDimensions.top - metricIndex * metricDimensions.height + 1.0
 		local textBottom = bottom + titleDimensions.padding
 
-		local middleKnobLeft = (knobDimensions.rightKnobLeft + knobDimensions.leftKnobRight) / 2 - knobDimensions.width
+		local middleKnobLeft = (knobDimensions.rightKnobLeft + knobDimensions.leftKnobRight) / 2 - knobDimensions.width / 2
 		local middleKnobBottom = textBottom
 
 		local middleKnobColor = colorKnobMiddleGrey
@@ -1824,16 +1825,17 @@ end
 
 local function hideEcostats()
 	if widgetEnabled and widgetHandler:IsWidgetKnown("Ecostats") then
-		ecostatsWidget = widgetHandler:FindWidget("Ecostats")
+		local ecostatsWidget = widgetHandler:FindWidget("Ecostats")
 		if (not ecostatsWidget) then return end
+		ecostatsHidden = true
 		widgetHandler:RemoveWidget(ecostatsWidget)
 	end
 end
 
 local function showEcostats()
-	if ecostatsWidget then
-		widgetHandler:InsertWidget(ecostatsWidget)
-		ecostatsWidget = nil
+	if ecostatsHidden then
+		widgetHandler:EnableWidget("Ecostats")
+		ecostatsHidden = false
 	end
 end
 
@@ -1884,8 +1886,8 @@ local function init()
 
 	if haveFullView then
 		updateStats()
-
 		moveMiddleKnobs()
+		updateNow = true
 	end
 end
 
@@ -1957,6 +1959,7 @@ end
 
 function widget:Shutdown()
 	deInit()
+	WG["spectator_hud"] = {}
 	showEcostats()
 
 	if shader then
@@ -2067,10 +2070,11 @@ function widget:GameFrame(frameNum)
 		addMiddleKnobs()
 	end
 
-	if frameNum % settings.statsUpdateFrequency == 1 then
+	if frameNum % settings.statsUpdateFrequency == 1 or updateNow then
 		updateStats()
 
 		moveMiddleKnobs()
+		updateNow = false
 	end
 end
 


### PR DESCRIPTION
### Work done

- Ecostats now re-enabled with `EnableWidget` instead of `InsertWidget` (InsertWidget can be dangerous to use like that).
- Fix ecostats bad initialization of widgetHeight and other sizings specially noticeable on toggling.
- Fix spectator_hud not freeing `WG["spectator_hud"]`, resulting in ecostats changing size wildly when changing spectator hud size at settings after having disabled the spectator hud.
- Fix spectator_hud middle knobs showing incorrectly on initialization.

### Remarks

- Most importantly, turns out doing RemoveWidget and then InsertWidget is quite a bad idea, since this means the widget will get reinserted without reloading it, so it won't call it's top level code again, also it can result in double Shutdown and other dangerous stuff. Also, when reinserting like that, the methods are getting "SafeWrapped" again and again, eventually resulting in lua errors.
  - The correct thing to do after RemoveWidget is simply EnableWidget again.
- The rest of the changes are just aesthetic fixes, so toggling doesn't glitch so much.

#### BEFORE:

Some examples of issues, there were more.

![ecostats_pre1](https://github.com/user-attachments/assets/5da33ae3-62eb-4dc7-8c06-133108fb26db)

![ecostats_pre2](https://github.com/user-attachments/assets/a2b7a6de-682e-4a57-9637-f5366faba5d8)

#### AFTER:

Switching red/blue sides here is the result of disabling and reenabling, it's ok.

No flickering is happening after this PR on toggling (afaics).

![ecostats_after](https://github.com/user-attachments/assets/5b6c36a3-0d41-475d-ab31-7247778227f8)

