### PR TITLE
Rename coop modoption key to avoid conflict

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -489,8 +489,8 @@ local options = {
     },
 
     {
-        key		= "coop",
-        name	= "Cooperative mode",
+        key		= "coopcoms",
+        name	= "Extra Commanders for Shared Teams",
         desc	= "Adds extra commanders to id-sharing teams, 1 com per player",
         type	= "bool",
         hidden 	= true,


### PR DESCRIPTION
### Summary

This PR updates `modoptions.lua` to rename the `"coop"` key to `"coopcoms"`.

### Motivation

- The original `"coop"` key conflicted with SPADS aliasing (where `!coop` maps to `!pset sharid`), which could cause confusion.
- The new key and option name are more descriptive and help prevent conflicts.
- Since the description field is not visible when the mod option is hidden, a clearer name is important. 

### Before:
- Players would use `!coop 1` and see `Cooperative mode = 1` in the lobby modoptions window. It is not clear what it is doing.
### After:
- Players can now use `!coop` to set a shareId preference instead of using `!pset shareId`
- Players can now use `!coopcoms 1` to use this hidden option and the lobby will now display `Extra Commanders for Shared Teams = 1
`
### Additional Context

This change is in support of this [PR(687)](https://github.com/beyond-all-reason/teiserver/pull/687) to allow easier ID sharing.