### PR TITLE
Reduce # of local variables in gui_top_bar.lua

### DIFF
--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -103,13 +103,15 @@ local GL_ONE_MINUS_SRC_ALPHA = GL.ONE_MINUS_SRC_ALPHA
 local GL_ONE = GL.ONE
 
 -- Graphics
-local noiseBackgroundTexture = ":g:LuaUI/Images/rgbnoise.png"
-local barGlowCenterTexture = ":l:LuaUI/Images/barglow-center.png"
-local barGlowEdgeTexture = ":l:LuaUI/Images/barglow-edge.png"
-local energyGlowTexture = "LuaUI/Images/paralyzed.png"
-local bladesTexture = ":n:LuaUI/Images/wind-blades.png"
-local wavesTexture = ":n:LuaUI/Images/tidal-waves.png"
-local comTexture = ":n:Icons/corcom.png"
+local textures = {
+	noiseBackground = ":g:LuaUI/Images/rgbnoise.png",
+	barGlowCenter = ":l:LuaUI/Images/barglow-center.png",
+	barGlowEdge = ":l:LuaUI/Images/barglow-edge.png",
+	energyGlow = "LuaUI/Images/paralyzed.png",
+	blades = ":n:LuaUI/Images/wind-blades.png",
+	waves = ":n:LuaUI/Images/tidal-waves.png",
+	com = ":n:Icons/corcom.png"
+}
 local textWarnColor = "\255\255\215\215"
 
 -- UI Elements
@@ -359,7 +361,7 @@ local function updateComs(forceText)
 		-- Commander icon
 		local sizeHalf = (height / 2.44) * widgetScale
 		local yOffset = ((area[3] - area[1]) * 0.025)
-		glTexture(comTexture)
+		glTexture(textures.com)
 		glTexRect(area[1] + ((area[3] - area[1]) / 2) - sizeHalf, area[2] + ((area[4] - area[2]) / 2) - sizeHalf +yOffset, area[1] + ((area[3] - area[1]) / 2) + sizeHalf, area[2] + ((area[4] - area[2]) / 2) + sizeHalf+yOffset)
 		glTexture(false)
 
@@ -417,7 +419,7 @@ local function updateWind()
 		glPushMatrix()
 		glTranslate(area[1] + ((area[3] - area[1]) / 2), area[2] + (bgpadding/2) + ((area[4] - area[2]) / 2), 0)
 		glColor(1, 1, 1, 0.2)
-		glTexture(bladesTexture)
+		glTexture(textures.blades)
 		-- glRotate is done after displaying this dl, and before dl2
 	end)
 
@@ -483,7 +485,7 @@ local function updateTidal()
 
 	tidaldlist2 = glCreateList(function()
 		glColor(1, 1, 1, 0.2)
-		glTexture(wavesTexture)
+		glTexture(textures.waves)
 		glTexRect(-wavesSize, -wavesSize, wavesSize, wavesSize)
 		glTexture(false)
 		glPopMatrix()
@@ -738,7 +740,7 @@ local function updateResbar(res)
 		local borderSize = 1
 		RectRound(barArea[1] - edgeWidth + borderSize, barArea[2] - edgeWidth + borderSize, barArea[3] + edgeWidth - borderSize, barArea[4] + edgeWidth - borderSize, barHeight * 0.2, 1, 1, 1, 1, { 0,0,0, 0.1 }, { 0,0,0, 0.13 })
 
-		glTexture(noiseBackgroundTexture)
+		glTexture(textures.noiseBackground)
 		glColor(1,1,1, 0.16)
 		TexturedRectRound(barArea[1] - edgeWidth, barArea[2] - edgeWidth, barArea[3] + edgeWidth, barArea[4] + edgeWidth, barHeight * 0.33, 1, 1, 1, 1, barWidth*0.33, 0)
 		glTexture(false)
@@ -851,15 +853,15 @@ local function updateResbarValues(res, update)
 				-- Bar value glow
 				glBlending(GL_SRC_ALPHA, GL_ONE)
 				glColor(resbarDrawinfo[res].barColor[1], resbarDrawinfo[res].barColor[2], resbarDrawinfo[res].barColor[3], glowAlpha)
-				glTexture(barGlowCenterTexture)
+				glTexture(textures.barGlowCenter)
 				DrawRect(resbarDrawinfo[res].barGlowMiddleTexRect[1], resbarDrawinfo[res].barGlowMiddleTexRect[2], resbarDrawinfo[res].barGlowMiddleTexRect[1] + valueWidth, resbarDrawinfo[res].barGlowMiddleTexRect[4], 0.008)
-				glTexture(barGlowEdgeTexture)
+				glTexture(textures.barGlowEdge)
 				DrawRect(resbarDrawinfo[res].barGlowLeftTexRect[1], resbarDrawinfo[res].barGlowLeftTexRect[2], resbarDrawinfo[res].barGlowLeftTexRect[3], resbarDrawinfo[res].barGlowLeftTexRect[4], 0.008)
 				DrawRect((resbarDrawinfo[res].barGlowMiddleTexRect[1] + valueWidth) + (glowSize * 3), resbarDrawinfo[res].barGlowRightTexRect[2], resbarDrawinfo[res].barGlowMiddleTexRect[1] + valueWidth, resbarDrawinfo[res].barGlowRightTexRect[4], 0.008)
 				glTexture(false)
 
 				if res == 'metal' then
-					glTexture(noiseBackgroundTexture)
+					glTexture(textures.noiseBackground)
 					glColor(1,1,1, 0.37)
 					TexturedRectRound(resbarDrawinfo[res].barTexRect[1], resbarDrawinfo[res].barTexRect[2], resbarDrawinfo[res].barTexRect[1] + valueWidth, resbarDrawinfo[res].barTexRect[4], barSize, 1, 1, 1, 1, barWidth*0.33, 0)
 					glTexture(false)
@@ -877,7 +879,7 @@ local function updateResbarValues(res, update)
 				-- energy flow effect
 				glColor(1,1,1, 0.33)
 				glBlending(GL_SRC_ALPHA, GL_ONE)
-				glTexture(energyGlowTexture)
+				glTexture(textures.energyGlow)
 				TexturedRectRound(resbarDrawinfo[res].barTexRect[1], resbarDrawinfo[res].barTexRect[2], resbarDrawinfo[res].barTexRect[1] + valueWidth, resbarDrawinfo[res].barTexRect[4], barSize, 0, 0, 1, 1, barWidth/0.5, -now/80)
 				TexturedRectRound(resbarDrawinfo[res].barTexRect[1], resbarDrawinfo[res].barTexRect[2], resbarDrawinfo[res].barTexRect[1] + valueWidth, resbarDrawinfo[res].barTexRect[4], barSize, 0, 0, 1, 1, barWidth/0.33, now/70)
 				TexturedRectRound(resbarDrawinfo[res].barTexRect[1], resbarDrawinfo[res].barTexRect[2], resbarDrawinfo[res].barTexRect[1] + valueWidth, resbarDrawinfo[res].barTexRect[4], barSize, 0, 0, 1, 1, barWidth/0.45,-now/55)
@@ -976,7 +978,7 @@ local function checkSelfStatus()
 	myTeamID = Spring.GetMyTeamID()
 
 	if myTeamID ~= gaiaTeamID and UnitDefs[Spring.GetTeamRulesParam(myTeamID, 'startUnit')] then
-		comTexture = ':n:Icons/'..UnitDefs[Spring.GetTeamRulesParam(myTeamID, 'startUnit')].name..'.png'
+		textures.com = ':n:Icons/'..UnitDefs[Spring.GetTeamRulesParam(myTeamID, 'startUnit')].name..'.png'
 	end
 end
 
@@ -2125,7 +2127,7 @@ function widget:Initialize()
 	if teamN > 2 then displayComCounter = true end
 
 	if UnitDefs[Spring.GetTeamRulesParam(Spring.GetMyTeamID(), 'startUnit')] then
-		comTexture = ':n:Icons/'..UnitDefs[Spring.GetTeamRulesParam(Spring.GetMyTeamID(), 'startUnit')].name..'.png'
+		textures.com = ':n:Icons/'..UnitDefs[Spring.GetTeamRulesParam(Spring.GetMyTeamID(), 'startUnit')].name..'.png'
 	end
 
 	for _, teamID in ipairs(myAllyTeamList) do


### PR DESCRIPTION
It is currently at exactly 200 local variables. Refactored textures into a table and updated their references to match.

Testing steps: Run the game, look at the top bar displaying the economy information and make sure everything is there.

<img width="1050" height="345" alt="image" src="https://github.com/user-attachments/assets/ce1da4f9-5c32-4f4a-935e-53e71ff046a5" />
Looks aight