### PR TITLE
Fix dof shader using old shaders folder path

### DIFF
--- a/luaui/Widgets/gfx_dof.lua
+++ b/luaui/Widgets/gfx_dof.lua
@@ -282,7 +282,7 @@ function init()
 			"#define LOW_QUALITY 0 \n",
 			"#define HIGH_QUALITY 1 \n"
 		},
-		fragment = VFS.LoadFile("LuaUI\\Widgets\\Shaders\\dof.fs", VFS.RAW_FIRST),
+		fragment = VFS.LoadFile("LuaUI/Shaders/dof.fs", VFS.RAW_FIRST),
 
 		uniformInt = {origTex = 0, blurTex0 = 1, blurTex1 = 2, blurTex2 = 3, blurTex3 = 4},
 	})


### PR DESCRIPTION
### Work done
Fix depth-of-field widget failing to load its shader due to shader path pointing to the old location
