### PR TITLE
Improve "Wait" key usability by making it a "Repeat" like toggle

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -71,8 +71,9 @@ bind               sc_w  resurrect
 bind         Shift+sc_w  resurrect
 bind               sc_w  capture
 bind         Shift+sc_w  capture
-bind               sc_y  wait
-bind         Shift+sc_y  wait queued
+bind          sc_y,sc_y  wait 0
+bind               sc_y  wait 1
+bind         Shift+sc_y  wait 1 queued
 
 bind          sc_b,sc_b  onoff 0
 bind               sc_b  onoff 1

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -73,8 +73,9 @@ bind               sc_w  resurrect
 bind         Shift+sc_w  resurrect
 bind               sc_w  capture
 bind         Shift+sc_w  capture
-bind               sc_y  wait
-bind         Shift+sc_y  wait queued
+bind          sc_y,sc_y  wait 0
+bind               sc_y  wait 1
+bind         Shift+sc_y  wait 1 queued
 
 bind          sc_b,sc_b  onoff 0
 bind               sc_b  onoff 1

--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -70,8 +70,9 @@ bind Shift+sc_s stop
 bind Ctrl+sc_s stopproduction
 bind sc_u unloadunits
 bind Shift+sc_u unloadunits
-bind sc_w wait
-bind Shift+sc_w wait queued
+bind sc_y,sc_y wait 0
+bind sc_y wait 1
+bind Shift+sc_w wait 1 queued
 bind sc_x onoff
 bind Shift+sc_x onoff
 

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -78,8 +78,9 @@ bind Shift+sc_s stop
 bind Ctrl+sc_s stopproduction
 bind sc_u unloadunits
 bind Shift+sc_u unloadunits
-bind sc_w wait
-bind Shift+sc_w wait queued
+bind sc_y,sc_y wait 0
+bind sc_y wait 1
+bind Shift+sc_w wait 1 queued
 bind sc_x onoff
 bind Shift+sc_x onoff
 


### PR DESCRIPTION
### Work done
Keybind presets changes to make the "Wait" keybind more convenient to use when half an army is on wait. This is achieved by changing the keybinds from a toggle to 0 1.

#### Addresses Issue(s)
- https://discord.com/channels/549281623154229250/1493570516361941143

#### Setup
No setup needed.

#### Test steps
- In game go to settings -> control -> Keybind preset and change it to `Custom`. This will generate a file called `uikeys.txt` in your `BAR/data` directory (BAR/data/uikeys.txt) with your previous keybinds. 
- Find your preset in the files changed and copy paste it into uikeys.txt overwriting the previous content 
- The changes will be loaded next game, by clicking `Custom` keybind preset, or by typing `/keyreload` into chat. 
- Instructions copied and slightly modified from https://discord.com/channels/549281623154229250/1018861299939168288/1477876330384195727

### NO TESTING HAS BEEN DONE YET