### PR TITLE
Fix shutdown from cmd_extractor_snap when WG.DrawUnitShapeGL4 not available.

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -323,5 +323,8 @@ end
 
 
 function widget:Shutdown()
+	if not WG.DrawUnitShapeGL4 then
+		return
+	end
 	clear()
 end


### PR DESCRIPTION
### Work done

Fix shutdown from cmd_extractor_snap when WG.DrawUnitShapeGL4 not available.

In that situation the widget will remove itself, but that will also call Shutdown and generate an error at clear (it does `WG.ExtractorSnap.position = nil` there that won't be defined).
