### PR TITLE
Fix unit info displaying negative eta time

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -419,13 +419,24 @@ local function drawStats(uDefID, uID)
 		local eRem = mathFloor(eTotal * buildRem)
 		local mIncome = mInc + mRec
 		local eIncome = eInc + eRec
-		local mEta = mIncome > 0 and mathMax(mRem - mCur, 0) / mIncome or 0
-		local eEta = eIncome > 0 and mathMax(eRem - eCur, 0) / eIncome or 0
+		local mEta = mIncome > 0 and (mRem - mCur) / mIncome or 0
+		local eEta = eIncome > 0 and (eRem - eCur) / eIncome or 0
 
 		DrawText(texts.prog..":", format("%d%%", 100 * buildProg))
-		DrawText(texts.metal..":", format("%d / %d (" .. yellow .. "%d" .. white .. ", %ds)", mTotal * buildProg, mTotal, mRem, mEta))
-		DrawText(texts.energy..":", format("%d / %d (" .. yellow .. "%d" .. white .. ", %ds)", eTotal * buildProg, eTotal, eRem, eEta))
-		--DrawText("MaxBP:", format(white .. '%d', buildRem * uDef.buildTime / mathMax(mEta, eEta)))
+
+		if mEta >= 0 then
+			DrawText(texts.metal..":", format("%d / %d (" .. yellow .. "%d" .. white .. ", %ds)", mTotal * buildProg, mTotal, mRem, mEta))
+		else
+			DrawText(texts.metal..":", format("%d / %d (" .. yellow .. "%d" .. white .. ")", mTotal * buildProg, mTotal, mRem))
+		end
+		
+		if eEta >= 0 then
+			DrawText(texts.energy..":", format("%d / %d (" .. yellow .. "%d" .. white .. ", %ds)", eTotal * buildProg, eTotal, eRem, eEta))
+		else
+			DrawText(texts.energy..":", format("%d / %d (" .. yellow .. "%d" .. white .. ")", eTotal * buildProg, eTotal, eRem))
+		end
+		
+			--DrawText("MaxBP:", format(white .. '%d', buildRem * uDef.buildTime / mathMax(mEta, eEta)))
 		cY = cY - fontSize
 	end
 


### PR DESCRIPTION
### Work done
Hides the metal and energy eta in the unit info screen when the time would be negative. Prevents negative time being displayed. 

#### Addresses Issue(s)
Fixes #3484

#### Test steps
- [ ] Enter a single player game
- [ ] Build a building while having more metal than the building cost
- [ ] Use `I` to view the unit info
- [ ] See that the number is capped at 0

### Screenshots:
#### BEFORE:
<img width="429" height="338" alt="image" src="https://github.com/user-attachments/assets/1034b301-c216-46d2-9293-b224a9d262e8" />

#### AFTER:
<img width="795" height="608" alt="image" src="https://github.com/user-attachments/assets/c438ccb0-7782-4536-b686-b8b6b14db199" />
