### PR TITLE
Territorial Domination - rounds duration / elimination rework

### DIFF
--- a/luarules/gadgets/game_territorial_domination.lua
+++ b/luarules/gadgets/game_territorial_domination.lua
@@ -16,27 +16,28 @@ local isSynced = gadgetHandler:IsSyncedCode()
 if modOptions.deathmode ~= "territorial_domination" or not isSynced then return false end
 
 local territorialDominationConfig = {
-	["18_minutes"] = {
-		maxRounds = 3,
-		minutesPerRound = 6,
-	},
-	["24_minutes"] = {
+	["20_minutes"] = {
 		maxRounds = 4,
-		minutesPerRound = 6,
+		minutesPerRound = 5,
+	},
+	["25_minutes"] = {
+		maxRounds = 5,
+		minutesPerRound = 5,
 	},
 	["30_minutes"] = {
-		maxRounds = 5,
-		minutesPerRound = 6,
+		maxRounds = 6,
+		minutesPerRound = 5,
 	},
-	["42_minutes"] = {
+	["35_minutes"] = {
 		maxRounds = 7,
-		minutesPerRound = 6,
+		minutesPerRound = 5,
 	}
 }
 
-local config = territorialDominationConfig[modOptions.territorial_domination_config] or territorialDominationConfig["30_minutes"]
+local config = territorialDominationConfig[modOptions.territorial_domination_config] or territorialDominationConfig["25_minutes"]
 local MAX_ROUNDS = config.maxRounds
 local ROUND_SECONDS = 60 * config.minutesPerRound
+local ELIMINATION_THRESHOLD_MULTIPLIER = modOptions.territorial_domination_elimination_threshold_multiplier or 1.2
 local DEBUGMODE = false
 
 local GRID_SIZE = 1024
@@ -99,7 +100,7 @@ local roundTimestamp = 0
 local currentRound = 0
 local gameOver = false
 local allyTeamsCount = 0
-local previousRoundHighestScore = 0
+local eliminationThreshold = 0
 local topLivingRankedScoreIndex = 1
 
 local allyTeamsWatch = {}
@@ -624,7 +625,7 @@ function gadget:GameFrame(frame)
 				end
 				currentRound = currentRound + 1
 				for allyID, scoreData in pairs(allyData) do
-					if scoreData.score < previousRoundHighestScore and allyTeamsWatch[allyID] and scoreData.rank > topLivingRankedScoreIndex then
+					if scoreData.score < eliminationThreshold and allyTeamsWatch[allyID] and scoreData.rank > topLivingRankedScoreIndex then
 						defeatAlly(allyID)
 						refreshLivingTeams = true
 					end
@@ -643,8 +644,8 @@ function gadget:GameFrame(frame)
 			end
 
 			if currentRound <= MAX_ROUNDS then
-				previousRoundHighestScore = newHighestScore
-				Spring.SetGameRulesParam("territorialDominationPrevHighestScore", previousRoundHighestScore)
+				eliminationThreshold = math.floor(newHighestScore * ELIMINATION_THRESHOLD_MULTIPLIER)
+				Spring.SetGameRulesParam("territorialDominationEliminationThreshold", eliminationThreshold)
 				roundTimestamp = seconds + ROUND_SECONDS
 			end
 		end

--- a/luaui/RmlWidgets/gui_territorial_domination/gui_territorial_domination.lua
+++ b/luaui/RmlWidgets/gui_territorial_domination/gui_territorial_domination.lua
@@ -103,7 +103,7 @@ local initialModel = {
 	roundEndTime = 0,
 	maxRounds = 0,
 	pointsCap = 0,
-	prevHighestScore = 0,
+	eliminationThreshold = 0,
 	timeRemaining = TIME_ZERO_STRING,
 	roundDisplayText = spI18N('ui.territorialDomination.round.displayDefault', { maxRounds = DEFAULT_MAX_ROUNDS }),
 	timeRemainingSeconds = 0,
@@ -360,7 +360,7 @@ local function updateLeaderboard()
 	if not allyTeams or #allyTeams == 0 then return end
 	
 	local dataModel = widgetState.dmHandle
-	local eliminationThreshold = spGetGameRulesParam("territorialDominationPrevHighestScore") or 0
+	local eliminationThreshold = spGetGameRulesParam("territorialDominationEliminationThreshold") or 0
 	
 	local livingTeams = {}
 	local eliminatedTeams = {}
@@ -728,7 +728,7 @@ end
 local function updateRoundInfo()
 	local roundEndTime = spGetGameRulesParam("territorialDominationRoundEndTimestamp") or 0
 	local gameRulesPointsCap = spGetGameRulesParam("territorialDominationPointsCap") or DEFAULT_POINTS_CAP
-	local prevHighestScore = spGetGameRulesParam("territorialDominationPrevHighestScore") or 0
+	local eliminationThreshold = spGetGameRulesParam("territorialDominationEliminationThreshold") or 0
 	local currentRound = spGetGameRulesParam("territorialDominationCurrentRound") or 0
 	local maxRounds = spGetGameRulesParam("territorialDominationMaxRounds") or DEFAULT_MAX_ROUNDS
 
@@ -771,7 +771,7 @@ local function updateRoundInfo()
 		roundEndTime = roundEndTime,
 		maxRounds = maxRounds,
 		pointsCap = pointsCap,
-		prevHighestScore = prevHighestScore,
+		eliminationThreshold = eliminationThreshold,
 		timeRemaining = timeString,
 		roundDisplayText = roundDisplayText,
 		timeRemainingSeconds = timeRemainingSeconds,
@@ -839,7 +839,7 @@ local function updatePlayerDisplay()
 	local territoryCount = selectedTeam.territoryCount or 0
 	local currentScore = selectedTeam.score or 0
 	local teamName = selectedTeam.name or ""
-	local eliminationThreshold = dataModel.prevHighestScore or 0
+	local eliminationThreshold = dataModel.eliminationThreshold or 0
 	
 	local allyTeams = widgetState.allyTeamData
 	local playerRank = 1
@@ -1053,7 +1053,7 @@ local function updateDataModel()
 		dataModel.roundEndTime = tostring(roundInfo.roundEndTime)
 		dataModel.maxRounds = roundInfo.maxRounds
 		dataModel.pointsCap = roundInfo.pointsCap
-		dataModel.prevHighestScore = roundInfo.prevHighestScore
+		dataModel.eliminationThreshold = roundInfo.eliminationThreshold
 		dataModel.timeRemaining = roundInfo.timeRemaining
 		dataModel.roundDisplayText = roundInfo.roundDisplayText
 		dataModel.timeRemainingSeconds = roundInfo.timeRemainingSeconds

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -120,12 +120,12 @@ local options = {
         def     = "com",
         section = "options_main",
         items   = {
-            { key = "neverend", name = "Never ending",             desc = "Teams are never eliminated",                       lock = { "territorial_domination_config" } },
-            { key = "com",     name = "Kill all enemy Commanders", desc = "When a team has no Commanders left, it loses",     lock = { "territorial_domination_config" } },
-            { key= "territorial_domination",  name= "Territorial Domination",     desc="Teams earn points by capturing territory to stay in the game. At the end of the final round, the team with the most points wins.", unlock = {"territorial_domination_config"} },
-            { key = "builders", name = "Kill all Builders",        desc = "When a team has no builders left, it loses",       lock = { "territorial_domination_config" } },
-            { key = "killall", name = "Kill everything",           desc = "Every last unit must be eliminated, no exceptions!", lock = { "territorial_domination_config" } },
-            { key = "own_com", name = "Player resign on Com death", desc = "When player commander dies, you auto-resign.",    lock = { "territorial_domination_config" } },
+            { key = "neverend", name = "Never ending",             desc = "Teams are never eliminated",                       lock = { "territorial_domination_config", "territorial_domination_elimination_threshold_multiplier" } },
+            { key = "com",     name = "Kill all enemy Commanders", desc = "When a team has no Commanders left, it loses",     lock = { "territorial_domination_config", "territorial_domination_elimination_threshold_multiplier" } },
+            { key= "territorial_domination",  name= "Territorial Domination",     desc="Teams earn points by capturing territory to stay in the game. At the end of the final round, the team with the most points wins.", unlock = {"territorial_domination_config", "territorial_domination_elimination_threshold_multiplier"} },
+            { key = "builders", name = "Kill all Builders",        desc = "When a team has no builders left, it loses",       lock = { "territorial_domination_config", "territorial_domination_elimination_threshold_multiplier" } },
+            { key = "killall", name = "Kill everything",           desc = "Every last unit must be eliminated, no exceptions!", lock = { "territorial_domination_config", "territorial_domination_elimination_threshold_multiplier" } },
+            { key = "own_com", name = "Player resign on Com death", desc = "When player commander dies, you auto-resign.",    lock = { "territorial_domination_config", "territorial_domination_elimination_threshold_multiplier" } },
         }
     },
 
@@ -135,14 +135,26 @@ local options = {
         desc    =
         "Configures the grace period and the amount of time in minutes it takes to reach the maximum required territory.",
         type    = "list",
-        def     = "24_minutes",
+        def     = "25_minutes",
         section = "options_main",
         items   = {
-            { key = "18_minutes", name = "3 Rounds, 18 Minutes",  desc = "Early tech emphasis, mathmathically certain comeback, elimination unlikely." },
-            { key = "24_minutes",  name = "4 Rounds, 24 Minutes(Default)",  desc = "Mid/late-game tech, comebacks a significant factor,eliminations uncommon" },
-            { key = "30_minutes", name = "5 Rounds, 30 Minutes", desc = "Late-game tech, comebacks less significant, eliminations likely" },
-            { key = "42_minutes",   name = "7 Rounds, 42 Minutes",   desc = "Super lategame tech, eliminations extremely likely" },
+            { key = "20_minutes", name = "4 Rounds, 20 Minutes",  desc = "Early tech emphasis, comebacks very likely, elimination unlikely." },
+            { key = "25_minutes",  name = "5 Rounds, 25 Minutes(Default)",  desc = "Mid/late-game tech, comebacks a significant factor, eliminations uncommon" },
+            { key = "30_minutes", name = "6 Rounds, 30 Minutes", desc = "Late-game tech, comebacks less significant, eliminations likely" },
+            { key = "35_minutes",   name = "7 Rounds, 35 Minutes",   desc = "Super lategame tech, eliminations extremely likely" },
         }
+    },
+
+    {
+        key     = "territorial_domination_elimination_threshold_multiplier",
+        name    = "Elimination Threshold Multiplier",
+        desc    = "Teams are eliminated at round end when score < elimination threshold which is set by highest score multiplied by this value. Lower values are more lenient.",
+        type    = "number",
+        def     = 1.2,
+        min     = 1.0,
+        max     = 1.5,
+        step    = 0.1,
+        section = "options_main",
     },
 
     {


### PR DESCRIPTION
Makes the default elimination threshold:
`= highestScore -> = highestScore * 1.2` by default, configurable via modoption for now. This modoption is intended to be deleted or hidden later.

6 minute rounds > 5 minutes, to make them feel a bit snappier