### PR TITLE
NightMode add is user Authorised check

### DIFF
--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -518,6 +518,7 @@ if gadgetHandler:IsSyncedCode() then
 		gadgetHandler:AddChatAction('loadmissiles', LoadMissiles, "")
 		gadgetHandler:AddChatAction('halfhealth', HalfHealth, "")
 
+		GG.isAuthorized = isAuthorized
 	end
 
 	function gadget:RecvLuaMsg(msg, playerID)
@@ -591,6 +592,8 @@ if gadgetHandler:IsSyncedCode() then
 	function gadget:Shutdown()
 		gadgetHandler:RemoveChatAction('loadmissiles')
 		gadgetHandler:RemoveChatAction('halfhealth')
+
+		GG.isAuthorized = nil
 	end
 	local featuredefstoremove = {}
 
@@ -924,6 +927,7 @@ else	-- UNSYNCED
 		gadgetHandler:AddChatAction('playertoteam', playertoteam, "") -- /luarules playertoteam [playerID] [teamID] -- playerID+teamID are optional, no playerID given = your own playerID, no teamID = selected unit team or hovered unit team
 		gadgetHandler:AddChatAction('killteam', killteam, "") -- /luarules killteam [teamID] -- kills the team
 		gadgetHandler:AddChatAction('desync', desync) -- /luarules desync
+		GG.isAuthorized = isAuthorized
 	end
 
 	function gadget:Shutdown()
@@ -946,6 +950,7 @@ else	-- UNSYNCED
 		gadgetHandler:RemoveChatAction('playertoteam')
 		gadgetHandler:RemoveChatAction('killteam')
 		gadgetHandler:RemoveChatAction('desync')
+		GG.isAuthorized = nil
 	end
 
 	function xpUnits(_, line, words, playerID)

--- a/luarules/gadgets/map_nightmode.lua
+++ b/luarules/gadgets/map_nightmode.lua
@@ -421,6 +421,15 @@ if not gadgetHandler:IsSyncedCode() then
 		lastSunChanged = df
 	end
 
+	local function isAuthorizedWrapper(func)
+		return function(cmd, line, words, playerID)
+			-- TODO: add some way for non admin users to authorize themselves in multiplier?
+			if GG.isAuthorized(playerID) then
+				func(cmd, line, words, playerID)
+			end
+		end
+	end
+
 	function gadget:Initialize()
 		initial_atmosphere_lighting = GetLightingAndAtmosphere()
 		for i, nightConf in ipairs(nightModeConfig) do 
@@ -430,9 +439,9 @@ if not gadgetHandler:IsSyncedCode() then
 		gadgetHandler:AddSyncAction("GetLightingAndAtmosphere", GetLightingAndAtmosphere)
 		gadgetHandler:AddSyncAction("SetLightingAndAtmosphere", SetLightingAndAtmosphere)
 		gadgetHandler:AddSyncAction("MixLightingAndAtmosphere", MixLightingAndAtmosphere)
-		gadgetHandler:AddChatAction("NightMode", SetNightMode)
-		gadgetHandler:AddChatAction("NightModeToggle", NightModeToggle)
-		gadgetHandler:AddChatAction("PrintSun", PrintSun)
+		gadgetHandler:AddChatAction("NightMode", isAuthorizedWrapper(SetNightMode))
+		gadgetHandler:AddChatAction("NightModeToggle", isAuthorizedWrapper(NightModeToggle))
+		gadgetHandler:AddChatAction("PrintSun", isAuthorizedWrapper(PrintSun))
 		gadgetHandler:RegisterGlobal("NightModeParams", {r=1, g=1, b=1, s=1, a= 1})
 	end
 


### PR DESCRIPTION
### Work done
Lock the nightmode option behind being an admin / singleplayer due to user abuse via a simple wrapper cause i'm lazy

#### Addresses Issue(s)
Private complaint from a user due to abuse.

#### Setup

Due to reuse of the authentication from dev helpers, singleplayer is authorised, as such to test it you will need to go into:
`luarules\configs\powerusers.lua` and change `singleplayer`, `devhelpers` to false.

#### Test Steps:
Once the above setup is done, toggle cheats with `/cheat`:
- run `/luarules NightMode 0 0 0 0 0 0`
- run `/luarules NightMode`

if cheats are enabled the above two will toggle darkness on and off, otherwise it won't