### PR TITLE
Fix legamph cmd.fight when moving in water

### DIFF
--- a/units/Legion/Bots/T2 Bots/legamph.lua
+++ b/units/Legion/Bots/T2 Bots/legamph.lua
@@ -172,6 +172,7 @@ return {
 				cratermult = 0,
 				edgeeffectiveness = 0.15,
 				explosiongenerator = "custom:genericshellexplosion-small-uw",
+				firesubmersed = false,
 				flighttime = 1.75,
 				gravityaffected = "true",
 				groundbounce = true,


### PR DESCRIPTION
### Work done

`legamph`/Telchine thinks it can fire its depth charges while submerged, while its unit script retracts the weapon and prevents aiming/firing it.

Fix is to set the correct traits for the command AI to know better, so `firesubmersed = false`.

Thanks to lamer for finding this one. This will help AI devs with classifying the unit, too.