### PR TITLE
Revert "Rework continuous_aim as a performance tradeoff, not just a spam penalty"

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -20,6 +20,5 @@
       "luaui/Tests",
       "luaui/TestsExamples"
     ]
-  },
-    "diagnostics.workspaceDelay": -1
+  }
 }

--- a/luarules/gadgets/unit_continuous_aim.lua
+++ b/luarules/gadgets/unit_continuous_aim.lua
@@ -7,8 +7,8 @@ function gadget:GetInfo()
 		author = "Doo, Beherith",
 		date = "April 2018",
 		license = "GNU GPL, v2 or later",
-		layer = 0, -- after game_dynamic_maxunits for accurate unit caps
-		enabled = tonumber(Engine.versionMajor) >= 105,
+		layer = 0,
+		enabled = true, -- When we will move on 105 :)
 	}
 end
 
@@ -16,99 +16,242 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
-local reaimTimeMax = 0.5 ---@type number Caps dynamic reaim times and filters unitDefs. In seconds.
-local spamRatingBase = 400 ---@type integer Team reaim time increases by 1 frame each X units made.
-local spamRatingMax = 1000 ---@type integer Sets the minimum performance penalty for spammed units.
-local unitCapDefault = 2400 ---@type integer The per-team unit cap we assume in these spam ratings.
-
-local math_floor = math.floor
-local math_max = math.max
-local math_clamp = math.clamp
-
-local spGetTeamMaxUnits = Spring.GetTeamMaxUnits
 local spSetUnitWeaponState = Spring.SetUnitWeaponState
+local tableCopy = table.copy
 
-local reaimFramesMax = math.round(reaimTimeMax * Game.gameSpeed)
-local unitCapReference = math_max(Spring.GetModOptions().maxunits, unitCapDefault)
-local unitCapNonPlayer = math.min(unitCapReference, unitCapDefault * 2) * 4 -- for one team vs. many
 
-local unitReaimTimes = {}
-local unitSpamRating = {}
-local unitWeaponCount = {}
+local convertedUnitsNames = {
+	-- value is reaimtime in frames, engine default is 15
+	['armfav'] = 3,
+	['armbeamer'] = 3,
+	['armpw'] = 2,
+	['armpwt4'] = 2,
+	['armflea'] = 2,
+	['armrock'] = 2,
+	['armham'] = 2,
+	['armwar'] = 6,
+	['armjeth'] = 2,
+	['corfav'] = 3,
+	['corak'] = 2,
+	['corthud'] = 2,
+	['corstorm'] = 2,
+	['corcrash'] = 5,
+	['legkark'] = 2,
+	['corkark'] = 2,
+	['cordeadeye'] =2,
+	['armsnipe'] = 2,
+	['armfido'] = 3,
+	['armfboy'] = 2,
+	['armfast'] = 2,
+	['armamph'] = 3,
+	['armmav'] = 2,
+	['armspid'] = 3,
+	['armsptk'] = 5,
+	['armzeus'] = 3,
+	['coramph'] = 3,
+	['corcan'] = 2,
+	['corhrk'] = 5,
+	['cormando'] = 2,
+	['cormort'] = 2,
+	['corpyro'] = 2,
+	['cortermite'] = 2,
+	['armraz'] = 6,
+	['armmar'] = 3,
+	['armbanth'] = 1,
+	['corkorg'] = 1,
+	['armvang'] = 3,
+	['armcrus'] = 5,
+	['corsala'] = 6,
+	['corsiegebreaker'] = 5,
+	['legerailtank'] = 9,
 
--- Unit scripts have to manually check in script if it is at the desired heading.
--- See: https://springrts.com/phpbb/viewtopic.php?t=36654
-for unitDefID, unitDef in pairs(UnitDefs) do
-	if #unitDef.weapons >= 1 then
-		if tonumber(unitDef.customParams.continuous_aim_time) then
-			local reaimTime = tonumber(unitDef.customParams.continuous_aim_time)
-			local reaimFrames = math_max(math.round(reaimTime * Game.gameSpeed), 1)
-			if reaimFrames < reaimFramesMax then
-				unitReaimTimes[unitDefID] = reaimFrames
-				unitWeaponCount[unitDefID] = #unitDef.weapons
+	-- the following units get a faster reaimtime to counteract their turret acceleration
+	['armthor'] = 4,
+	['armflash'] = 6,
+	['corgator'] = 6,
+	['armdecade'] = 6,
+	['coresupp'] = 6,
+	['corhlt'] = 5,
+	['corfhlt'] = 5,
+	['cordoom'] = 5,
+	['corshiva'] = 5,
+	['corcat'] = 5,
+	['corkarg'] = 5,
+	['corbhmth'] = 5,
+	['armguard'] = 5,
+	['armamb'] = 5,
+	['corpun'] = 5,
+	['cortoast'] = 5,
+	['corbats'] = 5,
+	['corblackhy'] = 6,
+	['corscreamer'] = 5,
+	['corcom'] = 5,
+	['armcom'] = 5,
+	['cordecom'] = 5,
+	['armdecom'] = 5,
+	['legcom'] = 5,
+	['legdecom'] = 5,
+	['legcomlvl2'] = 5,
+	['legcomlvl3'] = 5,
+	['legcomlvl4'] = 5,
+	['legcomlvl5'] = 5,
+	['legcomlvl6'] = 5,
+	['legcomlvl7'] = 5,
+	['legcomlvl8'] = 5,
+	['legcomlvl9'] = 5,
+	['legcomlvl10'] = 5,
+	['legah'] = 5,
+	['legbal'] = 5,
+	['legbastion'] = 5,
+	['legcen'] = 3,
+	['legfloat'] = 5,
+	['leggat'] = 5,
+	['leggob'] = 5,
+	['leginc'] = 1,
+	['cordemon'] = 6,
+	['corcrwh'] = 7,
+	['leglob'] = 5,
+	['legmos'] = 5,
+	['leghades'] = 5,
+	['leghelios'] = 5,
+	['legheavydrone'] = 5,
+	['legkeres'] = 5,
+	['legrail'] = 5,
+	['legbar'] = 5,
+	['legcomoff'] = 5,
+	['legcomt2off'] = 5,
+	['legcomt2com'] = 5,
+	['legstr'] = 3,
+	['legamph'] = 4,
+	['legbart'] = 5,
+	['legmrv'] = 5,
+	['legsco'] = 5,
+	['leegmech'] = 5,
+	['legionnaire'] = 5,
+	['legafigdef'] = 5,
+	['legvenator'] = 5,
+    ['legmed'] = 5,
+	['legaskirmtank'] = 5,
+	['legaheattank'] = 3,
+	['legeheatraymech'] = 1,
+	['legtriariusdrone'] = 1,
+	['legnavydestro'] = 4,
+	['legeheatraymech_old'] = 1,
+	['legbunk'] = 3,
+	['legrwall'] = 4,
+	['legjav'] = 1,
+	['legeshotgunmech'] = 3,
+	['legehovertank'] = 4,
+	['armanavaldefturret'] = 4,
+	['leganavyflagship'] = 4,
+	['leganavyantiswarm'] = 5,
+	['leganavycruiser'] = 5,
+}
+--add entries for scavboss
+local scavengerBossV4Table = {'scavengerbossv4_veryeasy', 'scavengerbossv4_easy', 'scavengerbossv4_normal', 'scavengerbossv4_hard', 'scavengerbossv4_veryhard', 'scavengerbossv4_epic',
+ 'scavengerbossv4_veryeasy_scav', 'scavengerbossv4_easy_scav', 'scavengerbossv4_normal_scav', 'scavengerbossv4_hard_scav', 'scavengerbossv4_veryhard_scav', 'scavengerbossv4_epic_scav'}
+for _, name in pairs(scavengerBossV4Table) do
+	convertedUnitsNames[name] = 4
+end
+--if Spring.GetModOptions().emprework then
+	--convertedUnitsNames['armdfly'] = 50
+--end
+-- convert unitname -> unitDefID
+local convertedUnits = {}
+for name, params in pairs(convertedUnitsNames) do
+	if UnitDefNames[name] then
+		convertedUnits[UnitDefNames[name].id] = params
+	end
+end
+convertedUnitsNames = nil
+
+
+local spamUnitsTeamsNames = { --{unitDefID = {teamID = totalcreated,...}}
+	['armpw'] = {},
+	['armflea'] = {},
+	['armfav'] = {},
+	['corak'] = {},
+	['corfav'] = {},
+}
+-- convert unitname -> unitDefID
+local spamUnitsTeams = {}
+for name, params in pairs(spamUnitsTeamsNames) do
+	if UnitDefNames[name] then
+		spamUnitsTeams[UnitDefNames[name].id] = params
+	end
+end
+spamUnitsTeamsNames = nil
+
+
+local spamUnitsTeamsReaimTimes = {} --{unitDefID = {teamID = currentReAimTime,...}}
+
+
+-- for every spamThreshold'th spammable unit type built by this team, increase reaimtime by 1 for that team
+local spamThreshold = 100
+local maxReAimTime = 15
+
+-- add for scavengers copies
+local convertedUnitsCopy = tableCopy(convertedUnits)
+for id, v in pairs(convertedUnitsCopy) do
+	if UnitDefNames[UnitDefs[id].name..'_scav'] then
+		convertedUnits[UnitDefNames[UnitDefs[id].name..'_scav'].id] = v
+	end
+end
+
+local spamUnitsTeamsCopy = tableCopy(spamUnitsTeams)
+for id,v in pairs(spamUnitsTeamsCopy) do
+	if UnitDefNames[UnitDefs[id].name..'_scav'] then
+		spamUnitsTeams[UnitDefNames[UnitDefs[id].name..'_scav'].id] = {}
+	end
+end
+
+for unitDefID, _ in pairs(spamUnitsTeams) do
+	spamUnitsTeamsReaimTimes[unitDefID] = {}
+end
+
+local unitWeapons = {}
+for unitDefID, _ in pairs(convertedUnits) do
+	local unitDef = UnitDefs[unitDefID]
+	if unitDef then
+		local weapons = unitDef.weapons
+		if #weapons > 0 then
+			unitWeapons[unitDefID] = {}
+			for id, _ in pairs(weapons) do
+				unitWeapons[unitDefID][id] = true	-- no need to store weapondefid
+			end
+		else
+			-- units with no weapons shouldnt even be here
+			convertedUnits[unitDefID] = nil
+		end
+	end
+end
+
+function gadget:UnitCreated(unitID, unitDefID, teamID)
+	if convertedUnits[unitDefID] then
+		local currentReaimTime = convertedUnits[unitDefID]
+
+		if spamUnitsTeams[unitDefID] then
+			if not spamUnitsTeams[unitDefID][teamID] then
+				-- initialize for this team at base defaults
+				spamUnitsTeams[unitDefID][teamID] = 1
+				spamUnitsTeamsReaimTimes[unitDefID][teamID] = convertedUnits[unitDefID]
+			else
+				local spamCount = spamUnitsTeams[unitDefID][teamID] + 1
+				spamUnitsTeams[unitDefID][teamID] = spamCount
+				currentReaimTime = spamUnitsTeamsReaimTimes[unitDefID][teamID]
+				if spamCount % spamThreshold == 0 and currentReaimTime < maxReAimTime then
+					spamUnitsTeamsReaimTimes[unitDefID][teamID] = currentReaimTime + 1
+					--Spring.Echo("Unit type", unitDefID,'has been built', spamCount, 'times by team', teamID,'increasing reaimtime to ', currentReaimTime + 1)
+				end
 			end
 		end
-		-- Every combat unit gets a spam score for adjusting each team's reaimTime. However:
-		-- Actual amount of reaimTime each unit of one unitDef is worth depends on its team.
-		local spamCount = tonumber(unitDef.customParams.continuous_aim_spam) or spamRatingBase
-		local spamScore = 1 / math.clamp(spamCount, 1, spamRatingMax) -- as reaimTime per unit
-		unitSpamRating[unitDefID] = spamScore * unitCapDefault -- as reaimTime/(unit/maxunits)
-	end
-end
-
-local teamMaxUnits = {}
-local teamReaimTimes = {}
-local pveTeamID = Spring.Utilities.GetRaptorTeamID() or Spring.Utilities.GetScavTeamID()
-
-local function getTeamMaxUnits(teamID)
-	local actual = spGetTeamMaxUnits(teamID)
-	local reference = teamID == pveTeamID and unitCapNonPlayer or unitCapReference
-	-- Gravitate toward the reference value and don't allow any actual < reference.
-	return actual and (math_max(actual, reference) + reference) * 0.5 or reference
-end
-
-function gadget:MetaUnitAdded(unitID, unitDefID, unitTeam)
-	local unitReaimTime = unitReaimTimes[unitDefID]
-
-	if unitReaimTime then
-		local teamReaimTime = teamReaimTimes[unitTeam]
-		local addSpamRating = unitSpamRating[unitDefID] / teamMaxUnits[unitTeam]
-
-		teamReaimTime = teamReaimTime + addSpamRating
-		teamReaimTimes[unitTeam] = teamReaimTime
-		unitReaimTime = math_clamp(math_floor(unitReaimTime + teamReaimTime), 1, reaimFramesMax)
-
-		for weaponNum = 1, unitWeaponCount[unitDefID] do
-			-- NOTE: this will prevent unit from firing if it does not IMMEDIATELY return from AimWeapon (no sleeps, not wait for turns!)
-			-- So you have to manually check in script if it is at the desired heading
-			spSetUnitWeaponState(unitID, weaponNum, "reaimTime", unitReaimTime)
-		end
-	end
-end
-
-function gadget:MetaUnitRemoved(unitID, unitDefID, unitTeam)
-	if unitSpamRating[unitDefID] then
-		teamReaimTimes[unitTeam] = teamReaimTimes[unitTeam] - unitSpamRating[unitDefID] / teamMaxUnits[unitTeam]
-	end
-end
-
-function gadget:TeamDied(deadTeamID)
-	-- For now, this is our only source of TransferTeamMaxUnits after init.
-	for _, teamID in pairs(Spring.GetTeamList()) do
-		teamMaxUnits[teamID] = getTeamMaxUnits(teamID)
-	end
-end
-
-function gadget:Initialize()
-	teamMaxUnits = {}
-	teamReaimTimes = {}
-
-	for _, teamID in pairs(Spring.GetTeamList()) do
-		teamMaxUnits[teamID] = getTeamMaxUnits(teamID)
-		teamReaimTimes[teamID] = 0
-
-		for _, unitID in pairs(Spring.GetTeamUnits(teamID)) do
-			gadget:MetaUnitAdded(unitID, Spring.GetUnitDefID(unitID), teamID)
+		if currentReaimTime < 15 then
+			for id, _ in pairs(unitWeapons[unitDefID]) do
+				-- NOTE: this will prevent unit from firing if it does not IMMEDIATELY return from AimWeapon (no sleeps, not wait for turns!)
+				-- So you have to manually check in script if it is at the desired heading
+				-- https://springrts.com/phpbb/viewtopic.php?t=36654
+				spSetUnitWeaponState(unitID, id, "reaimTime", currentReaimTime)
+			end
 		end
 	end
 end

--- a/units/ArmBots/T2/armamph.lua
+++ b/units/ArmBots/T2/armamph.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weaponaa",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armdecom.lua
+++ b/units/ArmBots/T2/armdecom.lua
@@ -81,7 +81,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "buildert2",
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/ArmBots/T2/armfast.lua
+++ b/units/ArmBots/T2/armfast.lua
@@ -40,7 +40,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 400,
 			weapon1turrety = 500,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armfboy.lua
+++ b/units/ArmBots/T2/armfboy.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armfido.lua
+++ b/units/ArmBots/T2/armfido.lua
@@ -39,7 +39,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armmav.lua
+++ b/units/ArmBots/T2/armmav.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armsnipe.lua
+++ b/units/ArmBots/T2/armsnipe.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armspid.lua
+++ b/units/ArmBots/T2/armspid.lua
@@ -48,7 +48,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "emp",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armsptk.lua
+++ b/units/ArmBots/T2/armsptk.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/T2/armzeus.lua
+++ b/units/ArmBots/T2/armzeus.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "ArmBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/armflea.lua
+++ b/units/ArmBots/armflea.lua
@@ -38,8 +38,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "ArmBots",
 			unitgroup = "weapon",
-			continuous_aim_spam = 100,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/armham.lua
+++ b/units/ArmBots/armham.lua
@@ -39,7 +39,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "ArmBots",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/armjeth.lua
+++ b/units/ArmBots/armjeth.lua
@@ -38,7 +38,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "ArmBots",
 			unitgroup = "aa",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/armpw.lua
+++ b/units/ArmBots/armpw.lua
@@ -39,8 +39,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 300,
 			weapon1turrety = 300,
-			continuous_aim_spam = 100,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/armrock.lua
+++ b/units/ArmBots/armrock.lua
@@ -38,7 +38,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "ArmBots",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBots/armwar.lua
+++ b/units/ArmBots/armwar.lua
@@ -39,7 +39,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 200,
 			weapon1turrety = 200,
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBuildings/LandDefenceOffence/armamb.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armamb.lua
@@ -44,7 +44,6 @@ return {
 			techlevel = 2,
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBuildings/LandDefenceOffence/armbeamer.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armbeamer.lua
@@ -39,7 +39,6 @@ return {
 			subfolder = "ArmBuildings/LandDefenceOffence",
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBuildings/LandDefenceOffence/armguard.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armguard.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "ArmBuildings/LandDefenceOffence",
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmBuildings/SeaDefence/armanavaldefturret.lua
+++ b/units/ArmBuildings/SeaDefence/armanavaldefturret.lua
@@ -37,7 +37,6 @@ return {
 			removewait = true,
 			techlevel = 2,
 			subfolder = "CorBuildings/SeaDefence",
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmGantry/armbanth.lua
+++ b/units/ArmGantry/armbanth.lua
@@ -46,7 +46,6 @@ return {
 			subfolder = "ArmGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmGantry/armmar.lua
+++ b/units/ArmGantry/armmar.lua
@@ -43,7 +43,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 90,
 			weapon1turrety = 150,
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmGantry/armraz.lua
+++ b/units/ArmGantry/armraz.lua
@@ -42,8 +42,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 200,
 			weapon1turrety = 200,
-			continuous_aim_spam = 80,
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmGantry/armthor.lua
+++ b/units/ArmGantry/armthor.lua
@@ -49,7 +49,6 @@ return {
 			subfolder = "ArmGantry",
 			techlevel = 3,
 			unitgroup = "emp",
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmGantry/armvang.lua
+++ b/units/ArmGantry/armvang.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "ArmGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmShips/T2/armcrus.lua
+++ b/units/ArmShips/T2/armcrus.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "ArmShips/T2",
 			techlevel = 2,
 			unitgroup = "weaponsub",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmShips/armdecade.lua
+++ b/units/ArmShips/armdecade.lua
@@ -37,7 +37,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			subfolder = "ArmShips",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmVehicles/armfav.lua
+++ b/units/ArmVehicles/armfav.lua
@@ -49,8 +49,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 300,
 			weapon1turrety = 300,
-			continuous_aim_spam = 100,
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmVehicles/armflash.lua
+++ b/units/ArmVehicles/armflash.lua
@@ -46,7 +46,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 240,
 			weapon1turrety = 240,
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorAircraft/T2/corcrwh.lua
+++ b/units/CorAircraft/T2/corcrwh.lua
@@ -43,7 +43,6 @@ return {
 			subfolder = "CorAircraft/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.23,
 		},
 		sfxtypes = {
 			crashexplosiongenerators = {

--- a/units/CorBots/T2/coramph.lua
+++ b/units/CorBots/T2/coramph.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "weaponsub",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/T2/corcan.lua
+++ b/units/CorBots/T2/corcan.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/T2/cordecom.lua
+++ b/units/CorBots/T2/cordecom.lua
@@ -81,7 +81,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "buildert2",
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/CorBots/T2/corhrk.lua
+++ b/units/CorBots/T2/corhrk.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/T2/cormando.lua
+++ b/units/CorBots/T2/cormando.lua
@@ -62,7 +62,6 @@ return {
 			techlevel = 2,
 			unitgroup = "buildert2",
 			water_fall_damage_multiplier = 0,
-			continuous_aim_time = 0.07,
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/CorBots/T2/cormort.lua
+++ b/units/CorBots/T2/cormort.lua
@@ -39,7 +39,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/T2/corpyro.lua
+++ b/units/CorBots/T2/corpyro.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/T2/cortermite.lua
+++ b/units/CorBots/T2/cortermite.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/corak.lua
+++ b/units/CorBots/corak.lua
@@ -39,8 +39,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 300,
 			weapon1turrety = 300,
-			continuous_aim_spam = 100,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/corcrash.lua
+++ b/units/CorBots/corcrash.lua
@@ -38,7 +38,6 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "CorBots",
 			unitgroup = "aa",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/corstorm.lua
+++ b/units/CorBots/corstorm.lua
@@ -38,7 +38,6 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "CorBots",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBots/corthud.lua
+++ b/units/CorBots/corthud.lua
@@ -38,7 +38,6 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "CorBots",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/corbhmth.lua
+++ b/units/CorBuildings/LandDefenceOffence/corbhmth.lua
@@ -44,7 +44,6 @@ return {
 			techlevel = 2,
 			unitgroup = "energy",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/cordoom.lua
+++ b/units/CorBuildings/LandDefenceOffence/cordoom.lua
@@ -46,7 +46,6 @@ return {
 			techlevel = 2,
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/corhlt.lua
+++ b/units/CorBuildings/LandDefenceOffence/corhlt.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "CorBuildings/LandDefenceOffence",
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/corpun.lua
+++ b/units/CorBuildings/LandDefenceOffence/corpun.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "CorBuildings/LandDefenceOffence",
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/corscreamer.lua
+++ b/units/CorBuildings/LandDefenceOffence/corscreamer.lua
@@ -39,7 +39,6 @@ return {
 			techlevel = 2,
 			unitgroup = "aa",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/cortoast.lua
+++ b/units/CorBuildings/LandDefenceOffence/cortoast.lua
@@ -41,7 +41,6 @@ return {
 			techlevel = 2,
 			unitgroup = "weapon",
 			usebuildinggrounddecal = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/SeaDefence/corfhlt.lua
+++ b/units/CorBuildings/SeaDefence/corfhlt.lua
@@ -34,7 +34,6 @@ return {
 			removewait = true,
 			subfolder = "CorBuildings/SeaDefence",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorGantry/corcat.lua
+++ b/units/CorGantry/corcat.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "CorGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorGantry/cordemon.lua
+++ b/units/CorGantry/cordemon.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "CorGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorGantry/corkarg.lua
+++ b/units/CorGantry/corkarg.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "CorGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorGantry/corkorg.lua
+++ b/units/CorGantry/corkorg.lua
@@ -45,7 +45,6 @@ return {
 			subfolder = "CorGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.02,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorGantry/corshiva.lua
+++ b/units/CorGantry/corshiva.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "CorGantry",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorShips/T2/corbats.lua
+++ b/units/CorShips/T2/corbats.lua
@@ -39,7 +39,6 @@ return {
 			subfolder = "CorShips/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorShips/T2/corblackhy.lua
+++ b/units/CorShips/T2/corblackhy.lua
@@ -44,7 +44,6 @@ return {
 			subfolder = "CorShips/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorShips/coresupp.lua
+++ b/units/CorShips/coresupp.lua
@@ -37,7 +37,6 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "CorShips",
 			unitgroup = "weapon",
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorVehicles/T2/corsala.lua
+++ b/units/CorVehicles/T2/corsala.lua
@@ -51,7 +51,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 45,
 			weapon1turrety = 75,
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorVehicles/T2/corsiegebreaker.lua
+++ b/units/CorVehicles/T2/corsiegebreaker.lua
@@ -56,7 +56,6 @@ return {
 			turretname = "gun",
 			wpn1turretx = "1",
 			wpn1turrety = "1",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorVehicles/corfav.lua
+++ b/units/CorVehicles/corfav.lua
@@ -48,8 +48,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 300,
 			weapon1turrety = 300,
-			continuous_aim_spam = 100,
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorVehicles/corgator.lua
+++ b/units/CorVehicles/corgator.lua
@@ -47,7 +47,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 192.5,
 			weapon1turrety = 192.5,
-			continuous_aim_time = 0.2,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Air/T2 Air/legafigdef.lua
+++ b/units/Legion/Air/T2 Air/legafigdef.lua
@@ -46,7 +46,6 @@ return {
 			techlevel = 2,
 			attacksafetydistance = 300,
 			fighter = 1,
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/Legion/Air/T2 Air/legheavydrone.lua
+++ b/units/Legion/Air/T2 Air/legheavydrone.lua
@@ -38,7 +38,6 @@ return {
 			subfolder = "CorAircraft",
 			drone = 1,
 			nohealthbars = 1,
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			pieceexplosiongenerators = {

--- a/units/Legion/Air/T2 Air/legionnaire.lua
+++ b/units/Legion/Air/T2 Air/legionnaire.lua
@@ -46,7 +46,6 @@ return {
 			techlevel = 2,
 			attacksafetydistance = 300,
 			fighter = 1,
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			crashexplosiongenerators = {

--- a/units/Legion/Air/T2 Air/legvenator.lua
+++ b/units/Legion/Air/T2 Air/legvenator.lua
@@ -45,7 +45,6 @@ return {
 			techlevel = 2,
 			attacksafetydistance = 300,
 			fighter = 1,
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			crashexplosiongenerators = {

--- a/units/Legion/Air/legmos.lua
+++ b/units/Legion/Air/legmos.lua
@@ -34,7 +34,6 @@ return {
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "ArmAircraft",
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			crashexplosiongenerators = {

--- a/units/Legion/Bots/T2 Bots/legamph.lua
+++ b/units/Legion/Bots/T2 Bots/legamph.lua
@@ -46,7 +46,6 @@ return {
 			subfolder = "Legion/T2",
 			techlevel = 2,
 			unitgroup = "weaponsub",
-			continuous_aim_time = 0.13,
 			speedfactorinwater = 1.3,
 			speedfactoratdepth = 10,
 			reactive_armor_health = 750,

--- a/units/Legion/Bots/T2 Bots/legbart.lua
+++ b/units/Legion/Bots/T2 Bots/legbart.lua
@@ -38,7 +38,6 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "Legion/Bots/T2 Bots",
 			techlevel = 2,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/T2 Bots/legdecom.lua
+++ b/units/Legion/Bots/T2 Bots/legdecom.lua
@@ -82,7 +82,6 @@ return {
 			subfolder = "CorBots/T2",
 			techlevel = 2,
 			isdecoycommander = true,
-			continuous_aim_time = 0.17,
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/Legion/Bots/T2 Bots/leginc.lua
+++ b/units/Legion/Bots/T2 Bots/leginc.lua
@@ -39,7 +39,6 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "CorBots/T2",
 			techlevel = 2,
-			continuous_aim_time = 0.02,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/T2 Bots/legstr.lua
+++ b/units/Legion/Bots/T2 Bots/legstr.lua
@@ -40,7 +40,6 @@ return {
 			techlevel = 2,
 			weapon1turretx = 90,
 			weapon1turrety = 150,
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/legbal.lua
+++ b/units/Legion/Bots/legbal.lua
@@ -37,7 +37,6 @@ return {
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "CorBots",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/legcen.lua
+++ b/units/Legion/Bots/legcen.lua
@@ -38,7 +38,6 @@ return {
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "ArmBots",
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/leggob.lua
+++ b/units/Legion/Bots/leggob.lua
@@ -39,7 +39,6 @@ return {
 			subfolder = "CorBots",
 			weapon1turretx = 300,
 			weapon1turrety = 300,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/legkark.lua
+++ b/units/Legion/Bots/legkark.lua
@@ -43,7 +43,6 @@ return {
 			weapon1turrety = 200,
 			reactive_armor_health = 300,
 			reactive_armor_restore = 15,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Bots/leglob.lua
+++ b/units/Legion/Bots/leglob.lua
@@ -40,7 +40,6 @@ return {
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "CorBots",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Defenses/legbastion.lua
+++ b/units/Legion/Defenses/legbastion.lua
@@ -47,7 +47,6 @@ return {
 			removewait = true,
 			subfolder = "CorBuildings/LandDefenceOffence",
 			techlevel = 2,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Hovercraft/legah.lua
+++ b/units/Legion/Hovercraft/legah.lua
@@ -40,7 +40,6 @@ return {
 			model_author = "EnderRobo",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "CorHovercraft",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl10.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl10.lua
@@ -136,7 +136,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl2.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl2.lua
@@ -115,7 +115,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl3.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl3.lua
@@ -133,7 +133,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl4.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl4.lua
@@ -136,7 +136,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl5.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl5.lua
@@ -139,7 +139,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl6.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl6.lua
@@ -140,7 +140,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl7.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl7.lua
@@ -140,7 +140,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl8.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl8.lua
@@ -141,7 +141,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Legion EvoCom/legcomlvl9.lua
+++ b/units/Legion/Legion EvoCom/legcomlvl9.lua
@@ -142,7 +142,6 @@ return {
 			minimum_respawn_stun = 5,
 			distance_stun_multiplier = 1,
 			fall_damage_multiplier = 5,--this ensures commander dies when it hits the ground so effigies can trigger respawn.
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Other/Commanders/legcomoff.lua
+++ b/units/Legion/Other/Commanders/legcomoff.lua
@@ -95,7 +95,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			paralyzemultiplier = 0.025,
 			subfolder = "",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Other/Commanders/legcomt2com.lua
+++ b/units/Legion/Other/Commanders/legcomt2com.lua
@@ -99,7 +99,6 @@ return {
 			normaltex = "unittextures/Arm_normal.dds",
 			paralyzemultiplier = 0.025,
 			subfolder = "",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Other/Commanders/legcomt2off.lua
+++ b/units/Legion/Other/Commanders/legcomt2off.lua
@@ -108,7 +108,6 @@ return {
 			paralyzemultiplier = 0.025,
 			subfolder = "",
 			paratrooper = true,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Ships/T2/leganavyantiswarm.lua
+++ b/units/Legion/Ships/T2/leganavyantiswarm.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "Legion/Ships/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Ships/T2/leganavycruiser.lua
+++ b/units/Legion/Ships/T2/leganavycruiser.lua
@@ -40,7 +40,6 @@ return {
 			subfolder = "Legion/Ships/T2",
 			techlevel = 2,
 			unitgroup = "weaponsub",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Ships/T2/leganavyflagship.lua
+++ b/units/Legion/Ships/T2/leganavyflagship.lua
@@ -45,7 +45,6 @@ return {
 			subfolder = "Legion/Ships/T2",
 			techlevel = 2,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Ships/legnavydestro.lua
+++ b/units/Legion/Ships/legnavydestro.lua
@@ -43,7 +43,6 @@ return {
 			inheritxpratemultiplier = 1,
 			childreninheritxp = "DRONE",
 			parentsinheritxp = "DRONE",
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/leegmech.lua
+++ b/units/Legion/T3/leegmech.lua
@@ -42,7 +42,6 @@ return {
 			normaltex = "unittextures/leegmech_normal.dds",
 			subfolder = "leggantry",
 			techlevel = 3,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legbunk.lua
+++ b/units/Legion/T3/legbunk.lua
@@ -44,7 +44,6 @@ return {
 			techlevel = 3,
 			weapon1turretx = 200,
 			weapon1turrety = 200,
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legeheatraymech_old.lua
+++ b/units/Legion/T3/legeheatraymech_old.lua
@@ -45,7 +45,6 @@ return {
 			subfolder = "Legion/T3",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.02,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legehovertank.lua
+++ b/units/Legion/T3/legehovertank.lua
@@ -46,7 +46,6 @@ return {
 			subfolder = "Legion/T3",
 			techlevel = 3,
 			unitgroup = "weapon",
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legerailtank.lua
+++ b/units/Legion/T3/legerailtank.lua
@@ -45,7 +45,6 @@ return {
 			paralyzemultiplier = 0.5,
 			model_author = "ZephyrSkies",
 			techlevel = 3,
-			continuous_aim_time = 0.3,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legeshotgunmech.lua
+++ b/units/Legion/T3/legeshotgunmech.lua
@@ -41,7 +41,6 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "leggantry",
 			techlevel = 3,
-			continuous_aim_time = 0.1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legjav.lua
+++ b/units/Legion/T3/legjav.lua
@@ -43,7 +43,6 @@ return {
 			unitgroup = "weapon",
 			weapon1turretx = 90,
 			weapon1turrety = 150,
-			continuous_aim_time = 0.02,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/T3/legkeres.lua
+++ b/units/Legion/T3/legkeres.lua
@@ -44,7 +44,6 @@ return {
 			paralyzemultiplier = 0.5,
 			model_author = "EnderRobo",
 			techlevel = 3,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/T2 Vehicles/legaheattank.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legaheattank.lua
@@ -47,7 +47,6 @@ return {
 			techlevel = 2,
 			weapon1turretx = 65,
 			weapon1turrety = 105,
-			continuous_aim_time = 0.02,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/T2 Vehicles/legaskirmtank.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legaskirmtank.lua
@@ -47,7 +47,6 @@ return {
 			techlevel = 2,
 			weapon1turretx = 65,
 			weapon1turrety = 105,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/T2 Vehicles/legfloat.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legfloat.lua
@@ -47,7 +47,6 @@ return {
 			subfolder = "legvehicles/T2",
 			techlevel = 2,
 			enabled_on_no_sea_maps = true,
-			continuous_aim_time = 0.17,
 			speedfactorinwater = 1.3,
 		},
 		featuredefs = {

--- a/units/Legion/Vehicles/T2 Vehicles/legmed.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legmed.lua
@@ -41,7 +41,6 @@ return {
 			model_author = "ZephyrSkies, EnderRobo",
 			normaltex = "unittextures/leg_normal.dds",
 			techlevel = 2,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/T2 Vehicles/legmrv.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legmrv.lua
@@ -47,7 +47,6 @@ return {
 			techlevel = 2,
 			weapon1turretx = 65,
 			weapon1turrety = 105,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/legbar.lua
+++ b/units/Legion/Vehicles/legbar.lua
@@ -52,7 +52,6 @@ return {
 			subfolder = "CorVehicles/T2",
 			weapon1turretx = 30,
 			weapon1turrety = 40,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/leggat.lua
+++ b/units/Legion/Vehicles/leggat.lua
@@ -48,7 +48,6 @@ return {
 			subfolder = "Legion/Vehicles",
 			weapon1turretx = 45,
 			weapon1turrety = 80,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/leghades.lua
+++ b/units/Legion/Vehicles/leghades.lua
@@ -47,7 +47,6 @@ return {
 			subfolder = "ArmVehicles",
 			weapon1turretx = 240,
 			weapon1turrety = 240,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/leghelios.lua
+++ b/units/Legion/Vehicles/leghelios.lua
@@ -54,7 +54,6 @@ return {
 			turretname = "turret",
 			wpn1turretx = 192.5,
 			wpn1turrety = 192.5,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/legrail.lua
+++ b/units/Legion/Vehicles/legrail.lua
@@ -44,7 +44,6 @@ return {
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "ArmVehicles",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Vehicles/legscout.lua
+++ b/units/Legion/Vehicles/legscout.lua
@@ -49,7 +49,6 @@ return {
 			subfolder = "Legion",
 			--weapon1turretx = 300,
 			--weapon1turrety = 300,
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -103,7 +103,6 @@ return {
 			normaltex = "unittextures/leg_normal.dds",
 			paralyzemultiplier = 0.025,
 			subfolder = "",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Boss/scavengerbossv4.lua
+++ b/units/Scavengers/Boss/scavengerbossv4.lua
@@ -117,7 +117,6 @@ for difficulty, stats in pairs(difficultyParams) do
 			paralyzemultiplier = 0.025,
 			subfolder = "",
 			i18nfromunit = 'scavengerbossv4',
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Bots/armpwt4.lua
+++ b/units/Scavengers/Bots/armpwt4.lua
@@ -41,8 +41,6 @@ return {
 			techlevel = 3,
 			weapon1turretx = 300,
 			weapon1turrety = 300,
-			continuous_aim_spam = 90,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Bots/cordeadeye.lua
+++ b/units/Scavengers/Bots/cordeadeye.lua
@@ -39,7 +39,6 @@ return {
 			normaltex = "unittextures/cor_normal.dds",
 			subfolder = "CorBots/t2",
 			techlevel = 2,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Bots/corkark.lua
+++ b/units/Scavengers/Bots/corkark.lua
@@ -41,7 +41,6 @@ return {
 			subfolder = "Scavengers/Bots",
 			weapon1turretx = 200,
 			weapon1turrety = 200,
-			continuous_aim_time = 0.07,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Scavengers/Buildings/DefenseOffense/legrwall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legrwall.lua
@@ -47,7 +47,6 @@ return {
 			removewait = true,
 			subfolder = "CorBuildings/LandDefenceOffence",
 			techlevel = 2,
-			continuous_aim_time = 0.13,
 		},
 		featuredefs = {
 			dead = {

--- a/units/armcom.lua
+++ b/units/armcom.lua
@@ -95,7 +95,6 @@ return {
 			paralyzemultiplier = 0,
 			subfolder = "",
 			unitgroup = "builder",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {

--- a/units/corcom.lua
+++ b/units/corcom.lua
@@ -95,7 +95,6 @@ return {
 			paralyzemultiplier = 0,
 			subfolder = "",
 			unitgroup = "builder",
-			continuous_aim_time = 0.17,
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
Reverts beyond-all-reason/Beyond-All-Reason#6293. Unit aim tracking not behaving as expected in late game.