### PR TITLE
Fix the legion xmas comwreck resurrecting as armada instead of legion

### DIFF
--- a/luarules/gadgets/unit_xmas.lua
+++ b/luarules/gadgets/unit_xmas.lua
@@ -259,11 +259,8 @@ function gadget:FeatureCreated(featureID, allyTeam)
 		if xmasFeatureID then
 			Spring.SetFeatureRotation(xmasFeatureID, rx,ry,rz)
 			Spring.SetFeatureDirection(xmasFeatureID, dx,dy,dz)
-			local comtype = 'armcom'
-			if string.find(FeatureDefs[Spring.GetFeatureDefID(featureID)].modelname:lower(), 'corcom', nil, true) then
-				comtype = 'corcom'
-			end
-			Spring.SetFeatureResurrect(xmasFeatureID, comtype, "s", 0)
+			local featureResurrect = Spring.GetFeatureResurrect(featureID)
+			Spring.SetFeatureResurrect(xmasFeatureID, featureResurrect, "s", 0)
 		end
 	end
 end


### PR DESCRIPTION
### Work done
Use Spring.GetFeatureResurrect instead of hardcoding unit names so the xmas comwreck resurrect the right unit.

#### Test steps
- [ ] Spawn all three commanders units /give legcom, /give corcom, /give armcom
- [ ] Destroy them /destroy
- [ ] Use rezbots on the xmas comwreck and see if the right unit gets resurrected
