### PR TITLE
Fix Legion Stronghold Notif

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -154,7 +154,7 @@ local unitsOfInterestNames = {
 	legatrans = 'AirTransportDetected',
 	armdfly = 'AirTransportDetected',
 	corseah = 'AirTransportDetected',
-	legstronghold = 'SeaTransportDetected',
+	legstronghold = 'AirTransportDetected',
 	armtship = 'SeaTransportDetected',
 	cortship = 'SeaTransportDetected',
 }


### PR DESCRIPTION
## Work done
Self-explanatory, it no longer says "sea transport detected" when a stronghold comes into screen