### PR TITLE
Update cordronecarryair.lua

### DIFF
--- a/units/Scavengers/Air/cordronecarryair.lua
+++ b/units/Scavengers/Air/cordronecarryair.lua
@@ -32,7 +32,6 @@ return {
 		health = 3500,
 		speed = 34.5,
 		maxwaterdepth = 15,
-		movementclass = "BOAT5",
 		nochasecategory = "VTOL",
 		objectname = "Units/CORDRONECARRYAIR.s3o",
 		radardistance = 1500,


### PR DESCRIPTION
### Work done
Removes movedef from the flying aircraft drone carrier so that it doesn't get caught in removing sea units / default disabled by the build menu

#### Test steps
- Force load all units, bottom of adv options, cheats
- Pick a map that has no sea or disable all sea units unt adv options, 
- `/give corapt3`, and find cordronecarryair in the build list