### PR TITLE
Show transport weight indicators when you have multiple transports selected

### DIFF
--- a/luaui/Widgets/gui_transport_weight_limit.lua
+++ b/luaui/Widgets/gui_transport_weight_limit.lua
@@ -152,15 +152,14 @@ function widget:GameFrame(n)
 	for _, unitID in ipairs(visibleUnits) do
 		local passengerDefID = Spring.GetUnitDefID(unitID)
 		if not cantBeTransported[passengerDefID] and not Spring.IsUnitIcon(unitID) then
-			local passengerXSize = unitXSize[passengerDefID] / springFootprintScale
+			local passengerFootprintX = unitXSize[passengerDefID] / springFootprintScale
 			local canBePickedUp = false
 			for transDefID, _ in pairs(activeTransportDefs) do
 				local transDef = transDefs[transDefID]
 				local transMassLimit = transDef[1]
 				local transportSizeLimit = transDef[3]
 
-				-- transportSizeLimit: The size of units that the transport can pick up, in terms of the passengers footprintX.
-				if unitMass[passengerDefID] <= transMassLimit and passengerXSize <= transportSizeLimit then
+				if unitMass[passengerDefID] <= transMassLimit and passengerFootprintX <= transportSizeLimit then
 					canBePickedUp = true
 					break
 				end
@@ -169,8 +168,8 @@ function widget:GameFrame(n)
 			if canBePickedUp then
 				local x, y, z = Spring.GetUnitBasePosition(unitID)
 				if x then
-					-- we have to scale up passengerXSize otherwise indicator would be under the unit instead of around it
-					unitsToDraw[unitID] = { pos = { x, y, z }, size = (passengerXSize * indicatorSizeMultiplier) }
+					-- we have to scale up passengerFootprintX otherwise indicator would be under the unit instead of around it
+					unitsToDraw[unitID] = { pos = { x, y, z }, size = (passengerFootprintX * indicatorSizeMultiplier) }
 				end
 			end
 		end


### PR DESCRIPTION
### Work done
Currently weight indicators, aka green circle which shows that you can pick up unit, is shown only when single transport is selected. This PR improves it, so it can handle multiple transports at once. It filters out transports which already carry units, checks what transport types are selected and highlights units based on the 'best' transport type.


#### Test steps
- [ ] Build few light and heavy transports, some ticks and a fatboy
- [ ] Select light transports and enable load command - ticks should be highlighted 
- [ ] Select heavy transports and enable load command - ticks, commander and fatboy should be highlighted 
- [ ] Select light and heavy transport and enable load command -  ticks, commander and fatboy should be highlighted
- [ ] Select light and heavy transport, pickup commander and enable load command  - only ticks should be highlighted  


https://github.com/user-attachments/assets/ac8395ab-44d4-4e51-9583-3b37d661169a

(streamable link)
https://streamable.com/y5ncye

