### PR TITLE
Mission API: Victory and Defeat actions take winners/losers as args

### DIFF
--- a/luarules/mission_api/actions.lua
+++ b/luarules/mission_api/actions.lua
@@ -103,35 +103,21 @@ end
 
 --============================================================--
 
-local function getHumanAllyTeams()
-	local humanAllyTeams = {}
-	for _, playerID in pairs(Spring.GetPlayerList()) do
-		local _, _, spec, _, allyTeamID = Spring.GetPlayerInfo(playerID, false)
-		if not spec and not humanAllyTeams[allyTeamID] then
-			humanAllyTeams[allyTeamID] = allyTeamID
-		end
-	end
-	return humanAllyTeams
+local function victory(winningAllyTeamIDs)
+	Spring.GameOver({ unpack(winningAllyTeamIDs) })
 end
 
 ----------------------------------------------------------------
 
-local function victory()
-	Spring.GameOver({ unpack(getHumanAllyTeams()) })
-end
-
-----------------------------------------------------------------
-
-local function defeat()
-	local allyTeamsWithPlayers = getHumanAllyTeams()
+local function defeat(losingAllyTeamIDs)
 	local allAllyTeamIDs = Spring.GetAllyTeamList()
-	local allyTeamsWithoutPlayers = {}
+	local winningAllyTeamIDs = { }
 	for _, allyTeamID in pairs(allAllyTeamIDs) do
-		if not allyTeamsWithPlayers[allyTeamID] then
-			allyTeamsWithoutPlayers[allyTeamID] = allyTeamID
+		if not table.contains(losingAllyTeamIDs, allyTeamID) then
+			table.insert(winningAllyTeamIDs, allyTeamID)
 		end
 	end
-	Spring.GameOver({ unpack(allyTeamsWithoutPlayers) })
+	Spring.GameOver({ unpack(winningAllyTeamIDs) })
 end
 
 --============================================================--

--- a/luarules/mission_api/actions_schema.lua
+++ b/luarules/mission_api/actions_schema.lua
@@ -6,47 +6,47 @@
 
 local actionTypes = {
 	-- Triggers
-	EnableTrigger               = 100, --
-	DisableTrigger              = 101, --
+	EnableTrigger      = 100,       --
+	DisableTrigger     = 101,       --
 
 	-- Orders
-	IssueOrders                 = 200, --
-	AllowCommands               = 201,
-	RestrictCommands            = 202,
+	IssueOrders        = 200,       --
+	AllowCommands      = 201,
+	RestrictCommands   = 202,
 
 	-- Build Options
-	AlterBuildlist              = 300,
-	EnableBuildOption           = 301,
-	DisableBuildOption          = 302,
+	AlterBuildlist     = 300,
+	EnableBuildOption  = 301,
+	DisableBuildOption = 302,
 
 	-- Units
-	SpawnUnits                  = 400, --
-	DespawnUnits                = 401, --
-	TransferUnits               = 404, --
+	SpawnUnits         = 400,       --
+	DespawnUnits       = 401,       --
+	TransferUnits      = 404,       --
 
 	-- SFX
-	SpawnExplosion              = 500, --
-	SpawnWeapons                = 501,
-	SpawnEffects                = 502,
+	SpawnExplosion     = 500,       --
+	SpawnWeapons       = 501,
+	SpawnEffects       = 502,
 
 	-- Map
-	RevealLOS                   = 600,
-	UnrevealLOS                 = 601,
-	AlterMapZones               = 602,
+	RevealLOS          = 600,
+	UnrevealLOS        = 601,
+	AlterMapZones      = 602,
 
 	-- Media
-	ControlCamera               = 700,
-	Pause                       = 701,
-	Unpause                     = 702,
-	PlayMedia                   = 703,
-	SendMessage                 = 704,
+	ControlCamera      = 700,
+	Pause              = 701,
+	Unpause            = 702,
+	PlayMedia          = 703,
+	SendMessage        = 704,
 
 	-- Win Condition
-	Victory                     = 800,
-	Defeat                      = 801,
+	Victory            = 800,
+	Defeat             = 801,
 
 	-- Custom
-	Custom                      = 900, --
+	Custom             = 900,       --
 }
 
 --============================================================--
@@ -63,7 +63,7 @@ local parameters = {
 			required = true,
 			type = 'string',
 		},
-	 },
+	},
 
 	[actionTypes.DisableTrigger] = {
 		[1] = {
@@ -71,10 +71,10 @@ local parameters = {
 			required = true,
 			type = 'string',
 		},
-	 },
+	},
 
-	 -- Orders
-	[actionTypes.IssueOrders] = { 
+	-- Orders
+	[actionTypes.IssueOrders] = {
 		[1] = {
 			name = 'unit',
 			required = true,
@@ -85,14 +85,14 @@ local parameters = {
 			required = true,
 			type = 'table'
 		}
-	 },
-	[actionTypes.AllowCommands] = {  },
-	[actionTypes.RestrictCommands] = {  },
+	},
+	[actionTypes.AllowCommands] = {},
+	[actionTypes.RestrictCommands] = {},
 
 	-- Build Options
-	[actionTypes.AlterBuildlist] = {  },
-	[actionTypes.EnableBuildOption] = {  },
-	[actionTypes.DisableBuildOption] = {  },
+	[actionTypes.AlterBuildlist] = {},
+	[actionTypes.EnableBuildOption] = {},
+	[actionTypes.DisableBuildOption] = {},
 
 	-- Units
 	[actionTypes.SpawnUnits] = {
@@ -134,10 +134,10 @@ local parameters = {
 			required = true,
 			type = 'Unit',
 		},
-	 },
-	[actionTypes.SpawnWeapons] = {  },
-	[actionTypes.SpawnEffects] = {  },
-	[actionTypes.TransferUnits] = { 
+	},
+	[actionTypes.SpawnWeapons] = {},
+	[actionTypes.SpawnEffects] = {},
+	[actionTypes.TransferUnits] = {
 		[1] = {
 			name = 'unit',
 			required = true,
@@ -153,10 +153,10 @@ local parameters = {
 			required = false,
 			type = 'bool'
 		}
-	 },
+	},
 
 	-- SFX
-	[actionTypes.SpawnExplosion] = { 
+	[actionTypes.SpawnExplosion] = {
 		[1] = {
 			name = 'position',
 			required = true,
@@ -175,15 +175,15 @@ local parameters = {
 	},
 
 	-- Map
-	[actionTypes.RevealLOS] = {  },
-	[actionTypes.UnrevealLOS] = {  },
-	[actionTypes.AlterMapZones] = {  },
+	[actionTypes.RevealLOS] = {},
+	[actionTypes.UnrevealLOS] = {},
+	[actionTypes.AlterMapZones] = {},
 
 	-- Media
-	[actionTypes.ControlCamera] = {  },
-	[actionTypes.Pause] = {  },
-	[actionTypes.Unpause] = {  },
-	[actionTypes.PlayMedia] = {  },
+	[actionTypes.ControlCamera] = {},
+	[actionTypes.Pause] = {},
+	[actionTypes.Unpause] = {},
+	[actionTypes.PlayMedia] = {},
 
 	[actionTypes.SendMessage] = {
 		[1] = {
@@ -194,8 +194,20 @@ local parameters = {
 	},
 
 	-- Win Condition
-	[actionTypes.Victory] = {  },
-	[actionTypes.Defeat] = {  },
+	[actionTypes.Victory] = {
+		[1] = {
+			name = 'allyTeamIDs',
+			required = true,
+			type = 'table'
+		}
+	},
+	[actionTypes.Defeat] = {
+		[1] = {
+			name = 'allyTeamIDs',
+			required = true,
+			type = 'table'
+		}
+	},
 
 	-- Custom
 	[actionTypes.Custom] = {

--- a/singleplayer/test_mission.lua
+++ b/singleplayer/test_mission.lua
@@ -75,6 +75,9 @@ local actions = {
 
 	gameEnd = {
 		type = actionTypes.Defeat,
+		parameters = {
+			allyTeamIDs = {0},
+		},
 	},
 }
 


### PR DESCRIPTION
### Work done
Modified the Victory and Defeat actions, as suggested by @WatchTheFort on https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3662 : instead of trying to guess who's the winning ally team(s), let the scenario author provide their IDs to the actions.

#### Test steps
- [ ] Run the test mission and wait 7 seconds.
