### PR TITLE
Fix rare notification sound file path

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -109,7 +109,7 @@ for notifID, notifDef in pairs(notificationTable) do
 	end
 
 	if VFS.FileExists(soundFolder .. notifID .. '_rare' .. '.wav') then
-		notifSoundsRare[currentEntryRare] = soundFolder .. notifID .. '.wav'
+		notifSoundsRare[currentEntryRare] = soundFolder .. notifID .. '_rare' .. '.wav'
 	end
 	for i = 1, 20 do
 		if VFS.FileExists(soundFolder .. notifID .. '_rare' .. i .. '.wav') then


### PR DESCRIPTION
Corrected the file path for rare notification sounds to include the '_rare' suffix, ensuring the correct audio file is used.