### PR TITLE
remove arm sneaky pete from cloak widget

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -6252,7 +6252,6 @@ function init()
 
 	-- add auto cloak toggles
 	local defaultUnitdefConfig = {	-- copy pasted defaults from the widget
-		[UnitDefNames["armjamt"].id] = true,
 		[UnitDefNames["armdecom"].id] = false,
 		[UnitDefNames["cordecom"].id] = false,
 		[UnitDefNames["armferret"].id] = false,

--- a/luaui/Widgets/unit_auto_cloak.lua
+++ b/luaui/Widgets/unit_auto_cloak.lua
@@ -14,7 +14,6 @@ end
 
 -- defaults
 local unitdefConfigNames = {
-	['armjamt'] = true,
 	['armdecom'] = false,
 	['cordecom'] = false,
 	['armferret'] = false,


### PR DESCRIPTION
Viz only bug fix to remove sneaky pete from cloak options in GUI and auto cloak widget. 

