### PR TITLE
fix: LOS view after LuaUI reload

### DIFF
--- a/luaui/Widgets/gfx_los_view.lua
+++ b/luaui/Widgets/gfx_los_view.lua
@@ -55,6 +55,7 @@ function widget:GameFrame(frame)	-- somehow widget:GameStart() didnt work
 end
 
 function widget:Shutdown()
+    lastMapDrawMode = Spring.GetMapDrawMode()
     TurnOffLOS()
 end
 
@@ -71,7 +72,7 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:GetConfigData() --save config
-	return {lastMapDrawMode=Spring.GetMapDrawMode()}
+	return {lastMapDrawMode=lastMapDrawMode}
 end
 
 function widget:SetConfigData(data) --load config


### PR DESCRIPTION
### Current behavior:
Using `/luaui reload` mid-game turns off LOS shading (fog of war terrain appears fully lit). `/togglelos` restores LOS shading.

In the "LOS View" widget’s `Initialize()`, LOS is turned off before game start, otherwise uses the saved `lastMapDrawMode`.

**Reason for no LOS after reload:**
After using `/luaui reload`, the `lastMapDrawMode` value is "normal" instead of "los", so on initialize LOS is turned off.

### Work done
`Initialize()` now turns LOS off for full view spectating and turns LOS on for players / player view spectating. Pre game LOS stays off as before.

**Cleanup:**
`lastMapDrawMode` is no longer needed during initialize, so its config saving and loading was removed. All LOS changing behavior remains the same

#### Test steps
- [ ] Test pregame, midgame, and spectating LOS changes during normal play, and with `/luaui reload`

#### BEFORE:
<img width="235" height="168" alt="los1" src="https://github.com/user-attachments/assets/69f7f10f-8a8a-4dca-b277-5ff655ce786a" />
<img width="235" height="171" alt="los2" src="https://github.com/user-attachments/assets/83ad9e58-a075-439e-a6f6-019ce4227a4c" />

### AI / LLM usage statement:
Gpt used to find the source of the issue and iterate on the solution