### PR TITLE
Revert "Forward meta option from commandinsert widget."

### DIFF
--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -133,6 +133,8 @@ function widget:CommandNotify(id, params, options)
   if options.alt then opt = opt + CMD.OPT_ALT end
   if options.ctrl then opt = opt + CMD.OPT_CTRL end
   if options.right then opt = opt + CMD.OPT_RIGHT end
+  -- options.meta not forwarded since we're doing insert with it
+  -- and don't want to alias with engine at the same time.
   if options.shift then
     opt = opt + CMD.OPT_SHIFT
 

--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -133,7 +133,6 @@ function widget:CommandNotify(id, params, options)
   if options.alt then opt = opt + CMD.OPT_ALT end
   if options.ctrl then opt = opt + CMD.OPT_CTRL end
   if options.right then opt = opt + CMD.OPT_RIGHT end
-  if options.meta then opt = opt + CMD.OPT_META end
   if options.shift then
     opt = opt + CMD.OPT_SHIFT
 


### PR DESCRIPTION
### Work done

- Revert PR https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5145
- Also add a comment so it doesn't happen again.

### Remarks

- Meta is actually used here for insert reclaim (or other commands), so can't use it for other things or it will alias and not do what the user wants.