### PR TITLE
improve code qualtiy of unit_custom_weapons_behaviors

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -120,6 +120,35 @@ local function isProjectileInWater(projectileID)
 	return positionY <= 0
 end
 
+local getSpawnParams
+do
+	local spawnCache = {
+		pos     = { 0, 0, 0 },
+		speed   = { 0, 0, 0 },
+		gravity = gravityPerFrame,
+		ttl = 3000,
+	}
+
+	getSpawnParams = function(params, projectileID)
+		local spawnDefID = params.speceffect_def
+
+		local cache = spawnCache
+
+		local pos = spawnCache.pos
+		pos[1], pos[2], pos[3] = spGetProjectilePosition(projectileID)
+
+		local vel = spawnCache.speed
+		local speed
+		vel[1], vel[2], vel[3], speed = spGetProjectileVelocity(projectileID)
+
+		cache.owner = Spring.GetProjectileOwnerID(projectileID)
+		cache.cegTag = params.cegtag
+		cache.model = params.model
+
+		return spawnDefID, cache, vel, speed
+	end
+end
+
 -- Cruise
 
 weaponCustomParamKeys.cruise = {
@@ -249,9 +278,9 @@ local function split(params, projectileID)
 	cache.gravity = gravityPerFrame
 
 	for _ = 1, params.number do
-		velocity[1] = velocityX + speed * (math_random(-100, 100) / 880)
-		velocity[2] = velocityY + speed * (math_random(-100, 100) / 440)
-		velocity[3] = velocityZ + speed * (math_random(-100, 100) / 880)
+		velocity[1] = velocity[1] + speed * (math_random(-100, 100) / 880)
+		velocity[2] = velocity[2] + speed * (math_random(-100, 100) / 440)
+		velocity[3] = velocity[3] + speed * (math_random(-100, 100) / 880)
 
 		Spring.SpawnProjectile(spawnDefID, cache)
 	end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -110,6 +110,16 @@ end
 
 --- Weapon behaviors -----------------------------------------------------------
 
+local function isProjectileFalling(projectileID)
+	local _, velocityY = spGetProjectileVelocity(projectileID)
+	return velocityY < 0
+end
+
+local function isProjectileInWater(projectileID)
+	local _, positionY = spGetProjectilePosition(projectileID)
+	return positionY <= 0
+end
+
 -- Cruise
 
 weaponCustomParamKeys.cruise = {

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -2,13 +2,13 @@ local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
 	return {
-		name      = "Custom weapon behaviours",
-		desc      = "Handler for special weapon behaviours",
-		author    = "Doo",
-		date      = "Sept 19th 2017",
-		license   = "GNU GPL, v2 or later",
-		layer     = 0,
-		enabled   = true
+		name    = "Custom weapon behaviours",
+		desc    = "Handler for special weapon behaviours",
+		author  = "Doo",
+		date    = "Sept 19th 2017",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true
 	}
 end
 
@@ -25,7 +25,6 @@ local SpGetProjectileTarget = Spring.GetProjectileTarget
 local SpGetUnitIsDead = Spring.GetUnitIsDead
 
 if gadgetHandler:IsSyncedCode() then
-
 	local projectiles = {}
 	local active_projectiles = {}
 	local checkingFunctions = {}
@@ -45,95 +44,92 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	checkingFunctions.cruise = {}
-	checkingFunctions.cruise["distance>0"] = function (proID)
+	checkingFunctions.cruise["distance>0"] = function(proID)
 		--Spring.Echo()
 
 		if Spring.GetProjectileTimeToLive(proID) <= 0 then
 			return true
 		end
-		local targetTypeInt,target = Spring.GetProjectileTarget(proID)
-		local xx,yy,zz
-		local xxv,yyv,zzv
+		local targetTypeInt, target = Spring.GetProjectileTarget(proID)
+		local xx, yy, zz
+		local xxv, yyv, zzv
 		if targetTypeInt == string.byte('g') then
 			xx = target[1]
 			yy = target[2]
 			zz = target[3]
 		end
 		if targetTypeInt == string.byte('u') then
-			_,_,_,_,_,_,xx,yy,zz = Spring.GetUnitPosition(target,true,true)
+			_, _, _, _, _, _, xx, yy, zz = Spring.GetUnitPosition(target, true, true)
 		end
-		local xp,yp,zp = Spring.GetProjectilePosition(proID)
-		local vxp,vyp,vzp = Spring.GetProjectileVelocity(proID)
-		local mag = math_sqrt(vxp*vxp+vyp*vyp+vzp*vzp)
+		local xp, yp, zp = Spring.GetProjectilePosition(proID)
+		local vxp, vyp, vzp = Spring.GetProjectileVelocity(proID)
+		local mag = math_sqrt(vxp * vxp + vyp * vyp + vzp * vzp)
 		local infos = projectiles[proID]
-		if math_sqrt((xp-xx)^2 + (yp-yy)^2 + (zp-zz)^2) > tonumber(infos.lockon_dist) then
-			yg = Spring.GetGroundHeight(xp,zp)
-			nx,ny,nz,slope= Spring.GetGroundNormal(xp,zp)
+		if math_sqrt((xp - xx) ^ 2 + (yp - yy) ^ 2 + (zp - zz) ^ 2) > tonumber(infos.lockon_dist) then
+			yg = Spring.GetGroundHeight(xp, zp)
+			nx, ny, nz, slope = Spring.GetGroundNormal(xp, zp)
 			--Spring.Echo(Spring.GetGroundNormal(xp,zp))
 			--Spring.Echo(tonumber(infos.cruise_height)*slope)
 			if yp < yg + tonumber(infos.cruise_min_height) then
 				active_projectiles[proID] = true
-				Spring.SetProjectilePosition(proID,xp,yg + tonumber(infos.cruise_min_height),zp)
-				local norm = (vxp*nx+vyp*ny+vzp*nz)
-				xxv = vxp - norm*nx*0
-				yyv = vyp - norm*ny
-				zzv = vzp - norm*nz*0
-				Spring.SetProjectileVelocity(proID,xxv,yyv,zzv)
+				Spring.SetProjectilePosition(proID, xp, yg + tonumber(infos.cruise_min_height), zp)
+				local norm = (vxp * nx + vyp * ny + vzp * nz)
+				xxv = vxp - norm * nx * 0
+				yyv = vyp - norm * ny
+				zzv = vzp - norm * nz * 0
+				Spring.SetProjectileVelocity(proID, xxv, yyv, zzv)
 			end
-			if yp > yg + tonumber(infos.cruise_max_height) and active_projectiles[proID] and vyp > -mag*.25 then
+			if yp > yg + tonumber(infos.cruise_max_height) and active_projectiles[proID] and vyp > -mag * .25 then
 				-- do not clamp to max height if
 				-- vertical velocity downward is more than 1/4 of current speed
 				-- probably just went off lip of steep cliff
-				Spring.SetProjectilePosition(proID,xp,yg + tonumber(infos.cruise_max_height),zp)
-				local norm = (vxp*nx+vyp*ny+vzp*nz)
-				xxv = vxp - norm*nx*0
-				yyv = vyp - norm*ny
-				zzv = vzp - norm*nz*0
-				Spring.SetProjectileVelocity(proID,xxv,yyv,zzv)
+				Spring.SetProjectilePosition(proID, xp, yg + tonumber(infos.cruise_max_height), zp)
+				local norm = (vxp * nx + vyp * ny + vzp * nz)
+				xxv = vxp - norm * nx * 0
+				yyv = vyp - norm * ny
+				zzv = vzp - norm * nz * 0
+				Spring.SetProjectileVelocity(proID, xxv, yyv, zzv)
 			end
 			return false
 		else
 			return true
 		end
 	end
-
-	applyingFunctions.cruise = function (proID)
+	applyingFunctions.cruise = function(proID)
 		return false
-    end
+	end
 
 	checkingFunctions.sector_fire = {}
-	checkingFunctions.sector_fire["always"] = function (proID)
+	checkingFunctions.sector_fire["always"] = function(proID)
 		-- as soon as the siege projectile is created, pass true on the
 		-- checking function, to go to applying function
 		-- so the unit state is only checked when the projectile is created
 		return true
 	end
-
-	applyingFunctions.sector_fire = function (proID)
+	applyingFunctions.sector_fire = function(proID)
 		local infos = projectiles[proID]
 		local vx, vy, vz = SpGetProjectileVelocity(proID)
-		
+
 		local spread_angle = tonumber(infos.spread_angle)
 		local max_range_reduction = tonumber(infos.max_range_reduction)
-		
+
 		local angle_factor = (spread_angle * (random() - 0.5)) * mathPi / 180
 		local cos_angle = mathCos(angle_factor)
 		local sin_angle = mathSin(angle_factor)
-		
+
 		local vx_new = vx * cos_angle - vz * sin_angle
 		local vz_new = vx * sin_angle + vz * cos_angle
-		
+
 		local velocity_factor = 1 - (random() ^ (1 + max_range_reduction)) * max_range_reduction
-		
+
 		vx = vx_new * velocity_factor
 		vz = vz_new * velocity_factor
-		
+
 		SpSetProjectileVelocity(proID, vx, vy, vz)
 	end
-	
 
 	checkingFunctions.retarget = {}
-	checkingFunctions.retarget["always"] = function (proID)
+	checkingFunctions.retarget["always"] = function(proID)
 		-- Might be slightly more optimal to check the unit itself if it changes target,
 		-- then tell the in-flight missiles to change target if the unit changes target
 		-- instead of checking each in-flight missile
@@ -156,14 +152,14 @@ if gadgetHandler:IsSyncedCode() then
 			if dead_state == nil or dead_state == true then
 				--hardcoded to assume the retarget weapon is the primary weapon.
 				--TODO, make this more general
-				local target_type,_,owner_target = SpGetUnitWeaponTarget(SpGetProjectileOwnerID(proID),1)
+				local target_type, _, owner_target = SpGetUnitWeaponTarget(SpGetProjectileOwnerID(proID), 1)
 				if target_type == 1 then
 					--hardcoded to assume the retarget weapon does not target features or intercept projectiles, only targets units if not shooting ground.
 					--TODO, make this more general
-					 SpSetProjectileTarget(proID,owner_target,string.byte('u'))
+					SpSetProjectileTarget(proID, owner_target, string.byte('u'))
 				end
 				if target_type == 2 then
-					SpSetProjectileTarget(proID,owner_target[1],owner_target[2],owner_target[3])
+					SpSetProjectileTarget(proID, owner_target[1], owner_target[2], owner_target[3])
 				end
 			end
 		end
@@ -171,13 +167,13 @@ if gadgetHandler:IsSyncedCode() then
 		return false
 	end
 
-	applyingFunctions.retarget = function (proID)
+	applyingFunctions.retarget = function(proID)
 		return false
-    end
+	end
 
 	checkingFunctions.cannonwaterpen = {}
-	checkingFunctions.cannonwaterpen["ypos<0"] = function (proID)
-		local _,y,_ = Spring.GetProjectilePosition(proID)
+	checkingFunctions.cannonwaterpen["ypos<0"] = function(proID)
+		local _, y, _ = Spring.GetProjectilePosition(proID)
 		if y <= 0 then
 			return true
 		else
@@ -186,8 +182,8 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	checkingFunctions.split = {}
-	checkingFunctions.split["yvel<0"] = function (proID)
-		local _,vy,_ = Spring.GetProjectileVelocity(proID)
+	checkingFunctions.split["yvel<0"] = function(proID)
+		local _, vy, _ = Spring.GetProjectileVelocity(proID)
 		if vy < 0 then
 			return true
 		else
@@ -196,118 +192,94 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	checkingFunctions.torpwaterpen = {}
-    checkingFunctions.torpwaterpen["ypos<0"] = function (proID)
-        local _,py,_ = Spring.GetProjectilePosition(proID)
-        if py <= 0 then
-            return true
-        else
-            return false
-        end
-    end
-	
-	
-	--a Hornet special, mangle different two things into working as one (they're otherwise mutually exclusive)
-	checkingFunctions.torpwaterpenretarget = {}
-    checkingFunctions.torpwaterpenretarget["ypos<0"] = function (proID)
-	
-		checkingFunctions.retarget["always"](proID)--subcontract that part
-	
-        local _,py,_ = Spring.GetProjectilePosition(proID)
-        if py <= 0 then
-			--and delegate that too
-			applyingFunctions.torpwaterpen(proID)
-        else
-            return false
-        end
-    end
-	
-	--fake function
-	applyingFunctions.torpwaterpenretarget = function (proID)
-		return false
-
+	checkingFunctions.torpwaterpen["ypos<0"] = function(proID)
+		local _, py, _ = Spring.GetProjectilePosition(proID)
+		if py <= 0 then
+			return true
+		else
+			return false
+		end
 	end
 
-	
+	--a Hornet special, mangle different two things into working as one (they're otherwise mutually exclusive)
+	checkingFunctions.torpwaterpenretarget = {}
+	checkingFunctions.torpwaterpenretarget["ypos<0"] = function(proID)
+		checkingFunctions.retarget["always"](proID) --subcontract that part
 
-	applyingFunctions.split = function (proID)
+		local _, py, _ = Spring.GetProjectilePosition(proID)
+		if py <= 0 then
+			--and delegate that too
+			applyingFunctions.torpwaterpen(proID)
+		else
+			return false
+		end
+	end
+
+	--fake function
+	applyingFunctions.torpwaterpenretarget = function(proID)
+		return false
+	end
+
+	applyingFunctions.split = function(proID)
 		local px, py, pz = Spring.GetProjectilePosition(proID)
 		local vx, vy, vz = Spring.GetProjectileVelocity(proID)
-		local vw = math_sqrt(vx*vx + vy*vy + vz*vz)
+		local vw = math_sqrt(vx * vx + vy * vy + vz * vz)
 		local ownerID = Spring.GetProjectileOwnerID(proID)
 		local infos = projectiles[proID]
 		for i = 1, tonumber(infos.number) do
 			local projectileParams = {
-				pos = {px, py, pz},
-				speed = {vx - vw*(math.random(-100,100)/880), vy - vw*(math.random(-100,100)/440), vz - vw*(math.random(-100,100)/880)},
+				pos = { px, py, pz },
+				speed = { vx - vw * (math.random(-100, 100) / 880), vy - vw * (math.random(-100, 100) / 440), vz - vw * (math.random(-100, 100) / 880) },
 				owner = ownerID,
 				ttl = 3000,
-				gravity = -Game.gravity/900,
+				gravity = -Game.gravity / 900,
 				model = infos.model,
 				cegTag = infos.cegtag,
-				}
+			}
 			Spring.SpawnProjectile(weaponDefNamesID[infos.def], projectileParams)
 		end
-		Spring.SpawnCEG(infos.splitexplosionceg, px, py, pz,0,0,0,0,0)
+		Spring.SpawnCEG(infos.splitexplosionceg, px, py, pz, 0, 0, 0, 0, 0)
 		Spring.DeleteProjectile(proID)
 	end
 
-	applyingFunctions.torpwaterpen = function (proID)
+	applyingFunctions.torpwaterpen = function(proID)
 		local vx, vy, vz = Spring.GetProjectileVelocity(proID)
 		--if target is close under the shooter, however, this resetting makes the torp always miss, unless it has amazing tracking
 		--needs special case handling (and there's no point having it visually on top of water for an UW target anyway)
-		
+
 		local bypass = false
 		local targetType, targetID = Spring.GetProjectileTarget(proID)
-		
-		if (targetType ~= nil) and (targetID ~= nil) and (targetType ~= 103) then--ground attack borks it; skip
+
+		if (targetType ~= nil) and (targetID ~= nil) and (targetType ~= 103) then --ground attack borks it; skip
 			local unitPosX, unitPosY, unitPosZ = Spring.GetUnitPosition(targetID)
-			if (unitPosY ~= nil) and unitPosY<-10 then
+			if (unitPosY ~= nil) and unitPosY < -10 then
 				bypass = true
-				Spring.SetProjectileVelocity(proID,vx/1.3,vy/6,vz/1.3)--apply brake without fully halting, otherwise it will overshoot very close targets before tracking can reorient it
+				Spring.SetProjectileVelocity(proID, vx / 1.3, vy / 6, vz / 1.3) --apply brake without fully halting, otherwise it will overshoot very close targets before tracking can reorient it
 			end
 		end
-		
+
 		if not bypass then
-			Spring.SetProjectileVelocity(proID,vx,0,vz)
+			Spring.SetProjectileVelocity(proID, vx, 0, vz)
 		end
-    end
+	end
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-	applyingFunctions.cannonwaterpen = function (proID)
+	applyingFunctions.cannonwaterpen = function(proID)
 		local px, py, pz = Spring.GetProjectilePosition(proID)
 		local vx, vy, vz = Spring.GetProjectileVelocity(proID)
 		local nvx, nvy, nvz = vx * 0.5, vy * 0.5, vz * 0.5
 		local ownerID = Spring.GetProjectileOwnerID(proID)
 		local infos = projectiles[proID]
 		local projectileParams = {
-			pos = {px, py, pz},
-			speed = {nvx, nvy, nvz},
+			pos = { px, py, pz },
+			speed = { nvx, nvy, nvz },
 			owner = ownerID,
 			ttl = 3000,
-			gravity = -Game.gravity/3600,
+			gravity = -Game.gravity / 3600,
 			model = infos.model,
 			cegTag = infos.cegtag,
 		}
 		Spring.SpawnProjectile(weaponDefNamesID[infos.def], projectileParams)
-		Spring.SpawnCEG(infos.waterpenceg, px, py, pz,0,0,0,0,0)
+		Spring.SpawnCEG(infos.waterpenceg, px, py, pz, 0, 0, 0, 0, 0)
 		Spring.DeleteProjectile(proID)
 	end
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -68,7 +68,7 @@ local function parseCustomParams(weaponDef)
 	local effectName = weaponDef.customParams.speceffect
 
 	if not specialEffectFunction[effectName] then
-		local message = weaponDef.name .. " has bad speceffect: " .. effectName
+		local message = weaponDef.name .. " has bad speceffect: " .. tostring(effectName)
 		Spring.Log(gadget:GetInfo().name, LOG.ERROR, message)
 
 		success = false
@@ -83,7 +83,7 @@ local function parseCustomParams(weaponDef)
 				if value ~= nil then
 					effectParams[key] = value
 				else
-					local message = weaponDef.name .. " has bad customparam: " .. key
+					local message = weaponDef.name .. " has bad customparam: " .. tostring(key)
 					Spring.Log(gadget:GetInfo().name, LOG.ERROR, message)
 
 					success = false

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -158,6 +158,17 @@ do
 	end
 end
 
+---A condensed `unpack` for tables in a standard float3/xyz layout.
+---Useful for performance-sensitive contexts with frequent vectors.
+---@see unpack
+---@param vector float3
+---@return number x
+---@return number y
+---@return number z
+local function unpack3(vector)
+	return vector[1], vector[2], vector[3]
+end
+
 -- Cruise
 -- Missile guidance behavior that avoids crashing into terrain while heading toward the target.
 -- Intended to be used with non-homing weapons, since it updates the velocity independently.
@@ -186,7 +197,7 @@ specialEffectFunction.cruise = function(params, projectileID)
 			local _; -- declare a local sink var for unused values
 			_, _, _, targetX, targetY, targetZ = spGetUnitPosition(target, false, true)
 		elseif targetType == targetedGround then
-			targetX, targetY, targetZ = target[1], target[2], target[3]
+			targetX, targetY, targetZ = unpack3(target)
 		end
 
 		local distance = params.lockon_dist
@@ -234,7 +245,7 @@ specialEffectFunction.retarget = function(projectileID)
 				if ownerTargetType == 1 then
 					spSetProjectileTarget(projectileID, ownerTarget, targetedUnit)
 				elseif ownerTargetType == 2 then
-					spSetProjectileTarget(projectileID, unpack(ownerTarget))
+					spSetProjectileTarget(projectileID, unpack3(ownerTarget))
 				end
 
 				return false
@@ -293,11 +304,11 @@ local function split(params, projectileID)
 	local spawnDefID, spawnParams, speed = getProjectileArgs(params, projectileID)
 
 	spDeleteProjectile(projectileID)
-	spSpawnCEG(params.splitexplosionceg, unpack(spawnParams.pos))
+	spSpawnCEG(params.splitexplosionceg, unpack3(spawnParams.pos))
 
 	spawnParams.gravity = gravityPerFrame
 
-	local velocityX, velocityY, velocityZ = unpack(spawnParams.speed)
+	local velocityX, velocityY, velocityZ = unpack3(spawnParams.speed)
 
 	for _ = 1, params.number do
 		velocity[1] = velocityX + speed * (math_random(-100, 100) / 880)
@@ -331,7 +342,7 @@ local function cannonWaterPen(params, projectileID)
 	local spawnDefID, spawnParams = getProjectileArgs(params, projectileID)
 
 	spDeleteProjectile(projectileID)
-	spSpawnCEG(params.waterpenceg, unpack(spawnParams.pos))
+	spSpawnCEG(params.waterpenceg, unpack3(spawnParams.pos))
 
 	spawnParams.gravity = gravityPerFrame * 0.5
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -126,7 +126,7 @@ do
 		pos     = { 0, 0, 0 },
 		speed   = { 0, 0, 0 },
 		gravity = gravityPerFrame,
-		ttl = 3000,
+		ttl     = 3000,
 	}
 
 	getSpawnParams = function(params, projectileID)
@@ -168,17 +168,14 @@ weaponSpecialEffect.cruise = function(params, projectileID)
 	if spGetProjectileTimeToLive(projectileID) > 0 then
 		local positionX, positionY, positionZ = spGetProjectilePosition(projectileID)
 		local velocityX, velocityY, velocityZ, speed = spGetProjectileVelocity(projectileID)
+		local targetType, target = spGetProjectileTarget(projectileID)
 
 		local targetX, targetY, targetZ
-		do
-			local targetType, target = spGetProjectileTarget(projectileID)
-			if targetType == targetedUnit then
-				local _; -- sink for unused values
-				_, _, _, -- like so
-				targetX, targetY, targetZ = spGetUnitPosition(target, false, true)
-			elseif targetType == targetedGround then
-				targetX, targetY, targetZ = target[1], target[2], target[3]
-			end
+		if targetType == targetedUnit then
+			local _; -- declare a local sink var for unused values
+			_, _, _, targetX, targetY, targetZ = spGetUnitPosition(target, false, true)
+		elseif targetType == targetedGround then
+			targetX, targetY, targetZ = target[1], target[2], target[3]
 		end
 
 		local distance = params.lockon_dist

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -314,23 +314,19 @@ end
 
 -- Water penetration with retargeting (torpedo)
 
---a Hornet special, mangle different two things into working as one (they're otherwise mutually exclusive)
-checkingFunctions.torpwaterpenretarget = {}
-checkingFunctions.torpwaterpenretarget["ypos<0"] = function(proID)
-	checkingFunctions.retarget["always"](proID) --subcontract that part
+do
+	local retarget = weaponSpecialEffect.retarget
+	local torpedoWaterPen = weaponSpecialEffect.torpwaterpen
 
-	local _, positionY, _ = Spring.GetProjectilePosition(proID)
-	if positionY <= 0 then
-		--and delegate that too
-		applyingFunctions.torpwaterpen(proID)
-	else
-		return false
+	weaponSpecialEffect.torpedowaterpenretarget = function(params, projectileID)
+		if not projectilesData[projectileID] and torpedoWaterPen(nil, projectileID) then
+			projectilesData[projectileID] = true
+		end
+		if retarget(nil, projectileID) then
+			projectilesData[projectileID] = nil
+			return true
+		end
 	end
-end
-
---fake function
-applyingFunctions.torpwaterpenretarget = function(proID)
-	return false
 end
 
 --------------------------------------------------------------------------------

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -263,34 +263,26 @@ weaponCustomParamKeys.cannonwaterpen = {
 	model = tostring,
 }
 
-checkingFunctions.cannonwaterpen = {}
-checkingFunctions.cannonwaterpen["ypos<0"] = function(proID)
-	local _, positionY, _ = Spring.GetProjectilePosition(proID)
-	if positionY <= 0 then
-		return true
-	else
-		return false
-	end
+local function cannonWaterPen(params, projectileID)
+	local spawnDefID, cache, velocity = getSpawnParams(params, projectileID)
+
+	Spring.DeleteProjectile(projectileID)
+	Spring.SpawnCEG(params.waterpenceg, cache.pos[1], cache.pos[2], cache.pos[3])
+
+	cache.gravity = gravityPerFrame * 0.5
+
+	velocity[1] = velocity[1] * 0.5
+	velocity[2] = velocity[2] * 0.5
+	velocity[3] = velocity[3] * 0.5
+
+	Spring.SpawnProjectile(spawnDefID, cache)
 end
 
-applyingFunctions.cannonwaterpen = function(proID)
-	local projectileX, projectileY, projectileZ = Spring.GetProjectilePosition(proID)
-	local velocityX, velocityY, velocityZ = Spring.GetProjectileVelocity(proID)
-	velocityX, velocityY, velocityZ = velocityX * 0.5, velocityY * 0.5, velocityZ * 0.5
-	local ownerID = spGetProjectileOwnerID(proID)
-	local params = projectiles[proID]
-	local projectileParams = {
-		pos = { projectileX, projectileY, projectileZ },
-		speed = { velocityX, velocityY, velocityZ },
-		owner = ownerID,
-		ttl = 3000,
-		gravity = -Game.gravity / 3600,
-		model = params.model,
-		cegTag = params.cegtag,
-	}
-	Spring.SpawnProjectile(weaponDefNamesID[params.def], projectileParams)
-	Spring.SpawnCEG(params.waterpenceg, projectileX, projectileY, projectileZ, 0, 0, 0, 0, 0)
-	Spring.DeleteProjectile(proID)
+weaponSpecialEffect.cannonwaterpen = function(projectileID)
+	if isProjectileInWater(projectileID) then
+		cannonWaterPen(projectileID)
+		return true
+	end
 end
 
 -- Water penetration (torpedo)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -389,7 +389,11 @@ function gadget:Initialize()
 		end
 	end
 
-	if not next(weaponParams) then
+	if next(weaponParams) then
+		for weaponDefID in pairs(weaponParams) do
+			Script.SetWatchProjectile(weaponDefID, true)
+		end
+	else
 		Spring.Log(gadget:GetInfo().name, LOG.INFO, "No custom weapons found.")
 		gadgetHandler:RemoveGadget(self)
 	end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -12,6 +12,10 @@ function gadget:GetInfo()
 	}
 end
 
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
 local random = math.random
 
 local SpSetProjectileVelocity = Spring.SetProjectileVelocity
@@ -24,284 +28,282 @@ local SpGetUnitWeaponTarget = Spring.GetUnitWeaponTarget
 local SpGetProjectileTarget = Spring.GetProjectileTarget
 local SpGetUnitIsDead = Spring.GetUnitIsDead
 
-if gadgetHandler:IsSyncedCode() then
-	local projectiles = {}
-	local active_projectiles = {}
-	local checkingFunctions = {}
-	local applyingFunctions = {}
-	local math_sqrt = math.sqrt
-	local mathCos = math.cos
-	local mathSin = math.sin
-	local mathPi = math.pi
+local projectiles = {}
+local active_projectiles = {}
+local checkingFunctions = {}
+local applyingFunctions = {}
+local math_sqrt = math.sqrt
+local mathCos = math.cos
+local mathSin = math.sin
+local mathPi = math.pi
 
-	local specialWeaponCustomDefs = {}
-	local weaponDefNamesID = {}
-	for id, def in pairs(WeaponDefs) do
-		weaponDefNamesID[def.name] = id
-		if def.customParams.speceffect then
-			specialWeaponCustomDefs[id] = def.customParams
-		end
+local specialWeaponCustomDefs = {}
+local weaponDefNamesID = {}
+for id, def in pairs(WeaponDefs) do
+	weaponDefNamesID[def.name] = id
+	if def.customParams.speceffect then
+		specialWeaponCustomDefs[id] = def.customParams
 	end
+end
 
-	checkingFunctions.cruise = {}
-	checkingFunctions.cruise["distance>0"] = function(proID)
-		--Spring.Echo()
+checkingFunctions.cruise = {}
+checkingFunctions.cruise["distance>0"] = function(proID)
+	--Spring.Echo()
 
-		if Spring.GetProjectileTimeToLive(proID) <= 0 then
-			return true
-		end
-		local targetTypeInt, target = Spring.GetProjectileTarget(proID)
-		local xx, yy, zz
-		local xxv, yyv, zzv
-		if targetTypeInt == string.byte('g') then
-			xx = target[1]
-			yy = target[2]
-			zz = target[3]
-		end
-		if targetTypeInt == string.byte('u') then
-			_, _, _, _, _, _, xx, yy, zz = Spring.GetUnitPosition(target, true, true)
-		end
-		local xp, yp, zp = Spring.GetProjectilePosition(proID)
-		local vxp, vyp, vzp = Spring.GetProjectileVelocity(proID)
-		local mag = math_sqrt(vxp * vxp + vyp * vyp + vzp * vzp)
-		local infos = projectiles[proID]
-		if math_sqrt((xp - xx) ^ 2 + (yp - yy) ^ 2 + (zp - zz) ^ 2) > tonumber(infos.lockon_dist) then
-			yg = Spring.GetGroundHeight(xp, zp)
-			nx, ny, nz, slope = Spring.GetGroundNormal(xp, zp)
-			--Spring.Echo(Spring.GetGroundNormal(xp,zp))
-			--Spring.Echo(tonumber(infos.cruise_height)*slope)
-			if yp < yg + tonumber(infos.cruise_min_height) then
-				active_projectiles[proID] = true
-				Spring.SetProjectilePosition(proID, xp, yg + tonumber(infos.cruise_min_height), zp)
-				local norm = (vxp * nx + vyp * ny + vzp * nz)
-				xxv = vxp - norm * nx * 0
-				yyv = vyp - norm * ny
-				zzv = vzp - norm * nz * 0
-				Spring.SetProjectileVelocity(proID, xxv, yyv, zzv)
-			end
-			if yp > yg + tonumber(infos.cruise_max_height) and active_projectiles[proID] and vyp > -mag * .25 then
-				-- do not clamp to max height if
-				-- vertical velocity downward is more than 1/4 of current speed
-				-- probably just went off lip of steep cliff
-				Spring.SetProjectilePosition(proID, xp, yg + tonumber(infos.cruise_max_height), zp)
-				local norm = (vxp * nx + vyp * ny + vzp * nz)
-				xxv = vxp - norm * nx * 0
-				yyv = vyp - norm * ny
-				zzv = vzp - norm * nz * 0
-				Spring.SetProjectileVelocity(proID, xxv, yyv, zzv)
-			end
-			return false
-		else
-			return true
-		end
-	end
-	applyingFunctions.cruise = function(proID)
-		return false
-	end
-
-	checkingFunctions.sector_fire = {}
-	checkingFunctions.sector_fire["always"] = function(proID)
-		-- as soon as the siege projectile is created, pass true on the
-		-- checking function, to go to applying function
-		-- so the unit state is only checked when the projectile is created
+	if Spring.GetProjectileTimeToLive(proID) <= 0 then
 		return true
 	end
-	applyingFunctions.sector_fire = function(proID)
-		local infos = projectiles[proID]
-		local vx, vy, vz = SpGetProjectileVelocity(proID)
-
-		local spread_angle = tonumber(infos.spread_angle)
-		local max_range_reduction = tonumber(infos.max_range_reduction)
-
-		local angle_factor = (spread_angle * (random() - 0.5)) * mathPi / 180
-		local cos_angle = mathCos(angle_factor)
-		local sin_angle = mathSin(angle_factor)
-
-		local vx_new = vx * cos_angle - vz * sin_angle
-		local vz_new = vx * sin_angle + vz * cos_angle
-
-		local velocity_factor = 1 - (random() ^ (1 + max_range_reduction)) * max_range_reduction
-
-		vx = vx_new * velocity_factor
-		vz = vz_new * velocity_factor
-
-		SpSetProjectileVelocity(proID, vx, vy, vz)
+	local targetTypeInt, target = Spring.GetProjectileTarget(proID)
+	local xx, yy, zz
+	local xxv, yyv, zzv
+	if targetTypeInt == string.byte('g') then
+		xx = target[1]
+		yy = target[2]
+		zz = target[3]
 	end
-
-	checkingFunctions.retarget = {}
-	checkingFunctions.retarget["always"] = function(proID)
-		-- Might be slightly more optimal to check the unit itself if it changes target,
-		-- then tell the in-flight missiles to change target if the unit changes target
-		-- instead of checking each in-flight missile
-		-- but not sure if there is an easy hook function or callin function
-		-- that only runs if a unit changes target
-
-		-- refactor slightly, only do target change if the target the missile
-		-- is heading towards is dead
-		-- karganeth switches away from alive units a little too often, causing
-		-- missiles that would have hit to instead miss
-		if SpGetProjectileTimeToLive(proID) <= 0 then
-			-- stop missile retargeting when it runs out of fuel
-			return true
+	if targetTypeInt == string.byte('u') then
+		_, _, _, _, _, _, xx, yy, zz = Spring.GetUnitPosition(target, true, true)
+	end
+	local xp, yp, zp = Spring.GetProjectilePosition(proID)
+	local vxp, vyp, vzp = Spring.GetProjectileVelocity(proID)
+	local mag = math_sqrt(vxp * vxp + vyp * vyp + vzp * vzp)
+	local infos = projectiles[proID]
+	if math_sqrt((xp - xx) ^ 2 + (yp - yy) ^ 2 + (zp - zz) ^ 2) > tonumber(infos.lockon_dist) then
+		yg = Spring.GetGroundHeight(xp, zp)
+		nx, ny, nz, slope = Spring.GetGroundNormal(xp, zp)
+		--Spring.Echo(Spring.GetGroundNormal(xp,zp))
+		--Spring.Echo(tonumber(infos.cruise_height)*slope)
+		if yp < yg + tonumber(infos.cruise_min_height) then
+			active_projectiles[proID] = true
+			Spring.SetProjectilePosition(proID, xp, yg + tonumber(infos.cruise_min_height), zp)
+			local norm = (vxp * nx + vyp * ny + vzp * nz)
+			xxv = vxp - norm * nx * 0
+			yyv = vyp - norm * ny
+			zzv = vzp - norm * nz * 0
+			Spring.SetProjectileVelocity(proID, xxv, yyv, zzv)
 		end
-		local targetTypeInt, targetID = SpGetProjectileTarget(proID)
-		-- if the missile is heading towards a unit
-		if targetTypeInt == string.byte('u') then
-			--check if the target unit is dead or dying
-			local dead_state = SpGetUnitIsDead(targetID)
-			if dead_state == nil or dead_state == true then
-				--hardcoded to assume the retarget weapon is the primary weapon.
+		if yp > yg + tonumber(infos.cruise_max_height) and active_projectiles[proID] and vyp > -mag * .25 then
+			-- do not clamp to max height if
+			-- vertical velocity downward is more than 1/4 of current speed
+			-- probably just went off lip of steep cliff
+			Spring.SetProjectilePosition(proID, xp, yg + tonumber(infos.cruise_max_height), zp)
+			local norm = (vxp * nx + vyp * ny + vzp * nz)
+			xxv = vxp - norm * nx * 0
+			yyv = vyp - norm * ny
+			zzv = vzp - norm * nz * 0
+			Spring.SetProjectileVelocity(proID, xxv, yyv, zzv)
+		end
+		return false
+	else
+		return true
+	end
+end
+applyingFunctions.cruise = function(proID)
+	return false
+end
+
+checkingFunctions.sector_fire = {}
+checkingFunctions.sector_fire["always"] = function(proID)
+	-- as soon as the siege projectile is created, pass true on the
+	-- checking function, to go to applying function
+	-- so the unit state is only checked when the projectile is created
+	return true
+end
+applyingFunctions.sector_fire = function(proID)
+	local infos = projectiles[proID]
+	local vx, vy, vz = SpGetProjectileVelocity(proID)
+
+	local spread_angle = tonumber(infos.spread_angle)
+	local max_range_reduction = tonumber(infos.max_range_reduction)
+
+	local angle_factor = (spread_angle * (random() - 0.5)) * mathPi / 180
+	local cos_angle = mathCos(angle_factor)
+	local sin_angle = mathSin(angle_factor)
+
+	local vx_new = vx * cos_angle - vz * sin_angle
+	local vz_new = vx * sin_angle + vz * cos_angle
+
+	local velocity_factor = 1 - (random() ^ (1 + max_range_reduction)) * max_range_reduction
+
+	vx = vx_new * velocity_factor
+	vz = vz_new * velocity_factor
+
+	SpSetProjectileVelocity(proID, vx, vy, vz)
+end
+
+checkingFunctions.retarget = {}
+checkingFunctions.retarget["always"] = function(proID)
+	-- Might be slightly more optimal to check the unit itself if it changes target,
+	-- then tell the in-flight missiles to change target if the unit changes target
+	-- instead of checking each in-flight missile
+	-- but not sure if there is an easy hook function or callin function
+	-- that only runs if a unit changes target
+
+	-- refactor slightly, only do target change if the target the missile
+	-- is heading towards is dead
+	-- karganeth switches away from alive units a little too often, causing
+	-- missiles that would have hit to instead miss
+	if SpGetProjectileTimeToLive(proID) <= 0 then
+		-- stop missile retargeting when it runs out of fuel
+		return true
+	end
+	local targetTypeInt, targetID = SpGetProjectileTarget(proID)
+	-- if the missile is heading towards a unit
+	if targetTypeInt == string.byte('u') then
+		--check if the target unit is dead or dying
+		local dead_state = SpGetUnitIsDead(targetID)
+		if dead_state == nil or dead_state == true then
+			--hardcoded to assume the retarget weapon is the primary weapon.
+			--TODO, make this more general
+			local target_type, _, owner_target = SpGetUnitWeaponTarget(SpGetProjectileOwnerID(proID), 1)
+			if target_type == 1 then
+				--hardcoded to assume the retarget weapon does not target features or intercept projectiles, only targets units if not shooting ground.
 				--TODO, make this more general
-				local target_type, _, owner_target = SpGetUnitWeaponTarget(SpGetProjectileOwnerID(proID), 1)
-				if target_type == 1 then
-					--hardcoded to assume the retarget weapon does not target features or intercept projectiles, only targets units if not shooting ground.
-					--TODO, make this more general
-					SpSetProjectileTarget(proID, owner_target, string.byte('u'))
-				end
-				if target_type == 2 then
-					SpSetProjectileTarget(proID, owner_target[1], owner_target[2], owner_target[3])
-				end
+				SpSetProjectileTarget(proID, owner_target, string.byte('u'))
+			end
+			if target_type == 2 then
+				SpSetProjectileTarget(proID, owner_target[1], owner_target[2], owner_target[3])
 			end
 		end
+	end
 
+	return false
+end
+
+applyingFunctions.retarget = function(proID)
+	return false
+end
+
+checkingFunctions.cannonwaterpen = {}
+checkingFunctions.cannonwaterpen["ypos<0"] = function(proID)
+	local _, y, _ = Spring.GetProjectilePosition(proID)
+	if y <= 0 then
+		return true
+	else
 		return false
 	end
+end
 
-	applyingFunctions.retarget = function(proID)
+checkingFunctions.split = {}
+checkingFunctions.split["yvel<0"] = function(proID)
+	local _, vy, _ = Spring.GetProjectileVelocity(proID)
+	if vy < 0 then
+		return true
+	else
 		return false
 	end
+end
 
-	checkingFunctions.cannonwaterpen = {}
-	checkingFunctions.cannonwaterpen["ypos<0"] = function(proID)
-		local _, y, _ = Spring.GetProjectilePosition(proID)
-		if y <= 0 then
-			return true
-		else
-			return false
-		end
-	end
-
-	checkingFunctions.split = {}
-	checkingFunctions.split["yvel<0"] = function(proID)
-		local _, vy, _ = Spring.GetProjectileVelocity(proID)
-		if vy < 0 then
-			return true
-		else
-			return false
-		end
-	end
-
-	checkingFunctions.torpwaterpen = {}
-	checkingFunctions.torpwaterpen["ypos<0"] = function(proID)
-		local _, py, _ = Spring.GetProjectilePosition(proID)
-		if py <= 0 then
-			return true
-		else
-			return false
-		end
-	end
-
-	--a Hornet special, mangle different two things into working as one (they're otherwise mutually exclusive)
-	checkingFunctions.torpwaterpenretarget = {}
-	checkingFunctions.torpwaterpenretarget["ypos<0"] = function(proID)
-		checkingFunctions.retarget["always"](proID) --subcontract that part
-
-		local _, py, _ = Spring.GetProjectilePosition(proID)
-		if py <= 0 then
-			--and delegate that too
-			applyingFunctions.torpwaterpen(proID)
-		else
-			return false
-		end
-	end
-
-	--fake function
-	applyingFunctions.torpwaterpenretarget = function(proID)
+checkingFunctions.torpwaterpen = {}
+checkingFunctions.torpwaterpen["ypos<0"] = function(proID)
+	local _, py, _ = Spring.GetProjectilePosition(proID)
+	if py <= 0 then
+		return true
+	else
 		return false
 	end
+end
 
-	applyingFunctions.split = function(proID)
-		local px, py, pz = Spring.GetProjectilePosition(proID)
-		local vx, vy, vz = Spring.GetProjectileVelocity(proID)
-		local vw = math_sqrt(vx * vx + vy * vy + vz * vz)
-		local ownerID = Spring.GetProjectileOwnerID(proID)
-		local infos = projectiles[proID]
-		for i = 1, tonumber(infos.number) do
-			local projectileParams = {
-				pos = { px, py, pz },
-				speed = { vx - vw * (math.random(-100, 100) / 880), vy - vw * (math.random(-100, 100) / 440), vz - vw * (math.random(-100, 100) / 880) },
-				owner = ownerID,
-				ttl = 3000,
-				gravity = -Game.gravity / 900,
-				model = infos.model,
-				cegTag = infos.cegtag,
-			}
-			Spring.SpawnProjectile(weaponDefNamesID[infos.def], projectileParams)
-		end
-		Spring.SpawnCEG(infos.splitexplosionceg, px, py, pz, 0, 0, 0, 0, 0)
-		Spring.DeleteProjectile(proID)
+--a Hornet special, mangle different two things into working as one (they're otherwise mutually exclusive)
+checkingFunctions.torpwaterpenretarget = {}
+checkingFunctions.torpwaterpenretarget["ypos<0"] = function(proID)
+	checkingFunctions.retarget["always"](proID) --subcontract that part
+
+	local _, py, _ = Spring.GetProjectilePosition(proID)
+	if py <= 0 then
+		--and delegate that too
+		applyingFunctions.torpwaterpen(proID)
+	else
+		return false
 	end
+end
 
-	applyingFunctions.torpwaterpen = function(proID)
-		local vx, vy, vz = Spring.GetProjectileVelocity(proID)
-		--if target is close under the shooter, however, this resetting makes the torp always miss, unless it has amazing tracking
-		--needs special case handling (and there's no point having it visually on top of water for an UW target anyway)
+--fake function
+applyingFunctions.torpwaterpenretarget = function(proID)
+	return false
+end
 
-		local bypass = false
-		local targetType, targetID = Spring.GetProjectileTarget(proID)
-
-		if (targetType ~= nil) and (targetID ~= nil) and (targetType ~= 103) then --ground attack borks it; skip
-			local unitPosX, unitPosY, unitPosZ = Spring.GetUnitPosition(targetID)
-			if (unitPosY ~= nil) and unitPosY < -10 then
-				bypass = true
-				Spring.SetProjectileVelocity(proID, vx / 1.3, vy / 6, vz / 1.3) --apply brake without fully halting, otherwise it will overshoot very close targets before tracking can reorient it
-			end
-		end
-
-		if not bypass then
-			Spring.SetProjectileVelocity(proID, vx, 0, vz)
-		end
-	end
-
-	applyingFunctions.cannonwaterpen = function(proID)
-		local px, py, pz = Spring.GetProjectilePosition(proID)
-		local vx, vy, vz = Spring.GetProjectileVelocity(proID)
-		local nvx, nvy, nvz = vx * 0.5, vy * 0.5, vz * 0.5
-		local ownerID = Spring.GetProjectileOwnerID(proID)
-		local infos = projectiles[proID]
+applyingFunctions.split = function(proID)
+	local px, py, pz = Spring.GetProjectilePosition(proID)
+	local vx, vy, vz = Spring.GetProjectileVelocity(proID)
+	local vw = math_sqrt(vx * vx + vy * vy + vz * vz)
+	local ownerID = Spring.GetProjectileOwnerID(proID)
+	local infos = projectiles[proID]
+	for i = 1, tonumber(infos.number) do
 		local projectileParams = {
 			pos = { px, py, pz },
-			speed = { nvx, nvy, nvz },
+			speed = { vx - vw * (math.random(-100, 100) / 880), vy - vw * (math.random(-100, 100) / 440), vz - vw * (math.random(-100, 100) / 880) },
 			owner = ownerID,
 			ttl = 3000,
-			gravity = -Game.gravity / 3600,
+			gravity = -Game.gravity / 900,
 			model = infos.model,
 			cegTag = infos.cegtag,
 		}
 		Spring.SpawnProjectile(weaponDefNamesID[infos.def], projectileParams)
-		Spring.SpawnCEG(infos.waterpenceg, px, py, pz, 0, 0, 0, 0, 0)
-		Spring.DeleteProjectile(proID)
 	end
+	Spring.SpawnCEG(infos.splitexplosionceg, px, py, pz, 0, 0, 0, 0, 0)
+	Spring.DeleteProjectile(proID)
+end
 
-	function gadget:ProjectileCreated(proID, proOwnerID, weaponDefID)
-		if specialWeaponCustomDefs[weaponDefID] then
-			projectiles[proID] = specialWeaponCustomDefs[weaponDefID]
-			active_projectiles[proID] = nil
+applyingFunctions.torpwaterpen = function(proID)
+	local vx, vy, vz = Spring.GetProjectileVelocity(proID)
+	--if target is close under the shooter, however, this resetting makes the torp always miss, unless it has amazing tracking
+	--needs special case handling (and there's no point having it visually on top of water for an UW target anyway)
+
+	local bypass = false
+	local targetType, targetID = Spring.GetProjectileTarget(proID)
+
+	if (targetType ~= nil) and (targetID ~= nil) and (targetType ~= 103) then --ground attack borks it; skip
+		local unitPosX, unitPosY, unitPosZ = Spring.GetUnitPosition(targetID)
+		if (unitPosY ~= nil) and unitPosY < -10 then
+			bypass = true
+			Spring.SetProjectileVelocity(proID, vx / 1.3, vy / 6, vz / 1.3) --apply brake without fully halting, otherwise it will overshoot very close targets before tracking can reorient it
 		end
 	end
 
-	function gadget:ProjectileDestroyed(proID)
-		projectiles[proID] = nil
+	if not bypass then
+		Spring.SetProjectileVelocity(proID, vx, 0, vz)
+	end
+end
+
+applyingFunctions.cannonwaterpen = function(proID)
+	local px, py, pz = Spring.GetProjectilePosition(proID)
+	local vx, vy, vz = Spring.GetProjectileVelocity(proID)
+	local nvx, nvy, nvz = vx * 0.5, vy * 0.5, vz * 0.5
+	local ownerID = Spring.GetProjectileOwnerID(proID)
+	local infos = projectiles[proID]
+	local projectileParams = {
+		pos = { px, py, pz },
+		speed = { nvx, nvy, nvz },
+		owner = ownerID,
+		ttl = 3000,
+		gravity = -Game.gravity / 3600,
+		model = infos.model,
+		cegTag = infos.cegtag,
+	}
+	Spring.SpawnProjectile(weaponDefNamesID[infos.def], projectileParams)
+	Spring.SpawnCEG(infos.waterpenceg, px, py, pz, 0, 0, 0, 0, 0)
+	Spring.DeleteProjectile(proID)
+end
+
+function gadget:ProjectileCreated(proID, proOwnerID, weaponDefID)
+	if specialWeaponCustomDefs[weaponDefID] then
+		projectiles[proID] = specialWeaponCustomDefs[weaponDefID]
 		active_projectiles[proID] = nil
 	end
+end
 
-	function gadget:GameFrame(f)
-		for proID, infos in pairs(projectiles) do
-			if checkingFunctions[infos.speceffect][infos.when](proID) == true then
-				applyingFunctions[infos.speceffect](proID)
-				projectiles[proID] = nil
-				active_projectiles[proID] = nil
-			end
+function gadget:ProjectileDestroyed(proID)
+	projectiles[proID] = nil
+	active_projectiles[proID] = nil
+end
+
+function gadget:GameFrame(f)
+	for proID, infos in pairs(projectiles) do
+		if checkingFunctions[infos.speceffect][infos.when](proID) == true then
+			applyingFunctions[infos.speceffect](proID)
+			projectiles[proID] = nil
+			active_projectiles[proID] = nil
 		end
 	end
 end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -49,7 +49,7 @@ local targetedUnit = string.byte('u')
 local weaponCustomParamKeys = {} -- [effect] = { key => conversion function }
 local weaponSpecialEffect = {}
 
-local weaponParams = {}
+local weaponEffect = {}
 
 local projectiles = {}
 local projectilesData = {}
@@ -381,13 +381,13 @@ function gadget:Initialize()
 			local effectName, effectParams = parseCustomParams(weaponDef)
 
 			if effectName then
-				weaponParams[weaponDefID] = setmetatable(effectParams, metatables[effectName])
+				weaponEffect[weaponDefID] = setmetatable(effectParams, metatables[effectName])
 			end
 		end
 	end
 
-	if next(weaponParams) then
-		for weaponDefID in pairs(weaponParams) do
+	if next(weaponEffect) then
+		for weaponDefID in pairs(weaponEffect) do
 			Script.SetWatchProjectile(weaponDefID, true)
 		end
 	else
@@ -397,8 +397,8 @@ function gadget:Initialize()
 end
 
 function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
-	if weaponParams[weaponDefID] then
-		projectiles[projectileID] = weaponParams[weaponDefID]
+	if weaponEffect[weaponDefID] then
+		projectiles[projectileID] = weaponEffect[weaponDefID]
 	end
 end
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -363,18 +363,22 @@ local function torpedoWaterPen(projectileID)
 	local velocityX, velocityY, velocityZ = spGetProjectileVelocity(projectileID)
 	local targetType, targetID = spGetProjectileTarget(projectileID)
 
-	-- Underwater projectiles have low visibility, so remaining on surface is preferable.
+	-- Underwater projectiles have low visibility. Remaining on surface is preferable.
 	-- Only dive below the water's surface if the target is likely an underwater unit.
 	local diveSpeed = 0
 
 	if targetType == targetedUnit and targetID then
-		local _, positionY = spGetUnitPosition(targetID)
-		if positionY and positionY < -10 then
+		local _, unitDepth = spGetUnitPosition(targetID)
+		-- BAR trivia: Ships are at depth = -1, and subs at depth < -10.
+		-- Recoil factoid: There is a SolidObject.IsUnderWater() method.
+		if unitDepth and unitDepth < -10 then
+			-- Apply brake without halting, otherwise it will overshoot close targets.
 			diveSpeed = velocityY / 6
+			velocityX, velocityZ = velocityX / 1.3, velocityZ / 1.3
 		end
 	end
 
-	spSetProjectileVelocity(projectileID, velocityX / 1.3, diveSpeed, velocityZ / 1.3)
+	spSetProjectileVelocity(projectileID, velocityX, diveSpeed, velocityZ)
 end
 
 specialEffectFunction.torpwaterpen = function(projectileID)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -348,7 +348,7 @@ end
 
 specialEffectFunction.cannonwaterpen = function(params, projectileID)
 	if isProjectileInWater(projectileID) then
-		cannonWaterPen(projectileID)
+		cannonWaterPen(params, projectileID)
 		return true
 	end
 end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -370,7 +370,6 @@ local function torpedoWaterPen(projectileID)
 	if targetType == targetedUnit and targetID then
 		local _, unitDepth = spGetUnitPosition(targetID)
 		-- BAR trivia: Ships are at depth = -1, and subs at depth < -10.
-		-- Recoil factoid: There is a SolidObject.IsUnderWater() method.
 		if unitDepth and unitDepth < -10 then
 			-- Apply brake without halting, otherwise it will overshoot close targets.
 			diveSpeed = velocityY / 6
@@ -402,14 +401,12 @@ do
 	local retarget = specialEffectFunction.retarget
 	local torpedoWaterPen = specialEffectFunction.torpwaterpen
 
-	specialEffectFunction.torpedowaterpenretarget = function(projectileID)
-		if not projectilesData[projectileID] and torpedoWaterPen(projectileID) then
-			projectilesData[projectileID] = true
-		end
-
+	specialEffectFunction.torpwaterpenretarget = function(projectileID)
 		if retarget(projectileID) then
-			projectilesData[projectileID] = nil
-			return true
+			projectiles[projectileID] = torpedoWaterPen
+			return torpedoWaterPen(projectileID)
+		elseif torpedoWaterPen(projectileID) then
+			projectiles[projectileID] = retarget
 		end
 	end
 end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -235,7 +235,7 @@ end
 weaponCustomParamKeys.sector_fire = {
 	max_range_reduction = function(value)
 		value = tonumber(value)
-		return value and math.clamp(value, 0, 1)
+		return value and math.clamp(value, 0, 1) or nil
 	end,
 	spread_angle = function(value)
 		value = tonumber(value)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -230,36 +230,28 @@ weaponCustomParamKeys.split = {
 	model = tostring,
 }
 
-checkingFunctions.split = {}
-checkingFunctions.split["yvel<0"] = function(proID)
-	local _, velocityY, _ = Spring.GetProjectileVelocity(proID)
-	if velocityY < 0 then
-		return true
-	else
-		return false
+local function split(params, projectileID)
+	local spawnDefID, cache, velocity, speed = getSpawnParams(params, projectileID)
+
+	Spring.DeleteProjectile(projectileID)
+	Spring.SpawnCEG(params.splitexplosionceg, cache.pos[1], cache.pos[2], cache.pos[3])
+
+	cache.gravity = gravityPerFrame
+
+	for _ = 1, params.number do
+		velocity[1] = velocityX + speed * (math_random(-100, 100) / 880)
+		velocity[2] = velocityY + speed * (math_random(-100, 100) / 440)
+		velocity[3] = velocityZ + speed * (math_random(-100, 100) / 880)
+
+		Spring.SpawnProjectile(spawnDefID, cache)
 	end
 end
 
-applyingFunctions.split = function(proID)
-	local positionX, positionY, positionZ = Spring.GetProjectilePosition(proID)
-	local velocityX, velocityY, velocityZ = Spring.GetProjectileVelocity(proID)
-	local speed = math_sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ)
-	local ownerID = spGetProjectileOwnerID(proID)
-	local params = projectiles[proID]
-	for i = 1, tonumber(params.number) do
-		local projectileParams = {
-			pos = { positionX, positionY, positionZ },
-			speed = { velocityX - speed * (math_random(-100, 100) / 880), velocityY - speed * (math_random(-100, 100) / 440), velocityZ - speed * (math_random(-100, 100) / 880) },
-			owner = ownerID,
-			ttl = 3000,
-			gravity = -Game.gravity / 900,
-			model = params.model,
-			cegTag = params.cegtag,
-		}
-		Spring.SpawnProjectile(weaponDefNamesID[params.def], projectileParams)
+weaponSpecialEffect.split = function(params, projectileID)
+	if isProjectileFalling(projectileID) then
+		split(params, projectileID)
+		return true
 	end
-	Spring.SpawnCEG(params.splitexplosionceg, positionX, positionY, positionZ, 0, 0, 0, 0, 0)
-	Spring.DeleteProjectile(proID)
 end
 
 -- Water penetration (cannon)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -204,33 +204,20 @@ weaponCustomParamKeys.sector_fire = {
 	end,
 }
 
-checkingFunctions.sector_fire = {}
-checkingFunctions.sector_fire["always"] = function(proID)
-	-- as soon as the siege projectile is created, pass true on the
-	-- checking function, to go to applying function
-	-- so the unit state is only checked when the projectile is created
+weaponSpecialEffect.sector_fire = function(params, projectileID)
+	local rangeReductionMax = params.max_range_reduction
+	local transformXZ = 1 - (math_random() ^ (1 + rangeReductionMax)) * rangeReductionMax
+
+	local angleSpread = params.spread_angle * (math_random() - 0.5)
+	local transformX = math_cos(angleSpread)
+	local transformZ = math_sin(angleSpread)
+
+	local velocityX, velocityY, velocityZ = spGetProjectileVelocity(projectileID)
+	velocityX = (velocityX * transformX - velocityZ * transformZ) * transformXZ
+	velocityZ = (velocityX * transformZ + velocityZ * transformX) * transformXZ
+	spSetProjectileVelocity(projectileID, velocityX, velocityY, velocityZ)
+
 	return true
-end
-applyingFunctions.sector_fire = function(proID)
-	local params = projectiles[proID]
-	local velocityX, velocityY, velocityZ = spGetProjectileVelocity(proID)
-
-	local angleSpread = tonumber(params.spread_angle)
-	local rangeReductionMax = tonumber(params.max_range_reduction)
-
-	local angleFactor = (angleSpread * (math_random() - 0.5)) * math_pi / 180
-	local angleCos = math_cos(angleFactor)
-	local angleSin = math_sin(angleFactor)
-
-	local vx_new = velocityX * angleCos - velocityZ * angleSin
-	local vz_new = velocityX * angleSin + velocityZ * angleCos
-
-	local velocityFactor = 1 - (math_random() ^ (1 + rangeReductionMax)) * rangeReductionMax
-
-	velocityX = vx_new * velocityFactor
-	velocityZ = vz_new * velocityFactor
-
-	spSetProjectileVelocity(proID, velocityX, velocityY, velocityZ)
 end
 
 -- Split

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -224,10 +224,10 @@ specialEffectFunction.retarget = function(projectileID)
 	if spGetProjectileTimeToLive(projectileID) > 0 then
 		local targetType, target = spGetProjectileTarget(projectileID)
 
-		if targetType == targetedUnit and spGetUnitIsDead(target) ~= false then
-			local ownerID = spGetProjectileOwnerID(projectileID)
+		if targetType == targetedUnit then
+			if spGetUnitIsDead(target) ~= false then
+				local ownerID = spGetProjectileOwnerID(projectileID)
 
-			if ownerID then
 				-- Hardcoded to retarget only from the primary weapon and only units or ground
 				local ownerTargetType, _, ownerTarget = spGetUnitWeaponTarget(ownerID, 1)
 
@@ -236,12 +236,12 @@ specialEffectFunction.retarget = function(projectileID)
 				elseif ownerTargetType == 2 then
 					spSetProjectileTarget(projectileID, ownerTarget[1], ownerTarget[2], ownerTarget[3])
 				end
-
-				return false
 			end
+			return false
 		end
+	else
+		return true
 	end
-	return true
 end
 
 -- Sector fire

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -379,7 +379,7 @@ local function refreshUnitInfo()
 						calculateClusterDPS(weaponDef, weaponDef.damages[0])
 					elseif weaponDef.customParams.speceffect == "split" then -- Bullets that split into other, smaller bullets
 						unitExempt = true
-						local splitd = WeaponDefNames[weaponDef.customParams.def].damages[0]
+						local splitd = WeaponDefNames[weaponDef.customParams.speceffect_def].damages[0]
 						local splitn = weaponDef.customParams.number or 1
 						calculateWeaponDPS(weaponDef, splitd * splitn)
 					elseif weaponDef.customParams.spark_basedamage then -- Lightning

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -594,7 +594,7 @@ local function drawStats(uDefID, uID)
 				defaultDamage = defaultDamage + spDamage * spCount
 			elseif uWep.customParams.speceffect == "split" then
 				burst = burst * (uWep.customParams.number or 1)
-				uWep = WeaponDefNames[uWep.customParams.def] or uWep
+				uWep = WeaponDefNames[uWep.customParams.speceffect_def] or uWep
 				defaultDamage = uWep.damages[0]
 			elseif uWep.customParams.cluster then
 				local munition = uDef.name .. '_' .. uWep.customParams.cluster_def

--- a/units/ArmAircraft/T2/armlance.lua
+++ b/units/ArmAircraft/T2/armlance.lua
@@ -119,7 +119,6 @@ return {
 				weaponvelocity = 200,
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 					norangering = 1,
 				},
 				damage = {

--- a/units/ArmBots/T2/armsptk.lua
+++ b/units/ArmBots/T2/armsptk.lua
@@ -148,7 +148,6 @@ return {
 					overrange_distance = 600,
 					projectile_destruction_method = "descend",
 					speceffect = "cruise",
-					when = "distance>0",
 				},
 				damage = {
 					default = 200,

--- a/units/ArmSeaplanes/armseap.lua
+++ b/units/ArmSeaplanes/armseap.lua
@@ -112,7 +112,6 @@ return {
 				weaponvelocity = 200,
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 					noattackrangearc = 1,
 				},
 				damage = {

--- a/units/ArmShips/T2/armmship.lua
+++ b/units/ArmShips/T2/armmship.lua
@@ -189,12 +189,11 @@ return {
 				weaponvelocity = 450,
 				customparams = {
 					cegtag = "missiletrailcorroyspecial",
-					def = "armmship_rocket_split",
 					model = "airbomb",
 					number = "6",
 					speceffect = "split",
+					speceffect_def = "armmship_rocket_split",
 					splitexplosionceg = "genericshellexplosion-medium",
-					when = "yvel<0",
 					noattackrangearc= 1,
 				},
 				damage = {

--- a/units/ArmShips/T2/armtdrone.lua
+++ b/units/ArmShips/T2/armtdrone.lua
@@ -111,7 +111,6 @@ return {
 				weaponvelocity = 200,
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 				},
 				damage = {
 					commanders = 30,

--- a/units/CorAircraft/T2/cortitan.lua
+++ b/units/CorAircraft/T2/cortitan.lua
@@ -120,7 +120,6 @@ return {
 				weaponvelocity = 160,
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 					norangering = 1,
 				},
 				damage = {

--- a/units/CorGantry/corkarg.lua
+++ b/units/CorGantry/corkarg.lua
@@ -191,7 +191,6 @@ return {
 					overrange_distance = 690,
 					projectile_destruction_method = "descend",
 					speceffect = "retarget",
-					when = "always",
 				},
 				damage = {
 					default = 180,

--- a/units/CorSeaplanes/corseap.lua
+++ b/units/CorSeaplanes/corseap.lua
@@ -112,7 +112,6 @@ return {
 				weaponvelocity = 200,
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 					noattackrangearc = 1,
 				},
 				damage = {

--- a/units/CorShips/T2/cormship.lua
+++ b/units/CorShips/T2/cormship.lua
@@ -188,12 +188,11 @@ return {
 				weaponvelocity = 450,
 				customparams = {
 					cegtag = "missiletrailcorroyspecial",
-					def = "cormship_rocket_split",
 					model = "airbomb",
 					number = "8",
 					speceffect = "split",
+					speceffect_def = "cormship_rocket_split",
 					splitexplosionceg = "genericshellexplosion-medium",
-					when = "yvel<0",
 					noattackrangearc= 1,
 				},
 				damage = {

--- a/units/CorVehicles/T2/cortrem.lua
+++ b/units/CorVehicles/T2/cortrem.lua
@@ -137,7 +137,6 @@ return {
 					max_range_reduction = "0.30",
 					speceffect = "sector_fire",
 					spread_angle = "22",
-					when = "always",
 				},
 				damage = {
 					default = 200,

--- a/units/Legion/Air/T2 Air/legatorpbomber.lua
+++ b/units/Legion/Air/T2 Air/legatorpbomber.lua
@@ -120,7 +120,6 @@ return {
 				weaponvelocity = 200,
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 					norangering = 1,
 				},
 				damage = {

--- a/units/Legion/Ships/legpontus.lua
+++ b/units/Legion/Ships/legpontus.lua
@@ -151,7 +151,6 @@ return {
 				},
 				customparams = {
 					speceffect = "torpwaterpen",
-					when = "ypos<0",
 				},
 			},
 

--- a/units/Legion/T3/legeshotgunmech.lua
+++ b/units/Legion/T3/legeshotgunmech.lua
@@ -282,7 +282,6 @@ return {
 					cruise_min_height = "15",
 					lockon_dist = "150",
 					speceffect = "cruise",
-					when = "distance>0",
 					projectile_destruction_method = "descend",
 					overrange_distance = 750,
 				},


### PR DESCRIPTION
### Work done

This one gadget file is chaos and seeing it again was all it took to do this.

- Refactor existing unit_custom_weapons_behaviours for better practices
- Refactor existing weapon customparams to use better param names
- Add error checks, simplifies setup of weapon behaviors
- Some CPU, memory, and allocation improvements
- Remove stale todos that are obvious enough in code

Please wait to merge but feel free to review for code practices. It will take me a bit to test that each of these works exactly the same as before (cruise, retarget, sector_fire, cannon/torpedo water pen) via ingame validation. Won't be long.

One notable change that maybe testing will explain to me (so will revert): I made torpedo's velocity reduction of water impact consistent across target depths. The previous behavior, though, genuinely did not make sense to me.