### PR TITLE
Add alliance filter to spatial queries when possible.

### DIFF
--- a/luarules/gadgets/pve_boss_priority_targetting.lua
+++ b/luarules/gadgets/pve_boss_priority_targetting.lua
@@ -78,9 +78,10 @@ function gadget:GameFrame(frame)
     if frame%30 == 21 then
         for queenID, _ in pairs(aliveQueens) do
             local queenx,queeny,queenz = Spring.GetUnitPosition(queenID)
-            local surroundingUnits = Spring.GetUnitsInSphere(queenx, queeny, queenz, 750)
+            local queenTeamID = Spring.GetUnitTeam(queenID)
+            local surroundingUnits = CallAsTeam(queenTeamID, Spring.GetUnitsInSphere, queenx, queeny, queenz, 750, -4)
             for i = 1,#surroundingUnits do
-				if aliveTargets[surroundingUnits[i]] and Spring.GetUnitAllyTeam(surroundingUnits[i]) ~= Spring.GetUnitAllyTeam(queenID) then
+				if aliveTargets[surroundingUnits[i]] then
                     Spring.GiveOrderToUnit(queenID, CMD.STOP, 0, 0)
                     Spring.GiveOrderToUnit(queenID, CMD.ATTACK, {surroundingUnits[i]}, 0)
                     break

--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -218,15 +218,15 @@ if gadgetHandler:IsSyncedCode() then
 
 
 			if commandQueue[1] then
+				local teamID = Spring.GetUnitTeam(unitID)
 				for _,command in pairs(commandQueue) do
 					local coded = command.options.coded + (command.options.shift and 0 or CMD.OPT_SHIFT) -- orders without SHIFT can appear at positions other than the 1st due to CMD.INSERT; they'd cancel any previous commands if added raw
 					if command.id < 0 then -- repair case for construction
-						local units = Spring.GetUnitsInRectangle(command.params[1] - 16, command.params[3] - 16, command.params[1] + 16, command.params[3] + 16)
-						local allyTeam = Spring.GetUnitAllyTeam(unitID)
+						local units = CallAsTeam(teamID, Spring.GetUnitsInRectangle, command.params[1] - 16, command.params[3] - 16, command.params[1] + 16, command.params[3] + 16, -3)
 						local notFound = true
 						for j = 1, #units do
 							local areaUnitID = units[j]
-							if allyTeam == Spring.GetUnitAllyTeam(areaUnitID) and Spring.GetUnitDefID(areaUnitID) == -command.id then
+							if Spring.GetUnitDefID(areaUnitID) == -command.id then
 								Spring.GiveOrderToUnit(newUnitID, CMD.REPAIR, areaUnitID, coded)
 								notFound = false
 								break

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -389,10 +389,10 @@ if gadgetHandler:IsSyncedCode() then
 							top = cmdParams[3]
 						end
 
-						targets = CallAsTeam(teamID, spGetUnitsInRectangle, left, top, right, bot)
+						targets = CallAsTeam(teamID, spGetUnitsInRectangle, left, top, right, bot, -4)
 					elseif #cmdParams == 4 then
 						--circle
-						targets = CallAsTeam(teamID, spGetUnitsInCylinder, cmdParams[1], cmdParams[3], cmdParams[4])
+						targets = CallAsTeam(teamID, spGetUnitsInCylinder, cmdParams[1], cmdParams[3], cmdParams[4], -4)
 					end
 					if targets then
 						local orders = {}

--- a/luaui/Widgets/cmd_nanoturrets_assist_priority.lua
+++ b/luaui/Widgets/cmd_nanoturrets_assist_priority.lua
@@ -34,7 +34,7 @@ function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
     if (nanoDefs[unitDefID] ~= nil) then
         -- Echo(turretCreatedMessage .. ": " .. unitID)
         local pos = {GetUnitPosition(unitID)}
-        local unitsNear = GetUnitsInSphere(pos[1], pos[2], pos[3], nanoDefs[unitDefID])
+        local unitsNear = GetUnitsInSphere(pos[1], pos[2], pos[3], nanoDefs[unitDefID], -3)
         -- Echo("found units nearby: " .. unitsNear)
         for _, id in ipairs(unitsNear) do
             if (nanoDefs[GetUnitDefID(id)] ~= nil) then 

--- a/luaui/Widgets/cmd_share_unit.lua
+++ b/luaui/Widgets/cmd_share_unit.lua
@@ -241,7 +241,7 @@ local function findTeamInArea(mx, my)
 		return nil
 	end
 
-	local foundUnits = GetUnitsInCylinder(cUnitID[1], cUnitID[3], range)
+	local foundUnits = GetUnitsInCylinder(cUnitID[1], cUnitID[3], range, -3)
 
 	if #foundUnits < 1 then
 		return nil
@@ -251,7 +251,7 @@ local function findTeamInArea(mx, my)
 
 	for _, unitId in ipairs(foundUnits) do
 		local unitTeamId = GetUnitTeam(unitId)
-		if isAlly(unitTeamId) then
+		if unitTeamId ~= myTeamID then
 			unitTeamId = tostring(unitTeamId)
 			if unitTeamCounters[unitTeamId] == nil then
 				unitTeamCounters[unitTeamId] = 1

--- a/luaui/Widgets/unit_set_target_by_type.lua
+++ b/luaui/Widgets/unit_set_target_by_type.lua
@@ -54,12 +54,12 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	local cmdRadius = cmdParams[4]
 
 	local filterUnitDefID = spGetUnitDefID(targetId)
-	local areaUnits = Spring.GetUnitsInCylinder(cmdX, cmdZ, cmdRadius)
+	local areaUnits = Spring.GetUnitsInCylinder(cmdX, cmdZ, cmdRadius, -4)
 
 	local newCmds = {}
 	for i = 1, #areaUnits do
 		local unitID = areaUnits[i]
-		if spGetUnitAllyTeam(unitID) ~= allyTeam and spGetUnitDefID(unitID) == filterUnitDefID then
+		if spGetUnitDefID(unitID) == filterUnitDefID then
 			local newCmdOpts = {}
 			if #newCmds ~= 0 or cmdOpts.shift then
 				newCmdOpts = { "shift" }

--- a/luaui/Widgets/unit_specific_unit_loader.lua
+++ b/luaui/Widgets/unit_specific_unit_loader.lua
@@ -76,17 +76,19 @@ function widget:CommandNotify(id, params, options)
 
 			local targetEnemy = reclaimEnemy and spGetUnitAllyTeam(id) ~= allyTeam
 			local unitDef = spGetUnitDefID(id)
-			local preareaUnits = spGetUnitsInCylinder(cx ,cz , cr)
-			if not targetEnemy then
-				preareaUnits = spGetUnitsInCylinder(cx ,cz , cr, team)
-			end
+			local preareaUnits
 			local countarea = 0
 			local areaUnits = {}
-			for i=1,#preareaUnits do
-				local unitID = preareaUnits[i]
-				if (targetEnemy and spGetUnitAllyTeam(unitID) ~= allyTeam) or (options.alt and not targetEnemy and spGetUnitDefID(unitID) == unitDef ) or  (options.ctrl and not targetEnemy) then
-					countarea = countarea + 1
-					areaUnits[countarea] = unitID
+			if targetEnemy then
+				areaUnits = spGetUnitsInCylinder(cx, cz, cr, -4)
+			else
+				preareaUnits = spGetUnitsInCylinder(cx, cz, cr, team)
+				for i=1,#preareaUnits do
+					local unitID = preareaUnits[i]
+					if (options.alt and spGetUnitDefID(unitID) == unitDef) or options.ctrl then
+						countarea = countarea + 1
+						areaUnits[countarea] = unitID
+					end
 				end
 			end
 			for ct=1,#selUnits do

--- a/luaui/Widgets/unit_specific_unit_reclaimer.lua
+++ b/luaui/Widgets/unit_specific_unit_reclaimer.lua
@@ -75,9 +75,10 @@ function widget:CommandNotify(id, params, options)
 
 			local targetEnemy = reclaimEnemy and spGetUnitAllyTeam(id) ~= allyTeam
 			local unitDef = spGetUnitDefID(id)
-			local areaUnits = spGetUnitsInCylinder(cx ,cz , cr)
-
-			if not targetEnemy then
+			local areaUnits
+			if targetEnemy then
+				areaUnits = spGetUnitsInCylinder(cx, cz, cr, -4)
+			else
 				areaUnits = spGetUnitsInCylinder(cx ,cz , cr, team)
 			end
 
@@ -85,7 +86,7 @@ function widget:CommandNotify(id, params, options)
 			local count = 0
 			for i=1,#areaUnits do
 				local unitID    = areaUnits[i]
-				if (targetEnemy and spGetUnitAllyTeam(unitID) ~= allyTeam) or (options.alt and not targetEnemy and spGetUnitDefID(unitID) == unitDef ) or  (options.ctrl and not targetEnemy) then
+				if targetEnemy or (options.alt and spGetUnitDefID(unitID) == unitDef) or options.ctrl then
 					local cmdOpts = {}
 					if count ~= 0 or options.shift then
 						cmdOpts = {"shift"}


### PR DESCRIPTION
### Work done

- Add alliance filter to some spatial queries

### Affected widgets/gadgets

- Affected gadgets:
  - pve_boss_priority_targetting (tested)
  - unit_evolution
  - unit_target_on_the_move (tested)
- Affected widgets:
  - cmd_nanoturrets_assist_priority (tested)
  - cmd_share_unit
  - unit_set_target_by_type (tested)
  - unit_specific_unit_loader (tested)
  - unit_specific_unit_reclaimer (tested)

### Testing

I tried testing as much as possible but some cases are a bit tricky like the queen pve boss. The untested ones look pretty safe looking at the code, but pls help testing if possible and look at the code closely.

### Remarks

- There's other spatial queries without alliance filters, but I added just the ones where it looks safe to add the filter.
  - Particularly there are some checking with Spring.AreTeamsAllied, those checks the allyTeams are allied, but not sure it's a thing in BAR, most places just check if AllyTeam matches directly.