### PR TITLE
modify luaui/widgets/unit_auto_group.lua to fix issue #4457

### DIFF
--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -157,8 +157,7 @@ local function ChangeUnitTypeAutogroupHandler(_, _, args, data)
 			local curUnitDefID = GetUnitDefID(unitID)
 			if selUnitDefIDs[curUnitDefID] then
 				if gr then
-					local finishedBuilding = not GetUnitIsBeingBuilt(unitID)
-					if finishedBuilding then
+					if immediate or not GetUnitIsBeingBuilt(unitID) then
 						SetUnitGroup(unitID, gr)
 						SelectUnitArray({ unitID }, true)
 					end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Fix issue where units that were still being built would not be selected by Alt+num shortcut even when "immediate" mode was enabled


#### Addresses Issue(s)
[- Issue URL](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4457)



#### Test steps
- [x] select units with alt+num to add them to a group (including units being built)