### PR TITLE
fix rare issue with tweaks and translatedHumanName

### DIFF
--- a/luaui/i18nhelpers.lua
+++ b/luaui/i18nhelpers.lua
@@ -10,7 +10,7 @@ local function refreshUnitDefs()
 		if isScavenger then
 			local proxyUnitDefName = unitDef.customParams.fromunit
 			local proxyUnitDef = UnitDefNames[proxyUnitDefName]
-			proxyUnitDefName = proxyUnitDef.customParams.i18nfromunit or proxyUnitDefName
+			proxyUnitDefName = proxyUnitDef and proxyUnitDef.customParams.i18nfromunit or proxyUnitDefName
 
 			local fromUnitHumanName = Spring.I18N('units.names.' .. proxyUnitDefName)
 			humanName = Spring.I18N('units.scavenger', { name = fromUnitHumanName })


### PR DESCRIPTION
Most tweakdefs modders don't encounter this but when they do they get an error message they don't understand. This is slightly better for widget compatibility imo.

### Work done

- Guard a nil access when proxyUnitDef does not exist in a custom Scavenger unit with a bad `fromunit` field. This was just easier to do than refiguring how we do unit copying -- that's a lot of work.