### PR TITLE
August balance patch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+# August 2025
+• [Aircraft] Vision raised to 430, if it was lower previously
+• [T1 Bombers] Random inaccuracy removed from their bombs
+• [T2 Transports] Skyhook 235 -> 200 speed, Abductor 241 -> 225 speed
+• [Hound] 292 -> 340 weaponvelocity
+• [Razorback] 58 -> 22 damage vs air
+• [T2 AA bots] Sightdistance 925 -> 1200
+• [Flagships] Reduced damage vs submarines with main cannon
+
 # July, 30
 * gunslinger movement class changed to 3x3 and hitbox adjusted
 * Sprinter movement class changed to 3x3 and colvol adjusted to cover the funit fully at all angles

--- a/units/ArmAircraft/T2/armaca.lua
+++ b/units/ArmAircraft/T2/armaca.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/ARMACA.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-builder",
-		sightdistance = 383.5,
+		sightdistance = 430,
 		speed = 192,
 		terraformspeed = 650,
 		turninplaceanglelimit = 360,

--- a/units/ArmAircraft/T2/armdfly.lua
+++ b/units/ArmAircraft/T2/armdfly.lua
@@ -30,7 +30,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "hugeExplosionGenericSelfd",
 		sightdistance = 430,
-		speed = 241.5,
+		speed = 225,
 		stealth = true,
 		transportcapacity = 1,
 		transportsize = 4,

--- a/units/ArmAircraft/T2/armdfly.lua
+++ b/units/ArmAircraft/T2/armdfly.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/ARMDFLY.cob",
 		seismicsignature = 0,
 		selfdestructas = "hugeExplosionGenericSelfd",
-		sightdistance = 318,
+		sightdistance = 430,
 		speed = 241.5,
 		stealth = true,
 		transportcapacity = 1,

--- a/units/ArmAircraft/T2/armhawk.lua
+++ b/units/ArmAircraft/T2/armhawk.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/ARMHAWK.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 250,
+		sightdistance = 430,
 		speed = 358.79999,
 		speedtofront = 0.063,
 		stealth = true,

--- a/units/ArmAircraft/T2/armpnix.lua
+++ b/units/ArmAircraft/T2/armpnix.lua
@@ -30,7 +30,7 @@ return {
 		script = "Units/ARMPNIX.cob",
 		seismicsignature = 0,
 		selfdestructas = "largeExplosionGenericSelfd",
-		sightdistance = 260,
+		sightdistance = 430,
 		speed = 258,
 		speedtofront = 0.063,
 		turnradius = 64,

--- a/units/ArmAircraft/T2/armstil.lua
+++ b/units/ArmAircraft/T2/armstil.lua
@@ -32,7 +32,7 @@ return {
 		script = "Units/ARMSTIL.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 390,
+		sightdistance = 430,
 		speed = 300,
 		speedtofront = 0.06125,
 		stealth = true,

--- a/units/ArmAircraft/armatlas.lua
+++ b/units/ArmAircraft/armatlas.lua
@@ -25,7 +25,7 @@ return {
 		script = "Units/ARMATLAS.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 260,
+		sightdistance = 430,
 		speed = 207,
 		transportcapacity = 1,
 		transportmass = 750,

--- a/units/ArmAircraft/armca.lua
+++ b/units/ArmAircraft/armca.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/ARMCA.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-builder",
-		sightdistance = 390,
+		sightdistance = 430,
 		speed = 208.2,
 		terraformspeed = 225,
 		turninplaceanglelimit = 360,

--- a/units/ArmAircraft/armfig.lua
+++ b/units/ArmAircraft/armfig.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/ARMFIG.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 210,
+		sightdistance = 430,
 		speed = 289.20001,
 		speedtofront = 0.06417,
 		turnradius = 64,

--- a/units/ArmAircraft/armhvytrans.lua
+++ b/units/ArmAircraft/armhvytrans.lua
@@ -26,7 +26,7 @@ return {
 		script = "Units/armhvytrans.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 260,
+		sightdistance = 430,
 		speed = 110,
 		transportcapacity = 1,
 		transportsize = 4,

--- a/units/ArmAircraft/armthund.lua
+++ b/units/ArmAircraft/armthund.lua
@@ -79,7 +79,6 @@ return {
 		},
 		weapondefs = {
 			armbomb = {
-				accuracy = 500,
 				areaofeffect = 144,
 				avoidfeature = false,
 				burst = 5,

--- a/units/ArmAircraft/armthund.lua
+++ b/units/ArmAircraft/armthund.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/ARMTHUND.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 195,
+		sightdistance = 430,
 		speed = 255,
 		speedtofront = 0.063,
 		turnradius = 64,

--- a/units/ArmBots/T2/armaak.lua
+++ b/units/ArmBots/T2/armaak.lua
@@ -1,6 +1,6 @@
 return {
 	armaak = {
-		airsightdistance = 925,
+		airsightdistance = 1200,
 		buildpic = "ARMAAK.DDS",
 		buildtime = 7000,
 		canmove = true,

--- a/units/ArmBots/T2/armfido.lua
+++ b/units/ArmBots/T2/armfido.lua
@@ -113,7 +113,7 @@ return {
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-small",
 				gravityaffected = "true",
-				impulsefactor = 0.123,
+				impulsefactor = 0.6,
 				name = "Ballistic g2g AoE plasma cannon",
 				noselfdamage = true,
 				range = 650,
@@ -123,7 +123,7 @@ return {
 				soundstart = "cannon1",
 				turret = true,
 				weapontype = "Cannon",
-				weaponvelocity = 292,
+				weaponvelocity = 340,
 				damage = {
 					default = 255,
 					vtol = 35,

--- a/units/ArmGantry/armraz.lua
+++ b/units/ArmGantry/armraz.lua
@@ -144,7 +144,7 @@ return {
 				weaponvelocity = 920,
 				damage = {
 					default = 116,
-					vtol = 58,
+					vtol = 22,
 				},
 			},
 		},

--- a/units/ArmSeaplanes/armcsa.lua
+++ b/units/ArmSeaplanes/armcsa.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/ARMCSA.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-builder",
-		sightdistance = 364,
+		sightdistance = 430,
 		speed = 192,
 		terraformspeed = 300,
 		turninplaceanglelimit = 360,

--- a/units/ArmSeaplanes/armsfig.lua
+++ b/units/ArmSeaplanes/armsfig.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/ARMSFIG.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 230,
+		sightdistance = 430,
 		speed = 310.79999,
 		speedtofront = 0.07,
 		turnradius = 64,

--- a/units/ArmSeaplanes/armsfig2.lua
+++ b/units/ArmSeaplanes/armsfig2.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/ARMSFIG2.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 230,
+		sightdistance = 430,
 		speed = 310.79999,
 		speedtofront = 0.07,
 		turnradius = 64,

--- a/units/ArmShips/T2/armepoch.lua
+++ b/units/ArmShips/T2/armepoch.lua
@@ -235,6 +235,7 @@ return {
 				},
 				damage = {
 					default = 500,
+					subs = 100,
 					vtol = 200,
 				},
 			},

--- a/units/CorAircraft/T2/coraca.lua
+++ b/units/CorAircraft/T2/coraca.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/CORACA.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-builder",
-		sightdistance = 383.5,
+		sightdistance = 430,
 		speed = 181.5,
 		terraformspeed = 650,
 		turninplaceanglelimit = 360,

--- a/units/CorAircraft/T2/corhurc.lua
+++ b/units/CorAircraft/T2/corhurc.lua
@@ -30,7 +30,7 @@ return {
 		script = "Units/CORHURC.cob",
 		seismicsignature = 0,
 		selfdestructas = "largeExplosionGenericSelfd",
-		sightdistance = 221,
+		sightdistance = 430,
 		speed = 248.399,
 		speedtofront = 0.063,
 		turnradius = 64,

--- a/units/CorAircraft/T2/corseah.lua
+++ b/units/CorAircraft/T2/corseah.lua
@@ -29,7 +29,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "hugeExplosionGenericSelfd",
 		sightdistance = 500,
-		speed = 235,
+		speed = 200,
 		transportcapacity = 1,
 		transportsize = 4,
 		transportunloadmethod = 0,

--- a/units/CorAircraft/T2/corvamp.lua
+++ b/units/CorAircraft/T2/corvamp.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/CORVAMP.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 250,
+		sightdistance = 430,
 		speed = 379.5,
 		speedtofront = 0.06475,
 		stealth = true,

--- a/units/CorAircraft/corbw.lua
+++ b/units/CorAircraft/corbw.lua
@@ -26,7 +26,7 @@ return {
 		script = "Units/CORBW.cob",
 		seismicsignature = 0,
 		selfdestructas = "tinyExplosionGenericSelfd",
-		sightdistance = 364,
+		sightdistance = 430,
 		speed = 280.5,
 		turninplaceanglelimit = 360,
 		turnrate = 1100,

--- a/units/CorAircraft/corca.lua
+++ b/units/CorAircraft/corca.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/CORCA.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd",
-		sightdistance = 351,
+		sightdistance = 430,
 		speed = 201,
 		terraformspeed = 225,
 		turninplaceanglelimit = 360,

--- a/units/CorAircraft/corhvytrans.lua
+++ b/units/CorAircraft/corhvytrans.lua
@@ -26,7 +26,7 @@ return {
 		script = "Units/corhvytrans.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 260,
+		sightdistance = 430,
 		speed = 100,
 		transportcapacity = 1,
 		transportsize = 4,

--- a/units/CorAircraft/corshad.lua
+++ b/units/CorAircraft/corshad.lua
@@ -80,7 +80,6 @@ return {
 		},
 		weapondefs = {
 			corbomb = {
-				accuracy = 500,
 				areaofeffect = 168,
 				avoidfeature = false,
 				burst = 5,

--- a/units/CorAircraft/corshad.lua
+++ b/units/CorAircraft/corshad.lua
@@ -30,7 +30,7 @@ return {
 		script = "Units/CORSHAD.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 169,
+		sightdistance = 430,
 		speed = 234,
 		speedtofront = 0.06183,
 		turnradius = 64,

--- a/units/CorAircraft/corvalk.lua
+++ b/units/CorAircraft/corvalk.lua
@@ -25,7 +25,7 @@ return {
 		script = "Units/CORVALK.cob",
 		seismicsignature = 0,
 		selfdestructas = "mediumExplosionGenericSelfd",
-		sightdistance = 260,
+		sightdistance = 430,
 		speed = 198,
 		transportcapacity = 1,
 		transportmass = 750,

--- a/units/CorAircraft/corveng.lua
+++ b/units/CorAircraft/corveng.lua
@@ -28,7 +28,7 @@ return {
 		script = "Units/CORVENG.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 210,
+		sightdistance = 430,
 		speed = 297.60001,
 		speedtofront = 0.063,
 		turnradius = 64,

--- a/units/CorBots/T2/coraak.lua
+++ b/units/CorBots/T2/coraak.lua
@@ -1,6 +1,6 @@
 return {
 	coraak = {
-		airsightdistance = 925,
+		airsightdistance = 1200,
 		buildpic = "CORAAK.DDS",
 		buildtime = 7600,
 		canmove = true,

--- a/units/CorSeaplanes/corcsa.lua
+++ b/units/CorSeaplanes/corcsa.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/CORCSA.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericSelfd-builder",
-		sightdistance = 351,
+		sightdistance = 430,
 		speed = 217.5,
 		terraformspeed = 300,
 		turninplaceanglelimit = 360,

--- a/units/CorSeaplanes/corsfig.lua
+++ b/units/CorSeaplanes/corsfig.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/CORSFIG.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 230,
+		sightdistance = 430,
 		speed = 315.60001,
 		speedtofront = 0.07,
 		turnradius = 64,

--- a/units/CorSeaplanes/corsfig2.lua
+++ b/units/CorSeaplanes/corsfig2.lua
@@ -29,7 +29,7 @@ return {
 		script = "Units/CORSFIG2.cob",
 		seismicsignature = 0,
 		selfdestructas = "smallExplosionGenericAir",
-		sightdistance = 230,
+		sightdistance = 430,
 		speed = 315.60001,
 		speedtofront = 0.07,
 		turnradius = 64,

--- a/units/CorShips/T2/corblackhy.lua
+++ b/units/CorShips/T2/corblackhy.lua
@@ -257,6 +257,7 @@ return {
 				weaponvelocity = 600,
 				damage = {
 					default = 600,
+					subs = 120,
 					vtol = 250,
 				},
 			},


### PR DESCRIPTION
Changelog:

• [Aircraft] Vision raised to 430, if it was lower previously
• [T1 Bombers] Random inaccuracy removed from their bombs
• [T2 Transports] Skyhook 235 -> 200 speed, Abductor 241 -> 225 speed
• [Hound] 292 -> 340 weaponvelocity
• [Razorback] 58 -> 22 damage vs air
• [T2 AA bots] Sightdistance 925 -> 1200
• [Flagships] Reduced damage vs submarines with main cannon