### PR TITLE
test_runner: dont use cleanupImmediately

### DIFF
--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -772,7 +772,7 @@ Test = {
 	clearMap = function()
 		SyncedRun(function()
 			for _, unitID in ipairs(Spring.GetAllUnits()) do
-				Spring.DestroyUnit(unitID, false, true, nil, true)
+				Spring.DestroyUnit(unitID, false, true, nil, false)
 			end
 			for _, featureID in ipairs(Spring.GetAllFeatures()) do
 				Spring.DestroyFeature(featureID)


### PR DESCRIPTION
Don't use cleanupImmediately when calling DestroyUnit().

If a test ends with a transport carrying a unit, using cleanupImmediately will cause errors in gadget
unit_transport_dies_load_dies like follows:

Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_transport_dies_load_dies.lua"]:79: attempt to index a nil value stack traceback:
    [string "LuaRules/Gadgets/unit_transport_dies_load_dies.lua"]:79: in function 'GameFrame'
    [string "LuaRules/gadgets.lua"]:1160: in function 'selffunc'
    [string "LuaRules/gadgets.lua"]:826: in function <[string "LuaRules/gadgets.lua"]:823>