### PR TITLE
invoke Spring area reclaim logic for enemy unit reclaim

### DIFF
--- a/luaui/Widgets/unit_area_reclaim_enemy.lua
+++ b/luaui/Widgets/unit_area_reclaim_enemy.lua
@@ -69,7 +69,6 @@ function widget:CommandNotify(id, params, options)
 
 	-- x,y,radius of command
 	local selectedUnits = spGetSelectedUnits()
-	   
 	local areaUnits = spGetUnitsInCylinder(cx, cz, cr)
 	local enemyUnits = {}
 	-- get all enemy units in the area
@@ -107,7 +106,9 @@ function widget:CommandNotify(id, params, options)
 		if #newCmds ~= 0 or options.shift then
 			cmdOpts = cmdOpts + CMD.OPT_SHIFT
 		end
-		newCmds[#newCmds + 1] = { CMD_RECLAIM, unitID , cmdOpts }
+		-- cmd_reclaim with 1 arg reclaims specific unitid, 4 args untargeted
+		-- reclaim, 5 args is targeted area reclaim
+		newCmds[#newCmds + 1] = { CMD_RECLAIM, {unitID, cx, cy, cz, cr} , cmdOpts }
 	end
 
 	-- add the command to all units with reclaim


### PR DESCRIPTION
### Work done
Pass the necessary 5 arguments, via Spring.GiveOrderArrayToUnitArray(), to Spring's [ExecuteReclaim](https://github.com/beyond-all-reason/RecoilEngine/blob/7f94da3117bc1e2fe88379d53a7744c2b509bd1f/rts/Sim/Units/CommandAI/BuilderCAI.cpp#L1043) function. This enables default Spring reclaim behavior, with the enemy allegiance set. The cmdopts "Ctrl" and "Meta" are passed to Spring, although the BAR hotkey is only to hold Space.

**Known issue**: if there is one unit in the reclaim circle, and it's slower than the reclaimers, they may pursue it an indefinite distance until it is consumed. This also occurs in the existing main branch BAR (because the current area reclaim doesn't use actual area commands), so it's not a regression, and it might be reasonable to merge without solving it. I don't currently know the underlying Spring code well enough to diagnose, but could explore further if someone has a promising idea.

#### Addresses Issue(s)
- Issue #6164 

#### Setup
Make sure that the enemy unit reclaim widget is active. Use godmode and other necessary skirmish cheats to obtain reclaimable enemy units.


#### Test steps
Select a reclaim-capable unit and use reclaim + meta key (space bar by default) to drag a circle over a group of enemy units. The reclaim order should not target any friendly units or environment features within the area. Immediately move the targeted units out of the circle. If the target units are faster than the reclaimers, they should "give up" almost immediately and seek new targets. If the reclaimers are faster, they should pursue slightly outside of the circle command area before giving up. The reclaimers *may* switch to closer targets within the circle even if neither of these two criteria are met; see the underlying [Spring code](https://github.com/beyond-all-reason/RecoilEngine/blob/7f94da3117bc1e2fe88379d53a7744c2b509bd1f/rts/Sim/Units/CommandAI/BuilderCAI.cpp#L986) for explanation.

