### PR TITLE
fix: build buggeroff destroys decorations actively

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -54,7 +54,7 @@ local BUILDER_BUILD_RADIUS  = 200 * Spring.GetModOptions().multiplier_builddista
 -- Assume the units are super-fast and medium-sized.
 local SEARCH_RADIUS_OFFSET  = unitSpeedMax + 2 * footprint
 local FAST_UPDATE_FREQUENCY = gameSpeed * 0.5
-local SLOW_UPDATE_FREQUENCY = gameSpeed * 1.5
+local SLOW_UPDATE_FREQUENCY = FAST_UPDATE_FREQUENCY * 3 -- NB: must be a multiple
 local BUGGEROFF_RADIUS_INCREMENT = footprint
 -- Move away based on predicted position with lookahead:
 local BUGGEROFF_LOOKAHEAD   = (1/6) * gameSpeed


### PR DESCRIPTION
still unclear to me what the consequences are of immediate-free unitIDs but seems fine for decorations

### Work done

- Unfortunately large refactor for a tiny change, contained in the first commit, to get ready to switch from unit radius to unit footprints/actual blocking maps, which are just more involved all around.
- Then: delete decorations within the entire search/buggeroff radius around build commands. This can be an over-large area, for sure.

### Addresses issue

Xmas decorations drop from units destroyed by an attacker. These are units, for whatever reason, possibly to use unit cap to limit the screen clutter. Not sure.

Regardless, they are not reclaimable, and cannot move, so builders do not clear them from build sites and builder buggeroff cannot influence them. They will block a blueprint indefinitely.

My solution was to delete any interfering decorative units. They are deleted anywhere within the buggeroff search radius, not just within the building footprint. I started the work to detect them by actual ground blocking and footprint size/rotation.