### PR TITLE
Fix metal value format in armcomboss.lua

### DIFF
--- a/units/Scavengers/Boss/armcomboss.lua
+++ b/units/Scavengers/Boss/armcomboss.lua
@@ -79,7 +79,7 @@ return {
 				footprintx = 2,
 				footprintz = 2,
 				height = 55,
-				metal = "2500",
+				metal = 2500,
 				object = "Units/scavboss/armcomboss_dead.s3o",
 				reclaimable = true,
 			},


### PR DESCRIPTION
metal value should a float/int value instead of a string

