### PR TITLE
Update proposed_unit_reworks_defs.lua

### DIFF
--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -1,6 +1,79 @@
 local function proposed_unit_reworksTweaks(name, uDef)
 
-		
+	if tonumber(uDef.customparams.techlevel) == 2 and uDef.energycost and uDef.metalcost and uDef.buildtime and not (name == "armavp" or name == "coravp" or name == "armalab" or name == "coralab" or name == "armaap" or name == "coraap") then
+		uDef.energycost = math.ceil((uDef.energycost + (uDef.energycost + uDef.metalcost * 60) * 0.05) * 0.002) * 500
+		uDef.buildtime = math.ceil(uDef.buildtime * 0.013 / 5) * 500
+	end
+	if name == "armmoho" or name == "cormoho" or name == "cormexp" then
+		uDef.metalcost = uDef.metalcost + 50
+	end
+	if name == "armageo" or name == "corageo" then
+		uDef.metalcost = uDef.metalcost + 200
+	end
+	if name == "armavp" or name == "coravp" or name == "armalab" or name == "coralab" or name == "armaap" or name == "coraap" or name == "armasy" or name == "corasy" then
+		uDef.metalcost = uDef.metalcost - 1000
+		uDef.workertime = 400
+	end
+	if name == "armvp" or name == "corvp" or name == "armlab" or name == "corlab" or name == "armsy" or name == "corsy"then
+		uDef.metalcost = uDef.metalcost - 50
+		uDef.buildtime = uDef.buildtime - 1500
+		uDef.energycost = uDef.energycost - 280
+	end
+	if name == "armap" or name == "corap" or name == "armhp" or name == "corhp" or name == "armfhp" or name == "corfhp" then
+		uDef.metalcost = uDef.metalcost - 100
+		uDef.buildtime = uDef.buildtime - 600
+		uDef.energycost = uDef.energycost - 100
+	end
+
+	if tonumber(uDef.customparams.techlevel) == 1 and uDef.customparams.subfolder and uDef.buildtime and (uDef.customparams.subfolder == "CorShips" or uDef.customparams.subfolder == "ArmShips") then
+		uDef.buildtime = math.ceil(uDef.buildtime * 0.015) * 100
+	end
+
+	if name == "armnanotc" or name == "cornanotc" or name == "armnanotcplat" or name == "cornanotcplat" then
+		uDef.metalcost = uDef.metalcost + 40
+		uDef.corpse = "DEAD"
+		uDef.explodeas = "mediumBuildingExplosionGeneric"
+		uDef.selfdestructas = "mediumBuildingExplosionGenericSelfd"
+		uDef.featuredefs = {
+			dead = {
+				blocking = false,
+				category = "heaps",
+				collisionvolumescales = "35.0 4.0 6.0",
+				collisionvolumetype = "cylY",
+				damage = uDef.health,
+				energy = 0,
+				featurereclamate = "SMUDGE01",
+				footprintx = 2,
+				footprintz = 2,
+				height = 4,
+				hitdensity = 100,
+				metal = math.floor(uDef.metalcost*0.6),
+				object = "Units/cor2X2C.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+				seqnamereclamate = "TREE1RECLAMATE",
+				world = "All Worlds",
+			},
+		}
+	end
+	
+	if name == "corafus" or  name == "armafus" then
+		uDef.metalcost = 12000
+		uDef.energycost = 84000
+		uDef.buildtime = 240000
+	end
+	if name == "armacv" or name == "coracv" or name == "armack" or name == "corack" or name == "armaca" or name == "coraca" then
+		uDef.workertime = math.ceil(uDef.workertime * 0.13) * 10
+	end
+
+	if name == "armshltx" or name == "corgant" or name == "armshltxuw" or name == "corgantuw" then
+		uDef.workertime = 2000
+	end
+	if tonumber(uDef.customparams.techlevel) == 3 and uDef.energycost and uDef.metalcost and uDef.buildtime then
+		uDef.energycost = math.ceil((uDef.energycost) * 0.00105) * 1000
+		uDef.metalcost = math.ceil(uDef.metalcost * 0.0105) * 100
+		uDef.buildtime = math.ceil(uDef.buildtime * 0.0016) * 1000
+	end
 	return uDef
 end
 


### PR DESCRIPTION
T1 bot/veh/ship factories
    -50m, -1500bt, -280e  //has ~same amount of resources available upon factory completion with a 3mex+2solar start, game starts 5s faster, having multiple factories is less costly. Also favors faster openings a tiny bit, on the order of ~10m per mex skipped
T1 air/hover/amphib factories
    -100m, -600bt, -100e  //smaller buildtime buff than main starting factories, for comparatively slower start, but bigger m cost decrease to encourage use as secondary factory

T1 ships
    1.5x buildtimes //makes them more in line with land unit ratios, and makes it harder for a sea player to get slinged metal into play

T2 factories
    -1000m
    300bp -> 400bp
T2 cons
    buildpower = 1.3 * buildpower  //they will be as fast at building their buildlist as before, but assisting them will be slower for others
T2 units, buildings (includes cons, but not labs)
    energycost =  energycost + (Metalcost * 60 + Energycost) * 0.05
    buildtime = 1.3 * buildtime
T2 mexes
    +50m on top of e/bt increases
T2 ageos
    +200m on top of e/bt increases
Afus
    metalcost 9700 -> 12000
    energycost 84000
    buildtime 240000 //costs more metal but needs less of a nanofarm to make

T3 gantry
    600bp -> 2000bp
T3 units
    buildtime = 1.6 * buildtime
    energycost = 1.05 * energycost
    metalcost = 1.05 * metalcost

Nano turrets
    210m -> 250m
    Leaves heap     //ie. not resurrectable
    Death explosion damages non-nano units, self-d does damage. Same explosion stats as llt. Slightly less damage to other nanos but in bigger aoe. Tight nano grid still chainreacts killing all of them

--

T1 factory costs make it more effective to make multiple factories, a bit faster to switch tech, and a slight nerf to factory sharing / skipping factories. Air comes a tad later compared to land factory opening. Nano cost nerf also makes keeping commander at home a bit better, and the explosion/wreck changes just make them follow similar logic that every other unit in the game has.

Cheaper t2 factory makes it t2 potentially easier to reach early, especially in small games where you can't share big amount of metal so easily. But the added infra requirement to spamming lots t2 units should make for a smoother transition, where you have a longer period of t1 and t2 units fighting in combination. Sharing a lot of resources to a single t2 player to pump out a lot of t2 is still possible, but will not generally be more efficient than now since the savings from cheaper lab would have to go to building more e/bp first, to allow it. Decreased factory cost also makes it more plausible to have multiple t2 factories even for a single player for more unit variety.

The energy cost increase combined with buildtime increase, means that the energy drain per buildpower for t2 units remains roughly similar, with individual variance - high metal:energy ratio units will see energy drain rise a bit more.

Gantry bp + buildtime increase combo means that you make units faster than now when using <10 nanos, at 10 and above you will get units slower. Making it more costly to dump a ton of a team's resources on assisting a single gantry, but possibly allowing for some earlier plays of getting smaller number of t3 to micro alongside lower tier units, instead of replacing them. Though cheaper t2 factory means you get less metal back from reclaiming t2, to finance going t3. T3 getting cost increase in both energy and metal, unlike t2 which got it in only energy, makes them easier to afford in mex-based economy, but harder in converter-based economy, due to the need to build converters (compared to t2's).

The buildtime increases of t2/t3 units also make it slower to spend metal on them, and also make it slower to rez them (or repair). Potentially opening some lategame use for metal-heavy t1 units even outside of full metal plate, when combined with reclaiming those big units instead of rezzing. T2 eco nerfs will make eco progress a bit slower, also making reclaim comparatively more efficient. Afus lower buildtime will make it more reasonable to make in a metalrich situation, for just powering energy needs, so you don't need a huge nanofarm geared for converter eco just to consider making them.

Unit to unit combat interactions (once they are built) are basically unchanged, though repair speed is changed. You could try to anticipate which units would be helped or hurt by this patch, but trying to adjust all that could easily be just wrong, and also just bloat up the changelog. It might be a bit bloated already, but I wanted to go through all the eco issues including the simple stuff like wind asymmetry in one go. For the first test version not all of that necessarily needs to be included. Overall I'd expect the impact to be overall surprisingly subtle, with people still building mostly similar armies as now, just with the timings changed. But who knows what the social effect would be. And the exact numbers can and will be adjusted.
