### PR TITLE
Fix: Cancel the Alt Set target when Stop is pressed

### DIFF
--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -26,6 +26,7 @@ local unitRanges = {}
 local myAllyTeam = Spring.GetMyAllyTeamID()
 
 local POLLING_RATE = 15
+local CMD_STOP = CMD.STOP
 local CMD_UNIT_CANCEL_TARGET = GameCMD.UNIT_CANCEL_TARGET
 local CMD_SET_TARGET = GameCMD.UNIT_SET_TARGET
 -- Set target on units that aren't in range yet but may come in range soon
@@ -87,7 +88,7 @@ function widget:GameFrame(frame)
 				newCmdOpts = { "shift" }
 			end
 
-			commandsToGive[#commandsToGive+1] = { CMD_SET_TARGET, { targetID }, newCmdOpts }			
+			commandsToGive[#commandsToGive+1] = { CMD_SET_TARGET, { targetID }, newCmdOpts }
 		end
 
 		spGiveOrderArrayToUnit(unitID, commandsToGive)
@@ -101,12 +102,12 @@ end
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	local shouldCleanupTargeting = false
 	local selectedUnits = spGetSelectedUnits()
-	if cmdID == CMD_UNIT_CANCEL_TARGET then
+	if cmdID == CMD_UNIT_CANCEL_TARGET or cmdID == CMD_STOP then
 		shouldCleanupTargeting = true
 	end
 
 	if cmdID == CMD_SET_TARGET and not cmdOpts.alt then
-		shouldCleanupTargeting = true		
+		shouldCleanupTargeting = true
 	end
 
 	if cmdID == CMD_SET_TARGET and #cmdParams ~= 1 then


### PR DESCRIPTION
### Work done
The persistent Set target (set target + alt + click on the unit) wasn't cancelled when Stop command was issued. The regular Set target is cancelled by Stop so I added the same logic to persistent one. 

#### Test steps
- [ ] Select combat unit, choose "Set Target" and click on enemy unit while holding Alt. You should see that the target is set on all units of this type which are close to your unit.
- [ ] Press Stop - the Set Target should be cancelled