### PR TITLE
Revert recent blueprint changes

### DIFF
--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -304,7 +304,7 @@ local function getUnitsBounds(units)
 		{}
 	)
 
-	return r.xMin or 0, r.xMax or 0, r.zMin or 0, r.zMax or 0
+	return r.xMin, r.xMax, r.zMin, r.zMax
 end
 
 local function getBlueprintDimensions(blueprint, facing)

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -325,9 +325,7 @@ local function postProcessBlueprint(bp)
 	-- precompute some useful information
 	bp.dimensions = pack(WG["api_blueprint"].getBlueprintDimensions(bp))
 	bp.floatOnWater = table.any(bp.units, function(u)
-		if UnitDefs[u.unitDefID] then
-			return UnitDefs[u.unitDefID].floatOnWater
-		end
+		return UnitDefs[u.unitDefID].floatOnWater
 	end)
 	bp.minBuildingDimension = table.reduce(bp.units, function(acc, u)
 		local w, h = WG["api_blueprint"].getBuildingDimensions(
@@ -1040,13 +1038,11 @@ local function serializeBlueprint(blueprint)
 		facing = blueprint.facing,
 		ordered = blueprint.ordered,
 		units = table.map(blueprint.units, function(blueprintUnit)
-			if UnitDefs[blueprintUnit.unitDefID] then
-				return {
-					unitName = UnitDefs[blueprintUnit.unitDefID].name,
-					position = blueprintUnit.position,
-					facing = blueprintUnit.facing
-				}
-			end
+			return {
+				unitName = UnitDefs[blueprintUnit.unitDefID].name,
+				position = blueprintUnit.position,
+				facing = blueprintUnit.facing
+			}
 		end),
 	}
 end
@@ -1056,14 +1052,12 @@ end
 local function deserializeBlueprint(serializedBlueprint)
 	local result = table.copy(serializedBlueprint)
 	result.units = table.map(serializedBlueprint.units, function(serializedBlueprintUnit)
-		if UnitDefNames[serializedBlueprintUnit.unitName] then
-			return {
-				blueprintUnitID = nextBlueprintUnitID(),
-				unitDefID = UnitDefNames[serializedBlueprintUnit.unitName].id,
-				position = serializedBlueprintUnit.position,
-				facing = serializedBlueprintUnit.facing
-			}
-		end
+		return {
+			blueprintUnitID = nextBlueprintUnitID(),
+			unitDefID = UnitDefNames[serializedBlueprintUnit.unitName].id,
+			position = serializedBlueprintUnit.position,
+			facing = serializedBlueprintUnit.facing
+		}
 	end)
 
 	postProcessBlueprint(result)


### PR DESCRIPTION
### Work done

- Revert some recent blueprint changes, since they working around the same problem https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3861 is fixing

### Remarks

- Tested and recent commits don't really fix the issue, still have nil errors (luckily, since otherwise legion blueprints would be wiped out)
- With those changes the legion blueprints will incorrectly be stored without the units after a game with no legion is played (where possibly other blueprints are saved)