### PR TITLE
avoid using reissueOrder across unit queues

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -18,8 +18,7 @@ if not gadgetHandler:IsSyncedCode() then
 end
 
 local spGetUnitHealth = Spring.GetUnitHealth
-
-local reissueOrder = Game.Commands.ReissueOrder
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
 -- TODO: do not use hardcoded unit names
 local unitDefData = {
@@ -215,7 +214,7 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 	if mexTurretDefID[unitDefID] then
 		local mexID = pairedUnits[unitID]
 		if mexID then
-			reissueOrder(mexID, cmdID, cmdParams, cmdOptions, cmdTag, fromInsert)
+			spGiveOrderToUnit(mexID, cmdID, cmdParams, cmdOptions)
 			setMexSpeed[unitID] = mexID
 		end
 	end


### PR DESCRIPTION
Fairly sure that processing a CMD_INSERT can throw on a bad cmdTag being passed when the command options require matching on that tag. So just avoid that pattern in the Legion Fortifier code.