### PR TITLE
Fix loading widgets with locals access enabled.

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -438,7 +438,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess)
 			return nil
 		end
 
-		local widget = widgetHandler:NewWidget()
+		local widget = widgetHandler:NewWidget(enableLocalsAccess)
 		setfenv(chunk, widget)
 		local success, err = pcall(chunk)
 		if not success then
@@ -460,7 +460,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess)
 		return nil
 	end
 
-	local widget = widgetHandler:NewWidget()
+	local widget = widgetHandler:NewWidget(enableLocalsAccess)
 	setfenv(chunk, widget)
 	local success, err = pcall(chunk)
 	if not success then
@@ -567,9 +567,19 @@ local WidgetMeta =
 	__metatable = true,
 }
 
-function widgetHandler:NewWidget()
+function widgetHandler:NewWidget(enableLocalsAccess)
 	tracy.ZoneBeginN("W:NewWidget")
-	local widget = setmetatable({}, WidgetMeta)
+	local widget = {}
+	if enableLocalsAccess then
+		-- copy the system calls into the widget table
+		for k, v in pairs(System) do
+			widget[k] = v
+		end
+	else
+		-- use metatable redirection
+		setmetatable(widget, WidgetMeta)
+	end
+
 	widget.WG = self.WG    -- the shared table
 	widget.widget = widget -- easy self referencing
 


### PR DESCRIPTION
### Work done

- Fix LoadWidget enableLocalsAccess mode.

### Remarks

- This was broken with 26905213a251b2268b3c74789dce83c31ff264c0
- It's a mechanism used by the test runner.
- Gives "can't change read only metatable" or similar unless fixed.
