### PR TITLE
Attack range fixes for cannons under 700 range

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -605,9 +605,9 @@ local function AddSelectedUnit(unitID, mouseover)
 				if weapon.onlyTargets and weapon.onlyTargets.vtol then
 					entry.weapons[weaponNum] = 3 -- weaponTypeMap[3] is "AA"
 				elseif weaponDef.type == "Cannon" then
-					if weaponDef.range < 700 then 
-						entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground"
-					elseif weaponDef.range > 2600 then 
+					-- if weaponDef.range < 700 then 
+					-- 	entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground"
+					if weaponDef.range > 2600 then 
 						entry.weapons[weaponNum] = 5 -- weaponTypeMap[5] is "lrpc"
 					else
 						entry.weapons[weaponNum] = 4 -- weaponTypeMap[4] is "cannon"
@@ -1106,7 +1106,7 @@ local function DRAWRINGS(primitiveType, linethickness)
 				local atkRangeClass = allyState .. wt
 				local iT = attackRangeVAOs[atkRangeClass]
 				local stencilOffset = colorConfig.cannon_separate_stencil and 3 or 0
-				stencilMask = 2 ^ (4 * (i - 1) + stencilOffset) -- if 0 then it's on the same as "ground"
+				stencilMask = 2 --^ (4 * (i - 1) + stencilOffset) -- if 0 then it's on the same as "ground"
 				drawcounts[stencilMask] = iT.usedElements
 				if iT.usedElements > 0 then
 					if linethickness then

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -69,7 +69,7 @@ local buttonConfig = {
 
 local colorConfig = {
 	drawStencil = true,  -- whether to draw the outer, merged rings (quite expensive!)
-	cannon_separate_stencil = true, -- set to true to have cannon and ground be on different stencil mask
+	cannon_separate_stencil = false, -- set to true to have cannon and ground be on different stencil mask
 	drawInnerRings = true, -- whether to draw inner, per attack rings (very cheap)
 
 	externalalpha = 0.75, -- alpha of outer rings
@@ -1106,7 +1106,7 @@ local function DRAWRINGS(primitiveType, linethickness)
 				local atkRangeClass = allyState .. wt
 				local iT = attackRangeVAOs[atkRangeClass]
 				local stencilOffset = colorConfig.cannon_separate_stencil and 3 or 0
-				stencilMask = 2 --^ (4 * (i - 1) + stencilOffset) -- if 0 then it's on the same as "ground"
+				stencilMask = 2 ^ (4 * (i - 1) + stencilOffset) -- if 0 then it's on the same as "ground" 
 				drawcounts[stencilMask] = iT.usedElements
 				if iT.usedElements > 0 then
 					if linethickness then


### PR DESCRIPTION
unified attackrange for ground + cannon and fix for "cannon" weapons with < 700 range
+ merged ground & cannons stencils.
Wasn't initially the idea, but probably a good change + it fixes cannons <700 range to now show the correct range.