### PR TITLE
Improvements for builder buggeroff

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -183,8 +183,9 @@ function gadget:GameFrame(frame)
 					-- Only buggeroff from one build site at a time
 					visitedUnits[interferingUnitID] = true
 					local unitX, _, unitZ = Spring.GetUnitPosition(interferingUnitID)
-					if shouldIssueBuggeroff(cachedBuilderTeams[builderID], interferingUnitID, targetX, targetY, targetZ, buggerOffRadius) then
-						local sendX, sendZ = math.closestPointOnCircle(targetX, targetZ, buggerOffRadius, unitX, unitZ)
+					local unitBuggerRadius = cachedUnitDefs[builtUnitDefID].radius + buggerOffRadius
+					if shouldIssueBuggeroff(cachedBuilderTeams[builderID], interferingUnitID, targetX, targetY, targetZ, unitBuggerRadius) then
+						local sendX, sendZ = math.closestPointOnCircle(targetX, targetZ, unitBuggerRadius, unitX, unitZ)
 						for _ = 1, 2 do
 							if not Spring.TestMoveOrder(Spring.GetUnitDefID(interferingUnitID), sendX, targetY, sendZ) then
 								-- It is preferable to move the unit any distance at all toward the move goal. -- fixme: stupid hack


### PR DESCRIPTION
It's probably easier to read this from the 5th commit and on since the rest are mostly making sense of things first.

### Work done

This improves how the gadget detects unit blocking, especially for fast units:

- Better search for fast units that pass through the build site but do not end up blocking it.
- Increasing unit search radius with increasing buggeroff radius, and a slightly faster increase.
- Replaced some magic numbers and qualified the meaning of some other config values.
- Account for the radius of both units when predicting blocking in the near future.

Plus minor fixes:

- Fixed the `Gadget` class type declaration.
- Fixed units being given multiple buggeroff orders per-update (rarely).

### Test Steps

- [ ] Set up several labs and extra BP to produce unit spam.
- [ ] Send a line of spam through an area with some constructors.
- [ ] Place buildings in the path of the unit stream.
- [ ] Meausure time-to-place on different build sites.

In anything approaching normal conditions, the time to place a T2 lab inside a ball of units is still around 2 to 3 seconds. With this change, my worst case testing is around 8 seconds, with 6 labs producing Legion Wheelies and pathing them over the site. Previously, the building never finished placing in that scenario.

I also tested the above in narrow areas with blocking terrain and was able to place a T2 lab only after setting up the "stupid hack" in the step after testing the move order. That could be improved but works, at least. The engine gives a good example to follow.