### PR TITLE
fix: nil error, undefined var in stun_storage

### DIFF
--- a/luarules/gadgets/unit_stun_storage.lua
+++ b/luarules/gadgets/unit_stun_storage.lua
@@ -67,13 +67,16 @@ end
 
 local function reduceStorage(unitID, unitDefID, teamID)
 	paralyzedUnits[unitID] = unitDefID
-	if storageDefs[unitDefID].metal then
-		local _, totalStorage = spGetTeamResources(teamID, "metal")
-		spSetTeamResource(teamID, "ms", totalStorage - storageDefs[unitDefID].metal)
-	end
-	if storageDefs[unitDefID].energy then
-		local _, totalStorage = spGetTeamResources(teamID, "energy")
-		spSetTeamResource(teamID, "es", totalStorage - storageDefs[unitDefID].energy)
+	local storage = storageDefs[unitDefID]
+	if storage then
+		if storage.metal then
+			local _, totalStorage = spGetTeamResources(teamID, "metal")
+			spSetTeamResource(teamID, "ms", totalStorage - storage.metal)
+		end
+		if storage.energy then
+			local _, totalStorage = spGetTeamResources(teamID, "energy")
+			spSetTeamResource(teamID, "es", totalStorage - storage.energy)
+		end
 	end
 end
 


### PR DESCRIPTION
### Work done

- Two minor bugfixes for unit_stun_storage

#### Addresses issue

Resolves error:

```
log\20260114011338_infolog.txt
[t=01:19:45.642567][f=0094486] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=UnitDestroyed trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_stun_storage.lua"]:54: attempt to index field '?' (a nil value)
```