### PR TITLE
Fix: EMP units can not manually target floating labs

### DIFF
--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -45,6 +45,8 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 			return false
 		else
 			local _,_,_,_, y = Spring.GetUnitPosition(cmdParams[1], true)
+			local _, scaleY, _, _, offY = Spring.GetUnitCollisionVolumeData(cmdParams[1])
+			y = y + offY + (scaleY * 0.5)
 			if y and y >= 0 then
 				return true
 			else


### PR DESCRIPTION
Fix for EMP units not being able to manually target a large portion of floating buildings because the mid point being checked is below water. (most labs, torp launchers, some economy buildings)

Replace midpoint check with collision volume check to allow manual targeting when the collision vol extends above 0.
This also allows seaplane lab targeting to be dynamic when raised or lowered.

Tested in skirmish, targeting behaved as expected with buildings and units.

Fixes #7098