### PR TITLE
Fix T2 Unit "Dragon" getting stuck on factory

### DIFF
--- a/luarules/gadgets/unit_factory_unblocking.lua
+++ b/luarules/gadgets/unit_factory_unblocking.lua
@@ -21,12 +21,26 @@ local setBlockingOnFinished = {}
 local factoryUnits = {}
 local isFactory = {}
 local canFly = {}
+local waitFlickerUnits = {}
+local pendingWaitFrame = {}
+local pendingWaitToggleFrame = {}
+local spGetGameFrame = Spring.GetGameFrame
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local CMD_WAIT = CMD.WAIT
+local WAIT_FLICKER_DELAY_FRAMES = Game.gameSpeed * 1
+local WAIT_FLICKER_TOGGLE_DELAY_FRAMES = 1
 for unitDefID, unitDef in pairs(UnitDefs) do
 	if unitDef.isFactory and #unitDef.buildOptions > 0 then
 		isFactory[unitDefID] = true
 	end
 	if unitDef.canFly then
 		canFly[unitDefID] = true
+	end
+
+	--"Dragon" needs a flicker of the "wait" command to prevent it from getting stuck on factory exit
+	if unitDef.name == "corcrwh" then
+		waitFlickerUnits[unitDefID] = true
 	end
 end
 
@@ -42,6 +56,9 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 			-- also the second false is to clear CSTATE_BIT_SOLIDOBJECTS, so landing aircraft do not claim dumb spots as blocking
 			-- TODO, engine fix to prevent this nonsense
 			Spring.SetUnitBlocking(unitID, false, false)
+			if waitFlickerUnits[unitDefID] then
+				pendingWaitFrame[unitID] = spGetGameFrame() + WAIT_FLICKER_DELAY_FRAMES
+			end
 		else
 			Spring.SetUnitBlocking(unitID, true)
 		end
@@ -60,6 +77,34 @@ end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
 	factoryUnits[unitID] = nil
 	setBlockingOnFinished[unitID] = nil
+	pendingWaitFrame[unitID] = nil
+	pendingWaitToggleFrame[unitID] = nil
+end
+
+function gadget:GameFrame(frame)
+	if next(pendingWaitFrame) then
+		for unitID, waitFrame in pairs(pendingWaitFrame) do
+			if frame >= waitFrame then
+				local unitDefID = spGetUnitDefID(unitID)
+				if unitDefID and waitFlickerUnits[unitDefID] then
+					spGiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
+					pendingWaitToggleFrame[unitID] = frame + WAIT_FLICKER_TOGGLE_DELAY_FRAMES
+				end
+				pendingWaitFrame[unitID] = nil
+			end
+		end
+	end
+	if next(pendingWaitToggleFrame) then
+		for unitID, toggleFrame in pairs(pendingWaitToggleFrame) do
+			if frame >= toggleFrame then
+				local unitDefID = spGetUnitDefID(unitID)
+				if unitDefID and waitFlickerUnits[unitDefID] then
+					spGiveOrderToUnit(unitID, CMD_WAIT, {}, 0)
+				end
+				pendingWaitToggleFrame[unitID] = nil
+			end
+		end
+	end
 end
 
 function gadget:Initialize()


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->
The COR unit dragon sometimes gets after completion at the advanced aircraft plant. Does not get unstuck until the next unit is built or the wait or stop command is given to the unit. 

Fixes issues #6567 and #6325


### Work done

Updated gadget ``unit_factory_unblocking.lua``. All completed Dragon units toggle the ``wait`` command after completion which  unstucks them without affecting any functionality. I tried to change the collision volume and scale and also tried to temporally turn of blocking for the unit however it the unit kept getting stuck which led me to this "fix". Legion also has a T2 air unit which has blocking however it does not suffer from getting stuck like the Dragon. 
<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->



Video files too large to upload on Github, can be found on discord
BEFORE:
https://discord.com/channels/549281623154229250/1127191779280699442/1457153566874538106

AFTER:
https://discord.com/channels/549281623154229250/1127191779280699442/1457153566874538106