### PR TITLE
test_runner: Automatic endmode override, readying and game start.

### DIFF
--- a/luarules/gadgets/dbg_test_env_helper.lua
+++ b/luarules/gadgets/dbg_test_env_helper.lua
@@ -47,6 +47,9 @@ if gadgetHandler:IsSyncedCode() then
 	function gadget:Initialize()
 		gadgetHandler.actionHandler.AddChatAction(gadget, 'setTestEndConditions', SetTestEndConditionsCmd)
 		gadgetHandler.actionHandler.AddChatAction(gadget, 'setTestReadyPlayers', SetTestReadyPlayersCmd)
+		if Spring.GetGameRulesParam("testEndConditionsOverride") then
+			SetTestEndConditionsCmd()
+		end
 	end
 
 	function gadget:Shutdown()

--- a/luarules/gadgets/dbg_test_env_helper.lua
+++ b/luarules/gadgets/dbg_test_env_helper.lua
@@ -40,7 +40,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 		local playerList = Spring.GetPlayerList()
 		for _, playerID in pairs(playerList) do
-			Spring.SetGameRulesParam("player_" .. playerID .. "_readyState", initState)
+			Spring.SetGameRulesParam("player_" .. playerID .. "_readyState", 1)
 		end
 	end
 

--- a/luarules/gadgets/dbg_test_env_helper.lua
+++ b/luarules/gadgets/dbg_test_env_helper.lua
@@ -62,8 +62,6 @@ if gadgetHandler:IsSyncedCode() then
 		if msg == 'testEnvironmentStarting' then
 			Spring.SetGameRulesParam('testEnvironmentStarting', true)
 			gadgetHandler:RemoveGadgetCallIn('RecvLuaMsg', self)
-		elseif Spring.GetGameFrame() > 0 then
-			gadgetHandler:RemoveGadgetCallIn('RecvLuaMsg', self)
 		end
 	end
 else

--- a/luarules/gadgets/dbg_test_env_helper.lua
+++ b/luarules/gadgets/dbg_test_env_helper.lua
@@ -1,0 +1,77 @@
+function gadget:GetInfo()
+	return {
+		name = "Test Environment Helper",
+		desc = "Helper to setup test environment conditions",
+		license = "GNU GPL, v2 or later",
+		layer = 9999,
+		handler = true,
+		enabled = true,
+	}
+end
+
+local ENABLED_RULES_PARAM = 'isTestEnvironmentHelperEnabled'
+
+if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() then
+	Spring.SetGameRulesParam(ENABLED_RULES_PARAM, false)
+	return
+end
+
+if gadgetHandler:IsSyncedCode() then
+
+	local removeGadgets = {'Team Com Ends', 'Game End'}
+
+	Spring.SetGameRulesParam(ENABLED_RULES_PARAM, true)
+
+	local function SetTestEndConditionsCmd(cmd, line, words, playerID)
+		if not Spring.IsCheatingEnabled() then
+			return
+		end
+		for _, gadgetName in pairs(removeGadgets) do
+			local g = gadgetHandler:FindGadget(gadgetName)
+			gadgetHandler:RemoveGadget(g)
+		end
+
+		Spring.SetGameRulesParam("testEndConditionsOverride", true)
+	end
+
+	local function SetTestReadyPlayersCmd(cmd, line, words, playerID)
+		if not Spring.IsCheatingEnabled() then
+			return
+		end
+		local playerList = Spring.GetPlayerList()
+		for _, playerID in pairs(playerList) do
+			Spring.SetGameRulesParam("player_" .. playerID .. "_readyState", initState)
+		end
+	end
+
+	function gadget:Initialize()
+		gadgetHandler.actionHandler.AddChatAction(gadget, 'setTestEndConditions', SetTestEndConditionsCmd)
+		gadgetHandler.actionHandler.AddChatAction(gadget, 'setTestReadyPlayers', SetTestReadyPlayersCmd)
+	end
+
+	function gadget:Shutdown()
+		gadgetHandler.actionHandler.RemoveChatAction(gadget, 'setTestEndConditions')
+		gadgetHandler.actionHandler.RemoveChatAction(gadget, 'setTestReadyPlayers')
+		Spring.SetGameRulesParam(ENABLED_RULES_PARAM, false)
+	end
+
+	function gadget:RecvLuaMsg(msg, playerID)
+		if msg == 'testEnvironmentStarting' then
+			Spring.SetGameRulesParam('testEnvironmentStarting', true)
+			gadgetHandler:RemoveGadgetCallIn('RecvLuaMsg', self)
+		elseif Spring.GetGameFrame() > 0 then
+			gadgetHandler:RemoveGadgetCallIn('RecvLuaMsg', self)
+		end
+	end
+else
+	-- taken from gui_pregameui.lua, check there for more information
+	local NETMSG_STARTPLAYING = 4
+	local SYSTEM_ID = -1
+
+	function gadget:Update(n)
+		if (Spring.GetPlayerTraffic(SYSTEM_ID, NETMSG_STARTPLAYING) or 0) > 0 then
+			Spring.SendLuaRulesMsg('testEnvironmentStarting')
+			gadgetHandler:RemoveGadget(self)
+		end
+	end
+end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -349,7 +349,7 @@ local function startTests(patterns)
 	if #neededActions > 0 then
 		if not queuedStartTests then
 			-- enable required actions, then wait for them to go through
-			for _, action in pairs(neededActions) do
+			for _, action in ipairs(neededActions) do
 				log(LOG.INFO, action[2])
 				Spring.SendCommands(action[1])
 			end
@@ -361,7 +361,7 @@ local function startTests(patterns)
 			return
 		else
 			-- ran out of retries, so fail
-			for _, action in pairs(neededActions) do
+			for _, action in ipairs(neededActions) do
 				log(LOG.ERROR, action[3])
 			end
 			queuedStartTests = false

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -299,9 +299,11 @@ registerCallins(widget, function(name, args)
 end)
 
 local MAX_START_TESTS_ATTEMPTS = 10
+local MAX_START_WAIT_SECS = 10
 local queuedStartTests = false
 local queuedStartTestsPatterns = nil
 local startTestsAttempts = 0
+local startGameTime = 0
 local function queueStartTests(patterns)
 	queuedStartTests = true
 	queuedStartTestsPatterns = patterns
@@ -327,20 +329,30 @@ local function startTests(patterns)
 		return
 	end
 
-	if Spring.GetModOptions().deathmode ~= 'neverend' then
-		log(
-			LOG.ERROR,
-			"deathmode='neverend' game end mode is required in order to run tests, so that the game stays " ..
-				"active between tests"
-		)
-		return
-	end
-
+	local neededActions = {}
 	if not Spring.IsCheatingEnabled() then
+		neededActions[#neededActions+1] = {'cheat',
+						   'Cheats are disabled; attempting to enable them...',
+						   'Could not enable cheats; tests cannot be run.'}
+	end
+	if Spring.GetModOptions().deathmode ~= 'neverend' and not Spring.GetGameRulesParam('testEndConditionsOverride') then
+		neededActions[#neededActions+1] = {'luarules setTestEndConditions',
+						   "Disabling end conditions...",
+						   "Could not override game end condition. Please use deathmode='neverend' game end mode. " ..
+					           "This is required in order to run tests, so that the game stays active between tests."}
+	end
+	if Spring.GetGameFrame() < 1 and not Spring.GetGameRulesParam('testEnvironmentStarting') then
+		neededActions[#neededActions+1] = {'luarules setTestReadyPlayers',
+						   "Preparing players to start game...",
+						   'Could not prepare players. Please start game manually.'}
+	end
+	if #neededActions > 0 then
 		if not queuedStartTests then
-			-- enable cheats, then wait for it to go through
-			log(LOG.INFO, "Cheats are disabled; attempting to enable them...")
-			Spring.SendCommands("cheat")
+			-- enable required actions, then wait for them to go through
+			for _, action in pairs(neededActions) do
+				log(LOG.INFO, action[2])
+				Spring.SendCommands(action[1])
+			end
 			queueStartTests(patterns)
 			return
 		elseif startTestsAttempts < MAX_START_TESTS_ATTEMPTS then
@@ -349,12 +361,28 @@ local function startTests(patterns)
 			return
 		else
 			-- ran out of retries, so fail
-			log(LOG.ERROR, "Could not enable cheats; tests cannot be run.")
+			for _, action in pairs(neededActions) do
+				log(LOG.ERROR, action[3])
+			end
 			queuedStartTests = false
 			return
 		end
 	end
+	if Spring.GetGameFrame() < 1 then
+		if not queuedStartTests then
+			queueStartTests(patterns)
+		end
+		if startGameTime == 0 then
+			startGameTime = os.clock()
+		elseif os.clock() - startGameTime > MAX_START_WAIT_SECS then
+			startGameTime = 0
+			queuedStartTests = false
+			log(LOG.ERROR, "Game didn't start in time for tests", os.clock() - (startGameTime))
+		end
+		return
+	end
 
+	startGameTime = 0
 	queuedStartTests = false
 
 	logStartTests()


### PR DESCRIPTION
### Work done

- Allow test_runner to:
  - Override endmode by disabling appropriate gadgets.
  - Ready players.
  - Wait for game start.
- Accomplished through new "Test Environment Helper" gadget.

#### Addresses Issue(s)

- Having to set endmode, place commander and hit start is very annoying when working on tests.
- Also having to explain to ppl every time when you want them to run a test.

#### Test steps

- Run some test without setting 'neverend' game end mode, placing commander, or starting game.
  - Ie, just don't worry about it, start skirmish and run test immediately.
- For example `/runtests test_cmd_stop_selfd`
