### PR TITLE
Allow napalm/overpen to produce heaps properly

### DIFF
--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -283,7 +283,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
                     spSetFeatureHealth(featureID, health)
                     featDamageTaken[featureID] = damageTaken + damage
                 else
-                    Spring.DestroyFeature(featureID)
+                    GG.reduceWreckageToDebris(featureID, health, damage)
                 end
             end
         end

--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -373,7 +373,7 @@ function gadget:GameFrame(gameFrame)
 						if health > 1 then
 							Spring.SetFeatureHealth(targetID, health)
 						else
-							Spring.DestroyFeature(targetID)
+							GG.reduceWreckageToDebris(targetID, health, damage)
 						end
 					end
 				end

--- a/luaui/Widgets/api_wrecks_to_rubble.lua
+++ b/luaui/Widgets/api_wrecks_to_rubble.lua
@@ -1,0 +1,84 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+    return {
+        name    = "Wrecks to Rubble API",
+        desc    = "When destroying a wreck via script, allow transforming it to debris.",
+        author  = "efrec",
+        date    = "2025",
+        license = "GNU GPL, v2 or later",
+        layer   = 0,
+        enabled = true,
+    }
+end
+
+local metalMinimum = 6 -- 10 x 60%
+
+local wreckToHeapDefID = {}
+
+for unitDefID, unitDef in ipairs(UnitDefs) do
+    local wreckDefID, heapDefID
+
+    if FeatureDefNames[unitDef.name .. "_dead"] then
+        wreckDefID = FeatureDefNames[unitDef.name .. "_dead"].id
+    end
+
+    if FeatureDefNames[unitDef.name .. "_heap"] then
+        heapDefID = FeatureDefNames[unitDef.name .. "_heap"].id
+    end
+
+    if wreckDefID and heapDefID then
+        local wreckDef = FeatureDefs[wreckDefID]
+        local heapDef = FeatureDefs[heapDefID]
+
+        if wreckDef.metal >= metalMinimum and heapDef.metal >= metalMinimum then
+            wreckToHeapDefID[wreckDefID] = {
+                heapDefID    = heapDefID,
+                healthBefore = wreckDef.damage,
+                health       = heapDef.damage,
+                metal        = heapDef.metal,
+                energy       = heapDef.energy,
+                time         = heapDef.reclaimTime,
+            }
+        end
+    end
+end
+
+local function reduceWreckageToDebris(featureID, healthBefore, damageTaken)
+    local featureDefID = Spring.GetFeatureDefID(featureID)
+
+    if healthBefore - damageTaken <= 0 and wreckToHeapDefID[featureDefID] then
+        local metal, metalMax, _, _, reclaimLeft = Spring.GetFeatureResources(featureID)
+
+        if metal >= metalMinimum and metalMax >= metalMinimum then
+            local heapInfo = wreckToHeapDefID[featureDefID]
+            local healthLeft = heapInfo.health + healthBefore - damageTaken
+
+            if healthLeft >= 0.5 * heapInfo.health then
+                local heapID = Spring.CreateFeature(heapInfo.heapDefID, Spring.GetFeaturePosition(featureID))
+
+                -- The main reason we are here is because this "Destroy" is a Delete:
+                Spring.DestroyFeature(featureID)
+
+                if heapID then
+                    local healthPercentage = healthLeft / heapInfo.health
+
+                    Spring.SetFeatureHealth(heapID, healthPercentage * heapInfo.health)
+                    Spring.SetFeatureResources(heapID,
+                        heapInfo.metal * reclaimLeft,
+                        heapInfo.energy * reclaimLeft,
+                        heapInfo.time * reclaimLeft,
+                        reclaimLeft)
+                end
+            end
+        end
+    end
+end
+
+function gadget:Initialize()
+    GG.reduceWreckToHeap = reduceWreckageToDebris
+end
+
+function gadget:Shutdown()
+    GG.reduceWreckToHeap = nil
+end


### PR DESCRIPTION
Currently, the Spring.DestroyFeature function acts more like a DeleteFeature. Nothing is left behind. This is generally preferable for scripted effects, but since napalm and railguns are weapons that should apply weapon-type effect damage, the result looks unusual.

### Work done

Set up an api gadget with a global function for other gadgets to reduce unit wrecks to debris. Reclaim %remaining and any excess damage are carried over to the heap.