### PR TITLE
crashing aircraft: use Spring.SetUnitCrashing

### DIFF
--- a/luarules/gadgets/unit_crashing_aircraft.lua
+++ b/luarules/gadgets/unit_crashing_aircraft.lua
@@ -63,6 +63,7 @@ if gadgetHandler:IsSyncedCode() then
 			Spring.SetUnitAlwaysVisible(unitID, false)
 			Spring.SetUnitNeutral(unitID, true)
 			Spring.SetUnitBlocking(unitID, false)
+			Spring.SetUnitCrashing(unitID, true)
 			if unitWeapons[unitDefID] then
 				for weaponID, _ in pairs(unitWeapons[unitDefID]) do
 					SetUnitWeaponState(unitID, weaponID, "reloadState", 0)


### PR DESCRIPTION
Apparently Spring.SetUnitCrashing exists for at least 14 years but never was used here. 
Not sure what it actually does
I did test it but didnt notice a difference.