### PR TITLE
Create custom keybinds for builder priority

### DIFF
--- a/luaui/Widgets/unit_builder_priority.lua
+++ b/luaui/Widgets/unit_builder_priority.lua
@@ -47,6 +47,7 @@ local lowpriorityNanos = true
 local lowpriorityCons = false
 
 -- controlled units by category
+local builders = {}
 local builderLabs = {}
 local builderNanos = {}
 local builderCons = {}
@@ -96,13 +97,17 @@ local function priorityKeyHandler(_,_,args)
 	end
 
 	for i = 1, #selectedUnits do
-		toggleUnit(selectedUnits[i], passive)
+		if builders[selectedUnits[i]] then
+			toggleUnit(selectedUnits[i], passive)
+		end
 	end
 	return true
 end
 
 local function classifyUnit(unitID, unitDefID)
-	if unitIsBuilder[unitDefID] and not unitIsCommander[unitDefID] then
+	if unitIsBuilder[unitDefID] then
+		builders[unitID] = true
+		if unitIsCommander[unitDefID] then return end
 		if unitIsNano[unitDefID] then
 			builderNanos[unitID] = true
 			toggleUnit(unitID, lowpriorityNanos)


### PR DESCRIPTION
Create custom keybinds for builder priority toggle. 

### Work done
Usage:
Bind actions to a key of your choice in /Beyond-All-Reason/data/uikeys.txt
`priority` 	will toggle the selected builders between low and high priority mode.
`priority low` 	will set the selected builders to low priority mode.
`priority high` will set the selected builders to high priority mode.

Correctly shows in ordermenu after binding and initialising ordermenu:
`bind sc_\ priority`
<img width="892" height="176" alt="image" src="https://github.com/user-attachments/assets/7f243fca-94af-47b6-9025-a149d58b000b" />


### Test steps

`bind sc_comma,sc_comma priority low`
`bind sc_comma priority high`

Note a double press puts all selected in low priority, single press for high priority. 

### Considerations

- Still unsure about the ideal functionality of toggles in BAR. If you select a variety of units in various states then the hud will show one particular state, low or high. When issued with no args priority will toggle ALL selected units into the newly displayed state on the hud. I.e. 'low' is shown, then pressing it will toggle ALL units to 'high'. 

The state shown however depends on the IDs of the units selected. E.g. If a commander and a constructor are both selected, it will always show the current state of the lower unitID unit. 

This behavior is consistent with how other toggles like firestates and cloak function. However isn't a true toggle like `selecttoggle` is for groups. Which would switch all units in state A to state B and all unit in state B to state A. (In the case of selecttoggle it selects or deselects group members), regardless of ID

- [x] Now correctly only issues order to builders
- [x] Could change it to Spring.[GiveOrderToUnitArray] seems unlikely to be needed