### PR TITLE
feat: custom preaim_range in Praetorian aimhull

### DIFF
--- a/units/Legion/T3/legeshotgunmech.lua
+++ b/units/Legion/T3/legeshotgunmech.lua
@@ -128,6 +128,9 @@ return {
 				turret = true,
 				weapontype = "Cannon",
 				weaponvelocity = 360,
+				customparams = {
+					preaim_range = 650,
+				},
 				damage = {
 					default = 0,
 				},


### PR DESCRIPTION
### Work done

- Increase Praetorian missile targeting range to its full range. This sometimes works currently, and sometimes does not, depending on how the unit receives its targets/commands.
- After the change, there are probably some side effects to figure out, but the main and important side effect is the +130 range on those missiles.