### PR TITLE
Introduce new dbg_test_headless_overrides widget

### DIFF
--- a/luaui/Widgets/dbg_test_headless_overrides.lua
+++ b/luaui/Widgets/dbg_test_headless_overrides.lua
@@ -1,0 +1,22 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Headless environment overrides",
+		desc = "Overrides for running on headless environment",
+		license = "GNU GPL, v2 or later",
+		layer = -9999999999,
+		enabled = true,
+	}
+end
+
+if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePlayer() or Platform.gl then
+	return
+end
+
+-- PushMatrix and PopMatrix still perform accounting and can generate errors on headless.
+-- Problem here is CallList won't really call dlists, so when a PushMatrix or PopMatrix
+-- is placed inside a display list, this can cause problems.
+gl.PushMatrix = function() end
+gl.PopMatrix = function() end
+


### PR DESCRIPTION
### Work done

- Introduce new `dbg_test_headless_overrides` widget, for headless test environment
  - Overrides gl.PushMatrix and gl.PopMatrix with noop overrides.

### Remarks

- Fix/workaround for a pattern of using PushMatrix/PopMatrix inside Dlists
  - Seen in gui_top_bar `tidaldlist2`
  - A bit of a dubious pattern, but with this override the tests don't condition other widgets writing style.
- The widget can be used for other overrides in the future, could be refactored into a common module to share with other application lua handles.