### PR TITLE
feat: select idle builders by distance to camera

### DIFF
--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -26,7 +26,7 @@ local maxIcons = 9
 local showRez = true
 local doUpdateForce = true
 local justSelected = false
-local listSorted = {} -- listSorted[unitDefID]: set to true when idle list is updated, set to false when idleList[unitDefID] is sorted
+local listSorted = {} -- listSorted[unitDefID]: set to nil when idle list is updated, set to true when idleList[unitDefID] is sorted
 
 local leftclick = 'LuaUI/Sounds/buildbar_add.wav'
 local rightclick = 'LuaUI/Sounds/buildbar_click.wav'

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -26,7 +26,7 @@ local maxIcons = 9
 local showRez = true
 local doUpdateForce = true
 local justSelected = false
-local listSorted = {} -- listUpdated[unitDefID]: set to true when idle list is updated, set to false when idleList[unitDefID] is sorted
+local listSorted = {} -- listSorted[unitDefID]: set to true when idle list is updated, set to false when idleList[unitDefID] is sorted
 
 local leftclick = 'LuaUI/Sounds/buildbar_add.wav'
 local rightclick = 'LuaUI/Sounds/buildbar_click.wav'

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -742,6 +742,7 @@ function widget:MousePress(x, y, button)
 								num = (clicks[unitDefID]) % (#idleList[unitDefID]) + 1
 							end
 							if not listSorted[unitDefID] then
+								-- FIXME: should use center of screen rather than camera
 								local camX, _, camZ = Spring.GetCameraPosition()
 								table.sort(idleList[unitDefID], function (a, b)
 									local unitAX, _, unitAZ = spGetUnitPosition(a)

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -27,6 +27,7 @@ local showRez = true
 local doUpdateForce = true
 local justSelected = false
 local listSorted = {} -- listSorted[unitDefID]: set to nil when idle list is updated, set to true when idleList[unitDefID] is sorted
+local prevCameraPosition -- {posX, posY, posZ}: camera position for sorting idle units, used to have consistent point of reference when right clicking
 
 local leftclick = 'LuaUI/Sounds/buildbar_add.wav'
 local rightclick = 'LuaUI/Sounds/buildbar_click.wav'
@@ -743,7 +744,8 @@ function widget:MousePress(x, y, button)
 							end
 							if not listSorted[unitDefID] then
 								-- FIXME: should use center of screen rather than camera
-								local camX, _, camZ = Spring.GetCameraPosition()
+								local camX, camY, camZ = unpack(prevCameraPosition or {Spring.GetCameraPosition()})
+								prevCameraPosition = {camX, camY, camZ}
 								table.sort(idleList[unitDefID], function (a, b)
 									local unitAX, _, unitAZ = spGetUnitPosition(a)
 									local unitBX, _, unitBZ = spGetUnitPosition(b)
@@ -776,6 +778,7 @@ function widget:SelectionChanged(sel)
 		justSelected = false
 		return
 	end
+	prevCameraPosition = nil
 	listSorted = {}
 	clicks = {}
 end

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -772,7 +772,7 @@ end
 
 function widget:SelectionChanged(sel)
 	selectedUnits = sel or {}
-	if justSelected then
+	if justSelected then -- ignore selections done by the widget itself 
 		justSelected = false
 		return
 	end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
The idle builder list is sorted by distance to the camera to select the closest idle builder to the camera.

fixes #5496
<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->
<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
