### PR TITLE
Feb '26 Community Balance Patch

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1545,45 +1545,32 @@ local options = {
 
     {
         key     = "community_balance_patch",
-        name    = "Community Balance Patch Jan '26",
+        name    = "Community Balance Patch Feb '26",
         desc    = "Enable community balance patch changes\n(overwrites changes in official seasonal balance test)",
         type    = "list",
         def     = "disabled",
         section = "options_experimental",
         items   = {
             { key = "disabled", name = "Disabled", desc = "No community balance changes",
-            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armwar","community_balance_armfast","community_balance_corjamt"} },
+            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armfast","community_balance_armcroc","community_balance_corkorg","community_balance_corspy"} },
 
-            { key = "enabled",  name = "Enabled",  desc = "Enable all community balance changes\nCommando\nTermite\nCenturion\nSprinter\nCastro",
-            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armwar","community_balance_armfast","community_balance_corjamt"} },
+            { key = "enabled",  name = "Enabled",  desc = "Enable all community balance changes\nCommando\nTermite\nSprinter\nTurtle\nJuggernaut\nSpectre",
+            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armfast","community_balance_armcroc","community_balance_corkorg","community_balance_corspy"} },
 
             { key = "custom",   name = "Custom",   desc = "Customize individual community balance changes",
-            unlock = {"community_balance_commando", "community_balance_cortermite", "community_balance_armwar", "community_balance_armfast", "community_balance_corjamt"} },
+            unlock = {"community_balance_commando", "community_balance_cortermite", "community_balance_armfast", "community_balance_armcroc", "community_balance_corkorg", "community_balance_corspy"} },
         }
     },
 
     {
         key     = "community_balance_patch_changelog_link",
-        name    = "Changelog",
+        name    = "Changelog/Feedback",
         desc    = "Community Balance Patch changelog",
         section = "options_experimental",
         type    = "link",
-        link    = "https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6550",
-        width   = 195,
+        link    = "https://discord.com/channels/549281623154229250/1462625474344783872/1462625474344783872",
+        width   = 235,
         column  = 2.025,
-        linkheight = 325,
-        linkwidth = 350,
-    },
-
-    {
-        key     = "community_balance_patch_feedback_link",
-        name    = "Feedback Thread",
-        desc    = "Discord discussion about Community Balance Patch.",
-        section = "options_experimental",
-        type    = "link",
-        link    = "https://discord.com/channels/549281623154229250/1447954953481228529/1447954953481228529",
-        width   = 215,
-        column  = 2.35,
         linkheight = 325,
         linkwidth = 350,
     },
@@ -1591,7 +1578,7 @@ local options = {
     {
         key     = "community_balance_commando",
         name    = "(CBP) Commando",
-        desc    = "+130 jammer range (150 -> 280)\n+300 radar and LoS (900 -> 1200, 600 -> 900)\nAdd light and heavy mines to build options\n80% EMP resist\n2s self-destruct timer\nx2 autoheal (9 -> 18)\nWeapon: Cannon -> Laser\n100 dmg, 50 vs air (w/ laser damage falloff)\n2 shots/second (unchanged)\n100% accuracy\n8 aoe, 20 e/shot\n300 -> 450 range\nTargets air units\nCan be built in amphibious complex",
+        desc    = "(From January)\n+130 jammer range (150 -> 280)\n+300 radar and LoS (900 -> 1200, 600 -> 900)\nAdd light and heavy mines to build options\n80% EMP resist\n2s self-destruct timer\nx2 autoheal (9 -> 18)\nWeapon: Cannon -> Laser\n100 dmg, 50 vs air (w/ laser damage falloff)\n2 shots/second (unchanged)\n100% accuracy\n8 aoe, 20 e/shot\n300 -> 450 range\nTargets air units\nCan be built in amphibious complex",
         type    = "bool",
         def     = false,
         section = "options_experimental",
@@ -1600,16 +1587,7 @@ local options = {
     {
         key     = "community_balance_cortermite",
         name    = "(CBP) Termite",
-        desc    = "Added stealth",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_armwar",
-        name    = "(CBP) Centurion",
-        desc    = "Weapon range: 325 (from 330)\nSight distance: 330 (from 350)",
+        desc    = "(From January)\nAdded stealth",
         type    = "bool",
         def     = false,
         section = "options_experimental",
@@ -1618,16 +1596,34 @@ local options = {
     {
         key     = "community_balance_armfast",
         name    = "(CBP) Sprinter",
-        desc    = "Energy cost: 3500 (from 4140)\nAcceleration: 0.37 (from 0.414)\nSpeed: 115 (from 111.3)\nTurn-in-place angle: 115° (from 90°)\nTurn-in-place speed: 2.75 (from 2.4486)\nTurn rate: 1320 (from 1644.5)\nSight distance: 380 (from 351)\nWeapon: 18 AoE (from 16), 230 range (from 220), 15/5 damage (from 12/4)",
+        desc    = "(From January)\nEnergy cost: 3500 (from 4140)\nAcceleration: 0.37 (from 0.414)\nSpeed: 115 (from 111.3)\nTurn-in-place angle: 115° (from 90°)\nTurn-in-place speed: 2.75 (from 2.4486)\nTurn rate: 1320 (from 1644.5)\nSight distance: 380 (from 351)\nWeapon: 18 AoE (from 16), 230 range (from 220), 15/5 damage (from 12/4)",
         type    = "bool",
         def     = false,
         section = "options_experimental",
     },
 
     {
-        key     = "community_balance_corjamt",
-        name    = "(CBP) Castro",
-        desc    = "Build time: 9950 (from 4570)\nEnergy cost: 8500 (from 5200)\nEnergy upkeep: 40 (from 25)\nHealth: 790 (from 1070)\nMetal cost: 240 (from 115)\nRadar jammer distance: 500 (from 360)",
+        key     = "community_balance_armcroc",
+        name    = "(CBP) Turtle",
+        desc    = "(New)\nHealth: 5250 (from 5000)\nMain gun AoE: 80 (from 64), impulse factor: 0.50 (from 0.123)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_corkorg",
+        name    = "(CBP) Juggernaut",
+        desc    = "(New)\nAir LOS: 1600 (from 1260)\nMetal cost: 26000 (from 29000)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_corspy",
+        name    = "(CBP) Spectre",
+        desc    = "(New)\nEnergy cost: 8800 (from 12500)\nMetal cost: 135 (from 165)",
         type    = "bool",
         def     = false,
         section = "options_experimental",

--- a/unitbasedefs/community_balance_patch_defs.lua
+++ b/unitbasedefs/community_balance_patch_defs.lua
@@ -77,34 +77,11 @@ local function communityBalanceTweaks(name, uDef, modOptions)
 					end
 				end
 			end
-
-			-- Allow building cormando in amphib complex
-			if name == "coramsub" then
-				local numBuildoptions = #uDef.buildoptions
-				uDef.buildoptions[numBuildoptions + 1] = "cormando"
-			end
 		end
 
 		if all or (custom and modOptions.community_balance_cortermite) then
 			if name == "cortermite" then
 				uDef.stealth = true
-			end
-		end
-
-		if all or (custom and modOptions.community_balance_armwar) then
-			if name == "armwar" then
-				-- Reduce weapon range by 5 (330 - 5 = 325)
-				if uDef.weapondefs then
-					for weaponName, weaponDef in pairs(uDef.weapondefs) do
-						if weaponDef.range then
-							weaponDef.range = 325
-						end
-					end
-				end
-				-- Reduce LoS by 20 (350 - 20 = 330)
-				if uDef.sightdistance then
-					uDef.sightdistance = 330
-				end
 			end
 		end
 
@@ -132,14 +109,27 @@ local function communityBalanceTweaks(name, uDef, modOptions)
 			end
 		end
 
-		if all or (custom and modOptions.community_balance_corjamt) then
-			if name == "corjamt" then
-				uDef.buildtime = 9950
-				uDef.energycost = 8500
-				uDef.energyupkeep = 40
-				uDef.health = 790
-				uDef.metalcost = 240
-				uDef.radardistancejam = 500
+		if all or (custom and modOptions.community_balance_armcroc) then
+			if name == "armcroc" then
+				uDef.health = 5250
+				if uDef.weapondefs and uDef.weapondefs.arm_triton then
+					uDef.weapondefs.arm_triton.areaofeffect = 80
+					uDef.weapondefs.arm_triton.impulsefactor = 0.5
+				end
+			end
+		end
+
+		if all or (custom and modOptions.community_balance_corkorg) then
+			if name == "corkorg" then
+				uDef.airsightdistance = 1600
+				uDef.metalcost = 26000
+			end
+		end
+
+		if all or (custom and modOptions.community_balance_corspy) then
+			if name == "corspy" then
+				uDef.energycost = 8800
+				uDef.metalcost = 135
 			end
 		end
 	end


### PR DESCRIPTION
# Community Balance Patch — February '26
Enable in-game under **Experimental** → **Community Balance Patch**. Use **Enabled** for all changes or **Custom** to toggle units individually.
---
## Cortex — Commando
*From January*
- **Jammer range:** 150 → **280**
- **Radar range:** 900 → **1200**
- **Line of sight:** 600 → **900**
- **Build options:** Can build *light* and *heavy* mines
- **EMP resistance:** **80%**
- **Self-destruct timer:** **2s**
- **Autoheal:** 9 → **18** (idle and combat)
- **Weapon — Blaster:** *Cannon → beam laser*
  - **Damage:** 100 (50 vs air, with laser falloff)
  - **Fire rate:** 2 shots/sec *(unchanged)*
  - **Accuracy:** 100%
  - **AoE:** 8 | **20** e/shot
  - **Range:** 300 → **450**
  - Can target **air units**
---
## Cortex — Termite
*From January*
- **Stealth:** *Added*
---
## Armada — Sprinter
*From January*
- **Energy cost:** 4140 → **3500**
- **Acceleration:** 0.414 → **0.37**
- **Speed:** 111.3 → **115**
- **Turn-in-place angle:** 90° → **115°**
- **Turn-in-place speed:** 2.45 → **2.75**
- **Turn rate:** 1644 → **1320**
- **Sight distance:** 351 → **380**
- **Weapon:** AoE 16 → **18** | Range 220 → **230** | Damage **15**/5 *(was 12/4)*
---
## Armada — Turtle
*New*
- **Health:** 5000 → **5250**
- **Triton main gun**
  - **AoE:** 64 → **80**
  - **Impulse factor:** 0.123 → **0.50**
---
## Cortex — Juggernaut
*New*
- **Air LOS:** 1260 → **1600**
- **Metal cost:** 29 000 → **26 000**
---
## Cortex — Spectre
*New*
- **Energy cost:** 12 500 → **8800**
- **Metal cost:** 165 → **135**
---

These were selected by the community's votes. :thumbsup:  - :thumbsdown:  = :trophy: 
See the results [here](https://discord.com/channels/549281623154229250/1462625474344783872/1477784631989244186)

This PR was made with AI assistance from Cursor's Auto mode with careful supervision.