### PR TITLE
Add a stats counter to aa target priority to identify some perf issues

### DIFF
--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -63,12 +63,14 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	local targetCheckStats = {} -- unitDefID : count
 	function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
 		if targetID == -1 and attackerWeaponNum == -1 then
 			return true, defPriority
 		end
 		local unitDefID = spGetUnitDefID(targetID)
 		if unitDefID then
+			targetCheckStats[unitDefID] = (targetCheckStats[unitDefID] or 0) + 1
 			local priority = defPriority or 1.0
 			local airCategory = airCategories[unitDefID]
 			if airCategory then
@@ -78,5 +80,23 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			return true, priority
 		end
+	end
+	function gadget:Shutdown()
+		local totalChecks = 0 
+		local totalunitDefs = 1
+		for unitDefID, count in pairs(targetCheckStats) do
+			totalChecks = totalChecks + count
+			totalunitDefs = totalunitDefs + 1
+		end
+		-- Find outliers with more checks than average
+		local averageChecks = totalChecks / totalunitDefs
+		local resultStr = string.format("AA Targeting Priority Stats: total = %d, unitDefs = %d, average = %.2f; Above average:", totalChecks, totalunitDefs, averageChecks)
+		for unitDefID, count in pairs(targetCheckStats) do
+			if count > averageChecks then
+				local unitDef = UnitDefs[unitDefID]
+				resultStr = resultStr .. unitDef.name .. ": " .. tostring(count) .. ", "
+			end
+		end
+		Spring.Echo(resultStr)
 	end
 end


### PR DESCRIPTION
Like so:

[t=00:01:48.816531][f=0002638] AA Targeting Priority Stats: total = 249526, unitDefs = 2, average = 124763.00; Above average:corvamp: 249526, 
