### PR TITLE
feat(snd_notifications): disable heavily damaged warning if com is >85%

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -27,6 +27,7 @@ local spoken = true
 local idleBuilderNotificationDelay = 10 * 30    -- (in gameframes)
 local lowpowerThreshold = 7        -- if there is X secs a low power situation
 local tutorialPlayLimit = 2        -- display the same tutorial message only this many times in total (max is always 1 play per game)
+local updateCommandersFrames = Game.gameSpeed * 5
 
 --------------------------------------------------------------------------------
 
@@ -480,6 +481,10 @@ function widget:GameFrame(gf)
 			end
 		end
 	end
+
+	if gameframe % updateCommandersFrames == 0 then
+		updateCommanders()
+	end
 end
 
 function widget:UnitCommand(unitID, unitDefID, unitTeamID, cmdID, cmdParams, cmdOptions, cmdTag)
@@ -686,7 +691,7 @@ function widget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer)
 						commandersDamages[unitID][gf] = nil
 					end
 				end
-				if totalDamage >= commanders[unitID] * 0.2 then
+				if totalDamage >= commanders[unitID] * 0.2 and spGetUnitHealth(unitID)/commanders[unitID] <= 0.85 then
 					queueNotification('ComHeavyDamage')
 				end
 			end


### PR DESCRIPTION
When commanders have strong healing the "heavily damaged" notification loses it's meaning.

### Work done
* Added condition for heavily damaged notification that commander health must be below 85%
* Commander maxHealths are now periodically updated (every 5 seconds). This should fix an issue where the 20% damage requirement is using an old maxHealth value which decreases the % when xp increases the new maxHealth.

#### Test steps
- [x] Apply heavy healing and continous damage to commander. On master this will trigger warnings at any health %. On this branch health must be below 85%.
- [x] Same behavior if xp has increased maxHealth