### PR TITLE
Add missing Test.expectCallin to test_wait test example.

### DIFF
--- a/luaui/Widgets/TestsExamples/test_utilities/test_wait.lua
+++ b/luaui/Widgets/TestsExamples/test_utilities/test_wait.lua
@@ -1,5 +1,6 @@
 function setup()
 	Test.clearMap()
+	Test.expectCallin("UnitCreated")
 end
 
 function cleanup()


### PR DESCRIPTION
### Work done

- Add required Test.expectCallin("UnitCreated") to the `test_wait` test.

Now tests are required to call that when they will register a callin through the test_runner. I overlooked adding it to the 'test_wait' test example since examples not running by default through /runtests :P.