### PR TITLE
Lava use new engine feature damage

### DIFF
--- a/luarules/gadgets/map_lava.lua
+++ b/luarules/gadgets/map_lava.lua
@@ -36,12 +36,6 @@ if gadgetHandler:IsSyncedCode() then
 	local DAMAGE_RATE = 10 -- frames
 	local lavaDamage = lava.damage * (DAMAGE_RATE / gameSpeed)
 	local lavaDamageFeatures = lava.damageFeatures
-	if lavaDamageFeatures then
-		if not tonumber(lavaDamageFeatures) then
-			lavaDamageFeatures = 0.1
-		end
-		lavaDamageFeatures = lavaDamageFeatures * (DAMAGE_RATE / gameSpeed)
-	end
 
 	-- ceg effects
 	local lavaEffectBurst = lava.effectBurst


### PR DESCRIPTION
Switch from the custom lava damage features code that reduced reclaim value to the new engine 'AddFeatureDamage' that correctly applies damage and removes the features when hp < 0.

Requires engine 2025.06.08 or later
