### PR TITLE
enable depth testing for metalspots

### DIFF
--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -563,7 +563,7 @@ function widget:DrawWorldPreUnit()
 	gl.Culling(true)
 	gl.Texture(0, "$heightmap")
 	gl.Texture(1, AtlasTextureID)
-	gl.DepthTest(false)
+	gl.DepthTest(GL.LEQUAL)
 	gl.DepthMask(false)
 
 	local wl = getWaterLevel()


### PR DESCRIPTION
depth testing seems to work without occluding ghosts as long as the draw is in preunit. Am I missing some other edge cases @Ruwetuin ?

<img width="595" height="493" alt="image" src="https://github.com/user-attachments/assets/7281f9ff-29ee-428d-9588-1b1c0f779d50" />
