### PR TITLE
smart_selection: Decouple all modifier from append

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -30,9 +30,10 @@ local mods = {
  idle     = false, -- whether to select only idle units
  same     = false, -- whether to select only units that share type with current selection
  deselect = false, -- whether to select units not present in current selection
- all      = false, -- whether to select without filters
+ all      = false, -- whether to select without filters and append (backwards compatibility, it's like append+any)
  mobile   = false, -- whether to select only mobile units
  append   = false, -- whether to append units to current selection
+ any      = false, -- whether to select without filters
 }
 local customFilterDef = ""
 local lastMods = mods
@@ -262,12 +263,18 @@ function widget:Update(dt)
 		and mods.all == lastMods[4]
 		and mods.mobile == lastMods[5]
 		and mods.append == lastMods[6]
+		and mods.any == lastMods[7]
 		and customFilterDef == lastCustomFilterDef
 	then
 		return
 	end
 
-	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append }
+	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append, mods.any }
+	if mods.all then
+		-- backwards compatibility
+		mods.any = true
+		mods.append = true
+	end
 	lastCustomFilterDef = customFilterDef
 
 	-- Fill dictionary for set comparison
@@ -342,7 +349,7 @@ function widget:Update(dt)
 		end
 		mouseSelection = tmp
 
-	elseif selectBuildingsWithMobile == false and mods.all == false and mods.deselect == false then
+	elseif selectBuildingsWithMobile == false and mods.any == false and mods.deselect == false then
 		-- only select mobile units, not buildings
 		local mobiles = false
 		for i = 1, #mouseSelection do

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -30,8 +30,9 @@ local mods = {
  idle     = false, -- whether to select only idle units
  same     = false, -- whether to select only units that share type with current selection
  deselect = false, -- whether to select units not present in current selection
- all      = false, -- whether to select all units
+ all      = false, -- whether to select without filters
  mobile   = false, -- whether to select only mobile units
+ append   = false, -- whether to append units to current selection
 }
 local customFilterDef = ""
 local lastMods = mods
@@ -260,12 +261,13 @@ function widget:Update(dt)
 		and mods.deselect == lastMods[3]
 		and mods.all == lastMods[4]
 		and mods.mobile == lastMods[5]
+		and mods.append == lastMods[6]
 		and customFilterDef == lastCustomFilterDef
 	then
 		return
 	end
 
-	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile }
+	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append }
 	lastCustomFilterDef = customFilterDef
 
 	-- Fill dictionary for set comparison
@@ -394,7 +396,7 @@ function widget:Update(dt)
 		selectedUnits = newSelection
 		spSelectUnitArray(selectedUnits)
 
-	elseif mods.all then  -- append units inside selection rectangle to current selection
+	elseif mods.append then  -- append units inside selection rectangle to current selection
 		spSelectUnitArray(newSelection)
 		spSelectUnitArray(mouseSelection, true)
 		selectedUnits = Spring.GetSelectedUnits()

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -15,7 +15,8 @@ bind      Alt+backspace  fullscreen
 // common selectbox keys
 bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
 bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget
-bind          Any+shift  selectbox_all      // select all units modifier | Smart Select Widget
+bind          Any+shift  selectbox_append   // append to selection modifier | Smart Select Widget
+bind          Any+shift  selectbox_any      // select all units modifier | Smart Select Widget
 bind           Any+ctrl  selectbox_deselect // remove units from current selection modifier | Smart Select Widget
 bind            Any+alt  selectbox_mobile   // select only mobile units modifier | Smart Select Widget
 


### PR DESCRIPTION
### Work done

- Decouple smart_select all from append, so they can be used independently.
- Introduces new bindable actions: `selectbox_any` and `selectbox_append`

#### Addresses Issue(s)
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2220
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3347

### Remarks

- Update of https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2227
  - by request of @badosu and spreeezy
  - discard builder filter from there since it's now possible with the new selectApi doing `selectbox Not_Building_Builder_Buildoptions`

#### Backwards compatibility

Instead of simply keeping `all` without `append`, I chose here to add two new actions (`any` and `append`), and keep `all` with exactly the same behaviour (where `all = any + append`), so people with uikeys.txt remapping select_all won't suddently lose the ability to append (likely what they want, instead of being left with just `any` behaviour).

This might still break things for ppl using a custom `unit_smart_select.lua`, but I think there's no way around that, also those probably already have uikeys.txt and are more knowledgeable, so likely the lesser evil here.

If for some reason people is against this, and would rather have only `all` and `append`, but changing the meaning of `all`, please say so, it's easy to revert as it's an independent commit.

Also, if someone can think of a better name than `any` please say so.

see [this discord conversation](https://discord.com/channels/549281623154229250/680550534993805385/1356643558634815629) for more details.

#### The behaviour of the `all/any` filter

This PR doesn't  (or shouldn't) change the current filtering behaviour of `all` or `any` relative to master, and I think there could be a couple different 'all/any's, depending on the priority to override other filters. Probably for best effect still want to consider this for future PRs:

**any with top priority:** good when you have default with some filters, but want to override all of them and just get all (ie to clear filters)

**any with lowest priority:** good when you have default to all, but want to just skip it in place of other filters. Atm I think it mostly works like this.





I think this may need some discussion and maybe some additional work so people can configure the best defaults for them.
