### PR TITLE
Broadcast enemy/friendly commander destroyed notification even if they died on screen.

### DIFF
--- a/luarules/gadgets/sfx_notifications.lua
+++ b/luarules/gadgets/sfx_notifications.lua
@@ -234,7 +234,7 @@ else
 				local players =  PlayersInAllyTeamID(GetAllyTeamID(Spring.GetUnitTeam(unitID)))
 				for ct, player in pairs (players) do
 					if tostring(player) then
-						if not unitInView then
+						--if not unitInView then
 							if Spring.GetUnitRulesParam(unitID, "unit_evolved") then
 
 							elseif not attackerTeam and select(6, Spring.GetTeamInfo(unitTeam, false)) == myAllyTeamID and (not commanderLastDamaged[unitID] or commanderLastDamaged[unitID]+150 < Spring.GetGameFrame()) then
@@ -242,7 +242,7 @@ else
 							else
 								BroadcastEvent("NotificationEvent", "FriendlyCommanderDied", tostring(player))
 							end
-						end
+						--end
 						if enableLastcomNotif and allyComCount == 1 then
 							if myComCount == 1 then
 								BroadcastEvent("NotificationEvent", "YouHaveLastCommander", tostring(player))
@@ -253,14 +253,14 @@ else
 					end
 				end
 			end
-			if not unitInView then
+			--if not unitInView then
 				local players =  AllButAllyTeamID(GetAllyTeamID(Spring.GetUnitTeam(unitID)))
 				for ct, player in pairs (players) do
 					if tostring(player) and not Spring.GetUnitRulesParam(unitID, "unit_evolved") then
 						BroadcastEvent("NotificationEvent", "EnemyCommanderDied", tostring(player))
 					end
 				end
-			end
+			--end
 			commanderLastDamaged[unitID] = nil
 		end
 	end


### PR DESCRIPTION
It's very annoying to be confused if the commander that just died was your ally or enemy.
Just because it happened on screen doesn't mean the player was paying attention to it, so, we really shouldn't filter out the notification based on that.