### PR TITLE
Resurrected units wait

### DIFF
--- a/luarules/gadgets/unit_resurrected.lua
+++ b/luarules/gadgets/unit_resurrected.lua
@@ -28,9 +28,9 @@ if (gadgetHandler:IsSyncedCode()) then
 		if builderID and canResurrect[Spring.GetUnitDefID(builderID)] then
 			if not Spring.Utilities.Gametype.IsScavengers() then
 				Spring.SetUnitRulesParam(unitID, "resurrected", 1, {inlos=true})
-				Spring.GiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
 			end
 			Spring.SetUnitHealth(unitID, Spring.GetUnitHealth(unitID) * 0.05)
+			Spring.GiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
 		end
 		-- See: https://github.com/beyond-all-reason/spring/pull/471
 		-- if builderID and Spring.GetUnitCurrentCommand(builderID) == CMD.RESURRECT then

--- a/luarules/gadgets/unit_resurrected.lua
+++ b/luarules/gadgets/unit_resurrected.lua
@@ -12,6 +12,8 @@ function gadget:GetInfo()
     }
 end
 
+local CMD_WAIT = CMD.WAIT
+
 if (gadgetHandler:IsSyncedCode()) then
 
     local canResurrect = {}
@@ -26,6 +28,7 @@ if (gadgetHandler:IsSyncedCode()) then
 		if builderID and canResurrect[Spring.GetUnitDefID(builderID)] then
 			if not Spring.Utilities.Gametype.IsScavengers() then
 				Spring.SetUnitRulesParam(unitID, "resurrected", 1, {inlos=true})
+				Spring.GiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
 			end
 			Spring.SetUnitHealth(unitID, Spring.GetUnitHealth(unitID) * 0.05)
 		end


### PR DESCRIPTION
Makes newly resurrected units wait. This prevents them from roaming away from the repairing resurrection bot if the resurrected unit inherited a roam state, or use roam as default through the state_prefs widget. 

After:
https://github.com/user-attachments/assets/438ce07d-d757-45b3-9a4e-bf321fe86198

