### PR TITLE
Notifications Improvements

### DIFF
--- a/luarules/gadgets/sfx_notifications.lua
+++ b/luarules/gadgets/sfx_notifications.lua
@@ -207,10 +207,7 @@ else
 	}
 	function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 		if unitTeam == myTeamID and isLrpc[attackerDefID] and attackerTeam and GetAllyTeamID(attackerTeam) ~= myAllyTeamID then
-			if unitLostOrDamagedCooldowns["LrpcTargetUnits"] <= 0 then
-				BroadcastEvent("NotificationEvent", 'LrpcTargetUnits', tostring(myPlayerID))
-			end
-			unitLostOrDamagedCooldowns["LrpcTargetUnits"] = 60
+			BroadcastEvent("NotificationEvent", 'LrpcTargetUnits', tostring(myPlayerID))
 		end
 		if isCommander[unitDefID] then
 			commanderLastDamaged[unitID] = Spring.GetGameFrame()
@@ -219,26 +216,14 @@ else
 			if isCommander[unitDefID] then
 				local health, maxhealth = Spring.GetUnitHealth(unitID)
 				local healthPercent = health/maxhealth
-				if healthPercent >= 0.2 and unitLostOrDamagedCooldowns["CommanderUnderAttack"] <= 0 then
-					BroadcastEvent("NotificationEvent", 'CommanderUnderAttack', tostring(myPlayerID))
-				end
+				BroadcastEvent("NotificationEvent", 'CommanderUnderAttack', tostring(myPlayerID))
 				if healthPercent < 0.2 then
-					if unitLostOrDamagedCooldowns["CommanderTakingHeavyDamage"] <= 0 then
-						BroadcastEvent("NotificationEvent", 'ComHeavyDamage', tostring(myPlayerID))
-					end
-					unitLostOrDamagedCooldowns["CommanderTakingHeavyDamage"] = 10
+					BroadcastEvent("NotificationEvent", 'ComHeavyDamage', tostring(myPlayerID))
 				end
-				unitLostOrDamagedCooldowns["CommanderUnderAttack"] = 10
 			elseif isBuilding[unitDefID] == true and (not isMex[unitDefID]) and (not hasWeapons[unitDefID]) then
-				if unitLostOrDamagedCooldowns["BaseUnderAttack"] <= 0 then
-					BroadcastEvent("NotificationEvent", 'BaseUnderAttack', tostring(myPlayerID))
-				end
-				unitLostOrDamagedCooldowns["BaseUnderAttack"] = 30
+				BroadcastEvent("NotificationEvent", 'BaseUnderAttack', tostring(myPlayerID))
 			elseif isBuilding[unitDefID] == false then
-				if unitLostOrDamagedCooldowns["UnitsUnderAttack"] <= 0 then
-					BroadcastEvent("NotificationEvent", 'UnitsUnderAttack', tostring(myPlayerID))
-				end
-				unitLostOrDamagedCooldowns["UnitsUnderAttack"] = 60
+				BroadcastEvent("NotificationEvent", 'UnitsUnderAttack', tostring(myPlayerID))
 			end
 		end
 	end
@@ -252,32 +237,21 @@ else
 	end
 
 	function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-		local unitInView = Spring.IsUnitInView(unitID)
+		--local unitInView = Spring.IsUnitInView(unitID)
 
 		-- if own and not killed by yourself
 		if not isSpec and unitTeam == myTeamID and attackerTeam and attackerTeam ~= unitTeam then -- and not unitInView
 			if isRadar[unitDefID] then
-				if unitLostOrDamagedCooldowns["RadarLost"] <= 0 then
-					local event = isRadar[unitDefID] > 2800 and 'AdvRadarLost' or 'RadarLost'
-					BroadcastEvent("NotificationEvent", event, tostring(myPlayerID))
-					unitLostOrDamagedCooldowns["UnitLost"] = 60
-				end
-				unitLostOrDamagedCooldowns["RadarLost"] = 30
+				local event = isRadar[unitDefID] > 2800 and 'AdvRadarLost' or 'RadarLost'
+				BroadcastEvent("NotificationEvent", event, tostring(myPlayerID))
 				return
 			end
 			if isMex[unitDefID] then
-				if unitLostOrDamagedCooldowns["MexLost"] <= 0 then
-					BroadcastEvent("NotificationEvent", "MetalExtractorLost", tostring(myPlayerID))
-					unitLostOrDamagedCooldowns["UnitLost"] = 60
-				end
-				unitLostOrDamagedCooldowns["MexLost"] = 30
+				BroadcastEvent("NotificationEvent", "MetalExtractorLost", tostring(myPlayerID))
 				return
 			end
 			if not isCommander[unitDefID] then
-				if unitLostOrDamagedCooldowns["UnitLost"] <= 0 then
-					BroadcastEvent("NotificationEvent", "UnitLost", tostring(myPlayerID))
-				end
-				unitLostOrDamagedCooldowns["UnitLost"] = 60
+				BroadcastEvent("NotificationEvent", "UnitLost", tostring(myPlayerID))
 				return
 			end
 		end

--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -37,11 +37,10 @@ local silentTime = 0.7    -- silent time between queued notifications
 local globalVolume = 0.7
 local playTrackedPlayerNotifs = false
 local muteWhenIdle = true
-local idleTime = 10        -- after this much sec: mark user as idle
+--local idleTime = 10        -- after this much sec: mark user as idle
 local displayMessages = true
 local spoken = true
 local idleBuilderNotificationDelay = 10 * 30    -- (in gameframes)
-local lowpowerThreshold = 7        -- if there is X secs a low power situation
 local tutorialPlayLimit = 2        -- display the same tutorial message only this many times in total (max is always 1 play per game)
 local updateCommandersFrames = Game.gameSpeed * 5
 
@@ -103,17 +102,7 @@ if not voiceSetFound then
 end
 
 local function addNotification(name, soundFiles, minDelay, i18nTextID, tutorial, soundEffect)
-	notification[name] = {
-		delay = minDelay,
-		textID = i18nTextID,
-		voiceFiles = soundFiles,
-		tutorial = tutorial,
-		soundEffect = soundEffect,
-	}
-	notificationList[name] = true
-	if not tutorial then
-		notificationOrder[#notificationOrder + 1] = name
-	end
+
 end
 
 -- load and parse sound files/notifications
@@ -122,6 +111,7 @@ if VFS.FileExists(soundFolder .. 'config.lua') then
 	local voicesetNotificationTable = VFS.Include(soundFolder .. 'config.lua')
 	notificationTable = table.merge(notificationTable, voicesetNotificationTable)
 end
+
 for notifID, notifDef in pairs(notificationTable) do
 	local notifTexts = {}
 	local notifSounds = {}
@@ -141,7 +131,21 @@ for notifID, notifDef in pairs(notificationTable) do
 			notifSounds[currentEntry] = defaultSoundFolder .. notifID .. '.wav'
 		end
 	end
-	addNotification(notifID, notifSounds, notifDef.delay or 2, notifTexts[1], notifDef.tutorial, notifDef.soundEffect) -- bandaid, picking text from first variation always.
+
+	notification[notifID] = {
+		delay = notifDef.delay or 2,
+		stackedDelay = notifDef.stackedDelay, -- reset delay even with failed play
+		textID = notifTexts[1],
+		voiceFiles = notifSounds,
+		tutorial = notifDef.tutorial,
+		soundEffect = notifDef.soundEffect,
+		resetOtherEventDelay = notifDef.resetOtherEventDelay,
+	}
+
+	notificationList[notifID] = true
+	if not notifDef.tutorial then
+		notificationOrder[#notificationOrder + 1] = notifID
+	end
 end
 
 local unitsOfInterestNames = {
@@ -201,7 +205,6 @@ local nextSoundQueued = 0
 local hasBuildMex = false
 local hasBuildEnergy = false
 local taggedUnitsOfInterest = {}
-local lowpowerDuration = 0
 local idleBuilder = {}
 local commanders = {}
 local commandersDamages = {}
@@ -216,7 +219,6 @@ local spIsUnitInView = Spring.IsUnitInView
 local spGetUnitHealth = Spring.GetUnitHealth
 
 local isIdle = false
-local lastUserInputTime = os.clock()
 local lastMouseX, lastMouseY = spGetMouseState()
 
 local isSpec = spGetSpectatingState()
@@ -378,6 +380,10 @@ local function queueNotification(event, forceplay)
 						soundQueue[#soundQueue + 1] = event
 					end
 				end
+
+				if notification[event].stackedDelay then
+					LastPlay[event] = spGetGameFrame()
+				end
 			end
 		end
 	end
@@ -522,6 +528,10 @@ function widget:Initialize()
 		end
 	end
 
+	WG['notifications'].resetEventDelay = function(event)
+		LastPlay[event] = spGetGameFrame()
+	end
+
 	if Spring.Utilities.Gametype.IsRaptors() and Spring.Utilities.Gametype.IsScavengers() then
 		queueNotification('RaptorsAndScavsMixed')
 	end
@@ -575,14 +585,7 @@ function widget:GameFrame(gf)
 
 		-- low power check
 		if e_currentLevel and (e_currentLevel / e_storage) < 0.025 and e_currentLevel < 3000 then
-			lowpowerDuration = lowpowerDuration + 1
-			if lowpowerDuration >= lowpowerThreshold then
-				queueNotification('LowPower')
-				lowpowerDuration = 0
-
-				-- increase next low power delay
-				notification["LowPower"].delay = notification["LowPower"].delay + 15
-			end
+			queueNotification('LowPower')
 		end
 
 		-- idle builder check
@@ -896,7 +899,11 @@ local function playNextSound()
 				WG['messages'].addMessage(Spring.I18N(notification[event].textID))
 			end
 		end
+
 		LastPlay[event] = spGetGameFrame()
+		if notification[event].resetOtherEventDelay then
+			LastPlay[notification[event].resetOtherEventDelay] = spGetGameFrame()
+		end
 
 		-- for tutorial event: log number of plays
 		if notification[event].tutorial then
@@ -942,11 +949,11 @@ function widget:Update(dt)
 		end
 		lastMouseX, lastMouseY = mouseX, mouseY
 		-- set user idle when no mouse movement or no commands have been given
-		if lastUserInputTime < os.clock() - idleTime then
-			isIdle = true
-		else
+		--if lastUserInputTime < os.clock() - idleTime then
+		--	isIdle = true
+		--else
 			isIdle = false
-		end
+		--end
 		if WG['rejoin'] and WG['rejoin'].showingRejoining() then
 			isIdle = true
 		end

--- a/sounds/voice/config.lua
+++ b/sounds/voice/config.lua
@@ -1,3 +1,16 @@
+--[[
+EventName = {
+	delay = integrer - Minimum seconds that have to pass to play this notification again.
+	stackedDelay = bool - Reset the delay even when attempted to play the notif under cooldown. 
+							Useful for stuff you want to be able to hear often, but not repeatedly if the condition didn't change.
+	resetOtherEventDelay = string - Name of 'fallback' event that will get it's delay reset. 
+							For example, UnitLost, is a general notif for losing units, but we have MetalExtractorLost, or RadarLost. I want those to reset UnitLost as well.
+	soundEffect = string - Sound Effect to play alongside the notification, located in 'sounds/voice-soundeffects'
+	tutorial = bool - Sound effect used for the tutorial messages, there's a whole different handling of those. (WIP)
+}
+]]
+
+
 return {
 
 	-- Commanders
@@ -22,7 +35,8 @@ return {
 		soundEffect = "NeutralComDead",
 	},
 	ComHeavyDamage = {
-		delay = 12,
+		delay = 10,
+		stackedDelay = true,
 		soundEffect = "CommanderHeavilyDamaged",
 	},
 	TeamDownLastCommander = {
@@ -78,7 +92,9 @@ return {
 		delay = 90,
 	},
 	BaseUnderAttack = {
-		delay = 5,
+		delay = 30,
+		stackedDelay = true,
+		resetOtherEventDelay = "UnitsUnderAttack",
 		soundEffect = "UnitUnderAttack",
 	},
 	UnitsCaptured = {
@@ -88,48 +104,64 @@ return {
 		delay = 5,
 	},
 	CommanderUnderAttack = {
-		delay = 5,
+		delay = 10,
+		stackedDelay = true,
+		resetOtherEventDelay = "UnitsUnderAttack",
 		soundEffect = "CommanderUnderAttack",
 	},
 	UnitsUnderAttack = {
-		delay = 5,
+		delay = 60,
+		stackedDelay = true,
 		soundEffect = "UnitUnderAttack",
 	},
 	UnitLost = {
-		delay = 5,
+		delay = 60,
+		stackedDelay = true,
 		soundEffect = "UnitUnderAttack",
 	},
 	RadarLost = {
-		delay = 5,
+		delay = 30,
+		stackedDelay = true,
+		resetOtherEventDelay = "UnitLost",
 		soundEffect = "UnitUnderAttack",
 	},
 	AdvancedRadarLost = {
-		delay = 5,
+		delay = 30,
+		stackedDelay = true,
+		resetOtherEventDelay = "UnitLost",
 		soundEffect = "UnitUnderAttack",
 	},
 	MetalExtractorLost = {
-		delay = 5,
+		delay = 30,
+		stackedDelay = true,
+		resetOtherEventDelay = "UnitLost",
 		soundEffect = "UnitUnderAttack",
 	},
 
 	-- Resources
 	YouAreOverflowingMetal = {
-		delay = 80,
+		delay = 60,
+		stackedDelay = true,
 	},
 	WholeTeamWastingMetal = {
-		delay = 120,
+		delay = 60,
+		stackedDelay = true,
 	},
 	WholeTeamWastingEnergy = {
-		delay = 240,
+		delay = 120,
+		stackedDelay = true,
 	},
 	YouAreWastingMetal = {
-		delay = 120,
+		delay = 60,
+		stackedDelay = true,
 	},
 	YouAreWastingEnergy = {
-		delay = 240,
+		delay = 120,
+		stackedDelay = true,
 	},
 	LowPower = {
-		delay = 50,
+		delay = 10,
+		stackedDelay = true,
 	},
 
 	-- Alerts
@@ -138,7 +170,8 @@ return {
 		soundEffect = "NukeAlert",
 	},
 	LrpcTargetUnits = {
-		delay = 5,
+		delay = 30,
+		stackedDelay = true,
 	},
 
 	-- Unit Ready
@@ -208,61 +241,80 @@ return {
 		delay = 9999999,
 	},
 	MinesDetected = {
-		delay = 200,
+		delay = 60,
+		stackedDelay = true,
 	},
 	StealthyUnitsDetected = {
-		delay = 55,
+		delay = 30,
+		stackedDelay = true,
 	},
 	LrpcDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	EmpSiloDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	TacticalNukeSiloDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	LongRangeNapalmLauncherDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	NuclearSiloDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	CalamityDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	RagnarokDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	StarfallDetected = {
 		delay = 25,
+		stackedDelay = true,
 	},
 	NuclearBomberDetected = {
 		delay = 60,
+		stackedDelay = true,
 	},
 	BehemothDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	SolinvictusDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	JuggernautDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	TitanDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	ThorDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	FlagshipDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	AstraeusDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 	AirTransportDetected = {
-		delay = 300,
+		delay = 120,
+		stackedDelay = true,
 	},
 
 	-- Lava


### PR DESCRIPTION
added new features to the notifications widget which allow for more fine tuning.

- stackedDelay = bool - Reset the delay even when attempted to play the notif under cooldown.
- resetOtherEventDelay = string - Name of 'fallback' event that will get it's delay reset. For example, UnitLost, is a general notif for losing units, but we have MetalExtractorLost, or RadarLost. I want those to reset UnitLost as well.

Adopted all notifications to use this new system where applicable. 
Added a little "documentation" to the config file explaining what different parameters do.
