### PR TITLE
Fix bug disabling repeat builds

### DIFF
--- a/luaui/Widgets/unit_clean_builder_queue.lua
+++ b/luaui/Widgets/unit_clean_builder_queue.lua
@@ -95,7 +95,7 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	local x, _, z = GetUnitPosition(unitID)
 
 	for builderID in pairs(trackedBuilders) do
-		if IsUnitRepeatOn(builderID) then
+		if not IsUnitRepeatOn(builderID) then
 			local commands = GetUnitCommands(builderID, 32)
 			for i = #commands, 1, -1 do
 				local cmd = commands[i]


### PR DESCRIPTION
I have regressed the repeat build getting broken to this PR: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5018

Fix the bug introduced into the widget. Now it does the thing for non-repeating builders, instead of for repeating ones only.