### PR TITLE
fix(Unit_Explosions): set default damage to 0 for wall explosions

### DIFF
--- a/weapons/Unit_Explosions.lua
+++ b/weapons/Unit_Explosions.lua
@@ -886,8 +886,7 @@ local unitDeaths = {
 		--soundstart = "metalhit",
 		explosiongenerator = "custom:wallexplosion-metal",
 		damage = {
-			default = 610,
-			walls = 0,
+			default = 0,
 		},
 		customparams = {
 			unitexplosion = 1,
@@ -902,8 +901,7 @@ local unitDeaths = {
 		--soundstart = "metalhit",
 		explosiongenerator = "custom:wallexplosion-metal",
 		damage = {
-			default = 1530,
-			walls = 0,
+			default = 0,
 		},
 		customparams = {
 			unitexplosion = 1,
@@ -918,8 +916,7 @@ local unitDeaths = {
 		--soundstart = "metalhit",
 		explosiongenerator = "custom:wallexplosion-concrete",
 		damage = {
-			default = 610,
-			walls = 0,
+			default = 0,
 		},
 		customparams = {
 			unitexplosion = 1,
@@ -934,8 +931,7 @@ local unitDeaths = {
 		--soundstart = "metalhit",
 		explosiongenerator = "custom:wallexplosion-concrete",
 		damage = {
-			default = 1530,
-			walls = 0,
+			default = 0,
 		},
 		customparams = {
 			unitexplosion = 1,
@@ -950,8 +946,7 @@ local unitDeaths = {
 		--soundstart = "metalhit",
 		explosiongenerator = "custom:wallexplosion-water",
 		damage = {
-			default = 560,
-			walls = 0,
+			default = 0,
 		},
 		customparams = {
 			unitexplosion = 1,


### PR DESCRIPTION
### Work done
When walls and buildings have overlapping hitboxes, walls damaged, crushed, or self destructed can deal damage to neighbouring buildings upon death. This can trigger larger damage chains along friendly buildings (such as a geothermal exploding when the walls around it are destroyed).

This commit removes all damage from wall explosions. These explosion types are only used by dragon's teeth and fortification wall utility buildings in the standard game.

#### Addresses Issue(s)
#4411 

#### Test steps
- [x] Manual testing