### PR TITLE
Custom Raptors have customizable cruise altitude

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -842,7 +842,9 @@ function UnitDef_Post(name, uDef)
 				uDef.turnradius = 64
 				uDef.turnrate = 50
 				uDef.speedtofront = 0.06
-				uDef.cruisealtitude = 220
+				if not uDef.customparams.raptorcustomsquad then
+					uDef.cruisealtitude = 220
+				end
 				--uDef.attackrunlength = 32
 			else
 				uDef.maxacc = 1
@@ -860,7 +862,9 @@ function UnitDef_Post(name, uDef)
 				uDef.turnradius = 64
 				uDef.turnrate = 1600
 				uDef.speedtofront = 0.01
-				uDef.cruisealtitude = 220
+				if not uDef.customparams.raptorcustomsquad then
+					uDef.cruisealtitude = 220
+				end
 				--uDef.attackrunlength = 32
 			end
 		end


### PR DESCRIPTION


### Work done
Custom raptors are not assigned a static cruise altitude anymore.
This way custom raptors have a configurable flying altitude.

#### Test steps
- Make a custom raptor that flies at a different altitude than 220 using customparams raptorcustomsquad.
- It must contain raptor in its unit name.
- Start a game with raptors, and give it to yourself, and it will fly at the configured altitude.