### PR TITLE
Modified to allow for unlimited pages instead of 2

### DIFF
--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -174,12 +174,13 @@ local function getGridForCategory(builderId, buildOptions, currentCategory)
 		end
 
 		-- everything that doesn't have a defined position (i.e. scav units) gets placed into the grid in any empty spots.
-		for i = 1, 24 do
-			if #undefinedOpts < 1 then break end
+		local i = 1
+		while #undefinedOpts > 0 do
 			if not options[i] then
 				local opt = table.remove(undefinedOpts, 1)
 				options[i] = constructBuildOption(opt)
 			end
+			i = i + 1
 		end
 
 		return options
@@ -276,12 +277,13 @@ local function getSortedGridForLab(builderId, cmds)
 		end
 	end
 	-- go through the cmds with undefined positions (i.e. scav units) and put them in the next available empty spot
-	for i = 1, 24 do
-		if #undefinedCmds < 1 then break end
+	local i = 1
+	while #undefinedCmds > 0 do
 		if not options[i] then
 			local cmd = table.remove(undefinedCmds, 1)
 			options[i] = constructBuildOption(-cmd.id, cmd)
 		end
+		i = i + 1
 	end
 	return options
 end


### PR DESCRIPTION
Modified to allow for any number of pages per grid category, instead of having a hard limit of 2 pages per category.
### Work done
* **Unlimited pages** – removed the legacy hard-cap of 24 build-options.  
  * Replaced the two `for i = 1, 24 do` spill-over loops with a while loop that keeps writing to successive indices until all build-options are placed.

#### Setup
You may need to use a developer unit to see the additional pages ( [https://discord.com/channels/549281623154229250/1365809647826505849/1365809647826505849](url) ) until there are enough units to warrant additional pages in actual gameplay.

#### Test steps
Simply create a page of build options that go beyond the list of the typical two pages.
Before: Units/commander would be capped to 24 build options per category
![image](https://github.com/user-attachments/assets/8bc7462b-8a7f-4b87-ad6d-ba2ef69bb034)

After: Units/commander now see all specified build options instead of being limited to 24, expanding to additional pages.
![Screenshot 2025-04-26 183159](https://github.com/user-attachments/assets/6f1f32ae-bf0b-4d0c-a217-5ec1ce00cc10)

[https://streamable.com/ixf04j](https://streamable.com/ixf04j)

Previously related to pull request: [4910](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4910), but I reset my branch and had to create a new PR. This version of the PR contains the minimum changes required to implement this functionality. I believe this will satisfy all comments on the previous PR as it maintains as much existing code and convention as possible.