### PR TITLE
Workaround BARb crash when other profiles mixed in with hard_aggressive Legion

### DIFF
--- a/luarules/configs/BARb/stable/config/easy/economy.json
+++ b/luarules/configs/BARb/stable/config/easy/economy.json
@@ -44,11 +44,13 @@
 
 	"geo": {
 		"armada": "armgeo",
-		"cortex": "corgeo"
+		"cortex": "corgeo",
+		"legion": "armgeo"
 	},
 	"mex": {
 		"armada": "armmex",
-		"cortex": "cormex"
+		"cortex": "cormex",
+		"legion": "armmex"
 	},
 	"mex_up": 1,  // maximum number of simultaneous mex upgrades
 
@@ -95,7 +97,8 @@
 	// Unknown UnitDef replacer
 	"default": {
 		"armada": "armwin",
-		"cortex": "corwin"
+		"cortex": "corwin",
+		"legion": "armwin"
 	}
 }
 }

--- a/luarules/configs/BARb/stable/config/economy.json
+++ b/luarules/configs/BARb/stable/config/economy.json
@@ -46,11 +46,13 @@
 
 	"geo": {
 		"armada": "armgeo",
-		"cortex": "corgeo"
+		"cortex": "corgeo",
+		"legion": "armgeo"
 	},
 	"mex": {
 		"armada": "armmex",
-		"cortex": "cormex"
+		"cortex": "cormex",
+		"legion": "armmex"
 	},
 	"mex_up": 2,  // maximum number of simultaneous mex upgrades
 
@@ -96,7 +98,8 @@
 	// Unknown UnitDef replacer
 	"default": {
 		"armada": "armwin",
-		"cortex": "corwin"
+		"cortex": "corwin",
+		"legion": "armwin"
 	}
 }
 }

--- a/luarules/configs/BARb/stable/config/hard/economy.json
+++ b/luarules/configs/BARb/stable/config/hard/economy.json
@@ -72,11 +72,13 @@
 
 	"geo": {
 		"armada": "armgeo",
-		"cortex": "corgeo"
+		"cortex": "corgeo",
+		"legion": "armgeo"
 	},
 	"mex": {
 		"armada": "armmex",
-		"cortex": "cormex"
+		"cortex": "cormex",
+		"legion": "armmex"
 	},
 // buildpower -  Mobile buildpower to metal income ratio,
 // works but with regard to behaviour->UnitDef->build_speed. With 1.25 and m-income=100 means AI will try to build at max 125 mobile build_speed in total.
@@ -127,7 +129,8 @@
 	// Unknown UnitDef replacer
 	"default": {
 		"armada": "armwin",
-		"cortex": "corwin"
+		"cortex": "corwin",
+		"legion": "armwin"
 	}
 }
 }

--- a/luarules/configs/BARb/stable/config/hard_aggressive/economy.json
+++ b/luarules/configs/BARb/stable/config/hard_aggressive/economy.json
@@ -49,11 +49,13 @@
 
 	"geo": {
 		"armada": "armgeo",
-		"cortex": "corgeo"
+		"cortex": "corgeo",
+		"legion": "armgeo"
 	},
 	"mex": {
 		"armada": "armmex",
-		"cortex": "cormex"
+		"cortex": "cormex",
+		"legion": "armmex"
 	},
 	"mex_up": 3,  // maximum number of simultaneous mex upgrades
 
@@ -100,7 +102,8 @@
 	// Unknown UnitDef replacer
 	"default": {
 		"armada": "armwin",
-		"cortex": "corwin"
+		"cortex": "corwin",
+		"legion": "armwin"
 	}
 }
 }

--- a/luarules/configs/BARb/stable/config/medium/economy.json
+++ b/luarules/configs/BARb/stable/config/medium/economy.json
@@ -44,11 +44,13 @@
 
 	"geo": {
 		"armada": "armgeo",
-		"cortex": "corgeo"
+		"cortex": "corgeo",
+		"legion": "armgeo"
 	},
 	"mex": {
 		"armada": "armmex",
-		"cortex": "cormex"
+		"cortex": "cormex",
+		"legion": "armmex"
 	},
 	"mex_up": 1,  // maximum number of simultaneous mex upgrades
 
@@ -95,7 +97,8 @@
 	// Unknown UnitDef replacer
 	"default": {
 		"armada": "armwin",
-		"cortex": "corwin"
+		"cortex": "corwin",
+		"legion": "armwin"
 	}
 }
 }

--- a/luarules/configs/BARb/stable/script/common.as
+++ b/luarules/configs/BARb/stable/script/common.as
@@ -5,7 +5,7 @@ namespace Side {
  */
 TypeMask ARMADA = aiSideMasker.GetTypeMask("armada");
 TypeMask CORTEX = aiSideMasker.GetTypeMask("cortex");
-TypeMask LEGION = ARMADA;  // legion, depending on modoptions initialized in <profile>/init.as
+TypeMask LEGION = aiSideMasker.GetTypeMask("legion");
 
 }  // namespace Side
 

--- a/luarules/configs/BARb/stable/script/hard_aggressive/init.as
+++ b/luarules/configs/BARb/stable/script/hard_aggressive/init.as
@@ -12,13 +12,8 @@ SInitInfo AiInit()
 	data.armor = InitArmordef();
 	data.category = InitCategories();
 	@data.profile = @(array<string> = {"behaviour", "block_map", "build_chain", "commander", "economy", "factory", "response"});
-	if (string(aiSetupMgr.GetModOptions()["experimentallegionfaction"]) == "1") {
-		AiLog("inserting economy_leg");
-		Side::LEGION = aiSideMasker.GetTypeMask("legion");
+	if (string(aiSetupMgr.GetModOptions()["experimentallegionfaction"]) == "1")
 		data.profile.insertAt(data.profile.length(), {"behaviour_leg", "build_chain_leg", "commander_leg", "economy_leg", "factory_leg"});
-	} else {
-		AiLog("Ignoring Legion");
-	}
 	return data;
 }
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Added minimum required params for other profiles of BARb not to crash on Legion present in `hard_aggressive`.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- Add `hard_aggressive`
- Add `hard` to same team as `hard_aggressive`
- Enable `Legion`
- Start game

Expected outcome is game won't crash. (Though `Legion` may not play properly if `hard_aggressive` is not the first AI; hence - not fix, only workaround)