### PR TITLE
fix(pve): adding logs, boss spawning can return nil

### DIFF
--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1662,9 +1662,12 @@ if gadgetHandler:IsSyncedCode() then
 		if nSpawnedQueens < nTotalQueens and not gameOver then
 			-- spawn queen if not exists
 			local queenID = SpawnQueen()
-			nSpawnedQueens = nSpawnedQueens + 1
 			if queenID then
 				queenIDs[queenID] = true
+				nSpawnedQueens = nSpawnedQueens + 1
+				Spring.Echo("Spawned queen " .. nSpawnedQueens.. "/" .. nTotalQueens)
+				SetGameRulesParam("nSpawnedQueens", nSpawnedQueens)
+
 				local queenSquad = table.copy(squadCreationQueueDefaults)
 				queenSquad.life = 999999
 				queenSquad.role = "raid"
@@ -1995,8 +1998,10 @@ if gadgetHandler:IsSyncedCode() then
 		if queenIDs[unitID] then
 			nKilledQueens = nKilledQueens + 1
 			queenIDs[unitID] = nil
+			Spring.Echo("Killed " .. nKilledQueens .. " of " .. nSpawnedQueens .. " spawned queens")
+			SetGameRulesParam("nKilledQueens", nKilledQueens)
 
-			if nKilledQueens == nTotalQueens then
+			if nKilledQueens >= nTotalQueens then
 				Spring.SetGameRulesParam("BossFightStarted", 0)
 				if Spring.GetModOptions().raptor_endless then
 					updateDifficultyForSurvival()

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1663,10 +1663,9 @@ if gadgetHandler:IsSyncedCode() then
 			-- spawn queen if not exists
 			local queenID = SpawnQueen()
 			if queenID then
-				queenIDs[queenID] = true
 				nSpawnedQueens = nSpawnedQueens + 1
-				Spring.Echo("Spawned queen " .. nSpawnedQueens.. "/" .. nTotalQueens)
-				SetGameRulesParam("nSpawnedQueens", nSpawnedQueens)
+				queenIDs[queenID] = true
+				Spring.Echo({func="updateSpawnQueen", queen_status = {spawned = nSpawnedQueens, killed = nKilledQueens, ids = queenIDs}})
 
 				local queenSquad = table.copy(squadCreationQueueDefaults)
 				queenSquad.life = 999999
@@ -1998,8 +1997,7 @@ if gadgetHandler:IsSyncedCode() then
 		if queenIDs[unitID] then
 			nKilledQueens = nKilledQueens + 1
 			queenIDs[unitID] = nil
-			Spring.Echo("Killed " .. nKilledQueens .. " of " .. nSpawnedQueens .. " spawned queens")
-			SetGameRulesParam("nKilledQueens", nKilledQueens)
+			Spring.Echo({func="UnitDestroyed", boss_status = {spawned = nSpawnedQueens, killed = nKilledQueens, ids = queenIDs}})
 
 			if nKilledQueens >= nTotalQueens then
 				Spring.SetGameRulesParam("BossFightStarted", 0)

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1858,9 +1858,12 @@ if gadgetHandler:IsSyncedCode() then
 		if nSpawnedBosses < nTotalBosses and not gameOver then
 			-- spawn boss if not exists
 			local bossID = SpawnBoss()
-			nSpawnedBosses = nSpawnedBosses + 1
 			if bossID then
+				nSpawnedBosses = nSpawnedBosses + 1
 				bossIDs[bossID] = true
+				Spring.Echo("Spawned queen " .. nSpawnedBosses .. "/" .. nTotalBosses)
+				SetGameRulesParam("nSpawnedBosses", nSpawnedBosses)
+
 				local bossSquad = table.copy(squadCreationQueueDefaults)
 				bossSquad.life = 999999
 				bossSquad.role = "raid"
@@ -2236,8 +2239,10 @@ if gadgetHandler:IsSyncedCode() then
 		if bossIDs[unitID] then
 			nKilledBosses = nKilledBosses + 1
 			bossIDs[unitID] = nil
+			Spring.Echo("Killed " .. nKilledBosses .. " of " .. nSpawnedBosses .. " spawned Bosses")
+			SetGameRulesParam("nKilledBosses", nKilledBosses)
 
-			if nKilledBosses == nTotalBosses then
+			if nKilledBosses >= nTotalBosses then
 				Spring.SetGameRulesParam("BossFightStarted", 0)
 
 				if Spring.GetModOptions().scav_endless then

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1861,8 +1861,7 @@ if gadgetHandler:IsSyncedCode() then
 			if bossID then
 				nSpawnedBosses = nSpawnedBosses + 1
 				bossIDs[bossID] = true
-				Spring.Echo("Spawned queen " .. nSpawnedBosses .. "/" .. nTotalBosses)
-				SetGameRulesParam("nSpawnedBosses", nSpawnedBosses)
+				Spring.Echo({func="updateSpawnBoss", boss_status = {spawned = nSpawnedBosses, killed = nKilledBosses, ids = bossIDs}})
 
 				local bossSquad = table.copy(squadCreationQueueDefaults)
 				bossSquad.life = 999999
@@ -2239,8 +2238,7 @@ if gadgetHandler:IsSyncedCode() then
 		if bossIDs[unitID] then
 			nKilledBosses = nKilledBosses + 1
 			bossIDs[unitID] = nil
-			Spring.Echo("Killed " .. nKilledBosses .. " of " .. nSpawnedBosses .. " spawned Bosses")
-			SetGameRulesParam("nKilledBosses", nKilledBosses)
+			Spring.Echo({func="UnitDestroyed", boss_status = {spawned = nSpawnedBosses, killed = nKilledBosses, ids = bossIDs}})
 
 			if nKilledBosses >= nTotalBosses then
 				Spring.SetGameRulesParam("BossFightStarted", 0)


### PR DESCRIPTION
There is a a bug where the game does not end. ~~I have only seen it in one out of three games so maybe rare. [Replay](https://bar-rts.com/replays/ba4fd46755318df16ec88fca5b0bc2d9)~~
It seems to be quite common for large lobbies. What happens is probably that some queen fails one or more spawns due to so much stuff on the map. but the spawn counter is increased anyway preventing game over.
I'm not sure if this change solves it.

### Work done
* Added logs for spawning and killing bosses as well as setting a rulesparam.
* Spawn function can return nil so checking for that before updating the counters
* the `>=` shouldn't be needed but I don't see how it can hurt

#### Test steps
- [x] Tested raptor/scav defense in skirmish from start to game over with 7 bosses