### PR TITLE
Settarget with shift keybind file fix

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -61,7 +61,9 @@ bind         Shift+sc_p  gatherwait
 bind               sc_r  repair
 bind         Shift+sc_r  repair
 bind               sc_s  settarget
+bind         Shift+sc_s  settarget
 bind           Alt+sc_s  settargetnoground
+bind     Shift+Alt+sc_s  settargetnoground
 bind          Ctrl+sc_s  canceltarget
 bind               sc_u  unloadunits
 bind         Shift+sc_u  unloadunits

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -61,7 +61,9 @@ bind         Shift+sc_o  guard
 bind               sc_r  repair
 bind         Shift+sc_r  repair
 bind               sc_s  settarget
+bind         Shift+sc_s  settarget
 bind           Alt+sc_s  settargetnoground
+bind     Shift+Alt+sc_s  settargetnoground
 bind          Ctrl+sc_s  canceltarget
 bind               sc_u  unloadunits
 bind         Shift+sc_u  unloadunits

--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -266,7 +266,9 @@ bind Ctrl+Shift+sc_o cameraflip // CameraFlip
 
 //if not WG[ Set target default ] then
 bind Alt+sc_y settarget
+bind Shift+Alt+sc_y settarget
 bind sc_y settargetnoground
+bind Shift+sc_y settargetnoground
 
 bind Ctrl+sc_` group unset
 

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -266,7 +266,9 @@ bind Ctrl+Shift+sc_o cameraflip
 
 //if not WG[bind Set target default ] then
 bind Alt+sc_y settarget
+bind Shift+Alt+sc_y settarget
 bind sc_y settargetnoground
+bind Shift+sc_y settargetnoground
 
 bind Ctrl+meta+sc_q group unset
 // if WG[bind Auto Group ] then


### PR DESCRIPTION
Currently, trying to do settarget via keybind with shift held isn't possible. This can be an issue if units already have stuff in their targeting queues and a player wants to add additional targets to the queues. The player has to let go of shift, press the key for setting targets, and then press shift again before adding additional targets.

This issue is afaik only for settarget, and not any other of the similar commands (repair, attack etc.), which all have "double-binds" with and without shift.

I searched the keybind files for conflicts and didn't find any.

### Work done
added the shift double-binds for settarget and settargetnoground for both grid and legacy keybind files.