### PR TITLE
test_runner: Stress test scenario system

### DIFF
--- a/luaui/Scenarios/stresstest/circle_attack.lua
+++ b/luaui/Scenarios/stresstest/circle_attack.lua
@@ -1,0 +1,31 @@
+VFS.Include("luaui/Scenarios/stresstest/multi_attack.lua")
+
+function radius_attack(attackers, targetsCenter)
+	local y = Spring.GetGroundHeight(targetsCenter[1], targetsCenter[2])
+	local targetPosition = {targetsCenter[1], y+5, targetsCenter[2], targetsCenter[3]}
+
+	local CMD_ATTACK = CMD.ATTACK
+	local spGiveOrderToUnit = Spring.GiveOrderToUnit
+
+	Spring.SelectUnitArray(attackers)
+	Spring.GiveOrder(CMD_ATTACK, targetPosition, 0)
+end
+
+function test()
+	local t0 = os.clock()
+
+	local nattackers = 100*Scenario.stressLevel
+	local ntargets = 100*Scenario.stressLevel
+	local attackerDef = Scenario.attackerDef
+	local targetDef = Scenario.targetDef
+	local radarDef = Scenario.radarDef
+
+	local attackers, targetsCenter = SyncedRun(synced_setup)
+
+	Test.waitFrames(1)
+
+	radius_attack(attackers, targetsCenter)
+
+	Spring.Echo("total time:", os.clock()-t0)
+end
+

--- a/luaui/Scenarios/stresstest/circle_attack.lua
+++ b/luaui/Scenarios/stresstest/circle_attack.lua
@@ -19,6 +19,7 @@ function test()
 	local attackerDef = Scenario.attackerDef
 	local targetDef = Scenario.targetDef
 	local radarDef = Scenario.radarDef
+	local doCircle = true
 
 	local attackers, targetsCenter = SyncedRun(synced_setup)
 

--- a/luaui/Scenarios/stresstest/circle_attack.lua
+++ b/luaui/Scenarios/stresstest/circle_attack.lua
@@ -1,14 +1,29 @@
 VFS.Include("luaui/Scenarios/stresstest/multi_attack.lua")
 
-function radius_attack(attackers, targetsCenter)
+function radius_attack(targetsCenter, nattackers)
 	local y = Spring.GetGroundHeight(targetsCenter[1], targetsCenter[2])
 	local targetPosition = {targetsCenter[1], y+5, targetsCenter[2], targetsCenter[3]}
 
 	local CMD_ATTACK = CMD.ATTACK
-	local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
+	-- get units
+	local spGetUnitDefID = Spring.GetUnitDefID
+
+	local attackers = table.new and table.new(nattackers) or {}
+	local attackerDefID = UnitDefNames[Scenario.attackerDef].id
+
+	local all_units = Spring.GetAllUnits()
+	for _, unitID in ipairs(all_units) do
+		local unitDefID = spGetUnitDefID(unitID)
+		if unitDefID == attackerDefID then
+			attackers[#attackers+1] = unitID
+		end
+	end
+
+	-- give order
 	Spring.SelectUnitArray(attackers)
 	Spring.GiveOrder(CMD_ATTACK, targetPosition, 0)
+	Spring.SelectUnitArray({})
 end
 
 function test()
@@ -21,11 +36,12 @@ function test()
 	local radarDef = Scenario.radarDef
 	local doCircle = true
 
-	local attackers, targetsCenter = SyncedRun(synced_setup)
+	local circle = SyncedRun(synced_setup)
+	Spring.Echo("init time preinit:", os.clock()-t0)
 
 	Test.waitFrames(1)
 
-	radius_attack(attackers, targetsCenter)
+	radius_attack(circle, nattackers)
 
 	Spring.Echo("total time:", os.clock()-t0)
 end

--- a/luaui/Scenarios/stresstest/multi_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_attack.lua
@@ -1,0 +1,98 @@
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function scenario_arguments()
+	return {{stressLevel = 1}, {attackerDef = "armpw"}, {targetDef = "armwin"}, {radarDef = "armarad"}}
+end
+
+function setup()
+	-- test on quicksilver remake 1.24
+	Test.clearMap()
+
+	Spring.SetCameraTarget(Game.mapSizeX/2, 50, Game.mapSizeZ / 2 - 500, 0.5)
+end
+
+function synced_setup(locals)
+	local function createUnitAt(unitdefname, x, z, teamID)
+		local y = Spring.GetGroundHeight(x, z)
+		return Spring.CreateUnit(unitdefname, x, y, z, 1, teamID)
+	end
+
+	local colattackers = 10
+	local coltargets = 20
+	local rowattackers = math.floor(locals.nattackers/colattackers)
+	local rowtargets = math.floor(locals.ntargets/coltargets)
+	local attackerDef = locals.attackerDef
+	local targetDef = locals.targetDef
+
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	x = x+450
+
+	local team1 = 0
+	local team2 = 1
+	local sep = 40
+	local currunit
+	local attackers = {}
+	local targets = {}
+	createUnitAt(locals.radarDef, x-1000, z+300, team1)
+	for i=0, colattackers-1 do
+		for j=0, rowattackers-1 do
+			currunit = createUnitAt(attackerDef, x+i*sep, z-j*sep, team1)
+			attackers[#attackers+1] = currunit
+		end
+	end
+
+	for i=0, coltargets-1 do
+		for j=0, rowtargets-1 do
+			currunit = createUnitAt(targetDef, x-1500+i*sep, z-j*sep, team2)
+			targets[#targets+1] = currunit
+		end
+	end
+	-- make sure the attackers don't have other orders
+	for _, unitID in pairs(attackers) do
+		Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+	end
+
+	return attackers, targets
+end
+
+function synced_commands(locals)
+	local attackers = locals.attackers
+	local targets = locals.targets
+	local shiftOpts = {"shift"}
+	local currOpt
+	local CMD_ATTACK = CMD.ATTACK
+	local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
+
+	local orders = {}
+	for idx, targetID in pairs(targets) do
+		currOpt = (idx == 1) and 0 or shiftOpts
+		orders[#orders+1] = {CMD_ATTACK, {targetID}, currOpt}
+	end
+
+	for _, unitID in pairs(attackers) do
+		currOpt = (idx == 1) and opts or shiftOpts
+		spGiveOrderArrayToUnit(unitID, orders)
+	end
+end
+
+function test()
+	local t0 = os.clock()
+
+	local nattackers = 100*Scenario.stressLevel
+	local ntargets = 100*Scenario.stressLevel
+	local attackerDef = Scenario.attackerDef
+	local targetDef = Scenario.targetDef
+	local radarDef = Scenario.radarDef
+
+	local attackers, targets = SyncedRun(synced_setup)
+
+	Test.waitFrames(1)
+
+	SyncedRun(synced_commands)
+
+	Spring.Echo("total time:", os.clock()-t0)
+end
+

--- a/luaui/Scenarios/stresstest/multi_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_attack.lua
@@ -52,7 +52,7 @@ function synced_setup(locals)
 	end
 	-- make sure the attackers don't have other orders
 	for _, unitID in pairs(attackers) do
-		Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+		Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
 	end
 
 	return attackers, targets

--- a/luaui/Scenarios/stresstest/multi_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_attack.lua
@@ -80,9 +80,12 @@ function run_commands(nattackers, ntargets, attackerDef, targetDef)
 	local currOpt
 	local CMD_ATTACK = CMD.ATTACK
 	local spGiveOrderToUnit = Spring.GiveOrderToUnit
+	local attackerTeam = 0
+	local defenderTeam = 1
 
 	-- get units
 	local spGetUnitDefID = Spring.GetUnitDefID
+	local spGetUnitTeam = Spring.GetUnitTeam
 
 	local attackers = table.new and table.new(nattackers) or {}
 	local targets = table.new and table.new(ntargets) or {}
@@ -92,9 +95,10 @@ function run_commands(nattackers, ntargets, attackerDef, targetDef)
 	local all_units = Spring.GetAllUnits()
 	for _, unitID in ipairs(all_units) do
 		local unitDefID = spGetUnitDefID(unitID)
-		if unitDefID == attackerDefID then
+		local unitTeamID = spGetUnitTeam(unitID)
+		if unitDefID == attackerDefID and unitTeamID == attackerTeam then
 			attackers[#attackers+1] = unitID
-		elseif unitDefID == targetDefID then
+		elseif unitDefID == targetDefID and unitTeamID == defenderTeam then
 			targets[#targets+1] = unitID
 		end
 	end

--- a/luaui/Scenarios/stresstest/multi_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_attack.lua
@@ -20,6 +20,7 @@ function synced_setup(locals)
 		return Spring.CreateUnit(unitdefname, x, y, z, 1, teamID)
 	end
 
+	local doCircle = locals.doCircle
 	local colattackers = 10
 	local coltargets = 20
 	local rowattackers = math.floor(locals.nattackers/colattackers)
@@ -36,7 +37,17 @@ function synced_setup(locals)
 	local currunit
 	local attackers = {}
 	local targets = {}
+	if doCircle then
+		-- when circle requested just return the targets center and radius
+		local maxX = (coltargets*sep)/2.0
+		local maxZ = (rowtargets*sep)/2.0
+		local targetsCenter = {x-1500+maxX, z-maxZ}
+		local radius = math.sqrt(maxX*maxX + maxZ*maxZ)
+		targets = {targetsCenter[1], targetsCenter[2], radius}
+	end
+
 	createUnitAt(locals.radarDef, x-1000, z+300, team1)
+
 	for i=0, colattackers-1 do
 		for j=0, rowattackers-1 do
 			currunit = createUnitAt(attackerDef, x+i*sep, z-j*sep, team1)
@@ -47,7 +58,9 @@ function synced_setup(locals)
 	for i=0, coltargets-1 do
 		for j=0, rowtargets-1 do
 			currunit = createUnitAt(targetDef, x-1500+i*sep, z-j*sep, team2)
-			targets[#targets+1] = currunit
+			if not doCircle then
+				targets[#targets+1] = currunit
+			end
 		end
 	end
 	-- make sure the attackers don't have other orders

--- a/luaui/Scenarios/stresstest/multi_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_attack.lua
@@ -64,16 +64,15 @@ function synced_commands(locals)
 	local shiftOpts = {"shift"}
 	local currOpt
 	local CMD_ATTACK = CMD.ATTACK
-	local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
+	local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
-	local orders = {}
-	for idx, targetID in pairs(targets) do
-		currOpt = (idx == 1) and 0 or shiftOpts
-		orders[#orders+1] = {CMD_ATTACK, {targetID}, currOpt}
-	end
-
+	local arr = {}
 	for _, unitID in pairs(attackers) do
-		spGiveOrderArrayToUnit(unitID, orders)
+		for idx, targetID in pairs(targets) do
+			currOpt = (idx == 1) and opts or shiftOpts
+			arr[1] = targetID
+			spGiveOrderToUnit(unitID, CMD_ATTACK, arr, currOpt)
+		end
 	end
 end
 

--- a/luaui/Scenarios/stresstest/multi_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_attack.lua
@@ -73,7 +73,6 @@ function synced_commands(locals)
 	end
 
 	for _, unitID in pairs(attackers) do
-		currOpt = (idx == 1) and opts or shiftOpts
 		spGiveOrderArrayToUnit(unitID, orders)
 	end
 end

--- a/luaui/Scenarios/stresstest/multi_unsynced_attack.lua
+++ b/luaui/Scenarios/stresstest/multi_unsynced_attack.lua
@@ -1,0 +1,21 @@
+VFS.Include("luaui/Scenarios/stresstest/multi_attack.lua")
+
+function test()
+	local t0 = os.clock()
+
+	local nattackers = 100*Scenario.stressLevel
+	local ntargets = 100*Scenario.stressLevel
+	local attackerDef = Scenario.attackerDef
+	local targetDef = Scenario.targetDef
+	local radarDef = Scenario.radarDef
+
+	SyncedRun(synced_setup)
+	Spring.Echo("init time preinit:", os.clock()-t0)
+
+	Test.waitFrames(1)
+
+	run_commands(nattackers, ntargets, attackerDef, targetDef)
+
+	Spring.Echo("total time:", os.clock()-t0)
+end
+

--- a/luaui/Scenarios/stresstest/nano_commands.lua
+++ b/luaui/Scenarios/stresstest/nano_commands.lua
@@ -50,7 +50,7 @@ function synced_nano_setup(locals)
 	end
 	-- make sure the turrets don't have other orders
 	for _, unitID in pairs(nanoturrets) do
-		Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+		Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
 	end
 	return nanoturrets, targets
 end

--- a/luaui/Scenarios/stresstest/nano_commands.lua
+++ b/luaui/Scenarios/stresstest/nano_commands.lua
@@ -1,0 +1,95 @@
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function scenario_arguments()
+	return {{stressLevel = 1}, {builderDef = "armnanotc"}, {targetDef = "armwin"}}
+end
+
+function setup()
+	-- test on quicksilver remake 1.24
+	Test.clearMap()
+
+	Spring.SetCameraTarget(Game.mapSizeX/2 + 500, 50, Game.mapSizeZ / 2 - 500, 0.5)
+end
+
+function synced_nano_setup(locals)
+	local function createUnitAt(unitdefname, x, z, teamID)
+		local y = Spring.GetGroundHeight(x, z)
+		return Spring.CreateUnit(unitdefname, x, y, z, 1, teamID)
+	end
+
+	local colturrets = 5
+	local coltargets = 8
+	local rowturrets = math.floor(locals.nturrets/colturrets)
+	local rowtargets = math.floor(locals.ntargets/coltargets)
+	local turretDef = locals.turretDef
+	local targetDef = locals.targetDef
+
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	x = x+450
+
+	local team1 = 0
+	local sep = 50
+	local currunit
+	local nanoturrets = {}
+	local targets = {}
+	for i=0, colturrets-1 do
+		for j=0, rowturrets-1 do
+			currunit = createUnitAt(turretDef, x+i*sep-100, z-j*sep, team1)
+			nanoturrets[#nanoturrets+1] = currunit
+		end
+	end
+
+	for i=0, coltargets-1 do
+		for j=0, rowtargets-1 do
+			currunit = createUnitAt(targetDef, x+350+i*sep, z-j*sep, team1)
+			targets[#targets+1] = currunit
+		end
+	end
+	-- make sure the turrets don't have other orders
+	for _, unitID in pairs(nanoturrets) do
+		Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+	end
+
+	return nanoturrets, targets
+end
+
+function synced_nano_commands(locals)
+	local nanoturrets = locals.nanoturrets
+	local targets = locals.targets
+	local shiftOpts = {"shift"}
+	local currOpt
+	local CMD_RECLAIM = CMD.RECLAIM
+	local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
+
+	local orders = {}
+	for idx, targetID in pairs(targets) do
+		currOpt = (idx == 1) and 0 or shiftOpts
+		orders[#orders+1] = {CMD_RECLAIM, {targetID}, currOpt}
+	end
+
+	for _, unitID in pairs(nanoturrets) do
+		currOpt = (idx == 1) and opts or shiftOpts
+		spGiveOrderArrayToUnit(unitID, orders)
+	end
+end
+
+function test()
+	local t0 = os.clock()
+
+	local nturrets = 50*Scenario.stressLevel
+	local ntargets = 50*Scenario.stressLevel
+	local turretDef = Scenario.builderDef
+	local targetDef = Scenario.targetDef
+
+	local nanoturrets, targets = SyncedRun(synced_nano_setup)
+
+	Test.waitFrames(1)
+
+	SyncedRun(synced_nano_commands)
+
+	Spring.Echo("total time:", os.clock()-t0)
+end
+

--- a/luaui/Scenarios/stresstest/nano_commands.lua
+++ b/luaui/Scenarios/stresstest/nano_commands.lua
@@ -71,7 +71,6 @@ function synced_nano_commands(locals)
 	end
 
 	for _, unitID in pairs(nanoturrets) do
-		currOpt = (idx == 1) and opts or shiftOpts
 		spGiveOrderArrayToUnit(unitID, orders)
 	end
 end

--- a/luaui/Scenarios/stresstest/nano_commands.lua
+++ b/luaui/Scenarios/stresstest/nano_commands.lua
@@ -52,7 +52,6 @@ function synced_nano_setup(locals)
 	for _, unitID in pairs(nanoturrets) do
 		Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
 	end
-
 	return nanoturrets, targets
 end
 
@@ -62,16 +61,15 @@ function synced_nano_commands(locals)
 	local shiftOpts = {"shift"}
 	local currOpt
 	local CMD_RECLAIM = CMD.RECLAIM
-	local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
+	local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
-	local orders = {}
-	for idx, targetID in pairs(targets) do
-		currOpt = (idx == 1) and 0 or shiftOpts
-		orders[#orders+1] = {CMD_RECLAIM, {targetID}, currOpt}
-	end
-
+	local arr = {}
 	for _, unitID in pairs(nanoturrets) do
-		spGiveOrderArrayToUnit(unitID, orders)
+		for idx, targetID in pairs(targets) do
+			currOpt = (idx == 1) and opts or shiftOpts
+			arr[1] = targetID
+			spGiveOrderToUnit(unitID, CMD_RECLAIM, arr, currOpt)
+		end
 	end
 end
 
@@ -91,4 +89,5 @@ function test()
 
 	Spring.Echo("total time:", os.clock()-t0)
 end
+
 

--- a/luaui/Scenarios/stresstest/nano_unsynced_commands.lua
+++ b/luaui/Scenarios/stresstest/nano_unsynced_commands.lua
@@ -1,0 +1,21 @@
+VFS.Include("luaui/Scenarios/stresstest/nano_commands.lua")
+
+function test()
+	local t0 = os.clock()
+
+	local nturrets = 50*Scenario.stressLevel
+	local ntargets = 50*Scenario.stressLevel
+	local turretDef = Scenario.builderDef
+	local targetDef = Scenario.targetDef
+
+	SyncedRun(synced_nano_setup)
+	Spring.Echo("init time preinit:", os.clock()-t0)
+
+	Test.waitFrames(1)
+
+	run_nano_commands(nturrets, ntargets, turretDef, targetDef)
+
+	Spring.Echo("total time:", os.clock()-t0)
+end
+
+

--- a/luaui/Scenarios/stresstest/unsynced_attack.lua
+++ b/luaui/Scenarios/stresstest/unsynced_attack.lua
@@ -1,0 +1,31 @@
+VFS.Include("luaui/Scenarios/stresstest/multi_attack.lua")
+
+function radius_attack(attackers, targetsCenter)
+	local y = Spring.GetGroundHeight(targetsCenter[1], targetsCenter[2])
+	local targetPosition = {targetsCenter[1], y+5, targetsCenter[2], targetsCenter[3]}
+
+	local CMD_ATTACK = CMD.ATTACK
+	local spGiveOrderToUnit = Spring.GiveOrderToUnit
+
+	Spring.SelectUnitArray(attackers)
+	Spring.GiveOrder(CMD_ATTACK, targetPosition, 0)
+end
+
+function test()
+	local t0 = os.clock()
+
+	local nattackers = 100*Scenario.stressLevel
+	local ntargets = 100*Scenario.stressLevel
+	local attackerDef = Scenario.attackerDef
+	local targetDef = Scenario.targetDef
+	local radarDef = Scenario.radarDef
+
+	local attackers, targetsCenter = SyncedRun(synced_setup)
+
+	Test.waitFrames(1)
+
+	radius_attack(attackers, targetsCenter)
+
+	Spring.Echo("total time:", os.clock()-t0)
+end
+

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -158,7 +158,7 @@ local function processScenarioArguments(args)
 		for index, pair in ipairs(args) do
 			for key, default in pairs(pair) do
 				local val = scenarioOpts[index+1]
-				if val and tonumber(val) then
+				if val and type(default) == 'number' then
 					val = tonumber(val)
 				end
 				scenarioConfig[key] = val or default


### PR DESCRIPTION
### Work done

- Add a "scenario" subsystem to the test runner.
  - minimal changes to the test_runner
- Adds the /runscenario command.
- This is designed to run one file at a time, and allow running parametrized scenarios, to test different units, stress levels, etc.
- See further below for screenshots of the provided scenarios.

<p align="center">
  <img src="https://github.com/user-attachments/assets/f88c95be-b58e-406a-8096-df201ad4b389">
</p>


#### Test steps

- Open Skirmish with "game end mode" set to `neverend`.
- Place commander and press start.
- Run the provided scenarios:
  - /runscenario nano_commands
  - /runscenario multi_attack
  - /runscenario circle_attack
  - /runscenario nano_unsynced_commands
  - /runscenario multi_unsynced_attack

### More information

The scenario subsystem is designed as a way to design and run test scenarios, aimed at stress testing the game and engine, and also providing presets for developers.

Each scenario can be made configurable through the `scenario_arguments()` method:

```lua
function scenario_arguments()
        return {{stressLevel = 1}, {attackerDef = "armpw"}, {targetDef = "armwin"}, {radarDef = "armarad"}}
end
```

This allows the testrunner to parse the command line intelligently and put defaults or provided arguments into the `Scenario` global, accessible from scenario lua test files.

For example, the above arguments would allow running like: `/runscenario <stresslevel> <attackerDef> <targetDef> <radarDef>`, for example `/runscenario 2 cormort corak corarad`. Those would then be accessible as `Scenario.stressLevel`, `Scenario.attackerDef`, and so on.

If some parameters are not provided on the command they will be set to defaults, so for example `/runscenario 2` would pickup defaults of armpw, armwin and armarad.

### Provided scenarios

#### multi_attack & circle_attack

<img align="right" width="200" src="https://github.com/user-attachments/assets/75ad999c-8211-4499-a8dc-b8f67a1eba01">

These scenarios are designed to stress test the attack command.

A number of attackers and defenders will be spawned (100 x stressLevel).

For multi_attack, the attackers will each get an attack command against all the defenders. For radius_attack, all attackers will be selected and a radius attack command will be given comprising all of the defenders.

A radar is also placed to give radar coverage for the attackers.

Allowed parameters:

- stressLevel: This multiplies the number of attackers and defenders, default `1`
- attackerDef: Unitdef for the attackers, default `armpw`
- targetDef: Unitdef for the defenders, default `armwin`
- radarDef: Unitdef for the radar, default `armarad`

#### nano_commands


<img align="right" width="200" src="https://github.com/user-attachments/assets/d5e2dfaa-8b39-494b-b14a-9c55cdad9bac">

This scenario is designed to stress test the reclaim command for nano towers, or any builders.

A number of towers and targets will be spawned (50 x stressLevel), and the towers will each get a reclaim command against all the targets.

Allowed parameters:

- stressLevel: This multiplies the number of towers and targets, default `1`
- builderDef: Unitdef for the builders, default `armnanotc`
- targetDef: Unitdef for the targets, default `armwin`

#### Note on unsynced variants

Some scenarios have unsynced variants, other are already unsynced due to their own nature.

- multi_attack: multi_unsynced_attack
- nano_commands: nano_unsynced_commands

This unsynced version is usually slower to run, because of network bandwidth restriction, but can also work better since it doesn't try to do everything in one frame. Also, for profiling, it's more similar to real play since in that case commands would be given unsynced.

### Remarks

- At the test runner, the arguments are parsed before the `skip` test, while they could be parsed after that. This is done atm to avoid conflicts with #3993. It's not a big deal, but at some point later it can be placed after that.
- I tested both with master and #3993 applied to make sure it works when that will be applied.
- At the moment the scenarios don't increase the distance among units, so changing attackers/defenders and so on can result in overlapping units. In the future this can be solved by checking for unit sizes.
- Eventually, I imagine the subsystem will be improved to provide common functionality and powerful methods to create big scenarios, like one method bases and so on.
- Since the scenarios are designed also as developer presets, I don't do cleanup after running the scenario, only before. This way it can be run to quickly setup a game for testing different things.
- I purposedly placed the scenarios at a different folder (luaui/Scenarios or luaui/Widgets/Scenarios) than tests, since they don't aim so much at testing things, and also some of them could be too stressful (although I have set low stress mode as default so it shouldn't crash the game). This way /runtests won't run the scenarios so we can keep tests and scenarios as different concepts, although they are compatible.
- Maybe in the future scenarios can be set also as presets for tests, so you can load a scenario and then run some test. That could be really powerful.

### Screenshots:

#### multi_attack scenario

`/runscenario multi_attack 2`

![scenario2_2](https://github.com/user-attachments/assets/65663527-377e-4369-b825-4fdbccc85488)

`/runscenario multi_attack 2 cormort`

![scenario2_2 sheldon](https://github.com/user-attachments/assets/49f17978-fece-43cd-946f-cbd69f6127b2)

`/runscenario multi_attack 10 cormort`

![scenario2_10_sheldon](https://github.com/user-attachments/assets/75ad999c-8211-4499-a8dc-b8f67a1eba01)


#### nano_commands scenario

`/runscenario nano_commands`

![scenario1_1](https://github.com/user-attachments/assets/237afab0-ccd2-4058-8e2f-03f647af7f78)

`/runscenario nano_commands 2`

![scenario1_2](https://github.com/user-attachments/assets/d5e2dfaa-8b39-494b-b14a-9c55cdad9bac)
