### PR TITLE
Fix drawing of unified range rings with rotated minimap

### DIFF
--- a/luaui/Shaders/weapon_range_rings_unified_gl4.vert.glsl
+++ b/luaui/Shaders/weapon_range_rings_unified_gl4.vert.glsl
@@ -20,7 +20,7 @@ uniform float lineAlphaUniform = 1.0;
 uniform float cannonmode = 0.0;
 uniform float fadeDistOffset = 0.0;
 uniform float inMiniMap = 0.0;
-uniform int flipMiniMap = 0;
+uniform int rotationMiniMap = 0;
 
 
 uniform float selUnitCount = 1.0;
@@ -451,8 +451,12 @@ void main() {
 		gl_Position.z = (gl_Position.z) - 128.0 / (gl_Position.w); // send 16 elmos forward in Z
 	} else {
 		vec4 ndcxy = mmDrawViewProj * vec4(circleWorldPos.xyz, 1.0);
-		if (flipMiniMap == 1) {
+		if (rotationMiniMap == 1) {
+			ndcxy.xy = vec2(-ndcxy.y, ndcxy.x);
+		}else if (rotationMiniMap == 2) {
 			ndcxy.xy = -ndcxy.xy;
+		}else if (rotationMiniMap == 3) {
+			ndcxy.xy = vec2(ndcxy.y, -ndcxy.x);
 		}
 		gl_Position = ndcxy;
 	}

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -177,7 +177,8 @@ local vtoldamagetag = Game.armorTypes['vtol']
 local defaultdamagetag = Game.armorTypes['default']
 
 -- globals
-local getMiniMapFlipped = VFS.Include("luaui/Include/minimap_utils.lua").getMiniMapFlipped
+local getCurrentMiniMapRotationOption = VFS.Include("luaui/Include/minimap_utils.lua").getCurrentMiniMapRotationOption
+local ROTATION = VFS.Include("luaui/Include/minimap_utils.lua").ROTATION
 local selUnitCount = 0
 local selBuilderCount = 0 -- we need builder count separately
 local shifted = false
@@ -310,10 +311,10 @@ local function initializeUnitDefRing(unitDefID)
     local color      = colorConfig[cfgKey].color
     local fadeparams = colorConfig[cfgKey].fadeparams
 
-			local isCylinder = 0 
+			local isCylinder = 0
 			if (weaponDef.cylinderTargeting)  and (weaponDef.cylinderTargeting > 0.0) then
 				isCylinder = 1
-			end	
+			end
 			local isDgun = (weaponDef.type == "DGun") and 1 or 0
 
 			local wName = weaponDef.name
@@ -372,7 +373,7 @@ local function initializeUnitDefRing(unitDefID)
 					maxangledif = maxangledif  + difffract
 				else
 
-				end 
+				end
 
 
 
@@ -390,11 +391,11 @@ local function initializeUnitDefRing(unitDefID)
 				weaponDef.projectilespeed or 1, --10
 				isCylinder,-- and 1 or 0, (11)
 				weaponDef.heightBoostFactor or 0, --12
-				weaponDef.heightMod or 0, --13 
+				weaponDef.heightMod or 0, --13
 				groupselectionfadescale, --14
 				weaponType, --15
 				isDgun, --16
-				maxangledif  --17 
+				maxangledif  --17
 			}
 			unitDefRings[unitDefID]['rings'][weaponNum] = ringParams
 		end
@@ -551,7 +552,7 @@ local shaderSourceCache = {
 		drawMode = 0,
 		selBuilderCount = 1.0,
 		selUnitCount = 1.0,
-		inMiniMap = 0.0, 
+		inMiniMap = 0.0,
 	},
 }
 
@@ -608,9 +609,9 @@ local function AddSelectedUnit(unitID, mouseover)
 				if weapon.onlyTargets and weapon.onlyTargets.vtol then
 					entry.weapons[weaponNum] = 3 -- weaponTypeMap[3] is "AA"
 				elseif weaponDef.type == "Cannon" then
-					-- if weaponDef.range < 700 then 
+					-- if weaponDef.range < 700 then
 					-- 	entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground"
-					if weaponDef.range > 2600 then 
+					if weaponDef.range > 2600 then
 						entry.weapons[weaponNum] = 5 -- weaponTypeMap[5] is "lrpc"
 					else
 						entry.weapons[weaponNum] = 4 -- weaponTypeMap[4] is "cannon"
@@ -618,12 +619,12 @@ local function AddSelectedUnit(unitID, mouseover)
 				elseif weaponDef.type == "Melee" then
 					entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground"
 				else
-					if weaponDef.range < 700 then 
+					if weaponDef.range < 700 then
 						entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground
-					elseif weaponDef.range > 2600 then 
+					elseif weaponDef.range > 2600 then
 						entry.weapons[weaponNum] = 5 -- weaponTypeMap[5] is "lrpc"
 					else
-						entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground"						
+						entry.weapons[weaponNum] = 1 -- weaponTypeMap[1] is "ground"
 					end
 				end
 			end
@@ -677,7 +678,7 @@ local function AddSelectedUnit(unitID, mouseover)
 		local ringParams = unitDefRings[unitDefID]['rings'][j]
 		if drawIt and ringParams[1] > 0 then
 
-			local weaponID = j 
+			local weaponID = j
 			-- TODO:
 			-- Weapons aim from their WPY positions, but that can change for e.g. popups!
 			-- This is quite important to pass in as posscale.y!
@@ -685,7 +686,7 @@ local function AddSelectedUnit(unitID, mouseover)
 			-- also assumes that weapons are centered onto drawpos
 			local wpx, wpy, wpz, wdx, wdy, wdz = spGetUnitWeaponVectors(unitID, weaponID)
 			--Spring.Echo("unitID", unitID,"weaponID", weaponID, "y", y, "mpy",  mpy,"wpy", wpy)
-			
+
 			-- Now this is a truly terrible hack, we cache each unitDefID's max weapon turret height at position 18 in the table
 			-- so it only goes up with popups
 			local turretHeight = math.max(ringParams[18] or 0, (wpy or mpy ) - y)
@@ -1069,7 +1070,7 @@ function widget:RecvLuaMsg(msg, playerID)
 	end
 end
 
-local drawcounts = {} 
+local drawcounts = {}
 
 local cameraHeightFactor = 0
 
@@ -1104,11 +1105,11 @@ local function DRAWRINGS(primitiveType, linethickness)
 	attackRangeShader:SetUniform("cannonmode", 1)
 	for i, allyState in ipairs(allyenemypairs) do
 		for j, wt in ipairs(cannonlrpc) do
-			if linethickness or wt == 'cannon' then 
+			if linethickness or wt == 'cannon' then
 				local atkRangeClass = allyState .. wt
 				local iT = attackRangeVAOs[atkRangeClass]
 				local stencilOffset = colorConfig.cannon_separate_stencil and 3 or 0
-				stencilMask = 2 ^ (4 * (i - 1) + stencilOffset) -- if 0 then it's on the same as "ground" 
+				stencilMask = 2 ^ (4 * (i - 1) + stencilOffset) -- if 0 then it's on the same as "ground"
 				drawcounts[stencilMask] = iT.usedElements
 				if iT.usedElements > 0 then
 					if linethickness then
@@ -1141,7 +1142,7 @@ function widget:DrawWorld(inMiniMap)
 			glClear(GL_STENCIL_BUFFER_BIT)   -- clear previous stencil
 			glDepthTest(false)               -- always draw, ignore depth test
 
-			-- Draw the filled circles onto the stencil buffer 
+			-- Draw the filled circles onto the stencil buffer
 			glStencilTest(true)              -- enable stencil test
 			glStencilMask(255)               -- set all 8 bits to writeable
 
@@ -1155,7 +1156,7 @@ function widget:DrawWorld(inMiniMap)
 			attackRangeShader:SetUniform("selBuilderCount", selBuilderCount)
 			attackRangeShader:SetUniform("drawMode", 0.0)
 			attackRangeShader:SetUniform("inMiniMap", inMiniMap and 1.0 or 0.0)
-			attackRangeShader:SetUniformInt("flipMiniMap", getMiniMapFlipped() and 1 or 0)
+			attackRangeShader:SetUniformInt("rotationMiniMap", getCurrentMiniMapRotationOption() or ROTATION.DEG_0)
 			attackRangeShader:SetUniform("drawAlpha", colorConfig.fill_alpha)
 			attackRangeShader:SetUniform("fadeDistOffset", colorConfig.outer_fade_height_difference)
 
@@ -1164,7 +1165,7 @@ function widget:DrawWorld(inMiniMap)
 			-- Draw the outside rings by testing the stencil buffer
 			glLineWidth(math.max(0.1, 4 + math.sin(gameFrame * 0.04) * 10))
 			glColorMask(true, true, true, true) -- re-enable color drawing
-			glStencilMask(0) 
+			glStencilMask(0)
 			glDepthTest(GL_LEQUAL) -- test for depth on these outside cases
 
 			attackRangeShader:SetUniform("lineAlphaUniform", colorConfig.externalalpha)
@@ -1172,14 +1173,14 @@ function widget:DrawWorld(inMiniMap)
 			attackRangeShader:SetUniform("drawAlpha", 1.0)
 
 			DRAWRINGS(GL_LINE_LOOP, inMiniMap and 'minimapexternallinethickness' or 'externallinethickness') -- DRAW THE OUTER RINGS
-			
+
 			-- This is the correct way to exit out of the stencil mode, to not break drawing of area commands:
 			glStencilTest(false) -- Disable the stencil test
 			glStencilMask(255)   -- Set all bits of stencil buffer to writeable
 			glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP) -- Reset default stencil operation (which is the do nothing operation)
 			glClear(GL_STENCIL_BUFFER_BIT) -- Clear the stencil buffer for whichever widget wants it next (this is probably redundant)
 			-- All the above are needed :O
-		end 
+		end
 
 		-- After all the stenciled drawings, we have disabled the stencil test, so we can draw the inner rings
 		if colorConfig.drawInnerRings then
@@ -1200,7 +1201,7 @@ end
 function widget:DrawInMiniMap()
 	-- TODO:
 	-- do a sanity check and dont draw here if there are too many units selected...
-	widget:DrawWorld(true) 
+	widget:DrawWorld(true)
 end
 
 function widget:VisibleUnitAdded(unitID, unitDefID, unitTeam)
@@ -1219,7 +1220,7 @@ end
 
 
 
-if autoReload then 
+if autoReload then
     function widget:DrawScreen()
         if attackRangeShader.DrawPrintf then attackRangeShader.DrawPrintf(0, 64) end
     end


### PR DESCRIPTION
### Work done
- Acknowledges #5103 for the case where the minimap gets rotated (This is considered a part of #4858)

#### Setup
- To test this, you will need to disable `minimapcanflip` (named auto flip) option from the settings. This will disable the legacy engine behavior and allow Widgets to control MMRotation (you can also type /option minimapcanflip)
- You need an external widget to change the minimap's rotation using `Spring.SetMiniMapRotation`

#### Test steps
- [ ] Make units and select them all at the same time

### Screenshots:
#### BEFORE:
![image](https://github.com/user-attachments/assets/c42d8bc1-a0f0-4cd6-9384-9bee080ff1b8)


#### AFTER:
![image](https://github.com/user-attachments/assets/e0cc6a29-aaee-437d-9c5d-1f71aa2b4c0d)
![image](https://github.com/user-attachments/assets/5d7adc9b-f5fd-494a-86c6-968cc7d72576)

