### PR TITLE
Buggeroff-math-fix-and-etc

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -54,7 +54,7 @@ local BUGGEROFF_RADIUS_INCREMENT = 2 * Game.squareSize
 -- Move away based on predicted position with lookahead:
 local BUGGEROFF_LOOKAHEAD   = (1/6) * gameSpeed
 -- The max buggeroff radius = increment * (time * update rate - 1), so we set a max time here also, implicitly.
--- Prevent units from roaming by maintaining a max raduis <= 400, the engine's max leash radius (see e.g. CMobileCAI::ExecuteFight).
+-- Prevent units from roaming by maintaining a max radius <= 400, the engine's max leash radius (see e.g. CMobileCAI::ExecuteFight).
 local MAX_BUGGEROFF_TIME    = 13
 local MAX_BUGGEROFF_RADIUS  = BUGGEROFF_RADIUS_INCREMENT * (MAX_BUGGEROFF_TIME * gameSpeed / FAST_UPDATE_FREQUENCY - 1) -- => 400 elmos
 -- Don't buggeroff units that were ordered to do something recently


### PR DESCRIPTION
After talking with @Flameink there were clear regressions in builder buggeroff to fix. See https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6057

### Work done

- Fixed area test not being cylindrical (to match blocking)
- Fixed wrong sign when checking if unit's future position is in area
- Better search radius: Per Flameink this needs to be a fixed size, and per Floris' performance optimizations that is doubly preferable. Made that work.
- Better buggeroff radius: Catch very-large units without requiring the buggeroff radius to grow, first.
- Faster updates. Performance seemed good enough but should test.
- Reverted move order change. This was not a general improvement.

Should get a round of comments to be sure we are in the clear.