### PR TITLE
fix: startbox syntax

### DIFF
--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -150,6 +150,7 @@ local function ParseBoxes ()
 				local point = boxRow[j]
 				if point[2] > maxZ then
 					point[2] = maxZ
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Missing an end, breaks stylua but would also break the game if the interpretter were to find its way there instead of short circuiting (I think what is happening)