### PR TITLE
Use scancodes for number keys

### DIFF
--- a/luaui/configs/hotkeys/num_keys.txt
+++ b/luaui/configs/hotkeys/num_keys.txt
@@ -1,97 +1,97 @@
-bind 1 specteam 0
-bind 2 specteam 1
-bind 3 specteam 2
-bind 4 specteam 3
-bind 5 specteam 4
-bind 6 specteam 5
-bind 7 specteam 6
-bind 8 specteam 7
-bind 9 specteam 8
+bind sc_1 specteam 0
+bind sc_2 specteam 1
+bind sc_3 specteam 2
+bind sc_4 specteam 3
+bind sc_5 specteam 4
+bind sc_6 specteam 5
+bind sc_7 specteam 6
+bind sc_8 specteam 7
+bind sc_9 specteam 8
 
-bind Alt+0 add_to_autogroup 0
-bind Alt+1 add_to_autogroup 1
-bind Alt+2 add_to_autogroup 2
-bind Alt+3 add_to_autogroup 3
-bind Alt+4 add_to_autogroup 4
-bind Alt+5 add_to_autogroup 5
-bind Alt+6 add_to_autogroup 6
-bind Alt+7 add_to_autogroup 7
-bind Alt+8 add_to_autogroup 8
-bind Alt+9 add_to_autogroup 9
+bind Alt+sc_0 add_to_autogroup 0
+bind Alt+sc_1 add_to_autogroup 1
+bind Alt+sc_2 add_to_autogroup 2
+bind Alt+sc_3 add_to_autogroup 3
+bind Alt+sc_4 add_to_autogroup 4
+bind Alt+sc_5 add_to_autogroup 5
+bind Alt+sc_6 add_to_autogroup 6
+bind Alt+sc_7 add_to_autogroup 7
+bind Alt+sc_8 add_to_autogroup 8
+bind Alt+sc_9 add_to_autogroup 9
 
-bind Shift+Alt+0 load_autogroup_preset 0
-bind Shift+Alt+1 load_autogroup_preset 1
-bind Shift+Alt+2 load_autogroup_preset 2
-bind Shift+Alt+3 load_autogroup_preset 3
-bind Shift+Alt+4 load_autogroup_preset 4
-bind Shift+Alt+5 load_autogroup_preset 5
-bind Shift+Alt+6 load_autogroup_preset 6
-bind Shift+Alt+7 load_autogroup_preset 7
-bind Shift+Alt+8 load_autogroup_preset 8
-bind Shift+Alt+9 load_autogroup_preset 9
+bind Shift+Alt+sc_0 load_autogroup_preset 0
+bind Shift+Alt+sc_1 load_autogroup_preset 1
+bind Shift+Alt+sc_2 load_autogroup_preset 2
+bind Shift+Alt+sc_3 load_autogroup_preset 3
+bind Shift+Alt+sc_4 load_autogroup_preset 4
+bind Shift+Alt+sc_5 load_autogroup_preset 5
+bind Shift+Alt+sc_6 load_autogroup_preset 6
+bind Shift+Alt+sc_7 load_autogroup_preset 7
+bind Shift+Alt+sc_8 load_autogroup_preset 8
+bind Shift+Alt+sc_9 load_autogroup_preset 9
 
-bind 0,0 group focus 0
-bind 1,1 group focus 1
-bind 2,2 group focus 2
-bind 3,3 group focus 3
-bind 4,4 group focus 4
-bind 5,5 group focus 5
-bind 6,6 group focus 6
-bind 7,7 group focus 7
-bind 8,8 group focus 8
-bind 9,9 group focus 9
+bind sc_0,sc_0 group focus 0
+bind sc_1,sc_1 group focus 1
+bind sc_2,sc_2 group focus 2
+bind sc_3,sc_3 group focus 3
+bind sc_4,sc_4 group focus 4
+bind sc_5,sc_5 group focus 5
+bind sc_6,sc_6 group focus 6
+bind sc_7,sc_7 group focus 7
+bind sc_8,sc_8 group focus 8
+bind sc_9,sc_9 group focus 9
 
-bind 0 group select 0
-bind 1 group select 1
-bind 2 group select 2
-bind 3 group select 3
-bind 4 group select 4
-bind 5 group select 5
-bind 6 group select 6
-bind 7 group select 7
-bind 8 group select 8
-bind 9 group select 9
+bind sc_0 group select 0
+bind sc_1 group select 1
+bind sc_2 group select 2
+bind sc_3 group select 3
+bind sc_4 group select 4
+bind sc_5 group select 5
+bind sc_6 group select 6
+bind sc_7 group select 7
+bind sc_8 group select 8
+bind sc_9 group select 9
 
-bind Ctrl+0 group set 0
-bind Ctrl+1 group set 1
-bind Ctrl+2 group set 2
-bind Ctrl+3 group set 3
-bind Ctrl+4 group set 4
-bind Ctrl+5 group set 5
-bind Ctrl+6 group set 6
-bind Ctrl+7 group set 7
-bind Ctrl+8 group set 8
-bind Ctrl+9 group set 9
+bind Ctrl+sc_0 group set 0
+bind Ctrl+sc_1 group set 1
+bind Ctrl+sc_2 group set 2
+bind Ctrl+sc_3 group set 3
+bind Ctrl+sc_4 group set 4
+bind Ctrl+sc_5 group set 5
+bind Ctrl+sc_6 group set 6
+bind Ctrl+sc_7 group set 7
+bind Ctrl+sc_8 group set 8
+bind Ctrl+sc_9 group set 9
 
-bind Shift+0 group selectadd 0
-bind Shift+1 group selectadd 1
-bind Shift+2 group selectadd 2
-bind Shift+3 group selectadd 3
-bind Shift+4 group selectadd 4
-bind Shift+5 group selectadd 5
-bind Shift+6 group selectadd 6
-bind Shift+7 group selectadd 7
-bind Shift+8 group selectadd 8
-bind Shift+9 group selectadd 9
+bind Shift+sc_0 group selectadd 0
+bind Shift+sc_1 group selectadd 1
+bind Shift+sc_2 group selectadd 2
+bind Shift+sc_3 group selectadd 3
+bind Shift+sc_4 group selectadd 4
+bind Shift+sc_5 group selectadd 5
+bind Shift+sc_6 group selectadd 6
+bind Shift+sc_7 group selectadd 7
+bind Shift+sc_8 group selectadd 8
+bind Shift+sc_9 group selectadd 9
 
-bind Ctrl+Shift+0 group add 0
-bind Ctrl+Shift+1 group add 1
-bind Ctrl+Shift+2 group add 2
-bind Ctrl+Shift+3 group add 3
-bind Ctrl+Shift+4 group add 4
-bind Ctrl+Shift+5 group add 5
-bind Ctrl+Shift+6 group add 6
-bind Ctrl+Shift+7 group add 7
-bind Ctrl+Shift+8 group add 8
-bind Ctrl+Shift+9 group add 9
+bind Ctrl+Shift+sc_0 group add 0
+bind Ctrl+Shift+sc_1 group add 1
+bind Ctrl+Shift+sc_2 group add 2
+bind Ctrl+Shift+sc_3 group add 3
+bind Ctrl+Shift+sc_4 group add 4
+bind Ctrl+Shift+sc_5 group add 5
+bind Ctrl+Shift+sc_6 group add 6
+bind Ctrl+Shift+sc_7 group add 7
+bind Ctrl+Shift+sc_8 group add 8
+bind Ctrl+Shift+sc_9 group add 9
 
-bind Ctrl+Alt+0 group selecttoggle 0
-bind Ctrl+Alt+1 group selecttoggle 1
-bind Ctrl+Alt+2 group selecttoggle 2
-bind Ctrl+Alt+3 group selecttoggle 3
-bind Ctrl+Alt+4 group selecttoggle 4
-bind Ctrl+Alt+5 group selecttoggle 5
-bind Ctrl+Alt+6 group selecttoggle 6
-bind Ctrl+Alt+7 group selecttoggle 7
-bind Ctrl+Alt+8 group selecttoggle 8
-bind Ctrl+Alt+9 group selecttoggle 9
+bind Ctrl+Alt+sc_0 group selecttoggle 0
+bind Ctrl+Alt+sc_1 group selecttoggle 1
+bind Ctrl+Alt+sc_2 group selecttoggle 2
+bind Ctrl+Alt+sc_3 group selecttoggle 3
+bind Ctrl+Alt+sc_4 group selecttoggle 4
+bind Ctrl+Alt+sc_5 group selecttoggle 5
+bind Ctrl+Alt+sc_6 group selecttoggle 6
+bind Ctrl+Alt+sc_7 group selecttoggle 7
+bind Ctrl+Alt+sc_8 group selecttoggle 8
+bind Ctrl+Alt+sc_9 group selecttoggle 9


### PR DESCRIPTION
### Work done
Convert number key bindings to use scancodes.

#### Addresses Issue
I use the dvorak programmer keyboard layout (`xkb_layout="us",xkb_variant="dvp"` under linux), which has an unusual layout of number keys. With this layout, the number keys were non-functional. For instance, when pressing the `1` key (`\keydebug` output) :
```
[t=00:00:52.083598][f=0000255] [KeyBindings] GetActions: codeChain="&" scanChain="sc_1" keyCode="0x026" scanCode="sc_0x01E":
[t=00:00:52.083610][f=0000255] [KeyBindings] Action List:
[t=00:00:52.083613][f=0000255] [KeyBindings]    EMPTY
```
The number keys did work with a more standard layout like qwerty or azerty.

With this patch, they work correctly for all three layouts. `\keydebug` when pressing `1` again:
```
[t=00:00:54.416945][f=0000277] [KeyBindings] GetActions: codeChain="&" scanChain="sc_1" keyCode="0x026" scanCode="sc_0x01E":
[t=00:00:54.416966][f=0000277] [KeyBindings] Action List:
[t=00:00:54.416973][f=0000277] [KeyBindings]    1.  action="specteam"  rawline="specteam 0"  shortcut="sc_1"  index="72"
[t=00:00:54.416980][f=0000277] [KeyBindings]    2.  action="group"  rawline="group select 1"  shortcut="sc_1"  index="112"
```


I hope this change does not break any other setup. I think using scancodes is the preferred approach in general?