### PR TITLE
Fix water restrictions in water shifted games

### DIFF
--- a/common/configs/unit_restrictions_config.lua
+++ b/common/configs/unit_restrictions_config.lua
@@ -44,10 +44,10 @@ local function shouldShowWaterUnits()
 
 	-- terraform, done too late to read w/ get ground, and too hectic to even try and guess
 	if debugCommands and debugCommands:len() > 1 then
-		if	string.find(debugCommands, "waterlevel")
-		or	string.find(debugCommands, "height")
-		or	string.find(debugCommands, "extreme")
-		or	string.find(debugCommands, "invertmap")
+		if	debugCommands:find("waterlevel")
+		or	debugCommands:find("height")
+		or	debugCommands:find("extreme")
+		or	debugCommands:find("invertmap")
 		then
 			return true
 		end


### PR DESCRIPTION
#### Addresses Issue(s)
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6591

#### Test steps
- Set Water Level, found under Adv Options, Extra, to add water to a dry map, e.g. All that gliters, set it to 400
    With this sea units will now be useable

#### Problems:
Doesn't address if the water was added later, e.g. via /luarules waterlevel