### PR TITLE
add missing RegisterAllowCommand's during gadget initialization

### DIFF
--- a/luarules/gadgets/api_build_blocking.lua
+++ b/luarules/gadgets/api_build_blocking.lua
@@ -272,6 +272,8 @@ if gadgetHandler:IsSyncedCode() then
 
 		gadgetHandler:AddChatAction('buildblock', commandBuildBlock, "Block units from being built by reason")
 		gadgetHandler:AddChatAction('buildunblock', commandBuildUnblock, "Unblock units from being built by reason")
+
+		gadgetHandler:RegisterAllowCommand(CMD.BUILD)
 	end
 
 	function gadget:Shutdown()
@@ -313,18 +315,16 @@ if gadgetHandler:IsSyncedCode() then
 		return true
 	end
 
-
 	function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID)
-		if cmdID < 0 then --it's a build command
-			local buildDefID = -cmdID
-			local blockedUnitDefs = teamBlockedUnitDefs[unitTeam]
-			if blockedUnitDefs and blockedUnitDefs[buildDefID] and next(blockedUnitDefs[buildDefID]) then
-				return false
-			end
+		-- Allows CMD.BUILD (cmdID < 0)
+		local buildDefID = -cmdID
+		local blockedUnitDefs = teamBlockedUnitDefs[unitTeam]
+		if blockedUnitDefs and blockedUnitDefs[buildDefID] and next(blockedUnitDefs[buildDefID]) then
+			return false
 		end
 		return true
 	end
-	
+
 	function gadget:GameFrame(frame)
 		if not geoInitialized then -- because the geothermal features don't exist until after Initialize() and GameStart()
 			landGeoAvailable, seaGeoAvailable = unitRestrictions.hasGeothermalFeatures()

--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -76,8 +76,13 @@ function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
 	return false
 end
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.RECLAIM)
+	gadgetHandler:RegisterAllowCommand(CMD.GUARD)
+end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+	-- Allows CMD.RECLAIM, CMD.GUARD
 	-- Disallow reclaiming allied units for metal
 	if (cmdID == CMD.RECLAIM and #cmdParams >= 1) then
 		local targetID = cmdParams[1]

--- a/luarules/gadgets/game_tech_blocking.lua
+++ b/luarules/gadgets/game_tech_blocking.lua
@@ -109,6 +109,8 @@ local function increaseTechLevel(teamList, notificationEvent, techLevel)
 end
 
 function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.BUILD)
+
 	local teamList = Spring.GetTeamList()
 	for _, teamID in ipairs(teamList) do
 		if not ignoredTeams[teamID] then
@@ -227,15 +229,14 @@ function gadget:GameFrame(frame)
 end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID)
-	if cmdID < 0 then
-		local buildUnitDefID = -cmdID
-		if not blockTechDefs[buildUnitDefID] then
-			return true
-		end
-		local techLevel = spGetTeamRulesParam(unitTeam, "tech_level")
-		if techLevel < blockTechDefs[buildUnitDefID] then
-			return false
-		end
+	-- Allows CMD.BUILD (cmdID < 0)
+	local buildUnitDefID = -cmdID
+	if not blockTechDefs[buildUnitDefID] then
+		return true
+	end
+	local techLevel = spGetTeamRulesParam(unitTeam, "tech_level")
+	if techLevel < blockTechDefs[buildUnitDefID] then
+		return false
 	end
 	return true
 end


### PR DESCRIPTION
### Work done

Filters some AllowCommand callins from newer gadgets into the sub-lists used by RegisterAllowCommand.