### PR TITLE
feat(autocheat): enable cheating during gamesetup

### DIFF
--- a/luaui/Widgets/autocheat.lua
+++ b/luaui/Widgets/autocheat.lua
@@ -14,31 +14,17 @@ function widget:GetInfo()
 	}
 end
 
-local gf = Spring.GetGameFrame()
+function widget:Update(f)
+	if not Spring.IsCheatingEnabled() then
+		Spring.SendCommands("say !cheats")
+		Spring.SendCommands("say !hostsay /globallos")
+		Spring.SendCommands("say !hostsay /godmode")
+		--Spring.SendCommands("say !hostsay /nocost")
 
-function widget:Initialize()
-	local enable = (not Spring.IsCheatingEnabled())
-	if enable then
-		widgetHandler:UpdateCallIn('GameFrame');
-	else
-		widgetHandler:RemoveCallIn('GameFrame');
+		Spring.SendCommands("cheat")
+		Spring.SendCommands("globallos")
+		Spring.SendCommands("godmode")
+		--Spring.SendCommands("nocost")
 	end
-end
-
-function widget:GameFrame(f)
-	if f > gf then
-		if not Spring.IsCheatingEnabled() and not Spring.IsReplay() then 
-			Spring.SendCommands("say !cheats")
-			Spring.SendCommands("say !hostsay /globallos")
-			Spring.SendCommands("say !hostsay /godmode")
-			--Spring.SendCommands("say !hostsay /nocost")
-
-			Spring.SendCommands("cheat")
-			Spring.SendCommands("globallos")
-			Spring.SendCommands("godmode")
-			--Spring.SendCommands("nocost")
-		end
-
-		widgetHandler:RemoveCallIn('GameFrame');
-	end
+	widgetHandler:RemoveCallIn('Update');
 end

--- a/luaui/Widgets/dev_autocheat.lua
+++ b/luaui/Widgets/dev_autocheat.lua
@@ -4,7 +4,7 @@ end
 
 function widget:GetInfo()
 	return {
-		name      = "Auto cheat",
+		name      = "Dev Auto cheat",
 		desc      = "Enables cheats for $VERSION game versions",
 		author    = "ivand",
 		date      = "2017",


### PR DESCRIPTION
### Work done
* Switched from gameframe callin to update so that cheating is enabled already during gamesetup so that you dont have to wait the 3 countdown seconds before the gameframes starts. Also to be able to construct test cases before starting.
* Prefixed widget name with Dev and file name with dev_. I think it would be nice to add more with this naming so that there is a higher probability of finding these useful widgets.

#### Test steps
- [x] Skirmish
- [ ] Multiplayer/autohosted has not been tested (I don't know how to do it)
