### PR TITLE
Use VFS.RAW_FIRST instead of VFS.RAW_ONLY when IsDevLuaEnabled.

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -19,7 +19,7 @@
 
 local VFSMODE = VFS.ZIP_ONLY -- FIXME: ZIP_FIRST ?
 if Spring.IsDevLuaEnabled() then
-	VFSMODE = VFS.RAW_ONLY
+	VFSMODE = VFS.RAW_FIRST
 end
 
 VFS.Include('init.lua', nil, VFSMODE)


### PR DESCRIPTION
### Work done

- Use VFS.RAW_FIRST instead of VFS.RAW_ONLY when IsDevLuaEnabled.

### Remarks

- RAW_FIRST breaks lua reload, at least with BAR.sdd setup.
  - Not really sure this is needed at all, but in case it is, RAW_FIRST should be ok.
  - Seems more in line with what engine is doing.
  - RAW_ONLY is deprecated by engine too
- At first I though [I broke it](https://github.com/beyond-all-reason/RecoilEngine/pull/2297) myself