### PR TITLE
Add functionality to disable unit dancing for improved immersion

### DIFF
--- a/luarules/gadgets/game_disable_dancing.lua
+++ b/luarules/gadgets/game_disable_dancing.lua
@@ -1,0 +1,30 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = 'Disable Unit Dancing',
+		desc    = 'Disable unit dancing for increased immersion.',
+		author  = 'uBdead',
+		date    = 'Jun, 2025',
+		license = 'GNU GPL, v2 or later',
+		layer   = -1,
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+function gadget:RecvLuaMsg(msg, playerID)
+	if msg == 'dancingDisabled' then
+		--Spring.Echo("[Disable Unit Dancing] Unit dancing has been disabled.")
+		GG.DancingDisabled = true
+	elseif msg == 'dancingEnabled' then
+		--Spring.Echo("[Disable Unit Dancing] Unit dancing has been re-enabled.")
+		GG.DancingDisabled = false
+	end
+end

--- a/luarules/gadgets/game_end.lua
+++ b/luarules/gadgets/game_end.lua
@@ -383,16 +383,18 @@ if gadgetHandler:IsSyncedCode() then
 				gameoverWinners = winners
 
 				-- make all winner commanders dance!
-				gameoverAnimFrame = gf + 55		-- delay a bit because walking commanders need to stop walking + a delay look nice
-				gameoverAnimUnits = {}
-				if type(winners) == 'table' then
-					local units = Spring.GetAllUnits()
-					for i, unitID in ipairs(units) do
-						if isCommander[Spring.GetUnitDefID(unitID)] then
-							for u, allyTeamID in pairs(winners) do
-								if Spring.GetUnitAllyTeam(unitID) == allyTeamID then
-									Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)	-- give stop cmd so commanders can animate in place
-									gameoverAnimUnits[unitID] = true
+				if not GG.DancingDisabled then
+					gameoverAnimFrame = gf + 55		-- delay a bit because walking commanders need to stop walking + a delay look nice
+					gameoverAnimUnits = {}
+					if type(winners) == 'table' then
+						local units = Spring.GetAllUnits()
+						for i, unitID in ipairs(units) do
+							if isCommander[Spring.GetUnitDefID(unitID)] then
+								for u, allyTeamID in pairs(winners) do
+									if Spring.GetUnitAllyTeam(unitID) == allyTeamID then
+										Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)	-- give stop cmd so commanders can animate in place
+										gameoverAnimUnits[unitID] = true
+									end
 								end
 							end
 						end

--- a/luaui/Widgets/unit_dancing_disable.lua
+++ b/luaui/Widgets/unit_dancing_disable.lua
@@ -1,0 +1,23 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name      = "Unit dancing disable",
+		desc      = "Disables dancing for increased immersion.",
+		author    = "uBdead",
+		date      = "Jun, 2025",
+		license   = "GNU GPL, v2 or later",
+		layer     = 0,
+		enabled   = false
+	}
+end
+
+function widget:Initialize()
+	-- Send a lua message to the game engine to disable dancing
+	Spring.SendLuaRulesMsg("dancingDisabled")
+end
+
+function widget:Shutdown()
+	-- Send a lua message to the game engine to re-enable dancing
+	Spring.SendLuaRulesMsg("dancingEnabled")
+end

--- a/scripts/Units/armcom_lus.lua
+++ b/scripts/Units/armcom_lus.lua
@@ -459,6 +459,10 @@ end
 
 local isDancing = false
 local function Dance1()
+	if GG.DancingDisabled then
+		return
+	end
+
 	Signal(SIG_WALK)
 	SetSignalMask(SIG_WALK)
 	local speedMult = 1/4

--- a/scripts/Units/armcomhilvl.lua
+++ b/scripts/Units/armcomhilvl.lua
@@ -464,6 +464,10 @@ end
 
 local isDancing = false
 local function Dance1()
+	if GG.DancingDisabled then
+		return
+	end
+
 	Signal(SIG_WALK)
 	SetSignalMask(SIG_WALK)
 	local speedMult = 1/4


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
For my first PR I wanted to fix an immersion break of mine with the commander dancing. The widget is off by default and can be enabled with F11. Note I'm note sure how to handle the `corcom.bos` file, does it have to be compiled or so? Only here the "idle" case remains.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Wait for `boredTime > (600 * (1000/131))` to elapse after moving your commander at least once (alternatively temporarily set the boredTime to a very high number)
- [ ] If the widget is loaded the commander should not start dancing
- [ ] After the game is won, the commander should not start dancing

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
