### PR TITLE
Banned Procedures for making changes (Baking Unitdefs)

### DIFF
--- a/.github/PULL_REQUEST_GUIDELINES.md
+++ b/.github/PULL_REQUEST_GUIDELINES.md
@@ -20,3 +20,6 @@
 - The default merge message is all the individual commit names, delete these and provide a proper summary.
 - Only push code you want to merge.
 - Use git stash to store your unrelated or unwanted changes temporarily without committing them.
+
+## Banned Procedures for making changes
+- You may not use Unitdef Baking to create changes in Unitdefs.

--- a/.github/PULL_REQUEST_GUIDELINES.md
+++ b/.github/PULL_REQUEST_GUIDELINES.md
@@ -22,4 +22,4 @@
 - Use git stash to store your unrelated or unwanted changes temporarily without committing them.
 
 ## Banned Procedures for making changes
-- You may not use Unitdef Baking to create changes in Unitdefs.
+- You may not use mass formatters to create changes in Unitdefs.


### PR DESCRIPTION
### Work done
Unitdef baking creates significant burdens on everyone else who has open/draft PRs.

Unitdef baking has created issues where PRs have had to be fully redone due to someone using Unitdef baking to make changes.
See #3818 where this matter made significant headache causing Kroyla to kill and open a new PR.

Unitdef baking also kills all comments in Unitdefs.
I do believe it is possible to do unitdef baking while retaining comments but im not sure.
all cases of Unitdef baking that I have seen have resulted in comments being deleted.