### PR TITLE
test_runner: Don't SetGameRulesParam at unsynced.

### DIFF
--- a/luarules/gadgets/dbg_test_env_helper.lua
+++ b/luarules/gadgets/dbg_test_env_helper.lua
@@ -12,7 +12,6 @@ end
 local ENABLED_RULES_PARAM = 'isTestEnvironmentHelperEnabled'
 
 if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() then
-	Spring.SetGameRulesParam(ENABLED_RULES_PARAM, false)
 	return
 end
 


### PR DESCRIPTION
### Work done

* Remove useless general SetGameRulesParam at initial test, that also doesn't work for unsynced, thus generating error logs.


### Trace

- Provided by Moose at discord `attempt to call field 'SetGameRulesParam' (a nil value))`