### PR TITLE
.editorconfig CRLF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ root = true
 # Set default charset
 [*.{lua,md}]
 charset = utf-8
-end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 # Set default charset
 [*.{lua,md}]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
### Work done
We use CRLF line endings, for some reason .editorconfig is using LF line endings.