### PR TITLE
feature models can be s3o

### DIFF
--- a/gamedata/featuredefs_post.lua
+++ b/gamedata/featuredefs_post.lua
@@ -97,6 +97,7 @@ local function isModelOK(featureDef)
 	local modelPath = "objects3d/" .. featureDef.object
 	return VFS.FileExists(modelPath          , VFS.ZIP)
 	    or VFS.FileExists(modelPath .. ".3do", VFS.ZIP)
+	    or VFS.FileExists(modelPath .. ".s3o", VFS.ZIP)
 end
 
 for name, def in pairs(FeatureDefs) do


### PR DESCRIPTION
### Work done

- Allow feature models to use explicit .s3o extension
- By adding .s3o in featuredefs_post

Fixes an issue introduced in #4641.

Currently, only feature defs with an implicit .s3o model path extension will load. This recently impacted the xmas commander wrecks, fixed in #6385.

Looks like when an object name is passed w/ no extension, all the extensions of each known parser type are checked (includes 3do, s3o, gltf, glb): https://github.com/beyond-all-reason/RecoilEngine/blob/a5e9db90f450a72ce9c5f341d617df9297ce3bfa/rts/Rendering/Models/IModelParser.cpp#L58-L61