### PR TITLE
sync Proteus gridmenu with its buildoptions

### DIFF
--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -2335,13 +2335,13 @@ local unitGrids = {
 		},
 		{
 			{ "legdtr", "legstr", "legacluster", },               	  -- dragon's jaw, strider, t2 cluster arty
-			{ "legflak", "legrhapsis", "legaabot", "leggob", },    	  -- Ravager Flak, Rhapsis, T1 aa bot, Goblin
-			{ "legctl", "legnavyfrigate", },               			  -- coastal torp launcher, frigate
+			{ "legflak", "", "legaabot", "leggob", },                 -- Ravager Flak, intentional blank, T1 aa bot, Goblin
+			{ "legctl", "legnavyfrigate", "", "legamph" },            -- coastal torp launcher, frigate, intentional blank, Telchine
 		},
 		{
 			{ "legarad", "legeyes", "legforti", "legajam", },         -- adv radar, camera, wall, adv jammer
 			{ },                                                      --
-			{ },                                          			  -- med mine
+			{ },                                          			  -- med mine -- intentional blank
 		},
 		{
 			{ "leglab", "legck", },                                   -- bot lab, bot con


### PR DESCRIPTION
### Work done

The Proteus (legaceb) has fewer build options due to its advanced mobility. This leaves some holes in the grid menu, since its build options are intended to align with the other combat engineer's options.

This isn't entirely ideal but should be fine.

- Removed old build options no longer on legaceb
- Specified the location of legamph to match other combat engineers' amphibious options

#### Addresses Issue(s)

- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6718
- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6721
