### PR TITLE
Fix the AI seeing enemy armthor being 10x more threatening/influencing than it should be.

### DIFF
--- a/units/ArmGantry/armthor.lua
+++ b/units/ArmGantry/armthor.lua
@@ -200,7 +200,7 @@ return {
 					stockpilelimit = 2,
 				},
 				damage = {
-					default = 80000,
+					default = 0,
 				},
 			},
 			thunder = {


### PR DESCRIPTION
There are some issues with the AI being too defensive / not attacking late game, this is one of the major contributors to that issue.

For some reason a weapon that does zero damage (paralysing missle) is marked to do 80000 damage, and because it also has a big range, results in some insane numbers on the threat and influence map that results in the opposing AI wanting to be nowhere near it (unless they also have armthors)

Setting to 0 fixes it, doesn't seem to cause any side effects. Not sure if it should be something a little higher so that it still contributes to threat, but the code only pays attention to the highest weapon and the highest range separately currently so it wouldn't change anything without further PRs anyways. (eg calculating a units effective range by factoring in each weapons range, weighted by the damage it does, which is another WIP PR I am working on, but requires a lot more balence testing as it affects 90 units with that change)

The result is that it takes the empmissle weapon out of the equation, and the results in the pictures below make a huge difference, 10x less threat value on the threat map, and way less range on the influence map.

90% sure these pics are from only this change and not other changes muddled in, even if it is the impact is still very huge.

#### BEFORE:
Threat map:
![before_1](https://github.com/user-attachments/assets/46b58126-77f3-4d67-adbc-81a185c0c842)

Influence map:
![before_2](https://github.com/user-attachments/assets/09fcc67e-d3c4-476b-8109-4b30c5f085fd)



#### AFTER:
Threat map:
![after_1](https://github.com/user-attachments/assets/14304f87-985f-472f-a72f-15c4177403b7)

Influence map:
![after_2](https://github.com/user-attachments/assets/cf29ee98-b613-4288-a83d-f4a00b4d44fc)


