### PR TITLE
Fix Legion Playable when NOT on.

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -52,7 +52,7 @@ if gadgetHandler:IsSyncedCode() then
 		local modoptions = Spring.GetModOptions()
 		local factionlimiter = tonumber(modoptions.factionlimiter) or 0
 		if factionlimiter > 0 then
-			local legcomDefID = UnitDefNames.legcom and UnitDefNames.legcom.id
+			local legcomDefID = modoptions.experimentallegionfaction and UnitDefNames.legcom and UnitDefNames.legcom.id
 			local armcomDefID = UnitDefNames.armcom and UnitDefNames.armcom.id
 			local corcomDefID = UnitDefNames.corcom and UnitDefNames.corcom.id
 			local ARM_MASK = 2^0
@@ -130,7 +130,7 @@ if gadgetHandler:IsSyncedCode() then
 			if corcomDefID then
 				validStartUnits[#validStartUnits+1] = corcomDefID
 			end
-			local legcomDefID = UnitDefNames.legcom and UnitDefNames.legcom.id
+			local legcomDefID = modoptions.experimentallegionfaction and UnitDefNames.legcom and UnitDefNames.legcom.id
 			if legcomDefID then
 				validStartUnits[#validStartUnits+1] = legcomDefID
 			end


### PR DESCRIPTION
### Work done

Fixes Legion appearing as an option to pick or random-roll when anything else that uses legion, i.e. scavs, loaded the faction in.

#### Addresses Issue(s)
https://discord.com/channels/549281623154229250/1387786568093274162

#### Test steps
- Open game, use `!bset forceallunits 1` or add scavs, and during game start legion will be an option despite not being enabled. This fixes that.