### PR TITLE
Grid build for pregame

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -21,31 +21,70 @@ local buildQueue = {}
 local selBuildQueueDefID
 local facingMap = { south = 0, east = 1, north = 2, west = 3 }
 
+local buildModeState = {
+	startPosition = nil,
+	endPosition = nil,
+	buildPositions = {},
+	mode = nil,
+	buildAroundTarget = nil,
+	spacing = 0,
+}
+
 local isSpec = Spring.GetSpectatingState()
 local myTeamID = Spring.GetMyTeamID()
 local preGamestartPlayer = Spring.GetGameFrame() == 0 and not isSpec
 local startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 local prevStartDefID = startDefID
-local metalMap = false
+local isMetalMap = false
 
 local unitshapes = {}
 
-local function buildFacingHandler(_, _, args)
+local BUILD_MODE = {
+	SINGLE = 0,
+	LINE = 1,
+	GRID = 2,
+	BOX = 3,
+	AROUND = 4
+}
+
+local SQUARE_SIZE = 8
+local BUILD_SQUARE_SIZE = SQUARE_SIZE * 2
+local BUILDING_COUNT_FUDGE_FACTOR = 1.4
+local BUILDING_DETECTION_TOLERANCE = 10
+local HALF = 0.5
+
+local function buildFacingHandler(command, line, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
 		return
 	end
 
 	local facing = Spring.GetBuildFacing()
-	if args and args[1] == "inc" then
+	local action = args and args[1]
+	if action == "inc" then
 		facing = (facing + 1) % 4
 		Spring.SetBuildFacing(facing)
 		return true
-	elseif args and args[1] == "dec" then
+	elseif action == "dec" then
 		facing = (facing - 1) % 4
 		Spring.SetBuildFacing(facing)
 		return true
-	elseif args and facingMap[args[1]] then
-		Spring.SetBuildFacing(facingMap[args[1]])
+	elseif action and facingMap[action] then
+		Spring.SetBuildFacing(facingMap[action])
+		return true
+	end
+end
+
+local function buildSpacingHandler(command, line, args)
+	if not (preGamestartPlayer and selBuildQueueDefID) then
+		return
+	end
+
+	local action = args and args[1]
+	if action == "inc" then
+		buildModeState.spacing = buildModeState.spacing + 1
+		return true
+	elseif action == "dec" then
+		buildModeState.spacing = math.max(0, buildModeState.spacing - 1)
 		return true
 	end
 end
@@ -95,22 +134,22 @@ local function setPreGamestartDefID(uDefID)
 	return true
 end
 
-local function GetUnitCanCompleteQueue(uID)
-	local uDefID = Spring.GetUnitDefID(uID)
-	if uDefID == startDefID then
+local function GetUnitCanCompleteQueue(unitID)
+	local unitDefID = Spring.GetUnitDefID(unitID)
+	if unitDefID == startDefID then
 		return true
 	end
 
 	-- What can this unit build ?
-	local uCanBuild = {}
-	local uBuilds = UnitDefs[uDefID].buildOptions
-	for i = 1, #uBuilds do
-		uCanBuild[uBuilds[i]] = true
+	local buildableUnits = {}
+	local unitBuildOptions = UnitDefs[unitDefID].buildOptions
+	for i = 1, #unitBuildOptions do
+		buildableUnits[unitBuildOptions[i]] = true
 	end
 
 	-- Can it build everything that was queued ?
 	for i = 1, #buildQueue do
-		if not uCanBuild[buildQueue[i][1]] then
+		if not buildableUnits[buildQueue[i][1]] then
 			return false
 		end
 	end
@@ -182,6 +221,7 @@ end
 function widget:Initialize()
 	widgetHandler:AddAction("stop", clearPregameBuildQueue, nil, "p")
 	widgetHandler:AddAction("buildfacing", buildFacingHandler, nil, "p")
+	widgetHandler:AddAction("buildspacing", buildSpacingHandler, nil, "p")
 	widgetHandler:AddAction("buildmenu_pregame_deselect", buildmenuPregameDeselectHandler, nil, "p")
 
 	Spring.Log(widget:GetInfo().name, LOG.INFO, "Pregame Queue Initializing. Local SubLogic is assumed available.")
@@ -193,7 +233,7 @@ function widget:Initialize()
 		end
 	end
 
-	metalMap = WG["resource_spot_finder"].isMetalMap
+	isMetalMap = WG["resource_spot_finder"].isMetalMap
 
 	WG["pregame-build"] = {}
 	WG["pregame-build"].getPreGameDefID = function()
@@ -227,20 +267,270 @@ function widget:Initialize()
 	widgetHandler:RegisterGlobal("GetBuildQueue", WG["pregame-build"].getBuildQueue)
 end
 
-local function GetBuildingDimensions(uDefID, facing)
-	local bDef = UnitDefs[uDefID]
-	if facing % 2 == 1 then
-		return 4 * bDef.zsize, 4 * bDef.xsize
+local function GetBuildingDimensions(unitDefID, facing)
+	local buildingDef = UnitDefs[unitDefID]
+	if not buildingDef then return 0, 0 end
+
+	local FACING_WEST_OR_EAST = 1
+	if facing % 2 == FACING_WEST_OR_EAST then
+		return SQUARE_SIZE * buildingDef.zsize, SQUARE_SIZE * buildingDef.xsize
 	else
-		return 4 * bDef.xsize, 4 * bDef.zsize
+		return SQUARE_SIZE * buildingDef.xsize, SQUARE_SIZE * buildingDef.zsize
 	end
 end
 
-local function DoBuildingsClash(buildData1, buildData2)
-	local w1, h1 = GetBuildingDimensions(buildData1[1], buildData1[5])
-	local w2, h2 = GetBuildingDimensions(buildData2[1], buildData2[5])
+local function snapPosition(unitDefID, pos, facing)
+	local result = { x = 0, y = pos.y, z = 0 }
+	local buildingWidth, buildingHeight = GetBuildingDimensions(unitDefID, facing or 0)
 
-	return math.abs(buildData1[2] - buildData2[2]) < w1 + w2 and math.abs(buildData1[4] - buildData2[4]) < h1 + h2
+	if math.floor(buildingWidth / BUILD_SQUARE_SIZE) % 2 > 0 then
+		result.x = math.floor(pos.x / BUILD_SQUARE_SIZE) * BUILD_SQUARE_SIZE + SQUARE_SIZE
+	else
+		result.x = math.floor((pos.x + SQUARE_SIZE) / BUILD_SQUARE_SIZE) * BUILD_SQUARE_SIZE
+	end
+
+	if math.floor(buildingHeight / BUILD_SQUARE_SIZE) % 2 > 0 then
+		result.z = math.floor(pos.z / BUILD_SQUARE_SIZE) * BUILD_SQUARE_SIZE + SQUARE_SIZE
+	else
+		result.z = math.floor((pos.z + SQUARE_SIZE) / BUILD_SQUARE_SIZE) * BUILD_SQUARE_SIZE
+	end
+	
+	return result
+end
+
+local function fillRow(startX, startZ, stepX, stepZ, count, facing)
+	local result = {}
+	for _ = 1, count do
+		local groundY = Spring.GetGroundHeight(startX, startZ)
+		result[#result + 1] = { x = startX, y = groundY, z = startZ, facing = facing }
+		startX = startX + stepX
+		startZ = startZ + stepZ
+	end
+	return result
+end
+
+local function calculateBuildingPlacementSteps(unitDefID, startPos, endPos, spacing, facing)
+	local buildingWidth, buildingHeight = GetBuildingDimensions(unitDefID, facing)
+	local delta = { x = endPos.x - startPos.x, z = endPos.z - startPos.z }
+	
+	local xSize = buildingWidth + SQUARE_SIZE * spacing * 2
+	local zSize = buildingHeight + SQUARE_SIZE * spacing * 2
+	
+	local xCount = math.floor((math.abs(delta.x) + xSize * BUILDING_COUNT_FUDGE_FACTOR) / xSize)
+	local zCount = math.floor((math.abs(delta.z) + zSize * BUILDING_COUNT_FUDGE_FACTOR) / zSize)
+
+	local xStep = math.floor((delta.x > 0) and xSize or -xSize)
+	local zStep = math.floor((delta.z > 0) and zSize or -zSize)
+
+	return xStep, zStep, xCount, zCount, delta
+end
+
+local function getBuildPositionsSingle(unitDefID, facing, startPos)
+	if not startPos then
+		return {}
+	end
+
+	local snappedPos = snapPosition(unitDefID, startPos, facing)
+	local groundY = Spring.GetGroundHeight(snappedPos.x, snappedPos.z)
+	return { { x = snappedPos.x, y = groundY, z = snappedPos.z, facing = facing } }
+end
+
+local function getBuildPositionsLine(unitDefID, facing, startPos, endPos, spacing)
+	if not startPos or not endPos then
+		return {}
+	end
+	
+	local snappedStart = snapPosition(unitDefID, startPos, facing)
+	local snappedEnd = snapPosition(unitDefID, endPos, facing)
+	
+	local xStep, zStep, xCount, zCount, delta = calculateBuildingPlacementSteps(unitDefID, snappedStart, snappedEnd, spacing or 0, facing)
+	
+	local xGreaterThanZ = math.abs(delta.x) > math.abs(delta.z)
+
+	if xGreaterThanZ then
+		zStep = xStep * delta.z / (delta.x ~= 0 and delta.x or 1)
+	else
+		xStep = zStep * delta.x / (delta.z ~= 0 and delta.z or 1)
+	end
+
+	return fillRow(snappedStart.x, snappedStart.z, xStep, zStep, xGreaterThanZ and xCount or zCount, facing)
+end
+
+local function getBuildPositionsGrid(unitDefID, facing, startPos, endPos, spacing)
+	if not startPos or not endPos then
+		return {}
+	end
+	
+	local snappedStart = snapPosition(unitDefID, startPos, facing)
+	local snappedEnd = snapPosition(unitDefID, endPos, facing)
+
+	local xStep, zStep, xCount, zCount = calculateBuildingPlacementSteps(unitDefID, snappedStart, snappedEnd, spacing or 0, facing)
+
+	local result = {}
+	local currentRowZ = snappedStart.z
+	for rowIndex = 1, zCount do
+		if rowIndex % 2 == 0 then
+			table.append(result, fillRow(snappedStart.x + (xCount - 1) * xStep, currentRowZ, -xStep, 0, xCount, facing))
+		else
+			table.append(result, fillRow(snappedStart.x, currentRowZ, xStep, 0, xCount, facing))
+		end
+		currentRowZ = currentRowZ + zStep
+	end
+	
+	return result
+end
+
+local function getBuildPositionsBox(unitDefID, facing, startPos, endPos, spacing)
+	if not startPos or not endPos then
+		return {}
+	end
+	
+	local snappedStart = snapPosition(unitDefID, startPos, facing)
+	local snappedEnd = snapPosition(unitDefID, endPos, facing)
+
+	local xStep, zStep, xCount, zCount = calculateBuildingPlacementSteps(unitDefID, snappedStart, snappedEnd, spacing or 0, facing)
+
+	local result = {}
+
+	if xCount > 1 and zCount > 1 then
+		-- Left side: start from bottom-left + 1 up, go up (positive Z)
+		table.append(result, fillRow(snappedStart.x, snappedStart.z + zStep, 0, zStep, zCount - 1, facing))
+		-- Top side: start from top-left + 1 right, go right (positive X)
+		table.append(result, fillRow(snappedStart.x + xStep, snappedStart.z + (zCount - 1) * zStep, xStep, 0, xCount - 1, facing))
+		-- Right side: start from top-right, go down (negative Z)
+		table.append(result, fillRow(snappedStart.x + (xCount - 1) * xStep, snappedStart.z + (zCount - 2) * zStep, 0, -zStep, zCount - 1, facing))
+		-- Bottom side: start from bottom-right, go left (negative X)
+		table.append(result, fillRow(snappedStart.x + (xCount - 2) * xStep, snappedStart.z, -xStep, 0, xCount - 1, facing))
+	elseif xCount == 1 then
+		table.append(result, fillRow(snappedStart.x, snappedStart.z, 0, zStep, zCount, facing))
+	elseif zCount == 1 then
+		table.append(result, fillRow(snappedStart.x, snappedStart.z, xStep, 0, xCount, facing))
+	end
+	
+	return result
+end
+
+local function getBuildPositionsAround(unitDefID, facing, target)
+	if not target then
+		return {}
+	end
+
+	local targetBuildingWidth, targetBuildingHeight = GetBuildingDimensions(target.unitDefID, target.facing)
+	local currentBuildingWidth, currentBuildingHeight = GetBuildingDimensions(unitDefID, facing)
+
+	local widthBuildingCount = math.ceil((targetBuildingWidth + 2 * currentBuildingWidth) / currentBuildingWidth)
+	local heightBuildingCount = math.ceil((targetBuildingHeight + 2 * currentBuildingHeight) / currentBuildingHeight)
+
+	local perimeterWidth = widthBuildingCount * currentBuildingWidth
+	local perimeterHeight = heightBuildingCount * currentBuildingHeight
+
+	local startX = target.x - perimeterWidth * HALF + currentBuildingWidth * HALF
+	local startZ = target.z - perimeterHeight * HALF + currentBuildingHeight * HALF
+
+	local result = {}
+
+	local sides = {
+		-- top (south)
+		{z = target.z + targetBuildingHeight * HALF + currentBuildingHeight * HALF, count = widthBuildingCount, step = currentBuildingWidth, facing = 0, axis = "x"},
+		-- bottom (north)
+		{z = target.z - targetBuildingHeight * HALF - currentBuildingHeight * HALF, count = widthBuildingCount, step = currentBuildingWidth, facing = 2, axis = "x"},
+		-- left (west)
+		{x = target.x - targetBuildingWidth * HALF - currentBuildingWidth * HALF, count = heightBuildingCount, step = currentBuildingHeight, facing = 3, axis = "z"},
+		-- right (east)
+		{x = target.x + targetBuildingWidth * HALF + currentBuildingWidth * HALF, count = heightBuildingCount, step = currentBuildingHeight, facing = 1, axis = "z"}
+	}
+
+	for _, side in ipairs(sides) do
+		for i = 0, side.count - 1 do
+			local pos = {x = side.x or startX, y = 0, z = side.z or startZ, facing = side.facing}
+			if side.axis == "x" then
+				pos.x = startX + i * side.step
+			else
+				pos.z = startZ + i * side.step
+			end
+			table.insert(result, pos)
+		end
+	end
+
+	return result
+end
+
+local function determineBuildMode(modKeys, buildAroundTarget, startPosition)
+	local alt, ctrl, meta, shift = unpack(modKeys)
+
+	local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+	if isMex and not isMetalMap then
+		return BUILD_MODE.SINGLE
+	end
+
+	if shift and ctrl and buildAroundTarget then
+		return BUILD_MODE.AROUND
+	elseif shift and startPosition then
+		if alt and ctrl then
+			return BUILD_MODE.BOX
+		elseif alt and not ctrl then
+			return BUILD_MODE.GRID
+		elseif not alt and not ctrl then
+			return BUILD_MODE.LINE
+		end
+	end
+
+	return BUILD_MODE.SINGLE
+end
+
+local BUILD_POSITION_FUNCTIONS = {
+	[BUILD_MODE.SINGLE] = getBuildPositionsSingle,
+	[BUILD_MODE.LINE] = getBuildPositionsLine,
+	[BUILD_MODE.GRID] = getBuildPositionsGrid,
+	[BUILD_MODE.BOX] = getBuildPositionsBox,
+	[BUILD_MODE.AROUND] = getBuildPositionsAround
+}
+
+local function getGhostBuildingUnderCursor(mouseX, mouseY)
+	local _, cursorWorldPositionRaw = Spring.TraceScreenRay(mouseX, mouseY, true, false, false, false)
+	if not cursorWorldPositionRaw then
+		return nil
+	end
+	local cursorWorldPosition = { x = cursorWorldPositionRaw[1], y = cursorWorldPositionRaw[2], z = cursorWorldPositionRaw[3]}
+
+	for buildingIndex = #buildQueue, 1, -1 do
+		local buildingData = buildQueue[buildingIndex]
+		if buildingData[1] > 0 then
+			local ghostPosition = {
+				x = buildingData[2],
+				y = buildingData[3],
+				z = buildingData[4]
+			}
+			local distanceToBuilding = math.distance2d(cursorWorldPosition.x, cursorWorldPosition.z, ghostPosition.x, ghostPosition.z)
+			local buildingWidth, buildingHeight = GetBuildingDimensions(buildingData[1], buildingData[5] or 0)
+			local maximumDetectionDistance = math.max(buildingWidth * HALF, buildingHeight * HALF) + BUILDING_DETECTION_TOLERANCE
+
+			if distanceToBuilding <= maximumDetectionDistance then
+				return {
+					unitDefID = buildingData[1],
+					x = buildingData[2],
+					y = buildingData[3],
+					z = buildingData[4],
+					facing = buildingData[5] or 0
+				}
+			end
+		end
+	end
+
+	return nil
+end
+
+local function DoBuildingsClash(buildingData1, buildingData2)
+	local building1Width, building1Height = GetBuildingDimensions(buildingData1[1], buildingData1[5])
+	local building2Width, building2Height = GetBuildingDimensions(buildingData2[1], buildingData2[5])
+
+	local halfBuilding1Width, halfBuilding1Height = building1Width * HALF, building1Height * HALF
+	local halfBuilding2Width, halfBuilding2Height = building2Width * HALF, building2Height * HALF
+
+	local xDistance = math.abs(buildingData1[2] - buildingData2[2])
+	local zDistance = math.abs(buildingData1[4] - buildingData2[4])
+
+	return xDistance < halfBuilding1Width + halfBuilding2Width and zDistance < halfBuilding1Height + halfBuilding2Height
 end
 
 local function removeUnitShape(id)
@@ -254,22 +544,23 @@ local function addUnitShape(id, unitDefID, px, py, pz, rotationY, teamID, alpha)
 	if unitshapes[id] then
 		removeUnitShape(id)
 	end
-	unitshapes[id] = WG.DrawUnitShapeGL4(unitDefID, px, py, pz, rotationY, alpha or 1, teamID, nil, nil, nil)
+	unitshapes[id] = WG.DrawUnitShapeGL4(unitDefID, px, py, pz, rotationY, alpha or 1, teamID, nil, nil, nil, widget:GetInfo().name)
 	return unitshapes[id]
 end
 
 local function DrawBuilding(buildData, borderColor, drawRanges, alpha)
 	local bDefID, bx, by, bz, facing = buildData[1], buildData[2], buildData[3], buildData[4], buildData[5]
-	local bw, bh = GetBuildingDimensions(bDefID, facing)
+	local buildingWidth, buildingHeight = GetBuildingDimensions(bDefID, facing)
+	local halfBuildingWidth, halfBuildingHeight = buildingWidth * HALF, buildingHeight * HALF
 
 	gl.DepthTest(false)
 	gl.Color(borderColor)
 
 	gl.Shape(GL.LINE_LOOP, {
-		{ v = { bx - bw, by, bz - bh } },
-		{ v = { bx + bw, by, bz - bh } },
-		{ v = { bx + bw, by, bz + bh } },
-		{ v = { bx - bw, by, bz + bh } },
+		{ v = { bx - halfBuildingWidth, by, bz - halfBuildingHeight } },
+		{ v = { bx + halfBuildingWidth, by, bz - halfBuildingHeight } },
+		{ v = { bx + halfBuildingWidth, by, bz + halfBuildingHeight } },
+		{ v = { bx - halfBuildingWidth, by, bz + halfBuildingHeight } },
 	})
 
 	if drawRanges then
@@ -279,11 +570,6 @@ local function DrawBuilding(buildData, borderColor, drawRanges, alpha)
 			gl.DrawGroundCircle(bx, by, bz, Game.extractorRadius, 50)
 		end
 
-		local wRange = false --unitMaxWeaponRange[bDefID]
-		if wRange then
-			gl.Color(1.0, 0.3, 0.3, 0.7)
-			gl.DrawGroundCircle(bx, by, bz, wRange, 40)
-		end
 	end
 	if WG.StopDrawUnitShapeGL4 then
 		local id = buildData[1]
@@ -303,7 +589,132 @@ local function isUnderwater(unitDefID)
 	return UnitDefs[unitDefID].modCategories.underwater
 end
 
--- Special handling for buildings before game start, since there isn't yet a unit spawned to give normal orders to
+local function getMouseWorldPosition(unitDefID, x, y)
+	local _, pos = Spring.TraceScreenRay(x, y, true, false, false, isUnderwater(unitDefID))
+	if pos then
+		local buildFacing = Spring.GetBuildFacing()
+		local posX = pos.x or pos[1]
+		local posY = pos.y or pos[2]
+		local posZ = pos.z or pos[3]
+		local bx, by, bz = Spring.Pos2BuildPos(unitDefID, posX, posY, posZ, buildFacing)
+		return { x = bx, y = by, z = bz }
+	end
+	return nil
+end
+
+local UPDATE_PERIOD = 1 / 30
+local updateTime = 0
+function widget:Update(dt)
+	if not preGamestartPlayer or not selBuildQueueDefID then
+		return
+	end
+	
+	updateTime = updateTime + dt
+	if updateTime < UPDATE_PERIOD then
+		return
+	end
+	updateTime = 0
+	
+	local x, y, leftButton = Spring.GetMouseState()
+	
+	if not leftButton then
+		if buildModeState.startPosition and #buildModeState.buildPositions > 0 then
+			local newBuildQueue = {}
+
+			for _, buildPos in ipairs(buildModeState.buildPositions) do
+				local buildPosX = buildPos.x
+				local buildPosY = buildPos.y
+				local buildPosZ = buildPos.z
+				local buildPosFacing = buildPos.facing
+				local posX, posY, posZ = Spring.Pos2BuildPos(selBuildQueueDefID, buildPosX, buildPosY, buildPosZ, buildPosFacing or Spring.GetBuildFacing())
+				local buildFacingPos = buildPosFacing or Spring.GetBuildFacing()
+				local buildDataPos = { selBuildQueueDefID, posX, posY, posZ, buildFacingPos }
+
+				local hasConflicts = false
+
+				local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+				if cx ~= -100 then
+					local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+					if DoBuildingsClash(buildDataPos, { startDefID, cbx, cby, cbz, 1 }) then
+						hasConflicts = true
+					end
+				end
+
+				if not hasConflicts then
+					for i = #buildQueue, 1, -1 do
+						if buildQueue[i][1] > 0 and DoBuildingsClash(buildDataPos, buildQueue[i]) then
+							table.remove(buildQueue, i)
+							hasConflicts = true
+						end
+					end
+				end
+				if not hasConflicts and Spring.TestBuildOrder(selBuildQueueDefID, posX, posY, posZ, buildFacingPos) == 0 then
+					hasConflicts = true
+				end
+				if not hasConflicts then
+					local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+					if isMex and not isMetalMap then
+						local spot = WG["resource_spot_finder"].GetClosestMexSpot(posX, posZ)
+						local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid(spot, posX, posZ) or false
+						local spotIsTaken = spot and WG["resource_spot_builder"].SpotHasExtractorQueued(spot) or false
+						if not validPos or spotIsTaken then
+							hasConflicts = true
+						end
+					end
+				end
+
+				if not hasConflicts then
+					table.insert(newBuildQueue, buildDataPos)
+				end
+			end
+			if #newBuildQueue > 0 then
+				for _, buildDataPos in ipairs(newBuildQueue) do
+					buildQueue[#buildQueue + 1] = buildDataPos
+				end
+			end
+		end
+
+		buildModeState.startPosition = nil
+		buildModeState.buildPositions = {}
+		return
+	end
+	
+	local alt, ctrl, meta, shift = Spring.GetModKeyState()
+	
+	if not shift and buildModeState.startPosition then
+		buildModeState.startPosition = nil
+		buildModeState.buildPositions = {}
+		return
+	end
+	
+	if not buildModeState.startPosition then
+		return
+	end
+	local modKeys = { alt, ctrl, meta, shift }
+	
+	local buildAroundTarget = getGhostBuildingUnderCursor(x, y)
+
+	local endPosition = getMouseWorldPosition(selBuildQueueDefID, x, y)
+	if not endPosition then
+		return
+	end
+
+	buildModeState.endPosition = endPosition
+	buildModeState.buildAroundTarget = buildAroundTarget
+
+	local buildFacing = Spring.GetBuildFacing()
+	local mode = determineBuildMode(modKeys, buildAroundTarget, buildModeState.startPosition)
+	buildModeState.mode = mode
+
+	if mode == BUILD_MODE.AROUND then
+		buildModeState.buildPositions = BUILD_POSITION_FUNCTIONS[mode](selBuildQueueDefID, buildFacing, buildAroundTarget)
+	elseif mode == BUILD_MODE.SINGLE then
+		buildModeState.buildPositions = BUILD_POSITION_FUNCTIONS[mode](selBuildQueueDefID, buildFacing, endPosition)
+	else
+		buildModeState.buildPositions = BUILD_POSITION_FUNCTIONS[mode](selBuildQueueDefID, buildFacing, buildModeState.startPosition, endPosition, buildModeState.spacing)
+	end
+end
+
 function widget:MousePress(mx, my, button)
 	if Spring.IsGUIHidden() then
 		return
@@ -318,85 +729,201 @@ function widget:MousePress(mx, my, button)
 	end
 	local _, _, meta, shift = Spring.GetModKeyState()
 
-	if selBuildQueueDefID then
-		local _, pos = Spring.TraceScreenRay(mx, my, true, false, false, isUnderwater(selBuildQueueDefID))
-		if button == 1 then
-			local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
-			if WG.ExtractorSnap then
-				local snapPos = WG.ExtractorSnap.position
-				if snapPos then
-					pos = { snapPos.x, snapPos.y, snapPos.z }
-				end
-			end
+	if not selBuildQueueDefID then
+		return false
+	end
 
-			if not pos then
-				return
-			end
-
+	local alt, ctrl = Spring.GetModKeyState()
+	if button == 1 and shift and ctrl then
+		local buildAroundTarget = getGhostBuildingUnderCursor(mx, my)
+		if buildAroundTarget then
 			local buildFacing = Spring.GetBuildFacing()
-			local bx, by, bz = Spring.Pos2BuildPos(selBuildQueueDefID, pos[1], pos[2], pos[3], buildFacing)
-			local buildData = { selBuildQueueDefID, bx, by, bz, buildFacing }
-			local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID) -- Returns -100, -100, -100 when none chosen
+			local aroundPositions = BUILD_POSITION_FUNCTIONS[BUILD_MODE.AROUND](selBuildQueueDefID, buildFacing, buildAroundTarget)
 
-			if (meta or not shift) and cx ~= -100 then
-				local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+			if #aroundPositions > 0 then
+				local newBuildQueue = {}
 
-				if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then -- avoid clashing building and commander position
-					return true
-				end
-			end
+				local filteredAroundPositions = {}
+				for _, buildPos in ipairs(aroundPositions) do
+					local buildPosX = buildPos.x
+					local buildPosY = buildPos.y
+					local buildPosZ = buildPos.z
+					local buildPosFacing = buildPos.facing
+					local posX, posY, posZ = Spring.Pos2BuildPos(selBuildQueueDefID, buildPosX, buildPosY, buildPosZ, buildPosFacing or buildFacing)
+					local buildFacingPos = buildPosFacing or buildFacing
+					local buildDataPos = { selBuildQueueDefID, posX, posY, posZ, buildFacingPos }
 
-			if Spring.TestBuildOrder(selBuildQueueDefID, bx, by, bz, buildFacing) ~= 0 then
-				if meta then
-					table.insert(buildQueue, 1, buildData)
-				elseif shift then
-					local anyClashes = false
-					for i = #buildQueue, 1, -1 do
-						if buildQueue[i][1] > 0 then
-							if DoBuildingsClash(buildData, buildQueue[i]) then
-								anyClashes = true
-								table.remove(buildQueue, i)
+					local hasOverlap = false
+					for i = 1, #buildQueue do
+						if buildQueue[i][1] > 0 and DoBuildingsClash(buildDataPos, buildQueue[i]) then
+							hasOverlap = true
+							break
+						end
+					end
+
+					if not hasOverlap then
+						for _, existingPos in ipairs(filteredAroundPositions) do
+							local existingPosX, existingPosY, existingPosZ = existingPos[2], existingPos[3], existingPos[4]
+							local existingBuildData = { selBuildQueueDefID, existingPosX, existingPosY, existingPosZ, existingPos[5] }
+							if DoBuildingsClash(buildDataPos, existingBuildData) then
+								hasOverlap = true
+								break
 							end
 						end
 					end
 
-					if isMex and not metalMap then
-						-- Special handling to check if mex position is valid
-						local spot = WG["resource_spot_finder"].GetClosestMexSpot(bx, bz)
-						local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid(spot, bx, bz) or false
-						local spotIsTaken = spot and WG["resource_spot_builder"].SpotHasExtractorQueued(spot) or false
-						if not validPos or spotIsTaken then
-							return true
+					if not hasOverlap then
+						table.insert(filteredAroundPositions, buildDataPos)
+					end
+				end
+
+				for _, buildDataPos in ipairs(filteredAroundPositions) do
+					local posX, posY, posZ, buildFacingPos = buildDataPos[2], buildDataPos[3], buildDataPos[4], buildDataPos[5]
+
+					local hasConflicts = false
+
+					local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+					if cx ~= -100 then
+						local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+						if DoBuildingsClash(buildDataPos, { startDefID, cbx, cby, cbz, 1 }) then
+							hasConflicts = true
 						end
 					end
 
-					if not anyClashes then
-						buildQueue[#buildQueue + 1] = buildData
-						handleBuildMenu(shift)
+					if not hasConflicts and Spring.TestBuildOrder(selBuildQueueDefID, posX, posY, posZ, buildFacingPos) == 0 then
+						hasConflicts = true
 					end
+
+					local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+					if not hasConflicts and isMex and not isMetalMap then
+						local spot = WG["resource_spot_finder"].GetClosestMexSpot(posX, posZ)
+						local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid(spot, posX, posZ) or false
+						local spotIsTaken = spot and WG["resource_spot_builder"].SpotHasExtractorQueued(spot) or false
+						if not validPos or spotIsTaken then
+							hasConflicts = true
+						end
+					end
+
+					if not hasConflicts then
+						table.insert(newBuildQueue, buildDataPos)
+					end
+				end
+
+				if #newBuildQueue > 0 then
+					for _, buildDataPos in ipairs(newBuildQueue) do
+						buildQueue[#buildQueue + 1] = buildDataPos
+					end
+				end
+
+				return true
+			end
+		end
+	end
+
+	local _, pos = Spring.TraceScreenRay(mx, my, true, false, false, isUnderwater(selBuildQueueDefID))
+	if button == 1 then
+		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+		if WG.ExtractorSnap then
+			local snapPos = WG.ExtractorSnap.position
+			if snapPos then
+				pos = { snapPos.x, snapPos.y, snapPos.z }
+			end
+		end
+
+		if not pos then
+			return
+		end
+
+		local buildFacing = Spring.GetBuildFacing()
+		local posX = pos.x or pos[1]
+		local posY = pos.y or pos[2]
+		local posZ = pos.z or pos[3]
+		local bx, by, bz = Spring.Pos2BuildPos(selBuildQueueDefID, posX, posY, posZ, buildFacing)
+		local buildData = { selBuildQueueDefID, bx, by, bz, buildFacing }
+		local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+
+		local alt, ctrl = Spring.GetModKeyState()
+
+		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+		if shift and not buildModeState.startPosition and not (isMex and not isMetalMap) then
+			buildModeState.startPosition = { x = bx, y = by, z = bz }
+			buildModeState.endPosition = { x = bx, y = by, z = bz }
+			buildModeState.buildPositions = {}
+			return true
+		end
+		
+		
+		if (meta or not shift) and cx ~= -100 then
+			local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+
+			if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then
+				return true
+			end
+		end
+
+		if Spring.TestBuildOrder(selBuildQueueDefID, bx, by, bz, buildFacing) ~= 0 then
+			local hasConflicts = false
+
+			local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+			if cx ~= -100 then
+				local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+				if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then
+					hasConflicts = true
+				end
+			end
+
+			if not hasConflicts then
+				for i = #buildQueue, 1, -1 do
+					if buildQueue[i][1] > 0 and DoBuildingsClash(buildData, buildQueue[i]) then
+						table.remove(buildQueue, i)
+						hasConflicts = true
+					end
+				end
+			end
+
+			if not hasConflicts and isMex and not isMetalMap then
+				local spot = WG["resource_spot_finder"].GetClosestMexSpot(bx, bz)
+				local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid(spot, bx, bz) or false
+				local spotIsTaken = spot and WG["resource_spot_builder"].SpotHasExtractorQueued(spot) or false
+				if not validPos or spotIsTaken then
+					hasConflicts = true
+				end
+			end
+
+			if not hasConflicts then
+				if meta then
+					table.insert(buildQueue, 1, buildData)
+				elseif shift then
+					buildQueue[#buildQueue + 1] = buildData
+					handleBuildMenu(shift)
 				else
-					-- don't place mex if the spot is not valid
 					if isMex then
-						if WG.ExtractorSnap.position or metalMap then
+						if WG.ExtractorSnap.position or isMetalMap then
 							buildQueue = { buildData }
+							handleBuildMenu(false)
 						end
 					else
 						buildQueue = { buildData }
-						handleBuildMenu(shift)
+						handleBuildMenu(false)
 					end
 				end
 
 				if not shift then
 					setPreGamestartDefID(nil)
-					handleBuildMenu(shift)
 				end
 			end
-
-			return true
-		elseif button == 3 then
-			setPreGamestartDefID(nil)
 		end
-	elseif button == 1 and #buildQueue > 0 and buildQueue[1][1]>0 then -- avoid clashing first building and commander position
+
+		return true
+	end
+
+	if button == 3 then
+		setPreGamestartDefID(nil)
+		buildModeState.startPosition = nil
+		buildModeState.buildPositions = {}
+	end
+
+	if button == 1 and #buildQueue > 0 and buildQueue[1][1]>0 then
 		local _, pos = Spring.TraceScreenRay(mx, my, true, false, false, isUnderwater(startDefID))
 		if not pos then
 			return
@@ -406,7 +933,9 @@ function widget:MousePress(mx, my, button)
 		if DoBuildingsClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1]) then
 			return true
 		end
-	elseif button == 3 and shift then
+	end
+
+	if button == 3 and shift then
 		local x, y, _ = Spring.GetMouseState()
 		local _, pos = Spring.TraceScreenRay(x, y, true, false, false, true)
 		if pos and pos[1] then
@@ -414,8 +943,9 @@ function widget:MousePress(mx, my, button)
 
 			buildQueue[#buildQueue + 1] = buildData
 		end
-	elseif button == 3 and #buildQueue > 0 then -- remove units from buildqueue one by one
-		-- TODO: If mouse is over a building, remove only that building instead
+	end
+
+	if button == 3 and #buildQueue > 0 then
 		table.remove(buildQueue, #buildQueue)
 
 		return true
@@ -561,12 +1091,183 @@ function widget:DrawWorld()
 	gl.Shape(GL.LINE_STRIP, queueLineVerts)
 	gl.LineStipple(false)
 
-	-- Draw selected building
-	if selBuildData then
+	local function convertBuildPosToPreviewData(buildPos, buildFacing)
+		local posX, posY, posZ = Spring.Pos2BuildPos(selBuildQueueDefID, buildPos.x, buildPos.y, buildPos.z, buildPos.facing or buildFacing)
+		local buildFacingPos = buildPos.facing or buildFacing
+		return { selBuildQueueDefID, posX, posY, posZ, buildFacingPos }
+	end
+
+	local function checkCommanderClash(previewBuildData, cx, cy, cz)
+		if cx == -100 then
+			return false
+		end
+		local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+		return DoBuildingsClash(previewBuildData, { startDefID, cbx, cby, cbz, 1 })
+	end
+
+	local function checkMexValidity(posX, posZ, isMex)
+		if not isMex or isMetalMap then
+			return true
+		end
+		local spot = WG["resource_spot_finder"] and WG["resource_spot_finder"].GetClosestMexSpot and WG["resource_spot_finder"].GetClosestMexSpot(posX, posZ)
+		local validPos = spot and WG["resource_spot_finder"].IsMexPositionValid and WG["resource_spot_finder"].IsMexPositionValid(spot, posX, posZ) or false
+		local spotIsTaken = spot and WG["resource_spot_builder"] and WG["resource_spot_builder"].SpotHasExtractorQueued and WG["resource_spot_builder"].SpotHasExtractorQueued(spot) or false
+		return validPos and not spotIsTaken
+	end
+
+	local function isBuildAroundModeActive()
+		local alt, ctrl, meta, shift = Spring.GetModKeyState()
+		if not (shift and ctrl) then
+			return false, nil
+		end
+		local x, y = Spring.GetMouseState()
+		local buildAroundTarget = getGhostBuildingUnderCursor(x, y)
+		return buildAroundTarget ~= nil, buildAroundTarget
+	end
+
+	local showPreview = false
+	local previewPositions = {}
+	local isBuildAroundMode = false
+
+	if buildModeState.startPosition and #buildModeState.buildPositions > 0 and selBuildQueueDefID then
+		showPreview = true
+		previewPositions = buildModeState.buildPositions
+	elseif selBuildQueueDefID then
+		local buildAroundActive, buildAroundTarget = isBuildAroundModeActive()
+		if buildAroundActive then
+			local buildFacing = Spring.GetBuildFacing()
+			previewPositions = BUILD_POSITION_FUNCTIONS[BUILD_MODE.AROUND](selBuildQueueDefID, buildFacing, buildAroundTarget)
+			if #previewPositions > 0 then
+				showPreview = true
+				isBuildAroundMode = true
+			end
+		end
+	end
+
+	if showPreview then
+		local buildFacing = Spring.GetBuildFacing()
+		local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+
+		local previewSpawnStatus = {}
+		local getBuildQueueSpawnStatus = WG["getBuildQueueSpawnStatus"]
+		if getBuildQueueSpawnStatus then
+			local tempQueue = {}
+			for _, b in ipairs(buildQueue) do
+				table.insert(tempQueue, b)
+			end
+
+			local validPreviewPositions = {}
+
+			for _, buildPos in ipairs(previewPositions) do
+				local previewBuildData = convertBuildPosToPreviewData(buildPos, buildFacing)
+				local hasConflicts = false
+
+				if isBuildAroundMode then
+					for _, existingPos in ipairs(validPreviewPositions) do
+						if DoBuildingsClash(previewBuildData, existingPos) then
+							hasConflicts = true
+							break
+						end
+					end
+				end
+
+				if not hasConflicts then
+					table.insert(validPreviewPositions, previewBuildData)
+				end
+			end
+
+			local validPreviewCount = 0
+			for _, previewBuildData in ipairs(validPreviewPositions) do
+				local posX, posY, posZ, buildFacingPos = previewBuildData[2], previewBuildData[3], previewBuildData[4], previewBuildData[5]
+				local isValid = Spring.TestBuildOrder(selBuildQueueDefID, posX, posY, posZ, buildFacingPos) ~= 0
+				local clashesWithCommander = checkCommanderClash(previewBuildData, cx, cy, cz)
+				local mexValid = checkMexValidity(posX, posZ, isMex)
+
+				if not clashesWithCommander and isValid and mexValid then
+					table.insert(tempQueue, previewBuildData)
+					validPreviewCount = validPreviewCount + 1
+				end
+			end
+
+			if validPreviewCount > 0 then
+				local spawnStatus = getBuildQueueSpawnStatus(tempQueue, nil)
+				for i = #buildQueue + 1, #tempQueue do
+					previewSpawnStatus[i - #buildQueue] = spawnStatus.queueSpawned[i] or false
+				end
+			end
+		end
+
+		local filteredPreviewPositions = {}
+		local filteredPreviewBuildData = {}
+		for _, buildPos in ipairs(previewPositions) do
+			local previewBuildData = convertBuildPosToPreviewData(buildPos, buildFacing)
+			local hasOverlap = false
+
+			if isBuildAroundMode then
+				for _, existingBuildData in ipairs(filteredPreviewBuildData) do
+					if DoBuildingsClash(previewBuildData, existingBuildData) then
+						hasOverlap = true
+						break
+					end
+				end
+
+				if not hasOverlap then
+					for i = 1, #buildQueue do
+						if buildQueue[i][1] > 0 and DoBuildingsClash(previewBuildData, buildQueue[i]) then
+							hasOverlap = true
+							break
+						end
+					end
+				end
+			end
+
+			if not hasOverlap then
+				table.insert(filteredPreviewPositions, buildPos)
+				table.insert(filteredPreviewBuildData, previewBuildData)
+			end
+		end
+
+		local previewIndex = 1
+		for _, buildPos in ipairs(filteredPreviewPositions) do
+			local previewBuildData = convertBuildPosToPreviewData(buildPos, buildFacing)
+			local posX, posY, posZ, buildFacingPos = previewBuildData[2], previewBuildData[3], previewBuildData[4], previewBuildData[5]
+			local isValid = Spring.TestBuildOrder(selBuildQueueDefID, posX, posY, posZ, buildFacingPos) ~= 0
+			local clashesWithCommander = checkCommanderClash(previewBuildData, cx, cy, cz)
+
+			if clashesWithCommander then
+				DrawBuilding(previewBuildData, BORDER_COLOR_CLASH, false, ALPHA_DEFAULT)
+			elseif isValid then
+				local mexValid = checkMexValidity(posX, posZ, isMex)
+				if mexValid then
+					local wouldBeSpawned = previewSpawnStatus[previewIndex] or false
+					local borderColor = wouldBeSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID
+					local previewAlpha = wouldBeSpawned and ALPHA_SPAWNED or ALPHA_DEFAULT
+					DrawBuilding(previewBuildData, borderColor, false, previewAlpha)
+					previewIndex = previewIndex + 1
+				else
+					DrawBuilding(previewBuildData, BORDER_COLOR_INVALID, false, ALPHA_DEFAULT)
+				end
+			else
+				DrawBuilding(previewBuildData, BORDER_COLOR_INVALID, false, ALPHA_DEFAULT)
+			end
+		end
+	end
+
+	local showSelectedBuilding = true
+	if buildModeState.startPosition then
+		showSelectedBuilding = false
+	else
+		local buildAroundActive = isBuildAroundModeActive()
+		if buildAroundActive then
+			showSelectedBuilding = false
+		end
+	end
+
+	if selBuildData and showSelectedBuilding then
 		local selectedAlpha = alphaResults.selectedAlpha or ALPHA_DEFAULT
 		local isSelectedSpawned = selectedAlpha >= ALPHA_SPAWNED
 		
-		-- mmm, convoluted logic. Pregame handling is hell
 		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
 		local testOrder = spTestBuildOrder(
 			selBuildQueueDefID,
@@ -579,7 +1280,7 @@ function widget:DrawWorld()
 			local color = testOrder and (isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID) or BORDER_COLOR_INVALID
 			DrawBuilding(selBuildData, color, true, selectedAlpha)
 		elseif isMex then
-			if WG.ExtractorSnap.position or metalMap then
+			if WG.ExtractorSnap.position or isMetalMap then
 				local color = isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID
 				DrawBuilding(selBuildData, color, true, selectedAlpha)
 			else
@@ -679,6 +1380,7 @@ function widget:GameStart()
 	-- Deattach pregame action handlers
 	widgetHandler:RemoveAction("stop")
 	widgetHandler:RemoveAction("buildfacing")
+	widgetHandler:RemoveAction("buildspacing")
 	widgetHandler:RemoveAction("buildmenu_pregame_deselect")
 end
 


### PR DESCRIPTION
adds grid, square, line, and surround build key combos for pregame build. Works with quickstart custom square colors. See attached video.

Testing steps:
- play game normally or  with quickstart
- if using quickstart, pay attention to purple square outlines around buildings when they're in the budget.
- otherwise, try CTRL + Shift for surround build
- hold shift only and click+drag to do line builds
- hold shift and click and it'll append another build to the queue
- CTRL + Shift + Alt for square build (empty space in middle)
- Shift + Alt for grid build
- while Shift + Alt, press Z or X to increase or decrease spacing

abuse it, try to break it.
## known suckiness
the performance of this widget is ass. Prior attempts with more major overhauls barely yielded performance improvements. The only real option for improvement is to use ghost VBO's, square vbo's, range vbo's etc instead of drawing gl.shapes. This is very complicated and I don't wanna do it. Shaders are pain.
as it is, it performs just fine so long as you don't try to cover an absurd area (like an entire 12x12 map) with a grid build.

This was made in tandem with an AI assistant. I've read and tested the code myself. See video (which I forgot to do line build on. Whoops. Trust me bro, it totally works.)
https://youtu.be/YwpeycDdtz8