### PR TITLE
Fix deselecting by click and drag on empty space

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -147,6 +147,7 @@ function widget:SelectionChanged(sel)
 			-- if empty selection box and engine hardcoded deselect modifier is not
 			-- pressed, user is selected empty space
 			-- let engine deselect everything by itself since we didn't modify its provided value
+			selectedUnits = {}
 			return false
 		else
 			-- we also want to override back from engine selection to our selection

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -240,11 +240,11 @@ function widget:Update(dt)
 	local tmp = {}
 	local n = 0
 	local equalsMouseSelection = #mouseSelection == lastMouseSelectionCount
-	if equalsMouseSelection and lastMouseSelectionCount == 0 then
+	if equalsMouseSelection and lastMouseSelectionCount == 0 and not mods.deselect and not mods.append then
 		-- if its an empty selection but reference selection isn't empty consider
 		-- it non equal so deselect by selecting empty space always works.
 		-- skip if deselect or append since it won't deselect on empty selection.
-		equalsMouseSelection = #referenceSelection == 0 and not mods.deselect and not mods.append
+		equalsMouseSelection = #referenceSelection == 0
 	end
 	local isGodMode = spIsGodModeEnabled()
 

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -146,9 +146,8 @@ function widget:SelectionChanged(sel)
 		if #sel == 0 and not select(2, spGetModKeyState()) then -- ctrl
 			-- if empty selection box and engine hardcoded deselect modifier is not
 			-- pressed, user is selected empty space
-			-- we must clear selection to disambiguate from our own deselect modifier
-			selectedUnits = {}
-			spSelectUnitArray({})
+			-- let engine deselect everything by itself since we didn't modify its provided value
+			return false
 		else
 			-- we also want to override back from engine selection to our selection
 			spSelectUnitArray(selectedUnits)
@@ -241,6 +240,12 @@ function widget:Update(dt)
 	local tmp = {}
 	local n = 0
 	local equalsMouseSelection = #mouseSelection == lastMouseSelectionCount
+	if equalsMouseSelection and lastMouseSelectionCount == 0 then
+		-- if its an empty selection but reference selection isn't empty consider
+		-- it non equal so deselect by selecting empty space always works.
+		-- skip if deselect or append since it won't deselect on empty selection.
+		equalsMouseSelection = #referenceSelection == 0 and not mods.deselect and not mods.append
+	end
 	local isGodMode = spIsGodModeEnabled()
 
 	for i = 1, #mouseSelection do
@@ -255,7 +260,6 @@ function widget:Update(dt)
 			end
 		end
 	end
-
 	if equalsMouseSelection
 		and mods.idle == lastMods[1]
 		and mods.same == lastMods[2]


### PR DESCRIPTION
### Work done

- Fix deselecting by selecting empty area with click and drag.

#### Related issues

- https://discord.com/channels/549281623154229250/1362600128107511908

### How to test

- Start skirmish
- `/cheat on`
- `/give 10 armpw`
- double click on armpw to select all
- click and drag selection over empty space
- it deselects
- double click on armpw again to select all again
- click and drag over empty space
- with PR it will deselect, without PR it won't deselect.


### Remarks

- Seems to be two independent issues, the first part of the fix isn't strictly needed (selection is cleared by the time it enters there thx to the other fix) but when testing noticed it's wrong.
- The problem is the widget thinks nothing changed and it has nothing to do, since it just checks to see if what's under the mouse drag area didn't change, but for the case where there's nothing there (and not a remove or append selection) but we actually have a reference selection, we do need to consider it changed.