### PR TITLE
Optimize Start Position Suggestions

### DIFF
--- a/luaui/Widgets/map_start_position_suggestions.lua
+++ b/luaui/Widgets/map_start_position_suggestions.lua
@@ -192,27 +192,10 @@ local function selectModoptionConfigForPlayers(modoptionData, allyTeamCount, pla
 	return nil
 end
 
-local DEBUG_TEST_MODE = true
-
 local function loadStartPositions()
 	local modoptionDataRaw = Spring.GetModOptions().mapmetadata_startpos
 
 	if modoptionDataRaw == nil or string.len(modoptionDataRaw) == 0 then
-		if DEBUG_TEST_MODE then
-			Spring.Log(widget:GetInfo().name, LOG.INFO, "Using debug test positions")
-			local mapX = Game.mapSizeX
-			local mapZ = Game.mapSizeZ
-			return {
-				[0] = {
-					{ spawnPoint = { x = mapX * 0.15, z = mapZ * 0.15 }, baseCenter = { x = mapX * 0.25, z = mapZ * 0.25 }, role = "air" },
-					{ spawnPoint = { x = mapX * 0.15, z = mapZ * 0.5 }, role = "front" },
-				},
-				[1] = {
-					{ spawnPoint = { x = mapX * 0.85, z = mapZ * 0.85 }, baseCenter = { x = mapX * 0.75, z = mapZ * 0.75 }, role = "air" },
-					{ spawnPoint = { x = mapX * 0.85, z = mapZ * 0.5 }, role = "front" },
-				},
-			}
-		end
 		Spring.Log(widget:GetInfo().name, LOG.WARNING, "No modoption start position data found")
 		return
 	end


### PR DESCRIPTION
Performance was bad. Still had some premium AI credits to burn before the 20th - I dumped them into optimizing this widget. Tested the results and will momentarily attach images before/after.

before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2a421024-66c1-4347-a9c5-d167f441349d" />

after:
<img width="1556" height="884" alt="image" src="https://github.com/user-attachments/assets/a2325e6a-0001-47c5-acd9-39cdc8cca000" />

Roughly 92% decrease in load. Largely from caching, reducing string lookups from the i18n library, localizing functions, caching data that doesn't need regenerating.

Tested working with placeholder debug data I put into the widget - all seems to be working including tooltips for the starting location and the move-to location. Splitting team colors in shared zones, moving in and out of zones.
