### PR TITLE
fix potential nil in GameEnd in gfx_wade_fx

### DIFF
--- a/luarules/gadgets/gfx_wade_fx.lua
+++ b/luarules/gadgets/gfx_wade_fx.lua
@@ -93,11 +93,15 @@ end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
 	local data = unit[unitID]
 	if data then
-		-- move last entry to position of current unit destroyed
 		local unitIndex = data.id
 		local lastUnitID = unitsData[unitsCount]
-		unitsData[unitIndex] = lastUnitID
-		unit[lastUnitID].id = unitIndex
+		if lastUnitID then
+			-- move last entry to position of current unit destroyed
+			unitsData[unitIndex] = lastUnitID
+			unit[lastUnitID].id = unitIndex
+		else
+			unitsData[unitIndex] = nil
+		end
 		-- remove destroyed unit from data
 		unit[unitID] = nil
 		-- remove last entry


### PR DESCRIPTION
Previous code could pass a nil `lastUnitID`.

#### Addresses Issue(s)

Fixes error message:

```
log\20260208200437_infolog.txt
[t=02:12:41.250011][f=0051893] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=UnitDestroyed trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/gfx_wade_fx.lua"]:100: attempt to index field '?' (a nil value)
```