### PR TITLE
unit_aa_targeting_priority: SetWatchWeapon -> SetWatchAllowTarget.

### DIFF
--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -54,7 +54,7 @@ if gadgetHandler:IsSyncedCode() then
 					if weapon.onlyTargets then
 						for category, _ in pairs(weapon.onlyTargets) do
 							if category == 'vtol' then
-								Script.SetWatchWeapon(weapon.weaponDef, true) -- watch weapon so AllowWeaponTarget works
+								Script.SetWatchAllowTarget(weapon.weaponDef, true) -- watch so AllowWeaponTarget works
 							end
 						end
 					end


### PR DESCRIPTION
### Work done

- unit_aa_targeting_priority: Use SetWatchAllowTarget instead of SetWatchWeapon

### Remarks

- No need to watch weapon since only using the AllowWeaponTarget callin.
  -  SetWatchWeapon == (SetWatchExplosion + SetWatchProjectile + SetWatchAllowTarget)

