### PR TITLE
Fix typo in scenario010.lua tips section

### DIFF
--- a/singleplayer/scenarios/scenario010.lua
+++ b/singleplayer/scenarios/scenario010.lua
@@ -15,7 +15,7 @@ Tips:
  - If this scenario seems difficult, try it at a lower difficulty override
  - The enemy will expand rapidly, and the map is particularly resource rich
  - The enemy might send early aircraft raids, so your forward base has been equipped with anti-air turrets
- - The enemy base is very heavily defended with both Tier 2 ground defences and and anti-air.
+ - The enemy base is very heavily defended with both Tier 2 ground defences and anti-air.
 
 Scoring:
  - Time taken to complete the scenario


### PR DESCRIPTION
### Work done
remove duplicate "and"

before:

>  - The enemy base is very heavily defended with both Tier 2 ground defences and and anti-air.

after:

> - The enemy base is very heavily defended with both Tier 2 ground defences and anti-air.


<img width="2001" height="2002" alt="image" src="https://github.com/user-attachments/assets/51e8f0a8-c02d-4576-9f0c-caed2e5f1f06" />