### PR TITLE
fix damage modifiers display

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -709,8 +709,8 @@ local function drawStats(uDefID, uID)
 				table.sort(sorted, descending)
 
 				local modifierText = { ("default = %s%d%%"):format(yellow, floor(100 * damages[defaultArmorIndex] / baseArmorDamage)) }
-				for _, rate in ipairs(sorted) do
-					tableInsert(modifierText, ("%s = %s%d%%"):format(table.concat(modifiers[rate], ", "), yellow, floor(100 * rate / baseArmorDamage)))
+				for _, armorDamage in ipairs(sorted) do
+					tableInsert(modifierText, ("%s = %s%d%%"):format(table.concat(modifiers[armorDamage], ", "), yellow, floor(100 * armorDamage / baseArmorDamage)))
 				end
 				DrawText(texts.modifiers..":", table.concat(modifierText, white.."; ") .. white .. ".")
 			end


### PR DESCRIPTION
Fixes the order, base percentage, and etc. for damage modifiers.

Anti-mine weapons are no longer really a thing so we don't care about that anymore. Touches a bunch of stuff because of course it does this file is a mess.

### Work done

- demystified some variable names
- default damage displayed first
- damage to armor classes listed next, in descending order
- damage% shown relative to damage to base armor type (greatest of default or vtol)
- removed the "indestructable" armor type from the display

### Addresses issue

Anti-air weapons had massive %modifiers compared to their default damage category.

Fake weapons were showing damage values. They should, at most, display ranges when that information is useful.

They're calling it an extremely well-received PR, very good:

https://discord.com/channels/549281623154229250/1090730219356307496/1451362778932707469