### PR TITLE
Hide retreat/idle mode buttons from aircraft UI

### DIFF
--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -97,6 +97,7 @@ local hiddenCommands = {
 	[CMD.SQUADWAIT] = true,
 	[CMD.DEATHWAIT] = true,
 	[CMD.TIMEWAIT] = true,
+	[CMD.IDLEMODE] = true, -- retreat/idle mode (air repair pads removed)
 	[39812] = true, -- raw move
 	[34922] = true, -- set unit target
 }


### PR DESCRIPTION
## Summary
Air repair pads were previously removed from the game, but the retreat buttons (No Retreat, Retreat 30%, Retreat 50%, Retreat 80%) remained visible in the aircraft command panel. These buttons are non-functional without repair pads and may confuse new players.

## Changes
- Added `CMD.IDLEMODE` to the `hiddenCommands` list in `gui_ordermenu.lua`
- This hides the obsolete retreat/idle mode buttons from the UI

## Testing
- Widget change only, no gameplay impact
- Can be tested with `/luaui reload` in dev mode
- Retreat buttons should no longer appear for aircraft units

Fixes #5949