### PR TITLE
Rml translation table population

### DIFF
--- a/luaui/main.lua
+++ b/luaui/main.lua
@@ -18,9 +18,10 @@ local spSendCommands = Spring.SendCommands
 spSendCommands("ctrlpanel " .. LUAUI_DIRNAME .. "ctrlpanel.txt")
 
 VFS.Include("init.lua", nil, VFS.ZIP)
-Spring.I18N.setLanguage( Spring.GetConfigString('language', 'en') )
 
 VFS.Include(LUAUI_DIRNAME .. "rml_setup.lua",  nil, VFS.ZIP)
+Spring.I18N.setLanguage( Spring.GetConfigString('language', 'en') )
+
 VFS.Include(LUAUI_DIRNAME .. "utils.lua",      nil, VFS.ZIP)
 VFS.Include(LUAUI_DIRNAME .. "setupdefs.lua",  nil, VFS.ZIP)
 VFS.Include(LUAUI_DIRNAME .. "savetable.lua",  nil, VFS.ZIP)

--- a/modules/i18n/i18n.lua
+++ b/modules/i18n/i18n.lua
@@ -5,6 +5,28 @@ local i18n = VFS.Include(I18N_PATH .. "init.lua", nil, VFS.ZIP)
 local asianFont = 'fallbacks/SourceHanSans-Regular.ttc'
 local translationDirs = VFS.SubDirs('language')
 
+-- map of languageCode -> map of translation key -> translation string
+local languageTranslations = {}
+
+local function loadTranslationTable(languageCode, currentContext, data)
+  local composedKey
+  for k,v in pairs(data) do
+    composedKey = (currentContext and (currentContext .. '.') or "") .. tostring(k)
+    if type(v) == 'string' then
+		languageTranslations[languageCode][composedKey] = v
+    elseif type(v) == 'table' then
+      loadTranslationTable(languageCode, composedKey, v)
+    end
+  end
+end
+
+local function loadRmlTranslations(languageCode)
+	RmlUi.ClearTranslations()
+	for k,v in pairs(languageTranslations[languageCode]) do
+		RmlUi.AddTranslationString('!!' .. k, v)
+	end
+end
+
 -- Construct a map of
 -- languageCode -> list of translation files associated with that language.
 local languageFiles = {}
@@ -20,9 +42,11 @@ local function loadLanguageFiles(languageCode)
 		return
 	end
 
+	languageTranslations[languageCode] = {}
 	for _, file in ipairs(languageFiles[languageCode]) do
 		local i18nJson = VFS.LoadFile(file)
 		local i18nLua = { [languageCode] = Json.decode(i18nJson) }
+		loadTranslationTable(languageCode, nil, i18nLua[languageCode])
 		i18n.load(i18nLua)
 	end
 end
@@ -59,6 +83,7 @@ ensureLanguageLoaded('en')
 function i18n.setLanguage(language)
 	ensureLanguageLoaded(language)
 	i18n.setLocale(language)
+	loadRmlTranslations(language)
 
 	if gl.AddFallbackFont then return end
 

--- a/modules/i18n/i18n.lua
+++ b/modules/i18n/i18n.lua
@@ -9,15 +9,15 @@ local translationDirs = VFS.SubDirs('language')
 local languageTranslations = {}
 
 local function loadTranslationTable(languageCode, currentContext, data)
-  local composedKey
-  for k,v in pairs(data) do
-    composedKey = (currentContext and (currentContext .. '.') or "") .. tostring(k)
-    if type(v) == 'string' then
-		languageTranslations[languageCode][composedKey] = v
-    elseif type(v) == 'table' then
-      loadTranslationTable(languageCode, composedKey, v)
-    end
-  end
+	local composedKey
+	for k,v in pairs(data) do
+		composedKey = (currentContext and (currentContext .. '.') or "") .. tostring(k)
+		if type(v) == 'string' then
+			languageTranslations[languageCode][composedKey] = v
+		elseif type(v) == 'table' then
+			loadTranslationTable(languageCode, composedKey, v)
+		end
+	end
 end
 
 local function loadRmlTranslations(languageCode)


### PR DESCRIPTION
Adds translation strings to the rml translations table. Then rml files can use the translated text like so `<span>!!ui.topbar.resources.metal</span>`

### Work done
Add new functionality to i18n initialization file.


#### Test steps
Add a rml widget that uses a translation string in the rml file.