### PR TITLE
Teammate/Enemy notifs now reset delays of Neutral notifs

### DIFF
--- a/sounds/voice/config.lua
+++ b/sounds/voice/config.lua
@@ -18,14 +18,17 @@ return {
 	EnemyCommanderDied = {
 		delay = 1,
 		soundEffect = "EnemyComDead",
+		resetOtherEventDelay = "NeutralCommanderDied",
 	},
 	FriendlyCommanderDied = {
 		delay = 1,
 		soundEffect = "FriendlyComDead",
+		resetOtherEventDelay = "NeutralCommanderDied",
 	},
 	FriendlyCommanderSelfD = {
 		delay = 1,
 		soundEffect = "FriendlyComDead",
+		resetOtherEventDelay = "NeutralCommanderSelfD",
 	},
 	NeutralCommanderDied = {
 		delay = 1,
@@ -77,40 +80,52 @@ return {
 
 	TeammateCaughtUp = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerCaughtUp",
 	},
 	TeammateDisconnected = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerDisconnected",
 	},
 	TeammateLagging = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerLagging",
 	},
 	TeammateReconnected = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerReconnected",
 	},
 	TeammateResigned = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerResigned",
 	},
 	TeammateTimedout = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerTimedout",
 	},
 
 	EnemyPlayerCaughtUp = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerCaughtUp",
 	},
 	EnemyPlayerDisconnected = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerDisconnected",
 	},
 	EnemyPlayerLagging = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerLagging",
 	},
 	EnemyPlayerReconnected = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerReconnected",
 	},
 	EnemyPlayerResigned = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerResigned",
 	},
 	EnemyPlayerTimedout = {
 		delay = 5,
+		resetOtherEventDelay = "NeutralPlayerTimedout",
 	},
 
 	NeutralPlayerCaughtUp = {


### PR DESCRIPTION
Teammate/Enemy notifs now reset delays of Neutral notifs.