### PR TITLE
fx_watersplash: `water_splash` customParam (+fixes widget crash on missing units)

### DIFF
--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -42,7 +42,7 @@ local weaponAoe = {}
 local weaponNoSplash = {}
 for weaponDefID, def in pairs(WeaponDefs) do
 	weaponAoe[weaponDefID] = def.damageAreaOfEffect
-	if nonexplosiveWeapons[def.type] or def.customParams.no_water_splash then
+	if nonexplosiveWeapons[def.type] or def.customParams.water_splash == 0 then
 		weaponNoSplash[weaponDefID] = true
 	end
 	-- add damage bonus, since LRPC dont have a lot of AoE, but do pack a punch

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -28,14 +28,6 @@ local nonexplosiveWeapons = {
 	LightningCannon = true,
 }
 
-local COR_SEAADVBOMB = WeaponDefNames['corsb_cor_seaadvbomb'].id --corsb gets a special ceg with less particles, because it has lots of bouncing bombs
-local ARM_JUNO = WeaponDefNames['armjuno_juno_pulse'].id --juno can explode on water
-local COR_JUNO = WeaponDefNames['corjuno_juno_pulse'].id --juno can explode on water
-local COR_JUNO = WeaponDefNames['legjuno_juno_pulse'].id --juno can explode on water
-local COR_TRON = WeaponDefNames['cortron_cortron_weapon'].id
-local LEG_PHOENIX = WeaponDefNames['legphoenix_legphtarg'] and WeaponDefNames['legphoenix_legphtarg'].id --targetting weapon aircraftbomb
--- maybe need addition of scav version or better solution
-
 local splashCEG1 = "splash-tiny"
 local splashCEG2 = "splash-small"
 local splashCEG3 = "splash-medium"
@@ -46,11 +38,13 @@ local splashCEG7 = "splash-nuke"
 local splashCEG8 = "splash-nukexl"
 
 
-local weaponType = {}
 local weaponAoe = {}
+local weaponNoSplash = {}
 for weaponDefID, def in pairs(WeaponDefs) do
-	weaponType[weaponDefID] = def.type
 	weaponAoe[weaponDefID] = def.damageAreaOfEffect
+	if nonexplosiveWeapons[def.type] or def.customParams.no_water_splash then
+		weaponNoSplash[weaponDefID] = true
+	end
 	-- add damage bonus, since LRPC dont have a lot of AoE, but do pack a punch
 	if def.type == 'DGun' then
 		weaponAoe[weaponDefID] = weaponAoe[weaponDefID] + 80
@@ -74,7 +68,7 @@ end
 function gadget:Explosion(weaponID, px, py, pz, ownerID)
 	if Spring.GetGroundHeight(px,pz) < 0 then
 		local aoe = weaponAoe[weaponID] / 2
-		if not nonexplosiveWeapons[weaponType[weaponID]]  and abs(py) <= aoe and (not GetGroundBlocked(px, pz)) and weaponID ~= COR_SEAADVBOMB and weaponID ~= ARM_JUNO and weaponID ~= COR_JUNO and weaponID ~= LEG_PHOENIX then
+		if not weaponNoSplash[weaponID] and abs(py) <= aoe and (not GetGroundBlocked(px, pz)) then
 			if aoe >= 6 and aoe < 12 then
 				Spring.SpawnCEG(splashCEG1, px, 0, pz)
 			elseif  aoe >= 12 and aoe < 24 then

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -108,8 +108,8 @@ end
 function gadget:Initialize()
 	local minHeight, maxHeight = Spring.GetGroundExtremes()
 	if minHeight < 100 then
-		for _,wDef in pairs(WeaponDefs) do
-			if wDef.damageAreaOfEffect ~= nil and wDef.damageAreaOfEffect >8 and (not nonexplosiveWeapons[wDef.type]) then
+		for wDefID, wDef in pairs(WeaponDefs) do
+			if wDef.damageAreaOfEffect ~= nil and wDef.damageAreaOfEffect > 8 and (not weaponNoSplash[wDefID]) then
 				Script.SetWatchExplosion(wDef.id, true)
 			end
 		end

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -28,6 +28,9 @@ local nonexplosiveWeapons = {
 	LightningCannon = true,
 }
 
+local cortronWeaponDef = WeaponDefNames['cortron_cortron_weapon']
+local COR_TRON = cortronWeaponDef and cortronWeaponDef.id
+
 local splashCEG1 = "splash-tiny"
 local splashCEG2 = "splash-small"
 local splashCEG3 = "splash-medium"

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -42,7 +42,11 @@ local weaponAoe = {}
 local weaponNoSplash = {}
 for weaponDefID, def in pairs(WeaponDefs) do
 	weaponAoe[weaponDefID] = def.damageAreaOfEffect
-	if nonexplosiveWeapons[def.type] or def.customParams.water_splash == 0 then
+
+	local waterSplash = def.customParams.water_splash and tonumber(def.customParams.water_splash)
+	waterSplash = waterSplash or (nonexplosiveWeapons[def.type] and 0 or 1)
+
+	if waterSplash == 0 then
 		weaponNoSplash[weaponDefID] = true
 	end
 	-- add damage bonus, since LRPC dont have a lot of AoE, but do pack a punch

--- a/units/ArmBuildings/LandDefenceOffence/armjuno.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armjuno.lua
@@ -143,6 +143,7 @@ return {
 				customparams = {
 					nofire = true,
 					stockpilelimit = 20,
+					no_water_splash = 1, -- juno can explode on water
 				},
 				damage = {
 					default = 1,

--- a/units/ArmBuildings/LandDefenceOffence/armjuno.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armjuno.lua
@@ -143,7 +143,7 @@ return {
 				customparams = {
 					nofire = true,
 					stockpilelimit = 20,
-					no_water_splash = 1, -- juno can explode on water
+					water_splash = 0, -- juno can explode on water
 				},
 				damage = {
 					default = 1,

--- a/units/CorBuildings/LandDefenceOffence/corjuno.lua
+++ b/units/CorBuildings/LandDefenceOffence/corjuno.lua
@@ -144,6 +144,7 @@ return {
 					stockpilelimit = 20,
 					lups_noshockwave = 1,
 					nofire = true,
+					no_water_splash = 1, -- juno can explode on water
 				},
 				damage = {
 					default = 1,

--- a/units/CorBuildings/LandDefenceOffence/corjuno.lua
+++ b/units/CorBuildings/LandDefenceOffence/corjuno.lua
@@ -144,7 +144,7 @@ return {
 					stockpilelimit = 20,
 					lups_noshockwave = 1,
 					nofire = true,
-					no_water_splash = 1, -- juno can explode on water
+					water_splash = 0, -- juno can explode on water
 				},
 				damage = {
 					default = 1,

--- a/units/CorBuildings/LandDefenceOffence/cortron.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortron.lua
@@ -142,7 +142,6 @@ return {
 				weapontype = "StarburstLauncher",
 				weaponvelocity = 1200,
 				customparams = {
-					water_splash = 0,
 					stockpilelimit = 10,
 				},
 				damage = {

--- a/units/CorBuildings/LandDefenceOffence/cortron.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortron.lua
@@ -142,6 +142,7 @@ return {
 				weapontype = "StarburstLauncher",
 				weaponvelocity = 1200,
 				customparams = {
+					no_water_splash = 1,
 					stockpilelimit = 10,
 				},
 				damage = {

--- a/units/CorBuildings/LandDefenceOffence/cortron.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortron.lua
@@ -142,7 +142,7 @@ return {
 				weapontype = "StarburstLauncher",
 				weaponvelocity = 1200,
 				customparams = {
-					no_water_splash = 1,
+					water_splash = 0,
 					stockpilelimit = 10,
 				},
 				damage = {

--- a/units/CorSeaplanes/corsb.lua
+++ b/units/CorSeaplanes/corsb.lua
@@ -119,6 +119,9 @@ return {
 				damage = {
 					default = 50,
 				},
+				customParams = {
+					no_water_splash = 1, -- corsb gets a special ceg with less particles, because it has lots of bouncing bombs
+				},
 			},
 		},
 		weapons = {

--- a/units/CorSeaplanes/corsb.lua
+++ b/units/CorSeaplanes/corsb.lua
@@ -120,7 +120,7 @@ return {
 					default = 50,
 				},
 				customParams = {
-					no_water_splash = 1, -- corsb gets a special ceg with less particles, because it has lots of bouncing bombs
+					water_splash = 0, -- corsb gets a special ceg with less particles, because it has lots of bouncing bombs
 				},
 			},
 		},

--- a/units/Legion/Air/T2 Air/legphoenix.lua
+++ b/units/Legion/Air/T2 Air/legphoenix.lua
@@ -183,7 +183,7 @@ return {
 				customparams = {
 					bogus = 1,
 					nodecal = 1,
-					no_water_splash = 1, -- targetting weapon aircraftbomb
+					water_splash = 0, -- targetting weapon aircraftbomb
 				},
 			},
 			legphsound = {

--- a/units/Legion/Air/T2 Air/legphoenix.lua
+++ b/units/Legion/Air/T2 Air/legphoenix.lua
@@ -183,6 +183,7 @@ return {
 				customparams = {
 					bogus = 1,
 					nodecal = 1,
+					no_water_splash = 1, -- targetting weapon aircraftbomb
 				},
 			},
 			legphsound = {

--- a/units/Legion/Utilities/legjuno.lua
+++ b/units/Legion/Utilities/legjuno.lua
@@ -144,6 +144,7 @@ return {
 					stockpilelimit = 20,
 					lups_noshockwave = 1,
 					nofire = true,
+					no_water_splash = 1, -- juno can explode on water
 				},
 				damage = {
 					default = 1,

--- a/units/Legion/Utilities/legjuno.lua
+++ b/units/Legion/Utilities/legjuno.lua
@@ -144,7 +144,7 @@ return {
 					stockpilelimit = 20,
 					lups_noshockwave = 1,
 					nofire = true,
-					no_water_splash = 1, -- juno can explode on water
+					water_splash = 0, -- juno can explode on water
 				},
 				damage = {
 					default = 1,


### PR DESCRIPTION
### Work done

- fx_watersplash: Add `water_splash` weapon customParam.

### Addresses Issue(s)
- `Error: Failed to load: fx_watersplash.lua  ([string "LuaRules/Gadgets/fx_watersplash.lua"]:34: attempt to index field 'legjuno_juno_pulse' (a nil value))`
  - was broken with 6b5a2748d3b40eb8f17bda0d9eb04c97103bd119, making the gadget unusable unless legion is enabled, also breaking corjuno non-splashing
- Fixes corjuno_juno_pulse no splash (was overwriting with the legion id)

### Remarks

- Removes hardcoded weapon names thus preventing similar breakage in the future.
  - Had to leave cortron exception for now, remove that in next branch adding `water_splash_size` customParam: see https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5118
- Maybe legcib could use `water_splash = 0` too since its a juno.
- Looked for "scav version" as of the comment `maybe need addition of scav version or better solution`, but not sure which units could that be.
- Also remove the `weaponType` table since just storing everything inside `weaponNoSplash` table more efficient.
