### PR TITLE
Allow zero frame dwell advanced lava tide.

### DIFF
--- a/modules/lava.lua
+++ b/modules/lava.lua
@@ -178,7 +178,7 @@ local function validateTideRhythm(modoptionDataRaw)
 		if #partRhythm ~= 3 then
 			Spring.Echo("Lava Advanced Tide Rhythm data is not valid, invalid tide definition: ", partRhythm)
 			return false
-		elseif not ((partRhythm[1] >= 0) and (partRhythm[2] > 0) and (partRhythm[3] > 0)) then
+		elseif not ((partRhythm[1] >= 0) and (partRhythm[2] > 0) and (partRhythm[3] >= 0)) then
 			Spring.Echo("Lava Advanced Tide Rhythm data is not valid, negative or zero values: ", partRhythm)
 			return false
 		end


### PR DESCRIPTION
Allows for a zero frame dwell for the lava tides when setting the advanced option.  

After discussion here: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5548#discussion_r2455818829 I did some testing and 0 frame dwell functions with no issues. 