### PR TITLE
fix: scav override for unit creation has unreachable condition for legmohocon

### DIFF
--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1578,12 +1578,12 @@ if gadgetHandler:IsSyncedCode() then
 						createUnitQueue[#createUnitQueue+1] = {UnitDefs[unitDefID].name .. "_scav", x, y, z, Spring.GetUnitBuildFacing(unitID) or 0, scavTeamID}
 						Spring.DestroyUnit(unitID, true, true)
 					end
+				elseif UnitDefs[unitDefID].customParams.scav_swap_override_created == "delete" then
+					Spring.DestroyUnit(unitID, true, true)
 				elseif UnitDefs[unitDefID].customParams.scav_swap_override_created ~= "null" then
 					if UnitDefNames[UnitDefs[unitDefID].customParams.scav_swap_override_created] then
 						createUnitQueue[#createUnitQueue+1] = {UnitDefs[unitDefID].customParams.scav_swap_override_created, x, y, z, Spring.GetUnitBuildFacing(unitID) or 0, scavTeamID}
 					end
-					Spring.DestroyUnit(unitID, true, true)
-				elseif UnitDefs[unitDefID].customParams.scav_swap_override_created == "delete" then
 					Spring.DestroyUnit(unitID, true, true)
 				end
 				return


### PR DESCRIPTION
### Work done

- Reach the "delete" condition for the multi-unit and mex-swapping Fortifier, which is two, or possibly three, units in a trenchcoat. Scavengers have a hard time figuring out what to do with the unit.

Maybe this doesn't even help. But it does fix the code issue.