### PR TITLE
Heavy plasma ceg

### DIFF
--- a/effects/cannons.lua
+++ b/effects/cannons.lua
@@ -146,6 +146,29 @@ local definitions = {
  --        	},
  --    	},
 	},
+		["Heavy-Plasma"] = {
+		flame = {
+            air                = true,
+            class              = [[CBitmapMuzzleFlame]],
+            count              = 1,
+            ground             = true,
+            underwater         = true,
+            water              = true,
+            properties = {
+                colormap           = [[0.9 0.65 0.3 0.007   0.9 0.6 0.2 0.006   0.8 0.3 0.1 0.004   0 0 0 0.01]],
+                dir                = [[dir]],
+                frontoffset        = 0, --0.03
+                fronttexture       = [[null]], --glow
+                length             = -3.5,
+                sidetexture        = [[trail]],
+                size               = 8,
+                sizegrowth         = 0.0,
+                ttl                = 3,
+                useairlos          = true,
+                castShadow         = true,
+        	},
+    	},
+	},
 	["arty-small"] = {
 		flame = {
             air                = true,

--- a/units/ArmBots/T2/armfboy.lua
+++ b/units/ArmBots/T2/armfboy.lua
@@ -104,6 +104,7 @@ return {
 			arm_fatboy_notalaser = {
 				areaofeffect = 240,
 				avoidfeature = false,
+				cegtag = "Heavy-Plasma",
 				craterareaofeffect = 240,
 				craterboost = 0,
 				cratermult = 0,

--- a/units/CorVehicles/T2/corgol.lua
+++ b/units/CorVehicles/T2/corgol.lua
@@ -121,6 +121,7 @@ return {
 			cor_gol = {
 				areaofeffect = 292,
 				avoidfeature = false,
+				cegtag = "Heavy-Plasma",
 				craterareaofeffect = 292,
 				craterboost = 0,
 				cratermult = 0,


### PR DESCRIPTION


### Work done
ADDS heavy plasma CEG which enables goliath and fatboy projectiles to be more identifiable than they are currently.
its almost impossible to identify if a projectile is from heavy plasma units or meduim tanks or plasma bots.
they are too similar in shape and both lack a trail.


#### BEFORE:
<img width="465" height="662" alt="image" src="https://github.com/user-attachments/assets/c9bb4711-14a9-4c9b-ae7a-eed7cd432091" />

#### AFTER:
<img width="498" height="412" alt="image" src="https://github.com/user-attachments/assets/9b521b31-9b02-4057-b292-9a96c0dfc164" />
