### PR TITLE
feat(scav/raptor spawners): support mixing barb, scavs, raptors AIs

### DIFF
--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -133,7 +133,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spawnAreaMultiplier = 2
 	local gameOver = nil
 	local humanTeams = {}
-	local pvpAllyTeamIDs = {}
+	local alliedTeamIDs = {}
 	local spawnQueue = {}
 	local deathQueue = {}
 	local queenResistance = {}
@@ -222,7 +222,7 @@ end
 			local _,_,_,AI = Spring.GetTeamInfo(raptorAllies[i])
 			local LuaAI = Spring.GetTeamLuaAI(raptorAllies[i])
 			if (AI or LuaAI) and raptorAllies[i] ~= raptorTeamID and raptorAllies[i] ~= scavTeamID then
-				table.insert(pvpAllyTeamIDs, raptorAllies[i])
+				alliedTeamIDs[raptorAllies[i]] = true
 			end
 		end
 	end
@@ -1334,6 +1334,9 @@ end
 	--------------------------------------------------------------------------------
 
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+		if alliedTeamIDs[unitTeam] or unitTeam == scavTeamID then
+			return
+		end
 
 		local unitDef = UnitDefs[unitDefID]
 
@@ -1875,7 +1878,7 @@ end
 		end
 
 		if n%30 == 0 and n > 100 then
-			for _, teamID in ipairs(pvpAllyTeamIDs) do
+			for teamID, _ in pairs(alliedTeamIDs) do
 				local commanderCount = getTeamCommanderCount(teamID)
 				if commanderCount == 0 or not commanderCount then
 					Spring.KillTeam(teamID)

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -140,6 +140,7 @@ if gadgetHandler:IsSyncedCode() then
 	local queenIDs = {}
 	local bosses = {resistances = queenResistance, statuses = {}, playerDamages = {}}
 	local raptorTeamID = Spring.Utilities.GetRaptorTeamID()
+	local scavTeamID = Spring.Utilities.GetScavTeamID()
 	local raptorAllyTeamID = Spring.Utilities.GetRaptorAllyTeamID()
 	local lsx1, lsz1, lsx2, lsz2
 	local burrows = {}
@@ -212,7 +213,6 @@ end
 				for u = 1,#units do
 					Spring.DestroyUnit(units[u], false, true)
 				end
-				Spring.Echo("Killing Team (raptors): " .. teamID)
 				Spring.KillTeam(teamID)
 			end
 		end
@@ -221,8 +221,7 @@ end
 		for i = 1,#raptorAllies do
 			local _,_,_,AI = Spring.GetTeamInfo(raptorAllies[i])
 			local LuaAI = Spring.GetTeamLuaAI(raptorAllies[i])
-			if (AI or LuaAI) and raptorAllies[i] ~= raptorTeamID then
-				Spring.Echo("Would have killed Ally (raptors): " .. raptorAllies[i])
+			if (AI or LuaAI) and raptorAllies[i] ~= raptorTeamID and raptorAllies[i] ~= scavTeamID then
 				table.insert(pvpAllyTeamIDs, raptorAllies[i])
 			end
 		end
@@ -1875,12 +1874,11 @@ end
 			end
 		end
 
-		if n%30 == 0 then
+		if n%30 == 0 and n > 100 then
 			for _, teamID in ipairs(pvpAllyTeamIDs) do
 				local commanderCount = getTeamCommanderCount(teamID)
 				if commanderCount == 0 or not commanderCount then
-					Spring.Echo('game frame killing team (raptors): ' .. teamID)
-					-- Spring.KillTeam(teamID)
+					Spring.KillTeam(teamID)
 				end
 			end
 		end

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -135,7 +135,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spawnAreaMultiplier = 2
 	local gameOver = nil
 	local humanTeams = {}
-	local pvpAllyTeamIDs = {}
+	local alliedTeamIDs = {}
 	local spawnQueue = {}
 	local deathQueue = {}
 	local bossResistance = {}
@@ -229,7 +229,7 @@ if gadgetHandler:IsSyncedCode() then
 			local _,_,_,AI = Spring.GetTeamInfo(scavAllies[i])
 			local LuaAI = Spring.GetTeamLuaAI(scavAllies[i])
 			if (AI or LuaAI) and scavAllies[i] ~= scavTeamID and scavAllies[i] ~= raptorTeamID then
-				table.insert(pvpAllyTeamIDs, scavAllies[i])
+				alliedTeamIDs[scavAllies[i]] = true
 			end
 		end
 	end
@@ -1580,6 +1580,10 @@ if gadgetHandler:IsSyncedCode() then
 	--------------------------------------------------------------------------------
 	local createUnitQueue = {}
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+		if alliedTeamIDs[unitTeam] or unitTeam == raptorTeamID then
+			return
+		end
+
 		if unitTeam == scavTeamID then
 			local _, maxH = Spring.GetUnitHealth(unitID)
 			Spring.SetUnitHealth(unitID, maxH)
@@ -2003,7 +2007,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 
 		if n%30 == 0 and n > 100 then
-			for _, teamID in ipairs(pvpAllyTeamIDs) do
+			for teamID, _ in pairs(alliedTeamIDs) do
 				local commanderCount = getTeamCommanderCount(teamID)
 				if commanderCount == 0 or not commanderCount then
 					Spring.KillTeam(teamID)
@@ -2224,7 +2228,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
 
-		if oldTeam == scavTeamID then
+		if oldTeam == scavTeamID and not (alliedTeamIDs[newTeam] or newTeam == raptorTeamID) then
 			if unitSquadTable[unitID] then
 				for index, id in ipairs(squadsTable[unitSquadTable[unitID]].squadUnits) do
 					if id == unitID then
@@ -2377,6 +2381,10 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+		if alliedTeamIDs[unitTeam] or unitTeam == raptorTeamID then
+			return
+		end
+
 		if unitTeam ~= scavTeamID and unitTeam ~= gaiaTeamID then
 			local unitTech = tonumber(UnitDefs[unitDefID].customParams.techlevel)
 			HumanTechLevel = math.max(HumanTechLevel, unitTech)

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -141,6 +141,7 @@ if gadgetHandler:IsSyncedCode() then
 	local bossResistance = {}
 	local bossIDs = {}
 	local bosses = {resistances = bossResistance, statuses = {}, playerDamages = {}}
+	local raptorTeamID = Spring.Utilities.GetRaptorTeamID()
 	local scavTeamID = Spring.Utilities.GetScavTeamID()
 	local scavAllyTeamID = Spring.Utilities.GetScavAllyTeamID()
 	local lsx1, lsz1, lsx2, lsz2
@@ -219,7 +220,6 @@ if gadgetHandler:IsSyncedCode() then
 				for u = 1,#units do
 					Spring.DestroyUnit(units[u], false, true)
 				end
-				Spring.Echo("Killing Team (scavs): " .. teamID)
 				Spring.KillTeam(teamID)
 			end
 		end
@@ -228,8 +228,7 @@ if gadgetHandler:IsSyncedCode() then
 		for i = 1,#scavAllies do
 			local _,_,_,AI = Spring.GetTeamInfo(scavAllies[i])
 			local LuaAI = Spring.GetTeamLuaAI(scavAllies[i])
-			if (AI or LuaAI) and scavAllies[i] ~= scavTeamID then
-				Spring.Echo("Would have killed Ally (scavs): " .. scavAllies[i])
+			if (AI or LuaAI) and scavAllies[i] ~= scavTeamID and scavAllies[i] ~= raptorTeamID then
 				table.insert(pvpAllyTeamIDs, scavAllies[i])
 			end
 		end
@@ -2007,7 +2006,6 @@ if gadgetHandler:IsSyncedCode() then
 			for _, teamID in ipairs(pvpAllyTeamIDs) do
 				local commanderCount = getTeamCommanderCount(teamID)
 				if commanderCount == 0 or not commanderCount then
-					Spring.Echo('game frame killing team (scavs): ' .. teamID)
 					Spring.KillTeam(teamID)
 				end
 			end

--- a/luaui/Widgets/gui_raptorStatsPanel.lua
+++ b/luaui/Widgets/gui_raptorStatsPanel.lua
@@ -1,4 +1,4 @@
-if not (Spring.Utilities.Gametype.IsRaptors() and not Spring.Utilities.Gametype.IsScavengers()) then
+if not Spring.Utilities.Gametype.IsRaptors() then
 	return false
 end
 

--- a/luaui/Widgets/gui_scavStatsPanel.lua
+++ b/luaui/Widgets/gui_scavStatsPanel.lua
@@ -1,4 +1,4 @@
-if not (Spring.Utilities.Gametype.IsScavengers() and not Spring.Utilities.Gametype.IsRaptors()) then
+if not Spring.Utilities.Gametype.IsScavengers() then
 	return false
 end
 

--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -430,10 +430,6 @@ function widget:Initialize()
 			end
 		end
 	end
-
-	if Spring.Utilities.Gametype.IsRaptors() and Spring.Utilities.Gametype.IsScavengers() then
-		queueNotification('RaptorsAndScavsMixed')
-	end
 end
 
 function widget:Shutdown()
@@ -478,11 +474,6 @@ function widget:GameFrame(gf)
 				--	queueNotification('BuildIntrusionCounterMeasure')
 				--end
 			end
-		end
-
-		-- raptors and scavs mixed check
-		if Spring.Utilities.Gametype.IsRaptors() and Spring.Utilities.Gametype.IsScavengers() then
-			queueNotification('RaptorsAndScavsMixed')
 		end
 
 		-- low power check


### PR DESCRIPTION
### Work done
- AI team limiting guards removed
- Unit management team guards added in callins
- Added that a barb team is killed when their respective com(s) are dead

### Work not done
- The raptor creep (scum?) is not showing
- Commander team counting from mo_com_counter.lua should probably be in a utility function

#### Test steps
- [x] Test combinations of barb, scav and raptors. Kill in different order and play till game over
- [x] Make sure scav/raptors are not targeting barb allies
- [ ] Human players on the AI allyteam (not tested)