### PR TITLE
Improve processing of CMD_INSERT

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1343,6 +1343,7 @@ end
 
 local CMD_ANY = CMD.ANY
 local CMD_NIL = CMD.NIL
+local CMD_INSERT = CMD.INSERT
 local allowCommandList = {[CMD_ANY] = {}}
 
 function gadgetHandler:ReorderAllowCommands(gadget, f)
@@ -1480,7 +1481,7 @@ end
 
 function gadgetHandler:AllowCommand(unitID, unitDefID, unitTeam,
 									cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	local cmdKey = cmdID or CMD_NIL
+	local cmdKey = cmdID == CMD_INSERT and cmdParams[2] or cmdID or CMD_NIL
 	if not allowCommandList[cmdKey] then cmdKey = CMD_ANY end
 
 	tracy.ZoneBeginN("G:AllowCommand")

--- a/luarules/gadgets/cmd_factory_stop_production.lua
+++ b/luarules/gadgets/cmd_factory_stop_production.lua
@@ -105,7 +105,7 @@ if gadgetHandler:IsSyncedCode() then
 		spGiveOrderToUnit(unitID, CMD_WAIT, EMPTY, 0) -- Removes wait if there is a wait but doesn't readd it.
 		spGiveOrderToUnit(unitID, CMD_WAIT, EMPTY, 0) -- If a factory is waiting, it will not clear the current build command, even if the cmd is removed.
 		-- See: http://zero-k.info/Forum/Post/237176#237176 for details.
-		SendToUnsynced(identifier, unitID, unitDefID, unitTeam, cmdID)
+		SendToUnsynced(identifier, unitID, unitDefID, unitTeam, CMD_STOP_PRODUCTION)
 	end
 
 	-- Add the command to factories

--- a/luarules/gadgets/cmd_manual_launch.lua
+++ b/luarules/gadgets/cmd_manual_launch.lua
@@ -34,16 +34,14 @@ local launchCommand = {
 }
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-	if cmdID == CMD.INSERT and cmdParams[2] == CMD_MANUAL_LAUNCH then
-		cmdParams[2] = CMD.MANUALFIRE
+	if cmdID == CMD.INSERT then
+		cmdParams[2] = CMD.MANUALFIRE -- replace CMD_MANUAL_LAUNCH
 		Spring.GiveOrderToUnit(unitID, CMD.INSERT, cmdParams, cmdOptions.coded)
-		return false
-	elseif cmdID == CMD_MANUAL_LAUNCH then
+	else
 		Spring.GiveOrderToUnit(unitID, CMD.MANUALFIRE, cmdParams, cmdOptions.coded)
-		return false
 	end
 
-	return true
+	return false
 end
 
 function gadget:UnitCreated(unitID, unitDefID, teamID)
@@ -56,6 +54,5 @@ end
 
 function gadget:Initialize()
 	gadgetHandler:RegisterCMDID(CMD_MANUAL_LAUNCH)
-	gadgetHandler:RegisterAllowCommand(CMD.INSERT)
 	gadgetHandler:RegisterAllowCommand(CMD_MANUAL_LAUNCH)
 end

--- a/luarules/gadgets/cmd_mex_denier.lua
+++ b/luarules/gadgets/cmd_mex_denier.lua
@@ -38,11 +38,17 @@ function gadget:Initialize()
 	metalSpotsList = GG["resource_spot_finder"].metalSpotsList
 end
 
--- function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3] = cmdParams[4], cmdParams[5], cmdParams[6]
+	return cmdParams[2], p
+end
+
 function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
-	local isInsert = cmdID == CMD_INSERT
-	if isInsert and cmdParams[2] then
-		cmdID = cmdParams[2] -- this is where the ID is placed in prepended commands with commandinsert
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
 	end
 
 	if not isMex[-cmdID] then
@@ -50,9 +56,6 @@ function gadget:AllowCommand(_, _, _, cmdID, cmdParams)
 	end
 
 	local bx, bz = cmdParams[1], cmdParams[3]
-	if isInsert then
-		bx, bz = cmdParams[4], cmdParams[6] -- this is where the cmd position is placed in prepended commands with commandinsert
-	end
 
 	-- We find the closest metal spot to the assigned command position
 	local closestSpot = math.getClosestPosition(bx, bz, metalSpotsList)

--- a/luarules/gadgets/gaia_critters.lua
+++ b/luarules/gadgets/gaia_critters.lua
@@ -583,8 +583,21 @@ function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDef
 	end
 end
 
+local CMD_INSERT = CMD.INSERT
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
+
 --http://springrts.com/phpbb/viewtopic.php?f=23&t=30109
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	-- accepts: CMD.ATTACK
 	if cmdParams and #cmdParams == 1 then
 		local critter = critterUnits[cmdParams[1]]
@@ -592,5 +605,6 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 			return false
 		end
 	end
+
 	return true
 end

--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -25,6 +25,8 @@ if allowAssist then
 	return false
 end
 
+local CMD_INSERT = CMD.INSERT
+
 local function isComplete(u)
 	local _,_,_,_,buildProgress=Spring.GetUnitHealth(u)
 	if buildProgress and buildProgress>=1 then
@@ -34,8 +36,23 @@ local function isComplete(u)
 	end
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.GUARD)
+	gadgetHandler:RegisterAllowCommand(CMD.REPAIR)
+end
+
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
 
 	-- Disallow guard commands onto labs, units that have buildOptions or can assist
 

--- a/luarules/gadgets/game_no_rush_mode.lua
+++ b/luarules/gadgets/game_no_rush_mode.lua
@@ -71,26 +71,27 @@ if gadgetHandler:IsSyncedCode() then
 	function gadget:Initialize()
 		gadgetHandler:RegisterAllowCommand(CMD.ANY)
 	end
+
+	local params = {}
+
+	local function fromInsert(cmdParams)
+		local p = params
+		-- Avoid modifying `cmdParams` directly. It gets reused on any following AllowCommand calls.
+		p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+		return cmdParams[2], p
+	end
+
 	function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
 		local allowed = true
 		local frame = Spring.GetGameFrame()
 
 		if frame < norushtimer and (not TeamIDsToExclude[unitTeam]) then
 			local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(unitTeam)
+
 			if cmdID == CMD.INSERT then
-			  -- CMD.INSERT wraps another command, so we need to extract it
-			  cmdID = cmdParams[2]
-			  -- Area commands have an extra radius parameter, so they shift by 4 instead of 3
-			  local paramCountToShift = #cmdParams - 3
-			  -- Shift the parameters to remove the CMD.INSERT wrapper and match normal command format
-			  for i = 1, paramCountToShift do
-			    cmdParams[i] = cmdParams[i + 3]
-			  end
-			  -- Clear any unused parameters after the shift
-			  for i = paramCountToShift + 1, #cmdParams do
-			    cmdParams[i] = nil
-			  end
+				cmdID, cmdParams = fromInsert(cmdParams)
 			end
+
 			if cmdID < 0 then
 				if cmdParams[1] and cmdParams[2] and cmdParams[3] then
 					if not positionCheckLibrary.StartboxCheck(cmdParams[1], cmdParams[2], cmdParams[3], allyTeamID) then

--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -33,6 +33,10 @@ local sharingTax = Spring.GetModOptions().tax_resource_sharing_amount
 -- Callins
 ----------------------------------------------------------------
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.GUARD)
+	gadgetHandler:RegisterAllowCommand(CMD.RECLAIM)
+end
 
 
 function gadget:AllowResourceTransfer(senderTeamId, receiverTeamId, resourceType, amount)
@@ -68,6 +72,7 @@ function gadget:AllowResourceTransfer(senderTeamId, receiverTeamId, resourceType
 	return false
 end
 
+
 function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
 	local unitCount = spGetTeamUnitCount(newTeam)
 	if capture or spIsCheatingEnabled() or unitCount < gameMaxUnits then
@@ -77,7 +82,19 @@ function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
 end
 
 
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1] = cmdParams[4]
+	return cmdParams[2], p
+end
+
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+	if cmdID == CMD.INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	-- Disallow reclaiming allied units for metal
 	if (cmdID == CMD.RECLAIM and #cmdParams >= 1) then
 		local targetID = cmdParams[1]

--- a/luarules/gadgets/unit_block_fake_geo.lua
+++ b/luarules/gadgets/unit_block_fake_geo.lua
@@ -16,6 +16,8 @@ function gadget:GetInfo()
 	}
 end
 
+local CMD_INSERT = CMD.INSERT
+
 local function isNearGeo(x, z)
 	-- modded geos can be bigger than 40 elmo but w/e, this gadget only lives
 	-- until next engine anyway, plus centered placement still works
@@ -33,10 +35,17 @@ function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD.ANY)
 end
 
-local CMD_INSERT = CMD.INSERT
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
 	if cmdID == CMD_INSERT then
-		return gadget:AllowCommand(unitID, unitDefID, teamID, cmdParams[2], {cmdParams[4], cmdParams[5], cmdParams[6]}, cmdParams[3])
+		cmdID, cmdParams = fromInsert(cmdParams)
 	end
 
 	return cmdID >= 0 or not UnitDefs[-cmdID].needGeo or isNearGeo(cmdParams[1], cmdParams[3])

--- a/luarules/gadgets/unit_capture_only_enemy.lua
+++ b/luarules/gadgets/unit_capture_only_enemy.lua
@@ -16,9 +16,21 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
-local CMD_CAPTURE = CMD.CAPTURE
+local CMD_INSERT = CMD.INSERT
+
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1] = cmdParams[4]
+	return cmdParams[2], p
+end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	-- accepts: CMD.CAPTURE
 	if Spring.GetUnitAllyTeam(unitID) == Spring.GetUnitAllyTeam(cmdParams[1]) and not select(4, Spring.GetTeamInfo(Spring.GetUnitTeam(cmdParams[1]))) and not Spring.GetTeamLuaAI(Spring.GetUnitTeam(cmdParams[1])) then
 		return false
@@ -27,5 +39,5 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 end
 
 function gadget:Initialize()
-	gadgetHandler:RegisterAllowCommand(CMD_CAPTURE)
+	gadgetHandler:RegisterAllowCommand(CMD.CAPTURE)
 end

--- a/luarules/gadgets/unit_cloak.lua
+++ b/luarules/gadgets/unit_cloak.lua
@@ -191,15 +191,20 @@ end
 
 GG.SetWantedCloaked = SetWantedCloaked
 
-function gadget:AllowCommand_GetWantedCommand()
-	return {[CMD_CLOAK] = true, [CMD_WANT_CLOAK] = true}
-end
+local CMD_INSERT = CMD.INSERT
+local params = {}
 
-function gadget:AllowCommand_GetWantedUnitDefID()
-	return true
+local function fromInsert(cmdParams)
+	local p = params
+	p[1] = cmdParams[4]
+	return cmdParams[2], p
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	if cmdID == CMD_WANT_CLOAK then
 		if canCloak[unitDefID] then
 			SetWantedCloaked(unitID, cmdParams[1])

--- a/luarules/gadgets/unit_objectify.lua
+++ b/luarules/gadgets/unit_objectify.lua
@@ -117,7 +117,20 @@ if gadgetHandler:IsSyncedCode() then
         return damage, nil
     end
 
+	local CMD_INSERT = CMD.INSERT
+	local params = {}
+
+	local function fromInsert(cmdParams)
+		local p = params
+		p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+		return cmdParams[2], p
+	end
+
 	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+		if cmdID == CMD_INSERT then
+			cmdID, cmdParams = fromInsert(cmdParams)
+		end
+
 		if cmdID and (numObjects > 0 or numDecorations > 0) then
 			-- prevents area targetting
 			if cmdID == CMD_ATTACK then
@@ -129,6 +142,7 @@ if gadgetHandler:IsSyncedCode() then
 				end
 
 			-- remove any decoration that is blocking a queued build order
+			-- todo: this will delete decorations over any distance and even for enqueued commands
 			elseif cmdID < 0 and numDecorations > 0 then
 				if cmdParams[3] and isBuilder[spGetUnitDefID(unitID)] then
 					local udefid = math.abs(cmdID)

--- a/luarules/gadgets/unit_onlytargetcategory.lua
+++ b/luarules/gadgets/unit_onlytargetcategory.lua
@@ -46,7 +46,20 @@ function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
 end
 
+local CMD_INSERT = CMD.INSERT
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	-- accepts: CMD.ATTACK
 	if cmdParams[2] == nil
 	and unitOnlyTargetsCategory[unitDefID]

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -30,7 +30,20 @@ function gadget:Initialize()
     gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
 end
 
+local CMD_INSERT = CMD.INSERT
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	-- accepts: CMD.ATTACK
 	if empUnits[unitDefID]
 	and cmdParams[2] == nil

--- a/luarules/gadgets/unit_prevent_aircraft_hax.lua
+++ b/luarules/gadgets/unit_prevent_aircraft_hax.lua
@@ -31,6 +31,7 @@ local spValidUnitID = Spring.ValidUnitID
 local spIsPosInMap = Spring.IsPosInMap
 local CMD_STOP = CMD.STOP
 local CMD_GUARD = CMD.GUARD
+local CMD_INSERT = CMD.INSERT
 
 local isMobileUnit = {}
 local isBuilder = {}
@@ -87,12 +88,23 @@ function gadget:GameFrame(f)
 	end
 end
 
+local params = {}
+local function fromInsert(cmdParams)
+	local p = params
+	p[1] = cmdParams[4]
+	return cmdParams[2], p
+end
+
 local function isInsideMap(unitID)
 	local x,_,z = spGetUnitPosition(unitID)
 	return spIsPosInMap(x, z)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	if cmdID == CMD_STOP and isMobileUnit[unitDefID] then
 		return isInsideMap(unitID)
 	elseif cmdID == CMD_GUARD then
@@ -105,5 +117,6 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 			end
 		end
 	end
+
 	return true
 end

--- a/luarules/gadgets/unit_prevent_nanoframe_blocking_hax.lua
+++ b/luarules/gadgets/unit_prevent_nanoframe_blocking_hax.lua
@@ -102,8 +102,21 @@ function gadget:GameFrame(n)
 	end
 end
 
+local CMD_INSERT = CMD.INSERT
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
+
 -- make it not manually or accidentally targetable
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	-- accepts: CMD.ATTACK
 	if not cmdParams[2] and newNanoFrameNeutralState[cmdParams[1]] ~= nil then
 		return false

--- a/luarules/gadgets/unit_transportable_nanos.lua
+++ b/luarules/gadgets/unit_transportable_nanos.lua
@@ -45,7 +45,20 @@ function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD_UNLOAD_UNITS)
 end
 
+local CMD_INSERT = CMD.INSERT
+local params = {}
+
+local function fromInsert(cmdParams)
+	local p = params
+	p[1], p[2], p[3], p[4], p[5] = cmdParams[4], cmdParams[5], cmdParams[6], cmdParams[7], cmdParams[8]
+	return cmdParams[2], p
+end
+
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		cmdID, cmdParams = fromInsert(cmdParams)
+	end
+
 	if cmdID == CMD_LOAD_UNITS then
 		if #cmdParams == 1 then -- if unit is target
 			if ValidUnitID(cmdParams[1]) and GetUnitTeam(cmdParams[1]) ~= teamID and Nanos[GetUnitDefID(cmdParams[1])] then

--- a/luarules/gadgets/unit_transportee_hider.lua
+++ b/luarules/gadgets/unit_transportee_hider.lua
@@ -24,6 +24,7 @@ local GiveOrderToUnit = Spring.GiveOrderToUnit
 
 local CMD_LOAD_ONTO = CMD.LOAD_ONTO
 local CMD_STOP = CMD.STOP
+local CMD_INSERT = CMD.INSERT
 
 local massLeft = {}
 local toBeLoaded = {}
@@ -43,7 +44,13 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
+local insParams = {}
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if cmdID == CMD_INSERT then
+		insParams[1] = cmdParams[4]
+		cmdParams = insParams
+	end
+
 	-- accepts: CMD.LOAD_ONTO
 	local transportID = cmdParams[1]
 	toBeLoaded[unitID] = transportID


### PR DESCRIPTION
### Work done

I changed the `AllowCommand` call-in in `gadgets.lua` to handle inserted commands, like from `cmd_commandinsert.lua`, before invoking any gadgets. Then I updated all impacted gadgets, so there are some repetitive edits.

Gadgets already can register only the command id(s) that they want passed. This PR changes the lookup to first check for an inserted command id before invoking any gadgets.

This better supports consistent handling of inserted commands—and in fact requires it. Every gadget *will* be passed each `CMD_INSERT` that contains their registered command id(s).

There is no actual dependence in `AllowCommand` on `cmd_commandinsert`. That is just the source of most inserted commands. So the relation of gadgets to the gadget handler is not being inverted, here.

#### Addresses Issue(s)

I noticed odd behaviors when working through [another PR](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5485#issuecomment-3084347759):

- Across many gadgets, `AllowCommand` allows or disallows an inserted command in error.
    - `unit_objectify` disallows direct attack orders. This can be bypassed by issuing an Attack order + `space`.
    - `cmd_guard_remove` prevents commands from enqueueing after a non-terminating command. This can be bypassed by issuing multiple Guard orders, each + `space`.
    - etc.
- It is a minor enhancement to `AllowCommand`, since this was possible but more cumbersome to do before on a per-gadget level. It also improves performance slightly, including for cases like #431, wherever a `CMD_INSERT` is involved.

A command once issued, accepted, and enqueued may become invalid in the future, which this PR doesn't address.

### Testing

I've had no errors or warnings in tests across multiple scenarios and skirmishes.

This almost certainly has unintended consequences, though:

- Patrol + meta does not work as before.
- Guard + meta does not work as before.
- If the space key was being used to "force" any other command: It no longer does so.

### Some caveats

There is no opt-out of receiving inserted commands in `AllowCommand`, which may not be ideal.

Likewise, there is no way to register `CMD_INSERT` to receive all inserts.

Finally, a couple commands seem not to have an id set in their gadget -- I wonder if these are deprecated -- and there are unused methods for WantedCommand or WantedDefID that are dead code atm. None of these are a big deal but I wonder if this work area has not been coordinated in a while.