### PR TITLE
Fix no rush command inserting

### DIFF
--- a/luarules/gadgets/game_no_rush_mode.lua
+++ b/luarules/gadgets/game_no_rush_mode.lua
@@ -69,8 +69,9 @@ end
 if gadgetHandler:IsSyncedCode() then
 	function gadget:Initialize()
 		gadgetHandler:RegisterAllowCommand(CMD.BUILD)
+		gadgetHandler:RegisterAllowCommand(CMD.INSERT)
 
-		local registered = { [CMD.BUILD] = true }
+		local registered = { [CMD.BUILD] = true, [CMD.INSERT] = true }
 
 		for _, commandList in ipairs { CommandsToCatchMap, CommandsToCatchUnit, CommandsToCatchFeature } do
 			for command in pairs(commandList) do


### PR DESCRIPTION
### Work done

Registered `CMD.INSERT`  to restore handling of inserted commands.

#### Test steps
- [ ] Start a match with no rush. Commands can no longer be issued outside of the start box with space bar

