### PR TITLE
Fix: repair pad default commands

### DIFF
--- a/luarules/gadgets/unit_airbase.lua
+++ b/luarules/gadgets/unit_airbase.lua
@@ -93,6 +93,8 @@ if gadgetHandler:IsSyncedCode() then
 		cursor = 'landatairbase',
 		type = CMDTYPE.ICON,
 		tooltip = "Airbase: Tells the unit to land at the nearest available airbase for repairs",
+		hidden = true,
+		queueing = true,
 	}
 
 	local landAtSpecificAirbaseCmd = {
@@ -102,11 +104,13 @@ if gadgetHandler:IsSyncedCode() then
 		cursor = 'landatspecificairbase',
 		type = CMDTYPE.ICON_UNIT,
 		tooltip = "Airbase: Tells the unit to land at an airbase for repairs ",
+		hidden = true,
+		queueing = true,
 	}
 
 	function InsertLandAtAirbaseCommands(unitID)
-		--Spring.InsertUnitCmdDesc(unitID, landAtSpecificAirbaseCmd)
 		Spring.InsertUnitCmdDesc(unitID, landAtAnyAirbaseCmd)
+		Spring.InsertUnitCmdDesc(unitID, landAtSpecificAirbaseCmd)
 	end
 
 	---------------------------------------
@@ -481,7 +485,7 @@ if gadgetHandler:IsSyncedCode() then
 					pendingLanders[unitID] = nil
 					Spring.SetUnitLoadingTransport(unitID, airbaseID)
 					RemoveOrderFromQueue(unitID, CMD_LAND_AT_AIRBASE)
-					Spring.GiveOrderToUnit(unitID, CMD_INSERT, { 0, CMD_LAND_AT_SPECIFIC_AIRBASE, 0, airbaseID }, { "alt" }) --fixme: it fails without "alt", but idk why
+					Spring.GiveOrderToUnit(unitID, CMD_INSERT, { 0, CMD_LAND_AT_SPECIFIC_AIRBASE, 0, airbaseID }, { "alt" })
 				end
 			end
 		end
@@ -649,22 +653,21 @@ else	-- Unsynced
 	end
 
 	function gadget:DefaultCommand(type, id, cmd)
-		if type ~= "unit" then
+		if type == "unit" and isAirbase[spGetUnitDefID(id)] then
+			if Spring.GetUnitIsBeingBuilt(id) or not spAreTeamsAllied(myTeamID, spGetUnitTeam(id)) then
+				return
+			end
 
-		elseif not spAreTeamsAllied(myTeamID, spGetUnitTeam(id)) then
+			local units = spGetSelectedUnits()
 
-		elseif not isAirbase[spGetUnitDefID(id)] then
+			for i = 1, #units do
+				local unitDefID = spGetUnitDefID(units[i])
 
-		else
-			local sUnits = spGetSelectedUnits()
-			for i = 1, #sUnits do
-				local unitDefID = spGetUnitDefID(sUnits[i])
-				if isAirUnit[unitDefID] and not isAirCon[unitDefID] then -- cons still default to their usual construction tasks
+				if isAirUnit[unitDefID] and not isAirCon[unitDefID] then
 					return CMD_LAND_AT_SPECIFIC_AIRBASE
 				end
 			end
 		end
-		return false
 	end
 
 end


### PR DESCRIPTION
Just to watch them ride into the sunset.

#### Work Done

Fix the default command to dock to specific air repair pads

Fix air constructor behaviors with air repair pads (sorta, they never check their own hp%)

Add queueing hint to commands