### PR TITLE
use default corpse for Armada Experimental Shipyard (armhasy) to fix feature not found error and lack of wreck

### DIFF
--- a/units/ArmBuildings/SeaFactories/armhasy.lua
+++ b/units/ArmBuildings/SeaFactories/armhasy.lua
@@ -7,7 +7,7 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "256 80 221",
 		collisionvolumetype = "Box",
-		corpse = "ARMSHLT_DEAD",
+		corpse = "DEAD",
 		energycost = 44000,
 		energystorage = 1400,
 		explodeas = "hugeBuildingexplosiongeneric-uw",


### PR DESCRIPTION
### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
- updated unit definition for Armada Experimental Shipyard (armhasy) to use its existing corpse definition
- found using the infolog integration test runner, so this furthers the goal of re-enabling the infolog integration test runner
- many thanks to @badosu for his assistance




#### Test steps
- [ ] Enable experimental units
- [ ] create arm experimental shipyard
- [ ] kill the shipyard without overkill
- [ ] expect experimental shipyard wreck to be left behind


### Screenshots:

#### BEFORE:
(screenshot from master)

live shipyard 

<img width="665" height="699" alt="live_shipyard" src="https://github.com/user-attachments/assets/01bedce8-c54d-49d2-8416-ee1b2a843624" />

no wreck (bad)

<img width="567" height="637" alt="no_wreck" src="https://github.com/user-attachments/assets/4bd38319-bb14-4a69-b86b-3295fb461e89" />




#### AFTER:
(screenshot from branch)


left a wreck behind (good) 

<img width="684" height="688" alt="yes_wreck" src="https://github.com/user-attachments/assets/757e8834-e04b-420e-9f32-daaea9c4ea2f" />

#### LLM Disclosure:
No LLM was used in this PR