### PR TITLE
Default to not use English unit names for other languages

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3243,7 +3243,7 @@ function init()
 				end
 			end
 		},
-		{ id = "language_english_unit_names", group = "ui", category = types.basic, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.language_english_unit_names'), type = "bool", value = (Spring.GetConfigInt("language_english_unit_names", 1) == 1),
+		{ id = "language_english_unit_names", group = "ui", category = types.basic, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.language_english_unit_names'), type = "bool", value = Spring.GetConfigInt("language_english_unit_names", 0) == 1,
 			onchange = function(i, value)
 				WG['language'].setEnglishUnitNames(value)
 			end,


### PR DESCRIPTION
The option to use English unit names when the game is set to another language needs to be opt-in, not opt-out.

### Work done
Change the default value of the `language_english_unit_names` setting to be 0 instead of 1.

#### Test steps
- [ ] Delete `language_english_unit_names` in springsettings.cfg, if present
- [ ] Start game
- [ ] Change to a non-English language
- [ ] Verify unit names are not in English