### PR TITLE
Allow sound notifications to be suspended

### DIFF
--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -467,7 +467,7 @@ local function queueNotification(event, forceplay)
 end
 
 function widget:RecvLuaMsg(message)
-	if message:find("suspendNotifications|") then
+	if message:find("suspendNotifications ") then
 		local duration = tonumber(message:sub(22))
 		if duration and duration > 0 then
 			suspendUntilSec = sec + duration


### PR DESCRIPTION
### Work done

Allow the sound notifications queue to be suspended temporarily.

This is needed by the Mission API for avoiding its voice alerts to play at the same time as the sound notifications.

### Testing
These changes are also in https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6964 where a test mission tests them.