### PR TITLE
Quick Start projected budget cost shows correctly

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -285,6 +285,9 @@ function widget:Initialize()
 	WG["pregame-build"].getBuildQueue = function()
 		return buildQueue
 	end
+	WG["pregame-build"].getBuildPositions = function()
+		return buildModeState.buildPositions
+	end
 	widgetHandler:RegisterGlobal("GetPreGameDefID", WG["pregame-build"].getPreGameDefID)
 	widgetHandler:RegisterGlobal("GetBuildQueue", WG["pregame-build"].getBuildQueue)
 end


### PR DESCRIPTION
Before
The quick start budget deduction cost was based on the thing selected, not how many were being built including drag grid, square and surround builds.
After
It correctly shows the projected cost of however many things you're building.