### PR TITLE
fix blueprints

### DIFF
--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -1052,7 +1052,7 @@ local function serializeBlueprint(blueprint)
 end
 
 ---@param serializedBlueprint SerializedBlueprint
----@return Blueprint
+---@return Blueprint | nil
 local function deserializeBlueprint(serializedBlueprint)
 	local result = table.copy(serializedBlueprint)
 	result.units = table.map(serializedBlueprint.units, function(serializedBlueprintUnit)
@@ -1066,6 +1066,9 @@ local function deserializeBlueprint(serializedBlueprint)
 		end
 	end)
 
+	if #result.units == 0 then -- empty blueprint
+		return
+	end
 	postProcessBlueprint(result)
 
 	return result


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Fixes `Error: Error in Initialize(): [string LuaUI/Widgets/api_blueprint.lua]:314: attempt to perform arithmetic on local xMax (a nil value)` by ignoring blueprints that are empty.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Play around with legion on and off.
<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
