### PR TITLE
add fastquerypointupdate = true to corak, to eliminate an engine source of Friendly Fire

### DIFF
--- a/units/CorBots/corak.lua
+++ b/units/CorBots/corak.lua
@@ -140,6 +140,7 @@ return {
 				badtargetcategory = "VTOL",
 				def = "GATOR_LASER",
 				onlytargetcategory = "NOTSUB",
+				fastquerypointupdate = true,
 			},
 		},
 	},


### PR DESCRIPTION
Incorporate this engine update into the game. 

https://github.com/beyond-all-reason/RecoilEngine/pull/901

Should solve *almost* all grunt friendly fire situations. Only situation left I am aware of is a friendly walking into the 2nd and 3rd frame of the laser, after the 1st frame has cleared the FF check and fired clear. 