### PR TITLE
fx_watersplash: Customizable splash ceg through `water_splash_ceg`

### DIFF
--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -117,7 +117,6 @@ function gadget:Explosion(weaponID, px, py, pz, ownerID)
 		if not weaponNoSplash[weaponID] and abs(py) <= aoe and (not GetGroundBlocked(px, pz)) then
 			local splashCEG = weaponSplashCEG[weaponID]
 			if splashCEG then
-				Spring.Echo(splashCEG)
 				Spring.SpawnCEG(splashCEG, px, 0, pz)
 			end
 			return true

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -28,9 +28,6 @@ local nonexplosiveWeapons = {
 	LightningCannon = true,
 }
 
-local cortronWeaponDef = WeaponDefNames['cortron_cortron_weapon']
-local COR_TRON = cortronWeaponDef and cortronWeaponDef.id
-
 local splashCEG1 = "splash-tiny"
 local splashCEG2 = "splash-small"
 local splashCEG3 = "splash-medium"
@@ -40,11 +37,58 @@ local splashCEG6 = "splash-gigantic"
 local splashCEG7 = "splash-nuke"
 local splashCEG8 = "splash-nukexl"
 
+local function getWeaponAOE(weaponDef, waterSplash)
+	local aoe = weaponDef.damageAreaOfEffect
+	-- add damage bonus, since LRPC dont have a lot of AoE, but do pack a punch
+	if weaponDef.type == 'DGun' then
+		aoe = aoe + 80
+	else
+		if weaponDef.damages and waterSplash ~= 0 then
+			local maxDmg = 0
+			for _,v in pairs(weaponDef.damages) do
+				if v > maxDmg then
+					maxDmg = v
+				end
+			end
+			if weaponDef.paralyzer then
+				maxDmg = maxDmg / 25
+			end
+			aoe = (aoe + (maxDmg/20))
+		end
+	end
+	return aoe / 2
+end
 
-local weaponAoe = {}
+local function getSplashSize(weaponDef, aoe)
+	local splashSize = weaponDef.customParams.water_splash_size
+	if splashSize then
+		splashSize = tonumber(splashSize)
+	else
+		if aoe >= 6 and aoe < 12 then
+			splashSize = 1
+		elseif  aoe >= 12 and aoe < 24 then
+			splashSize = 2
+		elseif aoe >= 24 and aoe < 48 then
+			splashSize = 3
+		elseif aoe >= 48 and aoe < 64 then
+			splashSize = 4
+		elseif aoe >= 64 and aoe < 200 then
+			splashSize = 5
+		elseif aoe >= 200 and aoe < 400 then
+			splashSize = 6
+		elseif aoe >= 400 and aoe < 600 then
+			splashSize = 7
+		elseif aoe >= 600 then
+			splashSize = 8
+		end
+	end
+	return splashSize
+end
+
 local weaponNoSplash = {}
+local weaponAoe = {}
+local weaponSplashCEG = {}
 for weaponDefID, def in pairs(WeaponDefs) do
-	weaponAoe[weaponDefID] = def.damageAreaOfEffect
 
 	local waterSplash = def.customParams.water_splash and tonumber(def.customParams.water_splash)
 	waterSplash = waterSplash or (nonexplosiveWeapons[def.type] and 0 or 1)
@@ -52,49 +96,24 @@ for weaponDefID, def in pairs(WeaponDefs) do
 	if waterSplash == 0 then
 		weaponNoSplash[weaponDefID] = true
 	end
-	-- add damage bonus, since LRPC dont have a lot of AoE, but do pack a punch
-	if def.type == 'DGun' then
-		weaponAoe[weaponDefID] = weaponAoe[weaponDefID] + 80
-	else
-		if def.damages then
-			-- get highest damage category
-			local maxDmg = 0
-			for _,v in pairs(def.damages) do
-				if v > maxDmg then
-					maxDmg = v
-				end
-			end
-			if def.paralyzer then
-				maxDmg = maxDmg / 25
-			end
-			weaponAoe[weaponDefID] = weaponAoe[weaponDefID] + (maxDmg/20)
+
+	weaponAoe[weaponDefID] = getWeaponAOE(def, waterSplash)
+
+	if def.damages and waterSplash ~= 0 then
+		local splashSize = getSplashSize(def, weaponAoe[weaponDefID])
+		if splashSize then
+			weaponSplashCEG[weaponDefID] = splashCEGs[splashSize]
 		end
 	end
 end
 
 function gadget:Explosion(weaponID, px, py, pz, ownerID)
 	if Spring.GetGroundHeight(px,pz) < 0 then
-		local aoe = weaponAoe[weaponID] / 2
+		local aoe = weaponAoe[weaponID]
 		if not weaponNoSplash[weaponID] and abs(py) <= aoe and (not GetGroundBlocked(px, pz)) then
-			if aoe >= 6 and aoe < 12 then
-				Spring.SpawnCEG(splashCEG1, px, 0, pz)
-			elseif  aoe >= 12 and aoe < 24 then
-				Spring.SpawnCEG(splashCEG2, px, 0, pz)
-			elseif aoe >= 24 and aoe < 48 then
-				Spring.SpawnCEG(splashCEG3, px, 0, pz)
-			elseif aoe >= 48 and aoe < 64 then
-				Spring.SpawnCEG(splashCEG4, px, 0, pz)
-			elseif aoe >= 64 and aoe < 200 then
-				if weaponID == COR_TRON then
-					Spring.SpawnCEG(splashCEG6, px, 0, pz)
-				end
-				Spring.SpawnCEG(splashCEG5, px, 0, pz)
-			elseif aoe >= 200 and aoe < 400 then
-				Spring.SpawnCEG(splashCEG6, px, 0, pz)
-			elseif aoe >= 400 and aoe < 600 then
-				Spring.SpawnCEG(splashCEG7, px, 0, pz)
-			elseif aoe >= 600 then
-				Spring.SpawnCEG(splashCEG8, px, 0, pz)
+			local splashCEG = weaponSplashCEG[weaponID]
+			if splashCEG then
+				Spring.SpawnCEG(splashCEG, px, 0, pz)
 			end
 			return true
 		else

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -28,14 +28,16 @@ local nonexplosiveWeapons = {
 	LightningCannon = true,
 }
 
-local splashCEG1 = "splash-tiny"
-local splashCEG2 = "splash-small"
-local splashCEG3 = "splash-medium"
-local splashCEG4 = "splash-large"
-local splashCEG5 = "splash-huge"
-local splashCEG6 = "splash-gigantic"
-local splashCEG7 = "splash-nuke"
-local splashCEG8 = "splash-nukexl"
+local splashCEGs = {
+	"splash-tiny",
+	"splash-small",
+	"splash-medium",
+	"splash-large",
+	"splash-huge",
+	"splash-gigantic",
+	"splash-nuke",
+	"splash-nukexl",
+}
 
 local function getWeaponAOE(weaponDef, waterSplash)
 	local aoe = weaponDef.damageAreaOfEffect
@@ -60,27 +62,23 @@ local function getWeaponAOE(weaponDef, waterSplash)
 end
 
 local function getSplashSize(weaponDef, aoe)
-	local splashSize = weaponDef.customParams.water_splash_size
-	if splashSize then
-		splashSize = tonumber(splashSize)
-	else
-		if aoe >= 6 and aoe < 12 then
-			splashSize = 1
-		elseif  aoe >= 12 and aoe < 24 then
-			splashSize = 2
-		elseif aoe >= 24 and aoe < 48 then
-			splashSize = 3
-		elseif aoe >= 48 and aoe < 64 then
-			splashSize = 4
-		elseif aoe >= 64 and aoe < 200 then
-			splashSize = 5
-		elseif aoe >= 200 and aoe < 400 then
-			splashSize = 6
-		elseif aoe >= 400 and aoe < 600 then
-			splashSize = 7
-		elseif aoe >= 600 then
-			splashSize = 8
-		end
+	local splashSize
+	if aoe >= 6 and aoe < 12 then
+		splashSize = 1
+	elseif  aoe >= 12 and aoe < 24 then
+		splashSize = 2
+	elseif aoe >= 24 and aoe < 48 then
+		splashSize = 3
+	elseif aoe >= 48 and aoe < 64 then
+		splashSize = 4
+	elseif aoe >= 64 and aoe < 200 then
+		splashSize = 5
+	elseif aoe >= 200 and aoe < 400 then
+		splashSize = 6
+	elseif aoe >= 400 and aoe < 600 then
+		splashSize = 7
+	elseif aoe >= 600 then
+		splashSize = 8
 	end
 	return splashSize
 end
@@ -100,9 +98,15 @@ for weaponDefID, def in pairs(WeaponDefs) do
 	weaponAoe[weaponDefID] = getWeaponAOE(def, waterSplash)
 
 	if def.damages and waterSplash ~= 0 then
-		local splashSize = getSplashSize(def, weaponAoe[weaponDefID])
-		if splashSize then
-			weaponSplashCEG[weaponDefID] = splashCEGs[splashSize]
+		local splashCEG = def.customParams.water_splash_ceg
+		if not splashCEG then
+			local splashSize = getSplashSize(def, weaponAoe[weaponDefID])
+			if splashSize then
+				splashCEG = splashCEGs[splashSize]
+			end
+		end
+		if splashCEG then
+			weaponSplashCEG[weaponDefID] = splashCEG
 		end
 	end
 end
@@ -113,6 +117,7 @@ function gadget:Explosion(weaponID, px, py, pz, ownerID)
 		if not weaponNoSplash[weaponID] and abs(py) <= aoe and (not GetGroundBlocked(px, pz)) then
 			local splashCEG = weaponSplashCEG[weaponID]
 			if splashCEG then
+				Spring.Echo(splashCEG)
 				Spring.SpawnCEG(splashCEG, px, 0, pz)
 			end
 			return true

--- a/luarules/gadgets/fx_watersplash.lua
+++ b/luarules/gadgets/fx_watersplash.lua
@@ -61,26 +61,28 @@ local function getWeaponAOE(weaponDef, waterSplash)
 	return aoe / 2
 end
 
-local function getSplashSize(weaponDef, aoe)
-	local splashSize
-	if aoe >= 6 and aoe < 12 then
-		splashSize = 1
-	elseif  aoe >= 12 and aoe < 24 then
-		splashSize = 2
-	elseif aoe >= 24 and aoe < 48 then
-		splashSize = 3
-	elseif aoe >= 48 and aoe < 64 then
-		splashSize = 4
-	elseif aoe >= 64 and aoe < 200 then
-		splashSize = 5
-	elseif aoe >= 200 and aoe < 400 then
-		splashSize = 6
-	elseif aoe >= 400 and aoe < 600 then
-		splashSize = 7
-	elseif aoe >= 600 then
-		splashSize = 8
+local function getSplashCEG(weaponDef, aoe)
+	local index
+	if aoe < 6 then
+		return nil
+	elseif aoe < 12 then
+		index = 1
+	elseif aoe < 24 then
+		index = 2
+	elseif aoe < 48 then
+		index = 3
+	elseif aoe < 64 then
+		index = 4
+	elseif aoe < 200 then
+		index = 5
+	elseif aoe < 400 then
+		index = 6
+	elseif aoe < 600 then
+		index = 7
+	else
+		index = 8
 	end
-	return splashSize
+	return splashCEGs[index]
 end
 
 local weaponNoSplash = {}
@@ -100,10 +102,7 @@ for weaponDefID, def in pairs(WeaponDefs) do
 	if def.damages and waterSplash ~= 0 then
 		local splashCEG = def.customParams.water_splash_ceg
 		if not splashCEG then
-			local splashSize = getSplashSize(def, weaponAoe[weaponDefID])
-			if splashSize then
-				splashCEG = splashCEGs[splashSize]
-			end
+			splashCEG = getSplashCEG(def, weaponAoe[weaponDefID])
 		end
 		if splashCEG then
 			weaponSplashCEG[weaponDefID] = splashCEG

--- a/units/CorBuildings/LandDefenceOffence/cortron.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortron.lua
@@ -142,6 +142,7 @@ return {
 				weapontype = "StarburstLauncher",
 				weaponvelocity = 1200,
 				customparams = {
+					water_splash_size = 6, -- 1 bigger than it would get
 					stockpilelimit = 10,
 				},
 				damage = {

--- a/units/CorBuildings/LandDefenceOffence/cortron.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortron.lua
@@ -142,7 +142,7 @@ return {
 				weapontype = "StarburstLauncher",
 				weaponvelocity = 1200,
 				customparams = {
-					water_splash_size = 6, -- 1 bigger than it would get
+					water_splash_ceg = "splash-gigantic", -- 1 bigger than it would get
 					stockpilelimit = 10,
 				},
 				damage = {


### PR DESCRIPTION
### Work done

- Allow setting a custom splash ceg

#### Addresses Issue(s)
- Remove ceg size exception for cortron
- Allow tackling of custom ceg for corsb?
  - was going to add it but didn't see a ceg to set

### New unitDef:

- water_splash_ceg: 'splash-huge'

### Screenshots:

legmg with forced splash through `water_splash = 1` and huge splash (just a test, legmg change not included in PR):

splash-huge:

![splash2](https://github.com/user-attachments/assets/a1c92f88-c0fe-4bdb-99ba-6fde422ada82)

splash-gigantic:

![bigsplash](https://github.com/user-attachments/assets/d25c6102-636d-4e20-a324-e950564cfa27)

using this diff on the unit:

```diff
diff --git a/units/Legion/Defenses/legmg.lua b/units/Legion/Defenses/legmg.lua
index 78a680cf5b..ed2709892d 100644
--- a/units/Legion/Defenses/legmg.lua
+++ b/units/Legion/Defenses/legmg.lua
@@ -143,6 +143,10 @@ return {
                                        default = 18,
                                        vtol = 18,
                                },
+                               customParams = {
+                                       water_splash = 1,
+                                       water_splash_ceg = 'splash-huge',
+                               },
                        },
                },
                weapons = {
```