### PR TITLE
Fix some proximity priority issues using weaponAimAdjustPriority

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -90,7 +90,7 @@ local function processWeapons(unitDefName, unitDef)
 			weaponDef.proximitypriority = proximity
 
 			if proximity >= -1 and proximity <= -0.4 then
-				-- Encourage changing targets more as the range preference increases.
+				-- Decrease the penalty of small angle changes with stronger range preferences.
 				local priority = math.mix(0.75, 1, ((proximity) - (-1)) / ((-0.4) - (-1)))
 				priority = math.clamp(priority, 0.85, 0.95)
 

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -58,8 +58,9 @@ local function round_to_frames(wd, key)
 end
 
 local function processWeapons(unitDefName, unitDef)
+	local weapons = unitDef.weapons
 	local weaponDefs = unitDef.weapondefs
-	if not weaponDefs then
+	if not weapons or not weaponDefs then
 		return
 	end
 
@@ -72,9 +73,40 @@ local function processWeapons(unitDefName, unitDef)
 		weaponDef.burstrate = round_to_frames(weaponDef, "burstrate")
 
 		local custom = weaponDef.customparams
+
 		if custom.cluster_def then
 			custom.cluster_def = unitDefName .. "_" .. custom.cluster_def
 			custom.cluster_number = custom.cluster_number or 5
+		end
+
+		if weaponDef.proximitypriority and not custom.exclude_preaim then
+			-- Prevent weapons from aiming only at auto-generated targets beyond their own range.
+			-- Prevent individual weapons from waffling between targets due to hyper-sensitivity.
+			local weaponRange = math.max(weaponDef.range or 10, 1) -- prevent div0 -- todo: account for multiplier_weaponrange
+			local preaimRange = math.max(weaponRange * 1.1, weaponRange + 20, tonumber(weaponDef.customparams.preaim_range or 0) or 0)
+			custom.preaim_range = preaimRange
+
+			local proximity = math.max(weaponDef.proximitypriority, (-0.4 * preaimRange - 100) / weaponRange) -- see CGameHelper::GenerateWeaponTargets
+			local isDroneBomber = custom.carried_unit and UnitDefs[custom.carried_unit] and custom.drone_type == "bomber"
+			local proximityMin = isDroneBomber and -1.5 or -1 -- drone bombers can overrange by quite a lot
+			proximity = math.clamp(proximity, proximityMin, 10)
+			weaponDef.proximitypriority = proximity
+
+			if proximity >= -1 and proximity <= -0.4 then
+				-- Encourage changing targets more as the range preference increases.
+				local priority = math.mix(0.75, 1, ((proximity) - (-1)) / ((-0.4) - (-1)))
+				priority = math.clamp(priority, 0.85, 0.95)
+
+				for weaponNum, weapon in pairs(weapons) do
+					if weapon.def:lower() == weaponDefName:lower()
+						and not weapon.slaveto
+						and not weapon.weaponaimadjustpriority
+						and not weapon.weaponAimAdjustPriority -- FIXME: use standard defs casing
+					then
+						weapon.weaponaimadjustpriority = priority
+					end
+				end
+			end
 		end
 	end
 end
@@ -1946,14 +1978,6 @@ function WeaponDef_Post(name, wDef)
 			if wDef.weapontype == "BeamLaser" or wDef.weapontype == "LightningCannon" then
 				wDef.targetborder = 0.33 --approximates in current engine with bugged calculation, to targetborder = 1.
 			end
-		end
-
-		-- Prevent weapons from aiming only at auto-generated targets beyond their own range.
-		if wDef.proximitypriority then
-			local range = math.max(wDef.range or 10, 1) -- prevent div0 -- todo: account for multiplier_weaponrange
-			local rangeBoost = math.max(range + ((wDef.customparams.exclude_preaim and 0) or (wDef.customparams.preaim_range or math.max(range * 0.1, 20))), range) -- see unit_preaim
-			local proximity = math.max(wDef.proximitypriority, (-0.4 * rangeBoost - 100) / range) -- see CGameHelper::GenerateWeaponTargets
-			wDef.proximitypriority = math.clamp(proximity, -1, 10) -- upper range allowed for targeting weapons for drone bombers which can overrange massively
 		end
 
 		if wDef.craterareaofeffect then

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -101,7 +101,6 @@ local function processWeapons(unitDefName, unitDef)
 					if weapon.def:lower() == weaponDefName:lower()
 						and not weapon.slaveto
 						and not weapon.weaponaimadjustpriority
-						and not weapon.weaponAimAdjustPriority -- FIXME: use standard defs casing
 					then
 						weapon.weaponaimadjustpriority = priority
 					end

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -64,12 +64,17 @@ local function processWeapons(unitDefName, unitDef)
 	end
 
 	for weaponDefName, weaponDef in pairs(weaponDefs) do
+		if not weaponDef.customparams then
+			weaponDef.customparams = {}
+		end
+
 		weaponDef.reloadtime = round_to_frames(weaponDef, "reloadtime")
 		weaponDef.burstrate = round_to_frames(weaponDef, "burstrate")
 
-		if weaponDef.customparams and weaponDef.customparams.cluster_def then
-			weaponDef.customparams.cluster_def = unitDefName .. "_" .. weaponDef.customparams.cluster_def
-			weaponDef.customparams.cluster_number = weaponDef.customparams.cluster_number or 5
+		local custom = weaponDef.customparams
+		if custom.cluster_def then
+			custom.cluster_def = unitDefName .. "_" .. custom.cluster_def
+			custom.cluster_number = custom.cluster_number or 5
 		end
 	end
 end

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -60,7 +60,7 @@ end
 local function processWeapons(unitDefName, unitDef)
 	local weapons = unitDef.weapons
 	local weaponDefs = unitDef.weapondefs
-	if not weapons or not weaponDefs then
+	if not weaponDefs then
 		return
 	end
 
@@ -89,7 +89,7 @@ local function processWeapons(unitDefName, unitDef)
 			proximity = math.clamp(proximity, proximityMin, 10)
 			weaponDef.proximitypriority = proximity
 
-			if proximity >= -1 and proximity <= -0.4 then
+			if proximity >= -1 and proximity <= -0.4 and weapons then
 				-- Decrease the penalty of small angle changes with stronger range preferences.
 				local priority = math.mix(0.75, 1, ((proximity) - (-1)) / ((-0.4) - (-1)))
 				priority = math.clamp(priority, 0.85, 0.95)

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -65,14 +65,11 @@ local function processWeapons(unitDefName, unitDef)
 	end
 
 	for weaponDefName, weaponDef in pairs(weaponDefs) do
-		if not weaponDef.customparams then
-			weaponDef.customparams = {}
-		end
+		local custom = weaponDef.customparams or {}
+		weaponDef.customparams = custom
 
 		weaponDef.reloadtime = round_to_frames(weaponDef, "reloadtime")
 		weaponDef.burstrate = round_to_frames(weaponDef, "burstrate")
-
-		local custom = weaponDef.customparams
 
 		if custom.cluster_def then
 			custom.cluster_def = unitDefName .. "_" .. custom.cluster_def
@@ -83,7 +80,7 @@ local function processWeapons(unitDefName, unitDef)
 			-- Prevent weapons from aiming only at auto-generated targets beyond their own range.
 			-- Prevent individual weapons from waffling between targets due to hyper-sensitivity.
 			local weaponRange = math.max(weaponDef.range or 10, 1) -- prevent div0 -- todo: account for multiplier_weaponrange
-			local preaimRange = math.max(weaponRange * 1.1, weaponRange + 20, tonumber(weaponDef.customparams.preaim_range or 0) or 0)
+			local preaimRange = math.max(weaponRange * 1.1, weaponRange + 20, tonumber(custom.preaim_range or 0) or 0)
 			custom.preaim_range = preaimRange
 
 			local proximity = math.max(weaponDef.proximitypriority, (-0.4 * preaimRange - 100) / weaponRange) -- see CGameHelper::GenerateWeaponTargets

--- a/units/CorVehicles/T2/corsiegebreaker.lua
+++ b/units/CorVehicles/T2/corsiegebreaker.lua
@@ -236,7 +236,7 @@ return {
 				onlytargetcategory = "SURFACE",
 				fastautoretargeting = true,
 				burstControlWhenOutOfArc = 2,
-				weaponAimAdjustPriority = 125,
+				weaponaimadjustpriority = 125,
 			},
 			--[2] = {--not used directly, silent version for animation reasons
 				--badtargetcategory = "VTOL GROUNDSCOUT",
@@ -246,7 +246,7 @@ return {
 				--onlytargetcategory = "SURFACE",
 				--fastautoretargeting = true,
 				--burstControlWhenOutOfArc = 2,
-				--weaponAimAdjustPriority = 125,
+				--weaponaimadjustpriority = 125,
 			--},
 		},
 	},

--- a/units/Legion/Air/T2 Air/legafigdef.lua
+++ b/units/Legion/Air/T2 Air/legafigdef.lua
@@ -142,7 +142,7 @@ return {
 				maindir = "0 0 1",
 				maxangledif = 18,
 				onlytargetcategory = "VTOL",
-				weaponAimAdjustPriority = 20,
+				weaponaimadjustpriority = 20,
 				fastAutoRetargeting = true,
 			},
 		},

--- a/units/Legion/Air/T2 Air/legionnaire.lua
+++ b/units/Legion/Air/T2 Air/legionnaire.lua
@@ -136,7 +136,7 @@ return {
 				maindir = "0 0 1",
 				maxangledif = 18,
 				onlytargetcategory = "VTOL",
-				weaponAimAdjustPriority = 20,
+				weaponaimadjustpriority = 20,
 				fastAutoRetargeting = true,
 			},
 		},

--- a/units/Legion/Air/T2 Air/legvenator.lua
+++ b/units/Legion/Air/T2 Air/legvenator.lua
@@ -125,7 +125,7 @@ return {
 				maindir = "0 0 1",
 				maxangledif = 25,
 				fastautoretargeting = true,
-				weaponAimAdjustPriority = 20,
+				weaponaimadjustpriority = 20,
 			},
 		},
 	},

--- a/units/Scavengers/Vehicles/corgolt4.lua
+++ b/units/Scavengers/Vehicles/corgolt4.lua
@@ -194,7 +194,7 @@ return {
 				badtargetcategory = "VTOL",
 				def = "CORLEVLR_WEAPON",
 				onlytargetcategory = "SURFACE",
-				weaponAimAdjustPriority = 9,
+				weaponaimadjustpriority = 9,
 			},
 			[2] = {
 				badtargetcategory = "VTOL",


### PR DESCRIPTION
### Work done

- Determines an aim angle sensitivity/insensitivity for units with (1) a preaim range that extends their targeting distance and (2) a targeting priority that favors units further away.
- Moved weapon processing that depends on both the weapondefs and weapons unitDef tables into `processWeapons`, which seems good enough

I was not brave enough to make the values more extreme than [0.85, 0.95]. The danger is that a targeted enemy will not maintain the attention of the weapon. That did not seem to occur, ever, with values as low as 0.85, so that is what I kept.

#### Addresses Issue(s)

PR #6538 limited the distance-based target priority on units which solves issues with negative proximity priority but did not touch an issue with targeting units just because they are near the current aim angle. This is a normal consequence of aiming at a target in the first place, which is fine, but can cause valid targets to be ignored when an enemy exits weapon range and hovers on the edge of the range.

#### Tests done

This was tested with Mercuries, Screamers, Tremors, and Incinerators after the last patch and fixes very rare target priority issues in those units. Testing should be done without `/globallos` and using a mix of target unit types and LOS access (radar/vision/etc.), which is a pain to continue with past this handful of usual suspects.

This does influence overall target selection, but the rules and tradeoffs are complicated. I assume this is, essentially, too difficult to test. A targeting priority visualization could be created, though, which seems like a good next step. Maybe this could be treated like the passive targeting priority change and converted to a modoption.