### PR TITLE
added gadget: volcango pyroclastic (by Steel)

### DIFF
--- a/effects/volcano.lua
+++ b/effects/volcano.lua
@@ -1,0 +1,1189 @@
+-- Cinematic volcano effects for BAR Made by Steel December 2025
+-- Supports volcano_projectile_unit.lua and game_volcano_pyroclastic.lua
+----------------------------------------------------------------------
+-- VOLCANO SMOKE INTENSITY CONTROL
+-- 1.0 = current heavy-ish plume
+-- 0.5 = roughly “moderate”
+-- 0.25 = “light”
+-- 0.1 = ultra-light
+----------------------------------------------------------------------
+local VOLCANO_SMOKE_INTENSITY = 1.0  -- << EDIT THIS TO DIAL BACK >>
+
+local function SmokeCount(base)
+  -- scale counts for all our micro-emitters
+  return math.max(1, math.floor(base * VOLCANO_SMOKE_INTENSITY + 0.5))
+end
+
+return {
+["volcano_smoke_turbulence"] = {
+    turbulence = {
+      air      = true,
+      ground   = true,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.72,
+        colormap           = [[0.07 0.07 0.07 0.65   0.08 0.08 0.08 0.45   0.05 0.05 0.05 0.25   0 0 0 0.01]],
+        directional        = false,
+
+        emitrot            = 40,
+        emitrotspread      = 60,
+        emitvector         = [[0.4 r0.4, 1, 0.4 r0.4]],
+
+        gravity            = [[-0.02 r0.05, 0.2 r0.4, -0.02 r0.05]],
+
+        numparticles       = 6,
+        particlelife       = 80,
+        particlelifespread = 60,
+
+        particlesize       = 90,
+        particlesizespread = 100,
+
+        particlespeed      = 2.0,
+        particlespeedspread = 2.5,
+
+        pos                = [[0 r200, 0 r200, 0 r200]],
+
+        sizegrowth         = 1.2,
+        sizemod            = 0.97,
+
+        rotParams          = [[-20 r40, -20 r40, -180 r360]],
+
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-beh-anim]],
+
+        castShadow         = true,
+        useairlos          = false,
+      },
+    },
+  },
+["volcano_ash_build"] = {
+    -- main wide low ash
+    ash = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.92,
+        colormap           = [[0.08 0.08 0.08 0.8   0.07 0.07 0.07 0.5   0.05 0.05 0.05 0.25   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 80,
+        emitrotspread      = 30,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.01, 0]],
+        -- reduced per-burst particles; micro wisps fill in
+        numparticles       = 12,
+        particlelife       = 210,
+        particlelifespread = 80,
+        particlesize       = 80,
+        particlesizespread = 40,
+        particlespeed      = 1.2,
+        particlespeedspread = 0.8,
+        pos                = [[-180 r360, 10, -180 r360]],
+        sizegrowth         = 0.9,
+        sizemod            = 0.97,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    -- taller, thinner ash above the rim
+    ash_high = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.95,
+        colormap           = [[0.07 0.07 0.07 0.6   0.06 0.06 0.06 0.35   0.04 0.04 0.04 0.18   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 85,
+        emitrotspread      = 20,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.005, 0]],
+        numparticles       = 8,
+        particlelife       = 260,
+        particlelifespread = 90,
+        particlesize       = 110,
+        particlesizespread = 45,
+        particlespeed      = 0.7,
+        particlespeedspread = 0.4,
+        pos                = [[-140 r280, 80, -140 r280]],
+        sizegrowth         = 0.7,
+        sizemod            = 0.985,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    ------------------------------------------------------------------
+    -- micro “wisps” to break up the pulses
+    ------------------------------------------------------------------
+    micro = {
+      class    = [[CExpGenSpawner]],
+      count    = SmokeCount(35),   -- << adjust base 35 for more / less ambient wisps
+      properties = {
+        delay              = [[0 r90]],  -- random up to 3 seconds per volcano_ash_build CEG
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[-200 r400, 0 r120, -200 r400]],
+      },
+    },
+  },
+["volcano_ash_big"] = {
+    column_core = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.90,
+        colormap           = [[0.07 0.07 0.07 1.0   0.06 0.06 0.06 0.8   0.05 0.05 0.05 0.45   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 90,
+        emitrotspread      = 20,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.015, 0]],
+        -- fewer particles per single burst; micro system below handles “fill”
+        numparticles       = 18,
+        particlelife       = 260,
+        particlelifespread = 110,
+
+        -- SHRUNK FROM 150 / 70
+        particlesize       = 90,
+        particlesizespread = 40,
+
+        particlespeed      = 4.0,
+        particlespeedspread = 2.0,
+        pos                = [[-80 r160, 40, -80 r160]],
+        sizegrowth         = 1.4,
+        sizemod            = 0.97,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-beh-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    column_sheath = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.93,
+        colormap           = [[0.10 0.10 0.10 0.9   0.09 0.09 0.09 0.6   0.07 0.07 0.07 0.3   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 90,
+        emitrotspread      = 35,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.01, 0]],
+        numparticles       = 16,
+        particlelife       = 300,
+        particlelifespread = 120,
+
+        -- SHRUNK FROM 220 / 80
+        particlesize       = 130,
+        particlesizespread = 50,
+
+        particlespeed      = 3.2,
+        particlespeedspread = 1.6,
+        pos                = [[-140 r280, 80, -140 r280]],
+        sizegrowth         = 1.7,
+        sizemod            = 0.975,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-beh-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    column_cap = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.96,
+        colormap           = [[0.09 0.09 0.09 0.7   0.08 0.08 0.08 0.4   0.06 0.06 0.06 0.2   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 0,
+        emitrotspread      = 20,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.0, 0]],
+        numparticles       = 14,
+        particlelife       = 320,
+        particlelifespread = 130,
+
+        -- SHRUNK FROM 260 / 90
+        particlesize       = 160,
+        particlesizespread = 55,
+
+        particlespeed      = 2.2,
+        particlespeedspread = 1.2,
+        pos                = [[-220 r440, 500, -220 r440]],
+        sizegrowth         = 1.1,
+        sizemod            = 0.985,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    column_skirt = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.92,
+        colormap           = [[0.10 0.10 0.10 0.8   0.09 0.09 0.09 0.5   0.07 0.07 0.07 0.25   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 5,
+        emitrotspread      = 35,
+        emitvector         = [[0.9, 0.4, 0.9]],
+        gravity            = [[0, -0.02, 0]],
+        numparticles       = 18,
+        particlelife       = 180,
+        particlelifespread = 80,
+
+        -- SHRUNK FROM 140 / 60
+        particlesize       = 85,
+        particlesizespread = 36,
+
+        particlespeed      = 8.5,
+        particlespeedspread = 3.0,
+        pos                = [[-140 r280, 260, -140 r280]],
+        sizegrowth         = 1.3,
+        sizemod            = 0.98,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-beh-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    ------------------------------------------------------------------
+    -- random micro turbulence inside the column volume
+    ------------------------------------------------------------------
+    micro = {
+      class    = [[CExpGenSpawner]],
+      count    = SmokeCount(35),    -- was 50, slightly less dense
+      properties = {
+        delay              = [[0 r120]],  -- random up to 4 seconds per volcano_ash_big CEG
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[-220 r440, 80 r520, -220 r440]],
+      },
+    },
+  },
+["volcano_ash_small"] = {
+    puff = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.93,
+        colormap           = [[0.10 0.10 0.10 0.8   0.07 0.07 0.07 0.5   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 80,
+        emitrotspread      = 30,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.01, 0]],
+        numparticles       = 10,
+        particlelife       = 160,
+        particlelifespread = 70,
+        particlesize       = 90,
+        particlesizespread = 35,
+        particlespeed      = 2.6,
+        particlespeedspread = 1.4,
+        pos                = [[-160 r320, 140 r80, -160 r320]],
+        sizegrowth         = 1.0,
+        sizemod            = 0.98,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    puff_drift = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.97,
+        colormap           = [[0.08 0.08 0.08 0.6   0.06 0.06 0.06 0.35   0.04 0.04 0.04 0.15   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 60,
+        emitrotspread      = 40,
+        emitvector         = [[0.4, 1, 0.4]],
+        gravity            = [[0, 0.002, 0]],
+        numparticles       = 6,
+        particlelife       = 200,
+        particlelifespread = 80,
+        particlesize       = 120,
+        particlesizespread = 40,
+        particlespeed      = 1.4,
+        particlespeedspread = 0.9,
+        pos                = [[-200 r400, 180 r80, -200 r400]],
+        sizegrowth         = 0.9,
+        sizemod            = 0.99,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    ------------------------------------------------------------------
+    -- micro chaos for side puffs
+    ------------------------------------------------------------------
+    micro = {
+      class    = [[CExpGenSpawner]],
+      count    = SmokeCount(18),  -- << adjust base 18 for side puff chaos level
+      properties = {
+        delay              = [[0 r60]],
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[-200 r400, 120 r140, -200 r400]],
+      },
+    },
+  },
+["volcano_eject"] = {
+    flame_core = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.86,
+        colormap           = [[1.0 0.85 0.5 1.0   1.0 0.55 0.2 0.7   0.8 0.3 0.1 0.4   0.25 0.08 0.03 0.15   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 90,
+        emitrotspread      = 28,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, -0.20, 0]],
+        numparticles       = 26,
+        particlelife       = 32,
+        particlelifespread = 10,
+        particlesize       = 140,
+        particlesizespread = 60,
+        particlespeed      = 20,
+        particlespeedspread = 9,
+        pos                = [[0, 18, 0]],
+        sizegrowth         = -1.6,
+        sizemod            = 0.96,
+        texture            = [[flame]],
+        useairlos          = true,
+      },
+    },
+
+    eject_smoke = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.93,
+        colormap           = [[0.14 0.12 0.11 0.95   0.11 0.10 0.10 0.6   0.08 0.08 0.08 0.28   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 75,
+        emitrotspread      = 35,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, 0.01, 0]],
+        numparticles       = 22,
+        particlelife       = 200,
+        particlelifespread = 80,
+        particlesize       = 120,
+        particlesizespread = 50,
+        particlespeed      = 4.8,
+        particlespeedspread = 2.3,
+        pos                = [[0, 26, 0]],
+        sizegrowth         = 1.3,
+        sizemod            = 0.97,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-beh-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    -- Turbulence to roughen ejection smoke
+    turbulence = {
+      class    = [[CExpGenSpawner]],
+      count    = 8,
+      properties = {
+        delay              = [[0 r40]],
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[-60 r120, 24 r40, -60 r120]],
+      },
+    },
+  },
+["volcano_rock_impact"] = {
+    smoke = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.90,
+        colormap           = [[0.10 0.10 0.10 1.0   0.09 0.09 0.09 0.65   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 70,
+        emitrotspread      = 30,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, -0.06, 0]],
+        numparticles       = 22,
+        particlelife       = 90,
+        particlelifespread = 40,
+        particlesize       = 90,
+        particlesizespread = 40,
+        particlespeed      = 6.0,
+        particlespeedspread = 2.5,
+        pos                = [[0, 12, 0]],
+        sizegrowth         = 1.0,
+        sizemod            = 0.97,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    flame = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.88,
+        colormap           = [[1.0 0.8 0.3 0.9   0.8 0.4 0.1 0.5   0.3 0.12 0.04 0.15   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 80,
+        emitrotspread      = 25,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, -0.20, 0]],
+        numparticles       = 14,
+        particlelife       = 40,
+        particlelifespread = 16,
+        particlesize       = 80,
+        particlesizespread = 30,
+        particlespeed      = 10,
+        particlespeedspread = 4,
+        pos                = [[0, 6, 0]],
+        sizegrowth         = -0.7,
+        sizemod            = 0.96,
+        texture            = [[flame]],
+        useairlos          = true,
+      },
+    },
+
+    dust = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.91,
+        colormap           = [[0.15 0.12 0.08 0.6   0.10 0.08 0.06 0.35   0.05 0.04 0.03 0.15   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 70,
+        emitrotspread      = 40,
+        emitvector         = [[0.7, 1, 0.7]],
+        gravity            = [[0, -0.04, 0]],
+        numparticles       = 20,
+        particlelife       = 70,
+        particlelifespread = 30,
+        particlesize       = 70,
+        particlesizespread = 30,
+        particlespeed      = 7,
+        particlespeedspread = 3,
+        pos                = [[0, 6, 0]],
+        sizegrowth         = 0.9,
+        sizemod            = 0.98,
+        texture            = [[smoke]],
+        useairlos          = true,
+      },
+    },
+
+    -- Impact turbulence: adds breakup to the smoke cap
+    turbulence = {
+      class    = [[CExpGenSpawner]],
+      count    = 6,
+      properties = {
+        delay              = [[0 r20]],
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[0 r30, 6 r16, 0 r30]],
+      },
+    },
+  },
+["volcano_lava_splash_nukexl"] = {
+  waterring = {
+    air                = true,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 1,
+    ground             = true,
+    underwater         = 1,
+    water              = true,
+    properties = {
+      colormap           = [[1.0 0.75 0.35 0.013   0.85 0.35 0.12 0.01   0.25 0.08 0.03 0.006   0 0 0 0.01]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[explowater]],
+      length             = 45,
+      sidetexture        = [[none]],
+      size               = 190.9,
+      sizegrowth         = 2,
+      ttl                = 170,
+      pos                = [[0.5, 1, 0.0]],
+      alwaysvisible      = true,
+    },
+  },
+
+  brightflare = {
+    air                = true,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 1,
+    ground             = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      colormap           = [[1.0 0.95 0.75 0.8    1.0 0.45 0.12 0.5    0 0 0 0]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[exploflare]],
+      length             = 40,
+      sidetexture        = [[none]],
+      size               = 1100,
+      sizegrowth         = [[0.1 r0.2]],
+      ttl                = 15,
+      pos                = [[0, 10, 0]],
+    },
+  },
+
+  brightwake = {
+    air                = true,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 1,
+    ground             = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      colormap           = [[0 0 0 0    1.0 0.55 0.18 0.4    0.35 0.12 0.05 0.2    0 0 0 0]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[wake]],
+      length             = 40,
+      sidetexture        = [[none]],
+      size               = [[280 r340]],
+      sizegrowth         = [[0.15 r0.7]],
+      ttl                = [[90 r70]],
+      pos                = [[0, 5, 0]],
+      rotParams          = [[-6 r12, -0.5 r1, -180 r360]],
+    },
+  },
+
+  brightwakefoam = {
+    air                = true,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 1,
+    ground             = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      colormap           = [[0 0 0 0   1.0 0.65 0.25 0.8    0.35 0.14 0.06 0.2    0 0 0 0]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[waterfoam]],
+      length             = 40,
+      sidetexture        = [[none]],
+      size               = [[400 r120]],
+      sizegrowth         = [[0.15 r0.7]],
+      ttl                = [[120 r40]],
+      pos                = [[0, 5, 0]],
+      rotParams          = [[-2 r4, -0.5 r1, -180 r360]],
+      alwaysvisible      = true,
+    },
+  },
+
+  brightwakewave = {
+    air                = true,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 2,
+    ground             = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      colormap           = [[0 0 0 0   0.85 0.35 0.12 0.5    0.30 0.10 0.05 0.2    0 0 0 0]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[explosionwave]],
+      length             = 40,
+      sidetexture        = [[none]],
+      size               = [[120 r240]],
+      sizegrowth         = [[0.15 r0.7]],
+      ttl                = [[110 r40]],
+      pos                = [[0, 0, 0]],
+      alwaysvisible      = true,
+    },
+  },
+
+  circlewaves = {
+    air                = false,
+    class              = [[CSimpleParticleSystem]],
+    count              = 1,
+    ground             = false,
+    underwater         = 1,
+    water              = true,
+    properties = {
+      airdrag            = 0.98,
+      colormap           = [[0 0 0 0  1.0 0.55 0.18 .013     0.85 0.35 0.12 .008    0.25 0.08 0.03 .006   0 0 0 0.01]],
+      directional        = true,
+      emitrot            = 90,
+      emitrotspread      = 0,
+      emitvector         = [[0, 1, 0]],
+      gravity            = [[0, 0, 0]],
+      numparticles       = 20,
+      particlelife       = 80,
+      particlelifespread = 110,
+      particlesize       = [[12 r27]],
+      particlesizespread = 0,
+      particlespeed      = [[3.5 i1.9]],
+      particlespeedspread = 1.9,
+      pos                = [[0 r-10 r10,4, 0 r-10 r10]],
+      sizegrowth         = [[0.78]],
+      sizemod            = 1.0,
+      texture            = [[wave]],
+      useairlos          = true,
+      alwaysvisible      = true,
+    },
+  },
+
+  waterrush = {
+    air                = false,
+    class              = [[CSimpleParticleSystem]],
+    count              = 3,
+    ground             = false,
+    underwater         = 1,
+    water              = true,
+    properties = {
+      airdrag            = 0.97,
+      colormap           = [[0 0 0 0.005  0.35 0.12 0.05 .011     0.25 0.08 0.03 .006    0.1 0.03 0.01 .005   0 0 0 0.01]],
+      directional        = false,
+      emitrot            = 1,
+      emitrotspread      = 0,
+      emitvector         = [[r0.12, 0.7, r0.12]],
+      gravity            = [[0, -0.06, 0]],
+      numparticles       = 3,
+      particlelife       = 100,
+      particlelifespread = 140,
+      particlesize       = [[120 r140]],
+      particlesizespread = 140,
+      particlespeed      = [[25.8 i1]],
+      particlespeedspread = 15,
+      pos                = [[-130 r260, 110 r60, -130 r260]],
+      sizegrowth         = [[0.8]],
+      sizemod            = 1,
+      texture            = [[waterrush]],
+      useairlos          = true,
+      alwaysvisible      = true,
+    },
+  },
+
+  sparks = {
+    air                = true,
+    class              = [[CSimpleParticleSystem]],
+    count              = 1,
+    ground             = true,
+    water              = true,
+    underwater         = true,
+    properties = {
+      airdrag            = 0.95,
+      colormap           = [[1.0 0.65 0.25 0.020   0.85 0.35 0.12 0.01   0 0 0 0.005]],
+      directional        = true,
+      emitrot            = 12,
+      emitrotspread      = 12,
+      emitvector         = [[0, 1, 0]],
+      gravity            = [[0, 0, 0]],
+      numparticles       = 26,
+      particlelife       = 90,
+      particlelifespread = 65,
+      particlesize       = 80,
+      particlesizespread = 80,
+      particlespeed      = 16.8,
+      particlespeedspread = 26,
+      pos                = [[0 r-10 r10,-32, 0 r-10 r10]],
+      sizegrowth         = -0.25,
+      sizemod            = 0.99,
+      texture            = [[gunshotxl2]],
+      useairlos          = false,
+      alwaysvisible      = true,
+    },
+  },
+
+  waterexplosion = {
+    air                = false,
+    class              = [[CSimpleParticleSystem]],
+    count              = 1,
+    ground             = false,
+    underwater         = 1,
+    water              = true,
+    properties = {
+      airdrag            = 0.952,
+      colormap           = [[1.0 0.75 0.35 0.009   0.85 0.35 0.12 0.013   0.25 0.08 0.03 0.006   0 0 0 0.01]],
+      directional        = true,
+      emitrot            = 70,
+      emitrotspread      = [[-20 r20]],
+      emitvector         = [[0,1,0]],
+      gravity            = [[0, -0.045, 0]],
+      numparticles       = 24,
+      particlelife       = 110,
+      particlelifespread = 45,
+      particlesize       = 60,
+      particlesizespread = 150,
+      particlespeed      = [[11 i1.95]],
+      particlespeedspread = 10,
+      rotParams          = [[-50 r100, -7 r14, -180 r360]],
+      pos                = [[0, 18, 0]],
+      sizegrowth         = -0.21,
+      sizemod            = 1.0,
+      texture            = [[explowater]],
+      useairlos          = true,
+      alwaysvisible      = true,
+    },
+  },
+
+  shockwave = {
+    air                = false,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 1,
+    ground             = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      colormap           = [[1.0 0.65 0.25 0.011   0.85 0.35 0.12 0.01   0.25 0.08 0.03 0.006   0 0 0 0.01]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[blastwave]],
+      length             = 40,
+      sidetexture        = [[none]],
+      size               = 20,
+      sizegrowth         = [[-22 r6]],
+      ttl                = 20,
+      pos                = [[0, 5, 0]],
+      alwaysvisible      = true,
+    },
+  },
+
+  shockwave_slow = {
+    air                = false,
+    class              = [[CBitmapMuzzleFlame]],
+    count              = 1,
+    ground             = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      colormap           = [[1.0 0.65 0.25 0.013   0.85 0.35 0.12 0.008   0.25 0.08 0.03 0.005   0 0 0 0.01]],
+      dir                = [[0, 1, 0]],
+      --gravity            = [[0.0, 0.1, 0.0]],
+      frontoffset        = 0,
+      fronttexture       = [[explosionwave]],
+      length             = 0,
+      sidetexture        = [[none]],
+      size               = 50,
+      sizegrowth         = [[-18 r5]],
+      ttl                = 220,
+      pos                = [[0, 0, 0]],
+      alwaysvisible      = true,
+    },
+  },
+
+  dirt = {
+    class              = [[CSimpleParticleSystem]],
+    count              = 4,
+    ground             = true,
+    air                = true,
+    underwater         = true,
+    water              = true,
+    properties = {
+      airdrag            = 0.97,
+      colormap           = [[0.35 0.12 0.05 0.013   0.25 0.08 0.03 0.01   0.1 0.03 0.01 0.006   0 0 0 0.01]],
+      directional        = false,
+      emitrot            = 30,
+      emitrotspread      = 16,
+      emitvector         = [[0, 1, 0]],
+      gravity            = [[0, -0.12, 0]],
+      numparticles       = 7,
+      particlelife       = 80,
+      particlelifespread = 85,
+      particlesize       = 39,
+      particlesizespread = 42,
+      particlespeed      = 6,
+      particlespeedspread = 15,
+      rotParams          = [[-50 r100, -7 r14, -180 r360]],
+      pos                = [[0, 3, 0]],
+      sizegrowth         = -0.08,
+      sizemod            = 1,
+      texture            = [[randomdots]],
+      useairlos          = false,
+      alwaysvisible      = true,
+    },
+  },
+
+  groundflash_white = {
+    class              = [[CSimpleGroundFlash]],
+    count              = 1,
+    air                = false,
+    ground             = true,
+    water              = true,
+    underwater         = true,
+    properties = {
+      colormap           = [[1.0 0.9 0.7 0.8   1.0 0.45 0.12 0.5   0.25 0.08 0.03 0.2   0 0 0 0.01]],
+      size               = 520,
+      sizegrowth         = 5,
+      ttl                = 220,
+      texture            = [[groundflashwhite]],
+      alwaysvisible      = true,
+    },
+  },
+},
+["volcano1_flames"] = {
+    rocks = {
+      air                = true,
+      class              = [[CSimpleParticleSystem]],
+      count              = 30,
+      ground             = true,
+      water              = true,
+      underwater         = true,
+      properties = {
+        airdrag            = 0.97,
+        alwaysvisible      = true,
+        colormap           = [[0.0 0.00 0.0 0.01
+                               0.9 0.90 0.0 0.50
+                               0.9 0.90 0.0 0.50
+                               0.9 0.90 0.0 0.50
+                               0.9 0.90 0.0 0.50
+                               0.9 0.90 0.0 0.50
+                               0.8 0.80 0.1 0.50
+                               0.7 0.70 0.2 0.50
+                               0.5 0.35 0.0 0.50
+                               0.5 0.35 0.0 0.50
+                               0.5 0.35 0.0 0.50
+                               0.5 0.35 0.0 0.50
+                               0.0 0.00 0.0 0.01]],
+        directional        = true,
+        emitrot            = 90,
+        emitrotspread      = 0,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0.001 r-0.002, 0.0, 0.001 r-0.002]],
+        numparticles       = 1,
+        particlelife       = 180,
+        particlelifespread = 20,
+        particlesize       = 120,
+        particlesizespread = 120,
+        particlespeed      = 24,
+        particlespeedspread = 0,
+        pos                = [[0, 0, 0]],
+        sizegrowth         = 0.05,
+        sizemod            = 1.0,
+        texture            = [[fireball]],
+      },
+    },
+  },
+["volcano_rising_fireball_spawner"] = {
+    nw = {
+      air                = true,
+      class              = [[CExpGenSpawner]],
+      count              = 150,
+      ground             = true,
+      water              = true,
+      underwater         = true,
+      properties = {
+        delay              = [[0  i1]],
+        explosiongenerator = [[custom:volcano_rising_fireball_sub]],
+        pos                = [[20 r40, i20, -20 r40]],
+      },
+    },
+  },
+["volcano_rising_fireball_sub"] = {
+    rocks = {
+      air                = true,
+      class              = [[CSimpleParticleSystem]],
+      count              = 1,
+      ground             = true,
+      water              = true,
+      underwater         = true,
+      properties = {
+        airdrag            = 0.97,
+        alwaysvisible      = true,
+        colormap           = [[
+			     0.9  0.45 0.15 0.75
+			     0.4  0.2  0.08 0.65
+			     0.12 0.1  0.1  0.6
+			     0.08 0.08 0.08 0.5
+			     0.05 0.05 0.05 0.35
+			     0.02 0.02 0.02 0.18
+			     0.0  0.0  0.0  0.0
+			     ]],
+        directional        = true,
+        emitrot            = 90,
+        emitrotspread      = 10,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0.001 r-0.002, 0.01 r-0.02, 0.001 r-0.002]],
+        numparticles       = 1,
+        particlelife       = 150,
+        particlelifespread = 150,
+        particlesize       = 90,
+        particlesizespread = 90,
+        particlespeed      =  3,
+        particlespeedspread = 5,
+        pos                = [[0, 0, 0]],
+        sizegrowth         = 0.05,
+        sizemod            = 1.0,
+        texture            = [[fireball]],
+      },
+    },
+  },
+
+  ----------------------------------------------------------------------
+  -- LAVA ROCK TRAIL – EXTREME STREAKING FIREBALL
+  ----------------------------------------------------------------------
+  ["volcano_rock_trail"] = {
+    trail_flame = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.85,
+        colormap           = [[1.0 0.8 0.4 1.0   1.0 0.45 0.12 0.7   0.7 0.2 0.06 0.4   0.25 0.08 0.03 0.12   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 0,
+        emitrotspread      = 20,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, -0.30, 0]],
+        numparticles       = 6,
+        particlelife       = 40,
+        particlelifespread = 14,
+        particlesize       = 25,
+        particlesizespread = 12,
+        particlespeed      = 2.2,
+        particlespeedspread = 1.3,
+        pos                = [[0, 0, 0]],
+        sizegrowth         = -0.5,
+        sizemod            = 0.96,
+        texture            = [[flame]],
+        useairlos          = true,
+      },
+    },
+
+    trail_smoke = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.93,
+        colormap           = [[0.08 0.07 0.07 0.95   0.09 0.09 0.09 0.7   0.07 0.07 0.07 0.4   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 10,
+        emitrotspread      = 30,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, -0.08, 0]],
+        numparticles       = 5,
+        particlelife       = 80,
+        particlelifespread = 30,
+        particlesize       = 30,
+        particlesizespread = 12,
+        particlespeed      = 1.0,
+        particlespeedspread = 0.7,
+        pos                = [[0, -2, 0]],
+        sizegrowth         = 0.9,
+        sizemod            = 0.98,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    sparks = {
+      air      = true,
+      ground   = true,
+      water    = false,
+      class    = [[CSimpleParticleSystem]],
+      count    = 1,
+      properties = {
+        airdrag            = 0.86,
+        colormap           = [[1.0 0.9 0.6 0.9   1.0 0.6 0.25 0.6   0.8 0.35 0.1 0.3   0 0 0 0.01]],
+        directional        = false,
+        emitrot            = 0,
+        emitrotspread      = 45,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[0, -0.35, 0]],
+        numparticles       = 7,
+        particlelife       = 22,
+        particlelifespread = 8,
+        particlesize       = 6,
+        particlesizespread = 3,
+        particlespeed      = 4.5,
+        particlespeedspread = 2.5,
+        pos                = [[0, 0, 0]],
+        sizegrowth         = -0.7,
+        sizemod            = 0.97,
+        texture            = [[flame]],
+        useairlos          = true,
+      },
+    },
+
+    -- Small turbulence added to the trailing smoke
+    turbulence = {
+      class    = [[CExpGenSpawner]],
+      count    = 6,
+      properties = {
+        delay              = [[0 r30]],
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[0 r12, -4 r8, 0 r12]],
+      },
+    },
+  },
+
+  ----------------------------------------------------------------------
+  -- FIREBALL IMPACT EFFECT (EXTREME COMET IMPACT)
+  ----------------------------------------------------------------------
+  ["volcano_fireball_impact"] = {
+    impact_smoke = {
+      class  = [[CSimpleParticleSystem]],
+      count  = 1,
+      ground = true,
+      air    = true,
+      water  = false,
+      properties = {
+        airdrag            = 0.90,
+        colormap           = [[0.1 0.1 0.1 1   0.09 0.09 0.09 0.6   0 0 0 0.01]],
+        emitrot            = 80,
+        emitrotspread      = 45,
+        emitvector         = [[0,1,0]],
+        gravity            = [[0,-0.05,0]],
+        numparticles       = 20,
+        particlelife       = 80,
+        particlelifespread = 35,
+        particlesize       = 120,
+        particlesizespread = 60,
+        particlespeed      = 6,
+        particlespeedspread = 3,
+        pos                = [[0,5,0]],
+        sizegrowth         = 1.0,
+        sizemod            = 0.97,
+
+        rotParams          = [[-16 r16, -8 r8, -180 r360]],
+        -- TEXTURE/ANIM TWEAK
+        animParams         = [[8,8,120 r80]],
+        texture            = [[smoke-beh-anim]],
+
+        useairlos          = true,
+      },
+    },
+
+    impact_flame = {
+      class  = [[CSimpleParticleSystem]],
+      count  = 1,
+      air    = true,
+      ground = true,
+      water  = false,
+      properties = {
+        airdrag            = 0.90,
+        colormap           = [[1 0.8 0.3 1   1 0.3 0.1 0.5   0.3 0.1 0.05 0.2   0 0 0 0.01]],
+        emitrot            = 90,
+        emitrotspread      = 25,
+        emitvector         = [[0,1,0]],
+        gravity            = [[0,-0.2,0]],
+        numparticles       = 14,
+        particlelife       = 30,
+        particlelifespread = 12,
+        particlesize       = 90,
+        particlesizespread = 50,
+        particlespeed      = 8,
+        particlespeedspread = 3,
+        pos                = [[0,3,0]],
+        sizegrowth         = -1.4,
+        sizemod            = 0.96,
+        texture            = [[flame]],
+        useairlos          = true,
+      },
+    },
+
+    -- Extra churn in the impact smoke
+    turbulence = {
+      class    = [[CExpGenSpawner]],
+      count    = 8,
+      properties = {
+        delay              = [[0 r25]],
+        explosiongenerator = [[custom:volcano_smoke_turbulence]],
+        pos                = [[0 r40, 4 r20, 0 r40]],
+      },
+    },
+  },
+
+}

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -958,18 +958,20 @@ function UnitDef_Post(name, uDef)
 	-- Wreck and heap standardization
 	if not uDef.customparams.iscommander and not uDef.customparams.iseffigy then
 		if uDef.featuredefs and uDef.health then
+			local wreckRatio = modOptions.wreck_metal_ratio or 0.6
+			local heapRatio = modOptions.heap_metal_ratio or 0.25
 			-- wrecks
 			if uDef.featuredefs.dead then
 				uDef.featuredefs.dead.damage = uDef.health
 				if uDef.metalcost and uDef.energycost then
-					uDef.featuredefs.dead.metal = math.floor(uDef.metalcost * modOptions.wreck_metal_ratio)
+					uDef.featuredefs.dead.metal = math.floor(uDef.metalcost * wreckRatio)
 				end
 			end
 			-- heaps
 			if uDef.featuredefs.heap then
 				uDef.featuredefs.heap.damage = uDef.health
 				if uDef.metalcost and uDef.energycost then
-					uDef.featuredefs.heap.metal = math.floor(uDef.metalcost * modOptions.heap_metal_ratio)
+					uDef.featuredefs.heap.metal = math.floor(uDef.metalcost * heapRatio)
 				end
 			end
 		end

--- a/luarules/configs/powerusers.lua
+++ b/luarules/configs/powerusers.lua
@@ -6,6 +6,7 @@ local everything = {
 	playerdata = true,
 	waterlevel = true,
 	sysinfo = true,
+	volcano = true,
 }
 local moderator = {
 	give = false,
@@ -15,6 +16,7 @@ local moderator = {
 	playerdata = false,
 	waterlevel = false,
 	sysinfo = true,
+	volcano = true,
 }
 local singleplayer = {		-- note: these permissions override others when singleplayer
 	give = true,
@@ -24,6 +26,7 @@ local singleplayer = {		-- note: these permissions override others when singlepl
 	waterlevel = true,
 	playerdata = true,
 	sysinfo = false,
+	volcano = true,
 }
 
 return {
@@ -42,13 +45,13 @@ return {
 
 	-- temporary event admins for planetary campaign (remove when event is over)
 	[16285] = everything,	-- [BAB]Zer0_Cool
-	[42214] = everything,	-- [BAB]Tenebos 
-	[21783] = everything,	-- [BAB]Darknight_2277 
+	[42214] = everything,	-- [BAB]Tenebos
+	[21783] = everything,	-- [BAB]Darknight_2277
 	[64509] = everything,	-- Xix2g
 	[111659] = everything,	-- Snipebusher
-	[18436] = everything,	-- [BAB]Kuroi_Kitsune 
-	[303060] = everything,	-- [Mado]Tripl3 
-	[204872] = everything,	-- RAM_10rotator01 
+	[18436] = everything,	-- [BAB]Kuroi_Kitsune
+	[303060] = everything,	-- [Mado]Tripl3
+	[204872] = everything,	-- RAM_10rotator01
 
 	-- moderator level users
 	[3133] = moderator,		-- Lexon

--- a/luarules/gadgets/game_volcano_pyroclastic.lua
+++ b/luarules/gadgets/game_volcano_pyroclastic.lua
@@ -1,0 +1,468 @@
+--------------------------------------------------------------------------------
+-- VOLCANO PYROCLASTIC ERUPTIONS — 
+--------------------------------------------------------------------------------
+
+function gadget:GetInfo()
+    return {
+        name    = "Volcano Pyroclastic Eruptions",
+        desc    = "Cinematic volcano eruption event for BAR",
+        author  = "Steel",
+        date    = "Dec 2025",
+        layer   = 0,
+        enabled = true,
+    }
+end
+
+--------------------------------------------------------------------------------
+-- SYNCED
+--------------------------------------------------------------------------------
+if gadgetHandler:IsSyncedCode() then
+
+--------------------------------------------------------------------------------
+-- Shortcuts
+--------------------------------------------------------------------------------
+local spCreateUnit          = Spring.CreateUnit
+local spDestroyUnit         = Spring.DestroyUnit
+local spGiveOrderToUnit     = Spring.GiveOrderToUnit
+local spSpawnCEG            = Spring.SpawnCEG
+local spGetGroundHeight     = Spring.GetGroundHeight
+local spSetUnitCloak        = Spring.SetUnitCloak
+local spMoveCtrlEnable      = Spring.MoveCtrl.Enable
+local spMoveCtrlSetPosition = Spring.MoveCtrl.SetPosition
+
+local GameFrame      = Spring.GetGameFrame
+local SendToUnsynced = SendToUnsynced
+
+local CMD_ATTACK     = CMD.ATTACK
+local CMD_FIRE_STATE = CMD.FIRE_STATE
+
+--------------------------------------------------------------------------------
+-- Volcano center
+--------------------------------------------------------------------------------
+local VX = Game.mapSizeX * 0.5
+local VZ = Game.mapSizeZ * 0.5
+
+local VRIM = 600
+local LAUNCHER_Y = VRIM - 300
+
+--------------------------------------------------------------------------------
+-- Timing control
+--------------------------------------------------------------------------------
+local VOLCANO_EJECT_DELAY_FRAMES = 86   -- << EDIT THIS ONLY
+
+local FIRST_MIN    = 8  * 60 * 30   -- 8 minutes
+local FIRST_MAX    = 12 * 60 * 30   -- 12 minutes
+local COOLDOWN_MIN = 8  * 60 * 30   -- 8 minutes
+local COOLDOWN_MAX = 12 * 60 * 30   -- 12 minutes
+local BUILDUP      = 20 * 30
+
+--------------------------------------------------------------------------------
+-- Runtime / map control
+--------------------------------------------------------------------------------
+local REQUIRED_MAP = "forge v2.3"
+local volcanoActive = true
+
+local function Normalize(s)
+    s = tostring(s or "")
+    s = string.lower(s)
+    s = s:gsub(";", "")
+    s = s:gsub("%s+", " ")
+    s = s:gsub("^%s+", ""):gsub("%s+$", "")
+    return s
+end
+
+local function IsVolcanoEnabled()
+    local modOpts = (Spring.GetModOptions and Spring.GetModOptions()) or {}
+    local v = modOpts.forge_volcano
+    return v == nil or v == true or v == 1 or v == "1" or v == "true"
+end
+
+--------------------------------------------------------------------------------
+-- State
+--------------------------------------------------------------------------------
+local nextErupt = nil
+local delayed = {}
+local pendingDestroy = {}
+local firstFireballFrame = nil
+local ejectScheduled = false
+local buildupSoundPlayed = false
+
+local function R(a,b) return a + math.random()*(b-a) end
+
+--------------------------------------------------------------------------------
+-- DelayCall helper
+--------------------------------------------------------------------------------
+local function DelayCall(func, args, delay)
+    local f = GameFrame() + delay
+    delayed[f] = delayed[f] or {}
+    delayed[f][#delayed[f]+1] = {func,args}
+end
+
+--------------------------------------------------------------------------------
+-- Volcano Controls "/luarules volcano" to pause/resume volcano explosion
+--------------------------------------------------------------------------------
+
+local function ResetVolcanoState()
+    nextErupt = GameFrame() + R(COOLDOWN_MIN, COOLDOWN_MAX)
+    delayed = {}
+    pendingDestroy = {}
+    firstFireballFrame = nil
+    ejectScheduled = false
+    buildupSoundPlayed = false
+end
+
+function gadget:Initialize()
+    if Normalize(Game.mapName) ~= REQUIRED_MAP then
+        gadgetHandler:RemoveGadget(self)
+        return
+    end
+
+    volcanoActive = IsVolcanoEnabled()
+    if not volcanoActive then
+        ResetVolcanoState()
+    end
+
+    gadgetHandler:AddChatAction("volcano", function(cmd, line, words, playerID)
+        local accountInfo = select(11, Spring.GetPlayerInfo(playerID))
+        local accountID = (accountInfo and accountInfo.accountid) and tonumber(accountInfo.accountid) or -1
+        local authorized = _G.permissions.volcano[accountID]
+
+        if not (authorized or Spring.IsCheatingEnabled()) then
+            Spring.Echo("[Volcano] Unauthorized command.")
+            return
+        end
+
+        volcanoActive = not volcanoActive
+        if volcanoActive then
+            nextErupt = GameFrame() + R(COOLDOWN_MIN, COOLDOWN_MAX)
+            Spring.Echo("[Volcano] Volcano system resumed.")
+        else
+            ResetVolcanoState()
+            Spring.Echo("[Volcano] Volcano system paused.")
+        end
+    end)
+end
+
+function gadget:Shutdown()
+    gadgetHandler:RemoveChatAction("volcano")
+end
+
+--------------------------------------------------------------------------------
+-- Ash helpers
+--------------------------------------------------------------------------------
+local function spawnAshBuild()
+    local x = VX + math.random(-160,160)
+    local z = VZ + math.random(-160,160)
+    spSpawnCEG("volcano_ash_build", x, spGetGroundHeight(x,z) + VRIM, z)
+end
+
+local function spawnAshBig()
+    local x = VX + math.random(-260,260)
+    local z = VZ + math.random(-260,260)
+    spSpawnCEG("volcano_ash_big", x, spGetGroundHeight(x,z) + VRIM + 50, z)
+end
+
+local function spawnAshSmall()
+    local x = VX + math.random(-320,320)
+    local z = VZ + math.random(-320,320)
+    spSpawnCEG("volcano_ash_small", x, spGetGroundHeight(x,z) + VRIM, z)
+end
+
+--------------------------------------------------------------------------------
+-- FIRE HELPERS
+--------------------------------------------------------------------------------
+local FIRE_CEG = "fire-area-150"
+
+local FIRE_RIM_RADIUS = 160 * 1.20
+local VRIM_FIRE_HEIGHT = VRIM
+
+local function spawnFireRimCEG()
+    local a = math.random() * math.pi * 2
+    local x = VX + math.cos(a) * FIRE_RIM_RADIUS
+    local z = VZ + math.sin(a) * FIRE_RIM_RADIUS
+    local y = spGetGroundHeight(VX, VZ) + VRIM_FIRE_HEIGHT
+    spSpawnCEG(FIRE_CEG, x, y, z)
+end
+
+local function spawnFireMouthCEG()
+    local y = spGetGroundHeight(VX, VZ) + VRIM
+    spSpawnCEG(
+        FIRE_CEG,
+        VX + math.random(-30,30),
+        y,
+        VZ + math.random(-30,30)
+    )
+end
+
+local FIRE_OUTER_RADIUS_MIN = 220
+local FIRE_OUTER_RADIUS_MAX = 900
+
+local function spawnFireSlopeCEG()
+    local a = math.random() * math.pi * 2
+    local d = FIRE_OUTER_RADIUS_MIN +
+              math.random() * (FIRE_OUTER_RADIUS_MAX - FIRE_OUTER_RADIUS_MIN)
+
+    local x = VX + math.cos(a) * d
+    local z = VZ + math.sin(a) * d
+    local y = spGetGroundHeight(x, z) + 14
+
+    spSpawnCEG(FIRE_CEG, x, y, z)
+end
+
+--------------------------------------------------------------------------------
+-- Fireball launcher
+--------------------------------------------------------------------------------
+local function launchFireball()
+    if not firstFireballFrame then
+        firstFireballFrame = GameFrame()
+        ejectScheduled = false
+    end
+
+    local uid = spCreateUnit(
+        "volcano_projectile_unit",
+        VX, LAUNCHER_Y, VZ, 0,
+        Spring.GetGaiaTeamID()
+    )
+    if not uid then return end
+
+    spSetUnitCloak(uid, true, 100000)
+    spMoveCtrlEnable(uid)
+    spMoveCtrlSetPosition(uid, VX, LAUNCHER_Y, VZ)
+    spGiveOrderToUnit(uid, CMD_FIRE_STATE, {2}, {})
+
+    local a = math.random()*math.pi*2
+    local d = 900 + math.random(900)
+    spGiveOrderToUnit(
+        uid,
+        CMD_ATTACK,
+        { VX + math.cos(a)*d,
+          spGetGroundHeight(VX,VZ) + 20,
+          VZ + math.sin(a)*d },
+        {}
+    )
+
+    pendingDestroy[uid] = GameFrame() + 90
+end
+
+--------------------------------------------------------------------------------
+-- Main loop
+--------------------------------------------------------------------------------
+function gadget:GameFrame(f)
+
+    if not volcanoActive then
+        return
+    end
+
+    if delayed[f] then
+        for _,d in ipairs(delayed[f]) do
+            local fn,args = d[1],d[2]
+            if args then fn(unpack(args)) else fn() end
+        end
+        delayed[f] = nil
+    end
+
+    for uid,kill in pairs(pendingDestroy) do
+        if f >= kill then
+            spDestroyUnit(uid,false,true)
+            pendingDestroy[uid] = nil
+        end
+    end
+
+    if not nextErupt then
+        nextErupt = f + R(FIRST_MIN,FIRST_MAX)
+        return
+    end
+
+    local remain = nextErupt - f
+
+    if remain > 0 and remain <= BUILDUP then
+        if f % 4 == 0 then spawnAshBuild() end
+        if math.random() < 0.02 then spawnFireRimCEG() end
+        if math.random() < 0.03 then spawnFireSlopeCEG() end
+
+        if not buildupSoundPlayed then
+            SendToUnsynced("volcano_buildup_rumble")
+            SendToUnsynced("quake_warning", "SEISMIC ACTIVITY DETECTED")
+            buildupSoundPlayed = true
+        end
+        return
+    end
+
+    if f >= nextErupt then
+        buildupSoundPlayed = false
+
+        for b = 1, 3 do
+            DelayCall(function()
+                for i = 1, math.random(3,5) do
+                    spawnFireRimCEG()
+                end
+            end, nil, b * (3 * 30))
+        end
+
+        math.random()
+        local n = math.random(5,11) -- number of fireballs
+        local step = math.max(1, math.floor(60 / n))
+        local start = 30 + math.random(0,4)
+
+        for i=1,n do
+            DelayCall(launchFireball, nil,
+                start + (i-1)*step + math.random(0,4))
+        end
+
+        for i = 1, math.random(10,16) do
+            DelayCall(spawnFireMouthCEG, nil, math.random(0,150))
+        end
+
+        for i = 1, math.random(12,18) do
+            DelayCall(spawnFireSlopeCEG, nil, math.random(0,180))
+        end
+
+        DelayCall(function()
+            for i=1,28 do spawnAshBig() end
+        end, nil, start)
+
+        for i=1,18 do spawnAshSmall() end
+
+        nextErupt = f + R(COOLDOWN_MIN,COOLDOWN_MAX)
+    end
+
+    ------------------------------------------------------------------
+    -- EJECT PLUME + LAVA SPLASHES + SHOCKWAVE
+    ------------------------------------------------------------------
+    if firstFireballFrame and not ejectScheduled then
+        if f >= firstFireballFrame + VOLCANO_EJECT_DELAY_FRAMES then
+            ejectScheduled = true
+            firstFireballFrame = nil
+
+            SendToUnsynced("volcano_eject_sound")
+
+            local groundY = spGetGroundHeight(VX, VZ)
+            local baseY   = groundY + VRIM
+
+            -- Eject plume (unchanged)
+            for i=1,math.random(3,5) do
+                DelayCall(function()
+                    spSpawnCEG(
+                        "volcano_eject",
+                        VX + math.random(-40,40),
+                        baseY + math.random(180,420),
+                        VZ + math.random(-40,40)
+                    )
+                end, nil, math.random(0,25))
+            end
+
+            -- Lava splashes (nukexl)
+            local splashBaseY = baseY + 34
+            local splashCount = math.random(2,3)
+
+            for i = 1, splashCount do
+                DelayCall(function()
+                    spSpawnCEG(
+                        "volcano_lava_splash_nukexl",
+                        VX + math.random(-45,45),
+                        splashBaseY,
+                        VZ + math.random(-45,45)
+                    )
+                end, nil, (i-1) * math.random(2,4))
+            end
+
+            -- Shockwave (single, anchored)
+            spSpawnCEG(
+                "shockwaveceg",
+                VX,
+                baseY,
+                VZ
+            )
+
+            -- Additional fire effects (same height as shockwave)
+            spSpawnCEG(
+                "volcano1_flames",
+                VX,
+                baseY,
+                VZ
+            )
+            spSpawnCEG(
+                "volcano_rising_fireball_spawner",
+                VX,
+                baseY,
+                VZ
+            )
+	   
+        end
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Projectile visuals
+--------------------------------------------------------------------------------
+local activeFireballs = {}
+
+function gadget:ProjectileCreated(id, ownerID, weaponDefID)
+    local wd = WeaponDefs[weaponDefID]
+    if wd and wd.name == "Volcano Fireball" then
+        activeFireballs[id] = true
+    end
+end
+
+function gadget:ProjectileDestroyed(id)
+    activeFireballs[id] = nil
+end
+
+function gadget:ProjectileMoved(id,x,y,z)
+    if activeFireballs[id] then
+        spSpawnCEG(FIRE_CEG, x,y,z)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- UNSYNCED (SOUNDS + WARNING UI)
+--------------------------------------------------------------------------------
+else
+
+local spPlaySoundFile   = Spring.PlaySoundFile
+local spGetGameFrame    = Spring.GetGameFrame
+local spGetViewGeometry = Spring.GetViewGeometry
+
+local glPushMatrix = gl.PushMatrix
+local glPopMatrix  = gl.PopMatrix
+local glTranslate  = gl.Translate
+local glText       = gl.Text
+
+local WARNING_FRAMES = 90 -- ~3 seconds at 30 fps
+
+local warningText, warningEnd
+
+function gadget:Initialize()
+    gadgetHandler:AddSyncAction("volcano_buildup_rumble", function()
+        spPlaySoundFile("sounds/atmos/lavarumble2.wav", 1.0, "ui")
+    end)
+
+    gadgetHandler:AddSyncAction("volcano_eject_sound", function()
+        spPlaySoundFile("sounds/atmos-local/lavaburst2.wav", 1.5, "ui")
+        spPlaySoundFile("sounds/atmos/lavarumble3.wav", 0.9, "ui")
+        spPlaySoundFile("sounds/weapons/xplolrg1.wav", 0.55, "ui")
+    end)
+
+    gadgetHandler:AddSyncAction("quake_warning", function(_, msg)
+        warningText = msg or "SEISMIC ACTIVITY DETECTED"
+        warningEnd  = spGetGameFrame() + WARNING_FRAMES
+
+        Spring.Echo("[Volcano] Warning: " .. warningText)
+        spPlaySoundFile("sounds/voice-soundeffects/LavaAlert.wav", 1.0, "ui")
+    end)
+end
+
+-- Big warning text at top of screen during WARNING_FRAMES
+function gadget:DrawScreen()
+    local frame = spGetGameFrame()
+    if warningText and frame < warningEnd then
+        local vsx, vsy = spGetViewGeometry()
+        glPushMatrix()
+        glTranslate(vsx * 0.5, vsy * 0.7, 0)
+        glText(warningText, 0, 0, 36, "oc")
+        glPopMatrix()
+    end
+end
+
+end
+--------------------------------------------------------------------------------

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1561,7 +1561,7 @@ local options = {
             unlock = {"community_balance_commando", "community_balance_cortermite", "community_balance_armwar", "community_balance_armfast", "community_balance_corjamt"} },
         }
     },
-    
+
     {
         key     = "community_balance_patch_changelog_link",
         name    = "Changelog",
@@ -1874,6 +1874,16 @@ local options = {
     },
 
     {
+        key     = "forge_volcano",
+        name    = "Forge Volcano Event",
+        desc    = "Enable the cinematic volcano eruption event on Forge v2.3.",
+        type    = "bool",
+        hidden 	= true,
+        section = "options_experimental",
+        def     = false,
+    },
+
+    {
         key 	= "factory_costs",
         name 	= "Factory Costs Test Patch",
         desc 	= "Cheaper and more efficient factories, more expensive nanos, and slower to build higher-tech units. Experimental, not expected to be balanced by itself - a test to try how the game plays if each player is more able to afford their own T2 factory, while making assisting them less efficient.",
@@ -2180,7 +2190,7 @@ Example: Armada VS Cortex VS Legion: 273 or 100 010 001 or 256 + 16 + 1]],
         max		= 10000,
         step	= 1,
     },
-    
+
     {
         key		= "startmetalstorage",
         name	= "Starting Metal Storage",

--- a/units/other/volcano_projectile_unit.lua
+++ b/units/other/volcano_projectile_unit.lua
@@ -1,0 +1,126 @@
+--------------------------------------------------------------------------------
+-- Dummy Projectile Unit written by Steel December 2025
+--
+-- Overview:
+--   This unit definition exists solely to support game_volcano_pyroclastic.lua
+--   This dummy unit launches the fireballs from the volcano on Forge v2.3
+
+return {
+	volcano_projectile_unit = {
+
+		--------------------------------------------------------------------------
+		-- REQUIRED BY BAR (DO NOT REMOVE)
+		--------------------------------------------------------------------------
+		customparams     = {
+			faction = "NONE",
+			is_volcano_launcher = 1,
+		},
+
+		--------------------------------------------------------------------------
+		-- Give it non-zero power (prevents XP / division warnings)
+		--------------------------------------------------------------------------
+		metalcost        = 100,
+		energycost       = 100,
+		buildtime        = 1,
+		health           = 1000000,
+		power            = 1,
+
+		--------------------------------------------------------------------------
+		-- No wreckage
+		--------------------------------------------------------------------------
+		corpse           = "",
+		leavetracks      = false,
+
+		--------------------------------------------------------------------------
+		-- Real combat unit (engine requirement)
+		--------------------------------------------------------------------------
+		canmove          = true,
+		movementclass    = "BOT3",
+		speed            = 0.0001,
+
+		canattack        = true,
+		canattackground  = true,
+		category         = "SURFACE",
+
+		--------------------------------------------------------------------------
+		-- Invisible & non-interactive
+		--------------------------------------------------------------------------
+		drawtype         = 0,
+		selectable       = false,
+		blocking         = false,
+		yardmap          = "o",
+
+		canstop          = false,
+		canpatrol        = false,
+		canrepeat        = false,
+
+		-- invisible in-game without removing the model/script pipeline
+		initcloaked      = true,
+		cloakcost        = 0,
+		cloakcostmoving  = 0,
+		mincloakdistance = 0,
+		stealth          = true,
+		sonarstealth     = true,
+
+		--------------------------------------------------------------------------
+		-- Known-good firing pipeline
+		--------------------------------------------------------------------------
+		objectname       = "Units/CORTHUD.s3o",
+		script           = "Units/CORTHUD.cob",
+
+		footprintx       = 2,
+		footprintz       = 2,
+
+		sightdistance    = 0,
+		radardistance    = 0,
+		seismicsignature = 0,
+
+		--------------------------------------------------------------------------------
+		-- WEAPON
+		--------------------------------------------------------------------------------
+		weapondefs       = {
+			volcano_fireball = {
+				name               = "Volcano Fireball",
+				weapontype         = "Cannon",
+
+				model              = "Raptors/greyrock2.s3o",
+				cegtag             = "volcano_rock_trail",
+				explosiongenerator = "custom:volcano_rock_impact",
+
+				gravityaffected    = true,
+				hightrajectory     = 1,
+				trajectoryheight   = 1.1,
+				mygravity          = 0.16,
+
+				range              = 32000,
+				reloadtime         = 5,
+				weaponvelocity     = 780,
+				impulsefactor      = 3,
+				impulseboost       = 400,
+				turret             = true,
+				tolerance          = 5000,
+				areaofeffect       = 220,
+				edgeeffectiveness  = 0.9,
+
+				collideground      = true,
+				avoidfriendly      = false,
+				avoidfeature       = false,
+
+				soundhit           = "xplolrg1",
+				soundhitvolume     = 75,
+
+				damage             = {
+					default = 100,
+				},
+
+			},
+		},
+
+		weapons          = {
+			[1] = {
+				def = "VOLCANO_FIREBALL",
+				onlyTargetCategory = "SURFACE",
+			},
+		},
+	},
+}


### PR DESCRIPTION
Cinematic environmental volcano event system for Beyond All Reason (BAR).

This gadget orchestrates a staged volcanic eruption including seismic buildup, warning systems, eruption column, projectile launch, shockwave, smoke turbulence, and impact effects.

📌 Usage: !bset forge_volcano 1 within the lobby, make sure the map Forge v2.3 is selected. Admin / host can issue the command /luarules volcano to pause / resume the event with cheats enabled.

📌 Scope

Map locked: Forge v2.3

Automatically unloads itself on all other maps

Purely environmental / cinematic (no direct gameplay logic)

⏱ Event Timeline

Each eruption cycle follows this sequence:

1️⃣ Dormant Interval

Randomized cooldown:

8–12 minutes

2️⃣ Seismic Buildup (~20 seconds)

Low-frequency rumble

Voice alert (LavaAlert.wav)

On-screen warning:

SEISMIC ACTIVITY DETECTED

3️⃣ Eruption Trigger

Shockwave CEG

Rising fireball column

Smoke turbulence

Volcanic projectile spawn

4️⃣ Projectile Phase

In-flight volcanic visuals

Impact effects on landing

Environmental smoke/debris

5️⃣ Reschedule

Next eruption randomized between 8–12 minutes.

🧱 Architecture 🔹 Synced

Frame-based eruption scheduler

State machine (Dormant → Buildup → Eruption)

Projectile spawning

CEG triggering

Sync→Unsynced messaging

🔹 Unsynced

Rumble audio

LavaAlert voice playback

Screen warning text rendering

Communication handled via:

SendToUnsynced() 📦 Dependencies Effects effects/volcano.lua

Defines:

volcano_rising_fireball_spawner

volcano_rising_fireball_sub

shockwaveceg

volcano_smoke_turbulence

Projectile impact CEG chains

Projectile Unit volcano_projectile_unit.lua

Handles:

Spawned volcanic projectile entity

In-flight visuals

Impact behavior

Audio sounds/voice-soundeffects/LavaAlert.wav ⚙ Timing Configuration

All timing values are frame-based (30 FPS baseline):

Constant Purpose FIRST_MIN / FIRST_MAX Initial eruption delay COOLDOWN_MIN / COOLDOWN_MAX Repeat interval (8–12 min) BUILDUP Pre-eruption escalation duration WARNING_FRAMES On-screen text duration 🎯 Design Goals

Large-scale cinematic environmental event

Deterministic scheduling

Strict map isolation

🛠 Notes

Eruption intervals are randomized per cycle.

All CEGs in volcano.lua are actively referenced.

Designed specifically for Forge volcano terrain.
