### PR TITLE
Fix drawing of unified range rings with flipped minimap.

### DIFF
--- a/luaui/Shaders/weapon_range_rings_unified_gl4.vert.glsl
+++ b/luaui/Shaders/weapon_range_rings_unified_gl4.vert.glsl
@@ -20,6 +20,7 @@ uniform float lineAlphaUniform = 1.0;
 uniform float cannonmode = 0.0;
 uniform float fadeDistOffset = 0.0;
 uniform float inMiniMap = 0.0;
+uniform int flipMiniMap = 0;
 
 
 uniform float selUnitCount = 1.0;
@@ -449,7 +450,11 @@ void main() {
 		//pull 16 elmos forward in Z:
 		gl_Position.z = (gl_Position.z) - 128.0 / (gl_Position.w); // send 16 elmos forward in Z
 	} else {
-		gl_Position = mmDrawViewProj * vec4(circleWorldPos.xyz, 1.0);
+		vec4 ndcxy = mmDrawViewProj * vec4(circleWorldPos.xyz, 1.0);
+		if (flipMiniMap == 1) {
+			ndcxy.xy = -ndcxy.xy;
+		}
+		gl_Position = ndcxy;
 	}
 
 	//lets blend the alpha here, and save work in FS:

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -133,6 +133,7 @@ local vtoldamagetag = Game.armorTypes['vtol']
 local defaultdamagetag = Game.armorTypes['default']
 
 -- globals
+local getMiniMapFlipped = VFS.Include("luaui/Include/minimap_utils.lua").getMiniMapFlipped
 local selUnitCount = 0
 local selBuilderCount = 0 -- we need builder count separately
 local shifted = false
@@ -1074,6 +1075,7 @@ function widget:DrawWorld(inMiniMap)
 			attackRangeShader:SetUniform("selBuilderCount", selBuilderCount)
 			attackRangeShader:SetUniform("drawMode", 0.0)
 			attackRangeShader:SetUniform("inMiniMap", inMiniMap and 1.0 or 0.0)
+			attackRangeShader:SetUniformInt("flipMiniMap", getMiniMapFlipped() and 1 or 0)
 			attackRangeShader:SetUniform("drawAlpha", colorConfig.fill_alpha)
 			attackRangeShader:SetUniform("fadeDistOffset", colorConfig.outer_fade_height_difference)
 


### PR DESCRIPTION
### Work done

- Fixes drawing of unified range rings with flipped minimap.

### Remarks

- Will have to be ported to https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4890 when that's merged for 90 degree steps.

### Screenshots

![rangesflip](https://github.com/user-attachments/assets/20bb956a-bdfb-4824-bc08-ae9e25293ea1)
