### PR TITLE
limit pregame drag-build size

### DIFF
--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -76,6 +76,7 @@ local BUILD_SQUARE_SIZE = SQUARE_SIZE * 2
 local BUILDING_COUNT_FUDGE_FACTOR = 1.4
 local BUILDING_DETECTION_TOLERANCE = 10
 local HALF = 0.5
+local MAX_DRAG_BUILD_COUNT = 200
 
 local function buildFacingHandler(command, line, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
@@ -336,6 +337,17 @@ local function fillRow(startX, startZ, stepX, stepZ, count, facing)
 	return result
 end
 
+local function truncateBuildPositions(result)
+	if #result > MAX_DRAG_BUILD_COUNT then
+		local truncated = {}
+		for i = 1, MAX_DRAG_BUILD_COUNT do
+			truncated[i] = result[i]
+		end
+		return truncated
+	end
+	return result
+end
+
 local function calculateBuildingPlacementSteps(unitDefID, startPos, endPos, spacing, facing)
 	local buildingWidth, buildingHeight = GetBuildingDimensions(unitDefID, facing)
 	local delta = { x = endPos.x - startPos.x, z = endPos.z - startPos.z }
@@ -380,7 +392,8 @@ local function getBuildPositionsLine(unitDefID, facing, startPos, endPos, spacin
 		xStep = zStep * delta.x / (delta.z ~= 0 and delta.z or 1)
 	end
 
-	return fillRow(snappedStart.x, snappedStart.z, xStep, zStep, xGreaterThanZ and xCount or zCount, facing)
+	local result = fillRow(snappedStart.x, snappedStart.z, xStep, zStep, xGreaterThanZ and xCount or zCount, facing)
+	return truncateBuildPositions(result)
 end
 
 local function getBuildPositionsGrid(unitDefID, facing, startPos, endPos, spacing)
@@ -403,8 +416,8 @@ local function getBuildPositionsGrid(unitDefID, facing, startPos, endPos, spacin
 		end
 		currentRowZ = currentRowZ + zStep
 	end
-	
-	return result
+
+	return truncateBuildPositions(result)
 end
 
 local function getBuildPositionsBox(unitDefID, facing, startPos, endPos, spacing)
@@ -433,8 +446,8 @@ local function getBuildPositionsBox(unitDefID, facing, startPos, endPos, spacing
 	elseif zCount == 1 then
 		table.append(result, fillRow(snappedStart.x, snappedStart.z, xStep, 0, xCount, facing))
 	end
-	
-	return result
+
+	return truncateBuildPositions(result)
 end
 
 local function getBuildPositionsAround(unitDefID, facing, target)


### PR DESCRIPTION
limits the number of builds you can drag-build to 200 to prevent accidental map-coverings causing lagouts. This doesn't happen in the normal game because there isn't as much performance hungry gl calls there. Here, it's necessary to keep it small as a bandaid for a complete overhaul of the visuals.