### PR TITLE
Fix bug with SSAO on older/underpowered hardware

### DIFF
--- a/luaui/Widgets/gfx_ssao.lua
+++ b/luaui/Widgets/gfx_ssao.lua
@@ -2,10 +2,10 @@
 local isPotatoGpu = false
 local gpuMem = (Platform.gpuMemorySize and Platform.gpuMemorySize or 1000) / 1000
 if Platform ~= nil and Platform.gpuVendor == 'Intel' then
-	isPotatoGpu = true
+	return false
 end
 if gpuMem and gpuMem > 0 and gpuMem < 1800 then
-	isPotatoGpu = true
+	return false
 end
 
 
@@ -21,7 +21,7 @@ function widget:GetInfo()
         date      = "2019",
         license   = "GPL",
         layer     = 999999,
-        enabled   = not isPotatoGpu,
+        enabled   = false,
         depends   = {'gl4'},
     }
 end

--- a/luaui/Widgets/gfx_ssao.lua
+++ b/luaui/Widgets/gfx_ssao.lua
@@ -21,7 +21,7 @@ function widget:GetInfo()
         date      = "2019",
         license   = "GPL",
         layer     = 999999,
-        enabled   = false,
+        enabled   = true,
         depends   = {'gl4'},
     }
 end

--- a/luaui/Widgets/gfx_ssao.lua
+++ b/luaui/Widgets/gfx_ssao.lua
@@ -1,5 +1,3 @@
-
-local isPotatoGpu = false
 local gpuMem = (Platform.gpuMemorySize and Platform.gpuMemorySize or 1000) / 1000
 if Platform ~= nil and Platform.gpuVendor == 'Intel' then
 	return false


### PR DESCRIPTION
This pr disables ssao on unsupported hardware as it turns half the screen black

before: 
![image](https://github.com/user-attachments/assets/de1f2d15-6ab6-41fd-9b73-07fc8d916019)

after: 
![image](https://github.com/user-attachments/assets/c2841e5e-7753-4ddb-b56b-6d8a53de2c76)

