### PR TITLE
Update proposed_unit_reworks_defs.lua

### DIFF
--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -24,7 +24,7 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	or name == "coraap" or name == "coralab" or name == "corasy" or name == "coravp"
 	then
 		uDef.metalcost = uDef.metalcost - 300
-		uDef.buildtime = uDef.buildtime * 1.2
+		uDef.buildtime = uDef.buildtime * 1.3
 		uDef.workertime = uDef.workertime * 2
 	end
 


### PR DESCRIPTION
- Revert T2 mex change
- T2 factory buildtime 1.5x -> 1.3x of original cost
- Revert previous T1 factory changes. Instead: 
   - Hover platforms 80m, 750e, 800bt cheaper 
   - T1 airplants 60m, 300bt cheaper
- Revert rezzers cost change
- Naval engineers +10% m cost, to match other combat engineers 
- Fatboy AoE 240->300
