### PR TITLE
Fix: Spawn Assist Turret no longer spawns turret on resources

### DIFF
--- a/luarules/Utilities/damgam_lib/position_checks.lua
+++ b/luarules/Utilities/damgam_lib/position_checks.lua
@@ -145,6 +145,25 @@ local function OccupancyCheck(posx, posy, posz, posradius) -- Returns true if th
 	end
 end
 
+local function ResourceCheck(posx, posz, posradius) -- Returns true if there are no resources in the spawn area
+    local posradiusSquared = posradius * posradius
+    local metalSpots = GG["resource_spot_finder"].metalSpotsList
+    for _,spot in ipairs(metalSpots) do
+        if math.distance2dSquared(spot.x, spot.z, posx, posz) < posradiusSquared then
+            return false
+        end
+    end
+
+    local geoSpots = GG["resource_spot_finder"].geoSpotsList
+    for _,spot in ipairs(geoSpots) do
+        if math.distance2dSquared(spot.x, spot.z, posx, posz) < posradiusSquared then
+            return false
+        end
+    end
+
+    return true
+end
+
 local function VisibilityCheck(posx, posy, posz, posradius, allyTeamID, checkLoS, checkAirLos, checkRadar) -- Return True when position is not in sensor ranges of specified allyTeam.
 
 	local posradius = posradius or 1000
@@ -357,6 +376,7 @@ return {
     LavaCheck = LavaCheck,
     MapIsLandOrSea = MapIsLandOrSea,
     LandOrSeaCheck = LandOrSeaCheck,
+    ResourceCheck = ResourceCheck,
 
     -- Scavengers
     ScavengerSpawnAreaCheck = ScavengerSpawnAreaCheck,

--- a/luarules/gadgets/game_commander_builder.lua
+++ b/luarules/gadgets/game_commander_builder.lua
@@ -53,6 +53,9 @@ function SpawnAssistTurret(unitID, unitDefID, unitTeam)
             canSpawnTurret = positionCheckLibrary.OccupancyCheck(posx, posy, posz, 96)
         end
         if canSpawnTurret then
+            canSpawnTurret = positionCheckLibrary.ResourceCheck(posx, posz, 96)
+        end
+        if canSpawnTurret then
             spawnpadID = Spring.CreateUnit(spawnpadunit, posx, posy, posz, 0, unitTeam)
             break
         end


### PR DESCRIPTION
No more builder turret on mexes & geos!

### Work done

I've added a fragment of code to the logic spawning the Base Builder Turret, which checks for geo spots & metal spots and avoids them.

#### Setup

Enable **Base Builder Turret**

#### Test steps

- Start game
- Start close to geo and/or mexes
- Turret doesn't ruin your resource spots

### Screenshots:

In this screenshot, I made it spawn 100 turrets, and i temporarily disabled the `OccupancyCheck`. You can clearly see they will avoid the eco spots.

![image](https://github.com/user-attachments/assets/a39d5b86-a4b2-4748-933a-4ed59b5f39c4)


In-game name: gamebuster  (if it gets merged, can i get the🏴‍☠️ ?)
