### PR TITLE
bugfix pregame build, legacy cancel's last command + restore shift+right click move in pregame

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -762,6 +762,17 @@ function widget:MousePress(mx, my, button)
 	end
 	local _, _, meta, shift = Spring.GetModKeyState()
 
+	if button == 3 and shift then
+		local x, y, _ = spGetMouseState()
+		local _, pos = spTraceScreenRay(x, y, true, false, false, true)
+		if pos and pos[1] then
+			local buildData = { -CMD.MOVE, pos[1], pos[2], pos[3], nil }
+
+			buildQueue[#buildQueue + 1] = buildData
+		end
+		return true
+	end
+
 	if not selBuildQueueDefID then
 		return false
 	end
@@ -965,16 +976,6 @@ function widget:MousePress(mx, my, button)
 
 		if DoBuildingsClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1]) then
 			return true
-		end
-	end
-
-	if button == 3 and shift then
-		local x, y, _ = spGetMouseState()
-		local _, pos = spTraceScreenRay(x, y, true, false, false, true)
-		if pos and pos[1] then
-			local buildData = { -CMD.MOVE, pos[1], pos[2], pos[3], nil }
-
-			buildQueue[#buildQueue + 1] = buildData
 		end
 	end
 


### PR DESCRIPTION
BUG 1:
in the legacy buildmenu layout, releasing shift didn't deselect the build. In pregame, and only for legacy, this would cause the last thing placed in the build queue to be removed. Fixed this by adding shift-release deselect same as the during the game and in gridmenu pre-game. Bug fixed.

BUG 2:
move commands ceased to work since drag-builds were introduced. Had to do with the order in which the drag/build/click commands were detected and executed. Now you can shift + right click with no build selected to add a move order in the command queue just as before.
tested an old branch to verify this used to work. No, there were not move icons before the update for the move positions - just the lines.

Tried it with quickstart, without quickstart, with legacy and with gridmenu pre and during game with grid, line, square and surround builds and all seems to work.