### PR TITLE
docked drones assume the LOS type of their carrier

### DIFF
--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -1281,6 +1281,7 @@ local function updateCarrier(carrierID, carrierMetaData, frame)
 			
 			if droneDocked and droneData.maxAmmo > 0 then 
 				droneData.remainingAmmo = droneData.maxAmmo
+				spSetUnitUseAirLos(subUnitID, carrierMetaData.isAirUnit)
 			end
 			
 			if droneCurrentHealth then


### PR DESCRIPTION
### Work done

Set docked drones to use non-air LOS when docked to a non-air unit. Restores LOS type when undocking.

The engine restores the air LOS type on units through their move type data, also. When that data has a state assigned to it – any state – it will flip that bit back to normal. So there are some effects that interfere with this, in rare cases. The fix I went with was very effective but is genuinely mysterious; just keep resetting the air LOS flag when docked.

#### Addresses Issue(s)

- Resolves https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6757