### PR TITLE
attempt 2 on pausing stencil rerender

### DIFF
--- a/luaui/Widgets/gui_sensor_ranges_jammer.lua
+++ b/luaui/Widgets/gui_sensor_ranges_jammer.lua
@@ -161,6 +161,16 @@ end
 
 function widget:GamePaused(playerID, paused)
 	isPaused = paused
+
+	if paused then
+		widgetHandler:UpdateCallIn("CameraPositionChanged")
+	else
+		widgetHandler:RemoveCallin("CameraPositionChanged")
+	end
+end
+
+function widget:CameraPositionChanged(posX, posY, posZ)
+	inUpdate = true
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen

--- a/luaui/Widgets/gui_sensor_ranges_jammer.lua
+++ b/luaui/Widgets/gui_sensor_ranges_jammer.lua
@@ -148,8 +148,19 @@ local function DrawLOSStencil() -- about 0.025 ms
 	end
 end
 
+-- Handle high frame rates during pause causing high CPU:
+local isPaused = false
+local inUpdate = true
+
 function widget:DrawGenesis()
-    gl.RenderToTexture(jammerStencilTexture, DrawLOSStencil)
+	if not isPaused or inUpdate then
+		inUpdate = false
+		gl.RenderToTexture(jammerStencilTexture, DrawLOSStencil)
+	end
+end
+
+function widget:GamePaused(playerID, paused)
+	isPaused = paused
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen
@@ -207,6 +218,7 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	inUpdate = true
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_los.lua
+++ b/luaui/Widgets/gui_sensor_ranges_los.lua
@@ -168,8 +168,20 @@ local function DrawLOSStencil() -- about 0.025 ms
 	end
 end
 
+
+-- Handle high frame rates during pause causing high CPU:
+local isPaused = false
+local inUpdate = true
+
 function widget:DrawGenesis()
-    gl.RenderToTexture(losStencilTexture, DrawLOSStencil)
+	if not isPaused or inUpdate then
+		inUpdate = false
+		gl.RenderToTexture(losStencilTexture, DrawLOSStencil)
+	end
+end
+
+function widget:GamePaused(playerID, paused)
+	isPaused = paused
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen
@@ -225,6 +237,7 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	inUpdate = true
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_los.lua
+++ b/luaui/Widgets/gui_sensor_ranges_los.lua
@@ -182,6 +182,16 @@ end
 
 function widget:GamePaused(playerID, paused)
 	isPaused = paused
+
+	if paused then
+		widgetHandler:UpdateCallIn("CameraPositionChanged")
+	else
+		widgetHandler:RemoveCallin("CameraPositionChanged")
+	end
+end
+
+function widget:CameraPositionChanged(posX, posY, posZ)
+	inUpdate = true
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen

--- a/luaui/Widgets/gui_sensor_ranges_radar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar.lua
@@ -32,7 +32,6 @@ local gaiaTeamID = Spring.GetGaiaTeamID()
 
 
 
-
 local LuaShader = gl.LuaShader
 local InstanceVBOTable = gl.InstanceVBOTable
 
@@ -161,6 +160,16 @@ end
 
 function widget:GamePaused(playerID, paused)
 	isPaused = paused
+
+	if paused then
+		widgetHandler:UpdateCallIn("CameraPositionChanged")
+	else
+		widgetHandler:RemoveCallin("CameraPositionChanged")
+	end
+end
+
+function widget:CameraPositionChanged(posX, posY, posZ)
+	inUpdate = true
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen

--- a/luaui/Widgets/gui_sensor_ranges_radar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar.lua
@@ -148,8 +148,19 @@ local function DrawLOSStencil() -- about 0.025 ms
 	end
 end
 
+-- Handle high frame rates during pause causing high CPU:
+local isPaused = false
+local inUpdate = true
+
 function widget:DrawGenesis()
-    gl.RenderToTexture(radarStencilTexture, DrawLOSStencil)
+	if not isPaused or inUpdate then
+		inUpdate = false
+		gl.RenderToTexture(radarStencilTexture, DrawLOSStencil)
+	end
+end
+
+function widget:GamePaused(playerID, paused)
+	isPaused = paused
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen
@@ -207,6 +218,7 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	inUpdate = true
 end
 
 function widget:PlayerChanged()

--- a/luaui/Widgets/gui_sensor_ranges_sonar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_sonar.lua
@@ -162,6 +162,16 @@ end
 
 function widget:GamePaused(playerID, paused)
 	isPaused = paused
+
+	if paused then
+		widgetHandler:UpdateCallIn("CameraPositionChanged")
+	else
+		widgetHandler:RemoveCallin("CameraPositionChanged")
+	end
+end
+
+function widget:CameraPositionChanged(posX, posY, posZ)
+	inUpdate = true
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen

--- a/luaui/Widgets/gui_sensor_ranges_sonar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_sonar.lua
@@ -149,8 +149,19 @@ local function DrawLOSStencil() -- about 0.025 ms
 	end
 end
 
+-- Handle high frame rates during pause causing high CPU:
+local isPaused = false
+local inUpdate = true
+
 function widget:DrawGenesis()
-    gl.RenderToTexture(sonarStencilTexture, DrawLOSStencil)
+	if not isPaused or inUpdate then
+		inUpdate = false
+		gl.RenderToTexture(sonarStencilTexture, DrawLOSStencil)
+	end
+end
+
+function widget:GamePaused(playerID, paused)
+	isPaused = paused
 end
 
 -- This shows the debug stencil texture in the bottom left corner of the screen
@@ -212,6 +223,7 @@ local function InitializeUnits()
 		end
 	end
 	InstanceVBOTable.uploadAllElements(circleInstanceVBO)
+	inUpdate = true
 end
 
 function widget:PlayerChanged()


### PR DESCRIPTION
Without breaking the game this time. The previous didn't delay rerender until after the PlayerChanged even when trying to get team colors correct, so would attempt to draw outside of a frame draw, which is an error. Probably specs were triggering it when switching to player view during pause.

---

This is a fix for high CPU consumption during pause with very high frame rates. I'm not sure if my AMD is partially to blame for this, btw, but the effect is genuinely only during pause and shows only on the stencil widgets.

This still doesn't update quite correctly when spawning in radars with commands during pause. I think that's an okay defect.