### PR TITLE
Remove option to disable custom widgets

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -74,6 +74,7 @@ local options = {
         desc   	= "Allow custom user widgets or disallow them",
         type   	= "bool",
         def    	= true,
+		hidden	= true,
         section	= "options_main",
     },
 


### PR DESCRIPTION
### Work done
Removing option to disable custom widgets should help revive widget development and is essential for long term game development - widgets are an important way to improve QoL and introduce and encourage new contributors to BAR.

This has been discussed and agreed on in Contributor meetings, 

Option to disable user control widgets remains enabled.


<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [x] Applied the changes locally and tested in skirmish
