### PR TITLE
fix: many issues with attached_con_turret_mex

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -96,6 +96,7 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	Spring.SetUnitHealth(conID, unitHealth)
 	Spring.SetUnitStealth(conID, true)
 	-- TODO: Is this still needed, given the `pairedUnitID`?
+	-- TODO: Set on-off methods for extration, energy upkeep
 	Spring.SetUnitResourcing(conID, "umm", unitExtraction)
 	Spring.SetUnitResourcing(mexID, "umm", -unitExtraction)
 	if isUnitNeutral then


### PR DESCRIPTION
### Work done

Refactor and rewrite of unit_attached_con_turret_mex (Legion Fortifier code).

#### Addresses issue

- The code would always try to replace a unit, and only ran when it found a unit to replace.
- The replaced unit could be any nearby unit, not necessarily an underlying extractor.
- The code then would error when replacing a non-extractor unit. (At least this meant we were not sending Legion units to the void, one at a time. But it broke the gadget.)
- Unit cap was probed by trying to create units; this now checks for available overhead.
- Code would fail out and never reattempt to run. Now, when any step fails, it continuously retries (as long as the failure is potentially resolvable).

Also:
https://discord.com/channels/549281623154229250/1461550374845681665