### PR TITLE
Refund metal when lab is reclaimed while producing a unit

### DIFF
--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -52,6 +52,9 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
     return
   end
 
+  local unitBeingBuilt = factoryQueue[unitID]
+  
+  factoryQueue[unitID] = nil
   if weaponDefID ~= reclaimedWeaponDefID then
     return
   end
@@ -60,7 +63,6 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
     return
   end
   
-  local unitBeingBuilt = factoryQueue[unitID]
   if not unitBeingBuilt then
     return
   end
@@ -70,5 +72,4 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   local refund = math.floor(metalCost * buildProgress)
   
   spAddTeamResource(unitTeam, 'metal', refund)
-  factoryQueue[unitID] = nil
 end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -41,8 +41,8 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   end
 end
 
-function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factID)
-  factoryQueue[factID] = nil
+function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factoryID)
+  factoryQueue[factoryID] = nil
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -49,7 +49,8 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   if not unitBeingBuilt then
     return
   end
-  
+
+  factoryQueue[unitID] = nil
   if weaponDefID ~= reclaimedWeaponDefID then
     return
   end
@@ -63,5 +64,4 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   local refund = math.floor(metalCost * buildProgress)
   
   spAddTeamResource(unitTeam, 'metal', refund)
-  factoryQueue[unitID] = nil
 end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -22,6 +22,8 @@ local spAddTeamResource = Spring.AddTeamResource
 local spAreTeamsAllied = Spring.AreTeamsAllied
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
 
+local reclaimedWeaponDefID = Game.envDamageTypes.Reclaimed
+
 local factoryQueue = {}
 
 local isFactory = {}
@@ -53,7 +55,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   local unitBeingBuilt = factoryQueue[unitID]
   
   factoryQueue[unitID] = nil
-  if weaponDefID ~= Game.envDamageTypes.Reclaimed then
+  if weaponDefID ~= reclaimedWeaponDefID then
     return
   end
   

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -35,7 +35,7 @@ for udid = 1, #UnitDefs do
 end
 
 
-function gadget:UnitCreated(unitID, unitDefID, _, builderID)
+function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   if builderID and isFactory[spGetUnitDefID(builderID)] then
     factoryQueue[builderID] = { unitID = unitID, defID = unitDefID }
   end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -18,7 +18,7 @@ end
 
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitCosts = Spring.GetUnitCosts
-local spAddTeamResource = Spring.AddTeamResource
+local spAddUnitResource = Spring.AddUnitResource
 local spAreTeamsAllied = Spring.AreTeamsAllied
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
 
@@ -58,10 +58,9 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   if not attackerTeam or not spAreTeamsAllied(unitTeam, attackerTeam) then
     return
   end
-  
+
   local _, buildProgress = spGetUnitIsBeingBuilt(unitBeingBuiltId)
   local _, metalCost, _ = spGetUnitCosts(unitBeingBuiltId)
-  local refund = math.floor(metalCost * buildProgress)
-  
-  spAddTeamResource(unitTeam, 'metal', refund)
+  local refund = metalCost * buildProgress
+  spAddUnitResource(unitBeingBuiltId, "m", refund)
 end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -35,9 +35,9 @@ for udid = 1, #UnitDefs do
 end
 
 
-function gadget:UnitCreated(unitID, unitDefID, _, factID)
-  if factID then
-    factoryQueue[factID] = { unitID = unitID, defID = unitDefID }
+function gadget:UnitCreated(unitID, unitDefID, _, builderID)
+  if builderID and isFactory[spGetUnitDefID(builderID)] then
+    factoryQueue[builderID] = { unitID = unitID, defID = unitDefID }
   end
 end
 

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -22,8 +22,6 @@ local spAddTeamResource = Spring.AddTeamResource
 local spAreTeamsAllied = Spring.AreTeamsAllied
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
 
-local reclaimedWeaponDefID = -12
-
 local factoryQueue = {}
 
 local isFactory = {}
@@ -55,7 +53,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   local unitBeingBuilt = factoryQueue[unitID]
   
   factoryQueue[unitID] = nil
-  if weaponDefID ~= reclaimedWeaponDefID then
+  if weaponDefID ~= Game.envDamageTypes.Reclaimed then
     return
   end
   

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -36,7 +36,9 @@ end
 
 
 function gadget:UnitCreated(unitID, unitDefID, _, factID)
-  factoryQueue[factID] = { unitID = unitID, defID = unitDefID }
+  if factID then
+    factoryQueue[factID] = { unitID = unitID, defID = unitDefID }
+  end
 end
 
 function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factID)

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -34,7 +34,6 @@ for udid = 1, #UnitDefs do
   end
 end
 
-
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   if builderID and isFactory[spGetUnitDefID(builderID)] then
     factoryQueue[builderID] = { unitID = unitID, defID = unitDefID }
@@ -46,22 +45,16 @@ function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factoryID)
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-  if not isFactory[spGetUnitDefID(unitID)] then
+  local unitBeingBuilt = factoryQueue[unitID]
+  if not unitBeingBuilt then
     return
   end
-
-  local unitBeingBuilt = factoryQueue[unitID]
-  factoryQueue[unitID] = nil -- Clear the queue for this factory now as it's destroyed, no matter how
   
   if weaponDefID ~= reclaimedWeaponDefID then
     return
   end
-  
+
   if not attackerTeam or not spAreTeamsAllied(unitTeam, attackerTeam) then
-    return
-  end
-  
-  if not unitBeingBuilt then
     return
   end
   
@@ -70,4 +63,5 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   local refund = math.floor(metalCost * buildProgress)
   
   spAddTeamResource(unitTeam, 'metal', refund)
+  factoryQueue[unitID] = nil
 end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -1,0 +1,74 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+    return {
+        name      = "Refund on lab reclaimed",
+        desc      = "Refunds metal when factory is reclaimed by ally while producing",
+        author    = "Pexo",
+        date      = "29.03.2026",
+        license   = "GNU GPL, v2 or later",
+        layer     = 0,
+        enabled   = true
+    }
+end
+
+if not gadgetHandler:IsSyncedCode() then
+  return
+end
+
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitCosts = Spring.GetUnitCosts
+local spAddTeamResource = Spring.AddTeamResource
+local spAreTeamsAllied = Spring.AreTeamsAllied
+local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
+
+local reclaimedWeaponDefID = -12
+
+local factoryQueue = {}
+
+local isFactory = {}
+for udid = 1, #UnitDefs do
+  local ud = UnitDefs[udid]
+  if ud.isFactory then
+    isFactory[udid] = true
+  end
+end
+
+
+function gadget:UnitFromFactory(unitID, unitDefID, _, factID)
+  if factoryQueue[factID] and factoryQueue[factID].unitID == unitID then
+    factoryQueue[factID] = nil
+  end
+end
+
+function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+  if isFactory[spGetUnitDefID(builderID)] then
+    factoryQueue[builderID] = { unitID = unitID, defID = unitDefID }
+  end
+end
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
+  if not isFactory[spGetUnitDefID(unitID)] then
+    return
+  end
+
+  if weaponDefID ~= reclaimedWeaponDefID then
+    return
+  end
+  
+  if not attackerTeam or not spAreTeamsAllied(unitTeam, attackerTeam) then
+    return
+  end
+  
+  local unitBeingBuilt = factoryQueue[unitID]
+  if not unitBeingBuilt then
+    return
+  end
+  
+  local _, buildProgress = spGetUnitIsBeingBuilt(unitBeingBuilt.unitID)
+  local _, metalCost, _ = spGetUnitCosts(unitBeingBuilt.unitID)
+  local refund = math.floor(metalCost * buildProgress)
+  
+  spAddTeamResource(unitTeam, 'metal', refund)
+  factoryQueue[unitID] = nil
+end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -35,16 +35,12 @@ for udid = 1, #UnitDefs do
 end
 
 
-function gadget:UnitFromFactory(unitID, unitDefID, _, factID)
-  if factoryQueue[factID] and factoryQueue[factID].unitID == unitID then
-    factoryQueue[factID] = nil
-  end
+function gadget:UnitCreated(unitID, unitDefID, _, factID)
+  factoryQueue[factID] = { unitID = unitID, defID = unitDefID }
 end
 
-function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
-  if isFactory[spGetUnitDefID(builderID)] then
-    factoryQueue[builderID] = { unitID = unitID, defID = unitDefID }
-  end
+function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factID)
+  factoryQueue[factID] = nil
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
@@ -53,8 +49,8 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
   end
 
   local unitBeingBuilt = factoryQueue[unitID]
+  factoryQueue[unitID] = nil -- Clear the queue for this factory now as it's destroyed, no matter how
   
-  factoryQueue[unitID] = nil
   if weaponDefID ~= reclaimedWeaponDefID then
     return
   end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -1,19 +1,19 @@
 local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
-    return {
-        name      = "Refund on lab reclaimed",
-        desc      = "Refunds metal when factory is reclaimed by ally while producing",
-        author    = "Pexo",
-        date      = "29.03.2026",
-        license   = "GNU GPL, v2 or later",
-        layer     = 0,
-        enabled   = true
-    }
+	return {
+		name      = "Refund on lab reclaimed",
+		desc      = "Refunds metal when factory is reclaimed by ally while producing",
+		author    = "Pexo",
+		date      = "29.03.2026",
+		license   = "GNU GPL, v2 or later",
+		layer     = 0,
+		enabled   = true
+	}
 end
 
 if not gadgetHandler:IsSyncedCode() then
-  return
+	return
 end
 
 local spGetUnitDefID = Spring.GetUnitDefID
@@ -28,39 +28,39 @@ local factoryQueue = {}
 
 local isFactory = {}
 for udid = 1, #UnitDefs do
-  local ud = UnitDefs[udid]
-  if ud.isFactory then
-    isFactory[udid] = true
-  end
+	local ud = UnitDefs[udid]
+	if ud.isFactory then
+		isFactory[udid] = true
+	end
 end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
-  if builderID and isFactory[spGetUnitDefID(builderID)] then
-    factoryQueue[builderID] = unitID
-  end
+	if builderID and isFactory[spGetUnitDefID(builderID)] then
+		factoryQueue[builderID] = unitID
+	end
 end
 
 function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factoryID)
-  factoryQueue[factoryID] = nil
+	factoryQueue[factoryID] = nil
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-  local unitBeingBuiltId = factoryQueue[unitID]
-  if not unitBeingBuiltId then
-    return
-  end
+	local unitBeingBuiltId = factoryQueue[unitID]
+	if not unitBeingBuiltId then 
+		return
+	end
 
-  factoryQueue[unitID] = nil
-  if weaponDefID ~= reclaimedWeaponDefID then
-    return
-  end
+	factoryQueue[unitID] = nil
+	if weaponDefID ~= reclaimedWeaponDefID then 
+		return
+	end
 
-  if not attackerTeam or not spAreTeamsAllied(unitTeam, attackerTeam) then
-    return
-  end
+	if not attackerTeam or not spAreTeamsAllied(unitTeam, attackerTeam) then 
+		return
+	end
 
-  local _, buildProgress = spGetUnitIsBeingBuilt(unitBeingBuiltId)
-  local _, metalCost, _ = spGetUnitCosts(unitBeingBuiltId)
-  local refund = metalCost * buildProgress
-  spAddUnitResource(unitBeingBuiltId, "m", refund)
+	local _, buildProgress = spGetUnitIsBeingBuilt(unitBeingBuiltId)
+	local _, metalCost, _ = spGetUnitCosts(unitBeingBuiltId)
+	local refund = metalCost * buildProgress
+	spAddUnitResource(unitBeingBuiltId, "m", refund)
 end

--- a/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
+++ b/luarules/gadgets/unit_refund_on_lab_reclaimed.lua
@@ -36,7 +36,7 @@ end
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   if builderID and isFactory[spGetUnitDefID(builderID)] then
-    factoryQueue[builderID] = { unitID = unitID, defID = unitDefID }
+    factoryQueue[builderID] = unitID
   end
 end
 
@@ -45,8 +45,8 @@ function gadget:UnitFromFactory(unitID, unitDefID, unitTeam, factoryID)
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-  local unitBeingBuilt = factoryQueue[unitID]
-  if not unitBeingBuilt then
+  local unitBeingBuiltId = factoryQueue[unitID]
+  if not unitBeingBuiltId then
     return
   end
 
@@ -59,8 +59,8 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
     return
   end
   
-  local _, buildProgress = spGetUnitIsBeingBuilt(unitBeingBuilt.unitID)
-  local _, metalCost, _ = spGetUnitCosts(unitBeingBuilt.unitID)
+  local _, buildProgress = spGetUnitIsBeingBuilt(unitBeingBuiltId)
+  local _, metalCost, _ = spGetUnitCosts(unitBeingBuiltId)
   local refund = math.floor(metalCost * buildProgress)
   
   spAddTeamResource(unitTeam, 'metal', refund)


### PR DESCRIPTION
### Work done
Implemented a new gadget addressing Issue #5603. Now the factory tracks metal spent on the units being produced, when the lab is being reclaimed by the player or his allies (but not enemies) the metal spent on unit being produced is refunded to the player.  


#### Addresses Issue(s)
[Issue 5603](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5603)


#### Test steps
- [ ] Build any lab
- [ ] Start producing unit
- [ ] Reclaim lab while unit is being produced
- [ ] Observe metal spent on the unit being refunded once the lab is reclaimed