### PR TITLE
Remove upright from legkark

### DIFF
--- a/units/Legion/Bots/legkark.lua
+++ b/units/Legion/Bots/legkark.lua
@@ -34,7 +34,6 @@ return {
 		turninplaceanglelimit = 90,
 		turninplacespeedlimit = 0.99,
 		turnrate = 900,
-		upright = true,
 		customparams = {
 			unitgroup = 'weapon',
 			model_author = "Tharsis",


### PR DESCRIPTION
Property was copied from another unit but shouldn't be used.