### PR TITLE
 Attempt at fixing ALT+Set Target snapping to wrong units 

### DIFF
--- a/luaui/Widgets/cmd_area_commands_filter.lua
+++ b/luaui/Widgets/cmd_area_commands_filter.lua
@@ -40,6 +40,7 @@ local spGetUnitPosition = Spring.GetUnitPosition
 local spGetFeaturePosition = Spring.GetFeaturePosition
 local spGetUnitArrayCentroid = Spring.GetUnitArrayCentroid
 local spGetFeatureResurrect = Spring.GetFeatureResurrect
+local spGetMyTeamID = Spring.GetMyTeamID
 
 local ENEMY_UNITS = Spring.ENEMY_UNITS
 local ALLY_UNITS = Spring.ALLY_UNITS
@@ -542,23 +543,27 @@ function widget:CommandNotify(cmdId, params, options)
 	local targetType, targetId
 
 	if currentCommand.allowedTargetTypes[UNIT] then
-		local nearbyUnits = spGetUnitsInCylinder(cmdX, cmdZ, CLICK_SEARCH_RADIUS, currentCommand.targetAllegiance)
-		if nearbyUnits then
-			local bestDistSq = math.huge
-			for _, uid in ipairs(nearbyUnits) do
-				local ux, _, uz = spGetUnitPosition(uid)
-				if ux then
-					local dx, dz = ux - cmdX, uz - cmdZ
-					local distSq = dx * dx + dz * dz
-					if distSq < bestDistSq then
-						bestDistSq = distSq
-						targetId = uid
+		if currentCommand.targetAllegiance == ENEMY_UNITS and WG.FindNearestEnemyUnit then
+			targetId = WG.FindNearestEnemyUnit(cmdX, cmdY, cmdZ, CLICK_SEARCH_RADIUS, spGetMyTeamID())
+		else
+			local nearbyUnits = spGetUnitsInCylinder(cmdX, cmdZ, CLICK_SEARCH_RADIUS, currentCommand.targetAllegiance)
+			if nearbyUnits then
+				local bestDistSq = math.huge
+				for _, uid in ipairs(nearbyUnits) do
+					local ux, _, uz = spGetUnitPosition(uid)
+					if ux then
+						local dx, dz = ux - cmdX, uz - cmdZ
+						local distSq = dx * dx + dz * dz
+						if distSq < bestDistSq then
+							bestDistSq = distSq
+							targetId = uid
+						end
 					end
 				end
 			end
-			if targetId then
-				targetType = UNIT
-			end
+		end
+		if targetId then
+			targetType = UNIT
 		end
 	end
 

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -296,4 +296,9 @@ function widget:Initialize()
 	if Spring.IsReplay() or spGetGameFrame() > 0 then
 		maybeRemoveSelf()
 	end
+	WG.FindNearestEnemyUnit = FindNearestEnemyUnit
+end
+
+function widget:Shutdown()
+	WG.FindNearestEnemyUnit = nil
 end


### PR DESCRIPTION
### Work done

ALT+Set Target (ALT+S) became increasingly unreliable in multiplayer games as more units populated the map, often targeting the wrong unit even when the cursor was precisely on the intended target.

https://github.com/user-attachments/assets/feb8de54-237b-413d-90d9-fc067677ae7c

This is a likely fix, but since I can't test it in multiplayer without merging, I can't fully confirm. Tested if the changes mess anything up in single player and they are fine. Worst case scenario is this does the same thing as before, different way. Performance seems unchanged. 

**Root cause (likely):** cmd_area_commands_filter.lua resolves which unit the player clicked on by round-tripping through screen-space:
```lua
local mouseX, mouseY = spWorldToScreenCoords(cmdX, cmdY, cmdZ)
local targetType, targetId = spTraceScreenRay(mouseX, mouseY)
```

The problem is that `cmdY` is the ground height, not the unit's visual center. `spWorldToScreenCoords` projects this ground point to screen coordinates, which at non-overhead camera angles maps to a position lower on screen than where the cursor actually was. `spTraceScreenRay` then fires from that displaced position and hits a different unit. This gets worse with more on-screen units (more models for the displaced ray to intersect) and in multiplayer where `spWorldToScreenCoords` and `spTraceScreenRay` can operate on different frame-interpolated positions under simulation load. This does not reproduce in skirmish because there is no frame interpolation divergence.

**Fix:** Replaced the screen-space roundtrip with a direct world-space search using `spGetUnitsInCylinder` / `spGetFeaturesInCylinder` within a small radius (60 elmos) of the command center point. The nearest valid unit/feature is the one the user intended - no camera angle or interpolation dependency. This also fixes the same class of bug for other ALT+area commands that go through this widget (Attack, Reclaim, Capture, etc.).

#### Addresses Issue(s)
- ALT+Set Target selecting wrong unit / not working in multiplayer games with many units

#### Setup
- Must be tested in a public lobby, not skirmish - the bug does not reproduce in skirmish due to absence of engine frame interpolation issues.

#### Test steps
- [ ] Join a public lobby, spawn SimpleAIs on the enemy team.
- [ ] Select own units, hold ALT and use Set Target (S) on a specific enemy unit in a dense group. Verify the correct unit is targeted consistently.
- [ ] Repeat in late-game with many units on the map - confirm targeting remains reliable.
- [ ] Test ALT+area Reclaim on a specific wreck in a dense wreck field - verify correct wreck type is filtered.
- [ ] Test ALT+area Attack on a specific unit type in a dense group - verify correct unit type is filtered.
- [ ] Test CTRL+area commands still work correctly (targets all units in area regardless of type).

### AI / LLM usage statement:
GitHub Copilot (Claude) was used to assist with tracing the command pipeline, identifying the root cause, and implementing the fix.