### PR TITLE
refactor(ShowOrders + Blast Radius): Unhardcode and fix show orders

### DIFF
--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -12,7 +12,12 @@ bind                esc  customgameinfo_close
 bind                esc  buildmenu_pregame_deselect
 bind      Alt+backspace  fullscreen
 
-// common selectbox keys
+
+// common widget modifiers
+//_
+
+//   selectbox
+//___
 bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
 bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget
 bind          Any+shift  selectbox_append   // append to selection modifier | Smart Select Widget
@@ -24,9 +29,29 @@ bind          Any+space  selectloop         // activate select shape | Loop Sele
 bind           Any+ctrl  selectloop_invert  // select units not present in current selection modifier | Loop Select Widget
 bind          Any+shift  selectloop_add     // add to selection modifier | Loop Select Widget
 
+//   buildsplit
+//___
 bind          Any+space  buildsplit         // activate build split mode (distribute orders between selected builders) | Build Split Widget
 
-// commandinsert keys
+//   show
+//___
+
+//     blast
+//_____
+
+// NOTE: Dumbass engine derps because when meta == space it does meta+shift+space
+// (adds the modifier)
+// See: https://github.com/beyond-all-reason/RecoilEngine/pull/1074
+bind any+space show blast next_queued_building
+bind meta+sc_x show blast selected
+
+//     orders
+//_____
+bind any+space show orders
+
+
+//   commandinsert
+//___
 bind          Any+space  commandinsert prepend_between // prepend command into the queue between 2 commands close to cursor
 // bind          Any+space  commandinsert prepend_queue // prepend command into a separate prepend queue until key released
 


### PR DESCRIPTION
Edit: Moved to draft to address some architectural inconsistencies (unrelated to the featureset of this PR, but to clean up a few things).

### Work done

Unhardcode bindings and refactor show orders logic.

Unhardcoded actions:

```
bind <key> show blast selected -> show blast radius of selected units
bind <key> show blast next_queued_building -> show blast radius of current selected building to be built
bind <key> show orders -> show allied units orders
```

#### Notes:

- show orders by default also draws allied buildings, this is not necessary if player has the option to show all queued orders (gfx_show_builder_queue does the same damn thing). This logic and unhardcoding should be moved to that widget instead so this widget only concerns itself with the lab drawings.
- modifier bindings need to be fixed in engine asap
- we now check if the unit is visible on show orders before drawing

#### Disclaimer:

I use [stylua](https://github.com/JohnnyMorganz/StyLua) formatter for lua, the convenience of having standardized formatting is a requirement for me. It's not an attempt to force BAR to use stylua, if any other formatter is decided as the convention to be used in BAR, that's completely fine, I'll use it.

It's a lot of friction, for me, who is used to always have some convention adhered to in most projects I work on, to realize later that I have to go and pick only the particular places to unformat when I realize. For cases where the change is minimal I keep it unformatted.

If there's a requirement to not have changes formatted, and BAR has no formatter used as convention, I'd rather close this PR and someone else is free to pull my changes unformatted (my only requirement is to add me as coauthor to the commit). 

#### Setup

- Start a skirmish with a nullai bot on the allyteam

- Select your teams commander again

#### Test steps

##### Action: `show orders`

- Disable the "show queue" or similarly named setting
- Give a lab to your team, queue a few different units with different counts
- `/cheat`, `/godmode`, control the bot teams commander to be assigned a big build queue
- Select your teams commander
- Verify: You can't see the queue of the bots commander
- Verify: You don't see any weird UI elements on top of your labs

- Press space
- Verify: The queue of the bots commander is drawn
- Verify: There are panes containing the units you queued and the current count on the queue on top of the labs

##### Action: `show blast selected`

- Have your current selection empty
- Press space+x
- Verify: there's no blinking range around the commander

- Select your commander
- Press space+x
- Verify: there's a blinking range around the commander

##### Action: `show blast next_queued_building`

- Select your commander
- Pick a building to be placed
- Verify: the drawn building ghost has no range around it

- Press space
- Verify: there's a red range around the building

- Redo the 2 steps above while placing many queued orders instead.
- Notice the red range is only drawn on the last item of the queue.

### Screenshots:

#### BEFORE:

broken.jpg

#### AFTER:

<img width="1548" height="699" alt="aaa250912_04h48m06s_screenshot" src="https://github.com/user-attachments/assets/d55646db-aee6-4210-862a-334f710594bf" />

