### PR TITLE
fix: i18n.interpolate can handle too many variables

### DIFF
--- a/modules/i18n/i18nlib/i18n/interpolate.lua
+++ b/modules/i18n/i18nlib/i18n/interpolate.lua
@@ -30,7 +30,20 @@ local function interpolate(str, vars)
   str = escapeDoublePercent(str)
   str = interpolateVariables(str, vars)
   str = interpolateFormattedVariables(str, vars)
-  str = string.format(str, unpack(vars))
+  -- Handle any remaining % positional placeholders (e.g., %s, %d)
+  -- Only if they exist and vars can be treated as array
+  if str:find('%%') and not str:find('%%{') and not str:find('%%<') then
+    local percentCount = 0
+    for _ in str:gmatch('%%') do
+      percentCount = percentCount + 1
+    end
+    -- For positional placeholders, assume vars[1], vars[2], etc.
+    local args = {}
+    for i = 1, percentCount do
+      args[i] = vars[i] or vars[tostring(i)] or 'nil'
+    end
+    str = string.format(str, unpack(args))
+  end
   str = unescapeDoublePercent(str)
   return str
 end


### PR DESCRIPTION
## I'm realizing I committed this to the wrong place?
Should this go [here](https://github.com/gajop/i18n), or there too?

## What's this do
Skip processing `string.format` interpolation path whenever we use named variables. As a byproduct of this, we can now send many named variables to named interpolations and as long as we're using the named parameter pattern instead of the string interpolation pattern, we're fine to send too many variables along in the table.

## Why

TLDR This simplifies my code

### Inconvenience Introduced to Callers
If I pass more variables than are contained within a translation string to i18n I get an error.

For example:
```json
"shareUnitsInvalid": {
	"all": "Sharing these units are not allowed",
	"one": "Double-click to share units (mode is %{unitSharingMode} - %{firstInvalidUnitName} cannot be shared)",
	"two": "Double-click to share units (mode is %{unitSharingMode} - %{firstInvalidUnitName} and %{secondInvalidUnitName} cannot be shared)",
	"other": "Double-click to share units (mode is %{unitSharingMode} - %{firstInvalidUnitName}, %{secondInvalidUnitName} and %{count} others cannot be shared)"
},
```
If I make my translation variables object like so:
```lua
local i18nData = {
      unitSharingMode = policy.sharingMode,
      firstInvalidUnitName = invalidNames[1] or "",
      secondInvalidUnitName = invalidNames[2] or "",
      count = #invalidNames - 2,
 }
--- this errors
Spring.I18N(baseKey .. '.shareUnitsInvalid.one', i18nData)
```

### We sometimes need to communicate with intermediate systems between us and translations without nuking our ability to translate
In another branch, I hit a situation where [gui_chat](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5704/files#diff-50e9e809ac9691ea91cf6bb0ce6b1cced195ea150a9fdcf978972faaf9970ab0R625) was sitting between me and talking to i18n.  That widget needed to highlight some resource-related fields with their color before it goes to chat but it has this implicit behavior around translation variable key names - a pretty fragile behavior - in order to know which resource/color that is (and my key names no longer speak to a specific resource type, e.g. "amountSendable" instead of "energyAmount"). I just wanted to say something to chat through i18n from my code, but inbetween me and i18n was gui_chat. No problem, I'll just tell it what color to make my payload with a `resourceType` parameter, but I can't, because that explodes translations.

## Alternative Solution (I am willing to do)

We could also
1) delete existing i18n fork
2) use [Lux](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6005) to include [kikito/i18n](https://github.com/kikito/i18n.lua)
3) refactor every Spring.i18n caller to be consistent with kikito expectations
4) test everything manually and see what breaks

## LLM Disclosure
None