### PR TITLE
fix: unit_evolution calls fake SetUnitTarget

### DIFF
--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -93,10 +93,11 @@ if gadgetHandler:IsSyncedCode() then
 	}
 
 	local function reAssignAssists(newUnit,oldUnit)
-		local allUnits = Spring.GetAllUnits(newUnit)
+		local allUnits = Spring.GetAllUnits()
 		for _,unitID in pairs(allUnits) do
 			if GG.GetUnitTarget and GG.GetUnitTarget(unitID) == oldUnit and newUnit then
-				GG.SetUnitTarget(unitID, newUnit)
+				-- GG.SetUnitTarget(unitID, newUnit) -- FIXME: unit_target_on_the_move provides only GetUnitTarget
+				Spring.SetUnitTarget(unitID, newUnit)
 			end
 
 			local cmds = Spring.GetUnitCommands(unitID, -1)


### PR DESCRIPTION
Though it would be better, probably, for the Set Target code to handle a GG.SetUnitTarget.

### Work done

- Swap GG.SetUnitTarget to Spring.SetUnitTarget, which is only slightly less good, but exists.

#### Addresses Issue(s)

Fixes error:

```
[t=00:24:32.180604][f=0037650] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/unit_evolution.lua"]:99: attempt to call field 'SetUnitTarget' (a nil value)
```