### PR TITLE
fix: decorations have speed 30 actually(?)

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -30,7 +30,7 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 
 	cachedUnitDefs[unitDefID] = {
 		isImmobile = unitDef.isImmobile,
-		isBlocking = unitDef.isImmobile and unitDef.customParams.decoration and not unitDef.reclaimable,
+		isBlocking = unitDef.customParams.decoration and not unitDef.reclaimable,
 		isBuilder  = unitDef.isBuilder,
 		radius     = unitDef.radius,
 		semiAxisX  = unitDef.xsize * footprint * 0.5,


### PR DESCRIPTION
Fix for my recent PR to clean up decorations in buggeroff. I'd added a check for `isImmobile` to speculate that some decorations might be mobile/animated, but it seems like they all are.