### PR TITLE
Don't run scheduled library updates on forks

### DIFF
--- a/.github/workflows/update-recoil-lua-library.yml
+++ b/.github/workflows/update-recoil-lua-library.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
 jobs:
   update:
+    # Only run this workflow on forks if it was triggered manually. Otherwise
+    # contributors will get extra commits in their PRs.
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'beyond-all-reason/beyond-all-reason'
     name: Update recoil-lua-library
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

> [!IMPORTANT]
> Would appreciate a quick merge from a maintainer. The longer this stays unfixed the higher chance of contributors running into this issue and being confused/having merge issues etc.

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

Disable the `update-recoil-lua-library` workflow on forks. This was causing additional unwanted (and confusing) commits in ppl's forks. Might lead to conflicts and master diverging too.

e.g. #4614

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Merge this PR
- [ ] Wait until the job runs to see if I made some subtle error.

I already tested manual dispatch [on my fork](https://github.com/rhys-vdw/Beyond-All-Reason/actions/runs/14108680725/job/39521397015#step:3:1).

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
