### PR TITLE
Revert factory stop production two step process

### DIFF
--- a/luarules/gadgets/cmd_factory_stop_production.lua
+++ b/luarules/gadgets/cmd_factory_stop_production.lua
@@ -29,7 +29,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	local CMD_WAIT = CMD.WAIT
 	local EMPTY = {}
-	local DEQUEUE_OPTS = CMD.OPT_RIGHT -- right: dequeue, ctrl+shift: 100
+	local DEQUEUE_OPTS = { "right", "ctrl", "shift" } -- right: dequeue, ctrl+shift: 100
 
 	local stopProductionCmdDesc = {
 		id = CMD_STOP_PRODUCTION,
@@ -50,21 +50,21 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function orderDequeue(unitID, buildDefID, count)
 		while count > 0 do
-			local opts = DEQUEUE_OPTS
-			if count >= 100 then
-				count = count - 100
-				opts = opts + CMD.OPT_SHIFT + CMD.OPT_CTRL
-			elseif count >= 20 then
-				count = count - 20
-				opts = opts + CMD.OPT_CTRL
-			elseif count >= 5 then
-				count = count - 5
-				opts = opts + CMD.OPT_SHIFT
-			else
-				count = count - 1
-			end
+			-- The commented code below might still be useful in some circumstance we need 'perfect' dequeue
+			--
+			-- if count >= 100 then
+			count = count - 100
+			-- elseif count >= 20 then
+			-- 	opts = { "ctrl" }
+			-- 	count = count - 20
+			-- elseif count >= 5 then
+			-- 	opts = { "shift" }
+			-- 	count = count - 5
+			-- else
+			-- 	count = count - 1
+			-- end
 
-			spGiveOrderToUnit(unitID, -buildDefID, EMPTY, opts)
+			spGiveOrderToUnit(unitID, -buildDefID, EMPTY, DEQUEUE_OPTS)
 		end
 	end
 
@@ -77,24 +77,8 @@ if gadgetHandler:IsSyncedCode() then
 		-- As opposed to removing each build command individually
 		local queue = spGetRealBuildQueue(unitID)
 		if queue ~= nil then
-			local total = 0
-			for _, buildPair in ipairs(queue) do
-				local _, count = next(buildPair, nil)
-				total = total + count
-			end
-			local keepDefID
-			if total > 1 then
-				local firstCommand = Spring.GetFactoryCommands(unitID, 1)
-				local firstID = firstCommand[1]['id']
-				if firstID < 0 then
-					keepDefID = -firstID
-				end
-			end
 			for _, buildPair in ipairs(queue) do
 				local buildUnitDefID, count = next(buildPair, nil)
-				if keepDefID == buildUnitDefID then
-					count = count - 1
-				end
 				orderDequeue(unitID, buildUnitDefID, count)
 			end
 		end

--- a/luarules/gadgets/cmd_factory_stop_production.lua
+++ b/luarules/gadgets/cmd_factory_stop_production.lua
@@ -94,7 +94,6 @@ if gadgetHandler:IsSyncedCode() then
 				local buildUnitDefID, count = next(buildPair, nil)
 				if keepDefID == buildUnitDefID then
 					count = count - 1
-					keepDefID = nil
 				end
 				orderDequeue(unitID, buildUnitDefID, count)
 			end


### PR DESCRIPTION
### Work done

- Revert PR #4762 and associated fix

### Related issues

People used to one click/keypress clearing of queue not very fond of the change, since they already have the previous behaviour deep in muscle memory (see [this](https://discord.com/channels/549281623154229250/1363189619012665446) and [this discord thread](https://discord.com/channels/549281623154229250/1363299201638863069)).

- Reopen https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2190

### Alternative "fixes"

- Could also make this leave one just when repeat not on. With factory repeat the behavior is awkward since the unit will then autoqueue again.
  - Could try something smart about clearing it when in repeat or when something else gets queued, but this might be non intuitive.
- Could add a separate action/command to have both "clear all but first" and "clear all available".
  - Don't see this gaining too much traction.
- Leave the unit being built, but still remove from queue, see below for more details about this.
- Leave the unit being built and in queue, but make the specific command "non-repeat", see more details below.

### Remarks

#### About leaving the unit building, but not in queue

Probably leaving the item in queue not the best way to go about this (unless in non-repeat mode, see below), so one option would be to leave the item being built, but not in queue. This is specially important when repeat is on, since otherwise the unit left in queue will keep autorepeating, so the factory will keep pumping units when it's supposed to just finish the last one in any case.

Problem with leaving the last command working but not in queue, is afaics it's not supported atm by the engine commands. I think it's possible by working on engine support for that (I have proof of concept working), but won't be available until next stable release after 2025.03 in any case, and will need considering and work on some corner cases, like when you have a unit being built, but you append/insert a new one.

This would require some kind of engine non-flushing mode for REMOVE or other commands, plus a special FLUSH command (or augmenting STOP so it will always manage to flush).

#### About leaving the unit building, but in queue as "non-repeat"

Another possible approach would be adding the possibility of `force-non-repeat` build order, so even if the unit is queued, it won't be repeated since it's just finishing it. This might need deeper change of engine logic, but maybe not, not sure since didn't try this approach. Could be simple by setting a command option onto the build command. It could be a useful feature though, since often you have a factory on repeat but need to quickly insert a couple special units but you don't want them to repeat. Could need some gui support, though, in order to be intuitive.



