### PR TITLE
feat(pve): resistances % in gui

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -626,8 +626,8 @@
 			},
 			"queensKilled": "Queens Killed: %{nKilled}/%{nTotal}",
 			"queenResistantToList": {
-				"one"   : "Queen is resistant to:",
-				"other" : "Queens are resistant to:"
+				"one"   : "Queen resistance:",
+				"other" : "Queen resistances:"
 			},
 			"gracePeriod": "Grace Period: %{time}",
 			"burrowCount": "Burrows: %{count}",

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -680,8 +680,8 @@
 			},
 			"bossesKilled": "Bosses Killed: %{nKilled}/%{nTotal}",
 			"bossResistantToList": {
-				"one"   : "Boss is resistant to:",
-				"other" : "Bosses are resistant to:"
+				"one"   : "Boss resistance:",
+				"other" : "Boss resistances:"
 			},
 			"gracePeriod": "Grace Period: %{time}",
 			"burrowCount": "Burrows: %{count}",

--- a/luaui/Widgets/gui_raptorStatsPanel.lua
+++ b/luaui/Widgets/gui_raptorStatsPanel.lua
@@ -170,15 +170,18 @@ local function CreatePanelDisplayList()
 
 			if bossInfo then
 				local nResistances = #bossInfo.resistances or 0
-				local headerRow = 11
-				printBossInfo(Spring.I18N('ui.raptors.queenResistantToList', {count = nResistances}) .. (nResistances > resistanceListLimit and ' (Ctrl+B Expands)' or ''), bossInfoMarginX, PanelRow(headerRow))
-				for i, resistance in ipairs(bossInfo.resistances) do
-					if not isBossInfoExpanded and i > resistanceListLimit then
-						break
+				if nResistances > 0 then
+					nPanelRows = 11
+					printBossInfo(Spring.I18N('ui.raptors.queenResistantToList', {count = nResistances}) .. (nResistances > resistanceListLimit and ' (Ctrl+B Expands)' or ''), bossInfoMarginX, PanelRow(nPanelRows))
+					for i, resistance in ipairs(bossInfo.resistances) do
+						if not isBossInfoExpanded and i > resistanceListLimit then
+							break
+						end
+						nPanelRows = nPanelRows + 1
+						printBossInfo(resistance.name, bossInfoMarginX + 10, PanelRow(nPanelRows))
+						local resistanceString = isAboveBossInfo and resistance.stringAbsolute or resistance.stringPercent
+						printBossInfo(resistanceString,bossInfoSubLabelMarginX + bossInfo.labelMaxLength + 23 - font:GetTextWidth(resistanceString) * panelFontSize,PanelRow(nPanelRows))
 					end
-					printBossInfo(resistance.name, bossInfoMarginX + 10, PanelRow(headerRow+i))
-					local resistanceString = isAboveBossInfo and resistance.stringAbsolute or resistance.stringPercent
-					printBossInfo(resistanceString,bossInfoSubLabelMarginX + bossInfo.labelMaxLength + 13 - font:GetTextWidth(resistanceString) * panelFontSize,PanelRow(headerRow+i))
 				end
 			end
 		end
@@ -240,7 +243,7 @@ local function getResistancesMessage()
 	return messages
 end
 
-local function Draw()
+function widget:DrawScreen()
 	if updatePanel then
 		if (guiPanel) then
 			gl.DeleteList(guiPanel);
@@ -430,12 +433,6 @@ function widget:GameFrame(n)
 	end
 end
 
-
-
-function widget:DrawScreen()
-	Draw()
-end
-
 function widget:MouseMove(x, y, dx, dy, button)
 	if moving then
 		updatePos(x1 + dx, y1 + dy)
@@ -495,5 +492,9 @@ function widget:IsAbove(x, y)
 	end
 
 	local bottomY = y1 + PanelRow(nPanelRows + 1)
+	local wasAboveBossInfo = isAboveBossInfo
 	isAboveBossInfo = x > x1 and x < x1 + (w * widgetScale) and y < y1 and y > math.max(0, bottomY)
+	if isAboveBossInfo ~= wasAboveBossInfo then
+		updatePanel = true
+	end
 end

--- a/luaui/Widgets/gui_raptorStatsPanel.lua
+++ b/luaui/Widgets/gui_raptorStatsPanel.lua
@@ -93,6 +93,7 @@ local textColor = "\255\255\255\255"
 local isRaptors = Spring.Utilities.Gametype.IsRaptors()
 local isBossInfoExpanded = false
 local isAboveBossInfo = false
+local resistanceListLimit = 10
 local stageGrace = 0
 local stageMain = 1
 local stageBoss = 2
@@ -169,16 +170,15 @@ local function CreatePanelDisplayList()
 
 			if bossInfo then
 				local nResistances = #bossInfo.resistances or 0
-				printBossInfo(Spring.I18N('ui.raptors.queenResistantToList', {count = nResistances}) .. (nResistances > 4 and ' (Ctrl+B Expands)' or ''), bossInfoMarginX, PanelRow(11))
-				local row = 11
+				local headerRow = 11
+				printBossInfo(Spring.I18N('ui.raptors.queenResistantToList', {count = nResistances}) .. (nResistances > resistanceListLimit and ' (Ctrl+B Expands)' or ''), bossInfoMarginX, PanelRow(headerRow))
 				for i, resistance in ipairs(bossInfo.resistances) do
-					row = row + 1
-					printBossInfo(resistance.name, bossInfoMarginX + 10, PanelRow(row))
-					local resistanceString = isAboveBossInfo and resistance.stringAbsolute or resistance.stringPercent
-					printBossInfo(resistanceString,bossInfoSubLabelMarginX + bossInfo.labelMaxLength + 13 - font:GetTextWidth(resistanceString) * panelFontSize,PanelRow(row))
-					if not isBossInfoExpanded and i > 3 then
+					if not isBossInfoExpanded and i > resistanceListLimit then
 						break
 					end
+					printBossInfo(resistance.name, bossInfoMarginX + 10, PanelRow(headerRow+i))
+					local resistanceString = isAboveBossInfo and resistance.stringAbsolute or resistance.stringPercent
+					printBossInfo(resistanceString,bossInfoSubLabelMarginX + bossInfo.labelMaxLength + 13 - font:GetTextWidth(resistanceString) * panelFontSize,PanelRow(headerRow+i))
 				end
 			end
 		end


### PR DESCRIPTION
### Work done
* Removed a lot of unused stuff from panels
* Panel now shows during gamesetup
* Added percent next to resistances and outline
* Can be expanded (>10) with ctrl+b

#### Test steps
- [x] Multiple games of endless raptors and scavengers with resistances reset disabled

#### BEFORE:
gamesetup
![image](https://github.com/user-attachments/assets/7b52fd08-96e2-4f72-8129-c9a12045303d)
one or more resistances
![image](https://github.com/user-attachments/assets/593c8a4d-e5ea-48a4-9385-6d38de051a59)
Scavengers example
![image](https://github.com/user-attachments/assets/a758529d-e6d4-4646-80e5-a222999e6679)

#### AFTER:
Gamesetup
![image](https://github.com/user-attachments/assets/2f24704e-881b-4a2a-9e09-4e3050ccdcf7)
![image](https://github.com/user-attachments/assets/1d329f44-af40-4ccb-ade6-a40c99ca4088)

Max unexpanded 10
![image](https://github.com/user-attachments/assets/c94e0e00-71e3-48ce-9ab7-10777400031e)
Over max unexpanded
![image](https://github.com/user-attachments/assets/9aa5fea5-c05d-4b84-9638-3a2a8d12b0f3)
Over max expanded
![image](https://github.com/user-attachments/assets/a7ff7963-acd5-44d1-b996-f3e348b5f9d0)
Scavengers example
![image](https://github.com/user-attachments/assets/b5833b81-e9ea-45c6-9416-af3560260a4b)
