### PR TITLE
Implement unused cruise_max_height and smooth movement between it and cruise_min_height

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -236,9 +236,6 @@ end
 local cruiseWaitingDefs = {}
 local cruiseEngagedDefs = {}
 
-local _; -- sink var for unused values
-local float3 = { 0, 0, 0 }
-
 local function applyCruiseCorrection(projectileID, elevation, cruiseHeight, positionX, positionY, positionZ, velocityX, velocityY, velocityZ)
 	local responseY = 0
 	if elevation > 0 then


### PR DESCRIPTION
### Work done

- divided the `cruise` speceffect into separate subfunctions
  - launch/ascent
  - ground-avoidance
  - ground-following
- using the `cruise_max_height` to provide a range of motion during the "following" stage
- some smoothing to prevent instantaneous 90-degree turns
- some performance gains from not checking extra conditions
- bonus: works above water, now

The current target units are armsptk, legeshotgunmech, and whatever extra units.

It also removes the restriction on future units that their launch point roughly follows the same elevation as the weapon's cruise height to behave consistently.

There is almost no effect on current gameplay. Recluse missiles cruise between 15 and 20 elmos, and 5 elmos is a super-tiny distance. They behave effectively the same as before, except when heading at angles near 90 degrees toward a surface. The missiles do move both less often and more smoothly, which was enough improvement for me to consider finishing this PR. But in balance or mechanical terms, all this does is add a knob for the BLT to turn if they want to, probably later on, and probably on another unit.

This does have marginally better performance, but it only shows up for me in huge armsptk fights (400 v 400). Splitting this into three functions lightens the workload somewhat, especially during the ascent phase. On weapons with a high launch angle and a larger difference between the min and max heights, I'd assume this improvement is larger, but still not very noticeable. Cruise is one of our heavier weapon effects, so any little bit helps.