### PR TITLE
Added modoption to disable individual surrender for team games.

### DIFF
--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -54,6 +54,7 @@ local gameStarted = (Spring.GetGameFrame() > 0)
 local gameFrame = Spring.GetGameFrame()
 local gameIsOver = false
 local graphsWindowVisible = false
+local teamResignMode = Spring.GetModOptions().team_resign
 
 -- Resources
 local r = { metal = { spGetTeamResources(myTeamID, 'metal') }, energy = { spGetTeamResources(myTeamID, 'energy') } }
@@ -316,7 +317,7 @@ local function updateButtons()
 	else
 		addButton('quit', Spring.I18N('ui.topbar.button.quit'))
 	end
-	if not gameIsOver and not spec and gameStarted and not isSinglePlayer then
+	if not gameIsOver and not spec and gameStarted and not isSinglePlayer and not teamResignMode then
 		addButton('resign', Spring.I18N('ui.topbar.button.resign'))
 	end
 

--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -46,6 +46,7 @@ local weAreVoteOwner, hovered, voteName, windowArea, closeButtonArea, yesButtonA
 local voteEndTime, voteEndText
 
 local eligibleToVote = false
+local teamResignMode = Spring.GetModOptions().team_resign
 
 local votesRequired, votesEligible
 local votesCountYes = 0
@@ -424,6 +425,10 @@ function widget:AddConsoleLine(lines, priority)
 					local teamResignTarget = string.match(line, TEAM_RESIGN_VOTE_PATTERN)
 
 					local isIndividualResignVote = individualResignTarget ~= nil
+					if teamResignMode then
+						isIndividualResignVote = nil
+					end
+
 					local isTeamResignVote = teamResignTarget ~= nil
 
 					local isResignVote = isIndividualResignVote or isTeamResignVote

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -66,7 +66,15 @@ local options = {
         section	= "options_main",
         def    	= true,
     },
-
+    
+    {
+        key        = "team_resign",
+        name       = "Team Resign",
+        desc       = "Forbids individual resign when true",
+        type       = "bool",
+        def        = false,
+        section    = "options_main",
+    },
 
     {
         key    	= "allowuserwidgets",


### PR DESCRIPTION
Individual surrender currently instantly specs the player. I added a modoption to disable the individual resign button and overwrote the resign vote to not allow individual resign.

### Why?
When players get specced, they instantly get access to all info on the map. This is problematic for tournament settings where players can spec cheat over voice chats. Honor based rules are okay, but disabling the button is a better solution. 