### PR TITLE
Display reactive shield stats

### DIFF
--- a/common/springFunctions.lua
+++ b/common/springFunctions.lua
@@ -5,6 +5,7 @@ local team = VFS.Include(utilitiesDirectory .. 'teamFunctions.lua')
 local syncFunctions = VFS.Include(utilitiesDirectory .. 'synced.lua')
 local tableFunctions = VFS.Include(utilitiesDirectory .. 'tableFunctions.lua')
 local colorFunctions = VFS.Include(utilitiesDirectory .. 'color.lua')
+local scriptFunctions = VFS.Include(utilitiesDirectory .. 'unitScripts.lua')
 
 local utilities = {
 	LoadTGA = tga.LoadTGA,
@@ -36,6 +37,10 @@ local utilities = {
 
 	Color = colorFunctions,
 }
+
+for name, func in pairs(scriptFunctions) do
+	utilities[name] = func
+end
 
 local debugUtilities = VFS.Include(utilitiesDirectory .. 'debug.lua')
 

--- a/common/springUtilities/unitScripts.lua
+++ b/common/springUtilities/unitScripts.lua
@@ -1,0 +1,273 @@
+-- Various helpers for bridging the gap in unit data between defs and scripts.
+
+---Based on C-style comments, so maybe I am assuming wrong.
+local function removeComments(content)
+	local n = #content
+	local i = 1
+	local output = {}
+
+	local escape = "\\"
+	local line_feed = "\n"
+	local line_return = "\r"
+	local line_ends = { [line_feed] = true, [line_return] = true }
+	local quotes = { ['"'] = true, ["'"] = true }
+
+	local insert = table.insert
+	local function current() return string.sub(content, i, i) end
+	local function starts_with(s)
+		return string.sub(content, i, i + #s - 1) == s
+	end
+
+	while i <= n do
+		local ch = current()
+
+		-- Literals
+		if quotes[ch] then
+			local quote = ch
+			insert(output, quote)
+			i = i + 1
+			while i <= n do
+				local c = current()
+				insert(output, c)
+				i = i + 1
+				if c == escape then
+					if i <= n then
+						insert(output, current())
+						i = i + 1
+					end
+				elseif c == quote then
+					break
+				end
+			end
+
+		elseif starts_with("//") then
+			-- Single-line comment
+			i = i + 2
+			while i <= n do
+				local c = current()
+				i = i + 1
+				if c == line_return then
+					insert(output, line_return)
+					if i <= n and current() == line_feed then
+						insert(output, line_feed)
+						i = i + 1
+					end
+					break
+				elseif c == line_feed then
+					insert(output, line_feed)
+					break
+				end
+			end
+
+		elseif starts_with("/*") then
+			-- Multi-line comment
+			i = i + 2
+			while i <= n do
+				if starts_with("*/") then
+					i = i + 2
+					break
+				else
+					local c = current()
+					if line_ends[c] then
+						insert(output, c)
+					end
+					i = i + 1
+				end
+			end
+		else
+			insert(output, ch)
+			i = i + 1
+		end
+	end
+
+	return table.concat(output)
+end
+
+---Test whether a unit's script is COB, as opposed to LUS.
+---@param unitDef table
+---@return boolean
+local function isUnitScriptCOB(unitDef)
+	local scriptName = unitDef.scriptName
+	return scriptName and scriptName:lower():find(".cob$") and true or false
+end
+
+---Test whether a unit's script is LUS, as opposed to COB.
+---@param unitDef table
+---@return boolean
+local function isUnitScriptLUS(unitDef)
+	local scriptName = unitDef.scriptName
+	return scriptName and scriptName:lower():find(".lua$") and true or false
+end
+
+local function getUnitScriptFile(unitDef)
+	local scriptName
+	if isUnitScriptCOB(unitDef) then
+		scriptName = unitDef.scriptName:lower():gsub(".cob$", ".bos")
+	else
+		scriptName = unitDef.scriptName
+	end
+	if scriptName and VFS.FileExists(scriptName) then
+		return scriptName
+	end
+end
+
+---Test whether a unit's unit script contains a given method or methods.
+--
+-- Units can do this with `GetScriptEnv`, for example. It's harder with UnitDefs.
+--
+-- Returns a more detailed table showing what methods exist and which are called
+-- within the unit's script to help with diagnosing scripts that never trigger.
+---@param unitDef table
+---@param ... string
+---@return boolean allTrue
+---@return table? report when methods are either not found or not called directly
+local function hasScriptMethod(unitDef, ...)
+	local scriptName = getUnitScriptFile(unitDef)
+
+	if not scriptName then
+		return false
+	end
+
+	-- We may need to load more files, e.g. any includes.
+	local files = { scriptName }
+
+	local methods = { ... }
+	if not next(methods) then
+		return false
+	end
+	local hasMethod = {}
+	local useMethod = {}
+	local hasMethodPattern = {}
+	local useMethodPattern = {}
+
+	-- Must not match lines like "//use call-script DeathAnim(); from Killed()"
+	-- though such a comment pretty strongly implies these methods are present.
+	local path = [[^#include "([^"]+])"]]
+
+	if isUnitScriptCOB(unitDef) then
+		for i, name in ipairs(methods) do
+			hasMethod[i] = false
+			useMethod[i] = false
+			-- double-escape symbols that need to be escaped after formatting:
+			hasMethodPattern[i] = ("^%%s*%s%%("):format(name)
+			useMethodPattern[i] = ("^%%s*%%a+-script %s%%([^%%)]*%%);"):format(name)
+		end
+	elseif isUnitScriptLUS(unitDef) then
+		for i, name in ipairs(methods) do
+			hasMethod[i] = false
+			useMethod[i] = false
+			hasMethodPattern[i] = ("f[%%a]function %s%%s?%%("):format(name)
+			useMethodPattern[i] = ("f[%%a]%s%%("):format(name)
+		end
+	else
+		return false
+	end
+
+	local index = 1
+	local file = files[index]
+	while file ~= nil do
+		index = index + 1
+		local data = VFS.LoadFile(file)
+		if data then
+			data = removeComments(data)
+			for _, line in ipairs(string.lines(data)) do
+				for i = 1, #methods do
+					if not hasMethod[i] and line:find(hasMethodPattern[i]) then
+						hasMethod[i] = true
+					end
+					if not useMethod[i] and line:find(useMethodPattern[i]) then
+						useMethod[i] = true
+					end
+
+					local _, _, include = line:find(path)
+					if include and not table.getKeyOf(files, include:lower()) then
+						files[#files + 1] = include:lower()
+					end
+				end
+			end
+		end
+		file = files[index]
+	end
+
+	local function setTrue(value)
+		return value == true
+	end
+
+	if table.all(hasMethod, setTrue) and table.all(useMethod, setTrue) then
+		return true
+	else
+		local report = {}
+		for i = 1, #methods do
+			report[methods[i]] = {
+				exists = hasMethod[i],
+				called = useMethod[i],
+			}
+		end
+		return false, report
+	end
+end
+
+---Test whether a unit's unit script contains a death animation sequence.
+---@param unitDef table
+---@return boolean
+local function hasDeathAnimation(unitDef)
+	local _, methods = hasScriptMethod(unitDef, "Killed", "DeathAnim")
+	-- We rely on the Killed method but do not need it to be called:
+	if methods and methods.Killed.exists and methods.DeathAnim.called then
+		return true
+	else
+		return false
+	end
+end
+
+---Test whether a unit's unit script contains reactive armor variables.
+---@param unitDef table
+---@return boolean
+---@return integer? armorHealth
+---@return integer? armorRecoverTime
+local function hasReactiveArmor(unitDef)
+	if hasScriptMethod(unitDef, "repairShield") then
+		local scriptName = getUnitScriptFile(unitDef)
+		local content = removeComments(VFS.LoadFile(scriptName))
+
+		local health = 0
+		for _, var in ipairs { "tdamage", "ldamage", "rdamage" } do
+			-- We do what we can just to find a matching variable:
+			local _, _, capture = content:find(var .. " > (%d+)")
+			if capture then
+				health = tonumber(capture) / 100
+			end
+		end
+
+		local recover = 0
+		local inMethod = false
+		for _, line in ipairs(string.lines(content)) do
+			if not inMethod and line:find("^repairShield%(%)") then
+				inMethod = true
+			end
+			if inMethod then
+				if line == "}" then
+					break
+				end
+				local _, _, duration = line:find("sleep (%d+)")
+				if duration then
+					recover = recover + tonumber(duration) / 1000 -- from ms
+				end
+			end
+		end
+
+		health = math.floor(health + 0.5)
+		recover = math.floor(recover + 0.5)
+		return true, health, recover
+	end
+	return false
+end
+
+return {
+	IsUnitScriptCOB   = isUnitScriptCOB,
+	IsUnitScriptLUS   = isUnitScriptLUS,
+	GetUnitScriptFile = getUnitScriptFile,
+	HasScriptMethod   = hasScriptMethod,
+	HasDeathAnimation = hasDeathAnimation,
+	HasReactiveArmor  = hasReactiveArmor,
+}

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -486,6 +486,10 @@ local function drawStats(uDefID, uID)
 
 		if armoredMultiple and armoredMultiple ~= 1 then
 			DrawText(texts.closed..":", format(" +%d%%, "..texts.maxhp..": %d", (1/armoredMultiple-1) *100,maxHP/armoredMultiple))
+
+			if uDef.armorHealth then
+				DrawText("Reactive:", format("%d "..texts.health..", %ds recovery", uDef.armorHealth, uDef.armorRecoverTime))
+			end
 		end
 	end
 

--- a/luaui/setupdefs.lua
+++ b/luaui/setupdefs.lua
@@ -32,6 +32,15 @@ for _,ud in pairs(UnitDefs) do
 			if (wd.waterWeapon) then ud.canAttackWater = true end
 		end
 	end
+
+	-- precalculate some gui values
+	if ud.armoredMultiple ~= 1 and ud.armoredMultiple ~= 0 then
+		local reactive, armorHealth, recoverTime = Spring.Utilities.HasReactiveArmor(ud)
+		if reactive then
+			ud.armorHealth = armorHealth
+			ud.armorRecoverTime = recoverTime
+		end
+	end
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### Work done

- Added some unit script functions to Spring.Utilities.
- Added `armorHealth` and `armorRecoveryTime` properties to the unit defs in widgets.
- Displayed these values in the unit stats popout.

The .bos files could be regularized for easier parsing, e.g. the armor health especially could use a named variable. I opted not to touch the scripts.

This is not good data handling, _but_ it is a constant complaint of players that they do not understand (and can find no help with understanding) the reactive armor mechanic. I'm open to suggestions, obviously, but I'd rather parse and display these stats than re-script how the mechanic works.

#### Test steps

- [ ] Enable Legion under experimental options.
- [ ] Build units with reactive armor: Karkinos (legkark), Telchine (legamph), and Phalanx (legshot).
- [ ] Select one and hit `i` to see the info popout.
- [ ] Check the new armor stats, just below the previous ones.

### Screenshot

<img width="637" height="462" alt="{7E08C643-3FDB-4CE3-8990-FA36BCE182C9}" src="https://github.com/user-attachments/assets/dd9445e9-77d1-4b11-a8be-71f58a024867" />
