### PR TITLE
Create animation_cleanup.yml PR blocker workflow

### DIFF
--- a/.github/workflows/animation_cleanup.yml
+++ b/.github/workflows/animation_cleanup.yml
@@ -1,0 +1,44 @@
+name: Block Unclean Script Modifications
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Important for comparing with base branch
+
+      - name: Get list of modified files
+        id: changed
+        run: |
+          echo "CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Check for forbidden modifications
+        run: |
+          BLOCKED=0
+          for file in ${{ steps.changed.outputs.CHANGED }}; do
+            if [[ "$file" =~ ^scripts/Units/.*\.(bos|cob)$ ]]; then
+              base_name="${file%.*}"      # remove extension
+              ext="${file##*.}"           # get extension
+              clean_file="${base_name}_clean.${ext}"
+
+              if [[ ! -f "$clean_file" ]]; then
+                echo "✅ File '$file' is not a deprecated animation."
+              else
+                echo "❌ File '$file' is a deprecated animation. Please only base changes on the clean counterpart: '$clean_file'."
+                BLOCKED=1
+              fi
+            fi
+          done
+
+          if [[ "$BLOCKED" -eq 1 ]]; then
+            echo "Blocking PR due to unclean modifications. Please switch the unit.lua over to its _clean animation counterpart, e.g. script = Units/CORINT_CLEAN.cob, test the new animation and base your changes on that."
+            exit 1
+          else
+            echo "All modified files are clean or allowed."
+          fi


### PR DESCRIPTION
This PR adds a workflow steps that disallows editing of deprecated .bos/.cob animations. If a cleaned up animation of your target unit exists, then please take the following steps:
1. In the unit's `.lua` file, change `script = *.cob`  over to the `*_clean. cob` version
2. Test that the new *_clean.cob animation works correctly
3. Base your intended changes from the *_clean.bos version
