### PR TITLE
fix: re-normalize unitdefs after receiving tweaks

### DIFF
--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -264,10 +264,10 @@ local function preProcessTweakOptions()
 					Spring.Echo(postsFuncStr)
 					if postfunc then
 						local success, result = pcall(postfunc)
-						if not success then
-							Spring.Echo("Error executing tweakdef", name, postsFuncStr, "Error :" .. result)
-						else
+						if success then
 							shouldNormalizeUnitDefs = true -- tweakdefs can add or denormalize units
+						else
+							Spring.Echo("Error executing tweakdef", name, postsFuncStr, "Error :" .. result)
 						end
 					end
 				end


### PR DESCRIPTION
### Work done

As tweaks (tweakdefs/tweakunits) add or modify unitdefs, continue to normalize those defs.

Tweaks that add new unitdefs (or maybe modify them extensively) are encountering errors due to #7146. This resolves those errors.