### PR TITLE
Move some projectile types overrange handling to engine.

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -17,6 +17,7 @@
 -- Switch for when we want to save defs into customparams as strings (so as a widget can then write them to file)
 -- The widget to do so is included in the game and detects these customparams auto-enables itself
 -- and writes them to Spring/baked_defs
+local calculateFlightFrames = VFS.Include("modules/projectileHelper.lua").calculateFlightFrames
 SaveDefsToCustomParams = false
 
 -------------------------
@@ -67,9 +68,23 @@ local function processWeapons(unitDefName, unitDef)
 		weaponDef.reloadtime = round_to_frames(weaponDef, "reloadtime")
 		weaponDef.burstrate = round_to_frames(weaponDef, "burstrate")
 
-		if weaponDef.customparams and weaponDef.customparams.cluster_def then
-			weaponDef.customparams.cluster_def = unitDefName .. "_" .. weaponDef.customparams.cluster_def
-			weaponDef.customparams.cluster_number = weaponDef.customparams.cluster_number or 5
+		local customParams = weaponDef.customparams
+
+		if customParams and customParams.cluster_def then
+			customParams.cluster_def = unitDefName .. "_" .. customParams.cluster_def
+			customParams.cluster_number = customParams.cluster_number or 5
+		end
+
+		-- precomputations for the 'unit_projectile_overrange' gadget.
+		if customParams and weaponDef.weapontype == "MissileLauncher" and customParams.projectile_destruction_method == 'descend' and (weaponDef.trajectoryheight == 0.0 or weaponDef.trajectoryheight == nil) then
+			local gameSpeed = Game.gameSpeed
+			local overRange = tonumber(customParams.overrange_distance) or weaponDef.range
+			weaponDef.flighttime = calculateFlightFrames(weaponDef.startvelocity or 0.0, weaponDef.weaponvelocity, weaponDef.weaponacceleration or 0.0, overRange)
+			weaponDef.mygravity = 5.0 * Game.gravity / (gameSpeed * gameSpeed)
+
+			-- gadget has no more work to do for these projectiles, so clear customParams.
+			customParams.projectile_destruction_method = nil
+			customParams.overrange_distance = nil
 		end
 	end
 end

--- a/luarules/gadgets/unit_projectile_overrange.lua
+++ b/luarules/gadgets/unit_projectile_overrange.lua
@@ -22,13 +22,19 @@ if not gadgetHandler:IsSyncedCode() then return end
 -- "descend" moves the projectile downward until it is destroyed by collision event.
 -- "expire" sets the TTL (time to live) of the projectile to 0. Awaiting pending engine addition 1/27/25
 
+---- static limits through alldefs_post.lua
+-- some weapons can set the autodestroy parameters directly at the weapondef and let engine handle them.
+
 --static values
 local lateralMultiplier = 0.85
 local compoundingMultiplier = 1.1 --compounding multiplier that influences the arc at which projectiles are forced to descend
 local descentSpeedStartingMultiplier = 0.15
+local engineDescent = true
 
 local descentModulo = math.floor(Game.gameSpeed / 4)
 local leashModulo = math.ceil(Game.gameSpeed / 3)
+
+local mapGravity = Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 
 --functions
 local spGetUnitPosition = Spring.GetUnitPosition
@@ -40,6 +46,9 @@ local spSetProjectileCollision = Spring.SetProjectileCollision
 local spGetProjectileVelocity = Spring.GetProjectileVelocity
 local spSetProjectileVelocity = Spring.SetProjectileVelocity
 local spSetProjectileTimeToLive = Spring.SetProjectileTimeToLive
+local spSetProjectileGravity = Spring.SetProjectileGravity
+
+local calculateFlightFrames = VFS.Include("modules/projectileHelper.lua").calculateFlightFrames
 
 --tables
 local defWatchTable = {}
@@ -51,27 +60,6 @@ local leashWatch = {}
 
 --variables
 local gameFrame = 0
-
-local function calculateFlightFrames(initialVelocity, maximumVelocity, accelerationRate, totalDistance)
-	local totalFrames = 0
-
-	-- Frames to reach maximum velocity
-	local framesToMaxVelocity = (maximumVelocity - initialVelocity) / accelerationRate
-
-	-- Distance traveled while accelerating
-	local distanceAccelerating = initialVelocity * framesToMaxVelocity + 0.5 * accelerationRate * framesToMaxVelocity^2
-
-	if distanceAccelerating > totalDistance then
-		-- We already traveled too much, so just calculate time with accelerated movement + quadratic equation formula
-		totalFrames = (mathSqrt(initialVelocity^2 + 2 * totalDistance * accelerationRate) - initialVelocity) / accelerationRate
-	else
-		-- Linear movement after accelerating
-		totalFrames = framesToMaxVelocity + (totalDistance - distanceAccelerating) / maximumVelocity
-	end
-
-	-- Return the floored value of total frames
-	return math.floor(totalFrames)
-end
 
 local function uptimeTurnFrames(turnRate)
 	local framesRequired = math.floor(math.rad(90) / turnRate)--the turning period is negated from uptime frames for StarburstMissiles
@@ -94,8 +82,8 @@ for weaponDefID, weaponDef in pairs(WeaponDefs) do
 		if weaponDef.type == "StarburstLauncher" then
 			ascentFrames = math.floor(weaponDef.uptime * Game.gameSpeed - uptimeTurnFrames(weaponDef.turnRate))
 		end
-		watchParams.flightTimeFrames = calculateFlightFrames(weaponDef.startvelocity, weaponDef.projectilespeed,
-			weaponDef.weaponAcceleration, overRange) + ascentFrames
+		watchParams.flightTimeFrames = math.floor(calculateFlightFrames(weaponDef.startvelocity, weaponDef.projectilespeed,
+			weaponDef.weaponAcceleration, overRange) + ascentFrames)
 		watchParams.weaponDefID = weaponDefID
 
 		--destruction methods
@@ -233,7 +221,12 @@ function gadget:GameFrame(frame)
 			if proData then
 				local defData = defWatchTable[proData.weaponDefID]
 				if defData.descentMethod then
-					descentTable[proID] = descentMultiplier
+					if engineDescent then
+						spSetProjectileTimeToLive(proID, 0)
+						spSetProjectileGravity(proID, -mapGravity*5)
+					else
+						descentTable[proID] = descentMultiplier
+					end
 				elseif defData.expireMethod then
 					spSetProjectileTimeToLive(proID, frame)
 				else

--- a/modules/projectileHelper.lua
+++ b/modules/projectileHelper.lua
@@ -1,0 +1,35 @@
+local mathSqrt = math.sqrt
+
+--- Calculate flightTime using the linear accelerated movement formula
+---
+--- It can work either in elmos/frame -> frames, or elmos/second -> seconds.
+--- Make sure all input parameters are in consistent units.
+---
+--- @param initialVelocity number Start velocity in either elmos/frame or elmos/s
+--- @param maximumVelocity number Maximum velocity in either elmos/frame or elmos/s
+--- @param accelerationRate number Acceleration in either elmos/frame^2 or elmos/s^2
+--- @param totalDistance number Distance in elmos
+local function calculateFlightFrames(initialVelocity, maximumVelocity, accelerationRate, totalDistance)
+	local totalFrames = 0
+
+	-- Frames to reach maximum velocity
+	local framesToMaxVelocity = (maximumVelocity - initialVelocity) / accelerationRate
+
+	-- Distance traveled while accelerating
+	local distanceAccelerating = initialVelocity * framesToMaxVelocity + 0.5 * accelerationRate * framesToMaxVelocity^2
+
+	if distanceAccelerating > totalDistance then
+		-- We already traveled too much, so just calculate time with accelerated movement + quadratic equation formula
+		totalFrames = (mathSqrt(initialVelocity^2 + 2 * totalDistance * accelerationRate) - initialVelocity) / accelerationRate
+	else
+		-- Linear movement after accelerating
+		totalFrames = framesToMaxVelocity + (totalDistance - distanceAccelerating) / maximumVelocity
+	end
+
+	-- Return the floored value of total frames
+	return totalFrames
+end
+
+return {
+	calculateFlightFrames = calculateFlightFrames,
+}


### PR DESCRIPTION
### Work done

- Make overrange handling use more engine features to save some lua processing.

### Remarks

- Last engine releases bring more control over projectile ttl/flighttime and gravity, both at the weaponDef, weapon and projectile level.
  - This allows setting engine parameters and not needing to babysit from lua
  - Can even preset some parameters into weaponDef and forget in some cases (best because then we don't need to set SetWatchProjectile).
- Currently sets 100% engine processing for MissileLauncher types with no trajectoryHeight and descent method.
  - affects units like missile bots
  - can be later improved to handle trajectoryheight and avoid more lua work.
- Also cuts some lua processing for other MissileLauncher types by triggering final descent from engine.
  - This is controllable for now from the `engineDescent` internal gadget variable, so it can be tested well and otherwise make it easy to revert.