### PR TITLE
Fix Riptide barrel animation - shots now fire from correct barrels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.iml
 .project
 *.code-workspace
+.claude

--- a/scripts/Units/corpship.bos
+++ b/scripts/Units/corpship.bos
@@ -131,7 +131,18 @@ AimFromWeapon1(pieceIndex)
 
 QueryWeapon1(pieceIndex)
 {
-	pieceIndex = flare1 + gun_1;
+	if( gun_1 == 0 )
+	{
+		pieceIndex = flare1;
+	}
+	if( gun_1 == 1 )
+	{
+		pieceIndex = flare2;
+	}
+	if( gun_1 == 2 )
+	{
+		pieceIndex = flare3;
+	}
 }
 
 


### PR DESCRIPTION
## Summary
Fixes the Riptide (corpship) weapon firing animation so that shots fire from the correct barrel positions instead of incorrectly calculated positions.

## Changes
- Updated `QueryWeapon1()` in `scripts/Units/corpship.bos` to properly map gun states to flare pieces
- Changed from incorrect arithmetic calculation (`flare1 + gun_1`) to explicit conditional mapping
- Now correctly cycles through flare1, flare2, and flare3 based on gun_1 state (0, 1, 2)

## Test plan
- [ ] Spawn Riptide unit in-game
- [ ] Observe weapon firing from all three barrels in correct sequence