### PR TITLE
Remove Weapontype = "Cannon" from death explosions

### DIFF
--- a/weapons/Raptors/flamebug_death.lua
+++ b/weapons/Raptors/flamebug_death.lua
@@ -1,6 +1,5 @@
 return {
 	flamebug_death = {
-		weaponType = "Cannon",
 		areaofeffect = 64,
 		camerashake = 48,
 		edgeeffectiveness = 0.9,

--- a/weapons/Unit_Explosions.lua
+++ b/weapons/Unit_Explosions.lua
@@ -3,7 +3,6 @@ local impulsefactor = 0.123
 local unitDeaths = {
 
 	blank = {
-		weaponType = "Cannon",
 		areaofeffect = 0,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -35,7 +34,6 @@ local unitDeaths = {
 	},
 
 	pyro = {
-		weaponType = "Cannon",
 		areaofeffect = 64,
 		camerashake = 64,
 		impulsefactor = impulsefactor,
@@ -50,7 +48,6 @@ local unitDeaths = {
 		}
 	},
 	pyroselfd = {
-		weaponType = "Cannon",
 		areaofeffect = 200,
 		camerashake = 200,
 		edgeeffectiveness = 0.5,
@@ -67,7 +64,6 @@ local unitDeaths = {
 	},
 
 	flamethrower = {
-		weaponType = "Cannon",
 		areaofeffect = 48,
 		camerashake = 48,
 		impulsefactor = impulsefactor,
@@ -82,7 +78,6 @@ local unitDeaths = {
 		}
 	},
 	flamethrowerSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 140,
 		camerashake = 140,
 		edgeeffectiveness = 0.5,
@@ -133,7 +128,6 @@ local unitDeaths = {
 	},
 
 	nanoboom = {
-		weaponType = "Cannon",
 		areaofeffect = 128,
 		camerashake = 128,
 		edgeeffectiveness = 0.75,
@@ -151,7 +145,6 @@ local unitDeaths = {
 	},
 
 	nanoselfd = {
-		weaponType = "Cannon",
 		areaofeffect = 64,
 		camerashake = 64,
 		edgeeffectiveness = 0.75,
@@ -169,7 +162,6 @@ local unitDeaths = {
 	},
 
 	smallbuilder = {
-		weaponType = "Cannon",
 		areaofeffect = 64,
 		camerashake = 64,
 		impulsefactor = impulsefactor,
@@ -184,7 +176,6 @@ local unitDeaths = {
 		}
 	},
 	smallbuilderSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 120,
 		camerashake = 120,
 		impulsefactor = impulsefactor,
@@ -200,7 +191,6 @@ local unitDeaths = {
 	},
 
 	windboom = {
-		weaponType = "Cannon",
 		AreaOfEffect = 180,
 		cameraShake = 180,
 		edgeeffectiveness = 0.75,
@@ -217,7 +207,6 @@ local unitDeaths = {
 	},
 
 	metalmaker = {
-		weaponType = "Cannon",
 		areaofeffect = 210,
 		camerashake = 210,
 		impulsefactor = impulsefactor,
@@ -232,7 +221,6 @@ local unitDeaths = {
 		}
 	},
 	metalmakerSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 260,
 		camerashake = 260,
 		impulsefactor = impulsefactor,
@@ -248,7 +236,6 @@ local unitDeaths = {
 	},
 
 	advmetalmaker = {
-		weaponType = "Cannon",
 		areaofeffect = 320,
 		camerashake = 320,
 		impulsefactor = impulsefactor,
@@ -264,7 +251,6 @@ local unitDeaths = {
 		}
 	},
 	advmetalmakerSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 480,
 		camerashake = 480,
 		impulsefactor = impulsefactor,
@@ -281,7 +267,6 @@ local unitDeaths = {
 	},
 
 	energystorage = {
-		weaponType = "Cannon",
 		areaofeffect = 420,
 		camerashake = 420,
 		impulsefactor = impulsefactor,
@@ -296,7 +281,6 @@ local unitDeaths = {
 		}
 	},
 	energystorageSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 520,
 		camerashake = 520,
 		impulsefactor = impulsefactor,
@@ -311,7 +295,6 @@ local unitDeaths = {
 		}
 	},
 	['energystorage-uw'] = {
-		weaponType = "Cannon",
 		areaofeffect = 420,
 		camerashake = 420,
 		impulsefactor = impulsefactor,
@@ -326,7 +309,6 @@ local unitDeaths = {
 		}
 	},
 	['energystorageSelfd-uw'] = {
-		weaponType = "Cannon",
 		areaofeffect = 520,
 		camerashake = 520,
 		impulsefactor = impulsefactor,
@@ -342,7 +324,6 @@ local unitDeaths = {
 	},
 
 	advenergystorage = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -358,7 +339,6 @@ local unitDeaths = {
 		}
 	},
 	advenergystorageSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 768,
 		cameraShake = 768,
 		impulsefactor = impulsefactor,
@@ -374,7 +354,6 @@ local unitDeaths = {
 		}
 	},
 	['advenergystorage-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -390,7 +369,6 @@ local unitDeaths = {
 		}
 	},
 	['advenergystorageSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 768,
 		cameraShake = 768,
 		impulsefactor = impulsefactor,
@@ -407,7 +385,6 @@ local unitDeaths = {
 	},
 
 	geo = {
-		weaponType = "Cannon",
 		areaofeffect = 520,
 		camerashake = 210,
 		impulsefactor = impulsefactor,
@@ -423,7 +400,6 @@ local unitDeaths = {
 	},
 
 	advgeo = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1280,
 		cameraShake = 1280,
 		impulsefactor = impulsefactor,
@@ -440,7 +416,6 @@ local unitDeaths = {
 	},
 
 	nukeBuilding = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -456,7 +431,6 @@ local unitDeaths = {
 		}
 	},
 	nukeBuildingSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1280,
 		cameraShake = 1280,
 		impulsefactor = impulsefactor,
@@ -472,7 +446,6 @@ local unitDeaths = {
 		}
 	},
 	nukeSub = {
-		weaponType = "Cannon",
 		AreaOfEffect = 780,
 		cameraShake = 780,
 		impulsefactor = impulsefactor,
@@ -489,7 +462,6 @@ local unitDeaths = {
 	},
 
 	penetrator = {
-		weaponType = "Cannon",
 		areaofeffect = 420,
 		camerashake = 420,
 		impulsefactor = impulsefactor,
@@ -504,7 +476,6 @@ local unitDeaths = {
 		}
 	},
 	penetratorSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 520,
 		camerashake = 520,
 		impulsefactor = impulsefactor,
@@ -520,7 +491,6 @@ local unitDeaths = {
 	},
 
 	deadeyeSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 520,
 		camerashake = 520,
 		impulsefactor = impulsefactor,
@@ -536,7 +506,6 @@ local unitDeaths = {
 	},
 
 	bantha = {
-		weaponType = "Cannon",
 		areaofeffect = 500,
 		camerashake = 500,
 		impulsefactor = impulsefactor,
@@ -552,7 +521,6 @@ local unitDeaths = {
 		}
 	},
 	banthaSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 800,
 		camerashake = 800,
 		impulsefactor = impulsefactor,
@@ -568,7 +536,6 @@ local unitDeaths = {
 		}
 	},
 	korgExplosion = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1280,
 		cameraShake = 1280,
 		impulsefactor = impulsefactor,
@@ -584,7 +551,6 @@ local unitDeaths = {
 		}
 	},
 	korgExplosionSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1920,
 		cameraShake = 1920,
 		impulsefactor = impulsefactor,
@@ -600,7 +566,6 @@ local unitDeaths = {
 		}
 	},
 	juggernaut = {
-		weaponType = "Cannon",
 		areaofeffect = 280,
 		camerashake = 280,
 		impulsefactor = impulsefactor,
@@ -617,7 +582,6 @@ local unitDeaths = {
 		}
 	},
 	juggernautSelfd = {
-		weaponType = "Cannon",
 		areaofeffect = 430,
 		camerashake = 430,
 		impulsefactor = impulsefactor,
@@ -635,7 +599,6 @@ local unitDeaths = {
 	},
 
 	flagshipExplosion = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -651,7 +614,6 @@ local unitDeaths = {
 		}
 	},
 	flagshipExplosionSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 700,
 		cameraShake = 700,
 		impulsefactor = impulsefactor,
@@ -669,7 +631,6 @@ local unitDeaths = {
 
 
 	decoycommander = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 48,
 		impulsefactor = impulsefactor,
@@ -684,7 +645,6 @@ local unitDeaths = {
 		}
 	},
 	decoycommanderSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -699,7 +659,6 @@ local unitDeaths = {
 		}
 	},
 	minifusionExplosion = {
-		weaponType = "Cannon",
 		AreaOfEffect = 320,
 		cameraShake = 320,
 		impulsefactor = impulsefactor,
@@ -715,7 +674,6 @@ local unitDeaths = {
 		}
 	},
 	fusionExplosion = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -731,7 +689,6 @@ local unitDeaths = {
 		}
 	},
 	fusionExplosionSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 768,
 		cameraShake = 768,
 		impulsefactor = impulsefactor,
@@ -748,7 +705,6 @@ local unitDeaths = {
 	},
 
 	['fusionExplosion-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -764,7 +720,6 @@ local unitDeaths = {
 		}
 	},
 	['fusionExplosionSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 768,
 		cameraShake = 768,
 		impulsefactor = impulsefactor,
@@ -781,7 +736,6 @@ local unitDeaths = {
 	},
 
 	advancedFusionExplosion = { --this explosion does not generate a distortion effect for unknown reasons
-		weaponType = "Cannon",
 		AreaOfEffect = 1280,
 		cameraShake = 1280,
 		impulsefactor = impulsefactor,
@@ -798,7 +752,6 @@ local unitDeaths = {
 	},
 
 	customfusionexplo = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1280,
 		cameraShake = 1280,
 		impulsefactor = impulsefactor,
@@ -815,7 +768,6 @@ local unitDeaths = {
 	},
 
 	advancedFusionExplosionSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1920,
 		cameraShake = 1920,
 		impulsefactor = impulsefactor,
@@ -832,7 +784,6 @@ local unitDeaths = {
 	},
 
 	scavcomexplosion = {
-		weaponType = "Cannon",
 		areaofeffect = 500,
 		camerashake = 500,
 		impulsefactor = impulsefactor,
@@ -849,7 +800,6 @@ local unitDeaths = {
 	},
 
 	ScavComBossExplo = {
-		weaponType = "Cannon",
 		AreaOfEffect = 3000,
 		cameraShake = 3000,
 		impulsefactor = impulsefactor,
@@ -870,7 +820,6 @@ local unitDeaths = {
 
 	oldcommanderexplosion = {
 		name = "Matter/AntimatterExplosion",
-		weaponType = "Cannon",
 		AreaOfEffect = 700,
 		cameraShake = 510,
 		explosionSpeed = 725,
@@ -895,7 +844,6 @@ local unitDeaths = {
 
 	commanderexplosion = {
 		name = "Matter/AntimatterExplosion",
-		weaponType = "Cannon",
 		AreaOfEffect = 700,
 		cameraShake = 510,
 		explosionSpeed = 725,
@@ -922,7 +870,6 @@ local unitDeaths = {
 	--BUILDING DEATHS--
 
 	WallExplosionMetal = {
-		weaponType = "Cannon",
 		AreaOfEffect = 36,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -937,7 +884,6 @@ local unitDeaths = {
 		},
 	},
 	WallExplosionMetalXL = {
-		weaponType = "Cannon",
 		AreaOfEffect = 38,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -952,7 +898,6 @@ local unitDeaths = {
 		},
 	},
 	WallExplosionConcrete = {
-		weaponType = "Cannon",
 		AreaOfEffect = 36,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -967,7 +912,6 @@ local unitDeaths = {
 		},
 	},
 	WallExplosionConcreteXL = {
-		weaponType = "Cannon",
 		AreaOfEffect = 38,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -982,7 +926,6 @@ local unitDeaths = {
 		},
 	},
 	WallExplosionWater = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -997,7 +940,6 @@ local unitDeaths = {
 		},
 	},
 	tinyBuildingExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 25,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1012,7 +954,6 @@ local unitDeaths = {
 		}
 	},
 	tinyBuildingExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 40,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1027,7 +968,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyBuildingExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 25,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1042,7 +982,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyBuildingExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 40,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1058,7 +997,6 @@ local unitDeaths = {
 	},
 
 	smallBuildingExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 180,
 		cameraShake = 180,
 		impulsefactor = impulsefactor,
@@ -1073,7 +1011,6 @@ local unitDeaths = {
 		}
 	},
 	smallBuildingExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 240,
 		cameraShake = 240,
 		impulsefactor = impulsefactor,
@@ -1088,7 +1025,6 @@ local unitDeaths = {
 		}
 	},
 	smallMex = {
-		weaponType = "Cannon",
 		AreaOfEffect = 240,
 		cameraShake = 240,
 		impulsefactor = impulsefactor,
@@ -1103,7 +1039,6 @@ local unitDeaths = {
 		}
 	},
 	['smallBuildingExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 180,
 		cameraShake = 180,
 		impulsefactor = impulsefactor,
@@ -1118,7 +1053,6 @@ local unitDeaths = {
 		}
 	},
 	['smallBuildingExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 240,
 		cameraShake = 240,
 		impulsefactor = impulsefactor,
@@ -1134,7 +1068,6 @@ local unitDeaths = {
 	},
 
 	mediumBuildingExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 260,
 		cameraShake = 260,
 		impulsefactor = impulsefactor,
@@ -1149,7 +1082,6 @@ local unitDeaths = {
 		}
 	},
 	mediumBuildingExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 360,
 		cameraShake = 360,
 		impulsefactor = impulsefactor,
@@ -1164,7 +1096,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumBuildingExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 260,
 		cameraShake = 260,
 		impulsefactor = impulsefactor,
@@ -1179,7 +1110,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumBuildingExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 360,
 		cameraShake = 360,
 		impulsefactor = impulsefactor,
@@ -1195,7 +1125,6 @@ local unitDeaths = {
 	},
 
 	largeBuildingExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 340,
 		cameraShake = 340,
 		impulsefactor = impulsefactor,
@@ -1210,7 +1139,6 @@ local unitDeaths = {
 		}
 	},
 	largeBuildingExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -1225,7 +1153,6 @@ local unitDeaths = {
 		}
 	},
 	['largeBuildingExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 340,
 		cameraShake = 340,
 		impulsefactor = impulsefactor,
@@ -1240,7 +1167,6 @@ local unitDeaths = {
 		}
 	},
 	['largeBuildingExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 480,
 		cameraShake = 480,
 		impulsefactor = impulsefactor,
@@ -1256,7 +1182,6 @@ local unitDeaths = {
 	},
 
 	hugeBuildingExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 420,
 		cameraShake = 420,
 		impulsefactor = impulsefactor,
@@ -1271,7 +1196,6 @@ local unitDeaths = {
 		}
 	},
 	hugeBuildingExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 580,
 		cameraShake = 580,
 		impulsefactor = impulsefactor,
@@ -1286,7 +1210,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeBuildingExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 420,
 		cameraShake = 420,
 		impulsefactor = impulsefactor,
@@ -1301,7 +1224,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeBuildingExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 580,
 		cameraShake = 580,
 		impulsefactor = impulsefactor,
@@ -1320,7 +1242,6 @@ local unitDeaths = {
 	--UNIT DEATHS--
 
 	tinyExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 24,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1335,7 +1256,6 @@ local unitDeaths = {
 		}
 	},
 	tinyExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 44,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1350,7 +1270,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyExplosionGeneric-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 24,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1365,7 +1284,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyExplosionGenericSelfd-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 44,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1380,7 +1298,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 24,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1395,7 +1312,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 44,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1410,7 +1326,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyExplosionGeneric-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 24,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1425,7 +1340,6 @@ local unitDeaths = {
 		}
 	},
 	['tinyExplosionGenericSelfd-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 44,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1441,7 +1355,6 @@ local unitDeaths = {
 	},
 
 	smallExplosionGenericAir = {
-		weaponType = "Cannon",
 		AreaOfEffect = 24,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1457,7 +1370,6 @@ local unitDeaths = {
 	},
 
 	smallExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 36,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1472,7 +1384,6 @@ local unitDeaths = {
 		}
 	},
 	smallExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 60,
 		cameraShake = 60,
 		impulsefactor = impulsefactor,
@@ -1487,7 +1398,6 @@ local unitDeaths = {
 		}
 	},
 	['smallExplosionGeneric-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 36,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1502,7 +1412,6 @@ local unitDeaths = {
 		}
 	},
 	['smallExplosionGenericSelfd-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 60,
 		cameraShake = 60,
 		impulsefactor = impulsefactor,
@@ -1517,7 +1426,6 @@ local unitDeaths = {
 		}
 	},
 	['smallExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 36,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1532,7 +1440,6 @@ local unitDeaths = {
 		}
 	},
 	['smallExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 60,
 		cameraShake = 60,
 		impulsefactor = impulsefactor,
@@ -1547,7 +1454,6 @@ local unitDeaths = {
 		}
 	},
 	['smallExplosionGeneric-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 36,
 		cameraShake = 0,
 		impulsefactor = impulsefactor,
@@ -1562,7 +1468,6 @@ local unitDeaths = {
 		}
 	},
 	['smallExplosionGenericSelfd-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 60,
 		cameraShake = 60,
 		impulsefactor = impulsefactor,
@@ -1578,7 +1483,6 @@ local unitDeaths = {
 	},
 
 	mediumExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 48,
 		impulsefactor = impulsefactor,
@@ -1593,7 +1497,6 @@ local unitDeaths = {
 		}
 	},
 	mediumExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1608,7 +1511,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumExplosionGeneric-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 48,
 		impulsefactor = impulsefactor,
@@ -1623,7 +1525,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumExplosionGenericSelfd-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1638,7 +1539,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 48,
 		impulsefactor = impulsefactor,
@@ -1653,7 +1553,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1668,7 +1567,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumExplosionGeneric-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 48,
 		impulsefactor = impulsefactor,
@@ -1683,7 +1581,6 @@ local unitDeaths = {
 		}
 	},
 	['mediumExplosionGenericSelfd-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1699,7 +1596,6 @@ local unitDeaths = {
 	},
 
 	largeExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 64,
 		cameraShake = 64,
 		impulsefactor = impulsefactor,
@@ -1714,7 +1610,6 @@ local unitDeaths = {
 		}
 	},
 	largeExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 120,
 		cameraShake = 120,
 		impulsefactor = impulsefactor,
@@ -1729,7 +1624,6 @@ local unitDeaths = {
 		}
 	},
 	['largeExplosionGeneric-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 64,
 		cameraShake = 64,
 		impulsefactor = impulsefactor,
@@ -1744,7 +1638,6 @@ local unitDeaths = {
 		}
 	},
 	['largeExplosionGenericSelfd-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 120,
 		cameraShake = 120,
 		impulsefactor = impulsefactor,
@@ -1759,7 +1652,6 @@ local unitDeaths = {
 		}
 	},
 	['largeExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 64,
 		cameraShake = 64,
 		impulsefactor = impulsefactor,
@@ -1774,7 +1666,6 @@ local unitDeaths = {
 		}
 	},
 	['largeExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 120,
 		cameraShake = 120,
 		impulsefactor = impulsefactor,
@@ -1789,7 +1680,6 @@ local unitDeaths = {
 		}
 	},
 	['largeExplosionGeneric-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 64,
 		cameraShake = 64,
 		impulsefactor = impulsefactor,
@@ -1804,7 +1694,6 @@ local unitDeaths = {
 		}
 	},
 	['largeExplosionGenericSelfd-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 120,
 		cameraShake = 120,
 		impulsefactor = impulsefactor,
@@ -1820,7 +1709,6 @@ local unitDeaths = {
 	},
 
 	hugeExplosionGeneric = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1835,7 +1723,6 @@ local unitDeaths = {
 		}
 	},
 	explosiont3 = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1850,7 +1737,6 @@ local unitDeaths = {
 		}
 	},
 	explosiont3med = {
-		weaponType = "Cannon",
 		AreaOfEffect = 48,
 		cameraShake = 48,
 		impulsefactor = impulsefactor,
@@ -1865,7 +1751,6 @@ local unitDeaths = {
 		}
 	},
 	explosiont3xl = {
-		weaponType = "Cannon",
 		AreaOfEffect = 160,
 		cameraShake = 160,
 		impulsefactor = impulsefactor,
@@ -1880,7 +1765,6 @@ local unitDeaths = {
 		}
 	},
 	explosiont3xxl = {
-		weaponType = "Cannon",
 		AreaOfEffect = 280,
 		cameraShake = 280,
 		impulsefactor = impulsefactor,
@@ -1895,7 +1779,6 @@ local unitDeaths = {
 		}
 	},
 	hugeExplosionGenericSelfd = {
-		weaponType = "Cannon",
 		AreaOfEffect = 160,
 		cameraShake = 160,
 		impulsefactor = impulsefactor,
@@ -1910,7 +1793,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeExplosionGeneric-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1925,7 +1807,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeExplosionGenericSelfd-builder'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 160,
 		cameraShake = 160,
 		impulsefactor = impulsefactor,
@@ -1940,7 +1821,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeExplosionGeneric-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1955,7 +1835,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeExplosionGenericSelfd-uw'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 160,
 		cameraShake = 160,
 		impulsefactor = impulsefactor,
@@ -1970,7 +1849,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeExplosionGeneric-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 96,
 		cameraShake = 96,
 		impulsefactor = impulsefactor,
@@ -1985,7 +1863,6 @@ local unitDeaths = {
 		}
 	},
 	['hugeExplosionGenericSelfd-phib'] = {
-		weaponType = "Cannon",
 		AreaOfEffect = 160,
 		cameraShake = 160,
 		impulsefactor = impulsefactor,
@@ -2000,7 +1877,6 @@ local unitDeaths = {
 		}
 	},
 	lootboxExplosion1 = {
-		weaponType = "Cannon",
 		AreaOfEffect = 340,
 		cameraShake = 340,
 		impulsefactor = impulsefactor,
@@ -2015,7 +1891,6 @@ local unitDeaths = {
 		}
 	},
 	lootboxExplosion2 = {
-		weaponType = "Cannon",
 		AreaOfEffect = 620,
 		cameraShake = 620,
 		impulsefactor = impulsefactor,
@@ -2030,7 +1905,6 @@ local unitDeaths = {
 		}
 	},
 	lootboxExplosion3 = {
-		weaponType = "Cannon",
 		AreaOfEffect = 920,
 		cameraShake = 920,
 		impulsefactor = impulsefactor,
@@ -2045,7 +1919,6 @@ local unitDeaths = {
 		}
 	},
 	lootboxExplosion4 = {
-		weaponType = "Cannon",
 		AreaOfEffect = 1280,
 		cameraShake = 1280,
 		impulsefactor = impulsefactor,


### PR DESCRIPTION
They're unnecessary and potentially misleading.

No gameplay effect.
