### PR TITLE
Fix incorrect damage modifier percentages in unit tooltip

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -705,17 +705,16 @@ local function drawStats(uDefID, uID)
 				local sorted = {}
 				for k ,_ in pairs(modifiers) do table.insert(sorted, k) end
 				table.sort(sorted, function(a, b) return a > b end) -- descending sort
-				local maxDamage = sorted[1]
 
-				if maxDamage ~= 0 then --FIXME: This is a temporary fix, ideally bogus weapons should not be listed.
-					local modString = "default = "..yellow..format("%d", 100 * defaultRate / maxDamage).."%"
+				if defaultRate ~= 0 then --FIXME: This is a temporary fix, ideally bogus weapons should not be listed.
+					local modString = "default = "..yellow.."100%"
 					local count = 0
 					for _ in pairs(modifiers) do count = count + 1 end
 					if count > 1 then
 						for _, rate in pairs(sorted) do
 							if rate ~= defaultRate then
 								local armors = table.concat(modifiers[rate], ", ")
-								local percent = format("%d", floor(100 * rate / maxDamage))
+								local percent = format("%d", floor(100 * rate / defaultRate))
 								if armors and percent then
 									modString = modString..white.."; "..armors.." = "..yellow..percent.."%"
 								end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Fixed the logic for displaying damage modifier percentages in the unit tooltip.

Previously, the percentages were calculated relative to the maximum damage value across armor types, which led to misleading or confusing values. This update changes the display so that all modifier percentages are now shown relative to the default armor type (100%), making the tooltip easier to understand and more consistent.

This is a UI-only change and does not affect game logic.

#### Addresses Issue(s)
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3199


### Screenshots:

#### BEFORE:
![unfixed](https://github.com/user-attachments/assets/69d12da1-948f-4597-9bba-2ce700a9e9c0)

#### AFTER:
![fixed_ui](https://github.com/user-attachments/assets/400cc913-bcc7-4cbc-89bb-17dfd3269c19)
