### PR TITLE
got lua regex wrong

### DIFF
--- a/effects/fire.lua
+++ b/effects/fire.lua
@@ -1460,7 +1460,7 @@ local definitions = {
 }
 
 -- Keep array in sync with values in unit_area_timed_damage:
-local areaSizesUnitTimedDamage = { 37.5, 46, 54, 63, 75, 88, 100, 125, 150, 175, 200, 225, 250, 275, 300 }
+local areaSizePresets = { 37.5, 46, 54, 63, 75, 88, 100, 125, 150, 175, 200, 225, 250, 275, 300 }
 
 local debugEffects = false
 local debugCircle = {

--- a/effects/fire.lua
+++ b/effects/fire.lua
@@ -1460,7 +1460,7 @@ local definitions = {
 }
 
 -- Keep array in sync with values in unit_area_timed_damage:
-local areaCegSizes = { 37.5, 46, 54, 62.5, 75, 87.5, 100, 125, 150, 175, 200, 225, 250, 275, 300 }
+local areaSizesUnitTimedDamage = { 37.5, 46, 54, 63, 75, 88, 100, 125, 150, 175, 200, 225, 250, 275, 300 }
 
 local debugEffects = false
 local debugCircle = {
@@ -1510,9 +1510,9 @@ definitions["fire-burnground-large-repeat"].flamemattalways.properties.particles
 definitions["fire-burnground-large-repeat"].flamemattrandom.properties.particlesize = radiusFlame
 definitions["fire-burnground-large-repeat"].flamemattrandom.properties.particlesizespread = radiusFlameLarge * 1.4
 
-for ii = 1, #areaCegSizes do
+for ii = 1, #areaSizePresets do
   local expgen = table.copy(definitions['fire-area-repeat'])
-  local radius = areaCegSizes[ii]
+  local radius = areaSizePresets[ii]
 
   local radiusFlame = 56
   local inset = radiusFlame * 0.5

--- a/effects/raptors/raptor-effects.lua
+++ b/effects/raptors/raptor-effects.lua
@@ -2416,7 +2416,7 @@ local definitions = {
   },
 }
 
-local areaSizesUnitTimedDamage = { 37.5, 46, 54, 62.5, 75, 87.5, 100, 125, 150, 175, 200, 225, 250, 275, 300 }
+local areaSizesUnitTimedDamage = { 37.5, 46, 54, 63, 75, 88, 100, 125, 150, 175, 200, 225, 250, 275, 300 }
 local areaSizesUnitDefinitions = { 75, 150, 192 } -- from raptor defs
 
 local debugEffects = false

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -42,6 +42,10 @@ local damage, time, range, resistance = 30, 10, 75, "none"
         <prefix>_resistance := <string>    Matched against areadamageresistance
     }
     prefix := area_ondeath | area_onhit  Units use ondeath; weapons use onhit.
+
+    When adding timed areas to existing weapons, you should tweak the weapon's
+    explosion ceg, too. There's a short delay between the hit and the area ceg,
+    which you can mask/make look nice with an explosion lasting about 0.5 secs.
 ]]--
 
 --------------------------------------------------------------------------------

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -33,13 +33,16 @@ local areaSizePresets = {
 local prefixes = { unit = 'area_ondeath_', weapon = 'area_onhit_' }
 local damage, time, range, resistance = 30, 10, 75, "none"
 
--- Customparams are named like <prefix>_<paramName>, for ex. "area_onhit_ceg".
--- ceg - ceg to spawn when explosion happens
--- damageCeg - ceg to spawn when damage is dealt
--- time - how long the effect should stay
--- damage - damage per second
--- range - from center to edge, in elmos
--- resistance - defines which units are resistant to this type of damage when it matches with 'areadamageresistance' customparameter in a unit.
+--[[
+    customparams = {
+        <prefix>_damage     := <number>    The damage done per second
+        <prefix>_time       := <number>    Duration of the timed area
+        <prefix>_range      := <number>    The radius of the timed area
+        <prefix>_damageCeg  := <ceg_name>  Spawns repeatedly for duration
+        <prefix>_resistance := <string>    Matched against areadamageresistance
+    }
+    prefix := area_ondeath | area_onhit  Units use ondeath; weapons use onhit.
+]]--
 
 --------------------------------------------------------------------------------
 -- Local variables -------------------------------------------------------------


### PR DESCRIPTION
### Work done

fixed the regex

#### Addresses Issue(s)
- the regex being wrong
- tweakunits not working w/ adding new fire and acid areas to weapons

#### Setup
- use tweakunits from robertthepie to make Grunt lasers cause burn aoe:
```lua
{
	corak = {
		weapondefs = {
			gator_laser = {
				customparams = {
					area_onhit_ceg = "fire-area-65-repeat",
					area_onhit_damageCeg = "burnflamexl-gen",
					area_onhit_resistance = "fire",
					area_onhit_damage = 30,
					area_onhit_range = 65,
					area_onhit_time = 10,},
			}
		}
	}
}
```

#### Test steps
- [ ] /give corak and shoot at ground; there should be a damaging fire area