### PR TITLE
Cluster munitions makeover

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_cluster.lua
+++ b/luarules/gadgets/unit_custom_weapons_cluster.lua
@@ -212,9 +212,9 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	unitBulks[unitDefID] = bulk
 end
 
-local bulkMin = UnitDefs[minUnitBounces] and unitBulks[UnitDefs[minUnitBounces].id] or 0.1
-
-for unitDefID in pairs(UnitDefs) do
+-- The value 0.1 is very low for an individual unit, but could potentially add up in groups:
+local bulkMin = UnitDefNames[minUnitBounces] and unitBulks[UnitDefNames[minUnitBounces].id] or 0.1
+for unitDefID in ipairs(UnitDefs) do
 	if unitBulks[unitDefID] < bulkMin then
 		unitBulks[unitDefID] = nil
 	end


### PR DESCRIPTION
### Work done

This is a proposal to update the scattering of cluster submitions.

The largest change here is a small amount of momentum carrying over from the base projectile to the sub-projectiles. The max velocity of a projectile from the point of impact is the same, so the secondary bounce range is not increased. This makes the spread slightly non-random by biasing it in the direction of the shot. Due to that bias, I decreased the amount of randomness per-projectile, which keeps them evenly spaced, despite the added bias. The net increase to predictability is greater than the sum of each change, so this may be what cluster's detractors wanted but cannot quite articulate.

Next, I readded water deflection. I wasn't around when this code was reverted so don't know the story there. This is a small change that points the response direction near/above/on water toward vertical and that treats water as about 85% solid.

Finally, this rebalances unit bulks. They are honestly about the same as before; the unit bulks are calculated from the unit properties which had drifted over time. Footprints in particular have been enlarged to keep units spaced further apart and prevent their weapon's aim points from being stuck inside each other's collision volume, preventing firing. But this means the footprints correspond even less to the models, so I changed the math over to use model dimensions.