### PR TITLE
fix: no_self_select error in headless and godmode

### DIFF
--- a/luaui/Widgets/cmd_no_self_selection.lua
+++ b/luaui/Widgets/cmd_no_self_selection.lua
@@ -190,7 +190,7 @@ function widget:ActiveCommandChanged(cmdid, type)
 	end
 end
 
--- Godmode and headless testing fixes.
+-- Godmode and headless testing LOS fixes.
 
 local function unitAccessLost(self, unitID, unitTeam, unitAllyTeam, unitDefID)
 	if unitID == selectedUnitID then


### PR DESCRIPTION
### Work done

- Fixes an error that crashes the widget in godmode when a single, selected enemy unit cloaks or leaves radar + LOS.

This still doesn't work well with enemy units; though, I am not sure what behavior to expect for them. The gui handler defaults to Attack orders with an enemy unit selected and hovering that unit.