### PR TITLE
Remove energy costs for minor secondary lasers

### DIFF
--- a/units/ArmSeaplanes/armsaber.lua
+++ b/units/ArmSeaplanes/armsaber.lua
@@ -85,7 +85,7 @@ return {
 				cratermult = 0,
 				duration = 0.05,
 				edgeeffectiveness = 0.15,
-				energypershot = 15,
+				energypershot = 0,
 				explosiongenerator = "custom:genericshellexplosion-small",
 				impulsefactor = 0,
 				intensity = 4,

--- a/units/CorHovercraft/corhal.lua
+++ b/units/CorHovercraft/corhal.lua
@@ -111,7 +111,7 @@ return {
 				craterboost = 0,
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
-				energypershot = 45,
+				energypershot = 0,
 				explosiongenerator = "custom:laserhit-medium-green",
 				firestarter = 90,
 				impactonly = 1,


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Remove energy costs for all t1 units of weapon type "BeamLaser"

#### Addresses Issue(s)
#1260 


