### PR TITLE
Update proposed reworks... modoption

### DIFF
--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -25,7 +25,7 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	then
 		uDef.metalcost = uDef.metalcost - 300
 		uDef.buildtime = uDef.buildtime * 1.3
-		uDef.workertime = uDef.workertime * 2
+		uDef.workertime = 600
 	end
 
 	if uDef.canmove and tonumber(uDef.customparams.techlevel) == 2 and uDef.energycost and uDef.metalcost and uDef.buildtime and not (name == "armavp" or name == "coravp" or name == "armalab" or name == "coralab" or name == "armaap" or name == "coraap" or name == "armasy" or name == "corasy" or name == "armfido" or name == "armmav" or name == "armvader" or name == "corroach" ) 


### PR DESCRIPTION
- Revert T2 mex change
- T2 factory buildtime 1.5x -> 1.3x of original cost
- Revert previous T1 factory changes. Instead:
   - Hover platforms 80m, 750e, 800bt cheaper
   - T1 airplants 60m, 300bt cheaper
- Revert rezzers cost change
- Naval engineers +10% m cost, to match other combat engineers
- Fatboy AoE 240->300, 11000e->15000e cost
- More rounding for Fusion values (most notably, cortex fus +825e -> +850e, 3500m->3600m cost)
- Fixed typo with Cortex seaplane buildtimes
- Hound, Gunslinger, Crawling bombs made exempt from buildtime increase
- Sumo, Battleships +10% health, to compensate repair speed loss
- Tzar speed 37 -> 39 (vanilla 40.5)
- Revert Quaker/Mauser changes
- T2 airplants buildpower 400->600, to match other T2 factories (in vanilla, air is 200 while others 300)