### PR TITLE
fix: allow self-guard on factories

### DIFF
--- a/luarules/gadgets/unit_prevent_self_guard.lua
+++ b/luarules/gadgets/unit_prevent_self_guard.lua
@@ -1,7 +1,7 @@
 function gadget:GetInfo()
     return {
         name      = "Prevent Self Guard",
-        desc      = "Prevents all units from issuing guard commands on themselves",
+        desc      = "Prevents units from issuing guard commands on themselves",
         author    = "Trunks",
         date      = "2025",
         enabled   = true,
@@ -14,17 +14,15 @@ if not gadgetHandler:IsSyncedCode() then
     return
 end
 
+local isFactory = {} -- Factory order queue goes to their units, not themselves.
+for unitDefID, unitDef in ipairs(UnitDefs) do
+	isFactory[unitDefID] = unitDef.isFactory and #unitDef.buildOptions > 0
+end
+
 function gadget:Initialize()
     gadgetHandler:RegisterAllowCommand(CMD.GUARD)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams)
-    local targetID = cmdParams[1]
-
-    -- Block self-guard for ALL units
-    if targetID == unitID then
-        return false
-    end
-
-    return true
+	return cmdParams[1] == unitID and not isFactory[unitDefID]
 end


### PR DESCRIPTION
Fix to allow Guard orders to be enqueued in the factory order queue, then applied to units. Factory command queues do not apply to themselves, per se, so this doesn't break any rules on self-guarding.

### Work done

- Filters on def.isFactory