### PR TITLE
Ignore DEPRECATED log level at AddConsoleLine receivers.

### DIFF
--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -19,6 +19,7 @@ local debuglevel = 0
 -- debuglevel 3 is super verbose mode
 
 local debugdrawvisible = false
+local L_DEPRECATED = LOG.DEPRECATED
 -- This widget's job is to provide a common interface for GL4 drawing widgets, that rely on having visible units present
 -- Widget draw classes:
 -- widgets that draw stuff for all visible units (trivial case)
@@ -774,6 +775,7 @@ local iHaveDesynced = false
 local syncerrorpattern = "Sync error for ([%w%[%]_]+) in frame (%d+) %(got (%x+), correct is (%x+)%)"
 
 function widget:AddConsoleLine(lines, priority)
+	if priority and priority == L_DEPRECATED then return end
 	--Spring.Echo(lines)
 	if iHaveDesynced then return end
     local username, frameNumber, gotChecksum, correctChecksum = lines:match(syncerrorpattern)

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -21,6 +21,8 @@ local LineTypes = {
 
 local utf8 = VFS.Include('common/luaUtilities/utf8.lua')
 
+local L_DEPRECATED = LOG.DEPRECATED
+
 local showHistoryWhenChatInput = true
 
 local showHistoryWhenCtrlShift = true
@@ -2088,6 +2090,7 @@ function widget:MapDrawCmd(playerID, cmdType, x, y, z, a, b, c)
 end
 
 function widget:AddConsoleLine(lines, priority)
+	if priority and priority == L_DEPRECATED then return end
 	lines = lines:match('^%[f=[0-9]+%] (.*)$') or lines
 	for line in lines:gmatch("[^\n]+") do
 		processAddConsoleLine(spGetGameFrame(), line, true)

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -22,6 +22,7 @@ local LineTypes = {
 local utf8 = VFS.Include('common/luaUtilities/utf8.lua')
 
 local L_DEPRECATED = LOG.DEPRECATED
+local isDevSingle = (Spring.Utilities.IsDevMode() and Spring.Utilities.Gametype.IsSinglePlayer())
 
 local showHistoryWhenChatInput = true
 
@@ -2090,7 +2091,7 @@ function widget:MapDrawCmd(playerID, cmdType, x, y, z, a, b, c)
 end
 
 function widget:AddConsoleLine(lines, priority)
-	if priority and priority == L_DEPRECATED then return end
+	if priority and priority == L_DEPRECATED and not isDevSingle then return end
 	lines = lines:match('^%[f=[0-9]+%] (.*)$') or lines
 	for line in lines:gmatch("[^\n]+") do
 		processAddConsoleLine(spGetGameFrame(), line, true)

--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -10,6 +10,8 @@ function widget:GetInfo()
 	}
 end
 
+local L_DEPRECATED = LOG.DEPRECATED
+
 local titlecolor = "\255\190\190\190"
 
 -- dont show vote buttons for specs when containing the following keywords (use lowercase)
@@ -374,7 +376,7 @@ local function colourNames(teamID)
 end
 
 function widget:AddConsoleLine(lines, priority)
-
+	if priority and priority == L_DEPRECATED then return end
 	if not WG['rejoin'] or not WG['rejoin'].showingRejoining() then
 
 		lines = lines:match('^%[f=[0-9]+%] (.*)$') or lines


### PR DESCRIPTION
### Work done

- Ignore DEPRECATED log level at AddConsoleLine receivers.
- But actually show when devmode AND singleplayer is detected

### Remarks

- Not yet in engine release but [PR merged](https://github.com/beyond-all-reason/spring/pull/1885), shouldn't hurt to have before that's available.
- DEPRECATED messages can be spammy and only aimed at developers so better not to show to users
  - removed handling in other places since those don't need to receive them either
- Other receivers could have a more specific matching of loglevel
  - api_unit_tracker_gl4 just checking desync, that probably has ERROR or FATAL level, but need to double check
    - Why is api_unit_tracker_gl4 doing desync detection?
  - vote_interface, likely just needs to parse NOTICE but not sure atm
  - gui_chat: could probably check level more extensively too, to save some string comparisons