### PR TITLE
Deduplicate buildoptions in UnitDef_Post

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1641,6 +1641,19 @@ function UnitDef_Post(name, uDef)
 			end
 		end
 	end
+
+	-- Deduplicate buildoptions (various modoptions or later mods can add the same units)
+	if uDef.buildoptions then
+		local seen = {}
+		local dedupedBuildoptions = {}
+		for _, unitName in ipairs(uDef.buildoptions) do
+			if not seen[unitName] then
+				seen[unitName] = true
+				dedupedBuildoptions[#dedupedBuildoptions + 1] = unitName
+			end
+		end
+		uDef.buildoptions = dedupedBuildoptions
+	end
 end
 
 local function ProcessSoundDefaults(wd)


### PR DESCRIPTION
### Work done

Adds automatic deduplication of buildoptions at the end of `UnitDef_Post` processing in `gamedata/alldefs_post.lua`.

Various modoptions (like `experimentalextraunits`, `scavunitsforplayers`) and later mods can add the same units to a factory's buildoptions, resulting in duplicate entries in the build menu. This change:

- Adds a deduplication step at the end of `UnitDef_Post` after all buildoption modifications have been applied
- Preserves the first occurrence of each unit while removing subsequent duplicates
- Maintains the original build order intent
- Uses a simple `seen` table lookup for efficient O(n) deduplication

The implementation is placed at the end of `UnitDef_Post` to ensure it catches all duplicates regardless of which modoption or processing step added them.

#### Addresses Issue(s)
- Fixes #4390

#### Test steps
- [ ] Start a game with multiple modoptions enabled that add units to factories (e.g., `experimentalextraunits` and `scavunitsforplayers`)
- [ ] Build a T2 Vehicle Factory (Cortex)
- [ ] Verify that units like corvac (Printer) only appear once in the build menu
- [ ] Expected: No duplicate entries in any factory's build menu