### PR TITLE
Fix: sharing blocked - validation bug

### DIFF
--- a/luarules/gadgets/cmd_idle_players.lua
+++ b/luarules/gadgets/cmd_idle_players.lua
@@ -201,7 +201,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:RecvLuaMsg(msg, playerID)
-		if msg:sub(1,2)~=validation and msg:sub(3,2+AFKMessageSize) ~= AFKMessage then --invalid message
+		if msg:sub(1,2)~=validation or msg:sub(3,2+AFKMessageSize) ~= AFKMessage then --invalid message
 			return
 		end
 		local afk = tonumber(msg:sub(2+AFKMessageSize+1))


### PR DESCRIPTION
The `RecvLuaMsg` filter uses `and` instead of `or` between two negative checks, so messages from other gadgets can pass through if the first two characters match the validation prefix.

Triggers in the rare instance of the random 2-char prefix matching the start of another LuaMsg (`"jo"` matching `"joined_game"`, `"vo"` matching `"vote_skip_turn"`), causing `numActivePlayers` to stay at 0 and blocking sharing to that team. Some players recover when a later `idleplayers` message overwrites the bad state.

Confirmed by parsing `NETMSG_LUAMSG` from 3 bugged replays:
- [6/16 players stuck](https://discord.com/channels/549281623154229250/1453276831569547435) — validation `jo`, collision with `joined_game`
- [2/16 players stuck](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5969) — validation `jo`, collision with `joined_game`
- [8/8 players stuck](https://www.beyondallreason.info/replays?gameId=ffa6d269c17cc2f62e9ff2720ad441d9) — validation `vo`, collision with `vote_skip_turn`

Fixes #5969

 AI / LLM usage statement
Claude used to create a replay parser and analyze bugged replays