### PR TITLE
Revert "smart_selection: Decouple all modifier from append"

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -30,10 +30,8 @@ local mods = {
  idle     = false, -- whether to select only idle units
  same     = false, -- whether to select only units that share type with current selection
  deselect = false, -- whether to select units not present in current selection
- all      = false, -- whether to select without filters and append (backwards compatibility, it's like append+any)
+ all      = false, -- whether to select all units
  mobile   = false, -- whether to select only mobile units
- append   = false, -- whether to append units to current selection
- any      = false, -- whether to select without filters
 }
 local customFilterDef = ""
 local lastMods = mods
@@ -262,19 +260,12 @@ function widget:Update(dt)
 		and mods.deselect == lastMods[3]
 		and mods.all == lastMods[4]
 		and mods.mobile == lastMods[5]
-		and mods.append == lastMods[6]
-		and mods.any == lastMods[7]
 		and customFilterDef == lastCustomFilterDef
 	then
 		return
 	end
 
-	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append, mods.any }
-	if mods.all then
-		-- backwards compatibility
-		mods.any = true
-		mods.append = true
-	end
+	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile }
 	lastCustomFilterDef = customFilterDef
 
 	-- Fill dictionary for set comparison
@@ -349,7 +340,7 @@ function widget:Update(dt)
 		end
 		mouseSelection = tmp
 
-	elseif selectBuildingsWithMobile == false and mods.any == false and mods.deselect == false then
+	elseif selectBuildingsWithMobile == false and mods.all == false and mods.deselect == false then
 		-- only select mobile units, not buildings
 		local mobiles = false
 		for i = 1, #mouseSelection do
@@ -403,7 +394,7 @@ function widget:Update(dt)
 		selectedUnits = newSelection
 		spSelectUnitArray(selectedUnits)
 
-	elseif mods.append then  -- append units inside selection rectangle to current selection
+	elseif mods.all then  -- append units inside selection rectangle to current selection
 		spSelectUnitArray(newSelection)
 		spSelectUnitArray(mouseSelection, true)
 		selectedUnits = Spring.GetSelectedUnits()

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -15,8 +15,7 @@ bind      Alt+backspace  fullscreen
 // common selectbox keys
 bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
 bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget
-bind          Any+shift  selectbox_append   // append to selection modifier | Smart Select Widget
-bind          Any+shift  selectbox_any      // select all units modifier | Smart Select Widget
+bind          Any+shift  selectbox_all      // select all units modifier | Smart Select Widget
 bind           Any+ctrl  selectbox_deselect // remove units from current selection modifier | Smart Select Widget
 bind            Any+alt  selectbox_mobile   // select only mobile units modifier | Smart Select Widget
 


### PR DESCRIPTION
Append does not "append only newly created selectboxes", reports state that "append 

Reverts beyond-all-reason/Beyond-All-Reason#4675