### PR TITLE
breaking reactive armor resets its restore time to max

### DIFF
--- a/luarules/gadgets/unit_reactive_armor.lua
+++ b/luarules/gadgets/unit_reactive_armor.lua
@@ -406,7 +406,7 @@ function gadget:Initialize()
 		unitArmorHealth[unitID] = armorHealth or nil
 		if armorFrames or not armorHealth or armorHealth < armor.health then
 			unitArmorFrames[unitID] = getArmorRestoreFrames(armor, armorFrames)
-			regenerateFrame[unitID] = combatUntil or combatEndFrame -- ?? why is this not set
+			regenerateFrame[unitID] = combatUntil or combatEndFrame
 		end
 
 		if debugReloads then


### PR DESCRIPTION
Resets armor restore times when reactive armor breaks, and shifts the restore time in proportion to armor damage/repair, as well.

### Work done

- Breaking reactive armor resets any ongoing restore progress.
- Damage decreases restore progress proportionally, up to a full reset.
- Reactive armor repair, for whatever reason, still supported here.
- A lot of these changes were made to support luarules reloads, so I could get exact numbers while testing and make quick changes. These are in the second half of the file.

This patches out the "surprise" element I mentioned in the initial PR but didn't make much noise about. After this change, even without knowing the exact mechanics but knowing "15 second restore time" (for legkark), I didn't encounter any moments when armor was lost or regained and that was outside of my expectation at all. I think this is the goal I had in mind, really, when making RA units slightly more robust against extremely minor chip damage, namely one Whistler/Lasher poking down a Karkinos.