### PR TITLE
April fools music

### DIFF
--- a/luarules/gadgets/ai_namer.lua
+++ b/luarules/gadgets/ai_namer.lua
@@ -201,6 +201,7 @@ if gadgetHandler:IsSyncedCode() then
 		"TIMBO",
 		"Titan",
 		"TopHatButcher",
+		"Unusual Emphasis",
 		"Woody",
 		"Yavarin",
 		"Zagupi",

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -343,8 +343,8 @@ if gadgetHandler:IsSyncedCode() then
 		nSpawnedQueens = 0
 		nKilledQueens = 0
 		queenResistance = {}
-		SetGameRulesParam("raptorQueenAnger", queenAnger)
-		SetGameRulesParam("raptorTechAnger", techAnger)
+		SetGameRulesParam("raptorQueenAnger", math.floor(queenAnger))
+		SetGameRulesParam("raptorTechAnger", math.floor(techAnger))
 		local nextDifficulty
 		difficultyCounter = difficultyCounter + 1
 		endlessLoopCounter = endlessLoopCounter + 1
@@ -389,8 +389,8 @@ if gadgetHandler:IsSyncedCode() then
 	--
 
 	SetGameRulesParam("raptorQueenTime", queenTime)
-	SetGameRulesParam("raptorQueenAnger", queenAnger)
-	SetGameRulesParam("raptorTechAnger", techAnger)
+	SetGameRulesParam("raptorQueenAnger", math.floor(queenAnger))
+	SetGameRulesParam("raptorTechAnger", math.floor(techAnger))
 	SetGameRulesParam("raptorGracePeriod", config.gracePeriod)
 	SetGameRulesParam("raptorDifficulty", config.difficulty)
 	SetGameRulesParam("RaptorQueenAngerGain_Base", 100/config.queenTime)
@@ -1853,8 +1853,8 @@ if gadgetHandler:IsSyncedCode() then
 				SetGameRulesParam("RaptorQueenAngerGain_Aggression", (playerAggression*0.01)/(config.queenTime/3600))
 				SetGameRulesParam("RaptorQueenAngerGain_Eco", playerAggressionEcoValue)
 			end
-			SetGameRulesParam("raptorQueenAnger", queenAnger)
-			SetGameRulesParam("raptorTechAnger", techAnger)
+			SetGameRulesParam("raptorQueenAnger", math.floor(queenAnger))
+			SetGameRulesParam("raptorTechAnger", math.floor(techAnger))
 
 			if queenAnger >= 100 or (burrowCount <= 1 and t > config.gracePeriod) then
 				-- check if the queen should be alive

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -344,8 +344,8 @@ if gadgetHandler:IsSyncedCode() then
 		nSpawnedBosses = 0
 		nKilledBosses = 0
 		bossResistance = {}
-		SetGameRulesParam("scavBossAnger", bossAnger)
-		SetGameRulesParam("scavTechAnger", techAnger)
+		SetGameRulesParam("scavBossAnger", math.floor(bossAnger))
+		SetGameRulesParam("scavTechAnger", math.floor(techAnger))
 		local nextDifficulty
 		difficultyCounter = difficultyCounter + 1
 		endlessLoopCounter = endlessLoopCounter + 1
@@ -390,8 +390,8 @@ if gadgetHandler:IsSyncedCode() then
 	--
 
 	SetGameRulesParam("scavBossTime", bossTime)
-	SetGameRulesParam("scavBossAnger", bossAnger)
-	SetGameRulesParam("scavTechAnger", techAnger)
+	SetGameRulesParam("scavBossAnger", math.floor(bossAnger))
+	SetGameRulesParam("scavTechAnger", math.floor(techAnger))
 	SetGameRulesParam("scavGracePeriod", config.gracePeriod)
 	SetGameRulesParam("scavDifficulty", config.difficulty)
 	SetGameRulesParam("ScavBossAngerGain_Base", 100/config.bossTime)
@@ -1982,8 +1982,8 @@ if gadgetHandler:IsSyncedCode() then
 				SetGameRulesParam("ScavBossAngerGain_Aggression", (playerAggression*0.01)/(config.bossTime/3600))
 				SetGameRulesParam("ScavBossAngerGain_Eco", playerAggressionEcoValue)
 			end
-			SetGameRulesParam("scavBossAnger", bossAnger)
-			SetGameRulesParam("scavTechAnger", techAnger)
+			SetGameRulesParam("scavBossAnger", math.floor(bossAnger))
+			SetGameRulesParam("scavTechAnger", math.floor(techAnger))
 
 			if bossAnger >= 100 or (burrowCount <= 1 and t > config.gracePeriod) then
 				-- check if the boss should be alive

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -95,6 +95,9 @@ local function ReloadMusicPlaylists()
 	if (tonumber(os.date("%m")) == 4 and tonumber(os.date("%d")) <= 3) and Spring.GetConfigInt('UseSoundtrackAprilFools', 1) == 1 then
 		table.append(menuTracksNew, VFS.DirList(musicDirNew..'/events/aprilfools/menu', allowedExtensions))
 		table.append(loadingTracksNew, VFS.DirList(musicDirNew..'/events/aprilfools/loading', allowedExtensions))
+		table.append(peaceTracksNew, VFS.DirList(musicDirNew..'/events/aprilfools/peace', allowedExtensions))
+		table.append(warlowTracksNew, VFS.DirList(musicDirNew..'/events/aprilfools/war', allowedExtensions))
+		table.append(warhighTracksNew, VFS.DirList(musicDirNew..'/events/aprilfools/war', allowedExtensions))
 	end
 
 	if (tonumber(os.date("%m")) == 12 and tonumber(os.date("%d")) >= 12) then
@@ -1022,6 +1025,7 @@ function PlayNewTrack(paused)
 	end
 	currentTrack = nil
 	currentTrackList = nil
+	currentTrackIsEventMusic = nil
 
 	if gameOver then
 		currentTrackList = gameoverTracks
@@ -1088,7 +1092,14 @@ function PlayNewTrack(paused)
 	if currentTrack then
 		Spring.PlaySoundStream(currentTrack, 1)
 		playing = true
-		interruptionTime = math.random(interruptionMinimumTime, interruptionMaximumTime)
+
+		if 	string.find(currentTrack, "aprilfools")
+		or	string.find(currentTrack, "xmas") then
+			interruptionTime = 999999
+		else
+			interruptionTime = math.random(interruptionMinimumTime, interruptionMaximumTime)
+		end
+
 		if fadeDirection then
 			setMusicVolume(fadeLevel)
 		else
@@ -1178,7 +1189,7 @@ function widget:GameFrame(n)
 						fadeDirection = -2
 						fadeOutSkipTrack = true
 					elseif (interruptionEnabled and (playedTime >= interruptionTime) and gameFrame >= serverFrame-300)
-					  and ((currentTrackListString == "intro" and n > 90)
+					  and ((currentTrackListString == "intro" and n > 9000)
 						or (currentTrackListString == "peace" and warMeter > warHighLevel * 0.5 ) -- Peace in battle times, let's play some WarLow music at half of WarHigh threshold
 						or (currentTrackListString == "warLow" and warMeter > warHighLevel * 2 ) -- WarLow music is playing but battle intensity is very high, Let's switch to WarHigh at double of WarHigh threshold
 						or (currentTrackListString == "warHigh" and warMeter <= warLowLevel * 0.5 ) -- WarHigh music is playing, but it has been quite peaceful recently. Let's switch to peace music at 50% of WarLow threshold

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -29,8 +29,8 @@ local showGUI = true
 local minSilenceTime = 30
 local maxSilenceTime = 120
 local warLowLevel = 1000
-local warHighLevel = 40000
-local warMeterResetTime = 30 -- seconds
+local warHighLevel = 32500
+local warMeterResetTime = 40 -- seconds
 local interruptionMinimumTime = 20 -- seconds
 local interruptionMaximumTime = 60 -- seconds
 
@@ -1169,8 +1169,23 @@ function widget:GameFrame(n)
 		--	Spring.StopSoundStream()
 		--	return
 		--end
-
-		if warMeter > 0 then
+		if Spring.Utilities.Gametype.IsRaptors() then
+			if (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 10 then
+				warMeter = warLowLevel+1
+			elseif (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 50 then
+				warMeter = warHighLevel+1
+			else
+				warMeter = 0
+			end
+		elseif Spring.Utilities.Gametype.IsScavengers() then
+			if (Spring.GetGameRulesParam("scavBossAnger", 0)) > 10 then
+				warMeter = warLowLevel+1
+			elseif (Spring.GetGameRulesParam("scavBossAnger", 0)) > 50 then
+				warMeter = warHighLevel+1
+			else
+				warMeter = 0
+			end
+		elseif warMeter > 0 then
 			warMeter = math.floor(warMeter - (warMeter * 0.04))
 			if warMeter > warHighLevel*3 then
 				warMeter = warHighLevel*3

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -1171,17 +1171,18 @@ function widget:GameFrame(n)
 		--end
 		if Spring.Utilities.Gametype.IsRaptors() then
 			if (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 50 then
-				warMeter = warHighLevel*1.1
+				warMeter = warHighLevel+1
 			elseif (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 10 then
-				warMeter = warLowLevel*1.1
+				warMeter = warLowLevel+1
 			else
 				warMeter = 0
 			end
+			Spring.Echo(warMeter)
 		elseif Spring.Utilities.Gametype.IsScavengers() then
 			if (Spring.GetGameRulesParam("scavBossAnger", 0)) > 50 then
-				warMeter = warHighLevel*1.1
+				warMeter = warHighLevel+1
 			elseif (Spring.GetGameRulesParam("scavBossAnger", 0)) > 10 then
-				warMeter = warLowLevel*1.1
+				warMeter = warLowLevel+1
 			else
 				warMeter = 0
 			end

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -1170,18 +1170,18 @@ function widget:GameFrame(n)
 		--	return
 		--end
 		if Spring.Utilities.Gametype.IsRaptors() then
-			if (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 10 then
-				warMeter = warLowLevel+1
-			elseif (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 50 then
-				warMeter = warHighLevel+1
+			if (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 50 then
+				warMeter = warHighLevel*1.1
+			elseif (Spring.GetGameRulesParam("raptorQueenAnger", 0)) > 10 then
+				warMeter = warLowLevel*1.1
 			else
 				warMeter = 0
 			end
 		elseif Spring.Utilities.Gametype.IsScavengers() then
-			if (Spring.GetGameRulesParam("scavBossAnger", 0)) > 10 then
-				warMeter = warLowLevel+1
-			elseif (Spring.GetGameRulesParam("scavBossAnger", 0)) > 50 then
-				warMeter = warHighLevel+1
+			if (Spring.GetGameRulesParam("scavBossAnger", 0)) > 50 then
+				warMeter = warHighLevel*1.1
+			elseif (Spring.GetGameRulesParam("scavBossAnger", 0)) > 10 then
+				warMeter = warLowLevel*1.1
 			else
 				warMeter = 0
 			end


### PR DESCRIPTION
- Prepared Music Player for Peace and War event music.
- Made Loading music not fade out after game starts.
- Tweaked WarHigh threshold which should result in music switching to WarHigh a bit earlier.
- Scavengers and Raptors warMeter is now tied to queen/boss progress instead of combat scores.