### PR TITLE
fix error in power calc when scavs have zero power

### DIFF
--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1170,10 +1170,6 @@ if gadgetHandler:IsSyncedCode() then
 		local couldDetermineDifficulty = calculateDifficultyMultiplier(peakScavPower, totalPlayerTeamPower)
 		squadManagerKillerLoop()
 
-		if not couldDetermineDifficulty then
-			return -- scavs were reported to have zero peak power, most likely
-		end
-
 		Spring.Log("Dynamic Difficulty", LOG.INFO, 'Scavengers dynamicDifficultyClamped:  ' .. tostring(dynamicDifficultyClamped))
 
 		waveParameters.baseCooldown = waveParameters.baseCooldown - 1
@@ -1185,6 +1181,10 @@ if gadgetHandler:IsSyncedCode() then
 		waveParameters.hugeWave.cooldown = waveParameters.hugeWave.cooldown - 1
 		waveParameters.epicWave.cooldown = waveParameters.epicWave.cooldown - 1
 		--waveParameters.frontbusters.cooldown = waveParameters.frontbusters.cooldown - 1
+
+		if not couldDetermineDifficulty then
+			return -- scavs were reported to have zero peak power, most likely
+		end
 
 		waveParameters.waveSpecialPercentage = mRandom(5,50)
 		waveParameters.waveAirPercentage = mRandom(10,25)


### PR DESCRIPTION
Seems to be an issue only with luarules reloads. At least, I couldn't figure out how else this would happen so far into a match (logs from 7 minutes, 8 minutes, 24 minutes, ...2 hours and 8 minutes).

### Work done

Check for div0 and arithmetic on nil before doing any computation on `peakScavPower` or `totalPlayerTeamPower` in scav_spawner_defense.

Fixes error:

```
[t=00:10:19.954098][f=0003016] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=GameFrame trace=[Internal Lua error: Call failure] [string "LuaRules/Gadgets/scav_spawner_defense.lua"]:1282: attempt to perform arithmetic on upvalue 'dynamicDifficultyClamped' (a nil value)
```