### PR TITLE
Order allyteam units to get out of the way of a construction site

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -1,0 +1,207 @@
+local gadget = gadget ---@type gadget
+
+function gadget:GetInfo()
+    return {
+        name    = "Builder buggeroff",
+        desc    = "Enables busy builders to buggeroff",
+        author  = "Flameink",
+        date    = "April 24, 2025",
+        version = "0.2.4",
+        license = "GNU GPL, v3 or later",
+        layer   = 0,
+        enabled = true   --  loaded by default?
+    }
+end
+
+local debugLog = false
+
+function print(Message)
+   if debugLog then
+        Spring.Echo(Message)
+    end
+end
+
+local shouldNotBuggeroff = {}
+local cachedUnitDefs = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+    if unitDef.speed == 0 or unitDef.isBuilding or unitDef.isFactory then
+        shouldNotBuggeroff[unitDefID] = true
+    end
+    cachedUnitDefs[unitDefID] = { radius = unitDef.radius, isBuilder = unitDef.isBuilder}
+end
+
+if gadgetHandler:IsSyncedCode() then
+    local function getUnitPositionTuple(unitID)
+        local x1, y1, z1 = Spring.GetUnitPosition(unitID)
+        local unitLocation = { x1, y1, z1 }
+        return unitLocation
+    end
+
+    local function closestPointOnCircle(cx, cz, radius, tx, tz)
+        local dx = tx - cx
+        local dz = tz - cz
+        local dist = math.sqrt(dx * dx + dz * dz)
+        if dist == 0 then
+            -- Target is exactly at center; choose arbitrary point on circle
+            return cx + radius, cz
+        end
+        local scale = radius / dist
+        local closestX = cx + dx * scale
+        local closestZ = cz + dz * scale
+        return closestX, closestZ
+    end
+
+    local function WillBeNearTarget(unitID, tx, ty, tz, frames, maxDistance)
+        local ux, uy, uz = Spring.GetUnitPosition(unitID)
+        if not ux then return false end
+        
+        local vx, vy, vz = Spring.GetUnitVelocity(unitID)
+        if not vx then return false end
+        
+        -- Predict future position
+        local futureX = ux + vx * frames
+        local futureY = uy + vy * frames
+        local futureZ = uz + vz * frames
+        
+        -- Compute distance to target
+        local dx = futureX - tx
+        local dy = futureY - ty
+        local dz = futureZ - tz
+        local distSq = dx*dx + dy*dy + dz*dz
+        
+        return distSq <= maxDistance * maxDistance
+    end
+
+    local function isInTargetArea(interferingUnitID, x, y, z, radius)
+        local ux, uy, uz = Spring.GetUnitPosition(interferingUnitID)
+        if not ux then return false end
+        local dx, dz = ux - x, uz - z
+        return (dx * dx + dz * dz) <= (radius * radius)    
+    end
+
+    local function shouldIssueBuggeroff(unitTeam, builderTeam, interferingUnitID, x, y, z, radius)
+        if Spring.AreTeamsAllied(unitTeam, builderTeam) == false and unitTeam ~= builderTeam then
+            return false
+        end
+        if shouldNotBuggeroff[Spring.GetUnitDefID(interferingUnitID)] then
+            return false
+        end
+        if WillBeNearTarget(interferingUnitID, x, y, z, 100, radius) then
+            return true
+        end
+        if isInTargetArea(interferingUnitID, x, y, z, radius) then
+            return true
+        end
+        return false
+    end
+
+    local function getFirstCommand(unitID)
+        local unitCommands = Spring.GetUnitCommands(unitID, -1)
+        if unitCommands == nil then
+            return nil
+        end
+        if next(unitCommands) == nil then
+            return nil
+        end
+        return unitCommands[1]
+    end
+
+    local function distance(pos1, x2, z2)
+        local x1, z1 = pos1[1], pos1[3]
+        local dx, dz = x2 - x1, z2 - z1
+        return math.sqrt(dx * dx + dz * dz)
+    end
+
+    local slowUpdateBuilders = {}
+    local watchedBuilders = {}
+    local builderRadiusOffsets = {}
+
+    local FAST_UPDATE_RADIUS = 300
+
+    function gadget:GameFrame(frame)
+        if frame % 10 ~= 0 then
+            return
+        end
+        for builderID, _ in pairs(watchedBuilders) do
+
+            local firstCommand = getFirstCommand(builderID)
+            local targetID     = Spring.GetUnitIsBuilding(builderID)
+            local isBuilding   = false
+            if targetID then
+                isBuilding = true
+            end
+
+            local x, y, z = Spring.GetUnitPosition(builderID)
+            if firstCommand == nil or firstCommand.id > -1 or isBuilding then
+                print("Clearing watched builder fast")
+                watchedBuilders[builderID]      = nil
+                builderRadiusOffsets[builderID] = nil
+            elseif distance(firstCommand.params, x, z) > FAST_UPDATE_RADIUS then
+                print("Too far, demoting to slow")
+                watchedBuilders[builderID]    = nil
+                slowUpdateBuilders[builderID] = true -- Do distance checks less frequently
+            elseif distance(firstCommand.params, x, z) > 200 then
+                -- Check distance frequently once you're closer
+            else
+                local cmdID           = firstCommand.id
+                local cmdParams       = firstCommand.params
+                local builtUnitDefID  = cmdID * -1
+                local builderTeam     = Spring.GetUnitTeam(builderID)
+                local buggerOffRadius = cachedUnitDefs[builtUnitDefID].radius + builderRadiusOffsets[builderID]
+
+                -- Get list of units to check
+                local targetX, targetY, targetZ = cmdParams[1], cmdParams[2], cmdParams[3]
+                local searchRadius     = cachedUnitDefs[builtUnitDefID].radius + 200
+                local x1, x2, z1, z2   = targetX - searchRadius, targetX + searchRadius, targetZ - searchRadius, targetZ + searchRadius
+                local interferingUnits = Spring.GetUnitsInRectangle(x1, z1, x2, z2)
+
+                -- Escalate the radius every update. We want to send units away the minimum distance, but  
+                -- if there are many units in the way, they may cause a traffic jam and need to clear more room.
+                builderRadiusOffsets[builderID] = builderRadiusOffsets[builderID] + 5 
+
+                for i = 1, #interferingUnits do
+                    local interferingUnitID = interferingUnits[i]
+                    if builderID ~= interferingUnitID then
+                        local unitPosition      = getUnitPositionTuple(interferingUnitID)
+                        local unitTeam          = Spring.GetUnitTeam(interferingUnitID)
+        
+                        if shouldIssueBuggeroff(unitTeam, builderTeam, interferingUnitID, targetX, targetY, targetZ, buggerOffRadius) then
+                            local sendX, sendZ = closestPointOnCircle(targetX, targetZ, buggerOffRadius, unitPosition[1], unitPosition[3])
+                            Spring.GiveOrderToUnit(interferingUnitID, CMD.INSERT, {0, CMD.MOVE, CMD.OPT_INTERNAL, sendX, targetY, sendZ}, {"alt"} )
+                        end    
+                    end
+                end
+            end
+        end
+        if frame % 100 ~= 0 then
+            return
+        end
+        for builderID, _ in pairs(slowUpdateBuilders) do
+            local firstCommand = getFirstCommand(builderID)
+            local x, y, z = Spring.GetUnitPosition(builderID)
+            if firstCommand == nil or firstCommand.id > -1 or isBuilding then
+                print("Clearing watched builder slow")
+                slowUpdateBuilders[builderID] = nil
+                builderRadiusOffsets[builderID] = nil
+            elseif distance(firstCommand.params, x, z) <= FAST_UPDATE_RADIUS then
+                print("Promote to fast")
+                slowUpdateBuilders[builderID] = nil
+                watchedBuilders[builderID] = true
+            end
+
+        end
+
+    end
+
+    function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+        local orderedUnit = unitID
+
+        local unitDefID = Spring.GetUnitDefID(orderedUnit)
+        if cachedUnitDefs[unitDefID].isBuilder then
+            watchedBuilders[orderedUnit] = true
+            builderRadiusOffsets[orderedUnit] = 1
+        end
+        return true
+
+    end
+end


### PR DESCRIPTION
https://github.com/user-attachments/assets/9a486e9d-facf-4af1-a924-9eb611b9c2eb

Relevant issue: https://github.com/beyond-all-reason/RecoilEngine/issues/2244

BuggerOff is currently broken in two cases.

Case 1: Unit moving through construction site
When a unit is moving through a construction site, BuggerOff won't be issued to it.

Case 2: Busy builder standing in construction site
When a builder is assisting some other task while standing in the construction site, it won't BuggerOff.

This happens because today, CMobileCAI::BuggerOff doesn't actually cause any movement. It just sets some flags on the unit. The actual function that does the moving is CMobileCAI::NonMoving. Since NonMoving doesn't get called while a unit is building or moving, the unit doesn't bugger off.

Justification:
When the user places a building, their intent is for the building to be built. They would expect that their own units would avoid the construction site unless directly ordered into it.

This gadget will make sure units clear a build site. If they are (or are going to be) in the way, then they are ordered to go to the closest spot on the circle around the construction site. The circle escalates in size until the building is placed, or the builder starts doing something else.