### PR TITLE
ignore_noair Customparam for NoAir mod option

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -199,7 +199,7 @@ function UnitDef_Post(name, uDef)
 			end
 		end
 
-		if modOptions.unit_restrictions_noair then
+		if modOptions.unit_restrictions_noair and not uDef.customparams.ignore_noair then
 			if string.find(uDef.customparams.subfolder, "Aircraft") then
 				uDef.maxthisunit = 0
 			elseif uDef.customparams.unitgroup and uDef.customparams.unitgroup == "aa" then


### PR DESCRIPTION
### Work done
This PR introduces support for a new customParams flag: ignore_noair.
When this flag is present in a unit definition, the unit will bypass the **no air** mod option check entirely, allowing it to be built even when the **noair** mod option is enabled.

#### Test steps
- Added the customparameter ignore_noair to a flying unit.
- Set mod option **no air** active.
- Start the game and build the unit.

### Purpose
- There is currently no use case in vanilla BAR where a flying unit should be buildable with **no air** enabled.
- Its main purpose is to increase modding flexibility, allowing for units that make use of flight but are not traditional planes.
- A use case example would be my BAR: Space Expansion mod, which introduces spaceships that are turned off by the **no air** mod option.
- Several players have requested that they should be active even with **no air**, and I see no possibility of achieving it without editing the base game.
- In summary, I hope this change is accepted by the nature of the script having an increased flexibility, despite not offering any current use for vanilla BAR.