### PR TITLE
Fix cleanup of unloaded units in prevent unload gadget

### DIFF
--- a/luarules/gadgets/unit_prevent_unload_hax.lua
+++ b/luarules/gadgets/unit_prevent_unload_hax.lua
@@ -68,7 +68,7 @@ function gadget:GameFrame(frame)
             SpSetUnitPhysics(unitID,data.px,data.py,data.pz,0,0,0,0,0,0,0,0,0)
             SpSetUnitDirection(unitID,data.dx,data.dy,data.dz)
             --Spring.GiveOrderToUnit(unitID,CMD.MOVE,{data.px+10*data.dx,data.py,data.pz+10*data.dz},CMD.OPT_SHIFT)
-            data = nil
+            unloadedUnits[unitID] = nil
         end
     end
 end


### PR DESCRIPTION
### Work done
- Drop stale entries from unloadedUnits after the velocity reset so the gadget stops iterating residual state every frame.

#### Test steps
- [ ] Start a skirmish with a transport that can unload a ground unit.
- [ ] Unload the unit onto the ground and confirm it only has its physics reset once (no repeated velocity zeroing on subsequent frames).