### PR TITLE
Widget subfolders

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -19,7 +19,6 @@ local gl = gl
 
 local CONFIG_FILENAME = LUAUI_DIRNAME .. 'Config/' .. Game.gameShortName .. '.lua'
 local WIDGET_DIRNAME = LUAUI_DIRNAME .. 'Widgets/'
-local WIDGET_DIRNAME_MAP = LUAUI_DIRNAME .. 'Widgets/'
 
 local SELECTOR_BASENAME = 'selector.lua'
 
@@ -301,6 +300,7 @@ end
 
 
 --------------------------------------------------------------------------------
+local unsortedWidgets = {}
 local doMoreYield = (Spring.Yield ~= nil);
 
 local function Yield()
@@ -314,59 +314,43 @@ local zipOnly = {
 	["Widget Profiler"] = true,
 }
 
+local function loadWidgetFiles(vfsMode)
+	local fromZip = vfsMode ~= VFS.RAW
+	local widgetFiles = VFS.DirList(WIDGET_DIRNAME, "*.lua", vfsMode)
+
+	for _, file in ipairs(widgetFiles) do
+		local widget = widgetHandler:LoadWidget(file, fromZip)
+		local excludeWidget = not fromZip and zipOnly[widget.whInfo.name]
+
+		if widget and not excludeWidget then
+			table.insert(unsortedWidgets, widget)
+			Yield()
+		end
+	end
+end
+
 function widgetHandler:Initialize()
 	widgetHandler:CreateQueuedReorderFuncs()
 	widgetHandler:HookReorderSpecialFuncs()
 	self:LoadConfigData()
 
-	-- do we allow userland widgets?
 	if self.allowUserWidgets == nil then
 		self.allowUserWidgets = true
 	end
+
+	
+	Spring.CreateDir(LUAUI_DIRNAME .. 'Config')
+	
 	if self.allowUserWidgets and allowuserwidgets then
 		Spring.Echo("LuaUI: Allowing User Widgets")
+		loadWidgetFiles(VFS.RAW)
 	else
 		Spring.Echo("LuaUI: Disallowing User Widgets")
 	end
 
-	-- create the "LuaUI/Config" directory
-	Spring.CreateDir(LUAUI_DIRNAME .. 'Config')
+	loadWidgetFiles(VFS.ZIP)
+	loadWidgetFiles(VFS.MAP)
 
-	local unsortedWidgets = {}
-
-	-- stuff the raw widgets into unsortedWidgets
-	if self.allowUserWidgets and allowuserwidgets then
-		local widgetFiles = VFS.DirList(WIDGET_DIRNAME, "*.lua", VFS.RAW)
-		for k, wf in ipairs(widgetFiles) do
-			local widget = self:LoadWidget(wf, false)
-			if widget and not zipOnly[widget.whInfo.name] then
-				table.insert(unsortedWidgets, widget)
-				Yield()
-			end
-		end
-	end
-
-	-- stuff the zip widgets into unsortedWidgets
-	local widgetFiles = VFS.DirList(WIDGET_DIRNAME, "*.lua", VFS.ZIP)
-	for k, wf in ipairs(widgetFiles) do
-		local widget = self:LoadWidget(wf, true)
-		if widget then
-			table.insert(unsortedWidgets, widget)
-			Yield()
-		end
-	end
-
-	-- stuff the map widgets into unsortedWidgets
-	local widgetFiles = VFS.DirList(WIDGET_DIRNAME_MAP, "*.lua", VFS.MAP)
-	for k, wf in ipairs(widgetFiles) do
-		local widget = self:LoadWidget(wf, true)
-		if widget then
-			table.insert(unsortedWidgets, widget)
-			Yield()
-		end
-	end
-
-	-- sort the widgets
 	table.sort(unsortedWidgets, function(w1, w2)
 		local l1 = w1.whInfo.layer
 		local l2 = w2.whInfo.layer
@@ -384,7 +368,6 @@ function widgetHandler:Initialize()
 		end
 	end)
 
-	-- add the widgets
 	for _, w in ipairs(unsortedWidgets) do
 		local name = w.whInfo.name
 		local basename = w.whInfo.basename
@@ -394,8 +377,7 @@ function widgetHandler:Initialize()
 		widgetHandler:InsertWidgetRaw(w)
 	end
 
-	-- Since Initialize is run out of the normal callin wrapper by InsertWidget,
-	-- we, need to reorder explicitly here.
+	-- Since Initialize is run out of the normal callin wrapper by InsertWidget, we, need to reorder explicitly here.
 	widgetHandler:PerformReorders()
 
 	-- save the active widgets, and their ordering

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -318,6 +318,10 @@ local function loadWidgetFiles(vfsMode)
 	local fromZip = vfsMode ~= VFS.RAW
 	local widgetFiles = VFS.DirList(WIDGET_DIRNAME, "*.lua", vfsMode)
 
+	for _, subDirectory in ipairs( VFS.SubDirs(WIDGET_DIRNAME) ) do
+		table.append( widgetFiles, VFS.DirList(subDirectory, "*.lua", vfsMode) )
+	end
+
 	for _, file in ipairs(widgetFiles) do
 		local widget = widgetHandler:LoadWidget(file, fromZip)
 		local excludeWidget = not fromZip and zipOnly[widget.whInfo.name]

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -354,7 +354,6 @@ function widgetHandler:Initialize()
 	end
 
 	loadWidgetFiles(VFS.ZIP)
-	loadWidgetFiles(VFS.MAP)
 
 	table.sort(unsortedWidgets, function(w1, w2)
 		local l1 = w1.whInfo.layer

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -324,7 +324,7 @@ local function loadWidgetFiles(vfsMode)
 
 	for _, file in ipairs(widgetFiles) do
 		local widget = widgetHandler:LoadWidget(file, fromZip)
-		local excludeWidget = not fromZip and zipOnly[widget.whInfo.name]
+		local excludeWidget = widget and not fromZip and zipOnly[widget.whInfo.name]
 
 		if widget and not excludeWidget then
 			table.insert(unsortedWidgets, widget)

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -300,7 +300,7 @@ end
 
 
 --------------------------------------------------------------------------------
-local unsortedWidgets = {}
+local unsortedWidgets
 local doMoreYield = (Spring.Yield ~= nil);
 
 local function Yield()
@@ -342,9 +342,10 @@ function widgetHandler:Initialize()
 		self.allowUserWidgets = true
 	end
 
-	
 	Spring.CreateDir(LUAUI_DIRNAME .. 'Config')
-	
+
+	unsortedWidgets = {}
+
 	if self.allowUserWidgets and allowuserwidgets then
 		Spring.Echo("LuaUI: Allowing User Widgets")
 		loadWidgetFiles(VFS.RAW)


### PR DESCRIPTION
### Work done
Support loading widgets inside subdirectories inside the widgets directory. This is to support development with rmlui, so each widget can group its .lua, .rml, and any resource files together.

#### Test steps
- [ ] Start game, verify nothing has changed.
- [ ] Add custom widget, start game, verify it loads properly.
- [ ] Add broken custom widget, start game, verify LuaUI still loads