### PR TITLE
Mute Commander Destroyed notifs for team that is already dead.

### DIFF
--- a/luarules/gadgets/sfx_notifications.lua
+++ b/luarules/gadgets/sfx_notifications.lua
@@ -242,7 +242,7 @@ else
 			end
 		end
 
-		if isCommander[unitDefID] then
+		if isCommander[unitDefID] and not select(3, Spring.GetTeamInfo(unitTeam)) then
 			local myComCount = 0
 			local allyComCount = 0
 			local myAllyTeamList = Spring.GetTeamList(myAllyTeamID)

--- a/sounds/voice/config.lua
+++ b/sounds/voice/config.lua
@@ -223,34 +223,44 @@ return {
 
 	-- Unit Ready
 	RagnarokIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	CalamityIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	StarfallIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	AstraeusIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	SolinvictusIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	TitanIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	ThorIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	JuggernautIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	BehemothIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	FlagshipIsReady = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	Tech2UnitReady = {
 		delay = 9999999,
@@ -282,10 +292,12 @@ return {
 		delay = 9999999,
 	},
 	EnemyDetected = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	AircraftDetected = {
-		delay = 9999999,
+		delay = 120,
+		stackedDelay = true,
 	},
 	MinesDetected = {
 		delay = 60,


### PR DESCRIPTION
- Mute Commander Destroyed notifs for team that is already dead. (usually the case with resigns)
- Adjusted some Detected and Ready notifs to use stackedDelay instead of being one-offs.