### PR TITLE
Unlink **Resource Sharing Tax** and **Disable Unit Sharing**

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -17,7 +17,7 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
-local disable_assist = Spring.GetModOptions().disable_assist_ally_construction
+local disableAssist = Spring.GetModOptions().disable_assist_ally_construction
 
 if not disable_assist then
 	return false

--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -16,9 +16,10 @@ end
 if not gadgetHandler:IsSyncedCode() then
 	return false
 end
-if	not (Spring.GetModOptions().disable_assist_ally_construction
-	-- tax force enables this
-	or (Spring.GetModOptions().tax_resource_sharing_amount or 0) ~= 0) then
+
+local disable_assist = Spring.GetModOptions().disable_assist_ally_construction
+
+if not disable_assist then
 	return false
 end
 

--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -19,8 +19,8 @@ end
 
 local disableAssist = Spring.GetModOptions().disable_assist_ally_construction
 
-if not disable_assist then
-	return false
+if disableAssist then
+	return true
 end
 
 local function isComplete(u)

--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -19,8 +19,8 @@ end
 
 local disableAssist = Spring.GetModOptions().disable_assist_ally_construction
 
-if disableAssist then
-	return true
+if allowAssist then
+	return false
 end
 
 local function isComplete(u)

--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -17,7 +17,7 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
-local disableAssist = Spring.GetModOptions().disable_assist_ally_construction
+local allowAssist = not Spring.GetModOptions().disable_assist_ally_construction
 
 if allowAssist then
 	return false

--- a/luarules/gadgets/game_disable_unit_sharing.lua
+++ b/luarules/gadgets/game_disable_unit_sharing.lua
@@ -18,21 +18,14 @@ if not gadgetHandler:IsSyncedCode() then
 end
 
 if not (Spring.GetModOptions().disable_unit_sharing
-	-- tax force enables this
-	or (Spring.GetModOptions().tax_resource_sharing_amount or 0) ~= 0)
-	-- unit market handles the restriction instead if enabled so that selling still works
-	or Spring.GetModOptions().unit_market then
+			-- unit market handles the restriction instead if enabled so that selling still works
+			or Spring.GetModOptions().unit_market) then
 	return false
 end
 
-
 function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
-
-	if(capture) then
+	if (capture) then
 		return true
 	end
 	return false
 end
-
-
-

--- a/luarules/gadgets/game_unit_market.lua
+++ b/luarules/gadgets/game_unit_market.lua
@@ -149,10 +149,6 @@ local function offerUnitForSale(unitID, sale_price, msgFromTeamID)
     end
 end
 
-local disable_unit_sharing = Spring.GetModOptions().disable_unit_sharing
-    and Spring.GetModOptions().unit_market
-local saleWhitelist = {}
-
 local function tryToBuyUnit(unitID, msgFromTeamID)
     if not unitID or unitsForSale[unitID] == nil or unitsForSale[unitID] == 0 then return end
     local unitDefID = spGetUnitDefID(unitID)
@@ -175,29 +171,12 @@ local function tryToBuyUnit(unitID, msgFromTeamID)
 
     if (current < price) then return end
 
-    if disable_unit_sharing then
-        saleWhitelist[unitID] = true
-    end
-
     TransferUnit(unitID, msgFromTeamID)
     if msgFromTeamID ~= old_ownerTeamID and price > 0 then -- don't send resources to yourself
         ShareTeamResource(msgFromTeamID, old_ownerTeamID, "metal", price)
     end
     setNotForSale(unitID)
     UnitSoldBroadcast(unitID, price, old_ownerTeamID, msgFromTeamID)
-end
-
-if disable_unit_sharing then
-    function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
-        if(capture) then
-            return true
-        end
-        if saleWhitelist[unitID] then
-            saleWhitelist[unitID] = nil
-            return true
-        end
-        return false
-    end
 end
 
 -- this takes control and makes all cons stop using metal, we remove all limits on a) shutdown b) storage getting full c) widget crash - should be safe enough

--- a/luarules/gadgets/game_unit_market.lua
+++ b/luarules/gadgets/game_unit_market.lua
@@ -149,10 +149,8 @@ local function offerUnitForSale(unitID, sale_price, msgFromTeamID)
     end
 end
 
-local disable_unit_sharing = (
-    Spring.GetModOptions().disable_unit_sharing
- or (Spring.GetModOptions().tax_resource_sharing_amount or 0) ~= 0)
-and Spring.GetModOptions().unit_market
+local disable_unit_sharing = Spring.GetModOptions().disable_unit_sharing
+    and Spring.GetModOptions().unit_market
 local saleWhitelist = {}
 
 local function tryToBuyUnit(unitID, msgFromTeamID)

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -244,7 +244,7 @@ local options = {
 		key		= "tax_resource_sharing_amount",
 		name	= "Resource Sharing Tax",
 		desc	=	"Taxes resource sharing".."\255\128\128\128".." and overflow (engine TODO:)\n"..
-					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)",
+					"Set to [0] to turn off. Recommended: [0.4]. (Ranges: 0 - 0.99)",
 		type	= "number",
 		def		= 0,
 		min		= 0,

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -244,8 +244,7 @@ local options = {
 		key		= "tax_resource_sharing_amount",
 		name	= "Resource Sharing Tax",
 		desc	=	"Taxes resource sharing".."\255\128\128\128".." and overflow (engine TODO:)\n"..
-					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)\n"..
-					"*Disables: Reclaiming of Allied Units, [Unit Sharing] and [Assisting Ally Construction] to prevent loopholes",
+					"Set to [0] to turn off. Recommened: [0.4]. (Ranges: 0 - 0.99)",
 		type	= "number",
 		def		= 0,
 		min		= 0,
@@ -253,8 +252,6 @@ local options = {
 		step	= 0.01,
 		section	= "options_main",
 		column	= 1,
-		lock	= {"disable_unit_sharing","disable_assist_ally_construction"},
-		unlock	= {"disable_unit_sharing_forced","disable_assist_ally_construction_forced"},
 	},
 	{
 		key		= "disable_unit_sharing",
@@ -272,23 +269,6 @@ local options = {
 		section	= "options_main",
 		def		=  false,
 		column	= 1.76,
-	},
-	{	key = "tax_padding", name = "", type = "subheader", section = "options_main", column = -3, },
-	{
-		key		= "disable_unit_sharing_forced",
-		--name	= "\255\252\191\76".."Disable Unit Sharing                              [Forced ON]",
-		name	= "\255\252\191\76".."Disable Unit Sharing                                                             Disable Assist Ally Construction",
-		type	= "subheader",
-		section	= "options_main",
-	},
-	{
-		key		= "disable_assist_ally_construction_forced",
-		--name	= "\255\252\191\76".."Disable Assist Ally Construction           [Forced ON]",
-		name	= "\255\252\191\76".."[■]                                                                          [■]",
-		type	= "subheader",
-		section	= "options_main",
-		column	= 1.505,
-		font	= 4,
 	},
 	{
 		key		= "unit_market",


### PR DESCRIPTION
closes #4415

### Description
Decouples resource sharing tax from unit sharing restrictions. Previously, setting a non-zero resource sharing tax would automatically enable and lock both "Disable Unit Sharing" and "Disable Assist Ally Construction" settings. This change removes that forced coupling, allowing these settings to be configured independently.

#### Changes
- Removed lock/unlock behavior from resource sharing tax
- Removed forced state UI indicators
- Settings remain functionally independent

#### Test steps
1. Open game settings under Main tab
2. Set Resource Sharing Tax to a non-zero value (e.g. 0.4)
3. Verify that both settings remain independently configurable:
   - Disable Unit Sharing
   - Disable Assist Ally Construction

#### Before
![image](https://github.com/user-attachments/assets/6a3f6277-7815-449f-9eae-0b197bddc635)

#### After
![image](https://github.com/user-attachments/assets/e01def18-9e7a-473f-a1b0-c53364f7a43d)


### Testers
This PR is contained in [this](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4447) branch and I would probably just test that once and then we can merge both PRs simultaneously.