### PR TITLE
Fix halos UnitRulesParam to respect setting to 0 to exclude halos

### DIFF
--- a/luarules/gadgets/unit_resurrected.lua
+++ b/luarules/gadgets/unit_resurrected.lua
@@ -24,7 +24,8 @@ if (gadgetHandler:IsSyncedCode()) then
     -- detect resurrected units here
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 		if builderID and canResurrect[Spring.GetUnitDefID(builderID)] then
-			if not Spring.Utilities.Gametype.IsScavengers() then
+			local rezRulesParam = Spring.GetUnitRulesParam(unitID, "resurrected")
+			if not Spring.Utilities.Gametype.IsScavengers()  and rezRulesParam == nil then
 				Spring.SetUnitRulesParam(unitID, "resurrected", 1, {inlos=true})
 			end
 			Spring.SetUnitHealth(unitID, Spring.GetUnitHealth(unitID) * 0.05)

--- a/luaui/Widgets/gui_resurrection_halos_gl4.lua
+++ b/luaui/Widgets/gui_resurrection_halos_gl4.lua
@@ -64,7 +64,8 @@ end
 
 
 function widget:VisibleUnitAdded(unitID, unitDefID, unitTeam)
-	if unitConf[unitDefID] == nil or Spring.GetUnitRulesParam(unitID, "resurrected") == nil then return end
+	local rezRulesParam = Spring.GetUnitRulesParam(unitID, "resurrected")
+	if unitConf[unitDefID] == nil or not rezRulesParam or rezRulesParam == 0 then return end
 
 	local gf = Spring.GetGameFrame()
 	pushElementInstance(


### PR DESCRIPTION
halos are applied to inappropriate units and there (was) no way to override this behavior. Fixes rulesparam. Tested and made sure resurrecting things still produces halo.