### PR TITLE
Exclude gfx_distortion_gl4 from headless runner.

### DIFF
--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -9,7 +9,8 @@ function widget:GetInfo()
 		date = "2022.06.10",
 		license = "Lua code is GPL V2, GLSL is (c) Beherith (mysterme@gmail.com)",
 		layer = -999999999, -- should be the last call of DrawWorld
-		enabled = true
+		enabled = true,
+		depends = {'gl4'},
 	}
 end
 


### PR DESCRIPTION
### Work done

- Make the gfx_distortion_gl4 depend on gl4 being available.


### Remarks

- The widget wouldn't do anything with no gl4 anyways.

### Addresses issues

- Lua error when running on headless.