### PR TITLE
Autogroup: delay rezzed units

### DIFF
--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -266,12 +266,7 @@ function widget:Shutdown()
 end
 
 function widget:UnitFinished(unitID, unitDefID, unitTeam)
-	if unitTeam ~= myTeam or unitID == nil then
-		return
-	end
-
-	if GetUnitRulesParam(unitID, "resurrected") then
-		toBeAddedLater[unitID] = unitDefID
+	if unitTeam ~= myTeam or unitID == nil or GetUnitRulesParam(unitID, "resurrected") then
 		return
 	end
 
@@ -310,6 +305,11 @@ function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 
 	if builderID and mobileBuilders[Spring.GetUnitDefID(builderID)] then
 		builtInPlace[unitID] = true
+	end
+
+	if GetUnitRulesParam(unitID, "resurrected") then
+		toBeAddedLater[unitID] = unitDefID
+		return
 	end
 
 	if immediate then


### PR DESCRIPTION

### Work done
Does what #2413 did, after it got broken by #3740.
Rezzed units will now only get added to autogroups after they have been fully healed.