### PR TITLE
ecostats: Fix bad check for maxMetal > 0.

### DIFF
--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -1168,7 +1168,7 @@ local function drawListStandard()
 					if maxEnergy > 0 then
 						DrawEBar(avgData[aID].tE / maxEnergy, (avgData[aID].tE - avgData[aID].tEr) / maxEnergy, posy - 1)
 					end
-					if maxEnergy > 0 then
+					if maxMetal > 0 then
 						DrawMBar(avgData[aID].tM / maxMetal, (avgData[aID].tM - avgData[aID].tMr) / maxMetal, posy + 2)
 					end
 				end


### PR DESCRIPTION
### Work done

- Check maxMetal > 0 to avoid NaN.


### Remarks

- Seems like it's erroneously checking maxEnergy instead, so if maxMetal is 0 it's going to NaN.
- Needed for tests.
- NaN protection was moved/changed here: 9d8c0fadb50