### PR TITLE
Fix railguns high/low impulse

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -402,7 +402,6 @@ local function _GameFramePost(collisionList)
 			else
 				if isTargetUnit then
 					local impulse = damageBase * factor * falloffRatio(damageLeft, 1) -- inverse ratio
-					setVelocityControl(targetID, true)
 					spAddUnitDamage(
 						targetID,
 						damageDealt,
@@ -413,6 +412,7 @@ local function _GameFramePost(collisionList)
 						penetrator.dirY * impulse,
 						penetrator.dirZ * impulse
 					)
+					setVelocityControl(targetID, true)
 				else
 					local health = collision.health - damageDealt
 					if health > 1 then


### PR DESCRIPTION
### Work done

Moved the calculation of remaining damage after applying that damage to fix odd impulse behaviors.

And a couple minor edits:

I made the damageLeft math consistent between unit and shield damage, so it's easier to read/compare them together and know they express the same logic.

After reading the unit_collision_damage_behavior gadget, also, I bumped the velocity control step to after the unit damage is applied. The controller does not smooth out velocities (as I'd misremembered) but only limits them to a max speed. This is speculative future-proofing, then, in case the velocity control step immediately clamps velocity, later.

#### Addresses Issue(s)

Answers a complaint in Legion chat about railguns either (a) pushing units too much or (b) not knocking them away.

Units in a weight class similar to medium tanks that were hit by the Arquebus were sometimes going into slides and sometimes not budging at all. They should be knocked away a tiny amount or stopped in place. So there was something inconsistent with overpen impulse, and possibly in the collision_damage gadget.

#### Testing Steps

1. Enable Legion
2. `/luarules fightertest legsrail armstump 40 4 1200`
3. `/luarules fightertest legsrail armch 40 4 1200`
4. Both units should respond now appropriately to railgun impulse.

I've tested and this sets the correct impulse.