### PR TITLE
Decloak range hold fire bugfix

### DIFF
--- a/luaui/Widgets/gui_emp_decloak_range.lua
+++ b/luaui/Widgets/gui_emp_decloak_range.lua
@@ -102,8 +102,8 @@ end
 
 local function addGremlin(unitID, unitDefID)
     units[unitID] = { isGremlin[unitDefID], 0 }
-    spGiveOrderToUnit(unitID, CMD_MOVE_STATE, { 0 }, 0)
-    spGiveOrderToUnit(unitID, CMD_FIRE_STATE, { 0 }, 0)
+    --spGiveOrderToUnit(unitID, CMD_MOVE_STATE, { 0 }, 0)
+    --spGiveOrderToUnit(unitID, CMD_FIRE_STATE, { 0 }, 0)
 end
 
 --------------------------------------------------------------------------------

--- a/luaui/Widgets/gui_emp_decloak_range.lua
+++ b/luaui/Widgets/gui_emp_decloak_range.lua
@@ -102,8 +102,6 @@ end
 
 local function addGremlin(unitID, unitDefID)
     units[unitID] = { isGremlin[unitDefID], 0 }
-    --spGiveOrderToUnit(unitID, CMD_MOVE_STATE, { 0 }, 0)
-    --spGiveOrderToUnit(unitID, CMD_FIRE_STATE, { 0 }, 0)
 end
 
 --------------------------------------------------------------------------------

--- a/units/ArmVehicles/T2/armgremlin.lua
+++ b/units/ArmVehicles/T2/armgremlin.lua
@@ -11,6 +11,7 @@ return {
 		corpse = "DEAD",
 		energycost = 3700,
 		explodeas = "smallexplosiongeneric",
+		firestate = 0,
 		footprintx = 2,
 		footprintz = 2,
 		health = 1060,


### PR DESCRIPTION
### Work done
Removes the state changes applied by the gui_emp_decloak_range widget.


#### Addresses Issue(s)
[Issue URL](https://www.reddit.com/r/beyondallreason/comments/1kp3eu7/)

Adds firestate = 0 to the gremlin to retain that default behavior for newly built gremlin 

#### BEFORE:
![image](https://github.com/user-attachments/assets/6cc7afad-b914-431e-8cb5-d073a01ed9fb)

#### AFTER:
![image](https://github.com/user-attachments/assets/8363f614-cc00-4e3b-bcad-10544405964f)
![image](https://github.com/user-attachments/assets/e595fd49-13b4-4a49-89a0-133adb687a77)
Still results in:
![image](https://github.com/user-attachments/assets/2e75272d-8703-4a9d-9eaf-62886a39426b)
