### PR TITLE
Update ai_ruins.lua to remove mines

### DIFF
--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -128,7 +128,7 @@ for i = 1,#scavConfig.unprocessedScavTurrets do
 			if not UnitDefNames[unitName] then
 				Spring.Echo("We got a fucked unit name here: " .. unitName)
 			end
-			if defs.type ~= "nuke" and UnitDefNames[unitName] and not UnitDefNames[unitName].isFactory then -- we don't want nukes and factories in ruins
+			if defs.type ~= "nuke" and defs.type ~= "explo" and UnitDefNames[unitName] and not UnitDefNames[unitName].isFactory then -- we don't want nukes and factories or mines in ruins
 				if defs.surface == "land" then
 					for _ = 1,defs.maxExisting*((7-i)^2) do
 						landDefences[#landDefences+1] = unitName


### PR DESCRIPTION
Update ai_ruins.lua to remove mines in ruin spawn by adding def.type ~= "explo" in the filter for nukes

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->


#### Addresses Issue(s)
- Ruins sometimes spawn mine fields and unlucky players get to move into them 🗡️ 


<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- no idea... 1st ever github here we go, 101% don't trust my syntax!!



#### Proposed changes:
![image](https://github.com/user-attachments/assets/527173a5-ce80-4af5-b85c-ac1157478ad4)
