### PR TITLE
Fix: Do not remove commands the engine will dedupe

### DIFF
--- a/luaui/Widgets/cmd_guard_remove.lua
+++ b/luaui/Widgets/cmd_guard_remove.lua
@@ -15,22 +15,29 @@ end
 
 -- Minimum time between checks per-builder. Increase to improve performance.
 local safeguardDuration = 0.1 ---@type number in seconds
+-- Remove non-terminating commands
+local removableCommand = {
+	[CMD.GUARD] = true,
+	[CMD.PATROL] = true,
+}
+-- Keep commands when in sequence
+local sequentialCommand = {
+	[CMD.PATROL] = true,
+}
 
 include("keysym.h.lua")
 
-local spGetUnitCommands = Spring.GetUnitCommands
+local math_distsq = math.distance3dSquared
+
 local spGetCmdDescIndex = Spring.GetCmdDescIndex
 local spGetActiveCmdDesc = Spring.GetActiveCmdDesc
+local spGetUnitCommandCount = Spring.GetUnitCommandCount
+local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
+local CMD_REMOVE = CMD.REMOVE
 local CMDTYPE_ICON_MODE = CMDTYPE.ICON_MODE
-local CMD_GUARD = CMD.GUARD
-local CMD_PATROL = CMD.PATROL
-
-local removableCommand = {
-	[CMD_GUARD] = true,
-	[CMD_PATROL] = true,
-}
+local CANCEL_DIST_SQUARED = (Game.squareSize * Game.footprintScale + 1) ^ 2 -- from CommandAI.cpp
 
 -- Performance safeguard: When certain commands are spammed, like reclaim, `UnitCommand` can cause
 -- extreme performance issues by parsing all of those commands. So we skip units recently touched.
@@ -55,35 +62,65 @@ local function clearRecentUnits()
 	updateTime = safeguardDuration * 0.5
 end
 
-local function isStateToggle(cmdID)
+local function isQueueing(cmdID)
 	local cmdIndex = spGetCmdDescIndex(cmdID)
 	if cmdIndex then
 		local cmdDescription = spGetActiveCmdDesc(cmdIndex)
-		if cmdDescription and cmdDescription.type == CMDTYPE_ICON_MODE then
-			return true
+		if cmdDescription then
+			return cmdDescription.queueing -- sufficient to check this?
+				or cmdDescription.type ~= CMDTYPE_ICON_MODE
 		end
 	end
 	return false
 end
 
-function widget:UnitCommand(unitID, unitDefID, _, cmdID, _, cmdOpts)
-	if not cmdOpts.shift or recentUnits[unitID] then
+-- Non-exhaustively determines whether the engine will cancel a command.
+-- The edge cases are not interesting to us given a limited remove list.
+local function willCancel(p1, p2, p3, q1, q2, q3)
+	if p1 == q1 and p2 == q2 and p3 == q3 then
+		return true
+	elseif p3 ~= nil and q3 ~= nil then
+		return math_distsq(p1, p2, p3, q1, q2, q3) < CANCEL_DIST_SQUARED
+	else
 		return false
 	end
+end
 
-	if validUnit[unitDefID] and not isStateToggle(cmdID) then
-		recentUnits[unitID] = gameTime
-		local cmd = spGetUnitCommands(unitID, 2)
-		if cmd then
-			for c = 1, #cmd do
-				if removableCommand[cmd[c].id] then
-					spGiveOrderToUnit(unitID, CMD.REMOVE, {cmd[c].tag}, 0)
-				end
+-- See `CCommandAI:GiveAllowedCommand`.
+-- The engine cancels the first duplicate command, starting from the end,
+-- then cancels overlapping commands by distance and BuildInfo footprint.
+--
+-- We want to remove non-duplicate, non-overlapping commands, then, that
+-- otherwise would prevent reaching our newer, higher-precedence command.
+local function removeCommands(unitID, command, params)
+	local p1, p2, p3 = params[1], params[2], params[3]
+
+	local tags = {}
+	local hasCanceled = not removableCommand[command]
+	local isReachable = sequentialCommand[command]
+
+	for i = spGetUnitCommandCount(unitID), 1, -1 do
+		local queued, _, qid, q1, q2, q3 = spGetUnitCurrentCommand(unitID, i)
+		if removableCommand[queued] then
+			if not hasCanceled and willCancel(p1, p2, p3, q1, q2, q3) then
+				hasCanceled = true
+			elseif not isReachable or not sequentialCommand[queued] then
+				isReachable = false
+				tags[#tags + 1] = qid
 			end
 		end
 	end
 
-	return false
+	if tags[1] then
+		spGiveOrderToUnit(unitID, CMD_REMOVE, tags)
+	end
+end
+
+function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOpts)
+	if cmdOpts.shift and not recentUnits[unitID] and validUnit[unitDefID] and isQueueing(cmdID) then
+		recentUnits[unitID] = gameTime
+		removeCommands(unitID, cmdID, cmdParams)
+	end
 end
 
 function widget:Update(dt)


### PR DESCRIPTION
This changes how commands are enqueued, so per usual there's a question of "what is the correct behavior", but I've played with this version of the widget for a while now and can vouch.

### Work done

Handle enqueued (shift-ed) Guard and Patrol orders correctly in the widget `cmd_guard_remove`. First, this re-enables removing commands by reissuing them, same as any other command. Next, it fixes an issue that was preventing longer patrol routes.

Also, I made the outcome of each click feel more consistent. The time window to filter recent units acted like an unintentional double-click that did not match the duration of any other command double-click. That should feel better, now.

#### Addresses issues

Resolves #926:

- `UnitCommand` runs after the command is allowed and before it is compared against the command queue. During that comparison, though, the command can still be canceled. By preventing commands, the widget also prevents canceling commands currently in a unit's queue.

In addition:

- The widget cancels parts of long Patrol orders. It is a game of speed and chance to shift-queue a full route within the widget's 0.25-second and 5-frame time window.
- The removed commands are inconsistent. It is based on time and limited to the command count from end (2).

#### Test steps

- [ ] Give a builder some orders, then shift+guard something, then shift+guard something again.
- [ ] Two identical guard commands should be removed.
- [ ] Two different guard commands should remove one.
- [ ] Give a builder a long patrol route, then shift+any other command. The route should be removed.
- [ ] Give a builder a long patrol route, then wait, then shift+patrol again. The route should be preserved and add a new waypoint.