### PR TITLE
Factory costs test patch

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1341,6 +1341,49 @@ function UnitDef_Post(name, uDef)
 		end
 	end
 
+	-- Factory costs test
+
+	if modOptions.factory_costs == true then
+
+		if name == "armmoho" or name == "cormoho" or name == "cormexp" then
+			uDef.metalcost = uDef.metalcost + 50
+			uDef.energycost = uDef.energycost + 2000
+		end
+		if name == "armageo" or name == "corageo" then
+			uDef.metalcost = uDef.metalcost + 100
+			uDef.energycost = uDef.energycost + 4000
+		end
+		if name == "armavp" or name == "coravp" or name == "armalab" or name == "coralab" or name == "armaap" or name == "coraap" or name == "armasy" or name == "corasy" then
+			uDef.metalcost = uDef.metalcost - 1000
+			uDef.workertime = 600
+			uDef.buildtime = uDef.buildtime * 2
+		end
+		if name == "armvp" or name == "corvp" or name == "armlab" or name == "corlab" or name == "armsy" or name == "corsy"then
+			uDef.metalcost = uDef.metalcost - 50
+			uDef.buildtime = uDef.buildtime - 1500
+			uDef.energycost = uDef.energycost - 280
+		end
+		if name == "armap" or name == "corap" or name == "armhp" or name == "corhp" or name == "armfhp" or name == "corfhp" or name == "armplat" or name == "corplat" then
+			uDef.metalcost = uDef.metalcost - 100
+			uDef.buildtime = uDef.buildtime - 600
+			uDef.energycost = uDef.energycost - 100
+		end
+		if name == "armshltx" or name == "corgant" or name == "armshltxuw" or name == "corgantuw" then
+			uDef.workertime = 2000
+			uDef.buildtime = uDef.buildtime * 2
+		end
+
+		if tonumber(uDef.customparams.techlevel) == 2 and uDef.energycost and uDef.metalcost and uDef.buildtime and not (name == "armavp" or name == "coravp" or name == "armalab" or name == "coralab" or name == "armaap" or name == "coraap") then
+			uDef.buildtime = math.ceil(uDef.buildtime * 0.015 / 5) * 500
+		end
+		if tonumber(uDef.customparams.techlevel) == 3 and uDef.energycost and uDef.metalcost and uDef.buildtime then
+			uDef.buildtime = math.ceil(uDef.buildtime * 0.002) * 1000
+		end
+
+		if name == "armnanotc" or name == "cornanotc" or name == "armnanotcplat" or name == "cornanotcplat" then
+			uDef.metalcost = uDef.metalcost + 40
+		end
+	end
 
 	-- Multipliers Modoptions
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1444,6 +1444,16 @@ local options = {
         def 	= false,
     },
 
+    {
+        key 	= "factory_costs",
+        name 	= "Factory Costs Test Patch",
+        desc 	= "Cheaper and more efficient factories, more expensive nanos, and slower to build higher-tech units. Experimental, not expected to be balanced by itself - a test to try how the game plays if each player is more able to afford their own T2 factory, while making assisting them less efficient.",
+        type 	= "bool",
+        --hidden 	= true,
+        section = "options_experimental",
+        def 	= false,
+    },
+
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     -- Unused Options


### PR DESCRIPTION
T1 bot/veh/ship factories
    Metalcost  -50
    Energycost -280
    Buildtime  -1500

T1 air/hover/amphib factories
    Metalcost  -100
    Energycost -100
    Buildtime  -600

T2 factories
    Metalcost  -1000
    Buildtime  2x
    Buildpower 300 -> 600

T2 mexes
    Metalcost  +50
    Energycost +2000

T2 ageos
    Metalcost  +100
    Energycost +4000

Non-factory T2 units and buildings
    Buildtime  1.5x

T3 gantries
    Buildtime 2x
    Buildpower 600 -> 2000

T3 units
    Buildtime  2x

Construction turrets
    Metalcost  +40



Modoption with cheaper and more efficient factories, more expensive nanos, and slower to build higher-tech units. 

Experimental, not expected to be well balanced by itself - a test to try how the game plays if each player is more able to afford their own T2 factory, while making assisting them less efficient.

Goal is to see how the game might play if a fast T2 factory is a possible option even for a single player, not just for a team pooling resources together. After getting a feel of how this plays, we should be more informed as to what kinds of changes might be needed to make a game with more accessible factories play well - cost changes or stat changes to specific units or categories of units, moving some units up a tier, change up the factory costs in either direction, and so on.

Goal is NOT to make sharing resources impossible or useless - rather to make the "solo" builds more competitive in comparison, and to further encourage having multiple factories also in 1v1 or FFA.

And while possibly wildly imbalanced, it is hopefully a fun experience to try something different - let's see who can come up with the craziest rushes.
