### PR TITLE
Fix default command when hovering objectified units

### DIFF
--- a/luarules/gadgets/unit_objectify.lua
+++ b/luarules/gadgets/unit_objectify.lua
@@ -158,7 +158,7 @@ else -- UNSYNCED
 			local uDefID = spGetUnitDefID(id)
 			if isObject[uDefID] or isDecoration[uDefID] then
 				-- make sure a command given on top of a objectified/decoration unit is a move command
-				if select(4, Spring.GetUnitHealth(id)) == 1 then
+				if select(5, Spring.GetUnitHealth(id)) == 1 then
 					return CMD_MOVE
 				end
 			end


### PR DESCRIPTION
The return value selected with `select(4, Spring.GetUnitHealth(id))` is the captureProgress, so hovering over a fully-captured unit will convert the default command to a CMD_MOVE. I'm not sure units can remain at 100% capture for any time period, so this likely never happens.

This should be `select(5, Spring.GetUnitHealth(id))`, which selects the buildProgress.

Idk what issues this might be causing, if even any. I just noticed this but didn't test.