### PR TITLE
cmd_share_unit: Don't crash when hovering over a unit in front of sky.

### DIFF
--- a/luaui/Widgets/cmd_share_unit.lua
+++ b/luaui/Widgets/cmd_share_unit.lua
@@ -130,7 +130,11 @@ local function getMouseTargetPosition()
 			return mouseTarget[1], mouseTarget[2], mouseTarget[3]
 		elseif mouseTargetType == "unit" then
 			local _, coordinates = TraceScreenRay(mx, my, true)
-			return coordinates[1], coordinates[2], coordinates[3], mouseTarget
+			if coordinates then
+				return coordinates[1], coordinates[2], coordinates[3], mouseTarget
+			else
+				return nil, nil, nil, mouseTarget
+			end
 		elseif mouseTargetType == "feature" then
 			local _, coordinates = TraceScreenRay(mx, my, true)
 			if coordinates then
@@ -285,7 +289,7 @@ local function getSelectedTeam()
 
 	local tx, ty, tz, targetUnitID = getMouseTargetPosition()
 
-	if (not tx) then
+	if (not tx and not targetUnitID) then
 		return nil
 	end
 


### PR DESCRIPTION
### Work done

- cmd_share_unit: Fix widget crash when hovering a unit against the sky

#### Addresses Issue(s)

-`Errorcode: Error in DrawWorld(): [string LuaUI/Widgets/cmd_share_unit.lua]:133: attempt to index local coordinates (a nil value) , count = 118`

#### Test steps

- Set BAR.sdd to this branch
- Start skirmish game with an ally
- /cheat on
- /give armpw
- Select armpw
- Move camera so you can see an ally unit with the sky as background
- Click on command "share unit"
- Hover on top of the ally unit, and click to share
  - Should work now when before it would crash the widget

### Screenshot

Notice the cursor on top of the unit against the sky, and "share unit" selected (the active unit is a pawn, although not seen at the screenshot). Active player is blue.

![share](https://github.com/user-attachments/assets/a3fe9ab6-a616-4694-9f0c-65e34da5580c)
