### PR TITLE
Properly consume command for Alt Set Target Type 

### DIFF
--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -8,7 +8,7 @@ function widget:GetInfo()
 		date	= "August 1, 2025",
 		version = "1.0",
 		license = "GNU GPL, v2 or later",
-		layer 	= -1,
+		layer 	= -1, -- won't work at layer 0 for unknown reasons
 		enabled = true
 	}
 end


### PR DESCRIPTION
The widget functions perfectly in:
1. Skirmish
2. Multiplayer games against AI
3. If added as a custom widget

The widget completely fails to function in multiplayer games where there are real people on the enemy team.
I don't have a great way to test any fixes I come up with for this, so I'm just trying stuff out. I've verified that the widget continues to function in skirmish after these changes.

Changes made:
Change the team logic to work with unit teams instead of allyteams
Null checks for teams
Decrease the layer to make the widget go first
Actually consume the alt command 