### PR TITLE
Fix: DGuns use actual weapon range

### DIFF
--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -51,7 +51,7 @@ local function generateWeaponTtlFunction(weaponDef)
 		end
 	else -- treat all other as cylinder == 0:
 		return function(unitID, projectileID)
-			local ux, uy, uz = spGetUnitPosition(unitID)
+			local _, _, _, ux, uy, uz = spGetUnitPosition(unitID, true)
 			local px, py, pz = spGetProjectilePosition(projectileID)
 			local dx, dy, dz = spGetProjectileDirection(projectileID)
 			local projection = (px - ux) * dx + (py - uy) * dy + (pz - uz) * dz


### PR DESCRIPTION
A very mildly spicy fix since it reduces DGun ranges (by about one frame's time).

### Work done

This fixes the calculation of projectile TTL to align with the weapon's range indicators by accounting for the start position of the projectile on firing.

#### Addresses issue

- Discord support post: https://discord.com/channels/549281623154229250/1457015337840283751

This has been vaguely known and vaguely addressed a few times, at least in part through some animation changes. I don't know the history of this at all. I just can do math.