### PR TITLE
Fix 'random' pregame build queue substitutions

### DIFF
--- a/luaui/Include/blueprint_substitution/logic.lua
+++ b/luaui/Include/blueprint_substitution/logic.lua
@@ -97,6 +97,11 @@ end
 
 function BlueprintSubLogic.getSideFromUnitName(unitName)
     if not unitName then return nil end
+    if unitName == 'dummycom' then
+	    -- special exception for dummycom when player is still 'random' faction, will
+	    -- behave as arm and be converted later
+	    return BlueprintSubLogic.SIDES.ARM
+    end
     local lowerName = unitName:lower()
     for side, prefix in pairs(BlueprintSubLogic.SIDES) do
         if lowerName:find("^" .. prefix) then


### PR DESCRIPTION
### Work done

- Makes dummycom look like an armada commander to BlueprintSubLogic.getSideFromUnitName so faction determination/substitution works fine.
  - fixes build queue substitution failures at gui_pregame_build.lua

#### Addresses Issue(s)
- https://discord.com/channels/549281623154229250/1383118825427304550

#### Test steps
- Start skirmish
- Select random
- Place a few blueprints
- Start game, if cortex is finally chosen by random, build queue would get cancelled

can also be reproduced like this:

- Start skirmish
- Select random
- Place blueprints
- Select cortex
- Blueprint substitutions will fail to take place

With this PR, both tests behave as expected, going to random in pregame will convert blueprints to arm, going to other faction will successfully convert to that faction, if needed.

### Remarks

- The faction determination works by finding the commander and looking for its faction through `BlueprintSubLogic.getSideFromUnitName`. When the commander is still dummycom, its faction will be `nil`, making `gui_pregame_build.lua` and possibly other widgets fail in determining faction (none seem to be using this atm).
- To all effects, dummycom will behave as an armada commander, so I think this is a good way to solve the problem, but if preferred could add exceptions inside `gui_pregame_build.lua` to handle this, or some other global method to find current faction instead, but imo would just complicate the fix and at this point be a bit of overengineering.
