### PR TITLE
feat(guard): implement area guard functionality

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -221,6 +221,8 @@
 			"resurrect_tooltip": "Revive wrecks to become units again (click-drag for area)",
 			"guard": "Guard",
 			"guard_tooltip": "Guard another unit against enemy units attacking it",
+			"areaguard": "Guard",
+			"areaguard_tooltip": "Guard a unit or area. Drag to issue multiple guard orders in an area.",
 			"factoryguard": "Factory Guard",
 			"factoryguard_tooltip": "Builders produced by this factory will automatically guard it",
 			"wait": "Wait",

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -226,6 +226,8 @@
 			"resurrect_tooltip": "Revive wrecks to become units again (click-drag for area)",
 			"guard": "Guard",
 			"guard_tooltip": "Guard another unit against enemy units attacking it",
+			"areaguard": "Guard",
+			"areaguard_tooltip": "Guard a unit or area. Drag to issue multiple guard orders in an area.",
 			"factoryguard": "Factory Guard",
 			"factoryguard_tooltip": "Builders produced by this factory will automatically guard it",
 			"wait": "Wait",

--- a/luarules/gadgets/cmd_test.lua
+++ b/luarules/gadgets/cmd_test.lua
@@ -1,6 +1,8 @@
 -- Temporary gadget to test if zoom level can be used to determine whether to
 -- use formation click drag (zoomed out) or area guard (zoomed in). If this works well, 
 -- we can expand this to other commands like repair area.
+local ZOOM_LEVEL_SWITCH = 2000
+
 
 local function tableToString(tbl, indent)
     if type(tbl) ~= "table" then return tostring(tbl) end
@@ -39,6 +41,7 @@ end
 --------------------------------
 local CMD_AREA_GUARD = GameCMD.AREA_GUARD
 local CMD_GUARD = CMD.GUARD
+local CMD_MOVE = CMD.MOVE
 
 local spGetAllUnits = Spring.GetAllUnits
 local spGetUnitDefID = Spring.GetUnitDefID
@@ -147,23 +150,16 @@ else
 		spSetCustomCommandDrawData(CMD_AREA_GUARD, "Guard", { 136/255, 251/255, 255, 0.7 }, true)
 	end
 
-    local last = false
 	function gadget:DefaultCommand(type, id, defaultCmd)
-        -- get the current zoom level
-        local cam = spGetCameraState()
-		if defaultCmd == CMD_GUARD and cam.dist < 3500 then
-            if last ~= true then
-                Spring.Echo("DefaultCommand: Replacing GUARD with AREA_GUARD due to zoom level", cam.dist)
-            end
-            last = true
-			return CMD_AREA_GUARD
+		if defaultCmd ~= CMD_GUARD then
+			return nil
 		end
 
-        if last ~= false then
-            Spring.Echo("DefaultCommand: Reverting to GUARD due to zoom level", cam.dist)
-        end
-        last = false
-    
-        return nil
+        -- Only remap GUARD based on current zoom level.
+        local cam = spGetCameraState()
+		if cam and cam.dist and cam.dist < ZOOM_LEVEL_SWITCH then
+			return CMD_AREA_GUARD
+		end
+		return CMD_MOVE
 	end
 end

--- a/luarules/gadgets/cmd_test.lua
+++ b/luarules/gadgets/cmd_test.lua
@@ -1,0 +1,169 @@
+-- Temporary gadget to test if zoom level can be used to determine whether to
+-- use formation click drag (zoomed out) or area guard (zoomed in). If this works well, 
+-- we can expand this to other commands like repair area.
+
+local function tableToString(tbl, indent)
+    if type(tbl) ~= "table" then return tostring(tbl) end
+    indent = indent or 0
+    local toprint = string.rep(" ", indent) .. "{\n"
+    indent = indent + 2
+    for k, v in pairs(tbl) do
+        toprint = toprint .. string.rep(" ", indent)
+        toprint = toprint .. tostring(k) .. " = "
+        if type(v) == "table" then
+            toprint = toprint .. tableToString(v, indent + 2) .. ",\n"
+        else
+            toprint = toprint .. tostring(v) .. ",\n"
+        end
+    end
+    toprint = toprint .. string.rep(" ", indent - 2) .. "}"
+    return toprint
+end
+
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Test gadget command",
+		desc	= 'Testing a new custom command',
+		author	= 'uBdead',
+		date	= 'May 2026',
+		license	= 'GNU GPL, v2 or later',
+		layer	= 0,
+		enabled	= true
+	}
+end
+
+--------------------------------
+-- SYNCED/UNSYNCED
+--------------------------------
+local CMD_AREA_GUARD = GameCMD.AREA_GUARD
+local CMD_GUARD = CMD.GUARD
+
+local spGetAllUnits = Spring.GetAllUnits
+local spGetUnitDefID = Spring.GetUnitDefID
+local spFindUnitCmdDesc = Spring.FindUnitCmdDesc
+local spRemoveUnitCmdDesc = Spring.RemoveUnitCmdDesc
+local spInsertUnitCmdDesc = Spring.InsertUnitCmdDesc
+local spGetCameraState = Spring.GetCameraState
+
+local canGuardDefs = {}
+local ignoreUnits = {}
+local areaGuardCmdDesc = {
+    id = CMD_AREA_GUARD,
+    type = CMDTYPE.ICON_UNIT_OR_AREA,
+    name = 'Guard!',
+    action = 'areaguard',
+    cursor = 'Guard',
+    tooltip = 'Guard a unit or area.\nDrag to issue multiple guard orders in an area.',
+    hidden = false,
+}
+
+for unitDefID, unitDef in pairs(UnitDefs) do
+        if unitDef.canGuard then
+                canGuardDefs[unitDefID] = true
+        end
+        if unitDef.modCategories and unitDef.modCategories['object']
+            or (unitDef.customParams and unitDef.customParams.objectify) then 
+        ignoreUnits[unitDefID] = true
+    end
+end  
+
+local function replaceGuardCommand(unitID)
+		-- If we've already inserted our AREA_GUARD button, skip
+		if spFindUnitCmdDesc(unitID, CMD_AREA_GUARD) then
+			return
+		end
+
+		local guardIndex = spFindUnitCmdDesc(unitID, CMD_GUARD)
+		if not guardIndex then
+			return
+		end
+
+		-- Remove engine GUARD button and insert our AREA_GUARD in its place
+		-- spRemoveUnitCmdDesc(unitID, guardIndex)
+		spInsertUnitCmdDesc(unitID, guardIndex, areaGuardCmdDesc)
+	end
+
+------------------------------------
+if gadgetHandler:IsSyncedCode() then
+    --------------------------------
+    -- SYNCED
+    --------------------------------
+
+	function gadget:Initialize()
+		gadgetHandler:RegisterCMDID(CMD_AREA_GUARD)
+		gadgetHandler:RegisterAllowCommand(CMD_AREA_GUARD)
+		gadgetHandler:RegisterAllowCommand(CMD_GUARD)
+
+		-- Replace guard button on existing units
+		local allUnits = spGetAllUnits()
+		for i = 1, #allUnits do
+			local unitID = allUnits[i]
+			local unitDefID = spGetUnitDefID(unitID)
+			if canGuardDefs[unitDefID] then
+				replaceGuardCommand(unitID)
+			end
+		end
+	end
+
+    function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+        if cmdID == CMD_AREA_GUARD then
+            Spring.Echo("Received AREA_GUARD command for unitID", unitID, "with params", cmdParams[1], cmdParams[2], cmdParams[3], cmdParams[4])
+            -- Here you would implement the logic to handle the AREA_GUARD command, such as issuing guard orders to units in the specified area.
+            return true -- Allow the command to be processed
+        end
+        return true -- Allow other commands
+    end
+
+    function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+        if canGuardDefs[unitDefID] then
+            replaceGuardCommand(unitID)
+        end
+    end
+
+    -- Handle transfer of units between teams (capture/share)
+    function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
+        if canGuardDefs[unitDefID] then
+            replaceGuardCommand(unitID)
+        end
+    end
+
+    function gadget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
+        if canGuardDefs[unitDefID] then
+            replaceGuardCommand(unitID)
+        end
+    end
+
+    --------------------------------
+    return
+else
+    --------------------------------
+    -- UNSYNCED
+    --------------------------------
+    local spSetCustomCommandDrawData = Spring.SetCustomCommandDrawData
+
+	function gadget:Initialize()
+		spSetCustomCommandDrawData(CMD_AREA_GUARD, "Guard", { 136/255, 251/255, 255, 0.7 }, true)
+	end
+
+    local last = false
+	function gadget:DefaultCommand(type, id, defaultCmd)
+        -- get the current zoom level
+        local cam = spGetCameraState()
+		if defaultCmd == CMD_GUARD and cam.dist < 3500 then
+            if last ~= true then
+                Spring.Echo("DefaultCommand: Replacing GUARD with AREA_GUARD due to zoom level", cam.dist)
+            end
+            last = true
+			return CMD_AREA_GUARD
+		end
+
+        if last ~= false then
+            Spring.Echo("DefaultCommand: Reverting to GUARD due to zoom level", cam.dist)
+        end
+        last = false
+    
+        return nil
+	end
+end

--- a/luarules/gadgets/unit_guard_area.lua
+++ b/luarules/gadgets/unit_guard_area.lua
@@ -1,0 +1,212 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Guard Area",
+		desc = "Overrides GUARD with area support.",
+		author = "uBdead",
+		date = "2026-04-11",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+local CMD_AREA_GUARD = GameCMD.AREA_GUARD
+local CMD_GUARD = CMD.GUARD
+
+-- Set of UnitDefIDs that should never be selected (decorative objects, etc.)
+local ignoreUnits = {}
+-- Which unitDefIDs can guard (shared between synced and unsynced)
+local canGuardDefs = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.canGuard then
+		canGuardDefs[unitDefID] = true
+	end
+	if unitDef.modCategories and unitDef.modCategories['object']
+      or (unitDef.customParams and unitDef.customParams.objectify) then
+    ignoreUnits[unitDefID] = true
+  end
+end
+
+if gadgetHandler:IsSyncedCode() then
+
+	local spInsertUnitCmdDesc = Spring.InsertUnitCmdDesc
+	local spFindUnitCmdDesc = Spring.FindUnitCmdDesc
+	local spEditUnitCmdDesc = Spring.EditUnitCmdDesc
+	local spGetUnitDefID = Spring.GetUnitDefID
+	local spGetUnitTeam = Spring.GetUnitTeam
+	local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
+	local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
+	local spAreTeamsAllied = Spring.AreTeamsAllied
+	local spValidUnitID = Spring.ValidUnitID
+	local spGiveOrderToUnit = Spring.GiveOrderToUnit
+	local spGetUnitCommands = Spring.GetUnitCommands
+	local spGetAllUnits = Spring.GetAllUnits
+
+	--------------------------------------------------------------------------------
+	-- Command description (replaces engine GUARD button)
+
+	local areaGuardCmdDesc = {
+		id = CMD_AREA_GUARD,
+		type = CMDTYPE.ICON_UNIT_OR_AREA,
+		name = 'Guard',
+		action = 'areaguard',
+		cursor = 'Guard',
+		tooltip = 'Guard a unit or area.\nDrag to issue multiple guard orders in an area.',
+		hidden = false,
+	}
+
+	--------------------------------------------------------------------------------
+	-- Helpers
+
+	local function isAllied(unitID, targetID)
+		local ownTeam = spGetUnitTeam(unitID)
+		local targetTeam = spGetUnitTeam(targetID)
+		return ownTeam and targetTeam and spAreTeamsAllied(ownTeam, targetTeam)
+	end
+
+	local function findGuardTargets(unitID, x, z, radius)
+		local unitDefID = spGetUnitDefID(unitID)
+		if not unitDefID then return {} end
+
+		-- local guardersIsAir = isAirDef[unitDefID] or false
+		local allyTeamID = spGetUnitAllyTeam(unitID)
+
+		local unitsInArea = spGetUnitsInCylinder(x, z, radius)
+		if not unitsInArea then return {} end
+
+		local targets = {}
+		for i = 1, #unitsInArea do
+			local targetID = unitsInArea[i]
+			if targetID ~= unitID then
+				local targetDefID = spGetUnitDefID(targetID)
+				if targetDefID then
+					local targetAllyTeam = spGetUnitAllyTeam(targetID)
+					-- Skip decorative/objectified units
+					if targetAllyTeam == allyTeamID and not ignoreUnits[targetDefID] then
+						targets[#targets + 1] = targetID
+					end
+				end
+			end
+		end
+
+		return targets
+	end
+
+	local function giveGuardOrders(unitID, targets)
+		if #targets == 0 then return end
+
+		-- Build set of targets already in the command queue
+		local alreadyGuarded = {}
+		local cmds = spGetUnitCommands(unitID, -1)
+		if cmds then
+			for _, cmd in ipairs(cmds) do
+				if cmd.id == CMD_GUARD and cmd.params then
+					alreadyGuarded[cmd.params[1]] = true
+				end
+			end
+		end
+
+		for _, targetID in ipairs(targets) do
+			if not alreadyGuarded[targetID] then
+				spGiveOrderToUnit(unitID, CMD_GUARD, { targetID }, { "shift" })
+			end
+		end
+	end
+
+	--------------------------------------------------------------------------------
+	-- Replace engine GUARD button with our area-guard version
+
+	local function replaceGuardCommand(unitID)
+		local guardIndex = spFindUnitCmdDesc(unitID, CMD_GUARD)
+		if guardIndex then
+			-- Hide engine GUARD but keep it so right-click default on allies still works
+			spEditUnitCmdDesc(unitID, guardIndex, { hidden = true })
+			-- Insert our AREA_GUARD button in its place
+			spInsertUnitCmdDesc(unitID, guardIndex, areaGuardCmdDesc)
+		end
+	end
+
+	--------------------------------------------------------------------------------
+	-- Lifecycle
+
+	function gadget:Initialize()
+		gadgetHandler:RegisterCMDID(CMD_AREA_GUARD)
+		gadgetHandler:RegisterAllowCommand(CMD_AREA_GUARD)
+		gadgetHandler:RegisterAllowCommand(CMD_GUARD)
+
+		-- Replace guard button on existing units
+		local allUnits = spGetAllUnits()
+		for i = 1, #allUnits do
+			local unitID = allUnits[i]
+			local unitDefID = spGetUnitDefID(unitID)
+			if canGuardDefs[unitDefID] then
+				replaceGuardCommand(unitID)
+			end
+		end
+	end
+
+	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+		if canGuardDefs[unitDefID] then
+			replaceGuardCommand(unitID)
+		end
+	end
+
+	--------------------------------------------------------------------------------
+	-- Command handling
+
+	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+		if not canGuardDefs[unitDefID] then
+			return cmdID == CMD_GUARD -- let engine handle GUARD for non-guard-capable units
+		end
+
+		-- Engine CMD_GUARD (e.g. right-click on ally): let engine handle it
+		if cmdID == CMD_GUARD then
+			return true
+		end
+
+		-- CMD_AREA_GUARD handling
+		local numParams = #cmdParams
+
+		if numParams == 1 then
+			-- Direct click on a unit via AREA_GUARD button: forward as engine CMD.GUARD
+			local targetID = cmdParams[1]
+			if spValidUnitID(targetID) and isAllied(unitID, targetID) then
+				spGiveOrderToUnit(unitID, CMD_GUARD, { targetID }, cmdOptions.coded or 0)
+			end
+			return false
+
+		elseif numParams == 4 then
+			-- Area drag: x, y, z, radius
+			local x, y, z, radius = cmdParams[1], cmdParams[2], cmdParams[3], cmdParams[4]
+
+			local targets = findGuardTargets(unitID, x, z, radius)
+			giveGuardOrders(unitID, targets, cmdOptions.shift or false)
+			return false
+		end
+
+		return true
+	end
+
+else -- UNSYNCED
+
+	local spSetCustomCommandDrawData = Spring.SetCustomCommandDrawData
+	local spIsUnitAllied = Spring.IsUnitAllied
+	local spGetSelectedUnitsCounts = Spring.GetSelectedUnitsCounts
+
+	function gadget:Initialize()
+		spSetCustomCommandDrawData(CMD_AREA_GUARD, "Guard", { 136/255, 251/255, 255, 0.7 }, true)
+	end
+
+	function gadget:DefaultCommand(type, id)
+		if type ~= "unit" then return end
+		if not spIsUnitAllied(id) then return end
+		for unitDefID in pairs(spGetSelectedUnitsCounts()) do
+			if canGuardDefs[unitDefID] then
+				return CMD_AREA_GUARD
+			end
+		end
+	end
+
+end

--- a/luarules/gadgets/unit_guard_area.lua
+++ b/luarules/gadgets/unit_guard_area.lua
@@ -33,7 +33,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	local spInsertUnitCmdDesc = Spring.InsertUnitCmdDesc
 	local spFindUnitCmdDesc = Spring.FindUnitCmdDesc
-	local spEditUnitCmdDesc = Spring.EditUnitCmdDesc
+	local spRemoveUnitCmdDesc = Spring.RemoveUnitCmdDesc
 	local spGetUnitDefID = Spring.GetUnitDefID
 	local spGetUnitTeam = Spring.GetUnitTeam
 	local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
@@ -41,8 +41,13 @@ if gadgetHandler:IsSyncedCode() then
 	local spAreTeamsAllied = Spring.AreTeamsAllied
 	local spValidUnitID = Spring.ValidUnitID
 	local spGiveOrderToUnit = Spring.GiveOrderToUnit
+	local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
 	local spGetUnitCommands = Spring.GetUnitCommands
 	local spGetAllUnits = Spring.GetAllUnits
+    local spEcho = Spring.Echo
+
+	-- Maximum number of guard orders we'll issue in one area-guard operation
+	local MAX_GUARD_ORDERS = 200
 
 	--------------------------------------------------------------------------------
 	-- Command description (replaces engine GUARD button)
@@ -68,13 +73,13 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function findGuardTargets(unitID, x, z, radius)
 		local unitDefID = spGetUnitDefID(unitID)
-		if not unitDefID then return {} end
+		if not unitDefID then return nil end
 
 		-- local guardersIsAir = isAirDef[unitDefID] or false
 		local allyTeamID = spGetUnitAllyTeam(unitID)
 
 		local unitsInArea = spGetUnitsInCylinder(x, z, radius)
-		if not unitsInArea then return {} end
+		if not unitsInArea then return nil end
 
 		local targets = {}
 		for i = 1, #unitsInArea do
@@ -94,8 +99,8 @@ if gadgetHandler:IsSyncedCode() then
 		return targets
 	end
 
-	local function giveGuardOrders(unitID, targets)
-		if #targets == 0 then return end
+	local function giveGuardOrders(unitID, targets, append)
+		if not targets or #targets == 0 then return end
 
 		-- Build set of targets already in the command queue
 		local alreadyGuarded = {}
@@ -108,10 +113,44 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 
-		for _, targetID in ipairs(targets) do
+		-- Build list of new targets (exclude ones already guarded)
+		local newTargets = {}
+		for i = 1, #targets do
+			local targetID = targets[i]
 			if not alreadyGuarded[targetID] then
-				spGiveOrderToUnit(unitID, CMD_GUARD, { targetID }, { "shift" })
+				newTargets[#newTargets + 1] = targetID
 			end
+		end
+
+		local attempted = #newTargets
+		local truncated = false
+		if attempted > MAX_GUARD_ORDERS then
+			truncated = true
+			for i = MAX_GUARD_ORDERS + 1, attempted do
+				newTargets[i] = nil
+			end
+		end
+
+		-- Build command array and send in one call to avoid many GiveOrder calls.
+		local cmdArray = {}
+		for i = 1, #newTargets do
+			local targetID = newTargets[i]
+			local options = CMD.OPT_SHIFT
+			if #cmdArray == 0 then
+				-- First command: only shift if user requested append
+				if not append then
+					options = 0
+				end
+			end
+			cmdArray[#cmdArray + 1] = { CMD_GUARD, targetID, options }
+		end
+
+		if #cmdArray > 0 then
+			spGiveOrderArrayToUnit(unitID, cmdArray)
+		end
+
+		if truncated then
+			spEcho(string.format("Area guard: attempted %d guard targets, truncated to %d.", attempted, MAX_GUARD_ORDERS))
 		end
 	end
 
@@ -119,13 +158,19 @@ if gadgetHandler:IsSyncedCode() then
 	-- Replace engine GUARD button with our area-guard version
 
 	local function replaceGuardCommand(unitID)
-		local guardIndex = spFindUnitCmdDesc(unitID, CMD_GUARD)
-		if guardIndex then
-			-- Hide engine GUARD but keep it so right-click default on allies still works
-			spEditUnitCmdDesc(unitID, guardIndex, { hidden = true })
-			-- Insert our AREA_GUARD button in its place
-			spInsertUnitCmdDesc(unitID, guardIndex, areaGuardCmdDesc)
+		-- If we've already inserted our AREA_GUARD button, skip
+		if spFindUnitCmdDesc(unitID, CMD_AREA_GUARD) then
+			return
 		end
+
+		local guardIndex = spFindUnitCmdDesc(unitID, CMD_GUARD)
+		if not guardIndex then
+			return
+		end
+
+		-- Remove engine GUARD button and insert our AREA_GUARD in its place
+		spRemoveUnitCmdDesc(unitID, guardIndex)
+		spInsertUnitCmdDesc(unitID, guardIndex, areaGuardCmdDesc)
 	end
 
 	--------------------------------------------------------------------------------
@@ -147,7 +192,21 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+	-- Use UnitFinished to ensure the engine has added its default commands first
+	function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+		if canGuardDefs[unitDefID] then
+			replaceGuardCommand(unitID)
+		end
+	end
+
+	-- Handle transfer of units between teams (capture/share)
+	function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
+		if canGuardDefs[unitDefID] then
+			replaceGuardCommand(unitID)
+		end
+	end
+
+	function gadget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
 		if canGuardDefs[unitDefID] then
 			replaceGuardCommand(unitID)
 		end
@@ -173,7 +232,7 @@ if gadgetHandler:IsSyncedCode() then
 			-- Direct click on a unit via AREA_GUARD button: forward as engine CMD.GUARD
 			local targetID = cmdParams[1]
 			if spValidUnitID(targetID) and isAllied(unitID, targetID) then
-				spGiveOrderToUnit(unitID, CMD_GUARD, { targetID }, cmdOptions.coded or 0)
+				spGiveOrderToUnit(unitID, CMD_GUARD, targetID, cmdOptions.coded or 0)
 			end
 			return false
 
@@ -190,22 +249,15 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 else -- UNSYNCED
-
 	local spSetCustomCommandDrawData = Spring.SetCustomCommandDrawData
-	local spIsUnitAllied = Spring.IsUnitAllied
-	local spGetSelectedUnitsCounts = Spring.GetSelectedUnitsCounts
 
 	function gadget:Initialize()
 		spSetCustomCommandDrawData(CMD_AREA_GUARD, "Guard", { 136/255, 251/255, 255, 0.7 }, true)
 	end
 
-	function gadget:DefaultCommand(type, id)
-		if type ~= "unit" then return end
-		if not spIsUnitAllied(id) then return end
-		for unitDefID in pairs(spGetSelectedUnitsCounts()) do
-			if canGuardDefs[unitDefID] then
-				return CMD_AREA_GUARD
-			end
+	function gadget:DefaultCommand(type, id, defaultCmd)
+		if defaultCmd == CMD_GUARD then
+			return CMD_AREA_GUARD
 		end
 	end
 

--- a/luarules/gadgets/unit_guard_area.lua
+++ b/luarules/gadgets/unit_guard_area.lua
@@ -1,3 +1,10 @@
+-- Temporarly disable while we evalute cmd_test.lua to see if it makes
+-- sense to have different order behavior based on the zoom level 
+-- (e.g. area guard when zoomed in when dragging op of unit, line formatation
+-- when zoomed out).
+
+return nil
+
 local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()

--- a/luaui/Widgets/cmd_guard_transport_factory.lua
+++ b/luaui/Widgets/cmd_guard_transport_factory.lua
@@ -463,7 +463,7 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 
     for _, orderedUnit in ipairs(selectedUnits) do
         if isTransport(orderedUnit) then
-            if cmdID == CMD.GUARD and isFactory(cmdParams[1]) then
+            if cmdID == GameCMD.AREA_GUARD and isFactory(cmdParams[1]) then
                 if cmdOpts.shift then
                     pendingGuardTransports[orderedUnit] = cmdParams[1]
                 else

--- a/luaui/Widgets/cmd_guard_transport_factory.lua
+++ b/luaui/Widgets/cmd_guard_transport_factory.lua
@@ -448,7 +448,7 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 
     for _, orderedUnit in ipairs(selectedUnits) do
         if isTransport(orderedUnit) then
-            if cmdID == CMD.GUARD and isFactory(cmdParams[1]) then
+            if cmdID == GameCMD.AREA_GUARD and isFactory(cmdParams[1]) then
                 if cmdOpts.shift then
                     pendingGuardTransports[orderedUnit] = cmdParams[1]
                 else

--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -54,8 +54,8 @@ bind               sc_m  restore
 bind         Shift+sc_m  restore
 bind               sc_n  command_skip_current
 bind          Ctrl+sc_n  command_cancel_last
-bind               sc_o  guard
-bind         Shift+sc_o  guard
+bind               sc_o  areaguard
+bind         Shift+sc_o  areaguard
 bind               sc_p  gatherwait
 bind         Shift+sc_p  gatherwait
 bind               sc_r  repair

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -58,8 +58,8 @@ bind               sc_n  command_skip_current
 bind          Ctrl+sc_n  command_cancel_last
 bind               sc_p  gatherwait
 bind         Shift+sc_p  gatherwait
-bind               sc_o  guard
-bind         Shift+sc_o  guard
+bind               sc_o  areaguard
+bind         Shift+sc_o  areaguard
 bind               sc_r  repair
 bind         Shift+sc_r  repair
 bind               sc_s  settarget

--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -45,8 +45,8 @@ bind Shift+sc_e reclaim
 bind sc_f fight
 bind Shift+sc_f fight
 bind Alt+sc_f chain force forcestart | say !cv forcestart
-bind sc_g guard
-bind Shift+sc_g guard
+bind sc_g areaguard
+bind Shift+sc_g areaguard
 bind sc_j canceltarget
 bind sc_k cloak
 bind Shift+sc_k cloak

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -53,8 +53,8 @@ bind Shift+sc_e reclaim
 bind sc_f fight
 bind Shift+sc_f fight
 bind Alt+sc_f chain force forcestart | say !cv forcestart
-bind sc_g guard
-bind Shift+sc_g guard
+bind sc_g areaguard
+bind Shift+sc_g areaguard
 bind sc_j canceltarget
 bind sc_k cloak
 bind Shift+sc_k cloak

--- a/modules/customcommands.lua
+++ b/modules/customcommands.lua
@@ -14,7 +14,7 @@
 
 local gameCommands = {
 	FACTORY_GUARD = 13921,
-	AREA_GUARD = 13922, -- unused
+	AREA_GUARD = 13922, -- unit_guard_area
 	STOP_PRODUCTION = 13923,
 
 	-- blueprint


### PR DESCRIPTION
### Work done
Added Guard Area (unit targets) command, works kinda like repair area.

#### Test steps
- [ ] Check for regression with normal guard right click unit
- [ ] Right click drag on an allied unit to start guard area command
- [ ] Queueing stuff
- [ ] Constructors guard behavior is different for some mysterious reason, not worth it to fix it with this PR

### AI / LLM usage statement:
Vibes for initial prototype then just manually fixed and optimized.

https://github.com/user-attachments/assets/4105f257-b636-4ee7-8334-77a99541b7fa

