### PR TITLE
Legion extra units balance

### DIFF
--- a/units/Legion/T3/legbunk.lua
+++ b/units/Legion/T3/legbunk.lua
@@ -18,7 +18,7 @@ return {
 		maxslope = 17,
 		maxacc = 0.253,
 		maxdec = 0.8211,
-		metalcost = 1850,
+		metalcost = 1450,
 		maxwaterdepth = 22,
 		movementclass = "HBOT4",
 		nochasecategory = "VTOL",

--- a/units/Scavengers/Buildings/DefenseOffense/legrwall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legrwall.lua
@@ -1,8 +1,8 @@
 return {
 	legrwall = {
 		maxacc = 0,
-		energycost = 7000,
-		metalcost = 1300,
+		energycost = 6000,
+		metalcost = 1200,
 		buildpic = "legrwall.DDS",
 		buildtime = 18000,
 		canrepeat = false,
@@ -18,7 +18,7 @@ return {
 		hidedamage = true,
 		levelground = false,
 		mass = 10000000000,
-		health = 7600,
+		health = 4000,
 		maxslope = 24,
 		maxwaterdepth = 0,
 		nochasecategory = "MOBILE",


### PR DESCRIPTION
Some of the Legion extra units have felt overly powerful and have been nerfed to help them remain balanced.

### Work done
Pilum (T3 mech) has had a straight metal cost increase, it works really well but trades too well for it to be fair.

Dragons constitution (T2 wall turret) was found to be far too durable for its cost and dealt with swarms of units too well. It has had a cost increase and the rate of fire dropped but a boost to the damage. It should deal _slightly_ more damage now and be effective against tougher units but given the cost increase and health decrease it felt appropriate.