### PR TITLE
Make grid 's' map to settargetnoground, and 'alt+s' to settarget

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -60,7 +60,8 @@ bind               sc_p  gatherwait
 bind         Shift+sc_p  gatherwait
 bind               sc_r  repair
 bind         Shift+sc_r  repair
-bind               sc_s  settarget
+bind               sc_s  settargetnoground
+bind           Alt+sc_s  settarget
 bind          Ctrl+sc_s  canceltarget
 bind               sc_u  unloadunits
 bind         Shift+sc_u  unloadunits

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -60,7 +60,8 @@ bind               sc_o  guard
 bind         Shift+sc_o  guard
 bind               sc_r  repair
 bind         Shift+sc_r  repair
-bind               sc_s  settarget
+bind               sc_s  settargetnoground
+bind           Alt+sc_s  settarget
 bind          Ctrl+sc_s  canceltarget
 bind               sc_u  unloadunits
 bind         Shift+sc_u  unloadunits


### PR DESCRIPTION
### Work done

- Change `s` mapping from settarget to settargetnoground.
- Add `alt+s` mapping for settarget.

### Remarks

- Alternative to https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4176.
- For consistency with legacy mappings.
- I think GDT wants this according to [this comment](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4176#issuecomment-2672596657)
  -  Alternatively, could keep `s` as settarget and simply add `alt+s` as settargetnoground. There's some conflicts here since `s` already used by the grid build menu, but I don't think `alt+s` conflict here will be much worse than `s`.
- There's been some confusion about different legacy and grid behaviours, since `y` at legacy maps to settargetnoground, using `alt` there maps to settarget, while grid maps `s` to settarget, and has no mapping for settargetnoground.

#### Addresses Issue(s)
- Possibly addresses [this GDT decision](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4176#issuecomment-2672596657)


