### PR TITLE
div0 error quickfix

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -708,21 +708,23 @@ local function drawStats(uDefID, uID)
 				table.sort(sorted, function(a, b) return a > b end) -- descending sort
 				local maxDamage = sorted[1]
 
-				modString = "default = "..yellow..format("%d", 100 * defaultRate / maxDamage).."%"
-				local count = 0
-				for _ in pairs(modifiers) do count = count + 1 end
-				if count > 1 then
-					for _, rate in pairs(sorted) do
-						if rate ~= defaultRate then
-							local armors = table.concat(modifiers[rate], ", ")
-							local percent = format("%d", floor(100 * rate / maxDamage))
-							if armors and percent then
-								modString = modString..white.."; "..armors.." = "..yellow..percent.."%"
+				if maxDamage ~= 0 then --FIXME: This is a temporary fix, ideally bogus weapons should not be listed.
+					modString = "default = "..yellow..format("%d", 100 * defaultRate / maxDamage).."%"
+					local count = 0
+					for _ in pairs(modifiers) do count = count + 1 end
+					if count > 1 then
+						for _, rate in pairs(sorted) do
+							if rate ~= defaultRate then
+								local armors = table.concat(modifiers[rate], ", ")
+								local percent = format("%d", floor(100 * rate / maxDamage))
+								if armors and percent then
+									modString = modString..white.."; "..armors.." = "..yellow..percent.."%"
+								end
 							end
 						end
 					end
+					DrawText(texts.modifiers..":", modString..'.')
 				end
-				DrawText(texts.modifiers..":", modString..'.')
 			end
 
 			if uWep.metalCost > 0 or uWep.energyCost > 0 then

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -682,7 +682,6 @@ local function drawStats(uDefID, uID)
 				end
 				DrawText(texts.dmg..":", dmgString)
 
-				local modString = ""
 				-- Group armor types by the damage they take.
 				local modifiers = {}
 				local defaultRate = uWep.damages[0] or 0
@@ -709,7 +708,7 @@ local function drawStats(uDefID, uID)
 				local maxDamage = sorted[1]
 
 				if maxDamage ~= 0 then --FIXME: This is a temporary fix, ideally bogus weapons should not be listed.
-					modString = "default = "..yellow..format("%d", 100 * defaultRate / maxDamage).."%"
+					local modString = "default = "..yellow..format("%d", 100 * defaultRate / maxDamage).."%"
 					local count = 0
 					for _ in pairs(modifiers) do count = count + 1 end
 					if count > 1 then


### PR DESCRIPTION
Bandaid fix for a div0 error revealed by the engine update on 16.04.

All this does it not display Modifiers on weapons with damage = 0, as that would cause a div0 error.

### BEFORE
https://github.com/user-attachments/assets/3ceb9023-ad49-4dbd-9824-6e1e0f047c21

### AFTER
https://github.com/user-attachments/assets/d4420f8e-4b5d-49ca-80ff-b3da015191a0

