### PR TITLE
fix: attached mexes destroy a unit, then try to get its properties

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -43,7 +43,8 @@ local function swapMex(unitID, unitDefID, unitTeam)
 	if original then
 		local orgbuildTime, orgmetalCost, orgenergyCost = Spring.GetUnitCosts(original)							-- gets metal cost of thing you are building over
 		local imex_id = Spring.CreateUnit("legmohoconin" .. scav,xx,yy,zz,facing,Spring.GetUnitTeam(unitID) )			-- creates imex on where mex was
-		--Spring.Echo(unitID, original, orgmetalCost)
+		local extractMetal = Spring.GetUnitMetalExtraction(unitID)
+
 		if Spring.GetUnitIsDead(unitID) == false then																-- if you build this over something then it doesnt remove mex, this removes and reclaims it
 			Spring.DestroyUnit(unitID, false, true)
 			Spring.AddTeamResource(unitTeam, "metal", metalCost)
@@ -74,10 +75,14 @@ local function swapMex(unitID, unitDefID, unitTeam)
 		end
 		Spring.UnitAttach(imex_id,nano_id,6)																-- attaches con to imex
 		Spring.SetUnitHealth(nano_id, health)																-- sets con health to be the same as mex
-		local extractMetal = Spring.GetUnitMetalExtraction(unitID)											-- moves the metal extraction from imex to turret.
-		Spring.SetUnitResourcing(nano_id, "umm", (extractMetal + orgExtractMetal))
-		Spring.SetUnitResourcing(imex_id, "umm", (-extractMetal - orgExtractMetal))
-		Spring.SetUnitStealth (nano_id, true) 
+
+		if extractMetal then
+			-- moves the metal extraction from imex to turret.
+			-- I do not understand this. Why would it work like this. But okay.
+			Spring.SetUnitResourcing(nano_id, "umm", (extractMetal + orgExtractMetal))
+			Spring.SetUnitResourcing(imex_id, "umm", (-extractMetal - orgExtractMetal))
+			Spring.SetUnitStealth (nano_id, true) 
+		end
 
 		mexesToSwap[unitID] = nil
 	end


### PR DESCRIPTION
### Work done

Both gets the value before destroying the unit and adds a nil check to guard vs regressions.

I suspect this is not the only issue in this code but it's the only thing that's producing errors.