### PR TITLE
Update game_end.lua

### DIFF
--- a/luarules/gadgets/game_end.lua
+++ b/luarules/gadgets/game_end.lua
@@ -55,7 +55,7 @@ if gadgetHandler:IsSyncedCode() then
 		if def.customParams.iscommander then
 			isCommander[udefID] = true
 		end
-		if def.customParams.decoration then
+		if def.customParams.decoration == true then
 			unitDecoration[udefID] = true
 		end
 	end


### PR DESCRIPTION
I encounter a bug while testing units that caused commanders to suddenly suicide in the middle of the game. 
The win condition was set to death of all commanders.

This made me investigate and found out that we don't look for decoration, true, but just decoration itself.
It would be safer if decoration = false would not make it a decoration as well.
This way we can exclude specific units from being seen as decoration.