### PR TITLE
Update proposed_unit_reworks_defs.lua

### DIFF
--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -109,6 +109,10 @@ local function proposed_unit_reworksTweaks(name, uDef)
 		uDef.metalcost = math.ceil(uDef.metalcost * 1.1 / 5) * 5
 	end
 
+	if name == "armspy" or name == "corspy" then
+		uDef.buildtime = 12000
+	end
+
 	return uDef
 end
 

--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -19,7 +19,7 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	or name == "coraap" or name == "coralab" or name == "corasy" or name == "coravp"
 	then
 		uDef.metalcost = uDef.metalcost - 300
-		uDef.buildtime = uDef.buildtime * 2
+		uDef.buildtime = uDef.buildtime * 1.5
 		uDef.workertime = uDef.workertime * 2
 	end
 
@@ -68,7 +68,7 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	if name == "armmoho" or name == "armuwmme"
 	or name == "cormoho" or name == "coruwmme"
 	then
-		uDef.metalcost = math.ceil(uDef.metalcost * 0.12) * 10
+		--uDef.metalcost = math.ceil(uDef.metalcost * 0.12) * 10
 		uDef.energycost = math.ceil(uDef.energycost * 0.012) * 100
 		uDef.buildtime = math.ceil(uDef.buildtime * 0.0012) * 1000 
 	end
@@ -83,6 +83,30 @@ local function proposed_unit_reworksTweaks(name, uDef)
 
 	if name == "armshltxuw" or name == "armshltx" or name == "corgantuw" or name == "corgant" then
 		uDef.workertime = 1800
+	end
+	
+	if name == "corgol" then
+		uDef.speed = 37
+		uDef.weapondefs.cor_gol.reloadtime = 3.5
+	end
+	if name == "armfboy" then
+		uDef.weapondefs.arm_fatboy_notalaser.edgeeffectiveness = 0.15
+	end
+	if name == "armmart" then
+		uDef.weapondefs.arm_artillery.edgeeffectiveness = 0.15
+		uDef.weapondefs.arm_artillery.accuracy = 0
+	end
+	if name == "cormart" then
+		uDef.weapondefs.cor_artillery.edgeeffectiveness = 0.15
+		uDef.weapondefs.cor_artillery.accuracy = 0
+	end
+	if name == "cormort" then
+		uDef.energycost = 2800
+		uDef.metalcost = 400
+	end
+
+	if name == "armrectr" or name == "cornecro" or name == "armconsul" or name == "armfark" or name == "corfast" then
+		uDef.metalcost = math.ceil(uDef.metalcost * 1.1 / 5) * 5
 	end
 
 	return uDef


### PR DESCRIPTION
- Lower T2 factory buildtimes 2x -> 1.5x of vanilla
- Remove metalcost raise for T2 mex. E/BT cost is still 1.2x vanilla.
- Rezbots and combat engineers metalcost +10%

Combat unit changes:

- [Sheldon] 2200 -> 2800 energycost, 410 -> 400 metalcost 
- [Tzar] 3s -> 3.5s reloadtime, 40.5 -> 37 speed
- [Quaker, Mauser] 0.65 -> 0.15 edgeeffectiveness, base inaccuracy removed
- [Fatboy] 0.85 -> 0.15 edgeeffectiveness
- [Spybots] 17600 / 22200 -> 12000 buildtime, change overrides the buildtime formula for them

