### PR TITLE
fix: incorrect unit damages display

### DIFF
--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -175,7 +175,7 @@ local anonymousName = '?????'
 local showStats = false
 
 -- TODO: Shield damages are overridden in the shields rework (now in main game)
-local shieldsRework = Spring.GetModOptions().experimentalshields:find("absorb")
+local shieldsRework = not Spring.GetModOptions().experimentalshields:find("bounce")
 
 ------------------------------------------------------------------------------------
 -- Functions


### PR DESCRIPTION
### Work done

Shield damages are forced to zero in the shieldsrework, which is now in the base game. This just hides them. They are misleading.

Also, I assume when armor types were made tweak-able, they were sorted. Indestructable is no longer last -- so this iterates the final armor type in the displays. This was previously a pretty fragile assumption. Now, it inspects each armor type, guaranteed.

#### Addresses Issue(s)
- https://discord.com/channels/549281623154229250/1090730219356307496/1465402815521493114

#### Test result

<img width="736" height="352" alt="{49A22104-191E-44D5-A2EF-49B908DE0694}" src="https://github.com/user-attachments/assets/3a64f9e9-2fec-4e44-8d58-677cb67ef1e8" />
