### PR TITLE
test_runner: Add 'timeout' parameter to SyncedRun.

### DIFF
--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -615,14 +615,14 @@ end
 
 SyncedProxy = createNestedProxy(Proxy.PREFIX.CALL)
 
-SyncedRun = function(fn)
+SyncedRun = function(fn, timeout)
 	local serializedFn, returnID = rpc:serializeFunctionRun(fn, 3)
 
 	returnState = {
 		waitingForReturnID = returnID,
 		success = nil,
 		pendingValueOrError = nil,
-		timeoutExpireFrame = Spring.GetGameFrame() + config.returnTimeout,
+		timeoutExpireFrame = Spring.GetGameFrame() + (timeout or config.returnTimeout),
 	}
 
 	log(LOG.DEBUG, "[SyncedRun.send]")


### PR DESCRIPTION
### Work done

- Add a 'timeout' parameter to SyncedRun.
  - allows overriding the default timeout 

### Remarks

- This is needed when you need to wait more than the measly default 30 frames, like for levelling terrain.