### PR TITLE
unit_projectile_overrange: Fix for missing projectile owner.

### DIFF
--- a/luarules/gadgets/unit_projectile_overrange.lua
+++ b/luarules/gadgets/unit_projectile_overrange.lua
@@ -173,7 +173,6 @@ function gadget:ProjectileCreated(proID, proOwnerID, weaponDefID)
 	local metaData = { weaponDefID = weaponDefID, proOwnerID = proOwnerID }
 	local originX, _, originZ = spGetUnitPosition(proOwnerID)
 	if not originX then
-		local _
 		originX, _, originZ = spGetProjectilePosition(proID)
 	end
 	metaData.originX = originX


### PR DESCRIPTION
### Work done

- Account for spGetUnitPosition possibly not returning any information.

#### Addresses Issue(s)
- `Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_projectile_overrange.lua"]:130: attempt to perform arithmetic on local 'x1' (a nil value)`

### Remarks

- Found this in the logs while investigating some other problem (https://discord.com/channels/549281623154229250/1392442880421003314).
- Unsure why originally gets the owner position instead of the projectile start position, leaving to @SethDGamre to answer.
  - For now just using projectile initial position as fallback.
- Unsure how to test