### PR TITLE
fix: Legion torp launcher missing defense range

### DIFF
--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -333,6 +333,7 @@ local function initUnitList()
 		['leglraa'] = { weapons = { 'air' } }, --T2 LR-AA
 		['legperdition'] = { weapons = { 'cannon' } }, --T2 LR-AA
 		['legapopupdef'] = { weapons = { 'ground' } }, --popup riot/minigun turret
+		['leganavaltorpturret'] = { weapons = { 'ground' } }, --torpedo launcher
 
 		['legstarfall'] = { weapons = { 'lrpc' } },
 		['leglrpc'] = { weapons = { 'lrpc' } },


### PR DESCRIPTION
### Work done

Add legtl and leganavaltorpturret to defenserange_gl4 and organize the odd-man-out mobile unit category in that file.