### PR TITLE
Chat filter

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -1906,7 +1906,7 @@ function widget:KeyPress(key)
 						local badWord = findBadWords(inputText)
 						if badWord ~= nil and inputText ~= lastMessage then
 							addChat(Spring.GetGameFrame(), LineTypes.System, "\255\255\000\000Moderation:",
-							'Words such as "' .. badWord .. '" can be against the Code of Conduct if they are being used to abuse other players. Please take a moment to reevaluate your intentions. If your message was blocked in error you can send it again to bypass the filter.', true)
+							'Words such as "' .. badWord .. '" can be against the Code of Conduct if they are being used to abuse other players. Please take a moment to reevaluate your intentions. If your message was blocked in error, then you can send it again to bypass the filter.', true)
 						else
 							Spring.SendCommands("say "..inputMode..inputText)
 						end

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -453,6 +453,21 @@ local function getAIName(teamID)
 	return Spring.I18N('ui.playersList.aiName', { name = name })
 end
 
+local lastMessage
+local badWords = {
+	"^retard[s]?$",
+	"^retarded$",
+}
+local function findBadWords(str)
+	str = string.lower(str)
+	for w in str:gmatch("%w+") do
+		for _, bw in ipairs(badWords) do
+			if sfind(w, bw) then
+				return w
+			end
+		end
+	end
+end
 
 local teamColorKeys = {}
 local teams = Spring.GetTeamList()
@@ -1888,7 +1903,14 @@ function widget:KeyPress(key)
 					if ssub(inputText, 1, 1) == '/' then
 						Spring.SendCommands(ssub(inputText, 2))
 					else
-						Spring.SendCommands("say "..inputMode..inputText)
+						local badWord = findBadWords(inputText)
+						if badWord ~= nil and inputText ~= lastMessage then
+							addChat(Spring.GetGameFrame(), LineTypes.System, "\255\255\000\000Moderation:",
+							'Words such as "' .. badWord .. '" can be against the Code of Conduct if they are being used to abuse other players. Please take a moment to reevaluate your intentions. If your message was blocked in error you can send it again to bypass the filter.', true)
+						else
+							Spring.SendCommands("say "..inputMode..inputText)
+						end
+						lastMessage = inputText
 					end
 				end
 				cancelChatInput()


### PR DESCRIPTION
This chat filter resolves a lot of the objections I saw with the last one that was proposed. It aims to inform players that some language is not acceptable in BAR, and to reduce moderator burden. The goal is not to prevent all chat abuse, as that is not possible. I think DeviousNull has written a much better reflection on chat filters than I am capable of, and described what this implementation hopes to achieve, in this comment: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3539#issuecomment-2277226295

A list of the most problematic words from the moderation team would be nice to fill out the word list.
