### PR TITLE
fix: tolerate nils, hashed keys in buildoptions dedupe

### DIFF
--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -186,7 +186,7 @@ if not table.invert then
 	end
 end
 
-if not table.toUniqueArray then
+if not table.getUniqueArray then
 	local sort, floor = table.sort, math.floor
 
 	local lookup = {}
@@ -201,7 +201,7 @@ if not table.toUniqueArray then
 	---The final/sorted array forms a compact sequence with no gaps so can have new keys.
 	---@param tbl table may contain array, hash, or mixed data and can have gaps
 	---@return table sequence containing only unique entries, ordered by their integer indices
-	function table.toUniqueArray(tbl)
+	function table.getUniqueArray(tbl)
 		local unique, count = {}, 0
 		local invert = {}
 

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1714,7 +1714,7 @@ function UnitDef_Post(name, uDef)
 		end
 		-- Deduplicate buildoptions (various modoptions or later mods can add the same units)
 		-- Multiple unit defs can share the same table reference, so we create a new table for each
-		uDef.buildoptions = table.toUniqueArray(uDef.buildoptions)
+		uDef.buildoptions = table.getUniqueArray(uDef.buildoptions)
 	end
 end
 


### PR DESCRIPTION
### Work done

- Adds `table.getUniqueArray` to get the unique, compact sequence from a mixed data table.
- Changes buildoption dedupe to use this method.
- Removes all invalid/missing build options, not just `""`.

#### Addresses Issue(s)

- Players are reporting that old tweakdefs and especially tweakunits aren't working. These are probably rusted already but the current dedupe just rusts them even more.

#### BEFORE:

```lua
local a = { nil, 2, 6, 7, nil, 8, nil, 9, nil, 10, nil }

local function sortCurrent(tbl)
	local seen = {}
	local deduped = {}
	
	for i = 1, #tbl do
		local unitName = tbl[i]
		if type(unitName) == "string" and unitName ~= "" and not seen[unitName] then
			seen[unitName] = true
			deduped[#deduped + 1] = unitName
		end
	end
	
	return deduped
end

a = sortCurrent(a)

for i,v in ipairs(a) do print(v) end
if not a[1] then print("empty") end
```
```
Result:
Success #stdin #stdout 0s 5312KB
empty
```


#### AFTER:

```lua
local a = { nil, 2, 6, 7, nil, 8, nil, 9, nil, 10, nil }

if not table.toUniqueArray then
	local sort, floor = table.sort, math.floor

	local lookup = {}
	local function sortLookup(a, b)
		return lookup[a] < lookup[b]
	end

	function table.toUniqueArray(tbl)
		local unique, count = {}, 0
		local invert = {}

		for index, option in pairs(tbl) do
			if type(index) == "number" and index >= 1 and index == floor(index) then
				if not invert[option] then
					count = count + 1
					unique[count] = option
					invert[option] = index
				elseif invert[option] > index then
					invert[option] = index
				end
			end
		end

		lookup = invert
		sort(unique, sortLookup)

		return unique
	end
end

a = table.toUniqueArray(a)

for i,v in ipairs(a) do print(v) end
if not a[1] then print("empty") end
```
```
Result:
Success #stdin #stdout 0.01s 5320KB
2
6
7
8
9
10
```