### PR TITLE
Fix unknown shield weapon number in UnitDestroyed

### DIFF
--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -556,6 +556,10 @@ function gadget:ShieldPreDamaged(proID, proOwnerID, shieldWeaponNum, shieldUnitI
 		return true
 	end
 
+	if shieldWeaponNum and not shieldData.shieldWeaponNumber then
+		shieldData.shieldWeaponNumber = shieldWeaponNum
+	end
+
 	-- Process scripted weapon types first (dgun, cluster, overpen, area timed). These can override any behaviors, potentially.
 	for lookup, callback in pairs(scriptedShieldDamages) do
 		if lookup[proID] then -- TODO: filtering for beam weapons (projectileID == -1) is not especially effective here.


### PR DESCRIPTION
### Work done

- Get around having unknown shieldWeaponNumber in a few ways. This seems like unusual code.
- Use a more general method for getting the shield's emit position when a unit is destroyed.

#### Addresses Issue(s)

Fixes an error:

```
log\20260208111413_infolog.txt
[t=00:16:51.095181][f=0000750] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=UnitDestroyed trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_shield_behaviour.lua"]:307: bad argument #2 to 'spGetUnitWeaponVectors' (number expected, got nil)
```

When a unit is destroyed and we attempt to preserve its shield data for the next frame (to handle shields remaining active until the end of that frame).