### PR TITLE
Allow blueprint_api to work in headless mode

### DIFF
--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -1,9 +1,5 @@
 local widgetName = "Blueprint"
 
-function skip()
-	return not Platform.gl
-end
-
 function setup()
 	assert(widgetHandler.knownWidgets[widgetName] ~= nil)
 

--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -40,6 +40,7 @@ local SpringGetGroundHeight = Spring.GetGroundHeight
 local SpringPos2BuildPos = Spring.Pos2BuildPos
 local SpringTestBuildOrder = Spring.TestBuildOrder
 local SpringGetMyTeamID = Spring.GetMyTeamID
+local isHeadless = not Platform.gl
 
 -- util
 -- ====
@@ -529,6 +530,7 @@ local BUILD_MODES_HANDLERS = {
 local instanceIDs = {}
 
 local function clearInstances()
+	if isHeadless then return end
 	if outlineInstanceVBO then
 		clearInstanceTable(outlineInstanceVBO)
 	end
@@ -615,6 +617,8 @@ end
 ---@param buildPositions StartPoints
 ---@param teamID number
 local function updateInstances(blueprint, buildPositions, teamID)
+	if isHeadless then return end
+
 	if not blueprint or not buildPositions then
 		clearInstances()
 		return
@@ -650,7 +654,7 @@ local function updateInstances(blueprint, buildPositions, teamID)
 end
 
 local function drawOutlines()
-	if outlineInstanceVBO.usedElements == 0 then
+	if outlineInstanceVBO.usedElements == 0 or isHeadless then
 		return
 	end
 
@@ -672,7 +676,7 @@ local function drawOutlines()
 end
 
 function widget:DrawWorldPreUnit()
-	if not activeBlueprint then
+	if not activeBlueprint or isHeadless then
 		return
 	end
 
@@ -729,16 +733,12 @@ local function setActiveBuilders(unitIDs)
 end
 
 function widget:Initialize()
-	if not gl.CreateShader then
-		-- no shader support, so just remove the widget itself, especially for headless
-		widgetHandler:RemoveWidget()
-		return
-	end
-
-	if not initGL4() then
-		-- shader compile failed
-		widgetHandler:RemoveWidget()
-		return
+	if not isHeadless then
+		if not initGL4() then
+			-- shader compile failed
+			widgetHandler:RemoveWidget()
+			return
+		end
 	end
 
 	WG["api_blueprint"] = {
@@ -760,6 +760,8 @@ end
 
 function widget:Shutdown()
 	WG["api_blueprint"] = nil
+
+	if isHeadless then return end
 
 	clearInstances()
 


### PR DESCRIPTION
### Work done

- Allow blueprint_api to work in headless mode.
- Enable blueprint_single test for headless.

### Remarks

- Useless for game itself, but allows blueprint tests to work in headless mode.
- Blueprint api does both logic and gui, so with this change it can do logic only, so at least we can test that in headless.
- Don't usually like to do so many changes for headless mode, but I think in this case it's justified since it allows other blueprint modules and tests to work transparently.
- There's still one blueprint test disabled for headless, because that one suffers from a different problem, will tackle that at some point in a different way.
  - That one doesn't work because mouse warp doesn't work in headless. Workaround is to move the camera instead (mouse stays in 0,0 but we can RayTrace through it as if the mouse moved).
