### PR TITLE
gravity fix

### DIFF
--- a/units/ArmAircraft/T2/armbrawl.lua
+++ b/units/ArmAircraft/T2/armbrawl.lua
@@ -86,6 +86,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:plasmahit-medium",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				intensity = 0.8,
 				name = "Rapid-fire a2g plasma guns",

--- a/units/ArmBots/T2/armfast.lua
+++ b/units/ArmBots/T2/armfast.lua
@@ -115,6 +115,7 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:plasmahit-small",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				intensity = 0.7,
 				name = "Rapid-firing close-quarters g2g plasma guns",

--- a/units/ArmBots/T2/armmav.lua
+++ b/units/ArmBots/T2/armmav.lua
@@ -115,6 +115,7 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-small",
+				gravityaffected = "true",
 				impactonly = 1,
 				impulsefactor = 1.1,
 				name = "Anti-swarm g2g gauss-impulse guns",

--- a/units/ArmBots/T2/armsnipe.lua
+++ b/units/ArmBots/T2/armsnipe.lua
@@ -154,6 +154,7 @@ return {
 				edgeeffectiveness = 0.15,
 				energypershot = 500,
 				explosiongenerator = "custom:genericshellexplosion-sniper",
+				gravityaffected = "true",
 				impactonly = true,
 				impulsefactor = 0.234,
 				intensity = 0.75,

--- a/units/ArmBots/armpw.lua
+++ b/units/ArmBots/armpw.lua
@@ -114,6 +114,7 @@ return {
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:plasmahit-small",
 				firestarter = 100,
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				intensity = 0.7,
 				name = "Rapid-fire close-quarters g2g plasma guns",

--- a/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armshockwave.lua
@@ -133,6 +133,7 @@ return {
 				energypershot = 80,
 				explosiongenerator = "custom:genericshellexplosion-small-lightning",
 				firestarter = 100,
+				gravityaffected = "true",
 				impactonly = 0,
 				impulsefactor = 0,
 				laserflaresize = 7.7,

--- a/units/ArmBuildings/SeaDefence/armanavaldefturret.lua
+++ b/units/ArmBuildings/SeaDefence/armanavaldefturret.lua
@@ -137,6 +137,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Quad Medium Plasma Gauss Cannons",
 				nogap = false,

--- a/units/ArmBuildings/SeaDefence/armkraken.lua
+++ b/units/ArmBuildings/SeaDefence/armkraken.lua
@@ -108,6 +108,7 @@ return {
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
 				firestarter = 5,
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Rapid-fire gauss cannon",
 				noselfdamage = true,

--- a/units/ArmGantry/armmar.lua
+++ b/units/ArmGantry/armmar.lua
@@ -162,6 +162,7 @@ return {
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
 				firestarter = 5,
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Double close-quarters gauss cannon",
 				noselfdamage = true,

--- a/units/ArmGantry/armprowl.lua
+++ b/units/ArmGantry/armprowl.lua
@@ -161,6 +161,7 @@ return {
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
 				firestarter = 5,
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Double close-quarters gauss cannon",
 				noselfdamage = true,

--- a/units/ArmShips/T2/armcrus.lua
+++ b/units/ArmShips/T2/armcrus.lua
@@ -147,6 +147,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Long-range g2g gauss cannon",
 				noselfdamage = true,

--- a/units/ArmShips/armdecade.lua
+++ b/units/ArmShips/armdecade.lua
@@ -112,6 +112,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:laserhit-small-yellow",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				intensity = 0.7,
 				name = "Rapid-fire close-quarters plasma turret",

--- a/units/ArmVehicles/T2/armcroc.lua
+++ b/units/ArmVehicles/T2/armcroc.lua
@@ -123,6 +123,7 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Medium g2g gauss-cannon",
 				noselfdamage = true,

--- a/units/ArmVehicles/T2/armgremlin.lua
+++ b/units/ArmVehicles/T2/armgremlin.lua
@@ -125,6 +125,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-medium",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Light close-quarters gauss cannon",
 				noselfdamage = true,

--- a/units/ArmVehicles/T2/armyork.lua
+++ b/units/ArmVehicles/T2/armyork.lua
@@ -151,6 +151,7 @@ return {
 				edgeeffectiveness = 1,
 				explosiongenerator = "custom:flak",
 				impulsefactor = 0,
+				mygravity = 0.01,
 				name = "Heavy g2a flak cannon",
 				noselfdamage = true,
 				range = 775,

--- a/units/ArmVehicles/armflash.lua
+++ b/units/ArmVehicles/armflash.lua
@@ -120,6 +120,7 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:plasmahit-small",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				intensity = 0.7,
 				name = "Rapid-fire close-quarters plasma gun",

--- a/units/ArmVehicles/armmlv.lua
+++ b/units/ArmVehicles/armmlv.lua
@@ -134,6 +134,7 @@ return {
 				edgeeffectiveness = 0.4,
 				explosiongenerator = "custom:MINESWEEP",
 				firetolerance = 3000,
+				gravityaffected = "true",
 				name = "Seismic charge",
 				noselfdamage = true,
 				range = 220,

--- a/units/ArmVehicles/armpincer.lua
+++ b/units/ArmVehicles/armpincer.lua
@@ -122,6 +122,7 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-small",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "Light close-quarters plasma cannon",
 				noselfdamage = true,

--- a/units/CorBots/T2/coraak.lua
+++ b/units/CorBots/T2/coraak.lua
@@ -116,6 +116,7 @@ return {
 				edgeeffectiveness = 1,
 				explosiongenerator = "custom:flak",
 				impulsefactor = 0,
+				mygravity = 0.01,
 				name = "Heavy g2a flak cannon",
 				noselfdamage = true,
 				range = 775,

--- a/units/CorGantry/corkorg.lua
+++ b/units/CorGantry/corkorg.lua
@@ -114,6 +114,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.65,
 				explosiongenerator = "custom:genericshellexplosion-medium",
+				gravityaffected = "true",
 				impulsefactor = 0.8,
 				intensity = 5,
 				name = "GaussCannon",

--- a/units/CorSeaplanes/corcut.lua
+++ b/units/CorSeaplanes/corcut.lua
@@ -86,6 +86,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-small",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "RiotCannon",
 				noselfdamage = true,

--- a/units/CorVehicles/corgarp.lua
+++ b/units/CorVehicles/corgarp.lua
@@ -122,6 +122,7 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-small",
+				gravityaffected = "true",
 				impulsefactor = 0.123,
 				name = "PincerCannon",
 				noselfdamage = true,

--- a/units/CorVehicles/cormlv.lua
+++ b/units/CorVehicles/cormlv.lua
@@ -135,6 +135,7 @@ return {
 				edgeeffectiveness = 0.4,
 				explosiongenerator = "custom:MINESWEEP",
 				firetolerance = 3000,
+				gravityaffected = "true",
 				name = "Seismic charge",
 				noselfdamage = true,
 				range = 220,


### PR DESCRIPTION
a bunch of units weren't using the default gravity due to missing the tag (gravityaffected = "true") which alldefs_post checks for.

gravityaffected = "true" has no mechanical relevance otherwise (note how it's a string also), but for now let's keep using it as way to denote that the standardised gravity will be used instead of map gravity.

armyork/coraak also got mygravity = 0.01 to match other flaks (though functional difference is really small).
