### PR TITLE
Add Spanish language to in game options

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -28,7 +28,7 @@ local newerVersion = false	-- configdata will set this true if it's a newer vers
 
 local keyLayouts = VFS.Include("luaui/configs/keyboard_layouts.lua")
 
-local languageCodes = { 'en', 'fr', 'ru' }
+local languageCodes = { 'en', 'fr', 'ru', 'es' }
 languageCodes = table.merge(languageCodes, table.invert(languageCodes))
 
 local languageNames = {}
@@ -36,7 +36,7 @@ for key, code in ipairs(languageCodes) do
 	languageNames[key] = Spring.I18N.languages[code]
 end
 
-local devLanguageCodes = { 'en', 'fr', 'de', 'ru', 'zh', 'test_unicode', }
+local devLanguageCodes = { 'en', 'fr', 'de', 'ru', 'zh', 'es', 'test_unicode', }
 devLanguageCodes = table.merge(devLanguageCodes, table.invert(devLanguageCodes))
 
 local devLanguageNames = {}

--- a/modules/i18n/i18n.lua
+++ b/modules/i18n/i18n.lua
@@ -73,6 +73,7 @@ i18n.languages = {
 	de = "Deutsch",
 	ru = "Русский",
 	zh = "中文",
+	es = "Español",
 	test_unicode = "test_unicode"
 }
 


### PR DESCRIPTION
### Work done
- Added Spanish to list of available languages in i18n module
- Added Spanish to in game options widget

#### Test steps
- [ ] Launch Game in any mode
- [ ] Open settings menu and navigate to the interface tab
- [ ] Open the language selector, there should be an option for Spanish tagged `Español`
