### PR TITLE
Update gfx_raptor_scum_gl4.lua

### DIFF
--- a/luarules/gadgets/gfx_raptor_scum_gl4.lua
+++ b/luarules/gadgets/gfx_raptor_scum_gl4.lua
@@ -263,7 +263,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-		if scumSpawnerIDs[unitDefID] and (debugmode or (unitTeam == pveTeamID)) then
+		if scumSpawnerIDs[unitDefID] and (debugmode or (unitTeam and unitTeam == pveTeamID)) then
 			local px, py, pz = Spring.GetUnitPosition(unitID)
 			local gf = Spring.GetGameFrame()
 


### PR DESCRIPTION
fix a bug where if you don't define the teamID for the scavenger/raptor but you create a scum-able _scav unit while isScavengersMode is enabled, scum will be created