### PR TITLE
Fix blueprint orientations for rotated blueprints.

### DIFF
--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -131,7 +131,7 @@ local function rotateBlueprint(bp, facing)
 					facing = (bpu.facing + facing) % 4
 				}
 			end),
-			facing = (bp.facing + facing) % 4
+			facing = 0
 		}
 	)
 end


### PR DESCRIPTION
### Work done

- Fixes position and facing of individual buildings when the blueprint is rotated.


#### Addresses Issue(s)
- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5244
- Also see https://discord.com/channels/549281623154229250/1384990898521378816

### Remarks

- The problem is when the blueprint is rotated its own facing has to be set to "0" on the new effective blueprint, as having facing here means it will be rotated again when placing.
  - The problem would always show in the individual building facings of 90 and 270 degree rotated blueprints.
  - For asymmetric blueprints it would also convert 90 into 270 rotation and vice versa.


### How to test

See the above issue for some images of test cases, here a simple example:

Procedure:

1. Create a blueprint with some asymmetrically placed llts, like:

2. Try to place them in different orientations:

original blueprint:

![blueprints](https://github.com/user-attachments/assets/9711709d-d998-440b-9cec-9134c9e601c5)

#### before:

each copy of the blueprint has been rotated once clockwise, note how the second and fourth have incorrect locations, they also didn't place like the blueprint gui was showing:

![blueprints-bad](https://github.com/user-attachments/assets/96f8e544-d4d0-4971-bd33-f0706605ee59)

detail of bad placing (blueprint on the right was placed with same position as showing on left):

![badplace](https://github.com/user-attachments/assets/3e7709ba-562d-4b7b-a322-6ebb03f1a499)




#### after:

each copy of the blueprint has been rotated once clockwise, they place as expected the same way they render:

![blueprints-good](https://github.com/user-attachments/assets/b4e90dd2-94fc-4e75-857f-09cded40036d)


