### PR TITLE
fix: some projectiles had owner but not team still

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -147,7 +147,7 @@ local readAs = { read = -1 }
 
 local function readAsTeam(teamID, ...)
 	local read = readAs
-	read.read = teamID -- nil is OK
+	read.read = teamID or -1
 	return CallAsTeam(read, ...)
 end
 
@@ -157,7 +157,7 @@ end
 local function getTargetPositionWithError(projectileID)
 	local targetType, target = spGetProjectileTarget(projectileID)
 	if targetType == targetedUnit then
-		local teamID = spGetProjectileTeamID(projectileID)
+		local teamID = spGetProjectileTeamID(projectileID) or spGetProjectileTeamID(spGetProjectileOwnerID(projectileID) or -1)
 		local _, _, _, targetX, targetY, targetZ = readAsTeam(teamID, spGetUnitPosition, target, false, true)
 		return targetX, targetY, targetZ -- unit aim position
 	elseif targetType == targetedGround then

--- a/luarules/gadgets/unit_lightning_splash_dmg.lua
+++ b/luarules/gadgets/unit_lightning_splash_dmg.lua
@@ -156,7 +156,7 @@ function gadget:ProjectileDestroyed(proID)
 							projectileCacheTable['end'][2] = ey
 							projectileCacheTable['end'][3] = ez
 
-							--spSpawnProjectile(lightning.weaponDefID, projectileCacheTable)
+							-- NB: Lightning sparks have no team/owner. So are not subject to LOS (natural force). But they give no credit for damage (stats, xp, etc).
 							spSpawnProjectile(lightning.weaponDefID, {["pos"]={lightning.x,lightning.y,lightning.z},["end"] = {ex,ey,ez}, ["ttl"] = 2, ["owner"] = -1})
 							count = count - 1 -- spark target count accounting
 						end


### PR DESCRIPTION
### Work done

- Spawned cluster muntions guaranteed to have team/owner info.
- Some regression-proofing: When getting a projectile's teamID, on a failure, get -> owner -> ownerTeam.
- Cruise missiles were failing to grab targets.

Finishes up the effort to add team info to projectiles (in https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6572) & use their team's LOS access levels for targeting and other info on enemies.