### PR TITLE
use smaller explosion vfx for Medusa

### DIFF
--- a/units/Legion/Vehicles/T2 Vehicles/legmed.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legmed.lua
@@ -107,7 +107,7 @@ return {
 				craterboost = 0,
 				cratermult = 0,
 				edgeeffectiveness = 0.65,
-				explosiongenerator = "custom:genericshellexplosion-large-bomb",
+				explosiongenerator = "custom:genericshellexplosion-medium-bomb",
 				firestarter = 100,
 				flighttime = 5,
 				impulsefactor = 0.2,


### PR DESCRIPTION
### Work done

Change out large-bomb for medium-bomb to fit the Medusa's 50-diameter area of effect; small is too small and medium is about right.

There's also damage to consider, but I think getting the visual range of the effect right has to matter more.

The "bomb" style explosion doesn't fill in the impacted volume very well, but tries to kick up longer trails of dust and debris. So there's no great fit to any radius. Just needs to go by feel. But medium-bomb is used for most T2 artillery, generally with an area of effect much larger, e.g. armmart has 120 AOE.

That explosion type also tends to look better on flat terrain. It doesn't orient well on e.g. steep cliffs, and not vs tall units, either. Might be good to use a different generic CEG that handles these cases better since the Medusa has such a high hit rate vs units.
