### PR TITLE
grid keybinds: swap settarget and settargetnoground

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -60,8 +60,8 @@ bind               sc_p  gatherwait
 bind         Shift+sc_p  gatherwait
 bind               sc_r  repair
 bind         Shift+sc_r  repair
-bind               sc_s  settargetnoground
-bind           Alt+sc_s  settarget
+bind               sc_s  settarget
+bind           Alt+sc_s  settargetnoground
 bind          Ctrl+sc_s  canceltarget
 bind               sc_u  unloadunits
 bind         Shift+sc_u  unloadunits

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -60,8 +60,8 @@ bind               sc_o  guard
 bind         Shift+sc_o  guard
 bind               sc_r  repair
 bind         Shift+sc_r  repair
-bind               sc_s  settargetnoground
-bind           Alt+sc_s  settarget
+bind               sc_s  settarget
+bind           Alt+sc_s  settargetnoground
 bind          Ctrl+sc_s  canceltarget
 bind               sc_u  unloadunits
 bind         Shift+sc_u  unloadunits


### PR DESCRIPTION
### Work done

- Move settarget back to `s` for grid layout.
- Move settargetnoground to `alt+s` so it will remain accessible for grid users.

#### Addresses Issue(s)

- See the following request by @resopmok: https://discord.com/channels/549281623154229250/680550534993805385/1353440518473777212 

### Remarks

- Apparently users not happy about having settargetnoground instead of settarget as default non modified bind.
- Leaving setargetnoground accesible through `alt+s` since I see value in having it accessible, legacy has it and as GDT pointed out, it has the advantage of not allowing clicking on ground by mistake when you want to target a unit.
  - If you don't want this just remove the line from PR pls.
  - If left in, then keybind images should be updated at some point to reflect this.
- Further discussion should be done with @resopmok, also for future keybind changes I recommend discussion at #keybinds at discord, or at least notify @resopmok first.
- This change will leave `grid` and `legacy` with different defaults, imo not ideal and I think it might give one of them a small advantage (specially if grid ends with no settargetnoground access), but I think GDT can maybe resolve this with @resopmok... I won't point it more times XD.
  - I see a bit of conflict here among PR review, GDT decisions, user feedback and discord channel discussion, these discussion also surfaced some problems with blueprint bindings. Just something to think about, maybe the project lead want to develop better guidelines or goals for keybind layout/presets development for the future.