### PR TITLE
Custom maneuver behaviour gadget (Resolves: #75)

### DIFF
--- a/luarules/gadgets/unit_maneuver.lua
+++ b/luarules/gadgets/unit_maneuver.lua
@@ -24,7 +24,7 @@ local CMD_FIGHT = CMD.FIGHT
 local MOVESTATE_MANEUVER = 1
 local FIRESTATE_HOLDFIRE = 0
 local FIRESTATE_RETURNFIRE = 1
-local UPDATE_INTERVAL = 15 --is this too much/too little?
+local UPDATE_INTERVAL = 10
 local ATTACK_MEMORY_DURATION = 90
 local RADIUS_FALLBACK = 16
 
@@ -37,141 +37,112 @@ local spGetUnitRadius = Spring.GetUnitRadius
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetGameFrame = Spring.GetGameFrame
 
-local unitSightDistances = {}
 local lastMovePosition = {}
 local recentlyAttacked = {}
-local nonAirUnits = {}
+local customManeuverUnitIDs = {}
+local returnToOrigin = {}
+local notFlyingWithSight = {}
+
+for i = 1, #UnitDefs do
+	local def = UnitDefs[i]
+	if not def.canFly and def.sightDistance then
+		notFlyingWithSight[def.id] = {sightDist = def.sightDistance}
+	end
+end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
 		if (cmdID == CMD_MOVE or cmdID == CMD_FIGHT) and cmdParams[1] and cmdParams[2] and cmdParams[3] then
-			lastMovePosition[unitID] = {
-				x = cmdParams[1],
-				y = cmdParams[2],
-				z = cmdParams[3]
-			}
+			lastMovePosition[unitID] = { cmdParams[1], cmdParams[2], cmdParams[3] }
 		end
 		
 		if cmdID == CMD_STOP then
-			local x, y, z = spGetUnitPosition(unitID)
-			
-			if x and y and z then
-				lastMovePosition[unitID] = { 
-					x = x, 
-					y = y, 
-					z = z 
-				}
-			end
+			lastMovePosition[unitID] = { spGetUnitPosition(unitID) }
 		end
 
 	return true
 end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-	local def = UnitDefs[unitDefID]
-
-	if def and def.sightDistance and not def.canFly then
-		unitSightDistances[unitID] = def.sightDistance
-		nonAirUnits[unitID] = true
+	if notFlyingWithSight[unitDefID] then
+		customManeuverUnitIDs[unitID] = notFlyingWithSight[unitDefID].sightDist
 	end
 
-	if not lastMovePosition[unitID] then
-		local x, y, z = spGetUnitPosition(unitID)
-		
-		if x and y and z then
-			lastMovePosition[unitID] = { 
-				x = x, 
-				y = y, 
-				z = z 
-			}
-		end
-	end
+	-- if not lastMovePosition[unitID] then
+	-- 	lastMovePosition[unitID] = { spGetUnitPosition(unitID) }-- returning to origin on factory maneuver setting
+	-- end
 end
 
 function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponID, attackerID, attackerDefID, attackerTeam)
 	if attackerID and attackerTeam ~= unitTeam then
-		recentlyAttacked[unitID] = spGetGameFrame
+		recentlyAttacked[unitID] = spGetGameFrame()
 	end
 end
 
 function gadget:UnitDestroyed(unitID)
-	unitSightDistances[unitID] = nil
 	lastMovePosition[unitID] = nil
 	recentlyAttacked[unitID] = nil
-	nonAirUnits[unitID] = nil
+	returnToOrigin[unitID] = nil
+	customManeuverUnitIDs[unitID] = nil
 end
 
 function gadget:GameFrame(frame)
-	for unitID, sightDist in pairs(unitSightDistances) do
-		if nonAirUnits[unitID] then
-			if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then --first time trying something like this, let me know what you think
-				local unitStates = spGetUnitStates(unitID)
+	for unitID, sightDist in pairs(customManeuverUnitIDs) do
+		if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then
+			local unitStates = spGetUnitStates(unitID)
+			-- Spring.Echo(unitID, "[IDLE]")
 
-				if unitStates.firestate ~= FIRESTATE_HOLDFIRE then
-					if unitStates.movestate == MOVESTATE_MANEUVER then
-						local cmdQueue = spGetUnitCommands(unitID, 1) or {}
-						local currentPosition = { spGetUnitPosition(unitID) }
-						local validTargetID = nil
-						local targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
+			if unitStates.movestate == MOVESTATE_MANEUVER then
+				local cmdQueue = spGetUnitCommands(unitID, 1) or {}
 
-						if targetID then
+				if returnToOrigin[unitID] then
+					local currentPosition = { spGetUnitPosition(unitID) }
+					local originalPosition = lastMovePosition[unitID]
+					local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
+
+					if not cmdQueue[1] and (
+						not originalPosition or
+						math.abs(currentPosition[1] - originalPosition[1]) > (radius * 4) or -- spamming moves in large group becaue can't get to preferred spot
+						math.abs(currentPosition[3] - originalPosition[3]) > (radius * 4)
+					) then
+						Spring.Echo(unitID, "[RETURN TO ORIGIN]")
+						spGiveOrderToUnit(unitID, CMD_MOVE, { originalPosition[1], originalPosition[2], originalPosition[3] }, {})
+						returnToOrigin[unitID] = false
+					end
+
+					if not cmdQueue[1] then
+						returnToOrigin[unitID] = false
+					end
+				elseif unitStates.firestate == FIRESTATE_RETURNFIRE then
+					local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
+					local targetID
+					-- Spring.Echo(targetID)
+
+					if attackedRecently then
+						-- Spring.Echo("I've been attacked")
+						targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
+
+						if targetID then	
 							local targetDefID = spGetUnitDefID(targetID)
-							if targetDefID and not UnitDefs[targetDefID].canFly then
-								validTargetID = targetID 
+							if notFlyingWithSight[targetDefID] and not cmdQueue[1] then
+								Spring.Echo("[RETURNING CHASE]")
+								spGiveOrderToUnit(unitID, CMD_ATTACK, targetID)	
 							end
-						end
-
-						if validTargetID then
-							Spring.Echo(validTargetID, "is Valid target")
-							-- Spring.Echo(cmdQueue)
-							if unitStates.firestate == FIRESTATE_RETURNFIRE then
-								local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
-								
-								if attackedRecently then
-									if not cmdQueue[1] then
-										-- Spring.Echo("[RETURN-FIRE CHASE]", unitID, "->" ,validTargetID) --couldn't get this echo to work
-										Spring.Echo("[RETURN-FIRE CHASE]")
-										spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
-									end
-								end
-							else
-								if not cmdQueue[1] then
-									--This block never runs with current settings (UPDATE_INTERVAL = 15). Race condition with engine MOVESTATE_MANUEVER?
-									-- Spring.Echo("[CHASE]", unitID, "->", validTargetID)--couldn't get this echo to work
-									Spring.Echo("[CHASE]") 
-									spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
-								end
-							end
-						else
-							local origPosition = lastMovePosition[unitID]
-							local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
-
-							if not cmdQueue[1] and (
-								not origPosition or
-								math.abs(currentPosition[1] - origPosition.x) > (radius * 2) or
-								math.abs(currentPosition[3] - origPosition.z) > (radius * 2)
-							) then
-								-- Spring.Echo("[RETURNING]", unitID, "->", origPosition.x, origPosition.y, origPosition.z) --couldn't get this echo to work
-								Spring.Echo("[RETURNING]")
-								spGiveOrderToUnit(unitID, CMD_MOVE, {
-									origPosition.x,
-									origPosition.y,
-									origPosition.z
-								}, {})
-							end
-						end
-					else
-						local x, y, z = spGetUnitPosition(unitID)
-						
-						if x and y and z then
-							lastMovePosition[unitID] = { 
-								x = x, 
-								y = y, 
-								z = z 
-							}
 						end
 					end
+					
+					targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
+					
+					if not targetID then
+						-- Spring.Echo("[I'm done chasing]")
+						returnToOrigin[unitID] = true
+					end
+				elseif cmdQueue[1] and cmdQueue[1].id == CMD_ATTACK then
+					Spring.Echo(unitID, "[CHASING]")
+					returnToOrigin[unitID] = true
 				end
 			end
 		end
 	end
 end
+
+

--- a/luarules/gadgets/unit_maneuver.lua
+++ b/luarules/gadgets/unit_maneuver.lua
@@ -22,7 +22,6 @@ local CMD_MOVE = CMD.MOVE
 local CMD_STOP = CMD.STOP
 local CMD_FIGHT = CMD.FIGHT
 local MOVESTATE_MANEUVER = 1
-local FIRESTATE_HOLDFIRE = 0
 local FIRESTATE_RETURNFIRE = 1
 local UPDATE_INTERVAL = 10
 local ATTACK_MEMORY_DURATION = 90
@@ -45,30 +44,32 @@ local notFlyingWithSight = {}
 
 for i = 1, #UnitDefs do
 	local def = UnitDefs[i]
-	if not def.canFly and def.sightDistance then
-		notFlyingWithSight[def.id] = {sightDist = def.sightDistance}
+	if not def.canFly and not def.isBuilding and def.sightDistance then
+		notFlyingWithSight[i] = def.sightDistance
 	end
 end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
 		if (cmdID == CMD_MOVE or cmdID == CMD_FIGHT) and cmdParams[1] and cmdParams[2] and cmdParams[3] then
 			lastMovePosition[unitID] = { cmdParams[1], cmdParams[2], cmdParams[3] }
-		end
-		
-		if cmdID == CMD_STOP then
-			lastMovePosition[unitID] = { spGetUnitPosition(unitID) }
+	elseif cmdID == CMD_STOP then
+		local x, y, z = spGetUnitPosition(unitID)
+		lastMovePosition[unitID] = { x, y, z }
 		end
 
 	return true
 end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-	if notFlyingWithSight[unitDefID] then
-		customManeuverUnitIDs[unitID] = notFlyingWithSight[unitDefID].sightDist
-	end
+	local sightDist = notFlyingWithSight[unitDefID]
 
+	if sightDist then
+		customManeuverUnitIDs[unitID] = sightDist
+	end
+	-- returning to origin on factory maneuver setting
 	-- if not lastMovePosition[unitID] then
-	-- 	lastMovePosition[unitID] = { spGetUnitPosition(unitID) }-- returning to origin on factory maneuver setting
+	-- 	local x, y, z = spGetUnitPosition(unitID)
+	-- 	lastMovePosition[unitID] = { x, y, z }
 	-- end
 end
 
@@ -85,6 +86,40 @@ function gadget:UnitDestroyed(unitID)
 	customManeuverUnitIDs[unitID] = nil
 end
 
+local function IsAlreadyMovingTo()
+end
+
+-- units that are pushed out of lastmove position are calling this forever.
+-- maybe i need to reset last move for idle units somehow
+local function ReturnToOrigin(unitID, cmdQueue)
+	local currentPosition = { spGetUnitPosition(unitID) }
+	local originalPosition = lastMovePosition[unitID]
+	local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
+	cmdQueue = cmdQueue or {}
+
+	if originalPosition and --not
+		(math.abs(currentPosition[1] - originalPosition[1]) > radius * RADIUS_BUFFER_MULTIPLIER or 
+		math.abs(currentPosition[3] - originalPosition[3]) > radius * RADIUS_BUFFER_MULTIPLIER) 
+	then
+		if cmdQueue[1] then
+			local params = cmdQueue[1].params
+			if params and #params == 3 then
+				if not (math.abs(params[1] - originalPosition[1]) <= radius and
+						math.abs(params[3] - originalPosition[3]) <= radius)
+				then	 
+					Spring.Echo(unitID, "[RETURN TO ORIGIN]")
+					spGiveOrderToUnit(unitID, CMD_MOVE, originalPosition, {})
+				end
+			end
+		else
+			Spring.Echo(unitID, "[RETURN TO ORIGIN]")
+			spGiveOrderToUnit(unitID, CMD_MOVE, originalPosition, {})
+		end
+	end
+
+	returnToOrigin[unitID] = true
+end
+
 function gadget:GameFrame(frame)
 	for unitID, sightDist in pairs(customManeuverUnitIDs) do
 		if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then
@@ -94,55 +129,52 @@ function gadget:GameFrame(frame)
 			if unitStates.movestate == MOVESTATE_MANEUVER then
 				local cmdQueue = spGetUnitCommands(unitID, 1) or {}
 
-				if returnToOrigin[unitID] then
-					local currentPosition = { spGetUnitPosition(unitID) }
-					local originalPosition = lastMovePosition[unitID]
-					local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
+					-- if returnToOrigin[unitID] then
+					-- 		local currentPosition = { spGetUnitPosition(unitID) }
+					-- 		local originalPosition = lastMovePosition[unitID]
+					-- 		local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
 
-					if not cmdQueue[1] and (
-						not originalPosition or
-						math.abs(currentPosition[1] - originalPosition[1]) > (radius * 4) or -- spamming moves in large group becaue can't get to preferred spot
-						math.abs(currentPosition[3] - originalPosition[3]) > (radius * 4)
-					) then
-						Spring.Echo(unitID, "[RETURN TO ORIGIN]")
-						spGiveOrderToUnit(unitID, CMD_MOVE, { originalPosition[1], originalPosition[2], originalPosition[3] }, {})
-						returnToOrigin[unitID] = false
-					end
-
-					if not cmdQueue[1] then
-						returnToOrigin[unitID] = false
-					end
-				elseif unitStates.firestate == FIRESTATE_RETURNFIRE then
+					-- 		if not originalPosition or
+					-- 			(math.abs(currentPosition[1] - originalPosition[1]) > radius * RADIUS_BUFFER_MULTIPLIER or 
+					-- 			math.abs(currentPosition[3] - originalPosition[3]) > radius * RADIUS_BUFFER_MULTIPLIER) 
+					-- 		then
+					-- 			Spring.Echo(unitID, "[RETURN TO ORIGIN]")
+					-- 			spGiveOrderToUnit(unitID, CMD_MOVE, originalPosition, {})
+					-- 		end
+							
+					-- 		returnToOrigin[unitID] = false
+					-- 	end
+					-- elseif unitStates.firestate == FIRESTATE_RETURNFIRE then
+				if unitStates.firestate == FIRESTATE_RETURNFIRE then
 					local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
-					local targetID
-					-- Spring.Echo(targetID)
+					local targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
 
 					if attackedRecently then
-						-- Spring.Echo("I've been attacked")
-						targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
-
 						if targetID then	
 							local targetDefID = spGetUnitDefID(targetID)
-							if notFlyingWithSight[targetDefID] and not cmdQueue[1] then
-								Spring.Echo("[RETURNING CHASE]")
+							
+							-- if targetDefID and notFlyingWithSight[targetDefID] and not cmdQueue[1] then
+							if targetDefID and notFlyingWithSight[targetDefID] and (not cmdQueue[1] or returnToOrigin[unitID]) then
+								Spring.Echo(unitID, "[RETURNING CHASE]")
 								spGiveOrderToUnit(unitID, CMD_ATTACK, targetID)	
+								returnToOrigin[unitID] = false
+							end
+						end
+					else
+						if not targetID then
+							-- returnToOrigin[unitID] = true
+							ReturnToOrigin(unitID, cmdQueue)
 							end
 						end
 					end
 					
-					targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
-					
-					if not targetID then
-						-- Spring.Echo("[I'm done chasing]")
-						returnToOrigin[unitID] = true
-					end
-				elseif cmdQueue[1] and cmdQueue[1].id == CMD_ATTACK then
-					Spring.Echo(unitID, "[CHASING]")
-					returnToOrigin[unitID] = true
+				if not cmdQueue[1] then
+					ReturnToOrigin(unitID)
+					-- elseif cmdQueue[1] and cmdQueue[1].id == CMD_ATTACK then
+					-- Spring.Echo(unitID, "[CHASING]")
+					-- returnToOrigin[unitID] = true
 				end
 			end
 		end
 	end
 end
-
-

--- a/luarules/gadgets/unit_maneuver.lua
+++ b/luarules/gadgets/unit_maneuver.lua
@@ -14,7 +14,7 @@ function gadget:GetInfo()
 end
 
 if not gadgetHandler:IsSyncedCode() then 
-    return 
+	return 
 end
 
 local CMD_ATTACK = CMD.ATTACK
@@ -43,125 +43,135 @@ local recentlyAttacked = {}
 local nonAirUnits = {}
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
-        if (cmdID == CMD_MOVE or cmdID == CMD_FIGHT) and cmdParams[1] and cmdParams[2] and cmdParams[3] then
-            lastMovePosition[unitID] = {
-                x = cmdParams[1],
-                y = cmdParams[2],
-                z = cmdParams[3]
-            }
-        end
-        
-        if cmdID == CMD_STOP then
-            local x, y, z = spGetUnitPosition(unitID)
-            if x and y and z then
-                lastMovePosition[unitID] = { 
-                    x = x, 
-                    y = y, 
-                    z = z 
-                }
-            end
-        end
-    return true
+		if (cmdID == CMD_MOVE or cmdID == CMD_FIGHT) and cmdParams[1] and cmdParams[2] and cmdParams[3] then
+			lastMovePosition[unitID] = {
+				x = cmdParams[1],
+				y = cmdParams[2],
+				z = cmdParams[3]
+			}
+		end
+		
+		if cmdID == CMD_STOP then
+			local x, y, z = spGetUnitPosition(unitID)
+			
+			if x and y and z then
+				lastMovePosition[unitID] = { 
+					x = x, 
+					y = y, 
+					z = z 
+				}
+			end
+		end
+
+	return true
 end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-    local def = UnitDefs[unitDefID]
-    if def and def.sightDistance and not def.canFly then
-        unitSightDistances[unitID] = def.sightDistance
-        nonAirUnits[unitID] = true
-    end
+	local def = UnitDefs[unitDefID]
 
-    if not lastMovePosition[unitID] then
-        local x, y, z = spGetUnitPosition(unitID)
-        if x and y and z then
-            lastMovePosition[unitID] = { 
-                x = x, 
-                y = y, 
-                z = z 
-            }
-        end
-    end
+	if def and def.sightDistance and not def.canFly then
+		unitSightDistances[unitID] = def.sightDistance
+		nonAirUnits[unitID] = true
+	end
+
+	if not lastMovePosition[unitID] then
+		local x, y, z = spGetUnitPosition(unitID)
+		
+		if x and y and z then
+			lastMovePosition[unitID] = { 
+				x = x, 
+				y = y, 
+				z = z 
+			}
+		end
+	end
 end
 
 function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponID, attackerID, attackerDefID, attackerTeam)
-    if attackerID and attackerTeam ~= unitTeam then
-        recentlyAttacked[unitID] = spGetGameFrame
-    end
+	if attackerID and attackerTeam ~= unitTeam then
+		recentlyAttacked[unitID] = spGetGameFrame
+	end
 end
 
 function gadget:UnitDestroyed(unitID)
-    unitSightDistances[unitID] = nil
-    lastMovePosition[unitID] = nil
-    recentlyAttacked[unitID] = nil
-    nonAirUnits[unitID] = nil
+	unitSightDistances[unitID] = nil
+	lastMovePosition[unitID] = nil
+	recentlyAttacked[unitID] = nil
+	nonAirUnits[unitID] = nil
 end
 
 function gadget:GameFrame(frame)
-    for unitID, sightDist in pairs(unitSightDistances) do
-        if nonAirUnits[unitID] then
-            if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then --first time trying something like this, let me know what you think
-                local unitStates = spGetUnitStates(unitID)
-                if unitStates.firestate ~= FIRESTATE_HOLDFIRE then
-                    if unitStates.movestate == MOVESTATE_MANEUVER then
-                        local cmdQueue = spGetUnitCommands(unitID, 1) or {}
-                        local currentPosition = { spGetUnitPosition(unitID) }
-                        local validTargetID = nil
-                        local targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
-                        if targetID then
-                            local targetDefID = spGetUnitDefID(targetID)
-                            if targetDefID and not UnitDefs[targetDefID].canFly then
-                                validTargetID = targetID 
-                            end
-                        end
-                        if validTargetID then
-                            Spring.Echo(validTargetID, "is Valid target")
-                            -- Spring.Echo(cmdQueue)
-                            if unitStates.firestate == FIRESTATE_RETURNFIRE then
-                                local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
-                                if attackedRecently then
-                                    if not cmdQueue[1] then
-                                        -- Spring.Echo("[RETURN-FIRE CHASE]", unitID, "->" ,validTargetID) --couldn't get this echo to work
-                                        Spring.Echo("[RETURN-FIRE CHASE]")
-                                        spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
-                                    end
-                                end
-                            else
-                                if not cmdQueue[1] then
-                                    --This block never runs with current settings (UPDATE_INTERVAL = 15). Race condition with engine MOVESTATE_MANUEVER?
-                                    -- Spring.Echo("[CHASE]", unitID, "->", validTargetID)--couldn't get this echo to work
-                                    Spring.Echo("[CHASE]") 
-                                    spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
-                                end
-                            end
-                        else
-                            local origPosition = lastMovePosition[unitID]
-                            local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
-                            if not cmdQueue[1] and (
-                                not origPosition or
-                                math.abs(currentPosition[1] - origPosition.x) > (radius * 2) or
-                                math.abs(currentPosition[3] - origPosition.z) > (radius * 2)
-                            ) then
-                                -- Spring.Echo("[RETURNING]", unitID, "->", origPosition.x, origPosition.y, origPosition.z) --couldn't get this echo to work
-                                Spring.Echo("[RETURNING]")
-                                spGiveOrderToUnit(unitID, CMD_MOVE, {
-                                    origPosition.x,
-                                    origPosition.y,
-                                    origPosition.z
-                                }, {})
-                            end
-                        end
-                    else
-                        local x, y, z = spGetUnitPosition(unitID)
-                        if x and y and z then
-                            lastMovePosition[unitID] = { 
-                                x = x, 
-                                y = y, 
-                                z = z 
-                            }
-                        end
-                    end
-                end
-            end
-        end
-    end
+	for unitID, sightDist in pairs(unitSightDistances) do
+		if nonAirUnits[unitID] then
+			if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then --first time trying something like this, let me know what you think
+				local unitStates = spGetUnitStates(unitID)
+
+				if unitStates.firestate ~= FIRESTATE_HOLDFIRE then
+					if unitStates.movestate == MOVESTATE_MANEUVER then
+						local cmdQueue = spGetUnitCommands(unitID, 1) or {}
+						local currentPosition = { spGetUnitPosition(unitID) }
+						local validTargetID = nil
+						local targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
+
+						if targetID then
+							local targetDefID = spGetUnitDefID(targetID)
+							if targetDefID and not UnitDefs[targetDefID].canFly then
+								validTargetID = targetID 
+							end
+						end
+
+						if validTargetID then
+							Spring.Echo(validTargetID, "is Valid target")
+							-- Spring.Echo(cmdQueue)
+							if unitStates.firestate == FIRESTATE_RETURNFIRE then
+								local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
+								
+								if attackedRecently then
+									if not cmdQueue[1] then
+										-- Spring.Echo("[RETURN-FIRE CHASE]", unitID, "->" ,validTargetID) --couldn't get this echo to work
+										Spring.Echo("[RETURN-FIRE CHASE]")
+										spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
+									end
+								end
+							else
+								if not cmdQueue[1] then
+									--This block never runs with current settings (UPDATE_INTERVAL = 15). Race condition with engine MOVESTATE_MANUEVER?
+									-- Spring.Echo("[CHASE]", unitID, "->", validTargetID)--couldn't get this echo to work
+									Spring.Echo("[CHASE]") 
+									spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
+								end
+							end
+						else
+							local origPosition = lastMovePosition[unitID]
+							local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
+
+							if not cmdQueue[1] and (
+								not origPosition or
+								math.abs(currentPosition[1] - origPosition.x) > (radius * 2) or
+								math.abs(currentPosition[3] - origPosition.z) > (radius * 2)
+							) then
+								-- Spring.Echo("[RETURNING]", unitID, "->", origPosition.x, origPosition.y, origPosition.z) --couldn't get this echo to work
+								Spring.Echo("[RETURNING]")
+								spGiveOrderToUnit(unitID, CMD_MOVE, {
+									origPosition.x,
+									origPosition.y,
+									origPosition.z
+								}, {})
+							end
+						end
+					else
+						local x, y, z = spGetUnitPosition(unitID)
+						
+						if x and y and z then
+							lastMovePosition[unitID] = { 
+								x = x, 
+								y = y, 
+								z = z 
+							}
+						end
+					end
+				end
+			end
+		end
+	end
 end

--- a/luarules/gadgets/unit_maneuver.lua
+++ b/luarules/gadgets/unit_maneuver.lua
@@ -1,9 +1,10 @@
-lastReturnMovePositionlocal gadget = gadget ---@type Gadget
+local gadget = gadget ---@type Gadget
+--make this a widget
 
 function gadget:GetInfo()
 	return {
-		name = 'Custom Maneuver behaviour',
-		desc = 'Return unit to it\'s last move position when it no longer has a valid target in sight',
+		name = 'Custom Maneuver/Chase behaviour',
+		desc = 'Return unit to it\'s last move position when it no longer has a valid target',
 		author = 'chocolatemalc',
 		version = 'v1.0',
 		date = 'July 2025',

--- a/luarules/gadgets/unit_maneuver.lua
+++ b/luarules/gadgets/unit_maneuver.lua
@@ -1,0 +1,167 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = 'Custom Maneuver behaviour',
+		desc = 'Return unit to it\'s last move position when it no longer has a valid target in sight',
+		author = 'chocolatemalc',
+		version = 'v1.0',
+		date = 'July 2025',
+		license = 'GNU GPL, v2 or later',
+		layer = 0,
+		enabled = true
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then 
+    return 
+end
+
+local CMD_ATTACK = CMD.ATTACK
+local CMD_MOVE = CMD.MOVE
+local CMD_STOP = CMD.STOP
+local CMD_FIGHT = CMD.FIGHT
+local MOVESTATE_MANEUVER = 1
+local FIRESTATE_HOLDFIRE = 0
+local FIRESTATE_RETURNFIRE = 1
+local UPDATE_INTERVAL = 15 --is this too much/too little?
+local ATTACK_MEMORY_DURATION = 90
+local RADIUS_FALLBACK = 16
+
+local spGetUnitCommands = Spring.GetUnitCommands
+local spGetUnitNearestEnemy = Spring.GetUnitNearestEnemy
+local spGetUnitStates = Spring.GetUnitStates
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spGetUnitRadius = Spring.GetUnitRadius
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetGameFrame = Spring.GetGameFrame
+
+local unitSightDistances = {}
+local lastMovePosition = {}
+local recentlyAttacked = {}
+local nonAirUnits = {}
+
+function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
+        if (cmdID == CMD_MOVE or cmdID == CMD_FIGHT) and cmdParams[1] and cmdParams[2] and cmdParams[3] then
+            lastMovePosition[unitID] = {
+                x = cmdParams[1],
+                y = cmdParams[2],
+                z = cmdParams[3]
+            }
+        end
+        
+        if cmdID == CMD_STOP then
+            local x, y, z = spGetUnitPosition(unitID)
+            if x and y and z then
+                lastMovePosition[unitID] = { 
+                    x = x, 
+                    y = y, 
+                    z = z 
+                }
+            end
+        end
+    return true
+end
+
+function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+    local def = UnitDefs[unitDefID]
+    if def and def.sightDistance and not def.canFly then
+        unitSightDistances[unitID] = def.sightDistance
+        nonAirUnits[unitID] = true
+    end
+
+    if not lastMovePosition[unitID] then
+        local x, y, z = spGetUnitPosition(unitID)
+        if x and y and z then
+            lastMovePosition[unitID] = { 
+                x = x, 
+                y = y, 
+                z = z 
+            }
+        end
+    end
+end
+
+function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponID, attackerID, attackerDefID, attackerTeam)
+    if attackerID and attackerTeam ~= unitTeam then
+        recentlyAttacked[unitID] = spGetGameFrame
+    end
+end
+
+function gadget:UnitDestroyed(unitID)
+    unitSightDistances[unitID] = nil
+    lastMovePosition[unitID] = nil
+    recentlyAttacked[unitID] = nil
+    nonAirUnits[unitID] = nil
+end
+
+function gadget:GameFrame(frame)
+    for unitID, sightDist in pairs(unitSightDistances) do
+        if nonAirUnits[unitID] then
+            if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then --first time trying something like this, let me know what you think
+                local unitStates = spGetUnitStates(unitID)
+                if unitStates.firestate ~= FIRESTATE_HOLDFIRE then
+                    if unitStates.movestate == MOVESTATE_MANEUVER then
+                        local cmdQueue = spGetUnitCommands(unitID, 1) or {}
+                        local currentPosition = { spGetUnitPosition(unitID) }
+                        local validTargetID = nil
+                        local targetID = spGetUnitNearestEnemy(unitID, sightDist, true)
+                        if targetID then
+                            local targetDefID = spGetUnitDefID(targetID)
+                            if targetDefID and not UnitDefs[targetDefID].canFly then
+                                validTargetID = targetID 
+                            end
+                        end
+                        if validTargetID then
+                            Spring.Echo(validTargetID, "is Valid target")
+                            -- Spring.Echo(cmdQueue)
+                            if unitStates.firestate == FIRESTATE_RETURNFIRE then
+                                local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
+                                if attackedRecently then
+                                    if not cmdQueue[1] then
+                                        -- Spring.Echo("[RETURN-FIRE CHASE]", unitID, "->" ,validTargetID) --couldn't get this echo to work
+                                        Spring.Echo("[RETURN-FIRE CHASE]")
+                                        spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
+                                    end
+                                end
+                            else
+                                if not cmdQueue[1] then
+                                    --This block never runs with current settings (UPDATE_INTERVAL = 15). Race condition with engine MOVESTATE_MANUEVER?
+                                    -- Spring.Echo("[CHASE]", unitID, "->", validTargetID)--couldn't get this echo to work
+                                    Spring.Echo("[CHASE]") 
+                                    spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
+                                end
+                            end
+                        else
+                            local origPosition = lastMovePosition[unitID]
+                            local radius = spGetUnitRadius(unitID) or RADIUS_FALLBACK
+                            if not cmdQueue[1] and (
+                                not origPosition or
+                                math.abs(currentPosition[1] - origPosition.x) > (radius * 2) or
+                                math.abs(currentPosition[3] - origPosition.z) > (radius * 2)
+                            ) then
+                                -- Spring.Echo("[RETURNING]", unitID, "->", origPosition.x, origPosition.y, origPosition.z) --couldn't get this echo to work
+                                Spring.Echo("[RETURNING]")
+                                spGiveOrderToUnit(unitID, CMD_MOVE, {
+                                    origPosition.x,
+                                    origPosition.y,
+                                    origPosition.z
+                                }, {})
+                            end
+                        end
+                    else
+                        local x, y, z = spGetUnitPosition(unitID)
+                        if x and y and z then
+                            lastMovePosition[unitID] = { 
+                                x = x, 
+                                y = y, 
+                                z = z 
+                            }
+                        end
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
### Work done
This is a new lua gadget that modifies the default behaviour of the "Maneuver" movestate.

#### OLD BEHAVIOUR
1. IDLE "Maneuver" state enabled unit encounters enemy unit in sight range.
2. "Maneuver" unit issues an attack command on enemy unit.
3. When no enemy units remain in sight range, "Maneuver" unit stops.

#### NEW BEHAVIOUR
1. IDLE "Maneuver" state enabled unit encounters enemy unit in sight range.
2. "Maneuver" unit issues an attack command on enemy unit.
3. When no enemy units remain in sight range, "Maneuver" returns to the coordinates of the last MOVE (or FIGHT) command it received prior to being IDLE.

I've written this with the following in mind:
1. Do not override behaviours other than MANEUVER. 
 Here it is worth mentioning that during testing I found that ATTACK commands issued in the RETURNFIRE firestate are not reset in the same way by the engine as ATTACK commands in the FIREATWILL firestate. RETURNFIRE ATTACK commands persist beyond sight range. FIREATWILL ATTACK commands will be canceled outside of sight range. I do not know if this is intended, and I have not modified the behaviour in this gadget, even though it  produces unintuitive in the case where you are using RETURNFIRE + MANEUVER (I'd say an extreme edge case) 
1. Do no apply to air units and new behaviour ignores air units.

#### Addresses Issue(s)
beyond-all-reason/Beyond-All-Reason#75

#### Testing
- I've attempted to test every NEW BEHAVIOUR scenario I could think of that to ensure it's functioning as described above (including while moving, issuing other commands, stopping, vs Air, etc).
- I have not tested any navy unit
- I have only tested the OLD BEHAVIOUR in the simple IDLE "Manuever" land unit vs enemy land unit entering sight range.

### Questions
For my own education and for best performance I would appreciate any feedback, particularly on the following (comments exist in initial version of the PR):

``` lua
local UPDATE_INTERVAL = 15 --is this too much/too little?
```

``` lua
--first time trying something like this. is it necessary or common to distribute logic across periods of frames?
if unitID % UPDATE_INTERVAL == frame % UPDATE_INTERVAL then 
```

``` lua
                         if validTargetID then
                            Spring.Echo(validTargetID, "is Valid target")
                            -- Spring.Echo(cmdQueue)
                            if unitStates.firestate == FIRESTATE_RETURNFIRE then
                                local attackedRecently = recentlyAttacked[unitID] and (frame - recentlyAttacked[unitID] <= ATTACK_MEMORY_DURATION)
                                if attackedRecently then
                                    if not cmdQueue[1] then
                                        -- Spring.Echo("[RETURN-FIRE CHASE]", unitID, "->" ,validTargetID) --couldn't get this echo to work
                                        Spring.Echo("[RETURN-FIRE CHASE]")
                                        spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
                                    end
                                end
                            else
                                if not cmdQueue[1] then
                                    --This block never runs with current settings (UPDATE_INTERVAL = 15). Race condition with engine MOVESTATE_MANUEVER?
                                    -- Spring.Echo("[CHASE]", unitID, "->", validTargetID)--couldn't get this echo to work
                                    Spring.Echo("[CHASE]") 
                                    spGiveOrderToUnit(unitID, CMD_ATTACK, {validTargetID}, {})
                                end
                            end
```
P.S. I know there's a little repetition that I can refactor. I still plan on doing this, but it's very late and I'm too excited to share this PR to wait.