### PR TITLE
Added cormando mine back to utility build tab to maintain consistency

### DIFF
--- a/luaui/configs/gridmenu_layouts.lua
+++ b/luaui/configs/gridmenu_layouts.lua
@@ -2411,9 +2411,9 @@ local unitGrids = {
 			{ },                                                     --
 		},
 		{
-			{ "corfink", "coreyes", "cordrag", "corjamt", },         -- scout plane, camera, dragon's teeth, jammer
+			{ "cormine2", "coreyes", "cordrag", "corjamt", },         -- commando mine, camera, dragon's teeth, jammer
 			{ "corvalk", },                                          -- transport
-			{ "cormine4" },                                          -- commando mine
+			{ "corfink" },                                          -- scout plane
 		},
 		{
 			{ },        --


### PR DESCRIPTION

### Work done

Took out cormando's mine from the combat build tab back to the utility build tab to keep consistency across all builders.
Also made it the default build when selecting the utility tab (Z) and moved scout plane to Q.

One thing to note here before merging. Technically, cormando's mine was already in the utility tab, but in it's buildOptions property we were using cormine2. And in the gridmenu file we were using cormine4, so the mine was defaulting to the combat tab.

I don't know which mine cormando should use at this point, since it was probably an old change, but it should be a simple change in case the correct mine is cormine4


#### Addresses Issue(s)
Fixes #4041 

#### Test steps
Build a Cormando in T2 lab
Change to utility tab, the mine should be in Z and should be the default build option as you change to the tab


#### BEFORE:

<img width="382" height="319" alt="before1" src="https://github.com/user-attachments/assets/c2b10719-e3d9-41c3-8aaa-d13ceb8e7dc0" />


<img width="382" height="327" alt="before2" src="https://github.com/user-attachments/assets/c430c05f-5f62-49bd-b491-65af7146a12b" />



#### AFTER:

<img width="379" height="321" alt="after1" src="https://github.com/user-attachments/assets/6204fafc-60cc-4e26-81a4-9d5809ef3298" />

<img width="383" height="323" alt="after2" src="https://github.com/user-attachments/assets/755e8eb4-f862-4fa0-8d60-d0959f773ab8" />