### PR TITLE
Improve autoplace to include mexes out of start box

### DIFF
--- a/luarules/gadgets/lib_startpoint_guesser.lua
+++ b/luarules/gadgets/lib_startpoint_guesser.lua
@@ -119,6 +119,24 @@ function GuessOne(teamID, allyID, xmin, zmin, xmax, zmax, startPointTable)
 				freeMetalSpotScores[i] = freeMetalSpotScores[i] + score
 			end
 		end
+		-- Also check all the walkable spots as some may be on the edge of the startbox
+		for j=1,#walkableMetalSpots do
+			local jx,jz = walkableMetalSpots[j][1],walkableMetalSpots[j][2]
+			if ix ~= jx or iz ~= jz then
+				local r = math.sqrt((ix-jx)^2+(iz-jz)^2)
+				local iy = Spring.GetGroundHeight(ix,iz)
+				local jy = Spring.GetGroundHeight(jx,jz)
+				local isWithinClaimRadius = (r <= claimRadius)
+				local isWithinClaimHeight = (math.abs(iy-jy) <= claimHeight)
+				local score -- Magic formula. Assumes all metal spots are of equal production value, TODO...
+				if isWithinClaimRadius and isWithinClaimHeight then
+					score = 10
+				else
+					score = r^(-1/2)
+				end
+				freeMetalSpotScores[i] = freeMetalSpotScores[i] + score
+			end
+		end
 	end
 
 	-- find free metal spot with highest score


### PR DESCRIPTION
Improve autoplace to include mexes out of start box

### Work done
Previously, autoplace was not considering mexes outside of the start box when it decided where to place you. This can cause issues as even on the most popular maps (e.g. glitters), it is by intention that you take the mexes outside of the starting map by starting at the edge of the start box. 

Easiest to see visually:
Before: 
![image](https://github.com/user-attachments/assets/6267be80-8534-4a16-9308-600edc21eb83)

After:
![image](https://github.com/user-attachments/assets/5ad85552-97ba-4bb3-a890-0eadf66e4492)

Here's what the algorithm considered before:
![image](https://github.com/user-attachments/assets/23b9c22b-3440-4d32-86e5-cfe091c23f4c)
(note the third mex is cut off)

The algorithm itself is pretty old (~2014) so no major changes for a first PR. Can probably change the entire thing to a clustering approach down the line.

