### PR TITLE
Remove `math.round`

### DIFF
--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -4,12 +4,6 @@ if not math.isInRect then
 	end
 end
 
-if not math.round then
-	function math.round(num, idp)
-		return ("%." .. (((num == 0) and 0) or idp or 0) .. "f"):format(num)
-	end
-end
-
 if not math.cross_product then
 	function math.cross_product (px, pz, ax, az, bx, bz)
 		return ((px - bx) * (az - bz) - (ax - bx) * (pz - bz))


### PR DESCRIPTION
Which is already defined in Recoil (and returns a number)

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Remove an implementation/shim for `math.round` which will never be defined because it is [already defined in Recoil](https://github.com/beyond-all-reason/spring/blob/c3d683dd93c43b6df48a65c2ddbbec8d8e822456/rts/Lua/LuaMathExtra.cpp#L150-L170
).

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
