### PR TITLE
New Gadget `unit_landspeedmultiplier` To Selectively Adjust Land and Sea Traversal Speeds Seperately

### DIFF
--- a/luarules/gadgets/unit_landspeedmultiplier.lua
+++ b/luarules/gadgets/unit_landspeedmultiplier.lua
@@ -68,8 +68,17 @@ if gadgetHandler:IsSyncedCode() then
                 acc   = ud.maxAcc,
                 dec   = ud.maxDec,
             }
-            -- Default to water speed when first created (safe assumption).
-            ApplySpeed(unitID, unitBaseStats[unitID], 1)
+
+            -- get unit position and ground height
+            local x, y, z = Spring.GetUnitPosition(unitID)
+            local groundHeight = Spring.GetGroundHeight(x, z)
+
+            -- if in water, default speed, if on land, speed up or slow down immediately
+            if groundHeight < 0 then
+                ApplySpeed(unitID, unitBaseStats[unitID], 1)
+            else
+                ApplySpeed(unitID, unitBaseStats[unitID], factor)
+            end
         end
     end
 

--- a/luarules/gadgets/unit_landspeedmultiplier.lua
+++ b/luarules/gadgets/unit_landspeedmultiplier.lua
@@ -1,0 +1,98 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+    return {
+        name      = "Land Speed Multiplier",
+        desc      = "Speeds up or slows down units on land compared to their default water speed.",
+        author    = "ZephyrSkies, with a lot of help from [BONELESS]/qscrew/efrec",
+        date      = "2025-09-14",
+        license   = "GNU GPL, v2 or later",
+        layer     = 0,
+        enabled   = true
+    }
+end
+
+-- units need to have the following customparam set for this to work properly:
+-- landspeedfactor (number, e.g. 0.5 = half speed on land, 1 = no change, 2 = double speed)
+
+if not gadgetHandler:IsSyncedCode() then return false end
+
+if gadgetHandler:IsSyncedCode() then
+
+    ---------------------------------------------------------------------------------------------
+    -- Setup and Data Storage -------------------------------------------------------------------
+
+    local unitDefsWithFactor = {}  -- unitDefID -> factor
+    local unitBaseStats = {}       -- unitID -> {speed, turnRate, accRate, decRate}
+    local SMC = Spring.MoveCtrl
+
+    ---------------------------------------------------------------------------------------------
+    -- store which units are affected -----------------------------------------------------------
+
+    -- this runs once when the gadget is loaded, checks units which have landspeedfactor, only runs once and only these units are then affected
+    for defID, ud in pairs(UnitDefs) do
+        local cp = ud.customParams or {}
+        if cp.landspeedfactor then
+            local factor = tonumber(cp.landspeedfactor)
+            if factor then
+                unitDefsWithFactor[defID] = factor
+            end
+        end
+    end
+
+    ---------------------------------------------------------------------------------------------
+    -- Helper Function --------------------------------------------------------------------------
+
+    -- uses maxSpeed and wantedMaxSpeed to make adjustments, grabs other variables too now
+    local function ApplySpeed(unitID, stats, factor)
+        SMC.SetGroundMoveTypeData(unitID, {
+            maxSpeed       = stats.speed   * factor,
+            maxWantedSpeed = stats.speed   * factor,
+            turnRate       = stats.turn    * factor,
+            accRate        = stats.acc     * factor,
+            decRate        = stats.dec     * factor,
+        })
+    end
+
+    ---------------------------------------------------------------------------------------------
+    -- Engine Callins ---------------------------------------------------------------------------
+
+    -- store the base movement values
+    function gadget:UnitCreated(unitID, unitDefID, teamID)
+        local factor = unitDefsWithFactor[unitDefID]
+        if factor then
+            local ud = UnitDefs[unitDefID]
+            unitBaseStats[unitID] = {
+                speed = ud.speed,
+                turn  = ud.turnRate,
+                acc   = ud.maxAcc,
+                dec   = ud.maxDec,
+            }
+            -- Default to water speed when first created (safe assumption).
+            ApplySpeed(unitID, unitBaseStats[unitID], 1)
+        end
+    end
+
+    -- allows units to go at full speed in water
+    function gadget:UnitEnteredWater(unitID, unitDefID, teamID)
+        local stats = unitBaseStats[unitID]
+        if stats then
+            ApplySpeed(unitID, stats, 1)
+        end
+    end
+
+    -- slows unit down on land
+    function gadget:UnitLeftWater(unitID, unitDefID, teamID)
+        local stats = unitBaseStats[unitID]
+        local factor = unitDefsWithFactor[unitDefID]
+        if stats and factor then
+            ApplySpeed(unitID, stats, factor)
+        end
+    end
+
+    -- clear stored values in case unitID is used again
+    function gadget:UnitDestroyed(unitID, unitDefID, teamID)
+        unitBaseStats[unitID] = nil
+    end
+
+end


### PR DESCRIPTION
### Work done
Introduces a new gadget called `unit_landspeedmultiplier` which takes the base maxSpeed value assigned to a unit inside their unitDef and uses a custom parameter called `landspeedfactor` (default set to 1.0) to determine what percent the unit should speed up or slow down on land. It is only useful for units that can traverse across both land and sea, such as hovercrafts and Platypuses, which help slow them down when they are on land such that other factors for their balance can be made stronger in compensation for reduced traversal speed on land compared to water (where ships require better stats as a base as standard to fight against effectively).

This gadget does not affect how units that traverse *underwater* behave. Only over water.

#### Addresses Issue(s)
- Previously, there was no way to force units to move at different speeds on land and across water, not even with moveDefs. Introduces ways to help better balance units that cross both land and water without being locked onto one specific traversal speed.

#### Setup
Provide any unit with the customParam field `landspeedfactor` and set it to any value. Right now, only units with HOVER movedefs are eligible.

#### Test steps
- [ ] Add `landspeedfactor` value from -10.0 to 10.0 (there is no actual limit)
- [ ] Check and see if the unit is faster or slower on land appropriately
- [ ] Check and see if the unit properly transitions to the faster/slower assigned speed when crossing the threshold between land and water.
- [ ] Check and see if the unit properly transitions when being given various commands and various combinations and frequency of them to see if the speed transition is ever interrupted.

#### Video:
https://github.com/user-attachments/assets/32bbeb24-69ab-4f24-a754-4003456cf47b

