### PR TITLE
Fix defs -> unit in scenario loadout gadget

### DIFF
--- a/luarules/gadgets/unit_scenario_loadout.lua
+++ b/luarules/gadgets/unit_scenario_loadout.lua
@@ -84,7 +84,7 @@ function gadget:GamePreload()
 									additionalStorage[unit.team].energy  = additionalStorage[unit.team].energy + (UnitDefNames[unit.name].energyStorage or 0 )
 								end
 							end
-							if string.find(defs.name, "nanotc") then
+							if string.find(unit.name, "nanotc") then
 								nanoturretunitIDs[unitID] = true
 							end
 							if unit.neutral == true or unit.neutral == 'true' then


### PR DESCRIPTION
### Work done
Fix bug introduced in 995edee1b77e0031687cdcfde2a27a1ada042189

#### Test steps
- [x] Start scenario King of the Hill, verify default unit loadout is present, Commanders spawn