### PR TITLE
Fix commander placement

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -223,8 +223,8 @@ if gadgetHandler:IsSyncedCode() then
 	local function isFootingUntraversable(x, y, z, unitDefID)
 		-- type: 1|2|3 : air | ground mobile | building
 		local type = _unitType[unitDefID]
-		local unitDef = UnitDefs[unitDefID]
 		if not type then
+			local unitDef = UnitDefs[unitDefID]
 			type = unitDef.canFly and 1 or (unitDef.moveDef and unitDef.moveDef.id) and 2 or 3
 			_unitType[unitDefID] = type
 		end


### PR DESCRIPTION
### Work done
When selecting a start position the Ground Normal is now checked against the unit's movedef capabilties

#### Addresses Issue(s)
#5159

#### Test steps
- Attempt to place a commander on a cliff and fail.