### PR TITLE
add Game constants for initial spawn and warp-in

### DIFF
--- a/common/constants.lua
+++ b/common/constants.lua
@@ -41,3 +41,16 @@ if CMD then
 	CMD.a     = "ANY"
 	CMD.b     = "BUILD"
 end
+
+--------------------------------------------------------------------------------
+-- Game constants --------------------------------------------------------------
+
+if Game then
+	---The first frame that units are spawned. Used for scenario units and commanders.
+	---@type integer
+	Game.spawnInitialFrame = 2 * Game.gameSpeed
+
+	---Non-scenario starting units spend a number of frames warping/teleporting in.
+	---@type integer
+	Game.spawnWarpInFrame = 3 * Game.gameSpeed
+end

--- a/luarules/gadgets/fx_atmosphere.lua
+++ b/luarules/gadgets/fx_atmosphere.lua
@@ -49,7 +49,7 @@ local data = {
     beach_rareSoundBank = {"ocean1", "ocean2", "ocean3", "ocean4", "ocean5", "ocean6", },
 }
 
-
+local spawnWarpInFrame = Game.spawnWarpInFrame
 
 
 
@@ -148,12 +148,11 @@ end
 
 function gadget:GameFrame(n)
     -- Collect data for sounds.
-    if n == 90 then 
+    if n == spawnWarpInFrame then
         CollectGeoVentPositions()
         UpdateAllData()
-    end
 
-    if n > 90 then
+	elseif n > spawnWarpInFrame then
 
         if data.geo_numberOfGeoVentPositions > 0 then
             if n%data.geo_soundDelay == 0 then -- play sound

--- a/luarules/gadgets/game_commander_builder.lua
+++ b/luarules/gadgets/game_commander_builder.lua
@@ -42,6 +42,8 @@ if Spring.GetModOptions().experimentallegionfaction then
 	spawnpads[UDN.legcom.id] = "legnanotcbase"
 end
 
+local spawnFrame = Game.spawnWarpInFrame + Game.gameSpeed * 2 -- add time to deconflict initial build orders
+
 function SpawnAssistTurret(unitID, unitDefID, unitTeam)
 	local posx, posy, posz = Spring.GetUnitPosition(unitID)
     local spawnpadunit = spawnpads[unitDefID]
@@ -84,7 +86,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 end
 
 function gadget:GameFrame(n)
-    if n == 150 then
+    if n == spawnFrame then
         for comID, _ in pairs(commandersList) do
             local comDefID = Spring.GetUnitDefID(comID)
             local comTeam = Spring.GetUnitTeam(comID)

--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -206,7 +206,7 @@ local function AllowUnitBuildStep(self, builderID, builderTeam, unitID, unitDefI
 	return true
 end
 
-local seed = math.random(91, 119) -- skip spawn-in frames
+local seed = math.random(Game.spawnWarpInFrame + 1, Game.spawnWarpInFrame + Game.gameSpeed - 1)
 
 function gadget:GameFrame(frame)
     if frame % seed == 0 then

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -46,6 +46,9 @@ if gadgetHandler:IsSyncedCode() then
 
 	local allowEnemyAIPlacement = Spring.GetModOptions().allow_enemy_ai_spawn_placement or false
 
+	local spawnInitialFrame = Game.spawnInitialFrame
+	local spawnWarpInFrame = Game.spawnWarpInFrame
+
 	----------------------------------------------------------------
 	-- Vars
 	----------------------------------------------------------------
@@ -689,7 +692,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:GameFrame(n)
 		if not scenarioSpawnsUnits then
-            if n == 60 then
+            if n == spawnInitialFrame then
 
                 for i = 1, #startUnitList do
                     local x = startUnitList[i].x
@@ -700,7 +703,7 @@ if gadgetHandler:IsSyncedCode() then
 
                 end
             end
-            if n == 90 then
+            if n == spawnWarpInFrame then
                 for i = 1, #startUnitList do
                     local unitID = startUnitList[i].unitID
                     Spring.MoveCtrl.Disable(unitID)
@@ -713,7 +716,7 @@ if gadgetHandler:IsSyncedCode() then
                 end
             end
 		end
-		if n > 90 then
+		if n > spawnWarpInFrame then
 			gadgetHandler:RemoveGadget(self)
 		end
 	end
@@ -732,17 +735,19 @@ else -- UNSYNCED
 		gadgetHandler:AddSyncAction("PositionTooClose", positionTooClose)
 	end
 
+	local spawnInitialFrame = Game.spawnInitialFrame
+	local spawnWarpInFrame = Game.spawnWarpInFrame
+
 	function gadget:GameFrame(n)
-		if n == 60 then
+		if n == spawnInitialFrame then
 			Spring.PlaySoundFile("commanderspawn", 0.6, 'ui')
 		end
-		if n > 90 then
+		if n > spawnWarpInFrame then
 			gadgetHandler:RemoveGadget(self)
 		end
 	end
 
 	function gadget:Shutdown()
 		gadgetHandler:RemoveSyncAction("PositionTooClose")
-
 	end
 end

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -145,8 +145,10 @@ local function MatchPlayer(awardees, name, accountID)
 	return false
 end
 
+local spawnWarpInFrame = Game.spawnWarpInFrame
+
 function gadget:GameFrame(gf)
-	if gf == 90 then
+	if gf == spawnWarpInFrame then
 		for _, playerID in ipairs(Spring.GetPlayerList()) do
 
 			local accountID = false

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -34,6 +34,8 @@ local spEcho = Spring.Echo
 
 local spTestBuildOrder = Spring.TestBuildOrder
 
+local spawnWarpInFrame = Game.spawnWarpInFrame
+
 local buildQueue = {}
 local selBuildQueueDefID
 local facingMap = { south = 0, east = 1, north = 2, west = 3 }
@@ -1410,7 +1412,7 @@ function widget:GameFrame(n)
 	end
 
 	-- handle the pregame build queue
-	if not (n <= 90 and n > 1) then
+	if n <= 1 or n > spawnWarpInFrame then
 		return
 	end
 

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -45,6 +45,7 @@ local borderPadding = 5
 local bladeSpeedMultiplier = 0.2
 local escapeKeyPressesQuit = false
 local allowSavegame = true -- Spring.Utilities.ShowDevUI()
+local spawnWarpInFrame = Game.spawnWarpInFrame
 
 -- System
 local guishaderEnabled = false
@@ -587,7 +588,7 @@ local function updateResbarText(res, force)
 		end
 	end
 
-	if not spec and gameFrame > 90 then
+	if not spec and gameFrame > spawnWarpInFrame then
 		-- display overflow notification
 		if (res == 'metal' and (allyteamOverflowingMetal or overflowingMetal)) or (res == 'energy' and (allyteamOverflowingEnergy or overflowingEnergy)) then
 			if not showOverflowTooltip[res] then showOverflowTooltip[res] = now + 1.1 end
@@ -1389,7 +1390,7 @@ local function drawResBars()
 		if not useRenderToTexture then
 			glCallList(dlistResbar[res][1])
 		end
-		if not spec and gameFrame > 90 and dlistResbar[res][4] then
+		if not spec and gameFrame > spawnWarpInFrame and dlistResbar[res][4] then
 			glBlending(GL.SRC_ALPHA, GL.ONE)
 			if allyteamOverflowingMetal then
 				gl.Color(1, 0, 0, 0.1 * allyteamOverflowingMetal * blinkProgress)
@@ -1436,7 +1437,7 @@ local function drawResBars()
 			glCallList(dlistResbar[res][1])
 		end
 
-		if not spec and gameFrame > 90 and dlistResbar[res][4] then
+		if not spec and gameFrame > spawnWarpInFrame and dlistResbar[res][4] then
 			glBlending(GL.SRC_ALPHA, GL.ONE)
 			if allyteamOverflowingEnergy then
 				gl.Color(1, 0, 0, 0.1 * allyteamOverflowingEnergy * blinkProgress)


### PR DESCRIPTION
### Work done

- add Game.spawnInitialFrame and Game.spawnWarpInFrame to handle BAR's staggered spawn times at game start
- use these in places of magicky numbers in various code
