### PR TITLE
Account for set target problems

### DIFF
--- a/luarules/gadgets/cmd_place_target_on_ground.lua
+++ b/luarules/gadgets/cmd_place_target_on_ground.lua
@@ -7,7 +7,7 @@ function gadget:GetInfo()
 		author    = 'Itanthias',
 		date      = 'August 2023',
 		license   = 'GNU GPL, v2 or later',
-		layer     = 12,
+		layer     = -12,
 		enabled   = true
 	}
 end
@@ -33,8 +33,6 @@ local spFindUnitCmdDesc = Spring.FindUnitCmdDesc
 local spGetUnitCmdDescs = Spring.GetUnitCmdDescs
 local spEditUnitCmdDesc = Spring.EditUnitCmdDesc
 local spGetUnitPosition = Spring.GetUnitPosition
-local spGetUnitPosition = Spring.GetUnitPosition
-local spGetUnitPosition = Spring.GetUnitPosition
 local spGetGroundHeight = Spring.GetGroundHeight
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
@@ -43,17 +41,25 @@ local CMD_UNIT_SET_TARGET = GameCMD.UNIT_SET_TARGET
 local CMD_UNIT_SET_TARGET_NO_GROUND = GameCMD.UNIT_SET_TARGET_NO_GROUND
 local CMD_UNIT_SET_TARGET_RECTANGLE = GameCMD.UNIT_SET_TARGET_RECTANGLE 
 local CMDTYPE_ICON_MAP = CMDTYPE.ICON_MAP
-local cmdDesc
+
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_ATTACK)
+	-- note to future devs, if you are registering UNIT_SET_TARGET, then the gadget layer must be below unit_target_on_the_move.lua
+	gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET)
+	gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET_NO_GROUND)
+	gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET_RECTANGLE)
+end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam)
     if place_target_on_ground[unitDefID] then
+		local cmdDesc
         local cmdIdx = spFindUnitCmdDesc(unitID, CMD_ATTACK)
         if cmdIdx then
             cmdDesc = spGetUnitCmdDescs(unitID, cmdIdx, cmdIdx)[1]
             if cmdDesc then
                 cmdDesc.type = CMDTYPE_ICON_MAP -- Forces attack commands to accept (x,y,z) spatial coordinates, and not allow unitIDs as valid parameters.
 				-- HOWEVER, this does not seem to propogate to default right click commands.
-				-- so the below AllowCommand function checks for any attacks just targeting a unitID and denies them.  
+				-- so the below AllowCommand function checks for any attacks just targeting a unitID and places the command on the floor.  
                 spEditUnitCmdDesc(unitID, cmdIdx, cmdDesc)
             end
         end
@@ -88,12 +94,14 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
-	-- Final fallback if an attack command with a untiID parameter is otherwise given unexpectedly
+	-- Final fallback if an attack or set-target command with a untiID parameter is otherwise given unexpectedly
+	-- usually from user side DefaultCommand widget function
 	if place_target_on_ground[unitDefID] then
-		if (cmdID == CMD_ATTACK) and (#cmdParams == 1) then -- give an attack command at the ground, and deny the intial attack unit command
+		-- no need to check cmdID due to RegisterAllowCommand above
+		if (#cmdParams == 1) then -- give an attack command at the ground, and deny the intial attack unit command
 			local basePointX, basePointY, basePointZ = spGetUnitPosition(cmdParams[1])
 			local yGround = spGetGroundHeight(basePointX, basePointZ)
-			spGiveOrderToUnit(unitID,cmdID,{basePointX,yGround,basePointZ},cmdOptions)
+			spGiveOrderToUnit(unitID, cmdID, {basePointX, yGround, basePointZ}, cmdOptions)
 			return false
 		end
 	end


### PR DESCRIPTION
### Work done
1. Prevent nukes from targeting units with Set Target.
2. Despite the previous workaround to set nuke attack commands to `CMDTYPE.ICON_MAP` so only (x,y,z) coordinates are accepted (disallowing unitIDs as a valid target), this does not seem to apply to Default Commands via right click, so an `AllowCommand` was added to check for, and reject, any attack commands that are targeting a unitID. 

#### Addresses Issue(s)
https://discord.com/channels/549281623154229250/1403854216329695284
[Please note, nukes overshooting past mountain peaks will be solved by a later update to `unit_projectile_overrange.lua`]

#### Test steps
Spawn in `corsilo` and `armsilo`, make sure you can still nuke things, without pinning an attack command or set target command to an enemy unit.
