### PR TITLE
Fix: loopholes allowing capture of allied units

### DIFF
--- a/luarules/gadgets/unit_capture_only_enemy.lua
+++ b/luarules/gadgets/unit_capture_only_enemy.lua
@@ -22,11 +22,6 @@ local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
 
 local reissueOrder = Game.Commands.ReissueOrder
 
-local allowAreaCapture = false
-	or Spring.Utilities.Gametype.isSinglePlayer() -- Other teams are AI.
-	or (not Spring.Utilities.Gametype.isTeams()) -- Other teams are enemies.
-	or Spring.Utilities.Gametype.isSandbox() -- There is only one ally team.
-
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, fromSynced, fromLua, fromInsert)
 	-- accepts: CMD.CAPTURE
 	local nParams = #cmdParams
@@ -41,9 +36,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		end
 	elseif nParams == 4 then
 		-- Command is targeting an area.
-		if allowAreaCapture or not cmdOptions.ctrl then
-			return true
-		else
+		if cmdOptions.ctrl then
 			cmdOptions.ctrl = false
 			reissueOrder(unitID, cmdID, cmdParams, cmdOptions, cmdTag, fromInsert)
 			return false


### PR DESCRIPTION
### Work done

- Adds capture area command handling in unit_capture_only_enemy
- Reissues area commands with benign command modifiers to disallow allied capture
- Fixes misuse of `Spring.GetTeamInfo` in unit_capture_only_enemy

#### Addresses Issue(s)

We had multiple reports that it was possible to capture allied team's units. This addresses some bugs, which are unlikely to cause the behavior (but can), and then handles area commands with the CTRL modifier, which are a known cause. Inserted space+capture commands were fixed in an earlier PR.

### Test steps

- [ ] Spawn into a match with allies. Try to capture them directly. Then, try to capture them with an area capture command.
- [ ] Repeat above with all command modifiers (or just Ctrl).