### PR TITLE
gaia_critters: remove critters unconditionally when killed

### DIFF
--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -570,7 +570,7 @@ end
 
 function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
 	commanders[unitID] = nil
-	if critterUnits[unitID] ~= nil and attackerID ~= nil then
+	if critterUnits[unitID] ~= nil then
 		critterUnits[unitID] = nil
 		totalCritters = totalCritters - 1
 	end

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -70,6 +70,8 @@ local companionRadius = companionRadiusStart
 local processOrders = true
 local addedInitialCritters
 
+local ownCritterDestroy = false
+
 local function randomPatrolInBox(unitID, box, minWaterDepth)	-- only define minWaterDepth if unit is a submarine
 	local ux,_,uz = GetUnitPosition(unitID,true,true)
 	local waterRadius = 1000		-- max distance a submarine unit will travel
@@ -275,6 +277,7 @@ local function adjustCritters(newAliveCritters)
 
 	local removeKeys = {}
 	local removeKeysCount = 0
+	ownCritterDestroy = true -- flag to skip UnitDestroyed callin
 	for unitID, critter in pairs(critterUnits) do
 		if add and not critter.alive  or  not add and critter.alive then
 			if add then
@@ -299,6 +302,7 @@ local function adjustCritters(newAliveCritters)
 			if critterDifference > -1 and critterDifference < 1  then break end
 		end
 	end
+	ownCritterDestroy = false
 	if add then
 		for i, unitID in ipairs(removeKeys) do
 			critterUnits[unitID] = nil		-- this however leaves these keys still being iterated
@@ -570,7 +574,7 @@ end
 
 function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
 	commanders[unitID] = nil
-	if critterUnits[unitID] ~= nil then
+	if not ownCritterDestroy and critterUnits[unitID] ~= nil then
 		critterUnits[unitID] = nil
 		totalCritters = totalCritters - 1
 	end

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -574,7 +574,7 @@ end
 
 function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
 	commanders[unitID] = nil
-	if not ownCritterDestroy and critterUnits[unitID] ~= nil then
+	if not ownCritterDestroy and critterUnits[unitID] and critterUnits[unitID].alive then
 		critterUnits[unitID] = nil
 		totalCritters = totalCritters - 1
 	end
@@ -584,7 +584,8 @@ end
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	-- accepts: CMD.ATTACK
 	if cmdParams and #cmdParams == 1 then
-		if critterUnits[cmdParams[1]] ~= nil then
+		local critter = critterUnits[cmdParams[1]]
+		if critter and critter.alive then
 			return false
 		end
 	end


### PR DESCRIPTION
### Work done

- Remove critters from gaia_critters list even if no attacker was reported.
  - actually checks to see if the widget itself destroyed it so it can keep track of critters to restore

#### Test steps

- Run the test from https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4056
- Due to critters not being removed gaia_critters will often (most of the time?) abort the command thinking units are critters (when the unitID is reused).
  - Test destroys all units before running and that triggers the problem.

### Remarks

- Maybe should also discount from aliveCritters if it was alive?