### PR TITLE
Fix chat widget crash that occurs when sending "> ."

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -611,6 +611,8 @@ local function addChatLine(gameFrame, lineType, name, nameText, text, orgLineID,
 	-- determine text typing start time
 	local startTime = clock()
 
+	local text_orig = text
+
 	-- metal/energy given
 	if lineType == LineTypes.Player and ssub(text, 5, 6) == '> ' then
 		text = ssub(text, 7)
@@ -635,6 +637,8 @@ local function addChatLine(gameFrame, lineType, name, nameText, text, orgLineID,
 				end
 			end
 			text = Spring.I18N(params[1], t)
+			-- Fix a widget crash that could occur with message "> ."
+			if type(text) ~= "string" then text = text_orig end
 			if text:lower():find(I18N.energy, nil, true) then
 				local pos = text:lower():find(I18N.energy, nil, true)
 				local len = slen(I18N.energy)


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Adds a check that value returned from `Spring.I18N()` is a string, and replace it with original text if it isn't.
This makes sure that further code that expects the value to be a string continues to work.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Type `> .` in chat.
- [ ] Send.
Chat widget crashes.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
