### PR TITLE
Nanotcs leave vision ghosts after leaving LOS

### DIFF
--- a/units/ArmBuildings/LandUtil/armnanotc.lua
+++ b/units/ArmBuildings/LandUtil/armnanotc.lua
@@ -22,7 +22,7 @@ return {
 		health = 560,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 700,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/ArmBuildings/LandUtil/armnanotct2.lua
+++ b/units/ArmBuildings/LandUtil/armnanotct2.lua
@@ -22,7 +22,7 @@ return {
 		health = 2200,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 5100,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/ArmBuildings/SeaUtil/armnanotc2plat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotc2plat.lua
@@ -23,7 +23,7 @@ return {
 		health = 2200,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 5100,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/ArmBuildings/SeaUtil/armnanotcplat.lua
+++ b/units/ArmBuildings/SeaUtil/armnanotcplat.lua
@@ -23,7 +23,7 @@ return {
 		health = 560,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 700,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/CorBuildings/LandUtil/cornanotc.lua
+++ b/units/CorBuildings/LandUtil/cornanotc.lua
@@ -22,7 +22,7 @@ return {
 		health = 560,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 700,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/CorBuildings/LandUtil/cornanotct2.lua
+++ b/units/CorBuildings/LandUtil/cornanotct2.lua
@@ -22,7 +22,7 @@ return {
 		health = 2200,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 5100,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/CorBuildings/SeaUtil/cornanotc2plat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotc2plat.lua
@@ -23,7 +23,7 @@ return {
 		health = 2200,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 5100,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/CorBuildings/SeaUtil/cornanotcplat.lua
+++ b/units/CorBuildings/SeaUtil/cornanotcplat.lua
@@ -23,7 +23,7 @@ return {
 		health = 560,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 700,
 		maxacc = 0,
 		maxdec = 4.5,

--- a/units/Legion/Utilities/legnanotc.lua
+++ b/units/Legion/Utilities/legnanotc.lua
@@ -24,7 +24,7 @@ return {
 		footprintz = 3,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 700,
 		health = 560,
 		maxslope = 10,

--- a/units/Legion/Utilities/legnanotcplat.lua
+++ b/units/Legion/Utilities/legnanotcplat.lua
@@ -25,7 +25,7 @@ return {
 		footprintz = 3,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 700,
 		health = 560,
 		maxslope = 10,

--- a/units/Legion/Utilities/legnanotct2.lua
+++ b/units/Legion/Utilities/legnanotct2.lua
@@ -24,7 +24,7 @@ return {
 		footprintz = 4,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 5100,
 		health = 2200,
 		maxslope = 10,

--- a/units/Legion/Utilities/legnanotct2plat.lua
+++ b/units/Legion/Utilities/legnanotct2plat.lua
@@ -25,7 +25,7 @@ return {
 		footprintz = 4,
 		idleautoheal = 5,
 		idletime = 1800,
-		leavesGhost = true,
+		leavesghost = true,
 		mass = 5100,
 		health = 2200,
 		maxslope = 10,


### PR DESCRIPTION
Updated all nanotcs to leave ghosts with new engine unitdef `leavesGhost = true`. 

#### Addresses Issue(s)
[See various discussions on discord.](https://discord.com/channels/549281623154229250/1132764739399856210/1338290879789666346)

https://discord.com/channels/549281623154229250/1123564289291190313/1123564289291190313

Would work well together with: 
https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6291

However not strictly dependent. 

#### BEFORE:
Scouting nanotc:
<img width="1077" height="601" alt="image" src="https://github.com/user-attachments/assets/74d4dbbd-476f-4f39-a553-02a775256c6a" />

Ghosts are removed:
<img width="1498" height="969" alt="image" src="https://github.com/user-attachments/assets/b854087c-e24e-4361-b25e-834c830c6e21" />


#### AFTER:
Scouting nanotc:
<img width="953" height="525" alt="image" src="https://github.com/user-attachments/assets/917ff348-3dca-4ef9-b4cc-1d02c4d6808f" />

Ghosts remain: 
<img width="1368" height="725" alt="image" src="https://github.com/user-attachments/assets/c3be9924-b9ce-40ce-987b-81b39016cf1c" />

