### PR TITLE
Added Unit XP as an evolution trigger

### DIFF
--- a/luarules/gadgets/unit_evolution.lua
+++ b/luarules/gadgets/unit_evolution.lua
@@ -61,10 +61,11 @@ if gadgetHandler:IsSyncedCode() then
 		-- evolution_announcement_size = 18.5, 		-- Size of the onscreen announcement
 
 		--	-- Has a default value, as indicated, if not chosen:
-		-- evolution_condition = "timer",    		-- condition type for the evolution. "timer", "timer_global", "health", or "power"
+		-- evolution_condition = "timer",    		-- condition type for the evolution. "timer", "timer_global", "health", "power", or "xp"
 		-- evolution_timer = 600, 					-- set the timer used for the timer condition. Given in secons from when the unit was created.
 		-- evolution_health_threshold = 0,			-- threshold for triggering the "health" evolution condition.
 		-- evolution_power_threshold = 600,			-- threshold for triggering the "power" evolution condition.
+		-- evolution_xp_threshold = 0.8,			-- threshold for triggering the "xp" evolution condition. Max rank icon reached at 0.8
 		-- evolution_power_enemy_multiplier = 1,	-- Scales the power calculated based on the average enemy combined power.
 		-- evolution_power_multiplier = 1,			-- Scales the power calculated based on your own combined power.
 		-- combatradius = 1000,						-- Range for setting in-combat status if enemies are within range, and disabling evolution while in-combat.
@@ -272,6 +273,7 @@ if gadgetHandler:IsSyncedCode() then
 				evolution_power_enemy_multiplier = tonumber(udcp.evolution_power_enemy_multiplier),
 				evolution_power_multiplier       = tonumber(udcp.evolution_power_multiplier),
 				evolution_power_threshold        = tonumber(udcp.evolution_power_threshold),
+				evolution_xp_threshold           = tonumber(udcp.evolution_xp_threshold),
 				evolution_timer                  = tonumber(udcp.evolution_timer),
 				timeCreated                      = spGetGameSeconds(),
 			})
@@ -390,6 +392,18 @@ if gadgetHandler:IsSyncedCode() then
 		return false
 	end
 
+	local function isEvolutionXPPassed(unitID, evolution)
+		if evolution.evolution_condition ~= 'xp' then
+			return false
+		end
+		local threshold = evolution.evolution_xp_threshold
+		if not threshold then
+			return false
+		end
+		local xp = spGetUnitExperience(unitID) or 0
+		return xp >= threshold
+	end
+
 	function gadget:GameFrame(f)
 		if f % GAME_SPEED ~= 0 or fillToCheckUnitIDs() then
 			return
@@ -412,7 +426,7 @@ if gadgetHandler:IsSyncedCode() then
 
 			if evolution and not combatCheckUpdate(unitID, evolution, currentTime)
 				and not spGetUnitTransporter(unitID)
-				and (isEvolutionTimePassed(evolution, currentTime) or isEvolutionPowerPassed(evolution)) then
+				and (isEvolutionTimePassed(evolution, currentTime) or isEvolutionPowerPassed(evolution) or isEvolutionXPPassed(unitID, evolution)) then
 					evolve(unitID)
 			end
 


### PR DESCRIPTION
### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Added XP as a possible unit evolution trigger, to support modding. This can allow veteran units to upgrade to a stronger version

#### Setup
Create a new unit with tweakdefs using the new param
example:  [gruntPawnEvo.txt](https://github.com/user-attachments/files/26263744/gruntPawnEvo.txt)


#### Test steps
Make pawn and grunt, then use /luarules xp 1. Units will evolve

![gif](https://github.com/user-attachments/assets/b098c675-f6c9-418f-8a80-70b7399d06e8)
