### PR TITLE
Remove code to fix math.random returning float instead of int

### DIFF
--- a/unitbasedefs/lootboxes/lootboxnano.lua
+++ b/unitbasedefs/lootboxes/lootboxnano.lua
@@ -1,8 +1,3 @@
--- Workaround for engine bug https://github.com/beyond-all-reason/spring/issues/45
-local math_random = function(x, y)
-	return x + math.floor( y * math.random() )
-end
-
 local tiers = {
 	T1 = 1,
 	T2 = 2,
@@ -23,7 +18,7 @@ local createCustomBuildList = function(tier)
 	local buildList = {}
 
 	for i = 1, buildListSize do
-		local buildOption = buildOptions[tier][math_random(1, #buildOptions[tier])]
+		local buildOption = buildOptions[tier][math.random(1, #buildOptions[tier])]
 		buildList[i] = buildOption
 	end
 
@@ -77,7 +72,7 @@ local function getRandomModel(tier)
 		},
 	}
 
-	local randomModel = math_random(1, 2)
+	local randomModel = math.random(1, 2)
 
 	return models[tier][randomModel].objectName, models[tier][randomModel].script
 end


### PR DESCRIPTION
https://github.com/beyond-all-reason/spring/issues/45 has been fixed for a long, long time.

### Work done
Removed code to overwrite `math.random(x,y)`, as an engine bug was returning a float instead of an int. The engine issue has since been fixed.