### PR TITLE
Fix lua error taking down gui_selectedunits_gl4 widget

### DIFF
--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -183,7 +183,7 @@ local function RemovePrimitive(unitID)
 	if selectionVBOGround.instanceIDtoIndex[unitID] then selectionVBO =  selectionVBOGround end
 	if selectionVBOAir.instanceIDtoIndex[unitID] then selectionVBO =  selectionVBOAir end
 
-	if selectionVBO.instanceIDtoIndex[unitID] then
+	if selectionVBO and selectionVBO.instanceIDtoIndex[unitID] then
 		if selectionHighlight then
 			unitBufferUniformCache[1] = 0
 			if Spring.ValidUnitID(unitID) then


### PR DESCRIPTION
### Work done

- Avoid error at UnitDestroyed when unit wasn't added to vbo.

### Widget Crash

```
[t=00:41:52.401734][f=0054274] Error in UnitDestroyed(): [string "LuaUI/Widgets/gui_selectedunits_gl4.lua"]:186: attempt to index local 'selectionVBO' (a nil value)
[t=00:41:52.401769][f=0054274] Removed widget: Selected Units GL4
```


### Remarks

- The vbo instance might not be there because some unitdefs don't get instanced (see AddPrimitiveAtUnit)
- Because of yesterdays merge https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3965
- More at https://discord.com/channels/549281623154229250/1317089164813926430
