### PR TITLE
Redefine "Utility Value" in the Spectator HUD widget

### DIFF
--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -293,12 +293,14 @@ local function buildUnitDefs()
 		return unitDef.weapons and (#unitDef.weapons > 0) and (not unitDef.speed or (unitDef.speed == 0))
 	end
 
-	local function isUtilityUnit(unitDefID, unitDef)
-		return unitDef.customParams.unitgroup == 'util'
-	end
-
 	local function isEconomyBuilding(unitDefID, unitDef)
 		return (unitDef.customParams.unitgroup == 'metal') or (unitDef.customParams.unitgroup == 'energy')
+	end
+
+	local function isUtilityUnit(unitDefID, unitDef)
+		-- anything that is not economy, army, or defense is considered utility
+		-- thus, utility serves as a catch-all for unit value that does not fall into the other categories
+		return not (isEconomyBuilding(unitDefID, unitDef) or isArmyUnit(unitDefID, unitDef) or isDefenseUnit(unitDefID, unitDef))
 	end
 
 	unitDefsToTrack = {}


### PR DESCRIPTION
Utility value in the Spectator HUD widget is not very useful. It only includes things like radars and jammers. These rarely exceed 2k metal in value, even for a full 8 player team, and being such a small value category means it is quite insignificant.

This commit redefines utility value to include the metal value of all units that are not included in the other value categories. Thus, every unit contributes value to one of the 4 value categories: army, defense, economy, or utility.

I especially like that labs are included in one of the value categories now. Currently, labs are not included anywhere in the spectator HUD numbers.

This is a 2 line change, so just look at the code.

#### Test steps
Spectate a game, enable the utility value category in the settings, observe that the utility value category looks good (it mainly includes labs and con turrets).