### PR TITLE
Ghost icon brightness default to 0.75

### DIFF
--- a/luaintro/springconfig.lua
+++ b/luaintro/springconfig.lua
@@ -4,6 +4,11 @@
 
 Spring.SetConfigString("SplashScreenDir", "./MenuLoadscreens")
 
+-- ghost icons dimming, override engine default but allow user setting
+if Spring.GetConfigFloat("UnitGhostIconsDimming", 0.5) == 0.5 then
+	Spring.SetConfigFloat("UnitGhostIconsDimming", 0.75)
+end
+
 -- set default unit rendering vars
 Spring.SetConfigFloat("tonemapA", 4.75)
 Spring.SetConfigFloat("tonemapB", 0.75)


### PR DESCRIPTION
### Work done

- Default to 0.75 instead of 0.5

#### Addresses Issue(s)

- Player feedback: Too dim icons makes some team colors difficult to tell apart (specially brown and red)
- Full brightness icons makes zones not in radar more confusing

### Remarks

- Note: this is only for those icons not under radar, others are always full brightness.
- See also https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4810
- For team battles the brightness has to be kept high, while for 1v1 it could be 0.5 since it helps in telling apart units in radar or not.
- Maybe later could just set some default for different kind of games or color schemes.
- See https://github.com/beyond-all-reason/spring/pull/2099 for more info
  - Original issue was fixing dead ghost icons so they won't leak information about buildings being dead
- Feel free to make separate PR or modify this one if you want to merge smth but I'm not around to modify this one.

### Screenshots

0.75:

![ghosticons](https://github.com/user-attachments/assets/c6fb7b61-d699-4800-9867-272d5e312f9f)

default 0.5:

![comparisonimage](https://private-user-images.githubusercontent.com/183745590/428660294-cbd05728-aa63-4164-8788-88436db191a0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ4OTMwMjYsIm5iZiI6MTc0NDg5MjcyNiwicGF0aCI6Ii8xODM3NDU1OTAvNDI4NjYwMjk0LWNiZDA1NzI4LWFhNjMtNDE2NC04Nzg4LTg4NDM2ZGIxOTFhMC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNDE3JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDQxN1QxMjI1MjZaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0xZGQwM2EzOGJlZWQ2ZTA5ODVkMDA2YjM1MzRmZGY4MzVlNGJlMWY3ZGI1MTU1OTM1YTg1OGY0ZTQ4YmZmMTAxJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.DttUhXECj2JBVbl_efMZQIEZxDECkC5EDT7oU5Hk2E4)

0.5 same as top image:

![ghosticons05](https://github.com/user-attachments/assets/671048de-3af2-4df2-b472-1097851813cd)

0.9:

![ghosticons09](https://github.com/user-attachments/assets/80971dbc-3e6b-4f2f-8c5d-5d446c24f0f7)
