### PR TITLE
Update Proposed Unit Reworks Modoption for August Coop Balance Patch

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1379,6 +1379,16 @@ local options = {
         def  	= false,
     },
 
+    {
+        key 	= "proposed_unit_reworks",
+        name 	= "Proposed Unit Reworks",
+        desc 	= "Modoption used to test and balance unit reworks that are being considered for the base game.",
+        type 	= "bool",
+        --hidden 	= true,
+        section = "options_experimental",
+        def 	= false,
+    },
+
     -- Hidden Tests
 
 	{
@@ -1460,16 +1470,6 @@ local options = {
         hidden 	= true,
         section = "options_experimental",
         def  	= false,
-    },
-
-    {
-        key 	= "proposed_unit_reworks",
-        name 	= "Proposed Unit Reworks",
-        desc 	= "Modoption used to test and balance unit reworks that are being considered for the base game.",
-        type 	= "bool",
-        hidden 	= true,
-        section = "options_experimental",
-        def 	= false,
     },
 
     {

--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -1,5 +1,71 @@
 local function proposed_unit_reworksTweaks(name, uDef)
 
+	if name == "armap" or name == "armlab" or name == "armsy" or name == "armvp"
+	or name == "corap" or name == "corlab" or name == "corsy" or name == "corvp"
+	then
+		uDef.metalcost = math.ceil(uDef.metalcost * 0.08) * 10
+		uDef.energycost = math.ceil(uDef.energycost * 0.08) * 10
+		uDef.buildtime = math.ceil(uDef.buildtime * 0.008) * 100
+	end
+
+	if name == "armnanotc" or name == "armnanotcplat" 
+	or name == "cornanotc" or name == "cornanotcplat"
+	then
+		uDef.metalcost = 250
+		uDef.energycost = 3000
+	end
+	
+	if name == "armalab" or name == "armasy" or name == "armavp"
+	or name == "coralab" or name == "corasy" or name == "coravp"
+	then
+		uDef.buildtime = uDef.buildtime * 2
+		uDef.workertime = uDef.workertime * 2
+	end
+
+	if uDef.customparams.techlevel == 2 
+	and not (uDef.canfly == 1
+	or name == "armalab" or name == "armasy" or name == "armavp"
+	or name == "coralab" or name == "corasy" or name == "coravp")
+	then
+		uDef.buildtime = math.ceil(uDef.buildtime * 0.012) * 100
+	end
+
+	if name == "armadvsol" or name == "coradvsol" then
+		uDef.energymake = 80
+	end
+
+	if name == "armfus" then
+		uDef.energymake = 475
+		uDef.metalcost = 2400
+		uDef.energycost = 12000
+		uDef.buildtime = 38000
+	end
+
+	if name == "armckfus" then 
+		uDef.energymake = 500
+		uDef.metalcost = 2800
+		uDef.energycost = 15000
+		uDef.buildtime = 44000
+		uDef.cloakcost = 50
+	end
+
+	if name == "corfus" then
+		uDef.energymake = 500
+		uDef.metalcost = 2500
+		uDef.energycost = 14000
+		uDef.buildtime = 40000
+	end
+
+	if name == "armmoho" or name == "armuwmme"
+	or name == "cormoho" or name == "coruwmme"
+	then
+		uDef.metalcost = uDef.metalcost + 120
+		uDef.energycost = uDef.energycost + 1620
+	end
+
+
+
+
 
 
 	return uDef

--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -1,7 +1,7 @@
 local function proposed_unit_reworksTweaks(name, uDef)
 
-	if name == "armap" or name == "armlab" or name == "armsy" or name == "armvp"
-	or name == "corap" or name == "corlab" or name == "corsy" or name == "corvp"
+	if name == "armap" or name == "armlab" or name == "armfhp" or name == "armhp" or name == "armvp"
+	or name == "corap" or name == "corlab" or name == "corfhp" or name == "corhp" or name == "corvp"
 	then
 		uDef.metalcost = math.ceil(uDef.metalcost * 0.08) * 10
 		uDef.energycost = math.ceil(uDef.energycost * 0.08) * 10
@@ -15,17 +15,18 @@ local function proposed_unit_reworksTweaks(name, uDef)
 		uDef.energycost = 3000
 	end
 	
-	if name == "armalab" or name == "armasy" or name == "armavp"
-	or name == "coralab" or name == "corasy" or name == "coravp"
+	if name == "armaap" or name == "armalab" or name == "armasy" or name == "armavp"
+	or name == "coraap" or name == "coralab" or name == "corasy" or name == "coravp"
 	then
+		uDef.metalcost = uDef.metalcost - 300
 		uDef.buildtime = uDef.buildtime * 2
 		uDef.workertime = uDef.workertime * 2
 	end
 
 	if uDef.customparams.techlevel == 2 
 	and not (uDef.canfly == 1
-	or name == "armalab" or name == "armasy" or name == "armavp"
-	or name == "coralab" or name == "corasy" or name == "coravp")
+	or name == "armaap" or name == "armalab" or name == "armasy" or name == "armavp"
+	or name == "coraap" or name == "coralab" or name == "corasy" or name == "coravp")
 	then
 		uDef.buildtime = math.ceil(uDef.buildtime * 0.012) * 100
 	end
@@ -35,25 +36,17 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	end
 
 	if name == "armfus" then
-		uDef.energymake = 475
-		uDef.metalcost = 2400
-		uDef.energycost = 12000
-		uDef.buildtime = 38000
-	end
-
-	if name == "armckfus" then 
-		uDef.energymake = 500
-		uDef.metalcost = 2800
-		uDef.energycost = 15000
-		uDef.buildtime = 44000
-		uDef.cloakcost = 50
+		uDef.energymake = 750
+		uDef.metalcost = 3350
+		uDef.energycost = 17500
+		uDef.buildtime = 53800
 	end
 
 	if name == "corfus" then
-		uDef.energymake = 500
-		uDef.metalcost = 2500
-		uDef.energycost = 14000
-		uDef.buildtime = 40000
+		uDef.energymake = 825
+		uDef.metalcost = 3500
+		uDef.energycost = 21000
+		uDef.buildtime = 58500
 	end
 
 	if name == "armmoho" or name == "armuwmme"


### PR DESCRIPTION
reduce t1 factory cost -> building multiple t1 factories is less inefficient (no t1 slave gaming)

500m
950e
5000bt
150bp

0.3 bp/metal
0.16 bp/e

botlab
500m -> 400m
950e -> 760e
5000bt -> 4000bt
0.375 bp/metal

nano
0.95 bp/metal
0.0625 bp/energy

new nano:
210m -> 250m
3200e -> 3000e
0.8 bp/m
0.07 bp/e

conbot
0.72 bp/metal
0.05 bp/e

increase t2 buildtime -> t2 coop rush requires more infrastructure cost -> there's more time for t1 to punish t2 rushes (atm making t2 spends resources much faster than building t1 units)

t2 bot lab
16200bt -> 32000bt

(old) 0.18 m/bt

mace
0.06 m/bt

increase t2 factory bp -> building multiple t2 factories is less inefficient

t2 bot lab
300bp -> 600bp

nerf buildtime of t2 units in general, keep nerfing most prominent t2 units -> t2 pays off slower army-wise

t2 unit bt nerfs across the board
bt for all t2 land units +20%

sheldon
0.08 m/bt -> 0.066 m/bt

Kuchys Fusion change
Asol
75 e prod -> 80

t2 mex cost increase -> t2 pays off slower economically, t1 has more time to do damage -> t2 rush is nerfed (besides positive effects in 1v1 and so on)

620 -> 740m
8100 -> 9720e

13.06 e/m (old)
sheldon: 5.36


new core fusion:
4500m -> 2500m
26000e -> 14000e
75400bt -> 40000bt
1100e/s -> 500e/s

new arm fusion:
4300m -> 2400m
21000e -> 12000e
70000bt -> 38000bt
1000e/s -> 475e/s

new arm cloak fus:
4700m -> 2800m
26000e -> 15000e
84400bt -> 44000bt
1050e/s -> 500e/s
-100e/s -> -50e/s