### PR TITLE
Fix: prevent self-commands on units

### DIFF
--- a/common/upgets/cmd_no_self_selection.lua
+++ b/common/upgets/cmd_no_self_selection.lua
@@ -1,19 +1,26 @@
-local widget = widget ---@type Widget
+local upget = gadget or widget ---@type Addon
+local UG = (gadget and GG) or (widget and WG) or false
 
-function widget:GetInfo()
+function upget:GetInfo()
 	return {
 		name    = "Ignore Self",
 		desc    = "With only one unit selected, avoid self-targeting with default commands (e.g. self-Guard)",
 		author  = "efrec",
 		date    = "2025",
 		license = "GNU GPL, v2 or later",
-		layer   = -100, -- preempt widgets loading wrapped Spring func -- todo: override engine api funcs after setting up env
-		enabled = true,
+		layer   = -1e9, -- before wupgets that handle unit selections
+		enabled = (not not UG),
 	}
 end
 
+if gadget then
+	if not gadgetHandler:IsSyncedCode() then
+		return
+	end
+end
+
+local selectedUnitID
 local restoreVolumeData = {}
-local selectedID
 
 local function removeSelectionVolume(unitID)
 	local sx, sy, sz, ox, oy, oz, shape, cont, axis = Spring.GetUnitSelectionVolumeData(unitID)
@@ -37,20 +44,22 @@ local function restoreSelectionVolume(unitID)
 	Spring.SetUnitSelectionVolumeData(unitID, unpack(restoreVolumeData))
 end
 
-function widget:SelectionChanged(selected)
-	if selectedID ~= selected[1] then
-		if selectedID ~= nil then
-			restoreSelectionVolume(selectedID)
-			selectedID = nil
-		end
-		if selected[1] ~= nil and selected[2] == nil then
-			removeSelectionVolume(selected[1])
-			selectedID = selected[1]
+if widget then
+	function widget:SelectionChanged(selected)
+		if selectedUnitID ~= selected[1] then
+			if selectedUnitID ~= nil then
+				restoreSelectionVolume(selectedUnitID)
+				selectedUnitID = nil
+			end
+			if selected[1] ~= nil and selected[2] == nil then
+				removeSelectionVolume(selected[1])
+				selectedUnitID = selected[1]
+			end
 		end
 	end
 end
 
--- todo: wrap TraceScreenRay in both gadget + widget space
+-- Override API functions that need to restore the selection volume temporarily.
 
 local sp_TraceScreenRay = Spring.TraceScreenRay
 
@@ -64,21 +73,21 @@ local sp_TraceScreenRay = Spring.TraceScreenRay
 ---@return ("unit"|"feature"|"ground"|"sky")? description of traced object or position
 ---@return (number|xyz)? result unitID, featureID, or position triple; when `onlyCoords` is true, units/features also give position.
 Spring.TraceScreenRay = function(screenX, screenY, onlyCoords, useMinimap, includeSky, ignoreWater, heightOffset)
-	local unitID = selectedID
+	local unitID = selectedUnitID
 
 	if unitID then
 		restoreSelectionVolume(unitID)
 	end
 
-	local description, xyzOrID = sp_TraceScreenRay(screenX, screenY, onlyCoords, useMinimap, includeSky, ignoreWater, heightOffset)
+	local description, result = sp_TraceScreenRay(screenX, screenY, onlyCoords, useMinimap, includeSky, ignoreWater, heightOffset)
 
 	if unitID then
 		removeSelectionVolume(unitID)
 	end
 
-	return description, xyzOrID
+	return description, result
 end
 
-function widget:Shutdown()
+function upget:Shutdown()
 	Spring.TraceScreenRay = sp_TraceScreenRay
 end

--- a/luarules/gadgets/cmd_no_self_selection.lua
+++ b/luarules/gadgets/cmd_no_self_selection.lua
@@ -1,0 +1,1 @@
+VFS.Include("common/upgets/cmd_no_self_selection.lua")

--- a/luaui/Widgets/cmd_ignore_self.lua
+++ b/luaui/Widgets/cmd_ignore_self.lua
@@ -7,7 +7,7 @@ function widget:GetInfo()
 		author  = "efrec",
 		date    = "2025",
 		license = "GNU GPL, v2 or later",
-		layer   = 0,
+		layer   = -100, -- preempt widgets loading wrapped Spring func -- todo: override engine api funcs after setting up env
 		enabled = true,
 	}
 end
@@ -48,4 +48,37 @@ function widget:SelectionChanged(selected)
 			selectedID = selected[1]
 		end
 	end
+end
+
+-- todo: wrap TraceScreenRay in both gadget + widget space
+
+local sp_TraceScreenRay = Spring.TraceScreenRay
+
+---@param screenX number position on x axis in mouse coordinates (origin on left border of view)
+---@param screenY number position on y axis in mouse coordinates (origin on top border of view)
+---@param onlyCoords boolean? (Default: `false`) `result` includes only coordinates
+---@param useMinimap boolean? (Default: `false`) if position arguments are contained by minimap, use the minimap corresponding world position
+---@param includeSky boolean? (Default: `false`)
+---@param ignoreWater boolean? (Default: `false`)
+---@param heightOffset number? (Default: `0`)
+---@return ("unit"|"feature"|"ground"|"sky")? description of traced object or position
+---@return (number|xyz)? result unitID, featureID, or position triple; when `onlyCoords` is true, units/features also give position.
+Spring.TraceScreenRay = function(screenX, screenY, onlyCoords, useMinimap, includeSky, ignoreWater, heightOffset)
+	local unitID = selectedID
+
+	if unitID then
+		restoreSelectionVolume(unitID)
+	end
+
+	local description, xyzOrID = sp_TraceScreenRay(screenX, screenY, onlyCoords, useMinimap, includeSky, ignoreWater, heightOffset)
+
+	if unitID then
+		removeSelectionVolume(unitID)
+	end
+
+	return description, xyzOrID
+end
+
+function widget:Shutdown()
+	Spring.TraceScreenRay = sp_TraceScreenRay
 end

--- a/luaui/Widgets/cmd_ignore_self.lua
+++ b/luaui/Widgets/cmd_ignore_self.lua
@@ -3,7 +3,7 @@ local widget = widget ---@type Widget
 function widget:GetInfo()
 	return {
 		name    = "Ignore Self",
-		desc    = "Remove selection volume to prevent mouse hover over the only selected unit",
+		desc    = "With only one unit selected, avoid self-targeting with default commands (e.g. self-Guard)",
 		author  = "efrec",
 		date    = "2025",
 		license = "GNU GPL, v2 or later",

--- a/luaui/Widgets/cmd_ignore_self.lua
+++ b/luaui/Widgets/cmd_ignore_self.lua
@@ -1,0 +1,51 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name    = "Ignore Self",
+		desc    = "Remove selection volume to prevent mouse hover over the only selected unit",
+		author  = "efrec",
+		date    = "2025",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+local restoreVolumeData = {}
+local selectedID
+
+local function removeSelectionVolume(unitID)
+	local sx, sy, sz, ox, oy, oz, shape, cont, axis, ignoreHits = Spring.GetUnitSelectionVolumeData(unitID)
+
+	local rvd = restoreVolumeData
+	rvd[1] = sx
+	rvd[2] = sy
+	rvd[3] = sz
+	rvd[4] = ox
+	rvd[5] = oy
+	rvd[6] = oz
+	rvd[7] = shape
+	rvd[8] = cont
+	rvd[9] = axis
+
+	---@diagnostic disable-next-line -- just not correct?
+	Spring.SetUnitSelectionVolumeData(unitID, 0, 0, 0, ox, oy, oz, 1, cont, axis)
+end
+
+local function restoreSelectionVolume(unitID)
+	Spring.SetUnitSelectionVolumeData(unitID, unpack(restoreVolumeData))
+end
+
+function widget:SelectionChanged(selected)
+	if selectedID ~= selected[1] then
+		if selectedID ~= nil then
+			restoreSelectionVolume(selectedID)
+			selectedID = nil
+		end
+		if selected[1] ~= nil and selected[2] == nil then
+			removeSelectionVolume(selected[1])
+			selectedID = selected[1]
+		end
+	end
+end

--- a/luaui/Widgets/cmd_ignore_self.lua
+++ b/luaui/Widgets/cmd_ignore_self.lua
@@ -16,7 +16,7 @@ local restoreVolumeData = {}
 local selectedID
 
 local function removeSelectionVolume(unitID)
-	local sx, sy, sz, ox, oy, oz, shape, cont, axis, ignoreHits = Spring.GetUnitSelectionVolumeData(unitID)
+	local sx, sy, sz, ox, oy, oz, shape, cont, axis = Spring.GetUnitSelectionVolumeData(unitID)
 
 	local rvd = restoreVolumeData
 	rvd[1] = sx

--- a/luaui/Widgets/cmd_no_self_selection.lua
+++ b/luaui/Widgets/cmd_no_self_selection.lua
@@ -1,0 +1,1 @@
+VFS.Include("common/upgets/cmd_no_self_selection.lua")


### PR DESCRIPTION
### Work done

- Avoid setting default command (and etc) by just removing the ability to re-hover a unit when it is the only unit selected. Areas and dragging will still select the unit.

#### Addresses Issue(s)

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3538

This is a very-minimal fix to the issue since it does not address group selections. I didn't cover that case since logic is not quite the same with groups; some commands should pass through and others not.