### PR TITLE
Transportability bugfix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 # May 2025
+• [Tiger, Turtle, Sumo] Mass 750, to make them transportable by light transports.
 • [Spybot] Emp immune again. Max stuntime vs units 8 -> 10
 • [Banisher] Energycost 17000 -> 23000, Turnrate 300 -> 250, Acceleration 0.2269 -> 0.2
 • [Tzar] Buildcost 26100 -> 30000

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -994,6 +994,9 @@ function UnitDef_Post(name, uDef)
 	if uDef.metalcost and uDef.health and uDef.canmove == true and uDef.mass == nil then
 		local healthmass = math.ceil(uDef.health/6)
 		uDef.mass = math.max(uDef.metalcost, healthmass)
+		if uDef.metalcost < 751 and uDef.mass > 750 then
+			uDef.mass = 750
+		end
 		--if uDef.metalcost < healthmass then
 		--	Spring.Echo(name, uDef.mass, uDef.metalcost, uDef.mass - uDef.metalcost)
 		--end


### PR DESCRIPTION
Caps the increase in mass from high hp:mcost ratio units to 750 for the units below that, to keep them in the Transportable: Light category.

Changes following units:
Turtle, Tiger, Sumo, (Printer).