### PR TITLE
Add radar wobble to weapon speceffects

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -27,6 +27,8 @@ local math_pi = math.pi
 local math_tau = math.tau
 local distance3dSquared = math.distance3dSquared
 
+local CallAsTeam = CallAsTeam
+
 local spDeleteProjectile = Spring.DeleteProjectile
 local spGetGroundHeight = Spring.GetGroundHeight
 local spGetGroundNormal = Spring.GetGroundNormal
@@ -141,6 +143,28 @@ local function equalTargets(target1, target2)
 	)
 end
 
+local readAs = { read = -1 }
+
+local function readAsTeam(teamID, ...)
+	local read = readAs
+	read.read = teamID -- nil is OK
+	return CallAsTeam(read, ...)
+end
+
+---@return number? targetX xyz coords
+---@return number? targetY
+---@return number? targetZ
+local function getTargetPositionWithError(projectileID)
+	local target, targetType = spGetProjectileTarget(projectileID)
+	if targetType == targetedUnit then
+		local teamID = spGetProjectileTeamID(projectileID)
+		local _, _, _, targetX, targetY, targetZ = readAsTeam(teamID, spGetUnitPosition, target, false, true)
+		return targetX, targetY, targetZ -- unit aim position
+	elseif targetType == targetedGround then
+		return target[1], target[2], target[3]
+	end
+end
+
 ---Translate between TargetType enum and byte-integer target types (why are there two?)
 ---@param projectileID integer
 ---@param target integer|xyz?
@@ -211,19 +235,11 @@ specialEffectFunction.cruise = function(params, projectileID)
 	if spGetProjectileTimeToLive(projectileID) > 0 then
 		local positionX, positionY, positionZ = spGetProjectilePosition(projectileID)
 		local velocityX, velocityY, velocityZ, speed = spGetProjectileVelocity(projectileID)
-		local targetType, target = spGetProjectileTarget(projectileID)
-
-		local targetX, targetY, targetZ
-		if targetType == targetedUnit then
-			local _; -- declare a local sink var for unused values
-			_, _, _, targetX, targetY, targetZ = spGetUnitPosition(target, false, true)
-		elseif targetType == targetedGround then
-			targetX, targetY, targetZ = target[1], target[2], target[3]
-		end
+		local targetX, targetY, targetZ = getTargetPositionWithError(projectileID)
 
 		local distance = params.lockon_dist
 
-		if distance * distance < distance3dSquared(positionX, positionY, positionZ, targetX, targetY, targetZ) then
+		if not targetX or distance * distance < distance3dSquared(positionX, positionY, positionZ, targetX, targetY, targetZ) then
 			local cruiseHeight = spGetGroundHeight(positionX, positionZ) + params.cruise_min_height
 
 			if positionY < cruiseHeight then
@@ -274,61 +290,91 @@ end
 -- Missile guidance behavior that changes the projectile's target when the primary weapon changes targets.
 -- If the primary weapon stops firing (no LoS/unit dead) the missiles will go for the last location that was targeted.
 
--- Based on retarget
--- Uses no weapon customParams.
-
--- Guidance weapon must be the primary and have burst/reload > 1 frame.
--- This is hackish but works well to prevent spammy retargeting anyway.
 weaponCustomParamKeys.guidance = {
 	guidance_lost_radius = toPositiveNumber,
 }
 
-local function guidanceLost(projectileID, radius, targetID)
-	local tx, ty, tz
+-- General info, since this became long:
+-- (1) The primary weapon's targeting must be used as guidance for the guidee weapon.
+-- (2) The primary weapon must be continuously firing or burst-firing e.g. BeamLaser.
+-- (3) You must add a guidance_lost_radius, even if it is zero, to the guidee weapon.
+-- (4) The code below has a bunch of perf hax to cache results for the Legion Medusa.
+
+---@class GuidanceEffectResult
+---@field [1] boolean isFiring
+---@field [2] TargetType guidanceType
+---@field [3] boolean isUserTarget, nil when guidanceType is `0`
+---@field [4] integer|xyz guidanceTarget, nil when guidanceType is `0`
+
+local guidanceResults = {} ---@type table<integer, GuidanceEffectResult|xyz>
+
+local lookahead = 0.6667 * Game.gameSpeed -- projectile position lookahead
+
+local function getGuidanceLost(projectileID, radius, targetID)
+	local ux, uy, uz
+	local teamID = spGetProjectileTeamID(projectileID)
 
 	if radius and radius > 0 then
-		local _, _, _, ux, uy, uz = spGetUnitPosition(targetID, false, true)
-		local elevation = math_max(spGetGroundHeight(ux, uz), 0)
-		local dx, dy, dz, slope = spGetGroundNormal(ux, uz, true)
+		ux, uy, uz = readAsTeam(teamID, spGetUnitPosition, targetID, false, true)
+	else
+		ux, uy, uz = readAsTeam(teamID, spGetUnitPosition, targetID)
+	end
+
+	if not ux then
+		-- We lost LOS on the target, most likely. Act casual.
+		local px, py, pz = spGetProjectilePosition(projectileID)
+		local vx, vy, vz = spGetProjectileVelocity(projectileID)
+		ux, uy, uz = px + vx * lookahead, py + vy * lookahead, pz + vz * lookahead
+	end
+
+	local result = { ux, uy, uz }
+	guidanceResults[-targetID - 1] = result
+	return result
+end
+
+local function guidanceLost(projectileID, radius, targetID)
+	local result = guidanceResults[-targetID - 1] or getGuidanceLost(projectileID, radius, targetID)
+	local tx, ty, tz = result[1], result[2], result[3]
+
+	if radius and radius > 0 then
+		local elevation = math_max(spGetGroundHeight(tx, tz), 0)
+		local dx, dy, dz = spGetGroundNormal(tx, tz, true)
 		local swerveRadius = radius * (0.25 + 0.75 * math_random())
 		local swerveAngle = math_tau * math_random()
 		local cosAngle = math_cos(swerveAngle)
 		local sinAngle = math_sin(swerveAngle)
 
-		if elevation <= 0 or slope <= 0.1 then
+		if elevation <= 0 or dy > 0.9 then
 			-- Scatter within a ring in the XZ plane.
-			tx = ux + swerveRadius * cosAngle
-			ty = uy
-			tz = uz + swerveRadius * sinAngle
+			tx = tx + swerveRadius * cosAngle
+			tz = tz + swerveRadius * sinAngle
 		else
 			-- Scatter within a ring rotated to align with terrain.
 			local ax, ay, az = 0, 1, 0
-			if dy >= 0.99 then ax, ay = 1, 0 end
 			local bx = ay * dz - az * dy
 			local by = az * dx - ax * dz
 			local bz = ax * dy - ay * dx
 			local cx = dy * bz - dz * by
 			local cy = dz * bx - dx * bz
 			local cz = dx * by - dy * bx
-			tx = ux + swerveRadius * (cosAngle * bx + sinAngle * cx)
-			ty = uy + swerveRadius * (cosAngle * by + sinAngle * cy)
-			tz = uz + swerveRadius * (cosAngle * bz + sinAngle * cz)
+			tx = tx + swerveRadius * (cosAngle * bx + sinAngle * cx)
+			ty = ty + swerveRadius * (cosAngle * by + sinAngle * cy)
+			tz = tz + swerveRadius * (cosAngle * bz + sinAngle * cz)
 		end
-	else
-		tx, ty, tz = spGetUnitPosition(targetID)
 	end
 
 	local elevation = math_max(spGetGroundHeight(tx, tz), 0)
 	spSetProjectileTarget(projectileID, tx, (ty - elevation < 40) and elevation or ((ty + elevation) * 0.5), tz)
 end
 
----@class GuidanceEffectResult
----@field [1] boolean isFiring
----@field [2] TargetType guidanceType
----@field [3] boolean? isUserTarget, nil when guidanceType is `0`
----@field [4] integer|xyz? guidanceTarget, nil when guidanceType is `0`
+local noGuidance = { false, 0, false, -1 }
 
-local guidanceResults = {} ---@type table<integer, GuidanceEffectResult>
+local function getGuidanceResult(ownerID)
+	local nextSalvo = spGetUnitWeaponState(ownerID, 1, "nextSalvo")
+	local result = nextSalvo and (nextSalvo + 1 >= gameFrame) and { true, spGetUnitWeaponTarget(ownerID, 1) } or noGuidance
+	guidanceResults[ownerID] = result
+	return result
+end
 
 specialEffectFunction.guidance = function(params, projectileID)
 	if spGetProjectileTimeToLive(projectileID) > 0 then
@@ -336,19 +382,12 @@ specialEffectFunction.guidance = function(params, projectileID)
 		local targetType, target = spGetProjectileTarget(projectileID)
 
 		if ownerID and spGetUnitIsDead(ownerID) == false then
-			local result = guidanceResults[ownerID]
-			if not result then
-				local nextSalvo = spGetUnitWeaponState(ownerID, 1, "nextSalvo")
-				result = { nextSalvo and (nextSalvo + 1 >= gameFrame) or false, spGetUnitWeaponTarget(ownerID, 1) }
-				guidanceResults[ownerID] = result
-			end
-			local hasGuidance, guidanceType, guidanceTarget = result[1], result[2], result[4]
-
-			if hasGuidance and guidanceTarget and
-				not equalTargets(guidanceTarget, target) and
-				setProjectileTarget(projectileID, guidanceTarget, guidanceType)
-			then
-				return false
+			local result = guidanceResults[ownerID] or getGuidanceResult(ownerID)
+			if result[1] then
+				local guidanceType, guidanceTarget = result[2], result[4]
+				if equalTargets(guidanceTarget, target) or setProjectileTarget(projectileID, guidanceTarget, guidanceType) then
+					return false
+				end
 			end
 		end
 


### PR DESCRIPTION
### Work done

- Add team ID to spawned projectiles, for consistency
- Get projectile team/owner team and use its LOS access level to determine unit positions in unit_custom_weapons_behaviours
- Some just-in-case handling for projectiles that lose their targets but haven't acquired a new one yet. This does nothing now, but if we clear projectile targets in the future via Lua, then we will be covered.

#### Addresses Issue(s)

- When the Medusa would target a unit in LOS, which then left LOS and into radar range, it would not receive radar wobble against its target.
- The Recluse's cruise effect also determined its range to target based on the unit's exact position, even if the unit is not in direct vision, and even if its position is completely lost (cloaked + jammed + etc).