### PR TITLE
Removed green circle in upper left corner for Skirmish maps

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -549,8 +549,11 @@ function widget:DrawWorld()
 		startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 	end
 
-	local sx, sy, sz = Spring.GetTeamStartPosition(myTeamID) -- Returns -100, -100, -100 when none chosen
-	local startChosen = (sx ~= -100)
+
+	local sx, sy, sz = Spring.GetTeamStartPosition(myTeamID) -- Returns 0, 0, 0 when none chosen (was -100, -100, -100 previously)
+	--should startposition not match 0,0,0 and no commander is placed, then there is a green circle on the map till one is placed
+	--TODO: be based on the map, if position is changed from default(?)
+	local startChosen = (sx ~= 0) or (sy ~=0) or (sz~=0)
 	if startChosen and startDefID then
 		-- Correction for start positions in the air
 		sy = Spring.GetGroundHeight(sx, sz)


### PR DESCRIPTION
Currently there is a green circle in the upper left corner on the Skirmish maps I played. This change should remove this circle at least for those maps. Due to the way it was and still is implemented it might add it to other maps, that have a default starting position of -100, -100, -100 instead of the now 0, 0, 0 the Skirmish maps use

This circle here should be now gone from them
<img width="714" alt="Circle" src="https://github.com/user-attachments/assets/e6d0b166-6754-4c6f-8d29-98bca34b392f" />
