### PR TITLE
UnitIsDead and nil checks in guidance speceffect

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -271,7 +271,7 @@ specialEffectFunction.guidance = function(projectileID)
 	if spGetProjectileTimeToLive(projectileID) > 0 then
 		local ownerID = spGetProjectileOwnerID(projectileID)
 
-		if not ownerID then
+		if spGetUnitIsDead(ownerID) ~= false then
 			return true
 		end
 


### PR DESCRIPTION
### Work done

Adds a check for dead units instead of just invalid ones, since projectiles don't seem to lose track of their ownerID on the owner's death.

Also prevents a potential nil error if weapon state becomes unavailable.