### PR TITLE
Enable state preference widget by default.

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -11,7 +11,7 @@ function widget:GetInfo()
 		date = "April 21, 2023",
 		license = "GNU GPL, v2 or later",
 		layer = 1000,
-		enabled = false,
+		enabled = true,
 	}
 end
 


### PR DESCRIPTION
As the widget selector is now hidden from users this should be activated by default to enable easier binding of this feature for users of custom keybinds.

`stateprefs_record` is not bound by default so there is no risk of unintended or confusing unit behavior for new players.
