### PR TITLE
fix: area timed damage regressions/merge conflict variety pack

### DIFF
--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -540,7 +540,7 @@ function gadget:GameFrame(frame)
     frameNumber = frame
 
     for unitID, expire in pairs(isNewUnit) do
-        if expire > frame then
+        if expire < frame then
             isNewUnit[unitID] = nil
         end
     end


### PR DESCRIPTION
These are minor regressions in napalm/acid:

- The damage frame guard on factory-built units was always one frame long
- Some AI goofs during optimization passes were anti-optimizations
- Some human goofs during a merge conflict regressed the hit detection on units, so only features are using fancy base position + mid position math

I wanted to do an actual optimization pass on this and found the file not as I expected it to be. These are not causing problems in the game but also are a blocker on further work here.

Tested each of these changes and they are working correctly.