### PR TITLE
Extract builder queue api from gfx_showbuilderqueue.lua

### DIFF
--- a/luaui/Widgets/api_builder_queue.lua
+++ b/luaui/Widgets/api_builder_queue.lua
@@ -1,0 +1,342 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "API Builder Queue",
+		desc = "Provides builder queue data tracking and management for other widgets",
+		author = "SuperKitowiec (extracted from 'Show Builder Queue' by WarXperiment, Decay, Floris)",
+		date = "August 26, 2025",
+		license = "GNU GPL, v2 or later",
+		version = 1,
+		layer = 0,
+		enabled = true
+	}
+end
+
+--------------------------------------------------------------------------------
+-- Spring API Imports
+--------------------------------------------------------------------------------
+
+local spGetUnitCommands = Spring.GetUnitCommands
+local spGetUnitCommandCount = Spring.GetUnitCommandCount
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetAllUnits = Spring.GetAllUnits
+local spEcho = Spring.Echo
+
+local floor = math.floor
+
+--------------------------------------------------------------------------------
+-- Constants
+--------------------------------------------------------------------------------
+
+local MAX_QUEUE_DEPTH = 2000
+
+--------------------------------------------------------------------------------
+-- State Management
+--------------------------------------------------------------------------------
+
+---@type table<string, BuildCommandEntry>
+local buildCommands = {}
+local unitBuildCommands = {}
+local commandIdToCreatedUnitIdMap = {}
+local createdUnitIdToCommandIdMap = {}
+local unitsAwaitingCommandProcessing = {}
+local buildersList = {}
+
+-- Event system for notifying consumers
+local Event = {
+	onBuildCommandAdded = 'onBuildCommandAdded',
+	onBuildCommandRemoved = 'onBuildCommandRemoved',
+	onUnitCreated = 'onUnitCreated',
+	onUnitFinished = 'onUnitFinished',
+	onBuilderDestroyed = 'onBuilderDestroyed',
+
+}
+
+local eventCallbacks = {
+	[Event.onBuildCommandAdded] = {},
+	[Event.onBuildCommandRemoved] = {},
+	[Event.onUnitCreated] = {},
+	[Event.onUnitFinished] = {},
+	[Event.onBuilderDestroyed] = {}
+}
+
+local elapsedSeconds = 0
+local lastUpdateTime = 0
+local periodicCheckCounter = 1
+
+--------------------------------------------------------------------------------
+-- Setup
+--------------------------------------------------------------------------------
+
+for unitDefId, unitDefinition in ipairs(UnitDefs) do
+	if unitDefinition.isBuilder and not unitDefinition.isFactory and unitDefinition.buildOptions[1] then
+		buildersList[unitDefId] = true
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Event System Functions
+--------------------------------------------------------------------------------
+
+local function notifyEvent(eventName, ...)
+	for _, callback in pairs(eventCallbacks[eventName] or {}) do
+		callback(...)
+	end
+end
+
+---@param eventName string
+---@param callback function()
+local function registerCallback(eventName, callback)
+	if eventCallbacks[eventName] then
+		table.insert(eventCallbacks[eventName], callback)
+	else
+		spEcho("Warn: Unknown event name " .. eventName)
+	end
+	---@class BuilderQueueEventCallback
+	local callbackEntry = {}
+	callbackEntry.eventName = eventName
+	callbackEntry.callback = callback
+	return callbackEntry
+end
+
+local function unregisterCallback(eventName, callback)
+	if eventCallbacks[eventName] then
+		for i, registeredCallback in ipairs(eventCallbacks[eventName]) do
+			if registeredCallback == callback then
+				table.remove(eventCallbacks[eventName], i)
+				break
+			end
+		end
+	else
+		spEcho("Warn: Unknown event name " .. eventName)
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Core Functions
+--------------------------------------------------------------------------------
+---
+local function generateId(unitDefId, positionX, positionZ)
+	return string.format('%s_%s_%s', unitDefId, positionX, positionZ)
+end
+
+local function removeBuilderFromCommand(commandId, unitId)
+	local command = buildCommands[commandId]
+	if command and command.builderIds[unitId] then
+		command.builderIds[unitId] = nil
+		command.builderCount = command.builderCount - 1
+		if command.builderCount == 0 then
+			local commandData = command
+			buildCommands[commandId] = nil
+			notifyEvent(Event.onBuildCommandRemoved, commandId, commandData)
+		end
+	end
+end
+
+local function clearBuilderCommands(unitId)
+	if not unitBuildCommands[unitId] then
+		return
+	end
+
+	for commandId, _ in pairs(unitBuildCommands[unitId]) do
+		removeBuilderFromCommand(commandId, unitId)
+	end
+	unitBuildCommands[unitId] = nil
+end
+
+local function checkBuilder(unitId)
+	local queueDepth = spGetUnitCommandCount(unitId)
+	if not queueDepth or queueDepth <= 0 then
+		clearBuilderCommands(unitId)
+		return
+	end
+
+	local currentCommands = {}
+	local queue = spGetUnitCommands(unitId, math.min(queueDepth, MAX_QUEUE_DEPTH))
+
+	-- Step 1: Process the current queue and identify active commands
+	for i = 1, #queue do
+		local queueCommand = queue[i]
+		if queueCommand.id < 0 then
+			local unitDefId = math.abs(queueCommand.id)
+			local positionX = floor(queueCommand.params[1])
+			local positionZ = floor(queueCommand.params[3])
+			local commandId = generateId(unitDefId, positionX, positionZ)
+
+			currentCommands[commandId] = true
+
+			if commandIdToCreatedUnitIdMap[commandId] == nil then
+				local isNewCommand = false
+				if buildCommands[commandId] == nil then
+					local buildCommand = {} --- @class BuildCommandEntry
+					buildCommand.builderCount = 0
+					buildCommand.unitDefId = unitDefId
+					buildCommand.teamId = spGetUnitTeam(unitId)
+					buildCommand.positionX = positionX
+					buildCommand.positionY = floor(queueCommand.params[2])
+					buildCommand.positionZ = positionZ
+					buildCommand.rotation = floor(queueCommand.params[4])
+					buildCommand.builderIds = {}
+					buildCommands[commandId] = buildCommand
+					isNewCommand = true
+				end
+
+				if not buildCommands[commandId].builderIds[unitId] then
+					buildCommands[commandId].builderIds[unitId] = true
+					buildCommands[commandId].builderCount = buildCommands[commandId].builderCount + 1
+				end
+
+				if isNewCommand then
+					notifyEvent(Event.onBuildCommandAdded, commandId, buildCommands[commandId])
+				end
+			end
+		end
+	end
+
+	-- Step 2: Compare old commands with current commands to find what was removed
+	if unitBuildCommands[unitId] then
+		for oldCommandId, _ in pairs(unitBuildCommands[unitId]) do
+			if not currentCommands[oldCommandId] then
+				removeBuilderFromCommand(oldCommandId, unitId)
+			end
+		end
+	end
+
+	unitBuildCommands[unitId] = currentCommands
+end
+
+local function clearUnit(unitId)
+	if not createdUnitIdToCommandIdMap[unitId] then
+		return
+	end
+	local commandId = createdUnitIdToCommandIdMap[unitId]
+	local commandData = buildCommands[commandId]
+	buildCommands[commandId] = nil
+	commandIdToCreatedUnitIdMap[commandId] = nil
+	createdUnitIdToCommandIdMap[unitId] = nil
+	notifyEvent(Event.onUnitFinished, unitId, commandId, commandData)
+end
+
+local function processNewBuildCommands()
+	local currentTime = os.clock()
+	for unitId, commandClockTime in pairs(unitsAwaitingCommandProcessing) do
+		if currentTime > commandClockTime then
+			checkBuilder(unitId)
+			unitsAwaitingCommandProcessing[unitId] = nil
+		end
+	end
+end
+
+local function periodicBuilderCheck()
+	periodicCheckCounter = periodicCheckCounter + 1
+	for unitId, _ in pairs(unitBuildCommands) do
+		--- Load balancer which ensures that at most 30 units are checked per frame
+		if (unitId + periodicCheckCounter) % 30 == 1 and not unitsAwaitingCommandProcessing[unitId] then
+			checkBuilder(unitId)
+		end
+	end
+end
+
+local function resetStateAndReinitialize()
+	buildCommands = {}
+	unitBuildCommands = {}
+	commandIdToCreatedUnitIdMap = {}
+	createdUnitIdToCommandIdMap = {}
+	unitsAwaitingCommandProcessing = {}
+
+	-- Re-scan all units
+	local allUnits = spGetAllUnits()
+	for i = 1, #allUnits do
+		local unitId = allUnits[i]
+		if buildersList[spGetUnitDefID(unitId)] then
+			checkBuilder(unitId)
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+-- API Definition
+--------------------------------------------------------------------------------
+
+--- @class BuilderQueueApi
+local BuilderQueueApi = {}
+
+---@param callback fun(commandId: string, data: BuildCommandEntry)
+function BuilderQueueApi.ForEachActiveBuildCommand(callback)
+	for commandId, commandEntry in pairs(buildCommands) do
+		if commandEntry.builderCount > 0 then
+			callback(commandId, commandEntry)
+		end
+	end
+end
+
+BuilderQueueApi.OnBuildCommandAdded = function(callback) return registerCallback(Event.onBuildCommandAdded, callback) end
+BuilderQueueApi.OnBuildCommandRemoved = function(callback) return registerCallback(Event.onBuildCommandRemoved, callback) end
+BuilderQueueApi.OnUnitCreated = function(callback) return registerCallback(Event.onUnitCreated, callback) end
+BuilderQueueApi.OnUnitFinished = function(callback) return registerCallback(Event.onUnitFinished, callback) end
+BuilderQueueApi.OnBuilderDestroyed = function(callback) return registerCallback(Event.onBuilderDestroyed, callback) end
+BuilderQueueApi.UnregisterCallback = unregisterCallback
+
+--------------------------------------------------------------------------------
+-- Widget Callins
+--------------------------------------------------------------------------------
+
+function widget:Initialize()
+	resetStateAndReinitialize()
+	WG.BuilderQueueApi = BuilderQueueApi
+end
+
+function widget:Update(dt)
+	elapsedSeconds = elapsedSeconds + dt
+	if elapsedSeconds > lastUpdateTime + 0.12 then
+		lastUpdateTime = elapsedSeconds
+		processNewBuildCommands()
+		periodicBuilderCheck()
+	end
+end
+
+function widget:PlayerChanged(playerId)
+	-- Clear all data when player changes (spectating state changes)
+	local myPlayerId = Spring.GetMyPlayerID()
+	if playerId == myPlayerId then
+		resetStateAndReinitialize()
+	end
+end
+
+function widget:UnitCommand(unitId, unitDefId)
+	if buildersList[unitDefId] then
+		unitsAwaitingCommandProcessing[unitId] = os.clock() + 0.13
+	end
+end
+
+function widget:UnitCreated(unitId, unitDefId)
+	local x, _, z = spGetUnitPosition(unitId)
+	if x then
+		local commandId = generateId(unitDefId, floor(x), floor(z))
+		local commandData = buildCommands[commandId]
+		buildCommands[commandId] = nil
+		commandIdToCreatedUnitIdMap[commandId] = unitId
+		createdUnitIdToCommandIdMap[unitId] = commandId
+		notifyEvent(Event.onUnitCreated, unitId, unitDefId, commandId, commandData)
+	end
+end
+
+function widget:UnitFinished(unitId)
+	clearUnit(unitId)
+end
+
+function widget:UnitDestroyed(unitId, unitDefId)
+	if buildersList[unitDefId] then
+		unitsAwaitingCommandProcessing[unitId] = nil
+		clearBuilderCommands(unitId)
+		notifyEvent(Event.onBuilderDestroyed, unitId, unitDefId)
+	end
+	clearUnit(unitId)
+end
+
+function widget:Shutdown()
+	WG.BuilderQueueApi = nil
+end

--- a/luaui/Widgets/gfx_showbuilderqueue.lua
+++ b/luaui/Widgets/gfx_showbuilderqueue.lua
@@ -2,20 +2,19 @@ local widget = widget ---@type Widget
 
 function widget:GetInfo()
 	return {
-		name      = "Show Builder Queue",
-		desc      = "Shows buildings about to be built",
-		author    = "WarXperiment, Decay, Floris",
-		date      = "February 15, 2010",
-		license   = "GNU GPL, v2 or later",
-        version   = 8,
-        layer     = 55,
-		enabled   = true,
-    }
+		name = "Show Builder Queue",
+		desc = "Shows buildings about to be built",
+		author = "WarXperiment, Decay, Floris, SuperKitowiec",
+		date = "February 15, 2010",
+		license = "GNU GPL, v2 or later",
+		version = 9,
+		layer = 55,
+		enabled = true,
+	}
 end
 
 local shapeOpacity = 0.26
 local maxUnitShapes = 4096
-local maxQueueDepth = 2000	-- not literal depth
 
 --Changelog
 -- before v2 developed by WarXperiment
@@ -26,207 +25,152 @@ local maxQueueDepth = 2000	-- not literal depth
 -- v6 Floris - limited to not show when (would be) icon
 -- v7 Floris - simplified/cleanup
 -- v8 Floris - GL4 unit shape rendering
+-- v9 SuperKitowiec - Extract builder queue related code to api_builder_queue.lua.
 
-local myPlayerID = Spring.GetMyPlayerID()
-local _,fullview,_ = Spring.GetSpectatingState()
+local myPlayerId = Spring.GetMyPlayerID()
+local _, fullView, _ = Spring.GetSpectatingState()
 
-local spGetUnitCommands = Spring.GetUnitCommands
-local spGetUnitCommandCount = Spring.GetUnitCommandCount
-local spGetUnitDefID = Spring.GetUnitDefID
-local spGetUnitTeam = Spring.GetUnitTeam
 local spGetGroundHeight = Spring.GetGroundHeight
-local spGetUnitPosition = Spring.GetUnitPosition
-local floor = math.floor
-local math_halfpi = math.pi / 2
+local halfPi = math.pi / 2
 
-local sec = 0
-local lastUpdate = 0
-local reinit
+local reInitialize
 
 local numUnitShapes = 0
-local unitshapes = {}
-local removedUnitshapes = {}
-local command = {}
-local builderCommands = {}
-local createdUnitLocDefID = {}
-local createdUnitID = {}
-local newBuildCmdUnits = {}
+local unitShapes = {}
+local removedUnitShapes = {}
 
-local isBuilder = {}
-local unitWaterline = {}
-for udefID,def in ipairs(UnitDefs) do
-	if def.isBuilder and not def.isFactory and def.buildOptions[1] then
-		isBuilder[udefID] = true
-	end
-	if def.waterline and def.waterline > 0 then
-		unitWaterline[udefID] = def.waterline
-	end
-end
+local builderQueueAPI --- @type BuilderQueueApi
+local builderQueueApiCallbacks = {} --- @type BuilderQueueEventCallback[]
 
-local function addUnitShape(shapeID, unitDefID, px, py, pz, rotationY, teamID)
+-- Used to ensure proper display of submerged buildings
+local unitWaterlineMap = {}
+
+--- @param buildCommand BuildCommandEntry
+local function drawUnitShape(shapeId, unitDefId, groundHeight, buildCommand)
 	if not WG.DrawUnitShapeGL4 then
 		widget:Shutdown()
+	end
+	local px = buildCommand.positionX
+	local pz = buildCommand.positionZ
+	local rotationY = buildCommand.rotation and (buildCommand.rotation * halfPi) or 0
+	local teamId = buildCommand.teamId
+	local py = groundHeight
+
+	if numUnitShapes < maxUnitShapes and not removedUnitShapes[shapeId] then
+		unitShapes[shapeId] = WG.DrawUnitShapeGL4(unitDefId, px, py - 0.01, pz, rotationY, shapeOpacity, teamId)
+		numUnitShapes = numUnitShapes + 1
+		return unitShapes[shapeId]
 	else
-		if numUnitShapes < maxUnitShapes and not removedUnitshapes[shapeID] then
-			unitshapes[shapeID] = WG.DrawUnitShapeGL4(unitDefID, px, py-0.01, pz, rotationY, shapeOpacity, teamID)
-			numUnitShapes = numUnitShapes + 1
-			return unitshapes[shapeID]
-		else
-			return nil
-		end
+		return nil
 	end
 end
 
-local function removeUnitShape(shapeID)
+local function removeUnitShape(shapeId)
+	if not unitShapes[shapeId] then
+		return
+	end
 	if not WG.StopDrawUnitShapeGL4 then
 		widget:Shutdown()
-	elseif shapeID and unitshapes[shapeID] then
-		WG.StopDrawUnitShapeGL4(unitshapes[shapeID])
+	elseif shapeId and unitShapes[shapeId] then
+		WG.StopDrawUnitShapeGL4(unitShapes[shapeId])
 		numUnitShapes = numUnitShapes - 1
-		unitshapes[shapeID] = nil
-		removedUnitshapes[shapeID] = true	-- in extreme cases the delayed widget:UnitCommand processing is slower than the actual UnitCreated/Finished, this table is to make sure a unitshape isnt created after
+		unitShapes[shapeId] = nil
+		removedUnitShapes[shapeId] = true
 	end
 end
 
-local function clearbuilderCommands(unitID)
-	if builderCommands[unitID] then
-		for id, _ in pairs(builderCommands[unitID]) do
-			if command[id] and command[id][unitID] then
-				command[id][unitID] = nil
-				command[id].builders = command[id].builders - 1
-				if command[id].builders == 0 then
-					command[id] = nil
-					removeUnitShape(id)
-				end
-			end
-		end
-		builderCommands[unitID] = nil
+-- Event handlers for API notifications
+--- @param id string
+--- @param buildCommand BuildCommandEntry
+local function onBuildCommandAdded(id, buildCommand)
+	if unitShapes[id] or removedUnitShapes[id] then
+		return
 	end
+	local unitDefId = buildCommand.unitDefId
+	local groundHeight = spGetGroundHeight(buildCommand.positionX, buildCommand.positionZ)
+	if unitWaterlineMap[unitDefId] then
+		groundHeight = math.max(groundHeight, -1 * unitWaterlineMap[unitDefId])
+	end
+	drawUnitShape(id, unitDefId, groundHeight, buildCommand)
 end
 
-local function checkBuilder(unitID)
-	local queueDepth = spGetUnitCommandCount(unitID)
-	if queueDepth and queueDepth > 0 then
-		local queue = spGetUnitCommands(unitID, math.min(queueDepth, maxQueueDepth))
-		for i=1, #queue do
-			local cmd = queue[i]
-			if cmd.id < 0 then
-				local myCmd = {
-					id = -cmd.id,
-					teamid = spGetUnitTeam(unitID),
-					params = cmd.params
-				}
-				local id = math.abs(cmd.id)..'_'..floor(cmd.params[1])..'_'..floor(cmd.params[3])
-				if createdUnitLocDefID[id] == nil then
-					if command[id] == nil then
-						command[id] = {id = myCmd, builders = 0}
-						local unitDefID = math.abs(cmd.id)
+local function onBuildCommandRemoved(commandId)
+	removeUnitShape(commandId)
+end
 
-						local groundheight = spGetGroundHeight(floor(cmd.params[1]), floor(cmd.params[3]))
-						if unitWaterline[unitDefID] then
-							groundheight = math.max (groundheight, -1 * unitWaterline[unitDefID])
-						end
-						addUnitShape(id, math.abs(cmd.id), floor(cmd.params[1]), groundheight, floor(cmd.params[3]), cmd.params[4] and (cmd.params[4] * math_halfpi) or 0, myCmd.teamid)
-					end
-					if not command[id][unitID] then
-						command[id][unitID] = true
-						command[id].builders = command[id].builders + 1
-					end
-					if builderCommands[unitID] == nil then
-						builderCommands[unitID] = {}
-					end
-					builderCommands[unitID][id] = true
-				end
-			end
-		end
-	else
-		clearbuilderCommands(unitID)
-	end
+local function onUnitCreated(_, _, commandId)
+	removeUnitShape(commandId)
+end
+
+local function onUnitFinished(_, commandId)
+	removeUnitShape(commandId)
 end
 
 function widget:Initialize()
 	if not WG.DrawUnitShapeGL4 then
 		widgetHandler:RemoveWidget()
 	else
-		widget:Shutdown()	-- to clear first
+		widget:Shutdown()    -- to clear first
 	end
 
-	unitshapes = {}
-	removedUnitshapes = {}
-	numUnitShapes = 0
-	builderCommands = {}
-	createdUnitLocDefID = {}
-	createdUnitID = {}
-	newBuildCmdUnits = {}
-	command = {}
-	local allUnits = Spring.GetAllUnits()
-	for i=1, #allUnits do
-		local unitID = allUnits[i]
-		if isBuilder[ spGetUnitDefID(unitID) ] then
-			checkBuilder(unitID)
+	if not WG.BuilderQueueApi then
+		error("API Builder Queue is disabled")
+		widget:Shutdown()
+		return
+	end
+
+	builderQueueAPI = WG.BuilderQueueApi
+
+	for unitDefId, unitDefinition in ipairs(UnitDefs) do
+		if unitDefinition.waterline and unitDefinition.waterline > 0 then
+			unitWaterlineMap[unitDefId] = unitDefinition.waterline
 		end
 	end
+
+	-- Register event callbacks
+	table.insert(builderQueueApiCallbacks, builderQueueAPI.OnBuildCommandAdded(onBuildCommandAdded))
+	table.insert(builderQueueApiCallbacks, builderQueueAPI.OnBuildCommandRemoved(onBuildCommandRemoved))
+	table.insert(builderQueueApiCallbacks, builderQueueAPI.OnUnitCreated(onUnitCreated))
+	table.insert(builderQueueApiCallbacks, builderQueueAPI.OnUnitFinished(onUnitFinished))
+
+	unitShapes = {}
+	removedUnitShapes = {}
+	numUnitShapes = 0
+
+	-- Initialize shapes for existing build commands
+	builderQueueAPI.ForEachActiveBuildCommand(function(commandId, commandData)
+		onBuildCommandAdded(commandId, commandData)
+	end)
 end
 
 function widget:Shutdown()
 	if WG.StopDrawUnitShapeGL4 then
-		for shapeID, _ in pairs(unitshapes) do
-			removeUnitShape(shapeID)
+		for shapeId, _ in pairs(unitShapes) do
+			removeUnitShape(shapeId)
 		end
 	end
-end
-
-function widget:PlayerChanged(playerID)
-	local prevFullview = fullview
-	_, fullview,_ = Spring.GetSpectatingState()
-	if playerID == myPlayerID and prevFullview ~= fullview then
-		for _, unitID in pairs(builderCommands) do
-			clearbuilderCommands(unitID)
-		end
-		reinit = true
+	for _, callbackData in ipairs(builderQueueApiCallbacks) do
+		builderQueueAPI.UnregisterCallback(callbackData.eventName, callbackData.callback)
 	end
 end
 
--- process newly given commands batched in Update() (because with huge build queue it eats memory and can crash lua)
-function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts, cmdTag, playerID, fromSynced, fromLua)
-	if isBuilder[unitDefID] then
-		clearbuilderCommands(unitID)
-		newBuildCmdUnits[unitID] = os.clock() + 0.13
+function widget:PlayerChanged(playerId)
+	local prevFullView = fullView
+	_, fullView, _ = Spring.GetSpectatingState()
+	if playerId == myPlayerId and prevFullView ~= fullView then
+		reInitialize = true
 	end
 end
-
-
 
 local prevGuiHidden = Spring.IsGUIHidden()
-local checkCount = 1
-function widget:Update(dt)
-	sec = sec + dt
+
+function widget:Update()
 	if not Spring.IsGUIHidden() then
-		if reinit then
-			reinit = nil
+		if reInitialize then
+			reInitialize = nil
 			widget:Initialize()
-		elseif sec > lastUpdate + 0.12 then
-			lastUpdate = sec
-
-			-- sometimes build commands are dropped because the building cant be placed anymore and are skipped (due to terrain height changes)
-			-- there is no engine feedback/callin as far as I know of that can detect this, so we'd have to check up periodically on all builders with a buildqueue
-			checkCount = checkCount + 1
-			for unitID, _ in pairs(builderCommands) do
-				if (unitID+checkCount) % 30 == 1 and not newBuildCmdUnits[unitID] then
-					checkBuilder(unitID)
-				end
-			end
-
-			-- process newly given commands (not done in widget:UnitCommand() because with huge build queue it eats memory and can crash lua)
-			local clock = os.clock()
-			for unitID, cmdClock in pairs(newBuildCmdUnits) do
-				if clock > cmdClock then
-					checkBuilder(unitID)
-					newBuildCmdUnits[unitID] = nil
-				end
-			end
-			removedUnitshapes = {}	-- in extreme cases the delayed widget:UnitCommand processing is slower than the actual UnitCreated/Finished, this table is to make sure a unitshape isnt created after
 		end
+		removedUnitShapes = {}
 	end
 	if Spring.IsGUIHidden() ~= prevGuiHidden then
 		prevGuiHidden = Spring.IsGUIHidden()
@@ -238,42 +182,3 @@ function widget:Update(dt)
 	end
 end
 
-function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
-	local x,_,z = spGetUnitPosition(unitID)
-	if x then
-		local udefLocID = unitDefID..'_'..floor(x)..'_'..floor(z)
-
-		if unitshapes[udefLocID] then
-			removeUnitShape(udefLocID)
-		end
-		command[udefLocID] = nil
-		-- we need to store all newly created units cause unitcreated can be earlier than our delayed processing of widget:UnitCommand (when a newly queued cmd is first and within builder range)
-		createdUnitLocDefID[udefLocID] = unitID
-		createdUnitID[unitID] = udefLocID
-	end
-end
-
-local function clearUnit(unitID)
-	if createdUnitID[unitID] then
-		local udefLocID = createdUnitID[unitID]
-		if unitshapes[udefLocID] then
-			removeUnitShape(udefLocID)
-		end
-		removedUnitshapes[udefLocID] = true		-- in extreme cases the delayed widget:UnitCommand processing is slower than the actual UnitCreated/Finished, this table is to make sure a unitshape isnt created after
-		command[udefLocID] = nil
-		createdUnitLocDefID[udefLocID] = nil
-		createdUnitID[unitID] = nil
-	end
-end
-
-function widget:UnitFinished(unitID, unitDefID, unitTeam)
-	clearUnit(unitID)
-end
-
-function widget:UnitDestroyed(unitID, unitDefID, unitTeam, builderID)
-	if isBuilder[unitDefID] then
-		newBuildCmdUnits[unitID] = nil
-		clearbuilderCommands(unitID)
-	end
-	clearUnit(unitID)
-end


### PR DESCRIPTION
`gfx_showbuilderqueue.lua`was responsible for tracking active build orders and displaying their building ghosts. I want to create another widget that also needs to track build orders, so I’ve extracted that logic into `api_builder_queue.lua`.

The API now handles build order tracking, while `gfx_showbuilderqueue`is only responsible for displaying the ghosts.

The only functional change is that previously, whenever a unit’s commands changed, all of its ghosts were redrawn. Now, only obsolete ghosts are removed. From the player’s perspective, there should be no visible difference in behavior.


#### Test steps
- [ ] Start a match with allied AI. Make some long build queues with various constructors. 
- [ ] The building ghosts should be visible for both player and allies.
- [ ] Cancel and/or modify the orders - the ghosts should update properly
- [ ] Destroy the builder in the middle of the queue - ghosts should be cleared
- [ ] Share the builder in the middle of the queue - ghosts should be still visible if builder continues the queue
- [ ] Open some 8v8 replay. You should see ghosts of both teams
- [ ] Enable Player View. You should see ghosts only of this player's team
