### PR TITLE
Movedefs data file cleanup

### DIFF
--- a/gamedata/movedefs.lua
+++ b/gamedata/movedefs.lua
@@ -71,12 +71,12 @@ local SLOPE_MOD = {
 local depthModGeneric = {
 	minheight   = 4,
 	linearcoeff = 0.03,
-	maxvalue    = 0.7, -- TODO: Should be "maxScale" and should be > 1.
+	maxscale    = 1.4, -- at depth 46.67
 }
 
 ---@type DepthModParams
 local depthModCommanders = {
-	maxscale       = 1.5,
+	maxscale       = 1.5, -- at depth 149.14
 	quadraticcoeff = (9.9 / 22090) / 2,
 	linearcoeff    = (0.1 / 470) / 2,
 }


### PR DESCRIPTION
### Work done

Changed the movedefs validation to only log warnings. The engine provides sensible defaults for movedefs so errors are not useful.

Removed keys:

- badslope
- badwaterslope
- maxwaterslope
- maxvalue

These keys do nothing but might express some intent. With planned variable unit speeds (e.g. for amphibious units), we might want to revisit that intent, but the actual values used don't appear useful.

Fixed the mixed casing of keys.

Set a maxScale value on the general-use depthModParams based on the inverse of the removed maxValue key. That caps the water depth that slows most units to 47 elmos, but the deepest water depth of those units is 30, so there is no net change to balance.