### PR TITLE
Update cmd_context_build.lua (Changing Offshore TL land equivilant from LLT to Coastal TL + T1 AA equivilants + Legion updates)

### DIFF
--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -1,4 +1,3 @@
-
 local voidWater = false
 local waterLevel = Spring.GetModOptions().map_waterlevel
 local waterIsLava = Spring.Lava.isLavaMap
@@ -65,8 +64,8 @@ local unitlist = {
 	{'corsolar','cortide'},
 	{'armlab','armsy'},
 	{'corlab','corsy'},
-	{'armllt','armtl'},
-	{'corllt','cortl'},
+	{'armdl','armtl'},
+	{'cortl','cortl'},
 	{'armnanotc','armnanotcplat'},
 	{'cornanotc','cornanotcplat'},
 	{'armvp','armamsub'},
@@ -79,27 +78,36 @@ local unitlist = {
 	{'armageo','armuwageo'},
 	{'corgeo','coruwgeo'},
 	{'corageo','coruwageo'},
+	{'armferret','armfrock'},
+    {'cormadsam','corfrock'},
 }
 
 
-
 local legionUnitlist = {
+	{'legeconv','legfeconv'},
+	{'legmstor','leguwmstore'},
+	{'legestor','leguwestore'},
+	{'legdrag','legfdrag'},
+	{'legctl','legtl'},
+	{'legflak','corenaa'},
+	{'leggeo','leguwgeo'},
+	{'legageo','coruwageo'},
+	{'legmg','legfmg'},
 	--{'cormakr','legfmkr'},
 	--{'cordrag','corfdrag'},
 	--{'cormstor', 'coruwms'},
 	--{'corestor', 'coruwes'},
 	--{'legrl','corfrt'},--
 	{'leghp','legfhp'},
-	--{'legrad','corfrad'},--asym pairs cannot overlap with core placeholders
+	{'legrad','legfrad'},
 	--{'legmg','corfhlt'},--
 	--{'cortarg','corfatf'},
 	--{'cormmkr','coruwmmm'},
 	--{'corfus','coruwfus'},
 	--{'corflak','corenaa'},
-	--{'cormoho','coruwmme'},--does this combo actually manifest on anything...?
+	{'legmoho','coruwmme'},
 	{'legsolar','legtide'},
 	--{'leglab','corsy'},--soon(tm)
-	{'leglht','legtl'},
 	{'leghive', 'legfhive'},
 	--{'cornanotc','cornanotcplat'},
 	{'legvp','legamsub'},
@@ -294,5 +302,3 @@ function widget:Initialize()
 
 	for _,unitNames in ipairs(unitlist) do
 		addUnitDefPair(unitNames[1], unitNames[2])
-	end
-end

--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -110,7 +110,7 @@ local legionUnitlist = {
 	--{'leglab','corsy'},--soon(tm)
 	{'leghive', 'legfhive'},
 	--{'cornanotc','cornanotcplat'},
-	{'legvp','legamsub'},
+	{'legvp','legamphlab'},
 	--{'corap','corplat'},
 	--{'corasp','corfasp'},
 	--{'corgeo','coruwgeo'},

--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -65,7 +65,7 @@ local unitlist = {
 	{'armlab','armsy'},
 	{'corlab','corsy'},
 	{'armdl','armtl'},
-	{'cortl','cortl'},
+	{'cordl','cortl'},
 	{'armnanotc','armnanotcplat'},
 	{'cornanotc','cornanotcplat'},
 	{'armvp','armamsub'},


### PR DESCRIPTION


### Work done
Changed LLT -> Offshore TL  _to_ Coastal TL -> Offshore TL for Arm/Core/Leg 
Added Arm Ferret/Scumbag AA
Added Core Madsam/Janitor AA

Updated/Added Legions latest buildings and or current cores equivilant. E converter, Radar, Dragon Teeth, Bramble/Polybolos, Advanced Mex, Geo and Advanced Geo, Pluto/Birdshot, Cacophany/Gelasma

#### Test steps
- Test that LLT has no naval equivilant swap.
- Test that Offshore/Coastal Torpedo Launchers switch type automatically
- Test Arm Ferret/Scumbag, Madsam/Janitor
- Test Legion Econverter/radar/dragonteeth/bramble/amex/geo/ageo/pluto/cacophany