### PR TITLE
Shields Re-Rework Buff Shield Capacity

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -860,10 +860,15 @@ function UnitDef_Post(name, uDef)
 
 	-- Shield Rework
 	if modOptions.shieldsrework == true and uDef.weapondefs then
+		local shieldPowerMultiplier = 1.9-- To compensate for always taking full damage from projectiles in contrast to bounce-style only taking partial
+
 		for _, weapon in pairs(uDef.weapondefs) do
 			if weapon.shield and weapon.shield.repulser then
 				uDef.onoffable = true
 			end
+		end
+		if uDef.customparams.shield_power then
+			uDef.customparams.shield_power = uDef.customparams.shield_power * shieldPowerMultiplier
 		end
 	end
 
@@ -1479,7 +1484,8 @@ function WeaponDef_Post(name, wDef)
 		--Shields Rework
 		if modOptions.shieldsrework == true then
 			-- To compensate for always taking full damage from projectiles in contrast to bounce-style only taking partial
-			local shieldRechargeRateMultiplier = 2.5
+			local shieldPowerMultiplier = 1.9
+			local shieldRegenMultiplier = 2.5
 			local shieldRechargeCostMultiplier = 1
 
 			-- For balance, paralyzers need to do reduced damage to shields, as their raw raw damage is outsized
@@ -1523,7 +1529,8 @@ function WeaponDef_Post(name, wDef)
 			if wDef.shield then
 				wDef.shield.exterior = true
 				if wDef.shield.repulser == true then --isn't an evocom
-					wDef.shield.powerregen = wDef.shield.powerregen * shieldRechargeRateMultiplier
+					wDef.shield.powerregen = wDef.shield.powerregen * shieldRegenMultiplier
+					wDef.shield.power = wDef.shield.power * shieldPowerMultiplier
 					wDef.shield.powerregenenergy = wDef.shield.powerregenenergy * shieldRechargeCostMultiplier
 				end
 				wDef.shield.repulser = false


### PR DESCRIPTION
Received a report that the re-reworked shields capacity was much, much lower than the vanilla shields and didn't block as much damage. A quick test confirmed this. For the rework, this PR buffs the shield capacity to bring it roughly in line with the vanilla shield's ability to block lolcannons + a little margin to compensate for the extra damage taken from "blocking" rather than "deflecting" at less cost the shots hitting the edges of the shield.