### PR TITLE
Fix corsacvsub.lua to return the correct unit

### DIFF
--- a/units/CorShips/T2/corsacvsub.lua
+++ b/units/CorShips/T2/corsacvsub.lua
@@ -1,5 +1,5 @@
 return {
-	coracsub = {
+	corsacvsub = {
 		builddistance = 180,
 		builder = true,
 		buildpic = "CORACSUB.DDS",


### PR DESCRIPTION
(cherry picked from commit 2a8b4faedb0f2e87891b28dfc1439e820349db9b)

Fix corsacvsub.lua to return the correct unit