### PR TITLE
fix(gridmenu): put (arm|cor|leg)wint2 in the same position

### DIFF
--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -2034,6 +2034,12 @@ local unitGrids = {
 	},
 }
 
+if Spring.GetModOptions().experimentalextraunits then
+	for _, builder in pairs({"armaca", "coraca", "legaca", "armack", "corack", "legack", "armacv", "coracv", "legacv"}) do
+		unitGrids[builder][1][3][3] = builder:sub(1, 3) .. "wint2"
+	end
+end
+
 if Spring.Utilities.Gametype.IsScavengers() or Spring.GetModOptions().forceallunits then
 	local scavLabGrids = {}
 	local scavUnitGrids = {}

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1452,7 +1452,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1475,7 +1475,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1522,7 +1522,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1545,7 +1545,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1568,7 +1568,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1592,7 +1592,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1615,7 +1615,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron" },    -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1637,7 +1637,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1635,7 +1635,7 @@ local unitGrids = {
 	},
 	legaca = {
 		{
-			{ "legmoho", "legfus", "legafus", },                 -- moho, fusion, afus
+			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
 			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1452,7 +1452,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1475,7 +1475,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1522,7 +1522,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1545,7 +1545,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1568,7 +1568,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1592,7 +1592,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1615,7 +1615,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron" },    -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1637,7 +1637,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1452,7 +1452,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1475,7 +1475,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1522,7 +1522,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1545,7 +1545,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1568,7 +1568,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1592,7 +1592,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
+			{ "armuwadves", "armuwadvms", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1615,7 +1615,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "coruwadves", "coruwadvms", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron" },    -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1637,7 +1637,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
+			{ "legadvestore", "legamstor", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1452,7 +1452,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, T2 wind energy generator
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1475,7 +1475,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1522,7 +1522,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, T2 wind energy generator
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1545,7 +1545,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1568,7 +1568,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1592,7 +1592,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, T2 wind energy generator
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1615,7 +1615,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron" },    -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1637,7 +1637,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1452,7 +1452,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
+			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1475,7 +1475,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1522,7 +1522,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
+			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1545,7 +1545,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1568,7 +1568,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1592,7 +1592,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
+			{ "armuwadves", "armuwadvms", "armwint2", },                           -- hardened energy storage, hardened metal storage
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1615,7 +1615,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "coruwadves", "coruwadvms", "corwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron" },    -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1637,7 +1637,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "legadvestore", "legamstor", "legwint2", },                    -- hardened energy storage, hardened metal storage,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1452,7 +1452,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, T2 wind energy generator
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1475,7 +1475,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1522,7 +1522,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, T2 wind energy generator
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1545,7 +1545,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron", },   -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1568,7 +1568,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1592,7 +1592,7 @@ local unitGrids = {
 		{
 			{ "armmoho", "armfus", "armafus", "armgmm", },             -- moho, fusion, afus, safe geo
 			{ "armmmkr", "armageo", "armckfus", "armshockwave" },                     -- T2 converter, T2 geo, cloaked fusion
-			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine
+			{ "armuwadves", "armuwadvms", "armwint2", },               -- hardened energy storage, hardened metal storage, T2 wind energy generator
 		},
 		{
 			{ "armpb", "armanni", "armamb", "armemp", },        -- pop-up gauss, annihilator, pop-up artillery, EMP missile
@@ -1615,7 +1615,7 @@ local unitGrids = {
 		{
 			{ "cormoho", "corfus", "corafus", },                -- moho, fusion, afus
 			{ "cormmkr", "corageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "coruwadves", "coruwadvms", "corwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "corvipe", "cordoom", "cortoast", "cortron" },    -- pop-up gauss, DDM, pop-up artillery, tac nuke
@@ -1637,7 +1637,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, Tech 2 Wind Turbine,
+			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -1498,7 +1498,7 @@ local unitGrids = {
 		{
 			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp", },               -- T2 converter, T2 geo, armed moho
-			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
+			{ "legadvestore", "legamstor", "legwint2", },       -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},
 		{
 			{ "legbombard", "legbastion", "legacluster", "legperdition", },   -- pop-up gauss, heavy defence, pop-up artillery, tac nuke
@@ -1635,7 +1635,7 @@ local unitGrids = {
 	},
 	legaca = {
 		{
-			{ "legmoho", "legfus", "legafus", },                -- moho, fusion, afus
+			{ "legmoho", "legfus", "legafus", },                 -- moho, fusion, afus
 			{ "legadveconv", "legageo", "cormexp","coruwageo", },               -- T2 converter, T2 geo, armed moho
 			{ "legadvestore", "legamstor", "legwint2", },        -- hardened energy storage, hardened metal storage, T2 wind energy generator,
 		},


### PR DESCRIPTION
### Work done
* Added t2 winds to gridmenu layouts so that they are fixed and not filled up in the grid as uncategorized

#### Test steps
- [x] Doesn't show T2 wind without extra units
- [x] Same placement for bots, vehicles, aircrafts and scav respective versions

#### BEFORE:
![image](https://github.com/user-attachments/assets/72a7e382-fd5e-44cc-82cc-713fdb3d3edc)
![image](https://github.com/user-attachments/assets/60dda44e-589c-4db9-8054-32452c058e2d)
![image](https://github.com/user-attachments/assets/c98d32fb-a28c-4ba6-973c-f391996bcad0)
![image](https://github.com/user-attachments/assets/c0e97261-8992-44d5-aeee-7f5b028491a3)

#### AFTER:
![image](https://github.com/user-attachments/assets/34711bd7-3a70-4d20-a32c-71d78a76d889)
![image](https://github.com/user-attachments/assets/02a630d1-0439-4041-930c-ac9d23825be6)
![image](https://github.com/user-attachments/assets/68689a2e-7914-4a92-8119-7b6a2241e011)
