### PR TITLE
Update unit_air_attacksafetydistance.lua

### DIFF
--- a/luarules/gadgets/unit_air_attacksafetydistance.lua
+++ b/luarules/gadgets/unit_air_attacksafetydistance.lua
@@ -42,7 +42,11 @@ function gadget:UnitCreated(unitID, unitDefID)
 		if curMoveCtrl then
 			Spring.MoveCtrl.Disable(unitID)
 		end
-		Spring.MoveCtrl.SetAirMoveTypeData(unitID, "attackSafetyDistance", 300)
+		local success = pcall(Spring.MoveCtrl.SetAirMoveTypeData, unitID, "attackSafetyDistance", 300)
+		if not success then
+			isFighter[unitDefID] = false
+			Spring.Log(gadget:GetInfo().name, LOG.WARNING, "Unit", UnitDefs[unitDefID].name, "Could not have its attack distance set, are you sure it is a fighter/bomber?")
+		end
 		if curMoveCtrl then
 			Spring.MoveCtrl.Enable(unitID)
 		end


### PR DESCRIPTION
### Work done
Wrap a SetAirMoveTypeData in a pcall, its failure can have knock-on effects on other gadgets breaking them or the game.
While not an issue in the base game, the poor state of the modding support means its failure is often ignored.

#### Addresses Issue(s)

Addresses: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5414
...Yes, that is a pr

#### Test steps
- Add the `fighter` custom param to a gunship unit, watch it not error out anymore.