### PR TITLE
Accurate reclaim value on large wrecks

### DIFF
--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -576,13 +576,13 @@ local function UpdateFeatureReclaim()
 		end
 	end
 
-	if #dirty>0 and not removed then
+	if removed then
+		clusterizingNeeded = true
+	elseif next(dirty) then
+		redrawingNeeded = true
 		for ii in pairs(dirty) do
 			featureClusters[ii].text = string.formatSI(featureClusters[ii].metal)
 		end
-		redrawingNeeded = true
-	elseif removed then
-		clusterizingNeeded = true
 	end
 end
 


### PR DESCRIPTION
I saw a reclaim area's value not update for a long time on someone's stream earlier. This is an issue when reclaiming commander wrecks, mostly, since it's often ideal to leave a tiny amount of metal instead of destroying the wreck.

The issue was a sequence-length check done on a hash map; the proper way to check for entries in a hash in lua is `next(tbl)`.

### Work done

- update reclaim text at same rate as reclustering
- update reclaim text even when clustering doesn't occur