### PR TITLE
cmd_context_build: Avoid lua error because of missing hardcoded unitdefs.

### DIFF
--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -22,6 +22,8 @@ end
 
 local isPregame = Spring.GetGameFrame() == 0 and not isSpec
 
+local uDefNames = UnitDefNames
+
 local GetActiveCommand		= Spring.GetActiveCommand
 local SetActiveCommand		= Spring.SetActiveCommand
 local spGetMouseState 		= Spring.GetMouseState
@@ -283,6 +285,28 @@ function widget:GameStart()
 	isPregame = false
 end
 
+local function addUnitDefPair(firstUnitName, lastUnitName)
+	local firstUnitDef = uDefNames[firstUnitName]
+	local lastUnitDef = uDefNames[lastUnitName]
+
+	if not (firstUnitDef and lastUnitDef and firstUnitDef.id and lastUnitDef.id) then
+		Spring.Echo(string.format("%s: can't add %s/%s pair", "cmd_context_build", firstUnitName, lastUnitName))
+		return
+	end
+
+	for i, unitDef in ipairs({firstUnitDef, lastUnitDef}) do
+		local unitDefID = unitDef.id
+		local isWater = i % 2 == 0
+
+		-- Break the unit list into two matching arrays
+		if isWater then
+			table.insert(waterBuildings, unitDefID)
+		else
+			table.insert(groundBuildings, unitDefID)
+		end
+	end
+end
+
 function widget:Initialize()
 	if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
 		maybeRemoveSelf()
@@ -295,20 +319,7 @@ function widget:Initialize()
 	end
 
 	
-	local uDefNames = UnitDefNames
 	for _,unitNames in ipairs(unitlist) do
-		for i, unitName in ipairs(unitNames) do
-			local unitDefID = uDefNames[unitName].id
-			local isWater = i % 2 == 0
-
-			-- Break the unit list into two matching arrays
-			if unitDefID then
-				if isWater then
-					table.insert(waterBuildings, unitDefID)
-				else
-					table.insert(groundBuildings, unitDefID)
-				end
-			end
-		end
+		addUnitDefPair(unitNames[1], unitNames[2])
 	end
 end


### PR DESCRIPTION
### Work done

- Check both members of each pair exist before trying to add them.

#### Addresses Issue(s)

- `Errorcode: Error in Initialize(): [string LuaUI/Widgets/cmd_context_build.lua]:301: attempt to index field ? (a nil value) , count = 743`

#### Test steps

Not sure how to reproduce the issue since this is from telemetry, but this is the way to check the widget still works after the changes:

- Set BAR.sdd to use this branch
- Start game on a world with both ground and water
- Select a laser turret to build
- Move the cursor over ground and water to see it still switches with torpedo launcher.

### Remarks

- Not totally sure why this is happening, but I think maybe the unitdefs are disabled through unittweaks or some similar mechanism?
  - Could also happen when any of these units get removed from the codebase, although I looked a bit and didn't seem to be the case.
- Adding the check probably a good idea anyways, what I'm not sure is whether to show the log when this situation happens. For now I'm showing it in case this happens because of something unexpected.
- Not sure if unitDef.id can be falsy when unitDef actually exists at the UnitDefNames table. The code was already testing this, so I'm leaving it in just in case.