### PR TITLE
Disable Radar Tutorial Notification For Now

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -461,6 +461,7 @@ function widget:GameFrame(gf)
 			if e_income >= 50 and m_income >= 4 then
 				queueTutorialNotification('BuildFactory')
 			end
+			-- playing this line even when tutorial mode is off for players, but fixed when turned on and off again, why is doTutorialMode not respected for this block?
 			-- if e_income >= 125 and m_income >= 8 and gameframe > 600 then
 			-- 	queueTutorialNotification('BuildRadar')
 			-- end


### PR DESCRIPTION
### Work Done
Comments out the radar building tutorial notification. Bizarre behaviour where `doTutorialMode` is not respected for specfically the IF block where BuildRadar notification is meant to be played. No other tutorial notifications are played, just this one.

Turning tutorial mode on and off again is the solution but this is not a reasonable ask for most players, so commenting it out until I can find a more elegant solution that doesn't require player input.

### Work Needed
- [ ] A more permanent fix in the future.
