### PR TITLE
Remove friendly crush damage

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -70,7 +70,7 @@ local modrules = {
 	movement = {
 		allowUnitCollisionDamage = true,	-- default: true if using QTPFS pathfinder.  Do unit-unit (skidding) collisions cause damage?
 		allowUnitCollisionOverlap = false,	-- can mobile units collision volumes overlap one another? Allows unit movement like this (video http://www.youtube.com/watch?v=mRtePUdVk2o ) at the cost of more 'clumping'.
-		allowCrushingAlliedUnits = true,	-- default: false.  Can allied ground units crush each other during collisions? Units still have to be explicitly set as crushable using the crushable parameter of Spring.SetUnitBlocking.
+		allowCrushingAlliedUnits = false,	-- default: false.  Can allied ground units crush each other during collisions? Units still have to be explicitly set as crushable using the crushable parameter of Spring.SetUnitBlocking.
 		allowGroundUnitGravity = false,		-- default: true.   Allows fast moving mobile units to 'catch air' as they move over terrain.
 		--NOTE: allowGroundUnitGravity was set to false to "Fix units flying over hills and bumps", but this came at a cost for unit impulse which was a desired trait
 		--allowGroundUnitGravity = true, is possibly causing units getting stuck in labs


### PR DESCRIPTION
### Work done
Change the value `allowCrushingAlliedUnits` to false in modrules.lua. Units no longer destroy friendly units through crush damage, they now pass through them. This removes a large point of frustration, especially in PvE matches.

#### Test steps
- [ ] Spawn some Dragon's Teeth (armdrag) and Fortification Walls (armfort)
- [ ] Spawn a heavy unit (e.g. Thor (armthor))
- [ ] Give heavy unit order to move through walls

#### BEFORE:
![screen_2025-02-21_20-59-26-737](https://github.com/user-attachments/assets/46a51598-1a2a-4852-9fe8-3eb715803721)

#### AFTER:
![screen_2025-02-21_20-56-04-795](https://github.com/user-attachments/assets/587a323a-5305-406f-8c3d-18f886274924)