### PR TITLE
Fix headless docker build dependencies

### DIFF
--- a/tools/headless_testing/Dockerfile
+++ b/tools/headless_testing/Dockerfile
@@ -7,7 +7,8 @@ ENV BAR_CONFIG_JSON=./config.json
 ENV BAR_CONFIG_ENV=./config.env
 
 RUN apt-get update && \
-    apt-get install -y curl jq 7zip
+    apt-get install -y curl jq p7zip-full && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p maps games engine
 

--- a/tools/headless_testing/download-engine.sh
+++ b/tools/headless_testing/download-engine.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+set -euo pipefail
+
 mkdir -p "$ENGINE_DESTINATION"
 
 TEMP_FILE=$(mktemp --suffix=.7z)
 
-curl -L "$ENGINE_URL" -o "$TEMP_FILE" && 7z x "$TEMP_FILE" -o"$ENGINE_DESTINATION" && rm -f temp.7z
+curl -L "$ENGINE_URL" -o "$TEMP_FILE"
+7z x "$TEMP_FILE" -o"$ENGINE_DESTINATION"
+rm -f "$TEMP_FILE"


### PR DESCRIPTION
## Summary
- install correct 7zip package and clean apt cache in headless test Dockerfile
- harden download-engine.sh with strict error handling and cleanup of temp archive

## Testing
- docker compose -f tools/headless_testing/docker-compose.yml build
- docker compose -f tools/headless_testing/docker-compose.yml run --rm bar