### PR TITLE
Transport factory guard bug fix

### DIFF
--- a/luaui/Widgets/cmd_guard_transport_factory.lua
+++ b/luaui/Widgets/cmd_guard_transport_factory.lua
@@ -308,16 +308,10 @@ local function removePreDestinationMoveCommands(unitID, destination)
             if not isSameMoveDestination then
                 tags[#tags + 1] = tag
             else 
-                if tags[1] then
-                    spGiveOrderToUnit(unitID, CMD_REMOVE, tags)
-                    return
-                end
+                break
             end
 		else
-            if tags[1] then
-                spGiveOrderToUnit(unitID, CMD_REMOVE, tags)
-                return
-            end
+            break
         end
 	end
 


### PR DESCRIPTION
Work done:
Change function to remove any move command before the destination, instead of just close by ones.

The engine inserts a move command into the queue after a unit emerges from factory. We want to get rid of that command because it'll mess up the ferry functionality. The previous approach just removed any move commands nearby, but it wasn't big enough for some labs(namely cortex t2 bot) and it was broken in those cases.
Now we just remove whatever is between us and the destination command.
