### PR TITLE
S2 balance tuning changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 • [Pawn] 52m 870e -> 54m 900e
 • [Grunt] 210 -> 215 range
 • [Spybots] Can paralyze buildings up to 20s
+• [Antinuke buildings] Health 3650 -> 3300 (facilitating a full-length stun from spybot)
 • [Shuriken + Abductor] Regain targetmoveerror, revert Shuriken reloadtime 1.3s -> 1.2s
 
 # March 2025

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+# April 2025
+• [Pawn] 52m 870e -> 54m 900e
+• [Grunt] 210 -> 215 range
+• [Spybots] Can paralyze buildings up to 20s
+• [Shuriken + Abductor] Regain targetmoveerror, revert Shuriken reloadtime 1.3s -> 1.2s
+
 # March 2025
 • [Armada solar] Buildtime 2800 -> 2600 
 • [Armada wind] Metalcost 37 -> 40


### PR DESCRIPTION
Adds to changelog following changes

• [Pawn] 52m 870e -> 54m 900e
• [Grunt] 210 -> 215 range
• [Spybots] Can paralyze buildings up to 20s
• [Antinuke buildings] Health 3650 -> 3300 (facilitating a full-length stun from spybot)
• [Shuriken + Abductor] Regain targetmoveerror, revert Shuriken reloadtime 1.3s -> 1.2s



Which are in following PRs:
spybot/antinuke
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4485 https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4730

targetmoveerror/shuri
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4681

pawn/grunt
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4731
