### PR TITLE
Add gui_reactive_armor params to Legion units

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -89,6 +89,16 @@ function UnitDef_Post(name, uDef)
 		uDef.minCollisionSpeed = 75 / Game.gameSpeed -- define the minimum velocity(speed) required for all units to suffer fall/collision damage.
 	end
 
+	local customparams = uDef.customparams or {}
+	if customparams.gui_reactive_armor_health then
+		if not uDef.damagemodifier or uDef.damagemodifier == 1 then
+			customparams.gui_reactive_armor_health = nil
+			customparams.gui_reactive_armor_restore = nil
+		elseif not customparams.gui_reactive_armor_restore then
+			customparams.gui_reactive_armor_health = nil
+		end
+	end
+
 	-- Event Model Replacements: ----------------------------------------------------------------------------- 
 
 	-- April Fools

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -854,6 +854,8 @@
 			"exp": "Exp",
 			"open": "Open",
 			"closed": "Closed",
+			"reactive": "Reactive",
+			"restore": "restore",
 			"maxhp": "max HP",
 			"health": "health",
 			"assist": "Assist",

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -497,12 +497,15 @@ local function drawStats(uDefID, uID)
 		DrawText(texts.open..":", format(texts.maxhp..": %d", maxHP) )
 
 		if armoredMultiple and armoredMultiple ~= 1 then
-			DrawText(texts.closed..":", format(" +%d%%, "..texts.maxhp..": %d", (1/armoredMultiple-1) *100,maxHP/armoredMultiple))
+			DrawText(texts.closed..":", format(" +%d%%, %s: %d", (1 / armoredMultiple - 1) * 100, texts.maxhp, maxHP / armoredMultiple))
+
+			if uDef.customParams.gui_reactive_armor_health then
+				DrawText(texts.reactive..":", format("%d %s, %d%s %s", uDef.customParams.gui_reactive_armor_health, texts.health, uDef.customParams.gui_reactive_armor_restore, texts.s, texts.restore))
+			end
 		end
 	end
 
 	cY = cY - fontSize
-
 
 	------------------------------------------------------------------------------------
 	-- Transportable

--- a/units/Legion/Bots/T2 Bots/legamph.lua
+++ b/units/Legion/Bots/T2 Bots/legamph.lua
@@ -48,6 +48,8 @@ return {
 			unitgroup = "weaponsub",
 			--iswatervariable = true,
 			speedfactorwater = "1.3",
+			gui_reactive_armor_health = 750,
+			gui_reactive_armor_restore = 17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/T2 Bots/legshot.lua
+++ b/units/Legion/Bots/T2 Bots/legshot.lua
@@ -40,6 +40,8 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "Legion/Bots/T2 Bots",
 			techlevel = 2,
+			gui_reactive_armor_health = 4000,
+			gui_reactive_armor_restore = 20,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/legkark.lua
+++ b/units/Legion/Bots/legkark.lua
@@ -42,6 +42,8 @@ return {
 			subfolder = "Legion/Bots",
 			weapon1turretx = 200,
 			weapon1turrety = 200,
+			gui_reactive_armor_health = 300,
+			gui_reactive_armor_restore = 15,
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
### Work done

Adds a simple customparam-based approach to displaying reactive armor stats. This is undiscoverable information to the players that we should be communicating to them, at a minimum.

Prefixing with `gui_` should help instruct modders that this is a purely informational value with no function. Though I had a long moment of doubt where maybe it should be `display_` or something.

This is a more simple approach than PR #5865 which was a start on automating the process of extracting the health & restore times from the unit script files. But it requires us to maintain the correct/matching values between unit script & unit def. That is probably a lighter maintenance burden.

So it's either this or #5865, imo, and probably this.

<img width="681" height="313" alt="{621A09D4-F69B-4D73-BD3B-9417BCA0A036}" src="https://github.com/user-attachments/assets/3185b58c-eed8-4805-abf0-f9d7a22e6f41" />
