### PR TITLE
Prevent units from guarding themselves (fixes guard-self stall)

### DIFF
--- a/luarules/gadgets/unit_prevent_self_guard.lua
+++ b/luarules/gadgets/unit_prevent_self_guard.lua
@@ -14,10 +14,8 @@ if not gadgetHandler:IsSyncedCode() then
     return
 end
 
-local CMD_GUARD = CMD.GUARD
-
 function gadget:Initialize()
-    gadgetHandler:RegisterAllowCommand(CMD_GUARD)
+    gadgetHandler:RegisterAllowCommand(CMD.GUARD)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams)


### PR DESCRIPTION
- Fixed units able to self guard causing unexpected behaviors
    Fixes issue[#6324](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6324)