### PR TITLE
Fix ArrayRemove

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -789,18 +789,18 @@ local function ArrayInsert(t, f, w)
 	end
 end
 
-local function ArrayRemove(t, w)
-	local i = 1
-	local n = #t
-	while i <= n do
-	  	if t[i] == w then
+---Removes all elements equal to value from given array.
+---@generic V
+---@param t V[]
+---@param value V
+local function ArrayRemove(t, value)
+	for i = #t, 1, -1 do
+		if t[i] == value then
 			table.remove(t, i)
-			n = n - 1
-		else
-			i = i + 1
-	  	end
+		end
 	end
 end
+
 
 --------------------------------------------------------------------------------
 --- Safe reordering

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -790,11 +790,14 @@ local function ArrayInsert(t, f, w)
 end
 
 local function ArrayRemove(t, w)
-	for k, v in ipairs(t) do
-		if v == w then
-			table.remove(t, k)
-			--break
-		end
+	local i = 1
+	local n = #t
+	while i < n do
+	  	if t[i] == w then
+			table.remove(t, i)
+		else
+			i = i + 1
+	  	end
 	end
 end
 

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -792,9 +792,10 @@ end
 local function ArrayRemove(t, w)
 	local i = 1
 	local n = #t
-	while i < n do
+	while i <= n do
 	  	if t[i] == w then
 			table.remove(t, i)
+			n = n - 1
 		else
 			i = i + 1
 	  	end


### PR DESCRIPTION
### Work done
Fixes `ArrayRemove` function in `barwidgets.lua`.
Before the fix, any table with consecutive elements equal to each other, passed to a function, would produce an incorrect result.
Example:
```lua
local t = {1,2,1,1,2,1,}
ArrayRemove(t, 1)
--- t = {2, 1, 2}
```
Corrected version doesn't have this flaw.