### PR TITLE
gui_transport_weight_limit: Fix typo later causing lua crash.

### DIFF
--- a/luaui/Widgets/gui_transport_weight_limit.lua
+++ b/luaui/Widgets/gui_transport_weight_limit.lua
@@ -110,8 +110,8 @@ function widget:SelectionChanged(sel)
 	elseif selectedUnitsCount > 1 then
 		for i = 1, #selectedUnits do
 			local unitID = selectedUnits[i]
-			local unitdefID = Spring.GetUnitDefID(unitID)
-			if validTrans[unitdefID] then
+			local unitDefID = Spring.GetUnitDefID(unitID)
+			if validTrans[unitDefID] then
 				transID = unitID
 				transDefID = unitDefID
 				unitcount = unitcount + 1


### PR DESCRIPTION
### Work done

- Fix capitalization typo

#### Addresses Issue(s)

- `Errorcode: Error in GameFrame(): [string LuaUI/Widgets/gui_transport_weight_limit.lua]:149: attempt to index local transDef (a nil value) , count = 64`

### Remarks

- The typo is: originally gets local `unitdefID`, then assigns it as `unitDefID`. I changed all to `unitDefID` since it looks more consistent with code style in the file.