### PR TITLE
Fix: Lava slow MoveCtrl error

### DIFF
--- a/luarules/gadgets/map_lava.lua
+++ b/luarules/gadgets/map_lava.lua
@@ -124,7 +124,7 @@ if gadgetHandler:IsSyncedCode() then
 		_G.lavaGrow = lavaGrow
 	end
 
-	function slowUnit(unitID, unitDefID, unitSlow)
+	function updateSlow(unitID, unitDefID, unitSlow)
 		if spMoveCtrlEnabled(unitID) then return end
 		local slowedMaxSpeed = speedDefs[unitDefID] * unitSlow
 		local slowedTurnRate = turnDefs[unitDefID] * unitSlow
@@ -155,13 +155,13 @@ if gadgetHandler:IsSyncedCode() then
 					end
 					if lavaUnits[unitID].slowed and (unitSlow ~= lavaUnits[unitID].currentSlow) then
 						lavaUnits[unitID].currentSlow = unitSlow
-						slowUnit(unitID, unitDefID, unitSlow)
+						updateSlow(unitID, unitDefID, unitSlow)
 					end
 				spAddUnitDamage(unitID, lavaDamage, 0, gaiaTeamID, 1)
 				spSpawnCEG(lavaEffectDamage, x, y+5, z)
 				elseif lavaUnits[unitID] then -- unit exited lava
 					if lavaUnits[unitID].slowed then
-						slowUnit(unitID, unitDefID, 1)
+						updateSlow(unitID, unitDefID, 1)
 					end
 				lavaUnits[unitID] = nil
 				end


### PR DESCRIPTION
Adds a check before slowing a unit to return early if movectrl is enabled (i.e. scripted movement).

Also moved the two instances of setting move data to a common function. Called when the unit is in lava, and when it has exited.


#### Addresses Issue(s)
"incompatible movetype for SetGroundMoveTypeData" e.g.:
https://server4.beyondallreason.info/telemetry/infolog/462054

https://discord.com/channels/549281623154229250/1044675665112350770/1432926559739707432