### PR TITLE
Fix negative health causing extra over-penetration

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -66,6 +66,7 @@ local slowingPerType = { -- Whether the projectile loses velocity, as well.
 --------------------------------------------------------------------------------
 -- Locals ----------------------------------------------------------------------
 
+local abs  = math.abs
 local min  = math.min
 local sqrt = math.sqrt
 
@@ -199,6 +200,7 @@ local function addPenetratorCollision(targetID, isUnit, armorType, damage, proje
 		health, healthMax = spGetUnitHealth(targetID)
 	else
 		health, healthMax = spGetFeatureHealth(targetID)
+		health = abs(health)
 	end
 	projectileHits[projectileID] = penetrator
 	local collisions = penetrator.collisions


### PR DESCRIPTION
Before: Overpen weapons would test their remaining damage vs a negative health pool and gain additional damage remaining.

After: Feature health is taken as its absolute value to prevent this.

---

I don't know why features would have negative hp but it seemed common to wrecks. If units can have negative health also, I can fix that in this PR as well.