### PR TITLE
hotfix: Comment out broken code from snd_notifications.

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -468,10 +468,11 @@ function widget:GameFrame(gf)
 				queueTutorialNotification('ReadyForTech2')
 			end
 			if hasMadeT2 then
-				local udefIDTemp = spGetUnitDefID(unitID)
-				if isT2[udefIDTemp] then
-					queueNotification('BuildIntrusionCounterMeasure')
-				end
+				-- FIXME
+				--local udefIDTemp = spGetUnitDefID(unitID)
+				--if isT2[udefIDTemp] then
+				--	queueNotification('BuildIntrusionCounterMeasure')
+				--end
 			end
 		end
 


### PR DESCRIPTION
### Work done

- Removed a new test to run the BuildIntrusionCounterMeasure notification.

#### Addresses Issue(s)
- `[t=00:00:38.580795][f=0000465] Error in GameFrame(): [string "LuaUI/Widgets/snd_notifications.lua"]:471: [GetUnitDefID] unitID (arg #1) not a number`

#### Test steps
- Start skirmish
- /cheat on
- /give armarad
  - any t2 unit would do
- Without this PR will get the above error at this point.

### Remarks

- Broken at 6ad3fec4039b29c926643c57cff625a985050860
- Not really fixing it, but commenting some code to prevent the error until this is fixed.
- Could fix in some way to allow the notification, but unsure about the idea.
  - I think maybe when first spybot is detected, but maybe @ZephyrSkies7 knows :).