### PR TITLE
remove flighttime from arbiter

### DIFF
--- a/units/CorBots/T2/corhrk.lua
+++ b/units/CorBots/T2/corhrk.lua
@@ -112,7 +112,7 @@ return {
 				edgeeffectiveness = 0.61,
 				explosiongenerator = "custom:genericshellexplosion-large-bomb",
 				firestarter = 100,
-				flighttime = 7.4,
+				flighttime = 99,
 				impulsefactor = 0.8,
 				metalpershot = 0,
 				model = "corkbmissl1.s3o",


### PR DESCRIPTION
projectile overrange handles preventing absurdly high ranges now

this addresses a bug report here:

see before and after videos therein

https://discord.com/channels/549281623154229250/1296091978097758313/1345927844949262447

https://discord.com/channels/549281623154229250/1296091978097758313/1345930800297807893