### PR TITLE
Fix incorrect UnitCmdDone callin parameter ordering in several places.

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1797,9 +1797,9 @@ function gadgetHandler:UnitIdle(unitID, unitDefID, unitTeam)
 	return
 end
 
-function gadgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+function gadgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	for _, g in ipairs(self.UnitCmdDoneList) do
-		g:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+		g:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	end
 	return
 end

--- a/luarules/gadgets/dbg_unit_callins.lua
+++ b/luarules/gadgets/dbg_unit_callins.lua
@@ -145,9 +145,9 @@ function gadget:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams, cmdOp
 	if showcallins then addEvent(unitID, "UnitCommand") end
 end
 
-function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	if enabledcallins.UnitCmdDone == nil then return end
-	if printcallins then Spring.Echo("g:UnitCmdDone",unitID, unitDefID and UnitDefs[unitDefID].name, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts) end
+	if printcallins then Spring.Echo("g:UnitCmdDone",unitID, unitDefID and UnitDefs[unitDefID].name, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag) end
 	if showcallins then addEvent(unitID, "UnitCmdDone") end
 end
 

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -686,7 +686,7 @@ function gadget:UnitGiven(unitID, unitDefID, unitTeam, oldTeam)
 end
 
 
-function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	local carrierUnitID = spGetUnitRulesParam(unitID, "carrier_host_unit_id")
 	if carrierUnitID then
 		if carrierMetaList[carrierUnitID].subUnitsList[unitID] then

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -550,12 +550,7 @@ if gadgetHandler:IsSyncedCode() then
 		pausedTargets[unitID] = nil
 	end
 
-	local emptyCmdOptions = {}
 	function gadget:UnitCmdDone(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag)
-		if type(cmdOptions) ~= 'table' then
-			-- does UnitCmdDone always returns number instead of table?
-			cmdOptions = emptyCmdOptions
-		end
 		processCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
 		if cmdID == CMD_STOP then
 			if unitTargets[unitID] and not unitTargets[unitID].ignoreStop then

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -551,7 +551,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local emptyCmdOptions = {}
-	function gadget:UnitCmdDone(unitID, unitDefID, teamID, cmdID, cmdTag, cmdParams, cmdOptions)
+	function gadget:UnitCmdDone(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag)
 		if type(cmdOptions) ~= 'table' then
 			-- does UnitCmdDone always returns number instead of table?
 			cmdOptions = emptyCmdOptions

--- a/luaui/Widgets/dbg_unit_callins.lua
+++ b/luaui/Widgets/dbg_unit_callins.lua
@@ -166,9 +166,9 @@ function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams, cmdOp
 	if showcallins then addEvent(unitID, "UnitCommand") end 
 end
 
-function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	if enabledcallins.UnitCmdDone == nil then return end
-	if printcallins then Spring.Echo("w:UnitCmdDone",unitID, unitDefID and UnitDefs[unitDefID].name, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts) end
+	if printcallins then Spring.Echo("w:UnitCmdDone",unitID, unitDefID and UnitDefs[unitDefID].name, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag) end
 	if showcallins then addEvent(unitID, "UnitCmdDone") end 
 end
 

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -2329,10 +2329,10 @@ function widgetHandler:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams
 	return
 end
 
-function widgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+function widgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	tracy.ZoneBeginN("W:UnitCmdDone")
 	for _, w in ipairs(self.UnitCmdDoneList) do
-		w:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+		w:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
 	end
 	tracy.ZoneEnd()
 	return


### PR DESCRIPTION
### Work done

- Fix incorrect UnitCmdDone callin parameter ordering in several places.

### Remarks

  - While it was wrong in several places, I think `unit_target_on_the_move` was the only really affected gadget, due to others not really using the incorrect parameters.
    - Not sure about what the effect was (was using empty options instead of the command ones), so might want to test this a bit.
- It was ok in some places too.

For reference, relevant engine code:

https://github.com/saurtron/spring/blob/849fa6f7d08da11a324cb25b801054495b739d77/rts/Lua/LuaHandle.cpp#L1290

https://github.com/saurtron/spring/blob/849fa6f7d08da11a324cb25b801054495b739d77/rts/Lua/LuaUtils.cpp#L942

and all callins before the fix:

```LUA
./luaui/Widgets/unit_load_own_moving.lua:function widget:UnitCmdDone(uID, uDefID, uTeam)
./luaui/Widgets/unit_idle_guard.lua:function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, _, _)
./luaui/Widgets/gui_selfd_icons.lua:function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
./luaui/Widgets/gui_gridmenu.lua:function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, options, cmdTag)
./luaui/Widgets/dbg_unit_callins.lua:function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
./luaui/barwidgets.lua:function widgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
./luaui/barwidgets.lua:		w:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
./luarules/gadgets/unit_airbase.lua:	function gadget:UnitCmdDone(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
./luarules/gadgets/unit_target_on_the_move.lua:	function gadget:UnitCmdDone(unitID, unitDefID, teamID, cmdID, cmdTag, cmdParams, cmdOptions)
./luarules/gadgets/unit_carrier_spawner.lua:function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
./luarules/gadgets/unit_reverse_move.lua:function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts, cmdTag)
./luarules/gadgets/dbg_unit_callins.lua:function gadget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
./luarules/gadgets.lua:function gadgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
```