### PR TITLE
fix broken budget cost display for legacy buildmenu

### DIFF
--- a/luaui/RmlWidgets/gui_quick_start/gui_quick_start.lua
+++ b/luaui/RmlWidgets/gui_quick_start/gui_quick_start.lua
@@ -329,10 +329,6 @@ local function hideWarnings()
 end
 
 local function updateAllCostOverrides()
-	if not wgBuildMenu or not wgGridMenu then
-		return
-	end
-
 	local myTeamID = spGetMyTeamID()
 	local gameRules = getCachedGameRules()
 	local buildQueue = wgPregameBuild and wgPregameBuild.getBuildQueue and wgPregameBuild.getBuildQueue() or {}
@@ -375,10 +371,10 @@ local function updateAllCostOverrides()
 			}
 		}
 
-		if wgBuildMenu.setCostOverride then
+		if wgBuildMenu and wgBuildMenu.setCostOverride then
 			wgBuildMenu.setCostOverride(unitDefID, costOverride)
 		end
-		if wgGridMenu.setCostOverride then
+		if wgGridMenu and wgGridMenu.setCostOverride then
 			wgGridMenu.setCostOverride(unitDefID, costOverride)
 		end
 	end


### PR DESCRIPTION
there was some silly logic I left in that allowed gridmenu to display prices correctly but not legacy mode
this fixes that. 