### PR TITLE
Faction limiter mk2

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -58,6 +58,7 @@ if gadgetHandler:IsSyncedCode() then
 			local ARM_MASK = 2^0
 			local COR_MASK = 2^1
 			local LEG_MASK = 2^2
+			local FULL_BITMASK = math.bit_and(ARM_MASK, COR_MASK, LEG_MASK)
 
 			local allyTeams = Spring.GetAllyTeamList()
 			for i = 1, #allyTeams do
@@ -65,16 +66,16 @@ if gadgetHandler:IsSyncedCode() then
 				local allyStartUnits = {}
 				local unitsCount = 1
 
-				local allyTeamBitmask = math.bit_and(math.floor(factionlimiter/2^(allyTeam*3)), 7)
-				allyTeamBitmask = allyTeamBitmask == 0 and 7 or allyTeamBitmask
+				local allyTeamBitmask = math.bit_and(math.floor(factionlimiter/2^(allyTeam*3)), FULL_BITMASK)
+				allyTeamBitmask = allyTeamBitmask == 0 and FULL_BITMASK or allyTeamBitmask
 
 				if legcomDefID then
 					if math.bit_and(allyTeamBitmask, LEG_MASK) ~= 0 then
 						allyStartUnits[unitsCount] = legcomDefID
 						unitsCount = unitsCount + 1
 					end
-				elseif allyTeamBitmask == 4 then
-					allyTeamBitmask = 7
+				elseif allyTeamBitmask == LEG_MASK then
+					allyTeamBitmask = FULL_BITMASK
 				end
 
 				if armcomDefID and math.bit_and(allyTeamBitmask, ARM_MASK) ~= 0 then

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -52,6 +52,10 @@ if gadgetHandler:IsSyncedCode() then
 		local modoptions = Spring.GetModOptions()
 		local factionlimiter = tonumber(modoptions.factionlimiter) or 0
 		if factionlimiter > 0 then
+			local legcomDefID = UnitDefNames.legcom and UnitDefNames.legcom.id
+			local armcomDefID = UnitDefNames.armcom and UnitDefNames.armcom.id
+			local corcomDefID = UnitDefNames.corcom and UnitDefNames.corcom.id
+
 			local allyTeams = Spring.GetAllyTeamList()
 			for i = 1, #allyTeams do
 				local allyTeam = allyTeams[i]
@@ -62,7 +66,6 @@ if gadgetHandler:IsSyncedCode() then
 				local allyTeamBitmask = math.bit_and(math.floor(factionlimiter/2^(allyTeam*3)), 7)
 				allyTeamBitmask = allyTeamBitmask == 0 and 7 or allyTeamBitmask
 
-				local legcomDefID = UnitDefNames.legcom and UnitDefNames.legcom.id
 				if legcomDefID then
 					if math.bit_and(allyTeamBitmask, 4) == 4 then
 						allyStartUnits[unitsCount] = legcomDefID
@@ -72,12 +75,10 @@ if gadgetHandler:IsSyncedCode() then
 					allyTeamBitmask = 7
 				end
 
-				local armcomDefID = UnitDefNames.armcom and UnitDefNames.armcom.id
 				if armcomDefID and math.bit_and(allyTeamBitmask, 1) == 1 then
 					allyStartUnits[unitsCount] = armcomDefID
 					unitsCount = unitsCount + 1
 				end
-				local corcomDefID = UnitDefNames.corcom and UnitDefNames.corcom.id
 				if corcomDefID and math.bit_and(allyTeamBitmask, 2) == 2 then
 					allyStartUnits[unitsCount] = corcomDefID
 					unitsCount = unitsCount + 1

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -55,19 +55,21 @@ if gadgetHandler:IsSyncedCode() then
 			local legcomDefID = UnitDefNames.legcom and UnitDefNames.legcom.id
 			local armcomDefID = UnitDefNames.armcom and UnitDefNames.armcom.id
 			local corcomDefID = UnitDefNames.corcom and UnitDefNames.corcom.id
+			local ARM_MASK = 2^0
+			local COR_MASK = 2^1
+			local LEG_MASK = 2^2
 
 			local allyTeams = Spring.GetAllyTeamList()
 			for i = 1, #allyTeams do
 				local allyTeam = allyTeams[i]
 				local allyStartUnits = {}
-				-- for some reason lua ain't liking using #allyStartUnits
 				local unitsCount = 1
 
 				local allyTeamBitmask = math.bit_and(math.floor(factionlimiter/2^(allyTeam*3)), 7)
 				allyTeamBitmask = allyTeamBitmask == 0 and 7 or allyTeamBitmask
 
 				if legcomDefID then
-					if math.bit_and(allyTeamBitmask, 4) == 4 then
+					if math.bit_and(allyTeamBitmask, LEG_MASK) ~= 0 then
 						allyStartUnits[unitsCount] = legcomDefID
 						unitsCount = unitsCount + 1
 					end
@@ -75,15 +77,30 @@ if gadgetHandler:IsSyncedCode() then
 					allyTeamBitmask = 7
 				end
 
-				if armcomDefID and math.bit_and(allyTeamBitmask, 1) == 1 then
+				if armcomDefID and math.bit_and(allyTeamBitmask, ARM_MASK) ~= 0 then
 					allyStartUnits[unitsCount] = armcomDefID
 					unitsCount = unitsCount + 1
 				end
-				if corcomDefID and math.bit_and(allyTeamBitmask, 2) == 2 then
+				if corcomDefID and math.bit_and(allyTeamBitmask, COR_MASK) ~= 0 then
 					allyStartUnits[unitsCount] = corcomDefID
 					unitsCount = unitsCount + 1
 				end
+
+				local packedOptions = allyStartUnits[1]
+				if unitsCount > 1 then
+					for j = 2, #allyStartUnits do
+						packedOptions = packedOptions.."|"..allyStartUnits[j]
+					end
+					packedOptions = packedOptions.."|"..RANDOM_DUMMY
+				end
+
 				validStartUnits[allyTeam] = allyStartUnits
+
+				local allyTeamList = Spring.GetTeamList(allyTeam)
+				---@diagnostic disable-next-line: param-type-mismatch
+				for _, teamID in ipairs(allyTeamList) do
+					Spring.SetTeamRulesParam(teamID, "validStartUnits", packedOptions)
+				end
 			end
 
 			getValidRandom = function(allyTeamID)
@@ -133,6 +150,16 @@ if gadgetHandler:IsSyncedCode() then
 					return true
 				end
 			end
+
+			local packedOptions = validStartUnits[1]
+			if #validStartUnits > 1 then
+				for j = 2, #validStartUnits do
+					packedOptions = packedOptions.."|"..validStartUnits[j]
+				end
+				packedOptions = packedOptions.."|"..RANDOM_DUMMY
+			end
+			Spring.SetGameRulesParam("validStartUnits", packedOptions)
+
 		end
 	end
 

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -82,9 +82,6 @@ if gadgetHandler:IsSyncedCode() then
 					allyStartUnits[unitsCount] = corcomDefID
 					unitsCount = unitsCount + 1
 				end
-				for v, k in pairs(allyStartUnits) do
-					Spring.Echo(v, k)
-				end
 				validStartUnits[allyTeam] = allyStartUnits
 			end
 

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -51,12 +51,13 @@ if gadgetHandler:IsSyncedCode() then
 	do
 		local modoptions = Spring.GetModOptions()
 		local factionlimiter = tonumber(modoptions.factionlimiter) or 0
-		local legionEnabled = modoptions
 		if factionlimiter > 0 then
 			local allyTeams = Spring.GetAllyTeamList()
 			for i = 1, #allyTeams do
 				local allyTeam = allyTeams[i]
 				local allyStartUnits = {}
+				-- for some reason lua ain't liking using #allyStartUnits
+				local unitsCount = 1
 
 				local allyTeamBitmask = math.bit_and(math.floor(factionlimiter/2^(allyTeam*3)), 7)
 				allyTeamBitmask = allyTeamBitmask == 0 and 7 or allyTeamBitmask
@@ -64,7 +65,8 @@ if gadgetHandler:IsSyncedCode() then
 				local legcomDefID = UnitDefNames.legcom and UnitDefNames.legcom.id
 				if legcomDefID then
 					if math.bit_and(allyTeamBitmask, 4) == 4 then
-						allyStartUnits[#validStartUnits+1] = legcomDefID
+						allyStartUnits[unitsCount] = legcomDefID
+						unitsCount = unitsCount + 1
 					end
 				elseif allyTeamBitmask == 4 then
 					allyTeamBitmask = 7
@@ -72,11 +74,16 @@ if gadgetHandler:IsSyncedCode() then
 
 				local armcomDefID = UnitDefNames.armcom and UnitDefNames.armcom.id
 				if armcomDefID and math.bit_and(allyTeamBitmask, 1) == 1 then
-					allyStartUnits[#validStartUnits+1] = armcomDefID
+					allyStartUnits[unitsCount] = armcomDefID
+					unitsCount = unitsCount + 1
 				end
 				local corcomDefID = UnitDefNames.corcom and UnitDefNames.corcom.id
 				if corcomDefID and math.bit_and(allyTeamBitmask, 2) == 2 then
-					allyStartUnits[#validStartUnits+1] = corcomDefID
+					allyStartUnits[unitsCount] = corcomDefID
+					unitsCount = unitsCount + 1
+				end
+				for v, k in pairs(allyStartUnits) do
+					Spring.Echo(v, k)
 				end
 				validStartUnits[allyTeam] = allyStartUnits
 			end

--- a/luaui/Widgets/gui_factionpicker.lua
+++ b/luaui/Widgets/gui_factionpicker.lua
@@ -16,14 +16,40 @@ local factions = {}
 if UnitDefNames.dummycom then
 	factions[#factions+1] = { startUnit = UnitDefNames.dummycom.id, faction = 'random' }
 end
-if UnitDefNames.corcom then
-	factions[#factions+1] = { startUnit = UnitDefNames.corcom.id, faction = 'cor' }
+
+local allyTeamBitmask = 0
+do
+	local factionlimiter = tonumber(Spring.GetModOptions().factionlimiter)
+	if factionlimiter and factionlimiter > 0 then
+		local allyTeamID = Spring.GetMyAllyTeamID()
+		factionlimiter = math.floor(factionlimiter/2^(allyTeamID*3))
+		allyTeamBitmask = math.bit_and(factionlimiter, 7)
+	end
 end
-if UnitDefNames.armcom then
-	factions[#factions+1] = { startUnit = UnitDefNames.armcom.id, faction = 'arm' }
+if allyTeamBitmask == 0 then
+	allyTeamBitmask = 7
 end
-if Spring.GetModOptions().experimentallegionfaction and UnitDefNames.legcom then
-	factions[#factions+1] = { startUnit = UnitDefNames.legcom.id, faction = 'leg' }
+
+local function addOptions(bitmask)
+	if UnitDefNames.corcom and math.bit_and(bitmask, 2) == 2 then
+		factions[#factions+1] = { startUnit = UnitDefNames.corcom.id, faction = 'cor' }
+	end
+	if UnitDefNames.armcom and math.bit_and(bitmask, 1) == 1 then
+		factions[#factions+1] = { startUnit = UnitDefNames.armcom.id, faction = 'arm' }
+	end
+	if Spring.GetModOptions().experimentallegionfaction and UnitDefNames.legcom and math.bit_and(bitmask, 4) == 4 then
+		factions[#factions+1] = { startUnit = UnitDefNames.legcom.id, faction = 'leg' }
+	end
+end
+
+addOptions(allyTeamBitmask)
+-- if we failed to get a commander pass in a full bitmask
+if #factions == (UnitDefNames.dummycom and 1 or 0) then
+	addOptions(7)
+end
+if #factions == 2 and UnitDefNames.dummycom then
+	factions[1] = factions[2]
+	factions[2] = nil
 end
 
 local doUpdate

--- a/luaui/Widgets/gui_factionpicker.lua
+++ b/luaui/Widgets/gui_factionpicker.lua
@@ -40,7 +40,7 @@ do
 		end
 	end
 end
-if factions == {} then
+if #factions == 0 then
 	Spring.Log(gadget:GetInfo().name, LOG.ERROR, "No Start Options Recived")
 	return false
 end

--- a/luaui/Widgets/gui_factionpicker.lua
+++ b/luaui/Widgets/gui_factionpicker.lua
@@ -37,7 +37,7 @@ local function addOptions(bitmask)
 	if UnitDefNames.armcom and math.bit_and(bitmask, 1) == 1 then
 		factions[#factions+1] = { startUnit = UnitDefNames.armcom.id, faction = 'arm' }
 	end
-	if Spring.GetModOptions().experimentallegionfaction and UnitDefNames.legcom and math.bit_and(bitmask, 4) == 4 then
+	if UnitDefNames.legcom and math.bit_and(bitmask, 4) == 4 then
 		factions[#factions+1] = { startUnit = UnitDefNames.legcom.id, faction = 'leg' }
 	end
 end

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1447,8 +1447,16 @@ local options = {
         def     =  false,
     },
     {
+        key     = "dummyboolfeelfreetotouch",
+        name    = "dummy to hide the faction limiter",
+        desc    = "This is a dummy to hide the faction limiter from the text field, it needs to exploit or work around some flaws to hide it...",
+        section = "dev",
+        type    = "bool",
+        unlock  = {"dummyboolfeelfreetotouch", "factionlimiter"},
+    },
+    {
         key     = "factionlimiter",
-        name    = "Faction Limiter:".."\255\255\191\76".." ON\nBITMASK",
+        name    = "Faction Limiter:".."\255\255\191\76".." ON\n".."\255\125\125\125".."BITMASK",
         desc    = [[BITMASK to be used via custom ui, only visible when boss
 Set to [0] To disable.
 Otherwise: 0th, 1st and 2nd bit are armada, cortex and legion respectively.
@@ -1459,7 +1467,7 @@ Example: Armada VS Cortex VS Legion: 273 or 100 010 001 or 256 + 16 + 1]],
         type    = "number",
         def     =  0,
         min    	= 0,
-        max    	= 8388607,-- might be double?
+        max    	= 16777215,-- math hard, 24 bit limitish?
         step   	= 1,
     },
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1446,6 +1446,23 @@ local options = {
         type    = "bool",
         def     =  false,
     },
+    {
+        key     = "factionlimiter",
+        name    = "Faction Limiter:".."\255\255\191\76".." ON\nBITMASK",
+        desc    = "\255\255\122\122".."WARNING: peepeepoopoo\n"..
+[[BITMASK to be used via custom ui, only visible when boss
+Set to [0] To disable.
+Otherwise: 0th, 1st and 2nd bit are armada, cortex and legion respectively.
+Offset by 3 for each consecutive team.
+If a team's bitmask is 0, All are Enabled.
+Example: Armada VS Cortex VS Legion: 273 or 100 010 001 or 256 + 16 + 1]],
+        section = "dev",
+        type    = "number",
+        def     =  0,
+        min    	= 0,
+        max    	= 8388607,-- might be double?
+        step   	= 1,
+    },
 
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1449,8 +1449,7 @@ local options = {
     {
         key     = "factionlimiter",
         name    = "Faction Limiter:".."\255\255\191\76".." ON\nBITMASK",
-        desc    = "\255\255\122\122".."WARNING: peepeepoopoo\n"..
-[[BITMASK to be used via custom ui, only visible when boss
+        desc    = [[BITMASK to be used via custom ui, only visible when boss
 Set to [0] To disable.
 Otherwise: 0th, 1st and 2nd bit are armada, cortex and legion respectively.
 Offset by 3 for each consecutive team.


### PR DESCRIPTION
Sub-dependant: https://github.com/beyond-all-reason/BYAR-Chobby/pull/977

### Work done
Adds the faction locker, implemented using a bitmask instead of text
As well as easier to use chobby ui that doesn't require spads regex

Hidden in singleplayer unless the modoption is set to something else under _DEV tab
Or Show Hidden Modoptions is enabled
In Multiplayer it is shown when the player is the BOSS of the lobby.
*i think, hope i didn't make it only visible when there is a boss

When the modoption is used non-boss players will be able to see the respective team's icons in the top right of the player list of each team.


When all factions are enabled
- The ui is hidden unless boss
- Pressing on a faction will set the team to that faction only

When One faction is selected
- Pressing it again will invert the options so that only that faction isn't enabled
- Pressing another faction will add it

When Two factions are selected
- Adding a third resets it to all

#### Setup
Before opening Skirmish head to developer settings, and press show hidden modoptions to see the new buttons in singleplayer
Testing in multiplayer requires remapping all the instances of factionlimiter to another int modoption

#### Test steps
- Set faction Limits, and see that the respective team is forced to the respective option

### Screenshots:
![image](https://github.com/user-attachments/assets/8aed0431-b032-4bf6-8be8-b23141d9197a)
![image](https://github.com/user-attachments/assets/8bf05c3e-1606-4c6d-9b90-f5d6b8086c49)
