### PR TITLE
"Unit Dead" gadget

### DIFF
--- a/luarules/gadgets/game_remove_dead.lua
+++ b/luarules/gadgets/game_remove_dead.lua
@@ -1,0 +1,22 @@
+function gadget:GetInfo()
+	return {
+		name      = "Remove dead units",
+		desc      = "Remove dead units from engine lists where possible",
+		license   = "GNU GPL, v2 or later",
+		layer     = -1999999,
+		enabled   = true,
+	}
+end
+
+if gadgetHandler:IsSyncedCode() then
+	return
+end
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+	Spring.SetUnitNoSelect(unitID, true)
+	if Spring.SetUnitNoGroup then
+		Spring.SetUnitNoGroup(unitID, true)
+	else
+		Spring.SetUnitGroup(unitID, -1)
+	end
+end

--- a/luarules/gadgets/unit_dead.lua
+++ b/luarules/gadgets/unit_dead.lua
@@ -1,7 +1,7 @@
 function gadget:GetInfo()
 	return {
-		name      = "Remove dead units",
-		desc      = "Remove dead units from engine lists where possible",
+		name      = "Dead Unit",
+		desc      = "Remove behaviours from dead units",
 		license   = "GNU GPL, v2 or later",
 		layer     = -1999999,
 		enabled   = true,

--- a/luarules/gadgets/unit_death_animations.lua
+++ b/luarules/gadgets/unit_death_animations.lua
@@ -40,7 +40,6 @@ for udid, ud in pairs(UnitDefs) do --almost all raptors have dying anims
 	end
 end
 
-local SetUnitNoSelect	= Spring.SetUnitNoSelect
 local GiveOrderToUnit	= Spring.GiveOrderToUnit
 local SetUnitBlocking 	= Spring.SetUnitBlocking
 local UnitIconSetDraw   = Spring.UnitIconSetDraw
@@ -56,7 +55,6 @@ end
 function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
 	if hasDeathAnim[unitDefID] then
 		--Spring.Echo("gadget:UnitDestroyed",unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
-		SetUnitNoSelect(unitID,true)
     	SetUnitBlocking(unitID,false) -- non blocking while dying
 		Spring.UnitIconSetDraw(unitID, false) -- dont draw icons
 		GiveOrderToUnit(unitID, CMD_STOP, 0, 0)


### PR DESCRIPTION
### Work done

- Add a gadget to remove dead units from selection and groups.

#### Test steps

To see problems created by inconsistent selection management:

- Get test file from [test_attackrange.lua](https://raw.githubusercontent.com/saurtron/Beyond-All-Reason/refs/heads/test-selection-destroy/luaui/Widgets/Tests/attackrange/test_attackrange.lua)
  - Place it inside luaui/Widgets/Tests/attackrange/
- Start skirmish
- Run /runtests attackrange
  - You might need to run this several times, but finally the assertion will trigger without this PR
  - gui_attackrange_gl4.lua has an issue where GetSelection still returns dead units, thus corrupting its logic
  - Might be other widgets affected by this

### Remarks

- Gave the gadget a generic "Dead Unit" name since I believe we might want to do more things with dead units.
  - For example check [unit_death_animations.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luarules/gadgets/unit_death_animations.lua#L59) or [unit_crashing_aircraft.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luarules/gadgets/unit_crashing_aircraft.lua#L56)
- Should help all widget and gadgets working with selection in maintaining consistency since with this you can count on GetSelection not returning dead units.
- Dead units can appear in lots of places you wouldn't expect them, like selection or GetAllUnits, entered/leavingLOS... this is probably not handled well in many places and currently thinking about further steps to facilitate not tripping on them.