### PR TITLE
Fix feature bar counter underflow

### DIFF
--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -799,11 +799,22 @@ end
 
 local function removeBarFromFeature(featureID, targetVBO)
 	--Spring.Echo("removeBarFromFeature", featureID, targetVBO.myName)
-	if targetVBO.instanceIDtoIndex[featureID] then
-		popElementInstance(targetVBO, featureID)
+	if not targetVBO.instanceIDtoIndex[featureID] then
+		return
 	end
-	if featureBars[featureID] then
-		featureBars[featureID] = featureBars[featureID] - 1 -- TODO ERROR
+
+	popElementInstance(targetVBO, featureID)
+
+	local barCount = featureBars[featureID]
+	if not barCount then
+		return
+	end
+
+	barCount = barCount - 1
+	if barCount > 0 then
+		featureBars[featureID] = barCount
+	else
+		featureBars[featureID] = nil
 	end
 end
 


### PR DESCRIPTION
Updated the GL4 health bar widget so feature feature counters only decrement when an instance actually existed, preventing negative indices when removing non-existent bars.

luaui/Widgets/gui_healthbars_gl4.lua:800-817: bail out when the VBO lacks the feature ID, pop the instance before touching the counter, and reset the counter to nil once it reaches zero so future additions can start from zero cleanly.

Tests: Not run (no automated widget tests available).