### PR TITLE
Tweaks attack defense ranges v2.1

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -274,17 +274,17 @@ local function initializeUnitDefRing(unitDefID)
 		local baseKey = weaponTypeMap[ weaponType ]      -- e.g. "ground", "AA", etc.
 		local cfgKey  = baseKey
 
-		-- 1) DGun override (takes absolute precedence) 
-    if weaponDef.type == "DGun" then
-        cfgKey = baseKey .. "_dgun"
-        Spring.Echo("[AttackRange] using DGun style for:", weaponDef.name)
-    -- 2) then water override (as before)
-    elseif weaponDef.waterWeapon
-        or (weaponDef.customParams and weaponDef.customParams.waterweapon == "true")
-    then
-        cfgKey = baseKey .. "_water"
-        Spring.Echo("[AttackRange] using water style for:", weaponDef.name)
-    end
+		-- 1) DGun override
+		if weaponDef.type == "DGun" then
+			cfgKey = baseKey .. "_dgun"
+			--Spring.Echo("[AttackRange] using DGun style for:", weaponDef.name)
+		-- 2) then water override
+		elseif weaponDef.waterWeapon
+			or (weaponDef.customParams and weaponDef.customParams.waterweapon == "true")
+		then
+			cfgKey = baseKey .. "_water"
+			--Spring.Echo("[AttackRange] using water style for:", weaponDef.name)
+		end
 
     -- safety fallback if you typo the key
     if not colorConfig[cfgKey] then

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -73,7 +73,7 @@ local colorConfig = {
 	drawInnerRings = true, -- whether to draw inner, per attack rings (very cheap)
 
 	externalalpha = 0.75, -- alpha of outer rings
-	internalalpha = 0.15, -- alpha of inner rings
+	internalalpha = 0.12, -- alpha of inner rings
 	fill_alpha = 0.12, -- this is the solid color in the middle of the stencil
 	outer_fade_height_difference = 2500, -- this is the height difference at which the outer ring starts to fade out compared to inner rings
 	ground = {
@@ -121,6 +121,39 @@ local colorConfig = {
 		minimapexternallinethickness = 2.0,
 		minimapinternallinethickness = 0.5,
 	},
+	-- ground_water = {
+	-- 	color       = { 0.2, 0.5, 1.0, 0.60 },  -- RGBA blue
+	-- 	fadeparams  = colorConfig.ground.fadeparams,
+	-- 	groupselectionfadescale    = colorConfig.ground.groupselectionfadescale,
+	-- 	externallinethickness      = colorConfig.ground.externallinethickness,
+	-- 	internallinethickness      = colorConfig.ground.internallinethickness,
+	-- 	minimapexternallinethickness = colorConfig.ground.minimapexternallinethickness,
+	-- 	minimapinternallinethickness = colorConfig.ground.minimapinternallinethickness,
+	-- },
+}
+
+-- Sub WEAPON types:
+
+-- DGUN
+colorConfig.ground_dgun = {
+    color                       = colorConfig.ground.color,       -- reuse ground colour
+    fadeparams                  = colorConfig.ground.fadeparams,  -- same fade curve
+    groupselectionfadescale     = colorConfig.ground.groupselectionfadescale,
+    externallinethickness      = colorConfig.ground.externallinethickness,
+	internallinethickness      = colorConfig.ground.internallinethickness,
+	minimapexternallinethickness = colorConfig.ground.minimapexternallinethickness,
+	minimapinternallinethickness = colorConfig.ground.minimapinternallinethickness,
+}
+
+-- WATER WEAPONS
+colorConfig.ground_water = {
+  color                      = {0.48, 0.67, 1.0, 0.30},
+  fadeparams                 = colorConfig.ground.fadeparams,
+  groupselectionfadescale    = colorConfig.ground.groupselectionfadescale,
+  externallinethickness      = colorConfig.ground.externallinethickness,
+  internallinethickness      = colorConfig.ground.internallinethickness,
+  minimapexternallinethickness = colorConfig.ground.minimapexternallinethickness,
+  minimapinternallinethickness = colorConfig.ground.minimapinternallinethickness,
 }
 
 ----------------------------------
@@ -216,6 +249,12 @@ local function initializeUnitDefRing(unitDefID)
 		local weaponDefID = weapons[weaponNum].weaponDef
 		local weaponDef = WeaponDefs[weaponDefID]
 
+		-- ── your debug & color‐pick here ──
+    -- Spring.Echo(string.format(
+    --   "[AttackRange] %s.waterweapon = %s",
+    --   weaponDef.name, tostring(weaponDef.waterweapon)
+    -- ))
+
 		local range = weaponDef.range
 		local dps = 0
 		local weaponType = unitDefRings[unitDefID]['weapons'][weaponNum]
@@ -228,8 +267,32 @@ local function initializeUnitDefRing(unitDefID)
 				damage = weaponDef.damages[defaultdamagetag]
 			end
 			dps = damage * (weaponDef.salvoSize or 1) / (weaponDef.reload or 1)
-			local color = colorConfig[weaponTypeMap[weaponType]].color
-			local fadeparams = colorConfig[weaponTypeMap[weaponType]].fadeparams
+			-- local color = colorConfig[weaponTypeMap[weaponType]].color
+			-- local fadeparams = colorConfig[weaponTypeMap[weaponType]].fadeparams
+
+			-- after you have `weaponDef` and `weaponType`…
+		local baseKey = weaponTypeMap[ weaponType ]      -- e.g. "ground", "AA", etc.
+		local cfgKey  = baseKey
+
+		-- 1) DGun override (takes absolute precedence) 
+    if weaponDef.type == "DGun" then
+        cfgKey = baseKey .. "_dgun"
+        Spring.Echo("[AttackRange] using DGun style for:", weaponDef.name)
+    -- 2) then water override (as before)
+    elseif weaponDef.waterWeapon
+        or (weaponDef.customParams and weaponDef.customParams.waterweapon == "true")
+    then
+        cfgKey = baseKey .. "_water"
+        Spring.Echo("[AttackRange] using water style for:", weaponDef.name)
+    end
+
+    -- safety fallback if you typo the key
+    if not colorConfig[cfgKey] then
+        cfgKey = baseKey
+    end
+
+    local color      = colorConfig[cfgKey].color
+    local fadeparams = colorConfig[cfgKey].fadeparams
 
 			local isCylinder = 0 
 			if (weaponDef.cylinderTargeting)  and (weaponDef.cylinderTargeting > 0.0) then
@@ -238,7 +301,7 @@ local function initializeUnitDefRing(unitDefID)
 			local isDgun = (weaponDef.type == "DGun") and 1 or 0
 
 			local wName = weaponDef.name
-			if (weaponDef.type == "AircraftBomb") or (wName:find("bogus")) or weaponDef.customParams.bogus then
+			if (weaponDef.type == "AircraftBomb") or (wName:find("bogus")) or weaponDef.customParams.bogus or weaponDef.customParams.norangering then
 				range = 0
 			end
 			--Spring.Echo("weaponNum: ".. weaponNum ..", name: " .. tableToString(weaponDef.name))

--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -204,7 +204,7 @@ local function initializeUnitDefRing(unitDefID)
 	        local cfg    = colorConfig[baseKey]
 	        if (baseKey == "ground") and (weaponDef.waterWeapon) then
 	            cfg = colorConfig.ground_water
-	            Spring.Echo("[DefenseRange] using water colour for:", weaponDef.name)
+	            --Spring.Echo("[DefenseRange] using water colour for:", weaponDef.name)
 	        end
 	        local color      = cfg.color
 	        local fadeparams = cfg.fadeparams

--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -81,7 +81,7 @@ local colorConfig = { --An array of R, G, B, Alpha
     distanceScaleEnd = 8000, -- Linewidth becomes 50% above this camera height
 	drawAllyCategoryBuildQueue = true,
     ground = {
-        color = {1.3, 0.18, 0.04, 0.74},
+        color = {1.3, 0.18, 0.04, 0.70},
         fadeparams = { 2200, 5500, 1.0, 0.0}, -- FadeStart, FadeEnd, StartAlpha, EndAlpha
         externallinethickness = 5.0, -- can be 2 or 3 if we can distiquish its looks from attackranges
         internallinethickness = 3.0, -- can be 1.8 if we can distiquish its looks from attackranges
@@ -92,7 +92,7 @@ local colorConfig = { --An array of R, G, B, Alpha
 		internalalpha = 0.10, -- alpha of inner rings
     },
     air = {
-        color = {0.8, 0.44, 1.6, 0.74},
+        color = {0.8, 0.44, 1.6, 0.70},
         fadeparams = { 3200, 8000, 0.4, 0.0}, -- FadeStart, FadeEnd, StartAlpha, EndAlpha
         externallinethickness = 5.0,
         internallinethickness = 3.0,
@@ -103,7 +103,7 @@ local colorConfig = { --An array of R, G, B, Alpha
 		internalalpha = 0.10, -- alpha of inner rings
     },
     nuke = {
-        color = {1.05, 1.0, 0.2, 0.76},
+        color = {1.05, 1.0, 0.2, 0.72},
         fadeparams = {6000, 3000, 0.6, 0.0}, -- FadeStart, FadeEnd, StartAlpha, EndAlpha
         externallinethickness = 5.0,
         internallinethickness = 2.0,
@@ -114,7 +114,7 @@ local colorConfig = { --An array of R, G, B, Alpha
 		internalalpha = 0.15, -- alpha of inner rings
     },
     cannon = {
-        color = {1.3, 0.18, 0.04, 0.74}, --orange 1.2, 0.55, 0.08, 0.74
+        color = {1.3, 0.18, 0.04, 0.70}, --orange 1.2, 0.55, 0.08, 0.74
         fadeparams = {2000, 8000, 0.8, 0.0}, -- FadeStart, FadeEnd, StartAlpha, EndAlpha
         externallinethickness = 5.0,
         internallinethickness = 2.5,
@@ -125,7 +125,7 @@ local colorConfig = { --An array of R, G, B, Alpha
 		internalalpha = 0.10, -- alpha of inner rings
     },
 	lrpc = {
-        color = {1.3, 0.18, 0.04, 0.7},
+        color = {1.3, 0.18, 0.04, 0.68},
         fadeparams = {9000, 6000, 0.8, 0.0}, -- FadeStart, FadeEnd, StartAlpha, EndAlpha
         externallinethickness = 3.0,
         internallinethickness = 1.5,
@@ -135,6 +135,11 @@ local colorConfig = { --An array of R, G, B, Alpha
     },
 }
 
+-- add a “water” variant so we can stay in the ground-stencil pass but colour blue
+colorConfig.ground_water = {
+    color      = {0.48, 0.67, 1.0, 0.30},      -- nice RGBA blue
+    fadeparams = colorConfig.ground.fadeparams, -- reuse the same fade curve
+}
 
 --- Camera Height based line shrinkage:
 
@@ -191,8 +196,18 @@ local function initializeUnitDefRing(unitDefID)
 				range = weaponDef.coverageRange
 				--Spring.Echo("init antinuke", range)
 			end
-			local color = colorConfig[weaponType].color
-			local fadeparams =  colorConfig[weaponType].fadeparams
+			-- local color = colorConfig[weaponType].color
+			-- local fadeparams =  colorConfig[weaponType].fadeparams
+
+			-- pick blue for underwater weapons, otherwise fall back to normal
+	        local baseKey = weaponType
+	        local cfg    = colorConfig[baseKey]
+	        if (baseKey == "ground") and (weaponDef.waterWeapon) then
+	            cfg = colorConfig.ground_water
+	            Spring.Echo("[DefenseRange] using water colour for:", weaponDef.name)
+	        end
+	        local color      = cfg.color
+	        local fadeparams = cfg.fadeparams
 
 			local isCylinder = 0
 			if (weaponDef.cylinderTargeting)  and (weaponDef.cylinderTargeting > 0.0) then
@@ -227,7 +242,8 @@ local function initUnitList()
 		['armfhlt'] = { weapons = { 'ground' } },  --floating hlt
 		['armfrt'] = { weapons = { 'air' } },  --floating rocket laucher
 		['armfflak'] = { weapons = { 'air' } },  --floating flak AA
-		['armatl'] = { weapons = { 'ground' } },  --adv torpedo launcher
+		['armatl'] = { weapons = { 'ground' } }, --adv torpedo launcher
+		['armkraken'] = { weapons = { 'cannon' } }, --adv torpedo launcher  
 
 		['armamb'] = { weapons = { 'cannon' } }, --ambusher 'cannon'
 		['armpb'] = { weapons = { 'ground' } }, --pitbull 'cannon'
@@ -259,6 +275,7 @@ local function initUnitList()
 		['coratl'] = { weapons = { 'ground' } }, --T2 torp launcher
 		['corfrt'] = { weapons = { 'air' } }, --floating rocket laucher
 		['corenaa'] = { weapons = { 'air' } }, --floating flak AA
+		['corfdoom'] = { weapons = { [1] = 'cannon' } },
 
 		['cortoast'] = { weapons = { 'cannon' } },
 		['corvipe'] = { weapons = { 'ground' } },
@@ -281,8 +298,9 @@ local function initUnitList()
 		['legabm'] = { weapons = { 'nuke' } }, --antinuke
 		['legrampart'] = { weapons = { 'nuke', 'ground' } }, --rampart
 		['leglht'] = { weapons = { 'ground' } }, --llt
-		['legcluster'] = { weapons = { 'ground' } }, --short range arty T1
-		['legacluster'] = { weapons = { 'ground' } }, --T2 arty
+		['legcluster'] = { weapons = { 'cannon' } }, --short range arty T1
+		['legacluster'] = { weapons = { 'cannon' } }, --T2 arty
+		['legdtr'] = { weapons = { 'ground' } }, --dragons jaw
 		['leghive'] = { weapons = { 'ground' } }, --Drone-defense
 		['legmg'] = { weapons = { 'ground' } }, --ground-AA MG defense
 		['legbombard'] = { weapons = { 'ground' } }, --Grenadier defense
@@ -791,6 +809,27 @@ function widget:Update(dt)
 	--if spec then
 	--	return
 	--end
+
+-- detect if our “myAllyTeam” has changed (e.g. a spec following a different player)
+   local currentAllyTeam = Spring.GetMyAllyTeamID()
+   if currentAllyTeam ~= myAllyTeam then
+     myAllyTeam = currentAllyTeam
+     -- clear out all the old rings
+     defenses, enemydefenses, defensePosHash, mobileAntiUnits = {}, {}, {}, {}
+     for _, ivt in pairs(defenseRangeVAOs) do
+       clearInstanceTable(ivt)
+     end
+     -- rebuild from whatever visibleUnits API you have
+     local extVisibleUnits = (WG.unittrackerapi and WG.unittrackerapi.visibleUnits)
+                           or (function()
+                                local t = {}
+                                for _, uid in ipairs(Spring.GetAllUnits()) do
+                                  t[uid] = spGetUnitDefID(uid)
+                                end
+                                return t
+                              end)()
+     widget:VisibleUnitsChanged(extVisibleUnits, nil)
+   end
 
 	if gameFrame >= lastUpdatedGameFrame + antiupdaterate then
 		lastUpdatedGameFrame = gameFrame

--- a/units/ArmAircraft/T2/armlance.lua
+++ b/units/ArmAircraft/T2/armlance.lua
@@ -120,6 +120,7 @@ return {
 				customparams = {
 					speceffect = "torpwaterpen",
 					when = "ypos<0",
+					norangering = 1,
 				},
 				damage = {
 					default = 375,

--- a/units/ArmBuildings/LandDefenceOffence/armamb.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armamb.lua
@@ -141,6 +141,7 @@ return {
 				customparams = {
 					exclude_preaim = true,
 					smart_priority = true,
+					norangering = 1,
 				}
 			},
 			armamb_gun_high = {
@@ -205,6 +206,7 @@ return {
 				customparams = {
 					exclude_preaim = true,
 					smart_trajectory_checker = true,
+					norangering = 1,
 				}
 			},
 		},

--- a/units/ArmBuildings/LandDefenceOffence/armguard.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armguard.lua
@@ -134,6 +134,7 @@ return {
 				customparams = {
 					exclude_preaim = true,
 					smart_priority = true,
+					norangering = 1,
 				}
 			},
 			plasma_high = {
@@ -196,7 +197,8 @@ return {
 				},
 				customparams = {
 					exclude_preaim = true,
-					smart_trajectory_checker = true
+					smart_trajectory_checker = true,
+					bogus = 1,
 				}
 			},
 		},

--- a/units/ArmSeaplanes/armseap.lua
+++ b/units/ArmSeaplanes/armseap.lua
@@ -113,6 +113,7 @@ return {
 				customparams = {
 					speceffect = "torpwaterpen",
 					when = "ypos<0",
+					noattackrangearc = 1,
 				},
 				damage = {
 					commanders = 150,

--- a/units/ArmShips/T2/armaas.lua
+++ b/units/ArmShips/T2/armaas.lua
@@ -211,6 +211,9 @@ return {
 				weapontimer = 1,
 				weapontype = "Cannon",
 				weaponvelocity = 1300,
+				customparams = {
+					norangering = 1,
+				},
 				damage = {
 					vtol = 200,
 				},

--- a/units/ArmShips/T2/armcrus.lua
+++ b/units/ArmShips/T2/armcrus.lua
@@ -198,6 +198,9 @@ return {
 					default = 75,
 					vtol = 8,
 				},
+				customparams = {
+					norangering = 1,
+				},
 			},
 		},
 		weapons = {

--- a/units/ArmShips/T2/armepoch.lua
+++ b/units/ArmShips/T2/armepoch.lua
@@ -265,7 +265,7 @@ return {
 					vtol = 65,
 				},
 				customparams = {
-					noattackrangearc= 1,
+					noattackrangearc = 1,
 				},
 			},
 		},

--- a/units/ArmShips/armdecade.lua
+++ b/units/ArmShips/armdecade.lua
@@ -132,6 +132,9 @@ return {
 					default = 9,
 					vtol = 2,
 				},
+				customparams = {
+					noattackrangearc= 1,
+				},
 			},
 		},
 		weapons = {

--- a/units/CorAircraft/T2/cortitan.lua
+++ b/units/CorAircraft/T2/cortitan.lua
@@ -121,6 +121,7 @@ return {
 				customparams = {
 					speceffect = "torpwaterpen",
 					when = "ypos<0",
+					norangering = 1,
 				},
 				damage = {
 					default = 1200,

--- a/units/CorBuildings/SeaDefence/corfdoom.lua
+++ b/units/CorBuildings/SeaDefence/corfdoom.lua
@@ -157,6 +157,9 @@ return {
 				turret = true,
 				weapontype = "BeamLaser",
 				weaponvelocity = 900,
+				customparams = {
+					norangering = 1,
+				},
 				damage = {
 					default = 231,
 					vtol = 52,
@@ -194,6 +197,9 @@ return {
 				turret = true,
 				weapontype = "BeamLaser",
 				weaponvelocity = 2250,
+				customparams = {
+					norangering = 1,
+				},
 				damage = {
 					default = 40,
 				},

--- a/units/CorSeaplanes/corseap.lua
+++ b/units/CorSeaplanes/corseap.lua
@@ -113,6 +113,7 @@ return {
 				customparams = {
 					speceffect = "torpwaterpen",
 					when = "ypos<0",
+					noattackrangearc = 1,
 				},
 				damage = {
 					default = 342,

--- a/units/CorShips/T2/corarch.lua
+++ b/units/CorShips/T2/corarch.lua
@@ -216,6 +216,9 @@ return {
 				weapontimer = 1,
 				weapontype = "Cannon",
 				weaponvelocity = 1550,
+				customparams = {
+					norangering = 1,
+				},
 				damage = {
 					vtol = 200,
 				},

--- a/units/CorShips/T2/corcrus.lua
+++ b/units/CorShips/T2/corcrus.lua
@@ -138,6 +138,9 @@ return {
 					default = 75,
 					vtol = 15,
 				},
+				customparams = {
+					norangering = 1,
+				},
 			},
 			advdepthcharge = {
 				areaofeffect = 32,

--- a/units/Legion/Air/T2 Air/legatorpbomber.lua
+++ b/units/Legion/Air/T2 Air/legatorpbomber.lua
@@ -121,6 +121,7 @@ return {
 				customparams = {
 					speceffect = "torpwaterpen",
 					when = "ypos<0",
+					norangering = 1,
 				},
 				damage = {
 					default = 750,

--- a/units/armcom.lua
+++ b/units/armcom.lua
@@ -237,6 +237,9 @@ return {
 				waterweapon = true,
 				weapontype = "BeamLaser",
 				weaponvelocity = 900,
+				customparams = {
+					norangering= 1,
+				},
 				damage = {
 					default = 200,
 					subs = 100,

--- a/units/corcom.lua
+++ b/units/corcom.lua
@@ -238,6 +238,9 @@ return {
 				waterweapon = true,
 				weapontype = "BeamLaser",
 				weaponvelocity = 900,
+				customparams = {
+					norangering= 1,
+				},
 				damage = {
 					default = 200,
 					subs = 100,


### PR DESCRIPTION
filter out more multieweapons
filter out more arcs (where not needed)
added waterweapon (torpedoes/depthcharges) with blue range ring
removed some double range rings for units/defenses
fixed spectator swap change allyteam preset for defense-ranges (ally/enemy)
Should all work, but some more tests could be nice.