### PR TITLE
Startboxes now work in no enemy Skirmish

### DIFF
--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -338,6 +338,12 @@ local function InitStartPolygons()
 		end
 	end
 
+	--Case we start with only one team(no enemies)
+	--The shader doesn't like that so we have to let it think there are more then one
+	if(#StartPolygons == 0) then
+		StartPolygons[#StartPolygons+1] = StartPolygons[#StartPolygons]
+	end
+
 	shaderSourceCache.shaderConfig.NUM_BOXES = #StartPolygons
 
 	local minY, maxY = Spring.GetGroundExtremes()


### PR DESCRIPTION
When starting a game with no enemy, the startbox doesn't load the visual part but still functions. This change makes the startbox visible