### PR TITLE
Disables Legion Fortifier

### DIFF
--- a/units/Legion/Constructors/legaca.lua
+++ b/units/Legion/Constructors/legaca.lua
@@ -40,7 +40,7 @@ return {
 			"leganavaladvgeo",
 			"legrampart",
 			"legmoho",
-			"legmohocon",
+			--"legmohocon",
 			"legadveconv",
 			"legadvestore",
 			"legamstor",

--- a/units/Legion/Constructors/legack.lua
+++ b/units/Legion/Constructors/legack.lua
@@ -43,7 +43,7 @@ return {
 			"legageo",
 			"legrampart",
 			"legmoho",
-			"legmohocon",
+			--"legmohocon",
 			"legadveconv",
 			"legadvestore",
 			"legamstor",

--- a/units/Legion/Constructors/legacv.lua
+++ b/units/Legion/Constructors/legacv.lua
@@ -46,7 +46,7 @@ return {
 			"legageo",
 			"legrampart",
 			"legmoho",
-			"legmohocon",
+			--"legmohocon",
 			"legadveconv",
 			"legadvestore",
 			"legamstor",


### PR DESCRIPTION
Fortifier is removed from T2 con build lists until fixes have been made.