### PR TITLE
fix: missing arg in UnitDamaged for attached_con code

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -60,6 +60,7 @@ if not next(fakeBuildDefID) or not next(isExtractor) then
 end
 
 local mexesToSwap = {}
+local pairedUnits = {}
 
 local function doSwapMex(unitID, unitTeam, unitData)
 	local Spring = Spring
@@ -92,6 +93,8 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	Spring.UnitAttach(mexID, conID, 6)
 	Spring.SetUnitRulesParam(conID, "pairedUnitID", mexID)
 	Spring.SetUnitRulesParam(mexID, "pairedUnitID", conID)
+	pairedUnits[conID] = mexID
+	pairedUnits[mexID] = conID
 
 	Spring.SetUnitHealth(conID, unitHealth)
 	Spring.SetUnitStealth(conID, true)
@@ -147,8 +150,7 @@ end
 
 function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
 	if mexTurretDefID[unitDefID] then
-		local pairedUnitID = Spring.GetUnitRulesParam(unitID, "pairedUnitID")
-		Spring.TransferUnit(pairedUnitID, newTeam)
+		Spring.TransferUnit(pairedUnits[unitID], newTeam)
     end
 end
 
@@ -181,8 +183,9 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 	mexesToSwap[unitID] = nil
 
 	if mexActualDefID[unitDefID] or mexTurretDefID[unitDefID] then
-		local pairedUnitID = Spring.GetUnitRulesParam(unitID, "pairedUnitID")
-		if pairedUnitID and Spring.GetUnitIsDead(pairedUnitID) == false then
+		local pairedUnitID = pairedUnits[unitID]
+		if pairedUnitID then
+			pairedUnits[pairedUnitID] = nil
 			Spring.DestroyUnit(pairedUnitID, false, true)
 		end
     end


### PR DESCRIPTION
I figure we have some global named `unitDefID` somewhere, and that's enough for my diagnostics not to notice that the var is uninitialized. Lua development.

### Work done

- Adds a missing arg to the UnitDamaged function.
- With that done, the selfd bug that wouldn't replicate returns. So, fixed the Fortifier selfd leaving a phantom unit.

Tested with a bunch of damaging and selfd scenarios, plus deleting the Fortifier units individually via scripts. Everything seems to be working, now.

#### Addresses Issue(s)

Resolves error:
```
[t=01:08:13.038121][f=0089927] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=UnitDamaged trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_attached_con_turret_mex.lua"]:174: attempt to concatenate local 'buildAsUnitName' (a nil value)
```
