### PR TITLE
Area Command Filter has to run before Smart Area Reclaim

### DIFF
--- a/luaui/Widgets/cmd_area_commands_filter.lua
+++ b/luaui/Widgets/cmd_area_commands_filter.lua
@@ -12,7 +12,7 @@ function widget:GetInfo()
 		author = "SuperKitowiec. Based on Specific Unit Reclaimer and Loader by Google Frog",
 		date = "October 16, 2025",
 		license = "GNU GPL, v2 or later",
-		layer = 0,
+		layer = -1,
 		enabled = true
 	}
 end


### PR DESCRIPTION
Currently the Smart Area Reclaim might get loaded before Area Command Filter, consuming reclaim order in the process. Area Command Filter should run first because it's more restricitve - you have to point at unit/wreck and hold modifier. Only if these conditions are not met, the command should be handled by Smart Area Reclaim.