### PR TITLE
No economic sharing modoption; aka The Nuclear Option

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -1,5 +1,4 @@
 local gadget = gadget ---@type Gadget
-
 function gadget:GetInfo()
 	return {
 		name    = 'Disable Assist Ally Construction',
@@ -19,32 +18,31 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
-local allowAssist = not Spring.GetModOptions().disable_assist_ally_construction
-
+local allowAssist = not Spring.GetModOptions().disable_assist_ally_construction and not Spring.GetModOptions().disable_economic_sharing
 if allowAssist then
 	return false
 end
 
-local function isComplete(u)
-	local _,_,_,_,buildProgress=Spring.GetUnitHealth(u)
-	if buildProgress and buildProgress>=1 then
-		return true
-	else
-		return false
-	end
-end
+Spring.Echo("Restrictions on assisting allies with BP are enabled")
+
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitIsBuilding = Spring.GetUnitIsBuilding
+local spGetUnitTeam = Spring.GetUnitTeam
+local spAreTeamsAllied = Spring.AreTeamsAllied
+
+local CMD_GUARD = CMD.GUARD
+local CMD_REPAIR = CMD.REPAIR
 
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
 
 	-- Disallow guard commands onto labs, units that have buildOptions or can assist
-
-	if (cmdID == CMD.GUARD) then
+	if (cmdID == CMD_GUARD) then
 		local targetID = cmdParams[1]
-		local targetTeam = Spring.GetUnitTeam(targetID)
-		local targetUnitDef = UnitDefs[Spring.GetUnitDefID(targetID)]
-		
-		if (unitTeam ~= Spring.GetUnitTeam(targetID)) and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+		local targetTeam = spGetUnitTeam(targetID)
+		local targetUnitDef = UnitDefs[spGetUnitDefID(targetID)]
+
+		if (unitTeam ~= targetTeam) and spAreTeamsAllied(unitTeam, targetTeam) then
 			if #targetUnitDef.buildOptions > 0 or targetUnitDef.canAssist then
 				return false
 			end
@@ -52,22 +50,18 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 		return true
 	end
 
-	-- Also disallow assisting building (caused by a repair command) units under construction 
+	-- Also disallow assisting building (caused by a repair command) units under construction
 	-- Area repair doesn't cause assisting, so it's fine that we can't properly filter it
-
-	if (cmdID == CMD.REPAIR and #cmdParams == 1) then
+	if (cmdID == CMD_REPAIR and #cmdParams == 1) then
 		local targetID = cmdParams[1]
-		local targetTeam = Spring.GetUnitTeam(targetID)
+		local targetTeam = spGetUnitTeam(targetID)
 
-		if (unitTeam ~= Spring.GetUnitTeam(targetID)) and Spring.AreTeamsAllied(unitTeam, targetTeam) then
-			if(not isComplete(targetID)) then
+		if (unitTeam ~= targetTeam) and spAreTeamsAllied(unitTeam, targetTeam) then
+			if(spGetUnitIsBuilding(targetID)) then
 				return false
 			end
 		end
-		return true
 	end
-
-
 
 	return true
 end

--- a/luarules/gadgets/game_disable_econ_unit_sharing.lua
+++ b/luarules/gadgets/game_disable_econ_unit_sharing.lua
@@ -1,0 +1,43 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = 'Disable Economic Unit Sharing',
+		desc    = 'Disable sharing any economic or builder units when modoption is enabled',
+		author  = 'Hobo Joe',
+		date    = 'August 2025',
+		license = 'GNU GPL, v2 or later',
+		layer   = 0,
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+if not Spring.GetModOptions().disable_economic_sharing then
+	return false
+end
+
+Spring.Echo("Sharing restrictions on economic units are active")
+
+local unshareable = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.canAssist or unitDef.isFactory then
+		unshareable[unitDefID] = true
+	end
+	if unitDef.customparams and (unitDef.customparams.unitgroup == "energy" or unitDef.customparams.unitgroup == "metal") then
+		unshareable[unitDefID] = true
+	end
+end
+
+function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
+	if unshareable[unitDefID] then
+		return false
+	end
+	return true
+end

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -298,6 +298,14 @@ local options = {
 		column	= 1.76,
 	},
 	{
+		key 	= "disable_economic_sharing",
+		name 	= "Disable Economic Sharing",
+		desc 	= "Disables sharing of any resources, sharing of resource producing units/structures, and sharing of constructors. Only combat units can be shared",
+		type 	= "bool",
+		section = "options_main",
+		def 	= false,
+	},
+	{
 		key		= "unit_market",
 		name	= "Unit Market",
 		desc	= "Allow players to trade units. (Select unit, press 'For Sale' in order window or say /sell_unit in chat to mark the unit for sale. Double-click to buy from allies. T2cons show up in shop window!)",
@@ -916,7 +924,7 @@ local options = {
         section = "options_extra",
         def  	= false,
     },
-	
+
     {
         key    	= "scavunitsforplayers",
         name   	= "Scavengers Units Pack",
@@ -967,17 +975,17 @@ local options = {
         column	= 1,
         items	= {
             { key= "default", 	name= "Default", desc= "Map Settings",
-                lock = 
+                lock =
                 {"map_lavatidemode", "map_lavahighlevel", "map_lavahighdwell", "map_lavalowlevel", "map_lavalowdwell", "sub_header_lava3", "sub_header_lava4"},
                 unlock =
                     { "sub_header_lava1", "sub_header_lava2"}},
             { key= "enabled",	name= "Enable/Override",desc= "Lava tides will use these settings over the map defaults",
-                unlock = 
+                unlock =
                 {"map_lavatidemode", "map_lavahighlevel", "map_lavahighdwell", "map_lavalowlevel", "map_lavalowdwell", "sub_header_lava3", "sub_header_lava4"},
                 lock =
                     { "sub_header_lava1", "sub_header_lava2"}},
             { key= "disabled",	name= "Disable",desc= "Lava will not have tides, even on maps that normally have it",
-                lock = 
+                lock =
                 {"map_lavatidemode", "map_lavahighlevel", "map_lavahighdwell", "map_lavalowlevel", "map_lavalowdwell", "sub_header_lava3", "sub_header_lava4"},
                 unlock =
                     { "sub_header_lava1", "sub_header_lava2"}},
@@ -1036,7 +1044,7 @@ local options = {
         step 	= 1,
         section = "options_extra",
         column	= 1,
-    },  
+    },
 
     {
         key 	= "map_lavalowdwell",
@@ -1055,8 +1063,8 @@ local options = {
     { key = "sub_header_lava2", section = "options_extra", type    = "subheader", name = "",},
     { key = "sub_header_lava3", section = "options_extra", type    = "subheader", name = "",},
     { key = "sub_header_lava4", section = "options_extra", type    = "subheader", name = "",},
- 
-    
+
+
     {
         key     = "sub_header",
         section = "options_extra",
@@ -1390,7 +1398,7 @@ local options = {
     },
 
     -- Hidden Tests
-	
+
 	{
         key   	= "splittiers",
         name   	= "Split T2",
@@ -1400,7 +1408,7 @@ local options = {
         def  	= false,
         hidden 	= true,
 	},
-	
+
     {
         key    	= "shieldsrework",
         name   	= "Shields Rework v2.0",


### PR DESCRIPTION
### Work done
Draft because the work is in progress.

- New modoption `disable_economic_sharing`
- Will disable sharing of all economic and builder units
- Will disable all direct resource sharing
- Will disable overflow resource sharing
- Will disable assisting ally constructions
- Will address many sharing loopholes, details to be filled out as they get solved.

### Current state
- Disables sharing of all economic and builder units
- Disables assisting ally constructions