### PR TITLE
Remove 'handler = true' from various widgets

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -8,7 +8,6 @@ function widget:GetInfo()
 		version = "2.0",
 		date = "Oct 23, 2010; last update: April 12, 2022",
 		license = "GNU GPL, v2 or later",
-		handler = true,
 		layer = -1, -- load before all widgets that need these mex/geo building tools
 		enabled = true
 	}

--- a/luaui/Widgets/cmd_area_unload.lua
+++ b/luaui/Widgets/cmd_area_unload.lua
@@ -7,7 +7,6 @@ function widget:GetInfo()
 		author = "Doo",
 		date = "April 2018",
 		license = "GNU GPL, v2 or later",
-		handler = true,
 		layer = 0,
 		enabled = true
 	}

--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -9,7 +9,6 @@ function widget:GetInfo()
 		license = "GNU GPL, v2 or later",
 		layer = -99999, -- run before gui_options, so that we can appropriately transform stuff here when keybind changes happen
 		enabled = true,
-		handler = true,
 	}
 end
 

--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -8,7 +8,6 @@ function widget:GetInfo()
 		version = "1.0",
 		date = "Jan 2024",
 		license = "GNU GPL, v2 or later",
-		handler = true,
 		layer = 1000,
 		enabled = true
 	}

--- a/luaui/Widgets/gui_unit_market.lua
+++ b/luaui/Widgets/gui_unit_market.lua
@@ -10,7 +10,6 @@ function widget:GetInfo() return {
     author  = "Tom Fyuri",
     date    = "2024",
     license = "GNU GPL v2",
-    handler = true,
     layer   = 0,
     enabled = true
 } end

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -10,7 +10,6 @@ function widget:GetInfo()
       license = "GNU GPL, v2 or later",
       layer = 0,
       enabled = true,
-      handler = true
     }
 end
 
@@ -173,7 +172,7 @@ end
 
 function widget:PlayerChanged(playerID)
     if Spring.GetSpectatingState() then
-        widgetHandler:RemoveWidget(self)
+        widgetHandler:RemoveWidget()
     end
     myTeam = Spring.GetMyTeamID()
 end


### PR DESCRIPTION
### Work done

- Remove `handler = true` from various widgets not using the widgetHandler, or with minimal usage.
- Affects api_resource_spot_builder, cmd_area_unload, cmd_bar_hotkeys, cmd_quick_build_extractor, unit_factory_quota, unit_market.

### Remarks

- Added all these widgets since they either not using the widgetHandler at all, or with minimal usage, thus adaptation not really needed for them when removing `handler`.
- See https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5447 for remarks applicable to this PR too.