### PR TITLE
Show scatter area when it's bigger than aoe

### DIFF
--- a/luaui/Widgets/gui_attack_aoe.lua
+++ b/luaui/Widgets/gui_attack_aoe.lua
@@ -1292,7 +1292,7 @@ local function DrawBallisticScatter(data)
 	-- VISIBILITY
 	----------------------------------------------------------------------------
 	local scatterSize = max(naturalRadius, lenUp)
-	local minScatterRadius = max(weaponInfo.aoe, 15) * 0.7
+	local minScatterRadius = max(weaponInfo.aoe, 15) * 1.4
 	local scatterAlphaFactor = GetSizeBasedAlpha(scatterSize, minScatterRadius)
 
 	if scatterAlphaFactor <= 0 then


### PR DESCRIPTION
### Work done
Change the threshold when the scatter area is shown so that it's drawn only when the area is bigger than aoe

#### BEFORE:
<img width="997" height="713" alt="image" src="https://github.com/user-attachments/assets/ebcb484a-69fd-4e2a-bb69-28774b111b3f" />
<img width="745" height="520" alt="image" src="https://github.com/user-attachments/assets/38b6990b-6312-47c2-b246-dec9af1b6b5f" />
<img width="773" height="486" alt="image" src="https://github.com/user-attachments/assets/6bc6dfe2-addc-4f9d-82bd-5c9e4facf409" />


#### AFTER:
<img width="1493" height="948" alt="image" src="https://github.com/user-attachments/assets/f0557f32-ceb5-4853-9ba8-4282ddf1a64a" />
<img width="898" height="576" alt="image" src="https://github.com/user-attachments/assets/4bf03cbc-144b-444a-adf0-a8149a86793c" />
<img width="1055" height="677" alt="image" src="https://github.com/user-attachments/assets/2e8134e3-d435-4fcc-bd01-0c1c19a8d232" />
