### PR TITLE
Fixup chat color stripping

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -199,14 +199,25 @@ local ColorIsDark = Spring.Utilities.Color.ColorIsDark
 
 local soundErrors = {}
 
+-- Filter color codes and control characters from player input to prevent injection
+-- Based on engine TextWrap.h constants
 local function stripColorCodes(text)
 	local result = text
-	-- First remove 8-byte color codes (extended format with outline)
-	result = result:gsub("\254........", "")
-	result = result:gsub("\018........", "")
-	-- Then remove 3-byte color codes (standard RGB format)
+	-- Remove color codes and control characters according to Spring's TextWrap.h:
+	-- ColorCodeIndicator (0xFF / \255) - followed by 3 bytes RGB
 	result = result:gsub("\255...", "")
-	result = result:gsub("\017...", "")
+	result = result:gsub("\255", "")  -- ÿ
+	result = result:gsub("ÿ", "")  -- ÿ
+	-- ColorCodeIndicatorEx (0xFE / \254) - followed by 8 bytes RGBA + outline RGBA
+	result = result:gsub("\254........", "")
+	result = result:gsub("\254", "")  -- þ
+	result = result:gsub("þ", "")  -- þ
+	-- ColorResetIndicator (0x08 / \008) - reset to default color
+	result = result:gsub("\008", "")
+	-- SetColorIndicator (0x01 / \001) - followed by 3 bytes RGB (legacy)
+	result = result:gsub("\001...", "")
+	-- Also strip any remaining standalone control characters that might affect rendering
+	result = result:gsub("\001", "")  -- SOH
 	return result
 end
 
@@ -808,8 +819,6 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 		lineType = LineTypes.Player
 		name = ssub(line,2,sfind(line,"> ", nil, true)-1)
 		text = ssub(line,slen(name)+4)
-		-- Filter color codes from player input
-		text = stripColorCodes(text)
 
 		if sfind(text,'Allies: ', nil, true) == 1 then
 			text = ssub(text,9)
@@ -830,6 +839,9 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 			text = ssub(text,2)
 		end
 
+		-- Filter color codes from player input
+		text = stripColorCodes(text)
+
 		nameText = getPlayerColorString(name, gameFrame)..(playernames[name] and playernames[name][7] or name)
 		line = ColorString(c[1],c[2],c[3])..text
 
@@ -843,8 +855,6 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 			name = ssub(line,2,sfind(line," (replay)] ", nil, true)-1)
 			text = ssub(line,slen(name)+13)
 		end
-		-- Filter color codes from spectator input
-		text = stripColorCodes(text)
 
 		-- filter specs
 		if hideSpecChat and (not hideSpecChatPlayer or not mySpec) then
@@ -866,6 +876,9 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 			text = ssub(text,2)
 		end
 
+		-- Filter color codes from spectator input
+		text = stripColorCodes(text)
+
 		nameText = ColorString(colorSpec[1],colorSpec[2],colorSpec[3])..'(s) '..(playernames[name] and playernames[name][7] or name)
 		line = ColorString(c[1],c[2],c[3])..text
 
@@ -874,8 +887,10 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 		lineType = LineTypes.Mapmark
 		name = ssub(line,1,sfind(line," added point: ", nil, true)-1)
 		text = ssub(line,slen(name.." added point: ")+1)
+
 		-- Filter color codes from mapmark text
 		text = stripColorCodes(text)
+
 		if text == '' then
 			text = 'Look here!'
 		end
@@ -918,8 +933,6 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 		else
 			bypassThisMessage = true
 		end
-		-- Filter color codes from battleroom input
-		text = stripColorCodes(text)
 		-- filter specs
 		local spectator = false
 		if playernames[name] ~= nil then
@@ -933,6 +946,9 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 		if ssub(text,1,1) == ' ' then
 			text = ssub(text,2)
 		end
+
+		-- Filter color codes from battleroom input
+		text = stripColorCodes(text)
 
 		nameText = ColorString(colorGame[1],colorGame[2],colorGame[3])..'<'..(playernames[name] and playernames[name][7] or name)..'>'
 		line = ColorString(colorGame[1],colorGame[2],colorGame[3])..text


### PR DESCRIPTION
1) the magic for extended color code is 254, not 255. Perhaps these should even the named `Engine.textColorCodes.Color(AndOutline)` values to avoid mistakes?
2) there's also alternative magic values for these, since recently, which don't have a named value yet so have to be specified as numbers.

See https://github.com/beyond-all-reason/RecoilEngine/blob/561e6b890aeb00241f90edb2cc0b57a0dd3f3146/rts/Rendering/Fonts/TextWrap.h#L23-L26
