### PR TITLE
Lava slow Pcall

### DIFF
--- a/luarules/gadgets/map_lava.lua
+++ b/luarules/gadgets/map_lava.lua
@@ -125,11 +125,14 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function updateSlow(unitID, unitDefID, unitSlow)
-		if spMoveCtrlEnabled(unitID) then return end
+		if spMoveCtrlEnabled(unitID) then return false end
 		local slowedMaxSpeed = speedDefs[unitDefID] * unitSlow
 		local slowedTurnRate = turnDefs[unitDefID] * unitSlow
 		local slowedAccRate = accDefs[unitDefID] * unitSlow
-		spSetMoveData(unitID, {maxSpeed = slowedMaxSpeed, turnRate = slowedTurnRate, accRate = slowedAccRate})
+		local sucess = pcall(function()
+			spSetMoveData(unitID, {maxSpeed = slowedMaxSpeed, turnRate = slowedTurnRate, accRate = slowedAccRate})
+		end)
+		return sucess
 	end
 
 	-- slow down and damage unit+features in lava
@@ -154,16 +157,20 @@ if gadgetHandler:IsSyncedCode() then
 						end
 					end
 					if lavaUnits[unitID].slowed and (unitSlow ~= lavaUnits[unitID].currentSlow) then
-						lavaUnits[unitID].currentSlow = unitSlow
-						updateSlow(unitID, unitDefID, unitSlow)
+						local sucess = updateSlow(unitID, unitDefID, unitSlow)
+						if sucess then 
+							lavaUnits[unitID].currentSlow = unitSlow
+						end
 					end
 				spAddUnitDamage(unitID, lavaDamage, 0, gaiaTeamID, 1)
 				spSpawnCEG(lavaEffectDamage, x, y+5, z)
 				elseif lavaUnits[unitID] then -- unit exited lava
 					if lavaUnits[unitID].slowed then
-						updateSlow(unitID, unitDefID, 1)
+						local sucess = updateSlow(unitID, unitDefID, 1)
 					end
-				lavaUnits[unitID] = nil
+					if sucess then 
+						lavaUnits[unitID] = nil
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Wraps the lava slow in a pcall(). Not an ideal solution but some people playing modded T3/T4 lava still report it crashing out regularly late game. I've asked for logs and replays but until I can pinpoint the cause this should protect against some issues. 
