### PR TITLE
fix recursive call to spEcho which crashes headless

### DIFF
--- a/luaui/Widgets/gfx_volumetric_clouds.lua
+++ b/luaui/Widgets/gfx_volumetric_clouds.lua
@@ -59,7 +59,7 @@ local function convertAltitude(input, default)
 		local percent = input:match("(%d+)%%")
 		result = gnd_max * (percent / 100)
 	end
-	--Spring.Echo(result)
+	--spEcho(result)
 	return result
 end
 
@@ -109,6 +109,7 @@ local glTexture              = gl.Texture
 local LuaShader 			 = gl.LuaShader
 local spGetCameraPosition    = Spring.GetCameraPosition
 local spGetWind              = Spring.GetWind
+local spEcho				 = Spring.Echo
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -170,7 +171,7 @@ function widget:ViewResize()
 
 
 	if depthTexture == nil or fogTexture == nil then
-		Spring.Echo("<Volumetric Clouds> Removing fog widget, bad depth texture")
+		spEcho("<Volumetric Clouds> Removing fog widget, bad depth texture")
 		widgetHandler:RemoveWidget()
 	end
 end
@@ -560,7 +561,7 @@ local function init()
 		}, "Volumetric Clouds Depth Shader")
 
 		if not depthShader:Initialize() then
-			Spring.Echo("<Volumetric Clouds> Bad shader, reverting to non-GLSL widget.")
+			spEcho("<Volumetric Clouds> Bad shader, reverting to non-GLSL widget.")
 			enabled = false
 		end
 	end


### PR DESCRIPTION
introduced in a8664cd3cde14aa74524cb5a5decf6f0658bc43d

calling spEcho will call spEcho which will call spEcho, and so on, leading to
```
Error: [LuaUI::RunCallInTraceback] error=4 (LUA_ERRMEM) callin=LoadCode trace=[Internal Lua error: Call failure] not enough memory
```

this breaks headless because spEcho is called when the widget is removed

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Write the steps needed to test out the changes. Include the expected result.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
