### PR TITLE
Fix: Depreciated getunitcommands usage

### DIFF
--- a/luaui/Widgets/cmd_commandq_manager.lua
+++ b/luaui/Widgets/cmd_commandq_manager.lua
@@ -21,7 +21,7 @@ end
 -- Locals
 local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
-local spGetUnitCommandsSize = Spring.GetUnitCommands
+local spGetUnitCommandCount = Spring.GetUnitCommandCount
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGetUnitCommands = Spring.GetUnitCommands
 local spGetGameFrame = Spring.GetGameFrame
@@ -37,7 +37,7 @@ function SkipCurrentCommand()
 		if force then
 			RemoveCommand(nil, 1, nil)
 		else
-			RemoveCommand(id, 1, spGetUnitCommandsSize(id, 0))
+			RemoveCommand(id, 1, spGetUnitCommandCount(id))
 		end
 	end)
 end
@@ -47,7 +47,7 @@ function CancelLastCommand()
 		if force then
 			RemoveCommand(nil, #WG["pregame-build"].getBuildQueue(), nil)
 		else
-			local commandQueueSize = spGetUnitCommandsSize(id, 0)
+			local commandQueueSize = spGetUnitCommandCount(id)
 			if not commandQueueSize or commandQueueSize < 1 then
 				return
 			end


### PR DESCRIPTION
Fixes warning in commandq_manager:

```Deprecated: This game is issuing `Spring.GetUnitCommands(unitId, 0)`, `Spring.GetCommandQueue(unitId, 0)` or passing a third argument to these functions. This usage is deprecated, please use `Spring.GetUnitCommandCount(unitId)` instead or fix some underlying bug.```

I.e. When pressing `n` or `ctrl+n`