### PR TITLE
Protect advplayerslist and ecostats from early NaN because of no storage

### DIFF
--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -2300,6 +2300,7 @@ function DrawResources(energy, energyStorage, energyShare, energyConversion, met
         y2Offset = 8.6 * sizeMult
     end
     local maxStorage = (maxAllyTeamMetalStorage and maxAllyTeamMetalStorage or metalStorage)
+    if not maxStorage or maxStorage == 0 then return end -- protect from NaN
     --gl_Color(0,0,0, 0.05)
     --gl_Texture(false)
     --DrawRect(m_resources.posX + widgetPosX + paddingLeft-bordersize, posY + y1Offset+bordersize, m_resources.posX + widgetPosX + paddingLeft + (barWidth * (metalStorage/maxStorage))+bordersize, posY + y2Offset-bordersize)

--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -1065,6 +1065,10 @@ local function drawListStandard()
 		end
 	end
 
+	if maxMetal == 0 or maxEnergy == 0 then
+		return -- protect from NaN
+	end
+
 	for _, data in ipairs(allyData) do
 		local aID = data.aID
 		if aID ~= nil then


### PR DESCRIPTION
### Work done

- Fix early NaNs at advplayerlist and ecostats because of no total storage.

#### Addresses Issue(s)

- Engine will start [erroring on NaNs](https://github.com/beyond-all-reason/spring/commit/a87d53bdf0c563334fa91eeb7d9624a6fdf1598c) and also they're not good.
