### PR TITLE
Makes cloak hold fire immediately

### DIFF
--- a/luaui/Widgets/cmd_holdfire_fix.lua
+++ b/luaui/Widgets/cmd_holdfire_fix.lua
@@ -1,4 +1,3 @@
-
 local widget = widget ---@type Widget
 
 function widget:GetInfo()
@@ -17,6 +16,7 @@ local CMD_FIRE_STATE = CMD.FIRE_STATE
 local CMD_INSERT = CMD.INSERT
 local CMD_STOP = CMD.STOP
 local spGiveOrder = Spring.GiveOrder
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local gameStarted
 
 function maybeRemoveSelf()
@@ -43,5 +43,11 @@ end
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	if cmdID == CMD_FIRE_STATE and cmdParams[1] == 0 then
 		spGiveOrder(CMD_INSERT, {0, CMD_STOP, 0}, {"alt"})
+	end
+end
+
+function widget:UnitCommandNotify(unitID, cmdID, cmdParams, cmdOpts)
+	if cmdID == CMD_FIRE_STATE and cmdParams[1] == 0 then
+		spGiveOrderToUnit(unitID, CMD_INSERT, {0, CMD_STOP, 0}, {"alt"})
 	end
 end

--- a/luaui/Widgets/unit_cloak_firestate.lua
+++ b/luaui/Widgets/unit_cloak_firestate.lua
@@ -11,7 +11,8 @@ function widget:GetInfo()
 		date      = "Feb 14, 2010",
 		license   = "GNU GPL, v2 or later",
 		layer     = -1,
-		enabled   = true
+		enabled   = true,
+		handler   = true,-- So it can notify other widgets
 	}
 end
 
@@ -23,7 +24,6 @@ VFS.Include('luarules/configs/customcmds.h.lua')
 local GiveOrderToUnit   = Spring.GiveOrderToUnit
 local GetUnitStates     = Spring.GetUnitStates
 local CMD_CLOAK         = CMD_WANT_CLOAK
-
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 local myTeam = Spring.GetMyTeamID()
@@ -58,6 +58,19 @@ end
 
 local decloakFireState = {} --stores the desired fire state when decloaked of each unitID
 
+local function GiveNotifyingOrderToUnit(uID, cmdID, cmdParams, cmdOpts)
+	-- Other widgets interact with the fire state, so we need to notify them when issuing the order. This affects the holdfire fix and when cloak "kicks in".
+	for _, w in ipairs(widgetHandler.widgets) do
+		if w.UnitCommandNotify and w:UnitCommandNotify(uID, cmdID, cmdParams, cmdOpts) then
+			-- Per Spring, if Notify returns true, it deletes the command.
+			return
+		end
+	end
+
+	GiveOrderToUnit(uID, cmdID, cmdParams, cmdOpts.coded)
+	return
+end
+
 function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts, cmdTag, playerID, fromSynced, fromLua)
 	if teamID ~= myTeam then return end
 
@@ -67,12 +80,12 @@ function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts
 		if cmdParams[1] == 1 then -- store current fire state and cloak
 			decloakFireState[unitID] = select(1, GetUnitStates(unitID, false)) --store last state
 			if decloakFireState[unitID] ~= 0 then
-				GiveOrderToUnit(unitID, CMD.FIRE_STATE, { 0 }, 0)
+				GiveNotifyingOrderToUnit(unitID, CMD.FIRE_STATE, { 0 }, {})
 			end
 		else -- decloak and restore previous fire state
 			if select(1, GetUnitStates(unitID, false)) == 0 then
 				local targetState = decloakFireState[unitID] or 0 -- default to hold fire if no cached state is found
-				GiveOrderToUnit(unitID, CMD.FIRE_STATE, { targetState }, 0) --revert to last state
+				GiveNotifyingOrderToUnit(unitID, CMD.FIRE_STATE, { targetState }, {}) --revert to last state
 			end
 			decloakFireState[unitID] = nil
 		end


### PR DESCRIPTION
Changes:
- Notifies other widgets when the cloak widget calls hold fire.
- This calls the hold fire fix widget which issues a stop firing command to the unit. 

Previously:
Hitting cloak doesn't cause the unit to stop firing immediately. It'll arbitrarily choose to fire one, two or three more times before it starts cloaking. 

Tested locally in-game and verified via Spring.Echo that it does now hold fire across Commander, Gremlin, etc. 
