### PR TITLE
Shields Re-Rework Handle Super High Damage

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1560,10 +1560,6 @@ function WeaponDef_Post(name, wDef)
 			end
 		end
 
-		if modOptions.evocom == true and wDef.weapontype == "DGun" then
-			wDef.interceptedbyshieldtype = 1
-		end
-
 		if modOptions.multiplier_shieldpower then
 			if wDef.shield then
 				local multiplier = modOptions.multiplier_shieldpower


### PR DESCRIPTION
When damage is super high, the downtime can last for minutes. This makes it more economical to selfD the shield than to pay the overkill cost. So, we must cap the amount of downtime via the gadget to something sane. I set it to 20 seconds it can be overkilled off before it comes back online (it would take very very large damage to reach this, not possible for vanilla shields) and this can be configured easily in the gadget later.

Also, removed an echo I spotted.