### PR TITLE
Update cmd_guard_remove.lua to support Anti-nuke ships ability to chain guard commands.

### DIFF
--- a/luaui/Widgets/cmd_guard_remove.lua
+++ b/luaui/Widgets/cmd_guard_remove.lua
@@ -34,7 +34,7 @@ local updateTime = 0
 
 local validUnit = {}
 for udid, ud in pairs(UnitDefs) do
-	validUnit[udid] = ud.isBuilder and not ud.isFactory
+	validUnit[udid] = ud.isBuilder and ud.canRepair and not ud.isFactory
 end
 
 function widget:UnitCommand(unitID, unitDefID, _, _, _, cmdOpts, _, _, _, _)


### PR DESCRIPTION
Related to: https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3062

Added check for if unit can repair, so that units such as Anti Nuke ships that require builder parameter but no repair can be guard command chained.

Test chaining guard commands with Anti-nuke ships and ensure it behaves like the rest of the navy and not like a repair guard.
