### PR TITLE
configure stylelua.toml for lx fmt

### DIFF
--- a/.stylelua.toml
+++ b/.stylelua.toml
@@ -1,10 +1,11 @@
 syntax = "All"
-column_width = 120
+column_width = 2000
 line_endings = "Unix"
-indent_type = "Spaces"
-indent_width = 2
+indent_type = "Tabs"
+indent_width = 4
 quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
+block_newline_gaps = "Preserve"
 collapse_simple_statement = "Never"
 space_after_function_names = "Never"
 


### PR DESCRIPTION
### Work done

- We use tab indentation, size-4
- Newlines around blocks are mildly encouraged and should be preserved in formatting

`lx fmt` is for our actions and automation but stylua also can run in LSP mode (`stylua --lsp`) so probably we should get this right before setting up any CI.

todo: Need a .styluaignore (no toml equiv?), probably should preserve some lua table/ascii art with ignore directives