### PR TITLE
unit_projectile_overrange: Use SetWatchProjectile instead of SetWatchWeapon

### DIFF
--- a/luarules/gadgets/unit_projectile_overrange.lua
+++ b/luarules/gadgets/unit_projectile_overrange.lua
@@ -107,7 +107,7 @@ for weaponDefID, weaponDef in pairs(WeaponDefs) do
 		end
 
 		defWatchTable[weaponDefID] = watchParams
-		Script.SetWatchWeapon(weaponDefID, true)
+		Script.SetWatchProjectile(weaponDefID, true)
 	end
 end
 


### PR DESCRIPTION
### Work done

- unit_projectile_overrange: Use SetWatchProjectile instead of SetWatchWeapon

### Remarks

- No need to watch weapon since only using ProjectileCreated and ProjectileDestroyed callins.
  -  SetWatchWeapon == (SetWatchExplosion + SetWatchProjectile + SetWatchAllowTarget)

