### PR TITLE
test_runner: Improve the callin test capabilities.

### DIFF
--- a/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -14,6 +14,10 @@ function test()
 	widget = widgetHandler:FindWidget("Stop means Stop")
 	assert(widget)
 
+	-- Make the test_runner start prerecording UnitCommand calls,
+	-- not really needed here, but recommended for new tests.
+	Test.expectCallin("UnitCommand", true)
+
 	local myTeamID = Spring.GetMyTeamID()
 
 	unitID = SyncedRun(function(locals)

--- a/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -4,6 +4,8 @@ end
 
 function setup()
 	Test.clearMap()
+	-- Enable UnitCommand callin for tests
+	Test.expectCallin("UnitCommand")
 end
 
 function cleanup()
@@ -13,10 +15,6 @@ end
 function test()
 	widget = widgetHandler:FindWidget("Stop means Stop")
 	assert(widget)
-
-	-- Make the test_runner start prerecording UnitCommand calls,
-	-- not really needed here, but recommended for new tests.
-	Test.expectCallin("UnitCommand", true)
 
 	local myTeamID = Spring.GetMyTeamID()
 

--- a/luaui/Widgets/Tests/selftests/test_callins.lua
+++ b/luaui/Widgets/Tests/selftests/test_callins.lua
@@ -34,7 +34,7 @@ function runBaseTests()
 	-- not calling expect first
 	assertThrowsMessage(function()
 		Test.waitUntilCallin("UnitCommand")
-	end, "[registerCallin:UnitCommand] need to call expectCallin(\"UnitCommand\") first")
+	end, "[registerCallin:UnitCommand] need to call Test.expectCallin(\"UnitCommand\") first")
 
 	Test.clearCallins()
 

--- a/luaui/Widgets/Tests/selftests/test_callins.lua
+++ b/luaui/Widgets/Tests/selftests/test_callins.lua
@@ -1,0 +1,71 @@
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function runBaseTests()
+	-- double expect should throw
+	Test.expectCallin("UnitCommand")
+
+	assertThrowsMessage(function()
+		Test.expectCallin("UnitCommand")
+	end, "[preRegisterCallin:UnitCommand] already pre-registered")
+
+	Test.clearCallins()
+
+	-- mismatching expect and wait
+	Test.expectCallin("UnitCommand")
+
+	assertThrowsMessage(function()
+		Test.waitUntilCallin("UnitCommand", function()
+			return true
+		end)
+	end, "[registerCallin:UnitCommand] expecting a different mode")
+
+	Test.clearCallins()
+
+	-- mismatching expect and wait
+	Test.expectCallin("UnitCommand", true)
+
+	assertThrowsMessage(function()
+		Test.waitUntilCallin("UnitCommand")
+	end, "[registerCallin:UnitCommand] expecting a different mode")
+
+	Test.clearCallins()
+end
+
+function runWaitUntil(expect)
+	-- test waitUntilCallinArgs with and without expectCallin preregister
+	local myTeamID = Spring.GetMyTeamID()
+	if expect then
+		Test.expectCallin("UnitCommand", true)
+	end
+
+	local unitID = SyncedRun(function(locals)
+		local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+		local y = Spring.GetGroundHeight(x, z)
+		return Spring.CreateUnit("armpw", x, y, z, 0, locals.myTeamID)
+	end)
+
+	-- issue selfd
+	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+
+	-- actual test
+	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
+	assert(Spring.GetUnitSelfDTime(unitID) > 0)
+
+	Test.clearCallins()
+end
+
+function test()
+	runBaseTests()
+	runWaitUntil()
+	runWaitUntil(true)
+end

--- a/luaui/Widgets/Tests/selftests/test_callins.lua
+++ b/luaui/Widgets/Tests/selftests/test_callins.lua
@@ -80,9 +80,9 @@ function test()
 
 	runBaseTests()
 	-- normal run, try full register, then only count, then only count and expect count
-	runWaitUntil(FULL, FULL, 0, EXPECT, CLEAR) -- full, full, 0...
-	runWaitUntil(COUNT, FULL, 0, EXPECT, CLEAR)  -- count, full, 0...
-	runWaitUntil(COUNT, COUNT, 0, EXPECT, CLEAR)   -- count, count, 0...
+	runWaitUntil(FULL, FULL, 0, EXPECT, CLEAR)
+	runWaitUntil(COUNT, FULL, 0, EXPECT, CLEAR)
+	runWaitUntil(COUNT, COUNT, 0, EXPECT, CLEAR)
 
 	-- same but now with wait before give order and waitUntilCallin
 	runWaitUntil(FULL, FULL, 3, EXPECT, CLEAR)

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -200,7 +200,7 @@ function registerCallin(name, predicate, target, depth)
 		target = widget
 	end
 	if not callinState.unsafe and not callinState.recording[name] then
-		error("[registerCallin:" .. name .. "] need to call expectCallin(\"" .. name .. "\") first", depth)
+		error("[registerCallin:" .. name .. "] need to call Test.expectCallin(\"" .. name .. "\") first", depth)
 	end
 	local mode = predicate and REGISTER_FULL or REGISTER_COUNT
 	if not callinState.callins[name] then

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -666,13 +666,14 @@ Test = {
 		-- stop buffering callin executions
 		removeCallin(name)
 	end,
-	waitUntilCallin = function(name, predicate, timeout, depth)
+	waitUntilCallin = function(name, predicate, timeout, count, depth)
 		local depth = depth and (depth + 1) or 2
 		log(LOG.DEBUG, "[waitUntilCallin] " .. name)
 		registerCallin(name, predicate, nil, depth)
 
+		local count = count or 1
 		local counts = callinState.counts
-		Test.waitUntil(function() return counts[name] > 0 end,
+		Test.waitUntil(function() return counts[name] >= count end,
 			       timeout,
 			       1)
 
@@ -683,7 +684,7 @@ Test = {
 		end
 		log(LOG.DEBUG, "[waitUntilCallin.done]")
 	end,
-	waitUntilCallinArgs = function(name, expectedArgs, timeout, depth)
+	waitUntilCallinArgs = function(name, expectedArgs, timeout, count, depth)
 		local depth = depth and (depth + 1) or 2
 		Test.waitUntilCallin(name, function(...)
 			local currentArgs = { ... }
@@ -693,7 +694,7 @@ Test = {
 				end
 			end
 			return true
-		end, timeout, depth)
+		end, timeout, count, depth)
 	end,
 	spy = function(...)
 		local spyCtrl = Mock.spy(...)

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -246,6 +246,9 @@ local function trackCallin(target, name, callback, mode)
 	if not target then
 		target = widget
 	end
+	if name == 'GameFrame' or name == 'Shutdown' then
+		error("Can't track GameFrame or Shutdown callins")
+	end
 	target[name] = callback
 	widgetHandler:UpdateWidgetCallInRaw(name, target)
 	callinState.callins[name] = mode

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -177,7 +177,7 @@ local testRunState
 local activeTestState
 local resumeState
 local returnState
-local callinState = {callins = {}, recording = {}}
+local callinState = {callins = {}, recording = {}, unsafe = false}
 local spyControls
 
 
@@ -339,6 +339,7 @@ end
 local function resetCallinState()
 	log(LOG.DEBUG, "[resetCallinState]")
 	removeAllCallins()
+	callinState.unsafe = false
 end
 
 local function resetSpyCtrls()

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -258,17 +258,18 @@ function preRegisterCallin(name, full, target, depth)
 	elseif callinState.callins[name] then
 		error("[preRegisterCallin:" .. name .. "] already registered", depth)
 	end
-	local predicate = false
+	local recorderFunc = false
 	if full then
+		-- create a fake 'predicate' to accumulate data until a real predicate is set.
 		local buffers = callinState.buffer
-		predicate = function(...)
+		recorderFunc = function(...)
 			local buffer = buffers[name]
 			local args = {...}
 			buffer[#buffer+1] = args
 		end
 	end
 	callinState.recording[name] = true --need to set this before registerCallin
-	registerCallin(name, predicate, target, depth)
+	registerCallin(name, recorderFunc, target, depth)
 end
 
 -- Unhook callin

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -205,16 +205,17 @@ function registerCallin(name, predicate, target, depth)
 		error("[registerCallin:" .. name .. "] need to call Test.expectCallin(\"" .. name .. "\") first", depth)
 	end
 	local mode = predicate and REGISTER_FULL or REGISTER_COUNT
-	if not callinState.callins[name] then
+	local prevMode = callinState.callins[name]
+	if not prevMode then
 		callinState.buffer[name] = {}
 	        callinState.counts[name] = 0
-	elseif callinState.callins[name] == REGISTER_COUNT and callinState.callins[name] ~= mode then
+	elseif prevMode == REGISTER_COUNT and prevMode ~= mode then
 		error("[registerCallin:" .. name .. "] expecting countOnly but requesting full", depth)
 	end
 
 	local counts = callinState.counts
 	-- preload recorded data when we have full record but just need a count
-	if mode == REGISTER_COUNT and callinState.callins[name] == REGISTER_FULL then
+	if mode == REGISTER_COUNT and prevMode == REGISTER_FULL then
 		counts[name] = #callinState.buffer[name]
 		callinState.buffer[name] = {}
 	end


### PR DESCRIPTION
### Work done:

- Allow using any callins with Test.waitUntilCallin* (except currently the ones already in use by dbg_test_runner itself, like Update or GameFrame).
- Don't record all data coming from callins by default.
- Allow parameter checks and predicates as always, but also just checking if a callin was called in a more optimal way.
- New api methods: Test.expectCallin, Test.unexpectCallin, Test.clearCallins, Test.setUnsafeCallins.
- New test for self-testing callin functionality: selftests/test_callins.lua.

### How to test

Check the new [test_callins](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/158a4c3e5ce1fa174bee58744fb1b6136aea799a/luaui/Widgets/Tests/selftests/test_callins.lua) test, and also all previous tests work as before, specially _test_cmd_stop_selfd_ (the only test using this functionality till now).

- Start Skirmish in neverend mode
- Place commander and start game
- /runtests test_callins
- /runtests test_cmd_stop_selfd

### Explanation

- The previous system has several limitations:
  - Doesn't allow registering all callins since it has a predefined list.
  - Even when not in use will be recording all callin arguments in lua tables. That's really bad for bigger tests.
- This re-implementation solves that by autoregistering callins on waitUntilCallin/waitUntilCallinArgs.
  - Also now allows waitUntilCallin with no predicate, that will simply wait until the callin is executed at least once.
  - **Drawback** is when api users need to wait for events that happened *before* calling waitUntilCallin/waitUntilCallinArgs.
    - To avoid that, a new api is provided: `Test.expectCallin(callinName, full)`, that will make the runner start listening for the callin so when api users waitUntilCallin/waitUntilCallinArgs it will also process previous calls.
    - **It is compulsory to always call it** at the beginning of tests with the desired callins to ensure callin executions won't be lost.
      - This can be overriden by setting Test.setUnsafeCallins(true) in the test setup (or anywhere else).

### New api methods

The api works similarly as before, but it is important to be aware from now on, when wanting to listen for a callin, users will generally need to use **Test.expectCallin**.

If not doing it an error will be produced [explaining what to do](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/158a4c3e5ce1fa174bee58744fb1b6136aea799a/luaui/Widgets/Tests/selftests/test_callins.lua#L37), so this shouldn't be a big issue.

#### Test.expectCallin

`function Test.expectCallin(name, countOnly)`

Starts listening/recording for callin events so later on waitUntilCallin or waitUntilCallinArgs can process pre-recorded events.

It's use is compulsory unless `Test.setUnsafeCallins(true) is called`.

This is to ensure callins already happened by the time api users want to call waitUntilCallin* get cought by default, so test creation is more intuitive. 

**countOnly** can be set to true when not using waitUntilCallinArgs or waitUntilCallin predicates. This optimizes memory usage for cases when full data recording isn't needed.

#### Test.unexpectCallin

`function Test.unexpectCallin(name)`

Stops listening/recording the callin and also clears the queue.

#### Test.setUnsafeCallins

`function Test.setUnsafeCallins(unsafe)`

Enable unsafe usage of the callin test api.

By setting this to true prerecording will **not** be enforced, and thus it will be the api user responsibility to enable prerecording (through Test.expectCallin) when callins are expected to happen before waitUntilCallin* are called.

If unsafe mode is enabled, but prerecording is not requested it will still work, but just with events happening after the waitUntilCallin* (this can be fine in many situations, but generally the test maker will need to know game/engine internals better).

#### Test.clearCallins

`function Test.clearCallins()`

Deregisters all callins.

### Api changes

#### Test.waitUntilCallin changes

`function Test.waitUntilCallin(name, predicate, timeout)`

Now accepts an empty predicate and in that case it will just wait until the callin is run at least once. This is better when api users don't need to check the callin arguments since we don't need to be passing all those tables around.

It can later be improved to count until a certain number of executions.

#### Test.waitUntilCallinArgs changes

`function Test.waitUntilCallinArgs(name, expectedArgs, timeout)`

The timeout parameter is new and will set a maximum timeout for the callin args test to succeed.
