### PR TITLE
Batched sendtounsynced lights

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -115,6 +115,7 @@ local callInLists = {
 	"PlayerRemoved",
 
 	"GameFrame",
+	"GameFramePost",
 	"GamePaused",
 
 	"ViewResize",  -- FIXME ?
@@ -1160,6 +1161,18 @@ function gadgetHandler:GameFrame(frameNum)
 	for _, g in ipairs(self.GameFrameList) do
 		tracy.ZoneBeginN("G:GameFrame:" .. g.ghInfo.name)
 		g:GameFrame(frameNum)
+		tracy.ZoneEnd()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function gadgetHandler:GameFramePost(frameNum)
+	frameNum = frameNum or Spring.GetGameFrame()
+	tracy.ZoneBeginN("G:GameFramePost")
+	for _, g in ipairs(self.GameFramePostList) do
+		tracy.ZoneBeginN("G:GameFramePost:" .. g.ghInfo.name)
+		g:GameFramePost(frameNum)
 		tracy.ZoneEnd()
 	end
 	tracy.ZoneEnd()

--- a/luarules/gadgets/gfx_explosion_lights.lua
+++ b/luarules/gadgets/gfx_explosion_lights.lua
@@ -13,6 +13,8 @@ function gadget:GetInfo()
     }
 end
 
+-- Pre-batching perf test done with 20 corhlt firing at once 
+
 if gadgetHandler:IsSyncedCode() then
 
     local cannonWeapons = {}
@@ -67,17 +69,58 @@ if gadgetHandler:IsSyncedCode() then
         end
     end
 
+    local explosionLightEventCache = {} -- px, py, pz, weaponID, ownerID
+    local explosionLightEventSize = 0
+    local explosionLightEventStride = 5
+    local barrelfireLightEventCache = {} -- px, py, pz, weaponID, ownerID
+    local barrelfireLightEventSize = 0
+    local barrelfireLightEventStride = 5
     function gadget:Explosion(weaponID, px, py, pz, ownerID, projectileID)
-        SendToUnsynced("explosion_light", px, py, pz, weaponID, ownerID)
+        explosionLightEventSize = explosionLightEventSize + 1
+        explosionLightEventCache[explosionLightEventSize] = px
+        explosionLightEventSize = explosionLightEventSize + 1
+        explosionLightEventCache[explosionLightEventSize] = py
+        explosionLightEventSize = explosionLightEventSize + 1
+        explosionLightEventCache[explosionLightEventSize] = pz
+        explosionLightEventSize = explosionLightEventSize + 1
+        explosionLightEventCache[explosionLightEventSize] = weaponID
+        explosionLightEventSize = explosionLightEventSize + 1
+        explosionLightEventCache[explosionLightEventSize] = ownerID
+        --SendToUnsynced("explosion_light", px, py, pz, weaponID, ownerID)
+        
     end
 
     function gadget:ProjectileCreated(projectileID, ownerID, weaponID)		-- needs: Script.SetWatchProjectile(weaponDefID, true)
 		if cannonWeapons[weaponID] then	-- optionally disable this to pass through missiles too
 			local px, py, pz = Spring.GetProjectilePosition(projectileID)
-			SendToUnsynced("barrelfire_light", px, py, pz, weaponID, ownerID)
+			--SendToUnsynced("barrelfire_light", px, py, pz, weaponID, ownerID)
+            barrelfireLightEventSize = barrelfireLightEventSize + 1
+            barrelfireLightEventCache[barrelfireLightEventSize] = px
+            barrelfireLightEventSize = barrelfireLightEventSize + 1
+            barrelfireLightEventCache[barrelfireLightEventSize] = py
+            barrelfireLightEventSize = barrelfireLightEventSize + 1
+            barrelfireLightEventCache[barrelfireLightEventSize] = pz
+            barrelfireLightEventSize = barrelfireLightEventSize + 1
+            barrelfireLightEventCache[barrelfireLightEventSize] = weaponID
+            barrelfireLightEventSize = barrelfireLightEventSize + 1
+            barrelfireLightEventCache[barrelfireLightEventSize] = ownerID
+
 		end
     end
 
+    function gadget:GameFramePost()
+        if next (explosionLightEventCache) then
+            SendToUnsynced("explosion_light_batched", explosionLightEventSize, explosionLightEventStride, unpack(explosionLightEventCache) )
+            explosionLightEventCache = {}
+            explosionLightEventSize = 0
+        end
+        
+        if next (barrelfireLightEventCache) then
+            SendToUnsynced("barrelfire_light_batched", barrelfireLightEventSize, barrelfireLightEventStride, unpack(barrelfireLightEventCache) )
+            barrelfireLightEventCache = {}
+            barrelfireLightEventSize = 0
+        end
+    end
 
 else	-- Unsynced
 
@@ -108,14 +151,100 @@ else	-- Unsynced
 			end
 		end
     end
+    local function SpawnExplosionBatched(_,explosionLightEventSize, explosionLightEventStride, ...)
+        local VisibleExplosionBatch = Script.LuaUI("VisibleExplosionBatch")
+        if not VisibleExplosionBatch then
+            return
+        end
+        VisibleExplosionBatch = Script.LuaUI.VisibleExplosionBatch
+        tracy.ZoneBeginN("SpawnExplosionBatched")
+        local args = { ... }
+        -- is in-place shifting of args table better than a new table?
+        -- We need to know last status as that tells us if we are finished with a batch 
+        -- We are filtering this down to only the visible events here: 
 
+        local spectatingState = select(2, spGetSpectatingState())
+        local currentIndex = 0
+        for i = 1, explosionLightEventSize, explosionLightEventStride do
+            local px = args[i]
+            local py = args[i + 1]
+            local pz = args[i + 2]
+            local weaponID = args[i + 3]
+            local ownerID = args[i + 4]
+            if ownerID ~= nil and (spectatingState or spGetUnitAllyTeam(ownerID) == myAllyID or spIsPosInLos(px, py, pz, myAllyID)) then
+                args[currentIndex + 1] = px
+                args[currentIndex + 2] = py
+                args[currentIndex + 3] = pz
+                args[currentIndex + 4] = weaponID
+                args[currentIndex + 5] = ownerID
+                currentIndex = currentIndex + explosionLightEventStride
+            end
+        end
+        local batchCount = currentIndex / explosionLightEventStride
+        tracy.ZoneEnd()
+        
+        if batchCount > 0 then
+            VisibleExplosionBatch(batchCount, explosionLightEventStride, unpack(args))
+        end
+        --local batchEndMarker = currentIndex + (explosionLightEventStride-1)
+        --for i = 1, currentIndex , explosionLightEventStride do
+        --    VisibleExplosionFunction(args[i], args[i + 1], args[i + 2], args[i + 3], args[i + 4], batchCount, i == batchEndMarker)
+        --end
+    end
+    local function SpawnBarrelfireBatched(_,barrelfireLightEventSize, barrelfireLightEventStride, ...)
+        local BarrelfireBatch = Script.LuaUI("BarrelfireBatch")
+        if not BarrelfireBatch then
+            return
+        end
+        BarrelfireBatch = Script.LuaUI.BarrelfireBatch
+        tracy.ZoneBeginN("SpawnBarrelfireBatched")
+        local args = { ... }
+        -- is in-place shifting of args table better than a new table?
+        -- We need to know last status as that tells us if we are finished with a batch 
+        -- We are filtering this down to only the visible events here: 
+        local spectatingState = select(2, spGetSpectatingState())
+        local currentIndex = 0
+        --Spring.Echo(barrelfireLightEventSize, barrelfireLightEventStride)
+        for i = 1, barrelfireLightEventSize, barrelfireLightEventStride do
+            local px = args[i]
+            local py = args[i + 1]
+            local pz = args[i + 2]
+            local weaponID = args[i + 3]
+            local ownerID = args[i + 4]
+            --Spring.Echo(px, py, pz, weaponID, ownerID)
+            if ownerID ~= nil and (spectatingState or spGetUnitAllyTeam(ownerID) == myAllyID or spIsPosInLos(px, py, pz, myAllyID)) then
+                args[currentIndex + 1] = px
+                args[currentIndex + 2] = py
+                args[currentIndex + 3] = pz
+                args[currentIndex + 4] = weaponID
+                args[currentIndex + 5] = ownerID
+                currentIndex = currentIndex + barrelfireLightEventStride
+            end
+        end
+        --Spring.Echo(barrelfireLightEventSize, barrelfireLightEventStride,args)
+        local batchCount = currentIndex / barrelfireLightEventStride
+        if batchCount > 0 then
+            BarrelfireBatch(batchCount, barrelfireLightEventStride, unpack(args))
+        end
+
+        tracy.ZoneEnd()
+        
+        --local batchEndMarker = currentIndex + (barrelfireLightEventStride-1)
+        --for i = 1, currentIndex , barrelfireLightEventStride do
+        --    BarrelfireFunction(args[i], args[i + 1], args[i + 2], args[i + 3], args[i + 4], batchCount, i == batchEndMarker)
+        --end
+    end
     function gadget:Initialize()
         gadgetHandler:AddSyncAction("explosion_light", SpawnExplosion)
         gadgetHandler:AddSyncAction("barrelfire_light", SpawnBarrelfire)
+        gadgetHandler:AddSyncAction("explosion_light_batched", SpawnExplosionBatched)
+        gadgetHandler:AddSyncAction("barrelfire_light_batched", SpawnBarrelfireBatched)
     end
 
     function gadget:Shutdown()
         gadgetHandler.RemoveSyncAction("explosion_light")
         gadgetHandler.RemoveSyncAction("barrelfire_light")
+        gadgetHandler.RemoveSyncAction("explosion_light_batched")
+        gadgetHandler.RemoveSyncAction("barrelfire_light_batched")
     end
 end

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -1081,6 +1081,13 @@ function widget:VisibleExplosion(px, py, pz, weaponID, ownerID)
 	)
 end
 
+
+function widget:VisibleExplosionBatch(dataSize, dataStride, data)
+	for i=1, dataSize, dataStride do
+		widget:VisibleExplosion(data[i], data[i+1], data[i+2], data[i+3], data[i+4])
+	end
+end
+
 local UnitScriptDecalsNames = {
 	['corkorg'] = {
 		[1] = {

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1003,7 +1003,7 @@ for wdid, wd in pairs(WeaponDefs) do
 	end
 end
 
-function widget:VisibleExplosion(px, py, pz, weaponID, ownerID)
+function widget:VisibleExplosion(px, py, pz, weaponID, ownerID, noUpload)
 	if targetable[weaponID] and py-300 > Spring.GetGroundHeight(px, pz) then	-- dont add light to (likely) intercepted explosions (mainly to curb nuke flashes)
 		return
 	end
@@ -1020,15 +1020,43 @@ function widget:VisibleExplosion(px, py, pz, weaponID, ownerID)
 	end
 end
 
-function widget:Barrelfire(px, py, pz, weaponID, ownerID)
+function widget:VisibleExplosionBatch(count, stride, ...)
+	--Spring.Echo("VisibleExplosionBatch", count, stride)
+	local args = {...}
+	local noUpload = true
+	local startElementIndex = pointLightVBO.usedElements
+	for i=1, count, stride do
+		widget:VisibleExplosion(args[i], args[i+1], args[i+2], args[i+3], args[i+4], noUpload)
+	end
+	if noUpload then
+		uploadElementRange(pointLightVBO, startElementIndex -1, pointLightVBO.usedElements)
+	end
+end
+
+
+function widget:Barrelfire(px, py, pz, weaponID, ownerID, noUpload)
 	if muzzleFlashLights[weaponID] then
 		local lightParamTable = muzzleFlashLights[weaponID].lightParamTable
 		if muzzleFlashLights[weaponID].alwaysVisible or spIsSphereInView(px,py,pz, lightParamTable[4]) then
 			lightParamTable[1] = px
 			lightParamTable[2] = py
 			lightParamTable[3] = pz
-			AddLight(nil, nil, nil, pointLightVBO, lightParamTable) --(instanceID, unitID, pieceIndex, targetVBO, lightparams, noUpload)
+			AddLight(nil, nil, nil, pointLightVBO, lightParamTable, noUpload) --(instanceID, unitID, pieceIndex, targetVBO, lightparams, noUpload)
 		end
+	end
+end
+
+function widget:BarrelfireBatch(count, stride, ...)
+	--Spring.Echo("BarrelfireBatch", count, stride)
+	local args = {...}
+	local noUpload = true
+	local startElementIndex = pointLightVBO.usedElements
+	for i=1, count, stride do
+		--Spring.Echo("BarrelfireBatch", args[i], args[i+1], args[i+2], args[i+3], args[i+4])
+		widget:Barrelfire(args[i], args[i+1], args[i+2], args[i+3], args[i+4], noUpload)
+	end
+	if noUpload then
+		uploadElementRange(pointLightVBO, startElementIndex-1, pointLightVBO.usedElements)
 	end
 end
 

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1004,6 +1004,7 @@ for wdid, wd in pairs(WeaponDefs) do
 end
 
 function widget:VisibleExplosion(px, py, pz, weaponID, ownerID, noUpload)
+	--Spring.Echo("widget:VisibleExplosion", px, py, pz, weaponID, ownerID)
 	if targetable[weaponID] and py-300 > Spring.GetGroundHeight(px, pz) then	-- dont add light to (likely) intercepted explosions (mainly to curb nuke flashes)
 		return
 	end
@@ -1020,19 +1021,17 @@ function widget:VisibleExplosion(px, py, pz, weaponID, ownerID, noUpload)
 	end
 end
 
-function widget:VisibleExplosionBatch(count, stride, ...)
-	--Spring.Echo("VisibleExplosionBatch", count, stride)
-	local args = {...}
+function widget:VisibleExplosionBatch(dataSize, dataStride, data)
 	local noUpload = true
 	local startElementIndex = pointLightVBO.usedElements
-	for i=1, count, stride do
-		widget:VisibleExplosion(args[i], args[i+1], args[i+2], args[i+3], args[i+4], noUpload)
+	for i=1, dataSize, dataStride do
+		widget:VisibleExplosion(data[i], data[i+1], data[i+2], data[i+3], data[i+4], noUpload)
 	end
 	if noUpload then
 		uploadElementRange(pointLightVBO, startElementIndex -1, pointLightVBO.usedElements)
 	end
 end
-
+ 
 
 function widget:Barrelfire(px, py, pz, weaponID, ownerID, noUpload)
 	if muzzleFlashLights[weaponID] then
@@ -1046,14 +1045,13 @@ function widget:Barrelfire(px, py, pz, weaponID, ownerID, noUpload)
 	end
 end
 
-function widget:BarrelfireBatch(count, stride, ...)
+function widget:BarrelfireBatch(dataSize, dataStride, data)
 	--Spring.Echo("BarrelfireBatch", count, stride)
-	local args = {...}
 	local noUpload = true
 	local startElementIndex = pointLightVBO.usedElements
-	for i=1, count, stride do
+	for i=1, dataSize, dataStride do
 		--Spring.Echo("BarrelfireBatch", args[i], args[i+1], args[i+2], args[i+3], args[i+4])
-		widget:Barrelfire(args[i], args[i+1], args[i+2], args[i+3], args[i+4], noUpload)
+		widget:Barrelfire(data[i], data[i+1], data[i+2], data[i+3], data[i+4], noUpload)
 	end
 	if noUpload then
 		uploadElementRange(pointLightVBO, startElementIndex-1, pointLightVBO.usedElements)

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -660,7 +660,7 @@ for wdid, wd in pairs(WeaponDefs) do
 	end
 end
 
-function widget:VisibleExplosion(px, py, pz, weaponID, ownerID)
+function widget:VisibleExplosion(px, py, pz, weaponID, ownerID, noUpload)
 	if targetable[weaponID] and py-7300 > Spring.GetGroundHeight(px, pz) then	-- dont add distortion to (likely) intercepted explosions (mainly to curb nuke flashes)
 		return
 	end
@@ -673,13 +673,25 @@ function widget:VisibleExplosion(px, py, pz, weaponID, ownerID)
 				distortionParamTable[1] = px
 				distortionParamTable[2] = py
 				distortionParamTable[3] = pz
-				AddDistortion(nil, nil, nil, pointDistortionVBO, distortionParamTable) --(instanceID, unitID, pieceIndex, targetVBO, distortionparams, noUpload)
+				AddDistortion(nil, nil, nil, pointDistortionVBO, distortionParamTable, noUpload) --(instanceID, unitID, pieceIndex, targetVBO, distortionparams, noUpload)
 			end
 		end
 	end
 end
 
-function widget:Barrelfire(px, py, pz, weaponID, ownerID)
+
+function widget:VisibleExplosionBatch(dataSize, dataStride, data)
+	local noUpload = true
+	local startElementIndex = pointDistortionVBO.usedElements
+	for i=1, dataSize, dataStride do
+		widget:VisibleExplosion(data[i], data[i+1], data[i+2], data[i+3], data[i+4])
+	end	
+	if noUpload then
+		uploadElementRange(pointDistortionVBO, startElementIndex -1, pointDistortionVBO.usedElements)
+	end
+end
+
+function widget:Barrelfire(px, py, pz, weaponID, ownerID, noUpload)
 	if muzzleFlashDistortions[weaponID] then
 		for i, distortion in pairs(muzzleFlashDistortions[weaponID]) do
 			local distortionParamTable = distortion.distortionParamTable
@@ -688,9 +700,21 @@ function widget:Barrelfire(px, py, pz, weaponID, ownerID)
 				distortionParamTable[1] = px
 				distortionParamTable[2] = py
 				distortionParamTable[3] = pz
-				AddDistortion(nil, nil, nil, pointDistortionVBO, distortionParamTable) --(instanceID, unitID, pieceIndex, targetVBO, distortionparams, noUpload)
+				AddDistortion(nil, nil, nil, pointDistortionVBO, distortionParamTable, noUpload) --(instanceID, unitID, pieceIndex, targetVBO, distortionparams, noUpload)
 			end
 		end
+	end
+end
+
+
+function widget:BarrelfireBatch(dataSize, dataStride, data)
+	local noUpload = true
+	local startElementIndex = pointDistortionVBO.usedElements
+	for i=1, dataSize, dataStride do
+		widget:Barrelfire(data[i], data[i+1], data[i+2], data[i+3], data[i+4], noUpload)
+	end	
+	if noUpload then
+		uploadElementRange(pointDistortionVBO, startElementIndex -1, pointDistortionVBO.usedElements)
 	end
 end
 

--- a/luaui/Widgets/map_grass_gl4.lua
+++ b/luaui/Widgets/map_grass_gl4.lua
@@ -756,6 +756,12 @@ function widget:VisibleExplosion(px, py, pz, weaponID, ownerID)
 	end
 end
 
+function widget:VisibleExplosionBatch(dataSize, dataStride, data)
+	for i=1, dataSize, dataStride do
+		widget:VisibleExplosion(data[i], data[i+1], data[i+2], data[i+3], data[i+4])
+	end
+end
+
 local function placegrassCmd(_, _, params)
 	placementMode = not placementMode
 	processChanges = true

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -211,7 +211,9 @@ local callInLists = {
 	'UnitSale',
 	'UnitSold',
 	'VisibleExplosion',
+	'VisibleExplosionBatch',
 	'Barrelfire',
+	'BarrelfireBatch',
 	'CrashingAircraft',
 	'ClearMapMarks',
 
@@ -2609,10 +2611,26 @@ function widgetHandler:VisibleExplosion(px, py, pz, weaponID, ownerID)
 	return
 end
 
+function widgetHandler:VisibleExplosionBatch(explosionSize, explosionStride, ...)
+	tracy.ZoneBeginN("W:VisibleExplosionBatch")
+	for _, w in ipairs(self.VisibleExplosionBatchList) do
+		w:VisibleExplosionBatch(explosionSize, explosionStride, ...)
+	end
+	tracy.ZoneEnd()
+	return
+end
 function widgetHandler:Barrelfire(px, py, pz, weaponID, ownerID)
 	tracy.ZoneBeginN("W:Barrelfire")
 	for _, w in ipairs(self.BarrelfireList) do
 		w:Barrelfire(px, py, pz, weaponID, ownerID)
+	end
+	tracy.ZoneEnd()
+	return
+end
+function widgetHandler:BarrelfireBatch(barrelfireSize, barrefireStride, ...)
+	tracy.ZoneBeginN("W:BarrelfireBatch")
+	for _, w in ipairs(self.BarrelfireBatchList) do
+		w:BarrelfireBatch(barrelfireSize, barrefireStride, ...)
 	end
 	tracy.ZoneEnd()
 	return

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -2611,10 +2611,11 @@ function widgetHandler:VisibleExplosion(px, py, pz, weaponID, ownerID)
 	return
 end
 
-function widgetHandler:VisibleExplosionBatch(explosionSize, explosionStride, ...)
+function widgetHandler:VisibleExplosionBatch(dataSize, dataStride, data)
+	-- dataSize, dataStride, data are flattened tables of (px, py, pz, weaponID, ownerID)
 	tracy.ZoneBeginN("W:VisibleExplosionBatch")
 	for _, w in ipairs(self.VisibleExplosionBatchList) do
-		w:VisibleExplosionBatch(explosionSize, explosionStride, ...)
+		w:VisibleExplosionBatch(dataSize, dataStride, data)
 	end
 	tracy.ZoneEnd()
 	return
@@ -2627,10 +2628,11 @@ function widgetHandler:Barrelfire(px, py, pz, weaponID, ownerID)
 	tracy.ZoneEnd()
 	return
 end
-function widgetHandler:BarrelfireBatch(barrelfireSize, barrefireStride, ...)
+function widgetHandler:BarrelfireBatch(dataSize, dataStride, data)
+	-- dataSize, dataStride, data are flattened tables of (px, py, pz, weaponID, ownerID)
 	tracy.ZoneBeginN("W:BarrelfireBatch")
 	for _, w in ipairs(self.BarrelfireBatchList) do
-		w:BarrelfireBatch(barrelfireSize, barrefireStride, ...)
+		w:BarrelfireBatch(dataSize, dataStride, data)
 	end
 	tracy.ZoneEnd()
 	return


### PR DESCRIPTION
This PR tries to reduce the amount of synced->unsynced->luaui data copying being done for explosions and barrel fire events. It does so by using the stack to pass data in varargs {...} to the unsynced side, where the events are LOS checked and forwarded as a table to the LuaUI side. 