### PR TITLE
Remove building ghosts from transported buildings

### DIFF
--- a/luarules/gadgets/unit_transported_building_ghost.lua
+++ b/luarules/gadgets/unit_transported_building_ghost.lua
@@ -1,0 +1,36 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name      = "Transported building Ghost Remover",
+		desc      = "Removes the ghosts left by transported buildings",
+		author    = "Chronographer",
+		date      = "Nov 2025",
+		license   = "GNU GPL, v2 or later",
+		layer     = 0,
+		enabled   = true
+	}
+end
+
+spSetUnitLeavesGhost = Spring.SetUnitLeavesGhost
+
+if not gadgetHandler:IsSyncedCode() then return end
+
+local leavesGhost = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.leavesGhost == true then
+		leavesGhost[unitDefID] = true
+	end
+end
+
+function gadget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
+	if leavesGhost[unitDefID] then
+		spSetUnitLeavesGhost(unitID, false, true) -- Old ghost persists until position re-enters LOS 
+	end
+end
+
+function gadget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
+	if leavesGhost[unitDefID] then
+		spSetUnitLeavesGhost(unitID, true)
+	end
+end


### PR DESCRIPTION
New gadget that stops transported buildings from updating ghosts until placed back into new location. This prevents the position of transported radar/llt/etc. from always being known without any sensor coverage. 

### Work done
Create unit_transported_building_ghost.lua

#### Test steps
- Spawn some transportable buildings e.g. llt, t1 radar. 
- Spot them with vision
- exit LOS and transport the buildings
- observe new ghost behaviour

### Screenshots:
#### BEFORE:
Original building position:
<img width="697" height="429" alt="image" src="https://github.com/user-attachments/assets/6231b0d9-f7d2-47f6-baee-15d712d01b68" />

Building transported, live position is known through fog:
<img width="732" height="403" alt="image" src="https://github.com/user-attachments/assets/54a31d4b-89ca-472e-9121-ab2ce8415b7a" />

With radar coverage, ghost matches radar icon as expected: 
<img width="702" height="397" alt="image" src="https://github.com/user-attachments/assets/2fce8c14-4ad0-4333-b1f2-d584f9d3e926" />

#### AFTER:
Without radar coverage, building about to be transported: 
<img width="615" height="403" alt="image" src="https://github.com/user-attachments/assets/d717451e-b5bc-494e-b432-dbeefae771c2" />

Building transported, the ghost remains: 
<img width="692" height="561" alt="image" src="https://github.com/user-attachments/assets/faf73cbf-fbab-472d-b3d3-13bd515c1f00" />

Building transported, the vision ghost updates when re-entering vision (in this case being removed now building is not there:
<img width="779" height="468" alt="image" src="https://github.com/user-attachments/assets/52b4d5d3-1088-4c7e-a0c9-3c1d656a53ac" />

With radar coverage:
Building about to be transported: 
<img width="995" height="713" alt="image" src="https://github.com/user-attachments/assets/7bbb4f71-2767-4196-a53b-8ad8e0f0aae5" />

Building transported, the vision ghost is cleared, radar icon updates as expected: 
<img width="734" height="377" alt="image" src="https://github.com/user-attachments/assets/e629800c-4ae4-4ba8-a4ef-481e3628f035" />

