### PR TITLE
cluster plasma: shield deflection based on shield radius

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_cluster.lua
+++ b/luarules/gadgets/unit_custom_weapons_cluster.lua
@@ -339,6 +339,12 @@ local function getSurfaceDeflection(x, y, z)
 	return dx, dy, dz
 end
 
+-- Average of the distance from the (nearest) surface of a sphere to an external point.
+-- With credit to steveOw, coffeemath: https://math.stackexchange.com/questions/1340438
+local function meanSphereDistance(radius, distance)
+	return (radius * radius) / (3 * distance) + distance
+end
+
 ---Shields can overlap with units, terrain, and other shields, so we should avoid both:
 -- (1) exaggerating other responses by adding new responses in the same direction, and
 -- (2) destructively negating other strong responses (> 1) when opposite in direction.
@@ -351,8 +357,12 @@ local function getShieldDeflection(x, y, z, dx, dy, dz, shieldUnits)
 		local sx, sy, sz, radius = getShieldPosition(shieldUnitID)
 
 		if sx then
-			-- Rescale to shield radius. This is incorrect for indirect hits/non-impacts only.
-			sx, sy, sz = dx + (x - sx) / radius, dy + (y - sy) / radius, dz + (z - sz) / radius
+			-- Get a response based on the distance to the sphere.
+			sx, sy, sz = x - sx, y - sy, z - sz
+			local distance = max(diag(sx, sy, sz), radius)
+			local scale = 1 / sqrt(meanSphereDistance(radius, distance))
+
+			sx, sy, sz = dx + sx * scale, dy + sy * scale, dz + sz * scale
 			local response = diag(sx, sy, sz)
 			local limitMin, limitMax = 1, responseMax
 


### PR DESCRIPTION
### Work done

The simple distance-to-surface calculation in shield deflection code for cluster plasma acts like a response to an infinite plane and not a sphere. This PR replaces that calc with a response curve based on the mean distance to the sphere surface. As radius->infinite, this conforms back to the inf-planar response.

Gameplay effect:

Ranges from very noticeable on evocomm to only slightly noticeable on regular shields and no human-noticeable effect on the T3 epic shields that block everything.

This spreads shots around slightly more when bouncing off of shields, especially in the up direction.

It looks more like it "should" look but if submunitions re-impacting with shields is not wanted then just reject this one & we will keep it as-is.