### PR TITLE
Enable DevLua before running tests.

### DIFF
--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -493,6 +493,11 @@ local function startTests(patterns)
 						   'Cheats are disabled; attempting to enable them...',
 						   'Could not enable cheats; tests cannot be run.'}
 	end
+	if not Spring.IsDevLuaEnabled() then
+		neededActions[#neededActions+1] = {'devlua',
+						   'DevLua mode disabled; attempting to enable it...',
+						   'Could not enable DevLua mode; tests cannot be run.'}
+	end
 	if Spring.GetModOptions().deathmode ~= 'neverend' and not Spring.GetGameRulesParam('testEndConditionsOverride') then
 		neededActions[#neededActions+1] = {'luarules setTestEndConditions',
 						   "Disabling end conditions...",


### PR DESCRIPTION
### Work done

- Since 2025.04.10 DevLua is required for the testrunner to work

### Remarks

- Engine forbid loading binary lua opcodes into the engine at 2025.04.08, but testrunner depends on this to run synced code from unsynced.
-  2025.04.10 allows running opcode when DevLua is enabled.

### How to test

- Use engine equal or greater to 2025.04.10
- Start skirmish
- /runtests

With PR it will run the tests, without it would fail all SyncedRun or SyncedProxy calls.