### PR TITLE
Update weapon range multiplier modoption to work with over range

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -2351,6 +2351,9 @@ function WeaponDef_Post(name, wDef)
 		if wDef.weapontype == "StarburstLauncher" and wDef.weapontimer then
 			wDef.weapontimer = wDef.weapontimer + (wDef.weapontimer * ((rangeMult - 1) * 0.4))
 		end
+		if wDef.customparams and wDef.customparams.overrange_distance then
+   			wDef.customparams.overrange_distance = wDef.customparams.overrange_distance * rangeMult
+		end
 	end
 
 	-- Weapon Damage

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -2352,7 +2352,7 @@ function WeaponDef_Post(name, wDef)
 			wDef.weapontimer = wDef.weapontimer + (wDef.weapontimer * ((rangeMult - 1) * 0.4))
 		end
 		if wDef.customparams and wDef.customparams.overrange_distance then
-   			wDef.customparams.overrange_distance = wDef.customparams.overrange_distance * rangeMult
+			wDef.customparams.overrange_distance = wDef.customparams.overrange_distance * rangeMult
 		end
 	end
 


### PR DESCRIPTION
The range multiplier modoption does not affect the `overrange_distance` custom param, causing certain projectiles to fall short.

### Work done
- Updated the range multiplier modoption to also multiply the `overrange_distance` custom param when present.

#### Test steps
- [ ] Set the weapon range multiplier modoption
- [ ] Start a game and use units with weapons that have the `overrange_distance` custom param (Arbiter, Negotiator, etc.).
- [ ] Confirm that their projectiles now travel the correct (multiplied) distance.