### PR TITLE
Legion Hotfix 11.25.5 - Sonar Removal

### DIFF
--- a/units/Legion/Ships/legnavyartyship.lua
+++ b/units/Legion/Ships/legnavyartyship.lua
@@ -30,7 +30,6 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "mediumexplosiongenericSelfd",
 		sightdistance = 500,
-		sonardistance = 400,
 		turninplace = true,
 		turninplaceanglelimit = 90,
 		turnrate = 150,

--- a/units/Legion/Ships/legnavydestro.lua
+++ b/units/Legion/Ships/legnavydestro.lua
@@ -30,7 +30,6 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "mediumexplosiongenericSelfd",
 		sightdistance = 500,
-		sonardistance = 400,
 		turninplace = true,
 		turninplaceanglelimit = 90,
 		turnrate = 280,


### PR DESCRIPTION
### Work Done
Removes sonar from the Syracusia and Octeres, which did not need it.