### PR TITLE
quickstart>evolution compatibility patch

### DIFF
--- a/luarules/gadgets/game_quick_start.lua
+++ b/luarules/gadgets/game_quick_start.lua
@@ -115,6 +115,21 @@ local optionDefIDToTypes = {}
 local queuedCommanders = {}
 local buildsInProgress = {}
 
+GG.quick_start = {}
+
+function GG.quick_start.transferCommanderData(oldUnitID, newUnitID)
+	if oldUnitID and newUnitID  and spValidUnitID(oldUnitID) and spValidUnitID(newUnitID) then
+		buildsInProgress[newUnitID] = buildsInProgress[oldUnitID]
+		buildsInProgress[oldUnitID] = nil
+
+		commanders[newUnitID] = commanders[oldUnitID]
+		commanders[oldUnitID] = nil
+
+		commanderFactoryDiscounts[newUnitID] = commanderFactoryDiscounts[oldUnitID]
+		commanderFactoryDiscounts[oldUnitID] = nil
+	end
+end
+
 local function getQuotas(isMetalMap, isInWater, isGoodWind)
 	return config.quotas[isMetalMap and "metalMap" or "nonMetalMap"][isInWater and "water" or "land"]
 	[isGoodWind and "goodWind" or "badWind"]
@@ -784,7 +799,7 @@ function gadget:UnitDestroyed(unitID)
 end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
-	if boostableCommanders[unitDefID] then
+	if boostableCommanders[unitDefID] and not commanders[unitID] then
 		queuedCommanders[unitTeam] = unitID
 	end
 

--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -201,6 +201,10 @@ if gadgetHandler:IsSyncedCode() then
 
 		spSetUnitRulesParam(unitID, "unit_evolved", newUnitID, PRIVATE)
 
+		if GG.quick_start and GG.quick_start.transferCommanderData then
+			GG.quick_start.transferCommanderData(unitID, newUnitID)
+		end
+
 		SendToUnsynced("unit_evolve_finished", unitID, newUnitID, announcement,announcementSize)
 		if evolution.evolution_health_transfer == "full" then
 		elseif evolution.evolution_health_transfer == "percentage" then


### PR DESCRIPTION
properly transfers and tracks the data between commander evolutions. Previously it sometimes wouldn't intercept the build queue correctly and would provide discounted first factory builds for each evolution

using the approach Sprunk suggested here: https://discord.com/channels/549281623154229250/549336627445760030/1436736132103803003