### PR TITLE
some DGun behavior improvements

### DIFF
--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -115,7 +115,7 @@ function gadget:GameFrame(frame)
 		local x, y, z = spGetProjectilePosition(proID)
 		local h = spGetGroundHeight(x, z)
 
-		if y < h + 1 or y < 0 then -- assume ground or water collision
+		if y < h + 1 or y < 1 then -- assume ground or water collision
 			-- normalize horizontal velocity
 			local dx, _, dz, speed = spGetProjectileVelocity(proID)
 			local horizontalMagnitude = mathSqrt(dx ^ 2 + dz ^ 2)


### PR DESCRIPTION
### Work done

I ran into odd cases in unit_dgun_behaviour.lua when trying to change how the projectile TTL is determined, and tried to fix them in a batch:

- Use the engine's explosions to avoid managing weaponDef properties in game code. I think this method can cause problems if not handled correctly (but this does so).
- Waits both to detonate and to delete DGun projectiles until the end of their last frame alive, allowing for shield collisions on that frame. This avoids reducing DGun range by about 1 frame (~30 distance) vs shields.
- Does not force the projectile to explode on the same frame that it becomes "grounded". Grounded DGuns already explode, so previously would explode twice.
- Projectiles pinned to exactly y=0 would not be transferred to the grounded DGuns, so also could detonate twice. I made the snap-to-ground range larger than strictly needed, but this way the water-height and terrain-height comparisons are the same as one another, which seems like a net good.

#### Addresses Issue(s)

- DGuns are weird
