### PR TITLE
Sneaky Pete Description Fix

### DIFF
--- a/language/en/units.json
+++ b/language/en/units.json
@@ -1027,7 +1027,7 @@
 			"armhlt": "Area Control Laser Tower",
 			"armhp": "Builds Hovercraft",
 			"armjam": "Radar Jammer Vehicle",
-			"armjamt": "Cloakable Jammer Tower",
+			"armjamt": "Jammer Tower",
 			"armjanus": "Twin Medium Rocket Launcher",
 			"armjeth": "Amphibious Anti-air Bot",
 			"armjuno": "Anti Radar / Jammer / Minefield / ScoutSpam Weapon",


### PR DESCRIPTION
Removes "Cloakable" from the Sneaky Pete's unit description.