### PR TITLE
Add helper function table.keys

### DIFF
--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -297,10 +297,11 @@ if not table.contains then
 end
 
 if not table.keys then
-	---Returns all keys of a table as an array.
+	---Returns all keys of a table as an array, and the count of keys.
 	---@generic K
 	---@param tbl table<K, any>
-	---@return K[]
+	---@return K[] keys
+	---@return number count
 	function table.keys(tbl)
 		local keys, count = {}, 0
 		for key in pairs(tbl) do


### PR DESCRIPTION

### Work done
Added helper function `table.keys`, which returns the keys of a table as an array.

#### Test steps
- Run the test mission on https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7018 where this is used.