### PR TITLE
Stop rerendering some textures during pause

### DIFF
--- a/luaui/Widgets/gui_sensor_ranges_jammer.lua
+++ b/luaui/Widgets/gui_sensor_ranges_jammer.lua
@@ -152,6 +152,19 @@ function widget:DrawGenesis()
     gl.RenderToTexture(jammerStencilTexture, DrawLOSStencil)
 end
 
+-- When paused, DrawGenesis is removed. We have to pick up some rerenders ourselves.
+local forceRender = false
+
+function widget:GamePaused(playerID, paused)
+	if paused then
+		widgetHandler:RemoveCallIn("DrawGenesis")
+		forceRender = true
+	else
+		widgetHandler:UpdateCallIn("DrawGenesis")
+		forceRender = false
+	end
+end
+
 -- This shows the debug stencil texture in the bottom left corner of the screen
 if debugmode then 
 	function widget:DrawScreen()	
@@ -207,6 +220,9 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	if forceRender then
+		gl.RenderToTexture(jammerStencilTexture, DrawLOSStencil)
+	end
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_los.lua
+++ b/luaui/Widgets/gui_sensor_ranges_los.lua
@@ -172,6 +172,14 @@ function widget:DrawGenesis()
     gl.RenderToTexture(losStencilTexture, DrawLOSStencil)
 end
 
+function widget:GamePaused(playerID, paused)
+	if paused then
+		widgetHandler:RemoveCallIn("DrawGenesis")
+	else
+		widgetHandler:UpdateCallIn("DrawGenesis")
+	end
+end
+
 -- This shows the debug stencil texture in the bottom left corner of the screen
 if debugmode then 
 	function widget:DrawScreen()	

--- a/luaui/Widgets/gui_sensor_ranges_los.lua
+++ b/luaui/Widgets/gui_sensor_ranges_los.lua
@@ -172,11 +172,16 @@ function widget:DrawGenesis()
     gl.RenderToTexture(losStencilTexture, DrawLOSStencil)
 end
 
+-- When paused, DrawGenesis is removed. We have to pick up some rerenders ourselves.
+local forceRender = false
+
 function widget:GamePaused(playerID, paused)
 	if paused then
 		widgetHandler:RemoveCallIn("DrawGenesis")
+		forceRender = true
 	else
 		widgetHandler:UpdateCallIn("DrawGenesis")
+		forceRender = false
 	end
 end
 
@@ -233,6 +238,9 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	if forceRender then
+		gl.RenderToTexture(losStencilTexture, DrawLOSStencil)
+	end
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_radar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar.lua
@@ -152,11 +152,16 @@ function widget:DrawGenesis()
     gl.RenderToTexture(radarStencilTexture, DrawLOSStencil)
 end
 
+-- When paused, DrawGenesis is removed. We have to pick up some rerenders ourselves.
+local forceRender = false
+
 function widget:GamePaused(playerID, paused)
 	if paused then
 		widgetHandler:RemoveCallIn("DrawGenesis")
+		forceRender = true
 	else
 		widgetHandler:UpdateCallIn("DrawGenesis")
+		forceRender = false
 	end
 end
 
@@ -215,6 +220,9 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	if forceRender then
+		gl.RenderToTexture(radarStencilTexture, DrawLOSStencil)
+	end
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_radar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar.lua
@@ -152,6 +152,14 @@ function widget:DrawGenesis()
     gl.RenderToTexture(radarStencilTexture, DrawLOSStencil)
 end
 
+function widget:GamePaused(playerID, paused)
+	if paused then
+		widgetHandler:RemoveCallIn("DrawGenesis")
+	else
+		widgetHandler:UpdateCallIn("DrawGenesis")
+	end
+end
+
 -- This shows the debug stencil texture in the bottom left corner of the screen
 if debugmode then 
 	function widget:DrawScreen()	

--- a/luaui/Widgets/gui_sensor_ranges_sonar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_sonar.lua
@@ -153,11 +153,16 @@ function widget:DrawGenesis()
     gl.RenderToTexture(sonarStencilTexture, DrawLOSStencil)
 end
 
+-- When paused, DrawGenesis is removed. We have to pick up some rerenders ourselves.
+local forceRender = false
+
 function widget:GamePaused(playerID, paused)
 	if paused then
 		widgetHandler:RemoveCallIn("DrawGenesis")
+		forceRender = true
 	else
 		widgetHandler:UpdateCallIn("DrawGenesis")
+		forceRender = false
 	end
 end
 
@@ -220,6 +225,9 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	if forceRender then
+		gl.RenderToTexture(sonarStencilTexture, DrawLOSStencil)
+	end
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_sonar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_sonar.lua
@@ -153,6 +153,14 @@ function widget:DrawGenesis()
     gl.RenderToTexture(sonarStencilTexture, DrawLOSStencil)
 end
 
+function widget:GamePaused(playerID, paused)
+	if paused then
+		widgetHandler:RemoveCallIn("DrawGenesis")
+	else
+		widgetHandler:UpdateCallIn("DrawGenesis")
+	end
+end
+
 -- This shows the debug stencil texture in the bottom left corner of the screen
 if debugmode then 
 	function widget:DrawScreen()	


### PR DESCRIPTION
These are taking up about 30% CPU during pause. I don't see any defects with the callins simply removed -- so hopefully this is a simple fix.

### Work done

Remove `DrawGenesis` callins during pause to prevent `gl.RenderToTexture` re-rendering the LOS, radar, sonar, and jammer* stencils.

The net result on my regular, daily laptop was to go from 30% CPU -> 0% CPU during pause.