### PR TITLE
add g:UnitAutoTargetRange artificial callin

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -208,6 +208,7 @@ local callInLists = {
 	"AllowWeaponTargetCheck",
 	"AllowWeaponTarget",
 	"AllowWeaponInterceptTarget",
+	"UnitAutoTargetRange",
 	-- unsynced
 	"DrawUnit",
 	"DrawFeature",
@@ -1701,22 +1702,32 @@ end
 
 function gadgetHandler:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
 	local allowed = true
-	local priority = 1.0
+	local result = 1.0
 
-	for _, g in ipairs(self.AllowWeaponTargetList) do
-		local targetAllowed, targetPriority = g:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
-
-		if not targetAllowed then
-			allowed = false;
-			break
+	if targetID == -1 and attackerWeaponNum == -1 then
+		-- The `targetPriority` return value is actually the autotarget search radius,
+		-- and applies to the unit's targeting search for its command AI, not weapons.
+		for _, g in ipairs(self.UnitAutoTargetRangeList) do
+			defPriority = g:UnitAutoTargetRange(attackerID, defPriority)
 		end
-		if targetPriority > priority then
-			priority = targetPriority
+		allowed, result = defPriority > 0, defPriority
+	else
+		for _, g in ipairs(self.AllowWeaponTargetList) do
+			local targetAllowed, targetPriority = g:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
+
+			if not targetAllowed then
+				allowed = false;
+				break
+			end
+			if targetPriority > result then
+				result = targetPriority
+			end
 		end
 	end
 
-	return allowed, priority
+	return allowed, result
 end
+
 
 function gadgetHandler:AllowWeaponInterceptTarget(interceptorUnitID, interceptorWeaponNum, interceptorTargetID)
 	for _, g in ipairs(self.AllowWeaponInterceptTargetList) do

--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -66,9 +66,6 @@ if gadgetHandler:IsSyncedCode() then
 
 	local targetCheckStats = {} -- unitDefID : count
 	function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
-		if targetID == -1 and attackerWeaponNum == -1 then
-			return true, defPriority
-		end
 		local unitDefID = spGetUnitDefID(targetID)
 		if unitDefID then
 			targetCheckStats[unitDefID] = (targetCheckStats[unitDefID] or 0) + 1


### PR DESCRIPTION
### Work done

Sets up a BAR-specific callin, UnitAutoTargetRange, to handle the special case in AllowWeaponTarget. This case asks for a different return value, the search radius, rather than a target priority, and it applies that search to the unit's target acquisition, not to a single weapon on the unit.

#### Addresses Issue(s)

See notes on https://github.com/beyond-all-reason/RecoilEngine/issues/1623

Maybe deprecated by https://github.com/beyond-all-reason/RecoilEngine/pull/2816 (edit: doesn't look like it)