### PR TITLE
Allow binding of specific blueprints by index

### DIFF
--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -828,6 +828,14 @@ end
 -- action handlers
 -- ===============
 
+local function handleBlueprintPlaceAction(_,_,args)
+	if args and tonumber(args[1]) then
+		index = tonumber(args[1])
+		setSelectedBlueprintIndex(index)
+	end
+	return false
+end
+
 local function handleBlueprintNextAction()
 	if not blueprintPlacementActive then
 		return
@@ -1239,6 +1247,7 @@ function widget:Initialize()
 	loadBlueprintsFromFile()
 	loadedBlueprints = true
 
+	widgetHandler.actionHandler:AddAction(self, "blueprint_place", handleBlueprintPlaceAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_create", handleBlueprintCreateAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_next", handleBlueprintNextAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_prev", handleBlueprintPrevAction, nil, "p")
@@ -1265,6 +1274,7 @@ function widget:Shutdown()
 		saveBlueprintsToFile()
 	end
 
+	widgetHandler.actionHandler:RemoveAction(self, "blueprint_place","p")
 	widgetHandler.actionHandler:RemoveAction(self, "blueprint_create", "p")
 	widgetHandler.actionHandler:RemoveAction(self, "blueprint_next", "p")
 	widgetHandler.actionHandler:RemoveAction(self, "blueprint_prev", "p")


### PR DESCRIPTION
### Work done
Allow binding of specific blueprints by index. Index is taken as the argument to the `blueprint_place` action.

`bind meta+sc_1 blueprint_place 1` Will recall blueprint index 1 as the active blueprint. 

#### Setup
Have blueprints in index 1-5 etc. 

Add keybindings: 
```
bind meta+sc_1 blueprint_place 1
bind meta+sc_2 blueprint_place 2
bind meta+sc_3 blueprint_place 3
bind meta+sc_4 blueprint_place 4
```

#### Test steps

- Test recalling a blueprint by index directly
- Test scrolling to a different index
- Test recalling a blueprint by index ignoring previous index position
- Test deleting a blueprint and observe any issues with recalling missing index. (opens empty blueprint and issuing `blueprint_place` command will fail with error 'No active blueprint ready for placement'

### Issues
- [ ] Currently returns `false` in action handler to allow for command to fire normally in command notify. But this prevents double press binds. Probably more elegant way to handle it. 
- [ ] Deleting a blueprint shifts all Indices which could be confusing to a user trying to access specific blueprints. 