### PR TITLE
Fix scav and raptor finding of initial spawn locations

### DIFF
--- a/luarules/gadgets/include/SpawnerEnemyLib.lua
+++ b/luarules/gadgets/include/SpawnerEnemyLib.lua
@@ -1,0 +1,37 @@
+local EnemyLib = {}
+
+local adjustSide = function(sideMin, sideMax, mapSize, spread)
+	local sideSize = sideMax - sideMin
+	if sideSize > spread then
+		return sideMin, sideMax
+	end
+
+	local incrementBy = math.ceil((spread - sideSize)/2)
+	sideMin = sideMin - incrementBy
+	sideMax = sideMax + incrementBy
+	if sideMin < 0 then
+		sideMax = sideMax - sideMin
+		sideMin = 0
+	elseif sideMax > mapSize then
+		sideMin = sideMin - (sideMax - mapSize)
+		sideMax = mapSize
+	end
+	return sideMin, sideMax
+
+end
+
+local adjustStartBox = function(startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax, spread)
+	startBoxXMin, startBoxXMax = adjustSide(startBoxXMin, startBoxXMax, Game.mapSizeX, spread)
+	startBoxZMin, startBoxZMax = adjustSide(startBoxZMin, startBoxZMax, Game.mapSizeZ, spread)
+	return startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax
+end
+
+EnemyLib.GetAdjustedStartBox = function(enemyAllyTeamID, spread)
+	local startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax = Spring.GetAllyTeamStartBox(enemyAllyTeamID)
+	if startBoxXMin and startBoxZMin and startBoxXMax and startBoxZMax then
+		startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax = adjustStartBox(startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax, spread)
+	end
+	return startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax
+end
+
+return EnemyLib

--- a/luarules/gadgets/include/SpawnerEnemyLib.lua
+++ b/luarules/gadgets/include/SpawnerEnemyLib.lua
@@ -9,13 +9,6 @@ local adjustSide = function(sideMin, sideMax, mapSize, spread)
 	local incrementBy = math.ceil((spread - sideSize)/2)
 	sideMin = sideMin - incrementBy
 	sideMax = sideMax + incrementBy
-	if sideMin < 0 then
-		sideMax = sideMax - sideMin
-		sideMin = 0
-	elseif sideMax > mapSize then
-		sideMin = sideMin - (sideMax - mapSize)
-		sideMax = mapSize
-	end
 	sideMin = math.max(sideMin, 0)
 	sideMax = math.min(sideMax, mapSize)
 	return sideMin, sideMax

--- a/luarules/gadgets/include/SpawnerEnemyLib.lua
+++ b/luarules/gadgets/include/SpawnerEnemyLib.lua
@@ -16,6 +16,8 @@ local adjustSide = function(sideMin, sideMax, mapSize, spread)
 		sideMin = sideMin - (sideMax - mapSize)
 		sideMax = mapSize
 	end
+	sideMin = math.max(sideMin, 0)
+	sideMax = math.min(sideMax, mapSize)
 	return sideMin, sideMax
 
 end

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1551,6 +1551,10 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:GameStart()
+		gadget:SetInitialSpawnBox()
+	end
+
+	function gadget:SetInitialSpawnBox()
 		if config.burrowSpawnType == "initialbox" or config.burrowSpawnType == "alwaysbox" or config.burrowSpawnType == "initialbox_post" then
 			local _, _, _, _, _, luaAllyID = Spring.GetTeamInfo(raptorTeamID, false)
 			if luaAllyID then
@@ -1794,7 +1798,7 @@ if gadgetHandler:IsSyncedCode() then
 			else
 				spawnAreaMultiplier = spawnAreaMultiplier + 1
 				RaptorStartboxXMin, RaptorStartboxZMin, RaptorStartboxXMax, RaptorStartboxZMax = EnemyLib.GetAdjustedStartBox(raptorAllyTeamID, config.burrowSize*1.5*spawnAreaMultiplier)
-				gadget:GameStart()
+				gadget:SetInitialSpawnBox()
 			end
 		end
 	end

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -731,6 +731,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function SpawnBurrow(number)
+		local foundLocation = false
 		tracy.ZoneBeginN("Raptors:SpawnBurrow")
 		for i = 1, (number or 1) do
 			local canSpawnBurrow = false
@@ -853,6 +854,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			if canSpawnBurrow then
+				foundLocation = true
 				local burrowID = CreateUnit(config.burrowName, spawnPosX, spawnPosY, spawnPosZ, mRandom(0,3), raptorTeamID)
 				if burrowID then
 					SetupBurrow(burrowID, spawnPosX, spawnPosY, spawnPosZ)
@@ -863,7 +865,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 		tracy.ZoneEnd()
-		return canSpawnBurrow
+		return foundLocation
 	end
 
 	function updateQueenHealth()

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1790,7 +1790,7 @@ if gadgetHandler:IsSyncedCode() then
 		tracy.ZoneEnd()
 	end
 
-	function gadget:TrySpawnBurrow()
+	function gadget:TrySpawnBurrow(t)
 		local spawned = SpawnBurrow()
 		timeOfLastSpawn = t
 		if firstSpawn then
@@ -1888,14 +1888,14 @@ if gadgetHandler:IsSyncedCode() then
 
 
 			if burrowCount < minBurrows then
-				gadget:TrySpawnBurrow()
+				gadget:TrySpawnBurrow(t)
 			end
 
 			if (t > config.burrowSpawnRate and burrowCount < minBurrows and (t > timeOfLastSpawn + 10 or burrowCount == 0)) or (config.burrowSpawnRate < t - timeOfLastSpawn and burrowCount < maxBurrows) then
 				if (config.burrowSpawnType == "initialbox") and (t > config.gracePeriod) then
 					config.burrowSpawnType = "initialbox_post"
 				end
-				gadget:TrySpawnBurrow()
+				gadget:TrySpawnBurrow(t)
 				raptorEvent("burrowSpawn")
 				SetGameRulesParam("raptor_hiveCount", SetCount(burrows))
 			elseif config.burrowSpawnRate < t - timeOfLastSpawn and burrowCount >= maxBurrows then

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1917,7 +1917,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	function gadget:TrySpawnBurrow()
+	function gadget:TrySpawnBurrow(t)
 		local spawned = SpawnBurrow()
 		timeOfLastSpawn = t
 		if firstSpawn then
@@ -2016,14 +2016,14 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			if burrowCount < minBurrows then
-				gadget:TrySpawnBurrow()
+				gadget:TrySpawnBurrow(t)
 			end
 
 			if (t > config.burrowSpawnRate and burrowCount < minBurrows and (t > timeOfLastSpawn + 10 or burrowCount == 0)) or (config.burrowSpawnRate < t - timeOfLastSpawn and burrowCount < maxBurrows) then
 				if (config.burrowSpawnType == "initialbox") and (t > config.gracePeriod) then
 					config.burrowSpawnType = "initialbox_post"
 				end
-				gadget:TrySpawnBurrow()
+				gadget:TrySpawnBurrow(t)
 				scavEvent("burrowSpawn")
 				SetGameRulesParam("scav_hiveCount", SetCount(burrows))
 			elseif config.burrowSpawnRate < t - timeOfLastSpawn and burrowCount >= maxBurrows then

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1911,6 +1911,21 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	function gadget:TrySpawnBurrow()
+		local spawned = SpawnBurrow()
+		timeOfLastSpawn = t
+		if firstSpawn then
+			if spawned then
+				timeOfLastWave = (config.gracePeriod + 10) - config.scavSpawnRate
+				firstSpawn = false
+			else
+				spawnAreaMultiplier = spawnAreaMultiplier + 1
+				RaptorStartboxXMin, RaptorStartboxZMin, RaptorStartboxXMax, RaptorStartboxZMax = EnemyLib.GetAdjustedStartBox(raptorAllyTeamID, config.burrowSize*1.5*spawnAreaMultiplier)
+				gadget:GameStart()
+			end
+		end
+	end
+
 	local announcedFirstWave = false
 	function gadget:GameFrame(n)
 
@@ -1995,33 +2010,14 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			if burrowCount < minBurrows then
-				local spawned = SpawnBurrow()
-				timeOfLastSpawn = t
-				if firstSpawn then
-					if spawned then
-						timeOfLastWave = (config.gracePeriod + 10) - config.scavSpawnRate
-						firstSpawn = false
-					else
-						spawnAreaMultiplier = spawnAreaMultiplier + 1
-						RaptorStartboxXMin, RaptorStartboxZMin, RaptorStartboxXMax, RaptorStartboxZMax = EnemyLib.GetAdjustedStartBox(raptorAllyTeamID, config.burrowSize*1.5*spawnAreaMultiplier)
-						gadget:GameStart()
-					end
-				end
+				gadget:TrySpawnBurrow()
 			end
 
 			if (t > config.burrowSpawnRate and burrowCount < minBurrows and (t > timeOfLastSpawn + 10 or burrowCount == 0)) or (config.burrowSpawnRate < t - timeOfLastSpawn and burrowCount < maxBurrows) then
 				if (config.burrowSpawnType == "initialbox") and (t > config.gracePeriod) then
 					config.burrowSpawnType = "initialbox_post"
 				end
-				if firstSpawn then
-					SpawnBurrow()
-					timeOfLastWave = (config.gracePeriod + 10) - config.scavSpawnRate
-					timeOfLastSpawn = t
-					firstSpawn = false
-				else
-					SpawnBurrow()
-					timeOfLastSpawn = t
-				end
+				gadget:TrySpawnBurrow()
 				scavEvent("burrowSpawn")
 				SetGameRulesParam("scav_hiveCount", SetCount(burrows))
 			elseif config.burrowSpawnRate < t - timeOfLastSpawn and burrowCount >= maxBurrows then

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -873,6 +873,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function SpawnBurrow(number)
+		local foundLocation = false
 		for i = 1, (number or 1) do
 			local canSpawnBurrow = false
 			local spread = config.burrowSize*1.5
@@ -1003,6 +1004,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			if canSpawnBurrow then
+				foundLocation = true
 				for name,data in pairs(config.burrowUnitsList) do
 					if math.random() <= config.spawnChance and data.minAnger < math.max(1, techAnger) and data.maxAnger > math.max(1, techAnger) then
 						local burrowID = CreateUnit(name, spawnPosX, spawnPosY, spawnPosZ, mRandom(0,3), scavTeamID)
@@ -1020,7 +1022,7 @@ if gadgetHandler:IsSyncedCode() then
 				--playerAggression = playerAggression + (config.angerBonus*(bossAnger*0.01))
 			end
 		end
-		return canSpawnBurrow
+		return foundLocation
 	end
 
 	function updateBossLife()

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1735,6 +1735,10 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:GameStart()
+		gadget:SetInitialSpawnBox()
+	end
+
+	function gadget:SetInitialSpawnBox()
 		if config.burrowSpawnType == "initialbox" or config.burrowSpawnType == "alwaysbox" or config.burrowSpawnType == "initialbox_post" then
 			local _, _, _, _, _, luaAllyID = Spring.GetTeamInfo(scavTeamID, false)
 			if luaAllyID then
@@ -1921,7 +1925,7 @@ if gadgetHandler:IsSyncedCode() then
 			else
 				spawnAreaMultiplier = spawnAreaMultiplier + 1
 				ScavStartboxXMin, ScavStartboxZMin, ScavStartboxXMax, ScavStartboxZMax = EnemyLib.GetAdjustedStartBox(scavAllyTeamID, config.burrowSize*1.5*spawnAreaMultiplier)
-				gadget:GameStart()
+				gadget:SetInitialSpawnBox()
 			end
 		end
 	end

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1920,7 +1920,7 @@ if gadgetHandler:IsSyncedCode() then
 				firstSpawn = false
 			else
 				spawnAreaMultiplier = spawnAreaMultiplier + 1
-				RaptorStartboxXMin, RaptorStartboxZMin, RaptorStartboxXMax, RaptorStartboxZMax = EnemyLib.GetAdjustedStartBox(raptorAllyTeamID, config.burrowSize*1.5*spawnAreaMultiplier)
+				ScavStartboxXMin, ScavStartboxZMin, ScavStartboxXMax, ScavStartboxZMax = EnemyLib.GetAdjustedStartBox(scavAllyTeamID, config.burrowSize*1.5*spawnAreaMultiplier)
 				gadget:GameStart()
 			end
 		end


### PR DESCRIPTION
### Work done

- Adjust scav and raptor startbox when smaller than twice the burrow spread size so the area will always be searchable.
- Incrementally enlarge the search area when failing to create the initial (first and second) burrows/beacons.
- Create a library for common scav and raptor code (gadgets/include/SpawnerEnemyLib.lua)

#### Addresses Issue(s)
- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4048
- Queen/boss spawning directly when spawn area too small and/or can't find a place for the initial two burrows/beacons.

### Remarks

- The issues happen when the player chooses a too small startbox for the scav/raptor player.
  - Not finding a burrow location can also happen when the startbox doesn't have enough flat areas.
- Talked to @Damgam about this, but maybe we can refine it further, or change the solution a bit.
- Created the library because I see a lot of duplicated scav and raptor code (and didn't want to add the new code duplicated), I think a lot of the scav and raptor code can be moved here for better reuse and maintainability, but let me know if you don't like that or think a different place could be used. I see there's also damgam_lib, but I think that one can be used for generic utilities, more than scav and raptor code.
  - didn't want to refactor a lot of existing code to not complicate the PR more than needed, so for now I placed the purely new methods in the library, and still had to perform some similar changes and additions for scav and raptor files.

### Details

The algorithm works as follows

- First makes sure startbox width and height is bigger than twice `spread = burrowsize*1.5`, since then we will be looking between min+spread and max-spread, so anything smaller than that will fail trying to find a random location inside (and generate lua errors when trying to `random(min+spread, max-spread)`, since `min+spread > max-spread`).
- After the first try, if it couldn't find a location for a spawn, it will increase the margin to three times the spread, then four and so on. This way the AI should be able to find a location, even in the face of difficult terrain.
- Each spawn try is done every 30 frames, just like it was doing before, the difference is it's enlarging the search area now (and also making sure its initially big enough).

After the first burrow, we assume we already have a placeable area, but still need to place a second burrow, so the code keeps trying with a less aggressive startbox expansion algo:

-  It will divide the remaining grace time by some number (currently 20), and use that as max retries before incrementing startbox again.
- Doing it like this to let the random placer some tries to find something, otherwise assume need to expand.
- If the grace period is arriving then that means we need to hurry up, so it starts more aggressively expanding the area, until in the end every second is going to be expanding.

### How to test

- Start a skirmish game against raptors or scav, and give the raptor/scav player a very small startbox, or placed in an unspawnable area.
- Start the game and see how the ai eventually finds a location.
  - also no more math.random errors.
  - queen shouldn't spawn directly now since it should always manage a first burrow spawn.

### Screenshots

As an example, when faced with a small box, that's also in an unspawnable part of the map like this:

![raptorboxes](https://github.com/user-attachments/assets/3924db54-6f68-49c4-8553-d2bf8bdd44c5)

it will successfully spawn as seen in the following image:

![raptorsstartsm](https://github.com/user-attachments/assets/f09439ac-78b6-4445-b50d-7c430616e202)

example of where the second burrow is placed:

![raptors2sm](https://github.com/user-attachments/assets/aa281e60-7598-4f25-a1d4-7b787a39bb65)

similarly for scavs:

![scavs](https://github.com/user-attachments/assets/5e1ca8a2-a73c-43ef-bffd-7ced7dff579e)



