### PR TITLE
fix: error in AreTeamsAllied in resource tax modoption

### DIFF
--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -29,6 +29,11 @@ local gameMaxUnits = math.min(Spring.GetModOptions().maxunits, math.floor(32000 
 
 local sharingTax = Spring.GetModOptions().tax_resource_sharing_amount
 
+local function isAlliedUnit(teamID, unitID)
+	local unitTeam = Spring.GetUnitTeam(unitID)
+	return teamID and unitTeam and teamID ~= unitTeam and Spring.AreTeamsAllied(teamID, unitTeam)
+end
+
 ----------------------------------------------------------------
 -- Callins
 ----------------------------------------------------------------
@@ -86,21 +91,18 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 	-- Disallow reclaiming allied units for metal
 	if (cmdID == CMD.RECLAIM and #cmdParams >= 1) then
 		local targetID = cmdParams[1]
-		local targetTeam
 		if(targetID >= Game.maxUnits) then
 			return true
 		end
-		targetTeam = Spring.GetUnitTeam(targetID)
-		if targetTeam and unitTeam ~= targetTeam and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+		if isAlliedUnit(unitTeam, targetID) then
 			return false
 		end
 	-- Also block guarding allied units that can reclaim
 	elseif (cmdID == CMD.GUARD) then
 		local targetID = cmdParams[1]
-		local targetTeam = Spring.GetUnitTeam(targetID)
 		local targetUnitDef = UnitDefs[Spring.GetUnitDefID(targetID)]
 
-		if (unitTeam ~= Spring.GetUnitTeam(targetID)) and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+		if isAlliedUnit(unitTeam, targetID) then
 			-- Labs are considered able to reclaim. In practice you will always use this modoption with "disable_assist_ally_construction", so disallowing guard labs here is fine
 			if targetUnitDef.canReclaim then
 				return false


### PR DESCRIPTION
### Work done

Bug squashing for game_tax_resource_sharing, which has some other bad habits that I left alone, which lead to an error throw.

The rest could use some work but is good enough.