### PR TITLE
fix: continuously check moveType in waterspeed gadget

### DIFF
--- a/luarules/gadgets/unit_waterspeedmultiplier.lua
+++ b/luarules/gadgets/unit_waterspeedmultiplier.lua
@@ -43,13 +43,19 @@ local spSetGroundMoveTypeData = Spring.MoveCtrl.SetGroundMoveTypeData
 
 local unitDefData = {}
 
+local function canHaveGroundMoveType(unitDef)
+	-- I think you are not supposed to be able to set a moveDef on air or immobile units,
+	-- but I think you can MoveCtrl.Enable, then MoveCtrl.SetMoveDef, to get around this.
+	return true -- so, lol
+end
+
 for defID, ud in pairs(UnitDefs) do
     local params = ud.customParams
 
 	local speedFactorInWater = tonumber(params.speedfactorinwater or 1) or 1
 	local speedFactorAtDepth = math.abs(params.speedfactoratdepth and tonumber(params.speedfactoratdepth) or 0) * -1
 
-	if speedFactorInWater ~= 1 and (not ud.isImmobile and not ud.canFly and not ud.isAirUnit) then
+	if speedFactorInWater ~= 1 and canHaveGroundMoveType(ud) then
 		if speedFactorAtDepth > -1 then
 			speedFactorAtDepth = 0
 		end


### PR DESCRIPTION
### Work done

Adds checks that a unit has a ground moveType before trying to set ground-type moveTypeData.

Lifts an otherwise-sensible restriction on what unitDefs are valid since invalid units no longer produce the error.

#### Addresses issue

Fixes a non-crash error in the variable inWaterSpeed gadget.

Since this checks moveType actively, now, I lifted restrictions on the unitDefs that are watched by the gadget. I scanned through moveDefs code and it looks possible that any unit can attain a ground moveDef, technically.

Tested this time with a long fightertest done on the lava map that might, maybe have been the issue here. It was a known todo to make this gadget work w/ other water types, namely lava. This only covers an error case, though, not other gameplay issues.