### PR TITLE
Balance test / proposed unit reworks modoption

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1408,7 +1408,7 @@ function WeaponDef_Post(name, wDef)
 		end
 		
 		-- Accurate Lasers		
-		if modOptions.accuratelasers then
+		if modOptions.proposed_unit_reworks then
 			if wDef.weapontype and wDef.weapontype == 'BeamLaser' then
 				wDef.targetmoveerror = nil
 			end

--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -36,7 +36,7 @@ local modrules = {
 	},
 
 	resurrect = {
-		energyCostFactor = 0.5, -- How much of the original energy cost it requires to resurrect something.
+		energyCostFactor = Spring.GetModOptions().proposed_unit_reworks==true and 1.0 or 0.5, -- How much of the original energy cost it requires to resurrect something.
 	},
 
 	capture = {

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1334,7 +1334,7 @@ local options = {
         name 	= "Proposed Unit Reworks",
         desc 	= "Modoption used to test and balance unit reworks that are being considered for the base game.",
         type 	= "bool",
-        hidden 	= true,
+        --hidden 	= true,
         section = "options_experimental",
         def 	= false,
     },

--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -1,5 +1,89 @@
 local function proposed_unit_reworksTweaks(name, uDef)
 
+		
+		if name == "cormex" then
+			uDef.health = 230
+		end
+		if name == "armmex" then
+			uDef.health = 225
+		end
+		if name == "armsolar" then
+			uDef.buildtime = 2600
+		end
+		if name == "armwin" then
+			uDef.metalcost = 40
+		end
+		if name == "corwin" then
+			uDef.metalcost = 43
+			uDef.health = 220
+		end
+		if name == "armtide" then
+			uDef.energycost = 200
+		end
+		if name == "armadvsolar" then
+			uDef.metalcost = 350
+		end
+		if name == "corcv" then
+			uDef.buildpower = 95
+		end
+		if name == "corck" then
+			uDef.buildpower = 85
+		end
+		if name == "cormuskrat" then
+			uDef.buildpower = 85
+		end
+		if name == "coracv" then
+			uDef.buildpower = 265
+		end
+		if name == "corack" then
+			uDef.buildpower = 190
+		end
+		if name == "coraca" then
+			uDef.buildpower = 105
+		end
+		if name == "corch" then
+			uDef.buildpower = 115
+		end
+		if name == "corexp" then
+			uDef.buildtime = 2900
+		end
+
+
+
+		if name == "corgator" then
+			uDef.buildtime = 2200
+			uDef.sightdistance = 330
+		end
+		if name == "armflash" then
+			uDef.sightdistance = 350
+			uDef.health = 725
+		end
+		if name == "armflea" then
+			uDef.metalcost = 20
+			uDef.energycost = 300
+			uDef.sightdistance = 500
+		end
+		if name == "armpw" then
+			uDef.metalcost = 54
+			uDef.energycost = 870
+			uDef.health = 370
+		end
+		if name == "corak" then
+			uDef.metalcost = 45
+			uDef.energycost = 750
+			uDef.health = 300
+		end
+		if name == "corbw" then
+			uDef.weapondefs.bladewing_lyzer.reloadtime = 1.4
+			uDef.weapondefs.bladewing_lyzer.damage = 700
+		end
+		if name == "armkam" then
+			uDef.health = 560
+		end
+		if name == "armthund" then
+			uDef.weapondefs.bombs.burstrate = 2.7
+		end
+
 	return uDef
 end
 


### PR DESCRIPTION
basic t1 mexes - +20% hp
arm solar 2800 -> 2600 buildtime
arm wind 37->40m
cor wind 45->43m, 199->220hp
arm tidal 250->200e
arm asolar 370->350m

corcv 90 -> 95bp    //cortex cons +5% bp, since they cost more
corck 80 -> 85
corca 60->65
cormuskrat 80 -> 85
coracv 250 -> 265
corack 180 -> 190
coraca  100 -> 105
corch 110 -> 115

corexp 2720 -> 2900 bt

Blitz 690 -> 725hp, LoS +50
Incisor buildtime +25%, LoS +50
Grunt 36->45m, 880->750e, 270->300hp
Pawn 48->54m, 960->870e, 340->370hp
Tick 17->20m, 340->300e

Stormbringer - drop bombs 10% closer together
Banshee - 485 -> 560 hp
Shuri 600 -> 700  dmg, 1.2 -> 1.4 reloadtime

Accurate lasers for everything
Rezzing energy cost 50% -> 100% of unit's original energy cost