### PR TITLE
Projectile underrange corrections

### DIFF
--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -4,6 +4,21 @@ if not math.isInRect then
 	end
 end
 
+if not math.dot_product then
+	function math.dot_product(ax, ay, az, bx, by, bz)
+		return ax * bx + ay * by + az * bz
+	end
+end
+
+if not math.cross_vector then
+	function math.cross_vector(ax, ay, az, bx, by, bz)
+		return
+			ay * bz - az * by,
+			az * bx - az * bz,
+			ax * by - ay * bx
+	end
+end
+
 if not math.cross_product then
 		function math.cross_product (px, pz, ax, az, bx, bz)
 		return ((px - bx) * (az - bz) - (ax - bx) * (pz - bz))

--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -4,21 +4,6 @@ if not math.isInRect then
 	end
 end
 
-if not math.dot_product then
-	function math.dot_product(ax, ay, az, bx, by, bz)
-		return ax * bx + ay * by + az * bz
-	end
-end
-
-if not math.cross_vector then
-	function math.cross_vector(ax, ay, az, bx, by, bz)
-		return
-			ay * bz - az * by,
-			az * bx - az * bz,
-			ax * by - ay * bx
-	end
-end
-
 if not math.cross_product then
 		function math.cross_product (px, pz, ax, az, bx, bz)
 		return ((px - bx) * (az - bz) - (ax - bx) * (pz - bz))

--- a/common/tablefunctions.lua
+++ b/common/tablefunctions.lua
@@ -416,7 +416,7 @@ if not table.map then
 	--- Applies a function to all elements of a table and returns a new table with the results.
 	---@generic K, V, RV, RK
 	---@param tbl table<K, V> The input table.
-	---@param callback fun(value: V, key: K, tbl: table<K, V>): RV, RK The function to apply to each element. It receives three arguments: the element's value, its key, and the original table. It should return the new value, and optionally, a new key.
+	---@param callback fun(value: V, key: K, tbl: table<K, V>): RV, RK? The function to apply to each element. It receives three arguments: the element's value, its key, and the original table. It should return the new value, and optionally, a new key.
 	---@return table<RK, RV> A new table containing the results of applying the callback to each element.
 	function table.map(tbl, callback)
 		local result = {}

--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -1953,7 +1953,7 @@ function WeaponDef_Post(name, wDef)
 		if wDef.targetborder == nil then
 			wDef.targetborder = 1 --Aim for just inside the hitsphere
 
-			if Engine.FeatureSupport.targetBorderBug and wDef.weapontype == "BeamLaser" or wDef.weapontype == "LightningCannon" then
+			if Engine.FeatureSupport.targetBorderBug and (wDef.weapontype == "BeamLaser" or wDef.weapontype == "LightningCannon") then
 				wDef.targetborder = 0.33 --approximates in current engine with bugged calculation, to targetborder = 1.
 			end
 		end

--- a/luarules/gadgets/unit_projectile_underrange.lua
+++ b/luarules/gadgets/unit_projectile_underrange.lua
@@ -182,6 +182,10 @@ local function buildRotation(ox, oy, oz, ax, ay, az, bx, by, bz, angleMax)
 	local uw = math_diag(ux, uy, uz)
 	local vw = math_diag(vx, vy, vz)
 
+	if uw == 0 or vw == 0 then
+		return 0, 0, 0, 0
+	end
+
 	local cosAngle = math_clamp((ux * vx + uy * vy + uz * vz) / uw / vw, -1, 1)
 	local angle = math_acos(cosAngle)
 	local factor = math_min(1, angleMax / angle)

--- a/luarules/gadgets/unit_projectile_underrange.lua
+++ b/luarules/gadgets/unit_projectile_underrange.lua
@@ -6,8 +6,8 @@ local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
 	return {
-		name    = "Projectile Aim Correction",
-		desc    = "Reaims projectiles as though they had `targetBorder = 0`",
+		name    = "Aim Compensation",
+		desc    = "Reaims shots to compensate for engine behaviors and BAR def configurations.",
 		author  = "efrec",
 		date    = "2026-04",
 		license = "GNU GPL, v2 or later",
@@ -16,34 +16,73 @@ function gadget:GetInfo()
 	}
 end
 
+-- This gadget compensates for some weaknesses in Recoil's targeting (lead prediction + aiming):
+-- (1) Lead prediction begins behind the "true" intercept and then catches up on each iteration.
+-- (2) Lead prediction iterations exit very early when the target is leaving the weapon's range.
+-- (3) Without accurateLeading > 0, the base prediction method makes no trajectory compensation.
+
+-- We also are compensating for some of BAR's unitdef and weapondef configurations, namely:
+-- (1) Our unit radii are not necessarily good fits of the unit's actual collision volumes.
+-- (2) Our collision volumes are not necessarily good fits of the unit's actual dimensions.
+-- (3) We use targetBorder = 1 so that units visibly within weapon range can be fired upon.
+-- (4) We do not make use of accurateLeading in our unitdefs (It is not a weapondef value).
+
+-- The above might not be self-explanatory to you. I find that the gadget's code outline helps:
+
+-- When a projectile is fired...
+-- 1. Infer the ranging/targeting used by the engine when placing and aiming the shot.
+-- 2. Construct our preferred target position with compensation to compare against.
+--    a. Time change. When a target is exiting range, the trajectory equations are unsolvable.
+--       To be more specific, they contain a positive, nonzero, "imaginary" component of time.
+--       We _add_ this imaginary component to our real component to construct our final point.
+--    b. Border change. Our calculations attempt to hit the target at its center-mass. When a
+--       target is missable due to accuracy constraints, and the projectile has a substantial
+--       area of effect, we introduce a moderate bias toward firing at the target unit's base.
+--       This bias is stronger against approaching targets and weaker against retreating ones.
+-- 3. Clamp the new target position to be within the weapon's maximum targeting volume.
+--    a. As needed, also clamp this final target position to the surface or to a low altitude.
+--       Different targeting volumes do this differently e.g. ballistics use a line-intercept.
+-- 4. Rotate the projectile's velocity by the difference in the launch angles between the two
+--    trajectories determined by re-aiming at the points determined in (1) and (3).
+--
+-- Alternatively, if we only want to add range corrections, which are a bit safer:
+-- 4. Pitch (and only pitch) the projectile up/down by the difference of launch angles between
+--    the trajectories determined by aiming at the points determined in (1) and (3).
+--    a. As needed, also reduce the inaccuracy in XZ introduced by the weapondef's accuracy or
+--       spray angles, since pitching up and down amplifies these errors a significant amount.
+
+-- TODO: Try to establish a more consistent notation.
+-- TODO: Linear algebra is rough to code without inlining. Try some optimizations.
+-- TODO: I'm not sure that I have satisfied the constraints of some high-trajectory weapons.
+-- TODO: Heightmod, dance, wobble are all trajectory modifications with different effects.
+
 --------------------------------------------------------------------------------
 -- Configuration ---------------------------------------------------------------
 
--- Try to prevent noticeable corrections with nearby targets. The typical angle
--- difference between the initial velocity and the post-correction velocity is
--- from 1 to 4 degrees. Closer targets tend to cause angles from 5 to 8 degrees.
-local correctionAngleMax = math.rad(12)
+-- Avoid overshooting by aiming max-range shots onto terrain, but also try not to
+-- force shots to reaim arbitrarily low, causing them to hit walls and/or allies.
+local surfaceTargetAltitude = 10.0
 
 --------------------------------------------------------------------------------
 -- Localization ----------------------------------------------------------------
 
-local math_min = math.min
+-- For lack of a better term or whatever
+
+local math_abs = math.abs
 local math_max = math.max
 local math_clamp = math.clamp
 local math_sqrt = math.sqrt
 local math_diag = math.diag
-local math_normalize = math.normalize
-local math_dot = math.dot_product
-local math_cross = math.cross_vector
 local dist2dSquared = math.distance2dSquared
 local dist3dSquared = math.distance3dSquared
 local math_cos = math.cos
 local math_sin = math.sin
 local math_acos = math.acos
 
+---@diagnostic disable-next-line: undefined-global
 local CallAsTeam = CallAsTeam
 
-local spGetProjectileDirection = Spring.GetProjectileDirection
+local spGetGroundHeight = Spring.GetGroundHeight
 local spGetProjectilePosition = Spring.GetProjectilePosition
 local spGetProjectileTarget = Spring.GetProjectileTarget
 local spGetProjectileTeamID = Spring.GetProjectileTeamID
@@ -51,7 +90,7 @@ local spGetProjectileVelocity = Spring.GetProjectileVelocity
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitRadius = Spring.GetUnitRadius
-local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitStates = Spring.GetUnitStates
 local spGetUnitVelocity = Spring.GetUnitVelocity
 local spSetProjectileVelocity = Spring.SetProjectileVelocity
 local spValidUnitID = Spring.ValidUnitID
@@ -59,17 +98,258 @@ local spValidUnitID = Spring.ValidUnitID
 local gameSpeed = Game.gameSpeed
 local gravityPerFrame = -Game.gravity / (gameSpeed ^ 2)
 
-local NAN_EPSILON = 1e-5
+---@diagnostic disable-next-line: undefined-field
 local TAANG2RAD = math.tau / COBSCALE
-local UNIT = string.byte("u")
+local TARGETTYPE_UNIT = ("u"):byte()
+
+local TRAJECTORY_LOW = 0
+local TRAJECTORY_HIGH = 1
 local TRAJECTORY_UNIT = 2
+local TRAJECTORY_DEFAULT = TRAJECTORY_LOW
+
+local RAD_EPSILON = 1e-6
+local NAN_EPSILON = 1e-5
+local DIST_EPSILON = 1e0
 
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
 local weaponAimCorrection = table.new(#WeaponDefs, 1) -- [0] is hashed
 
-local function clampToCylinder(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
+local clampToCone, clampToCylinder, clampToSphere
+
+local shortDuration = 0.3333 * gameSpeed
+local instantWeapons = { LightningCannon = true, Rifle = true, }
+local reaimEffects = { guidance = true, sector_fire = true }
+local spreadDistanceMax = Game.squareSize * Game.footprintScale * 5 -- Use a large-ish unit as an accuracy cutoff
+
+local function getAimCorrectionParams(weaponDef)
+	-- There are plenty of cases that make no sense or can cause errors. Avoid them.
+	local isFakeWeapon = weaponDef.customParams.bogus == "1" or tonumber(weaponDef.customParams.weapons_group or -1) <= -1
+	local isShieldWeapon = weaponDef.type == "Shield"
+	local isInstantHit = instantWeapons[weaponDef.type] or weaponDef.projectilespeed * shortDuration >= weaponDef.range
+	local isNonballistic = weaponDef.myGravity >= 0
+
+	if isFakeWeapon or isShieldWeapon or isNonballistic or isInstantHit then
+		return false
+	end
+
+	-- These may be fine but have reduced support for some other reason like performance.
+	local isHighTrajectory = weaponDef.highTrajectory == 1 or (weaponDef.type == "StarburstLauncher" and weaponDef.uptime >= 3)
+	local canTrackTarget = weaponDef.tracks and weaponDef.turnRate > weaponDef.projectilespeed * 0.1
+	local hasReaimEffect = weaponDef.customParams.speceffect and reaimEffects[weaponDef.customParams.speceffect]
+	local hasLowAccuracy = (weaponDef.accuracy + weaponDef.sprayAngle) * TAANG2RAD * weaponDef.range >= spreadDistanceMax + weaponDef.damageAreaOfEffect * 0.5
+	local hasLargeSalvo = weaponDef.salvoSize >= 6
+
+	if weaponDef.customParams.aim_compensation ~= "true" then
+		if isHighTrajectory or canTrackTarget or hasReaimEffect or hasLowAccuracy or hasLargeSalvo then
+			return false
+		end
+	end
+
+	-- NB: Recoil likely does not form proper trajectory envelopes due to max projectile speed.
+	-- A falling projectile at terminal velocity "gains" orientation toward dirDown, not speed.
+	local clampToTargetingVolume
+
+	-- TODO: We don't know the targeting volume for slaved weapons. These can't be processed from weapondefs, though:
+	-- local targetingDef = weaponDef
+	-- if weaponDef.customParams.speceffect == "guidance" then
+	-- 	targetingDef = need to check the weapon, not the weapondef
+	-- end
+
+	if weaponDef.cylinderTargeting >= 1 then
+		clampToTargetingVolume = clampToCylinder
+	elseif weaponDef.myGravity < 0 and (not weaponDef.tracks or weaponDef.turnRate < -weaponDef.myGravity) then
+		clampToTargetingVolume = clampToCone
+	else
+		-- Maybe we can have a gravity-affected weapon with spherical targeting for nonsense reasons
+		-- like a high-trajectory weapon that reuses the laser ranging method from the Legion Medusa.
+		clampToTargetingVolume = clampToSphere
+	end
+
+	local leadLimit = false
+		or weaponDef.leadLimit < 0 and 250 -- The engine has some technical-seeming limit like this.
+		or weaponDef.leadLimit + weaponDef.leadBonus * 0.25 -- We just bake in some unit XP for now.
+
+	return {
+		gravity      = weaponDef.myGravity,
+		heightMod    = weaponDef.heightMod,
+		range        = weaponDef.range,
+		speed        = weaponDef.projectilespeed,
+		targetBorder = weaponDef.targetBorder,
+		trajectory   = weaponDef.highTrajectory,
+
+		clamp        = clampToTargetingVolume,
+
+		leadingSteps = -1, -- not a weapondef property but a weapon property
+		leadLimit    = leadLimit,
+	}
+end
+
+for weaponDefID = 0, #WeaponDefs do
+	local weaponDef = WeaponDefs[weaponDefID]
+	if weaponDef.targetBorder > 0 and weaponDef.customParams.aim_compensation ~= "false" then
+		weaponAimCorrection[weaponDefID] = getAimCorrectionParams(weaponDef)
+	else
+		weaponAimCorrection[weaponDefID] = false
+	end
+end
+
+for unitDefID = 1, #UnitDefs do
+	local unitDef = UnitDefs[unitDefID]
+	for index, weapon in ipairs(unitDef.weapons) do
+		local aimParams = weaponAimCorrection[weapon.weaponDef]
+		if aimParams then
+			-- BAR units currently do not use accurateLeading. Still, for balance testing:
+			aimParams.leadingSteps = math_max(aimParams.leadingSteps, weapon.accurateLeading)
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Local functions -------------------------------------------------------------
+
+local function dot(ax, ay, az, bx, by, bz)
+	return ax * bx + ay * by + az * bz
+end
+
+local function cross(ax, ay, az, bx, by, bz)
+	return
+		ay * bz - az * by,
+		az * bx - ax * bz,
+		ax * by - ay * bx
+end
+
+local function isOnSurface(x, y, z)
+	return y <= math_max(spGetGroundHeight(x, z), 0) + 1
+end
+
+local function getPredictTimeAdapter(unitID, projectileID, params)
+	local ux, uy, uz, ax, ay, az = spGetUnitPosition(unitID, false, true)
+	local px, py, pz = spGetProjectilePosition(projectileID)
+	return px, py, pz, ax, ay, az, params.speed -- ! todo: fetch once, use multiple times, ideally
+end
+
+--------------------------------------------------------------------------------
+-- Engine targeting reproduction -----------------------------------------------
+
+-- This section reproduces the following CWeapon methods from Recoil:
+-- GetPredictTime, GetAccuratePredictTime, GetLeadVec, GetLeadTargetPosition
+
+local function getPredictTime(ax, ay, az, bx, by, bz, speed)
+	return math_diag(bx - ax, by - ay, bz - az) / speed
+end
+
+local function getAccuratePredictTime(unitID, projectileID, params, isHighTrajectory)
+	-- Uses no LOS access and no error parameters.
+	local ux, uy, uz = spGetUnitPosition(unitID)
+	local uvx, uvy, uvz = spGetUnitVelocity(unitID)
+
+	local px, py, pz = spGetProjectilePosition(projectileID)
+	local projSpeed = params.speed
+	local predictMult = params.predictBoost -- ignoring random seed and attackerXP
+	local gravity = params.gravity
+
+	local dx = 0.0
+	local dy = 0.0
+	local dz = 0.0
+	local gg = gravity * gravity
+	local ss = projSpeed * projSpeed
+	local t1 = 1.0
+	local dt1 = 1.0
+	local temp1 = 1.0
+	local temp2 = 1.0
+	local cc = 1.0
+
+	local predictTime = getPredictTime(px, py, pz, ux, uy, uz, projSpeed)
+	local deltaTime = predictTime
+
+	-- Generally, `leadingSteps` is not equal to `accurateLeading`. See setup code.
+	for i = 1, params.leadingSteps do
+		if deltaTime < 1 then
+			break
+		end
+
+		dx = ux + uvx * predictMult * predictTime - px
+		dy = uy + uvy * predictMult * predictTime - py
+		dz = uz + uvz * predictMult * predictTime - pz
+
+		cc = -ss - dy * gravity
+		temp1 = dot(dx, dy, dz, dx, dy, dz) * gg
+		temp2 = cc * cc
+
+		if temp1 >= temp2 then
+			break
+		end
+
+		t1 = math_sqrt((-cc + (isHighTrajectory and math_sqrt(temp2 - temp1) or 0)) / (gg * 0.5))
+		dt1 = (t1 - predictTime) / deltaTime
+
+		if math_abs(dt1 + NAN_EPSILON) < 1 then
+			predictTime = t1
+			break
+		end
+
+		deltaTime = t1 - predictTime
+		predictTime = t1
+	end
+
+	return predictTime
+end
+
+local function getLeadVec(unitID, projectileID, params, isHighTrajectory)
+	local predictTime
+
+	if params.leadingSteps > 0 then
+		predictTime = getAccuratePredictTime(unitID, projectileID, params, isHighTrajectory)
+	else
+		predictTime = getPredictTime(getPredictTimeAdapter(unitID, projectileID, params))
+	end
+
+	if not predictTime then
+		return
+	end
+
+	local predictMult = 1 -- We have to infer this.
+	predictTime = predictTime * predictMult
+
+	local uvx, uvy, uvz, unitSpeed = spGetUnitVelocity(unitID) -- We get these values too many times.
+
+	local leadX = uvx * predictTime
+	local leadY = uvy * predictTime
+	local leadZ = uvz * predictTime
+	local leadDistance = unitSpeed * predictTime
+
+	if leadDistance > params.leadLimit then
+		local ratio = params.leadLimit / (leadDistance + 0.01) -- We don't account for unit XP yet.
+		leadX, leadY, leadZ = leadX * ratio, leadY * ratio, leadZ * ratio
+	end
+
+	return leadX, leadY, leadZ
+end
+
+local function getEngineTargetPosition(unitID, projectileID, params, isHighTrajectory)
+	-- Get the error position for this one case.
+	local ux, uy, uz, ax, ay, az = CallAsTeam(spGetProjectileTeamID(projectileID), spGetUnitPosition, unitID, false, true)
+	if not ax then
+		return
+	end
+
+	local lx, ly, lz = getLeadVec(unitID, projectileID, params, isHighTrajectory)
+	if not lx then
+		return
+	end
+
+	return ax + lx, ay + ly, az + lz
+end
+
+--------------------------------------------------------------------------------
+-- Full-range targeting solution -----------------------------------------------
+
+-- "Clamping" fits a target point to anywhere on or within the targeting volume.
+-- After allowing for absurd (out-of-range) solutions, we clamp them to reality.
+
+function clampToCylinder(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 	local d2 = dist2dSquared(fromX, fromZ, toX, toZ)
 
 	if d2 > range * range and d2 < (range + radius) * (range + radius) then -- todo: change from spherical to cylindrical test
@@ -83,7 +363,7 @@ local function clampToCylinder(fromX, fromY, fromZ, toX, toY, toZ, range, radius
 	return toX, toY, toZ
 end
 
-local function clampToSphere(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
+function clampToSphere(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 	local d2 = dist3dSquared(fromX, fromY, fromZ, toX, toY, toZ)
 
 	if d2 > range * range and d2 <= (range + radius) * (range + radius) then
@@ -98,11 +378,11 @@ local function clampToSphere(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 	return toX, toY, toZ
 end
 
-local function clampToCone(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
+function clampToCone(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 	local dx, dy, dz = toX - fromX, toY - fromY, toZ - fromZ
 	local dxzSquared = dx * dx + dz * dz
-	local heightCone = range * range / gravityPerFrame
-	local radiusAtY = math_max(range * dy / heightCone, 0)
+	local heightCone = range * range / -gravityPerFrame
+	local radiusAtY = math_max(range * dy / heightCone, 0.0)
 
 	if radiusAtY <= 0 and dxzSquared <= radius * radius then
 		-- Probably bad to fire gravity-affected projectiles at dirUp:
@@ -118,203 +398,286 @@ local function clampToCone(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 	return toX, toY, toZ
 end
 
-local instantDuration = 0.3333 * Game.gameSpeed -- Fast enough, anyway
-local instantWeapons = { LightningCannon = true, Rifle = true, }
-local reaimEffects = { guidance = true, sector_fire = true }
-local spreadDistanceMax = Game.squareSize * Game.footprintScale * 5 -- Use the reference dimension of a large-ish unit as an accuracy cutoff
-
-local function getAimCorrectionParams(weaponDef)
-	local isFakeWeapon = weaponDef.range <= 10 or weaponDef.customParams.bogus == "1"
-	local isShieldWeapon = weaponDef.type == "Shield"
-	local isInstantHit = instantWeapons[weaponDef.type] or weaponDef.projectilespeed * instantDuration >= weaponDef.range
-	local isHighTrajectory = weaponDef.highTrajectory == 1 or (weaponDef.type == "StarburstLauncher" and weaponDef.uptime >= 3)
-	local canTrackTarget = weaponDef.tracks and weaponDef.turnRate > weaponDef.projectilespeed * 0.1
-	local hasReaimEffect = weaponDef.customParams.speceffect and reaimEffects[weaponDef.customParams.speceffect]
-	local hasLowAccuracy = (weaponDef.accuracy + weaponDef.sprayAngle) * TAANG2RAD * weaponDef.range >= spreadDistanceMax + weaponDef.damageAreaOfEffect * 0.5
-	local hasLargeSalvo = weaponDef.salvoSize >= 6
-
-	if isFakeWeapon or isShieldWeapon or isInstantHit or isHighTrajectory or canTrackTarget or hasReaimEffect or hasLowAccuracy or hasLargeSalvo then
-		return false
-	end
-
-	local clampToTargetingVolume
-
-	if weaponDef.cylinderTargeting >= 1 then
-		clampToTargetingVolume = clampToCylinder
-	elseif weaponDef.gravityAffected then -- todo: gravity over projectile lifetime should be >> some value
-		clampToTargetingVolume = clampToCone
-	else
-		clampToTargetingVolume = clampToSphere
-	end
-
-	local angleMax = correctionAngleMax -- todo: different weapons may need different amounts of correction
-
-	return {
-		angleMax     = angleMax,
-
-		targetBorder = weaponDef.targetBorder,
-		range        = weaponDef.range,
-		speed        = weaponDef.projectilespeed,
-
-		leadLimit    = math.abs(weaponDef.leadLimit), -- todo: the mystery of the negative lead limit
-		leadBonus    = weaponDef.leadBonus, -- todo: bonus/boost unused
-		predictBoost = weaponDef.predictBoost,
-
-		gravity      = weaponDef.gravityAffected, -- todo: handle special gravities
-		heightMod    = weaponDef.heightMod,
-		trajectory   = weaponDef.highTrajectory == TRAJECTORY_UNIT,
-
-		clamp        = clampToTargetingVolume,
-	}
+local function clampToAltitude(x, y, z, unitRadius)
+	local elevation = math_max(spGetGroundHeight(x, z), 0)
+	local altitude = math_max(unitRadius, surfaceTargetAltitude)
+	y = math_clamp(y, elevation, elevation + altitude)
+	return x, y, z
 end
 
-for weaponDefID = 0, #WeaponDefs do
-	local weaponDef = WeaponDefs[weaponDefID]
-	if weaponDef.targetBorder > 0 and not weaponDef.customParams.no_border_correction then
-		weaponAimCorrection[weaponDefID] = getAimCorrectionParams(weaponDef)
+local function getBetterTargetPosition(unitID, projectileID, params, isHighTrajectory, compensationType, isSurfaceTarget)
+	-- Uses no LOS access and no error parameters.
+	local ux, uy, uz, umx, umy, umz, uax, uay, uaz = spGetUnitPosition(unitID, true, true)
+	local uvx, uvy, uvz, unitSpeed = spGetUnitVelocity(unitID)
+
+	local px, py, pz = spGetProjectilePosition(projectileID)
+	local projSpeed = params.speed
+	local predictMult = params.predictBoost -- ignoring random seed and attackerXP
+	local gravity = params.gravity
+
+	local dx = 0.0
+	local dy = 0.0
+	local dz = 0.0
+	local gg = gravity * gravity
+	local ss = projSpeed * projSpeed
+	local t1 = 1.0
+	local dt1 = 1.0
+	local temp1 = 1.0
+	local temp2 = 1.0
+	local cc = 1.0
+
+	if compensationType == "short" and isSurfaceTarget then
+		ux, uy, uz = (ux + uax) * 0.5, (uy + uay) * 0.5, (uz + uaz) * 0.5
 	else
-		weaponAimCorrection[weaponDefID] = false
+		ux, uy, uz = umx, umy, umz
 	end
+
+	local predictTime = getPredictTime(px, py, pz, ux, uy, uz, projSpeed)
+	local deltaTime = predictTime
+
+	-- As "better target position" would imply, enforce at least one iteration.
+	for i = 1, math_max(params.leadingSteps, 1) do
+		if deltaTime < 1 then
+			break
+		end
+
+		dx = ux + uvx * predictMult * predictTime - px
+		dy = uy + uvy * predictMult * predictTime - py
+		dz = uz + uvz * predictMult * predictTime - pz
+
+		cc = -ss - dy * gravity
+		temp1 = dot(dx, dy, dz, dx, dy, dz) * gg
+		temp2 = cc * cc
+
+		if temp1 >= temp2 then
+			-- Since we clamp to within the targeting volume after this step, time past-range is fine.
+			-- So, materialize the imaginary time component of the solution from the nearest approach:
+			local approachDistance = math_sqrt(temp1 - temp2) / gravity
+			t1 = t1 + approachDistance / projSpeed
+			break
+		end
+
+		t1 = math_sqrt((-cc + (isHighTrajectory and math_sqrt(temp2 - temp1) or 0)) / (gg * 0.5))
+		dt1 = (t1 - predictTime) / deltaTime
+
+		if math_abs(dt1 + NAN_EPSILON) < 1 then
+			predictTime = t1
+			break
+		end
+
+		deltaTime = t1 - predictTime
+		predictTime = t1
+	end
+
+	predictTime = predictTime * predictMult
+
+	local leadX = uvx * predictTime
+	local leadY = uvy * predictTime
+	local leadZ = uvz * predictTime
+	local leadDistance = unitSpeed * predictTime
+
+	if leadDistance > params.leadLimit then
+		local ratio = params.leadLimit / (leadDistance + 0.01)
+		leadX, leadY, leadZ = leadX * ratio, leadY * ratio, leadZ * ratio
+	end
+
+	-- Refetch the unit position, this time with error.
+	ux, uy, uz, umx, umy, umz, uax, uay, uaz = CallAsTeam(spGetProjectileTeamID(projectileID), spGetUnitPosition, unitID, true, true)
+
+	if compensationType == "short" and isSurfaceTarget then
+		ux, uy, uz = (ux + uax) * 0.5, (uy + uay) * 0.5, (uz + uaz) * 0.5
+	else
+		ux, uy, uz = uax, uay, uaz
+	end
+
+	return ux + leadX, uy + leadY, uz + leadZ
 end
 
 --------------------------------------------------------------------------------
--- Local functions -------------------------------------------------------------
+-- Final aim compensation solution ---------------------------------------------
 
----Build the rotation around a non-trivial origin <o> of a vector <a> toward a vector <b>.
-local function buildRotation(ox, oy, oz, ax, ay, az, bx, by, bz, angleMax)
-	local ux, uy, uz = ax - ox, ay - oy, az - oz
-	local vx, vy, vz = bx - ox, by - oy, bz - oz
+local projectiles = 0
+local compensated = 0
+local compensation = {}
 
-	local uw = math_diag(ux, uy, uz)
+local function getAimDirection(params, trajectory, dx, dy, dz, predictTime)
+	local gravity = params.gravity
+	local speed = params.speed
+
+	local a = 0.25 * gravity * gravity
+	local b = dy * gravity - speed * speed
+	local c = dot(dx, dy, dz, dx, dy, dz)
+	local d = b * b - 4 * a * c
+	if d < 0 then
+		return
+	end
+
+	local dd = math_sqrt(d)
+	local t1 = (-b - dd) / (2 * a)
+	local t2 = (-b + dd) / (2 * a)
+
+	local t = t1
+	local e = NAN_EPSILON
+
+	if trajectory == TRAJECTORY_HIGH then
+		if t2 > e then
+			t = t2
+		else
+			return
+		end
+	else
+		if t1 > e then
+			if t2 > e and math_abs(predictTime - t1) > math_abs(predictTime - t2) then
+				t = t2
+			end
+		elseif t2 > e then
+			t = t2
+		else
+			return
+		end
+	end
+
+	local vx = dx / t
+	local vy = dy / t - 0.5 * gravity * t
+	local vz = dz / t
 	local vw = math_diag(vx, vy, vz)
 
-	if uw * vw <= NAN_EPSILON then
-		return 0, 0, 0, 0
+	if vw > e then
+		return vx / vw, vy / vw, vz / vw
 	end
-
-	ux, uy, uz = ux / uw, uy / uw, uz / uw
-	vx, vy, vz = vx / vw, vy / vw, vz / vw
-
-	local angle = math_acos(math_clamp(math_dot(ux, uy, uz, vx, vy, vz), -1, 1))
-	if angle <= NAN_EPSILON then
-		return 0, 0, 0, 0
-	end
-
-	local cx, cy, cz = math_normalize(math_cross(ux, uy, uz, vx, vy, vz))
-	return cx, cy, cz, math_min(angle, angleMax) * 0.5 -- This was double-ish somehow?
 end
 
-local function applyRotation(rx, ry, rz, angle, px, py, pz)
+local function buildRotation(dx0, dy0, dz0, dx1, dy1, dz1)
+	local angle = math_acos(math_clamp(dot(dx0, dy0, dz0, dx1, dy1, dz1), -1.0, 1.0))
+	if angle <= RAD_EPSILON then
+		return 0.0
+	end
+
+	local axisX, axisY, axisZ = cross(dx0, dy0, dz0, dx1, dy1, dz1)
+	local axisMag = math_diag(axisX, axisY, axisZ)
+	if axisMag <= NAN_EPSILON then
+		return 0.0 -- avoid math_normalize to exit when parallel/antiparallel here
+	end
+
+	axisX = axisX / axisMag
+	axisY = axisY / axisMag
+	axisZ = axisZ / axisMag
+
+	return angle, axisX, axisY, axisZ
+end
+
+local function applyRotation(angle, axisX, axisY, axisZ, vx, vy, vz)
 	local cosAngle = math_cos(angle)
 	local sinAngle = math_sin(angle)
-	local cx, cy, cz = math_cross(rx, ry, rz, px, py, pz)
-	local dotTerm = math_dot(rx, ry, rz, px, py, pz) * (1 - cosAngle)
-	-- Rodrigues: p' = p * cos(θ) + (r × p) * sin(θ) + r * (r · p) * (1 - cos(θ))
-	return
-		px * cosAngle + cx * sinAngle + rx * dotTerm,
-		py * cosAngle + cy * sinAngle + ry * dotTerm,
-		pz * cosAngle + cz * sinAngle + rz * dotTerm
+	local cosTerm = (1 - cosAngle) * dot(axisX, axisY, axisZ, vx, vy, vz)
+
+	local resultX = vx * cosAngle + (axisY * vz - axisZ * vy) * sinAngle + axisX * cosTerm
+	local resultY = vy * cosAngle + (axisZ * vx - axisX * vz) * sinAngle + axisY * cosTerm
+	local resultZ = vz * cosAngle + (axisX * vy - axisY * vx) * sinAngle + axisZ * cosTerm
+
+	return angle, resultX, resultY, resultZ
 end
 
-local function getTargetData(targetID)
-	local baseX, baseY, baseZ, midX, midY, midZ, aimX, aimY, aimZ = spGetUnitPosition(targetID, true, true)
-	return baseX, baseY, baseZ, midX, midY, midZ, aimX, aimY, aimZ, spGetUnitDefID(targetID), spGetUnitRadius(targetID)
-end
+local function applyAimCorrection(projectileID, ownerID, params)
+	-- Leave these in until we've collected enough weapon performance statistics.
+	compensation[projectileID] = "none"
+	projectiles = projectiles + 1
 
-local readAs = { read = -1 }
-local function readAsTeam(teamID, ...)
-	local read = readAs
-	read.read = teamID or -1
-	return CallAsTeam(read, ...)
-end
+	local targetType, targetID = spGetProjectileTarget(projectileID)
+	if targetType ~= TARGETTYPE_UNIT then
+		return
+	else
+		assert(type(targetID) == "number")
+		if not spValidUnitID(targetID) then
+			return
+		end
+	end
 
-local corrected = 0
-
-local function updateAimDirection(projectileID, params, targetID)
-	local baseX, baseY, baseZ, midX, midY, midZ, aimX, aimY, aimZ, targetDefID, targetRadius = getTargetData(targetID)
-	if not midX or not targetDefID or targetRadius == 0 then
+	local unitDefID, unitRadius = spGetUnitDefID(targetID), spGetUnitRadius(targetID)
+	if not unitDefID or unitRadius == 0 then
 		return
 	end
 
 	local uvx, uvy, uvz, unitSpeed = spGetUnitVelocity(targetID)
 	local pvx, pvy, pvz, projSpeed = spGetProjectileVelocity(projectileID)
-	if not uvx or (projSpeed or 0) == 0 then
-		return
-	end
-	if math.dot_product(uvx, uvy, uvz, pvx, pvy, pvz) < projSpeed * 0.25 then
-		return -- target is not retreating, underrange doesn't matter
-	end
-
-	-- todo: High trajectories need to use a counter-rotation for reaiming.
-	if params.trajectory and pvy >= math_diag(pvx, pvz) then
+	if unitSpeed * projSpeed <= NAN_EPSILON then
 		return
 	end
 
+	local ux, uy, uz, midX, midY, midZ, aimX, aimY, aimZ = spGetUnitPosition(targetID, true, true)
 	local px, py, pz = spGetProjectilePosition(projectileID)
-	local pdx, pdy, pdz = spGetProjectileDirection(projectileID)
 
-	local targetX, targetY, targetZ = midX, midY, midZ -- The inferred targetBorder-based position.
-	local aimPosX, aimPosY, aimPosZ = aimX, aimY, aimZ -- The new, preferred aimPos-based position.
+	local direction = dot(uvx, uvy, uvz, pvx, pvy, pvz) / projSpeed / unitSpeed
+	local separation = math_max(math_diag(midX - px, midY - py, midZ - pz) - unitRadius, 0) / params.range
+	local isSurfaceTarget = isOnSurface(ux, uy, uz)
 
-	if params.gravityAffected and baseY <= Spring.GetGroundHeight(baseX, baseZ) + 1 then
-		aimPosX = (aimPosX + baseX) * 0.5
-		aimPosY = (aimPosY + baseY) * 0.5
-		aimPosZ = (aimPosZ + baseZ) * 0.5
-	end
+	-- We use two types of aim correction, determined by the target's relative distance and speed.
+	-- 1. Surface targets can be hit indirectly by shooting at their base. This also limits overshooting.
+	-- 2. Receding targets should be targeted through their center-mass. This avoids shots falling short.
+	local compensationType
 
-	local targetBorderRadius = params.targetBorder * targetRadius
-	targetX = targetX - pdx * targetBorderRadius
-	targetY = targetY - pdy * targetBorderRadius
-	targetZ = targetZ - pdz * targetBorderRadius
-
-	local timeRemainingMax = params.leadLimit / (unitSpeed + projSpeed) -- close enough
-
-	for convergenceStep = 1, 2 do
-		local timeRemainingMid = math_min(math_diag(targetX - px, targetY - py, targetZ - pz) / projSpeed, timeRemainingMax)
-		targetX = targetX + uvx * timeRemainingMid
-		targetY = targetY + uvy * timeRemainingMid
-		targetZ = targetZ + uvz * timeRemainingMid
-
-		local timeRemainingAim = math_min(math_diag(aimX - px, aimY - py, aimZ - pz) / projSpeed, timeRemainingMax)
-		aimPosX = aimX + uvx * timeRemainingAim
-		aimPosY = aimY + uvy * timeRemainingAim
-		aimPosZ = aimZ + uvz * timeRemainingAim
-	end
-
-	targetX, targetY, targetZ = params.clamp(px, py, pz, targetX, targetY, targetZ, params.range, targetRadius)
-	aimPosX, aimPosY, aimPosZ = params.clamp(px, py, pz, aimPosX, aimPosY, aimPosZ, params.range, targetRadius)
-
-	local rx, ry, rz, rw = buildRotation(px, py, pz, targetX, targetY, targetZ, aimPosX, aimPosY, aimPosZ, params.angleMax)
-
-	if (rw or 0) == 0 then
+	if direction <= 0 and isSurfaceTarget and (separation <= 0.3333 or separation + direction < -0.3333) then
+		compensationType = "short"
+	elseif direction >= 0.75 or separation + direction >= 1.5 then
+		compensationType = "long"
+	else
 		return
 	end
 
-	corrected = corrected + 1
+	local trajectory = params.trajectory
+	if trajectory == TRAJECTORY_UNIT then
+		if spValidUnitID(ownerID) then
+			trajectory = spGetUnitStates(ownerID).trajectory and TRAJECTORY_HIGH or TRAJECTORY_LOW
+		else
+			trajectory = TRAJECTORY_DEFAULT -- Projectile was probably spawned via game code.
+		end
+	end
 
-	spSetProjectileVelocity(projectileID, applyRotation(rx, ry, rz, rw, pvx, pvy, pvz))
+	local isHighTrajectory = trajectory == TRAJECTORY_HIGH
 
-	-- lol just spawn two:
-	Spring.SpawnProjectile(Spring.GetProjectileDefID(projectileID), {
-		pos     = { px, py, pz },
-		speed   = { pvx, pvy, pvz },
-		owner   = Spring.GetProjectileOwnerID(projectileID),
-		team    = Spring.GetProjectileTeamID(projectileID),
-		gravity = gravityPerFrame,
-	})
-end
-
-local function applyAimCorrection(projectileID, ownerID, params)
-	local targetType, targetID = spGetProjectileTarget(projectileID)
-	if targetType ~= UNIT or not spValidUnitID(targetID) then
+	local ex, ey, ez, engineTime = getEngineTargetPosition(unitID, projectileID, params, isHighTrajectory)
+	if not ex then
 		return
 	end
-	local teamID = spGetUnitTeam(ownerID) or spGetProjectileTeamID(projectileID)
-	readAsTeam(teamID, updateAimDirection, projectileID, params, targetID)
+
+	local bx, by, bz, betterTime = getBetterTargetPosition(unitID, projectileID, params, isHighTrajectory, compensationType, isSurfaceTarget)
+	if not bx then
+		return
+	end
+
+	bx, by, bz = params.clamp(px, py, pz, bx, by, bz, params.range, unitRadius)
+
+	if isSurfaceTarget and separation + direction >= 0.75 then
+		bx, by, bz = clampToAltitude(bx, by, bz)
+	end
+
+	local edx, edy, edz = getAimDirection(params, trajectory, ex - px, ey - py, ez - pz, engineTime)
+	if not edx then
+		return
+	end
+
+	local bdx, bdy, bdz = getAimDirection(params, trajectory, bx - px, by - py, bz - pz, betterTime)
+	if not bdx then
+		return
+	end
+
+	-- This is a tempting thought but we have no clue what our weapon is: -- TODO
+	-- Spring.GetUnitWeaponTryTarget(ownerID, ...)
+
+	local angle, ax, ay, az = buildRotation(edx, edy, edz, bdx, bdy, bdz)
+	if angle <= RAD_EPSILON or angle * (params.range * separation) ^ 2 <= DIST_EPSILON then
+		return
+	end
+
+	spSetProjectileVelocity(projectileID, applyRotation(angle, ax, ay, az, vx, vy, vz))
+
+	-- Statistics gathering:
+	compensation[projectileID] = compensationType
+	compensated = compensated + 1
 end
 
 --------------------------------------------------------------------------------
--- Engine call-ins -------------------------------------------------------------
+-- Engine callins --------------------------------------------------------------
 
 function gadget:Initialize()
 	if not next(weaponAimCorrection) then
@@ -333,69 +696,5 @@ end
 function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
 	if weaponAimCorrection[weaponDefID] then
 		applyAimCorrection(projectileID, ownerID, weaponAimCorrection[weaponDefID])
-	end
-end
-
-local collectStats = true -- ! testing
-
-if collectStats then
-	local projectiles = {}
-	local destroyed = {}
-	local full = 0
-	local partial = 0
-	local hitRate = 0
-	local hitCount = 0
-	local fired = 0
-	local destroyed = 0
-
-	function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
-		if weaponAimCorrection[weaponDefID] then
-			applyAimCorrection(projectileID, ownerID, weaponAimCorrection[weaponDefID])
-			projectiles[projectileID] = 0
-			fired = fired + 1
-		end
-	end
-
-	local spGetProjectileDamages = Spring.GetProjectileDamages
-
-	function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
-		if projectiles[projectileID] and unitTeam ~= attackerTeam then
-			local damageBase = spGetProjectileDamages(projectileID, 0)
-			projectiles[projectileID] = math_clamp(projectiles[projectileID] + damage / damageBase, 0, 2)
-			if damage >= damageBase - 1 then
-				full = full + damage
-			else
-				partial = partial + damage
-			end
-		end
-	end
-
-	function gadget:ProjectileDestroyed(projectileID)
-		if projectiles[projectileID] then
-			destroyed[projectileID] = projectiles[projectileID]
-			projectiles[projectileID] = nil
-			destroyed = destroyed + 1
-		end
-	end
-
-	function gadget:GameFramePost(frame)
-		for _, damageRate in pairs(destroyed) do
-			hitRate = (hitRate * hitCount + damageRate) / (hitCount + 1)
-			hitCount = hitCount + 1
-		end
-		destroyed = {}
-		if frame % 300 == 0 or destroyed == 30000 then
-			Spring.Echo(
-				"corrections",
-				fired > 0 and corrected / fired or 0,
-				"hits",
-				hitCount,
-				hitRate,
-				(full > 0 or partial > 0) and partial / (full + partial) or 0
-			)
-		end
-		if destroyed == 30000 then
-			Spring.Echo("test completed")
-		end
 	end
 end

--- a/luarules/gadgets/unit_projectile_underrange.lua
+++ b/luarules/gadgets/unit_projectile_underrange.lua
@@ -55,7 +55,7 @@ local gameSpeed = Game.gameSpeed
 local gravityPerFrame = -Game.gravity / (gameSpeed ^ 2)
 
 local ARC_EPSILON = 1e-6
-local TAANG2RAD = 9.58738e-05
+local TAANG2RAD = math.tau / COBSCALE
 local UNIT = string.byte("u")
 local TRAJECTORY_UNIT = 2
 

--- a/luarules/gadgets/unit_projectile_underrange.lua
+++ b/luarules/gadgets/unit_projectile_underrange.lua
@@ -1,0 +1,315 @@
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Projectile Aim Correction",
+		desc    = "Reaims projectiles as though they had `targetBorder = 0`",
+		author  = "efrec",
+		date    = "2026-04",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true, -- auto-disables
+	}
+end
+
+--------------------------------------------------------------------------------
+-- Configuration ---------------------------------------------------------------
+
+local correctionAngleMax = math.rad(12) -- The maximum change in direction.
+
+--------------------------------------------------------------------------------
+-- Localization ----------------------------------------------------------------
+
+local math_abs = math.abs
+local math_min = math.min
+local math_max = math.max
+local math_clamp = math.clamp
+local math_sqrt = math.sqrt
+local math_diag = math.diag
+local dist2dSquared = math.distance2dSquared
+local dist3dSquared = math.distance3dSquared
+local math_cos = math.cos
+local math_sin = math.sin
+local math_acos = math.acos
+
+local CallAsTeam = CallAsTeam
+
+local spGetProjectileDirection = Spring.GetProjectileDirection
+local spGetProjectilePosition = Spring.GetProjectilePosition
+local spGetProjectileTarget = Spring.GetProjectileTarget
+local spGetProjectileTeamID = Spring.GetProjectileTeamID
+local spGetProjectileVelocity = Spring.GetProjectileVelocity
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetUnitRadius = Spring.GetUnitRadius
+local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitVelocity = Spring.GetUnitVelocity
+local spSetProjectileVelocity = Spring.SetProjectileVelocity
+local spValidUnitID = Spring.ValidUnitID
+
+local gameSpeed = Game.gameSpeed
+local gravityPerFrame = -Game.gravity / (gameSpeed ^ 2)
+
+local ARC_EPSILON = 1e-6
+local TAANG2RAD = 9.58738e-05
+local UNIT = string.byte("u")
+local TRAJECTORY_UNIT = 2
+
+--------------------------------------------------------------------------------
+-- Initialization --------------------------------------------------------------
+
+local weaponAimCorrection = table.new(#WeaponDefs, 1) -- [0] is hashed
+
+local function clampToCylinder(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
+	local d2 = dist2dSquared(fromX, fromZ, toX, toZ)
+
+	if d2 > range * range and d2 < (range + radius) * (range + radius) then -- todo: change from spherical to cylindrical test
+		local d = math_sqrt(d2)
+		local t = range / d
+		toX = fromX + (toX - fromX) * t
+		toY = fromY + math_clamp(toY - fromY, range * -2, range * 2) -- Assumes cylinder targeting with a multiplier of 2.
+		toZ = fromZ + (toZ - fromZ) * t
+	end
+
+	return toX, toY, toZ
+end
+
+local function clampToSphere(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
+	local d2 = dist3dSquared(fromX, fromY, fromZ, toX, toY, toZ)
+
+	if d2 > range * range and d2 <= (range + radius) * (range + radius) then
+		-- AimPos is out of range, but nearest targetBorder is within range:
+		local d = math_sqrt(d2)
+		local t = (range - radius) / d
+		toX = fromX + (toX - fromX) * t
+		toY = fromY + (toY - fromY) * t
+		toZ = fromZ + (toZ - fromZ) * t
+	end
+
+	return toX, toY, toZ
+end
+
+local function clampToCone(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
+	local dx, dy, dz = toX - fromX, toY - fromY, toZ - fromZ
+	local dxzSquared = dx * dx + dz * dz
+	local heightCone = range * range / gravityPerFrame
+	local radiusAtY = math_max(range * dy / heightCone, 0)
+
+	if radiusAtY <= 0 and dxzSquared <= radius * radius then
+		-- Probably bad to fire gravity-affected projectiles at dirUp:
+		toX, toY, toZ = fromX, fromY + heightCone, fromZ
+	elseif dxzSquared > radiusAtY * radiusAtY and dxzSquared <= (radiusAtY + radius) * (radiusAtY + radius) then
+		-- todo: Not as good as it should be considering the projectile is under gravity:
+		local t = radiusAtY / math_sqrt(dxzSquared)
+		toX = fromX + dx * t
+		toY = fromY + dy * t
+		toZ = fromZ + dz * t
+	end
+
+	return toX, toY, toZ
+end
+
+local instantDuration = 0.1667 * Game.gameSpeed ---Should be pretty fast
+local instantWeapons = { BeamLaser = true, LaserCannon = true, Rifle = true, }
+local reaimEffects = { guidance = true, sector_fire = true }
+local spreadDistanceMax = Game.squareSize * Game.footprintScale * 5 ---Measures inaccuracy at max range
+
+local function getAimCorrectionParams(weaponDef)
+	local isFakeWeapon = weaponDef.range <= 10 or weaponDef.customParams.bogus == "1"
+	local isShieldWeapon = weaponDef.type == "Shield"
+	local isInstantHit = instantWeapons[weaponDef.type] or weaponDef.projectilespeed * instantDuration >= weaponDef.range
+	local isHighTrajectory = weaponDef.highTrajectory == 1 or (weaponDef.type == "StarburstLauncher" and weaponDef.uptime >= 3)
+	local canTrackTarget = weaponDef.tracks and weaponDef.turnRate > weaponDef.projectilespeed * 0.1
+	local hasReaimEffect = weaponDef.customParams.speceffect and reaimEffects[weaponDef.customParams.speceffect]
+	local hasLowAccuracy = (weaponDef.accuracy + weaponDef.sprayAngle) * TAANG2RAD * weaponDef.range >= spreadDistanceMax + weaponDef.damageAreaOfEffect * 0.5
+
+	if isFakeWeapon or isShieldWeapon or isInstantHit or isHighTrajectory or canTrackTarget or hasReaimEffect or hasLowAccuracy then
+		return false
+	end
+
+	local clampToTargetingVolume
+
+	if weaponDef.cylinderTargeting >= 1 then
+		clampToTargetingVolume = clampToCylinder
+	elseif weaponDef.gravityAffected then -- todo: gravity over projectile lifetime should be >> some value
+		clampToTargetingVolume = clampToCone
+	else
+		clampToTargetingVolume = clampToSphere
+	end
+
+	local angleMax = correctionAngleMax -- todo: different weapons may need different amounts of correction
+
+	return {
+		angleMax     = angleMax,
+
+		targetBorder = weaponDef.targetBorder,
+		range        = weaponDef.range,
+		speed        = weaponDef.projectilespeed,
+
+		leadLimit    = math.abs(weaponDef.leadLimit),
+		leadBonus    = weaponDef.leadBonus,
+		predictBoost = weaponDef.predictBoost,
+
+		gravity      = weaponDef.gravityAffected, -- todo: handle special gravities
+		heightMod    = weaponDef.heightMod,
+		trajectory   = weaponDef.highTrajectory,
+
+		clamp        = clampToTargetingVolume,
+	}
+end
+
+for weaponDefID = 0, #WeaponDefs do
+	local weaponDef = WeaponDefs[weaponDefID]
+	if weaponDef.targetBorder > 0 and not weaponDef.customParams.no_border_correction then
+		weaponAimCorrection[weaponDefID] = getAimCorrectionParams(weaponDef)
+	else
+		weaponAimCorrection[weaponDefID] = false
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Local functions -------------------------------------------------------------
+
+---Build the rotation around a non-trivial origin <o> of a vector <a> toward a vector <b>.
+local function buildRotation(ox, oy, oz, ax, ay, az, bx, by, bz, angleMax)
+	local ux, uy, uz = ax - ox, ay - oy, az - oz
+	local vx, vy, vz = bx - ox, by - oy, bz - oz
+
+	local uw = math_diag(ux, uy, uz)
+	local vw = math_diag(vx, vy, vz)
+
+	local cosAngle = math_clamp((ux * vx + uy * vy + uz * vz) / uw / vw, -1, 1)
+	local angle = math_acos(cosAngle)
+	local factor = math_min(1, angleMax / angle)
+
+	if factor <= ARC_EPSILON then
+		return 0, 0, 0, 0
+	end
+
+	if factor >= 1 - ARC_EPSILON then
+		return vx / vw, vy / vw, vz / vw, angle
+	end
+
+	if math_abs(cosAngle) < 1 - ARC_EPSILON then
+		local weight1 = math_sin(angle * (1 - factor)) / uw
+		local weight2 = math_sin(angle * (    factor)) / vw
+		local rescale = uw / math_sin(angle)
+		local cx = (ux * weight1 + vx * weight2) * rescale
+		local cy = (uy * weight1 + vy * weight2) * rescale
+		local cz = (uz * weight1 + vz * weight2) * rescale
+		local cw = math_diag(cx, cy, cz)
+		return cx / cw, cy / cw, cz / cw, angle * factor
+	end
+
+	return cosAngle > 0
+end
+
+local function applyRotation(rx, ry, rz, angle, px, py, pz)
+	local crossX = ry * pz - rz * py
+	local crossY = rz * px - rx * pz
+	local crossZ = rx * py - ry * px
+	local dot = rx * px + ry * py + rz * pz
+	local cosAngle = math_cos(angle)
+	local sinAngle = math_sin(angle)
+	return
+		px * cosAngle + crossX * sinAngle + dot * rx * (1 - cosAngle),
+		py * cosAngle + crossY * sinAngle + dot * ry * (1 - cosAngle),
+		pz * cosAngle + crossZ * sinAngle + dot * rz * (1 - cosAngle)
+end
+
+local function getTargetData(targetID)
+	local _, _, _, midX, midY, midZ, aimX, aimY, aimZ = spGetUnitPosition(targetID, true, true)
+	return midX, midY, midZ, aimX, aimY, aimZ, spGetUnitDefID(targetID), spGetUnitRadius(targetID)
+end
+
+local readAs = { read = -1 }
+local function readAsTeam(teamID, ...)
+	local read = readAs
+	read.read = teamID or -1
+	return CallAsTeam(read, ...)
+end
+
+local function updateAimDirection(projectileID, params, targetID)
+	local midX, midY, midZ, aimX, aimY, aimZ, targetDefID, targetRadius = getTargetData(targetID)
+	if not midX or not targetDefID or targetRadius == 0 then
+		return
+	end
+
+	local uvx, uvy, uvz, unitSpeed = spGetUnitVelocity(targetID)
+	local pvx, pvy, pvz, projSpeed = spGetProjectileVelocity(projectileID)
+	if not uvx or (projSpeed or 0) == 0 then
+		return
+	end
+
+	-- todo: High trajectories need to use a counter-rotation for reaiming.
+	if params.trajectory == TRAJECTORY_UNIT and pvy >= math_diag(pvx, pvz) then
+		return
+	end
+
+	local px, py, pz = spGetProjectilePosition(projectileID)
+	local pdx, pdy, pdz = spGetProjectileDirection(projectileID)
+
+	local targetX, targetY, targetZ = midX, midY, midZ -- The inferred targetBorder-based position.
+	local aimPosX, aimPosY, aimPosZ = aimX, aimY, aimZ -- The new, preferred aimPos-based position.
+
+	local targetBorderRadius = params.targetBorder * targetRadius
+	targetX = targetX - pdx * targetBorderRadius
+	targetY = targetY - pdy * targetBorderRadius
+	targetZ = targetZ - pdz * targetBorderRadius
+
+	local timeRemainingMax = params.leadLimit / (unitSpeed + projSpeed) -- close enough
+
+	for _ = 1, 2 do
+		local timeRemainingMid = math_min(math_diag(targetX - px, targetY - py, targetZ - pz) / projSpeed, timeRemainingMax)
+		targetX = targetX + uvx * timeRemainingMid
+		targetY = targetY + uvy * timeRemainingMid
+		targetZ = targetZ + uvz * timeRemainingMid
+
+		local timeRemainingAim = math_min(math_diag(aimX - px, aimY - py, aimZ - pz) / projSpeed, timeRemainingMax)
+		aimPosX = aimX + uvx * timeRemainingAim
+		aimPosY = aimY + uvy * timeRemainingAim
+		aimPosZ = aimZ + uvz * timeRemainingAim
+	end
+
+	targetX, targetY, targetZ = params.clamp(px, py, pz, targetX, targetY, targetZ, params.range, targetRadius)
+	aimPosX, aimPosY, aimPosZ = params.clamp(px, py, pz, aimPosX, aimPosY, aimPosZ, params.range, targetRadius)
+
+	local rx, ry, rz, rw = buildRotation(px, py, pz, targetX, targetY, targetZ, aimPosX, aimPosY, aimPosZ, params.angleMax)
+	spSetProjectileVelocity(projectileID, applyRotation(rx, ry, rz, rw, pvx, pvy, pvz))
+end
+
+local function applyAimCorrection(projectileID, ownerID, params)
+	local targetType, targetID = spGetProjectileTarget(projectileID)
+	if targetType ~= UNIT or not spValidUnitID(targetID) then
+		return
+	end
+	local teamID = spGetUnitTeam(ownerID) or spGetProjectileTeamID(projectileID)
+	readAsTeam(teamID, updateAimDirection, projectileID, params, targetID)
+end
+
+--------------------------------------------------------------------------------
+-- Engine call-ins -------------------------------------------------------------
+
+function gadget:Initialize()
+	if not next(weaponAimCorrection) then
+		Spring.Log(gadget:GetInfo().name, LOG.INFO, "No weapons with under-range issues.")
+		gadgetHandler:RemoveGadget()
+		return
+	end
+
+	for weaponDefID, params in pairs(weaponAimCorrection) do
+		if params then
+			Script.SetWatchProjectile(weaponDefID, true)
+		end
+	end
+end
+
+function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
+	if weaponAimCorrection[weaponDefID] then
+		applyAimCorrection(projectileID, ownerID, weaponAimCorrection[weaponDefID])
+	end
+end

--- a/luarules/gadgets/unit_projectile_underrange.lua
+++ b/luarules/gadgets/unit_projectile_underrange.lua
@@ -19,17 +19,22 @@ end
 --------------------------------------------------------------------------------
 -- Configuration ---------------------------------------------------------------
 
-local correctionAngleMax = math.rad(12) -- Try to prevent noticeable corrections with nearby targets.
+-- Try to prevent noticeable corrections with nearby targets. The typical angle
+-- difference between the initial velocity and the post-correction velocity is
+-- from 1 to 4 degrees. Closer targets tend to cause angles from 5 to 8 degrees.
+local correctionAngleMax = math.rad(12)
 
 --------------------------------------------------------------------------------
 -- Localization ----------------------------------------------------------------
 
-local math_abs = math.abs
 local math_min = math.min
 local math_max = math.max
 local math_clamp = math.clamp
 local math_sqrt = math.sqrt
 local math_diag = math.diag
+local math_normalize = math.normalize
+local math_dot = math.dot_product
+local math_cross = math.cross_vector
 local dist2dSquared = math.distance2dSquared
 local dist3dSquared = math.distance3dSquared
 local math_cos = math.cos
@@ -54,7 +59,7 @@ local spValidUnitID = Spring.ValidUnitID
 local gameSpeed = Game.gameSpeed
 local gravityPerFrame = -Game.gravity / (gameSpeed ^ 2)
 
-local ARC_EPSILON = 1e-6
+local NAN_EPSILON = 1e-5
 local TAANG2RAD = math.tau / COBSCALE
 local UNIT = string.byte("u")
 local TRAJECTORY_UNIT = 2
@@ -113,8 +118,8 @@ local function clampToCone(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 	return toX, toY, toZ
 end
 
-local instantDuration = 0.1667 * Game.gameSpeed ---Should be pretty fast
-local instantWeapons = { BeamLaser = true, LaserCannon = true, LightningCannon = true, Rifle = true, }
+local instantDuration = 0.3333 * Game.gameSpeed -- Fast enough, anyway
+local instantWeapons = { LightningCannon = true, Rifle = true, }
 local reaimEffects = { guidance = true, sector_fire = true }
 local spreadDistanceMax = Game.squareSize * Game.footprintScale * 5 -- Use the reference dimension of a large-ish unit as an accuracy cutoff
 
@@ -126,8 +131,9 @@ local function getAimCorrectionParams(weaponDef)
 	local canTrackTarget = weaponDef.tracks and weaponDef.turnRate > weaponDef.projectilespeed * 0.1
 	local hasReaimEffect = weaponDef.customParams.speceffect and reaimEffects[weaponDef.customParams.speceffect]
 	local hasLowAccuracy = (weaponDef.accuracy + weaponDef.sprayAngle) * TAANG2RAD * weaponDef.range >= spreadDistanceMax + weaponDef.damageAreaOfEffect * 0.5
+	local hasLargeSalvo = weaponDef.salvoSize >= 6
 
-	if isFakeWeapon or isShieldWeapon or isInstantHit or isHighTrajectory or canTrackTarget or hasReaimEffect or hasLowAccuracy then
+	if isFakeWeapon or isShieldWeapon or isInstantHit or isHighTrajectory or canTrackTarget or hasReaimEffect or hasLowAccuracy or hasLargeSalvo then
 		return false
 	end
 
@@ -150,13 +156,13 @@ local function getAimCorrectionParams(weaponDef)
 		range        = weaponDef.range,
 		speed        = weaponDef.projectilespeed,
 
-		leadLimit    = math.abs(weaponDef.leadLimit),
-		leadBonus    = weaponDef.leadBonus,
+		leadLimit    = math.abs(weaponDef.leadLimit), -- todo: the mystery of the negative lead limit
+		leadBonus    = weaponDef.leadBonus, -- todo: bonus/boost unused
 		predictBoost = weaponDef.predictBoost,
 
 		gravity      = weaponDef.gravityAffected, -- todo: handle special gravities
 		heightMod    = weaponDef.heightMod,
-		trajectory   = weaponDef.highTrajectory,
+		trajectory   = weaponDef.highTrajectory == TRAJECTORY_UNIT,
 
 		clamp        = clampToTargetingVolume,
 	}
@@ -182,52 +188,37 @@ local function buildRotation(ox, oy, oz, ax, ay, az, bx, by, bz, angleMax)
 	local uw = math_diag(ux, uy, uz)
 	local vw = math_diag(vx, vy, vz)
 
-	if uw == 0 or vw == 0 then
+	if uw * vw <= NAN_EPSILON then
 		return 0, 0, 0, 0
 	end
 
-	local cosAngle = math_clamp((ux * vx + uy * vy + uz * vz) / uw / vw, -1, 1)
-	local angle = math_acos(cosAngle)
-	local factor = math_min(1, angleMax / angle)
+	ux, uy, uz = ux / uw, uy / uw, uz / uw
+	vx, vy, vz = vx / vw, vy / vw, vz / vw
 
-	if factor <= ARC_EPSILON then
+	local angle = math_acos(math_clamp(math_dot(ux, uy, uz, vx, vy, vz), -1, 1))
+	if angle <= NAN_EPSILON then
 		return 0, 0, 0, 0
 	end
 
-	if factor >= 1 - ARC_EPSILON then
-		return vx / vw, vy / vw, vz / vw, angle
-	end
-
-	if math_abs(cosAngle) < 1 - ARC_EPSILON then
-		local weight1 = math_sin(angle * (1 - factor)) / uw
-		local weight2 = math_sin(angle * (    factor)) / vw
-		local rescale = uw / math_sin(angle)
-		local cx = (ux * weight1 + vx * weight2) * rescale
-		local cy = (uy * weight1 + vy * weight2) * rescale
-		local cz = (uz * weight1 + vz * weight2) * rescale
-		local cw = math_diag(cx, cy, cz)
-		return cx / cw, cy / cw, cz / cw, angle * factor
-	end
-
-	return cosAngle > 0
+	local cx, cy, cz = math_normalize(math_cross(ux, uy, uz, vx, vy, vz))
+	return cx, cy, cz, math_min(angle, angleMax) * 0.5 -- This was double-ish somehow?
 end
 
 local function applyRotation(rx, ry, rz, angle, px, py, pz)
-	local crossX = ry * pz - rz * py
-	local crossY = rz * px - rx * pz
-	local crossZ = rx * py - ry * px
-	local dot = rx * px + ry * py + rz * pz
 	local cosAngle = math_cos(angle)
 	local sinAngle = math_sin(angle)
+	local cx, cy, cz = math_cross(rx, ry, rz, px, py, pz)
+	local dotTerm = math_dot(rx, ry, rz, px, py, pz) * (1 - cosAngle)
+	-- Rodrigues: p' = p * cos(θ) + (r × p) * sin(θ) + r * (r · p) * (1 - cos(θ))
 	return
-		px * cosAngle + crossX * sinAngle + dot * rx * (1 - cosAngle),
-		py * cosAngle + crossY * sinAngle + dot * ry * (1 - cosAngle),
-		pz * cosAngle + crossZ * sinAngle + dot * rz * (1 - cosAngle)
+		px * cosAngle + cx * sinAngle + rx * dotTerm,
+		py * cosAngle + cy * sinAngle + ry * dotTerm,
+		pz * cosAngle + cz * sinAngle + rz * dotTerm
 end
 
 local function getTargetData(targetID)
-	local _, _, _, midX, midY, midZ, aimX, aimY, aimZ = spGetUnitPosition(targetID, true, true)
-	return midX, midY, midZ, aimX, aimY, aimZ, spGetUnitDefID(targetID), spGetUnitRadius(targetID)
+	local baseX, baseY, baseZ, midX, midY, midZ, aimX, aimY, aimZ = spGetUnitPosition(targetID, true, true)
+	return baseX, baseY, baseZ, midX, midY, midZ, aimX, aimY, aimZ, spGetUnitDefID(targetID), spGetUnitRadius(targetID)
 end
 
 local readAs = { read = -1 }
@@ -237,8 +228,10 @@ local function readAsTeam(teamID, ...)
 	return CallAsTeam(read, ...)
 end
 
+local corrected = 0
+
 local function updateAimDirection(projectileID, params, targetID)
-	local midX, midY, midZ, aimX, aimY, aimZ, targetDefID, targetRadius = getTargetData(targetID)
+	local baseX, baseY, baseZ, midX, midY, midZ, aimX, aimY, aimZ, targetDefID, targetRadius = getTargetData(targetID)
 	if not midX or not targetDefID or targetRadius == 0 then
 		return
 	end
@@ -248,9 +241,12 @@ local function updateAimDirection(projectileID, params, targetID)
 	if not uvx or (projSpeed or 0) == 0 then
 		return
 	end
+	if math.dot_product(uvx, uvy, uvz, pvx, pvy, pvz) < projSpeed * 0.25 then
+		return -- target is not retreating, underrange doesn't matter
+	end
 
 	-- todo: High trajectories need to use a counter-rotation for reaiming.
-	if params.trajectory == TRAJECTORY_UNIT and pvy >= math_diag(pvx, pvz) then
+	if params.trajectory and pvy >= math_diag(pvx, pvz) then
 		return
 	end
 
@@ -259,6 +255,12 @@ local function updateAimDirection(projectileID, params, targetID)
 
 	local targetX, targetY, targetZ = midX, midY, midZ -- The inferred targetBorder-based position.
 	local aimPosX, aimPosY, aimPosZ = aimX, aimY, aimZ -- The new, preferred aimPos-based position.
+
+	if params.gravityAffected and baseY <= Spring.GetGroundHeight(baseX, baseZ) + 1 then
+		aimPosX = (aimPosX + baseX) * 0.5
+		aimPosY = (aimPosY + baseY) * 0.5
+		aimPosZ = (aimPosZ + baseZ) * 0.5
+	end
 
 	local targetBorderRadius = params.targetBorder * targetRadius
 	targetX = targetX - pdx * targetBorderRadius
@@ -283,7 +285,23 @@ local function updateAimDirection(projectileID, params, targetID)
 	aimPosX, aimPosY, aimPosZ = params.clamp(px, py, pz, aimPosX, aimPosY, aimPosZ, params.range, targetRadius)
 
 	local rx, ry, rz, rw = buildRotation(px, py, pz, targetX, targetY, targetZ, aimPosX, aimPosY, aimPosZ, params.angleMax)
+
+	if (rw or 0) == 0 then
+		return
+	end
+
+	corrected = corrected + 1
+
 	spSetProjectileVelocity(projectileID, applyRotation(rx, ry, rz, rw, pvx, pvy, pvz))
+
+	-- lol just spawn two:
+	Spring.SpawnProjectile(Spring.GetProjectileDefID(projectileID), {
+		pos     = { px, py, pz },
+		speed   = { pvx, pvy, pvz },
+		owner   = Spring.GetProjectileOwnerID(projectileID),
+		team    = Spring.GetProjectileTeamID(projectileID),
+		gravity = gravityPerFrame,
+	})
 end
 
 local function applyAimCorrection(projectileID, ownerID, params)
@@ -315,5 +333,69 @@ end
 function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
 	if weaponAimCorrection[weaponDefID] then
 		applyAimCorrection(projectileID, ownerID, weaponAimCorrection[weaponDefID])
+	end
+end
+
+local collectStats = true -- ! testing
+
+if collectStats then
+	local projectiles = {}
+	local destroyed = {}
+	local full = 0
+	local partial = 0
+	local hitRate = 0
+	local hitCount = 0
+	local fired = 0
+	local destroyed = 0
+
+	function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
+		if weaponAimCorrection[weaponDefID] then
+			applyAimCorrection(projectileID, ownerID, weaponAimCorrection[weaponDefID])
+			projectiles[projectileID] = 0
+			fired = fired + 1
+		end
+	end
+
+	local spGetProjectileDamages = Spring.GetProjectileDamages
+
+	function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+		if projectiles[projectileID] and unitTeam ~= attackerTeam then
+			local damageBase = spGetProjectileDamages(projectileID, 0)
+			projectiles[projectileID] = math_clamp(projectiles[projectileID] + damage / damageBase, 0, 2)
+			if damage >= damageBase - 1 then
+				full = full + damage
+			else
+				partial = partial + damage
+			end
+		end
+	end
+
+	function gadget:ProjectileDestroyed(projectileID)
+		if projectiles[projectileID] then
+			destroyed[projectileID] = projectiles[projectileID]
+			projectiles[projectileID] = nil
+			destroyed = destroyed + 1
+		end
+	end
+
+	function gadget:GameFramePost(frame)
+		for _, damageRate in pairs(destroyed) do
+			hitRate = (hitRate * hitCount + damageRate) / (hitCount + 1)
+			hitCount = hitCount + 1
+		end
+		destroyed = {}
+		if frame % 300 == 0 or destroyed == 30000 then
+			Spring.Echo(
+				"corrections",
+				fired > 0 and corrected / fired or 0,
+				"hits",
+				hitCount,
+				hitRate,
+				(full > 0 or partial > 0) and partial / (full + partial) or 0
+			)
+		end
+		if destroyed == 30000 then
+			Spring.Echo("test completed")
+		end
 	end
 end

--- a/luarules/gadgets/unit_projectile_underrange.lua
+++ b/luarules/gadgets/unit_projectile_underrange.lua
@@ -19,7 +19,7 @@ end
 --------------------------------------------------------------------------------
 -- Configuration ---------------------------------------------------------------
 
-local correctionAngleMax = math.rad(12) -- The maximum change in direction.
+local correctionAngleMax = math.rad(12) -- Try to prevent noticeable corrections with nearby targets.
 
 --------------------------------------------------------------------------------
 -- Localization ----------------------------------------------------------------
@@ -114,9 +114,9 @@ local function clampToCone(fromX, fromY, fromZ, toX, toY, toZ, range, radius)
 end
 
 local instantDuration = 0.1667 * Game.gameSpeed ---Should be pretty fast
-local instantWeapons = { BeamLaser = true, LaserCannon = true, Rifle = true, }
+local instantWeapons = { BeamLaser = true, LaserCannon = true, LightningCannon = true, Rifle = true, }
 local reaimEffects = { guidance = true, sector_fire = true }
-local spreadDistanceMax = Game.squareSize * Game.footprintScale * 5 ---Measures inaccuracy at max range
+local spreadDistanceMax = Game.squareSize * Game.footprintScale * 5 -- Use the reference dimension of a large-ish unit as an accuracy cutoff
 
 local function getAimCorrectionParams(weaponDef)
 	local isFakeWeapon = weaponDef.range <= 10 or weaponDef.customParams.bogus == "1"
@@ -267,7 +267,7 @@ local function updateAimDirection(projectileID, params, targetID)
 
 	local timeRemainingMax = params.leadLimit / (unitSpeed + projSpeed) -- close enough
 
-	for _ = 1, 2 do
+	for convergenceStep = 1, 2 do
 		local timeRemainingMid = math_min(math_diag(targetX - px, targetY - py, targetZ - pz) / projSpeed, timeRemainingMax)
 		targetX = targetX + uvx * timeRemainingMid
 		targetY = targetY + uvy * timeRemainingMid

--- a/units/Legion/Vehicles/T2 Vehicles/legaskirmtank.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legaskirmtank.lua
@@ -143,6 +143,7 @@ return {
 		},
 		weapons = {
 			[1] = {
+				accurateleading = 2,
 				badtargetcategory = "VTOL",
 				def = "LEGMGPLASMA",
 				onlytargetcategory = "SURFACE",


### PR DESCRIPTION
### Work done

This offsets the recent targetborder change – which caused units to aim at the nearest point on their targets – by redirecting the fired projectile toward the target's center-mass as though it were aimed and fired with targetborder = 0.

The correction consists of a few steps:

- Infer the targetBorder-based position and the ideal aimPos-based position
- Find the angle between the two from the projectile
- Rotate the projectile's velocity by that angle

These steps also respect the weapon's maximum lead limit, do not allow redirecting the projectile beyond its normal range, and restricts the maximum angle of correction to a reasonable size.

Asked Gemini nicely for an image and it got me 25% of the way to this:

<img width="1024" height="615" alt="image" src="https://github.com/user-attachments/assets/f1f1ccce-2d31-4c09-9cf2-d51d6d35508f" />

### Addresses Issue(s)

Units like Legion Gladiators appear functional on paper with decent stats for extended skirmishes, but they show catastrophic DPS loss (zero DPS) against the retreat. We saw this repeatedly during Faction Wars on any map open enough for medium tanks. This was not my previous experience with the unit before, so I highly suspect the target border change.

When I'd considered tweaks to those units, one possibility was to make their accuracy and lead prediction worse, since this actually makes some shots hit by random chance. We should avoid unintuitive configuration in general, but this was especially bad to me. Worse prediction should not give better prediction.

### Testing

In my testing, the difference in the initial velocity is very small, but the chance to hit retreating units is noticeably higher (still poor) on units with slow plasma projectiles. I am satisfied that it is an improvement to BAR's unit IQ and to plasma units in general.

This is not quite a full solution for BAR's kiting advantage. ZeroK explored an option to do that: [weapon_projectile_retarget.lua](https://github.com/ZeroK-RTS/Zero-K/blob/5eb1d5736e5c8f2e19fcd49679bfac140016423c/LuaRules/Gadgets/weapon_projectile_retarget.lua)

I think that is a pretty good solution, also, but it wasn't what I'd intended to do. If a more complete concept is wanted, then I'd need to test against these, as well.