### PR TITLE
Fix for manual targeting of Thor not working against emp immune units, issue #4207

### DIFF
--- a/luarules/gadgets/unit_onlytargetcategory.lua
+++ b/luarules/gadgets/unit_onlytargetcategory.lua
@@ -11,7 +11,6 @@ function gadget:GetInfo()
 		enabled	= true,
 	}
 end
-
 local unitCategories = {}
 local unitOnlyTargetsCategory = {}
 local unitDontAttackGround = {}
@@ -24,19 +23,22 @@ for udid, unitDef in pairs(UnitDefs) do
 	local add = false
 	for wid, weapon in ipairs(unitDef.weapons) do
 		if weapon.onlyTargets then
-			local i = 0
+			local disregard = false
 			for category, _ in pairs(weapon.onlyTargets) do
-				i = i + 1
-				if not unitOnlyTargetsCategory[udid] then
+				if unitOnlyTargetsCategory[udid] == nil then
 					unitOnlyTargetsCategory[udid] = category
 					if category == 'vtol' then
 						unitDontAttackGround[udid] = true
 					end
-				elseif unitOnlyTargetsCategory[udid] ~= category then	-- multiple different onlytargetcategory used: disregard
-					unitOnlyTargetsCategory[udid] = nil
+				elseif unitOnlyTargetsCategory[udid] ~= category then -- multiple different onlytargetcategory used: disregard
+					unitOnlyTargetsCategory[udid] = nil 
 					unitDontAttackGround[udid] = nil -- If there are multiple categories, then it can shoot ground, and should be allowed to do so
+					disregard = true
 					break
 				end
+			end
+			if disregard then
+				break
 			end
 		end
 	end

--- a/luarules/gadgets/unit_onlytargetcategory.lua
+++ b/luarules/gadgets/unit_onlytargetcategory.lua
@@ -11,6 +11,7 @@ function gadget:GetInfo()
 		enabled	= true,
 	}
 end
+
 local unitCategories = {}
 local unitOnlyTargetsCategory = {}
 local unitDontAttackGround = {}
@@ -30,8 +31,8 @@ for udid, unitDef in pairs(UnitDefs) do
 					if category == 'vtol' then
 						unitDontAttackGround[udid] = true
 					end
-				elseif unitOnlyTargetsCategory[udid] ~= category then -- multiple different onlytargetcategory used: disregard
-					unitOnlyTargetsCategory[udid] = nil 
+				elseif unitOnlyTargetsCategory[udid] ~= category then  -- multiple different onlytargetcategory used: disregard
+					unitOnlyTargetsCategory[udid] = nil
 					unitDontAttackGround[udid] = nil -- If there are multiple categories, then it can shoot ground, and should be allowed to do so
 					disregard = true
 					break

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -43,7 +43,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 	and type(cmdParams[1]) == 'number'
 	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])] ~= nil then
 		if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then	--	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
-			return true 
+			return false
 		else
 			local _,_,_,_,y = Spring.GetUnitPosition(cmdParams[1], true)
 			if y and y >= 0 then

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -16,11 +16,16 @@ local empUnits = {}
 local unEmpableUnits = {}
 for udid, unitDef in pairs(UnitDefs) do
 	local weapons = unitDef.weapons
+	
 	for i=1, #weapons do
 		if WeaponDefs[weapons[i].weaponDef].paralyzer then
-			empUnits[udid] = true
+			empUnits[udid] = true 
+		else
+			empUnits[udid] = false
+			break
 		end
 	end
+
 	if not unitDef.modCategories.empable then
 		unEmpableUnits[udid] = true
 	end
@@ -32,12 +37,13 @@ end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	-- accepts: CMD.ATTACK
+
 	if empUnits[unitDefID]
 	and cmdParams[2] == nil
 	and type(cmdParams[1]) == 'number'
 	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])] ~= nil then
-		if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then		--	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
-			return false
+		if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then	--	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
+			return true 
 		else
 			local _,_,_,_,y = Spring.GetUnitPosition(cmdParams[1], true)
 			if y and y >= 0 then

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -37,12 +37,11 @@ end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	-- accepts: CMD.ATTACK
-
 	if empUnits[unitDefID]
 	and cmdParams[2] == nil
 	and type(cmdParams[1]) == 'number'
 	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])] ~= nil then
-		if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then	--	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
+		if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then		--	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
 			return false
 		else
 			local _,_,_,_,y = Spring.GetUnitPosition(cmdParams[1], true)

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -16,7 +16,6 @@ local empUnits = {}
 local unEmpableUnits = {}
 for udid, unitDef in pairs(UnitDefs) do
 	local weapons = unitDef.weapons
-	
 	for i=1, #weapons do
 		if WeaponDefs[weapons[i].weaponDef].paralyzer then
 			empUnits[udid] = true 
@@ -25,7 +24,6 @@ for udid, unitDef in pairs(UnitDefs) do
 			break
 		end
 	end
-
 	if not unitDef.modCategories.empable then
 		unEmpableUnits[udid] = true
 	end

--- a/luaui/Widgets/gui_attack_aoe.lua
+++ b/luaui/Widgets/gui_attack_aoe.lua
@@ -259,10 +259,6 @@ local function SetupUnitDef(unitDefID, unitDef)
 					and not ToBool(weaponDef.interceptor)
 					and (weaponDef.damageAreaOfEffect > maxSpread or weaponDef.range * (weaponDef.accuracy + weaponDef.sprayAngle) > maxSpread)
 					and not string.find(weaponDef.name, "flak", nil, true)
-					and not string.find(weaponDef.name, "thunder", nil, true) then
-					
-					Spring.Echo("Heavy Lighting Cannon", weaponDef.name, " can attack")
-
 
 					maxSpread = max(weaponDef.damageAreaOfEffect, weaponDef.range * (weaponDef.accuracy + weaponDef.sprayAngle))
 					maxWeaponDef = weaponDef

--- a/luaui/Widgets/gui_attack_aoe.lua
+++ b/luaui/Widgets/gui_attack_aoe.lua
@@ -258,7 +258,11 @@ local function SetupUnitDef(unitDefID, unitDef)
 					and not (weaponDef.type == "Shield")
 					and not ToBool(weaponDef.interceptor)
 					and (weaponDef.damageAreaOfEffect > maxSpread or weaponDef.range * (weaponDef.accuracy + weaponDef.sprayAngle) > maxSpread)
-					and not string.find(weaponDef.name, "flak", nil, true) then
+					and not string.find(weaponDef.name, "flak", nil, true)
+					and not string.find(weaponDef.name, "thunder", nil, true) then
+					
+					Spring.Echo("Heavy Lighting Cannon", weaponDef.name, " can attack")
+
 
 					maxSpread = max(weaponDef.damageAreaOfEffect, weaponDef.range * (weaponDef.accuracy + weaponDef.sprayAngle))
 					maxWeaponDef = weaponDef

--- a/luaui/Widgets/gui_attack_aoe.lua
+++ b/luaui/Widgets/gui_attack_aoe.lua
@@ -258,7 +258,7 @@ local function SetupUnitDef(unitDefID, unitDef)
 					and not (weaponDef.type == "Shield")
 					and not ToBool(weaponDef.interceptor)
 					and (weaponDef.damageAreaOfEffect > maxSpread or weaponDef.range * (weaponDef.accuracy + weaponDef.sprayAngle) > maxSpread)
-					and not string.find(weaponDef.name, "flak", nil, true)
+					and not string.find(weaponDef.name, "flak", nil, true) then
 
 					maxSpread = max(weaponDef.damageAreaOfEffect, weaponDef.range * (weaponDef.accuracy + weaponDef.sprayAngle))
 					maxWeaponDef = weaponDef


### PR DESCRIPTION
### Work done
Hi, this is my first PR/contribution so let me know if there are any issues.

Decided to look into and fix #4207 since it's been there since January and seemed like a good start. 

`luarules/gadgets/unit_onlytargetcategory.lua`
Previously didn't correctly implement a break statement, which meant that the target categories for Thor (and possibly other units) weren't disregarded if there were multiple categories, which is the intended behaviour according to the original comment:

`elseif unitOnlyTargetsCategory[udid] ~= category then -- multiple different onlytargetcategory used: disregard`

Also removed a random incrementing `i = i + 1` which didn't do anything lol

`luarules/gadgets/unit_onlytargetempable.lua`
Changed the code to only consider a unit to be an "emp unit" if all of it's weapons have a `paralyze` effect, which sounds logical to me. If a unit has weapons that don't emp/paralyze, then the player should be able to target emp immune enemies as they have normal non emp weapons. The emp weapons will not fire anyway as those are handled elsewhere.

### Screenshots:

https://github.com/user-attachments/assets/2db8429a-41f1-428b-9e2c-2e6e0d4e742c

com goes boom (with manual click, you can see hold fire is enabled)
