### PR TITLE
performance and starfall energy symbol

### DIFF
--- a/luaui/Widgets/gui_pregameui_draft.lua
+++ b/luaui/Widgets/gui_pregameui_draft.lua
@@ -116,16 +116,11 @@ local anonymousMode = Spring.GetModOptions().teamcolors_anonymous_mode
 local anonymousTeamColor = {Spring.GetConfigInt("anonymousColorR", 255)/255, Spring.GetConfigInt("anonymousColorG", 0)/255, Spring.GetConfigInt("anonymousColorB", 0)/255}
 local imgDir = LUAUI_DIRNAME .. "Images/advplayerslist/"
 local imageDirectory = ":lc:" .. imgDir
+local rankAmount = 8
 local pics = {
     readyTexture = imageDirectory .. "indicator.dds",
-    rank0 = imageDirectory .. "ranks/1.png",
-    rank1 = imageDirectory .. "ranks/2.png",
-    rank2 = imageDirectory .. "ranks/3.png",
-    rank3 = imageDirectory .. "ranks/4.png",
-    rank4 = imageDirectory .. "ranks/5.png",
-    rank5 = imageDirectory .. "ranks/6.png",
-    rank6 = imageDirectory .. "ranks/7.png",
-    rank7 = imageDirectory .. "ranks/8.png",
+    rank = imageDirectory .. "ranks/",
+	rankFiletype = ".png",
 	hourglass = imageDirectory .. "hourglass.png"
 }
 local playerReadyState = {}
@@ -195,25 +190,9 @@ local function DrawRankImage(rankImage, posX, posY)
 end
 
 local function DrawRank(rank, posX, posY)
-    if rank == 0 then
-        DrawRankImage(pics["rank0"],  posX, posY)
-    elseif rank == 1 then
-        DrawRankImage(pics["rank1"],  posX, posY)
-    elseif rank == 2 then
-        DrawRankImage(pics["rank2"],  posX, posY)
-    elseif rank == 3 then
-        DrawRankImage(pics["rank3"],  posX, posY)
-    elseif rank == 4 then
-        DrawRankImage(pics["rank4"],  posX, posY)
-    elseif rank == 5 then
-        DrawRankImage(pics["rank5"],  posX, posY)
-    elseif rank == 6 then
-        DrawRankImage(pics["rank6"],  posX, posY)
-    elseif rank == 7 then
-        DrawRankImage(pics["rank7"],  posX, posY)
-    else
-
-    end
+	if(rank >= 0 and rank < rankAmount) then
+		DrawRankImage(pics["rank"] .. (rank+1) .. pics["rankFiletype"],  posX, posY)
+	end
 end
 
 local function DrawSkill(skill, posX, posY)

--- a/luaui/Widgets/gui_unit_energy_icons.lua
+++ b/luaui/Widgets/gui_unit_energy_icons.lua
@@ -22,7 +22,6 @@ local teamEnergy = {} -- table of teamid to current energy amount
 local teamUnits = {} -- table of teamid to table of stallable unitID : unitDefID
 local teamList = {} -- {team1, team2, team3....}
 
-local spec, fullview = Spring.GetSpectatingState()
 local lastGameFrame = 0
 
 local chobbyInterface
@@ -128,7 +127,7 @@ local function UpdateTeamEnergy()
 end
 
 function widget:VisibleUnitsChanged(extVisibleUnits, extNumVisibleUnits)
-	spec, fullview = Spring.GetSpectatingState()
+	local spec, fullview = Spring.GetSpectatingState()
 	if spec then
 		fullview = select(2,Spring.GetSpectatingState())
 	end
@@ -161,10 +160,13 @@ function widget:Initialize()
 end
 
 local function updateStalling()
+	UpdateTeamEnergy()
 	local gf = Spring.GetGameFrame()
 	for teamID, units in pairs(teamUnits) do
 		--Spring.Echo('teamID',teamID)
-		if teamEnergy[teamID] and teamEnergy[teamID] < maxStall then
+		if teamEnergy[teamID] then
+			--ToDO: Here can be a bit more performance increased by checking if energy production is bigger than upkeep and then just show symbol on all that have upkeep or shot per energy and are empty
+			--if(teamEnergy[teamID] < maxStall) then
 			for unitID, unitDefID in pairs(units) do
 				if teamEnergy[teamID] and unitConf[unitDefID][3] > teamEnergy[teamID] and -- more neededEnergy than we have
 					(not unitConf[unitDefID][4] or ((unitConf[unitDefID][4] and (select(4, spGetUnitResources(unitID))) or 999999) < unitConf[unitDefID][3])) then
@@ -194,13 +196,6 @@ local function updateStalling()
 	end
 	if energyIconVBO.dirty then
 		uploadAllElements(energyIconVBO)
-	end
-end
-
-function widget:Update(dt)
-	if Spring.GetGameFrame() ~= lastGameFrame then
-		lastGameFrame = Spring.GetGameFrame()
-		UpdateTeamEnergy()
 	end
 end
 


### PR DESCRIPTION
Starfall energy symbol previously did not disappear, now it can (#5158 )
Update was not needed for energy_icons. It is enough to update the energy when we update the symbols every 9 gameframes. 
Code for rank display streamlined