### PR TITLE
Fix mo_preventcombomb wrong weapon id

### DIFF
--- a/luarules/gadgets/mo_preventcombomb.lua
+++ b/luarules/gadgets/mo_preventcombomb.lua
@@ -1,5 +1,3 @@
-local gadgetEnabled = true
-
 local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
@@ -10,7 +8,7 @@ function gadget:GetInfo()
 		date      = "Aug 31, 2009",
 		license   = "GNU GPL, v2 or later",
 		layer     = 0,
-		enabled   = gadgetEnabled
+		enabled   = true,
 	}
 end
 


### PR DESCRIPTION
### Work done

s/identifier/id

#### Addresses Issue(s)

FFA players are getting com bombed and it's throwing matches rn