### PR TITLE
fix: landed aircraft are bombable and flying ones untargetable

### DIFF
--- a/luarules/gadgets/unit_bomber_no_air_target.lua
+++ b/luarules/gadgets/unit_bomber_no_air_target.lua
@@ -78,6 +78,28 @@ local function getPositionOnGround(targetID, teamID)
 	end
 end
 
+---Block bombers from attacking air units unless the target is landed (it becomes a ground attack).
+local function allowBomberAttackCommand(unitID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, fromInsert)
+	local targetID = cmdParams[1]
+	local targetDefID = spGetUnitDefID(targetID)
+
+	if targetDefID and isAir[targetDefID] then
+		if spGetUnitIsDead(targetID) == false and isLanded(targetID) then
+			-- Move the target onto the ground, whenever possible.
+			local x, y, z = getPositionOnGround(targetID, unitTeam)
+			if x then
+				cmdParams[1], cmdParams[2], cmdParams[3] = x, y, z
+				reissueOrder(unitID, cmdID, cmdParams, cmdOptions, cmdTag, fromInsert)
+				ensureTable(bomberAirTargets, unitID)[targetID] = { x, y, z, cmdID }
+				ensureTable(landedAirTargets, targetID)[unitID] = true
+			end
+		end
+		return false
+	else
+		return true
+	end
+end
+
 local function removeBomberOrder(bomberID, targetID)
 	local orders = bomberAirTargets[bomberID]
 
@@ -125,25 +147,12 @@ function gadget:Initialize()
 end
 
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua, fromInsert)
-	-- Block bombers from attacking air units (single-target only, not ground attack)
+	-- accepts: CMD.ATTACK, CMD.UNIT_SET_TARGET, CMD.UNIT_SET_TARGET_NO_GROUND
 	if isBomber[unitDefID] and cmdParams[1] and not cmdParams[2] then
-		local targetID = cmdParams[1]
-		local targetDefID = spGetUnitDefID(targetID)
-		if targetDefID and isAir[targetDefID] then
-			if spGetUnitIsDead(targetID) == false and isLanded(targetID) then
-				-- Move the target onto the ground, whenever possible.
-				local x, y, z = getPositionOnGround(targetID, unitTeam)
-				if x then
-					cmdParams[1], cmdParams[2], cmdParams[3] = x, y, z
-					reissueOrder(unitID, cmdID, cmdParams, cmdOptions, cmdTag, fromInsert);
-					ensureTable(bomberAirTargets, unitID)[targetID] = { x, y, z, cmdID }
-					ensureTable(landedAirTargets, targetID)[unitID] = true
-				end
-			end
-			return false
-		end
+		return allowBomberAttackCommand(unitID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, fromInsert)
+	else
+		return true
 	end
-	return true
 end
 
 function gadget:GameFrame(frame)


### PR DESCRIPTION
### Work done

- Re-allows bombing landed aircraft.
- Disallows bombers using Attack and Set Target on flying aircraft.

#### Addresses Issue(s)

unit_bomber_no_air_target.lua can be circumvented pretty easily, but also some bomb-able targets cannot be bombed. This is doable with s+drag to select in an area:

<img width="547" height="215" alt="image" src="https://github.com/user-attachments/assets/43691f3d-0dd5-4a81-9829-9e9ec2755e7e" />

#### Test steps

- [ ] Load into a skirmish with an inactive AI and make some enemy scouts. Put them on a patrol route or something to keep them in the air and moving. Area-select with Attack and Set Target onto enemy air scouts. They should not be targeted by the command.
- [ ] Land some of the scouts. Use Attack and Set Target on them. Bombers should target the ground at/near the position of the landed target.
- [ ] Repeat the attack orders with different visibility on the target. Widgets with tracked target IDs should not locate enemies without vision. Radar blips should be targeted instead of the units themselves.