### PR TITLE
Fix issue 3475 (units lose queue when multi-selection includes a transport giving a load/unload command)

### DIFF
--- a/luarules/gadgets/unit_transportable_nanos.lua
+++ b/luarules/gadgets/unit_transportable_nanos.lua
@@ -48,6 +48,9 @@ function gadget:Initialize()
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	if not UnitDefs[unitDefID].isTransport then
+		return false
+	end
 	if cmdID == CMD_LOAD_UNITS then
 		if #cmdParams == 1 then -- if unit is target
 			if ValidUnitID(cmdParams[1]) and GetUnitTeam(cmdParams[1]) ~= teamID and Nanos[GetUnitDefID(cmdParams[1])] then


### PR DESCRIPTION
Closes #3475

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

Have the AllowCommand gadget call-in return false if the selected unit isn't a transport for the commands CMD_LOAD_UNITS and CMD_UNLOAD_UNITS

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Start a game
- [ ] `/cheat` then `/give armatlas` then `/give armack` then `/give corkorg`
- [ ] queue some things with the t2 con
- [ ] select both the t2 con and the t1 air transport
- [ ] right click the t2 con to load it
- [ ] unload it and see that the queue is still there (this is what the fix does - before the queue of the t2 con would go away)
- [ ] repeat with the juggernaut (but when right clicking to load you click to load the t2 con with the transport and jugg selected and before this fix the jugg would lose its queue)

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

#### Additional Notes

It is debatable as to whether or not this change should have gone into the file that it did, but in my opinion it makes a lot of sense to go there. The issue was caused by false positives being returned from gadget:AllowCommand for the commands CMD_LOAD_UNITS and CMD_UNLOAD_UNITS, which is exactly what the modified gadget file deals with, and that is the only place that handles those commands in gadget:AllowCommand (aside from some that handle all commands but don't really handle those two specifically in actuality). Plus, we shouldn't ever return true for AllowCommand if the unit isn't a transport in this context, soooooo it fixes the problem and that's why I went with it. No new file, 3 line fix that could be one line, big win.