### PR TITLE
airunitsturnradius: pcall spMoveCtrlSetAirMoveTypeData

### DIFF
--- a/luarules/gadgets/unit_airunitsturnradius.lua
+++ b/luarules/gadgets/unit_airunitsturnradius.lua
@@ -69,7 +69,12 @@ local function processNextCmd(unitID, unitDefID, cmdID)
 	if curMoveCtrl then
 		spMoveCtrlDisable(unitID)
 	end
-	spMoveCtrlSetAirMoveTypeData(unitID, "turnRadius", (not cmdID or cmdID == CMD_ATTACK) and attackTurnRadius or bomberTurnRadius[unitDefID])
+	local success = pcall(function()
+		spMoveCtrlSetAirMoveTypeData(unitID, "turnRadius", (not cmdID or cmdID == CMD_ATTACK) and attackTurnRadius or bomberTurnRadius[unitDefID])
+	end)
+	if not success then
+		Spring.Echo("Error: unit_airunitsturnradius incompatible movetype for unitdef "..UnitDefs[unitDefID].name)
+	end
 	if curMoveCtrl then
 		spMoveCtrlEnable(unitID)
 	end


### PR DESCRIPTION
to circumvent and get more detail on errors like:
[t=01:39:57.519813][f=0040267] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_airunitsturnradius.lua"]:72: [SetMoveTypeData] unit 26956 has incompatible movetype for SetAirMoveTypeData