### PR TITLE
Minor Issues + Typo BOS Cleanup

### DIFF
--- a/scripts/Units/armfido_clean.bos
+++ b/scripts/Units/armfido_clean.bos
@@ -284,7 +284,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 3) / animSpeed; 
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<1) animSpeed=1;

--- a/scripts/Units/armspid.bos
+++ b/scripts/Units/armspid.bos
@@ -463,7 +463,7 @@ StartMoving(){
 	start-script Walk();
 }
 StopMoving(){
-	\signal SIG_WALK;
+	signal SIG_WALK;
 	bMoving=FALSE;
 	call-script StopWalking();
 }

--- a/scripts/Units/armspid_clean.bos
+++ b/scripts/Units/armspid_clean.bos
@@ -449,7 +449,7 @@ StartMoving(reversing){
 	start-script Walk();
 }
 StopMoving(){
-	\signal SIGNAL_MOVE;
+	signal SIGNAL_MOVE;
 	isMoving=FALSE;
 	call-script StopWalking();
 }

--- a/scripts/Units/armzeus.bos
+++ b/scripts/Units/armzeus.bos
@@ -371,7 +371,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 3) / animSpeed; 
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<1) animSpeed=1;
@@ -453,7 +453,7 @@ drawgun()
 	
 	hide gunstatic;
 	show gunhand;
-	//turn luparm to x-axis <0> speed <360>; //90   arm bleibt beim schieïssen nun unten
+	//turn luparm to x-axis <0> speed <360>; //90   arm bleibt beim schieï¿½ssen nun unten
 	turn ruparm to x-axis <-60> speed <360>; //-179*   720
 	sleep 125;
 	turn ruparm to x-axis <-10> speed <360>;  //0* ****** arm position when shooting (only ruparm, rloarm is in aiming)

--- a/scripts/Units/armzeus.bos
+++ b/scripts/Units/armzeus.bos
@@ -453,12 +453,12 @@ drawgun()
 	
 	hide gunstatic;
 	show gunhand;
-	//turn luparm to x-axis <0> speed <360>; //90   arm bleibt beim schiessen nun unten
+	//turn luparm to x-axis <0> speed <360>;
 	turn ruparm to x-axis <-60> speed <360>; //-179*   720
 	sleep 125;
 	turn ruparm to x-axis <-10> speed <360>;  //0* ****** arm position when shooting (only ruparm, rloarm is in aiming)
 	sleep 125;
-	turn rloarm to x-axis <-40> speed <360>; //new armhaltung nach dem schiessen wenn waffe wieder im holster
+	turn rloarm to x-axis <-40> speed <360>;
 	sleep 125;  //new
 */
 

--- a/scripts/Units/armzeus.bos
+++ b/scripts/Units/armzeus.bos
@@ -453,7 +453,7 @@ drawgun()
 	
 	hide gunstatic;
 	show gunhand;
-	//turn luparm to x-axis <0> speed <360>; //90   arm bleibt beim schie�ssen nun unten
+	//turn luparm to x-axis <0> speed <360>; //90   arm bleibt beim schiessen nun unten
 	turn ruparm to x-axis <-60> speed <360>; //-179*   720
 	sleep 125;
 	turn ruparm to x-axis <-10> speed <360>;  //0* ****** arm position when shooting (only ruparm, rloarm is in aiming)

--- a/scripts/Units/coraak.bos
+++ b/scripts/Units/coraak.bos
@@ -219,7 +219,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 5) / animSpeed; 
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<2) animSpeed=2;

--- a/scripts/Units/coraak_clean.bos
+++ b/scripts/Units/coraak_clean.bos
@@ -217,7 +217,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 5) / animSpeed; 
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<2) animSpeed=2;

--- a/scripts/Units/coresupp.bos
+++ b/scripts/Units/coresupp.bos
@@ -122,13 +122,13 @@ StartMoving()
 	}
 }
 
-boatposition(speed, maxspeed)
+boatposition(_speed, maxspeed)
 {
-	speed = (get CURRENT_SPEED);
+	_speed = (get CURRENT_SPEED);
 	maxspeed = (get MAX_SPEED);
-	speed = speed * 100 /maxspeed;
-	if (speed > 50) turn base to x-axis <45> speed <30>;
-	if (speed < 50) turn base to x-axis <0> speed <30>;
+	_speed = _speed * 100 /maxspeed;
+	if (_speed > 50) turn base to x-axis <45> speed <30>;
+	if (_speed < 50) turn base to x-axis <0> speed <30>;
 }
 
 

--- a/scripts/Units/coresupp.bos
+++ b/scripts/Units/coresupp.bos
@@ -122,13 +122,13 @@ StartMoving()
 	}
 }
 
-boatposition(_speed, maxspeed)
+boatposition(speedCurrent, maxSpeed)
 {
-	_speed = (get CURRENT_SPEED);
-	maxspeed = (get MAX_SPEED);
-	_speed = _speed * 100 /maxspeed;
-	if (_speed > 50) turn base to x-axis <45> speed <30>;
-	if (_speed < 50) turn base to x-axis <0> speed <30>;
+	speedCurrent = (get CURRENT_SPEED);
+	maxSpeed = (get MAX_SPEED);
+	speedCurrent = speedCurrent * 100 / maxSpeed;
+	if (speedCurrent > 50) turn base to x-axis <45> speed <30>;
+	if (speedCurrent < 50) turn base to x-axis <0> speed <30>;
 }
 
 

--- a/scripts/Units/corjamt.bos
+++ b/scripts/Units/corjamt.bos
@@ -21,7 +21,7 @@ Stop()
 	return (0);
 }
 SetStunned(State)
-{c
+{
     Stunned = State;
 	if (Stunned) {
 	    call-script Stop();

--- a/scripts/Units/corkarg.bos
+++ b/scripts/Units/corkarg.bos
@@ -535,7 +535,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 20/9) / animSpeed;
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<1) animSpeed=1;

--- a/scripts/Units/corkarg_clean.bos
+++ b/scripts/Units/corkarg_clean.bos
@@ -533,7 +533,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 20/9) / animSpeed;
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<1) animSpeed=1;

--- a/scripts/Units/cortship.bos
+++ b/scripts/Units/cortship.bos
@@ -17,7 +17,7 @@ static-var  Static_Var_1, Static_Var_2, Static_Var_3, Static_Var_4, oldHead, Sta
 #define UNITSIZE 9
 #define MAXTILT 200
 
-#include "unit_hitbyweaponid_and_smoke.h
+#include "unit_hitbyweaponid_and_smoke.h"
 
 SetDirection(heading)
 {

--- a/scripts/Units/legbastion.bos
+++ b/scripts/Units/legbastion.bos
@@ -19,7 +19,7 @@ static-var  restore_delay, shotcount, timer, lastfired, gameframe, state, statec
 // A high precision requirement can result in overshoots if desired 
 // (c) CC BY NC ND Beherith mysterme@gmail.com
 //#define MAX_AIMY1_VELOCITY <3.00>
-#define AIMY1_maxacc<0.16>
+#define AIMY1_maxacc <0.16>
 //#define AIMY1_JERK <0.5>
 //#define AIMY1_PRECISION <1.2>
 //#define AIMY1_RESTORE_SPEED <1.0>

--- a/scripts/Units/legcen.bos
+++ b/scripts/Units/legcen.bos
@@ -284,7 +284,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 3) / animSpeed; 
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<2) animSpeed=2;

--- a/scripts/Units/legcen_clean.bos
+++ b/scripts/Units/legcen_clean.bos
@@ -282,7 +282,7 @@ UnitSpeed(){
 	maxSpeed = maxSpeed + (maxSpeed /(2*animFramesPerKeyframe)); // add fudge
 	while(TRUE){
 		animSpeed = (get CURRENT_SPEED);
-	\if (animSpeed<1) animSpeed=1;
+	if (animSpeed<1) animSpeed=1;
 		animSpeed = (maxSpeed * 3) / animSpeed; 
 		//get PRINT(maxSpeed, animFramesPerKeyframe, animSpeed); //how to print debug info from bos
 		if (animSpeed<2) animSpeed=2;

--- a/scripts/Units/legmech.bos
+++ b/scripts/Units/legmech.bos
@@ -478,8 +478,8 @@ AimWeapon1(heading, pitch)
 	
 	var cauaim;
     var cauface;
-    cauaim = get ATAN(aim_z, aim_x);                        //use arctan (ATAN) to calculate the angle of the turret. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180°), positive or negative depending on direction
-    cauface = get ATAN(face_z, face_x);                        //use arctan (ATAN) to calculate the angle of the hull. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180°), positive or negative depending on direction
+    cauaim = get ATAN(aim_z, aim_x);                        //use arctan (ATAN) to calculate the angle of the turret. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180ï¿½), positive or negative depending on direction
+    cauface = get ATAN(face_z, face_x);                        //use arctan (ATAN) to calculate the angle of the hull. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180ï¿½), positive or negative depending on direction
     
     //var torsoaim;
     torsoaim = cauface - cauaim;                                //calculate angle of turret relative to the hull

--- a/scripts/Units/legmech.bos
+++ b/scripts/Units/legmech.bos
@@ -478,8 +478,8 @@ AimWeapon1(heading, pitch)
 	
 	var cauaim;
     var cauface;
-    cauaim = get ATAN(aim_z, aim_x);                        //use arctan (ATAN) to calculate the angle of the turret. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180�), positive or negative depending on direction
-    cauface = get ATAN(face_z, face_x);                        //use arctan (ATAN) to calculate the angle of the hull. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180�), positive or negative depending on direction
+    cauaim = get ATAN(aim_z, aim_x);                        //use arctan (ATAN) to calculate the angle of the turret. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180 degrees), positive or negative depending on direction
+    cauface = get ATAN(face_z, face_x);                        //use arctan (ATAN) to calculate the angle of the hull. The result is in cau, which is the unit this code format uses for angles. Its up to 32768 (180 degrees), positive or negative depending on direction
     
     //var torsoaim;
     torsoaim = cauface - cauaim;                                //calculate angle of turret relative to the hull

--- a/scripts/Units/scavboss/corthermite.bos
+++ b/scripts/Units/scavboss/corthermite.bos
@@ -5,7 +5,7 @@
 
 piece  body, head, barrel1, barrel2, flare1, flare2,  leg1a,leg1b,leg2a,leg2b,leg3a,leg3b,leg4a,leg4b,leg5a,leg5b,leg6a,leg6b, aimy1, turretr, borer, barrelr, flameflarer;
 
-static-var  moving, Static_Var_2, restore_delay, gun_1,moveSpeed, currentSpeed,WALK_PERIOD, wpn1_lasthead, wpn2_lasthead, wpn3_lasthead, shotcount, shotcount2, _rand, chillshots, isreset, rollingchill;
+static-var  moving, Static_Var_2, restore_delay, gun_1,moveSpeed, currentSpeed,WALK_PERIOD, wpn1_lasthead, wpn2_lasthead, wpn3_lasthead, shotcount, shotcount2, randTemp, chillshots, isreset, rollingchill;
 
 // Signal definitions
 #define SIG_AIM				2
@@ -248,7 +248,7 @@ Create()
 	hide flare1;
 	hide flare2;
 	hide aimy1;
-	_rand = 0;
+	randTemp = 0;
 	moving = FALSE;
 	//firing = FALSE;
 	isreset = TRUE;
@@ -305,10 +305,10 @@ puff() {
 			set-signal-mask SIG_PUFF;
 			emit-sfx 1024 + 1 from flameflarer;
 			sleep 5000;
-			_rand = Rand( 3, 5 );
-			sleep _rand * 1000;
-			_rand = Rand( 1, 5 );
-			if (_rand<5) start-script puff();
+			randTemp = Rand( 3, 5 );
+			sleep randTemp * 1000;
+			randTemp = Rand( 1, 5 );
+			if (randTemp<5) start-script puff();
 		}
 
 }// nothing to see here */

--- a/scripts/Units/scavboss/corthermite.bos
+++ b/scripts/Units/scavboss/corthermite.bos
@@ -5,7 +5,7 @@
 
 piece  body, head, barrel1, barrel2, flare1, flare2,  leg1a,leg1b,leg2a,leg2b,leg3a,leg3b,leg4a,leg4b,leg5a,leg5b,leg6a,leg6b, aimy1, turretr, borer, barrelr, flameflarer;
 
-static-var  moving, Static_Var_2, restore_delay, gun_1,moveSpeed, currentSpeed,WALK_PERIOD, wpn1_lasthead, wpn2_lasthead, wpn3_lasthead, shotcount, shotcount2, rand, chillshots, isreset, rollingchill;
+static-var  moving, Static_Var_2, restore_delay, gun_1,moveSpeed, currentSpeed,WALK_PERIOD, wpn1_lasthead, wpn2_lasthead, wpn3_lasthead, shotcount, shotcount2, _rand, chillshots, isreset, rollingchill;
 
 // Signal definitions
 #define SIG_AIM				2
@@ -248,7 +248,7 @@ Create()
 	hide flare1;
 	hide flare2;
 	hide aimy1;
-	rand = 0;
+	_rand = 0;
 	moving = FALSE;
 	//firing = FALSE;
 	isreset = TRUE;
@@ -305,10 +305,10 @@ puff() {
 			set-signal-mask SIG_PUFF;
 			emit-sfx 1024 + 1 from flameflarer;
 			sleep 5000;
-			rand = Rand( 3, 5 );
-			sleep rand * 1000;
-			rand = Rand( 1, 5 );
-			if (rand<5) start-script puff();
+			_rand = Rand( 3, 5 );
+			sleep _rand * 1000;
+			_rand = Rand( 1, 5 );
+			if (_rand<5) start-script puff();
 		}
 
 }// nothing to see here */

--- a/scripts/Units/scavboss/legfortt4.bos
+++ b/scripts/Units/scavboss/legfortt4.bos
@@ -1,5 +1,5 @@
 
-#include "../recoil_common_includes.h"
+#include "../../recoil_common_includes.h"
 
 piece  	leftplasmaflare1, leftplasmaflare2, leftplasmaflare3, rightplasmaflare1, rightplasmaflare2, rightplasmaflare3, 
 		rocketflare1, rocketflare2, rocketflare3, rocketflare4, rocketflare5, rocketflare6, 

--- a/scripts/Units/scavboss/leggobt3.bos
+++ b/scripts/Units/scavboss/leggobt3.bos
@@ -1,5 +1,5 @@
 
-#include "../recoil_common_includes.h"
+#include "../../recoil_common_includes.h"
 
 piece  torso, flare, sleeve, pelvis, rleg, rfoot, lleg, lfoot, lthigh, rthigh, aimx1, aimy1, lbarrel;
 

--- a/scripts/Units/scavboss/legsrailt4.bos
+++ b/scripts/Units/scavboss/legsrailt4.bos
@@ -1,5 +1,5 @@
 
-#include "../recoil_common_includes.h"
+#include "../../recoil_common_includes.h"
 		
 piece 	flare1, pelvis, aimy1, turret, aimx1, turretarm, sleeve, wedge, barrel, sleelvedeco1, sleevedeco2, armor,
 		hingefl, 	hingefr, 	hingeml, 	hingemr, 	hingebl, 	hingebr,

--- a/scripts/factories_common.h
+++ b/scripts/factories_common.h
@@ -31,7 +31,7 @@ Deactivate()
 		sleep 1430; \
 		set YARD_OPEN to 1; \
 	} \
-	set INBUILDSTANCE to 1; \
+	set INBUILDSTANCE to 1;
 	
 #define FACTORY_CLOSE_BUILD 	set YARD_OPEN to 0;\
 	while( get YARD_OPEN )\
@@ -41,4 +41,4 @@ Deactivate()
 		set YARD_OPEN to 0;\
 	}\
 	set BUGGER_OFF to 1;\
-	set INBUILDSTANCE to 0;\
+	set INBUILDSTANCE to 0;

--- a/scripts/freefusion.bos
+++ b/scripts/freefusion.bos
@@ -81,7 +81,6 @@ SweetSpot(piecenum)
 
 Killed(severity, corpsetype)
 {
-{
 	if( severity <= 25 )
 	{
 		corpsetype = 1;

--- a/scripts/freefusion_clean.bos
+++ b/scripts/freefusion_clean.bos
@@ -5,7 +5,7 @@ piece  base, column1,column2,column3,column4,fusionsphere, emit;
 
 #define BASEPIECE base
 #define MAXTILT 0
-#include "../unit_hitbyweaponid_and_smoke.h"
+#include "unit_hitbyweaponid_and_smoke.h"
 
 Activate()
 {


### PR DESCRIPTION
While toying around with making my own BOS parser, I found some issues in a few .bos files themselves.

### Work done
fix minor issues and typos in .bos files

11 instances of extraneous characters: `{`, `c`, or `\`
2 instances of character encoding being incorrect for UTF8
5 instances of broken `#include` statements (mostly making sure that relative imports have the correct depth)
2 instances of bad `#define` statements
2 instances of keyword <-> variable name collision (may or may not be an issue for BARScriptCompiler)
