### PR TITLE
Fix collapsed factory side menus being still active

### DIFF
--- a/luaui/Widgets/gui_buildbar.lua
+++ b/luaui/Widgets/gui_buildbar.lua
@@ -651,6 +651,8 @@ function widget:Update(dt)
 		if not moffscreen then
 			openedMenu = hoveredFac
 		end
+	elseif not (openedMenu >= 0 and isInRect(mx, my, boptRect)) then
+		openedMenu = -1
 	end
 
 	sec = sec + dt


### PR DESCRIPTION
### Work done

- Fix for buildbar closed side menu being still active and generating build orders

#### Addresses Issue(s)
- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5366

### Remarks

- I think it was broken recently with 57b6dc77d4b ([#5169](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5169)), itself fixing a regression from [#5151](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5151).
  - I'm simply reinstating the test to deactivate `openedMenu`, as it was before 57b6dc77d4b
  - hope I'm not creating further regressions in this cursed chain of events xd

### How to test

See [above issue](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5366) for video representation of the problem

- Activate buildbar widget
- Create a factory or more
- Hover over a buildbar factory area
- Hover out
- Go over the "would have been" position of a build order and click
- With PR
  - doesn't generate a build order
- Without PR
  - generates a build order