### PR TITLE
set Hecate engage range (maxrange) to its drone range

### DIFF
--- a/units/Legion/Ships/T2/leganavyantinukecarrier.lua
+++ b/units/Legion/Ships/T2/leganavyantinukecarrier.lua
@@ -48,6 +48,7 @@ return {
 		waterline = 0,
 		workertime = 1000,
 		customparams = {
+			maxrange = 1300,
 			model_author = "ZephyrSkies",
 			normaltex = "unittextures/leg_normal.dds",
 			subfolder = "Legion/Ships/T2",


### PR DESCRIPTION
### Work done

Make Hecate engage targets based on the range of its drone controller weapon.

#### Addresses Issue(s)

- Resolves https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6447