### PR TITLE
map_startbox: Fix incorrectly flipped minimap startboxes.

### DIFF
--- a/luaui/Shaders/map_startpolygon_gl4.frag.glsl
+++ b/luaui/Shaders/map_startpolygon_gl4.frag.glsl
@@ -189,6 +189,8 @@ void main(void)
 		mapWorldPos.xz = (v_position.xy * 0.5 + 0.5);
 		if (flipMiniMap == 0){
 			mapWorldPos.z = 1.0 - mapWorldPos.z;
+		}else{
+			mapWorldPos.x = 1.0 - mapWorldPos.x;
 		}
 		mapWorldPos.xz *= mapSize.xy;
 		


### PR DESCRIPTION
### Work done

- Fix x axis for flipped minimap startboxes

#### Addresses Issue(s)

- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4280

### Remarks

- The above issue isn't very clear about what exactly isn't flipped, at least in my tests z axis seems to be properly inverted, while x axis isn't. This PR fixes that.

#### Test steps

- Get this branch as BAR.sdd
- Start skirmish on a map where startboxes are not symmetrical over the x axis, like "Thermal Shock v1.1", or most horizontally aligned maps.
- Make sure minimap autoflip is on, and then flip view with "alt+o" (grid) or rotating camera.
- See the startboxes flip correctly


### Screenshots:

![flipping](https://github.com/user-attachments/assets/ffe20782-b190-499d-8605-a149b3ec71d0)
