### PR TITLE
update widget:UnitDestroyed to include attackerID, attackerDefID, and attackerTeam

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -2262,11 +2262,11 @@ function widgetHandler:UnitFromFactory(unitID, unitDefID, unitTeam, factID, fact
 	return
 end
 
-function widgetHandler:UnitDestroyed(unitID, unitDefID, unitTeam)
+function widgetHandler:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
 	widgetHandler:MetaUnitRemoved(unitID, unitDefID, unitTeam)
 	tracy.ZoneBeginN("W:UnitDestroyed")
 	for _, w in ipairs(self.UnitDestroyedList) do
-		w:UnitDestroyed(unitID, unitDefID, unitTeam)
+		w:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
 	end
 	tracy.ZoneEnd()
 	return

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -2262,11 +2262,11 @@ function widgetHandler:UnitFromFactory(unitID, unitDefID, unitTeam, factID, fact
 	return
 end
 
-function widgetHandler:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+function widgetHandler:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
 	widgetHandler:MetaUnitRemoved(unitID, unitDefID, unitTeam)
 	tracy.ZoneBeginN("W:UnitDestroyed")
 	for _, w in ipairs(self.UnitDestroyedList) do
-		w:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+		w:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
 	end
 	tracy.ZoneEnd()
 	return


### PR DESCRIPTION

### Work done

this PR exposes `attackerID`, `attackerDefID`, and `attackerTeam` to `widget:UnitDestroyed`. populating these fields is already done in spring: https://github.com/beyond-all-reason/spring/blob/master/rts/Lua/LuaHandle.cpp#L1135 , this PR just pass those fields along. gadgets are already provided these fields, so no work is needed there

[visibility checks already occur when populating these fields](https://github.com/beyond-all-reason/spring/blob/master/rts/Lua/LuaUtils.cpp#L1807), so this does not leak data that players wouldn't have access to otherwise

i tested 4 different scenarios to ensure that adding these fields does not leak info:

1. on screen enemy kills on screen ally: attacker info is provided, as this unit kill is visible to the player
2. off screen enemy kills on screen ally: attacker info is not provided, as telling the player what unit killed their unit would leak data
3. on screen ally kills off screen enemy: no `UnitDestroyed` event is expected at all. this PR does not change this logic, but was tested anyways to be thorough
4. on screen ally kills on screen enemy: attacker info is provided. in practice however, this info is not provided. this is a bug, but not introduced by these changes

### Addresses Issue(s)

https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4247

this was also discussed in the BAR Discord: https://discord.com/channels/549281623154229250/549282166543089674/1334245966026379356

### Setup

widget used for testing

```lua
function widget:GetInfo()
return {
	name    = "test",
	desc    = "a",
	author  = "varunda",
	date    = "2025",
	license = "MIT",
	layer   = 0,
	enabled = true,
}
end

function widget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
    Spring.Echo("handler", "unitID", unitID, "unitDefID", unitDefID, "unitTeam", unitTeam, "attackerID", attackerID, "attackerDefID", attackerDefID, "attackerTeam", attackerTeam)
end
```

#### Test steps
- [ ] spawn ally tick, spawn enemy LLT. have tick die to LLT, expected to see attacker info given
- [ ] spawn ally con, spawn enemy LLT, have con die to LLT outside of los from the con. expected not see attacker info
- [ ] spawn ally artillery, spawn enemy LLT, kill enemy LLT from outside los of the artillery. expected to not get an event
- [ ] spawn ally artillery, spawn ally tick, spawn enemy LLT. position tick so LLT is visible, but out of range of the LLT. kill enemy LLT with the artillery. expected to not see attacker info (to be clear this is a bug, but unrelated to these changes)

### Screenshots:

here is a video demonstrating the test steps above

https://www.youtube.com/watch?v=pzgmRS01xRk

