### PR TITLE
use dynamic piece colvols on scylla

### DIFF
--- a/luarules/configs/collisionvolumes.lua
+++ b/luarules/configs/collisionvolumes.lua
@@ -131,6 +131,16 @@ dynamicPieceCollisionVolume['cordoomt3'] = {
         ['0']={96,80,96,0,10,0,2,1,0},
     }
 }
+dynamicPieceCollisionVolume['leganavybattleship'] = {
+	on = {
+		['1'] = { 48, 48, 120, 0, 8, -58, 1, 2 },
+		offsets = { 0, 30, 0 },
+	},
+	off = {
+		['1'] = { 48, 48, 120, 0, 8, -58, 1, 2 },
+		offsets = { 0, 0, 0 },
+	},
+}
 
 unitCollisionVolume['armanni'] = {
 	on={54,81,54,0,-2,0,2,1,0},
@@ -390,9 +400,6 @@ pieceCollisionVolume['armshockwave'] = {
 pieceCollisionVolume['legmohoconct'] = {
 	['0']={70,30,70,0,-3,0,1,1},
 	['1']={21,16,30,0,-3,-1,2,1},
-}
-pieceCollisionVolume['leganavybattleship'] = {
-	['1'] = { 48, 48, 120, 0, 8, -58, 1, 2 },
 }
 
 for name, v in pairs(pieceCollisionVolume) do


### PR DESCRIPTION
### Work done

This sets a mid- and aim-point offset dynamically on the Scylla to raise the aim position as the unit's body raises up.

Previously, the leganavybattleship would have an aimpoint very low to the ground, that other units would fire at. Weapons with scatter would miss under the unit.

Now, inaccurate weapons very reliably hit this large, slow-moving unit, as they should.