### PR TITLE
Fix regression in builder buggeroff

### DIFF
--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -274,7 +274,7 @@ function gadget:GameFrame(frame)
 		end
 	end
 
-	if needsUpdate or frame % SLOW_UPDATE_FREQUENCY ~= 0 then
+	if frame % SLOW_UPDATE_FREQUENCY ~= 0 and not needsUpdate then
 		return
 	end
 


### PR DESCRIPTION
Work done:
This commit regressed builder buggeroff: https://github.com/beyond-all-reason/Beyond-All-Reason/commit/10f090b8ced052301715ccbbcbf188699f48e24f.
The widget no longer does anything after that commmit. This fix fixes the bug introduced.