### PR TITLE
Move gui_fonthandler to a lower layer.

### DIFF
--- a/luaui/Widgets/gui_fonthandler.lua
+++ b/luaui/Widgets/gui_fonthandler.lua
@@ -5,7 +5,7 @@ function widget:GetInfo()
 		author    = "Floris",
 		date      = "June 2020",
 		license   = "GNU GPL, v2 or later",
-		layer     = -999999,
+		layer     = -1000001,
 		enabled   = true
 	}
 end


### PR DESCRIPTION
### Work done

- Move gui_fonthandler to layer -1000001

### Remarks

- Should be lower than all font users since its the one initializing `WG['fonts']`
- Was at 999999, a very crowded level with several other WG['font'] users.
- Lowest I seen is dbg_widget_profiler.lua, that one isn't using WG['fonts'] atm but just in case.
