### PR TITLE
fix: overpen breaks early on a dead unit or invalid feature

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -388,8 +388,9 @@ end
 
 local function executeCollisions(projectileID, penetrator)
 	local collisions = penetrator.collisions
+	local n = #collisions
 
-	if collisions[2] then
+	if n > 1 then
 		sortPenetratorCollisions(collisions, projectileID, penetrator)
 	end
 
@@ -397,7 +398,7 @@ local function executeCollisions(projectileID, penetrator)
 	local damageLeft = damageLeftBefore
 	local collide, lastHit
 
-	for index = 1, #collisions do
+	for index = 1, n do
 		local collision = collisions[index]
 		local targetID = collision.targetID
 
@@ -436,7 +437,7 @@ local function executeCollisions(projectileID, penetrator)
 		loseMomentum(projectileID, damageLeftBefore, damageLeft)
 	end
 
-	for i = 1, #collisions do
+	for i = 1, n do
 		collisions[i] = nil
 	end
 end


### PR DESCRIPTION
### Work done

The penetrator code for railguns breaks early when an invalid collision is reached instead of skipping it. I am very unsure what side effects this has, but it is obviously incorrect. This fixes.

This became a minor refactoring process because (1) the code is not great to begin with and (2) Lua does not have a `continue`.