### PR TITLE
Add support for workman keyboard layout

### DIFF
--- a/luaui/configs/keyboard_layouts.lua
+++ b/luaui/configs/keyboard_layouts.lua
@@ -197,6 +197,49 @@ scanToCode["de-neo"] = {
 	-- NEEDS CORRECTION ABOVE
 }
 
+scanToCode["workman"] = {
+	Q = "Q",
+	W = "D",
+	E = "R",
+	R = "W",
+	T = "B",
+	Y = "J",
+	U = "F",
+	I = "U",
+	O = "P",
+	P = ";",
+	["["] = "[",
+	["]"] = "]",
+	["\\"] = "\\",
+	
+	A = "A",
+	S = "S",
+	D = "H",
+	F = "T",
+	G = "G",
+	H = "Y",
+	J = "N",
+	K = "E",
+	L = "O",
+	[";"] = "I",
+	["'"] = "'",
+	
+	Z = "Z",
+	X = "X",
+	C = "M",
+	V = "C",
+	B = "V",
+	N = "K",
+	M = "L",
+	[","] = ",",
+	["."] = ".",
+	["/"] = "/",
+	
+	["`"] = "`",
+	["-"] = "-",
+	["="] = "=",
+}
+
 local layouts = {
 	'qwerty',
 	'qwertz',
@@ -205,6 +248,7 @@ local layouts = {
 	'colemak-dh',
 	'dvorak',
 	'de-neo',
+	'workman',
 }
 
 local function sanitizeKey(key, layout)


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

Add support for workman keyboard layout.

This is useful for people using such keyboard to make the key bindings
more straight-forward.

See https://workmanlayout.org/ for the layout of the keys on the
keyboard.

Compare with e.g. https://en.wikipedia.org/wiki/Keyboard_layout#/media/File:Qwerty.svg
to see how the keys need to be mapped from US-ISO (QWERTY, BAR built-in
keymap) to Workman.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
1. [ ] Start a game and open Settings > Controls.
1. [ ] Change "Keyboard Layout" to "workman" (and check that "Keybind Preset" is set to "Grid").
2. [ ] Select your commander and check that the build menu keyboard shortcuts match the layout of the keys on the keyboard.
   - See https://workmanlayout.org/ instead, if you don't have a keyboard with Workman layout at hand.

Getting the keys to actually work might depend on https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3836.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
