### PR TITLE
Fix metalrings

### DIFF
--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -324,8 +324,6 @@ local function GetSpotsMetal()
 	end
 
 	-- Final processing
-	-- armmex used as representative unit for placement checking, since all metal extractors are the same size
-	local uDefID = UnitDefNames["armmex"].id
 	local spots = {}
 	for _, g in ipairs(uniqueGroups) do
 		local gMinX, gMaxX = huge, -1
@@ -352,12 +350,6 @@ local function GetSpotsMetal()
 		if gMaxX - gMinX > maxStripLength or g.maxZ - g.minZ > maxStripLength then
 			return false, true
 		end
-
-		local positions = GetBuildingPositions(g, uDefID, 0, false)
-		local pos = positions[floor(#positions / 2 + 1)]
-		g.x = pos.x
-		g.y = pos.y
-		g.z = pos.z
 	end
 
 	--for i = 1, #spots do

--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -187,6 +187,7 @@ local function IsBuildingPositionValid(spot, x, z)
 	end
 
 	local sLeft, sRight = spot.left, spot.right
+	-- add an extra mapSquareSize to account for snapping behaviours from api users
 	local metalMapSquareSizeSqr = metalMapSquareSize*metalMapSquareSize
 	for sz = spot.minZ, spot.maxZ, metalMapSquareSize do
 		local dz = sz - z

--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -182,16 +182,17 @@ end
 
 
 local function IsBuildingPositionValid(spot, x, z)
-	if z <= spot.maxZ - extractorRadius or z >= spot.minZ + extractorRadius then -- Test for metal being included is dist < extractorRadius
+	-- add an extra mapSquareSize to account for snapping behaviours from api users
+	local expandedRadius = extractorRadius + metalMapSquareSize
+	if z <= spot.maxZ - expandedRadius or z >= spot.minZ + expandedRadius then -- Test for metal being included is dist < extractorRadius
 		return false
 	end
 
+	local expandedRadiusSqr = expandedRadius*expandedRadius
 	local sLeft, sRight = spot.left, spot.right
-	-- add an extra mapSquareSize to account for snapping behaviours from api users
-	local metalMapSquareSizeSqr = metalMapSquareSize*metalMapSquareSize
 	for sz = spot.minZ, spot.maxZ, metalMapSquareSize do
 		local dz = sz - z
-		local maxXOffset = sqrt(extractorRadiusSqr + metalMapSquareSizeSqr - dz * dz) -- Test for metal being included is dist < extractorRadius
+		local maxXOffset = sqrt(expandedRadiusSqr - dz * dz) -- Test for metal being included is dist < extractorRadius
 		if x <= sRight[sz] - maxXOffset or x >= sLeft[sz] + maxXOffset then
 			return false
 		end

--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -187,9 +187,10 @@ local function IsBuildingPositionValid(spot, x, z)
 	end
 
 	local sLeft, sRight = spot.left, spot.right
+	local metalMapSquareSizeSqr = metalMapSquareSize*metalMapSquareSize
 	for sz = spot.minZ, spot.maxZ, metalMapSquareSize do
 		local dz = sz - z
-		local maxXOffset = sqrt(extractorRadiusSqr - dz * dz) -- Test for metal being included is dist < extractorRadius
+		local maxXOffset = sqrt(extractorRadiusSqr + metalMapSquareSizeSqr - dz * dz) -- Test for metal being included is dist < extractorRadius
 		if x <= sRight[sz] - maxXOffset or x >= sLeft[sz] + maxXOffset then
 			return false
 		end


### PR DESCRIPTION
### Work done

- Fix drawing of metal rings
  - Reverts 0746f4ac79b7db1a8bcea7e11aef86adb8618518.
  - Also applies a different fix.

### Remarks

- Adding some margin to account for extra squaresize half and snapping errors.
  - Api consumers snap to grid.
  - The PR tweaks IsBuildingPositionValid from api_resource_spot_finder, instead of the metal spot reference positions.
- The regression comes from https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4806
  - It has an analysis of the problem, but I think the solution wasn't good or properly reviewed.
  - It tries to snap the positions, but not the best for mexPositions here at that point imo.
    - Also the PR didn't properly chose the center.
       - It just takes the middle of all valid positions in array, but some in the middle might not be there because of smth else, otherwise if its even number of rows and cols its not going to be at the center, its going to be at a side.
       - So it sometimes finds a good position, but other times not at all.

#### Testing

Did the tests as in https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4806

1. Select "Silent Sea" map.
    Add 3v3 SimpleAI bots.
    Spectate how SimpleAI builds in non-optimal positions (requires echoing positions).
2. Select "Silent Sea" map.
    Add 3v3 BARbarIAn bots.
    Spectate how BARbarIAn can't build mexes because IsBuildingPositionValid rejects snapped (+8, +8) mex center positions.

At least the AIs seem to be working fine, with this PR, rings ok, will do more testing soon

### Screenshots

The problem with metal rings:

<image src="https://github.com/user-attachments/assets/e3616ab3-4fa9-481e-8323-33dc9ababaf9" width="480" />


Where the GetBuildingPositions actually are (they're fine, but previous pr not choosing the center of the group, it's choosing the rings position):

<image src="https://github.com/user-attachments/assets/2d6bb9f3-7577-4988-aa1d-fa446e4d5cf5" width="480" />

#### with this pr:

barb ai finds the spots:

<image src="https://github.com/user-attachments/assets/e106512a-00d8-4877-be6f-044d078f1b43" width="480" />

simpleai places the spots, maybe not optimal but imo that should be addressed at simpleai itself, also could be the min/maxX/Z be wrong at api_resource_spot_finder. also could be just the snapping making them look bad.

<image src="https://github.com/user-attachments/assets/b0bbdc4d-4ebd-420e-90aa-75438d52ad86" width="480" />

rings draw fine

<image src="https://github.com/user-attachments/assets/f07aca38-a943-4e2e-bc9e-0eeb899cf951" width="480" />
