### PR TITLE
Fix factory tab switch bug

### DIFF
--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2500,7 +2500,7 @@ function widget:KeyPress(key, modifier, isRepeat)
 			return true
 		elseif useLabBuildMode and labBuildModeActive then
 			setLabBuildMode(false)
-			refreshCommands()
+			updateGrid()
 			return true
 		end
 	end


### PR DESCRIPTION
Players:
Your last selected buildoption will not be forgotten in gridmenu when you switch the factory's tab and back.

Nerds:
Seems refreshing the commands instead of merely updating the ui did the trick.