### PR TITLE
Fix: overpen projectiles that hit terrain first awkwardly slide around

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -143,9 +143,10 @@ local function loadPenetratorWeaponDefs()
 			end
 
 			weaponParams[weaponDefID] = params
-		end
-		if weaponDef.waterWeapon then
-			waterWeapons[weaponDefID] = true
+
+			if weaponDef.waterWeapon then
+				waterWeapons[weaponDefID] = true
+			end
 		end
 	end
 	return (table.count(weaponParams) > 0)


### PR DESCRIPTION
This detects ground collisions in g:Explode, which is not really ideal, but is necessary for overpen's noexplode projectiles, which are deleted manually once they "exhaust" their damage output. Terrain collisions should exhaust, but do not.

This fixes an issue when railgun units are aimed at the ground which allows the projectile to skip along the terrain. It happens most often when the terrain is the first thing impacted.