### PR TITLE
Fix default-spy-move-cloaked when legion not enabled

### DIFF
--- a/luaui/Widgets/unit_default_spy_move_cloaked.lua
+++ b/luaui/Widgets/unit_default_spy_move_cloaked.lua
@@ -14,9 +14,12 @@ end
 
 local spies  = {
 	[UnitDefNames.armspy.id] = true,
-	[UnitDefNames.corspy.id] = true,
-	[UnitDefNames.legaspy.id] = true,
+	[UnitDefNames.corspy.id] = true
 }
+
+if UnitDefNames.legaspy then
+	spies[UnitDefNames.legaspy.id] = true
+end
 
 local GetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
 local GetUnitStates = Spring.GetUnitStates

--- a/luaui/Widgets/unit_default_spy_move_cloaked.lua
+++ b/luaui/Widgets/unit_default_spy_move_cloaked.lua
@@ -12,13 +12,18 @@ function widget:GetInfo()
 	}
 end
 
-local spies  = {
-	[UnitDefNames.armspy.id] = true,
-	[UnitDefNames.corspy.id] = true
+local spies  = {}
+
+local spynames = {
+	'armspy',
+	'corspy',
+	'legaspy',
 }
 
-if UnitDefNames.legaspy then
-	spies[UnitDefNames.legaspy.id] = true
+for _, spyname in ipairs(spynames) do
+	if UnitDefNames[spyname] then
+		spies[UnitDefNames[spyname].id] = true
+	end
 end
 
 local GetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
@@ -45,6 +50,10 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:Initialize()
+    if #spies == 0 then
+	    widgetHandler:RemoveWidget()
+	    return
+    end
     if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
         maybeRemoveSelf()
     end


### PR DESCRIPTION
### Work done

- Be more careful about accessing unitdef.id without testing for their existance before.

#### Addresses Issue(s)
- `[t=00:00:14.231212][f=-000001] Failed to load: unit_default_spy_move_cloaked.lua  ([string "LuaUI/Widgets/unit_default_spy_move_cloaked.lua"]:18: attempt to index field 'legaspy' (a nil value))
`

#### Test steps
- Start skirmish
- Check infolog.txt for the above error.
