### PR TITLE
For game_draft_spawn_order.lua, if array is nil when shuffling, fallback to 0 to trigger return ... end

### DIFF
--- a/luarules/gadgets/game_draft_spawn_order.lua
+++ b/luarules/gadgets/game_draft_spawn_order.lua
@@ -56,7 +56,7 @@ local function FindPlayerName(teamID)
 end
 
 local function shuffleArray(array)
-	local n = #array or 0
+	local n = array and #array or 0
 	if n <= 1 then return array end
 	local random = math.random
 	for i = 1, n do

--- a/luarules/gadgets/game_draft_spawn_order.lua
+++ b/luarules/gadgets/game_draft_spawn_order.lua
@@ -56,7 +56,7 @@ local function FindPlayerName(teamID)
 end
 
 local function shuffleArray(array)
-	local (n = array and #array) or 0
+	local n = (array and #array) or 0
 	if n <= 1 then return array end
 	local random = math.random
 	for i = 1, n do

--- a/luarules/gadgets/game_draft_spawn_order.lua
+++ b/luarules/gadgets/game_draft_spawn_order.lua
@@ -56,7 +56,7 @@ local function FindPlayerName(teamID)
 end
 
 local function shuffleArray(array)
-	local n = #array
+	local n = #array or 0
 	if n <= 1 then return array end
 	local random = math.random
 	for i = 1, n do

--- a/luarules/gadgets/game_draft_spawn_order.lua
+++ b/luarules/gadgets/game_draft_spawn_order.lua
@@ -56,7 +56,7 @@ local function FindPlayerName(teamID)
 end
 
 local function shuffleArray(array)
-	local n = array and #array or 0
+	local (n = array and #array) or 0
 	if n <= 1 then return array end
 	local random = math.random
 	for i = 1, n do


### PR DESCRIPTION
Should fix #4558 

Tested in singleplayer, both in current form and by forcing `local n = 0`, which does not produce any addition errors and the following appears in log, implying it's functioning at a basic level:
`
[t=00:04:09.373657][f=-000001] Random draft order start position mode activated. Players await their turn to place.
`
[infolog.txt](https://github.com/user-attachments/files/19397622/infolog.txt)
