### PR TITLE
handle nil's passed to math.getClosestPosition

### DIFF
--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -203,7 +203,7 @@ if not math.HSLtoRGB then
 		---@param positions {x:number, z:number}[] must have fields .x and .z
 		---@return {x:number, z:number}? position
 		function math.getClosestPosition(x, z, positions)
-			if not positions or #positions <= 0 then
+			if not (x and z and positions and positions[1]) then
 				return
 			end
 			local bestPos


### PR DESCRIPTION
### Work done

- The function checks for nils in its array argument, but the only non-validated args it receives in the code base are x-z coordinates from command parameters (which can be anything, because of user widgets). So, this PR checks its x and z args for nil.
- Fix the method signature on math.getClosestPosition, also.

#### Addresses Issue(s)

Fixes an error:

```
[t=00:04:02.649893][f=0002610] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=AllowCommand trace=[Internal Lua error: Call failure] [string "common/numberfunctions.lua"]:212: attempt to perform arithmetic on local 'x' (a nil value)
```

Math functions don't normally include any logical handling, though this one already does; so, just make it work safely.