### PR TITLE
Automaticially unwait fully healed units

### DIFF
--- a/luarules/gadgets/unit_resurrected.lua
+++ b/luarules/gadgets/unit_resurrected.lua
@@ -79,6 +79,7 @@ function gadget:GameFrame(n)
 			for unitID, check in pairs(toBeUnWaited) do
 				local health = spGetUnitHealth(unitID)
 				if health <= prevHealth[unitID] then -- stopped healing
+					createdFrame[unitID] = nil
 					toBeUnWaited[unitID] = nil
 					prevHealth[unitID] = nil
 					currentCmd = spGetUnitCurrentCommand(unitID, 1)


### PR DESCRIPTION
### Work done
Added a periodic check to unwait resurrected units when they are fully healed, or stopped being repaired. This is the same check as is used to add new units to autogroups. 

There is a slight chance of a unit being unwaited early if the checked frame lines up in a pause between the builder resurrecting and the builder repairing. 

Units that are builders are also not set to wait at all so they correctly appear as idle. 

Before:
<img width="2058" height="1053" alt="image" src="https://github.com/user-attachments/assets/352dca97-9713-4542-a541-704880a9d262" />

AFfter: 
<img width="1487" height="982" alt="image" src="https://github.com/user-attachments/assets/8922c273-6e48-485d-8f00-521024a85802" />
