### PR TITLE
fix shift + right click legacy buildmenu in pregame

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -762,6 +762,13 @@ function widget:MousePress(mx, my, button)
 	end
 	local _, _, meta, shift = Spring.GetModKeyState()
 
+	if button == 3 and selBuildQueueDefID then
+		setPreGamestartDefID(nil)
+		buildModeState.startPosition = nil
+		buildModeState.buildPositions = {}
+		return true
+	end
+
 	if button == 3 and shift then
 		local x, y, _ = spGetMouseState()
 		local _, pos = spTraceScreenRay(x, y, true, false, false, true)
@@ -959,12 +966,6 @@ function widget:MousePress(mx, my, button)
 		end
 
 		return true
-	end
-
-	if button == 3 then
-		setPreGamestartDefID(nil)
-		buildModeState.startPosition = nil
-		buildModeState.buildPositions = {}
 	end
 
 	if button == 1 and #buildQueue > 0 and buildQueue[1][1]>0 then


### PR DESCRIPTION
fixes the fix that didn't quite fix the problem.
affects pregame only

hold shift and release shift > deselect build
right click with build selected > deselect build
shift + right click with build selected > deselect build
right click with no build selected > move order

kills that pesky stupid aweful bug where the last issued command in pregame would be removed with a right click deselect once and for all.

Tested all the above things.