### PR TITLE
Update modoptions.lua com assist drone step value fix

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1371,7 +1371,7 @@ local options = {
         def    	= 1,
         min    	= 0.5,
         max    	= 5,
-        step   	= 1,
+        step   	= 0.1,
     },
 
     {


### PR DESCRIPTION
### Work done

Change to the assistdronesbuildpowermultiplier to allow Commander assist drones to take on its minimum values and gradations in its acceptable range. This was likely an oversight from previous updates.

#### Addresses Issue(s)
https://discord.com/channels/549281623154229250/549282587487502347/1459623229797830709
The multiplier previously did not allow the minimum value, 0.5, to be set. The step size of 1 and default of 1 allowed only values [1, 2, 3, 4, 5]. Now, 0.5 will be allowed, as will 1.1 and 1.5. This is helpful for giving the drones a smaller boost that doubling as a minimum multiplier.

#### Setup
In dev mode skirmish lobby, enable Commander Drones, and set the value to a non-integer number between 0.5 and 5, inclusive.

#### Test steps
Load the game, and watch the build power correctly adjust on the commander drone. Wait for the drone to spawn, and click on it to see the build power correctly adjust as a multiple of original.
