### PR TITLE
fix: lobbies without Legion cause error in defense range widget

### DIFF
--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -164,14 +164,20 @@ local unitDefRings = {} --each entry should be  a unitdefIDkey to very specific 
 ]]--
 
 local mobileAntiUnitDefs = {
-	[UnitDefNames.armscab.id ] = true,
-	[UnitDefNames.armcarry.id] = true,
-	[UnitDefNames.cormabm.id ] = true,
-	[UnitDefNames.corcarry.id] = true,
-	[UnitDefNames.armantiship.id] = true,
-	[UnitDefNames.corantiship.id] = true,
-	[UnitDefNames.leganavyantinukecarrier.id] = true,
+	armscab = true,
+	armcarry = true,
+	cormabm = true,
+	corcarry = true,
+	armantiship = true,
+	corantiship = true,
+	leganavyantinukecarrier = true,
 }
+for key, value in pairs(mobileAntiUnitDefs) do
+	mobileAntiUnitDefs[key] = nil
+	if UnitDefNames[key] then
+		mobileAntiUnitDefs[UnitDefNames[key].id] = true
+	end
+end
 
 local defensePosHash = {} -- key: {poshash=unitID}
 -- poshash is 4096 * posx/8 + posz/8


### PR DESCRIPTION
Patch for missing unitDefIDs when those units are not in the load path. Fixes a crash in gui_defenserange_gl4 when Legion is disabled ever since adding their antinuke ship.