### PR TITLE
pregame gridmenu text outline fix

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2715,7 +2715,7 @@ function widget:DrawScreen()
 					)
 				end
 				if not buildmenuTex then
-					buildmenuTex = gl.CreateTexture(math_floor(backgroundRect.xEnd-backgroundRect.x)*2, math_floor(buildersRectYend-backgroundRect.y)*2, {
+					buildmenuTex = gl.CreateTexture(math_floor(backgroundRect.xEnd-backgroundRect.x)*2, math_floor(buildersRectYend-backgroundRect.y)*2, {	--*(vsy<1400 and 2 or 2)
 						target = GL.TEXTURE_2D,
 						format = GL.RGBA,
 						fbo = true,


### PR DESCRIPTION
There's a weird issue in the pregame where in gridmenu and only in gridmenu the outline around text appears and disappears at random. Seems related to whenever certain updates happen and I'm not exactly sure why. It's totally fine during the game.

Explicitely adding the outline when creating the text seems to do the trick.

Before: 
https://github.com/user-attachments/assets/5385fbd3-ed5d-4140-af53-02fb7ccb3a2b

After
https://github.com/user-attachments/assets/8df598cc-6c99-498b-b907-09176f8da7e1
