### PR TITLE
fix: Disable Assist Ally remove Roam states, validate unit orders

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -199,7 +199,7 @@ end
 
 -- Temp anti-cheat-esque guard. We check on random frames for units bypassing the rules.
 local function AllowUnitBuildStep(self, builderID, builderTeam, unitID, unitDefID, part)
-    if part > 0 and builderTeam ~= spGetUnitTeam(unitID) then
+    if part > 0 and builderTeam ~= spGetUnitTeam(unitID) and not isComplete(unitID) then
 		checkUnitCommandList[builderID] = builderTeam
 		return false
     end


### PR DESCRIPTION
This is a bag of changes, I'd like this to be reviewed.

### Work done

- Removes Roam as a move state setting, otherwise visible but unreachable on the button for builders and build-assisters. Later, we could disable Roam like this more selectively: only in a Guard, Area Repair, or Fight command. But that is trickier to do.
- Added #params == 5 for CMD.REPAIR, which is the new "leashed" repair command.
- Prevented Guard orders on incomplete allied units, since this will cause builders to assist.
- Check for units that are transferred instantly, namely extractor and geothermal unit upgrades and sidegrades.
- Encapsulated all the common logic, so caused a lot of shuffling around, but hopefully this is modular enough to be updated more easily next time. This is a bit awkward, as noted, on `isBuilderAllowedCommand`.
- Delayed re-validating the command queue on shared builders until the end of the sim frame, so that no matter how units are transferred and no matter the call order to UnitGiven, the commands dropped are always the same.
- Added an intermittent peek to the UnitBuildStep callin. This is closer to an anti-cheat pattern, so I'm not so sure about it. On random frames, the AllowUnitBuildStep callin is reenabled in the gadget, and units with conflicting build tasks are added to the list for their command queue to re-validate at the end of the frame.

#### Setup

- Enable the disable_assist_ally_construction or easytax modoptions.

#### Test steps

- [ ] Builders should have the correct move states available on the button: Only two, Hold Position and Maneuver.
- [ ] Builders should work as before: they cannot assist or guard allied units or allied constructions that are in-progress. They can still repair allies.
- [ ] Sharing constructors in large batches when they are guarding one another or assisting building one another does not cause any of those commands to be dropped.
- [ ] Assuming you know other methods of bypassing this gadget: That method should be annoying and unreliable.


<img width="490" height="148" alt="{577F223A-9B9E-454D-85F9-E6B12CD3F552}" src="https://github.com/user-attachments/assets/e852b38f-ea1b-4d08-a159-9e1e78afa90f" />
