### PR TITLE
perf pass for gui sound effects player

### DIFF
--- a/luarules/gadgets/gui_soundeffects.lua
+++ b/luarules/gadgets/gui_soundeffects.lua
@@ -91,12 +91,6 @@ for name, defs in pairs(GUIUnitSoundEffects) do
 		if UnitDefNames[name..'_scav'] then
 			newGUIUnitSoundEffects[UnitDefNames[name..'_scav'].id] = defs
 		end
-		-- only use sub-tables for selecting multiple sounds
-		for key, value in pairs(defs) do
-			if type(value) == "table" and #value == 1 then
-				defs[key] = value[1]
-			end
-		end
 		-- ensure activate-able units have deactivate sounds
 		if not defs.BaseSoundDeactivate and defs.BaseSoundActivate then
 			defs.BaseSoundDeactivate = defs.BaseSoundActivate


### PR DESCRIPTION
- Command sound flood guard. Added a flood guard in front of the command sounds to prevent callins from making pointless engine calls and then playing no sound.

Removed, these cause almost the entire file to be revised, even when not changing any functionality:

- ~~Lots of micro opts. The gadget has some performance drag due to table accesses. When sending very large build orders, for instance, while the engine lags tremendously, the gadget adds to the overall high load.~~

- ~~Allied unit sounds weren't deduped. This is perf-related still because we have limited sound channels. The delay frames to dedupe allied unit sounds used the same frame delay as the player's unit sounds. If a player had no unit activity, maybe it made their allies unusually loud? I'm not even sure. Yolo. Fixed.~~