### PR TITLE
 Home grid prioritises Advanced labs and gantries

### DIFF
--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -3,11 +3,13 @@
 local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
 local labGrids = configs.LabGrids
 local unitGrids = configs.UnitGrids
+local priorityUnits = configs.PriorityUnits
 
 local unitGridPos = { }
 local gridPosUnit = { }
 local hasUnitGrid = { }
 local homeGridPos = { }
+local homePriority = {}
 
 local unitCategories = {}
 
@@ -121,6 +123,16 @@ for uname, ugrid in pairs(labGrids) do
 	end
 end
 
+for _, unit in ipairs(priorityUnits) do
+	local prioritDef = UnitDefNames[unit]
+	if not prioritDef then
+		Spring.Echo('gridmenu config: no unitdefname found for: '..unit)
+	else
+		local priorityId = prioritDef.id
+    	homePriority[priorityId] = true
+	end
+end
+
 
 for unitDefID, unitDef in pairs(UnitDefs) do
 	unitCategories[unitDefID] = categoryGroupMapping[unitDef.customParams.unitgroup] or BUILDCAT_UTILITY
@@ -187,6 +199,25 @@ local function getGridForCategory(builderId, buildOptions, currentCategory)
 	end
 end
 
+local function filterByPriority(uncategorizedOpts, homePriority)
+    if not uncategorizedOpts then
+		return nil
+	end
+
+	local priorityOpts = {}
+    	for catIndex, cat in ipairs(uncategorizedOpts) do
+        	local filteredCat = {}
+
+        	for _, unitID in ipairs(cat) do
+               	if homePriority[unitID] then
+                   	table.insert(filteredCat, unitID)
+				end
+        	end
+			priorityOpts[catIndex] = filteredCat
+    	end
+
+    return priorityOpts
+end
 
 -- grid indices are laid out like this
 -- 9  10 11 12
@@ -196,8 +227,10 @@ end
 function homeOptionsForBuilder(builderId, buildOptions)
 	local options = {}
 	local uncategorizedOpts = homeGridPos[builderId]
+	local priorityOpts = filterByPriority(uncategorizedOpts, homePriority)
 
 	if uncategorizedOpts then
+		local usedOptions = {}
 		local optionsInRow = 0
 		for cat = 1, #uncategorizedOpts do
 			for _, uDefID in pairs(uncategorizedOpts[cat]) do
@@ -207,10 +240,28 @@ function homeOptionsForBuilder(builderId, buildOptions)
 				optionsInRow = optionsInRow + 1
 				-- The grid is sorted by row, starting at the bottom. We want to order these items by column, so we switch their positions by changing the index
 				local index = (cat) + ((optionsInRow - 1) * columns)
-				options[index] = constructBuildOption(uDefID)
+                options[index] = constructBuildOption(uDefID)
+                usedOptions[uDefID] = true
 			end
 			optionsInRow = 0
 		end
+		-- Replace the top of row with the first unused priority unit in each category
+		local row = 3
+        for cat = 1, #priorityOpts do
+            local priorityUnits = priorityOpts[cat]
+            if priorityUnits then
+				local index = cat + ((row - 1) * columns)
+				local currentOption = -1*options[index].id
+				if not homePriority[currentOption] then -- Don't replace an already prioritized unit with another one
+					for i = 1, #priorityUnits do
+						if not usedOptions[priorityUnits[i]] then
+							options[index] = constructBuildOption(priorityUnits[i])
+							break
+						end
+					end
+				end
+        	end
+    	end
 	else
 		-- if the unit doesn't have a predefined grid we still want the "home" page to have units
 		-- So we build all the categories and grab the first 3 items from each one

--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -245,7 +245,7 @@ function homeOptionsForBuilder(builderId, buildOptions)
 			end
 			optionsInRow = 0
 		end
-		-- Replace the top of row with the first unused priority unit in each category
+		-- Replace the top row with the first unused priority unit in each category
 		local row = 3
         for cat = 1, #priorityOpts do
             local priorityUnits = priorityOpts[cat]

--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -199,22 +199,17 @@ local function getGridForCategory(builderId, buildOptions, currentCategory)
 	end
 end
 
-local function filterByPriority(uncategorizedOpts, homePriority)
-    if not uncategorizedOpts then
-		return nil
+local function filterByPriority(categoryOpts, homePriority)
+    local priorityOpts = {}
+	if not categoryOpts or next(homePriority) == nil then
+		return priorityOpts
 	end
 
-	local priorityOpts = {}
-    	for catIndex, cat in ipairs(uncategorizedOpts) do
-        	local filteredCat = {}
-
-        	for _, unitID in ipairs(cat) do
-               	if homePriority[unitID] then
-                   	table.insert(filteredCat, unitID)
-				end
-        	end
-			priorityOpts[catIndex] = filteredCat
-    	end
+    for _, unitID in ipairs(categoryOpts) do
+		if homePriority[unitID] then
+			table.insert(priorityOpts, unitID)
+		end
+	end
 
     return priorityOpts
 end
@@ -227,8 +222,7 @@ end
 function homeOptionsForBuilder(builderId, buildOptions)
 	local options = {}
 	local uncategorizedOpts = homeGridPos[builderId]
-	local priorityOpts = filterByPriority(uncategorizedOpts, homePriority)
-
+	
 	if uncategorizedOpts then
 		local usedOptions = {}
 		local optionsInRow = 0
@@ -243,25 +237,25 @@ function homeOptionsForBuilder(builderId, buildOptions)
                 options[index] = constructBuildOption(uDefID)
                 usedOptions[uDefID] = true
 			end
-			optionsInRow = 0
-		end
-		-- Replace the top row with the first unused priority unit in each category
-		local row = 3
-        for cat = 1, #priorityOpts do
-            local priorityUnits = priorityOpts[cat]
-            if priorityUnits then
+			-- Replace the top row with the first unused priority unit in each category
+			local priorityOpts = filterByPriority(uncategorizedOpts[cat], homePriority)
+			local row = 3 
+			if next(priorityOpts) ~= nil then
 				local index = cat + ((row - 1) * columns)
 				local currentOption = -1*options[index].id
 				if not homePriority[currentOption] then -- Don't replace an already prioritized unit with another one
-					for i = 1, #priorityUnits do
-						if not usedOptions[priorityUnits[i]] then
-							options[index] = constructBuildOption(priorityUnits[i])
+					for i = 1, #priorityOpts do
+						if not usedOptions[priorityOpts[i]] then
+							options[index] = constructBuildOption(priorityOpts[i])
 							break
 						end
 					end
 				end
         	end
-    	end
+
+			optionsInRow = 0
+		end
+
 	else
 		-- if the unit doesn't have a predefined grid we still want the "home" page to have units
 		-- So we build all the categories and grab the first 3 items from each one

--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -2521,6 +2521,8 @@ local unitGrids = {
 	},
 }
 
+local priorityUnits = {"armshltx","armshltxuw","corgant","corgantuw","leggant","leggantuw","armalab", "armavp", "armasy", "armaap", "coralab", "coravp", "corasy", "coraap", "legalab", "legavp", "legadvshipyard", "legaap"}
+
 unitGrids["dummycom"] = unitGrids["armcom"]
 
 if Spring.GetModOptions().experimentalextraunits or Spring.GetModOptions().scavunitsforplayers then
@@ -3327,4 +3329,5 @@ end
 return {
 	LabGrids = labGrids,
 	UnitGrids = unitGrids,
+	PriorityUnits = priorityUnits
 }


### PR DESCRIPTION
### Work done
Adds a priority filter to the grid menu to allow the top row to be replaced by chosen priority buildings. Initially this only prioritizes the 4 advanced labs and 2 experimental gantries. 

#### Addresses Issue(s)
[Issue URL](https://discord.com/channels/549281623154229250/1420636389418205225)

Note, only the bottom row of the home grid is accessible via keybind (the grid category keys `zxcv`). The second and third rows are only there to be clicked with the mouse and _already_ do not stay put in terms of ergonomics. I.e. In the current master base game, top right (index 12) is air lab for the T1 cons, which is `v,c`. But top right (index 12) for an advanced con is the advanced lab which is `v,s` due to the location of the items in the actual grid category menus. 

#### Setup
Be using grid menu

#### Test steps
- [ ] Test the home menu (before selecting a build category) for base game constructors
- [ ] Test the home menu (before selecting a build category) for  constructors with extensive options for example extra units+scav units for players. 

### Screenshots:

#### BEFORE:
Base game:
Note: Hover and seaplane cons don't show any advanced lab. 
<img width="451" height="1537" alt="Master_base" src="https://github.com/user-attachments/assets/cc47a9a1-3fcc-4752-a74c-f575c7c8d492" />

With extra units and scav units for players:
Note: Advanced con loses gantry visibility because advanced nano is lower index in the build category. Hover and seaplane cons don't show any advanced lab. 
<img width="454" height="1537" alt="Master_scav" src="https://github.com/user-attachments/assets/f2b72363-dd4f-4947-99aa-59e95c4c3053" />

#### AFTER:
Base game:
Note: No change to advanced con as already showed priority building. Hover and seaplane cons now show an advanced lab. (Hover only shows the first of two available) 
<img width="454" height="1541" alt="PR_base" src="https://github.com/user-attachments/assets/fad3f984-3bcb-4b0a-b237-269f7f1f5127" />

With extra units and scav units for players:
Note: Advanced con now keeps gantry (advanced nano is replaced). Hover and seaplane cons still show an advanced lab. (Hover only shows the first of two available) 
<img width="450" height="1537" alt="PR_scav" src="https://github.com/user-attachments/assets/1882129d-a17e-4019-9bd0-176c15fc517a" />

### AI / LLM usage statement:
LLM (copilot) only used to parse existing home grid building structures. 
