### PR TITLE
Disable unit control from widgets (UI widgets will work such as Ping Wheel)

### DIFF
--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -71,5 +71,19 @@ if Spring.Echo then
 		end
 	end
 
-	Spring.Echo = multiEcho
+        Spring.Echo = multiEcho
+end
+
+-- Disable widget issued unit orders
+if Spring.GiveOrderToUnit then
+    local function disabledOrder()
+        Spring.Echo("Widget issued unit order blocked")
+        return false
+    end
+
+    Spring.GiveOrder = disabledOrder
+    Spring.GiveOrderToUnit = disabledOrder
+    Spring.GiveOrderToUnitArray = disabledOrder
+    Spring.GiveOrderArrayToUnit = disabledOrder
+    Spring.GiveOrderArrayToUnitArray = disabledOrder
 end


### PR DESCRIPTION

### Work done

Added about 15 lines of simple code to springOverrides.lua to block out controlling units widgets.
In Discord main chat PR's welcome was mentioned about this specific fix, I reckoned I would give it a try.

Relevant code:

-- Disable widget issued unit orders
if Spring.GiveOrderToUnit then
    local function disabledOrder()
        Spring.Echo("Widget issued unit order blocked")
        return false
    end

    Spring.GiveOrder = disabledOrder
    Spring.GiveOrderToUnit = disabledOrder
    Spring.GiveOrderToUnitArray = disabledOrder
    Spring.GiveOrderArrayToUnit = disabledOrder
    Spring.GiveOrderArrayToUnitArray = disabledOrder

<!-- If relevant
#### Addresses Issue(s)
- Issue URL https://discord.com/channels/549281623154229250/1299513647302705276/1302784927149850698

-->

<!-- If relevant
#### Setup: Widgets must be allowed in lobby before game starts. 
 -->

#### Test steps
- [ ] To test one should have a unit micro widget, such as the Rocket dodging widget, and have it turned on from the widget selector menu/UI. This fix should block the actions of that widget, and similar widgets, without impacting game performance..

