### PR TITLE
Adds AA range circle for charon

### DIFF
--- a/units/Legion/Vehicles/T2 Vehicles/legvflak.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legvflak.lua
@@ -140,9 +140,6 @@ return {
 				weapontimer = 1,
 				weapontype = "Cannon",
 				weaponvelocity = 1900,
-				customparams = {
-					norangering = 1,
-				},
 				damage = {
 					vtol = 40,
 				},


### PR DESCRIPTION
The Legion T2 anti air vehicle, Charon, does not have an aa range ring. The COR and ARM equivalents have one. It would make sense to have the legion aa vehicle display the range circle as well. 

<img width="861" height="552" alt="image" src="https://github.com/user-attachments/assets/5ada1f85-5165-4a99-9a9b-581a3ad2b764" />
