### PR TITLE
Removing lava unit slowdown temporarily to fix issues #5056 and #5117

### DIFF
--- a/luarules/gadgets/map_lava.lua
+++ b/luarules/gadgets/map_lava.lua
@@ -24,7 +24,7 @@ if gadgetHandler:IsSyncedCode() then
 	local tideContinueFrame = 0
 	local gameframe = 0
 	local tideRhythm = {}
-	local lavaUnits = {}
+	--local lavaUnits = {}
 
 	local lavaLevel = lava.level
 	local lavaGrow = lava.grow
@@ -123,10 +123,10 @@ if gadgetHandler:IsSyncedCode() then
 				if y and y < lavaLevel then
 					spAddUnitDamage(unitID, lavaDamage, 0, gaiaTeamID, 1)
 					spSpawnCEG(lavaEffectDamage, x, y+5, z)
-					lavaUnits[unitID] = clamp(1-((lavaLevel-y) / unitHeight[UnitDefID]), 0.2, 0.9)
+					--lavaUnits[unitID] = clamp(1-((lavaLevel-y) / unitHeight[UnitDefID]), 0.2, 0.9)
 					--Spring.Echo(lavaUnits[unitID])
-				elseif lavaUnits[unitID] then
-					lavaUnits[unitID] = nil
+				--elseif lavaUnits[unitID] then
+					--lavaUnits[unitID] = nil
 				end
 			end
 		end
@@ -170,9 +170,9 @@ if gadgetHandler:IsSyncedCode() then
 			lavaObjectsCheck()
 		end
 
-		for unitID, speed in pairs(lavaUnits) do
-			spSetUnitVelocity(unitID, speed, speed, speed)
-		end
+		--for unitID, speed in pairs(lavaUnits) do
+			--spSetUnitVelocity(unitID, speed, speed, speed)
+		--end
 
 		updateLava()
 		lavaLevel = lavaLevel+lavaGrow


### PR DESCRIPTION
Since the issues #5056 and #5117 affect lava games strongly negatively, I propose the removal of the incorrect slowdown altogether until the code can be fixed.

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Commented out the incorrect code responsible for the slowdown
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

#### Addresses Issue(s)
#5056  and   #5117 


#### Test steps
Reproducing the following steps should no longer cause the unintended behaviour. 

Unit speedup: Sending a behemoth into lava should no longer speed it up.

Units have all the same speed: Sending a marauder and a titan into shallow lava (so the submersion level is not too different) should no longer have them move at the same speed.

Units should be able to stop moving in lava.

Units should no longer forever fly uncontrollably in lava when given a pushback. (i.e. behemoth hit by a few nukes at once.)

