### PR TITLE
Delete other noexplode projectiles in shields

### DIFF
--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -150,6 +150,8 @@ if not reworkEnabled then
 	function gadget:ProjectileDestroyed(proID)
 		projectileDefIDCache[proID] = nil
 	end
+
+	return
 end
 
 -- Shield Rework


### PR DESCRIPTION
Part of an unfortunate series of events

### Work Done

Restores part of the shield rework gadget:

- Deletes some `noexplode` projectiles inside of shields
- Don't need to delete non-`noexplode` Flame-type weapons
- Remove `if reworkEnabled` checks throughout code; split gadget neatly into shared logic, pre-rework logic, and rework logic

This is mostly organizing the layout of the shield rework gadget but also gets into some sense-making with the details.

I don't want to change the implementation, but it is potentially silly at the extremes, e.g. a Flame weapon with a large area of effect and a low edge% that barely taps a shield will deal a pitiful amount of damage and then be deleted instantly. The rest of the rework uses hardcoded values in alldefs, which I'd like to make flexible and moddable in another PR.