### PR TITLE
Remove SET_WANTED_MAX_SPEED support from unit_attributes.

### DIFF
--- a/luarules/gadgets/unit_attributes.lua
+++ b/luarules/gadgets/unit_attributes.lua
@@ -414,12 +414,10 @@ local currentMovement = {}
 local currentTurn = {}
 local currentAcc = {}
 
-local unitSlowed = {}
 local unitAbilityDisabled = {}
 local unitShieldDisabled = {}
 
 local function removeUnit(unitID)
-	unitSlowed[unitID] = nil
 	unitAbilityDisabled[unitID] = nil
 	unitShieldDisabled[unitID] = nil
 	unitReloadPaused[unitID] = nil
@@ -545,7 +543,6 @@ function UpdateUnitAttributes(unitID, frame)
 		GG.att_ReloadChange[unitID] = reloadMult
 		GG.att_MoveChange[unitID] = moveMult
 
-		unitSlowed[unitID] = moveMult < 1
 		if weaponMods or reloadMult ~= currentReload[unitID] then
 			UpdateReloadSpeed(unitID, unitDefID, weaponMods, reloadMult, frame)
 			currentReload[unitID] = reloadMult
@@ -570,8 +567,6 @@ function UpdateUnitAttributes(unitID, frame)
 		if econMult ~= 1 or moveMult ~= 1 or reloadMult ~= 1 or turnMult ~= 1 or maxAccMult ~= 1 then
 			changedAtt = true
 		end
-	else
-		unitSlowed[unitID] = nil
 	end
 
 	local forcedOff = spGetUnitRulesParam(unitID, "forcedOff")
@@ -627,7 +622,6 @@ local function SetAllowUnitCoast(unitID, allowed)
 end
 
 function gadget:Initialize()
-	gadgetHandler:RegisterAllowCommand(GameCMD.SET_WANTED_MAX_SPEED)
 	GG.UpdateUnitAttributes = UpdateUnitAttributes
 	GG.SetAllowUnitCoast = SetAllowUnitCoast
 
@@ -641,13 +635,6 @@ function gadget:GameFrame(f)
 			UpdatePausedReload(unitID, unitDefID, f)
 		end
 	end
-
-
-
-	if false and f % 50 == 1 then
-		Spring.Echo(unitSlowed)
-	end
-
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
@@ -662,11 +649,3 @@ function gadget:AllowCommand_GetWantedUnitDefID()
 	return true
 end
 
-function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	-- accepts: SET_WANTED_MAX_SPEED
-	if unitSlowed[unitID] then
-		return false
-	else
-		return true
-	end
-end

--- a/modules/customcommands.lua
+++ b/modules/customcommands.lua
@@ -26,7 +26,6 @@ local gameCommands = {
 
 	AREA_MEX = 30100,
 	SELL_UNIT = 30101,
-	SET_WANTED_MAX_SPEED = 70, -- TODO remove, was backwards compatibility
 
 	CARRIER_SPAWN_ONOFF = 31200,
 	MORPH = 31210,


### PR DESCRIPTION
### Work done

- Remove SET_WANTED_MAX_SPEED support from unit_attributes.

### Remarks

- Removed other vars only used for that.
- Unsure whether I should remove more stuff in that module since it's quite confusing so playing it safe.
- Looking at unit_attributes, not very sure what it is about, seems a lot of its code is not really used and probably imported from ZeroK without much cleanup.
  - Some `if` depending on GG.att_genericUsed but that's never set anywhere.
  - Sets dict `GG.att_MoveChange` but never used anywhere
    - Also `GG.att_ReloadChange` and `att_EconomyChange`
  - Sets a bunch of unitrulesparams that don't seem to be used anywhere too: `baseSpeedMult`, `totalReloadSpeedChange`, `totalEconomyChange`, `totalBuildPowerChange`, `totalMoveSpeedChange`
- It does support `slowState` that actually gets used by unit_timeslow.lua apparently for "emp rework".
  - Seems to support other rules params used or not used, but they're not documented