### PR TITLE
pregame_build unplaced builds purple/green for quickstart

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -1314,9 +1314,6 @@ function widget:DrawWorld()
 	end
 
 	if selBuildData and showSelectedBuilding then
-		local selectedAlpha = alphaResults.selectedAlpha or ALPHA_DEFAULT
-		local isSelectedSpawned = selectedAlpha >= ALPHA_SPAWNED
-		
 		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
 		local testOrder = spTestBuildOrder(
 			selBuildQueueDefID,
@@ -1325,18 +1322,28 @@ function widget:DrawWorld()
 			selBuildData[4],
 			selBuildData[5]
 		) ~= 0
+		
+		local isSelectedSpawned = false
+		local selectedAlpha = ALPHA_DEFAULT
+		local getBuildQueueSpawnStatus = WG["getBuildQueueSpawnStatus"]
+		if getBuildQueueSpawnStatus and testOrder then
+			local spawnStatus = getBuildQueueSpawnStatus(buildQueue, selBuildData)
+			isSelectedSpawned = spawnStatus.selectedSpawned or false
+			selectedAlpha = isSelectedSpawned and ALPHA_SPAWNED or ALPHA_DEFAULT
+		end
+		
 		if not isMex then
 			local color = testOrder and (isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID) or BORDER_COLOR_INVALID
 			DrawBuilding(selBuildData, color, true, selectedAlpha)
 		elseif isMex then
 			if WG.ExtractorSnap.position or isMetalMap then
-				local color = isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID
+				local color = testOrder and (isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID) or BORDER_COLOR_INVALID
 				DrawBuilding(selBuildData, color, true, selectedAlpha)
 			else
 				DrawBuilding(selBuildData, BORDER_COLOR_INVALID, true, selectedAlpha)
 			end
 		else
-			local color = isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID
+			local color = testOrder and (isSelectedSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_VALID) or BORDER_COLOR_INVALID
 			DrawBuilding(selBuildData, color, true, selectedAlpha)
 		end
 	end


### PR DESCRIPTION
This makes it so that when you've selected a build and haven't placed it yet, the build will be purple/green depending on spawnability with quick start. Before it was always green/red

image is of a un-placed build
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/2c558fe4-dafa-42bf-b6b7-2213d02ffc91" />
