### PR TITLE
Transport factory guard bug fix

### DIFF
--- a/luaui/Widgets/cmd_guard_transport_factory.lua
+++ b/luaui/Widgets/cmd_guard_transport_factory.lua
@@ -304,8 +304,8 @@ local function removePreDestinationMoveCommands(unitID, destination)
     for i = spGetUnitCommandCount(unitID), 1, -1 do
         local cmdID, options, tag, targetX, targetY, targetZ = Spring.GetUnitCurrentCommand(unitID, i)
 		if cmdID == CMD.MOVE then
-            local isDifferentDestination = targetX == destination[0] and targetY == destination[1] and targetZ == destination[2]
-            if isDifferentDestination then
+            local isSameMoveDestination = targetX == destination[0] and targetY == destination[1] and targetZ == destination[2]
+            if not isSameMoveDestination then
                 tags[#tags + 1] = qid
             end
 		else


### PR DESCRIPTION
Work done:
Change function to remove any move command before the destination, instead of just close by ones. 

The engine inserts a move command into the queue after a unit emerges from factory. We want to get rid of that command because it'll mess up the ferry functionality. The previous approach just removed any move commands nearby, but it wasn't big enough for some labs(namely cortex t2 bot) and it was broken in those cases.
Now we just remove whatever is between us and the destination command.