### PR TITLE
Hide feature reclaim/resurrect progress bars under fog of war

### DIFF
--- a/luarules/gadgets/unit_healthbars_widget_forwarding.lua
+++ b/luarules/gadgets/unit_healthbars_widget_forwarding.lua
@@ -105,6 +105,8 @@ else
 
 	local glSetFeatureBufferUniforms = gl.SetFeatureBufferUniforms
 	local GetFeatureResources = Spring.GetFeatureResources
+	local GetFeaturePosition = Spring.GetFeaturePosition
+	local IsPosInLos = Spring.IsPosInLos
 	local rezreclaim = {0.0, 1.0} -- this is just a small table cache, so we dont allocate a new table for every update
 	local forwardedFeatureIDsResurrect = {} -- so we only forward the start event once
 	local forwardedFeatureIDsReclaim = {} -- so we only forward the start event once
@@ -123,6 +125,13 @@ else
 
 	function featureReclaimFrame(cmd, featureID, step)
 		--Spring.Echo("HandleFeatureReclaimStarted", featureID)
+		if not fullview then
+			local x, y, z = GetFeaturePosition(featureID)
+			if x and not IsPosInLos(x, y, z, myAllyTeamID) then
+				return
+			end
+		end
+
 		rezreclaim[1] = select(3, GetFeatureHealth( featureID )) -- resurrect progress
 		rezreclaim[2] = select(5, GetFeatureResources(featureID)) -- reclaim percent
 

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -24,6 +24,8 @@ local spGetGameFrame = Spring.GetGameFrame
 local spEcho = Spring.Echo
 local spGetUnitTeam = Spring.GetUnitTeam
 local spGetSpectatingState = Spring.GetSpectatingState
+local spGetFeaturePosition = Spring.GetFeaturePosition
+local spIsPosInLos = Spring.IsPosInLos
 
 -- wellity wellity the time has come, and yes, this is design documentation
 -- what can we do with 64 verts per healthbars?
@@ -1211,6 +1213,12 @@ function widget:FeatureCreated(featureID)
 			if health ~= maxhealth then addBarToFeature(featureID, 'featurehealth') end
 		end
 
+		if not fullview then
+			local featureX, featureY, featureZ = spGetFeaturePosition(featureID)
+			if featureX and not spIsPosInLos(featureX, featureY, featureZ, myAllyTeamID) then
+				return
+			end
+		end
 
 		if rezProgress > 0 then
 			addBarToFeature(featureID, 'featureresurrect')


### PR DESCRIPTION
### Work done
Feature reclaim/resurrect progress bars (green reclaim bar, magenta resurrect bar) were visible under fog of war, leaking information about enemy activity on map features (rocks, trees, wrecks). Added LOS checks in both the forwarding gadget and the healthbars widget to hide these bars when the feature is outside the player's line of sight.

#### Test steps
- [ ] Start a multiplayer or skirmish game with an opponent
- [ ] Have the opponent reclaim a rock or tree that is outside your line of sight (under fog of war)
- [ ] Verify you do NOT see a green reclaim progress bar on the feature
- [ ] Move a unit to gain LOS on a feature being reclaimed — verify the bar appears once visible
- [ ] Spectate with fullview enabled — verify all reclaim/resurrect bars are visible as before
- [ ] Verify feature health bars (grey) still appear normally for all features

### AI / LLM usage statement:
AI (GitHub Copilot, Claude) was used to locate the relevant code paths and draft the LOS check implementation. All changes were reviewed by a bird for correctness.