### PR TITLE
Fix api_blueprint crash at Shutdown when there's no vbo

### DIFF
--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -527,7 +527,9 @@ local BUILD_MODES_HANDLERS = {
 local instanceIDs = {}
 
 local function clearInstances()
-	clearInstanceTable(outlineInstanceVBO)
+	if outlineInstanceVBO then
+		clearInstanceTable(outlineInstanceVBO)
+	end
 
 	if WG.StopDrawUnitShapeGL4 then
 		WG.StopDrawAll(widget:GetInfo().name)


### PR DESCRIPTION
### Work done

- Don't try to clear outlineInstanceVBO if it doesn't exist.

### Remarks

- Last fix for tests.
  - See https://github.com/saurtron/Beyond-All-Reason/pull/11#issuecomment-2578242036 for test results once this and [#4136](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4136) are applied
  - sorry, thought [#4136](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4136) was the last one