### PR TITLE
No radar tutorial notification for pros

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -537,9 +537,6 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			if isEnergyProducer[unitDefID] then
 				hasBuildEnergy = true
 			end
-			if isRadar[unitDefID] and not tutorialPlayedThisGame['BuildRadar'] then
-				tutorialPlayed['BuildRadar'] = tutorialPlayLimit
-			end
 		end
 
 		if unitDefID == vulcanDefID then
@@ -661,6 +658,10 @@ function widget:UnitCreated(unitID, unitDefID, unitTeam)
 		end
 
 		if tutorialMode then
+			if doTutorialMode and isRadar[unitDefID] and not tutorialPlayedThisGame['BuildRadar'] then
+				tutorialPlayed['BuildRadar'] = tutorialPlayLimit
+			end
+
 			if e_income < 2000 and m_income < 50 then
 				if isFactoryAir[unitDefID] then
 					numFactoryAir = numFactoryAir + 1

--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -537,7 +537,7 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			if isEnergyProducer[unitDefID] then
 				hasBuildEnergy = true
 			end
-			if isRadar[unitDefID] then
+			if isRadar[unitDefID] and not tutorialPlayedThisGame['BuildRadar'] then
 				tutorialPlayed['BuildRadar'] = tutorialPlayLimit
 			end
 		end

--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -282,7 +282,7 @@ for udefID, def in ipairs(UnitDefs) do
 		if def.extractsMetal > 0 then
 			isMex[udefID] = true
 		end
-		if def.isBuilding and def.radarDistance > 2000 then
+		if def.isBuilding and def.radarDistance > 1900 then
 			isRadar[udefID] = true
 		end
 		if def.energyMake > 10 then

--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -243,6 +243,7 @@ local hasMadeT2 = false
 local isCommander = {}
 local isBuilder = {}
 local isMex = {}
+local isRadar = {}
 local isEnergyProducer = {}
 local isWind = {}
 local isAircraft = {}
@@ -280,6 +281,9 @@ for udefID, def in ipairs(UnitDefs) do
 		end
 		if def.extractsMetal > 0 then
 			isMex[udefID] = true
+		end
+		if def.isBuilding and def.radarDistance > 2000 then
+			isRadar[udefID] = true
 		end
 		if def.energyMake > 10 then
 			isEnergyProducer[udefID] = def.energyMake
@@ -532,6 +536,9 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			end
 			if isEnergyProducer[unitDefID] then
 				hasBuildEnergy = true
+			end
+			if isRadar[unitDefID] then
+				tutorialPlayed['BuildRadar'] = tutorialPlayLimit
 			end
 		end
 


### PR DESCRIPTION
### Work done

- Make the new BuildRadar notification be marked "done" if a radar is built before the notification triggers.

#### Addresses Issue(s)
- Some confusion for people getting the notification even when they already built/building radar.

### Remarks

- Alternative to https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5424
- Since this is a new notification, it might be a long time since ppl received tutorial notifications, so this can be baffling, tied to the fact the notification plays even when you already built a radar.
