### PR TITLE
Add AiGetFactoryToBuild callback to barb hard factory.as script.

### DIFF
--- a/luarules/configs/BARb/stable/script/hard/manager/factory.as
+++ b/luarules/configs/BARb/stable/script/hard/manager/factory.as
@@ -123,6 +123,11 @@ bool AiIsSwitchAllowed(CCircuitDef@ facDef)
 	return true;
 }
 
+CCircuitDef@ AiGetFactoryToBuild(const AIFloat3& in pos, bool isStart, bool isReset)
+{
+	return aiFactoryMgr.DefaultGetFactoryToBuild(pos, isStart, isReset);
+}
+
 /* --- Utils --- */
 
 float MakeSwitchLimit()


### PR DESCRIPTION
### Work done

- Add CircuiAiGetFactoryToBuild callback to fix hard barb ai warning.

### Issues

- Resolves warning: `Script: 'CCircuitDef@ AiGetFactoryToBuild(const AIFloat3& in, bool, bool)' not found!`.


### Remarks

- I think this is safe to add, but maybe @rlcevg can chime in.

### Test steps

- Start game with hard barb ai
- Looks fine