### PR TITLE
Set all bombers to hold position as default

### DIFF
--- a/units/ArmAircraft/T2/armpnix.lua
+++ b/units/ArmAircraft/T2/armpnix.lua
@@ -24,6 +24,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 230,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMPNIX.s3o",

--- a/units/ArmAircraft/T2/armstil.lua
+++ b/units/ArmAircraft/T2/armstil.lua
@@ -27,6 +27,7 @@ return {
 		maxslope = 15,
 		maxwaterdepth = 0,
 		metalcost = 460,
+		movestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMSTIL.s3o",
 		script = "Units/ARMSTIL.cob",

--- a/units/ArmAircraft/armthund.lua
+++ b/units/ArmAircraft/armthund.lua
@@ -23,6 +23,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 145,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMTHUND.s3o",

--- a/units/ArmSeaplanes/armsb.lua
+++ b/units/ArmSeaplanes/armsb.lua
@@ -24,6 +24,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 255,
 		metalcost = 240,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMSB.s3o",

--- a/units/CorAircraft/T2/corhurc.lua
+++ b/units/CorAircraft/T2/corhurc.lua
@@ -24,6 +24,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 310,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORHURC.s3o",

--- a/units/CorAircraft/corshad.lua
+++ b/units/CorAircraft/corshad.lua
@@ -24,6 +24,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 150,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORSHAD.s3o",

--- a/units/CorSeaplanes/corsb.lua
+++ b/units/CorSeaplanes/corsb.lua
@@ -25,6 +25,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 255,
 		metalcost = 200,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORSB.s3o",

--- a/units/Legion/Air/T2 Air/legmineb.lua
+++ b/units/Legion/Air/T2 Air/legmineb.lua
@@ -26,6 +26,7 @@ return {
 		maxslope = 10,
 		speed = 210.0,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/legmineb.s3o",

--- a/units/Legion/Air/T2 Air/legnap.lua
+++ b/units/Legion/Air/T2 Air/legnap.lua
@@ -27,6 +27,7 @@ return {
 		maxslope = 10,
 		speed = 215,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/LEGNAP.s3o",

--- a/units/Legion/Air/T2 Air/legphoenix.lua
+++ b/units/Legion/Air/T2 Air/legphoenix.lua
@@ -27,6 +27,7 @@ return {
 		maxslope = 10,
 		speed = 270,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/legphoenix.s3o",

--- a/units/Legion/Air/legkam.lua
+++ b/units/Legion/Air/legkam.lua
@@ -30,6 +30,7 @@ return {
 		maxslope = 10,
 		speed = 230.0,
 		maxwaterdepth = 0,
+		movestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/legkam.s3o",
 		script = "Units/legkam.cob",

--- a/units/Legion/SeaPlanes/legspbomber.lua
+++ b/units/Legion/SeaPlanes/legspbomber.lua
@@ -24,6 +24,7 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 255,
 		metalcost = 240,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "Units/legspbomber.s3o",

--- a/units/Scavengers/Air/armlichet4.lua
+++ b/units/Scavengers/Air/armlichet4.lua
@@ -28,6 +28,7 @@ return {
 		maxslope = 10,
 		speed = 180.0,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = false,
 		nochasecategory = "VTOL",
 		objectname = "Units/scavboss/ARMLICHET4.s3o",

--- a/units/Scavengers/Air/armminebomber.lua
+++ b/units/Scavengers/Air/armminebomber.lua
@@ -25,6 +25,7 @@ return {
 		maxslope = 10,
 		speed = 255.0,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "MOBILE",
 		objectname = "Units/scavboss/ARMMINEBOMBER.s3o",

--- a/units/Scavengers/Air/armthundt4.lua
+++ b/units/Scavengers/Air/armthundt4.lua
@@ -26,6 +26,7 @@ return {
 		maxslope = 10,
 		speed = 367.5,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "MOBILE",
 		objectname = "Units/scavboss/ARMTHUNDT4.s3o",

--- a/units/Scavengers/Air/cords.lua
+++ b/units/Scavengers/Air/cords.lua
@@ -26,6 +26,7 @@ return {
 		maxslope = 10,
 		speed = 234.0,
 		maxwaterdepth = 0,
+		movestate = 0,
 		noautofire = true,
 		nochasecategory = "VTOL",
 		objectname = "scavs/CORDS.s3o",


### PR DESCRIPTION
Set all bombers to hold position as default to prevent accidental chasing of units while landed.

Players: 
Bombers no longer inherit the air plant movement state but will now be on hold position by default. This prevents accidental take off and chasing of units when landed. 

### Work done
Set all arm, cor and leg units with `weapontype = "AircraftBomb"` to hold position by default. 

Raptors not changed. Gunships not changed. 

#### Addresses Issue(s)
[Issue URL](https://discord.com/channels/549281623154229250/1458598553067847875/1458598553067847875)

#### Test steps
- Check movement state of bombers does not change based on lab state. 
- Check movement state of bombers does change based on state_prefs widget saved state. 
