### PR TITLE
Support mission API in scenarios

### DIFF
--- a/luarules/gadgets/api_missions.lua
+++ b/luarules/gadgets/api_missions.lua
@@ -31,6 +31,7 @@ local function loadMission(scriptPath)
 
 	GG['MissionAPI'].Triggers = triggersController.ProcessRawTriggers(rawTriggers, rawActions)
 	GG['MissionAPI'].Actions = actionsController.ProcessRawActions(rawActions)
+	GG['MissionAPI'].Loadout = mission.Loadout
 
 	local validateReferences = VFS.Include('luarules/mission_api/validation.lua').ValidateReferences
 	validateReferences()

--- a/luarules/gadgets/unit_scenario_loadout.lua
+++ b/luarules/gadgets/unit_scenario_loadout.lua
@@ -3,7 +3,7 @@ local gadget = gadget ---@type Gadget
 function gadget:GetInfo()
 	return {
 		name = "Scenario Loadout",
-		desc = "Places initial units defined in scenariooptions.loadout",
+		desc = "Places initial units defined in scenariooptions.loadout or in a mission script's Loadout table",
 		author = "Beherith",
 		date = "2021.03.20",
 		license = "GNU GPL, v2 or later",
@@ -45,74 +45,92 @@ local teamList = {}
 local additionalStorage = {}
 local gaiaTeamID = Spring.GetGaiaTeamID()
 
+--- Append unit and feature entries from a loadout source table into the running lists.
+local function appendLoadout(unitloadout, featureloadout, source)
+	if source.unitloadout    then table.append(unitloadout,    source.unitloadout)    end
+	if source.featureloadout then table.append(featureloadout, source.featureloadout) end
+end
+
+--- Collect unit and feature loadouts from scenariooptions and/or an active mission script.
+--- api_missions (layer 0) runs before this gadget (layer 999999), so GG['MissionAPI']
+--- is already populated by the time GetLoadout() is called.
+local function GetLoadout()
+	local unitloadout    = {}
+	local featureloadout = {}
+
+	-- Source 1: scenariooptions encoded in mod options
+	if Spring.GetModOptions().scenariooptions then
+		local scenariooptions = Json.decode(string.base64Decode(Spring.GetModOptions().scenariooptions))
+		if scenariooptions then
+			appendLoadout(unitloadout, featureloadout, scenariooptions)
+		end
+	end
+
+	-- Source 2: Loadout table returned by the mission script (stored by api_missions.lua)
+	if GG['MissionAPI'] and GG['MissionAPI'].Loadout then
+		appendLoadout(unitloadout, featureloadout, GG['MissionAPI'].Loadout)
+	end
+
+	return unitloadout, featureloadout
+end
+
 function gadget:Initialize()
 	gaiaTeamID = Spring.GetGaiaTeamID()
 end
 
 function gadget:GamePreload()
-  if Spring.GetGameRulesParam("loadedGame") == 1 then
-    Spring.Echo("Scenario: Loading saved game, skipping loadout")
+	if Spring.GetGameRulesParam("loadedGame") == 1 then
+		Spring.Echo("Scenario: Loading saved game, skipping loadout")
 		gadgetHandler:RemoveGadget(self)
-  end
+	end
 
 	if Spring.GetGameFrame() < 1 and not loadoutcomplete then
-		-- so that loaded savegames dont re-place
-		if Spring.GetModOptions().scenariooptions then
-			Spring.Echo("Scenario: Spawning on frame", Spring.GetGameFrame())
-			local scenariooptions = string.base64Decode(Spring.GetModOptions().scenariooptions)
-			scenariooptions = Json.decode(scenariooptions)
-			if scenariooptions and scenariooptions.unitloadout then
-				Spring.Echo("Scenario: Creating unit loadout")
-				local unitloadout = scenariooptions.unitloadout
-				if unitloadout then
-					for k, unit in pairs(unitloadout) do
-						-- make sure unitdefname is valid
-						if UnitDefNames[unit.name] then
+		local unitloadout, featureloadout = GetLoadout()
 
-							local rot = rot_to_facing(unit.rot)
-							local unitID = Spring.CreateUnit(unit.name, unit.x, Spring.GetGroundHeight(unit.x, unit.z), unit.z, rot, unit.team)
-							if unitID then
-								Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
-								if UnitDefNames[unit.name].energyStorage > 0 or UnitDefNames[unit.name].metalStorage > 0 then
-									if additionalStorage[unit.team] == nil then
-										additionalStorage[unit.team] = {metal = 0, energy = 0}
-									end
-									additionalStorage[unit.team].metal  = additionalStorage[unit.team].metal + (UnitDefNames[unit.name].metalStorage  or 0 )
-									additionalStorage[unit.team].energy  = additionalStorage[unit.team].energy + (UnitDefNames[unit.name].energyStorage or 0 )
-								end
+		if #unitloadout > 0 then
+			Spring.Echo("Scenario: Creating unit loadout")
+			for k, unit in pairs(unitloadout) do
+				if UnitDefNames[unit.name] then
+					local rot = rot_to_facing(unit.rot)
+					local unitID = Spring.CreateUnit(unit.name, unit.x, Spring.GetGroundHeight(unit.x, unit.z), unit.z, rot, unit.team)
+					if unitID then
+						Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
+						if UnitDefNames[unit.name].energyStorage > 0 or UnitDefNames[unit.name].metalStorage > 0 then
+							if additionalStorage[unit.team] == nil then
+								additionalStorage[unit.team] = {metal = 0, energy = 0}
 							end
-							if string.find(unit.name, "nanotc") then
-								nanoturretunitIDs[unitID] = true
-							end
-							if unit.neutral == true or unit.neutral == 'true' then
-								Spring.SetUnitNeutral(unitID, true)
-							end
-						else
-							Spring.Echo("Scenario: UnitDef name is invalid:", unit.name)
+							additionalStorage[unit.team].metal  = additionalStorage[unit.team].metal  + (UnitDefNames[unit.name].metalStorage  or 0)
+							additionalStorage[unit.team].energy = additionalStorage[unit.team].energy + (UnitDefNames[unit.name].energyStorage or 0)
 						end
 					end
+					if string.find(unit.name, "nanotc") then
+						nanoturretunitIDs[unitID] = true
+					end
+					if unit.neutral == true or unit.neutral == 'true' then
+						Spring.SetUnitNeutral(unitID, true)
+					end
+				else
+					Spring.Echo("Scenario: UnitDef name is invalid:", unit.name)
 				end
 			end
-			if scenariooptions and scenariooptions.featureloadout then
-				Spring.Echo("Scenario: Creating feature loadout")
-				local featureloadout = scenariooptions.featureloadout
-				if featureloadout and next(featureloadout) then
-					for k, feature in pairs(featureloadout) do
-						if FeatureDefNames[feature.name] then
-							local rot = tonumber(feature.rot) or 0
-							local featureID = Spring.CreateFeature(feature.name, feature.x, Spring.GetGroundHeight(feature.x, feature.z), feature.z, rot, gaiaTeamID)
-							if feature.resurrectas and UnitDefNames[feature.resurrectas] then
-								Spring.SetFeatureResurrect(featureID, feature.resurrectas)
-							end
-						else
-							Spring.Echo("Scenario: FeatureDef name is invalid:", feature.name)
-						end
+		end
+
+		if #featureloadout > 0 then
+			Spring.Echo("Scenario: Creating feature loadout")
+			for k, feature in pairs(featureloadout) do
+				if FeatureDefNames[feature.name] then
+					local rot = tonumber(feature.rot) or 0
+					local featureID = Spring.CreateFeature(feature.name, feature.x, Spring.GetGroundHeight(feature.x, feature.z), feature.z, rot, gaiaTeamID)
+					if feature.resurrectas and UnitDefNames[feature.resurrectas] then
+						Spring.SetFeatureResurrect(featureID, feature.resurrectas)
 					end
+				else
+					Spring.Echo("Scenario: FeatureDef name is invalid:", feature.name)
 				end
 			end
 		end
 	end
-  loadoutcomplete = true
+	loadoutcomplete = true
 	--gadgetHandler:RemoveGadget(self)
 end
 

--- a/singleplayer/scenarios/missions/scenario025_mission.lua
+++ b/singleplayer/scenarios/missions/scenario025_mission.lua
@@ -211,7 +211,46 @@ local actions = {
 	},
 }
 
+-- ============================================================
+-- LOADOUT
+-- ============================================================
+-- Starting units for both teams. Defined here rather than in the scenario file
+-- so that the mission script is the single source of truth for all game state.
+
+local loadout = {
+	unitloadout = {
+		-- Player (team 0) starting forces
+		{ name = 'armcom',   x = 2157, y = 154, z = 6976, rot = 16384,  team = 0 },
+		{ name = 'armck',    x = 2100, y = 154, z = 6850, rot = 16384,  team = 0 },
+		{ name = 'armck',    x = 2200, y = 154, z = 7050, rot = 16384,  team = 0 },
+		{ name = 'armsolar', x = 2040, y = 154, z = 6800, rot = 16384,  team = 0 },
+		{ name = 'armwin',   x = 1990, y = 154, z = 7100, rot = 16384,  team = 0 },
+		{ name = 'armwin',   x = 2040, y = 154, z = 7100, rot = 16384,  team = 0 },
+		{ name = 'armmex',   x = 2050, y = 154, z = 6970, rot = 16384,  team = 0 },
+		{ name = 'armmex',   x = 1760, y = 154, z = 7740, rot = 16384,  team = 0 },
+
+		-- Enemy (team 1) starting forces — forward base across the crossing
+		{ name = 'corcom',   x = 4800, y = 52,  z = 3600, rot = -16384, team = 1 },
+		{ name = 'corck',    x = 4750, y = 52,  z = 3200, rot = -16384, team = 1 },
+		{ name = 'corck',    x = 4800, y = 52,  z = 3000, rot = -16384, team = 1 },
+		{ name = 'corsolar', x = 5000, y = 52,  z = 3200, rot = 0,      team = 1 },
+		{ name = 'corwin',   x = 4950, y = 52,  z = 3300, rot = 0,      team = 1 },
+		{ name = 'cormex',   x = 5040, y = 52,  z = 2540, rot = 0,      team = 1 },
+		{ name = 'cormex',   x = 5650, y = 52,  z = 2480, rot = 0,      team = 1 },
+		{ name = 'corllt',   x = 4900, y = 52,  z = 3380, rot = -16384, team = 1 },
+	},
+	featureloadout = {
+		-- Wreckage near the crossing — evidence of an earlier skirmish.
+		{ name = 'armflea_dead',  x = 3700, y = 100, z = 4300, rot = 12000, resurrectas = 'armflea'  },
+		{ name = 'armflea_dead',  x = 3850, y = 100, z = 4450, rot = 4000,  resurrectas = 'armflea'  },
+		{ name = 'corak_dead',    x = 4000, y = 100, z = 4200, rot = 28000, resurrectas = 'corak'    },
+		{ name = 'corak_dead',    x = 4150, y = 100, z = 4400, rot = 8000,  resurrectas = 'corak'    },
+		{ name = 'armpw_dead',    x = 3900, y = 100, z = 4600, rot = 20000, resurrectas = 'armck'    },
+	},
+}
+
 return {
 	Triggers = triggers,
 	Actions  = actions,
+	Loadout  = loadout,
 }

--- a/singleplayer/scenarios/scenario025.lua
+++ b/singleplayer/scenarios/scenario025.lua
@@ -39,32 +39,22 @@ Scoring:
 	unitlimits       = {},
 
 	scenariooptions = {
-		scenarioid         = "firstcontact025", -- MUST match scenarioid above
+		scenarioid           = "firstcontact025", -- MUST match scenarioid above
 		disablefactionpicker = true,
-		missionscript      = "scenarios/missions/scenario025_mission.lua",
+		missionscript        = "scenarios/missions/scenario025_mission.lua",
 
+		-- These units are merged with the Loadout defined in the mission script.
 		unitloadout = {
-			-- Player (team 0) starting forces
-			{ name = 'armcom',   x = 2157, y = 154, z = 6976, rot = 16384, team = 0 },
-			{ name = 'armck',    x = 2100, y = 154, z = 6850, rot = 16384, team = 0 },
-			{ name = 'armck',    x = 2200, y = 154, z = 7050, rot = 16384, team = 0 },
-			{ name = 'armsolar', x = 2040, y = 154, z = 6800, rot = 16384, team = 0 },
-			{ name = 'armwin',   x = 1990, y = 154, z = 7100, rot = 16384, team = 0 },
-			{ name = 'armwin',   x = 2040, y = 154, z = 7100, rot = 16384, team = 0 },
-			{ name = 'armmex',   x = 2050, y = 154, z = 6970, rot = 16384, team = 0 },
-			{ name = 'armmex',   x = 1760, y = 154, z = 7740, rot = 16384, team = 0 },
-
-			-- Enemy (team 1) starting forces — forward base across the crossing
-			{ name = 'corcom',   x = 4800, y = 52,  z = 3600, rot = -16384, team = 1 },
-			{ name = 'corck',    x = 4750, y = 52,  z = 3200, rot = -16384, team = 1 },
-			{ name = 'corck',    x = 4800, y = 52,  z = 3000, rot = -16384, team = 1 },
-			{ name = 'corsolar', x = 5000, y = 52,  z = 3200, rot =      0, team = 1 },
-			{ name = 'corwin',   x = 4950, y = 52,  z = 3300, rot =      0, team = 1 },
-			{ name = 'cormex',   x = 5040, y = 52,  z = 2540, rot =      0, team = 1 },
-			{ name = 'cormex',   x = 5650, y = 52,  z = 2480, rot =      0, team = 1 },
-			{ name = 'corllt',   x = 4900, y = 52,  z = 3380, rot = -16384, team = 1 },
+			-- Player (team 0) scout patrol — spawned in addition to the base from the mission script
+			{ name = 'armflea', x = 2250, y = 154, z = 6800, rot = 16384, team = 0 },
+			{ name = 'armflea', x = 2250, y = 154, z = 6900, rot = 16384, team = 0 },
+			{ name = 'armflea', x = 2200, y = 154, z = 7000, rot = 16384, team = 0 },
 		},
-		featureloadout = {},
+		-- Wrecks near the player base — merged with featureloadout from the mission script.
+		featureloadout = {
+			{ name = 'armpw_dead', x = 2320, y = 154, z = 6300, rot = 5000,  resurrectas = 'armflea' },
+			{ name = 'corak_dead', x = 2250, y = 154, z = 6350, rot = 18000, resurrectas = 'corak'   },
+		},
 	},
 
 	-- https://github.com/spring/spring/blob/105.0/doc/StartScriptFormat.txt


### PR DESCRIPTION
### Work done

1. Path to mission script can be specified in `scenariooptions.missionscript` as in the example scenario.
2. Also adds support for loadouts in mission files.

#### Test steps

- Play the example scenario "First Contact".