### PR TITLE
Skip some modules on headless.

### DIFF
--- a/luaintro/Addons/main.lua
+++ b/luaintro/Addons/main.lua
@@ -438,6 +438,8 @@ end
 function addon.DrawLoadScreen()
 	local loadProgress = SG.GetLoadProgress()
 
+	if not Platform.gl then return end
+
 	if not aspectRatio then
 		local texInfo = gl.TextureInfo(backgroundTexture)
 		if not texInfo then return end

--- a/luaui/Tests/select_api/compare_to_spring.lua
+++ b/luaui/Tests/select_api/compare_to_spring.lua
@@ -6,7 +6,7 @@ local passed = true
 
 
 function skip()
-	return Spring.GetGameFrame() <= 0
+	return Spring.GetGameFrame() <= 0 or not Platform.gl
 end
 
 function setup()

--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -9,7 +9,8 @@ function widget:GetInfo()
         license = "GNU GPL, v2 or later",
 		version = 0.2,
         layer = -1,
-        enabled = false
+        enabled = false,
+        depends = {'gl4'},
     }
 end
 


### PR DESCRIPTION
### Work done

- Add skips for the following modules:
  - LuaIntro
  - select_api test
  - building_grid_gl4

### Remarks

Have to skip these so running tests won't generate extra errors.

- LuaIntro:
  -  `vsx, vsy, vpx, vpy = Spring.GetViewGeometry() -> vpx and vpy are 0 generate later NaNs`
- select_api test:
  - not sure but failing on headless, probably because setting mouse position doesnt really work
  - maybe can be worked around later, but I think it's fine to skip for now
- building_grid_gl4:
  -  `Error: [LuaVBOs:CheckAndReportSupported]: important OpenGL extension ARB_vertex_buffer_object is not supported for buffer type GL_ARRAY_BUFFER`
  - as usual with modules using instancevbotable just disable through `depends='{'gl4'}'`