### PR TITLE
fix music glitch after game start fade out

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -74,6 +74,7 @@ local gameFrame = 0
 local serverFrame = 0
 local bossHasSpawned = false
 local playInterlude = false
+local isChangingTrack = false
 
 local function ReloadMusicPlaylists()
 	-----------------------------------SETTINGS---------------------------------------
@@ -784,6 +785,7 @@ local function updatePosition(force)
 end
 
 function widget:Initialize()
+	isChangingTrack = false
 	if Spring.GetGameFrame() == 0 and Spring.GetConfigInt('music_loadscreen', 1) == 1 then
 		currentTrack = Spring.GetConfigString('music_loadscreen_track', '')
 	end
@@ -1192,7 +1194,11 @@ function widget:DrawScreen()
 end
 
 function PlayNewTrack(paused)
+	if isChangingTrack then return end
+	isChangingTrack = true
+	
 	if Spring.GetConfigInt('music', 1) ~= 1 then
+		isChangingTrack = false
 		return
 	end
 	if (not paused) and Spring.GetGameFrame() > 1 then
@@ -1357,6 +1363,7 @@ function PlayNewTrack(paused)
 	end
 
 	updateDrawing = true
+	isChangingTrack = false
 end
 
 function widget:UnitDamaged(unitID, unitDefID, _, damage)


### PR DESCRIPTION
Added a mutex / locking mechanism to fix a race condition that occurred shortly after the game starts. The problem caused music to glitch after the intro (loading) music fades out. This problem happens occasionally, and the user has to manually skip the track on the player to restore music. This problem was also reported here:

https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1792

### Work done

Problem summary:

This specific race condition is tied to the game start because of a rule designed to transition from the "intro" music to the gameplay music. Here's the sequence:

- The Intro State: The music player begins in a special "intro" state.
- The Timed Interruption Rule: The widget:GameFrame() function has a unique condition that triggers only when the music is in the "intro" state and the game has run for more than 90 frames (n > 90).
- Guaranteed Collision: This rule forces an interruption at a predictable, early point in the game. This creates the perfect timing for the updateFade() function (responding to the fade-out) and the widget:GameFrame() function (responding to the resulting silence) to both call PlayNewTrack() almost simultaneously.

Fix summary:

- Introduced a "Lock" Variable: A new flag, isChangingTrack, was added. This acts as a lock to prevent the PlayNewTrack function from running if it's already in the middle of executing.
- Fixed the Race Condition: The function now "locks" itself by setting isChangingTrack to true upon entry and "unlocks" it by setting it to false just before exiting. This solves the stuttering issue caused by multiple events trying to change the music track at the same time.
- Added Reload Safety: To prevent the music player from becoming permanently stuck if the widget is reloaded mid-operation, the lock is reset to false at the start of widget:Initialize, ensuring a clean state every time it loads.

#### Test steps

The setting "music start at loadscreen" must be enabled.

Start or join a game. Shortly after the game starts, the loading music fades out by design, and the next music track should start playing. There should be no glitch or stuttering or music stopping.

Also try other player functions: skipping to next track, pause, play. The fade out and fade in behavior should be consistent with the original version, minus any glitching.

Also try reloading the widget using F11 during gameplay intentionally testing during fade out. The reloaded widget should continue to play music as usual.