### PR TITLE
Hotfix "custom ai placements" modoption

### DIFF
--- a/luaui/Widgets/map_startbox_experimental.lua
+++ b/luaui/Widgets/map_startbox_experimental.lua
@@ -44,7 +44,7 @@ if Game.startPosType ~= 2 then
 end
 
 local draftMode = Spring.GetModOptions().draft_mode
-local allowEnemyAIPlacement = Spring.GetModOptions().allow_enemy_ai_spawn_placement or false
+local allowEnemyAIPlacement = Spring.GetModOptions().allow_enemy_ai_spawn_placement
 
 local tooCloseToSpawn
 


### PR DESCRIPTION
Was testing with cheats enabled. The logic was gated by a "isCheating" check, neglecting the modoption that allows placement of enemy AI's