### PR TITLE
bugfix: grid menu disappearing on non-english categories

### DIFF
--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -11,10 +11,10 @@ local homeGridPos = { }
 
 local unitCategories = {}
 
-local BUILDCAT_ECONOMY = "Economy"
-local BUILDCAT_COMBAT = "Combat"
-local BUILDCAT_UTILITY = "Utility"
-local BUILDCAT_PRODUCTION = "Build"
+local BUILDCAT_ECONOMY = Spring.I18N("ui.buildMenu.category_econ")
+local BUILDCAT_COMBAT = Spring.I18N("ui.buildMenu.category_combat")
+local BUILDCAT_UTILITY = Spring.I18N("ui.buildMenu.category_utility")
+local BUILDCAT_PRODUCTION = Spring.I18N("ui.buildMenu.category_production")
 
 local categories = {
 	BUILDCAT_ECONOMY,


### PR DESCRIPTION

### Work done
Fix a i18n bug that cause grid menu disappearing on category selection.

### Step to reproduce the bug
1. Download latest translation file from transfix.
2. Open a new game, select language in dev panel.
3. Click the third category meaning Utility
4. Build menu disappears, error log shown on screen.
