### PR TITLE
Music Fixes

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -103,6 +103,8 @@ local function ReloadMusicPlaylists()
 	local menuTracksNew 			= VFS.DirList(musicDirNew..'/menu', allowedExtensions)
 	local loadingTracksNew   		= VFS.DirList(musicDirNew..'/loading', allowedExtensions)
 	local bossFightTracksNew		= {}
+		  bossFightTracksAll 		= {}
+		  bonusTracks				= {}
 
 	if Spring.Utilities.Gametype.IsRaptors() then
 		table.append(bossFightTracksNew, VFS.DirList(musicDirNew..'/bossfight/raptors', allowedExtensions))

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -5834,6 +5834,9 @@ function init()
 		else
 			options[getOptionByID('soundtrackAprilFoolsPostEvent')] = nil
 		end
+	else
+		options[getOptionByID('soundtrackAprilFools')] = nil
+		options[getOptionByID('soundtrackAprilFoolsPostEvent')] = nil
 	end
 
 	-- hide English unit names toggle if using English


### PR DESCRIPTION
- Fixed April Fools Music toggles showing up when Original Soundtrack is disabled
- Fixed playlists getting flooded with duplicates while switching Original Soundtrack on and off.