### PR TITLE
test_runner: add test()

### DIFF
--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
@@ -28,7 +28,7 @@ function cleanup()
 end
 
 local delay = 5
-function test()
+test("Test Blueprint Line", function ()
 	VFS.Include("luarules/configs/customcmds.h.lua")
 
 	widget = widgetHandler:FindWidget(widgetName)
@@ -130,4 +130,4 @@ function test()
 
 	assert(#builderQueue == bpCount, #builderQueue)
 	assert(builderQueue[1].id == -blueprintUnitDefID)
-end
+end)

--- a/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Widgets/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -27,7 +27,7 @@ function cleanup()
 end
 
 local delay = 5
-function test()
+test("Test Blueprint Single", function ()
 	VFS.Include("luarules/configs/customcmds.h.lua")
 
 	widget = widgetHandler:FindWidget(widgetName)
@@ -111,4 +111,4 @@ function test()
 
 	assert(#builderQueue == 1)
 	assert(builderQueue[1].id == -blueprintUnitDefID)
-end
+end)

--- a/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Widgets/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -12,7 +12,7 @@ function cleanup()
 	Test.clearMap()
 end
 
-function test()
+test("Test Self-D Stop", function ()
 	widget = widgetHandler:FindWidget("Stop means Stop")
 	assert(widget)
 
@@ -44,4 +44,4 @@ function test()
 	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.STOP, nil, nil, nil })
 	assert(Spring.GetUnitSelfDTime(unitID) == 0)
 	assert(#(Spring.GetCommandQueue(unitID, 1)) == 0)
-end
+end)

--- a/luaui/Widgets/Tests/critters/test_critters.lua
+++ b/luaui/Widgets/Tests/critters/test_critters.lua
@@ -14,7 +14,7 @@ function cleanup()
 	Test.clearMap()
 end
 
-function runCritterTest()
+test("Test Critters", function ()
 	local WAIT_FRAMES = 204 -- enough to trigger critter cleanup/restoring by gaia_critters
 	local unitName = 'armpw'
 	local critterName = 'critter_crab'
@@ -118,8 +118,4 @@ function runCritterTest()
 	Test.waitFrames(WAIT_FRAMES - (Spring.GetGameFrame() % WAIT_FRAMES))
 
 	assert(countAliveCritters() == 36)
-end
-
-function test()
-	runCritterTest()
-end
+end)

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armasp.lua
@@ -14,7 +14,7 @@ function cleanup()
 	Test.clearMap()
 end
 
-function test()
+test("Test Self-D armsp", function ()
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
@@ -50,4 +50,4 @@ function test()
 	--Test.waitFrames(1)
 	--assert(table.count(widget.activeSelfD) == 0)
 	--assert(table.count(widget.queuedSelfD) == 0)
-end
+end)

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
@@ -14,7 +14,7 @@ function cleanup()
 	Test.clearMap()
 end
 
-function test()
+test("Test Self-D armpw", function ()
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 
@@ -56,4 +56,4 @@ function test()
 	Test.waitFrames(1)
 	assert(table.count(widget.activeSelfD) == 1)
 	assert(table.count(widget.queuedSelfD) == 0)
-end
+end)

--- a/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
+++ b/luaui/Widgets/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
@@ -14,7 +14,7 @@ function cleanup()
 	Test.clearMap()
 end
 
-function test()
+test("Test Self-D armvp", function ()
 	widget = widgetHandler:FindWidget(widgetName)
 	assert(widget)
 
@@ -51,4 +51,4 @@ function test()
 	--Test.waitFrames(1)
 	--assert(table.count(widget.activeSelfD) == 0)
 	--assert(table.count(widget.queuedSelfD) == 0)
-end
+end)

--- a/luaui/Widgets/Tests/mex-building/pregame_mex_queue.lua
+++ b/luaui/Widgets/Tests/mex-building/pregame_mex_queue.lua
@@ -35,7 +35,7 @@ function cleanup()
 end
 
 -- tests both pregame mex snap behavior, as well as basic queue and blueprint handling
-function test()
+test("Test pregame mex queue", function ()
 	local mexUnitDefId = UnitDefNames["armmex"].id
 	local metalSpots = WG['resource_spot_finder'].metalSpotsList
 
@@ -107,4 +107,4 @@ function test()
 	-- Did the mex get de-queued?
 	local buildQueue = WG['pregame-build'].getBuildQueue()
 	assert(#buildQueue == 0, "Build queue should be empty")
-end
+end)

--- a/luaui/Widgets/Tests/mex-building/pregame_mex_snap.lua
+++ b/luaui/Widgets/Tests/mex-building/pregame_mex_snap.lua
@@ -33,7 +33,7 @@ function cleanup()
 	Spring.SetCameraState(initialCameraState)
 end
 
-function test()
+test("Test pregame mex snap", function ()
 	mexUnitDefId = UnitDefNames["armmex"].id
 	metalSpots = WG['resource_spot_finder'].metalSpotsList
 
@@ -85,4 +85,4 @@ function test()
 		snappedPosition.z,
 		0
 	}, 0.1)
-end
+end)

--- a/luaui/Widgets/Tests/selftests/test_assertions.lua
+++ b/luaui/Widgets/Tests/selftests/test_assertions.lua
@@ -1,5 +1,5 @@
 
-function sanityChecks()
+test("SelfTest Sanity Checks", function ()
 	-- Just to make sure some standard methods used here work as expected.
 	Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
 	SyncedProxy.Spring.ValidUnitID(20)
@@ -7,8 +7,9 @@ function sanityChecks()
 		Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
 	end)
 	assert(err ~= "attempt to yield across metamethod/C-call boundary")
-end
+end)
 
+--test("SelfTest Failing Tests", function ()
 function failingTests()
 	-- All of these fail due to error "attempt to yield across metamethod/C-call boundary"
 	-- This is something to do with how the test system is structured.
@@ -60,9 +61,10 @@ function failingTests()
 	--	SyncedProxy.Spring.ValidUnitID(20)
 	--end, 1)
 	--
+--end)
 end
 
-function failingWhileSucceedingTests()
+test("SelfTest Failing While Succeeding", function ()
 	-- these ones are actually failing even when they don't throw exceptions,
 	-- it's because assertThrows is catching the exception, it's just not
 	-- the one we want.
@@ -75,15 +77,15 @@ function failingWhileSucceedingTests()
 		-- this actually throws an exception, but due to something else.
 		SyncedProxy.Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
 	end)
-end
+end)
 
-function testWaitUntil()
+test("SelfTest Wait Until", function ()
 	Test.waitUntil(function()
 		return true
 	end)
-end
+end)
 
-function testAssertSuccessBefore()
+test("SelfTest Assert Success Before", function ()
 	-- test the method succeeding
 	assertSuccessBefore(1, 10, function() return true end)
 	assertSuccessBefore(1, 10, function()
@@ -95,9 +97,9 @@ function testAssertSuccessBefore()
 	assertThrowsMessage(function()
 		assertSuccessBefore(1, 10, function() error("error") end)
 	end, "error")
-end
+end)
 
-function testAssertThrows()
+test("SelfTest Assert Throws", function ()
 	-- test detecting an exception
 	assertThrows(function()
 		error("error")
@@ -114,9 +116,9 @@ function testAssertThrows()
 		Spring.ValidUnitID(20)
 		error("error")
 	end)
-end
+end)
 
-function testAssertThrowsMessage()
+test("SelfTest Assert Throws Message", function ()
 	-- test throwing a specific message
 	assertThrowsMessage(function()
 		error("error")
@@ -146,14 +148,4 @@ function testAssertThrowsMessage()
 		Spring.ValidUnitID(20)
 		error("error")
 	end, "error")
-end
-
-function test()
-	sanityChecks()
-	testWaitUntil()
-	testAssertThrows()
-	testAssertSuccessBefore()
-	testAssertThrowsMessage()
-	--failingTests()
-	failingWhileSucceedingTests()
-end
+end)

--- a/luaui/Widgets/Tests/selftests/test_assertions.lua
+++ b/luaui/Widgets/Tests/selftests/test_assertions.lua
@@ -64,21 +64,6 @@ function failingTests()
 --end)
 end
 
-test("SelfTest Failing While Succeeding", function ()
-	-- these ones are actually failing even when they don't throw exceptions,
-	-- it's because assertThrows is catching the exception, it's just not
-	-- the one we want.
-
-	assertThrows(function()
-		-- this test should fail since ValidUnitID doesn't throw exceptions.
-		SyncedProxy.Spring.ValidUnitID(20)
-	end)
-	assertThrows(function()
-		-- this actually throws an exception, but due to something else.
-		SyncedProxy.Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
-	end)
-end)
-
 test("SelfTest Wait Until", function ()
 	Test.waitUntil(function()
 		return true
@@ -148,4 +133,19 @@ test("SelfTest Assert Throws Message", function ()
 		Spring.ValidUnitID(20)
 		error("error")
 	end, "error")
+end)
+
+test("SelfTest Failing While Succeeding", function ()
+	-- these ones are actually failing even when they don't throw exceptions,
+	-- it's because assertThrows is catching the exception, it's just not
+	-- the one we want.
+
+	assertThrows(function()
+		-- this test should fail since ValidUnitID doesn't throw exceptions.
+		SyncedProxy.Spring.ValidUnitID(20)
+	end)
+	assertThrows(function()
+		-- this actually throws an exception, but due to something else.
+		SyncedProxy.Spring.GiveOrderToUnit(2, CMD.FIRE_STATE, {0}, {})
+	end)
 end)

--- a/luaui/Widgets/Tests/selftests/test_callins.lua
+++ b/luaui/Widgets/Tests/selftests/test_callins.lua
@@ -72,7 +72,7 @@ function runWaitUntil(countOnly, reallyCountOnly, wait, expect, clear)
 	end
 end
 
-function test()
+test("SelfTest Callins", function ()
 	local FULL = false
 	local COUNT = true
 	local EXPECT = true
@@ -98,4 +98,4 @@ function test()
 	Test.setUnsafeCallins(true)
 	runWaitUntil(FULL, FULL, 0, not EXPECT, CLEAR)
 	Test.setUnsafeCallins(false)
-end
+end)

--- a/luaui/Widgets/Tests/weapondefs/test_flighttime.lua
+++ b/luaui/Widgets/Tests/weapondefs/test_flighttime.lua
@@ -83,8 +83,10 @@ function runDistanceTest(flightTime, shouldAlive)
 	assert(isAlive2 == shouldAlive)
 end
 
-function test()
+test("Test WeaponDef FlightTime Some Survive", function ()
 	runDistanceTest(30, true)
-	Test.clearMap()
+end)
+
+test("Test WeaponDef FlightTime All Die", function ()
 	runDistanceTest(0, false)
-end
+end)


### PR DESCRIPTION
Instead of having every test source code file define exactly one test() function, test files can now define multiple tests in a single file by calling addTest(). Multiple tests in a single file is convenient especially because the tests still share auxiliary functions such as setup() and cleanup().