### PR TITLE
Add keybind for the unit_stateprefs widget

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -174,3 +174,6 @@ bind           Alt+sc_]  blueprint_next
 
 // quotas
 bind           Alt+sc_g  factoryqueuemode
+
+// stateprefs
+bind           Any+Ctrl  stateprefs_record

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -173,3 +173,6 @@ bind           Alt+sc_c  blueprint_create
 bind           Alt+sc_d  blueprint_delete
 bind           Alt+sc_[  blueprint_prev
 bind           Alt+sc_]  blueprint_next
+
+// stateprefs
+bind           Any+Ctrl  stateprefs_record

--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -303,3 +303,6 @@ bind           Alt+sc_]  blueprint_next
 
 // quotas
 bind           Alt+sc_g  factoryqueuemode
+
+// stateprefs
+bind           Any+Ctrl  stateprefs_record

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -306,3 +306,6 @@ bind           Alt+sc_c  blueprint_create
 bind           Alt+sc_d  blueprint_delete
 bind           Alt+sc_[  blueprint_prev
 bind           Alt+sc_]  blueprint_next
+
+// stateprefs
+bind           Any+Ctrl  stateprefs_record


### PR DESCRIPTION
### Work done
Adds Any+Ctrl as the keybind for stateprefs_record now that unit_stateprefs is a default widget.

#### Setup
Control click the hud icon to set the default state (movement, fire state etc.) of newly built units from factories.
