### PR TITLE
Factory exitonly yardmaps

### DIFF
--- a/units/ArmBuildings/LandFactories/armalab.lua
+++ b/units/ArmBuildings/LandFactories/armalab.lua
@@ -30,7 +30,7 @@ return {
 		sightdistance = 286,
 		terraformspeed = 1000,
 		workertime = 300,
-		yardmap = "ooooooooo ooooooooo ooooooooo ooooooooo ccccccccc ccccccccc ccccccccc ccccccccc ccccccccc",
+		yardmap = "ooooooooo ooooooooo ooooooooo ooooooooo eeeeeeeee eeeeeeeee eeeeeeeee eeeeeeeee eeeeeeeee",
 		buildoptions = {
 			[1] = "armack",
 			[2] = "armfark",

--- a/units/ArmBuildings/LandFactories/armavp.lua
+++ b/units/ArmBuildings/LandFactories/armavp.lua
@@ -31,7 +31,7 @@ return {
 		sightdistance = 283.39999,
 		terraformspeed = 1000,
 		workertime = 300,
-		yardmap = "ooooooooo ooooooooo ooooooooo ooooooooo oocccccoo oocccccoo oocccccoo oocccccoo oocccccoo",
+		yardmap = "ooooooooo ooooooooo ooooooooo ooooooooo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo",
 		buildoptions = {
 			[1] = "armacv",
 			[2] = "armconsul",

--- a/units/ArmBuildings/LandFactories/armhp.lua
+++ b/units/ArmBuildings/LandFactories/armhp.lua
@@ -28,7 +28,7 @@ return {
 		sightdistance = 286,
 		terraformspeed = 1000,
 		workertime = 100,
-		yardmap = "occcco occcco occcco occcco occcco occcco",
+		yardmap = "oeeeeo oeeeeo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "armch",
 			[2] = "armsh",

--- a/units/ArmBuildings/LandFactories/armlab.lua
+++ b/units/ArmBuildings/LandFactories/armlab.lua
@@ -30,7 +30,7 @@ return {
 		sightdistance = 290,
 		terraformspeed = 500,
 		workertime = 100,
-		yardmap = "oooooooooooooooooocccccccccccccccccc",
+		yardmap = "ooooooooooooooooooeeeeeeeeeeeeeeeeee",
 		buildoptions = {
 			[1] = "armck",
 			[2] = "armpw",

--- a/units/ArmBuildings/LandFactories/armshltx.lua
+++ b/units/ArmBuildings/LandFactories/armshltx.lua
@@ -29,7 +29,7 @@ return {
 		sightdistance = 273,
 		terraformspeed = 3000,
 		workertime = 600,
-		yardmap = "oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo cccccccccccc cccccccccccc cccccccccccc cccccccccccc cccccccccccc cccccccccccc",
+		yardmap = "oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee",
 		buildoptions = {
 			[1] = "armbanth",
 			[2] = "armraz",

--- a/units/ArmBuildings/LandFactories/armvp.lua
+++ b/units/ArmBuildings/LandFactories/armvp.lua
@@ -30,7 +30,7 @@ return {
 		sightdistance = 273,
 		terraformspeed = 500,
 		workertime = 100,
-		yardmap = "oooooo oooooo oooooo occcco occcco occcco",
+		yardmap = "oooooo oooooo oooooo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "armcv",
 			[2] = "armbeaver",

--- a/units/ArmBuildings/SeaFactories/armamsub.lua
+++ b/units/ArmBuildings/SeaFactories/armamsub.lua
@@ -28,7 +28,7 @@ return {
 		sightdistance = 234,
 		terraformspeed = 750,
 		workertime = 150,
-		yardmap = "oooooo oooooo occcco occcco occcco occcco",
+		yardmap = "oooooo oooooo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "armbeaver",
 			[2] = "armpincer",

--- a/units/ArmBuildings/SeaFactories/armasy.lua
+++ b/units/ArmBuildings/SeaFactories/armasy.lua
@@ -29,7 +29,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 1.5,
 		workertime = 300,
-		yardmap = "wCCCCCCCCCCw CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC CCCCCCCCCCCC wCCCCCCCCCCw",
+		yardmap = "weeeeeeeeeew eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee weeeeeeeeeew",
 		buildoptions = {
 			[1] = "armacsub",
 			[2] = "armmls",

--- a/units/ArmBuildings/SeaFactories/armfhp.lua
+++ b/units/ArmBuildings/SeaFactories/armfhp.lua
@@ -28,7 +28,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 4,
 		workertime = 100,
-		yardmap = "wCCCCw wCCCCw wCCCCw wCCCCw wCCCCw wCCCCw",
+		yardmap = "weeeew weeeew weeeew weeeew weeeew weeeew",
 		buildoptions = {
 			[1] = "armch",
 			[2] = "armsh",

--- a/units/ArmBuildings/SeaFactories/armplat.lua
+++ b/units/ArmBuildings/SeaFactories/armplat.lua
@@ -30,7 +30,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 39,
 		workertime = 200,
-		yardmap = "wwwwww wCCCCw wCCCCw wCCCCw wCCCCw wwwwww",
+		yardmap = "wwwwww weeeew weeeew weeeew weeeew wwwwww",
 		buildoptions = {
 			[1] = "armcsa",
 			[2] = "armsaber",

--- a/units/ArmBuildings/SeaFactories/armshltxuw.lua
+++ b/units/ArmBuildings/SeaFactories/armshltxuw.lua
@@ -29,7 +29,7 @@ return {
 		sightdistance = 273,
 		terraformspeed = 3000,
 		workertime = 600,
-		yardmap = "oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo cccccccccccc cccccccccccc cccccccccccc cccccccccccc cccccccccccc cccccccccccc",
+		yardmap = "oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo oooooooooooo eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee eeeeeeeeeeee",
 		buildoptions = {
 			[1] = "armbanth",
 			[2] = "armmar",

--- a/units/ArmBuildings/SeaFactories/armsy.lua
+++ b/units/ArmBuildings/SeaFactories/armsy.lua
@@ -29,7 +29,7 @@ return {
 		terraformspeed = 500,
 		waterline = 1,
 		workertime = 165,
-		yardmap = "oyyyyo yccccy yccccy yccccy yccccy oyyyyo",
+		yardmap = "oyyyyo yeeeey yeeeey yeeeey yeeeey oyyyyo",
 		buildoptions = {
 			[1] = "armcs",
 			[2] = "armrecl",

--- a/units/CorBuildings/LandFactories/coralab.lua
+++ b/units/CorBuildings/LandFactories/coralab.lua
@@ -30,7 +30,7 @@ return {
 		sightdistance = 288.60001,
 		terraformspeed = 1000,
 		workertime = 300,
-		yardmap = "ooooooooo ooooooooo ooocccooo ooocccooo oocccccoo oocccccoo oocccccoo oocccccoo oocccccoo",
+		yardmap = "ooooooooo ooooooooo oooeeeooo oooeeeooo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo",
 		buildoptions = {
 			[1] = "corack",
 			[2] = "corfast",

--- a/units/CorBuildings/LandFactories/coravp.lua
+++ b/units/CorBuildings/LandFactories/coravp.lua
@@ -31,7 +31,7 @@ return {
 		sightdistance = 286,
 		terraformspeed = 1000,
 		workertime = 300,
-		yardmap = "ooooooooo ooooooooo ooooooooo oocccccoo oocccccoo oocccccoo oocccccoo oocccccoo oocccccoo",
+		yardmap = "ooooooooo ooooooooo ooooooooo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo",
 		buildoptions = {
 			[1] = "coracv",
 			[2] = "corsala",

--- a/units/CorBuildings/LandFactories/corgant.lua
+++ b/units/CorBuildings/LandFactories/corgant.lua
@@ -29,7 +29,7 @@ return {
 		sightdistance = 273,
 		terraformspeed = 3000,
 		workertime = 600,
-		yardmap = "oooooooooooo oooooooooooo oooooooooooo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo",
+		yardmap = "oooooooooooo oooooooooooo oooooooooooo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo",
 		buildoptions = {
 			[1] = "corkorg",
 			[2] = "corkarg",

--- a/units/CorBuildings/LandFactories/corhp.lua
+++ b/units/CorBuildings/LandFactories/corhp.lua
@@ -29,7 +29,7 @@ return {
 		sightdistance = 312,
 		terraformspeed = 1000,
 		workertime = 100,
-		yardmap = "occcco occcco occcco occcco occcco occcco",
+		yardmap = "oeeeeo oeeeeo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "corch",
 			[2] = "corsh",

--- a/units/CorBuildings/LandFactories/corlab.lua
+++ b/units/CorBuildings/LandFactories/corlab.lua
@@ -30,7 +30,7 @@ return {
 		sightdistance = 290,
 		terraformspeed = 500,
 		workertime = 100,
-		yardmap = "occccooccccooccccooccccooccccoocccco",
+		yardmap = "oeeeeooeeeeooeeeeooeeeeooeeeeooeeeeo",
 		buildoptions = {
 			[1] = "corck",
 			[2] = "corak",

--- a/units/CorBuildings/LandFactories/corvp.lua
+++ b/units/CorBuildings/LandFactories/corvp.lua
@@ -31,7 +31,7 @@ return {
 		sightdistance = 279,
 		terraformspeed = 500,
 		workertime = 100,
-		yardmap = "oooooo oooooo occcco occcco occcco occcco",
+		yardmap = "oooooo oooooo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "corcv",
 			[2] = "cormuskrat",

--- a/units/CorBuildings/SeaFactories/coramsub.lua
+++ b/units/CorBuildings/SeaFactories/coramsub.lua
@@ -28,7 +28,7 @@ return {
 		sightdistance = 240,
 		terraformspeed = 750,
 		workertime = 150,
-		yardmap = "oooooo oooooo oCCCCo oCCCCo oCCCCo oCCCCo",
+		yardmap = "oooooo oooooo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "cormuskrat",
 			[2] = "corgarp",

--- a/units/CorBuildings/SeaFactories/corasy.lua
+++ b/units/CorBuildings/SeaFactories/corasy.lua
@@ -29,7 +29,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 19,
 		workertime = 300,
-		yardmap = "wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw wCCCCCCCCCCw",
+		yardmap = "weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew weeeeeeeeeew",
 		buildoptions = {
 			[1] = "coracsub",
 			[2] = "cormls",

--- a/units/CorBuildings/SeaFactories/corfhp.lua
+++ b/units/CorBuildings/SeaFactories/corfhp.lua
@@ -29,7 +29,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 4,
 		workertime = 100,
-		yardmap = "wCCCCw wCCCCw wCCCCw wCCCCw wCCCCw wCCCCw",
+		yardmap = "weeeew weeeew weeeew weeeew weeeew weeeew",
 		buildoptions = {
 			[1] = "corch",
 			[2] = "corsh",

--- a/units/CorBuildings/SeaFactories/corgantuw.lua
+++ b/units/CorBuildings/SeaFactories/corgantuw.lua
@@ -29,7 +29,7 @@ return {
 		sightdistance = 273,
 		terraformspeed = 3000,
 		workertime = 600,
-		yardmap = "oooooooooooo oooooooooooo oooooooooooo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo",
+		yardmap = "oooooooooooo oooooooooooo oooooooooooo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo",
 		buildoptions = {
 			[1] = "corkorg",
 			[2] = "corshiva",

--- a/units/CorBuildings/SeaFactories/corplat.lua
+++ b/units/CorBuildings/SeaFactories/corplat.lua
@@ -28,7 +28,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 43,
 		workertime = 200,
-		yardmap = "wwwwww wCCCCw wCCCCw wCCCCw wCCCCw wwwwww",
+		yardmap = "wwwwww weeeew weeeew weeeew weeeew wwwwww",
 		buildoptions = {
 			[1] = "corcsa",
 			[2] = "corcut",

--- a/units/CorBuildings/SeaFactories/corsy.lua
+++ b/units/CorBuildings/SeaFactories/corsy.lua
@@ -29,7 +29,7 @@ return {
 		terraformspeed = 500,
 		waterline = 1,
 		workertime = 165,
-		yardmap = "oyyyyo occcco occcco occcco occcco oyyyyo",
+		yardmap = "oyyyyo oeeeeo oeeeeo oeeeeo oeeeeo oyyyyo",
 		buildoptions = {
 			[1] = "corcs",
 			[2] = "correcl",

--- a/units/Legion/Labs/legalab.lua
+++ b/units/Legion/Labs/legalab.lua
@@ -31,7 +31,7 @@ return {
 		sightdistance = 288.60001,
 		terraformspeed = 1000,
 		workertime = 300,
-		yardmap = "ooooooooo ooooooooo ooocccooo ooocccooo oocccccoo oocccccoo oocccccoo oocccccoo oocccccoo",
+		yardmap = "ooooooooo ooooooooo oooeeeooo oooeeeooo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo ooeeeeeoo",
 		buildoptions = {
 			[1] = "legack",
 			[2] = "legaceb",

--- a/units/Legion/Labs/legamsub.lua
+++ b/units/Legion/Labs/legamsub.lua
@@ -28,7 +28,7 @@ return {
 		sightdistance = 240,
 		terraformspeed = 750,
 		workertime = 150,
-		yardmap = "oooooo oooooo oCCCCo oCCCCo oCCCCo oCCCCo",
+		yardmap = "oooooo oooooo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "legotter",
 			[2] = "legamphtank",

--- a/units/Legion/Labs/legavp.lua
+++ b/units/Legion/Labs/legavp.lua
@@ -42,15 +42,15 @@ return {
         oo oo oo oo oo oo oo oo oo
         oo oo oo oo oo oo oo oo oo
         oo oo oo oo oo oo oo oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
-        oo oo oc cc cc cc co oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
+        oo oo oe ee ee ee eo oo oo
         ]],
 		buildoptions = {
 			"legacv",

--- a/units/Legion/Labs/legfhp.lua
+++ b/units/Legion/Labs/legfhp.lua
@@ -28,7 +28,7 @@ return {
 		terraformspeed = 1000,
 		waterline = 4,
 		workertime = 100,
-		yardmap = "wCCCCw wCCCCw wCCCCw wCCCCw wCCCCw wCCCCw",
+		yardmap = "weeeew weeeew weeeew weeeew weeeew weeeew",
 		buildoptions = {
 			[1] = "legch",
 			[2] = "legsh",

--- a/units/Legion/Labs/leggant.lua
+++ b/units/Legion/Labs/leggant.lua
@@ -30,7 +30,7 @@ return {
 		sightdistance = 273,
 		terraformspeed = 3000,
 		workertime = 600,
-		yardmap = "oooooooooooo oooooooooooo oooooooooooo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo ooccccccccoo yoccccccccoy",
+		yardmap = "oooooooooooo oooooooooooo oooooooooooo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo ooeeeeeeeeoo yoeeeeeeeeoy",
 		buildoptions = {
 			[1] = "corkorg",
 			[2] = "corkarg",

--- a/units/Legion/Labs/leghp.lua
+++ b/units/Legion/Labs/leghp.lua
@@ -29,7 +29,7 @@ return {
 		sightdistance = 312,
 		terraformspeed = 1000,
 		workertime = 100,
-		yardmap = "occcco occcco occcco occcco occcco occcco",
+		yardmap = "oeeeeo oeeeeo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "legch",
 			[2] = "legsh",

--- a/units/Legion/Labs/legjim.lua
+++ b/units/Legion/Labs/legjim.lua
@@ -29,7 +29,7 @@ return {
 		terraformspeed = 500,
 		waterline = 1,
 		workertime = 165,
-		yardmap = "oyyyyo yccccy yccccy yccccy yccccy oyyyyo",
+		yardmap = "oyyyyo yeeeey yeeeey yeeeey yeeeey oyyyyo",
 		buildoptions = {
 			[1] = "legcs",
 

--- a/units/Legion/Labs/leglab.lua
+++ b/units/Legion/Labs/leglab.lua
@@ -31,7 +31,7 @@ return {
 		sightdistance = 290,
 		terraformspeed = 500,
 		workertime = 100,
-		yardmap = "oooooo oooooo occcco occcco occcco occcco",
+		yardmap = "oooooo oooooo oeeeeo oeeeeo oeeeeo oeeeeo",
 		buildoptions = {
 			[1] = "legck",
 			[2] = "cornecro",

--- a/units/Legion/Labs/legvp.lua
+++ b/units/Legion/Labs/legvp.lua
@@ -37,14 +37,14 @@ return {
     oo oo oo oo oo oo
     oo oo oo oo oo oo
     oo oo oo oo oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
-    oc cc cc cc oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
+    oe ee ee ee oo oo
     ]],
 		buildoptions = {
 			[1] = "legscout",


### PR DESCRIPTION
All factory yardmaps updated to be exit only (c > e)

### Work done
Updated all factory yardmaps from "c" tags to "e"

#### Addresses Issue(s)
Prevents
* units traveling into yardmaps and blocking nanoframe placement
* units traveling into yardmaps and not being targetable 
* building on factory yardmaps with things like dragons teeth with the goal to self-d and perform faster reclaim of the building

#### Setup
Place labs, spawn unit, turn on /debugpath and compare unit pathing

### Notes/etc
This still allows units to travel through factories only if their directly touching another factory - hoverlabs & cor botlab for example
in action #dev-main: https://discord.com/channels/549281623154229250/549282166543089674/1336367965729325117

#### AFTER:
![Armada labs](https://github.com/user-attachments/assets/c69c8232-2789-400a-8312-68ad43c3f95e)
![Cortext labs](https://github.com/user-attachments/assets/4a923300-8bba-47de-b14f-cbeefe9301d4)
![Legion labs](https://github.com/user-attachments/assets/84326787-3ea8-4f65-9da0-395604dd299e)
