### PR TITLE
Season 2 balance tuning modoption

### DIFF
--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -1,6 +1,16 @@
 local function proposed_unit_reworksTweaks(name, uDef)
 
-		
+		if name == "armpw" then
+			uDef.metalcost = 60
+		end
+		if name == "corak" then
+			uDef.metalcost = 45
+			uDef.weapondefs.gator_laser.range = 220
+		end
+		if name == "corsktl" then
+			uDef.stealth = true
+		end
+
 	return uDef
 end
 


### PR DESCRIPTION
Pawn 52->60m
Grunt 43->45m, 210->220 range
Skuttle is stealthy


New values for the Pawn and Grunt, not necessarily final - the changes can be tuned down if they seem in the right direction, but too much.

Also to address the issue of Cortex T2 botlab lacking a good counter to T3, Skuttle is now stealthy to fill that role better.

In the proposed_unit_reworks modoption.