### PR TITLE
fix intro music stuttering and stopping after fade out

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -74,6 +74,7 @@ local gameFrame = 0
 local serverFrame = 0
 local bossHasSpawned = false
 local playInterlude = false
+local isChangingTrack = false
 
 local function ReloadMusicPlaylists()
 	-----------------------------------SETTINGS---------------------------------------
@@ -1192,7 +1193,11 @@ function widget:DrawScreen()
 end
 
 function PlayNewTrack(paused)
+	if isChangingTrack then return end
+	isChangingTrack = true
+	
 	if Spring.GetConfigInt('music', 1) ~= 1 then
+		isChangingTrack = false
 		return
 	end
 	if (not paused) and Spring.GetGameFrame() > 1 then
@@ -1357,6 +1362,7 @@ function PlayNewTrack(paused)
 	end
 
 	updateDrawing = true
+	isChangingTrack = false
 end
 
 function widget:UnitDamaged(unitID, unitDefID, _, damage)


### PR DESCRIPTION
### Work done

Problem description: The issue happens shortly after a new game starts. While the game is loading the intro (loading) music plays. Shortly after the game starts, that music will fade out but get stuck with a stuttering sound. The next track does not play.

The issue is caused by a race condition between two parts of widget:GameFrame():

The Fade-Out: The interruption logic (e.g., currentTrackListString == "intro") starts a fade-out. When it completes, updateFade() calls PlayNewTrack().

The Silence Check: A few frames later, the elseif totalTime == 0 then check also triggers because the fade-out has stopped the audio stream, and it calls PlayNewTrack() again.

This results in two calls to PlayNewTrack() in rapid succession from different parts of the same GameFrame update loop, causing the stutter.

Fix: A "lock" variable is used. The PlayNewTrack() function now acquires this lock at the start and releases it at the end, ensuring that if it's called a second time while already running, the redundant call is safely ignored, preventing the stutter.

#### Test steps

With music enabled (default), join a new or existing game. The intro music plays while loading. Shortly after the game begins, the intro music should fade out and the next song starts to play. This is the expected behavior.