### PR TITLE
fix: flip beingBuilt comparison in disable assist

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -31,8 +31,8 @@ for unitDefID, unitDef in ipairs(UnitDefs) do
 end
 
 local function isComplete(unitID)
-	local inProgress, progress = Spring.GetUnitIsBeingBuilt(unitID)
-	return inProgress or progress >= 1
+	local beingBuilt, buildProgress = Spring.GetUnitIsBeingBuilt(unitID)
+	return not beingBuilt or buildProgress >= 1
 end
 
 function gadget:Initialize()


### PR DESCRIPTION
### Work done

isComplete function checks for `not beingBuilt` instead of `beingBuilt`

#### Addresses issue

Fix for error message:

[string "LuaRules/Gadgets/game_disable_assist_ally.lua"]:35: attempt to compare number with nil