### PR TITLE
Allow targeting walls when they're the only attack targets.

### DIFF
--- a/luarules/gadgets/unit_objectify.lua
+++ b/luarules/gadgets/unit_objectify.lua
@@ -123,7 +123,7 @@ if gadgetHandler:IsSyncedCode() then
 			if cmdID == CMD_ATTACK then
 				if cmdParams and #cmdParams == 1 then
 					local uDefID = spGetUnitDefID(cmdParams[1])
-					if isObject[uDefID] or isDecoration[uDefID] then
+					if isDecoration[uDefID] then
 						return false
 					end
 				end

--- a/luaui/Widgets/cmd_exclude_walls_area_attacks.lua
+++ b/luaui/Widgets/cmd_exclude_walls_area_attacks.lua
@@ -2,8 +2,8 @@ local widget = widget ---@type Widget
 
 function widget:GetInfo()
 	return {
-		name 		= "Exclude walls from area set target",
-		desc 		= "Stops walls from being included in area set target if units are present",
+		name 		= "Exclude walls from area attacks",
+		desc 		= "Stops walls from being included in area attacks if units are present",
 		date		= "April 2025",
 		author		= "Slouse",
 		license 	= "GNU GPL, v2 or later",
@@ -14,6 +14,8 @@ end
 
 local CMD_UNIT_CANCEL_TARGET = GameCMD.UNIT_CANCEL_TARGET
 local CMD_UNIT_SET_TARGET = GameCMD.UNIT_SET_TARGET
+local CMD_ATTACK = CMD.ATTACK
+local CMD_STOP = CMD.STOP
 
 local excludedUnitsDefID = {}
 
@@ -26,17 +28,18 @@ for id, unitDef in pairs(UnitDefs) do
 	end
 end
 
-local function addNewCommand(newCmds, unitID, cmdOpts)
+local function addNewCommand(newCmds, unitID, cmdOpts, cmdID)
 	if #newCmds == 0 and not cmdOpts.shift then
 		-- Need to clear orders if not in shift, since just sending the first one
 		-- as not-shift would sometimes fail if that unit is in the end not valid
-		newCmds[1] = {CMD_UNIT_CANCEL_TARGET, {}, {}}
+		local stopCmd = (cmdID == CMD_ATTACK) and CMD_STOP or CMD_UNIT_CANCEL_TARGET
+		newCmds[1] = {stopCmd, {}, {}}
 	end
-	newCmds[#newCmds + 1] = {CMD_UNIT_SET_TARGET, unitID, CMD.OPT_SHIFT}
+	newCmds[#newCmds + 1] = {cmdID, unitID, CMD.OPT_SHIFT}
 end
 
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
-	if cmdID ~= CMD_UNIT_SET_TARGET or #cmdParams ~= 4 then
+	if (cmdID ~= CMD_UNIT_SET_TARGET and cmdID ~= CMD_ATTACK) or #cmdParams ~= 4 then
 		return
 	end
 
@@ -50,14 +53,13 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 		local unitDefID = spGetUnitDefID(unitID)
 
 		if not excludedUnitsDefID[unitDefID] then
-			addNewCommand(newCmds, unitID, cmdOpts)
+			addNewCommand(newCmds, unitID, cmdOpts, cmdID, (cmdID == CMD_ATTACK) and CMD_STOP or CMD_UNIT_CANCEL_TARGET)
 		elseif not spGetUnitNeutral(unitID) then	
-			addNewCommand(newCmds, unitID, cmdOpts)
+			addNewCommand(newCmds, unitID, cmdOpts, cmdID, (cmdID == CMD_ATTACK) and CMD_STOP or CMD_UNIT_CANCEL_TARGET)
 		else
 			somethingWasExcluded = true
 		end
 	end
-
 	if #newCmds > 0 and somethingWasExcluded then
 		Spring.GiveOrderArrayToUnitArray(Spring.GetSelectedUnits(), newCmds)
 		return true

--- a/luaui/Widgets/cmd_exclude_walls_area_attacks.lua
+++ b/luaui/Widgets/cmd_exclude_walls_area_attacks.lua
@@ -53,9 +53,9 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 		local unitDefID = spGetUnitDefID(unitID)
 
 		if not excludedUnitsDefID[unitDefID] then
-			addNewCommand(newCmds, unitID, cmdOpts, cmdID, (cmdID == CMD_ATTACK) and CMD_STOP or CMD_UNIT_CANCEL_TARGET)
+			addNewCommand(newCmds, unitID, cmdOpts, cmdID)
 		elseif not spGetUnitNeutral(unitID) then	
-			addNewCommand(newCmds, unitID, cmdOpts, cmdID, (cmdID == CMD_ATTACK) and CMD_STOP or CMD_UNIT_CANCEL_TARGET)
+			addNewCommand(newCmds, unitID, cmdOpts, cmdID)
 		else
 			somethingWasExcluded = true
 		end


### PR DESCRIPTION
### Work done

- Allow targeting walls if they're the only targets of the attack
  - removes filter at `objectify` gadget preventing all wall attacks.
  - adds area command filter inside `cmd_exclude_walls_area_set_target`
  - rename `cmd_exclude_walls_area_set_target` to `cmd_exclude_walls_area_attacks`


#### Addresses Issue(s)
- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4043

### Remarks

- This can make area attacks somewhat more expensive on the network when walls are excluded, since attack command will be split and sent as possibly 100s/1000s commands instead of just one area command.
  - Actually not 100% sure this is the case, but I think it works like this
  - Same as `unit_target_on_the_move`, and that one much worse due to other inefficiencies from lua implementation.
  - Tried first by filtering on `objectify` instead, but can't really tell if the command is stand alone or coming from area command :P, so need to prefilter/override on CommandNotify instead.
- Could be improved later by converting  `cmd_exclude_walls_area_attacks` into a gadget so we can make the filtering synced so just one command gets sent.
  - This is somewhat planned as it will help in improving set_target implementation when doing filtering.

### How to test

#### test setup

- start game
- /team 0
- /give 100 armpw
- (put them on hold fire)
- /give armarad
- /team 1
- /give 100 armdrag
- /give 100 armpw
- (put them on hold fire) 
- /team 0

#### tests

- select all (friendly) armpw
- right click an enemy wall -> works
- 'a' + attack enemy wall -> works
- area attack on walls only -> works
- area attack on walls+units -> only units targeted

