### PR TITLE
fix

### DIFF
--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -26,6 +26,7 @@ local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetGameFrame = Spring.GetGameFrame
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGetViewGeometry = Spring.GetViewGeometry
+local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
 
 --Changelog
 --1.4: fixed text alignment, changed layer cause other widgets are eating events otherwise (e.g. smartselect)


### PR DESCRIPTION


Define local spGetSelectedUnitsSorted

Seems it was removed from global scope a week ago and widget failed to work when loading a queue
