### PR TITLE
Fix clockwise triangles at MakeTexRectVAO and gui_metalspots.

### DIFF
--- a/luaui/Widgets/Include/instancevbotable.lua
+++ b/luaui/Widgets/Include/instancevbotable.lua
@@ -1283,11 +1283,11 @@ function MakeTexRectVAO(minX,minY, maxX, maxY, minU, minV, maxU, maxV)
 	rectVBO:Upload({
 			
 		minX,minY, minU, minV, --bl
-		minX,maxY, minU, maxV, --tr
 		maxX,maxY, maxU, maxV, --tr
+		minX,maxY, minU, maxV, --tl
 		maxX,maxY, maxU, maxV, --tr
-		maxX,minY, maxU, minV, --br
 		minX,minY, minU, minV, --bl
+		maxX,minY, maxU, minV, --br
 			})
 	
 	--[[rectVBO:Upload( {

--- a/luaui/Widgets/gfx_bloom_shader_deferred.lua
+++ b/luaui/Widgets/gfx_bloom_shader_deferred.lua
@@ -572,6 +572,7 @@ local function Bloom()
 	df = df + 1
 	gl.DepthMask(false)
 	gl.Color(1, 1, 1, 1)
+	gl.Culling(true)
 
 	glUseShader(brightShader)
 		glUniform(   brightShaderIllumLoc, illumThreshold)
@@ -633,6 +634,7 @@ local function Bloom()
 
 	gl.Blending("reset")
 	gl.DepthMask(false) --"BK OpenGL state resets", was true
+	gl.Culling(false)
 end
 
 function widget:DrawWorld()

--- a/luaui/Widgets/gfx_norush_timer_gl4.lua
+++ b/luaui/Widgets/gfx_norush_timer_gl4.lua
@@ -100,7 +100,7 @@ function widget:DrawWorldPreUnit()
 		end
 	end
 	
-	glCulling(GL.FRONT)
+	glCulling(true)
 	glDepthTest(false)
 	gl.DepthMask(false)
 

--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -195,8 +195,8 @@ local function makeSpotVBO()
 		arrayAppend(VBOData, {billboardsize, billboardsize, 1, 2})
 		arrayAppend(VBOData, {-billboardsize, 0, 1, 2})
 		arrayAppend(VBOData, {billboardsize, billboardsize, 1, 2})
-		arrayAppend(VBOData, {-billboardsize, 0, 1, 2})
 		arrayAppend(VBOData, {-billboardsize, billboardsize, 1, 2})
+		arrayAppend(VBOData, {-billboardsize, 0, 1, 2})
 	end
 
 	spotVBO:Define(#VBOData/4, VBOLayout)
@@ -519,6 +519,7 @@ function widget:DrawWorldPreUnit()
 	local clockDifference = (os.clock() - previousOsClock)
 	previousOsClock = os.clock()
 
+	gl.Culling(true)
 	gl.Texture(0, "$heightmap")
 	gl.Texture(1, AtlasTextureID)
 	gl.DepthTest(false)
@@ -532,6 +533,7 @@ function widget:DrawWorldPreUnit()
 		needsInit = false
 	end
 
+	gl.Culling(false)
 	gl.Texture(0, false)
 	gl.Texture(1, false)
 end

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -301,7 +301,7 @@ local fullScreenRectVAO
 local startPolygonShader
 local startPolygonBuffer = nil -- GL.SHADER_STORAGE_BUFFER for polygon
 
-local function DrawStartPolygons(inminimap)	
+local function DrawStartPolygons(inminimap)
 	local advUnitShading, advMapShading = Spring.HaveAdvShading()
 
 	if advMapShading then 
@@ -322,7 +322,7 @@ local function DrawStartPolygons(inminimap)
 
 	startPolygonBuffer:BindBufferRange(4)
 
-	gl.Culling(GL.FRONT)
+	gl.Culling(true)
 	gl.DepthTest(false)
 	gl.DepthMask(false)
 
@@ -339,7 +339,7 @@ local function DrawStartPolygons(inminimap)
 	gl.Texture(2, false)
 	gl.Texture(3, false)
 	gl.Texture(4, false)
-	gl.Culling(GL.BACK)
+	gl.Culling(false)
 	gl.DepthTest(false)
 end
 
@@ -504,7 +504,7 @@ local function DrawStartboxes3dWithStencil()
 
 	gl.CallList(startboxDListStencil)   --// draw
 
-	gl.Culling(GL.BACK)
+	gl.Culling(true)
 	gl.DepthTest(false)
 
 	gl.ColorMask(true, true, true, true)

--- a/luaui/Widgets/map_startpolygon_gl4.lua
+++ b/luaui/Widgets/map_startpolygon_gl4.lua
@@ -119,7 +119,7 @@ local function DrawStartPolygons(inminimap)
 
 	startPolygonBuffer:BindBufferRange(4)
 
-	gl.Culling(GL.FRONT)
+	gl.Culling(true)
 	gl.DepthTest(false)
 	gl.DepthMask(false)
 


### PR DESCRIPTION
### Work done

- Fix clockwise triangles at instancevbotable:MakeTexRectVAO and gui_metalspots
- Switch from GL.FRONT or enable Culling(true) there.

### Affected widgets

- gui_metalspots
- gfx_bloom_shader_deferred
- gfx_norush_timer_gl4
- map_startbox
- map_startpolygon_gl4

#### Addresses Issue(s)

- Default culling enabled mode is normally GL.BACK, anticlockwise triangles work better with this.

#### Test steps

- Set branch in BAR.sdd and see widgets still draw properly

### Remarks

- I think engine doesn't set the glCullFace mode when doing gl.Culling(true) or gl.Culling(false), I believe it just enables with whatever mode was there before. I'm not completely sure, but this seems very fragile since we will be enabling or disabling into an unknown mode. Reference: [LuaOpenGL.cpp](https://github.com/beyond-all-reason/spring/blob/29edeb15f5d66ad243db9084921af9ef4259de24/rts/Lua/LuaOpenGL.cpp#L2812)
  - Might be safer to always call with the mode, like GL.BACK here, but seems a bit wasteful.
  - Didn't see anything strange though.
  - Also can check everywhere GL.FRONT is set and make sure to call with GL.BACK before disabling.
    - looks like only lups/particleclasses/shieldjitter.lua not resetting properly
- I tested and looks like default mode initially is always gl.Culling(false) with glCullFace(GL_BACK).
  - We might want to cull more when possible.