### PR TITLE
gfx_airjets_gl4: Don't process UnitGiven/Taken if unit not in LOS.

### DIFF
--- a/luaui/Widgets/gfx_airjets_gl4.lua
+++ b/luaui/Widgets/gfx_airjets_gl4.lua
@@ -36,6 +36,7 @@ local spGetUnitPieceMap = Spring.GetUnitPieceMap
 local spGetUnitIsActive = Spring.GetUnitIsActive
 local spGetUnitVelocity = Spring.GetUnitVelocity
 local spGetUnitTeam = Spring.GetUnitTeam
+local spIsUnitInLos = Spring.IsUnitInLos
 local glBlending = gl.Blending
 local glTexture = gl.Texture
 
@@ -1028,9 +1029,15 @@ function widget:RenderUnitDestroyed(unitID, unitDefID, unitTeam)
 end
 
 function widget:UnitGiven(unitID, unitDefID, unitTeam, oldTeam)
+	if not spIsUnitInLos(unitID) then
+		return
+	end
 	AddUnit(unitID, unitDefID, unitTeam)
 end
 function widget:UnitTaken(unitID, unitDefID, unitTeam, newTeamId)
+	if not spIsUnitInLos(unitID) then
+		return
+	end
 	RemoveUnit(unitID, unitDefID, unitTeam)
 end
 


### PR DESCRIPTION
### Work done

- gfx_airjets_gl4: Skip processing UnitGiven/Taken callins when unit is not in LOS

#### Addresses Issue(s)

- at least some of the airjets vbo zombie errors at infolog.txt

### Remarks

- When a unit is given when out of LOS, we shouldn't process it, since this widget is only interested in LOS units.
  - Processing it makes the system re-add, resulting in the unit being in vbo when it shouldn't, when it goes out of radar it's unitID will become invalid thus generating the zombie error.
- Should be ack'd by @Beherith.
- Let's hope the EnterLos/ExitLos callins are properly in sync with IsUnitInLos since otherwise there will still be corner cases.
- Alternative solution is to skip the check when ally status doesn't change, since in that case LOS shouldn't change either (that solution also allows skipping some extra cases, since we could skip re-adding on transfers among allies).
  - let me know if you prefer the alternative solution and I can remake this PR.
- Unsure if other widgets could be experiencing this issue too, scanned a bit but didn't see any others with the same tracking pattern.