### PR TITLE
Make legacy 'y' key default to settarget, and 'alt+y' to

### DIFF
--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -269,8 +269,8 @@ bind Any+space unit_stats //unit_stats
 bind Ctrl+Shift+sc_o cameraflip // CameraFlip
 
 //if not WG[ Set target default ] then
-bind Alt+sc_y settarget
-bind sc_y settargetnoground
+bind Alt+sc_y settargetnoground
+bind sc_y settarget
 
 bind Ctrl+sc_` group unset
 

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -269,8 +269,8 @@ bind Any+space unit_stats
 bind Ctrl+Shift+sc_o cameraflip
 
 //if not WG[bind Set target default ] then
-bind Alt+sc_y settarget
-bind sc_y settargetnoground
+bind Alt+sc_y settargetnoground
+bind sc_y settarget
 
 bind Ctrl+meta+sc_q group unset
 // if WG[bind Auto Group ] then


### PR DESCRIPTION
### Work done

- Invert settarget legacy bindings: do 'y' for settarget and 'alt+y' for settargetnoground

#### Remarks

- Grid just has settarget bound to 's'.
  - Maybe grid could also map alt+s to alternative settarget, not sure if that's taken though.
- This has been causing quite some confusion, and been investigated as a bug since months XD
  - see https://discord.com/channels/549281623154229250/1308503461905825872
- cons: Changing this could be confusing for users currently happy with settargetnoground on 'y', but at least some are getting bewildered when they can't settarget at ghosts from far away, and ground generally.
- Change might not be wanted, but anyways hope this issue helps in raising awareness.
  - otherwise, settargetnoground should have some visual confirmation, maybe, about when a valid target is under cursor (actually settarget would also benefit from this)

Special thx to 'Graceful' at discord for reporting and finding what's going on.