### PR TITLE
feat: Update Factory Quota by holding [META] key

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1142,7 +1142,7 @@ local function gridmenuKeyHandler(_, _, args, _, isRepeat)
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 
 	if builderIsFactory then
-		if WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt then
+		if WG.Quotas and ((WG.Quotas.isOnQuotaMode(activeBuilderID) or meta) and not alt) then
 			local quantity = 1
 			if shift then
 				quantity = modKeyMultiplier.keyPress.shift
@@ -2442,7 +2442,8 @@ function widget:MousePress(x, y, button)
 					then
 						local alt, ctrl, meta, shift = Spring.GetModKeyState()
 						if button ~= 3 then
-							if builderIsFactory and WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt then
+							local isQuotaMode = WG.Quotas and WG.Quotas.isOnQuotaMode and WG.Quotas.isOnQuotaMode(activeBuilderID)
+							if builderIsFactory and WG.Quotas and (isQuotaMode or meta) and not alt then
 								local amount = 1
 								if ctrl then
 									amount = amount * modKeyMultiplier.click.ctrl
@@ -2461,7 +2462,8 @@ function widget:MousePress(x, y, button)
 								pickBlueprint(unitDefID)
 							end
 						elseif builderIsFactory and spGetCmdDescIndex(-unitDefID) then
-							if not (WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt) then
+							local isQuotaMode = WG.Quotas and WG.Quotas.isOnQuotaMode and WG.Quotas.isOnQuotaMode(activeBuilderID)
+							if not (WG.Quotas and (isQuotaMode or meta) and not alt) then
 								Spring.PlaySoundFile(CONFIG.sound_queue_rem, 0.75, "ui")
 								setActiveCommand(spGetCmdDescIndex(-unitDefID), 3, false, true)
 							else

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -133,6 +133,9 @@ end
 
 ----- handle toggle
 local function isOnQuotaBuildMode(unitID)
+    if not unitID or not factoryDefIDs[spGetUnitDefID(unitID)] then
+        return false
+    end
     local cmdDescIndex = spFindUnitCmdDesc(unitID, CMD_QUOTA_BUILD_TOGGLE)
 	return cmdDescIndex and spGetUnitCmdDescs(unitID)[cmdDescIndex].params[1]+0 == 1
 end


### PR DESCRIPTION
### Work done
In places where it is possible to use the Factory Quota, it is now possible to manipulate the quota when you are holding the META (spacebar) key. It is much "faster" (mentally and hotkey wise) to do it like this.

#### Test steps
- [ ] Build a factory
- [ ] Verify "Quota mode" is off
- [ ] Hold spacebar
- [ ] Press unit build hotkey
- [ ] Verify Quota was increased for unit
- [ ] (Still holding spacebar) right click unit
- [ ] Verify Quota was lowered
- [ ] Hold shift+spacebar, click unit
- [ ] Verify that multiplier for click using modifier worked (+5)
