### PR TITLE
HOTFIX: fix faction limiter full bitmask being 0

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -58,7 +58,7 @@ if gadgetHandler:IsSyncedCode() then
 			local ARM_MASK = 2^0
 			local COR_MASK = 2^1
 			local LEG_MASK = 2^2
-			local FULL_BITMASK = math.bit_and(ARM_MASK, COR_MASK, LEG_MASK)
+			local FULL_BITMASK = math.bit_or(ARM_MASK, COR_MASK, LEG_MASK)
 
 			local allyTeams = Spring.GetAllyTeamList()
 			for i = 1, #allyTeams do


### PR DESCRIPTION
### Work done
Last minute change to faction limiter to make the code more "readable" broke it, sorry

the full bitmask should be a value that has the first 3 bits on, but instead was a full on zero due to using an and instead of an or