### PR TITLE
Normalize line endings to LF for cross-platform consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-
-
 # EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
@@ -8,6 +6,7 @@ root = true
 # Set default charset
 [*.{lua,md}]
 charset = utf-8
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Declare files that will always have CRLF line endings on checkout.
-*.lua text eol=crlf
-*.txt text eol=crlf
-*.tdf text eol=crlf
+*.lua text eol=lf
+*.txt text eol=lf
+*.tdf text eol=lf


### PR DESCRIPTION
## Context

Having massive problems on windows with a modified file.  The file (modified:   luarules/configs/Atmosphereconfigs/all that smolders.lua) would persist in being a gremlin, despite attempting:

* `git reset --hard HEAD` from master or my branch
* `git checkout origin/master -- luarules/configs/Atmosphereconfigs/all\ that\ smolders.lua`
*  `git restore --staged luarules/configs/Atmosphereconfigs/all\ that\ smolders.lua`

## Solution
Normalize to LF. There is a reason that is best practice for code and it's precisely this problem.