### PR TITLE
Fix unit_collision_damage_behavior gadget being able to divide by 0.

### DIFF
--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -219,7 +219,8 @@ function gadget:GameFrame(frame)
 					newVelYToOldVelYRatio = 1
 				end
 
-				local scale = data.velocityCap / mathMax(mathAbs(velX), mathAbs(newVelY), mathAbs(velZ))
+				local divisor = mathMax(mathAbs(velX), mathAbs(newVelY), mathAbs(velZ), 0.001)
+				local scale = data.velocityCap / divisor
 
 				velX = velX * scale * newVelYToOldVelYRatio
 				velZ = velZ * scale * newVelYToOldVelYRatio


### PR DESCRIPTION
### Work done

- Fix unit_collision_damage_behavior gadget being able to divide by 0.

### Remarks

- Make sure divisor isnt 0
- Couldnt test, but looks like this has to be the culprit
- Crashes engine with 2025.01.5 or earlier, and generate tons of lua errors after that
- Not sure that's (0.001) the best minimum to set there, not very clear about what the code trying to do, @SethDGamre any ideas?
- There could be other sources of NaN here.