### PR TITLE
Consistency Change - RMB cancel attack command regardless of allied or enemy unit

### DIFF
--- a/luaui/Widgets/cmd_attack_no_ally.lua
+++ b/luaui/Widgets/cmd_attack_no_ally.lua
@@ -58,7 +58,8 @@ function widget:MousePress(x, y, button)
 		local _, activeCmdID = Spring.GetActiveCommand()
 		if activeCmdID and hasRightClickAttack[activeCmdID] then
 			local targetType, targetID = Spring.TraceScreenRay(x, y, false)
-			if targetType == "unit" and Spring.IsUnitAllied(targetID) then
+			--Changed to always cancel attack command on RMB, does not check for allied or enemy units
+			if targetType == "unit" then --and Spring.IsUnitAllied(targetID) then
 				Spring.SetActiveCommand(nil)
 				rmbCancelPending = false
 				return true


### PR DESCRIPTION
Right clicking while in the attack command cancels the attack in all cases but when hovering an enemy unit. To me it makes more sense to cancel if hovering enemy units as well using RMB to prevent accidentally shooting while trying to cancel the command.

Discussion about change occurred in discord. General consensus to have this change as there is an improvement with consistency with the attack command. 

[Discord Message](https://discord.com/channels/549281623154229250/549282166543089674/1455208319324000286)

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Small change, cancels attack on rmb click regardless if hovering friendly or enemy unit

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps, all features in the last approved PR are still working properly
- [ ] Guard is working
- [ ] Pressing right click on attack mode exits the command
- [ ] Units target ground if targeting an allied unit with the attack command (left click)
- [ ] Exits attack command if targeting an allied unit with the attack command (right click)
- [ ] Units do not fire if there is an allied unit blocking
- [ ] Drag right click on attack mode initiates ``attack line``
- [ ] Drag left click on attack mode initiates ``attack area``


<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->
