### PR TITLE
fix carriers reentering UnitDestroyed, nil accesses

### DIFF
--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -110,6 +110,7 @@ local droneMetaList = {}
 local lastCarrierUpdate = 0
 local lastSpawnCheck = 0
 local lastDockCheck = 0
+local inUnitDestroyed = false
 
 local coroutine = coroutine
 local Sleep     = coroutine.yield
@@ -810,6 +811,7 @@ end
 
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
+	inUnitDestroyed = true
 	local carrierUnitID = spGetUnitRulesParam(unitID, "carrier_host_unit_id")
 
 	if carrierUnitID and carrierMetaList[carrierUnitID] then
@@ -825,16 +827,19 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 					if stockpile > 0 then
 						stockpile = stockpile - 1
 						spSetUnitStockpile(carrierUnitID, stockpile, stockpilepercentage)
+						-- Sending commands updates carriers which can remove them afterward.
 						spGiveOrderToUnit(carrierUnitID, CMD.STOCKPILE, {}, 0)
 					end
 					if carrierMetaList[carrierUnitID] then
 						carrierMetaList[carrierUnitID].stockpilecount = carrierMetaList[carrierUnitID].stockpilecount - 1
 					end
-
 				end
 			end
-			carrierMetaList[carrierUnitID].subUnitsList[unitID] = nil
-			totalDroneCount = totalDroneCount - 1
+			-- For now, just check back through all the information needed to identify the drone.
+			if carrierMetaList[carrierUnitID] and carrierMetaList[carrierUnitID].subUnitsList and carrierMetaList[carrierUnitID].subUnitsList[unitID] then
+				carrierMetaList[carrierUnitID].subUnitsList[unitID] = nil
+				totalDroneCount = totalDroneCount - 1
+			end
 		end
 	end
 
@@ -938,6 +943,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 		carrierMetaList[unitID] = nil
 	end
 
+	inUnitDestroyed = false
 end
 
 
@@ -981,8 +987,9 @@ local function UpdateCarrier(carrierID, carrierMetaData, frame)
 
 	local carrierx, carriery, carrierz = spGetUnitPosition(carrierID)
 	if not carrierx then
-		gadget:UnitDestroyed(carrierID)
-		--carrierMetaList[carrierID] = nil
+		if not inUnitDestroyed then
+			gadget:UnitDestroyed(unitID)
+		end
 		return
 	end
 	local cmdID, _, _, cmdParam_1, cmdParam_2, cmdParam_3 = spGetUnitCurrentCommand(carrierID)


### PR DESCRIPTION
### Work done

Mini patch adding some guards and re-checking that tables are valid halfway through UnitDestroyed to avoid encountering this bug again.

### Fixes issue

Dead drones issue stockpile orders to their carriers, which triggers the carrier's UnitCommand, which reaches the UpdateCarrier method. That method may reenter UnitDestroyed. This is probably some modded garbage but that's none of my business.

Also, the subUnitID might be cleaned up, and the carrier might be cleaned up, by the time that we reach each of their UnitDestroyed methods. When unit deaths happen on the same frame, probably some of the code's assumptions go out the window. So I added a double-check that the table is valid. An easier method would be just to keep a copy of the table local, but that is not how any of this file was written, so I did not do that.

This is a frequent error in the current logs due to uptick in Legion games. Silencing it would be nice.