### PR TITLE
Added faction-specific simple team colors option

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1374,6 +1374,8 @@
 				"anonymous_b": "Anonymous Blue",
 				"playercolors": "Simple team colors",
 				"simpleteamcolors": "simple",
+				"simpleteamcolorsfactionspecific": "Faction Color",
+				"simpleteamcolorsfactionspecific_descr": "Replaces Simple Team Colors with Faction Colors based on player's starting commander, useful for cinematics.",
 				"simpleteamcolors_reset": "Reset (Restart to reset sliders)",
 				"simpleteamcolors_use_gradient": "Use a different shade for each player.",
 				"simpleteamcolors_player_r": "Player Red",

--- a/luarules/gadgets/game_autocolors.lua
+++ b/luarules/gadgets/game_autocolors.lua
@@ -476,7 +476,24 @@ local function setupTeamColor(teamID, allyTeamID, isAI, localRun)
 			maxColorVariation = 60
 		end
 		local color = hex2RGB(ffaColors[allyTeamID+1] or '#333333')
-		if teamID == gaiaTeamID then
+		if Spring.GetConfigInt("SimpleTeamColorsFactionSpecific", 0) == 1 then
+			if isAI and string.find(isAI, "Scavenger") then
+				color = hex2RGB(scavPurpColor)
+			elseif isAI and string.find(isAI, "Raptor") then
+				color = hex2RGB(raptorOrangeColor)
+			elseif teamID == gaiaTeamID then
+				color = hex2RGB(gaiaGrayColor)
+			elseif Spring.GetTeamRulesParam(teamID, 'startUnit') and anonymousMode ~= "allred" then
+				local side = string.sub(UnitDefs[Spring.GetTeamRulesParam(teamID, 'startUnit')].name, 1, 3)
+				if side == "arm" then
+					color = hex2RGB(armBlueColor)
+				elseif side == "cor" then
+					color = hex2RGB(corRedColor)
+				elseif side == "leg" then
+					color = hex2RGB(legGreenColor)
+				end
+			end
+		elseif teamID == gaiaTeamID then
 			brightnessVariation = 0
 			maxColorVariation = 0
 			color = hex2RGB(gaiaGrayColor)
@@ -712,6 +729,8 @@ else	-- UNSYNCED
 			updateTeamColors()
 			Spring.SetConfigInt("UpdateTeamColors", 0)
 			Spring.SetConfigInt("SimpleTeamColors_Reset", 0)
+		elseif Spring.GetConfigInt("SimpleTeamColors", 0) == 1 and Spring.GetConfigInt("SimpleTeamColorsFactionSpecific", 0) == 1 and Spring.GetGameFrame() < 300 then
+			Spring.SetConfigInt("UpdateTeamColors", 1)
 		end
 	end
 

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -4883,6 +4883,12 @@ function init()
 			  Spring.SetConfigInt("UpdateTeamColors", 1)
 		  end,
 		},
+		{ id = "simpleteamcolorsfactionspecific", group = "accessibility", category = types.dev, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.simpleteamcolorsfactionspecific'), type = "bool", value = tonumber(Spring.GetConfigInt("SimpleTeamColorsFactionSpecific", 0) or 0) == 1, description = Spring.I18N('ui.settings.option.simpleteamcolorsfactionspecific_descr'),
+		  onchange = function(i, value)
+			  Spring.SetConfigInt("SimpleTeamColorsFactionSpecific", (value and 1 or 0))
+			  Spring.SetConfigInt("UpdateTeamColors", 1)
+		  end,
+		},
 		{ id = "simpleteamcolors_player_r", group = "accessibility", category = types.basic, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.simpleteamcolors_player_r'), type = "slider", min = 0, max = 255, step = 1, value = tonumber(Spring.GetConfigInt("SimpleTeamColorsPlayerR", 0)),
 		  onchange = function(i, value)
 			  Spring.SetConfigInt("SimpleTeamColorsPlayerR", value)


### PR DESCRIPTION
Added new option for Simple Colors, allowing you to set colors based on the faction player is playing as. Meant for cinematics.
