### PR TITLE
Add baseline code for new sharing modoptions

### DIFF
--- a/luarules/gadgets/game_disable_ally_extractor_upgrade.lua
+++ b/luarules/gadgets/game_disable_ally_extractor_upgrade.lua
@@ -1,0 +1,87 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = 'Disable ally extractor upgrade',
+		desc    = 'Removes the ability for players to upgrade teammate mexes and geos in-place',
+		author  = 'Hobo Joe',
+		date    = 'August 2025',
+		license = 'GNU GPL, v2 or later',
+		layer   = 0,
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Decide whether to activate
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local shareAllowed = not Spring.GetModOptions().disable_economic_sharing
+if shareAllowed then
+	return false
+end
+
+
+----------------------------------------------------------------
+-- Caching
+----------------------------------------------------------------
+local extractorRadius = Game.extractorRadius
+
+local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitTeam = Spring.GetUnitTeam
+
+-- create a table of all mex and geo unitDefIDs
+local isMex = {}
+local isGeo = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.extractsMetal > 0 then
+		isMex[unitDefID] = true
+	end
+	if unitDef.customParams.geothermal then
+		isGeo[unitDefID] = true
+	end
+end
+
+
+----------------------------------------------------------------
+-- Main behavior
+----------------------------------------------------------------
+
+
+local function mexBlocked(myTeam, x, y, z)
+	local units = spGetUnitsInCylinder(x, z, extractorRadius)
+	for _, unitID in ipairs(units) do
+		if isMex[spGetUnitDefID(unitID)] then
+			if spGetUnitTeam(unitID) ~= myTeam then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+local function geoBlocked(myTeam, x, y, z)
+	local units = spGetUnitsInCylinder(x, z, extractorRadius)
+	for _, unitID in ipairs(units) do
+		if isGeo[spGetUnitDefID(unitID)] then
+			if spGetUnitTeam(unitID) ~= myTeam then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+function gadget:AllowUnitCreation(unitDefID, builderID, builderTeam, x, y, z)
+	-- Disallow upgrading allied mexes and allied geos
+	if isMex[unitDefID] then
+		return not mexBlocked(builderTeam, x, y, z)
+	elseif isGeo[unitDefID] then
+		return not geoBlocked(builderTeam, x, y, z)
+	end
+	return true
+end

--- a/luarules/gadgets/game_restrict_unit_sharing.lua
+++ b/luarules/gadgets/game_restrict_unit_sharing.lua
@@ -1,0 +1,70 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = 'Restrict Unit Sharing',
+		desc    = 'Disable unit sharing based on different rules',
+		author  = 'Hobo Joe',
+		date    = 'August 2025',
+		license = 'GNU GPL, v2 or later',
+		layer   = 0,
+		enabled = true
+	}
+end
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+----------------------------------------------------------------
+-- Modoption behavior
+----------------------------------------------------------------
+
+-- Each modoption defines its own *restricted* units
+local unshareable = {}
+
+-- No econ or builder sharing
+local disableEconSharing = Spring.GetModOptions().disable_economic_sharing
+if disableEconSharing then
+	for unitDefID, unitDef in pairs(UnitDefs) do
+		if unitDef.canAssist or unitDef.isFactory then
+			unshareable[unitDefID] = true
+		end
+		if unitDef.customparams and (unitDef.customparams.unitgroup == "energy" or unitDef.customparams.unitgroup == "metal") then
+			unshareable[unitDefID] = true
+		end
+	end
+end
+
+
+-- No building sharing
+if false then -- for demonstration
+	for unitDefID, unitDef in pairs(UnitDefs) do
+		if unitDef.isBuilding then
+			unshareable[unitDefID] = true
+		elseif unitDef.isBuilder and not unitDef.canMove and not unitDef.isFactory then
+			-- nanos
+			unshareable[unitDefID] = true
+		end
+	end
+end
+
+
+-- kill if empty array
+if #unshareable == 0 then
+	return false
+end
+
+
+function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, capture)
+	if (capture) then
+		return true
+	elseif (unshareable[unitDefID]) then
+		return false
+	else
+		return true
+	end
+end

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -34,6 +34,7 @@ local selectedUnits = spGetSelectedUnits()
 local Game_extractorRadius = Game.extractorRadius
 
 local isPregame = Spring.GetGameFrame() == 0 and not Spring.GetSpectatingState()
+local disableAllyUpgrade = false
 
 
 ------------------------------------------------------------
@@ -177,6 +178,10 @@ end
 ---@param newExtractorId number unitDefID of new extractor
 local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 	local isAllied = Spring.AreTeamsAllied(spGetMyTeamID(), Spring.GetUnitTeam(currentExtractorUuid))
+	local isOwnTeam = Spring.GetUnitTeam(currentExtractorUuid) == Spring.GetUnitTeam(newExtractorId)
+	if not isOwnTeam and disableAllyUpgrade then
+		return false
+	end
 	if not isAllied then
 		return false
 	end
@@ -491,6 +496,10 @@ function widget:Initialize()
 	----------------------------------------------
 	-- builders and buildings - MEX
 	----------------------------------------------
+
+	WG['resource_spot_builder'].SetAllyExtractorCanBeUpgraded = function(value)
+		disableAllyUpgrade = value
+	end
 
 	WG['resource_spot_builder'].GetMexConstructors = function()
 		return mexConstructors

--- a/luaui/Widgets/cmd_share_unit.lua
+++ b/luaui/Widgets/cmd_share_unit.lua
@@ -24,6 +24,7 @@ local circleList
 local secondPart = 0
 local mouseDistance = 1000
 local range = 200
+local restrictedUnits = {}
 
 --------------------------------------------------------------------------------
 --speedups
@@ -31,7 +32,7 @@ local range = 200
 local GetUnitsInCylinder = Spring.GetUnitsInCylinder
 local GetMyTeamID = Spring.GetMyTeamID
 local GetUnitTeam = Spring.GetUnitTeam
-local GetSelectedUnits = Spring.GetSelectedUnits
+local GetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
 local GetTeamAllyTeamID = Spring.GetTeamAllyTeamID
 local ShareResources = Spring.ShareResources
 local I18N = Spring.I18N
@@ -46,7 +47,6 @@ local TraceScreenRay = Spring.TraceScreenRay
 local GetPlayerList = Spring.GetPlayerList
 local GetPlayerInfo = Spring.GetPlayerInfo
 local GetGameRulesParam = Spring.GetGameRulesParam
-local GetViewGeometry = Spring.GetViewGeometry
 
 local glBeginEnd = gl.BeginEnd
 local glCallList = gl.CallList
@@ -352,8 +352,13 @@ function widget:CommandsChanged()
 		return
 	end
 
-	local selectedUnits = GetSelectedUnits()
-	if #selectedUnits > 0 then
+	local shareable = false
+	for unitDefID, _ in pairs(GetSelectedUnitsSorted()) do
+		if not restrictedUnits[unitDefID] then
+			shareable = true
+		end
+	end
+	if shareable then
 		local customCommands = widgetHandler.customCommands
 		customCommands[#customCommands + 1] = {
 			id = cmdQuickShareToTargetId,
@@ -373,6 +378,11 @@ function widget:Initialize()
 	widget:ViewResize()
 	defaultColor = { 0.88, 0.88, 0.88, 1 }
 	setupDisplayLists()
+
+	WG['sharecmd'] = {}
+	WG['sharecmd'].setRestrictedUnits = function(value)
+		restrictedUnits = value
+	end
 end
 
 function widget:Shutdown()

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -49,7 +49,6 @@ local numTeamsInAllyTeam = #myAllyTeamList
 local numPlayers = Spring.Utilities.GetPlayerCount()
 local isSinglePlayer = Spring.Utilities.Gametype.IsSinglePlayer()
 local chobbyLoaded = false
-local isSingle = false
 local gameStarted = (Spring.GetGameFrame() > 0)
 local gameFrame = Spring.GetGameFrame()
 local gameIsOver = false
@@ -134,6 +133,7 @@ local widgetScale = (0.80 + (vsx * vsy / 6000000))
 local xPos = math_floor(vsx * relXpos)
 local showButtons = true
 local autoHideButtons = false
+local shareSliderEnabled = true
 local widgetSpaceMargin, bgpadding, RectRound, TexturedRectRound, UiElement, UiButton, UiSliderKnob
 local updateRes = { metal = {false,false,false,false}, energy = {false,false,false,false} }
 
@@ -763,7 +763,7 @@ local function updateResbar(res)
 		end
 
 		-- Share slider
-		if not isSingle then
+		if shareSliderEnabled then
 			if res == 'energy' then
 				energyOverflowLevel = r[res][6]
 			else
@@ -2019,7 +2019,7 @@ function widget:MousePress(x, y, button)
 		end
 
 		if not spec then
-			if not isSingle then
+			if shareSliderEnabled then
 				if math_isInRect(x, y, shareIndicatorArea['metal'][1], shareIndicatorArea['metal'][2], shareIndicatorArea['metal'][3], shareIndicatorArea['metal'][4]) then
 					draggingShareIndicator = 'metal'
 				end
@@ -2143,7 +2143,7 @@ function widget:Initialize()
 
 	if not spec then
 		local teamList = Spring.GetTeamList(myAllyTeamID) or {}
-		isSingle = #teamList == 1
+		shareSliderEnabled = #teamList > 1
 	end
 
 	for unitDefID, unitDef in pairs(UnitDefs) do
@@ -2153,30 +2153,29 @@ function widget:Initialize()
 	end
 
 	WG['topbar'] = {}
-
 	WG['topbar'].showingQuit = function()
 		return (showQuitscreen)
 	end
-
 	WG['topbar'].hideWindows = function()
 		hideWindows()
 	end
-
+	WG['topbar'].setShareSliderEnabled = function(value)
+		shareSliderEnabled = value
+		updateResbar('energy')
+		updateResbar('metal')
+	end
 	WG['topbar'].setAutoHideButtons = function(value)
 		refreshUi = true
 		autoHideButtons = value
 		showButtons = not value
 		updateButtons()
 	end
-
 	WG['topbar'].getAutoHideButtons = function()
 		return autoHideButtons
 	end
-
 	WG['topbar'].getShowButtons = function()
 		return showButtons
 	end
-
 	WG['topbar'].updateTopBarEnergy = function(value)
 		draggingConversionIndicatorValue = value
 		updateResbar('energy')

--- a/luaui/Widgets/modoption_disable_economic_sharing.lua
+++ b/luaui/Widgets/modoption_disable_economic_sharing.lua
@@ -1,0 +1,32 @@
+function widget:GetInfo()
+	return {
+		name = "Modoption: Disable Economic Sharing",
+		desc = "UI behavior for disabled sharing",
+		author = "Hobo Joe",
+		date = "August 2025",
+		license = "GNU GPL, v2 or later",
+		layer = 9999, -- run this after all the UI widgets we touch have been initialized
+		enabled = false,
+	}
+end
+
+local enabled = Spring.GetModOptions().disable_economic_sharing
+if not enabled then
+	return false
+end
+
+local restrictedUnits = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.canAssist or unitDef.isFactory then
+		restrictedUnits[unitDefID] = true
+	end
+	if unitDef.customparams and (unitDef.customparams.unitgroup == "energy" or unitDef.customparams.unitgroup == "metal") then
+		restrictedUnits[unitDefID] = true
+	end
+end
+
+function widget:Initialize()
+	WG['resource_spot_builder'].SetAllyExtractorCanBeUpgraded(true)
+	WG['topbar'].setShareSliderEnabled(false)
+	WG['sharecmd'].setRestrictedUnits(restrictedUnits)
+end

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -298,6 +298,15 @@ local options = {
 		column	= 1.76,
 	},
 	{
+		key 	= "disable_economic_sharing",
+		name 	= "Disable Economic Sharing",
+		desc 	= "Disables sharing of any resources, sharing of resource producing units/structures, and sharing of constructors. Only combat units can be shared",
+		type 	= "bool",
+		section = "options_main",
+		hidden 	= true,
+		def 	= false,
+	},
+	{
 		key		= "unit_market",
 		name	= "Unit Market",
 		desc	= "Allow players to trade units. (Select unit, press 'For Sale' in order window or say /sell_unit in chat to mark the unit for sale. Double-click to buy from allies. T2cons show up in shop window!)",
@@ -916,7 +925,7 @@ local options = {
         section = "options_extra",
         def  	= false,
     },
-	
+
     {
         key    	= "scavunitsforplayers",
         name   	= "Scavengers Units Pack",
@@ -967,17 +976,17 @@ local options = {
         column	= 1,
         items	= {
             { key= "default", 	name= "Default", desc= "Map Settings",
-                lock = 
+                lock =
                 {"map_lavatidemode", "map_lavahighlevel", "map_lavahighdwell", "map_lavalowlevel", "map_lavalowdwell", "sub_header_lava3", "sub_header_lava4"},
                 unlock =
                     { "sub_header_lava1", "sub_header_lava2"}},
             { key= "enabled",	name= "Enable/Override",desc= "Lava tides will use these settings over the map defaults",
-                unlock = 
+                unlock =
                 {"map_lavatidemode", "map_lavahighlevel", "map_lavahighdwell", "map_lavalowlevel", "map_lavalowdwell", "sub_header_lava3", "sub_header_lava4"},
                 lock =
                     { "sub_header_lava1", "sub_header_lava2"}},
             { key= "disabled",	name= "Disable",desc= "Lava will not have tides, even on maps that normally have it",
-                lock = 
+                lock =
                 {"map_lavatidemode", "map_lavahighlevel", "map_lavahighdwell", "map_lavalowlevel", "map_lavalowdwell", "sub_header_lava3", "sub_header_lava4"},
                 unlock =
                     { "sub_header_lava1", "sub_header_lava2"}},
@@ -1036,7 +1045,7 @@ local options = {
         step 	= 1,
         section = "options_extra",
         column	= 1,
-    },  
+    },
 
     {
         key 	= "map_lavalowdwell",
@@ -1055,8 +1064,8 @@ local options = {
     { key = "sub_header_lava2", section = "options_extra", type    = "subheader", name = "",},
     { key = "sub_header_lava3", section = "options_extra", type    = "subheader", name = "",},
     { key = "sub_header_lava4", section = "options_extra", type    = "subheader", name = "",},
- 
-    
+
+
     {
         key     = "sub_header",
         section = "options_extra",
@@ -1390,7 +1399,7 @@ local options = {
     },
 
     -- Hidden Tests
-	
+
 	{
         key   	= "splittiers",
         name   	= "Split T2",
@@ -1400,7 +1409,7 @@ local options = {
         def  	= false,
         hidden 	= true,
 	},
-	
+
     {
         key    	= "shieldsrework",
         name   	= "Shields Rework v2.0",


### PR DESCRIPTION
### Goals
This is meant to be a foundation for further sharing modoptions to be built on. The intent is to merge this PR after structure is assessed, and then following modoption PR's should be refactored to fit this pattern before they can be merged.

I added the *hidden* modoption `disable_economic_sharing` just to provide a working example, this isn't intended to represent the final behavior for that modoption. That will happen in https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5624

### Changes
- Clean up and unify some existing code related to sharing modoptions
  - `game_tax_resource_sharing` handles purely resource transfers (tax or fully disable), no longer messes with commands or unit sharing.
  - `game_disable_assist_ally` cleanup
- Create new gadgets for granularly controlling sharing
  - `game_disable_ally_extractor_upgrade`
  - `game_restrict_unit_sharing`
- Create API's for UI widgets to handle sharing aspects
  - Allow disabling ally mex upgrade ghosts
  - Hide share unit button on any units that cannot be shared
  - Hide overflow sliders if resource transfers are disabled (engine-side work on overflow is unfinished)
- Create pattern for modoptions to manage UI changes with a single unifying widget
  - This should help cut down a lot on modoption pollution, especially within larger widgets. Configurable widgets will just have standard API's to control features, and a modoption widget will set these as granularly as needed.


### `modoption_disable_economic_sharing.lua`
```lua
function widget:GetInfo()
	return {
		name = "Modoption: Disable Economic Sharing",
		desc = "UI behavior for disabled sharing",
		author = "Hobo Joe",
		date = "August 2025",
		license = "GNU GPL, v2 or later",
		layer = 9999, -- run this after all the UI widgets we touch have been initialized
		enabled = false,
	}
end

local enabled = Spring.GetModOptions().disable_economic_sharing
if not enabled then
	return false
end

local restrictedUnits = {}
for unitDefID, unitDef in pairs(UnitDefs) do
	if unitDef.canAssist or unitDef.isFactory then
		restrictedUnits[unitDefID] = true
	end
	if unitDef.customparams and (unitDef.customparams.unitgroup == "energy" or unitDef.customparams.unitgroup == "metal") then
		restrictedUnits[unitDefID] = true
	end
end

function widget:Initialize()
	WG['resource_spot_builder'].SetAllyExtractorCanBeUpgraded(true)
	WG['topbar'].setShareSliderEnabled(false)
	WG['sharecmd'].setRestrictedUnits(restrictedUnits)
end
```

All modoptions that will affect any sharing behavior will be required to have a controlling widget like this to avoid code pollution.

#### Test steps
- [ ] tbd