### PR TITLE
smart_selection: Decouple all modifier from append (fixed)

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -270,11 +270,6 @@ function widget:Update(dt)
 	end
 
 	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append, mods.any }
-	if mods.all then
-		-- backwards compatibility
-		mods.any = true
-		mods.append = true
-	end
 	lastCustomFilterDef = customFilterDef
 
 	-- Fill dictionary for set comparison
@@ -349,7 +344,7 @@ function widget:Update(dt)
 		end
 		mouseSelection = tmp
 
-	elseif selectBuildingsWithMobile == false and mods.any == false and mods.deselect == false then
+	elseif selectBuildingsWithMobile == false and (mods.any == false and mods.all == false) and mods.deselect == false then
 		-- only select mobile units, not buildings
 		local mobiles = false
 		for i = 1, #mouseSelection do
@@ -403,7 +398,7 @@ function widget:Update(dt)
 		selectedUnits = newSelection
 		spSelectUnitArray(selectedUnits)
 
-	elseif mods.append then  -- append units inside selection rectangle to current selection
+	elseif (mods.append or mods.all) then  -- append units inside selection rectangle to current selection
 		spSelectUnitArray(newSelection)
 		spSelectUnitArray(mouseSelection, true)
 		selectedUnits = Spring.GetSelectedUnits()

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -30,9 +30,10 @@ local mods = {
  idle     = false, -- whether to select only idle units
  same     = false, -- whether to select only units that share type with current selection
  deselect = false, -- whether to select units not present in current selection
- all      = false, -- whether to select without filters
+ all      = false, -- whether to select without filters and append (backwards compatibility, it's like append+any)
  mobile   = false, -- whether to select only mobile units
  append   = false, -- whether to append units to current selection
+ any      = false, -- whether to select without filters
 }
 local customFilterDef = ""
 local lastMods = mods
@@ -262,12 +263,18 @@ function widget:Update(dt)
 		and mods.all == lastMods[4]
 		and mods.mobile == lastMods[5]
 		and mods.append == lastMods[6]
+		and mods.any == lastMods[7]
 		and customFilterDef == lastCustomFilterDef
 	then
 		return
 	end
 
-	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append }
+	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append, mods.any }
+	if mods.all then
+		-- backwards compatibility
+		mods.any = true
+		mods.append = true
+	end
 	lastCustomFilterDef = customFilterDef
 
 	-- Fill dictionary for set comparison
@@ -342,7 +349,7 @@ function widget:Update(dt)
 		end
 		mouseSelection = tmp
 
-	elseif selectBuildingsWithMobile == false and mods.all == false and mods.deselect == false then
+	elseif selectBuildingsWithMobile == false and mods.any == false and mods.deselect == false then
 		-- only select mobile units, not buildings
 		local mobiles = false
 		for i = 1, #mouseSelection do

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -30,8 +30,9 @@ local mods = {
  idle     = false, -- whether to select only idle units
  same     = false, -- whether to select only units that share type with current selection
  deselect = false, -- whether to select units not present in current selection
- all      = false, -- whether to select all units
+ all      = false, -- whether to select without filters
  mobile   = false, -- whether to select only mobile units
+ append   = false, -- whether to append units to current selection
 }
 local customFilterDef = ""
 local lastMods = mods
@@ -260,12 +261,13 @@ function widget:Update(dt)
 		and mods.deselect == lastMods[3]
 		and mods.all == lastMods[4]
 		and mods.mobile == lastMods[5]
+		and mods.append == lastMods[6]
 		and customFilterDef == lastCustomFilterDef
 	then
 		return
 	end
 
-	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile }
+	lastMods = { mods.idle, mods.same, mods.deselect, mods.all, mods.mobile, mods.append }
 	lastCustomFilterDef = customFilterDef
 
 	-- Fill dictionary for set comparison
@@ -394,7 +396,7 @@ function widget:Update(dt)
 		selectedUnits = newSelection
 		spSelectUnitArray(selectedUnits)
 
-	elseif mods.all then  -- append units inside selection rectangle to current selection
+	elseif mods.append then  -- append units inside selection rectangle to current selection
 		spSelectUnitArray(newSelection)
 		spSelectUnitArray(mouseSelection, true)
 		selectedUnits = Spring.GetSelectedUnits()

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -15,7 +15,8 @@ bind      Alt+backspace  fullscreen
 // common selectbox keys
 bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
 bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget
-bind          Any+shift  selectbox_all      // select all units modifier | Smart Select Widget
+bind          Any+shift  selectbox_append   // append to selection modifier | Smart Select Widget
+bind          Any+shift  selectbox_any      // select all units modifier | Smart Select Widget
 bind           Any+ctrl  selectbox_deselect // remove units from current selection modifier | Smart Select Widget
 bind            Any+alt  selectbox_mobile   // select only mobile units modifier | Smart Select Widget
 


### PR DESCRIPTION
### Work done

- RePR: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4675
- Decouples selection all append
- Introduces new `selectbox_any` and `selectbox_append` where `all = any+append` to ensure backwards compatibility with custom binds having the old `selectbox_all`.
- Fixes broken `select_all` backwards compatibility from previous PR.

#### Addresses Issue(s)

- `any` and `append` becoming sticky when `all` was being used.

### Player communication

Probably a good idea to communicate to players, people having custom binds but doing just `unbind selectbox_all` might have issues due to the new ones applying on `shift`, since they won't be unbinding the new ones and might have conflicts if they're using `shift` for something else.

### Remarks

- Very bad logic error and lack of adequate testing on last PR, very sorry about that. I did test but seems didn't test the backwards compatible `all` good enough since overlooked the problem.
- I have tested these scenarios with this PR:
  - using only `all` -> when pressed, behaves as always
  - using only `append` -> when pressed, only does append but not `any` behaviour (so doesn't select coms or buildigns for example)
  - using only `any` -> when pressed, no append behaviour, but always select `any` unit (ie including coms and buildings).
  - using `any` and `append` -> behaves as `all` above
- In all scenarios I tested for unwanted "sticky" modifiers.

Also tried to ensure `all` shoult play nice if used with `append` or `any`, since they're independent any press of `all` will make `append+any` behaviour apply independently of any or append being pressed/depressed during its use.

Also tested `any` and `append` to check they can be used independently in-game properly, ie, I can press `append` key to append with normal filtering, press `any` key for no default filter, or both for append and no default filter. I can also press/release the keys while doing the box and the smartselect reacts well.

Also tested `append` and `any` (also `all`) with custom filter `selectbox Not_Building_Builder_Buildoptions` (aka builder filter) and works as intended, the builder filter will be used, since `all` and `any` only discards the default filter (mobile units or similar, as configured by user at gui_options)
