### PR TITLE
map_startbox: Fix bad stretching of minimap start position dots.

### DIFF
--- a/luaui/Shaders/map_startcone_gl4.vert.glsl
+++ b/luaui/Shaders/map_startcone_gl4.vert.glsl
@@ -19,6 +19,7 @@ layout (location = 4) in vec4 teamcolor;
 
 uniform float isMinimap = 0;
 uniform int flipMiniMap = 0;
+uniform float startPosScale = 0.0005;
 
 out DataVS {
 	vec4 v_worldposrad;
@@ -39,8 +40,11 @@ void main()
 	}else{
 		//vec2 ndcxy = normalize(position.xz);//  * 100/256.0;
 		//if (length(position.xz) < 1e3) { ndcxy = vec2(0);}
-		vec2 ndcxy = position.xz * 0.0005;
-		ndcxy = (worldposrad.xz / mapSize.xy + ndcxy) * 2.0 - 1.0;
+		vec2 ndcxy = position.xz * startPosScale;
+		ndcxy.y *= mapSize.x/mapSize.y;
+
+		vec2 xz = worldposrad.xz;
+		ndcxy = (xz / mapSize.xy + ndcxy) * 2.0 - 1.0;
 		if (flipMiniMap < 1) {
 			ndcxy.y *= -1;
 		}else{

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -42,6 +42,8 @@ local commanderNameList = {}
 local usedFontSize = fontSize
 
 local widgetScale = (1 + (vsx * vsy / 5500000))
+local startPosRatio = 0.0001
+local startPosScale = (vsx*startPosRatio) / select(3, Spring.GetMiniMapGeometry())
 
 local isSpec = Spring.GetSpectatingState() or Spring.IsReplay()
 local myTeamID = Spring.GetMyTeamID()
@@ -311,6 +313,9 @@ local function DrawStartCones(inminimap)
 	startConeShader:Activate()
 	startConeShader:SetUniform("isMinimap", inminimap and 1 or 0)
 	startConeShader:SetUniformInt("flipMiniMap", getMiniMapFlipped() and 1 or 0)
+
+	startConeShader:SetUniformFloat("startPosScale", startPosScale)
+
 	startConeVBOTable:draw()
 	startConeShader:Deactivate()
 end
@@ -559,6 +564,8 @@ end
 function widget:ViewResize(x, y)
 	vsx, vsy = x, y
 	widgetScale = (0.75 + (vsx * vsy / 7500000))
+
+	startPosScale = (vsx*startPosRatio) / select(3, Spring.GetMiniMapGeometry())
 	removeTeamLists()
 	usedFontSize = fontSize * widgetScale
 	local newFontfileScale = (0.5 + (vsx * vsy / 5700000))


### PR DESCRIPTION
### Work done

- Fix bad stretching of the start position circles.

### Remarks

**note:** this is not about the dots being misplaced, it's about them not being round.

- Problem introduced with [#4084](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4084)
- This PR makes sure size remains constant relative to screen size, and with proper aspect ratio.
  - Chose the size by manual inspection to something that looks fine to me, but can be changed with startPosRatio.
- Might need some testing and maybe tweak for double screen, didn't test that and not sure if that's really supported atm.


#### Test steps
- Check out this branch
- Start skirmish on varied map sizes, see the dots are the same size, and aspect ratio remains ok.

### Screenshots:

**note:** this is not about the dots being misplaced, it's about them not being round.

The circles get stretched with the map aspect ratio, due to them having been rendered as circles over a square, that afterwards gets stretched over the whole minimap area.

vertical map:

![glitterdots](https://github.com/user-attachments/assets/c7cc211e-8d55-4eb1-b2ee-a4e2202f3d51)

horizontal map:

![widedots](https://github.com/user-attachments/assets/65ce85d4-041f-45ac-9551-3c92a1a17140)

detail:

![detaildots](https://github.com/user-attachments/assets/271c3b10-942a-4414-8133-eb3013021c9c)

