### PR TITLE
Fix gadget method errors in atmosphere configs

### DIFF
--- a/luarules/configs/Atmosphereconfigs/acidicquarry.lua
+++ b/luarules/configs/Atmosphereconfigs/acidicquarry.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/altored divide bar remake.lua
+++ b/luarules/configs/Atmosphereconfigs/altored divide bar remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/ascendancy.lua
+++ b/luarules/configs/Atmosphereconfigs/ascendancy.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/centerrock remake dry.lua
+++ b/luarules/configs/Atmosphereconfigs/centerrock remake dry.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/centerrock remake.lua
+++ b/luarules/configs/Atmosphereconfigs/centerrock remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/colorado_v2.lua
+++ b/luarules/configs/Atmosphereconfigs/colorado_v2.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/dsdr.lua
+++ b/luarules/configs/Atmosphereconfigs/dsdr.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/eye of horus.lua
+++ b/luarules/configs/Atmosphereconfigs/eye of horus.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/folsomdamr.lua
+++ b/luarules/configs/Atmosphereconfigs/folsomdamr.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/forge.lua
+++ b/luarules/configs/Atmosphereconfigs/forge.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/generic_config_setup.lua
+++ b/luarules/configs/Atmosphereconfigs/generic_config_setup.lua
@@ -64,6 +64,8 @@ end
 -- badweatherchance = 100
 -- fireflieschance = 100
 
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
     local clock = n%fullcyclelength
 

--- a/luarules/configs/Atmosphereconfigs/koom valley 3.lua
+++ b/luarules/configs/Atmosphereconfigs/koom valley 3.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/koomvalleybar.lua
+++ b/luarules/configs/Atmosphereconfigs/koomvalleybar.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/lv412.lua
+++ b/luarules/configs/Atmosphereconfigs/lv412.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/onyx cauldron.lua
+++ b/luarules/configs/Atmosphereconfigs/onyx cauldron.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/quicksilver remake.lua
+++ b/luarules/configs/Atmosphereconfigs/quicksilver remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/red comet remake.lua
+++ b/luarules/configs/Atmosphereconfigs/red comet remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/riverdale remake.lua
+++ b/luarules/configs/Atmosphereconfigs/riverdale remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/seths ravine.lua
+++ b/luarules/configs/Atmosphereconfigs/seths ravine.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/tabula_remake.lua
+++ b/luarules/configs/Atmosphereconfigs/tabula_remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/tma20x.lua
+++ b/luarules/configs/Atmosphereconfigs/tma20x.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)

--- a/luarules/configs/Atmosphereconfigs/trefoil remake.lua
+++ b/luarules/configs/Atmosphereconfigs/trefoil remake.lua
@@ -1,3 +1,5 @@
+local gadget = gadget ---@type Gadget
+
 function gadget:GameFrame(n)
 	if n == 31 then
 		Spring.Echo("Loaded atmosphere CEGs config for map: " .. Game.mapName)


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Suppress more `duplicate-set-field` complaints from LLS using the same method established in #4608.

This s a strict find+replace for `function gadget:GameFrame` in `./luarules/configs/Atmosphereconfigs`, and removing one instance of the warning per file.

These were not addressed in the first pass because I did a find and replace against `GetInfo` which these gagets do not use.

<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
n/a - only IDE facing changes.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
