### PR TITLE
Remove Bad Building Masks

### DIFF
--- a/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
@@ -2,7 +2,6 @@ return {
 	armshockwave = {
 		activatewhenbuilt = true,
 		buildangle = 32768,
-		buildingmask = 0,
 		buildpic = "ARMSHOCKWAVE.DDS",
 		buildtime = 15000,
 		canattack = true,

--- a/units/ArmBuildings/LandEconomy/armamex.lua
+++ b/units/ArmBuildings/LandEconomy/armamex.lua
@@ -2,7 +2,6 @@ return {
 	armamex = {
 		activatewhenbuilt = true,
 		buildangle = 6092,
-		buildingmask = 0,
 		buildpic = "ARMAMEX.DDS",
 		buildtime = 1800,
 		canrepeat = false,

--- a/units/ArmBuildings/LandEconomy/armmex.lua
+++ b/units/ArmBuildings/LandEconomy/armmex.lua
@@ -2,7 +2,6 @@ return {
 	armmex = {
 		activatewhenbuilt = true,
 		buildangle = 8192,
-		buildingmask = 0,
 		buildpic = "ARMMEX.DDS",
 		buildtime = 1800,
 		canrepeat = false,

--- a/units/ArmBuildings/LandEconomy/armmoho.lua
+++ b/units/ArmBuildings/LandEconomy/armmoho.lua
@@ -2,7 +2,6 @@ return {
 	armmoho = {
 		activatewhenbuilt = true,
 		buildangle = 2048,
-		buildingmask = 0,
 		buildpic = "ARMMOHO.DDS",
 		buildtime = 14900,
 		canrepeat = false,

--- a/units/ArmBuildings/SeaEconomy/armuwmme.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwmme.lua
@@ -2,7 +2,6 @@ return {
 	armuwmme = {
 		activatewhenbuilt = true,
 		buildangle = 32768,
-		buildingmask = 0,
 		buildpic = "ARMUWMME.DDS",
 		buildtime = 14900,
 		canrepeat = false,

--- a/units/CorBuildings/LandDefenceOffence/corexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/corexp.lua
@@ -2,7 +2,6 @@ return {
 	corexp = {
 		activatewhenbuilt = true,
 		buildangle = 32768,
-		buildingmask = 0,
 		buildpic = "COREXP.DDS",
 		buildtime = 2900,
 		canattack = true,

--- a/units/CorBuildings/LandDefenceOffence/cormexp.lua
+++ b/units/CorBuildings/LandDefenceOffence/cormexp.lua
@@ -2,7 +2,6 @@ return {
 	cormexp = {
 		activatewhenbuilt = true,
 		buildangle = 2048,
-		buildingmask = 0,
 		buildpic = "CORMEXP.DDS",
 		buildtime = 32500,
 		canattack = true,

--- a/units/CorBuildings/LandEconomy/cormex.lua
+++ b/units/CorBuildings/LandEconomy/cormex.lua
@@ -2,7 +2,6 @@ return {
 	cormex = {
 		activatewhenbuilt = true,
 		buildangle = 2048,
-		buildingmask = 0,
 		buildpic = "CORMEX.DDS",
 		buildtime = 1870,
 		canrepeat = false,

--- a/units/CorBuildings/LandEconomy/cormoho.lua
+++ b/units/CorBuildings/LandEconomy/cormoho.lua
@@ -2,7 +2,6 @@ return {
 	cormoho = {
 		activatewhenbuilt = true,
 		buildangle = 2048,
-		buildingmask = 0,
 		buildpic = "CORMOHO.DDS",
 		buildtime = 14100,
 		canrepeat = false,

--- a/units/CorBuildings/SeaEconomy/coruwmme.lua
+++ b/units/CorBuildings/SeaEconomy/coruwmme.lua
@@ -2,7 +2,6 @@ return {
 	coruwmme = {
 		activatewhenbuilt = true,
 		buildangle = 32768,
-		buildingmask = 0,
 		buildpic = "CORUWMME.DDS",
 		buildtime = 14100,
 		canrepeat = false,

--- a/units/Legion/Economy/legmex.lua
+++ b/units/Legion/Economy/legmex.lua
@@ -6,7 +6,6 @@ return {
 		buildangle = 2048,
 		energycost = 500,
 		metalcost = 50,
-		buildingmask = 0,
 		buildpic = "LEGMEX.DDS",
 		buildtime = 1880,
 		canrepeat = false,

--- a/units/Legion/Economy/legmext15.lua
+++ b/units/Legion/Economy/legmext15.lua
@@ -6,7 +6,6 @@ return {
 		buildangle = 2048,
 		energycost = 5000,
 		metalcost = 250,
-		buildingmask = 0,
 		buildpic = "LEGMEXT15.DDS",
 		buildtime = 5000,
 		canrepeat = false,

--- a/units/Legion/Economy/legmoho.lua
+++ b/units/Legion/Economy/legmoho.lua
@@ -6,7 +6,6 @@ return {
 		buildangle = 2048,
 		energycost = 8100,
 		metalcost = 640,
-		buildingmask = 0,
 		buildpic = "legmoho.DDS",
 		buildtime = 14100,
 		canrepeat = false,

--- a/units/Legion/Economy/legmohobp.lua
+++ b/units/Legion/Economy/legmohobp.lua
@@ -6,7 +6,6 @@ return {
 		buildangle = 2048,
 		energycost = 8100,
 		metalcost = 640,
-		buildingmask = 0,
 		buildpic = "LEGMOHOBP.DDS",
 		buildtime = 14100,
 		builder = true,

--- a/units/Legion/Economy/legmohocon.lua
+++ b/units/Legion/Economy/legmohocon.lua
@@ -6,7 +6,6 @@ return {						--costs should be same as legmohoconct and legmohoconin
 		buildangle = 2048,
 		energycost = 14500,
 		metalcost = 1060,
-		buildingmask = 0,
 		buildpic = "LEGMOHOCON.DDS",
 		buildtime = 19400,
 		canrepeat = false,

--- a/units/Legion/Economy/legmohoconin.lua
+++ b/units/Legion/Economy/legmohoconin.lua
@@ -6,7 +6,6 @@ return {						--costs should be same as legmohocon and legmohoconct
 		buildangle = 2048,
 		energycost = 14500,
 		metalcost = 1060,
-		buildingmask = 0,
 		buildpic = "LEGMOHOCON.DDS",
 		buildtime = 19400,
 		canrepeat = false,


### PR DESCRIPTION
### Work done
Remove Bad Building Masks from Mexes

The default building mask is 1,
We don't currently use building masks, but if we were to, e.g. [current lava blocking discussion](https://discord.com/channels/549281623154229250/549282166543089674/1392717330110353438),
it being set to zero would result in the relevant buildings ignoring it, see [[BuildingMaskMap.cpp#L37]](https://github.com/beyond-all-reason/RecoilEngine/blob/master/rts/Sim/Misc/BuildingMaskMap.cpp#L37)
```c++
return (maskMap[x + z * mapDims.hmapx] & value) == value;
```

where value is our building mask, this would result in always 0 == 0 which is true.
