### PR TITLE
Replace resurrection and ally assisting limits with tax in easytax

### DIFF
--- a/luarules/gadgets/game_disable_assist_ally.lua
+++ b/luarules/gadgets/game_disable_assist_ally.lua
@@ -8,7 +8,7 @@ function gadget:GetInfo()
 		date    = 'April 2024',
 		license = 'GNU GPL, v2 or later',
 		layer   = 1, -- after unit_mex_upgrade_reclaimer and unit_geo_upgrade_reclaimer
-		enabled = Spring.GetModOptions().disable_assist_ally_construction or Spring.GetModOptions().easytax,
+		enabled = Spring.GetModOptions().disable_assist_ally_construction, -- or Spring.GetModOptions().easytax,  -- disabled for easytax and replaced with tax in game_tax_resource_sharing.lua
 	}
 end
 

--- a/luarules/gadgets/game_restrict_resurrection.lua
+++ b/luarules/gadgets/game_restrict_resurrection.lua
@@ -8,7 +8,7 @@ function gadget:GetInfo()
 		date    = 'January 2026',
 		license = 'GNU GPL, v2 or later',
 		layer   = 0,
-		enabled = true
+		enabled = false -- disabled for now and replaced with tax in game_tax_resource_sharing.lua, delete this gadget if decision not reverted later
 	}
 end
 

--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -190,3 +190,73 @@ function gadget:GameFrame(f)
 		end
 	end
 end
+
+-- Tax inserting metal into wreck when resurrecting
+function gadget:AllowFeatureBuildStep(builderID, builderTeam, featureID, featureDefID, part)
+	-- Only tax resurrection steps (positive part = resurrecting, negative = reclaiming)
+	if part < 0 then
+		return true
+	end
+
+	local resurrectUnitName = Spring.GetFeatureResurrect(featureID)
+	if not resurrectUnitName or resurrectUnitName == "" then
+		return true -- not a resurrectable wreck
+	end
+
+	-- Only tax during phase 1 (metal insertion). Phase 2 is the actual resurrection which costs no metal.
+	local featureMetal, featureMaxMetal = Spring.GetFeatureResources(featureID)
+	if not featureMetal or featureMaxMetal <= 0 or featureMetal >= featureMaxMetal then
+		return true
+	end
+
+	local unitDef = UnitDefNames[resurrectUnitName]
+	if not unitDef then
+		return true
+	end
+
+	local metalTax = unitDef.metalCost * part * sharingTax
+	if metalTax <= 0 then
+		return true
+	end
+
+	local teamMetal = spGetTeamResources(builderTeam, "metal")
+	if teamMetal < (metalTax + unitDef.metalCost * part) then
+		return false
+	end
+
+	spUseTeamResource(builderTeam, "metal", metalTax)
+
+	return true
+end
+
+-- Tax assisting ally buildprogress
+function gadget:AllowUnitBuildStep(builderID, builderTeam, unitID, unitDefID, part)
+	-- Only tax when assisting an ally's unit construction
+	local unitTeam = Spring.GetUnitTeam(unitID)
+	if not unitTeam or builderTeam == unitTeam or not spAreTeamsAllied(builderTeam, unitTeam) then
+		return true
+	end
+
+	if part < 0 then
+		return true
+	end
+
+	local unitDef = UnitDefs[unitDefID]
+	if not unitDef then
+		return true
+	end
+
+	-- Tax the builder team for resources consumed while being assisted by an ally
+	local metalTax = unitDef.metalCost * part * sharingTax
+	local energyTax = unitDef.energyCost * part * sharingTax
+	local currentMetal = spGetTeamResources(builderTeam, "metal")
+	local currentEnergy = spGetTeamResources(builderTeam, "energy")
+	if currentMetal < (metalTax + unitDef.metalCost * part) or currentEnergy < (energyTax + unitDef.energyCost * part) then
+		return false
+	end
+
+	spUseTeamResource(builderTeam, "metal", metalTax)
+	spUseTeamResource(builderTeam, "energy", energyTax)
+
+	return true
+end


### PR DESCRIPTION
In easytax instead of preventing inserting metal into wrecks or assisting ally build, just tax these operations.