### PR TITLE
fix: builder buggeroff ignores repeat for immobile build tasks

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -234,8 +234,7 @@ function gadget:GameFrame(frame)
 				end
 			end
 
-			-- NB: Units with Repeat enabled only attempt a single buggeroff, which doesn't go well. Semi-intended.
-			if buggerOffRadiusOffset > MAX_BUGGEROFF_RADIUS or IsUnitRepeatOn(builderID) then
+			if buggerOffRadiusOffset > MAX_BUGGEROFF_RADIUS or (not buildUnitDefData.isImmobile and IsUnitRepeatOn(builderID)) then
 				removeBuilder(builderID)
 			else
 				builderRadiusOffsets[builderID] = buggerOffRadiusOffset


### PR DESCRIPTION
### Work done

Ignore the builder's repeat state when placing a static/structure unit.

### Addresses issue

Very minor issue: It is somewhat common to have Repeat enabled by accident on builders, since it has very few effects, ordinarily. With buggeroff, though, it causes the scram behavior to occur only once per build task, which isn't how the current gadget is designed (it needs multiple updates to orient units away from the build site).

Using command-style logic in a CommandFallback instead of current implementation, this type of fix is not necessary, so this change could be reverted in the future, maybe.