### PR TITLE
Camera_remember_mode should account for cardinal lock

### DIFF
--- a/luaui/Widgets/camera_remember_mode.lua
+++ b/luaui/Widgets/camera_remember_mode.lua
@@ -65,7 +65,7 @@ end
 
 function widget:GetConfigData()
 	local camState = table.copy(spGetCameraState())
-	if camState.ry and Spring.GetConfigInt("CamSpringLockCardinalDirections") == 1 then
+	if camState.ry and Spring.GetConfigInt("CamSpringLockCardinalDirections") == 1 and camState.mode == 2 then
 		camState.ry = GetCardinalLockSafeYaw(camState.ry)
 	elseif camState.ry then
 		camState.ry = math.clampRadians(camState.ry)


### PR DESCRIPTION
When joining a new match the camera should remember the old camera state. For spring camera if the cardinal lock direction setting is turned on, then the camera yaw can be rotated from the last state. This PR computes the engine applied cardinal lock rotation and accounts for it before clamping the rotation back near 0. An LLM was used to write the reversal logic to the engine side code.

Test by rotating the camera >360 degrees and then reloading the widget, especially to cardinal locked values. The camera should not move.
