### PR TITLE
Airpads soft removal fix

### DIFF
--- a/units/CorBots/T2/corack.lua
+++ b/units/CorBots/T2/corack.lua
@@ -52,7 +52,6 @@ return {
 			"corarad",
 			"corshroud",
 			"corfort",
-			"corasp",
 			"cortarg",
 			"corsd",
 			"corgate",


### PR DESCRIPTION
Zephyr missed corack buildlist change in https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5765 .

This fixes it so cortex t2 bot constructor can't make airpads anymore.