### PR TITLE
exclude antinuke from area select settings opton

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1669,6 +1669,8 @@
 				"smartselect_includebuildings_descr": "When rectangle-drag-selecting an area, include building units too?\n\nDisabled: non-mobile units will be excluded (hold Shift to override)\nNote: Construction Turrets will always be selected",
 				"smartselect_includebuilders": "include builders (if above is off)",
 				"smartselect_includebuilders_descr": "When rectangle-drag-selecting an area, exclude builder units (hold Shift to override)",
+				"smartselect_includeantinuke": "include antinuke units (if above is off)",
+				"smartselect_includeantinuke_descr": "When rectangle-drag-selecting an area, exclude antinuke units (hold Shift to override)",
 				"onlyfighterspatrol": "Only fighters patrol",
 				"onlyfighterspatrol_descr": "Only fighters obey a factory's patrol route after leaving airlab.",
 				"fightersfly": "Set fighters on Fly mode",

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4597,6 +4597,13 @@ function init()
 			  saveOptionValue('SmartSelect', 'smartselect', 'setIncludeBuilders', { 'includeBuilders' }, value)
 		  end,
 		},
+		{ id = "smartselect_includeantinuke", group = "game", category = types.basic, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.smartselect_includeantinuke'), type = "bool", value = false, description = Spring.I18N('ui.settings.option.smartselect_includeantinuke_descr'),
+		  onload = function(i)
+		  end,
+		  onchange = function(i, value)
+			  saveOptionValue('SmartSelect', 'smartselect', 'setIncludeAntinuke', { 'includeAntinuke' }, value)
+		  end,
+		},
 
 
 		{ id = "prioconturrets", group = "game", category = types.basic, widget = "Priority Construction Turrets", name = Spring.I18N('ui.settings.option.prioconturrets'), type = "bool", value = GetWidgetToggleValue("Priority Construction Turrets"), description = Spring.I18N('ui.settings.option.prioconturrets_descr') },
@@ -6417,9 +6424,11 @@ function init()
 	if WG['smartselect'] == nil then
 		options[getOptionByID('smartselect_includebuildings')] = nil
 		options[getOptionByID('smartselect_includebuilders')] = nil
+		options[getOptionByID('smartselect_includeantinuke')] = nil
 	else
 		options[getOptionByID('smartselect_includebuildings')].value = WG['smartselect'].getIncludeBuildings()
 		options[getOptionByID('smartselect_includebuilders')].value = WG['smartselect'].getIncludeBuilders()
+		options[getOptionByID('smartselect_includeantinuke')].value = WG['smartselect'].getIncludeAntinuke()
 	end
 
 	if WG['snow'] ~= nil and WG['snow'].getSnowMap ~= nil then

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -31,6 +31,7 @@ local referenceX, referenceY
 local selectBuildingsWithMobile = false		-- whether to select buildings when mobile units are inside selection rectangle
 local includeNanosAsMobile = true
 local includeBuilders = false
+local includeAntinuke = false
 
 -- selection modifiers
 local mods = {
@@ -78,6 +79,7 @@ local combatFilter = {}
 local builderFilter = {}
 local buildingFilter = {}
 local mobileFilter = {}
+local antinukeFilter = {}
 local customFilter = {}
 
 for udid, udef in pairs(UnitDefs) do
@@ -89,6 +91,7 @@ for udid, udef in pairs(UnitDefs) do
 	local builder = (udef.canReclaim and udef.reclaimSpeed > 0)  or  (udef.canResurrect and udef.resurrectSpeed > 0)  or  (udef.canRepair and udef.repairSpeed > 0) or (udef.buildOptions and udef.buildOptions[1])
 	local building = (isMobile == false)
 	local combat = (not builder) and isMobile and (#udef.weapons > 0)
+	local antinuke = udef.customParams and udef.customParams.unitgroup == "antinuke"
 
 	if string.find(udef.name, 'armspid') or string.find(udef.name, 'leginfestor') then
 		builder = false
@@ -97,6 +100,7 @@ for udid, udef in pairs(UnitDefs) do
 	builderFilter[udid] = builder
 	buildingFilter[udid] = building
 	mobileFilter[udid] = isMobile
+	antinukeFilter[udid] = antinuke
 end
 
 local dualScreen
@@ -375,7 +379,7 @@ function widget:Update(dt)
 				uid = mouseSelection[i]
 				udid = spGetUnitDefID(uid)
 				if buildingFilter[udid] == false then
-					if includeBuilders or not builderFilter[udid] then
+					if (includeBuilders or not builderFilter[udid]) and (includeAntinuke or not antinukeFilter[udid]) then
 						tmp[#tmp + 1] = uid
 					else
 						tmp2[#tmp2 + 1] = uid
@@ -592,7 +596,7 @@ function widget:Initialize()
 					uid = mouseSelection[i]
 					udid = spGetUnitDefID(uid)
 					if buildingFilter[udid] == false then
-						if includeBuilders or not builderFilter[udid] then
+						if (includeBuilders or not builderFilter[udid]) and (includeAntinuke or not antinukeFilter[udid]) then
 							tmp[#tmp + 1] = uid
 						else
 							tmp2[#tmp2 + 1] = uid
@@ -656,6 +660,12 @@ function widget:Initialize()
 	WG['smartselect'].setIncludeBuilders = function(value)
 		includeBuilders = value
 	end
+	WG['smartselect'].getIncludeAntinuke = function()
+		return includeAntinuke
+	end
+	WG['smartselect'].setIncludeAntinuke = function(value)
+		includeAntinuke = value
+	end
 
 	widget:ViewResize()
 end
@@ -664,7 +674,8 @@ function widget:GetConfigData()
 	return {
 		selectBuildingsWithMobile = selectBuildingsWithMobile,
 		includeNanosAsMobile = includeNanosAsMobile,
-		includeBuilders = includeBuilders
+		includeBuilders = includeBuilders,
+		includeAntinuke = includeAntinuke
 	}
 end
 
@@ -677,5 +688,8 @@ function widget:SetConfigData(data)
 	end
 	if data.includeBuilders ~= nil then
 		includeBuilders = data.includeBuilders
+	end
+	if data.includeAntinuke ~= nil then
+		includeAntinuke = data.includeAntinuke
 	end
 end


### PR DESCRIPTION
defaults to excluding antinuke, because I keep seeing the same thread over and over again with reputable players like Chronopolize and Blodir agreeing that you wouldn't want to area-select antinuke with your combat units. See the most recent incarnation: https://discord.com/channels/549281623154229250/1441111177605156986
This adds a settings toggle to do that.

https://github.com/user-attachments/assets/7c1d3b3f-2cd4-4220-b241-eab3db6273aa

