### PR TITLE
Shields rework bugfixes 2

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1560,10 +1560,6 @@ function WeaponDef_Post(name, wDef)
 			end
 		end
 
-		if modOptions.evocom == true and wDef.weapontype == "DGun" then
-			wDef.interceptedbyshieldtype = 1
-		end
-
 		if modOptions.multiplier_shieldpower then
 			if wDef.shield then
 				local multiplier = modOptions.multiplier_shieldpower


### PR DESCRIPTION
- reduce flickering of shield at 0% by having a 1 second minimum downtime
- fix bug with populating unitdef data tables with the last weapon in the unitdef causing cortex commanders to become invincible
- make recharge rate constant, transfer the overcharge to the shield charge when it comes back online