### PR TITLE
fix: unhardcode first weapon as main weapon in unit cards

### DIFF
--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -532,7 +532,7 @@ local function refreshUnitInfo()
 			local weaponDef = WeaponDefs[weapons[i].weaponDef]
 			-- Only groups 0 [always active] and 1 [primary weapon set] are aggregated.
 			-- Others might be checked for abilities still, e.g. antinuke interceptors.
-			if showWeaponGroups[weaponDef.customParams.weapons_group] then
+			if showWeaponGroups[weaponDef.customParams.weapons_group] and weaponDef.customParams.bogus ~= "1" then
 				refreshUnitWeaponInfo(i, weaponDef, weaponDef.customParams.weapons_role ~= "secondary")
 			end
 		end

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -162,6 +162,8 @@ local shiftTable = { "shift" }
 local unloadParams = { 0, 0, 0, 0 }  -- x, y, z, unitID
 local viewSelectionCmd = { "viewselection" }
 
+local showWeaponGroups = { ["0"] = true, ["1"] = true } -- <0:=fake weapons, 0:=always active, 1:=primary set, >1:=alternate sets
+
 local function refreshUnitInfo()
 	local builderTraits = {
 		canBuild   = function(def) return def.isFactory or next(def.buildOptions) ~= nil end,
@@ -362,7 +364,7 @@ local function refreshUnitInfo()
 				unitDefInfo[unitDefID].maxCoverage = math.max(unitDefInfo[unitDefID].maxCoverage or 1, weaponDef.coverageRange)
 
 			elseif weaponDef.shieldRadius and weaponDef.shieldRadius > 0 then
-				if #weapons <= 1 then
+				if #weapons == 1 then
 					unitDefInfo[unitDefID].weapons = {}
 					unitDefInfo[unitDefID].shieldOnly = true
 				end
@@ -449,7 +451,8 @@ local function refreshUnitInfo()
 					end
 				end
 
-				if unitDefInfo[unitDefID].mainWeapon == i then
+				if unitDefInfo[unitDefID].mainWeapon == 0 then
+					unitDefInfo[unitDefID].mainWeapon = i
 					unitDefInfo[unitDefID].range = weaponDef.range
 					unitDefInfo[unitDefID].reloadTime = weaponDef.customParams.dronesuesestockpile
 						and weaponDef.stockpileTime
@@ -524,15 +527,17 @@ local function refreshUnitInfo()
 				unitDefInfo[unitDefID].maxdps = 0
 				unitDefInfo[unitDefID].range = 0
 				unitDefInfo[unitDefID].reloadTime = 0
-				unitDefInfo[unitDefID].mainWeapon = 1
+				unitDefInfo[unitDefID].mainWeapon = 0
 			end
 			local weaponDef = WeaponDefs[weapons[i].weaponDef]
 			-- Only groups 0 [always active] and 1 [primary weapon set] are aggregated.
 			-- Others might be checked for abilities still, e.g. antinuke interceptors.
-			local weaponGroup = weaponDef.customParams.weapons_group
-			if weaponGroup == "0" or weaponGroup == "1" then
+			if showWeaponGroups[weaponDef.customParams.weapons_group] then
 				refreshUnitWeaponInfo(i, weaponDef, weaponDef.customParams.weapons_role ~= "secondary")
 			end
+		end
+		if unitDefInfo[unitDefID].mainWeapon == 0 then
+			unitDefInfo[unitDefID].mainWeapon = 1 -- All the unit's weapons were fakes.
 		end
 
 		if unitDef.customParams.unitgroup and unitDef.customParams.unitgroup == 'explo' and unitDef.deathExplosion and WeaponDefNames[unitDef.deathExplosion] then

--- a/units/ArmVehicles/armsam.lua
+++ b/units/ArmVehicles/armsam.lua
@@ -144,7 +144,7 @@ return {
 				weapontype = "MissileLauncher",
 				weaponvelocity = 670,
 				customparams = {
-					weapons_group = 2,
+					weapons_group = 1,
 				},
 				damage = {
 					default = 1,
@@ -194,7 +194,7 @@ return {
 				customparams = {
 					overrange_distance = 633,
 					projectile_destruction_method = "descend",
-					weapons_group = 1,
+					weapons_group = 2,
 				},
 				damage = {
 					default = 86,

--- a/units/CorVehicles/cormist.lua
+++ b/units/CorVehicles/cormist.lua
@@ -143,7 +143,7 @@ return {
 				weapontype = "MissileLauncher",
 				weaponvelocity = 680,
 				customparams = {
-					weapons_group = 2,
+					weapons_group = 1,
 				},
 				damage = {
 					default = 1,
@@ -192,7 +192,7 @@ return {
 				customparams = {
 					overrange_distance = 662,
 					projectile_destruction_method = "descend",
-					weapons_group = 1,
+					weapons_group = 2,
 				},
 				damage = {
 					default = 63,


### PR DESCRIPTION
### Work done

- Allows the first weapon entry to be skipped if the weapon is fake or inactive by default. We do have some bogus weapons in the primary slot (mostly aimhull?).
- Changes the Whistler and Lasher's primary weapon to their anti-air missile instead of their anti-surface missile so they display stats as an anti-air unit (just adds airLOS).
