### PR TITLE
Air Constructors can now target air repair pads

### DIFF
--- a/luarules/gadgets/unit_airbase.lua
+++ b/luarules/gadgets/unit_airbase.lua
@@ -23,12 +23,16 @@ CMD[CMD_LAND_AT_SPECIFIC_AIRBASE] = "LAND_AT_SPECIFIC_AIRBASE"
 local tractorDist = 100 ^ 2 -- default sqr tractor distance
 local isAirbase = {}
 local isAirUnit = {}
+local isAirCon = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
 	if unitDef.customParams.isairbase then
 		isAirbase[unitDefID] = { tractorDist, unitDef.buildSpeed }
 	end
 	if unitDef.isAirUnit and unitDef.canFly then
 		isAirUnit[unitDefID] = true
+		if unitDef.isBuilder then
+    		isAirCon[unitDefID] = true
+		end
 	end
 end
 
@@ -654,7 +658,11 @@ else	-- Unsynced
 		else
 			local sUnits = spGetSelectedUnits()
 			for i = 1, #sUnits do
-				if isAirUnit[spGetUnitDefID(sUnits[i])] then
+				if isAirCon[spGetUnitDefID(sUnits[i])] then
+                	-- allows air constructors to target air repair pads
+                	-- although I don't think the CMD below is working as intended since you can't select
+                	-- air pads with other types of units
+				elseif isAirUnit[spGetUnitDefID(sUnits[i])] then
 					return CMD_LAND_AT_SPECIFIC_AIRBASE
 				end
 			end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Air Constructors are now able to repair and gaurd Air Repair Pads. Although this fixes the behavior for Air Cons, this does not
fix the behavior for CMD_LAND_AT_SPECIFIC_AIRBASE which I think is not working. Currently the user has to click on the button in the UI for them to send a damaged air unit to the Pad.


#### Addresses Issue(s)
[- Issue URL](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3245)


<!-- If relevant
#### Setup
Air Units can now help another unit that is building an air pad or repair a damaged airpad without an explicit repair command.
-->

#### Test steps
- [ ] Create 2 air cons
- [ ] Use one air con to build the air pad
- [ ] Then use the second air con and right click on the air pad

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
