### PR TITLE
Allow camera anchors as text actions

### DIFF
--- a/luaui/Widgets/gui_camera_anchors.lua
+++ b/luaui/Widgets/gui_camera_anchors.lua
@@ -24,8 +24,8 @@ local GetConfigInt    = Spring.GetConfigInt
 local SendCommands    = Spring.SendCommands
 
 function widget:Initialize()
-	widgetHandler:AddAction("set_camera_anchor", SetCameraAnchor, nil, 'p')
-	widgetHandler:AddAction("focus_camera_anchor", FocusCameraAnchor, nil, 'p')
+	widgetHandler:AddAction("set_camera_anchor", SetCameraAnchor, nil, 'pt')
+	widgetHandler:AddAction("focus_camera_anchor", FocusCameraAnchor, nil, 'pt')
 end
 
 local cameraAnchors = {}

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -493,6 +493,8 @@ local autocompleteCommands = {
 	'defrange enemy air',
 	'defrange enemy nuke',
 	'defrange enemy ground',
+	'set_camera_anchor',
+	'focus_camera_anchor',
 }
 
 local playernames = {}


### PR DESCRIPTION
Allow setting and regaining focus on camera anchors as a chat/text action. This also allows them to be part of chain actions using the chain action widget.

### Test steps

Open chat and type `/set_camera_anchor [index]` then move the camera and type `/focus_camera_anchor [index]` to recall the saved camera state. 