### PR TITLE
Mines [Heavy/Medium/Light] detonate based on unit footprint [big/medium/small]

### DIFF
--- a/scripts/mines_lus.lua
+++ b/scripts/mines_lus.lua
@@ -1,30 +1,39 @@
+local Spring_GetUnitDefID = Spring.GetUnitDefID
+local Spring_GetUnitPosition = Spring.GetUnitPosition
+local Spring_GetUnitNearestEnemy = Spring.GetUnitNearestEnemy
+local Spring_GetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
+local Spring_GetUnitStates = Spring.GetUnitStates
+local Spring_GetUnitIsStunned = Spring.GetUnitIsStunned
+local Spring_DestroyUnit = Spring.DestroyUnit
 
 local base = piece("base")
-local unitDefID = Spring.GetUnitDefID(unitID)
+local unitDefID = Spring_GetUnitDefID(unitID)
 local triggerRange = tonumber(UnitDefs[unitDefID].customParams.detonaterange) or 64
 
 local math_sqrt = math.sqrt
+
+local ux, uy, uz
 
 -- Author: Doo
 -- Requires customParams.detonaterange in unitDefs or 64 elmos range will be used
 -- Possible enhancements: Use GetUnitsInCylinder(or sphere) of detonaterange and check for any restriction on target units
 
 function GetClosestEnemyDistance()
-	targetID = Spring.GetUnitNearestEnemy(unitID, triggerRange)
+	local targetID = Spring_GetUnitNearestEnemy(unitID, triggerRange)
 	if targetID then
-		local tx,ty,tz = Spring.GetUnitPosition(targetID)
-		local dis = distance(ux,uy,uz,tx,ty,tz)
+		local tx, ty, tz = Spring_GetUnitPosition(targetID)
+		local dis = distance(ux, uy, uz, tx, ty, tz)
 		return dis
 	else
 		return math.huge
 	end
 end
 
-function distance(x1,y1,z1,x2,y2,z2)
-	local x = (x1-x2)
-	local y = (y1-y2)
-	local z = (z1-z2)
-	local dist = math_sqrt(x*x + y*y + z*z)
+function distance(x1, y1, z1, x2, y2, z2)
+	local x = (x1 - x2)
+	local y = (y1 - y2)
+	local z = (z1 - z2)
+	local dist = math_sqrt(x * x + y * y + z * z)
 	return dist
 end
 
@@ -44,27 +53,31 @@ function script.FireWeapon()
 end
 
 function script.Create()
-	ux,uy,uz = Spring.GetUnitPosition(unitID)
+	ux, uy, uz = Spring_GetUnitPosition(unitID)
 	StartThread(EnemyDetect)
 end
 
 function EnemyDetect()
 	while true do
-		local inProgress = Spring.GetUnitIsBeingBuilt(unitID)
-		local firestate = Spring.GetUnitStates(unitID, false)
-		local stunned = Spring.GetUnitIsStunned (unitID) 
-		if not inProgress and firestate and firestate > 0 and GetClosestEnemyDistance() <= triggerRange and not stunned then
-			StartThread(Detonate)
-			break
-		else
-			Sleep(1)
+		if not Spring_GetUnitIsBeingBuilt(unitID) then
+			local firestate = Spring_GetUnitStates(unitID)
+			if firestate and firestate > 0 then
+				if not Spring_GetUnitIsStunned(unitID) then
+					if GetClosestEnemyDistance() <= triggerRange then
+						StartThread(Detonate)
+						return
+					end
+				end
+			end
 		end
+
+		Sleep(1)
 	end
 end
 
 function Detonate()
 	Sleep(500)
-	Spring.DestroyUnit(unitID, false, false)
+	Spring_DestroyUnit(unitID, false, false)
 end
 
 function script.Killed()

--- a/units/ArmBuildings/LandUtil/armmine1.lua
+++ b/units/ArmBuildings/LandUtil/armmine1.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "0",
 			instantselfd = true,
 			mine = true,
 			model_author = "Beherith",

--- a/units/ArmBuildings/LandUtil/armmine2.lua
+++ b/units/ArmBuildings/LandUtil/armmine2.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "2",
 			instantselfd = true,
 			mine = true,
 			model_author = "Beherith",

--- a/units/ArmBuildings/LandUtil/armmine2.lua
+++ b/units/ArmBuildings/LandUtil/armmine2.lua
@@ -38,7 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "2",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Beherith",

--- a/units/ArmBuildings/LandUtil/armmine3.lua
+++ b/units/ArmBuildings/LandUtil/armmine3.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Beherith",

--- a/units/ArmBuildings/LandUtil/armmine3.lua
+++ b/units/ArmBuildings/LandUtil/armmine3.lua
@@ -38,7 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "3",
+			minfootprint = "4",
 			instantselfd = true,
 			mine = true,
 			model_author = "Beherith",

--- a/units/CorBuildings/LandUtil/cormine1.lua
+++ b/units/CorBuildings/LandUtil/cormine1.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "0",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/CorBuildings/LandUtil/cormine2.lua
+++ b/units/CorBuildings/LandUtil/cormine2.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "2",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/CorBuildings/LandUtil/cormine2.lua
+++ b/units/CorBuildings/LandUtil/cormine2.lua
@@ -38,7 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "2",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/CorBuildings/LandUtil/cormine3.lua
+++ b/units/CorBuildings/LandUtil/cormine3.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/CorBuildings/LandUtil/cormine3.lua
+++ b/units/CorBuildings/LandUtil/cormine3.lua
@@ -38,7 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "3",
+			minfootprint = "4",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/CorBuildings/LandUtil/cormine4.lua
+++ b/units/CorBuildings/LandUtil/cormine4.lua
@@ -39,6 +39,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "2",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/CorBuildings/LandUtil/cormine4.lua
+++ b/units/CorBuildings/LandUtil/cormine4.lua
@@ -39,7 +39,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "2",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tristan",

--- a/units/Legion/Utilities/legmine1.lua
+++ b/units/Legion/Utilities/legmine1.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "0",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tharsis",

--- a/units/Legion/Utilities/legmine2.lua
+++ b/units/Legion/Utilities/legmine2.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "2",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tharsis",

--- a/units/Legion/Utilities/legmine2.lua
+++ b/units/Legion/Utilities/legmine2.lua
@@ -38,7 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "2",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tharsis",

--- a/units/Legion/Utilities/legmine3.lua
+++ b/units/Legion/Utilities/legmine3.lua
@@ -38,7 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
-			minfootprint = "3",
+			minfootprint = "4",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tharsis",

--- a/units/Legion/Utilities/legmine3.lua
+++ b/units/Legion/Utilities/legmine3.lua
@@ -38,6 +38,7 @@ return {
 		stealth = true,
 		customparams = {
 			detonaterange = "64",
+			minfootprint = "3",
 			instantselfd = true,
 			mine = true,
 			model_author = "Tharsis",


### PR DESCRIPTION
### Work done
Mines will now not explode under a certain threshold to avoid "wasting" mines on small units. 

Bigger mines are currently fairly difficult to use as they often wasted on very small units. You could place walls in front of them, but after a opponents notices that pattern for the first time, you might as well not cloak your mines anymore.

I found that using the unit footprint feels pretty natural. Using HP would be a more "optimal" way to pair mines with units, but my major goal was to make heavy mines useful against T3 in case a player is behind and needs to stall the T3 advance.

Alternatively I have been thinking about adding EMP mines that will work on nearly all units, with enough mines able to slightly stun a Titan for example.

### Screenshots:
Heavy -> Medium -> Light
[Screencast from 07-21-2025 11:03:47 PM.webm](https://github.com/user-attachments/assets/7fcaadae-7ef7-46a2-b1f0-56b3cd12b791)
