### PR TITLE
gaia_critters: Improve dead critter restoring and patrol methods

### DIFF
--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -283,6 +283,7 @@ local function adjustCritters(newAliveCritters)
 				CreateUnit(critter.unitName, critter.x, critter.y, critter.z, 0, GaiaTeamID)
 				critterDifference = critterDifference - 1
 				critterArrayFrom[unitID] = nil
+				totalCritters = totalCritters - 1 -- CreateUnit adds 1 here but we want to keep it constant
 				changed = true
 			end
 		else

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -243,7 +243,9 @@ function gadget:Initialize()
 end
 
 local function getUnitDefIdbyName(unitName)
-	return UnitDefNames[unitName]
+	for udid, unitDef in pairs(UnitDefs) do
+		if unitDef.name == unitName then return udid end
+	end
 end
 
 -- excluding gaia units

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -17,10 +17,14 @@ end
 
 local isCritter = {}
 local isCommander = {}
+local gullDefID
 
 for unidDefID, unitDef in pairs(UnitDefs) do
 	if string.sub(unitDef.name, 1, 7) == "critter" then
 		isCritter[unitDefID] = true
+		if unitDef.name == 'critter_gull' then
+			gullDefID = unitDefID
+		end
 	elseif unitDef.customParams.iscommander then
 		isCommander[unitDefID] = true
 	end
@@ -504,7 +508,7 @@ function gadget:UnitIdle(unitID, unitDefID, unitTeam)
 	if isCritter[unitDefID] and not sceduledOrders[unitID] then
 		local x,y,z = GetUnitPosition(unitID,true,true)
 		local radius = 220
-		if UnitDefs[unitDefID].name == "critter_gull" then
+		if unitDefID == gullDefID then
 			radius = 750
 		end
 		randomPatrolInCircle(unitID, x, z, radius)
@@ -532,7 +536,7 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 	elseif isCritter[unitDefID] then
 		local x,_,z = GetUnitPosition(unitID,true,true)
 		local radius = 300
-		if UnitDefs[unitDefID].name == "critter_gull" then
+		if unitDefID == gullDefID then
 			radius = 1500
 		end
 		randomPatrolInCircle(unitID, x, z, radius)

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -575,8 +575,9 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
-	commanders[unitID] = nil
-	if critterUnits[unitID] then
+	if commanders[unitID] then
+		commanders[unitID] = nil
+	elseif critterUnits[unitID] then
 		critterUnits[unitID] = nil
 		totalCritters = totalCritters - 1
 		aliveCritters = aliveCritters - 1

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -242,9 +242,7 @@ function gadget:Initialize()
 end
 
 local function getUnitDefIdbyName(unitName)
-	for udid, unitDef in pairs(UnitDefs) do
-		if unitDef.name == unitName then return udid end
-	end
+	return UnitDefNames[unitName]
 end
 
 -- excluding gaia units

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -16,15 +16,12 @@ if not gadgetHandler:IsSyncedCode() then
 end
 
 local isCritter = {}
-for udid, unitDef in pairs(UnitDefs) do
-	if string.sub(unitDef.name, 1, 7) == "critter" then
-		isCritter[udid] = true
-	end
-end
-
 local isCommander = {}
-for unitDefID, unitDef in pairs(UnitDefs) do
-	if unitDef.customParams.iscommander then
+
+for unidDefID, unitDef in pairs(UnitDefs) do
+	if string.sub(unitDef.name, 1, 7) == "critter" then
+		isCritter[unitDefID] = true
+	elseif unitDef.customParams.iscommander then
 		isCommander[unitDefID] = true
 	end
 end

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -19,7 +19,7 @@ local isCritter = {}
 local isCommander = {}
 local gullDefID
 
-for unidDefID, unitDef in pairs(UnitDefs) do
+for unitDefID, unitDef in pairs(UnitDefs) do
 	if string.sub(unitDef.name, 1, 7) == "critter" then
 		isCritter[unitDefID] = true
 		if unitDef.name == 'critter_gull' then

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -17,13 +17,13 @@ end
 
 local isCritter = {}
 local isCommander = {}
-local gullDefID
+local isFlyingCritter = {}
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 	if string.sub(unitDef.name, 1, 7) == "critter" then
 		isCritter[unitDefID] = true
-		if unitDef.name == 'critter_gull' then
-			gullDefID = unitDefID
+		if unitDef.canFly then
+			isFlyingCritter[unitDefID] = true
 		end
 	elseif unitDef.customParams.iscommander then
 		isCommander[unitDefID] = true
@@ -511,7 +511,7 @@ function gadget:UnitIdle(unitID, unitDefID, unitTeam)
 	if isCritter[unitDefID] and not sceduledOrders[unitID] then
 		local x,y,z = GetUnitPosition(unitID,true,true)
 		local radius = 220
-		if unitDefID == gullDefID then
+		if isFlyingCritter[unitDefID] then
 			radius = 750
 		end
 		randomPatrolInCircle(unitID, x, z, radius)
@@ -539,7 +539,7 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 	elseif isCritter[unitDefID] then
 		local x,_,z = GetUnitPosition(unitID,true,true)
 		local radius = 300
-		if unitDefID == gullDefID then
+		if isFlyingCritter[unitDefID] then
 			radius = 1500
 		end
 		randomPatrolInCircle(unitID, x, z, radius)

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -176,6 +176,7 @@ local function randomPatrolInCircle(unitID, ux, uz, ur, minWaterDepth)	-- only d
 				ordersGiven = ordersGiven + 1
 			end
 		end
+		if ordersGiven == orders then break end
 	end
 end
 

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -291,7 +291,6 @@ local function adjustCritters(newAliveCritters)
 			end
 		else
 			local x,y,z = GetUnitPosition(unitID,true,true)
-			aliveCritters = aliveCritters - 1
 			critterDifference = critterDifference + 1
 
 			critterArrayTo[unitID] = critter
@@ -582,6 +581,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDef
 	if critterUnits[unitID] then
 		critterUnits[unitID] = nil
 		totalCritters = totalCritters - 1
+		aliveCritters = aliveCritters - 1
 	end
 end
 

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -272,11 +272,9 @@ local function adjustCritters(newAliveCritters)
 	local critterDifference = newAliveCritters - aliveCritters
 	local add = false
 	local critterArrayFrom = critterUnits
-	local critterArrayTo = critterBackup
 	if critterDifference > 0 then
 		add = true
 		critterArrayFrom = critterBackup
-		critterArrayTo = critterUnits
 		if not addCrittersAgain then return end
 	end
 
@@ -293,10 +291,10 @@ local function adjustCritters(newAliveCritters)
 			local x,y,z = GetUnitPosition(unitID,true,true)
 			critterDifference = critterDifference + 1
 
-			critterArrayTo[unitID] = critter
-			critterArrayTo[unitID].x = x
-			critterArrayTo[unitID].y = y
-			critterArrayTo[unitID].z = z
+			critterBackup[unitID] = critter
+			critterBackup[unitID].x = x
+			critterBackup[unitID].y = y
+			critterBackup[unitID].z = z
 
 			Spring.DestroyUnit(unitID, false, true)	-- reclaimed
 			totalCritters = totalCritters + 1 -- DestroyUnit callin substracts 1 here but we want to keep it constant, so re-adding

--- a/luaui/Widgets/Tests/critters/test_critters.lua
+++ b/luaui/Widgets/Tests/critters/test_critters.lua
@@ -1,0 +1,125 @@
+function setup()
+	Test.clearMap()
+
+	Test.levelHeightMap()
+
+	Spring.SendCommands("globallos")
+	Spring.SendCommands("setspeed 5")
+end
+
+function cleanup()
+	Spring.SendCommands("globallos")
+	Spring.SendCommands("setspeed 1")
+
+	Test.clearMap()
+end
+
+function runCritterTest()
+	local WAIT_FRAMES = 204 -- enough to trigger critter cleanup/restoring by gaia_critters
+	local unitName = 'armpw'
+	local critterName = 'critter_crab'
+	local isCritter = {}
+	for udefID, def in ipairs(UnitDefs) do
+		if string.find(def.name, "critter_") then
+			isCritter[udefID] = true
+		end
+	end
+
+	local midX, midZ = Game.mapSizeX / 2, Game.mapSizeZ / 2
+
+	local function countAliveCritters()
+		local allUnits = Spring.GetAllUnits()
+		local alive = 0
+		for _, unitID in pairs(allUnits) do
+			local defID = Spring.GetUnitDefID(unitID)
+			if isCritter[defID] then
+				alive = alive + 1
+			end
+		end
+		return alive
+	end
+
+	local function destroyNonCritters()
+		local unitDefID = UnitDefNames[unitName].id
+		SyncedRun(function(locals)
+			local unitDefID = locals.unitDefID
+			local allUnits = Spring.GetAllUnits()
+			for _, unitID in pairs(allUnits) do
+				local defID = Spring.GetUnitDefID(unitID)
+				if defID == unitDefID then
+					Spring.DestroyUnit(unitID, false, true, nil, true)
+				end
+			end
+		end, 500)
+	end
+
+	-- 1. Create critters
+
+	SyncedRun(function(locals)
+		local GaiaTeamID  = Spring.GetGaiaTeamID()
+		local critterName = locals.critterName
+		local function createUnit(def, x, z, teamID)
+			local x = locals.midX + x
+			local z = locals.midZ + z
+			local y = Spring.GetGroundHeight(x, z) + 40
+			local unitID = Spring.CreateUnit(def, x, y, z, "south", teamID)
+		end
+		for i=0, 5 do
+			for j=0, 5 do
+				createUnit(critterName, 850+i*50, 100+j*50, GaiaTeamID)
+			end
+		end
+	end, 400)
+
+	assertSuccessBefore(5, 5, function()
+		return #Spring.GetAllUnits() == 36
+	end)
+
+	assert(countAliveCritters() == 36)
+
+
+	-- 2. Create lots of units so critters will be cleaned up
+
+	SyncedRun(function(locals)
+		local GaiaTeamID  = Spring.GetGaiaTeamID()
+		local midX, midZ = locals.midX, locals.midZ
+		local y = Spring.GetGroundHeight(-2000, -1500) + 40
+		local spCreateUnit = Spring.CreateUnit
+		local unitName = locals.unitName
+		local function createUnit(def, x, z, teamID)
+			local x = midX + x
+			local z = midZ + z
+			spCreateUnit(def, x, y, z, "south", teamID)
+		end
+		for i=1, 60 do
+			for j=1, 60 do
+				createUnit(unitName, -2000+i*50, -1500+j*50, 0)
+			end
+		end
+	end, 500)
+
+	assertSuccessBefore(15, 10, function()
+		return Spring.GetTeamUnitCount(0) == 3600
+	end)
+
+	Test.waitFrames(WAIT_FRAMES - (Spring.GetGameFrame() % WAIT_FRAMES))
+
+	assert(countAliveCritters() < 36)
+
+
+	-- 3. Destroy non critters so critters will be restored
+
+	destroyNonCritters()
+
+	assertSuccessBefore(15, 5, function()
+		return Spring.GetTeamUnitCount(0) == 0
+	end)
+
+	Test.waitFrames(WAIT_FRAMES - (Spring.GetGameFrame() % WAIT_FRAMES))
+
+	assert(countAliveCritters() == 36)
+end
+
+function test()
+	runCritterTest()
+end


### PR DESCRIPTION
### Work done

- Refactor adjustCritters code a bit to use separate tables for dead and alive critters
- Avoid superfluous work and array creation at patrol methods
- Fix bug at circle patrol where it would not enforce order limits (thus possibly creating too many orders for some critters)
- Misc other small efficiency changes
- Add new `test_critters` test

#### Testing

- Start skirmish and run `/runtests critters`
- Tests critter creation and restoring when there are too many units

### Remarks

- Separate arrays for alive and dead critters makes handling a bit more efficient by having quicker runtime checks (avoid checking row.alive).
  - Also avoids need for the ugly flag to skip UnitDestroyed.
  - Makes the reAdd logic a bit more straightforward.
  - Can probably skip newCritterUnits recreation altogether (line ~310), would like to see what @Ruwetuin thinks about that

