### PR TITLE
Disable blueprint tests on headless.

### DIFF
--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
@@ -1,7 +1,7 @@
 local widgetName = "Blueprint"
 
 function skip()
-	return Spring.GetGameFrame() <= 0
+	return not Platform.gl
 end
 
 function setup()

--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -1,7 +1,7 @@
 local widgetName = "Blueprint"
 
 function skip()
-	return Spring.GetGameFrame() <= 0
+	return not Platform.gl
 end
 
 function setup()


### PR DESCRIPTION
### Work done

- Disable the blueprint tests for headless.
- Remove check there too for gameframe<0 since it's redundant now.

### Remarks

- Last stepping stone for getting the [PR test runner](https://github.com/saurtron/Beyond-All-Reason/pull/9) in.
- The tests can be made to work with the following changes for [test_cmd_blueprint_line](https://github.com/saurtron/Beyond-All-Reason/pull/8/files#diff-c1c0b6feaf7855e709e4f29bc44ebcf1d86678fbab4afb10183aaff01126f761) and [api_blueprint](https://github.com/saurtron/Beyond-All-Reason/pull/8/files#diff-9fa3327faf593c766b27143f6295d2e176a8eff7841077f21d193a006cc5eead) but would prefer @salinecitrine to check and apply those.
