### PR TITLE
New customparameter raptorcruisealtitude allowing custom cruise height.

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -842,7 +842,9 @@ function UnitDef_Post(name, uDef)
 				uDef.turnradius = 64
 				uDef.turnrate = 50
 				uDef.speedtofront = 0.06
-				if not uDef.customparams.raptorcruisealtitude then
+				if uDef.customparams.raptorcruisealtitude then
+					uDef.cruisealtitude = tonumber(uDef.customparams.raptorcruisealtitude)
+				else
 					uDef.cruisealtitude = 220
 				end
 				--uDef.attackrunlength = 32
@@ -862,7 +864,9 @@ function UnitDef_Post(name, uDef)
 				uDef.turnradius = 64
 				uDef.turnrate = 1600
 				uDef.speedtofront = 0.01
-				if not uDef.customparams.raptorcruisealtitude then
+				if uDef.customparams.raptorcruisealtitude then
+					uDef.cruisealtitude = tonumber(uDef.customparams.raptorcruisealtitude)
+				else
 					uDef.cruisealtitude = 220
 				end
 				--uDef.attackrunlength = 32


### PR DESCRIPTION
Enables custom raptors cruise altitude via new custom parameter raptorcruisealtitude.

### Work done
- Added an if clause to the cruisealtitude assigned to all raptors, which checks for customparam raptorcruisealtitude.


#### Test steps
- Give a raptor unit raptorcruisealtitude with an altitude different from 220.
- Start a game and give yourself the raptor and see them fly at a different altitude.

