### PR TITLE
Improve Area Load order for specific unit types

### DIFF
--- a/luaui/Widgets/unit_specific_unit_loader.lua
+++ b/luaui/Widgets/unit_specific_unit_loader.lua
@@ -1,113 +1,125 @@
-
 local widget = widget ---@type Widget
 
 function widget:GetInfo()
 	return {
-		name		= "Specific Unit Loader",
-		desc		= "Hold down Alt or Ctrl and give an area load order, centered on a unit of the type to load.",
-		author		= "Google Frog, doo edit for load commands",
-		date		= "May 12, 2008",
-		license	 	= "GNU GPL, v2 or later",
-		layer		= 0,
-		enabled	 	= true
+		name = "Specific Unit Loader",
+		desc = "Hold down Alt or Ctrl and give an area load order, centered on a unit of the type to load. Ctrl picks up units of this type from selected team, Alt - only player",
+		author = "Google Frog, doo edit for load commands, SuperKitowiec",
+		date = "May 12, 2008",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true
 	}
 end
 
-local team = Spring.GetMyTeamID()
-local allyTeam = Spring.GetMyAllyTeamID()
+-- Changelog
+-- Sep 2025 SuperKitowiec:
+-- Ctrl picks up units of selected team. Alt picks up units of selected player. Units closest to area center will be picked up first
 
 -- Speedups
-
 local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
 local spWorldToScreenCoords = Spring.WorldToScreenCoords
 local spTraceScreenRay = Spring.TraceScreenRay
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
-
-local reclaimEnemy = Game.reclaimAllowEnemies
+local spGetUnitTeam = Spring.GetUnitTeam
 
 local CMD_LOAD_UNITS = CMD.LOAD_UNITS
 
 local gameStarted
 
-
 function maybeRemoveSelf()
-    if Spring.GetSpectatingState() and (Spring.GetGameFrame() > 0 or gameStarted) then
-        widgetHandler:RemoveWidget()
-    end
+	if Spring.GetSpectatingState() and (Spring.GetGameFrame() > 0 or gameStarted) then
+		widgetHandler:RemoveWidget()
+	end
 end
 
 function widget:GameStart()
-    gameStarted = true
-    maybeRemoveSelf()
+	gameStarted = true
+	maybeRemoveSelf()
 end
 
 function widget:PlayerChanged(playerID)
-    maybeRemoveSelf()
+	maybeRemoveSelf()
 end
 
 function widget:Initialize()
-    if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
-        maybeRemoveSelf()
-    end
+	if Spring.IsReplay() or Spring.GetGameFrame() > 0 then
+		maybeRemoveSelf()
+	end
 end
 
 function widget:CommandNotify(id, params, options)
 
 	if id ~= CMD_LOAD_UNITS or #params ~= 4 then
-		return
+		return false
 	end
-	if options.alt or options.ctrl then
 
-		local cx, cy, cz = params[1], params[2], params[3]
+	if not options.alt and not options.ctrl then
+		return false
+	end
 
-		local mx,my,mz = spWorldToScreenCoords(cx, cy, cz)
-		local cType,id = spTraceScreenRay(mx,my)
+	local cx, cy, cz = params[1], params[2], params[3]
 
-		if cType == "unit" then
+	local mx, my = spWorldToScreenCoords(cx, cy, cz)
+	local cType, targetUnitID = spTraceScreenRay(mx, my)
 
-			local cr = params[4]
+	-- prevent normal pickup if player tried to do a filtered one but missed the unit
+	if cType ~= "unit" then
+		return true
+	end
 
-			local selUnits = spGetSelectedUnits()
+	local targetUnitAllyTeam = spGetUnitAllyTeam(targetUnitID)
+	if not targetUnitAllyTeam then return end
+	local targetUnitTeam = spGetUnitTeam(targetUnitID)
+	if not targetUnitTeam then return end
 
-			local targetEnemy = reclaimEnemy and spGetUnitAllyTeam(id) ~= allyTeam
-			local unitDef = spGetUnitDefID(id)
-			local preareaUnits
-			local countarea = 0
-			local areaUnits = {}
-			if targetEnemy then
-				areaUnits = spGetUnitsInCylinder(cx, cz, cr, -4)
-			else
-				preareaUnits = spGetUnitsInCylinder(cx, cz, cr, team)
-				for i=1,#preareaUnits do
-					local unitID = preareaUnits[i]
-					if (options.alt and spGetUnitDefID(unitID) == unitDef) or options.ctrl then
-						countarea = countarea + 1
-						areaUnits[countarea] = unitID
-					end
-				end
+	local cr = params[4]
+	local targetUnitDefId = spGetUnitDefID(targetUnitID)
+	if not targetUnitDefId then return end
+
+	local selUnits = spGetSelectedUnits()
+	if #selUnits == 0 then return end
+
+	local allAreaUnits = spGetUnitsInCylinder(cx, cz, cr)
+	local cargoUnitsToSort = {}
+
+	for i = 1, #allAreaUnits do
+		local unitID = allAreaUnits[i]
+
+		if spGetUnitDefID(unitID) == targetUnitDefId then
+			local isCorrectTeam
+			if options.ctrl then
+				isCorrectTeam = (spGetUnitAllyTeam(unitID) == targetUnitAllyTeam)
+			elseif options.alt then
+				isCorrectTeam = (spGetUnitTeam(unitID) == targetUnitTeam)
 			end
-			for ct=1,#selUnits do
-				local unitID = selUnits[ct]
-				for i=1,#areaUnits do
-					local areaUnitID = areaUnits[i]
-					local cmdOpts = {}
-					if options.shift then
-						cmdOpts = {"shift"}
-					end
-					if i%#areaUnits == ct%#areaUnits or ct%#selUnits == i%#selUnits then
-						Spring.GiveOrderToUnit(unitID, CMD_LOAD_UNITS, {areaUnitID}, cmdOpts)
-					end
 
-				end
+			if isCorrectTeam then
+				local ux, _, uz = Spring.GetUnitPosition(unitID)
+				-- Calculate squared distance to the center for sorting
+				local distSq = (ux - cx) ^ 2 + (uz - cz) ^ 2
+				table.insert(cargoUnitsToSort, { id = unitID, dist = distSq })
 			end
-			return true
-
 		end
 	end
 
+	table.sort(cargoUnitsToSort, function(a, b)
+		return a.dist > b.dist
+	end)
 
+	local cmdOpts = {}
+	if options.shift then
+		cmdOpts = { "shift" }
+	end
+
+	for i = 1, #cargoUnitsToSort do
+		local cargoUnitID = cargoUnitsToSort[i].id
+		local transportIndex = (i - 1) % #selUnits + 1
+		local transportUnitID = selUnits[transportIndex]
+		Spring.GiveOrderToUnit(transportUnitID, CMD_LOAD_UNITS, { cargoUnitID }, cmdOpts)
+	end
+
+	return true
 end
-
-


### PR DESCRIPTION
Before:
- Alt targeted only own units.
- Ctrl was broken - didn't do any filtering and tried to pick up transports

After:
- Alt drag now respects the targeted player - it will pick up only his units. You can use it to target enemies now
- Ctrl drag now respects the targeted team. If you drag on the enemy, it will pick up only enemies. If on the ally - only allies (including you).
- in both cases units are sorted by the distance so the ones closest to an area center are picked up first


#### Test steps
- [ ] Start a match with allied AI and 2 enemy AIs
- [ ] Give all players some units of the same type + some random ones of different types
- [ ] Give yourself few transports
- [ ] Enable load command, point at the unit, hold ALT and drag a circle. It should pick up only units of this type of this player
- [ ] Do the same while holding CTRL. It should pick up units of this type from this team
- [ ] Make a big group of units in one spot. Do the ALT or CTRL drag. It should prioritize units closest to the selected unit

#### Pickup order
Before: https://streamable.com/2asx0a
https://github.com/user-attachments/assets/5563e3d3-7dbc-4a0f-a5ac-9e4a607d2426

After: https://streamable.com/sud2zl
https://github.com/user-attachments/assets/7d7655e3-2b3e-4ee7-8a79-bf30da409817


#### Modifiers
Ctrl: https://streamable.com/68c06v
https://github.com/user-attachments/assets/ce112d88-d143-412a-ac34-6f60c2c4416f

Alt: https://streamable.com/gx4rjn
https://github.com/user-attachments/assets/cb264bba-6b7c-4e84-897c-feb5376bc9f1


