### PR TITLE
T1 Amphibious Tank Turnrate Boost

### DIFF
--- a/scripts/Units/armpincer.bos
+++ b/scripts/Units/armpincer.bos
@@ -66,8 +66,8 @@ AimPrimary(heading, pitch)
 {
 	signal SIG_AIM;
 	set-signal-mask SIG_AIM;
-	turn turret to y-axis heading speed <75.000000>;
-	turn sleeve to x-axis <0.000000> - pitch speed <64.000000>;
+	turn turret to y-axis heading speed <130.000000>;
+	turn sleeve to x-axis <0.000000> - pitch speed <130.000000>;
 	wait-for-turn turret around y-axis;
 	wait-for-turn sleeve around x-axis;
 	start-script RestoreAfterDelay();

--- a/scripts/Units/corgarp.bos
+++ b/scripts/Units/corgarp.bos
@@ -66,8 +66,8 @@ AimPrimary(heading, pitch)
 {
 	signal SIG_AIM;
 	set-signal-mask SIG_AIM;
-	turn turret to y-axis heading speed <90.000000>;
-	turn sleeve to x-axis <0.000000> - pitch speed <90.000000>;
+	turn turret to y-axis heading speed <130.000000>;
+	turn sleeve to x-axis <0.000000> - pitch speed <130.000000>;
 	wait-for-turn turret around y-axis;
 	wait-for-turn sleeve around x-axis;
 	start-script RestoreAfterDelay();

--- a/scripts/Units/legamphtank.bos
+++ b/scripts/Units/legamphtank.bos
@@ -114,8 +114,8 @@ AimPrimary(heading, pitch)
 	{
 		start-script deploy();
 	}
-	turn turret to y-axis heading speed <75.000000>;
-	turn barrelPivot to x-axis <0.000000> - pitch speed <64.000000>;
+	turn turret to y-axis heading speed <130.000000>;
+	turn barrelPivot to x-axis <0.000000> - pitch speed <130.000000>;
 	wait-for-turn turret around y-axis;
 	wait-for-turn barrelPivot around x-axis;
 	start-script RestoreAfterDelay();


### PR DESCRIPTION
### Work Done
The Garpike, Pincer, and Cetus all received turret turnrate boosts to 130 degrees per frame over what they were previously (somewhere between 60-70 for the Pincer and Cetus and 90 for the Garpike).