### PR TITLE
Fixes #6745 Blueprint issues on change faction

### DIFF
--- a/luaui/Include/blueprint_substitution/logic.lua
+++ b/luaui/Include/blueprint_substitution/logic.lua
@@ -417,25 +417,29 @@ function BlueprintSubLogic.processBuildQueueSubstitution(originalBuildQueue, sou
     for _, bq_item in ipairs(originalBuildQueue) do
         if type(bq_item) == "table" and #bq_item >= 1 then
             local originalUnitDefID = bq_item[1]
-            if originalUnitDefID then
+            if originalUnitDefID and originalUnitDefID > 0 then
                 local originalUnitDef = UnitDefs[originalUnitDefID]
-                local originalUnitName = originalUnitDef.name
-                aggregatedStats.totalConsidered = aggregatedStats.totalConsidered + 1
-                local buildingData = BlueprintSubLogic.MasterBuildingData[originalUnitName:lower()]
-                if buildingData then
-                    local outcome = _getBuildingSubstitutionOutcome(originalUnitName, buildingData, targetSide, sourceSide)
-                    if outcome.status == "substituted" then
-                        bq_item[1] = unitNameToDefIDMap[outcome.newUnitName:lower()]
-                        aggregatedStats.substituted = aggregatedStats.substituted + 1
-                    elseif outcome.status == "failed_no_mapping" then aggregatedStats.failedNoMapping = aggregatedStats.failedNoMapping + 1
-                    elseif outcome.status == "failed_invalid_equivalent" then aggregatedStats.failedInvalidEquivalent = aggregatedStats.failedInvalidEquivalent + 1
-                    elseif outcome.status == "unchanged_same_side" then aggregatedStats.unchangedSameSide = aggregatedStats.unchangedSameSide + 1
+                if not originalUnitDef then
+                    aggregatedStats.unchangedNotBuilding = aggregatedStats.unchangedNotBuilding + 1
+                else
+                    local originalUnitName = originalUnitDef.name
+                    aggregatedStats.totalConsidered = aggregatedStats.totalConsidered + 1
+                    local buildingData = BlueprintSubLogic.MasterBuildingData[originalUnitName:lower()]
+                    if buildingData then
+                        local outcome = _getBuildingSubstitutionOutcome(originalUnitName, buildingData, targetSide, sourceSide)
+                        if outcome.status == "substituted" then
+                            bq_item[1] = unitNameToDefIDMap[outcome.newUnitName:lower()]
+                            aggregatedStats.substituted = aggregatedStats.substituted + 1
+                        elseif outcome.status == "failed_no_mapping" then aggregatedStats.failedNoMapping = aggregatedStats.failedNoMapping + 1
+                        elseif outcome.status == "failed_invalid_equivalent" then aggregatedStats.failedInvalidEquivalent = aggregatedStats.failedInvalidEquivalent + 1
+                        elseif outcome.status == "unchanged_same_side" then aggregatedStats.unchangedSameSide = aggregatedStats.unchangedSameSide + 1
+                        else 
+                            aggregatedStats.unchangedOther = aggregatedStats.unchangedOther + 1
+                        end
                     else 
                         aggregatedStats.unchangedOther = aggregatedStats.unchangedOther + 1
+                        Spring.Log("BlueprintSubLogic", LOG.DEBUG, string.format("processBuildQueueSubstitution: No MasterBuildingData for %s. Item not substituted.", originalUnitName:lower()))
                     end
-                else 
-                    aggregatedStats.unchangedOther = aggregatedStats.unchangedOther + 1
-                    Spring.Log("BlueprintSubLogic", LOG.DEBUG, string.format("processBuildQueueSubstitution: No MasterBuildingData for %s. Item not substituted.", originalUnitDefID:lower()))
                 end
             else 
                 aggregatedStats.unchangedNotBuilding = aggregatedStats.unchangedNotBuilding + 1


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Fix crash in `processBuildQueueSubstitution()` that causes the pregame build widget to crash and all blueprints to disappear when switching factions while MOVE waypoints are in the build queue.

The build queue can contain two types of entries: building placements (positive UnitDefID) and MOVE waypoints placed via Shift+Right-Click (negative command ID, e.g. `-CMD.MOVE`). The substitution code assumed all entries were buildings and attempted `UnitDefs[negativeID].name`, which crashes because `UnitDefs[-35]` is nil.

The rendering code in `gui_pregame_build.lua` already handles this correctly with `if buildData[1] > 0` guards, but the substitution logic in `logic.lua` did not.

Changes:
1. Added `originalUnitDefID > 0` guard to skip command entries (negative IDs)
2. Added nil check on `UnitDefs[originalUnitDefID]` before accessing `.name`
3. Fixed a secondary bug where a debug log called `originalUnitDefID:lower()` on a number instead of `originalUnitName:lower()` on the string

#### Addresses Issue(s)
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6745

#### Test steps
- Start a skirmish in the pregame phase
- Queue several buildings (solar collectors, metal extractors, etc.)
- Add MOVE waypoints between buildings via Shift+Right-Click
- Switch factions (e.g. Armada to Cortex or Legion (Tested with and without enabled)). Expected: all building blueprints convert to the new faction's equivalents, MOVE waypoints are preserved, no widget crash
- Switch factions again (e.g. Cortex to Legion). Expected: same correct behavior
- Test with only buildings in the queue (no MOVE waypoints). Expected: no regression, buildings convert normally
- TTest with an empty queue. Expected: no regression

### Evidence

**Unfixed** engine infolog shows the crash on faction switch:
```
Error in DrawWorld(): [string "luaui/Include/blueprint_substitution/logic.lua"]:422:
    attempt to index local 'originalUnitDef' (a nil value)
```
And then am unable to place blueprints at all

**Fixed** engine infolog shows zero widget errors. Blueprint widgets load and operate cleanly through faction switching.

**Claude Code Opus 4.6 was used to diagnose the issue and make the PR description look prettier than I care to make it**
