### PR TITLE
Fix incorrect or lagging commands on the Printer

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -168,7 +168,7 @@ local function auto_repair_routine(unitID, baseID)
 
 		-- Blanket-verify all parameter counts to avoid (e.g.) area commands:
 		if allowed == buildTarget then
-			if buildTarget[paramCount] then
+			if allowed[paramCount] then
 				local object_radius = 0
 				local tx, ty, tz
 
@@ -189,8 +189,8 @@ local function auto_repair_routine(unitID, baseID)
 				distance = math.sqrt(dx * dx + dy * dy + dz * dz) - object_radius
 			end
 		elseif
-			(allowed == buildOrder and buildOrder[paramCount]) or
-			(allowed == mapPosition and mapPosition[paramCount])
+			(allowed == buildOrder and allowed[paramCount]) or
+			(allowed == mapPosition and allowed[paramCount])
 		then
 			local tx, ty, tz = param1, param2, param3
 

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -17,9 +17,6 @@ if not gadgetHandler:IsSyncedCode() then
     return false
 end
 
-
-local CMD_REPAIR = CMD.REPAIR
-local CMD_RECLAIM = CMD.RECLAIM
 local SpGetUnitCommands = Spring.GetUnitCommands
 local SpGiveOrderToUnit = Spring.GiveOrderToUnit
 local SpGetUnitPosition = Spring.GetUnitPosition
@@ -41,6 +38,54 @@ local SpGetUnitSeparation = Spring.GetUnitSeparation
 local SpGetHeadingFromVector = Spring.GetHeadingFromVector
 local SpGetUnitHeading = Spring.GetUnitHeading
 local SpCallCOBScript = Spring.CallCOBScript
+
+local CMD_CAPTURE = CMD.CAPTURE
+local CMD_GUARD = CMD.GUARD
+local CMD_RECLAIM = CMD.RECLAIM
+local CMD_REPAIR = CMD.REPAIR
+local CMD_STOP = CMD.STOP
+
+--------------------------------------------------------------------------------
+-- Command introspection -------------------------------------------------------
+
+-- Parameter counts used with commands
+local always = {}; for i = 0, 8 do always[i] = true end
+local withParams = {}; for i = 1, 8 do withParams[i] = true end
+local never = {}
+local buildOrder = { [4] = true, }
+local buildTarget = { [1] = true, [5] = true }
+local mapPosition = { [3] = true, [4] = true, }
+
+local commandParamAllowed = {
+	[CMD.STOP]       = always,
+	[CMD.INSERT]     = always,
+	[CMD.REMOVE]     = always,
+	[CMD.WAIT]       = always,
+	[CMD.DEATHWAIT]  = always,
+	[CMD.GATHERWAIT] = always,
+	[CMD.TIMEWAIT]   = always,
+
+	[CMD.FIRE_STATE] = withParams,
+	[CMD.MOVE_STATE] = withParams,
+	[CMD.ONOFF]      = withParams,
+	[CMD.TRAJECTORY] = withParams,
+
+	[CMD.CAPTURE]    = buildTarget,
+	[CMD.RECLAIM]    = buildTarget,
+	[CMD.REPAIR]     = buildTarget,
+	[CMD.RESURRECT]  = buildTarget,
+
+	[CMD.RESTORE]    = mapPosition,
+}
+
+commandParamAllowed = setmetatable(commandParamAllowed, {
+	__index = function(self, key)
+		return key < 0 and buildOrder or never
+	end
+})
+
+local moveStateTeamAssist = CMD.MOVESTATE_MANEUVER
+local moveStateAllyAssist = CMD.MOVESTATE_ROAM
 
 --repairs and reclaims start at the edge of the unit radius
 --so we need to increase our search radius by the maximum unit radius

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -39,7 +39,6 @@ local SpGetHeadingFromVector = Spring.GetHeadingFromVector
 local SpGetUnitHeading = Spring.GetUnitHeading
 local SpCallCOBScript = Spring.CallCOBScript
 
-local CMD_CAPTURE = CMD.CAPTURE
 local CMD_GUARD = CMD.GUARD
 local CMD_RECLAIM = CMD.RECLAIM
 local CMD_REPAIR = CMD.REPAIR
@@ -85,9 +84,6 @@ commandParamAllowed = setmetatable(commandParamAllowed, {
 		return key < 0 and buildOrder or never
 	end
 })
-
-local moveStateTeamAssist = CMD.MOVESTATE_MANEUVER
-local moveStateAllyAssist = CMD.MOVESTATE_ROAM
 
 --repairs and reclaims start at the edge of the unit radius
 --so we need to increase our search radius by the maximum unit radius
@@ -273,7 +269,7 @@ local function auto_repair_routine(unitID, baseID)
 	end
 
 	-- give stop command to attached con turret if nothing to do
-	SpGiveOrderToUnit(unitID,CMD.STOP,{}, {})
+	SpGiveOrderToUnit(unitID, CMD_STOP, {}, {})
 
 end
 


### PR DESCRIPTION
### Work done

- Added simple command introspection to the Printer's con gadget.
- Forwarded certain commands from the base unit to the turret unit so that they are accepted immediately.

Some command IDs map to multiple command/parameter type sets, depending on modifier keys. Builder commands can be issued in an area, for instance. The gadget previously did not distinguish these from commands with a target.

In addition, the turret could lag behind the target of the base unit in awkward ways, or would prioritize reclaiming over build commands. That is fixed.

#### Setup

- Enable extra/all units

#### Test steps

- [ ] Give a corvac
- [ ] Place a build order while the corvac is in range of reclaim. The previous behavior would prioritize reclaim in many/most cases. Verify that it does not.
- [ ] Place many build orders in quick succession. The previous behavior would not update either the turret's order or its orientation. Verify that commands work and the unit feels snappy.

In addition, if you have some esoteric command wisdom, send an odd command to the corvac. The turret should not accept anything it cannot actually perform.