### PR TITLE
Fix prevent cloaked unit reclaim gadget

### DIFF
--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -44,7 +44,7 @@ if gadgetHandler:IsSyncedCode() then
         if (cloakedUnits[unitID]) and (not checkedUnits[unitID]) then  -- only needs to be checked when the unit barely is cloaked
             checkedUnits[unitID] = true
             local x, y, z = GetUnitPosition(unitID)
-            local units = GetUnitsInCylinder(x, z, maxBuildDist + unitRadius[GetUnitDefID(unitID)]) -- + 50 since reclaim also works if only the edge of the unit is in range
+            local units = GetUnitsInCylinder(x, z, maxBuildDist + unitRadius[GetUnitDefID(unitID)]) -- + unit radius since reclaim also works if only the edge of the unit is in range
             for _, bID in pairs(units) do
                 local unitDefID = GetUnitDefID(bID)
                 if canReclaim[unitDefID] then

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -13,6 +13,7 @@ function gadget:GetInfo()
 end
 
 local canReclaim = {}
+local unitRadius = {}
 local cloakedUnits = {}
 local checkedUnits = {}
 
@@ -43,7 +44,7 @@ if gadgetHandler:IsSyncedCode() then
         if (cloakedUnits[unitID]) and (not checkedUnits[unitID]) then  -- only needs to be checked when the unit barely is cloaked
             checkedUnits[unitID] = true
             local x, y, z = GetUnitPosition(unitID)
-            local units = GetUnitsInCylinder(x, z, maxBuildDist + 50) -- + 50 since reclaim also works if only the edge of the unit is in range
+            local units = GetUnitsInCylinder(x, z, maxBuildDist + unitRadius[GetUnitDefID(unitID)]) -- + 50 since reclaim also works if only the edge of the unit is in range
             for _, bID in pairs(units) do
                 local unitDefID = GetUnitDefID(bID)
                 if canReclaim[unitDefID] then
@@ -78,6 +79,9 @@ if gadgetHandler:IsSyncedCode() then
         for unitDefID, unitDef in pairs(UnitDefs) do
             if unitDef.canReclaim then
                 canReclaim[unitDefID] = unitDef.buildDistance or 0
+            end
+            if unitDef.canCloak then
+                unitRadius[unitDefID] = unitDef.radius
             end
         end
         -- handle luarules reload

--- a/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
+++ b/luarules/gadgets/unit_prevent_cloaked_unit_reclaim.lua
@@ -43,7 +43,7 @@ if gadgetHandler:IsSyncedCode() then
         if (cloakedUnits[unitID]) and (not checkedUnits[unitID]) then  -- only needs to be checked when the unit barely is cloaked
             checkedUnits[unitID] = true
             local x, y, z = GetUnitPosition(unitID)
-            local units = GetUnitsInCylinder(x, z, maxBuildDist)
+            local units = GetUnitsInCylinder(x, z, maxBuildDist + 50) -- + 50 since reclaim also works if only the edge of the unit is in range
             for _, bID in pairs(units) do
                 local unitDefID = GetUnitDefID(bID)
                 if canReclaim[unitDefID] then


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Adds unit radius to the checked range to account for units being able to be reclaimed even if their center isn't in the range.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->


<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
