### PR TITLE
Refactor attached con turrets and add unit customparam

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -1,43 +1,21 @@
 local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
-    return {
-        name      = 'Attached Construction Turret',
-        desc      = 'Attaches a builder to another mobile unit, so builder can repair while moving',
-        author    = 'Itanthias',
-        version   = 'v1.1',
-        date      = 'July 2023',
-        license   = 'GNU GPL, v2 or later',
-        layer     = 12,
-        enabled   = true
-    }
+	return {
+		name    = 'Attached Construction Turret',
+		desc    = 'Attaches a builder to another mobile unit, so builder can repair while moving',
+		author  = 'Itanthias',
+		version = 'v1.1',
+		date    = 'July 2023',
+		license = 'GNU GPL, v2 or later',
+		layer   = 12,
+		enabled = true
+	}
 end
 
 if not gadgetHandler:IsSyncedCode() then
-    return false
+	return false
 end
-
-local SpGetFeatureDefID = Spring.GetFeatureDefID
-local SpGetFeaturePosition = Spring.GetFeaturePosition
-local SpGetFeatureRadius = Spring.GetFeatureRadius
-local SpGetFeatureResurrect = Spring.GetFeatureResurrect
-local SpGetFeaturesInCylinder = Spring.GetFeaturesInCylinder
-local SpGetHeadingFromVector = Spring.GetHeadingFromVector
-local SpGetUnitAllyTeam = Spring.GetUnitAllyTeam
-local SpGetUnitCommands = Spring.GetUnitCommands
-local SpGetUnitDefDimensions = Spring.GetUnitDefDimensions
-local SpGetUnitDefID = Spring.GetUnitDefID
-local SpGetUnitFeatureSeparation = Spring.GetUnitFeatureSeparation
-local SpGetUnitHeading = Spring.GetUnitHeading
-local SpGetUnitHealth = Spring.GetUnitHealth
-local SpGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
-local SpGetUnitPosition = Spring.GetUnitPosition
-local SpGetUnitRadius = Spring.GetUnitRadius
-local SpGetUnitSeparation = Spring.GetUnitSeparation
-local SpGetUnitsInCylinder = Spring.GetUnitsInCylinder
-
-local SpCallCOBScript = Spring.CallCOBScript
-local SpGiveOrderToUnit = Spring.GiveOrderToUnit
 
 local CMD_REPAIR = CMD.REPAIR
 local CMD_RECLAIM = CMD.RECLAIM
@@ -50,7 +28,7 @@ local attachedBuilderDefID = {}
 local unitDefRadiusMax = 0
 
 for unitDefID, unitDef in pairs(UnitDefs) do
-	local dimensions = SpGetUnitDefDimensions(unitDef.id)
+	local dimensions = Spring.GetUnitDefDimensions(unitDef.id)
 	if dimensions then
 		unitDefRadiusMax = math.max(dimensions.radius, unitDefRadiusMax)
 	end
@@ -61,98 +39,99 @@ end
 
 local function updateTurretOrder(unitID, unitDefID)
 	-- first, check command the body is performing
-	local commandQueue = SpGetUnitCommands(attachedBuilders[unitID], 1)
+	local commandQueue = Spring.GetUnitCommands(attachedBuilders[unitID], 1)
 
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] < 0) then
-        -- build command
+		-- build command
 		-- The attached turret must have the same buildlist as the body for this to work correctly
 		--for XX,YY, base_unit_id in pairs(commandQueue[1]["params"]) do
 		--	Spring.Echo(XX,YY)
 		--end
-        SpGiveOrderToUnit(unitID, commandQueue[1]["id"], commandQueue[1]["params"], {})
-    end
+		Spring.GiveOrderToUnit(unitID, commandQueue[1]["id"], commandQueue[1]["params"], {})
+	end
 
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] == CMD_REPAIR) then
-        -- repair command
+		-- repair command
 		--for XX,YY, base_unit_id in pairs(commandQueue[1]["params"]) do
 		--	Spring.Echo(XX,YY)
 		--end
 		if #commandQueue[1]["params"] ~= 4 then
-			SpGiveOrderToUnit(unitID, CMD_REPAIR, commandQueue[1]["params"], {})
+			Spring.GiveOrderToUnit(unitID, CMD_REPAIR, commandQueue[1]["params"], {})
 		end
-    end
+	end
 
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] == CMD_RECLAIM) then
-        -- reclaim command
+		-- reclaim command
 		if #commandQueue[1]["params"] ~= 4 then
-			SpGiveOrderToUnit(unitID, CMD_RECLAIM, commandQueue[1]["params"], {})
+			Spring.GiveOrderToUnit(unitID, CMD_RECLAIM, commandQueue[1]["params"], {})
 		end
-    end
+	end
 
 	-- next, check to see if current command (including command from chassis) is in range
-	commandQueue = SpGetUnitCommands(unitID, 1)
-	local ux, uy, uz = SpGetUnitPosition(unitID)
+	commandQueue = Spring.GetUnitCommands(unitID, 1)
+	local ux, uy, uz = Spring.GetUnitPosition(unitID)
 	local tx, ty, tz
 	local radius = UnitDefs[unitDefID].buildDistance
-	local distance = radius^2 + 1
+	local distance = radius ^ 2 + 1
 	local targetRadius = 0
 
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] < 0) then
-        -- out of range build command
-		targetRadius = SpGetUnitDefDimensions(-commandQueue[1]["id"]).radius
-		distance = math.sqrt((ux-commandQueue[1]["params"][1])^2 + (uz-commandQueue[1]["params"][3])^2) - targetRadius
-    end
+		-- out of range build command
+		targetRadius = Spring.GetUnitDefDimensions(-commandQueue[1]["id"]).radius
+		distance = math.sqrt((ux - commandQueue[1]["params"][1]) ^ 2 + (uz - commandQueue[1]["params"][3]) ^ 2) -
+			targetRadius
+	end
 
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] == CMD_REPAIR) then
-        -- out of range repair command
+		-- out of range repair command
 		if (commandQueue[1]["params"][1] >= Game.maxUnits) then
-			tx,ty,tz = SpGetFeaturePosition(commandQueue[1]["params"][1] - Game.maxUnits)
-			targetRadius = SpGetFeatureRadius(commandQueue[1]["params"][1] - Game.maxUnits)
+			tx, ty, tz = Spring.GetFeaturePosition(commandQueue[1]["params"][1] - Game.maxUnits)
+			targetRadius = Spring.GetFeatureRadius(commandQueue[1]["params"][1] - Game.maxUnits)
 		else
-			tx,ty,tz = SpGetUnitPosition(commandQueue[1]["params"][1])
-			targetRadius = SpGetUnitRadius(commandQueue[1]["params"][1])
+			tx, ty, tz = Spring.GetUnitPosition(commandQueue[1]["params"][1])
+			targetRadius = Spring.GetUnitRadius(commandQueue[1]["params"][1])
 		end
 
 		if tx ~= nil then
-			distance = math.sqrt((ux-tx)^2 + (uz-tz)^2) - targetRadius
+			distance = math.sqrt((ux - tx) ^ 2 + (uz - tz) ^ 2) - targetRadius
 		end
-    end
+	end
 
 	if (commandQueue[1] ~= nil and commandQueue[1]["id"] == CMD_RECLAIM) then
 		-- out of range reclaim command
 		if (commandQueue[1]["params"][1] >= Game.maxUnits) then
-			tx,ty,tz = SpGetFeaturePosition(commandQueue[1]["params"][1] - Game.maxUnits)
-			targetRadius = SpGetFeatureRadius(commandQueue[1]["params"][1] - Game.maxUnits)
+			tx, ty, tz = Spring.GetFeaturePosition(commandQueue[1]["params"][1] - Game.maxUnits)
+			targetRadius = Spring.GetFeatureRadius(commandQueue[1]["params"][1] - Game.maxUnits)
 		else
-			tx,ty,tz = SpGetUnitPosition(commandQueue[1]["params"][1])
-			targetRadius = SpGetUnitRadius(commandQueue[1]["params"][1])
+			tx, ty, tz = Spring.GetUnitPosition(commandQueue[1]["params"][1])
+			targetRadius = Spring.GetUnitRadius(commandQueue[1]["params"][1])
 		end
 
 		if tx ~= nil then
-			distance = math.sqrt((ux-tx)^2 + (uz-tz)^2) - targetRadius
+			distance = math.sqrt((ux - tx) ^ 2 + (uz - tz) ^ 2) - targetRadius
 		end
-    end
+	end
 
 	if tx and distance <= radius then
 		--let auto con turret continue its thing
 		--update heading, by calling into unit script
-		local heading1 = SpGetHeadingFromVector(ux-tx,uz-tz)
-		local heading2 = SpGetUnitHeading(unitID)
-		SpCallCOBScript(unitID, 'UpdateHeading', 0, heading1-heading2+32768)
+		local heading1 = Spring.GetHeadingFromVector(ux - tx, uz - tz)
+		local heading2 = Spring.GetUnitHeading(unitID)
+		Spring.CallCOBScript(unitID, 'UpdateHeading', 0, heading1 - heading2 + 32768)
 		return
 	end
 
 	-- next, check to see if valid repair/reclaim targets in range
-	local nearUnits = SpGetUnitsInCylinder(ux,uz,radius + unitDefRadiusMax)
+	local nearUnits = Spring.GetUnitsInCylinder(ux, uz, radius + unitDefRadiusMax)
 
 	for _, nearID in pairs(nearUnits) do
 		-- check for free repairs
-		local nearDefID = SpGetUnitDefID(nearID)
-		if SpGetUnitAllyTeam(nearID) == SpGetUnitAllyTeam(unitID) then
-			if ( (SpGetUnitSeparation(nearID,unitID,true) - SpGetUnitRadius(nearID)) < radius) then
-				local health, maxHealth, paralyzeDamage, captureProgress, buildProgress = SpGetUnitHealth(nearID)
+		local nearDefID = Spring.GetUnitDefID(nearID)
+		if Spring.GetUnitAllyTeam(nearID) == Spring.GetUnitAllyTeam(unitID) then
+			if ((Spring.GetUnitSeparation(nearID, unitID, true) - Spring.GetUnitRadius(nearID)) < radius) then
+				local health, maxHealth, paralyzeDamage, captureProgress, buildProgress = Spring.GetUnitHealth(nearID)
 				if buildProgress == 1 and health < maxHealth and UnitDefs[nearDefID].repairable and nearID ~= attachedBuilders[unitID] then
-					SpGiveOrderToUnit(unitID,CMD_REPAIR,{nearID}, {})
+					Spring.GiveOrderToUnit(unitID, CMD_REPAIR, { nearID }, {})
 					return
 				end
 			end
@@ -161,25 +140,25 @@ local function updateTurretOrder(unitID, unitDefID)
 
 	for _, nearID in pairs(nearUnits) do
 		-- check for enemy to reclaim
-		local nearDefID = SpGetUnitDefID(nearID)
-		if SpGetUnitAllyTeam(nearID) ~= SpGetUnitAllyTeam(unitID) then
-			if ( (SpGetUnitSeparation(nearID,unitID,true) - SpGetUnitRadius(nearID)) < radius) then
+		local nearDefID = Spring.GetUnitDefID(nearID)
+		if Spring.GetUnitAllyTeam(nearID) ~= Spring.GetUnitAllyTeam(unitID) then
+			if ((Spring.GetUnitSeparation(nearID, unitID, true) - Spring.GetUnitRadius(nearID)) < radius) then
 				if UnitDefs[nearDefID].reclaimable then
-					SpGiveOrderToUnit(unitID,CMD_RECLAIM,{nearID}, {})
+					Spring.GiveOrderToUnit(unitID, CMD_RECLAIM, { nearID }, {})
 					return
 				end
 			end
 		end
 	end
 
-	local nearFeatures = SpGetFeaturesInCylinder(ux,uz,radius + unitDefRadiusMax)
+	local nearFeatures = Spring.GetFeaturesInCylinder(ux, uz, radius + unitDefRadiusMax)
 
 	for _, nearID in pairs(nearFeatures) do
 		-- check for non resurrectable feature to reclaim
-		local nearDefID = SpGetFeatureDefID(nearID)
-		if ( (SpGetUnitFeatureSeparation(unitID,nearID,true) - SpGetFeatureRadius(nearID)) < radius) then
-			if FeatureDefs[nearDefID].reclaimable and SpGetFeatureResurrect(nearID) == "" then
-				SpGiveOrderToUnit(unitID,CMD_RECLAIM,{nearID+Game.maxUnits}, {})
+		local nearDefID = Spring.GetFeatureDefID(nearID)
+		if ((Spring.GetUnitFeatureSeparation(unitID, nearID, true) - Spring.GetFeatureRadius(nearID)) < radius) then
+			if FeatureDefs[nearDefID].reclaimable and Spring.GetFeatureResurrect(nearID) == "" then
+				Spring.GiveOrderToUnit(unitID, CMD_RECLAIM, { nearID + Game.maxUnits }, {})
 				return
 			end
 		end
@@ -187,10 +166,10 @@ local function updateTurretOrder(unitID, unitDefID)
 
 	for _, nearID in pairs(nearUnits) do
 		-- check for nanoframe to build
-		if SpGetUnitAllyTeam(nearID) == SpGetUnitAllyTeam(unitID) then
-			if ( (SpGetUnitSeparation(nearID,unitID,true) - SpGetUnitRadius(nearID)) < radius) then
-				if SpGetUnitIsBeingBuilt(nearID) then
-					SpGiveOrderToUnit(unitID,CMD_REPAIR,{nearID}, {})
+		if Spring.GetUnitAllyTeam(nearID) == Spring.GetUnitAllyTeam(unitID) then
+			if ((Spring.GetUnitSeparation(nearID, unitID, true) - Spring.GetUnitRadius(nearID)) < radius) then
+				if Spring.GetUnitIsBeingBuilt(nearID) then
+					Spring.GiveOrderToUnit(unitID, CMD_REPAIR, { nearID }, {})
 					return
 				end
 			end
@@ -198,7 +177,7 @@ local function updateTurretOrder(unitID, unitDefID)
 	end
 
 	-- give stop command to attached con turret if nothing to do
-	SpGiveOrderToUnit(unitID,CMD.STOP,{}, {})
+	Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, {})
 end
 
 --------------------------------------------------------------------------------
@@ -214,41 +193,41 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 
 	-- for now, just corvac gets an attached con turret
 	if unitDef.name == "corvac" then
-		local xx,yy,zz = SpGetUnitPosition(unitID)
-		local turretID = Spring.CreateUnit("corvacct",xx,yy,zz,0,Spring.GetUnitTeam(unitID) )
+		local xx, yy, zz = Spring.GetUnitPosition(unitID)
+		local turretID = Spring.CreateUnit("corvacct", xx, yy, zz, 0, Spring.GetUnitTeam(unitID))
 		if not turretID then
 			-- unit limit hit or invalid spawn surface
 			return
 		end
-		Spring.UnitAttach(unitID,turretID,3)
+		Spring.UnitAttach(unitID, turretID, 3)
 		-- makes the attached con turret as non-interacting as possible
 		Spring.SetUnitBlocking(turretID, false, false, false)
-		Spring.SetUnitNoSelect(turretID,true)
+		Spring.SetUnitNoSelect(turretID, true)
 		attachedBuilders[turretID] = unitID
-		attachedBuilderDefID[turretID] = SpGetUnitDefID(turretID)
+		attachedBuilderDefID[turretID] = Spring.GetUnitDefID(turretID)
 	end
 
 	if unitDef.name == "legmohobp" then
-		local xx,yy,zz = SpGetUnitPosition(unitID)
-		local turretID = Spring.CreateUnit("legmohobpct",xx,yy,zz,0,Spring.GetUnitTeam(unitID) )
+		local xx, yy, zz = Spring.GetUnitPosition(unitID)
+		local turretID = Spring.CreateUnit("legmohobpct", xx, yy, zz, 0, Spring.GetUnitTeam(unitID))
 		if not turretID then
 			-- unit limit hit or invalid spawn surface
 			return
 		end
-		Spring.UnitAttach(unitID,turretID,3)
-		-- makes the attached con turret as non-interacting as possible 
+		Spring.UnitAttach(unitID, turretID, 3)
+		-- makes the attached con turret as non-interacting as possible
 		Spring.SetUnitBlocking(turretID, false, false, false)
-        Spring.SetUnitNoSelect(turretID,false)
+		Spring.SetUnitNoSelect(turretID, false)
 		attachedBuilders[turretID] = unitID
-		attachedBuilderDefID[turretID] = SpGetUnitDefID(turretID)
+		attachedBuilderDefID[turretID] = Spring.GetUnitDefID(turretID)
 	end
 end
 
 function gadget:GameFrame(gameFrame)
 	if gameFrame % 15 == 0 then
-	    -- go on a slowupdate cycle
+		-- go on a slowupdate cycle
 		for unitID in pairs(attachedBuilders) do
-			updateTurretOrder(unitID,attachedBuilderDefID[unitID])
+			updateTurretOrder(unitID, attachedBuilderDefID[unitID])
 		end
 	end
 end

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -122,8 +122,8 @@ local function echoTurretOrders(baseID, turretID, turretX, turretZ, radius)
 			end
 		elseif command == CMD_REPAIR or command == CMD_RECLAIM then
 			if param1 < FEATURE_BASE_INDEX then
-				-- Targets go out of sight (mostly) or are blocked, so this is nillable:
-				local separation = spGetUnitSeparation(turretID, param1, false, true)
+				-- Targets outside the team's LOS will return nil:
+				local separation = CallAsTeam(spGetUnitTeam(turretID), spGetUnitSeparation, turretID, param1, false, true)
 
 				if separation and radius >= separation then
 					local cx, cy, cz = spGetUnitPosition(param1)
@@ -131,7 +131,7 @@ local function echoTurretOrders(baseID, turretID, turretX, turretZ, radius)
 				end
 			else
 				local featureID = param1 - FEATURE_BASE_INDEX
-				local separation = spGetUnitFeatureSeparation(turretID, featureID)
+				local separation = CallAsTeam(teamID, Spring.GetUnitFeatureSeparation, turretID, featureID)
 
 				if separation and radius >= separation - spGetFeatureRadius(featureID) then
 					local cx, cy, cz = spGetFeaturePosition(featureID)

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -121,9 +121,11 @@ local function echoTurretOrders(baseID, turretID, turretX, turretZ, radius)
 				return turretX - param1, turretZ - param3
 			end
 		elseif command == CMD_REPAIR or command == CMD_RECLAIM then
+			local teamID = spGetUnitTeam(turretID)
+
 			if param1 < FEATURE_BASE_INDEX then
 				-- Targets outside the team's LOS will return nil:
-				local separation = CallAsTeam(spGetUnitTeam(turretID), spGetUnitSeparation, turretID, param1, false, true)
+				local separation = CallAsTeam(teamID, spGetUnitSeparation, turretID, param1, false, true)
 
 				if separation and radius >= separation then
 					local cx, cy, cz = spGetUnitPosition(param1)

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -221,9 +221,7 @@ local function updateTurretHeading(turretID, dx, dz)
 end
 
 local function updateAttachedTurret(baseID, turretID)
-	if transportedUnits[baseID] then
-		spGiveOrderToUnit(turretID, CMD_STOP, EMPTY, EMPTY)
-	else
+	if not transportedUnits[baseID] then
 		local ux, uy, uz = spGetUnitPosition(turretID)
 		local buildRadius = turretBuildRadius[turretID]
 
@@ -344,14 +342,20 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 	turretOrderPending[unitID] = nil
 end
 
+function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
+	return not transportedUnits[unitID]
+end
+
 function gadget:UnitCommand(unitID, unitDefID, unitTeam, cmdId, cmdParams, cmdOpts, cmdTag, playerID, fromSynced, fromLua)
 	turretOrderPending[unitID] = nil
 end
 
 function gadget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
 	if baseToTurretID[unitID] then
+		local turretID = baseToTurretID[unitID]
 		transportedUnits[unitID] = true
-		spGiveOrderToUnit(baseToTurretID[unitID], CMD_STOP, EMPTY, EMPTY)
+		transportedUnits[turretID] = true
+		spGiveOrderToUnit(turretID, CMD_STOP, EMPTY, EMPTY)
 	end
 end
 

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -68,12 +68,12 @@ local transportedUnits = {}
 ---Constructors with attached construction turrets must pass this check.
 ---Technically, it seems fine for the turret to have extra buildoptions.
 local function matchBuildOptions(unitDef1, unitDef2)
-	if #unitDef1.buildoptions == #unitDef2.buildoptions then
-		for i, unitName in ipairs(unitDef1.buildoptions) do
-			if not table.contains(unitDef2.buildoptions, unitName) then
+	if #unitDef1.buildOptions == #unitDef2.buildOptions then
+		for i, unitName in ipairs(unitDef1.buildOptions) do
+			if not table.contains(unitDef2.buildOptions, unitName) then
 				Spring.Log(gadget:GetInfo().name, LOG.ERROR, "Build option missing.")
 				return false
-			elseif unitName ~= unitDef2.buildoptions[i] then
+			elseif unitName ~= unitDef2.buildOptions[i] then
 				Spring.Log(gadget:GetInfo().name, LOG.ERROR, "Build option in different position.")
 				return false
 			end

--- a/units/CorVehicles/T2/corvac.lua
+++ b/units/CorVehicles/T2/corvac.lua
@@ -54,6 +54,7 @@ return {
 			subfolder = "CorVehicles/T2",
 			techlevel = 2,
 			unitgroup = "buildert2",
+			attached_con_turret = "corvacct",
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
Tested and working.

In short, this refactors the attached_con gadget to be more maintainable.

Hard-coded values are replaced with customparams and checked for correctness at init. The gadget now supports reloading luarules and can recover from error states caused by other gadgets.

There are some minor changes:
- copied the transport fix from Robert82
- separation distance checks respect line of sight
- the auto-order feature can retry up to three times when blocked by another gadget's AllowCommand