### PR TITLE
Reenabling stockpile use for drone carriers

### DIFF
--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -401,7 +401,7 @@ local function SpawnUnit(spawnData)
 							energyCost = subUnitDef.energyCost
 						end
 						---
-						if stockpilecount > 0 then
+						if carrierMetaList[spawnData.ownerID].usestockpile and stockpilecount > 0 then
 							if stockpiledMetal >= metalCost and stockpiledEnergy >= energyCost then
 								subUnitID = spCreateUnit(dronename, spawnData.x, spawnData.y, spawnData.z, 0, spawnData.teamID)
 								stockpiledMetal = stockpiledMetal - metalCost
@@ -801,7 +801,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 					carrierMetaList[carrierUnitID].availableSections[dronetypeIndex].availablePieces[carrierMetaList[carrierUnitID].subUnitsList[unitID].dockingPieceIndex].dockingPieceAvailable = true
 				end
 				carrierMetaList[carrierUnitID].subUnitCount[dronetypeIndex] = carrierMetaList[carrierUnitID].subUnitCount[dronetypeIndex] - 1
-				if carrierMetaList[carrierUnitID].stockpilecount > 0 then
+				if carrierMetaList[carrierUnitID].usestockpile and carrierMetaList[carrierUnitID].stockpilecount > 0 then
 					local stockpile,_,stockpilepercentage = Spring.GetUnitStockpile(carrierUnitID)
 					if stockpile > 0 then
 						stockpile = stockpile - 1

--- a/units/ArmShips/T2/armdronecarry.lua
+++ b/units/ArmShips/T2/armdronecarry.lua
@@ -168,6 +168,7 @@ return {
 					stockpilelimit = 16,
 					stockpilemetal = 25,
 					stockpileenergy = 600,
+					dronesusestockpile = true,
 				}
 			},
 			aamissile = {

--- a/units/ArmShips/T2/armtrident.lua
+++ b/units/ArmShips/T2/armtrident.lua
@@ -172,6 +172,7 @@ return {
 					stockpilelimit = 4,
 					stockpilemetal = 30,
 					stockpileenergy = 750,
+					dronesusestockpile = true,
 				}
 			},
 			

--- a/units/CorShips/T2/cordronecarry.lua
+++ b/units/CorShips/T2/cordronecarry.lua
@@ -168,6 +168,7 @@ return {
 					stockpilelimit = 10,
 					stockpilemetal = 30,
 					stockpileenergy = 750,
+					dronesusestockpile = true,
 				}
 			},
 			aamissile = {

--- a/units/CorShips/T2/corsentinel.lua
+++ b/units/CorShips/T2/corsentinel.lua
@@ -173,6 +173,7 @@ return {
 					stockpilelimit = 5,
 					stockpilemetal = 40,
 					stockpileenergy = 1000,
+					dronesusestockpile = true,
 				}
 			},
 			

--- a/units/Legion/Defenses/leghive.lua
+++ b/units/Legion/Defenses/leghive.lua
@@ -160,6 +160,7 @@ return {
 					stockpilelimit = 6,
 					stockpilemetal = 15,
 					stockpileenergy = 500,
+					dronesusestockpile = true,
 				}
 			},
 		},

--- a/units/Legion/SeaDefenses/legfhive.lua
+++ b/units/Legion/SeaDefenses/legfhive.lua
@@ -161,6 +161,7 @@ return {
 					stockpilelimit = 6,
 					stockpilemetal = 15,
 					stockpileenergy = 500,
+					dronesusestockpile = true,
 				}
 			},
 		},

--- a/units/Legion/Vehicles/T2 Vehicles/legvcarry.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legvcarry.lua
@@ -165,6 +165,7 @@ return {
 					stockpilelimit = 6,
 					stockpilemetal = 15,
 					stockpileenergy = 500,
+					dronesusestockpile = true,
 				}
 			},
 		},

--- a/units/Scavengers/Air/cordronecarryair.lua
+++ b/units/Scavengers/Air/cordronecarryair.lua
@@ -170,6 +170,7 @@ return {
 					stockpilelimit = 10,
 					stockpilemetal = 40,
 					stockpileenergy = 1000,
+					dronesusestockpile = true,
 				}
 			},
 		},

--- a/units/Scavengers/Vehicles/armdronecarryland.lua
+++ b/units/Scavengers/Vehicles/armdronecarryland.lua
@@ -167,6 +167,7 @@ return {
 					stockpilelimit = 16,
 					stockpilemetal = 30,
 					stockpileenergy = 750,
+					dronesusestockpile = true,
 				}
 			},
 		},


### PR DESCRIPTION
Reenables stockpile use for drone carriers while letting carriers with existing stockpile weapons to stay on the old drone spawn system. 