### PR TITLE
Auto Trajectory Patch 6

### DIFF
--- a/units/Legion/Defenses/legacluster.lua
+++ b/units/Legion/Defenses/legacluster.lua
@@ -24,7 +24,6 @@ return {
 		maxwaterdepth = 0,
 		nochasecategory = "MOBILE",
 		objectname = "Units/LEGACLUSTER.s3o",
-		onoffable = true,
 		script = "Units/LEGACLUSTER.cob",
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
@@ -39,7 +38,6 @@ return {
 			unitgroup = 'weapon',
 			model_author = "ZephyrSkies",
 			normaltex = "unittextures/leg_normal.dds",
-			onoffname = "trajectory",
 			subfolder = "Legion/Defenses",
 		},
 		featuredefs = {

--- a/units/Legion/Defenses/legcluster.lua
+++ b/units/Legion/Defenses/legcluster.lua
@@ -23,7 +23,6 @@ return {
 		maxwaterdepth = 0,
 		nochasecategory = "MOBILE",
 		objectname = "Units/LEGCLUSTER.s3o",
-		onoffable = true,
 		script = "Units/LEGCLUSTER.cob",
 		seismicsignature = 0,
 		selfdestructas = "largeBuildingExplosionGenericSelfd",
@@ -38,7 +37,6 @@ return {
 			unitgroup = 'weapon',
 			model_author = "ZephyrSkies",
 			normaltex = "unittextures/leg_normal.dds",
-			onoffname = "trajectory",
 			subfolder = "CorBuildings/LandDefenceOffence",
 		},
 		featuredefs = {


### PR DESCRIPTION
Removes the onoffable tag from legcluster and legacluster, which removes the firestate toggle (which doesn't work anyways)