### PR TITLE
Remove ESC keybind for abstaining votes ingame

### DIFF
--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -222,7 +222,7 @@ local function StartVote(name)	-- when called without params its just to refresh
 			font2:Begin()
 			font2:SetOutlineColor(1, 1, 1, 0.2)
 			font2:SetTextColor(0, 0, 0, 0.7)
-			font2:Print("\255\000\000\000" .. Spring.I18N('ui.voting.cancel'), closeButtonArea[1] + ((closeButtonArea[3] - closeButtonArea[1]) / 2), closeButtonArea[2] + ((closeButtonArea[4] - closeButtonArea[2]) / 2) - (fontSize / 3), fontSize, "cn")
+			font2:Print("\255\000\000\000X", closeButtonArea[1] + ((closeButtonArea[3] - closeButtonArea[1]) / 2), closeButtonArea[2] + ((closeButtonArea[4] - closeButtonArea[2]) / 2) - (fontSize / 3), fontSize, "cn")
 
 			-- NO / End Vote
 			local color1, color2, mult


### PR DESCRIPTION
### Work done
The removed widget:KeyPress function mapped one action (!vote b = abstain from vote) to the escape key, which could cause accidental abstain votes due to pressing escape during gameplay for other reasons.
 
Players can still abstain manually by clicking the x button in the GUI, or the SPADS afk config triggers it for them.


#### Addresses Issue(s)
[This thread](https://discord.com/channels/549281623154229250/1427176485562744914) from Discord.

#### Test steps
_This is untested_ as I don't have a test setup available! 
Seems to be straightforward though, would appreciate if someone can give it a go on their test setup.