### PR TITLE
Refactor: Optimize Order Menu by Caching Command Text

### DIFF
--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -280,6 +280,35 @@ local function refreshCommands()
 		commands[i + stateCommandsCount + waitCommandCount] = otherCommands[i]
 	end
 
+	-- OPTIMIZATION: Cache the display text for each command
+	for _, cmd in ipairs(commands) do
+		local text
+		-- First element of params represents selected state index, but Spring engine implementation returns a value 2 less than the actual index
+		local stateOffset = 2
+
+		if isStateCommand[cmd.id] then
+			local currentStateIndex = cmd.params[1]
+			if currentStateIndex then
+				local commandState = cmd.params[currentStateIndex + stateOffset]
+				if commandState then
+					text = Spring.I18N('ui.orderMenu.' .. commandState)
+				else
+					text = '?'
+				end
+			else
+				text = '?'
+			end
+		else
+			if cmd.action == 'stockpile' then
+				-- Stockpile command name gets mutated to reflect the current status, so can just pass it in
+				text  = Spring.I18N('ui.orderMenu.' .. cmd.action, { stockpileStatus = cmd.name })
+			else
+				text = Spring.I18N('ui.orderMenu.' .. cmd.action)
+			end
+		end
+		cmd.cachedText = text -- Store the translated text
+	end
+
 	setupCellGrid(false)
 end
 
@@ -574,30 +603,8 @@ local function drawCell(cell, zoom)
 
 		-- text
 		if not showIcons or not cursorTextures[cmd.cursor] then
-			local text
-			-- First element of params represents selected state index, but Spring engine implementation returns a value 2 less than the actual index
-			local stateOffset = 2
-
-			if isStateCommand[cmd.id] then
-				local currentStateIndex = cmd.params[1]
-				if currentStateIndex then
-					local commandState = cmd.params[currentStateIndex + stateOffset]
-					if commandState then
-						text = Spring.I18N('ui.orderMenu.' .. commandState)
-					else
-						text = '?'
-					end
-				else
-					text = '?'
-				end
-			else
-				if cmd.action == 'stockpile' then
-					-- Stockpile command name gets mutated to reflect the current status, so can just pass it in
-					text  = Spring.I18N('ui.orderMenu.' .. cmd.action, { stockpileStatus = cmd.name })
-				else
-					text = Spring.I18N('ui.orderMenu.' .. cmd.action)
-				end
-			end
+			-- OPTIMIZATION: Use the cached text instead of recalculating it
+			local text = cmd.cachedText or '?'
 
 			local fontSize = cellInnerWidth / font:GetTextWidth('  ' .. text .. ' ') * math_min(1, (cellInnerHeight / (rows * 6)))
 			if fontSize > cellInnerWidth / 7 then


### PR DESCRIPTION
Improve the performance of the Order Menu widget by caching the display text for command buttons. This reduces CPU load during rendering with no functional or visual changes.

### Work done

**Problem:**
The display text for each button was being recalculated within the `drawCell` function on every frame. This resulted in redundant logic and repeated `Spring.I18N()` calls, creating unnecessary overhead in the rendering loop.

**Solution:**
The text generation logic has been moved to the `refreshCommands` function, which only runs when the unit selection changes. The translated text is computed once and stored in a new `cmd.cachedText` field. The `drawCell` function now simply reads this cached value instead of performing the calculation itself.

This change significantly improves UI performance by minimizing processing in the high-frequency `DrawScreen` cycle.

#### Setup

Order menu widget must be enabled. It is enabled by default.

#### Test steps

There shoud be no functional changes to the order widget, it should function as it did before.