### PR TITLE
Commit updates to recoil lua library as bot.

### DIFF
--- a/.github/workflows/update-recoil-lua-library.yml
+++ b/.github/workflows/update-recoil-lua-library.yml
@@ -28,5 +28,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: recoil-lua-library
+          commit_author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           commit_message: |
             Update Lua libary submodule


### PR DESCRIPTION
Previously, it was commiting as the person that first initiated the github workflow run, which is not really accurate.