### PR TITLE
Shields - Dgun compatibility fix

### DIFF
--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -27,7 +27,7 @@ local spGetGameFrame = Spring.GetGameFrame
 local dgunData = {}
 local dgunDef = {}
 local dgunTimeouts = {}
-local dgunShieldPentrations = {}
+local dgunShieldPenetrations = {}
 
 for weaponDefID, weaponDef in ipairs(WeaponDefs) do
 	if weaponDef.type == 'DGun' then
@@ -95,7 +95,7 @@ function gadget:ProjectileDestroyed(proID)
 	flyingDGuns[proID] = nil
 	groundedDGuns[proID] = nil
 	dgunTimeouts[proID] = nil
-	dgunShieldPentrations[proID] = nil
+	dgunShieldPenetrations[proID] = nil
 	dgunData[proID] = nil
 end
 
@@ -161,7 +161,7 @@ end
 function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shieldCarrierUnitID, bounceProjectile,
 								 beamEmitterWeaponNum, beamEmitterUnitID, startX, startY, startZ, hitX, hitY, hitZ)
 	if proID > -1 and dgunTimeouts[proID] then
-		if dgunShieldPentrations[proID] then return true end
+		if dgunShieldPenetrations[proID] then return true end
 		local proDefID = dgunData[proID].weaponDefID
 		local shieldEnabledState, shieldPower = spGetUnitShieldState(shieldCarrierUnitID)
 		local damage = WeaponDefs[proDefID].damages[Game.armorTypes.shields] or
@@ -169,15 +169,15 @@ function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shie
 
 		local weaponDefID = dgunData[proID].weaponDefID
 
-		if not dgunShieldPentrations[proID] then
+		if not dgunShieldPenetrations[proID] then
 			if shieldPower <= damage then
 				shieldPower = 0
-				dgunShieldPentrations[proID] = true
+				dgunShieldPenetrations[proID] = true
 			end
 		end
 		-- Engine does not provide a way for shields to stop DGun projectiles, they will impact once and carry on through,
 		-- need to manually move them back a bit so the next touchdown hits the shield
-		if not dgunShieldPentrations[proID] then
+		if not dgunShieldPenetrations[proID] then
 			-- Adjusting the projectile position based on setback
 			local dx, dy, dz = spGetProjectileVelocity(proID)
 			local magnitude = math.sqrt(dx ^ 2 + dy ^ 2 + dz ^ 2)

--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -1,7 +1,7 @@
 function gadget:GetInfo()
 	return {
 		name = "D-Gun Behaviour",
-		desc = "D-Gun projectiles hug ground, volumetric damage, deterministic damage against Commanders, override interactions with shields",
+		desc ="D-Gun projectiles hug ground, volumetric damage, deterministic damage against Commanders, override interactions with shields",
 		author = "Anarchid, Sprung, SethDGamre",
 		layer = 0,
 		enabled = true
@@ -15,28 +15,26 @@ end
 local spSetProjectilePosition = Spring.SetProjectilePosition
 local spSetProjectileVelocity = Spring.SetProjectileVelocity
 local spGetProjectilePosition = Spring.GetProjectilePosition
-local spGetProjectileDefID = Spring.GetProjectileDefID
 local spGetUnitShieldState = Spring.GetUnitShieldState
 local spGetProjectileVelocity = Spring.GetProjectileVelocity
-local spSetUnitShieldState = Spring.SetUnitShieldState
 local spGetGroundHeight = Spring.GetGroundHeight
 local spDeleteProjectile = Spring.DeleteProjectile
-local spGetProjectileOwnerID = Spring.GetProjectileOwnerID
 local spSpawnExplosion = Spring.SpawnExplosion
 local spGetUnitPosition = Spring.GetUnitPosition
 local spSpawnCEG = Spring.SpawnCEG
 local spGetGameFrame = Spring.GetGameFrame
 
-local modOptions = Spring.GetModOptions()
-local dgunWeaponsTTL = {}
-local dgunWeapons = {}
+local dgunData = {}
+local dgunDef = {}
 local dgunTimeouts = {}
+local dgunShieldPentrations = {}
 
 for weaponDefID, weaponDef in ipairs(WeaponDefs) do
 	if weaponDef.type == 'DGun' then
 		Script.SetWatchProjectile(weaponDefID, true)
-		dgunWeapons[weaponDefID] = weaponDef
-		dgunWeaponsTTL[weaponDefID] = weaponDef.range / weaponDef.projectilespeed
+		dgunDef[weaponDefID] = weaponDef
+		dgunDef[weaponDefID].ttl = weaponDef.range / weaponDef.projectilespeed
+		dgunDef[weaponDefID].setback = weaponDef.projectilespeed
 	end
 end
 
@@ -63,32 +61,33 @@ local flyingDGuns = {}
 local groundedDGuns = {}
 
 local function addVolumetricDamage(projectileID)
-	local weaponDefID = spGetProjectileDefID(projectileID)
-	local ownerID = spGetProjectileOwnerID(projectileID)
-	local x,y,z =spGetProjectilePosition(projectileID)
-	local explosionParame ={
+	local projectileData = dgunData[projectileID]
+	local weaponDefID = projectileData.weaponDefID
+	local x, y, z = spGetProjectilePosition(projectileID)
+	local explosionParame = {
 		weaponDef = weaponDefID,
-		owner = ownerID,
+		owner = projectileData.proOwnerID,
 		projectileID = projectileID,
-		damages = dgunWeapons[weaponDefID].damages,
+		damages = dgunDef[weaponDefID].damages,
 		hitUnit = 1,
 		hitFeature = 1,
-		craterAreaOfEffect = dgunWeapons[weaponDefID].craterAreaOfEffect,
-		damageAreaOfEffect = dgunWeapons[weaponDefID].damageAreaOfEffect,
-		edgeEffectiveness = dgunWeapons[weaponDefID].edgeEffectiveness,
-		explosionSpeed = dgunWeapons[weaponDefID].explosionSpeed,
-		impactOnly = dgunWeapons[weaponDefID].impactOnly,
-		ignoreOwner = dgunWeapons[weaponDefID].noSelfDamage,
+		craterAreaOfEffect = dgunDef[weaponDefID].craterAreaOfEffect,
+		damageAreaOfEffect = dgunDef[weaponDefID].damageAreaOfEffect,
+		edgeEffectiveness = dgunDef[weaponDefID].edgeEffectiveness,
+		explosionSpeed = dgunDef[weaponDefID].explosionSpeed,
+		impactOnly = dgunDef[weaponDefID].impactOnly,
+		ignoreOwner = dgunDef[weaponDefID].noSelfDamage,
 		damageGround = true,
 	}
 
-	spSpawnExplosion(x, y ,z, 0, 0, 0, explosionParame)
+	spSpawnExplosion(x, y, z, 0, 0, 0, explosionParame)
 end
 
 function gadget:ProjectileCreated(proID, proOwnerID, weaponDefID)
-	if dgunWeapons[weaponDefID] then
+	if dgunDef[weaponDefID] then
+		dgunData[proID] = { proOwnerID = proOwnerID, weaponDefID = weaponDefID }
 		flyingDGuns[proID] = true
-		dgunTimeouts[proID] = (spGetGameFrame() + dgunWeaponsTTL[weaponDefID])
+		dgunTimeouts[proID] = (spGetGameFrame() + dgunDef[weaponDefID].ttl)
 	end
 end
 
@@ -96,6 +95,8 @@ function gadget:ProjectileDestroyed(proID)
 	flyingDGuns[proID] = nil
 	groundedDGuns[proID] = nil
 	dgunTimeouts[proID] = nil
+	dgunShieldPentrations[proID] = nil
+	dgunData[proID] = nil
 end
 
 function gadget:GameFrame(frame)
@@ -110,7 +111,7 @@ function gadget:GameFrame(frame)
 		if y < h + 1 or y < 0 then -- assume ground or water collision
 			-- normalize horizontal velocity
 			local dx, _, dz, speed = spGetProjectileVelocity(proID)
-			local norm = speed / math.sqrt(dx^2 + dz^2)
+			local norm = speed / math.sqrt(dx ^ 2 + dz ^ 2)
 			local ndx = dx * norm
 			local ndz = dz * norm
 			spSetProjectileVelocity(proID, ndx, 0, ndz)
@@ -140,58 +141,54 @@ function gadget:GameFrame(frame)
 	end
 end
 
-function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
-	if dgunWeapons[weaponDefID] and isCommander[attackerDefID] and (isCommander[unitDefID] or isDecoyCommander[unitDefID]) then
+function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID,
+							   attackerDefID, attackerTeam)
+	if dgunDef[weaponDefID] and isCommander[attackerDefID] and (isCommander[unitDefID] or isDecoyCommander[unitDefID]) then
 		if isDecoyCommander[unitDefID] then
-			return dgunWeapons[weaponDefID].damages[0]
+			return dgunDef[weaponDefID].damages[0]
 		else
 			spDeleteProjectile(projectileID)
 			local x, y, z = spGetUnitPosition(unitID)
 			spSpawnCEG("dgun-deflect", x, y, z, 0, 0, 0, 0, 0)
 			local armorClass = UnitDefs[unitDefID].armorType
-			return dgunWeapons[weaponDefID].damages[armorClass]
+			return dgunDef[weaponDefID].damages[armorClass]
 		end
 	end
 
 	return damage
 end
 
-local lastShieldFrameCheck = {}
-
-function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shieldCarrierUnitID, bounceProjectile, beamEmitterWeaponNum, beamEmitterUnitID, startX, startY, startZ, hitX, hitY, hitZ)
+function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shieldCarrierUnitID, bounceProjectile,
+								 beamEmitterWeaponNum, beamEmitterUnitID, startX, startY, startZ, hitX, hitY, hitZ)
 	if proID > -1 and dgunTimeouts[proID] then
-		local proDefID = spGetProjectileDefID(proID)
+		if dgunShieldPentrations[proID] then return true end
+		local proDefID = dgunData[proID].weaponDefID
 		local shieldEnabledState, shieldPower = spGetUnitShieldState(shieldCarrierUnitID)
-		local damage = WeaponDefs[proDefID].damages[Game.armorTypes.shields] or WeaponDefs[proDefID].damages[Game.armorTypes.default]
+		local damage = WeaponDefs[proDefID].damages[Game.armorTypes.shields] or
+		WeaponDefs[proDefID].damages[Game.armorTypes.default]
 
-		local gameframe = spGetGameFrame()
+		local weaponDefID = dgunData[proID].weaponDefID
 
-		if not modOptions.shieldsrework then
-			local damageCooldownFrames = 10
-			if shieldPower < damage then return false end
-
-			lastShieldFrameCheck[shieldCarrierUnitID] = lastShieldFrameCheck[shieldCarrierUnitID] or gameframe
-
-			if hitX > 0 and lastShieldFrameCheck[shieldCarrierUnitID] <= gameframe then
-				shieldPower = math.max(shieldPower - damage, 0)
-				spSetUnitShieldState(shieldCarrierUnitID, shieldEmitterWeaponNum, shieldEnabledState, shieldPower)
-				lastShieldFrameCheck[shieldCarrierUnitID] = gameframe + damageCooldownFrames
+		if not dgunShieldPentrations[proID] then
+			if shieldPower <= damage then
+				shieldPower = 0
+				dgunShieldPentrations[proID] = true
 			end
 		end
-
 		-- Engine does not provide a way for shields to stop DGun projectiles, they will impact once and carry on through,
 		-- need to manually move them back a bit so the next touchdown hits the shield
-		if shieldPower > 0 then
-			-- Extra offset required to avoid edgecase where projectile penetrates, value chosen empirically
-			local offsetFactor = 1.1
-			local dx, dy, dz, speed = spGetProjectileVelocity(proID)
-			local magnitude = math.sqrt(dx^2 + dy^2 + dz^2)
+		if not dgunShieldPentrations[proID] then
+			-- Adjusting the projectile position based on setback
+			local dx, dy, dz = spGetProjectileVelocity(proID)
+			local magnitude = math.sqrt(dx ^ 2 + dy ^ 2 + dz ^ 2)
 			local normalX, normalY, normalZ = dx / magnitude, dy / magnitude, dz / magnitude
 
+			local setback = dgunDef[weaponDefID].setback
+
 			local x, y, z = spGetProjectilePosition(proID)
-			local newX = x - speed * normalX * offsetFactor
-			local newY = y - speed * normalY * offsetFactor
-			local newZ = z - speed * normalZ * offsetFactor
+			local newX = x - normalX * setback
+			local newY = y - normalY * setback
+			local newZ = z - normalZ * setback
 
 			spSetProjectilePosition(proID, newX, newY, newZ)
 		end

--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -1,7 +1,7 @@
 function gadget:GetInfo()
 	return {
 		name = "D-Gun Behaviour",
-		desc ="D-Gun projectiles hug ground, volumetric damage, deterministic damage against Commanders, override interactions with shields",
+		desc = "D-Gun projectiles hug ground, volumetric damage, deterministic damage against Commanders, override interactions with shields",
 		author = "Anarchid, Sprung, SethDGamre",
 		layer = 0,
 		enabled = true


### PR DESCRIPTION
somewhere along the development path dguns stopped interacting with shields correctly - and they never worked consistently. This PR fixes that and adds the DGun to the bitmask that can be stopped by the extra units t3 shields.

Unchanged:
- Vanilla t2 shields don't block dgun

Changed:
- dgun projectile now sits in the same spot as it grinds against a shield, rather than jumping back arbitrary distance like before. looks better and applies damage more consistently.
- now works whether rework enabled or not consistently
- t3 shields now block dgun (but it eats through them super fast)

Other:
- GG.AddShieldDamage never worked due to being nested inside of a callin. I put it outside the callin and it now works. Ended up not using it, though.

Tested both vanilla modoptions and shield rework enabled in a crazy coop vs scavs game to check for crashes