### PR TITLE
Feat(unit evolution tweak): Ability to evolve 1000's of units

### DIFF
--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -103,13 +103,13 @@ if gadgetHandler:IsSyncedCode() then
 		-- evolution_health_threshold = 0,			-- threshold for triggering the "health" evolution condition.
 		-- evolution_power_threshold = 600,			-- threshold for triggering the "power" evolution condition.
 		-- evolution_power_enemy_multiplier = 1,	-- Scales the power calculated based on the average enemy combined power.
-		-- evolution_power_multiplier = 1,			-- Scales the power calculated based on your own combined power. 
+		-- evolution_power_multiplier = 1,			-- Scales the power calculated based on your own combined power.
 		-- combatradius = 1000,						-- Range for setting in-combat status if enemies are within range, and disabling evolution while in-combat.
 		-- evolution_health_transfer = "flat",		-- "flat", "percentage", or "full"
 
 
 		-- },
-  
+
 
 
 
@@ -134,11 +134,11 @@ if gadgetHandler:IsSyncedCode() then
 		local allUnits = Spring.GetAllUnits(newUnit)
 		for _,unitID in pairs(allUnits) do
 			--local unitID = allUnits[i]
-			
+
 			if GG.GetUnitTarget(unitID) == oldUnit and newUnit then
 				GG.SetUnitTarget(unitID, newUnit)
 			end
-			
+
 			local cmds = Spring.GetCommandQueue(unitID, -1)
 			for j = 1, #cmds do
 				local cmd = cmds[j]
@@ -156,7 +156,7 @@ if gadgetHandler:IsSyncedCode() then
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-	
+
 
 
 
@@ -190,7 +190,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			spSetUnitRulesParam(unitID, "unit_evolved", newUnitID, PRIVATE)
-			
+
 			SendToUnsynced("unit_evolve_finished", unitID, newUnitID, announcement,announcementSize)
 			if evolutionMetaList[unitID].evolution_health_transfer == "full" then
 			elseif evolutionMetaList[unitID].evolution_health_transfer == "percentage" then
@@ -205,7 +205,7 @@ if gadgetHandler:IsSyncedCode() then
 			spSetUnitExperience(newUnitID, experience)
 			spSetUnitStockpile(newUnitID, stockpile, stockpilebuildpercent)
 			spSetUnitDirection(newUnitID, dx, dy, dz)
-			
+
 
 			spGiveOrderToUnit(newUnitID, CMD.FIRE_STATE, { states.firestate },             { })
 			spGiveOrderToUnit(newUnitID, CMD.MOVE_STATE, { states.movestate },             { })
@@ -213,7 +213,7 @@ if gadgetHandler:IsSyncedCode() then
 			spGiveOrderToUnit(newUnitID, CMD_WANT_CLOAK,      {states.cloak and 1 or 0 },  { })
 			spGiveOrderToUnit(newUnitID, CMD.ONOFF,      { 1 },                            { })
 			spGiveOrderToUnit(newUnitID, CMD.TRAJECTORY, { states.trajectory and 1 or 0 }, { })
-			
+
 			ReAssignAssists(newUnitID,unitID)
 
 
@@ -265,8 +265,8 @@ if gadgetHandler:IsSyncedCode() then
 				evolution_announcement_size = tonumber(udcp.evolution_announcement_size),
 				combatRadius = tonumber(udcp.combatradius) or 1000,
 				evolution_health_transfer =  udcp.evolution_health_transfer or "flat",
-				
-				
+
+
 				timeCreated = spGetGameSeconds(),
 				combatTimer = spGetGameSeconds(),
 				inCombat = false,
@@ -312,7 +312,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 	end
-	
+
 	function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 		if evolutionMetaList[unitID] then
 			if evolutionMetaList[unitID].evolution_condition == "health" then
@@ -325,7 +325,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 	end
-	
+
 
 	function gadget:GameFrame(f)
 		if f % GAME_SPEED ~= 0 then
@@ -334,7 +334,7 @@ if gadgetHandler:IsSyncedCode() then
 
 		--if f % TIMER_CHECK_FREQUENCY == 0 then
 		if ((TIMER_CHECK_FREQUENCY + lastTimerCheck) < f) then
-			lastTimerCheck = f	
+			lastTimerCheck = f
 			for unitID, _ in pairs(evolutionMetaList) do
 				local currentTime =  spGetGameSeconds()
 				if (evolutionMetaList[unitID].evolution_condition == "timer" and (currentTime-evolutionMetaList[unitID].timeCreated) >= evolutionMetaList[unitID].evolution_timer) or
@@ -355,7 +355,7 @@ if gadgetHandler:IsSyncedCode() then
 
 		if ((POWER_CHECK_FREQUENCY + lastPowerCheck) < f) then
 			lastPowerCheck = f
-			
+
 			for unitID, _ in pairs(evolutionMetaList) do
 				local currentTime =  spGetGameSeconds()
 				local teamID = spGetUnitTeam(unitID)


### PR DESCRIPTION
### Work done
It is currently not possible to use an unit evolution tweak that affects very many units.
<details>
  <summary>Auto Unit Evolution Tweak</summary>

```
LS1BdXRvIFVuaXQgRXZvbHV0aW9uCmxvY2FsIGE9e2FybT17e2Zyb209J2FybXdpbicsZnJvbURlc2M9J1dpbmQgVHVyYmluZScsdG89J2FybXNvbGFyJyx0b0Rlc2M9J1NvbGFyIENvbGxlY3RvcicsdGltZXI9NjB9LHtmcm9tPSdhcm1zb2xhcicsZnJvbURlc2M9J1NvbGFyIENvbGxlY3RvcicsdG89J2FybWFkdnNvbCcsdG9EZXNjPSdBZHZhbmNlZCBTb2xhciBDb2xsZWN0b3InLHRpbWVyPTEyMH0se2Zyb209J2FybWFkdnNvbCcsZnJvbURlc2M9J0FkdmFuY2VkIFNvbGFyIENvbGxlY3RvcicsdG89J2FybXdpbnQyJyx0b0Rlc2M9J0FkdmFuY2VkIFdpbmQgVHVyYmluZScsdGltZXI9MjQwfSx7ZnJvbT0nYXJtd2ludDInLGZyb21EZXNjPSdGdXNpb24gUmVhY3RvcicsdG89J2FybWZ1cycsdG9EZXNjPSdBZHZhbmNlZCBGdXNpb24gUmVhY3RvcicsdGltZXI9MzYwfSx7ZnJvbT0nYXJtZnVzJyxmcm9tRGVzYz0nRnVzaW9uIFJlYWN0b3InLHRvPSdhcm1hZnVzJyx0b0Rlc2M9J0FkdmFuY2VkIEZ1c2lvbiBSZWFjdG9yJyx0aW1lcj0zNjB9LHtmcm9tPSdhcm1nZW8nLGZyb21EZXNjPSdHZW90aGVybWFsIFBvd2VycGxhbnQnLHRvPSdhcm1mYWtlZ2VvJyx0b0Rlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgR2VvLScsdGltZXI9MzYwfSx7ZnJvbT0nYXJtZmFrZWdlbycsZnJvbURlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgR2VvLScsdG89J2FybWFnZW8nLHRvRGVzYz0nQWR2YW5jZWQgR2VvdGhlcm1hbCBQb3dlcnBsYW50Jyx0aW1lcj0yfSx7ZnJvbT0nYXJtdGlkZScsZnJvbURlc2M9J1RpZGFsIEdlbmVyYXRvcicsdG89J2FybXV3ZnVzJyx0b0Rlc2M9J05hdmFsIEZ1c2lvbiBSZWFjdG9yJyx0aW1lcj0zMDB9LHtmcm9tPSdhcm1tZXgnLGZyb21EZXNjPSdNZXRhbCBFeHRyYWN0b3InLHRvPSdhcm1mYWtlbWV4Jyx0b0Rlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgTWV4LScsdGltZXI9MzYwfSx7ZnJvbT0nYXJtZmFrZW1leCcsZnJvbURlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgTWV4LScsdG89J2FybW1vaG8nLHRvRGVzYz0nQWR2YW5jZWQgTWV0YWwgRXh0cmFjdG9yJyx0aW1lcj0yfSx7ZnJvbT0nYXJtZHJhZycsZnJvbURlc2M9IkRyYWdvbidzIFRlZXRoIix0bz0nYXJtZm9ydCcsdG9EZXNjPSdGb3J0aWZpY2F0aW9uIFdhbGwnLHRpbWVyPTM2MH0se2Zyb209J2FybW5hbm90YycsZnJvbURlc2M9J0NvbnN0cnVjdGlvbiBUdXJyZXQnLHRvPSdhcm1uYW5vdGN0MicsdG9EZXNjPSdBZHZhbmNlZCBDb25zdHJ1Y3Rpb24gVHVycmV0Jyx0aW1lcj0xMjB9LHtmcm9tPSdhcm1uYW5vdGNwbGF0Jyxmcm9tRGVzYz0nTmF2YWwgQ29uc3RydWN0aW9uIFR1cnJldCcsdG89J2FybW5hbm90YzJwbGF0Jyx0b0Rlc2M9J0FkdmFuY2VkIE5hdmFsIENvbnN0cnVjdGlvbiBUdXJyZXQnLHRpbWVyPTEyMH0se2Zyb209J2FybWZhc3AnLGZyb21EZXNjPSdXYXRlciBBaXIgUmVwYWlyIFBhZCcsdG89J21pc3Npb25fY29tbWFuZF90b3dlcicsdG9EZXNjPSdNaXNzaW9uIENvbW1hbmQgVG93ZXInLHRpbWVyPTYwLGFubm91bmNlPXRydWUsYW5TaXplPTI1fX0sY29yPXt7ZnJvbT0nY29yd2luJyxmcm9tRGVzYz0nV2luZCBUdXJiaW5lJyx0bz0nY29yc29sYXInLHRvRGVzYz0nU29sYXIgQ29sbGVjdG9yJyx0aW1lcj02MH0se2Zyb209J2NvcnNvbGFyJyxmcm9tRGVzYz0nU29sYXIgQ29sbGVjdG9yJyx0bz0nY29yYWR2c29sJyx0b0Rlc2M9J0FkdmFuY2VkIFNvbGFyIENvbGxlY3RvcicsdGltZXI9MTIwfSx7ZnJvbT0nY29yYWR2c29sJyxmcm9tRGVzYz0nQWR2YW5jZWQgU29sYXIgQ29sbGVjdG9yJyx0bz0nY29yd2ludDInLHRvRGVzYz0nQWR2YW5jZWQgV2luZCBUdXJiaW5lJyx0aW1lcj0yNDB9LHtmcm9tPSdjb3J3aW50MicsZnJvbURlc2M9J0FkdmFuY2VkIFdpbmQgVHVyYmluZScsdG89J2NvcmZ1cycsdG9EZXNjPSdGdXNpb24gUmVhY3RvcicsdGltZXI9MzAwfSx7ZnJvbT0nY29yZnVzJyxmcm9tRGVzYz0nRnVzaW9uIFJlYWN0b3InLHRvPSdjb3JhZnVzJyx0b0Rlc2M9J0FkdmFuY2VkIEZ1c2lvbiBSZWFjdG9yJyx0aW1lcj0zNjB9LHtmcm9tPSdjb3JnZW8nLGZyb21EZXNjPSdHZW90aGVybWFsIFBvd2VycGxhbnQnLHRvPSdjb3JmYWtlZ2VvJyx0b0Rlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgR2VvLScsdGltZXI9MzYwfSx7ZnJvbT0nY29yZmFrZWdlbycsZnJvbURlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgR2VvLScsdG89J2NvcmFnZW8nLHRvRGVzYz0nQWR2YW5jZWQgR2VvdGhlcm1hbCBQb3dlcnBsYW50Jyx0aW1lcj0yfSx7ZnJvbT0nY29ydGlkZScsZnJvbURlc2M9J1RpZGFsIEdlbmVyYXRvcicsdG89J2NvcnV3ZnVzJyx0b0Rlc2M9J05hdmFsIEZ1c2lvbiBSZWFjdG9yJyx0aW1lcj0zMDB9LHtmcm9tPSdjb3JtZXgnLGZyb21EZXNjPSdNZXRhbCBFeHRyYWN0b3InLHRvPSdjb3JmYWtlbWV4Jyx0b0Rlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgTWV4LScsdGltZXI9MzYwfSx7ZnJvbT0nY29yZmFrZW1leCcsZnJvbURlc2M9Jy1Xb3JrYXJvdW5kIEZha2UgTWV4LScsdG89J2Nvcm1vaG8nLHRvRGVzYz0nQWR2YW5jZWQgTWV0YWwgRXh0cmFjdG9yJyx0aW1lcj0yfSx7ZnJvbT0nY29yZHJhZycsZnJvbURlc2M9IkRyYWdvbidzIFRlZXRoIix0bz0nY29yZm9ydCcsdG9EZXNjPSdGb3J0aWZpY2F0aW9uIFdhbGwnLHRpbWVyPTM2MH0se2Zyb209J2Nvcm5hbm90YycsZnJvbURlc2M9J0NvbnN0cnVjdGlvbiBUdXJyZXQnLHRvPSdjb3JuYW5vdGN0MicsdG9EZXNjPSdBZHZhbmNlZCBDb25zdHJ1Y3Rpb24gVHVycmV0Jyx0aW1lcj0xMjB9LHtmcm9tPSdjb3JuYW5vdGNwbGF0Jyxmcm9tRGVzYz0nTmF2YWwgQ29uc3RydWN0aW9uIFR1cnJldCcsdG89J2Nvcm5hbm90YzJwbGF0Jyx0b0Rlc2M9J0FkdmFuY2VkIE5hdmFsIENvbnN0cnVjdGlvbiBUdXJyZXQnLHRpbWVyPTEyMH0se2Zyb209J2NvcmZhc3AnLGZyb21EZXNjPSdXYXRlciBBaXIgUmVwYWlyIFBhZCcsdG89J21pc3Npb25fY29tbWFuZF90b3dlcicsdG9EZXNjPSdNaXNzaW9uIENvbW1hbmQgVG93ZXInLHRpbWVyPTYwLGFubm91bmNlPXRydWUsYW5TaXplPTI1fX0sbGVnPXt7ZnJvbT0nbGVnd2luJyxmcm9tRGVzYz0nV2luZCBUdXJiaW5lJyx0bz0nbGVnc29sYXInLHRvRGVzYz0nU29sYXIgQ29sbGVjdG9yJyx0aW1lcj02MH0se2Zyb209J2xlZ3NvbGFyJyxmcm9tRGVzYz0nU29sYXIgQ29sbGVjdG9yJyx0bz0nbGVnYWR2c29sJyx0b0Rlc2M9J0FkdmFuY2VkIFNvbGFyIENvbGxlY3RvcicsdGltZXI9MTIwfSx7ZnJvbT0nbGVnYWR2c29sJyxmcm9tRGVzYz0nQWR2YW5jZWQgU29sYXIgQ29sbGVjdG9yJyx0bz0nY29yd2ludDInLHRvRGVzYz0nQWR2YW5jZWQgV2luZCBUdXJiaW5lJyx0aW1lcj0yNDB9LHtmcm9tPSdsZWd0aWRlJyxmcm9tRGVzYz0nVGlkYWwgR2VuZXJhdG9yJyx0bz0nY29ydXdmdXMnLHRvRGVzYz0nTmF2YWwgRnVzaW9uIFJlYWN0b3InLHRpbWVyPTMwMH0se2Zyb209J2xlZ21leCcsZnJvbURlc2M9J01ldGFsIEV4dHJhY3RvcicsdG89J2xlZ2Zha2VtZXgnLHRvRGVzYz0nLVdvcmthcm91bmQgRmFrZSBNZXgtJyx0aW1lcj0zNjB9LHtmcm9tPSdsZWdmYWtlbWV4Jyxmcm9tRGVzYz0nLVdvcmthcm91bmQgRmFrZSBNZXgtJyx0bz0nbGVnbW9obycsdG9EZXNjPSdBZHZhbmNlZCBNZXRhbCBFeHRyYWN0b3InLHRpbWVyPTJ9LHtmcm9tPSdsZWdkcmFnJyxmcm9tRGVzYz0iRHJhZ29uJ3MgVGVldGgiLHRvPSdjb3Jmb3J0Jyx0b0Rlc2M9J0ZvcnRpZmljYXRpb24gV2FsbCcsdGltZXI9MzYwfX19VW5pdERlZnNbJ2FybWZha2VtZXgnXT10YWJsZS5jb3B5KFVuaXREZWZzWydhcm1tZXgnXSlVbml0RGVmc1snYXJtZmFrZW1leCddLmV4dHJhY3RzbWV0YWw9MDtVbml0RGVmc1snYXJtZmFrZWdlbyddPXRhYmxlLmNvcHkoVW5pdERlZnNbJ2FybWdlbyddKVVuaXREZWZzWydhcm1mYWtlZ2VvJ10uY3VzdG9tcGFyYW1zLmdlb3RoZXJtYWw9bmlsO1VuaXREZWZzWydjb3JmYWtlbWV4J109dGFibGUuY29weShVbml0RGVmc1snY29ybWV4J10pVW5pdERlZnNbJ2NvcmZha2VtZXgnXS5leHRyYWN0c21ldGFsPTA7VW5pdERlZnNbJ2NvcmZha2VnZW8nXT10YWJsZS5jb3B5KFVuaXREZWZzWydjb3JnZW8nXSlVbml0RGVmc1snY29yZmFrZWdlbyddLmN1c3RvbXBhcmFtcy5nZW90aGVybWFsPW5pbDtVbml0RGVmc1snbGVnZmFrZW1leCddPXRhYmxlLmNvcHkoVW5pdERlZnNbJ2xlZ21leCddKVVuaXREZWZzWydsZWdmYWtlbWV4J10uZXh0cmFjdHNtZXRhbD0wO2ZvciBiLGMgaW4gcGFpcnMoVW5pdERlZnMpZG8gZmFjdGlvbj1zdHJpbmcuc3ViKGIsMSwzKWZvciBkLGUgaW4gcGFpcnMoYSlkbyBpZiBmYWN0aW9uPT1kIHRoZW4gZm9yIGUsZiBpbiBpcGFpcnMoYVtkXSlkbyBpZiBiPT1mLmZyb20gdGhlbiBpZiBmLmFubm91bmNlPT1uaWwgdGhlbiBmLmFubm91bmNlPWZhbHNlIGVuZDtjLmN1c3RvbXBhcmFtcz1jLmN1c3RvbXBhcmFtcyBvcnt9Yy5jdXN0b21wYXJhbXMuZXZvbHV0aW9uX3RhcmdldD1mLnRvO2lmIGYuYW5ub3VuY2U9PXRydWUgdGhlbiBjLmN1c3RvbXBhcmFtcy5ldm9sdXRpb25fYW5ub3VuY2VtZW50PXN0cmluZy5mb3JtYXQoJyVzIGV2b2x2ZWQgdG8gJXMhJyxmLmZyb21EZXNjLGYudG9EZXNjKWMuY3VzdG9tcGFyYW1zLmV2b2x1dGlvbl9hbm5vdW5jZW1lbnRfc2l6ZT1mLmFuU2l6ZSBvciAxMi41IGVuZDtjLmN1c3RvbXBhcmFtcy5ldm9sdXRpb25fY29uZGl0aW9uPSd0aW1lcidjLmN1c3RvbXBhcmFtcy5ldm9sdXRpb25fdGltZXI9Zi50aW1lciBvciAxMjA7Yy5jdXN0b21wYXJhbXMuZXZvbHV0aW9uX2hlYWx0aF90cmFuc2Zlcj0nZmxhdCdlbmQgZW5kIGVuZCBlbmQ7aWYgYj09J21pc3Npb25fY29tbWFuZF90b3dlcid0aGVuIGMud2VhcG9uZGVmcz1jLndlYXBvbmRlZnMgb3J7fWMud2VhcG9uZGVmc1sncmVwdWxzb3InXT17YXZvaWRmZWF0dXJlPWZhbHNlLHRleHR1cmUxPSdGbGFtZScsY3JhdGVyYXJlYW9mZWZmZWN0PTAsY3JhdGVyYm9vc3Q9MCxjcmF0ZXJtdWx0PTAsZWRnZWVmZmVjdGl2ZW5lc3M9Yy5oZWFsdGgvMTIwMDArMC4wNCxuYW1lPSdQbGFzbWFSZXB1bHNvcicscmFuZ2U9Nzc3LHNvdW5kaGl0d2V0PSdzaXp6bGUnLHdlYXBvbnR5cGU9J1NoaWVsZCcsZGFtYWdlPXtkZWZhdWx0PTQyMH0sc2hpZWxkPXthbHBoYT0wLjIsYXJtb3J0eXBlPSdzaGllbGRzJyxmb3JjZT1jLmhlYWx0aC80MjAwKzAuNDIsaW50ZXJjZXB0dHlwZT0xMjgscG93ZXI9Yy5oZWFsdGgqMC4zNSs0MjAscG93ZXJyZWdlbj0xMTc1MjYuNSxwb3dlcnJlZ2VuZW5lcmd5PTUwMCxyYWRpdXM9Nzc3LHJlcHVsc2VyPXRydWUsc21hcnQ9dHJ1ZSxzdGFydGluZ3Bvd2VyPWMuaGVhbHRoKjAuMjEsdmlzaWJsZT10cnVlLHZpc2libGVyZXB1bHNlPXRydWUsYmFkY29sb3I9e1sxXT0wLjcsWzJdPTAuMSxbM109MC4xLFs0XT0wLjJ9LGdvb2Rjb2xvcj17WzFdPTEuMSxbMl09MS4xLFszXT0xLjEsWzRdPTF9fX1jLndlYXBvbnM9Yy53ZWFwb25zIG9ye31jLndlYXBvbnNbI2Mud2VhcG9ucysxXT17ZGVmPSdSRVBVTFNPUicsb25seXRhcmdldGNhdGVnb3J5PSdOT1RTVUInfWVuZCBlbmQ
```
</details>

Example of error:
```
[t=03:48:32.707391][f=0034500] Error: [LuaRules::RunCallInTraceback] error=4 (LUA_ERRMEM) callin=GameFrame trace=[Internal Lua error: Call failure] not enough memory
[t=03:48:33.721755][f=0034500] Fatal: [spring_lua_alloc_log_error][handle=LuaRules][OOM] synced=1 {alloced,maximum}={1610612977,1610612736}bytes
[t=03:48:33.777163][f=0034500] [SpringApp::Kill][1] fromRun=1
```

To solve this I remove old/used evolution meta table items and implement an evolution limit for each gameframe and defer units to the next check. The delay imposed is compensated when the new unit is created to prevent a cascading delay. Since the evolved units have new keys in the evolution meta table they will not appear in the same order of the evolution check loop such that the same units are not deferred in the same order over and over again.

#### Test steps
Settings I used 
![image](https://github.com/user-attachments/assets/8262c6b1-fe26-484a-8986-28a3de9fe23d)

- [ ] Insert the tweak above, enable all units and timed evocom
- [ ] Run `/cheat 1` and `/give 2000 armwin`
- [ ] Speed up to 20x and wait for all of them to evolve to afus
- [ ] Verify evocom evolves to level 10 (just as a regression test)

This should crash on master before afus.
On this branch it should not crash.