### PR TITLE
Forward meta option from commandinsert widget.

### DIFF
--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -133,6 +133,7 @@ function widget:CommandNotify(id, params, options)
   if options.alt then opt = opt + CMD.OPT_ALT end
   if options.ctrl then opt = opt + CMD.OPT_CTRL end
   if options.right then opt = opt + CMD.OPT_RIGHT end
+  if options.meta then opt = opt + CMD.OPT_META end
   if options.shift then
     opt = opt + CMD.OPT_SHIFT
 


### PR DESCRIPTION
### Work done

- Forward meta option inside the commandinsert widget

#### Addresses Issue(s)
- Related to:
  - Can't seem to reclaim "only enemies"
  - https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5102
  - https://github.com/beyond-all-reason/RecoilEngine/issues/2312

### Remarks

- Unsure if this wasn't forwarded for some reason or just overlooked
- Might have unwanted side effects?
  - Maybe only add it when not `shift`? (the "[else](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/89e691a77a9bf9b49975dd5fdb301a3a9c2c820f/luaui/Widgets/cmd_commandinsert.lua#L147)" part right after setting `opts`) don't really know, but think it should be forwarded unconditionally.
  - On the other hand not forwarding it probably has lots of side effects too, like the bug this aims to fix.
- Note META is actually "space" key afaics (customizable though `fakemeta xxx` inside uikeys.txt I think).

