### PR TITLE
Fix: Grid menu for modded configs without priority

### DIFF
--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -3,7 +3,7 @@
 local configs = VFS.Include('luaui/configs/gridmenu_layouts.lua')
 local labGrids = configs.LabGrids
 local unitGrids = configs.UnitGrids
-local priorityUnits = configs.PriorityUnits
+local priorityUnits = configs.PriorityUnits or {}
 
 local unitGridPos = { }
 local gridPosUnit = { }


### PR DESCRIPTION
That lack the new priority units table and don't update. 