### PR TITLE
Unit reverse move update - make it smart

### DIFF
--- a/luarules/gadgets/unit_reverse_move.lua
+++ b/luarules/gadgets/unit_reverse_move.lua
@@ -1,8 +1,8 @@
 function gadget:GetInfo()
     return {
         name      = "AutoReverse Movement",
-        desc      = "Units reverse intelligently instead of turning around",
-        author    = "DoodVanDaag + ChatGPT (used to port from tested armmanni_lus to gadget env)",
+        desc      = "Units reverse intelligently instead of turning around. This aims at replacing the old gadget (that is default disabled) and allow tweaks that use a defined r speed to work. There is no schedule for an implementation into the base game as this has not been approved by anyone.",
+        author    = "DoodVanDaag (LLM used)",
         date      = "2025",
         license   = "GPL",
         layer     = 0,


### PR DESCRIPTION
We're currently not using unit_reverse_move nor units with defined positive rSpeed, so this is mostly irrelevant work.

Although, in the event someone wants to try unit tweaks with positive rSpeed, we might want to have a gadget that handles those.

I worked on updating and creating a more intuitive logic:
> Units with defined r speed will attempt to follow their target's heading, and reverse if necessary. All other cases will remain normal forward movements.

Disclaimers:
>LLM was used during porting from LUS environment to gadget.
> This is not aimed as being published/implemented yet; it is a project that i feel needs to be seen/tested before going through GDT approval as the previous attempts at a smart control were mostly bad, and i don't think anyone can have a clear vision of the progress i made in making it better without actual tests in single player. So i'm trying to enhance visibility by still going through with making a draft PR.