### PR TITLE
Revert removing I18N initialization code from setupdefs.lua

### DIFF
--- a/luaui/setupdefs.lua
+++ b/luaui/setupdefs.lua
@@ -63,3 +63,11 @@ do
 	end
 	WeaponDefNames = tbl
 end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+-- Run I18N initialization here in case any widgets try to look up unit names/descriptions outside of callins
+-- as that will happen before the gui_language widget gets a chance to run.
+local i18nDefs = VFS.Include('luaui/i18nhelpers.lua')
+i18nDefs.RefreshDefs()


### PR DESCRIPTION
### Work done
#4038 moved running the I18N initialization code for defs from setupdefs.lua into purely widget space. This broke any widgets trying to look up these I18N entries outside of callins, as the code would run before gui_language had a chance to run, despite it being on a lower layer.

See #4186 