### PR TITLE
Add a mechanism to declare capability dependencies at widget/gadget GetInfo

### DIFF
--- a/common/platformFunctions.lua
+++ b/common/platformFunctions.lua
@@ -1,0 +1,53 @@
+if not Platform then return end
+local hasGL4 = false
+local hasGL = false
+local hasShaders = false
+local hasFBO = false
+local isSyncedCode = (SendToUnsynced ~= nil)
+
+local function determineCapabilities()
+	if not gl then
+		return
+	end
+	if gl.GetString(0x1F00) ~= "" then
+		hasGL = true
+	end
+	if gl.CreateShader and Platform.glHaveGLSL then
+		hasShaders = true
+	end
+	if gl.CreateFBO then
+		hasFBO = true
+	end
+
+	if hasFBO and hasShaders and Platform.glHaveGL4 then
+		hasGL4 = true
+	end
+end
+
+local function checkRequires(allRequires)
+	if not allRequires or isSyncedCode then
+		return true
+	end
+	for _, req in pairs(allRequires) do
+		if req == 'gl' and not hasGL then
+			return false
+		elseif req == 'gl4' and not hasGL4 then
+			return false
+		elseif req == 'shaders' and not hasShaders then
+			return false
+		elseif req == 'fbo' and not hasVBO then
+			return false
+		end
+	end
+	return true
+end
+
+local function extendPlatform()
+	Platform.gl = Platform.gl or hasGL
+	Platform.gl4 = Platform.gl4 or hasGL4
+	Platform.glHaveFBO = Platform.glHaveFBO or hasFBO
+	Platform.check = checkRequires
+end
+
+determineCapabilities()
+extendPlatform()

--- a/common/platformFunctions.lua
+++ b/common/platformFunctions.lua
@@ -9,7 +9,7 @@ local function determineCapabilities()
 	if not gl then
 		return
 	end
-	if gl.GetString(0x1F00) ~= "" then
+	if Platform.glVendor ~= "" then
 		hasGL = true
 	end
 	if gl.CreateShader and Platform.glHaveGLSL then

--- a/init.lua
+++ b/init.lua
@@ -32,6 +32,8 @@ if commonFunctions.spring[environment] then
 	local springFunctions = VFS.Include('common/springFunctions.lua')
 	Spring.Utilities = Spring.Utilities or springFunctions.Utilities
 	Spring.Debug = Spring.Debug or springFunctions.Debug
+	-- extend platform
+	VFS.Include('common/platformFunctions.lua')
 end
 
 if commonFunctions.i18n[environment] then

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -415,6 +415,11 @@ function gadgetHandler:LoadGadget(filename, overridevfsmode)
 		return nil -- gadget asked for a quiet death
 	end
 
+	if gadget.GetInfo and (Platform and not Platform.check(gadget.GetInfo().depends)) then
+		Spring.Echo('Missing capabilities:  ' .. gadget:GetInfo().name .. '. Disabling.')
+		return nil
+	end
+
 	-- raw access to gadgetHandler
 	if gadget.GetInfo and gadget:GetInfo().handler then
 		gadget.gadgetHandler = self

--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -8,6 +8,7 @@ function gadget:GetInfo()
 		license = "GNU GPL, v2 or later",
 		layer	= 0,
 		enabled	= true,
+		depends = {'gl4'},
 	}
 end
 

--- a/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
+++ b/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
@@ -8,6 +8,7 @@ function widget:GetInfo()
 	license   = "GNU GPL, v2 or later",
     layer     = -9999,
     enabled   = true,
+    depends   = {'gl4'},
   }
 end
 
@@ -438,10 +439,6 @@ if TESTMODE then
 end
 
 function widget:Initialize()
-	if not gl.CreateShader then -- no shader support, so just remove the widget itself, especially for headless
-		widgetHandler:RemoveWidget()
-		return
-	end
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		if unitDef.model and unitDef.model.textures and unitDef.model.textures.tex1 then 
 			unitDefIDtoTex1[unitDefID] = unitDef.model.textures.tex1:lower()

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -7,6 +7,7 @@ function widget:GetInfo()
 		license = "Lua code: GNU GPL, v2 or later, Shader GLSL code: (c) Beherith (mysterme@gmail.com)",
 		layer = 999,
 		enabled = true,
+		depends = {'gl4'},
 	}
 end
 
@@ -1925,10 +1926,6 @@ local function UnitScriptDecal(unitID, unitDefID, whichDecal, posx, posz, headin
 end
 
 function widget:Initialize()
-	if not gl.CreateShader then -- no shader support, so just remove the widget itself, especially for headless
-		widgetHandler:RemoveWidget()
-		return
-	end
 	local t0 = Spring.GetTimer()
 	--if makeAtlases() == false then
 	--	goodbye("Failed to init texture atlas for DecalsGL4")

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -12,6 +12,7 @@ function widget:GetInfo()
 		license = "Lua: GPLv2, GLSL: (c) Beherith (mysterme@gmail.com)",
 		layer   = -99,
 		enabled = true,
+		depends = {'gl4'},
 	}
 end
 
@@ -670,10 +671,6 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:Initialize()
-	if not gl.CreateShader then -- no shader support, so just remove the widget itself, especially for headless
-		widgetHandler:RemoveWidget(self)
-		return
-	end
 	initUnitList()
 
 	if initGL4() == false then

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -911,6 +911,14 @@ function widgetHandler:InsertWidgetRaw(widget)
 	if widget == nil then
 		return
 	end
+	if widget.GetInfo and not Platform.check(widget:GetInfo().depends) then
+		local name = widget.whInfo.name
+		if self.knownWidgets[name] then
+			self.knownWidgets[name].active = false
+		end
+		Spring.Echo('Missing capabilities:  ' .. name .. '. Disabling.')
+		return
+	end
 
 	SafeWrapWidget(widget)
 
@@ -930,6 +938,9 @@ end
 
 function widgetHandler:RemoveWidgetRaw(widget)
 	if widget == nil or widget.whInfo == nil then
+		return
+	end
+	if not Platform.check(widget.whInfo.depends) then
 		return
 	end
 


### PR DESCRIPTION
### Work done

- Add a mechanism to declare capability dependencies at widgets and gadgets
  - Through the new 'depends' field. 
  - For now added: gl, gl4, shaders, fbo.
  - This makes the widgets and gadgets automatically inactive if capabilities not present.
- Extends the Platform module for this.
  - Adds `Platform.check(capabilities)`, also `Platform.gl`, `Platform.gl4`, `Platform.glHaveFBO`.
    - These also allow testing for the features partially inside modules in a cleaner way than the current way of gl.CreateShader or similar, and it can be a central place where the tests can be improved.

### Remarks

Looking forward to hearing ideas for improving this PR.

- This allows cleaning a lot of checks from many widgets, also making those less error prone.
  - In many situations the tests aren't there, or they're at the wrong place.
  - A common error is testing at Initialize but not at Shutdown, this can make Shutdown err.
  - Current situation is bad for automatic testing since there is no gl there and that triggers a few errors (noticed it while preparingfor automated testing)
- The Platform module is just available for unsynced, but atm all the methods are just needed at unsynced
  - I was initially going to add a Capabilities module, but then seen the Platform module and thought better expand on that.
  - If we need this for synced could also create Platform for unsynced.
- The new attributes inside Platform combine Vendor and lua tests for best results. For example right now Platform.glHaveGLSL always returns true even when gl.CreateShader isn't defined, like for headless, but it's conceivable in the future it could be oposite, and have situations where Platform.glHaveGLSL is false but gl.CreateShader is defined.
- The Platform module is currently not used much, but imo it's the way to go specially if we add a few things there besides the ones the engine is [already adding](https://github.com/beyond-all-reason/spring/blob/master/rts/Lua/LuaConstPlatform.cpp#L47).

### Examples

There are a few examples already added in this PR, but works like this:

```LUA
function widget:GetInfo()
  return {
    name      = "DrawUnitShape GL4",
    version   = "v0.2",
    desc      = "Faster gl.UnitShape, Use WG.UnitShapeGL4",
    author    = "ivand, Beherith",
    date      = "2021.11.04",
        license   = "GNU GPL, v2 or later",
    layer     = -9999,
    enabled   = true,
    depends   = {'gl4'}, --   <----- this one
  }
end
```