### PR TITLE
fix(gui_advplayerslist): fix income multiplier display

### DIFF
--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -2477,10 +2477,10 @@ function DrawName(name, team, posY, dark, playerID, desynced)
 	elseif player[playerID] and not player[playerID].dead and player[playerID].incomeMultiplier and player[playerID].incomeMultiplier ~= 1 then
         if player[playerID].incomeMultiplier > 1 then
             font2:SetTextColor(0.5,1,0.5,1)
-            font2:Print('+'..math.floor((player[playerID].incomeMultiplier-1)*100)..'%', m_name.posX + widgetPosX + 5 + xPadding + (font2:GetTextWidth(nameText)*14), posY + (5.7*playerScale) , 8, "o")
+            font2:Print('+'..math.floor((player[playerID].incomeMultiplier-1+0.005)*100)..'%', m_name.posX + widgetPosX + 5 + xPadding + (font2:GetTextWidth(nameText)*14), posY + (5.7*playerScale) , 8, "o")
         else
             font2:SetTextColor(1,0.5,0.5,1)
-            font2:Print(math.floor((player[playerID].incomeMultiplier-1)*100)..'%', m_name.posX + widgetPosX + 5 + xPadding + (font2:GetTextWidth(nameText)*14), posY + (5.7*playerScale) , 8, "o")
+            font2:Print(math.floor((player[playerID].incomeMultiplier-1+0.005)*100)..'%', m_name.posX + widgetPosX + 5 + xPadding + (font2:GetTextWidth(nameText)*14), posY + (5.7*playerScale) , 8, "o")
         end
     end
     font2:End()


### PR DESCRIPTION
Due to Lua's inaccurate representation of floating point numbers, income bonuses entered into the lobby UI are sometimes rendered as 1% lower in the player list.

For example, a bonus of 15% is stored as 1.14999998 internally -- because of the use of math.floor(), this will be rendered as +14% in the player list. A bonus of 10% will be stored as 1.10000002 and rendered as +10%.

This commit adds +.5% to the income bonus *only* before rendering the value in order to have the output of math.floor() render the same number that is shown in the lobby. Lua's math libary does not contain a rounding function, just floor() and ceil().

Recoil uses the correct values internally, this is only a UI bug.

### Work done
This commit adds +.5% to the income bonus *only* before rendering the value in order to have the output of math.floor() render the same number that is shown in the lobby. Lua's math libary does not contain a rounding function, just floor() and ceil().

Recoil uses the correct values internally, this is only a UI bug.

#### Test steps
- [x] Manual testing.

You can use the following patch to display the value of the income multiplier (for your own team) in the chat window:
```diff
diff --git a/luaui/Widgets/gui_advplayerslist.lua b/luaui/Widgets/gui_advplayerslist.lua
index a2e33e1fe2..110324a0ee 100644
--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -1003,6 +1003,7 @@ function CreatePlayer(playerID)
     --generic player data
     local tname, _, tspec, tteam, tallyteam, tping, tcpu, tcountry, trank, _, _, desynced = Spring_GetPlayerInfo(playerID, false)
     local _, _, _, _, tside, tallyteam, tincomeMultiplier = Spring_GetTeamInfo(tteam, false)
+    Spring.Echo("DEBUG: tincomeMultiplier", tincomeMultiplier)
     local tred, tgreen, tblue = Spring_GetTeamColor(tteam)
 	if (not mySpecStatus) and anonymousMode ~= "disabled" and playerID ~= myPlayerID then
 		tred, tgreen, tblue = anonymousTeamColor[1], anonymousTeamColor[2], anonymousTeamColor[3]
```

### Screenshots:
![income_multiplier_debug](https://github.com/user-attachments/assets/8661be12-78e1-446b-bf50-bd42662d7573)
![lobby_bonus](https://github.com/user-attachments/assets/dbf30dbd-35df-49ea-bb7b-4caa221f49cf)

#### BEFORE:
![broken_advplayerslist_bonus](https://github.com/user-attachments/assets/4d0700b6-dd45-474e-af5b-e8a2efd71575)

#### AFTER:
![fixed_advplayerslist_bonus](https://github.com/user-attachments/assets/cd0b1684-bd50-4644-8581-23f74c04e81f)

