### PR TITLE
Unhardcode the pip keybinds

### DIFF
--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -2272,49 +2272,12 @@ local buttons = {
 	},
 }
 
--- Per-pip keyboard shortcuts: command → keybind string
--- pip1 has the original shortcuts; pip0 and pip2 have none by default.
--- Modify the table for other pips to assign shortcuts (e.g. pip_copy = 'alt+w').
-local pipShortcuts = {
-	[0] = {
-		-- pip_copy = nil,
-		-- pip_switch = nil,
-		-- pip_track = nil,
-	},
-	[1] = {
-		pip_copy = 'alt+q',
-		pip_switch = 'shift+q',
-		pip_track = 'alt+a',
-	},
-	[2] = {
-		-- pip_copy = nil,
-		-- pip_switch = nil,
-		-- pip_track = nil,
-	},
-}
-
--- Helper: convert a keybind string like 'alt+q' to display format 'Alt + Q'
-local function formatShortcutDisplay(keybind)
-	if not keybind then return nil end
-	local parts = {}
-	for part in keybind:gmatch('[^+]+') do
-		part = part:match('^%s*(.-)%s*$')  -- trim whitespace
-		parts[#parts + 1] = part:sub(1, 1):upper() .. part:sub(2)
-	end
-	return table.concat(parts, ' + ')
-end
-
--- Compute per-pip action names and shortcut display text for each button
-local myShortcuts = pipShortcuts[pipNumber] or {}
+-- Compute per-pip action names
 for i = 1, #buttons do
 	local btn = buttons[i]
 	if btn.command then
 		-- Unique action name per pip instance (e.g. pip_copy → pip1_copy)
 		btn.actionName = 'pip' .. pipNumber .. '_' .. btn.command:sub(5)
-		-- Set display shortcut from per-pip config
-		local keybind = myShortcuts[btn.command]
-		btn.shortcut = formatShortcutDisplay(keybind)
-		btn.keybind = keybind  -- raw keybind string for bind/unbind
 	end
 end
 
@@ -7736,12 +7699,6 @@ end
 		if button.command then
 			-- Register with pip-specific action name so each pip instance has unique commands
 			widgetHandler.actionHandler:AddAction(self, button.actionName, button.OnPress, nil, 'p')
-
-			-- Bind per-pip hotkey if configured
-			if button.keybind then
-				Spring.SendCommands("unbindkeyset " .. button.keybind)
-				Spring.SendCommands("bind " .. button.keybind .. " " .. button.actionName)
-			end
 		end
 	end
 
@@ -8346,10 +8303,6 @@ function widget:Shutdown()
 		if button.command then
 			widgetHandler.actionHandler:RemoveAction(self, button.actionName)
 
-			-- Unbind per-pip hotkey if configured
-			if button.keybind then
-				Spring.SendCommands("unbind " .. button.keybind .. " " .. button.actionName)
-			end
 		end
 	end
 end
@@ -15287,14 +15240,11 @@ local function DrawInteractiveOverlays(mx, my, usedButtonSize)
 					if visibleButtons[i].command == 'pip_help' and config.leftButtonPansCamera then
 						tooltipText = tooltipText .. Spring.I18N('ui.pip.help_leftclick')
 					end
-					-- Use button's shortcut field first, fall back to getActionHotkey
+					-- Use button's shortcut from getActionHotkey
 					-- In minimap mode, don't show shorcut for track units button
-					local shortcut = visibleButtons[i].shortcut
+					local shortcut = nil
 					local suppressShortcut = isMinimapMode and visibleButtons[i].command == 'pip_track'
-					if suppressShortcut then
-						shortcut = nil
-					end
-					if not shortcut and not suppressShortcut and visibleButtons[i].actionName then
+					if not suppressShortcut and visibleButtons[i].actionName then
 						shortcut = getActionHotkey(visibleButtons[i].actionName)
 					end
 					if shortcut and shortcut ~= "" then

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -33,7 +33,7 @@ bind          Any+space  commandinsert prepend_between // prepend command into t
 // attackrange keys
 bind           alt+sc_. attack_range_inc        // cycle to next attack range display config for current unit type.
 bind       alt+sc_comma attack_range_dec        // cycle to previous attack range display config for current unit type.
-//bind           alt+sc_/ cursor_range_toggle     // toggles display of the attack range of the unit under the mouse cursor.
+// bind           alt+sc_/ cursor_range_toggle  // toggles display of the attack range of the unit under the mouse cursor.
 
 // common chat keys
 bind          Any+enter  chat
@@ -68,3 +68,16 @@ bind       Any+pagedown  movedown
 bind            Any+alt  movereset      // fast camera reset on mousewheel
 bind            Any+alt  moverotate     // rotate on x,y with mmb hold + move (Spring Camera)
 bind           Any+ctrl  movetilt       // rotate on x with mousewheel
+
+// picture in picture camera controls
+// bind                  pip0_activity      // Focus advanced minimap onto recently placed map markers
+// bind                  pip0_trackplayer   // Focus advanced minimap (while spectating)
+// bind                  pip0_tv            // Advanced minimap follows the current action
+// bind                  pip0_view          // Limit advanced minimap to team view (while spectating)
+bind           alt+sc_q  pip1_copy      // Copy the current camera location to pip1
+bind         shift+sc_q  pip1_switch    // Switch the current camera location with pip1
+bind           alt+sc_a  pip1_track     // track the selected units with pip1
+// bind                  pip2_copy
+// bind                  pip2_switch
+// bind                  pip2_track
+


### PR DESCRIPTION
Un- hardcode the pip keybinds and expose the most likely to be used binds in chat and UI keys for players to modify.

### Work done
Removes a lot of junk related to hardcoded keybinds inside the pip widget.

`pip0_track` does not show in the tooltip because it is suppressed, but it works. Some only work if spectating (e.g. `pip0_trackplayer` ) 

#### Test steps
- [ ] Try some combination of custom binds for all 3 pips and test if keybinds work. 
- [ ] Check if tooltips update
```
bind               sc_\  pip0_activity      // Focus advanced minimap onto recently placed map markers
bind           alt+sc_\  pip0_track      // Focus advanced minimap onto recently placed map markers
bind          ctrl+sc_\  pip0_trackplayer   // Focus advanced minimap (while spectating)
bind      alt+ctrl+sc_\  pip0_tv            // Advanced minimap follows the current action
bind           alt+sc_'  pip0_view          // Limit advanced minimap to team view (while spectating)
bind           alt+sc_n  pip1_copy      // Copy the current camera location to pip1
bind         shift+sc_n  pip1_switch    // Switch the current camera location with pip1
bind           alt+sc_j  pip1_track     // track the selected units with pip1
bind          ctrl+sc_j  pip2_track
bind               sc_m  pip2_copy
bind         shift+sc_m  pip2_switch
```

### TO DO 

I also really don't want this to be on `alt+q` as default because I was about to add the 'select damaged units' keybind to `alt+q` . However this PR is keeping them same as the current hardcodes. `shift+q` also massively conflicts with standard gridkeys building. 

### AI / LLM usage statement:
No LLM used. 