### PR TITLE
fix headless failing to load LuaRules (fixes tests)

### DIFF
--- a/luarules/gadgets/gfx_unit_shield_effects.lua
+++ b/luarules/gadgets/gfx_unit_shield_effects.lua
@@ -649,11 +649,6 @@ local function InitializeShader()
 	local shaderCompiled = shieldShader:Initialize()
 	if not shaderCompiled then
 		Spring.Echo("Shield shader failed to compile!")
-		local shaderLog = shieldShader:GetLog()
-		if shaderLog and shaderLog ~= "" then
-			Spring.Echo("Shader compilation log:")
-			Spring.Echo(shaderLog)
-		end
 		shieldShader = nil
 		return false
 	end


### PR DESCRIPTION
this only occurs in headless because the shader compilation fails, similar to https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6139

shader compilation errors are already logged here https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/modules/graphics/LuaShader.lua#L887, and i can see them when running in headless already

```
[t=00:00:10.499523][f=-000001] LuaShader: [ShieldSphereColor] shader error(s):
GLSL Shaders are not supported by hardware or drivers
[t=00:00:10.505910][f=-000001] GLSL Shaders are not supported by hardware or drivers

[t=00:00:10.509027][f=-000001] Shield shader failed to compile!
[t=00:00:10.512006][f=-000001] Shield gadget: Failed to initialize shader, disabling
[t=00:00:10.516763][f=-000001] Loaded unsynced gadget:  Shield Effects      <gfx_unit_shield_effects.lua>
```

so calling `:GetLog` would not have provided any more info already

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->
