### PR TITLE
change spawn button to new strategy for forcestart reduction

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -710,8 +710,8 @@
 			"ready": "Ready",
 			"unready": "Unready",
 			"readied": "Readied",
-			"lock": "Lock Position",
-			"unlock": "Unlock Position",
+			"lock": "Start",
+			"unlock": "Cancel",
 			"startCountdown": "Game starting in %{time}...",
 			"choosePoint": "Please choose a start point!",
 			"tooClose": "You cannot place your start position too close to another player"


### PR DESCRIPTION
### Work done
Changed spawn button sting from "Lock" and "Unlock" to "Start" and "Cancel" to adapt to new strategy targeting the reduction of forcestart by influencing the locking feedback of the user to a more appetible approach with the Start string.

Changed string in en language interface json.