### PR TITLE
Fix undo gadget victim name lookup

### DIFF
--- a/luarules/gadgets/cmd_undo.lua
+++ b/luarules/gadgets/cmd_undo.lua
@@ -210,7 +210,7 @@ if gadgetHandler:IsSyncedCode() then
 	function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponID, projectileID, attackerID, attackerDefID, attackerTeam)
 		if safeguardedUnits[unitDefID] and attackerTeam and Spring.AreTeamsAllied(unitTeam, attackerTeam) then
 			if dgunDef[weaponID] or weaponUnitSelfd[weaponID] or not Spring.GetUnitNearestEnemy(unitID, 1000) then
-				local _, playerID, _, victimIsAi = Spring.GetTeamInfo(attackerTeam, false)
+				local _, playerID, _, victimIsAi = Spring.GetTeamInfo(unitTeam, false)
 				local name = Spring.GetPlayerInfo(playerID,false)
 				if victimIsAi and Spring.GetGameRulesParam('ainame_' .. unitTeam) then
 					name = Spring.GetGameRulesParam('ainame_' .. unitTeam)..' (AI)'


### PR DESCRIPTION
### Work done
- Correct undo gadget spectator alerts using the attacker's team info when retrieving the victim's player name.

#### Test steps
- [ ] Spectate a session with undo permissions, cause an allied safeguarded unit to be attacked (e.g. DGun a fusion), observe the alert uses the owning player's name rather than the attacker. (Not run; requires multiplayer environment.)
