### PR TITLE
feat(unitdefs): allow gaps in tweak slots

### DIFF
--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -221,11 +221,10 @@ local function preProcessTweakOptions()
 
 	local tweaks = {}
 	for name, value in pairs(modOptions) do
-		local type = name:match("^tweak(units)%d*$") or name:match("^tweak(defs)%d*$")
-		local index = name:match("^tweakunits(%d*)$") or name:match("^tweakdefs(%d*)$")
-		index = tonumber(index) or 0
-		if type and index then
-			table.insert(tweaks, {name = name, type = type, index = index, value = value})
+		local tweakType = name:match("^tweak([a-z]+)%d*$")
+		local index = tonumber(name:match("^tweak[a-z]+(%d*)$")) or 0
+		if (tweakType == 'defs' or tweakType == 'units') and index then
+			table.insert(tweaks, {name = name, type = tweakType, index = index, value = value})
 		end
 	end
 

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -210,8 +210,8 @@ end
 
 local function preProcessTweakOptions()
 	local modOptions = {}
-	if Spring.GetModOptions then
-		modOptions = Spring.GetModOptions()
+	if Spring.GetModOptionsCopy then
+		modOptions = Spring.GetModOptionsCopy()
 	end
 
 	--------------------------------------------------------------------------------
@@ -219,23 +219,36 @@ local function preProcessTweakOptions()
 	-- Balance Testing
 	--
 
-	-- modOptions.tweakdefs = 'Zm9yIG5hbWUsIHVkIGluIHBhaXJzKFVuaXREZWZzKSBkbwoJaWYgdWQuYnVpbGRjb3N0bWV0YWwgdGhlbgoJCXVkLmJ1aWxkY29zdG1ldGFsID0gMTAKCWVuZAplbmQ='
-	-- =>
-	-- for name, ud in pairs(UnitDefs) do
-	-- if ud.buildcostmetal then
-	--   ud.buildcostmetal = 10
-	-- end
-	do
-		local append = false
-		local name = "tweakdefs"
-		while modOptions[name] and string.len(modOptions[name]) > 1 do
-			local decodeSucess, postsFuncStr = pcall(string.base64Decode, modOptions[name])
-			if decodeSucess then
+	local tweaks = {}
+	for name, value in pairs(modOptions) do
+		local type = name:match("^tweak(units)%d*$") or name:match("^tweak(defs)%d*$")
+		local index = name:match("^tweakunits(%d*)$") or name:match("^tweakdefs(%d*)$")
+		index = tonumber(index) or 0
+		if type and index then
+			table.insert(tweaks, {name = name, type = type, index = index, value = value})
+		end
+	end
+
+	table.sort(tweaks, function(a, b)
+		if a.type == 'defs' and b.type == 'units' then
+			return true
+		elseif a.type == 'units' and b.type == 'defs' then
+			return false
+		end
+		return a.index < b.index
+	end)
+
+	for i = 1, #tweaks do
+		local tweak = tweaks[i]
+		local name = tweak.name
+		if tweak.type == 'defs' then
+			local decodeSuccess, postsFuncStr = pcall(string.base64Decode, modOptions[name])
+			if decodeSuccess then
 				local postfunc, err = loadstring(postsFuncStr)
 				if err then
 					Spring.Echo("Error parsing modoption", name, "from string", postsFuncStr, "Error: " .. err)
 				else
-					Spring.Echo("Loading tweakdefs modoption", append or 0)
+					Spring.Echo("Loading ".. name .. " modoption")
 					Spring.Echo(postsFuncStr)
 					if postfunc then
 						local success, result = pcall(postfunc)
@@ -247,39 +260,21 @@ local function preProcessTweakOptions()
 			else
 				Spring.Echo("Error parsing and decoding tweakdef", name, modOptions[name], "Error :" .. postsFuncStr)
 			end
-
-			append = (append or 0) + 1
-			name = "tweakdefs" .. append
-		end
-	end
-
-	--modOptions.tweakunits = 'ewphcm1sYWIgPSB7YnVpbGRDb3N0TWV0YWwgPSAxMCB9Cn0='
-	--=>
-	--{
-	--armlab = {buildCostMetal = 10 }
-	--}
-
-	do
-		local append = false
-		local modoptName = "tweakunits"
-		while modOptions[modoptName] and modOptions[modoptName] ~= "" do
-			local success, tweaks = pcall(Spring.Utilities.CustomKeyToUsefulTable, modOptions[modoptName])
-			if not success then
-				Spring.Echo("Failed to parse modoption", modoptName, "with value", modOptions[modoptName])
-			else
-				if type(tweaks) == "table" then
-					Spring.Echo("Loading tweakunits modoption", append or 0)
-					for name, ud in pairs(UnitDefs) do
-						if tweaks[name] then
-							Spring.Echo("Loading tweakunits for " .. name)
-							table.mergeInPlace(ud, system.lowerkeys(tweaks[name]), true)
+		else
+			local success, tweakunits = pcall(Spring.Utilities.CustomKeyToUsefulTable, modOptions[name])
+			if success then
+				if type(tweakunits) == "table" then
+					Spring.Echo("Loading ".. name .. " modoption")
+					for unitName, ud in pairs(UnitDefs) do
+						if tweakunits[unitName] then
+							Spring.Echo("Loading tweakunits for " .. unitName)
+							table.mergeInPlace(ud, system.lowerkeys(tweakunits[unitName]), true)
 						end
 					end
 				end
+			else
+				Spring.Echo("Failed to parse modoption", name, "with value", modOptions[name])
 			end
-
-			append = (append or 0) + 1
-			modoptName = "tweakunits" .. append
 		end
 	end
 end


### PR DESCRIPTION
This will help users that are not aware that all previous slots must be filled to load a tweak. It also makes it simpler to use saved pastes with multiple tweaks and reduces complexity for automated such tools.

### Work done
* Iterating modoptions, gathering all tweaks, sorting and loading without breaking on empty tweak

#### Test steps
- [x] For example setting `tweakdefs` to `U3ByaW5nLkVjaG8oJ0hlbGxvIGZyb20gdGVzdDEubHVhJyk` and `tweakdefs3` to `U3ByaW5nLkVjaG8oJ0hlbGxvIGZyb20gdGVzdDIubHVhJyk`. Both tweakdefs are expected to be loaded.
- [x] Correctly skips malformed tweaks like `dW5rbm93bmZ1bmN0aW9uKCk`
- [x] tweakdefs executed before tweakunits
- [x] Spread out tweaks like above + functional tweakunits like `LS1hcm1sYWIgdGVzdAp7YXJtbGFiPXttZXRhbGNvc3Q9MTIzfX0` loads like intended