### PR TITLE
fix hotkey connected to trajectory toggle, 60%

### DIFF
--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -77,6 +77,13 @@ bind               sc_b  onoff 1
 bind Shift+sc_b,Shift+sc_b  onoff 0
 bind         Shift+sc_b  onoff 1
 
+bind     sc_b,sc_b,sc_b  trajectory_toggle 1
+bind          sc_b,sc_b  trajectory_toggle 0
+bind     sc_b trajectory_toggle 2
+bind Shift+sc_b,Shift+sc_b,Shift+sc_b  trajectory_toggle 1
+bind Shift+sc_b,Shift+sc_b trajectory_toggle 0
+bind         Shift+sc_b  trajectory_toggle 2
+
 bind     sc_l,sc_l,sc_l  firestate 1
 bind          sc_l,sc_l  firestate 0
 bind               sc_l  firestate 2


### PR DESCRIPTION
Recently, trajectory toggling was uncoupled from on/off, and put into a widget for the order menu with 3 toggles: auto, low, and high. This PR connects a stateful activation of this toggle to the hotkey B for the grid keybind layout.
tap B once = auto
tap B twice = low
tap B 3x = high

This will align with the default behavior provided from the B hotkey before the trajectory change was made. This PR will maintain users' expected behavior from hotkeys.

### Work done
Added keybinds to grid_keys_60pct.txt

#### Addresses Issue(s)
Broken trajectory hotkey

#### Setup

#### Test steps
change tested. use altered uikeys.txt to test
### Screenshots:
#### BEFORE:
#### AFTER: