### PR TITLE
smothedResources lagged behind, when resources were shared

### DIFF
--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -1166,6 +1166,10 @@ function widget:Update(dt)
 		nextSlowUpdate = now + 0.5
 
 		r = { metal = { spGetTeamResources(myTeamID, 'metal') }, energy = { spGetTeamResources(myTeamID, 'energy') } }
+		if r['metal'][7] > 1 or r['metal'][8] > 1 or r['energy'][7] > 1 or r['energy'][8] > 1 then
+			r = { metal = { spGetTeamResources(myTeamID, 'metal') }, energy = { spGetTeamResources(myTeamID, 'energy') } }
+			smoothedResources = r
+		end
 
 		-- resbar values and overflow
 		updateAllyTeamOverflowing()


### PR DESCRIPTION
### Work done
smothedResources are refreshed if resources are are shared, now.

#### Before:
![image](https://github.com/user-attachments/assets/692eded8-ab8a-4349-801f-9fbc32d6b4f8)


