### PR TITLE
feat: dont use quota mode when alt key is pressed

### DIFF
--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -1186,11 +1186,12 @@ function widget:MousePress(x, y, button)
 					if cmds[cellRectID].id and unitTranslatedHumanName[-cmds[cellRectID].id] and math_isInRect(x, y, cellRect[1], cellRect[2], cellRect[3], cellRect[4]) and not (units.unitRestricted[-cmds[cellRectID].id]) then
 						local uDefID = cmds[cellRectID].id  --WARNING: THIS IS -unitDefID, not unitDefID
 						local setQuotas = isOnQuotaBuildMode(-uDefID)
+						local alt, ctrl, meta, shift = Spring.GetModKeyState()
 						if button ~= 3 then
 							if playSounds then
 								Spring.PlaySoundFile(sound_queue_add, 0.75, 'ui')
 							end
-							if setQuotas then
+							if setQuotas and not alt then
 								changeQuotas(-uDefID, 1)
 							else
 								if preGamestartPlayer then
@@ -1201,7 +1202,7 @@ function widget:MousePress(x, y, button)
 									if isRepeatMex then
 										WG['areamex'].setAreaMexType(uDefID)
 									end
-									Spring.SetActiveCommand(cmd, 1, true, false, Spring.GetModKeyState())
+									Spring.SetActiveCommand(cmd, 1, true, false, alt, ctrl, meta, shift)
 								end
 							end
 						else
@@ -1209,7 +1210,7 @@ function widget:MousePress(x, y, button)
 								-- has queue
 								Spring.PlaySoundFile(sound_queue_rem, 0.75, 'ui')
 							end
-							if setQuotas then
+							if setQuotas and not alt then
 								if changeQuotas(-uDefID, modKeyMultiplier.right) and playSounds then
 									Spring.PlaySoundFile(sound_queue_rem, 0.75, 'ui')
 								end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1143,7 +1143,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 
 	if builderIsFactory then
-		if WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID)  then
+		if WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt then
 			local quantity = 1
 			if shift then
 				quantity = modKeyMultiplier.keyPress.shift
@@ -2446,7 +2446,7 @@ function widget:MousePress(x, y, button)
 					then
 						local alt, ctrl, meta, shift = Spring.GetModKeyState()
 						if button ~= 3 then
-							if builderIsFactory and WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) then
+							if builderIsFactory and WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt then
 								local amount = 1
 								if ctrl then
 									amount = amount * modKeyMultiplier.click.ctrl
@@ -2465,7 +2465,7 @@ function widget:MousePress(x, y, button)
 								pickBlueprint(unitDefID)
 							end
 						elseif builderIsFactory and spGetCmdDescIndex(-unitDefID) then
-							if not (WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID)) then
+							if not (WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt) then
 								Spring.PlaySoundFile(CONFIG.sound_queue_rem, 0.75, "ui")
 								setActiveCommand(spGetCmdDescIndex(-unitDefID), 3, false, true)
 							else


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Since alt does nothing in quota mode and since it can be used to quickly queue units, the queue it always modified when alt is pressed, even on quota mode.
<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
