### PR TITLE
Fix Legion Commander Engage Range

### DIFF
--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -97,6 +97,7 @@ return {
 		customparams = {
 			unitgroup = 'builder',
 			combatradius = 600,
+			maxrange = 300,
 			iscommander = true,
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",


### PR DESCRIPTION
Changed engagement range of legion com(maxrange = 300) so they walk into range of their comlaser when given an attack order

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
- added `maxrange` customparam to `legcom.lua`


#### Addresses Issue(s)
[#4585](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4585)



#### Test steps
- [ ] Spawn as legion
- [ ] Issue an attack command with commander

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
