### PR TITLE
fix(gridmenu): put extra units t3 aircraft plant and t2 con turrets in the same positions

### DIFF
--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -2036,8 +2036,13 @@ local unitGrids = {
 
 if Spring.GetModOptions().experimentalextraunits then
 	for _, builder in pairs({"armaca", "coraca", "legaca", "armack", "corack", "legack", "armacv", "coracv", "legacv"}) do
-		unitGrids[builder][1][3][3] = builder:sub(1, 3) .. "wint2"
+		local faction = builder:sub(1, 3)
+		unitGrids[builder][1][3][3] =  faction .. "wint2"
+		unitGrids[builder][4][1][2] = faction .. "apt3"
+		unitGrids[builder][4][1][3] = faction .. "nanotct2"
 	end
+	unitGrids["armacsub"][4][1][3] = "armnanotc2plat"
+	unitGrids["coracsub"][4][1][3] = "cornanotc2plat"
 end
 
 if Spring.Utilities.Gametype.IsScavengers() or Spring.GetModOptions().forceallunits then


### PR DESCRIPTION
Similar to #4490. This is mostly an improvement for tweaks that are adding buildoptions producing much more drastic shuffling of the grid. It also makes the grid position for T2 con turrets coherent without tweaks.

### Work done
- Added Experimental Aircraft Plant to gridmenu layouts
- Added T2 Construction Turrets (including naval) to gridmenu layouts at position 3

#### Test steps
- [x] Tested Aircraft, bot, vehicle and sea T2 constructors as well as scav counterparts
- [x] Extra units off has no difference
- [x] Extra units on gives same positions of all buildoptions in the grid

### Screenshots:
#### BEFORE:
![image](https://github.com/user-attachments/assets/92271a13-5ef3-461b-96b5-0cb710a6086c)
![image](https://github.com/user-attachments/assets/763c5f16-c2e9-4ec6-b1e2-808e1f86355a)
![image](https://github.com/user-attachments/assets/614f55d7-0af3-428f-a837-81408584da3a)

#### AFTER:
![image](https://github.com/user-attachments/assets/3703693b-a9eb-45bf-b6e3-b23fe6bb9d56)
![image](https://github.com/user-attachments/assets/1d524f40-8be9-4b79-aec1-ee668e0f5fca)