### PR TITLE
autogroup: add rezzed units once stopped healing

### DIFF
--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -748,8 +748,8 @@ else -- UNSYNCED
 							totalEnemyDimmingCount = totalEnemyDimmingCount + count
 						end
 					end
-					brightnessVariation = (0.7 - ((1.1 / numEnemies) * totalEnemyDimmingCount)) * 255
-					maxColorVariation = math.floor(11 + (90 / (allyTeamCount)))
+					brightnessVariation = (0.7 - ((1.2 / numEnemies) * totalEnemyDimmingCount)) * 255
+					maxColorVariation = 100
 				end
 				local color = hex2RGB(ffaColors[allyTeamID+1] or '#333333')
 				if teamID == gaiaTeamID then
@@ -779,8 +779,8 @@ else -- UNSYNCED
 			elseif
 				not teamColors[allyTeamCount] or not teamColors[allyTeamCount][1][#Spring.GetTeamList(allyTeamCount-1)] --or #Spring.GetTeamList() > 30
 			then
-				local brightnessVariation = (0.7 - ((1.1 / #Spring.GetTeamList(allyTeamID)) * dimmingCount[allyTeamID])) * 255
-				local maxColorVariation = math.floor(11 + (90 / (allyTeamCount)))
+				local brightnessVariation = (0.7 - ((1.05 / #Spring.GetTeamList(allyTeamID)) * dimmingCount[allyTeamID])) * 255
+				local maxColorVariation = (120 / (allyTeamCount-1))
 				local color = hex2RGB(ffaColors[allyTeamID+1] or '#333333')
 				if teamID == gaiaTeamID then
 					brightnessVariation = 0

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -58,20 +58,19 @@ local unit2group = presets[currPreset] -- list of unit types to group
 local mobileBuilders = {}
 local builtInPlace = {}
 
-local unitHealth = {}
 for udefID, def in ipairs(UnitDefs) do
 	if not def.isFactory then
 		if def.buildOptions and #def.buildOptions > 0 then
 			mobileBuilders[udefID] = true
 		end
 	end
-	unitHealth[udefID] = def.health
 end
 
 local finiGroup = {}
 local myTeam = Spring.GetMyTeamID()
 local createdFrame = {}
 local toBeAddedLater = {}
+local prevHealth = {}
 
 local gameStarted
 
@@ -286,14 +285,20 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	builtInPlace[unitID] = nil
 end
 
-function widget:GameFrame()
-	for unitID, unitDefID in pairs(toBeAddedLater) do
-		if unitHealth[unitDefID] and GetUnitHealth(unitID) == unitHealth[unitDefID] then
-			local gr = unit2group[unitDefID]
-			if gr ~= nil and GetUnitGroup(unitID) == nil then
-				SetUnitGroup(unitID, gr)
+function widget:GameFrame(n)
+	if n % 10 == 0 then
+		for unitID, unitDefID in pairs(toBeAddedLater) do
+			local health = GetUnitHealth(unitID)
+			if health == prevHealth[unitID] then -- stopped healing
+				local gr = unit2group[unitDefID]
+				if gr ~= nil and GetUnitGroup(unitID) == nil then
+					SetUnitGroup(unitID, gr)
+				end
+				toBeAddedLater[unitID] = nil
+				prevHealth[unitID] = nil
+			else
+				prevHealth[unitID] = health
 			end
-			toBeAddedLater[unitID] = nil
 		end
 	end
 end
@@ -309,6 +314,7 @@ function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 
 	if GetUnitRulesParam(unitID, "resurrected") then
 		toBeAddedLater[unitID] = unitDefID
+		prevHealth[unitID] = 0
 		return
 	end
 
@@ -325,6 +331,7 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID)
 	createdFrame[unitID] = nil
 	builtInPlace[unitID] = nil
 	toBeAddedLater[unitID] = nil
+	prevHealth[unitID] = nil
 end
 
 function widget:UnitGiven(unitID, unitDefID, newTeamID, teamID)
@@ -338,6 +345,7 @@ function widget:UnitGiven(unitID, unitDefID, newTeamID, teamID)
 	createdFrame[unitID] = nil
 	builtInPlace[unitID] = nil
 	toBeAddedLater[unitID] = nil
+	prevHealth[unitID] = nil
 end
 
 function widget:UnitTaken(unitID, unitDefID, oldTeamID, teamID)

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -290,9 +290,9 @@ function widget:GameFrame(n)
 		for unitID, unitDefID in pairs(toBeAddedLater) do
 			local health = GetUnitHealth(unitID)
 			if health == prevHealth[unitID] then -- stopped healing
-				local gr = unit2group[unitDefID]
-				if gr ~= nil and GetUnitGroup(unitID) == nil then
-					SetUnitGroup(unitID, gr)
+				local group = unit2group[unitDefID]
+				if group ~= nil and GetUnitGroup(unitID) == nil then
+					SetUnitGroup(unitID, group)
 				end
 				toBeAddedLater[unitID] = nil
 				prevHealth[unitID] = nil


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Rezzed units will now get added to autogroups once they have stopped being healed. This happens once the unit is fully healed or the healing rezbot is not there anymore.

Small note: Would it be better to add the unit if its health is exactly the previous health or to add the unit if its health is less than or equal to the previous health?