### PR TITLE
Blueprint Subsitution Definition Update - addressing missing Cor entries and outdated Legion placeholders

### DIFF
--- a/luaui/Include/blueprint_substitution/definitions.lua
+++ b/luaui/Include/blueprint_substitution/definitions.lua
@@ -49,12 +49,12 @@ function DefinitionsModule.defineUnitCategories()
     DefCat("METAL_EXTRACTOR", {[SIDES.ARMADA]="armmex", [SIDES.CORTEX]="cormex", [SIDES.LEGION]="legmex"})
     DefCat("EXPLOITER", {[SIDES.ARMADA]="armamex", [SIDES.CORTEX]="corexp", [SIDES.LEGION]="legmext15"})
     DefCat("ADVANCED_EXTRACTOR", {[SIDES.ARMADA]="armmoho", [SIDES.CORTEX]="cormoho", [SIDES.LEGION]="legmoho"})
-    DefCat("ADVANCED_EXPLOITER", {[SIDES.ARMADA]="armmoho", [SIDES.CORTEX]="cormexp", [SIDES.LEGION]="legmohocon"}) -- NOT WORKING
+    DefCat("ADVANCED_EXPLOITER", {[SIDES.ARMADA]="armmoho", [SIDES.CORTEX]="cormexp", [SIDES.LEGION]="legmohocon"})
     DefCat("UW_EXTRACTOR", {[SIDES.ARMADA]="armuwmex", [SIDES.CORTEX]="coruwmex", [SIDES.LEGION]="leguwmex"})
     DefCat("ADVANCED_UW_EXTRACTOR", {[SIDES.ARMADA]="armuwmme", [SIDES.CORTEX]="coruwmme", [SIDES.LEGION]="leguwmme"})
     DefCat("METAL_STORAGE", {[SIDES.ARMADA]="armmstor", [SIDES.CORTEX]="cormstor", [SIDES.LEGION]="legmstor"})
     DefCat("ADVANCED_METAL_STORAGE", {[SIDES.ARMADA]="armuwadvms", [SIDES.CORTEX]="coramstor", [SIDES.LEGION]="legamstor"})
-    DefCat("UW_METAL_STORAGE", {[SIDES.ARMADA]="armuwms", [SIDES.CORTEX]="coruwms", [SIDES.LEGION]="leguwmstore"}) -- NOT WORKING
+    DefCat("UW_METAL_STORAGE", {[SIDES.ARMADA]="armuwms", [SIDES.CORTEX]="coruwms", [SIDES.LEGION]="leguwmstore"})
     DefCat("UW_ADVANCED_METAL_STORAGE", {[SIDES.ARMADA]="armuwadvms", [SIDES.CORTEX]="coruwadvms", [SIDES.LEGION]="coruwadvms"})
 
     -- Energy buildings


### PR DESCRIPTION
### Work done
The Cor blueprint substitution entries for ADVANCED_ENERGY_CONVERTER and SHIELD were missing. In addition, many Legion entries containing placeholders were outdated due to missing content being completed in recent months.

All blueprint substitution definitions were manually reviewed, ones in need of change identified, then tested in-game to confirm they didn't work. The correct buildings were then identified, their corresponding blueprint substitution definitions updated, then tested in-game to confirm they now worked.

#### Addresses Issue(s)
- fixes #7061 

#### Setup
Legion enabled. You will need T1+T2 Air and Naval cons, for both Cor and Legion. Since blueprints operate in a LIFO manner, it is possible to test items in rapid succession by using the Cor con to create the blueprint, switch to the Legion con, attempt to place the new blueprint (which is the first option), then repeat for the next blueprint.

#### Test steps (organized by Tier/Con for convenience)
**T1 Air**:
- [ ] DRAGONS_CLAW: create Cor Dragon's Maw blueprint, attempt to place with Legion con. Expected: Legion Dragon's Jaw is built.

**T2 Air**:
- [ ] ADVANCED_EXPLOITER: create Cor Exploiter blueprint, attempt to place with Legion con. Expected: Legion Fortifier is built.
- [ ] ADVANCED_ENERGY_CONVERTER : create Cor Advanced Energy Converter blueprint, attempt to place with Legion con. Expected: Legion Advanced Energy Converter is built.
- [ ] SHIELD: create Cor Shield blueprint, attempt to place with Legion con. Expected: Legion Shield is built.


**T1 Sea**:
- [ ] UW_METAL_STORAGE: create Cor Naval Metal Storage blueprint, attempt to place with Legion con. Expected: Legion Naval Metal Storage is built.
- [ ] AMPHIBIOUS_COMPLEX: create Cor Amphibious Complex blueprint, attempt to place with Legion con. Expected: Legion Amphibious Complex is built.
- [ ] SEAPLANE_PLATFORM: create Cor Seaplane Platform blueprint, attempt to place with Legion con. Expected: Legion Seaplane Platform built.
- [ ] FLOATING_MISSILE: create Cor Slingshot blueprint, attempt to place with Legion con. Expected: Legion Polybolos is built.
- [ ] TORPEDO: create Cor Jellyfish blueprint, attempt to place with Legion con. Expected: Legion Euryale is built.
- [ ] FLOATING_TORPEDO_LAUNCHER_PG: create Cor Urchin blueprint, attempt to place with Legion con. Expected: Legion Stheno is built.
- [ ] FLOATING_RADAR_PG: create Cor Naval Radar blueprint, attempt to place with Legion con. Expected: Legion Naval Radar is built.
- [ ] FLOATING_DRAGONSTEETH_PG: create Cor Shark's Teeth blueprint, attempt to place with Legion con. Expected: Legion Shark's Teeth is built.

**T2 Sea**:
- [ ] UW_ADVANCED_ENERGY_CONVERTER: create Cor Naval Advanced Energy Converter blueprint, attempt to place with Legion con. Expected: Legion Naval Advanced Energy Convertor is built.
- [ ] UW_EXPIREMENTAL_GANTRY: create Cor Naval Experimental Gantry blueprint, attempt to place with Legion con. Expected: Legion Naval Experimental Gantry is built.
- [ ] FLOATING_FLAK: create Cor Naval Birdshot blueprint, attempt to place with Legion con. Expected: Legion Fulmen is built.
- [ ] ADV_FLOATING_ANNIHILATOR: create Cor Devastator blueprint, attempt to place with Legion con. Expected: Legion Ionia is built.
- [ ] FLOATING_PINPOINTER: create Cor Naval Pinpointer blueprint, attempt to place with Legion con. Expected: Legion Naval Pinpointer is built.
