### PR TITLE
implement gui scaling to properly account for resolution and config

### DIFF
--- a/luaui/RmlWidgets/rml_context_manager.lua
+++ b/luaui/RmlWidgets/rml_context_manager.lua
@@ -9,7 +9,7 @@ function widget:GetInfo()
         author = "Mupersega",
         date = "2025",
         license = "GNU GPL, v2 or later",
-        layer = 0,
+        layer = -1000000,
         enabled = true
     }
 end

--- a/luaui/RmlWidgets/rml_context_manager.lua
+++ b/luaui/RmlWidgets/rml_context_manager.lua
@@ -43,6 +43,8 @@ function widget:ViewResize()
     updateContextsDpRatio()
 end
 
+-- include also a listener for the ui_scale config variable changes
+
 function widget:Shutdown()
     Spring.Echo("Rml Context Manager shutdown, dynamic context dp ratio updates to contexts disabled." )
 end

--- a/luaui/RmlWidgets/rml_context_manager.lua
+++ b/luaui/RmlWidgets/rml_context_manager.lua
@@ -1,0 +1,48 @@
+if not RmlUi then
+    return
+end
+
+function widget:GetInfo()
+    return {
+        name = "Rml context manager",
+        desc = "This widget is responsible for handling dynamic interactions with Rml contexts.",
+        author = "Mupersega",
+        date = "2025",
+        license = "GNU GPL, v2 or later",
+        layer = 0,
+        enabled = true
+    }
+end
+
+local function calculateDpRatio()
+    local viewSizeX, viewSizeY = Spring.GetViewGeometry()
+    local userScale = Spring.GetConfigFloat("ui_scale", 1)
+    local baseWidth = 1920
+    local baseHeight = 1080
+    local resFactor = math.min(viewSizeX / baseWidth, viewSizeY / baseHeight)
+    local dpRatio = resFactor * userScale
+    return math.floor(dpRatio * 100) / 100
+end
+
+local function updateContextsDpRatio()
+    local newDpRatio = calculateDpRatio()
+    local contexts = RmlUi.contexts()
+    for _, context in ipairs(contexts) do
+        context.dp_ratio = newDpRatio
+    end
+end
+
+function widget:Initialize()
+    if not RmlUi.GetContext("shared") then
+        RmlUi.CreateContext("shared")
+    end
+    updateContextsDpRatio()
+end
+
+function widget:ViewResize()
+    updateContextsDpRatio()
+end
+
+function widget:Shutdown()
+    Spring.Echo("Rml Context Manager shutdown, dynamic context dp ratio updates to contexts disabled." )
+end

--- a/luaui/rml_setup.lua
+++ b/luaui/rml_setup.lua
@@ -35,7 +35,19 @@ local oldCreateContext = RmlUi.CreateContext
 
 local function NewCreateContext(name)
 	local context = oldCreateContext(name)
-	context.dp_ratio = Spring.GetConfigFloat("ui_scale", 1)
+
+	-- set up dp_ratio considering the user's UI scale preference and the screen resolution
+	local viewSizeX, viewSizeY = Spring.GetViewGeometry()
+
+	local userScale = Spring.GetConfigFloat("ui_scale", 1)
+
+	local baseWidth = 1920
+	local baseHeight = 1080
+	local resFactor = math.min(viewSizeX / baseWidth, viewSizeY / baseHeight)
+
+	context.dp_ratio = resFactor * userScale
+
+	context.dp_ratio = math.floor(context.dp_ratio * 100) / 100
 	return context
 end
 


### PR DESCRIPTION
## Default Gui Scaling For RML


### Work done
Included automatic scaling to account for resolution as well as gui scaling setting.

#### Setup
Requires an rmlui widget
```
I used
<rml>
    <head>
        <title>Rml Test</title>
        <link type="text/rcss" href="../styles.rcss"/>
        <style>
            .outer {
                position:absolute;
                top: 0;
                left: 80dp;
                height: 200dp;
                width: 500dp;
                background-color: #333333;
            }
            .inner {
                position: absolute;
                top: 0;
                right: 10dp;
                height: 100dp;
                width: 100dp;
                background-color: #ffeb7ddc;
            }
        </style>
    </head>
    <body>
        <div class="outer" data-model="testModel">
            <div class="inner">{{test}}</div>
        </div>
    </body>
</rml>
```

#### Test steps
- [ ] Change resolutions (windowed works)
- [ ] Reload luaui
- [ ] Confirm relative sizing is same as original after reload in new resolution.

#### My tests
Created rmlui element as above and aligned with dp values to left of top bar
changed  resolutions to ensure still to left of top bar. Chose top bar because it is a working example of a scaling widget.

2560X1440
![Screenshot 2025-02-24 122758](https://github.com/user-attachments/assets/63281531-8e29-42c6-bc72-dcbc186cdf2f)
windowed at min resolution option 1024X 768
![image](https://github.com/user-attachments/assets/dc43931b-46e7-4f6c-9862-fb8898a79c64)

