### PR TITLE
(feat) Improve Area Mex and Extractor Snapping - added toggle to skip upgrading allied extractors

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -106,12 +106,11 @@ end
 local function spotHasExtractor(spot)
 	local units = Spring.GetUnitsInCylinder(spot.x, spot.z, Game_extractorRadius)
 	local type = spot.isMex and mexBuildings or geoBuildings
-	for j=1, #units do
+	for j = 1, #units do
 		if type[spGetUnitDefID(units[j])] then return units[j] end
 	end
 	return false
 end
-
 
 ---Checks if there is an existing command among the current builders to make an extractor on the given spot
 ---@param spot table
@@ -121,12 +120,12 @@ local function spotHasExtractorQueued(spot, builders)
 
 	-- annoying pregame stuff
 	local function checkQueue(queue)
-		for j=1, #queue do
+		for j = 1, #queue do
 			local command = queue[j]
 			local id = command.id and -command.id or command[1]
 			local x = command.params and command.params[1] or command[2]
 			local z = command.params and command.params[3] or command[4]
-			if(mexBuildings[id] or geoBuildings[id]) then
+			if (mexBuildings[id] or geoBuildings[id]) then
 				local dist = math.distance2dSquared(spot.x, spot.z, x, z)
 				-- Save a sqrt by multiplying by 4
 				-- Note that this is calculating by diameter, and could be too aggressive on maps with closely spaced mexes
@@ -144,8 +143,9 @@ local function spotHasExtractorQueued(spot, builders)
 		return checkQueue(queue)
 
 	else
-		for i=1, #builders do
-			local hasOrder = checkQueue(Spring.GetUnitCommands(builders[i], 100))
+		for i = 1, #builders do
+			-- GetUnitCommands returns nil if enemy unit is selected (with godmode on)
+			local hasOrder = checkQueue(Spring.GetUnitCommands(builders[i], 100) or {})
 			if hasOrder then
 				return true
 			end
@@ -153,7 +153,6 @@ local function spotHasExtractorQueued(spot, builders)
 	end
 	return false
 end
-
 
 ---Gets the naive best extractor, ignores special mexes (exploiter etc), just finds highest extraction amount
 ---@param units table selected units
@@ -170,7 +169,7 @@ local function getBestExtractorFromBuilders(units, constructorIds, extractors)
 		if constructor then
 			local buildingID = -constructor.building[1]
 			local extractionAmount = extractors[buildingID]
-			if(extractionAmount > bestExtraction) then
+			if (extractionAmount > bestExtraction) then
 				bestExtraction = extractionAmount
 				bestExtractor = buildingID
 			end
@@ -178,7 +177,6 @@ local function getBestExtractorFromBuilders(units, constructorIds, extractors)
 	end
 	return bestExtractor
 end
-
 
 ---extractorCanBeUpgraded
 ---@param currentExtractorUuid number uuid of current extractor
@@ -200,10 +198,10 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 
 	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0
 
-	if(newExtractorStrength > currentExtractorStrength) then
+	if (newExtractorStrength > currentExtractorStrength) then
 		return true
 	end
-	if(newExtractorStrength == currentExtractorStrength and newExtractorIsSpecial) then
+	if (newExtractorStrength == currentExtractorStrength and newExtractorIsSpecial) then
 		return true
 	end
 	if currentExtractorStrength == newExtractorStrength then
@@ -212,7 +210,6 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 
 	return false
 end
-
 
 ---Returns true if the specified extractor be built on this spot - considers upgrades and sidegrades
 ---@param spot table
@@ -231,7 +228,7 @@ local function extractorCanBeBuiltOnSpot(spot, extractorId)
 		local isExtractor = spot.isMex and mexBuildings[uDefId] or geoBuildings[uDefId]
 		local canUpgrade = extractorCanBeUpgraded(uid, extractorId)
 		local isBeingBuilt, _ = spGetUnitIsBeingBuilt(uid)
-		if(isExtractor and (not canUpgrade or isBeingBuilt)) then
+		if (isExtractor and (not canUpgrade or isBeingBuilt)) then
 			return false
 		end
 	end
@@ -239,13 +236,13 @@ local function extractorCanBeBuiltOnSpot(spot, extractorId)
 	return true
 end
 
-
 ---Finds the nearest unoccupied resource spot from the provided list
 ---@param x number
 ---@param z number
 ---@param spotsIn table
 ---@param extractor table unitDefID
-local function findNearestValidSpotForExtractor(x, z, spotsIn, extractor)
+---@param shouldIgnoreAlreadyQueuedUpSpots boolean
+local function findNearestValidSpotForExtractor(x, z, spotsIn, extractor, shouldIgnoreAlreadyQueuedUpSpots)
 	-- sort spots by distance
 	local spots = table.copy(spotsIn)
 	table.sort(spots, function(a, b)
@@ -255,17 +252,22 @@ local function findNearestValidSpotForExtractor(x, z, spotsIn, extractor)
 		local spot = spots[i]
 		local existingExtractor = spotHasExtractor(spot)
 		local hasExtractorQueued = spotHasExtractorQueued(spot)
-		if not existingExtractor and not hasExtractorQueued then
+
+		if shouldIgnoreAlreadyQueuedUpSpots and not existingExtractor and not hasExtractorQueued then
 			return spot
 		end
 
-		local canBeBuilt = extractorCanBeBuiltOnSpot(spot, extractor)
-		if canBeBuilt and not hasExtractorQueued then
+		local isUnoccupied = not existingExtractor
+		local canBeBuiltOn = extractorCanBeBuiltOnSpot(spot, extractor)
+		local notQueued = not hasExtractorQueued
+
+		local isValidSpot = (isUnoccupied or canBeBuiltOn) and (not shouldIgnoreAlreadyQueuedUpSpots or notQueued)
+
+		if isValidSpot then
 			return spot
 		end
 	end
 end
-
 
 ---Gives build order to the units that can make the selected building, all other builders get guard commands to the primary builders
 ---@param units table
@@ -284,7 +286,8 @@ local function sortBuilders(units, constructorIds, buildingId, shift)
 			-- iterate over constructor options to see if it can make the chosen extractor
 			local canBuild = false
 			for _, buildable in pairs(constructor.building) do
-				if -buildable == buildingId then -- assume that it's a valid extractor based on previous steps
+				if -buildable == buildingId then
+					-- assume that it's a valid extractor based on previous steps
 					mainBuilders[#mainBuilders + 1] = id
 					canBuild = true
 					break
@@ -308,7 +311,8 @@ local function sortBuilders(units, constructorIds, buildingId, shift)
 	end
 
 	local function hasExistingGuardOrder(uid)
-		local queue = Spring.GetUnitCommands(uid, 10)
+		-- GetUnitCommands returns nil if enemy unit is selected (with godmode on)
+		local queue = Spring.GetUnitCommands(uid, 10) or {}
 		for i = 1, #queue do
 			local cmd = queue[i]
 			if cmd.id == CMD_GUARD and (cmd.params and cmd.params[1] and isMainBuilderOfId(cmd.params[1])) then
@@ -341,7 +345,6 @@ local function sortBuilders(units, constructorIds, buildingId, shift)
 	return mainBuilders
 end
 
-
 local function previewMetalMapExtractorCommand(params, extractor)
 	local buildingId = -extractor
 	local facing = spGetBuildFacing() or 1
@@ -353,7 +356,6 @@ local function previewMetalMapExtractorCommand(params, extractor)
 	end
 	return nil
 end
-
 
 ---Puts together build orders for ghost previews (e.g. mex snap). These orders can be fed directly to
 ---ApplyPreviewCmds to actually give the orders to units
@@ -382,8 +384,8 @@ local function PreviewExtractorCommand(params, extractor, spot, metalMap)
 	local occupiedSpot = spotHasExtractor(spot)
 	if occupiedSpot then
 		local occupiedPos = { spGetUnitPosition(occupiedSpot) }
-		targetPos = { x=occupiedPos[1], y=occupiedPos[2], z=occupiedPos[3] }
-		targetOwner = spGetUnitTeam(occupiedSpot)	-- because gadget "Mex Upgrade Reclaimer" will share a t2 mex build upon ally t1 mex
+		targetPos = { x = occupiedPos[1], y = occupiedPos[2], z = occupiedPos[3] }
+		targetOwner = spGetUnitTeam(occupiedSpot)    -- because gadget "Mex Upgrade Reclaimer" will share a t2 mex build upon ally t1 mex
 	else
 		local buildingPositions = WG['resource_spot_finder'].GetBuildingPositions(spot, -buildingId, 0, true)
 		targetPos = math.getClosestPosition(cmdX, cmdZ, buildingPositions)
@@ -395,7 +397,6 @@ local function PreviewExtractorCommand(params, extractor, spot, metalMap)
 	end
 	return finalCommand
 end
-
 
 local function ApplyPreviewCmds(cmds, constructorIds, shift)
 	if not cmds or #cmds <= 0 then
@@ -420,11 +421,12 @@ local function ApplyPreviewCmds(cmds, constructorIds, shift)
 		local cmd = cmds[i]
 		local orderParams = { cmd[2], cmd[3], cmd[4], cmd[5] }
 
-		if meta then -- put at front of queue
+		if meta then
+			-- put at front of queue
 			-- cmd insert layout is really weird, it needs to be formatted like:
 			-- { CMD.INSERT, { queue_pos, cmd_id, opt, params_flattened, }, { "alt }}
 			-- this an engine command so index starts at 0. Increment position by command count
-			Spring.GiveOrderToUnitArray(unitArray, CMD.INSERT, {i-1, -buildingId, 0, unpack(orderParams) }, { "alt" })
+			Spring.GiveOrderToUnitArray(unitArray, CMD.INSERT, { i - 1, -buildingId, 0, unpack(orderParams) }, { "alt" })
 		else
 			-- we don't want to give a stop command to clear queue because it plays an unwanted sound
 			-- issuing any command without shift will clear the queue for us,
@@ -473,11 +475,9 @@ function widget:UnitGiven(unitID, unitDefID, newTeam)
 	end
 end
 
-
 function widget:GameStart()
 	isPregame = false
 end
-
 
 function widget:Initialize()
 	local units = spGetTeamUnits(spGetMyTeamID())
@@ -486,15 +486,16 @@ function widget:Initialize()
 		widget:UnitCreated(id, spGetUnitDefID(id))
 	end
 
-	--make interfaces available to other widgets:
-	WG['resource_spot_builder'] = { }
-	WG['resource_spot_builder'].ExtractorCanBeBuiltOnSpot = extractorCanBeBuiltOnSpot
-	WG['resource_spot_builder'].ExtractorCanBeUpgraded = extractorCanBeUpgraded
-	WG['resource_spot_builder'].FindNearestValidSpotForExtractor = findNearestValidSpotForExtractor
-	WG['resource_spot_builder'].PreviewExtractorCommand = PreviewExtractorCommand
-	WG['resource_spot_builder'].ApplyPreviewCmds = ApplyPreviewCmds
-	WG['resource_spot_builder'].SpotHasExtractorQueued = spotHasExtractorQueued
-	WG['resource_spot_builder'].GetBestExtractorFromBuilders = getBestExtractorFromBuilders
+	-- make interfaces available to other widgets:
+	WG['resource_spot_builder'] = {
+		ExtractorCanBeBuiltOnSpot = extractorCanBeBuiltOnSpot,
+		ExtractorCanBeUpgraded = extractorCanBeUpgraded,
+		FindNearestValidSpotForExtractor = findNearestValidSpotForExtractor,
+		PreviewExtractorCommand = PreviewExtractorCommand,
+		ApplyPreviewCmds = ApplyPreviewCmds,
+		SpotHasExtractorQueued = spotHasExtractorQueued,
+		GetBestExtractorFromBuilders = getBestExtractorFromBuilders,
+	}
 
 	----------------------------------------------
 	-- builders and buildings - MEX

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -92,7 +92,7 @@ local function getAvgPositionOfValidBuilders(units, constructorIds, buildingId, 
 						x, _, z = spGetUnitPosition(id)
 					end
 					if z then
-						tX, tZ = tX+x, tZ+z
+						tX, tZ = tX + x, tZ + z
 						builderCount = builderCount + 1
 					end
 				end
@@ -104,13 +104,14 @@ local function getAvgPositionOfValidBuilders(units, constructorIds, buildingId, 
 	return { x = tX / builderCount, z = tZ / builderCount }
 end
 
-
 ---Get all mex spots in an area
 ---@param x number
 ---@param z number
 ---@param radius number
+---@return table Array of spots within the specified area
 local function getSpotsInArea(x, z, radius)
 	local validSpots = {}
+
 	for i = 1, #metalSpots do
 		local spot = metalSpots[i]
 		local dist = math.distance2dSquared(x, z, spot.x, spot.z)
@@ -180,6 +181,9 @@ function widget:CommandNotify(id, params, options)
 
 	local cmdX, _, cmdZ, cmdRadius = params[1], params[2], params[3], params[4]
 	local spots = getSpotsInArea(cmdX, cmdZ, cmdRadius)
+	if WG['skip_allied_upgrade'] then
+		spots = WG['skip_allied_upgrade'].filterOutAlliedSpots(spots, mexBuildings)
+	end
 
 	if not selectedMex then
 		selectedMex = WG['resource_spot_builder'].GetBestExtractorFromBuilders(selectedUnits, mexConstructors, mexBuildings)
@@ -188,7 +192,6 @@ function widget:CommandNotify(id, params, options)
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 	local cmds = getCmdsForValidSpots(spots, shift)
 	local sortedCmds = calculateCmdOrder(cmds, spots, shift)
-
 
 	WG['resource_spot_builder'].ApplyPreviewCmds(sortedCmds, mexConstructors, shift)
 

--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -184,7 +184,7 @@ function widget:Update()
 
 	-- Attempt to get position of command
 	local buildingId = -activeCmdID
-	local mx, my, mb, mmb, mrb = spGetMouseState()
+	local mx, my = spGetMouseState()
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
 	local _, pos = spTraceScreenRay(mx, my, true)
 	if not pos or not pos[1] then
@@ -208,22 +208,22 @@ function widget:Update()
 		return
 	end
 
-	-- get nearest unoccupied spot, we have to separate shift behavior for pregame reasons here
-	local nearestSpot
-	if selectedMex then
-		nearestSpot = shift and
-			WG["resource_spot_builder"].FindNearestValidSpotForExtractor(x, z, metalSpots, selectedMex) or
-			WG["resource_spot_finder"].GetClosestMexSpot(x, z)
-	else
-		nearestSpot = shift and
-			WG["resource_spot_builder"].FindNearestValidSpotForExtractor(x, z, geoSpots, selectedGeo) or
-			WG["resource_spot_finder"].GetClosestGeoSpot(x, z)
+	local isMetalExtractor = selectedMex ~= nil
+	local spotsToSearch = isMetalExtractor and metalSpots or geoSpots
+	local selectedExtractor = isMetalExtractor and selectedMex or selectedGeo
+	local buildingsToCheck = isMetalExtractor and mexBuildings or geoBuildings
+
+	if WG['skip_allied_upgrade'] then
+		spotsToSearch = WG['skip_allied_upgrade'].filterOutAlliedSpots(spotsToSearch, buildingsToCheck)
 	end
+
+	local shouldIgnoreAlreadyQueuedUpSpots = shift
+	local nearestSpot = WG["resource_spot_builder"].FindNearestValidSpotForExtractor(x, z, spotsToSearch, selectedExtractor, shouldIgnoreAlreadyQueuedUpSpots)
+
 	if not nearestSpot then
 		clear()
 		return
 	end
-
 
 	buildCmd = {}
 	local cmd = WG["resource_spot_builder"].PreviewExtractorCommand(pos, buildingId, nearestSpot)
@@ -232,7 +232,7 @@ function widget:Update()
 		WG.ExtractorSnap.position = targetPos -- used by prospector and pregame queue
 
 		local dist = math.distance3dSquared(cursorPos.x, cursorPos.y, cursorPos.z, targetPos.x, targetPos.y, targetPos.z)
-		if(dist < 1) then
+		if (dist < 1) then
 			clear()
 			WG.ExtractorSnap.position = targetPos --bit of a hack, this still needs to be set during pregame
 			return
@@ -256,7 +256,7 @@ function widget:Update()
 	if WG.DrawUnitShapeGL4 then
 		if unitShape then
 			if not activeUnitShape and WG.DrawUnitShapeGL4 then
-				activeUnitShape = WG.DrawUnitShapeGL4(unitShape[1], unitShape[2], unitShape[3], unitShape[4], unitShape[5] * (math.pi/2), 0.66, unitShape[6], 0.15, 0.3)
+				activeUnitShape = WG.DrawUnitShapeGL4(unitShape[1], unitShape[2], unitShape[3], unitShape[4], unitShape[5] * (math.pi / 2), 0.66, unitShape[6], 0.15, 0.3)
 			end
 		elseif activeUnitShape then
 			clearGhostBuild()
@@ -317,9 +317,7 @@ end
 
 
 function widget:DrawWorld()
-	if not WG.DrawUnitShapeGL4
-	or not targetPos
-	or not cursorPos then
+	if not WG.DrawUnitShapeGL4 or not targetPos or not cursorPos then
 		return
 	end
 

--- a/luaui/Widgets/cmd_skip_allied_upgrade.lua
+++ b/luaui/Widgets/cmd_skip_allied_upgrade.lua
@@ -1,0 +1,67 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Skip Allied Upgrade Toggle",
+		desc = "Adds a toggle indicating if allied buildings should be ignored when upgrading mexes and geos.",
+		author = "SuperKitowiec",
+		date = "August 27, 2025",
+		license = "GNU GPL, v2 or later",
+		version = 1,
+		layer = -999999,
+		enabled = true,
+	}
+end
+
+local SkipAlliedUpgradeWidget = {}
+local toggleIsActive = false
+local shouldFilterByDefault = false
+
+---@param spots table Array of spots to filter
+---@param unitDefIdsToCheck table
+---@return table Filtered array of spots
+function SkipAlliedUpgradeWidget.filterOutAlliedSpots(spots, unitDefIdsToCheck)
+	local shouldFilter = shouldFilterByDefault ~= toggleIsActive
+	if not shouldFilter then
+		return spots
+	end
+	local filteredSpots = {}
+	local nextFilteredSpotIndex = 1 -- to avoid recalculating table length in case of large 'spots' table
+	local myTeamID = Spring.GetMyTeamID()
+
+	for i = 1, #spots do
+		local spot = spots[i]
+		local units = Spring.GetUnitsInCylinder(spot.x, spot.z, Game.extractorRadius)
+		local hasAlliedExtractor = false
+
+		for j = 1, #units do
+			local unitDefID = Spring.GetUnitDefID(units[j])
+
+			if unitDefIdsToCheck[unitDefID] then
+				local unitTeam = Spring.GetUnitTeam(units[j])
+				if Spring.AreTeamsAllied(myTeamID, unitTeam) and unitTeam ~= myTeamID then
+					hasAlliedExtractor = true
+					break
+				end
+			end
+		end
+
+		if not hasAlliedExtractor then
+			filteredSpots[nextFilteredSpotIndex] = spot
+			nextFilteredSpotIndex = nextFilteredSpotIndex + 1
+		end
+	end
+	return filteredSpots
+end
+
+function widget:Initialize()
+	toggleIsActive = false
+	WG['skip_allied_upgrade'] = SkipAlliedUpgradeWidget
+
+	widgetHandler:AddAction("toggle_allied_upgrade", function() toggleIsActive = true end, nil, "p")
+	widgetHandler:AddAction("toggle_allied_upgrade", function() toggleIsActive = false end, nil, "r")
+end
+
+function widget:Shutdown()
+	widgetHandler:RemoveAction("toggle_allied_upgrade")
+end

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -87,3 +87,5 @@ bind           Alt+sc_t  pip1_track     // track the selected units with pip1
 // bind                  pip2_switch
 // bind                  pip2_track
 
+// toggles
+bind            Any+alt toggle_allied_upgrade


### PR DESCRIPTION
### Work done
Added additional toggle in cmd_area_mex.lua and cmd_extractor_snap.lua. When holding ~ALT~, these commands will skip metal spots which have allied mexes. In other words, holding ~ALT~ will prevent your builder from upgrading allied mexes/geo when you do Area Mex or queue up mexes/geo using snapping. 

EDIT: instead of hardcoded ALT, there is a new `toggle_allied_upgrade` action which has to be bound in uikeys, for example 
`bind Alt toggle_allied_upgrade`

#### Setup
Start a skirmish with allied AI on a map with at least 2 geo spots. Give yourself a T2 con.

#### Test steps
- [ ] Build a few T1 mexes for you and your allied AI and allied geo
- [ ] Build T2 mex using Area Mex and Mex Snapping. Cover your mexes, allied mexes and empty spot. It should queue up T2 mexes in all of them
- [ ] Now do the same but while holding ~ALT~. It should skip allied mexes
- [ ] Build T2 geo using snapping. It should ignore allied geo when ~ALT~ is held


Vid:
https://github.com/user-attachments/assets/b03dc8ba-2f69-476d-a0f9-cf7741ff819c

