### PR TITLE
fix(gadget: overpen): Shield owner can not be valid

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -93,6 +93,7 @@ local spAddUnitDamage          = Spring.AddUnitDamage
 local spDeleteProjectile       = Spring.DeleteProjectile
 local spDestroyFeature         = Spring.DestroyFeature
 local spValidFeatureID         = Spring.ValidFeatureID
+local spValidUnitID            = Spring.ValidUnitID
 
 local armorDefault = Game.armorTypes.default
 local armorShields = Game.armorTypes.shields
@@ -501,24 +502,33 @@ function gadget:FeaturePreDamaged(featureID, featureDefID, featureTeam, damage, 
 end
 
 function gadget:ShieldPreDamaged(projectileID, attackerID, shieldWeaponIndex, shieldUnitID, bounceProjectile, beamWeaponIndex, beamUnitID, startX, startY, startZ, hitX, hitY, hitZ)
+	if not spValidUnitID(shieldUnitID) then
+		return
+	end
+
 	local penetrator = projectiles[projectileID]
-	if penetrator then
-		local damage = penetrator.params[armorShields]
-		if damage > 1 then
-			projectileHits[projectileID] = penetrator
-			local state, health = spGetUnitShieldState(shieldUnitID, shieldWeaponIndex)
-			local collisions = penetrator.collisions
-			collisions[#collisions+1] = {
-				targetID  = shieldUnitID,
-				shieldID  = shieldWeaponIndex,
-				armorType = armorShields,
-				healthMax = health,
-				damage    = damage,
-				hitX      = hitX,
-				hitY      = hitY,
-				hitZ      = hitZ,
-			}
-		end
+	if not penetrator then
+		return
+	end
+
+	local damage = penetrator.params[armorShields]
+	if damage <= 1 then
 		return true
 	end
+
+	projectileHits[projectileID] = penetrator
+	local state, health = spGetUnitShieldState(shieldUnitID, shieldWeaponIndex)
+	local collisions = penetrator.collisions
+	collisions[#collisions+1] = {
+		targetID  = shieldUnitID,
+		shieldID  = shieldWeaponIndex,
+		armorType = armorShields,
+		healthMax = health,
+		damage    = damage,
+		hitX      = hitX,
+		hitY      = hitY,
+		hitZ      = hitZ,
+	}
+
+	return true
 end


### PR DESCRIPTION
Added validation for shield unit ID in ShieldPreDamaged function and unnested conditionals.

```
[t=00:37:58.086529][f=0050061] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=ShieldPreDamaged trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_custom_weapons_overpen.lua"]:503: [GetUnitShieldState] unitID (arg #1) not a number

stack traceback:
    [C]: in function 'GetUnitShieldState'
    [string "LuaRules/Gadgets/unit_custom_weapons_overpen.lua"]:503: in function 'ShieldPreDamaged'
    [string "LuaRules/gadgets.lua"]:2118: in function 'selffunc'
    [string "LuaRules/gadgets.lua"]:829: in function <[string "LuaRules/gadgets.lua"]:826>
[t=00:37:58.119788][f=0050062] [Game::ClientReadNet][LOGMSG] sender="Player (spec)" string="[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_custom_weapons_overpen.lua"]:503: [GetUnitShieldState] unitID (arg #1) not a number
```

### Work done

What is says on the tin.

#### Test steps

I'd require someone to assist with testing (will add as a committer), if that is done in some other PR I will happily close this one.

`Spring.Echo(shieldUnitID)` would be very appreciated (I currently suspect nil).

##### Added context (by `Aurora` in discord)
- Timestamp: 27:48
- Replay: https://www.beyondallreason.info//replays?gameId=fa84f06812b96220918e51875cab5f26
- Recording of one occurrence: https://cloud.chocobos.de/s/czDoprbK7PZbZ9B
- infolog: [infolog(33).txt](https://github.com/user-attachments/files/23061052/infolog.33.txt)
