### PR TITLE
Fix: Home grid for modded layouts

### DIFF
--- a/luaui/configs/gridmenu_config.lua
+++ b/luaui/configs/gridmenu_config.lua
@@ -221,10 +221,15 @@ end
 
 function homeOptionsForBuilder(builderId, buildOptions)
 	local options = {}
+	local usedOptions = {}
 	local uncategorizedOpts = homeGridPos[builderId]
-	
+	local categoryOptions = {}
+
+	for cat = 1, 4 do
+		categoryOptions[cat] = getGridForCategory(builderId, buildOptions, categories[cat])
+	end
+
 	if uncategorizedOpts then
-		local usedOptions = {}
 		local optionsInRow = 0
 		for cat = 1, #uncategorizedOpts do
 			for _, uDefID in pairs(uncategorizedOpts[cat]) do
@@ -237,32 +242,12 @@ function homeOptionsForBuilder(builderId, buildOptions)
                 options[index] = constructBuildOption(uDefID)
                 usedOptions[uDefID] = true
 			end
-			-- Replace the top row with the first unused priority unit in each category
-			local priorityOpts = filterByPriority(uncategorizedOpts[cat], homePriority)
-			local row = 3 
-			if next(priorityOpts) ~= nil then
-				local index = cat + ((row - 1) * columns)
-				local currentOption = -1*options[index].id
-				if not homePriority[currentOption] then -- Don't replace an already prioritized unit with another one
-					for i = 1, #priorityOpts do
-						if not usedOptions[priorityOpts[i]] then
-							options[index] = constructBuildOption(priorityOpts[i])
-							break
-						end
-					end
-				end
-        	end
-
 			optionsInRow = 0
 		end
 
 	else
 		-- if the unit doesn't have a predefined grid we still want the "home" page to have units
 		-- So we build all the categories and grab the first 3 items from each one
-		local categoryOptions = {}
-		for cat = 1, 4 do
-			categoryOptions[cat] = getGridForCategory(builderId, buildOptions, categories[cat])
-		end
 		local optionsInRow = 0
 		for cat = 1, 4 do
 			for _, opt in pairs(categoryOptions[cat]) do
@@ -273,10 +258,42 @@ function homeOptionsForBuilder(builderId, buildOptions)
 				-- The grid is sorted by row, starting at the bottom. We want to order these items by column, so we switch their positions by changing the index
 				local index = (cat) + ((optionsInRow - 1) * columns)
 				options[index] = opt
+				local usedID = -opt.id
+				usedOptions[usedID] = true
 			end
 			optionsInRow = 0
 		end
 	end
+	for cat = 1, 4 do
+	-- Replace the top row with the first unused priority unit in each category
+		local possibleOpts = {}
+		for _, opt in pairs(categoryOptions[cat]) do
+			local optID = -opt.id
+			table.insert(possibleOpts, optID)
+		end
+		local priorityOpts = filterByPriority(possibleOpts, homePriority)
+		local row = 3 
+		local index = cat + ((row - 1) * columns)
+		local topOption = options[index]
+		if next(priorityOpts) ~= nil then
+			local shouldReplace = false
+			if topOption ~= nil then
+				local currentOption = -1 * topOption.id
+				shouldReplace = not homePriority[currentOption]
+			else
+				shouldReplace = true
+			end
+			if shouldReplace then
+				for i = 1, #priorityOpts do
+					if not usedOptions[priorityOpts[i]] then
+						options[index] = constructBuildOption(priorityOpts[i])
+						break
+					end
+				end
+			end
+		end
+	end
+	
 	return options
 end
 


### PR DESCRIPTION
Another quick fix for the home grid priority. Also moved the loop so it works for: fully defined grids (from base game), undefined buildoptions, and modded grids with both incomplete definitions, and superfluous non-buildable definitions.

#### Addresses Issue(s)
- [Issue URL](https://discord.com/channels/549281623154229250/1018861299939168288/1490066963328667840)

#### AFTER:
<img width="1309" height="607" alt="image" src="https://github.com/user-attachments/assets/533173df-b1e1-4993-babc-7d62138880d9" />


### AI / LLM usage statement:
Only argued with copilot for a bit but it couldn't understand these loops either. 