### PR TITLE
Rez'd units retain XP

### DIFF
--- a/luarules/gadgets/unit_resurrected.lua
+++ b/luarules/gadgets/unit_resurrected.lua
@@ -40,8 +40,7 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 end
 
 local function RestoreStateMechanics(unitID, featureID)
-	--uncomment this to set unitXP from their previous incarnation
-	--Spring.SetUnitExperience(unitID, spGetFeatureRulesParam(featureID, "previous_xp") or 0)
+	Spring.SetUnitExperience(unitID, spGetFeatureRulesParam(featureID, "previous_xp") or 0)
 end
 
 local function RestoreStateGUI(unitID, featureID)


### PR DESCRIPTION
SEASON 3 BALANCE RELEASE

Players:
Resurrected units will now retain XP from their previous life.

Nerds:
Uncomments a priorly tested line of code.