### PR TITLE
Only wait resurrected units

### DIFF
--- a/luarules/gadgets/unit_resurrected.lua
+++ b/luarules/gadgets/unit_resurrected.lua
@@ -17,10 +17,14 @@ local CMD_WAIT = CMD.WAIT
 if (gadgetHandler:IsSyncedCode()) then
 
     local canResurrect = {}
+	local isBuilding = {}
     for unitDefID, unitDef in pairs(UnitDefs) do
         if unitDef.canResurrect then
             canResurrect[unitDefID] = true
         end
+		if unitDef.isBuilding then
+			isBuilding[unitDefID] = true
+		end
     end
 
     -- detect resurrected units here
@@ -31,7 +35,9 @@ if (gadgetHandler:IsSyncedCode()) then
 				Spring.SetUnitRulesParam(unitID, "resurrected", 1, {inlos=true})
 			end
 			Spring.SetUnitHealth(unitID, Spring.GetUnitHealth(unitID) * 0.05)
-			Spring.GiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
+			if not isBuilding[unitDefID] then
+				Spring.GiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
+			end
 		end
 		-- See: https://github.com/beyond-all-reason/spring/pull/471
 		-- if builderID and Spring.GetUnitCurrentCommand(builderID) == CMD.RESURRECT then


### PR DESCRIPTION
Removes the wait for resurrected units that are buildings. 

This allows factories to be used as expected as enqueuing a unit does not unwait. 
