### PR TITLE
Render2texture overrides for headless

### DIFF
--- a/luaui/Widgets/dbg_test_headless_overrides.lua
+++ b/luaui/Widgets/dbg_test_headless_overrides.lua
@@ -22,3 +22,12 @@ gl.PopMatrix = function() end
 
 gl.CreateTexture = function() end
 gl.RenderToTexture = function() end
+
+local SetConfigInt = Spring.SetConfigInt
+Spring.SetConfigInt = function(section, value)
+	if section ~= "ui_rendertotexture" then
+		SetConfigInt(section, value)
+	else
+		SetConfigInt(section, 0)
+	end
+end

--- a/luaui/Widgets/dbg_test_headless_overrides.lua
+++ b/luaui/Widgets/dbg_test_headless_overrides.lua
@@ -22,6 +22,3 @@ Spring.SetConfigInt("ui_rendertotexture", 0)
 gl.PushMatrix = function() end
 gl.PopMatrix = function() end
 
-gl.CreateTexture = function() end
-gl.RenderToTexture = function() end
-

--- a/luaui/Widgets/dbg_test_headless_overrides.lua
+++ b/luaui/Widgets/dbg_test_headless_overrides.lua
@@ -14,6 +14,8 @@ if not Spring.Utilities.IsDevMode() or not Spring.Utilities.Gametype.IsSinglePla
 	return
 end
 
+Spring.SetConfigInt("ui_rendertotexture", 0)
+
 -- PushMatrix and PopMatrix still perform accounting and can generate errors on headless.
 -- Problem here is CallList won't really call dlists, so when a PushMatrix or PopMatrix
 -- is placed inside a display list, this can cause problems.
@@ -23,11 +25,3 @@ gl.PopMatrix = function() end
 gl.CreateTexture = function() end
 gl.RenderToTexture = function() end
 
-local SetConfigInt = Spring.SetConfigInt
-Spring.SetConfigInt = function(section, value)
-	if section ~= "ui_rendertotexture" then
-		SetConfigInt(section, value)
-	else
-		SetConfigInt(section, 0)
-	end
-end

--- a/luaui/Widgets/dbg_test_headless_overrides.lua
+++ b/luaui/Widgets/dbg_test_headless_overrides.lua
@@ -20,3 +20,5 @@ end
 gl.PushMatrix = function() end
 gl.PopMatrix = function() end
 
+gl.CreateTexture = function() end
+gl.RenderToTexture = function() end


### PR DESCRIPTION
### Work done

- Set  ui_rendertotexture to 0 since application setting it to 1 on intro.

#### Addresses Issue

- Tests failing on headless because of r2t widgets

### Remarks

- Probably better fix is making headless work transparently re: CreateTexture and RenderToTexture, but this fix good enough for now if we want to have master ready for headless tests.

### How to test

- merge this branch and pr-test-runner
- run like:
  - `./spring-headless --isolation --write-dir ~/.var/app/info.beyondallreason.bar/data/ ~/.var/app/info.beyondallreason.bar/data/games/BAR.sdd/tools/headless_testing/startscript.txt`