### PR TITLE
test_runner: deregister widget:Update when not needing it any more.

### DIFF
--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -1058,6 +1058,8 @@ end
 function widget:Update(dt)
 	if Spring.GetGameFrame() <= 0 then
 		step()
+	else
+		widgetHandler:RemoveWidgetCallIn('Update', self)
 	end
 end
 


### PR DESCRIPTION
### Work done

- Make the test runner deregister Update when not needing it any more.

### Remarks

- This leaves widget:Update free so tests can re-register it.

#### Test steps
- Get the [this test](https://github.com/saurtron/Beyond-All-Reason/blob/test-selection-destroy/luaui/Widgets/Tests/attackrange/test_attackrange.lua), or [this branch](https://github.com/saurtron/Beyond-All-Reason/tree/test-selection-destroy), that [includes the change](https://github.com/saurtron/Beyond-All-Reason/commit/a92827d118c0ab33ea97fe0b09c6c01d133d78d1#diff-7ba6638a3e917c266a765422852bed663bd5ddc4a2dc605b22552acd59d79771R1062)
  - If you took just the test, place it somewhere under luaui/Widgets/Tests/
- Start skirmish with neverend game mode
- Place commander
- Start game
- /runtests attackrange
  -  it can assert for the test due to what its testing, but it won't fail due to this code.
