### PR TITLE
Order menu: show per-state hotkey tap hints for state commands

### DIFF
--- a/luaui/Include/state_hotkey_hints.lua
+++ b/luaui/Include/state_hotkey_hints.lua
@@ -1,0 +1,82 @@
+local M = {}
+
+local function getTapCount(rawHotkey)
+	if type(rawHotkey) ~= "string" or rawHotkey == "" then
+		return 0
+	end
+
+	local taps = 1
+	for _ in string.gmatch(rawHotkey, ",") do
+		taps = taps + 1
+	end
+	return taps
+end
+
+function M.buildStateHotkeyHints(actionHotkeys, actionName, stateCount, sanitizeHotkeyFn, getStateLabelFn)
+	if type(actionHotkeys) ~= "table" or type(actionName) ~= "string" or type(stateCount) ~= "number" then
+		return {}
+	end
+
+	local hints = {}
+	local dedupe = {}
+
+	for stateValue = 0, stateCount - 1 do
+		local rawHotkey = actionHotkeys[actionName .. "_" .. stateValue]
+		if rawHotkey ~= nil and rawHotkey ~= "" then
+			local hotkey = rawHotkey
+			if sanitizeHotkeyFn then
+				hotkey = sanitizeHotkeyFn(rawHotkey)
+			end
+			if hotkey ~= nil and hotkey ~= "" then
+				local stateLabel = tostring(stateValue)
+				if getStateLabelFn then
+					stateLabel = getStateLabelFn(stateValue) or stateLabel
+				end
+
+				local dedupeKey = hotkey .. "\31" .. stateLabel
+				if not dedupe[dedupeKey] then
+					dedupe[dedupeKey] = true
+					hints[#hints + 1] = {
+						hotkey = hotkey,
+						stateLabel = stateLabel,
+						taps = getTapCount(rawHotkey),
+					}
+				end
+			end
+		end
+	end
+
+	table.sort(hints, function(a, b)
+		if a.taps ~= b.taps then
+			return a.taps < b.taps
+		end
+		if #a.hotkey ~= #b.hotkey then
+			return #a.hotkey < #b.hotkey
+		end
+		return a.hotkey < b.hotkey
+	end)
+
+	return hints
+end
+
+function M.formatStateHotkeyHints(hints, highlightColor, textColor)
+	if type(hints) ~= "table" or #hints == 0 then
+		return ""
+	end
+
+	local lines = {}
+	for i = 1, #hints do
+		local hint = hints[i]
+		lines[#lines + 1] = string.format(
+			"%s%s%s = %s",
+			highlightColor or "",
+			string.upper(hint.hotkey),
+			textColor or "",
+			hint.stateLabel
+		)
+	end
+
+	return table.concat(lines, "\n")
+end
+
+return M

--- a/luaui/Tests/gui_ordermenu/test_state_hotkey_hints.lua
+++ b/luaui/Tests/gui_ordermenu/test_state_hotkey_hints.lua
@@ -1,0 +1,54 @@
+local stateHotkeyHints = VFS.Include("luaui/Include/state_hotkey_hints.lua")
+
+local function sanitizeHotkey(rawHotkey)
+	return rawHotkey:gsub("sc_", "")
+end
+
+function test_builds_and_sorts_state_hotkeys_by_tap_count()
+	local actionHotkeys = {
+		firestate_0 = "sc_l,sc_l",
+		firestate_1 = "sc_l,sc_l,sc_l",
+		firestate_2 = "sc_l",
+	}
+	local stateLabels = {
+		[0] = "Hold fire",
+		[1] = "Fire at will",
+		[2] = "Return fire",
+	}
+
+	local hints = stateHotkeyHints.buildStateHotkeyHints(
+		actionHotkeys,
+		"firestate",
+		3,
+		sanitizeHotkey,
+		function(stateValue)
+			return stateLabels[stateValue]
+		end
+	)
+
+	assert(#hints == 3, "expected 3 hotkey hints")
+	assert(hints[1].hotkey == "l", "single tap hotkey should be first")
+	assert(hints[1].stateLabel == "Return fire", "single tap state label mismatch")
+	assert(hints[1].taps == 1, "single tap count mismatch")
+	assert(hints[2].hotkey == "l,l", "double tap hotkey should be second")
+	assert(hints[2].taps == 2, "double tap count mismatch")
+	assert(hints[3].hotkey == "l,l,l", "triple tap hotkey should be third")
+	assert(hints[3].taps == 3, "triple tap count mismatch")
+end
+
+function test_formats_state_hotkeys_with_labels()
+	local hints = {
+		{ hotkey = "l", stateLabel = "Return fire", taps = 1 },
+		{ hotkey = "l,l", stateLabel = "Hold fire", taps = 2 },
+	}
+
+	local text = stateHotkeyHints.formatStateHotkeyHints(hints, "<H>", "<T>")
+
+	assert(text:find("<H>L<T> = Return fire", 1, true) ~= nil, "formatted output missing first line")
+	assert(text:find("<H>L,L<T> = Hold fire", 1, true) ~= nil, "formatted output missing second line")
+end
+
+function test()
+	test_builds_and_sorts_state_hotkeys_by_tap_count()
+	test_formats_state_hotkeys_with_labels()
+end


### PR DESCRIPTION
## Summary
Fixes the hotkey UX mismatch behind #6323 by showing explicit per-state tap bindings in order-menu tooltips for state commands (firestate/movestate/repeat/onoff/trajectory).

Previously, tooltips only showed the shortest bind (for example L), which hides the configured multi-tap behavior (L, L,L, L,L,L) and makes state toggles feel inconsistent.

This PR:
- adds luaui/Include/state_hotkey_hints.lua to build and format per-state hotkey hints from existing action_hotkeys data
- integrates those hints into gui_ordermenu.lua tooltips for state commands
- adds regression test luaui/Tests/gui_ordermenu/test_state_hotkey_hints.lua

## Testing
Ran headless test runner with a targeted test pattern for this fix (
untestsheadless state_hotkey_hints).

Result (	ools/headless_testing/testlog/results.json):
- tests: 2
- passes: 1
- failures: 0
- skipped: 1
- passing test: gui_ordermenu/test_state_hotkey_hints.lua

