### PR TITLE
block_newline_gaps isnt a thing

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -5,7 +5,6 @@ indent_type = "Tabs"
 indent_width = 4
 quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
-block_newline_gaps = "Preserve"
 collapse_simple_statement = "Never"
 space_after_function_names = "Never"
 


### PR DESCRIPTION
at least not in modern 

Error:
```
8 | block_newline_gaps = "Preserve"
  | ^^^^^^^^^^^^^^^^^^
unknown field `block_newline_gaps`, expected one of `syntax`, `column_width`, `line_endings`, `indent_type`, `indent_width`, `quote_style`, `no_call_parentheses`, `call_parentheses`, `collapse_simple_statement`, `sort_requires`, `space_after_function_names`
```

I don't know how this happened but I blame @efrec 