### PR TITLE
Change extractor snap to respect "InvertQueueKey"

### DIFF
--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -284,6 +284,7 @@ function widget:MousePress(x, y, button)
 
 	if button == 1 and buildCmd and buildCmd[1] then
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
+		shift = Spring.GetInvertQueueKey() and (not shift) or shift
 		if selectedMex then
 			WG['resource_spot_builder'].ApplyPreviewCmds(buildCmd, mexConstructors, shift)
 			handleBuildMenu(shift)


### PR DESCRIPTION
"InvertQueueKey" allows players to avoid holding shift to queue items.
Crucially, this is important for a keyboardless interface, where the `/invqueuekey` command allows players to toggle queueing without the use of a keyboard.

This is already supported in engine queueing, but when a user was trying to make use of this feature, they discovered that snapping buildings do not respect the "InvertQueueKey" option as other options in the build menu do.

### Work done
Make extractor snap respect "InvertQueueKey" option.

#### Test steps

Use `/invqueuekey 1`, and `/invqueuekey 0` to verify that queuing an extractor appends/overrides correctly. `/invqueuekey 0` should be the default, shift-queues and no-shift-overwrites that most players are used to. `/invqueuekey 1` should be the desired shift-overwrites and no-shift-queues that applies to all other build options when "InvertQueueKey" is set to 1.