### PR TITLE
Add two bindable actions to clear state preferences

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -7,7 +7,7 @@ function widget:GetInfo()
 	return {
 		name = "State Prefs V2",
 		desc = "Sets pre-defined units states. Hold bindable action 'stateprefs_record' while clicking a unit's state commands to define the preferred state for newly produced units of its type. V2 fixes bug, improves console output to show unit and state change details.",
-		author = "Errrrrrr, quantum + Doo, sneyed",
+		author = "Errrrrrr, quantum + Doo, sneyed, Chronographer",
 		date = "April 21, 2023",
 		license = "GNU GPL, v2 or later",
 		layer = 1000,
@@ -18,10 +18,15 @@ end
 --[[------------------------------------------------------------------------------
 
 Usage:
-Bind stateprefs_record to a key of your choice in /Beyond-All-Reason/data/uikeys.txt
+Bind actions to a key of your choice in /Beyond-All-Reason/data/uikeys.txt
+stateprefs_record 		will save the preferred state for the selected unit/units for the selected command.
+stateprefs_clear 		will clears the preferred state for the selected unit/units for the selected command.
+stateprefs_clearunit 	will clears all saved states for the selected unit/units for all commands.
 
-e.g. Bind alt+ctrl stateprefs_clear
-bind  ctrl  stateprefs_record
+e.g. 
+bind alt 	stateprefs_clear
+bind ctrl 	stateprefs_record
+bind sc_\ 	stateprefs_clearunit
 
 --]]------------------------------------------------------------------------------
 local unitArray = {}


### PR DESCRIPTION
### Work done
Add two bindable actions to clear unit state preferences. 

The first `stateprefs_clear` works exactly like the reverse of `stateprefs_record` and clears just the state that is clicked on. The second is `stateprefs_clearunit` that when pressed clears all saved states for the selected unit/units.

If both `stateprefs_clear` and `stateprefs_record` actions are called simultaneously then the preference is cleared as the default. 

#### Addresses Issue(s)
[See discussion here](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5041#issuecomment-2899283065)

#### Test steps
1. Bind the new actions with:

``` 
/bind ctrl stateprefs_record
/bind alt stateprefs_clear
/bind sc_\ stateprefs_clearunit
```

2. Set lab to hold fire and hold position. 
3. Build a unit from the lab. 
4. Hold control and click fire state to return fire and move state to maneuver. 
5. Build a new unit and check that newly built unit is set to return fire and move state to maneuver. 
6. Hold alt and click fire state to any state. 
7. Build a new unit and check the newly build unit inherits the lab fire state of hold fire. It should still be set to maneuver. 
8. Click the unit and Press `\` 
9. Build a new unit and check both states are inherited from the lab. 