### PR TITLE
fix: revalidate commands when units change teams in Disable Ally Assist

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -66,7 +66,7 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 	end
 
 	-- Disallow guard commands onto labs, units that have buildOptions or can assist
-	if cmdID == CMD.GUARD then
+	if cmdID == CMD_GUARD then
 		local targetID = cmdParams[1]
 		local targetTeam = Spring.GetUnitTeam(targetID)
 
@@ -80,7 +80,7 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 
 	-- Also disallow assisting building (caused by a repair command) units under construction
 	-- Area repair doesn't cause assisting, so it's fine that we can't properly filter it
-	if cmdID == CMD.REPAIR and #cmdParams == 1 then
+	if cmdID == CMD_REPAIR and #cmdParams == 1 then
 		local targetID = cmdParams[1]
 		local targetTeam = Spring.GetUnitTeam(targetID)
 


### PR DESCRIPTION
### Work done

- Removes disallowed Guard and Repair orders when units are shared or taken.
- Odds and ends in game_disable_assist_ally.

#### Addresses Issue(s)

- Players could guard a construction turret with a mobile con, guard a lab with the construction turret, and share the mobile con to an allied player. The mobile con would then assist the lab, circumventing the modoption to disable build assist on allied units.
- Minor technicalities that might matter with modding.