### PR TITLE
[Deps] lux-i18n

### DIFF
--- a/lux.toml
+++ b/lux.toml
@@ -8,6 +8,9 @@ maintainer = "BAR Team"
 labels = [ "BAR" ]
 license = "GPLv2"
 
+[dependencies]
+i18n = ">=0.9.2"
+
 [test_dependencies]
 busted = "2.2.0"
 luassert = "1.9.0"


### PR DESCRIPTION
Add [kikito/i18n.lua](https://github.com/kikito/i18n.lua) as a Lux dependency.

This is a hand-maintained infrastructure branch. Dependent transforms cherry-pick it automatically.

### Branch Topology

All branches generated by [`just bar::fmt-mig-generate`](https://github.com/thvl3/BAR-Devtools).

*Generated 2026-03-31 03:27:39 UTC*

**Basal branches** (infrastructure — cherry-picked into dependent leaves):

| Branch | Description | Diff vs `master` |
|--------|-------------|------|
| lux-recoil | Replace the `recoil-lua-library` Git submodule with a [Lux](https://github.com/nvim-neorocks/lux) git dependency. | 5 files, +6 −6 |
| lux-i18n | Add [kikito/i18n.lua](https://github.com/kikito/i18n.lua) as a Lux dependency. | 1 files, +3 −0 |

**Standalone branches** (each targets `master`, can merge independently):

| Branch | Transform | Diff vs `master` |
|--------|-----------|------|
| [fmt](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7199) | `stylua .` | 1425 files, +178316 −183012 |
| mig-bracket | `bracket-to-dot` | 344 files, +7630 −7630 |
| mig-rename-aliases | `rename-aliases` | 161 files, +349 −349 |
| mig-detach-bar-modules | `detach-bar-modules` | 163 files, +1299 −1299 |
| mig-spring-split | `spring-split` (basal: `lux-recoil`) | 757 files, +9520 −9516 |
| mig-i18n | `i18n-kikito` (basal: `lux-i18n`) | 17 files, +46 −1187 |

**Combined branch** (stylua + all transforms — full preview):

| Branch | Diff vs `master` |
|--------|------|
| [mig](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7229) | 1436 files, +186318 −192169 |
