### PR TITLE
fix: guarantee math.random ( min, max ) has min <= max

### DIFF
--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -786,10 +786,18 @@ if gadgetHandler:IsSyncedCode() then
 				end
 			end
 
+			-- Ensure a good outline of the Spawnbox (not Startbox)
+			local spawnMinX = lsx1 + spread
+			local spawnMaxX = lsx2 - spread
+			local spawnMinZ = lsz1 + spread
+			local spawnMaxZ = lsz2 - spread
+			spawnMinX, spawnMaxX = math.min(spawnMinX, spawnMaxX), math.max(spawnMinX, spawnMaxX)
+			spawnMinZ, spawnMaxZ = math.min(spawnMinZ, spawnMaxZ), math.max(spawnMinZ, spawnMaxZ)
+
 			if (not canSpawnBurrow) then -- Attempt #3 Find some good position in Spawnbox (not Startbox)
 				for _ = 1,100 do
-					spawnPosX = mRandom(lsx1 + spread, lsx2 - spread)
-					spawnPosZ = mRandom(lsz1 + spread, lsz2 - spread)
+					spawnPosX = mRandom(spawnMinX, spawnMaxX)
+					spawnPosZ = mRandom(spawnMinZ, spawnMaxZ)
 					spawnPosY = Spring.GetGroundHeight(spawnPosX, spawnPosZ)
 					canSpawnBurrow = positionCheckLibrary.FlatAreaCheck(spawnPosX, spawnPosY, spawnPosZ, spread, 30, true)
 					if canSpawnBurrow then
@@ -810,8 +818,8 @@ if gadgetHandler:IsSyncedCode() then
 			if config.burrowSpawnType == "avoid" then -- Last Resort for Avoid Players burrow setup. Spawns anywhere that isn't in player sensor range
 
 				for _ = 1,100 do -- Attempt #1 Avoid all sensors
-					spawnPosX = mRandom(lsx1 + spread, lsx2 - spread)
-					spawnPosZ = mRandom(lsz1 + spread, lsz2 - spread)
+					spawnPosX = mRandom(spawnMinX, spawnMaxX)
+					spawnPosZ = mRandom(spawnMinZ, spawnMaxZ)
 					spawnPosY = Spring.GetGroundHeight(spawnPosX, spawnPosZ)
 					canSpawnBurrow = positionCheckLibrary.FlatAreaCheck(spawnPosX, spawnPosY, spawnPosZ, spread, 30, true)
 					if canSpawnBurrow then
@@ -827,8 +835,8 @@ if gadgetHandler:IsSyncedCode() then
 
 				if (not canSpawnBurrow) then -- Attempt #2 Don't avoid radars
 					for _ = 1,100 do
-						spawnPosX = mRandom(lsx1 + spread, lsx2 - spread)
-						spawnPosZ = mRandom(lsz1 + spread, lsz2 - spread)
+						spawnPosX = mRandom(spawnMinX, spawnMaxX)
+						spawnPosZ = mRandom(spawnMinZ, spawnMaxZ)
 						spawnPosY = Spring.GetGroundHeight(spawnPosX, spawnPosZ)
 						canSpawnBurrow = positionCheckLibrary.FlatAreaCheck(spawnPosX, spawnPosY, spawnPosZ, spread, 30, true)
 						if canSpawnBurrow then
@@ -845,8 +853,8 @@ if gadgetHandler:IsSyncedCode() then
 
 				if (not canSpawnBurrow) then -- Attempt #3 Only avoid LoS
 					for _ = 1,100 do
-						spawnPosX = mRandom(lsx1 + spread, lsx2 - spread)
-						spawnPosZ = mRandom(lsz1 + spread, lsz2 - spread)
+						spawnPosX = mRandom(spawnMinX, spawnMaxX)
+						spawnPosZ = mRandom(spawnMinZ, spawnMaxZ)
 						spawnPosY = Spring.GetGroundHeight(spawnPosX, spawnPosZ)
 						canSpawnBurrow = positionCheckLibrary.FlatAreaCheck(spawnPosX, spawnPosY, spawnPosZ, spread, 30, true)
 						if canSpawnBurrow then


### PR DESCRIPTION
Fix for an uncommon error when spawning Raptors that seems usually caused by putting a long, thin spawn box along the edge of the map but could be triggered through any small dimension on the spawn box. Players also have to use radar to restrict spawning, and etc., so it's their fault basically.

With the error in place, currently, radar really does repress these spawns. With it removed, Raptors should be able to spawn the minimum needed burrows again.