### PR TITLE
Fixed Infinite Loop with Raptors and Scavs

### DIFF
--- a/luarules/gadgets/ai_namer.lua
+++ b/luarules/gadgets/ai_namer.lua
@@ -129,9 +129,14 @@ if gadgetHandler:IsSyncedCode() then
 							end
 						end
 					end
-					if takenNames[aiName] == nil then
-						takenNames[aiName] = teamID
+
+					if raptor or scavenger then
 						confirmedAIName = aiName
+					else
+						if takenNames[aiName] == nil then
+							takenNames[aiName] = teamID
+							confirmedAIName = aiName
+						end
 					end
 				--end
 			until confirmedAIName ~= nil


### PR DESCRIPTION
Raptors and Scavengers were causing infinite loop in AI Namer when people added more than one of each, due to there only being one name available. Now it has an exception that allows it to pick the same name multiple times for these two AIs.

People are still not supposed to use more than one, but at least the game won't die.