### PR TITLE
fix: clamp weapondef proximityPriority to a rational range

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1946,9 +1946,9 @@ function WeaponDef_Post(name, wDef)
 
 		-- Prevent weapons from aiming only at auto-generated targets beyond their own range.
 		if wDef.proximitypriority then
-			local range = math.max(wDef.range or 10, 0) -- todo: account for multiplier_weaponrange
-			local rangeBoost = math.max(range + ((wDef.customparams.exclude_preaim and 0) or (wDef.customparams.preaim_range or math.max(range * 0.1, 20))), 10) -- see unit_preaim
-			local proximity = math.max(wDef.proximitypriority, -0.4 - 100 / rangeBoost) -- see CGameHelper::GenerateWeaponTargets
+			local range = math.max(wDef.range or 10, 1) -- prevent div0 -- todo: account for multiplier_weaponrange
+			local rangeBoost = math.max(range + ((wDef.customparams.exclude_preaim and 0) or (wDef.customparams.preaim_range or math.max(range * 0.1, 20))), range) -- see unit_preaim
+			local proximity = math.max(wDef.proximitypriority, (-0.4 * rangeBoost - 100) / range) -- see CGameHelper::GenerateWeaponTargets
 			wDef.proximitypriority = math.clamp(proximity, -1, 10) -- upper range allowed for targeting weapons for drone bombers which can overrange massively
 		end
 


### PR DESCRIPTION
Basic groundwork for evaluating a change to weapon autotargeting proximity. Weapons with prox <= -1 were permanently affixing to targets outside their range and even waffling between them.

### Work done

- Clamps proximity priority to guarantee that targets in range are always preferable to targets not in range.
- That change is not actually sufficient to achieve that result; a minor insensitivity to changing the aim angle is also needed. That is a change to unitDefs post-weaponDefs-post-processing, which isn't really how things work at the moment. A final follow-up pass would be good though. So, todo: Add a units-weapons link table and use it during post processing steps.
- minor code maint