### PR TITLE
Add missing shieldShader:Initialize to shieldsphere.lua.

### DIFF
--- a/lups/particleclasses/shieldsphere.lua
+++ b/lups/particleclasses/shieldsphere.lua
@@ -350,6 +350,7 @@ function ShieldSphereParticle:Initialize()
 		print(PRIO_MAJOR,"LUPS->Shield: critical shader error: "..gl.GetShaderLog())
 		return false
 	end
+	shieldShader:Initialize()
 
 	sphereList = gl.CreateList(DrawSphere, 0, 0, 0, 1, 30, false)
 end


### PR DESCRIPTION
### Work done

- Add missing shieldShader:Initialize to shieldsphere.lua.


#### Addresses Issue(s)

```
[t=00:01:02.306990][f=-000001] LuaShader: [ShieldSphereParticleShader] shader error(s):
Attempt to use invalid shader object in [Finalize](). Did you call :Compile() or :Initialize()
[t=00:01:02.307375][f=-000001] Attempt to use invalid shader object in [Finalize](). Did you call :Compile() or :Initialize()
```

### Remarks

- Probably broken since https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5454 was merged at 93834f37db55173d39223649282c877e53e37826
- Unsure whether this shader is actually used, maybe should be removed instead. Maybe @Ruwetuin or @Beherith know. 
- Otherwise safe to simply fix for now as I'm doing here.