### PR TITLE
unit_evolution.lua: Fix lua crash on Evolve()

### DIFF
--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -337,20 +337,8 @@ if gadgetHandler:IsSyncedCode() then
 			lastTimerCheck = f	
 			for unitID, _ in pairs(evolutionMetaList) do
 				local currentTime =  spGetGameSeconds()
-				if evolutionMetaList[unitID].evolution_condition == "timer" and (currentTime-evolutionMetaList[unitID].timeCreated) >= evolutionMetaList[unitID].evolution_timer then
-					local enemyNearby = spGetUnitNearestEnemy(unitID, evolutionMetaList[unitID].combatRadius)
-					local inCombat = false
-					if enemyNearby then
-						inCombat = true
-						evolutionMetaList[unitID].combatTimer = spGetGameSeconds()
-					end
-
-					if not inCombat and (currentTime-evolutionMetaList[unitID].combatTimer) >= 5 then
-						Evolve(unitID, evolutionMetaList[unitID].evolution_target)
-					end
-				end
-				-- evolutionMetaList[unitID] might have been invalidated if Evolve() was called before this, since that will destroy the unit.
-				if evolutionMetaList[unitID] and evolutionMetaList[unitID].evolution_condition == "timer_global" and currentTime >= evolutionMetaList[unitID].evolution_timer then
+				if (evolutionMetaList[unitID].evolution_condition == "timer" and (currentTime-evolutionMetaList[unitID].timeCreated) >= evolutionMetaList[unitID].evolution_timer) or
+				   (evolutionMetaList[unitID].evolution_condition == "timer_global" and currentTime >= evolutionMetaList[unitID].evolution_timer) then
 					local enemyNearby = spGetUnitNearestEnemy(unitID, evolutionMetaList[unitID].combatRadius)
 					local inCombat = false
 					if enemyNearby then

--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -349,7 +349,8 @@ if gadgetHandler:IsSyncedCode() then
 						Evolve(unitID, evolutionMetaList[unitID].evolution_target)
 					end
 				end
-				if evolutionMetaList[unitID].evolution_condition == "timer_global" and currentTime >= evolutionMetaList[unitID].evolution_timer then
+				-- evolutionMetaList[unitID] might have been invalidated if Evolve() was called before this, since that will destroy the unit.
+				if evolutionMetaList[unitID] and evolutionMetaList[unitID].evolution_condition == "timer_global" and currentTime >= evolutionMetaList[unitID].evolution_timer then
 					local enemyNearby = spGetUnitNearestEnemy(unitID, evolutionMetaList[unitID].combatRadius)
 					local inCombat = false
 					if enemyNearby then


### PR DESCRIPTION
### Work done

- Fix a lua crash at GameFrame in unit_evolution.lua

#### Addresses Issue(s)

- [Issue URL](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3983)

Not sure the issue game crash is directly related, probably not, but it shows in the logs there.

### Explanation

`Evolve(...)` is getting called at the first `if evolutionMetaList[unitID]...`. That destroys the unit and seems the destroy callback gets called immediately thus invalidating `evolutionMetaList[unitID]` for the if right after that.