### PR TITLE
Quick start auto placed mex - proper alignment for T2 upgrade

### DIFF
--- a/luarules/gadgets/game_quick_start.lua
+++ b/luarules/gadgets/game_quick_start.lua
@@ -414,7 +414,7 @@ local function refreshAndCheckAvailableMexSpots(commanderID)
 			local groundY = spGetGroundHeight(spot.x, spot.z)
 			local buildX, buildY, buildZ = spPos2BuildPos(mexDefID, spot.x, groundY, spot.z)
 			if buildX and spTestBuildOrder(mexDefID, buildX, buildY, buildZ, DEFAULT_FACING) == UNOCCUPIED then
-				spot.y = buildY
+				spot.x, spot.y, spot.z = buildX, buildY, buildZ
 				table.insert(validSpots, spot)
 			end
 		end


### PR DESCRIPTION
With quickstart, auto placed mex do not align to grid 100% of the time, preventing a T2 upgrade. 
Does not happen on all maps or metal spots and does not affect manually placed mex. 

Found this during the 70k event when many players could not que up buildings in time and received auto mex, but this affects AI as well. Tested the fix on several maps.

 Test steps
- [ ] Use quckstart on a map that has the issue. Mex now align properly and can be upgraded (Jade Impress and Glitters work fine before the fix but Supreme and Raptor Crator do not). Use forcestart to autospawn your own mex

#### BEFORE:
<img width="680" height="648" alt="quickstartmex" src="https://github.com/user-attachments/assets/0e192ce3-3e5f-43eb-b716-be547d3436f6" />
