### PR TITLE
Include legion in proposed unit reworks modoption

### DIFF
--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -22,7 +22,7 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	if name == "armllt" or name == "corllt" or name == "leglht"
 	or name == "armbeamer" or name == "corhllt"
 	or name == "corhlt" or name == "armhlt" or name == "legmg"
-	or name == "armguard" or name == "corpun" or name == "legguard"
+	or name == "armguard" or name == "corpun" or name == "legcluster"
 	or name == "armdl" or name == "cordl" or name == "legctl" then
 		uDef.buildtime = math.ceil(uDef.buildtime * 0.009) * 100	-- 0.9x buildtime
 	end


### PR DESCRIPTION
```
Legion Compatibility Update Includes:
- Legion T1 mex
- Legion T1 labs
- Legion Commander
- Legion Bot Con
- Light Heatray Tower
- Cacophony
- Amputator
- Euryale 
```
The changes follow the original Proposed Unit Reworks Modoption made by Johannes.