### PR TITLE
factoryclear: Fix factoryclear leaving more than 1 unit on first clear

### DIFF
--- a/luarules/gadgets/cmd_factory_stop_production.lua
+++ b/luarules/gadgets/cmd_factory_stop_production.lua
@@ -94,6 +94,7 @@ if gadgetHandler:IsSyncedCode() then
 				local buildUnitDefID, count = next(buildPair, nil)
 				if keepDefID == buildUnitDefID then
 					count = count - 1
+					keepDefID = nil
 				end
 				orderDequeue(unitID, buildUnitDefID, count)
 			end


### PR DESCRIPTION
### Work done

- Fix factory clear leaving some extra units besides the first, when more than one block of the same unitDefID are found in the queue.

### Remarks

- Fix is to mark keepDefID as done after the first block.
- Overlooked spGetRealBuildQueue can return several blocks of the same unitDefIDs.
- Would require 3 presses of factoryclear (in some situations) instead of 1 as originally intended.

#### Addresses Issue(s)

- More than 1 unit being left behind in the queue

### How to test

- Queue 1 Con, 5 Pawns, 1 Con, then press `g`
- 1 Con, 5 Pawns, 1 Con, 5 Pawns, 1 Con, then press `g`

With the fix will leave exactly 1 con each, before would leave 2 cons for the first case, and 3 for the second.