### PR TITLE
gui_chat: Cleanup excessive stored org and console lines.

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -42,13 +42,12 @@ local charSize = 21 - (3.5 * ((vsx/vsy) - 1.78))
 local consoleFontSizeMult = 0.85
 local maxLines = 5
 local maxConsoleLines = 2
-local maxOrgLines = 200
 local maxLinesScrollFull = 16
 local maxLinesScrollChatInput = 9
 local lineHeightMult = 1.36
 local lineTTL = 40
-local consoleLineCleanupThreshold = 200 -- cleanup stores once passing this many stored lines
-local orgLineCleanupThreshold = 600
+local consoleLineCleanupTarget = Spring.Utilities.IsDevMode() and 1200 or 400 -- cleanup stores once passing this many stored lines
+local orgLineCleanupTarget = Spring.Utilities.IsDevMode() and 1400 or 600
 local backgroundOpacity = 0.25
 local handleTextInput = true	-- handle chat text input instead of using spring's input method
 local maxTextInputChars = 127	-- tested 127 as being the true max
@@ -1623,13 +1622,13 @@ local function drawUi()
 				glTranslate(0, consoleLineHeight, 0)
 				i = i - 1
 			end
-			if i - 1 > consoleLineCleanupThreshold then
-				consoleLines = cleanupLineTable(consoleLines, maxConsoleLines)
+			if i - 1 > consoleLineCleanupTarget*1.15 then
+				consoleLines = cleanupLineTable(consoleLines, consoleLineCleanupTarget)
 			end
 			glPopMatrix()
 
-			if #orgLines > orgLineCleanupThreshold then
-				orgLines = cleanupLineTable(orgLines, maxOrgLines)
+			if #orgLines > orgLineCleanupTarget*1.15 then
+				orgLines = cleanupLineTable(orgLines, orgLineCleanupTarget)
 			end
 		end
 	end
@@ -2594,7 +2593,7 @@ function widget:GetConfigData(data)
 		end
 	end
 
-	local maxOrgLines = 600
+	local maxOrgLines = orgLineCleanupTarget
 	if #orgLines > maxOrgLines then
 		local prunedOrgLines = {}
 		for i=1, maxOrgLines do

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -42,10 +42,13 @@ local charSize = 21 - (3.5 * ((vsx/vsy) - 1.78))
 local consoleFontSizeMult = 0.85
 local maxLines = 5
 local maxConsoleLines = 2
+local maxOrgLines = 200
 local maxLinesScrollFull = 16
 local maxLinesScrollChatInput = 9
 local lineHeightMult = 1.36
 local lineTTL = 40
+local consoleLineCleanupThreshold = 200 -- cleanup stores once passing this many stored lines
+local orgLineCleanupThreshold = 600
 local backgroundOpacity = 0.25
 local handleTextInput = true	-- handle chat text input instead of using spring's input method
 local maxTextInputChars = 127	-- tested 127 as being the true max
@@ -1568,6 +1571,15 @@ local drawTextInput = function()
 	end
 end
 
+local function cleanupLineTable(prevTable, maxLines)
+	local newTable = {}
+	local start = #prevTable - maxLines
+	for i=1, maxLines do
+		newTable[i] = prevTable[start + i]
+	end
+	return newTable
+end
+
 local function drawUi()
 	if not historyMode then
 
@@ -1611,7 +1623,14 @@ local function drawUi()
 				glTranslate(0, consoleLineHeight, 0)
 				i = i - 1
 			end
+			if i - 1 > consoleLineCleanupThreshold then
+				consoleLines = cleanupLineTable(consoleLines, maxConsoleLines)
+			end
 			glPopMatrix()
+
+			if #orgLines > orgLineCleanupThreshold then
+				orgLines = cleanupLineTable(orgLines, maxOrgLines)
+			end
 		end
 	end
 


### PR DESCRIPTION
### Work done

- Make the chat widget cleanup org and console chat line arrays when they exceed a given threshold.

### Remarks

- Excessive logging by the engine or lua errors can stack up on the gui_chat widget and it never cleans up its tables, resulting in game perf drop and eventually oom crash.
- Not sure what orgLines mechanism is about, I think it could maybe be removed completely, but seems like the given thresholds work fine until this can be further improved.
- Specially useful for developers, but can help ppl getting some repeated error for the whole game.

### Howto test

- Make some widget emit about 100 lines per update so you reach excessive stored lines quick.
- See how the game reacts once lines start to accumulate beyond a certain limit, usually 100k-500k and the game will be crippled.