### PR TITLE
Standardize factory alt behavior

### DIFF
--- a/luaui/Widgets/cmd_factory_alt_behaviour.lua
+++ b/luaui/Widgets/cmd_factory_alt_behaviour.lua
@@ -1,0 +1,61 @@
+function widget:GetInfo()
+    return {
+      name = "Factory Alt Behaviour",
+      desc = "Queueing with alt in a factory won't cancel the current command.",
+      author = "hihoman23",
+      date = "2024",
+      license = "GNU GPL, v2 or later",
+      layer = 0,
+      enabled = false
+    }
+end
+
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spGetSelectedUnits = Spring.GetSelectedUnits
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitWorkerTask = Spring.GetUnitWorkerTask
+
+local CMD_INSERT = CMD.INSERT
+
+local isFactory = {}
+local buildOpts = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+    if unitDef.isFactory then
+        isFactory[unitDefID] = true
+    end
+    if unitDef.buildOptions then
+        local opts = {}
+        for _, opt in pairs(unitDef.buildOptions) do
+            opts[opt] = true
+        end
+        buildOpts[unitDefID] = opts
+    end
+end
+
+function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
+    if cmdID < 0 and cmdOpts.alt and not cmdOpts.right then
+        local factoryExists = false
+        for _, unitID in ipairs(spGetSelectedUnits()) do
+            local unitDefID = spGetUnitDefID(unitID)
+            if isFactory[unitDefID] and buildOpts[unitDefID][-cmdID] then
+                factoryExists = true
+                if not cmdOpts.internal then
+                    cmdOpts.coded = cmdOpts.coded + CMD.OPT_INTERNAL -- prevent repeating command
+                end
+                local currentCmdID, targetID = spGetUnitWorkerTask(unitID)
+                spGiveOrderToUnit(unitID, CMD_INSERT, {currentCmdID and 1 or 0, cmdID, cmdOpts.coded}, {"ctrl", "alt"})
+            end
+        end
+        return factoryExists
+    end
+end
+
+function widget:PlayerChanged()
+    if Spring.GetSpectatingState() then
+        widgetHandler:RemoveWidget(self)
+    end
+end
+
+function widget:Initialize()
+    widget:PlayerChanged()
+end

--- a/luaui/Widgets/cmd_factory_alt_behaviour.lua
+++ b/luaui/Widgets/cmd_factory_alt_behaviour.lua
@@ -1,12 +1,12 @@
 function widget:GetInfo()
     return {
-      name = "Factory Alt Behaviour",
+      name = "Factory Alt Behavior",
       desc = "Queueing with alt in a factory won't cancel the current command.",
       author = "hihoman23",
-      date = "2024",
+      date = "Jan 2025",
       license = "GNU GPL, v2 or later",
       layer = 0,
-      enabled = false
+      enabled = true
     }
 end
 
@@ -16,19 +16,14 @@ local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitWorkerTask = Spring.GetUnitWorkerTask
 
 local CMD_INSERT = CMD.INSERT
-
-local isFactory = {}
-local buildOpts = {}
+local factoryBuildOpts = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-    if unitDef.isFactory then
-        isFactory[unitDefID] = true
-    end
-    if unitDef.buildOptions then
+    if unitDef.isFactory and unitDef.buildOptions then
         local opts = {}
         for _, opt in pairs(unitDef.buildOptions) do
             opts[opt] = true
         end
-        buildOpts[unitDefID] = opts
+        factoryBuildOpts[unitDefID] = opts
     end
 end
 
@@ -37,25 +32,17 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
         local factoryExists = false
         for _, unitID in ipairs(spGetSelectedUnits()) do
             local unitDefID = spGetUnitDefID(unitID)
-            if isFactory[unitDefID] and buildOpts[unitDefID][-cmdID] then
+            if factoryBuildOpts[unitDefID] and factoryBuildOpts[unitDefID][-cmdID] then
                 factoryExists = true
                 if not cmdOpts.internal then
                     cmdOpts.coded = cmdOpts.coded + CMD.OPT_INTERNAL -- prevent repeating command
                 end
                 local currentCmdID, targetID = spGetUnitWorkerTask(unitID)
-                spGiveOrderToUnit(unitID, CMD_INSERT, {currentCmdID and 1 or 0, cmdID, cmdOpts.coded}, {"ctrl", "alt"})
+                
+                -- insert command into wanted position
+                spGiveOrderToUnit(unitID, CMD_INSERT, {currentCmdID and 1 or 0, cmdID, cmdOpts.coded}, CMD.OPT_CTRL + CMD.OPT_ALT)
             end
         end
         return factoryExists
     end
-end
-
-function widget:PlayerChanged()
-    if Spring.GetSpectatingState() then
-        widgetHandler:RemoveWidget(self)
-    end
-end
-
-function widget:Initialize()
-    widget:PlayerChanged()
 end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1143,6 +1143,10 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 
 			if alt then
 				table.insert(opts, "alt")
+				if not ctrl then
+					Spring.SetActiveCommand(spGetCmdDescIndex(-uDefID), 1, true, false, alt, false, meta, shift)
+					return true
+				end
 			end
 			if shift then
 				table.insert(opts, "shift")
@@ -2601,7 +2605,7 @@ function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, optio
 	-- If factory is in repeat, queue does not change, except if it is alt-queued
 	local factoryRepeat = select(4, Spring.GetUnitStates(unitID, false, true))
 
-	if factoryRepeat and not options.alt then
+	if factoryRepeat and not options.internal then
 		return
 	end
 

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1043,17 +1043,6 @@ local function setPregameBlueprint(uDefID)
 	end
 end
 
-local function queueUnit(uDefID, opts)
-	local sel = spGetSelectedUnitsSorted()
-	for unitDefID, unitIds in pairs(sel) do
-		if units.isFactory[unitDefID] then
-			for _, uid in ipairs(unitIds) do
-				spGiveOrderToUnit(uid, -uDefID, {}, opts)
-			end
-		end
-	end
-end
-
 local function clearCategory()
 	setLabBuildMode(false)
 
@@ -1131,28 +1120,8 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 				return false
 			end
 
-			local opts
-
-			if ctrl then
-				opts = { "right" }
-				Spring.PlaySoundFile(CONFIG.sound_queue_rem, 0.75, "ui")
-			else
-				opts = { "left" }
-				Spring.PlaySoundFile(CONFIG.sound_queue_add, 0.75, "ui")
-			end
-
-			if alt then
-				table.insert(opts, "alt")
-				if not ctrl then
-					Spring.SetActiveCommand(spGetCmdDescIndex(-uDefID), 1, true, false, alt, false, meta, shift)
-					return true
-				end
-			end
-			if shift then
-				table.insert(opts, "shift")
-			end
-
-			queueUnit(uDefID, opts)
+			-- using SetActiveCommand has the advantage of CommandNotify being called
+			Spring.SetActiveCommand(spGetCmdDescIndex(-uDefID), ctrl and 3 or 1, not ctrl, ctrl, alt, false, meta, shift)
 
 			return true
 		end


### PR DESCRIPTION


### Work done
Alt-queued units in factories will now always be queued after the current unit that is being built, even when not in repeat mode.


#### Addresses Issue(s)
- Fixes #1522



#### Test steps
- Test around with alt queues in factories with and without repeat mode, also with both buildmenus.

