### PR TITLE
add heat extinction rate to ground scarring in water

### DIFF
--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -1064,7 +1064,7 @@ for weaponDefID=1, #WeaponDefs do
 			positionVariation = buildingExplosionPositionVariation[weaponDef.name]
 		end
 
-		weaponConfig[weaponDef.id] = {
+		weaponConfig[weaponDefID] = {
 			--[[  1 ]] textures,
 			--[[  2 ]] radius,
 			--[[  3 ]] radiusVariation,


### PR DESCRIPTION
### Work done

Glowing ground scars from explosions have less initial heat and alpha in water.

I tested this on #6513 and am splitting this out to its own PR since it is a change that impacts all weapons, not just the timed area effects.

Our water fx don't obscure ground scar decals very much, and these can show visible scorches and glows through the water. The intention is both to realistically decrease the amount of ground scarring on underwater terrain and to give a more watery effect on the decals.

Very large detonations in shallow water, when water_splash is not disabled on the weapon, still might leave no crater at all. Which is awkward. These return noGfx in g:Explosion, so never reach w:VisibleExplosion, so get no decals. A Vanguard that hits a unit in a shallow crossing leaves a crater, while one that hits the water does not.