### PR TITLE
fix: attached_con_turret_mex unit queries

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -38,7 +38,7 @@ local function swapMex(unitID, unitDefID, unitTeam)
 	local buildTime, metalCost, energyCost = Spring.GetUnitCosts(unitID)
 	local neutral = Spring.GetUnitNeutral(unitID)
 	local health = Spring.GetUnitHealth(unitID)																-- saves location, rotation, cost and health of mex
-	local original = Spring.GetUnitNearestAlly(unitID)
+	local original = Spring.GetUnitNearestAlly(unitID, 32)
 	local orgExtractMetal = 0
 	if original then
 		local orgbuildTime, orgmetalCost, orgenergyCost = Spring.GetUnitCosts(original)							-- gets metal cost of thing you are building over


### PR DESCRIPTION
### Work done

- unit_attached_con_turret_mex still has a place where it deletes a unit, then tries to query its properties (fixed)
- it also has an unlimited-range search for the nearest unit, which is actually not that much worse than uncapped for performance, but this is slighty faster, may as well

#### Addresses Issue(s)

- Resolves an uncommon error:

```
[t=00:13:51.254655][f=0018680] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_attached_con_turret_mex.lua"]:82: attempt to perform arithmetic on local 'orgExtractMetal' (a nil value)
```