### PR TITLE
Remove S3 Modoption Link

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1508,19 +1508,6 @@ local options = {
     },
 
     {
-        key     = "proposed_unit_reworks_feedback_link",
-        name    = "Feedback Thread",
-        desc    = "Discord discussion about Season 3 balance test.",
-        section = "options_experimental",
-        type    = "link",
-        link    = "https://discord.com/channels/549281623154229250/1447323521662455910",
-        width   = 215,
-        column  = 2,
-        linkheight = 325,
-        linkwidth = 350,
-    },
-
-    {
         key     = "community_balance_patch",
         name    = "Community Balance Patch Jan '26",
         desc    = "Enable community balance patch changes\n(overwrites changes in official seasonal balance test)",


### PR DESCRIPTION
<img width="1463" height="855" alt="image" src="https://github.com/user-attachments/assets/95130042-4df3-44b5-b848-e2545d22f6d5" />

Gotta remember to remove the link for your modoptions, guys!
This makes the circled thing go away.