### PR TITLE
tiny fix: remove confusing use of SetUnitMaxRange

### DIFF
--- a/luarules/gadgets/game_team_death_effect.lua
+++ b/luarules/gadgets/game_team_death_effect.lua
@@ -80,7 +80,6 @@ local function wipeoutTeam(teamID, originX, originZ, attackerUnitID, periodMult)
 				i = i + 1
 			end
 			if i > 0 then
-				Spring.SetUnitMaxRange(unitID, 0)	-- looks like this one doesnt really work
 				Spring.GiveOrderToUnit(unitID, CMD.FIRE_STATE, {0}, 0)
 				Spring.SetUnitTarget(unitID, nil)
 				if GameCMD and GameCMD.UNIT_CANCEL_TARGET then	-- remove any settarget cmd


### PR DESCRIPTION
This method sets the engagement range (how close the unit approaches enemies). It has nothing to do with the unit's weapons.
