### PR TITLE
Fix mex denier not working with multiples of 16

### DIFF
--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -324,6 +324,7 @@ local function GetSpotsMetal()
 	end
 
 	-- Final processing
+	local uDefID = UnitDefNames["armmex"].id
 	local spots = {}
 	for _, g in ipairs(uniqueGroups) do
 		local gMinX, gMaxX = huge, -1
@@ -350,6 +351,12 @@ local function GetSpotsMetal()
 		if gMaxX - gMinX > maxStripLength or g.maxZ - g.minZ > maxStripLength then
 			return false, true
 		end
+
+		local positions = GetBuildingPositions(g, uDefID, 0, false)
+		local pos = positions[floor(#positions / 2 + 1)]
+		g.x = pos.x
+		g.y = pos.y
+		g.z = pos.z
 	end
 
 	--for i = 1, #spots do

--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -324,6 +324,7 @@ local function GetSpotsMetal()
 	end
 
 	-- Final processing
+	-- armmex used as representative unit for placement checking, since all metal extractors are the same size
 	local uDefID = UnitDefNames["armmex"].id
 	local spots = {}
 	for _, g in ipairs(uniqueGroups) do


### PR DESCRIPTION
### Work done
Snap positions to values that cmd_mex_denier works with.
Downside: [GetBuildingPositions](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/common/upgets/api_resource_spot_finder.lua#L152) has loops and requires UnitDef.

#### Addresses Issue:
Current calculated mex centers can appear in not multiples of 16, but multiples of 8.
[IsBuildingPositionValid](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/common/upgets/api_resource_spot_finder.lua#L184) also doesn't care about multiples of 16 and will accept raw mex centers.
But engine's [Pos2BuildPos](https://github.com/beyond-all-reason/spring/blob/master/rts/Game/GameHelper.cpp#L991) works in multiples of 16. That results in position passing IsBuildingPositionValid test, but actual unit created at non-optimal position.
BARbarIAn snaps all build-positions to multiples of 16 prior to giving order, and in case of mexes alignment goes always in positive (+8, +8) side if required. That may not be optimal mex position and is denied by IsBuildingPositionValid.

Example on "Silent Sea" map:
Raw calculated mex center: (5480, 1416) - IsBuildingPositionValid = True.
Then SimpleAI gives order with (5480, 1416) and unit created in non-optimal (5488, 1424).
BARbarIAn snaps before building: (5488, 1424) - IsBuildingPositionValid = False.
With proposed change raw mex center becomes (5488, 1408) - multiples of 16 and IsBuildingPositionValid = True.

#### Setup
1) Select "Silent Sea" map.
Add 3v3 SimpleAI bots.
Spectate how SimpleAI builds in non-optimal positions (requires echoing positions).
2) Select "Silent Sea" map.
Add 3v3 BARbarIAn bots.
Spectate how BARbarIAn can't build mexes because IsBuildingPositionValid rejects snapped (+8, +8) mex center positions.

#### Related/Outdated
- https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2602
- https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2603
- https://discord.com/channels/549281623154229250/549286426026573833/1362063822554136746 and few other reports exist in discord's support-bugs channel.