### PR TITLE
Add 'team resign' button to topbar 'resign' modal.

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -5,6 +5,10 @@
 			"catchingUp": "Catching up to "
 		},
 		"topbar": {
+			"hint": {
+				"resign": "Resign yourself.",
+				"teamResign": "Call for team resign."
+			},
 			"button": {
 				"quit": "Quit",
 				"resign": "Resign",
@@ -21,6 +25,7 @@
 				"stay": "Stay",
 				"quit": "Quit",
 				"resign": "Resign",
+				"teamResign": "Team Resign",
 				"reallyQuit": "Are you sure you want to quit?",
 				"reallyQuitResign": "Are you sure you want to resign or return to game lobby?",
 				"reallyResign": "Are you sure you want to resign?",

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1269,7 +1269,7 @@ local function drawQuitScreen()
 			quitscreenArea = { x, y, x + w, y + h }
 
 			if teamResign then
-				quitscreenArea[2] = quitscreenArea[2] - 20
+				quitscreenArea[2] = quitscreenArea[2] - math.floor(fontSize*1.7)
 			end
 
 			quitscreenStayArea   = { x + buttonMargin + 0 * (buttonWidth + buttonMargin), y + buttonMargin, x + buttonMargin + 0 * (buttonWidth + buttonMargin) + buttonWidth, y + buttonMargin + buttonHeight }
@@ -1336,7 +1336,7 @@ local function drawQuitScreen()
 					font2:Print(Spring.I18N('ui.topbar.quit.teamResign'), quitscreenTeamResignArea[1] + ((quitscreenTeamResignArea[3] - quitscreenTeamResignArea[1]) / 2), quitscreenTeamResignArea[2] + ((quitscreenTeamResignArea[4] - quitscreenTeamResignArea[2]) / 2) - (fontSize / 3), fontSize, "con")
 				end
 				if mouseOver and teamResign then
-					font:Print(Spring.I18N('ui.topbar.hint.'..mouseOver), quitscreenTeamResignArea[1] - buttonMargin , quitscreenArea[2] + (2*fontSize / 3), fontSize, "cn")
+					font:Print(Spring.I18N('ui.topbar.hint.'..mouseOver), quitscreenTeamResignArea[1] - buttonMargin , quitscreenArea[2] + (2.5*fontSize / 3), fontSize, "cn")
 				end
 			end
 

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -159,8 +159,8 @@ local prevShowButtons = showButtons
 -- Interactions
 local draggingShareIndicatorValue = {}
 local draggingConversionIndicatorValue, draggingShareIndicator, draggingConversionIndicator
-local conversionIndicatorArea, quitscreenArea, quitscreenStayArea, quitscreenQuitArea, quitscreenResignArea, hoveringTopbar, hideQuitWindow
-local font, font2, firstButton, fontSize, comcountChanged, showQuitscreen, resbarHover
+local conversionIndicatorArea, quitscreenArea, quitscreenStayArea, quitscreenQuitArea, quitscreenResignArea, quitscreenTeamResignArea, hoveringTopbar, hideQuitWindow
+local font, font2, firstButton, fontSize, comcountChanged, showQuitscreen, resbarHover, teamResign
 
 -- Audio
 local playSounds = true
@@ -1239,6 +1239,7 @@ local function drawQuitScreen()
 
 			local fontSize = h / 6
 			local text = Spring.I18N('ui.topbar.quit.reallyQuit')
+			teamResign = false
 
 			if not spec then
 				text = Spring.I18N('ui.topbar.quit.reallyQuitResign')
@@ -1246,6 +1247,7 @@ local function drawQuitScreen()
 					if numPlayers < 3 then
 						text = Spring.I18N('ui.topbar.quit.reallyResign')
 					else
+						teamResign = true
 						text = Spring.I18N('ui.topbar.quit.reallyResignSpectate')
 					end
 				end
@@ -1258,14 +1260,26 @@ local function drawQuitScreen()
 
 			local x = math_floor((vsx / 2) - (w / 2))
 			local y = math_floor((vsy / 1.8) - (h / 2))
+			local maxButtons = teamResign and 5 or 4
 			local buttonMargin = math_floor(h / 9)
-			local buttonWidth = math_floor((w - buttonMargin * 4) / 3) -- 4 margins for 3 buttons
+			local buttonWidth = math_floor((w - buttonMargin * maxButtons) / (maxButtons-1)) -- maxButtons+1 margins for maxButtons buttons
 			local buttonHeight = math_floor(h * 0.30)
 
+
 			quitscreenArea = { x, y, x + w, y + h }
+
+			if teamResign then
+				quitscreenArea[2] = quitscreenArea[2] - 20
+			end
+
 			quitscreenStayArea   = { x + buttonMargin + 0 * (buttonWidth + buttonMargin), y + buttonMargin, x + buttonMargin + 0 * (buttonWidth + buttonMargin) + buttonWidth, y + buttonMargin + buttonHeight }
 			quitscreenResignArea = { x + buttonMargin + 1 * (buttonWidth + buttonMargin), y + buttonMargin, x + buttonMargin + 1 * (buttonWidth + buttonMargin) + buttonWidth, y + buttonMargin + buttonHeight }
-			quitscreenQuitArea   = { x + buttonMargin + 2 * (buttonWidth + buttonMargin), y + buttonMargin, x + buttonMargin + 2 * (buttonWidth + buttonMargin) + buttonWidth, y + buttonMargin + buttonHeight }
+			local nextButton = 2
+			if teamResign then
+				quitscreenTeamResignArea = { x + buttonMargin + nextButton * (buttonWidth + buttonMargin), y + buttonMargin, x + buttonMargin + nextButton * (buttonWidth + buttonMargin) + buttonWidth, y + buttonMargin + buttonHeight }
+				nextButton = nextButton + 1
+			end
+			quitscreenQuitArea   = { x + buttonMargin + nextButton * (buttonWidth + buttonMargin), y + buttonMargin, x + buttonMargin + nextButton * (buttonWidth + buttonMargin) + buttonWidth, y + buttonMargin + buttonHeight }
 
 			-- window
 			UiElement(quitscreenArea[1], quitscreenArea[2], quitscreenArea[3], quitscreenArea[4], 1,1,1,1, 1,1,1,1, nil, {1, 1, 1, 0.6 + (0.34 * fadeProgress)}, {0.45, 0.45, 0.4, 0.025 + (0.025 * fadeProgress)}, nil)--, useRenderToTexture)
@@ -1297,15 +1311,33 @@ local function drawQuitScreen()
 
 			-- resign button
 			if not spec and not gameIsOver then
+				local mouseOver = false
 				if math_isInRect(mx, my, quitscreenResignArea[1], quitscreenResignArea[2], quitscreenResignArea[3], quitscreenResignArea[4]) then
-					color1 = { 0.28, 0.28, 0.28, 0.4 + (0.5 * fadeProgress) }
-					color2 = { 0.45, 0.45, 0.45, 0.4 + (0.5 * fadeProgress) }
+					color1 = { 0.4, 0, 0, 0.4 + (0.5 * fadeProgress) }
+					color2 = { 0.6, 0.05, 0.05, 0.4 + (0.5 * fadeProgress) }
+					mouseOver = 'resign'
 				else
-					color1 = { 0.18, 0.18, 0.18, 0.4 + (0.5 * fadeProgress) }
-					color2 = { 0.33, 0.33, 0.33, 0.4 + (0.5 * fadeProgress) }
+					color1 = { 0.25, 0, 0, 0.35 + (0.5 * fadeProgress) }
+					color2 = { 0.5, 0, 0, 0.35 + (0.5 * fadeProgress) }
 				end
 				UiButton(quitscreenResignArea[1], quitscreenResignArea[2], quitscreenResignArea[3], quitscreenResignArea[4], 1,1,1,1, 1,1,1,1, nil, color1, color2, padding * 0.5)
 				font2:Print(Spring.I18N('ui.topbar.quit.resign'), quitscreenResignArea[1] + ((quitscreenResignArea[3] - quitscreenResignArea[1]) / 2), quitscreenResignArea[2] + ((quitscreenResignArea[4] - quitscreenResignArea[2]) / 2) - (fontSize / 3), fontSize, "con")
+
+				if teamResign then
+					if math_isInRect(mx, my, quitscreenTeamResignArea[1], quitscreenTeamResignArea[2], quitscreenTeamResignArea[3], quitscreenTeamResignArea[4]) then
+						color1 = { 0.28, 0.28, 0.28, 0.4 + (0.5 * fadeProgress) }
+						color2 = { 0.45, 0.45, 0.45, 0.4 + (0.5 * fadeProgress) }
+						mouseOver = 'teamResign'
+					else
+						color1 = { 0.18, 0.18, 0.18, 0.4 + (0.5 * fadeProgress) }
+						color2 = { 0.33, 0.33, 0.33, 0.4 + (0.5 * fadeProgress) }
+					end
+					UiButton(quitscreenTeamResignArea[1], quitscreenTeamResignArea[2], quitscreenTeamResignArea[3], quitscreenTeamResignArea[4], 1,1,1,1, 1,1,1,1, nil, color1, color2, padding * 0.5)
+					font2:Print(Spring.I18N('ui.topbar.quit.teamResign'), quitscreenTeamResignArea[1] + ((quitscreenTeamResignArea[3] - quitscreenTeamResignArea[1]) / 2), quitscreenTeamResignArea[2] + ((quitscreenTeamResignArea[4] - quitscreenTeamResignArea[2]) / 2) - (fontSize / 3), fontSize, "con")
+				end
+				if mouseOver and teamResign then
+					font:Print(Spring.I18N('ui.topbar.hint.'..mouseOver), quitscreenTeamResignArea[1] - buttonMargin , quitscreenArea[2] + (2*fontSize / 3), fontSize, "cn")
+				end
 			end
 
 			-- quit button
@@ -1737,6 +1769,12 @@ function widget:MousePress(x, y, button)
 				if not spec and not gameIsOver and math_isInRect(x, y, quitscreenResignArea[1], quitscreenResignArea[2], quitscreenResignArea[3], quitscreenResignArea[4]) then
 					if playSounds then Spring.PlaySoundFile(leftclick, 0.75, 'ui') end
 					Spring.SendCommands("spectator")
+					showQuitscreen = nil
+					if WG['guishader'] then WG['guishader'].setScreenBlur(false) end
+				end
+				if not spec and not gameIsOver and teamResign and math_isInRect(x, y, quitscreenTeamResignArea[1], quitscreenTeamResignArea[2], quitscreenTeamResignArea[3], quitscreenTeamResignArea[4]) then
+					if playSounds then Spring.PlaySoundFile(leftclick, 0.75, 'ui') end
+					Spring.SendCommands("say !cv resign")
 					showQuitscreen = nil
 					if WG['guishader'] then WG['guishader'].setScreenBlur(false) end
 				end

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1336,7 +1336,7 @@ local function drawQuitScreen()
 					font2:Print(Spring.I18N('ui.topbar.quit.teamResign'), quitscreenTeamResignArea[1] + ((quitscreenTeamResignArea[3] - quitscreenTeamResignArea[1]) / 2), quitscreenTeamResignArea[2] + ((quitscreenTeamResignArea[4] - quitscreenTeamResignArea[2]) / 2) - (fontSize / 3), fontSize, "con")
 				end
 				if mouseOver and teamResign then
-					font:Print(Spring.I18N('ui.topbar.hint.'..mouseOver), quitscreenTeamResignArea[1] - buttonMargin , quitscreenArea[2] + (2.5*fontSize / 3), fontSize, "cn")
+					font:Print(Spring.I18N('ui.topbar.hint.'..mouseOver), quitscreenTeamResignArea[1] - buttonMargin , quitscreenArea[2] + (2.5*fontSize / 3), fontSize*0.9, "cn")
 				end
 			end
 

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -179,6 +179,19 @@ local blinkDirection = true
 local blinkProgress = 0
 local guishaderCheckUpdateRate = 0.5
 
+local function getPlayerLiveAllyCount()
+	local nAllies = 0
+	for _, teamID in ipairs(myAllyTeamList) do
+		if not teamID == myTeamID then
+			local _, _, isDead, hasAI = Spring.GetTeamInfo(teamID,false)
+			if not isDead and not hasAI then
+				nAllies = nAllies + 1
+			end
+		end
+	end
+	return nAllies
+end
+
 
 --------------------------------------------------------------------------------
 
@@ -1247,7 +1260,9 @@ local function drawQuitScreen()
 					if numPlayers < 3 then
 						text = Spring.I18N('ui.topbar.quit.reallyResign')
 					else
-						teamResign = true
+						if getPlayerLiveAllyCount() >= 1 then
+							teamResign = true
+						end
 						text = Spring.I18N('ui.topbar.quit.reallyResignSpectate')
 					end
 				end

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1265,7 +1265,6 @@ local function drawQuitScreen()
 			local buttonWidth = math_floor((w - buttonMargin * maxButtons) / (maxButtons-1)) -- maxButtons+1 margins for maxButtons buttons
 			local buttonHeight = math_floor(h * 0.30)
 
-
 			quitscreenArea = { x, y, x + w, y + h }
 
 			if teamResign then

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -182,7 +182,7 @@ local guishaderCheckUpdateRate = 0.5
 local function getPlayerLiveAllyCount()
 	local nAllies = 0
 	for _, teamID in ipairs(myAllyTeamList) do
-		if not teamID == myTeamID then
+		if teamID ~= myTeamID then
 			local _, _, isDead, hasAI = Spring.GetTeamInfo(teamID,false)
 			if not isDead and not hasAI then
 				nAllies = nAllies + 1

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -179,6 +179,9 @@ local blinkDirection = true
 local blinkProgress = 0
 local guishaderCheckUpdateRate = 0.5
 
+
+--------------------------------------------------------------------------------
+
 local function getPlayerLiveAllyCount()
 	local nAllies = 0
 	for _, teamID in ipairs(myAllyTeamList) do
@@ -191,9 +194,6 @@ local function getPlayerLiveAllyCount()
 	end
 	return nAllies
 end
-
-
---------------------------------------------------------------------------------
 
 local function RectQuad(px, py, sx, sy, offset)
 	gl.TexCoord(offset, 1 - offset)


### PR DESCRIPTION
### Work done

- Add 'team resign' button to topbar 'resign' modal.

#### Addresses Issue(s)

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4702

#### Remarks

- Not sure `say !cv resign` is the right mechanism to call for a resign vote.
- Might want to have also 'Stay' since maybe for some ppl it's not evident you can press `esc` or click out of the window to cancel.
- Shows teamResign if having at least 1 other alive ally player in the same allyTeam.
- Code to layout buttons was a bit weird, when "stay" and "quit" are the only options layout seemed a bit off to me.
  - My layout for resign+teamresign has them a bit closer, I guess we want them the same for stay+quit, so please chime in about what you think is the best option. When they're as separated as `stay+quit` not sure the hint will look fine tho.
  - When the new option isn't there layout should be exactly the same as before in all situations.
- Unsure about the button colors, just set them somehow random by keeping previous resign color, and cloning color from elsewhere for the new one.
- Added a 'hint' area below the buttons (only shows when teamResign is present), I think this helps in understanding what each button does. Otherwise could maybe add a tooltip instead, or just show nothing, but feel like 'resign' and 'team resign' might be hard to comprehend for newcomers.

### Screenshots

![resign-b](https://github.com/user-attachments/assets/4a4727b4-46cb-41f0-b053-c3dcbb56599c)

![teamresign-b](https://github.com/user-attachments/assets/b50e9b3d-c5d9-41d2-80e6-c7761397c512)

this might be more usable tho :D:

![opt1](https://github.com/user-attachments/assets/2362126c-0495-4c85-a920-cb7ab918cde0)

stay/quit

for reference:

![default](https://github.com/user-attachments/assets/2f29bca4-2b07-4215-8d35-067a4a9d41cc)


