### PR TITLE
fix: check dmg > 0 rather than hope everyone uses customparams

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -675,7 +675,7 @@ local function drawStats(uDefID, uID)
 			-- Draw the damage and damage modifiers strings.
 			if string.find(uWep.name, "disintegrator") then
 				DrawText(texts.dmg..": ", texts.infinite)
-			elseif not uWep.customParams.bogus then
+			elseif baseArmorDamage > 0 and not uWep.customParams.bogus then
 				local damageString = ""
 				local burstDamage = baseArmorDamage * burst
 				if wpnName == texts.deathexplosion or wpnName == texts.selfdestruct then


### PR DESCRIPTION
I guess this is nicer to modders, as well, in a way, so fine

But we are missing customparams.bogus on some newer weapons that are used only for targeting