### PR TITLE
add custom parameter to triton, allow it to be used on land

### DIFF
--- a/luaui/configs/unit_buildmenu_config.lua
+++ b/luaui/configs/unit_buildmenu_config.lua
@@ -29,6 +29,9 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	if unitDef.name == 'armthovr' or unitDef.name == 'corintr' then
 		isWaterUnit[unitDefID] = nil
 	end
+	if unitDef.customParams.convertibleboat then
+		isWaterUnit[unitDefID] = nil
+	end
 
 	if unitDef.needGeo then
 		isGeothermal[unitDefID] = true

--- a/units/Legion/Vehicles/T2 Vehicles/legfloat.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legfloat.lua
@@ -46,6 +46,7 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "legvehicles/T2",
 			techlevel = 2,
+			convertibleboat = true,
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
### Work Done
Adds a new custom parameter to the Legion Triton: `convertibleboat`, a true/false statement that aptly describes if something is a convertible boat or not.

Adjusts unit_buildmenu_config to ensure that units with this custom parameter as true will not be counted as a sea unit, and therefore excluded from when sea units are disabled on land-only maps. This makes the Triton usable on land again whilst keeping its ability to be treated as a regular boat and targeted by torpedoes and depth-charges whilst in the water.

### Testing Required
- [] Test on various land-only and sea maps to ensure all sea units are accessible/inaccessible whilst Triton is accessible all the time.

### Team and Lead
- Technical Interface Team, @Ruwetuin 
- Code Quality Team, @WatchTheFort 

