### PR TITLE
Correct selection filter in legacy keys

### DIFF
--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -109,7 +109,7 @@ bind sc_` drawinmap
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
 bind Ctrl+sc_c selectcomm focus
-bind Ctrl+sc_v select AllMap+_Not_Builder_Not_Commander_InPrevSel_Not_InHotkeyGroup+_SelectAll+
+bind Ctrl+sc_v select AllMap+_Not_Builder_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_w select AllMap+_Not_Aircraft_Weapons+_ClearSelection_SelectAll+
 bind Ctrl+sc_x select AllMap+_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_z select AllMap+_InPrevSel+_ClearSelection_SelectAll+

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -110,7 +110,7 @@ bind Alt+enter fullscreen
 bind Ctrl+sc_a select AllMap++_ClearSelection_SelectAll+
 bind Ctrl+sc_b select AllMap+_Builder_Idle+_ClearSelection_SelectOne+
 bind Ctrl+sc_c selectcomm focus
-bind Ctrl+sc_v select AllMap+_Not_Builder_Not_Commander_InPrevSel_Not_InHotkeyGroup+_SelectAll+
+bind Ctrl+sc_v select AllMap+_Not_Builder_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_w select AllMap+_Not_Aircraft_Weapons+_ClearSelection_SelectAll+
 bind Ctrl+sc_x select AllMap+_InPrevSel_Not_InHotkeyGroup+_SelectAll+
 bind Ctrl+sc_z select AllMap+_InPrevSel+_ClearSelection_SelectAll+


### PR DESCRIPTION
Legacy keys have a selection on ctrl+V, however it is bugged and errors out. 

### Work done
Removed the not_commander token which causes the error. It is also not needed as commanders are almost always builders (in the base game). Modded commanders with zero build power will be selected but this seems a niche change in function no one will notice. 


#### Addresses Issue(s)
- [Issue URL](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6414#issuecomment-3761917384)

#### Setup
Use legacy keys or 60% legacy keys. 

#### Test steps
- Press ctrl+V and note that units matching the type of the current selection are selected so long as they are _not_ in a current hotkey group. 

### Screenshots:

#### BEFORE:
<img width="1330" height="774" alt="image" src="https://github.com/user-attachments/assets/f0ff1aa3-ed40-4264-945f-b2c1dc1fc464" />


#### AFTER:
<img width="1436" height="870" alt="image" src="https://github.com/user-attachments/assets/d8818f52-f805-4f94-8011-e20e5e71a1bf" />

Note: This key is not in the help graphics. 
