### PR TITLE
Area DoTs use largest of area or target radius for hit check

### DIFF
--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -235,12 +235,6 @@ if not math.distance3d then
 	end
 end
 
-if not math.magnitudeSquared then
-	function math.magnitudeSquared(dx, dy, dz)
-		return dx * dx + dy * dy + dz * dz
-	end
-end
-
 if not math.getClosestPosition then
 	---Gets the closest position out of a list to given coordinates. 2d.
 	---@param x number

--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -235,6 +235,12 @@ if not math.distance3d then
 	end
 end
 
+if not math.magnitudeSquared then
+	function math.magnitudeSquared(dx, dy, dz)
+		return dx * dx + dy * dy + dz * dz
+	end
+end
+
 if not math.getClosestPosition then
 	---Gets the closest position out of a list to given coordinates. 2d.
 	---@param x number

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -72,10 +72,12 @@ local spAddUnitDamage         = Spring.AddUnitDamage
 local spAddFeatureDamage      = Spring.AddFeatureDamage
 local spGetFeaturePosition    = Spring.GetFeaturePosition
 local spGetFeaturesInCylinder = Spring.GetFeaturesInCylinder
+local spGetFeatureRadius      = Spring.GetFeatureRadius
 local spGetGroundHeight       = Spring.GetGroundHeight
 local spGetGroundNormal       = Spring.GetGroundNormal
 local spGetUnitDefID          = Spring.GetUnitDefID
 local spGetUnitPosition       = Spring.GetUnitPosition
+local spGetUnitRadius         = Spring.GetUnitRadius
 local spGetUnitsInCylinder    = Spring.GetUnitsInCylinder
 local spSpawnCEG              = Spring.SpawnCEG
 
@@ -310,41 +312,47 @@ end
 ---@return number? hitX reference coordinates <x, y, z>
 ---@return number? hitY
 ---@return number? hitZ
-local function getAreaHitPosition(area, baseX, baseY, baseZ, midX, midY, midZ)
-	if not baseX then
-		return
-	end
+local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX, midY, midZ)
+	local radius = max(area.range, targetRadius)
 
-	local radius = area.range
-
-	if midY >= area.ymin and midY <= area.ymax then
-		if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
-			return midX, midY, midZ
+	if radius > targetRadius then
+		-- Check if the area contains the target.
+		if midY >= area.ymin and midY <= area.ymax then
+			if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
+				return midX, midY, midZ
+			end
 		end
-	end
 
-	if baseY >= area.ymin and baseY <= area.ymax then
-		local dx = baseX - area.x
-		local dy = baseY - area.y
-		local dz = baseZ - area.z
+		if baseY >= area.ymin and baseY <= area.ymax then
+			local dx = baseX - area.x
+			local dy = baseY - area.y
+			local dz = baseZ - area.z
 
-		if diag(dx, dy, dz) <= radius then
-			-- The unit base point is in the area and the mid point is not.
-			-- Find the intersection of a ray from mid->base onto the area.
-			local rx, ry, rz = normalize(baseX - midX, baseY - midY, baseZ - midZ)
+			if diag(dx, dy, dz) <= radius then
+				-- The unit base point is in the area and the mid point is not.
+				-- Find the intersection of a ray from mid->base onto the area.
+				local rx, ry, rz = normalize(baseX - midX, baseY - midY, baseZ - midZ)
 
-			local a = rx * rx + ry * ry + rz * rz
-			local b = (dx * rx + dy * ry + dz * rz) * 2
-			local c = dx * dx + dy * dy + dz * dz - radius * radius
+				local a = rx * rx + ry * ry + rz * rz
+				local b = (dx * rx + dy * ry + dz * rz) * 2
+				local c = dx * dx + dy * dy + dz * dz - radius * radius
 
-			-- We already know the discriminant is positive:
-			local discriminant = b * b - 4 * a * c
-			local t = (b + sqrt(discriminant)) / (2 * a)
+				-- We already know the discriminant is positive:
+				local discriminant = b * b - 4 * a * c
+				local t = (b + sqrt(discriminant)) / (2 * a)
 
-			return
-				midX + t * rx,
-				midY + t * ry,
-				midZ + t * rz
+				return
+					midX + t * rx,
+					midY + t * ry,
+					midZ + t * rz
+			end
+		end
+	else
+		-- Check if the target contains the area.
+		if baseY >= area.ymin and baseY <= area.ymax then
+			if diag(baseX - area.x, baseY - area.y, baseZ - area.z) <= radius then
+				return area.x, midY, area.z
+			end
 		end
 	end
 end
@@ -365,7 +373,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
             local unitID = unitsInRange[j]
 			local data = unitData[unitID]
             if data and not data.resistances[area.resistance] and data.immuneUntil < gameFrame then
-                local hitX, hitY, hitZ = getAreaHitPosition(area, spGetUnitPosition(unitID, true))
+                local hitX, hitY, hitZ = getAreaHitPosition(area, spGetUnitRadius(unitID), spGetUnitPosition(unitID, true))
 
 				if hitX then
 					local damageTaken = data.damageTaken
@@ -405,7 +413,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
 			local data = featureData[featureID]
 
             if data and not data.damageImmune then
-                local hitX, hitY, hitZ = getAreaHitPosition(area, spGetFeaturePosition(featureID, true))
+                local hitX, hitY, hitZ = getAreaHitPosition(area, spGetFeatureRadius(featureID), spGetFeaturePosition(featureID, true))
 
                 if hitX then
                     local damageTaken = data.damageTaken

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -354,6 +354,11 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 				return area.x, midY, area.z
 			end
 		end
+		if midY >= area.ymin and midY <= area.ymax then
+			if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
+				return area.x, midY, area.z
+			end
+		end
 	end
 end
 

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -97,6 +97,8 @@ local timedDamageWeapons = {}
 local unitDamageImmunity = {}
 local featureDamageImmunity = {}
 local isFactory = {}
+local unitRadiusMax = 0
+local featureRadiusMax = 0
 
 local aliveExplosions = {}
 local frameExplosions = {}
@@ -373,7 +375,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
         local area = timedAreas[index]
         local x, z, radius = area.x, area.z, area.range
 
-        local unitsInRange = spGetUnitsInCylinder(x, z, radius)
+        local unitsInRange = spGetUnitsInCylinder(x, z, max(radius, unitRadiusMax))
 
         for j = 1, #unitsInRange do
             local unitID = unitsInRange[j]
@@ -412,7 +414,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
         local area = timedAreas[index]
         local x, z, radius = area.x, area.z, area.range
 
-        local featuresInRange = spGetFeaturesInCylinder(x, z, radius)
+        local featuresInRange = spGetFeaturesInCylinder(x, z, max(radius, featureRadiusMax))
 
         for j = 1, #featuresInRange do
             local featureID = featuresInRange[j]
@@ -544,6 +546,30 @@ function gadget:Initialize()
 	for featureDefID, featureDef in ipairs(FeatureDefs) do
 		featureDamageImmunity[featureDefID] = featureDef.indestructible or featureDef.geoThermal
 	end
+
+	unitRadiusMax = table.reduce(
+		UnitDefs,
+		function(radiusMax, unitDef, unitDefID)
+			if unitDamageImmunity[unitDefID] ~= immunities.all and unitDef.radius > radiusMax then
+				return unitDef.radius
+			else
+				return radiusMax
+			end
+		end,
+		0
+	)
+
+	featureRadiusMax = table.reduce(
+		FeatureDefs,
+		function(radiusMax, featureDef, featureDefID)
+			if not featureDamageImmunity[featureDefID] and featureDef.radius > radiusMax then
+				return featureDef.radius
+			else
+				return radiusMax
+			end
+		end,
+		0
+	)
 
 	aliveExplosions = {}
 	for ii = 1, frameInterval do

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -316,12 +316,12 @@ end
 ---@return number? hitY
 ---@return number? hitZ
 local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX, midY, midZ)
-	local radiusSquared = max(area.range, targetRadius) ^ 2
+	local radius = max(area.range, targetRadius)
 
-	if radiusSquared > targetRadius * targetRadius then
+	if radius > targetRadius then
 		-- Check if the area contains the target.
 		if midY >= area.ymin and midY <= area.ymax then
-			if diag(midX - area.x, midY - area.y, midZ - area.z) ^ 2 <= radiusSquared then
+			if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
 				return midX, midY, midZ
 			end
 		end
@@ -331,14 +331,14 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 			local dy = baseY - area.y
 			local dz = baseZ - area.z
 
-			if diag(dx, dy, dz) ^ 2 <= radiusSquared then
+			if diag(dx, dy, dz) <= radius then
 				-- The unit base point is in the area and the mid point is not.
 				-- Find the intersection of a ray from mid->base onto the area.
 				local rx, ry, rz = normalize(baseX - midX, baseY - midY, baseZ - midZ)
 
 				local a = rx * rx + ry * ry + rz * rz
 				local b = (dx * rx + dy * ry + dz * rz) * 2
-				local c = dx * dx + dy * dy + dz * dz - radiusSquared
+				local c = dx * dx + dy * dy + dz * dz - radius * radius
 
 				-- We already know the discriminant is positive:
 				local discriminant = b * b - 4 * a * c
@@ -353,12 +353,12 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 	else
 		-- Check if the target contains the area.
 		if baseY >= area.ymin and baseY <= area.ymax then
-			if diag(baseX - area.x, baseY - area.y, baseZ - area.z) ^ 2 <= radiusSquared then
+			if diag(baseX - area.x, baseY - area.y, baseZ - area.z) <= radius then
 				return area.x, midY, area.z
 			end
 		end
 		if midY >= area.ymin and midY <= area.ymax then
-			if diag(midX - area.x, midY - area.y, midZ - area.z) ^ 2 <= radiusSquared then
+			if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
 				return area.x, midY, area.z
 			end
 		end

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -547,29 +547,19 @@ function gadget:Initialize()
 		featureDamageImmunity[featureDefID] = featureDef.indestructible or featureDef.geoThermal
 	end
 
-	unitRadiusMax = table.reduce(
-		UnitDefs,
-		function(radiusMax, unitDef, unitDefID)
-			if unitDamageImmunity[unitDefID] ~= immunities.all and unitDef.radius > radiusMax then
-				return unitDef.radius
-			else
-				return radiusMax
-			end
-		end,
-		0
-	)
+	unitRadiusMax = 0
+	for unitDefID = 1, #UnitDefs do
+		if unitDamageImmunity[unitDefID] ~= immunities.all and UnitDefs[unitDefID].radius > unitRadiusMax then
+			unitRadiusMax = UnitDefs[unitDefID].radius
+		end
+	end
 
-	featureRadiusMax = table.reduce(
-		FeatureDefs,
-		function(radiusMax, featureDef, featureDefID)
-			if not featureDamageImmunity[featureDefID] and featureDef.radius > radiusMax then
-				return featureDef.radius
-			else
-				return radiusMax
-			end
-		end,
-		0
-	)
+	featureRadiusMax = 0
+	for featureDefID = 1, #FeatureDefs do
+		if not featureDamageImmunity[featureDefID] and FeatureDefs[featureDefID].radius > featureRadiusMax then
+			featureRadiusMax = FeatureDefs[featureDefID].radius
+		end
+	end
 
 	aliveExplosions = {}
 	for ii = 1, frameInterval do

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -302,13 +302,6 @@ end
 
 ---We prefer the target's midpoint if it is in the radius since the damaged CEGs are easier to see higher up
 ---on the model, but if it is too high/awkward then the base position is fine, with a small vertical offset.
----@param area table contains the timed area properties
----@param baseX? number unit base position coordinates <x, y, z>
----@param baseY number
----@param baseZ number
----@param midX number unit midpoint position coordinates <x, y, z>
----@param midY number
----@param midZ number
 ---@return number? hitX reference coordinates <x, y, z>
 ---@return number? hitY
 ---@return number? hitZ

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -300,6 +300,14 @@ local function spawnAreaCEGs(loopIndex)
     end
 end
 
+local function getUnitHitData(unitID)
+	return spGetUnitRadius(unitID), spGetUnitPosition(unitID, true)
+end
+
+local function getFeatureHitData(featureID)
+	return spGetFeatureRadius(featureID), spGetFeaturePosition(featureID, true)
+end
+
 ---We prefer the target's midpoint if it is in the radius since the damaged CEGs are easier to see higher up
 ---on the model, but if it is too high/awkward then the base position is fine, with a small vertical offset.
 ---@return number? hitX reference coordinates <x, y, z>
@@ -371,7 +379,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
             local unitID = unitsInRange[j]
 			local data = unitData[unitID]
             if data and not data.resistances[area.resistance] and data.immuneUntil < gameFrame then
-                local hitX, hitY, hitZ = getAreaHitPosition(area, spGetUnitRadius(unitID), spGetUnitPosition(unitID, true))
+                local hitX, hitY, hitZ = getAreaHitPosition(area, getUnitHitData(unitID))
 
 				if hitX then
 					local damageTaken = data.damageTaken
@@ -411,7 +419,7 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
 			local data = featureData[featureID]
 
             if data and not data.damageImmune then
-                local hitX, hitY, hitZ = getAreaHitPosition(area, spGetFeatureRadius(featureID), spGetFeaturePosition(featureID, true))
+                local hitX, hitY, hitZ = getAreaHitPosition(area, getFeatureHitData(featureID))
 
                 if hitX then
                     local damageTaken = data.damageTaken

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -58,9 +58,9 @@ local prefixes = { unit = 'area_ondeath_', weapon = 'area_onhit_' }
 local max                     = math.max
 local min                     = math.min
 local floor                   = math.floor
-local sqrt                    = math.sqrt
 local round                   = math.round
-local distanceSquared         = math.magnitudeSquared
+local sqrt                    = math.sqrt
+local diag                    = math.diag
 local normalize               = math.normalize
 local stringFind              = string.find
 local stringGsub              = string.gsub
@@ -321,7 +321,7 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 	if radiusSquared > targetRadius * targetRadius then
 		-- Check if the area contains the target.
 		if midY >= area.ymin and midY <= area.ymax then
-			if distanceSquared(midX - area.x, midY - area.y, midZ - area.z) <= radiusSquared then
+			if diag(midX - area.x, midY - area.y, midZ - area.z) ^ 2 <= radiusSquared then
 				return midX, midY, midZ
 			end
 		end
@@ -331,7 +331,7 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 			local dy = baseY - area.y
 			local dz = baseZ - area.z
 
-			if distanceSquared(dx, dy, dz) <= radiusSquared then
+			if diag(dx, dy, dz) ^ 2 <= radiusSquared then
 				-- The unit base point is in the area and the mid point is not.
 				-- Find the intersection of a ray from mid->base onto the area.
 				local rx, ry, rz = normalize(baseX - midX, baseY - midY, baseZ - midZ)
@@ -353,12 +353,12 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 	else
 		-- Check if the target contains the area.
 		if baseY >= area.ymin and baseY <= area.ymax then
-			if distanceSquared(baseX - area.x, baseY - area.y, baseZ - area.z) <= radiusSquared then
+			if diag(baseX - area.x, baseY - area.y, baseZ - area.z) ^ 2 <= radiusSquared then
 				return area.x, midY, area.z
 			end
 		end
 		if midY >= area.ymin and midY <= area.ymax then
-			if distanceSquared(midX - area.x, midY - area.y, midZ - area.z) <= radiusSquared then
+			if diag(midX - area.x, midY - area.y, midZ - area.z) ^ 2 <= radiusSquared then
 				return area.x, midY, area.z
 			end
 		end

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -60,7 +60,7 @@ local min                     = math.min
 local floor                   = math.floor
 local sqrt                    = math.sqrt
 local round                   = math.round
-local diag                    = math.diag
+local distanceSquared         = math.magnitudeSquared
 local normalize               = math.normalize
 local stringFind              = string.find
 local stringGsub              = string.gsub
@@ -316,12 +316,12 @@ end
 ---@return number? hitY
 ---@return number? hitZ
 local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX, midY, midZ)
-	local radius = max(area.range, targetRadius)
+	local radiusSquared = max(area.range, targetRadius) ^ 2
 
-	if radius > targetRadius then
+	if radiusSquared > targetRadius * targetRadius then
 		-- Check if the area contains the target.
 		if midY >= area.ymin and midY <= area.ymax then
-			if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
+			if distanceSquared(midX - area.x, midY - area.y, midZ - area.z) <= radiusSquared then
 				return midX, midY, midZ
 			end
 		end
@@ -331,14 +331,14 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 			local dy = baseY - area.y
 			local dz = baseZ - area.z
 
-			if diag(dx, dy, dz) <= radius then
+			if distanceSquared(dx, dy, dz) <= radiusSquared then
 				-- The unit base point is in the area and the mid point is not.
 				-- Find the intersection of a ray from mid->base onto the area.
 				local rx, ry, rz = normalize(baseX - midX, baseY - midY, baseZ - midZ)
 
 				local a = rx * rx + ry * ry + rz * rz
 				local b = (dx * rx + dy * ry + dz * rz) * 2
-				local c = dx * dx + dy * dy + dz * dz - radius * radius
+				local c = dx * dx + dy * dy + dz * dz - radiusSquared
 
 				-- We already know the discriminant is positive:
 				local discriminant = b * b - 4 * a * c
@@ -353,12 +353,12 @@ local function getAreaHitPosition(area, targetRadius, baseX, baseY, baseZ, midX,
 	else
 		-- Check if the target contains the area.
 		if baseY >= area.ymin and baseY <= area.ymax then
-			if diag(baseX - area.x, baseY - area.y, baseZ - area.z) <= radius then
+			if distanceSquared(baseX - area.x, baseY - area.y, baseZ - area.z) <= radiusSquared then
 				return area.x, midY, area.z
 			end
 		end
 		if midY >= area.ymin and midY <= area.ymax then
-			if diag(midX - area.x, midY - area.y, midZ - area.z) <= radius then
+			if distanceSquared(midX - area.x, midY - area.y, midZ - area.z) <= radiusSquared then
 				return area.x, midY, area.z
 			end
 		end


### PR DESCRIPTION
### Work done

Damaging areas check for "containment" rather than collision but are using incomplete logic to do so. This makes sure that damaging areas can both:
- check whether a unit is contained within its radius, and
- check whether a unit contains (at least a radial cutout of) the area.

#### Addresses Issue(s)

The Legion Barrage got a smaller area radius which brought buggy behavior to the surface. The area radius decreased from 75 to 60, so many more units have a larger radius than the area, now.

Chronopolize found a couple issues after the change. Most significant to me, the area can overlap a unit significantly without dealing damage: https://discord.com/channels/549281623154229250/1063217502898884701/1492065023751753769

#### Testing

This has a minor CPU cost which is fine. The majority of the performance cost for e.g. napalm is its CEGs, not this check.

CEG spawn position looks good and units with bad colvol/radius configuration are still detected when they should be, and are not when they should not. The armalab for example has an oversized collision volume and an undersized unit radius, so makes for a good test.