### PR TITLE
 Barb legion: Adapt 'easy' and 'medium' AS scripts

### DIFF
--- a/luarules/configs/BARb/stable/script/easy/manager/factory.as
+++ b/luarules/configs/BARb/stable/script/easy/manager/factory.as
@@ -17,6 +17,12 @@ string coravp ("coravp");
 string corasy ("corasy");
 string corap  ("corap");
 
+string leglab  ("leglab");
+string legalab ("legalab");
+string legvp   ("legvp");
+string legavp  ("legavp");
+string legap   ("legap");
+
 int switchInterval = MakeSwitchInterval();
 int switchFrame = 0;
 

--- a/luarules/configs/BARb/stable/script/easy/misc/commander.as
+++ b/luarules/configs/BARb/stable/script/easy/misc/commander.as
@@ -5,6 +5,7 @@ namespace Commander {
 
 string armcom("armcom");
 string corcom("corcom");
+string corcom("legcom");
 
 }
 
@@ -72,6 +73,18 @@ SOpener@ GetOpenInfo()
 		}},
 		{Factory::corap, array<SQueue> = {
 			SQueue(1.0f, {SO(RT::BUILDER), SO(RT::AA), SO(RT::RAIDER), SO(RT::BOMBER), SO(RT::SCOUT)})
+		}},
+		{Factory::leglab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER), SO(RT::SKIRM), SO(RT::BUILDER)})
+		}},
+		{Factory::legalab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::legavp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::legap, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::AA), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::BOMBER), SO(RT::SCOUT)})
 		}}
 		}, {SO(RT::BUILDER), SO(RT::SKIRM)}
 	);

--- a/luarules/configs/BARb/stable/script/medium/manager/factory.as
+++ b/luarules/configs/BARb/stable/script/medium/manager/factory.as
@@ -17,6 +17,12 @@ string coravp ("coravp");
 string corasy ("corasy");
 string corap  ("corap");
 
+string leglab  ("leglab");
+string legalab ("legalab");
+string legvp   ("legvp");
+string legavp  ("legavp");
+string legap   ("legap");
+
 int switchInterval = MakeSwitchInterval();
 int switchFrame = 0;
 

--- a/luarules/configs/BARb/stable/script/medium/misc/commander.as
+++ b/luarules/configs/BARb/stable/script/medium/misc/commander.as
@@ -5,6 +5,7 @@ namespace Commander {
 
 string armcom("armcom");
 string corcom("corcom");
+string corcom("legcom");
 
 }
 
@@ -72,6 +73,18 @@ SOpener@ GetOpenInfo()
 		}},
 		{Factory::corap, array<SQueue> = {
 			SQueue(1.0f, {SO(RT::BUILDER), SO(RT::AA), SO(RT::RAIDER), SO(RT::BOMBER), SO(RT::SCOUT)})
+		}},
+		{Factory::leglab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::SKIRM), SO(RT::BUILDER), SO(RT::SKIRM), SO(RT::BUILDER)})
+		}},
+		{Factory::legalab, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 3), SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::legavp, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::BUILDER2), SO(RT::SKIRM, 2), SO(RT::BUILDER2), SO(RT::SKIRM), SO(RT::BUILDER2), SO(RT::ARTY), SO(RT::AA), SO(RT::BUILDER2)})
+		}},
+		{Factory::legap, array<SQueue> = {
+			SQueue(1.0f, {SO(RT::AA), SO(RT::RAIDER), SO(RT::BUILDER), SO(RT::BOMBER), SO(RT::SCOUT)})
 		}}
 		}, {SO(RT::RAIDER), SO(RT::BUILDER)}
 	);


### PR DESCRIPTION
### Work done

- Adapt BARb 'easy' and 'medium' ai code to handle legion too

### Issues

- Related to https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5281

### Test steps

- Start game with easy or medium barb legion ai
- Looks fine