### PR TITLE
Expose Armor Defs to custom

### DIFF
--- a/gamedata/armordefs.lua
+++ b/gamedata/armordefs.lua
@@ -757,7 +757,7 @@ end
 
 -- expose armor defs to custom params
 for unitName, unitDef in pairs (DEFS.unitDefs) do
-	if unitDef.customparams.armordef then
+	if unitDef.customparams and unitDef.customparams.armordef then
 		local defCategory = armorDefs[unitDef.customparams.armordef]
 		if defCategory then
 			clearArmorDef(unitName)


### PR DESCRIPTION
### Work done
Allow the adding of a unit to armor defs via custom params

#### Setup

Here is a short tweakdef that adds 3 copies of units to armor defs,, they are `corak1`, `corak2`, and `corak3`, all immune to the dgun.
```
!bset tweakdefs VW5pdERlZnMuYXJtY29tLmN1c3RvbXBhcmFtcy5hcm1vcmRlZiA9ICJzdGFuZGFyZCI
```

#### Test steps
- Paste above into skirmish chat
- Start game
- Spawn and dgun armcom
- It should no longer be immune to dguns as it was removed from the `commanders` class automatically to move it into the `standard` armor def