### PR TITLE
feat: add "fightersynctest" debug command for engine CI sync testing

### DIFF
--- a/luarules/gadgets/dbg_fightersynctest.lua
+++ b/luarules/gadgets/dbg_fightersynctest.lua
@@ -405,7 +405,7 @@ else	-- UNSYNCED
 	function gadget:GameFrame(n)
 		if not hudActive then return end
 		if not Engine.hasSyncChecksums then return end
-		local checksum = tostring(Spring.GetPrevFrameSyncChecksum() or "")
+		local checksum = Spring.GetPrevFrameSyncChecksum()
 		synchashBuffer[#synchashBuffer + 1] = string.format("%d:%s", n, checksum)
 		if not synchashFirstFrame then synchashFirstFrame = n end
 		synchashLastFrame = n
@@ -415,7 +415,7 @@ else	-- UNSYNCED
 		hudActive = false
 		local count = #synchashBuffer
 		if count == 0 then
-			Spring.Echo("[fightersynctest] sync-hash: no frames collected (engine may lack Spring.GetPrevFrameSyncChecksum)")
+			Spring.Echo("[fightersynctest] sync-hash: no frames collected (Engine.hasSyncChecksums is false — engine built without SYNCCHECK)")
 			return
 		end
 		local blob = table.concat(synchashBuffer, "\n")

--- a/luarules/gadgets/dbg_fightersynctest.lua
+++ b/luarules/gadgets/dbg_fightersynctest.lua
@@ -145,7 +145,7 @@ if gadgetHandler:IsSyncedCode() then
 			"[fightersynctest] starting: totalframes=%d area=%.2f offset=%.2f,%.2f mult=%.2f categories=%d anchors land/water/deep/air=%d/%d/%d/%d",
 			totalFrames, areaFraction, areaOffsetX, areaOffsetZ, unitMultiplier, #enabledCats,
 			#anchorsByClass.land, #anchorsByClass.water, #anchorsByClass.deepwater, #anchorsByClass.air))
-		SendToUnsynced("fightersynctest_synchash_begin", totalFrames)
+		SendToUnsynced("fightersynctest_synchash_begin", totalFrames, runStartFrame)
 		active = true
 	end
 
@@ -169,15 +169,15 @@ if gadgetHandler:IsSyncedCode() then
 
 		local runFrame = n - runStartFrame
 
-		if n % feedMod == 0 then
+		if runFrame % feedMod == 0 then
 			for _, cat in ipairs(enabledCats) do
 				spawnBurstForCategory(cat)
 			end
 		end
 
-		if n % cleanupMod == 1 then
+		if runFrame % cleanupMod == 1 then
 			for featureID, deathtime in pairs(featurestoremove) do
-				if deathtime < n then
+				if deathtime < runFrame then
 					if Spring.ValidFeatureID(featureID) then
 						Spring.DestroyFeature(featureID)
 					end
@@ -341,7 +341,7 @@ if gadgetHandler:IsSyncedCode() then
 		if not active then return end
 		local fdID = Spring.GetFeatureDefID(featureID)
 		if fdID and featureDefsToRemove[fdID] then
-			featurestoremove[featureID] = Spring.GetGameFrame() + cleanupFeatureLife
+			featurestoremove[featureID] = (Spring.GetGameFrame() - runStartFrame) + cleanupFeatureLife
 		end
 	end
 
@@ -458,21 +458,22 @@ else	-- UNSYNCED
 	local synchashBuffer = {}
 	local synchashFirstFrame, synchashLastFrame
 
-	local function onSynchashBegin(_, totalFrames)
+	local function onSynchashBegin(_, totalFrames, runStartFrame)
 		synchashBuffer = {}
 		synchashFirstFrame, synchashLastFrame = nil, nil
 		hudActive = true
 		hudTotalFrames = tonumber(totalFrames) or 0
-		hudRunStartFrame = Spring.GetGameFrame()
+		hudRunStartFrame = tonumber(runStartFrame) or Spring.GetGameFrame()
 	end
 
 	function gadget:GameFrame(n)
 		if not hudActive then return end
 		if not Engine.hasSyncChecksums then return end
 		local checksum = Spring.GetPrevFrameSyncChecksum()
-		synchashBuffer[#synchashBuffer + 1] = string.format("%d:%s", n, checksum)
-		if not synchashFirstFrame then synchashFirstFrame = n end
-		synchashLastFrame = n
+		local runFrame = n - hudRunStartFrame
+		synchashBuffer[#synchashBuffer + 1] = string.format("%d:%s", runFrame, checksum)
+		if not synchashFirstFrame then synchashFirstFrame = runFrame end
+		synchashLastFrame = runFrame
 	end
 
 	local function onSynchashEnd()

--- a/luarules/gadgets/dbg_fightersynctest.lua
+++ b/luarules/gadgets/dbg_fightersynctest.lua
@@ -50,18 +50,9 @@ end
 
 if gadgetHandler:IsSyncedCode() then
 
-	local function checkStartPlayers()
-		for _, playerID in ipairs(Spring.GetPlayerList()) do
-			local playername, _, spec = Spring.GetPlayerInfo(playerID, false)
-			if not spec then
-				startPlayers[playername] = true
-			end
-		end
-	end
-
-	function gadget:GameStart()
-		checkStartPlayers()
-	end
+	--------------------------------------------------------------------
+	-- Run configuration and state
+	--------------------------------------------------------------------
 
 	local mapSX = Game.mapSizeX
 	local mapSZ = Game.mapSizeZ
@@ -81,64 +72,11 @@ if gadgetHandler:IsSyncedCode() then
 
 	local seededrand = {}
 	local randindex = 1
-	local function initrandom(seed)
-		math.randomseed(seed)
-		for i=1, 5000 do
-			seededrand[i] = math.random()
-		end
-		randindex = 1
-	end
-
-	local function getrandom()
-		if #seededrand < 1 then initrandom(RUN_SEED) end
-		randindex = randindex + 1
-		if randindex > #seededrand then randindex = 1 end
-		return seededrand[randindex]
-	end
 
 	local anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
 
-	local function scanAnchors()
-		anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
-		local stride = 256
-		local originX = mapSX * areaOffsetX
-		local originZ = mapSZ * areaOffsetZ
-		local areaX = mapSX * areaFraction
-		local areaZ = mapSZ * areaFraction
-		local regionW = areaX / anchorRegions
-		local regionH = areaZ / anchorRegions
-		for rz = 0, anchorRegions - 1 do
-			for rx = 0, anchorRegions - 1 do
-				local pickedLand, pickedWater, pickedDeep = false, false, false
-				local z0 = originZ + rz * regionH + stride * 0.5
-				local x0 = originX + rx * regionW + stride * 0.5
-				for z = z0, originZ + (rz + 1) * regionH, stride do
-					for x = x0, originX + (rx + 1) * regionW, stride do
-						local h = Spring.GetGroundHeight(x, z)
-						if not pickedLand and h > 32 then
-							anchorsByClass.land[#anchorsByClass.land + 1] = { x = x, z = z }
-							pickedLand = true
-						end
-						if not pickedWater and h < -16 then
-							anchorsByClass.water[#anchorsByClass.water + 1] = { x = x, z = z }
-							pickedWater = true
-						end
-						if not pickedDeep and h < -48 then
-							anchorsByClass.deepwater[#anchorsByClass.deepwater + 1] = { x = x, z = z }
-							pickedDeep = true
-						end
-						if pickedLand and pickedWater and pickedDeep then break end
-					end
-					if pickedLand and pickedWater and pickedDeep then break end
-				end
-			end
-		end
-		anchorsByClass.air = anchorsByClass.land
-	end
-
-
-	-- TODO: restore `cons` (with mex-build onSpawn) and `transports` (with
-	-- load/unload onSpawn) categories once the broader test is stable.
+	-- TODO: add `cons` (with mex-build onSpawn) and `transports` (with
+	-- load/unload onSpawn).
 	local categoryDefs = {
 		{ name = "bots",       t1 = "armpw",    t2 = "corak",    max = 400, step = 28, class = "land" },
 		{ name = "tanks",      t1 = "armbull",  t2 = "armbull",  max = 280, step = 14, class = "land" },
@@ -155,127 +93,22 @@ if gadgetHandler:IsSyncedCode() then
 	local enabledCats = {}
 	local allTeamUnitDefNames = {}
 
-	local function filterCategories()
-		enabledCats = {}
-		allTeamUnitDefNames = {}
-		for _, cat in ipairs(categoryDefs) do
-			if UnitDefNames[cat.t1] and UnitDefNames[cat.t2] then
-				local anchors = anchorsByClass[cat.class]
-				if anchors and #anchors > 0 then
-					cat.anchorCounter = 0
-					cat.t1id = UnitDefNames[cat.t1].id
-					cat.t2id = UnitDefNames[cat.t2].id
-					if cat.noMultiplier then
-						cat.effectiveMax  = cat.max
-						cat.effectiveStep = cat.step
-					else
-						cat.effectiveMax  = math.max(1, math.floor(cat.max  * unitMultiplier / 2.0))
-						cat.effectiveStep = math.max(1, math.floor(cat.step * unitMultiplier / 2.0))
-					end
-					enabledCats[#enabledCats + 1] = cat
-					allTeamUnitDefNames[cat.t1] = true
-					allTeamUnitDefNames[cat.t2] = true
-				else
-					Spring.Echo(string.format(
-						"[fightersynctest] skipping category %s: no %s anchors", cat.name, cat.class))
-				end
-			end
-		end
-	end
-
-	local function spawnBurstForCategoryAtAnchor(cat, teamID, udID, anchor)
-		if Spring.GetTeamUnitDefCount(teamID, udID) >= cat.effectiveMax then return {} end
-
-		local footprint = math.max(UnitDefs[udID].xsize, UnitDefs[udID].zsize)
-		local sqrtFeed = math.max(1, math.ceil(math.sqrt(cat.effectiveStep)))
-		local newUnitIDs = {}
-		local numspawned = 0
-		local cx = anchor.x + placementRadius * (getrandom() - 0.5)
-		local cz = anchor.z + placementRadius * (getrandom() - 0.5)
-		for x = 1, sqrtFeed do
-			for z = 1, sqrtFeed do
-				if numspawned < cat.effectiveStep then
-					local px = cx + 12 * footprint * x
-					local pz = cz + 12 * footprint * z
-					local py = Spring.GetGroundHeight(px, pz)
-					local uid = Spring.CreateUnit(udID, px, py, pz, "n", teamID)
-					if uid then
-						numspawned = numspawned + 1
-						newUnitIDs[#newUnitIDs + 1] = uid
-					end
-				end
-			end
-		end
-
-		if #newUnitIDs > 0 then
-			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.REPEAT, { 1 }, 0)
-			local classAnchors = anchorsByClass[cat.class]
-			for _ = 1, 3 do
-				local destIdx = 1 + math.floor(getrandom() * #classAnchors)
-				local dest = classAnchors[destIdx]
-				local gh = Spring.GetGroundHeight(dest.x, dest.z)
-				Spring.GiveOrderToUnitArray(newUnitIDs, CMD.FIGHT, { dest.x, gh, dest.z }, { "shift" })
-			end
-			local rh = Spring.GetGroundHeight(anchor.x, anchor.z)
-			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.FIGHT, { anchor.x, rh, anchor.z }, { "shift" })
-		end
-		return newUnitIDs
-	end
-
-	local function spawnBurstForCategory(cat)
-		local anchors = anchorsByClass[cat.class]
-		if not anchors or #anchors == 0 then return end
-		cat.anchorCounter = cat.anchorCounter + 1
-		local anchor = anchors[((cat.anchorCounter - 1) % #anchors) + 1]
-		spawnBurstForCategoryAtAnchor(cat, 0, cat.t1id, anchor)
-		spawnBurstForCategoryAtAnchor(cat, 1, cat.t2id, anchor)
-	end
-
-
-	-- TODO: restore scripted moments (commander dgun manualfire, armbull selfD
-	-- sampling, commander cloak toggle, and any future ones) once the base
-	-- test is solid. They previously fired at frames 300/600/900/1200 and
-	-- pushed a `fightersynctest_scripted_tick` event to the HUD.
-
 	local featurestoremove = {}
 	local featureDefsToRemove = {}
 
-	local function computeFeatureDefsToRemove()
-		featureDefsToRemove = {}
-		for udName in pairs(allTeamUnitDefNames) do
-			for _, suffix in ipairs({ "_dead", "_heap" }) do
-				local fd = FeatureDefNames[udName .. suffix]
-				if fd and fd.id then
-					featureDefsToRemove[fd.id] = true
-				end
-			end
-		end
-	end
+	--------------------------------------------------------------------
+	-- Forward declarations (so sections read top-down)
+	--------------------------------------------------------------------
 
+	local initrandom, getrandom
+	local scanAnchors
+	local filterCategories
+	local spawnBurstForCategory, spawnBurstForCategoryAtAnchor
+	local computeFeatureDefsToRemove, removeAllSpawnedUnits
 
-	local function removeAllSpawnedUnits()
-		local all = Spring.GetAllUnits()
-		local removedByDef = {}
-		for _, uid in ipairs(all) do
-			local udID = Spring.GetUnitDefID(uid)
-			local ud = udID and UnitDefs[udID]
-			if ud and allTeamUnitDefNames[ud.name] then
-				Spring.DestroyUnit(uid, false, true)
-				removedByDef[ud.name] = (removedByDef[ud.name] or 0) + 1
-			end
-		end
-		local allFeatures = Spring.GetAllFeatures()
-		for _, fid in ipairs(allFeatures) do
-			local fdID = Spring.GetFeatureDefID(fid)
-			if fdID and featureDefsToRemove[fdID] then
-				Spring.DestroyFeature(fid)
-			end
-		end
-		for name, n in pairs(removedByDef) do
-			Spring.Echo(string.format("[fightersynctest] removed %d x %s", n, name))
-		end
-	end
-
+	--------------------------------------------------------------------
+	-- Run lifecycle
+	--------------------------------------------------------------------
 
 	local function startRun(words)
 		if words[2] then
@@ -327,31 +160,9 @@ if gadgetHandler:IsSyncedCode() then
 		if active then endRun() else startRun(words) end
 	end
 
-	function gadget:Initialize()
-		checkStartPlayers()
-	end
-
-	function gadget:RecvLuaMsg(msg, playerID)
-		if string.sub(msg, 1, PACKET_HEADER_LENGTH) ~= PACKET_HEADER then
-			return
-		end
-		msg = string.sub(msg, PACKET_HEADER_LENGTH)
-		local words = {}
-		for word in msg:gmatch("[%-_%w%.]+") do
-			table.insert(words, word)
-		end
-		if words[1] ~= "fightersynctest" then return end
-		if not isAuthorized(playerID, "terrain") then return end
-		toggleRun(words)
-	end
-
-	function gadget:FeatureCreated(featureID, allyTeam)
-		if not active then return end
-		local fdID = Spring.GetFeatureDefID(featureID)
-		if fdID and featureDefsToRemove[fdID] then
-			featurestoremove[featureID] = Spring.GetGameFrame() + cleanupFeatureLife
-		end
-	end
+	--------------------------------------------------------------------
+	-- Main tick
+	--------------------------------------------------------------------
 
 	function gadget:GameFrame(n)
 		if not active then return end
@@ -380,19 +191,272 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	--------------------------------------------------------------------
+	-- Anchor selection (per-class spawn/destination points)
+	--------------------------------------------------------------------
+
+	function scanAnchors()
+		anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
+		local stride = 256
+		local originX = mapSX * areaOffsetX
+		local originZ = mapSZ * areaOffsetZ
+		local areaX = mapSX * areaFraction
+		local areaZ = mapSZ * areaFraction
+		local regionW = areaX / anchorRegions
+		local regionH = areaZ / anchorRegions
+		for rz = 0, anchorRegions - 1 do
+			for rx = 0, anchorRegions - 1 do
+				local pickedLand, pickedWater, pickedDeep = false, false, false
+				local z0 = originZ + rz * regionH + stride * 0.5
+				local x0 = originX + rx * regionW + stride * 0.5
+				for z = z0, originZ + (rz + 1) * regionH, stride do
+					for x = x0, originX + (rx + 1) * regionW, stride do
+						local h = Spring.GetGroundHeight(x, z)
+						if not pickedLand and h > 32 then
+							anchorsByClass.land[#anchorsByClass.land + 1] = { x = x, z = z }
+							pickedLand = true
+						end
+						if not pickedWater and h < -16 then
+							anchorsByClass.water[#anchorsByClass.water + 1] = { x = x, z = z }
+							pickedWater = true
+						end
+						if not pickedDeep and h < -48 then
+							anchorsByClass.deepwater[#anchorsByClass.deepwater + 1] = { x = x, z = z }
+							pickedDeep = true
+						end
+						if pickedLand and pickedWater and pickedDeep then break end
+					end
+					if pickedLand and pickedWater and pickedDeep then break end
+				end
+			end
+		end
+		anchorsByClass.air = anchorsByClass.land
+	end
+
+	--------------------------------------------------------------------
+	-- Spawning bursts of units, with randomized placement and orders
+	--------------------------------------------------------------------
+
+	-- TODO: add scripted moments (commander dgun manualfire, armbull selfD
+	-- sampling, commander cloak toggle, and any future ones) once the base
+	-- test is solid.
+
+	function spawnBurstForCategoryAtAnchor(cat, teamID, udID, anchor)
+		if Spring.GetTeamUnitDefCount(teamID, udID) >= cat.effectiveMax then return {} end
+
+		local footprint = math.max(UnitDefs[udID].xsize, UnitDefs[udID].zsize)
+		local sqrtFeed = math.max(1, math.ceil(math.sqrt(cat.effectiveStep)))
+		local newUnitIDs = {}
+		local numspawned = 0
+		local cx = anchor.x + placementRadius * (getrandom() - 0.5)
+		local cz = anchor.z + placementRadius * (getrandom() - 0.5)
+		for x = 1, sqrtFeed do
+			for z = 1, sqrtFeed do
+				if numspawned < cat.effectiveStep then
+					local px = cx + 12 * footprint * x
+					local pz = cz + 12 * footprint * z
+					local py = Spring.GetGroundHeight(px, pz)
+					local uid = Spring.CreateUnit(udID, px, py, pz, "n", teamID)
+					if uid then
+						numspawned = numspawned + 1
+						newUnitIDs[#newUnitIDs + 1] = uid
+					end
+				end
+			end
+		end
+
+		if #newUnitIDs > 0 then
+			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.REPEAT, { 1 }, 0)
+			local classAnchors = anchorsByClass[cat.class]
+			for _ = 1, 3 do
+				local destIdx = 1 + math.floor(getrandom() * #classAnchors)
+				local dest = classAnchors[destIdx]
+				local gh = Spring.GetGroundHeight(dest.x, dest.z)
+				Spring.GiveOrderToUnitArray(newUnitIDs, CMD.FIGHT, { dest.x, gh, dest.z }, { "shift" })
+			end
+			local rh = Spring.GetGroundHeight(anchor.x, anchor.z)
+			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.FIGHT, { anchor.x, rh, anchor.z }, { "shift" })
+		end
+		return newUnitIDs
+	end
+
+	function spawnBurstForCategory(cat)
+		local anchors = anchorsByClass[cat.class]
+		if not anchors or #anchors == 0 then return end
+		cat.anchorCounter = cat.anchorCounter + 1
+		local anchor = anchors[((cat.anchorCounter - 1) % #anchors) + 1]
+		spawnBurstForCategoryAtAnchor(cat, 0, cat.t1id, anchor)
+		spawnBurstForCategoryAtAnchor(cat, 1, cat.t2id, anchor)
+	end
+
+	--------------------------------------------------------------------
+	-- Unit categories
+	--------------------------------------------------------------------
+
+	function filterCategories()
+		enabledCats = {}
+		allTeamUnitDefNames = {}
+		for _, cat in ipairs(categoryDefs) do
+			if UnitDefNames[cat.t1] and UnitDefNames[cat.t2] then
+				local anchors = anchorsByClass[cat.class]
+				if anchors and #anchors > 0 then
+					cat.anchorCounter = 0
+					cat.t1id = UnitDefNames[cat.t1].id
+					cat.t2id = UnitDefNames[cat.t2].id
+					if cat.noMultiplier then
+						cat.effectiveMax  = cat.max
+						cat.effectiveStep = cat.step
+					else
+						cat.effectiveMax  = math.max(1, math.floor(cat.max  * unitMultiplier / 2.0))
+						cat.effectiveStep = math.max(1, math.floor(cat.step * unitMultiplier / 2.0))
+					end
+					enabledCats[#enabledCats + 1] = cat
+					allTeamUnitDefNames[cat.t1] = true
+					allTeamUnitDefNames[cat.t2] = true
+				else
+					Spring.Echo(string.format(
+						"[fightersynctest] skipping category %s: no %s anchors", cat.name, cat.class))
+				end
+			end
+		end
+	end
+
+	--------------------------------------------------------------------
+	-- Cleanup: wreckage expiry + end-of-run teardown
+	--------------------------------------------------------------------
+
+	function computeFeatureDefsToRemove()
+		featureDefsToRemove = {}
+		for udName in pairs(allTeamUnitDefNames) do
+			for _, suffix in ipairs({ "_dead", "_heap" }) do
+				local fd = FeatureDefNames[udName .. suffix]
+				if fd and fd.id then
+					featureDefsToRemove[fd.id] = true
+				end
+			end
+		end
+	end
+
+	function gadget:FeatureCreated(featureID, allyTeam)
+		if not active then return end
+		local fdID = Spring.GetFeatureDefID(featureID)
+		if fdID and featureDefsToRemove[fdID] then
+			featurestoremove[featureID] = Spring.GetGameFrame() + cleanupFeatureLife
+		end
+	end
+
+	function removeAllSpawnedUnits()
+		local all = Spring.GetAllUnits()
+		local removedByDef = {}
+		for _, uid in ipairs(all) do
+			local udID = Spring.GetUnitDefID(uid)
+			local ud = udID and UnitDefs[udID]
+			if ud and allTeamUnitDefNames[ud.name] then
+				Spring.DestroyUnit(uid, false, true)
+				removedByDef[ud.name] = (removedByDef[ud.name] or 0) + 1
+			end
+		end
+		local allFeatures = Spring.GetAllFeatures()
+		for _, fid in ipairs(allFeatures) do
+			local fdID = Spring.GetFeatureDefID(fid)
+			if fdID and featureDefsToRemove[fdID] then
+				Spring.DestroyFeature(fid)
+			end
+		end
+		for name, n in pairs(removedByDef) do
+			Spring.Echo(string.format("[fightersynctest] removed %d x %s", n, name))
+		end
+	end
+
+	--------------------------------------------------------------------
+	-- Chat entry point + startPlayers gating
+	--------------------------------------------------------------------
+
+	local function recordStartPlayers()
+		for _, playerID in ipairs(Spring.GetPlayerList()) do
+			local playername, _, spec = Spring.GetPlayerInfo(playerID, false)
+			if not spec then
+				startPlayers[playername] = true
+			end
+		end
+	end
+
+	function gadget:Initialize()
+		recordStartPlayers()
+	end
+
+	function gadget:GameStart()
+		recordStartPlayers()
+	end
+
+	function gadget:RecvLuaMsg(msg, playerID)
+		if string.sub(msg, 1, PACKET_HEADER_LENGTH) ~= PACKET_HEADER then
+			return
+		end
+		msg = string.sub(msg, PACKET_HEADER_LENGTH)
+		local words = {}
+		for word in msg:gmatch("[%-_%w%.]+") do
+			table.insert(words, word)
+		end
+		if words[1] ~= "fightersynctest" then return end
+		if not isAuthorized(playerID, "terrain") then return end
+		toggleRun(words)
+	end
+
+	--------------------------------------------------------------------
+	-- Seeded RNG
+	--------------------------------------------------------------------
+
+	function initrandom(seed)
+		math.randomseed(seed)
+		for i=1, 5000 do
+			seededrand[i] = math.random()
+		end
+		randindex = 1
+	end
+
+	function getrandom()
+		if #seededrand < 1 then initrandom(RUN_SEED) end
+		randindex = randindex + 1
+		if randindex > #seededrand then randindex = 1 end
+		return seededrand[randindex]
+	end
+
 
 else	-- UNSYNCED
 
 
+	--------------------------------------------------------------------
+	-- HUD
+	--------------------------------------------------------------------
+
 	local vsx, vsy = Spring.GetViewGeometry()
 	local uiScale = vsy / 1080
-
-	local synchashBuffer = {}
-	local synchashFirstFrame, synchashLastFrame
 
 	local hudActive = false
 	local hudTotalFrames = 0
 	local hudRunStartFrame = nil
+
+	function gadget:ViewResize()
+		vsx, vsy = Spring.GetViewGeometry()
+		uiScale = vsy / 1080
+	end
+
+	function gadget:DrawScreen()
+		if not hudActive then return end
+		local gameFrame = Spring.GetGameFrame()
+		local runFrame = hudRunStartFrame and (gameFrame - hudRunStartFrame) or 0
+		gl.Color(1, 1, 1, 1)
+		gl.Text(string.format("Fightertest Synctest  frame %d / %d", runFrame, hudTotalFrames),
+			600 * uiScale, 600 * uiScale, 16 * uiScale)
+	end
+
+	--------------------------------------------------------------------
+	-- Sync-hash capture
+	--------------------------------------------------------------------
+
+	local synchashBuffer = {}
+	local synchashFirstFrame, synchashLastFrame
 
 	local function onSynchashBegin(_, totalFrames)
 		synchashBuffer = {}
@@ -440,6 +504,10 @@ else	-- UNSYNCED
 		synchashBuffer = {}
 	end
 
+	--------------------------------------------------------------------
+	-- Chat action + gadget lifecycle
+	--------------------------------------------------------------------
+
 	local function fightersynctest(_, line, words, playerID, action)
 		if playerID ~= Spring.GetMyPlayerID() then return end
 		Spring.Echo("[fightersynctest]", line, playerID, action)
@@ -449,20 +517,6 @@ else	-- UNSYNCED
 			if words[i] then msg = msg .. " " .. tostring(words[i]) end
 		end
 		Spring.SendLuaRulesMsg(msg)
-	end
-
-	function gadget:ViewResize()
-		vsx, vsy = Spring.GetViewGeometry()
-		uiScale = vsy / 1080
-	end
-
-	function gadget:DrawScreen()
-		if not hudActive then return end
-		local gameFrame = Spring.GetGameFrame()
-		local runFrame = hudRunStartFrame and (gameFrame - hudRunStartFrame) or 0
-		gl.Color(1, 1, 1, 1)
-		gl.Text(string.format("Fightertest Synctest  frame %d / %d", runFrame, hudTotalFrames),
-			600 * uiScale, 600 * uiScale, 16 * uiScale)
 	end
 
 	function gadget:Initialize()

--- a/luarules/gadgets/dbg_fightersynctest.lua
+++ b/luarules/gadgets/dbg_fightersynctest.lua
@@ -1,0 +1,480 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Fightertest Synctest",
+		desc = "Expanded engine-API sync test: spawns a broad mix of unit categories (bots, tanks, air, hover, subs, ships, spiders, commanders) concurrently and collects a per-frame sync-hash artifact for RecoilEngine#2910. Independent of the fightertest benchmark gadget. See RecoilEngine#2928.",
+		author = "Bruno-DaSilva",
+		date = "2026-04-13",
+		license = "GNU GPL, v2 or later",
+		layer = -1999999999,
+		enabled = true
+	}
+end
+
+local PACKET_HEADER = "$fts$"
+local PACKET_HEADER_LENGTH = string.len(PACKET_HEADER)
+
+local RUN_SEED = 7654321
+
+if gadgetHandler:IsSyncedCode() then
+	startPlayers = startPlayers or {}
+end
+
+local function isAuthorized(playerID, subPermission)
+	if Spring.IsCheatingEnabled() then
+		return true
+	end
+	local playername = Spring.GetPlayerInfo(playerID)
+	local accountID = Spring.Utilities.GetAccountID(playerID)
+	local hasPermission = false
+	if (_G and _G.permissions.devhelpers and (_G.permissions.devhelpers[accountID] or (playername and _G.permissions.devhelpers[playername]))) or
+	   (SYNCED and SYNCED.permissions.devhelpers and (SYNCED.permissions.devhelpers[accountID] or (playername and SYNCED.permissions.devhelpers[playername]))) then
+		hasPermission = true
+	end
+	if not hasPermission and subPermission then
+		local permKey = "devhelpers_" .. subPermission
+		if (_G and _G.permissions[permKey] and (_G.permissions[permKey][accountID] or (playername and _G.permissions[permKey][playername]))) or
+		   (SYNCED and SYNCED.permissions[permKey] and (SYNCED.permissions[permKey][accountID] or (playername and SYNCED.permissions[permKey][playername]))) then
+			hasPermission = true
+		end
+	end
+	if hasPermission then
+		if startPlayers == nil or startPlayers[playername] == nil then
+			return true
+		end
+	end
+	return false
+end
+
+
+if gadgetHandler:IsSyncedCode() then
+
+	local function checkStartPlayers()
+		for _, playerID in ipairs(Spring.GetPlayerList()) do
+			local playername, _, spec = Spring.GetPlayerInfo(playerID, false)
+			if not spec then
+				startPlayers[playername] = true
+			end
+		end
+	end
+
+	function gadget:GameStart()
+		checkStartPlayers()
+	end
+
+	local mapSX = Game.mapSizeX
+	local mapSZ = Game.mapSizeZ
+
+	local active = false
+	local runStartFrame = 0
+	local totalFrames = 2000
+	local placementRadius = 400
+	local feedMod = 3
+	local cleanupMod = 3
+	local cleanupFeatureLife = 150
+	local anchorRegions = 8
+	local areaFraction = 1.0
+	local areaOffsetX = 0.0
+	local areaOffsetZ = 0.0
+	local unitMultiplier = 2.0
+
+	local seededrand = {}
+	local randindex = 1
+	local function initrandom(seed)
+		math.randomseed(seed)
+		for i=1, 5000 do
+			seededrand[i] = math.random()
+		end
+		randindex = 1
+	end
+
+	local function getrandom()
+		if #seededrand < 1 then initrandom(RUN_SEED) end
+		randindex = randindex + 1
+		if randindex > #seededrand then randindex = 1 end
+		return seededrand[randindex]
+	end
+
+	local anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
+
+	local function scanAnchors()
+		anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
+		local stride = 256
+		local originX = mapSX * areaOffsetX
+		local originZ = mapSZ * areaOffsetZ
+		local areaX = mapSX * areaFraction
+		local areaZ = mapSZ * areaFraction
+		local regionW = areaX / anchorRegions
+		local regionH = areaZ / anchorRegions
+		for rz = 0, anchorRegions - 1 do
+			for rx = 0, anchorRegions - 1 do
+				local pickedLand, pickedWater, pickedDeep = false, false, false
+				local z0 = originZ + rz * regionH + stride * 0.5
+				local x0 = originX + rx * regionW + stride * 0.5
+				for z = z0, originZ + (rz + 1) * regionH, stride do
+					for x = x0, originX + (rx + 1) * regionW, stride do
+						local h = Spring.GetGroundHeight(x, z)
+						if not pickedLand and h > 32 then
+							anchorsByClass.land[#anchorsByClass.land + 1] = { x = x, z = z }
+							pickedLand = true
+						end
+						if not pickedWater and h < -16 then
+							anchorsByClass.water[#anchorsByClass.water + 1] = { x = x, z = z }
+							pickedWater = true
+						end
+						if not pickedDeep and h < -48 then
+							anchorsByClass.deepwater[#anchorsByClass.deepwater + 1] = { x = x, z = z }
+							pickedDeep = true
+						end
+						if pickedLand and pickedWater and pickedDeep then break end
+					end
+					if pickedLand and pickedWater and pickedDeep then break end
+				end
+			end
+		end
+		anchorsByClass.air = anchorsByClass.land
+	end
+
+
+	-- TODO: restore `cons` (with mex-build onSpawn) and `transports` (with
+	-- load/unload onSpawn) categories once the broader test is stable.
+	local categoryDefs = {
+		{ name = "bots",       t1 = "armpw",    t2 = "corak",    max = 400, step = 28, class = "land" },
+		{ name = "tanks",      t1 = "armbull",  t2 = "armbull",  max = 280, step = 14, class = "land" },
+		{ name = "fighters",   t1 = "corvamp",  t2 = "armhawk",  max = 280, step = 14, class = "air" },
+		{ name = "bombers",    t1 = "armpnix",  t2 = "corshad",  max = 140, step = 7,  class = "air" },
+		{ name = "hover",      t1 = "armanac",  t2 = "corsh",    max = 200, step = 14, class = "land" },
+		{ name = "subs",       t1 = "armsub",   t2 = "corsub",   max = 200, step = 14, class = "deepwater" },
+		{ name = "ships",      t1 = "armpt",    t2 = "corpt",    max = 200, step = 14, class = "water" },
+		{ name = "spiders",    t1 = "armspid",  t2 = "armflea",  max = 200, step = 14, class = "land" },
+		{ name = "commanders", t1 = "armcom",   t2 = "corcom",   max = 3,   step = 1,  class = "land",
+			noMultiplier = true },
+	}
+
+	local enabledCats = {}
+	local allTeamUnitDefNames = {}
+
+	local function filterCategories()
+		enabledCats = {}
+		allTeamUnitDefNames = {}
+		for _, cat in ipairs(categoryDefs) do
+			if UnitDefNames[cat.t1] and UnitDefNames[cat.t2] then
+				local anchors = anchorsByClass[cat.class]
+				if anchors and #anchors > 0 then
+					cat.anchorCounter = 0
+					cat.t1id = UnitDefNames[cat.t1].id
+					cat.t2id = UnitDefNames[cat.t2].id
+					if cat.noMultiplier then
+						cat.effectiveMax  = cat.max
+						cat.effectiveStep = cat.step
+					else
+						cat.effectiveMax  = math.max(1, math.floor(cat.max  * unitMultiplier / 2.0))
+						cat.effectiveStep = math.max(1, math.floor(cat.step * unitMultiplier / 2.0))
+					end
+					enabledCats[#enabledCats + 1] = cat
+					allTeamUnitDefNames[cat.t1] = true
+					allTeamUnitDefNames[cat.t2] = true
+				else
+					Spring.Echo(string.format(
+						"[fightersynctest] skipping category %s: no %s anchors", cat.name, cat.class))
+				end
+			end
+		end
+	end
+
+	local function spawnBurstForCategoryAtAnchor(cat, teamID, udID, anchor)
+		if Spring.GetTeamUnitDefCount(teamID, udID) >= cat.effectiveMax then return {} end
+
+		local footprint = math.max(UnitDefs[udID].xsize, UnitDefs[udID].zsize)
+		local sqrtFeed = math.max(1, math.ceil(math.sqrt(cat.effectiveStep)))
+		local newUnitIDs = {}
+		local numspawned = 0
+		local cx = anchor.x + placementRadius * (getrandom() - 0.5)
+		local cz = anchor.z + placementRadius * (getrandom() - 0.5)
+		for x = 1, sqrtFeed do
+			for z = 1, sqrtFeed do
+				if numspawned < cat.effectiveStep then
+					local px = cx + 12 * footprint * x
+					local pz = cz + 12 * footprint * z
+					local py = Spring.GetGroundHeight(px, pz)
+					local uid = Spring.CreateUnit(udID, px, py, pz, "n", teamID)
+					if uid then
+						numspawned = numspawned + 1
+						newUnitIDs[#newUnitIDs + 1] = uid
+					end
+				end
+			end
+		end
+
+		if #newUnitIDs > 0 then
+			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.REPEAT, { 1 }, 0)
+			local classAnchors = anchorsByClass[cat.class]
+			for _ = 1, 3 do
+				local destIdx = 1 + math.floor(getrandom() * #classAnchors)
+				local dest = classAnchors[destIdx]
+				local gh = Spring.GetGroundHeight(dest.x, dest.z)
+				Spring.GiveOrderToUnitArray(newUnitIDs, CMD.FIGHT, { dest.x, gh, dest.z }, { "shift" })
+			end
+			local rh = Spring.GetGroundHeight(anchor.x, anchor.z)
+			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.FIGHT, { anchor.x, rh, anchor.z }, { "shift" })
+		end
+		return newUnitIDs
+	end
+
+	local function spawnBurstForCategory(cat)
+		local anchors = anchorsByClass[cat.class]
+		if not anchors or #anchors == 0 then return end
+		cat.anchorCounter = cat.anchorCounter + 1
+		local anchor = anchors[((cat.anchorCounter - 1) % #anchors) + 1]
+		spawnBurstForCategoryAtAnchor(cat, 0, cat.t1id, anchor)
+		spawnBurstForCategoryAtAnchor(cat, 1, cat.t2id, anchor)
+	end
+
+
+	-- TODO: restore scripted moments (commander dgun manualfire, armbull selfD
+	-- sampling, commander cloak toggle, and any future ones) once the base
+	-- test is solid. They previously fired at frames 300/600/900/1200 and
+	-- pushed a `fightersynctest_scripted_tick` event to the HUD.
+
+	local featurestoremove = {}
+	local featureDefsToRemove = {}
+
+	local function computeFeatureDefsToRemove()
+		featureDefsToRemove = {}
+		for udName in pairs(allTeamUnitDefNames) do
+			for _, suffix in ipairs({ "_dead", "_heap" }) do
+				local fd = FeatureDefNames[udName .. suffix]
+				if fd and fd.id then
+					featureDefsToRemove[fd.id] = true
+				end
+			end
+		end
+	end
+
+
+	local function removeAllSpawnedUnits()
+		local all = Spring.GetAllUnits()
+		local removedByDef = {}
+		for _, uid in ipairs(all) do
+			local udID = Spring.GetUnitDefID(uid)
+			local ud = udID and UnitDefs[udID]
+			if ud and allTeamUnitDefNames[ud.name] then
+				Spring.DestroyUnit(uid, false, true)
+				removedByDef[ud.name] = (removedByDef[ud.name] or 0) + 1
+			end
+		end
+		local allFeatures = Spring.GetAllFeatures()
+		for _, fid in ipairs(allFeatures) do
+			local fdID = Spring.GetFeatureDefID(fid)
+			if fdID and featureDefsToRemove[fdID] then
+				Spring.DestroyFeature(fid)
+			end
+		end
+		for name, n in pairs(removedByDef) do
+			Spring.Echo(string.format("[fightersynctest] removed %d x %s", n, name))
+		end
+	end
+
+
+	local function startRun(words)
+		if words[2] then
+			local f = tonumber(words[2])
+			if f then totalFrames = math.max(60, math.floor(f)) end
+		end
+		if words[3] then
+			local af = tonumber(words[3])
+			if af and af > 0 and af <= 1 then areaFraction = af end
+		end
+		if words[4] then
+			local ox = tonumber(words[4])
+			if ox and ox >= 0 and ox <= 1 then areaOffsetX = ox end
+		end
+		if words[5] then
+			local oz = tonumber(words[5])
+			if oz and oz >= 0 and oz <= 1 then areaOffsetZ = oz end
+		end
+		if words[6] then
+			local m = tonumber(words[6])
+			if m and m > 0 and m <= 8 then unitMultiplier = m end
+		end
+		if areaOffsetX + areaFraction > 1 then areaOffsetX = 1 - areaFraction end
+		if areaOffsetZ + areaFraction > 1 then areaOffsetZ = 1 - areaFraction end
+
+		runStartFrame = Spring.GetGameFrame()
+		initrandom(RUN_SEED)
+		scanAnchors()
+		filterCategories()
+		computeFeatureDefsToRemove()
+		featurestoremove = {}
+
+		Spring.Echo(string.format(
+			"[fightersynctest] starting: totalframes=%d area=%.2f offset=%.2f,%.2f mult=%.2f categories=%d anchors land/water/deep/air=%d/%d/%d/%d",
+			totalFrames, areaFraction, areaOffsetX, areaOffsetZ, unitMultiplier, #enabledCats,
+			#anchorsByClass.land, #anchorsByClass.water, #anchorsByClass.deepwater, #anchorsByClass.air))
+		SendToUnsynced("fightersynctest_synchash_begin", totalFrames)
+		active = true
+	end
+
+	local function endRun()
+		active = false
+		Spring.Echo(string.format("[fightersynctest] ending after %d frames", Spring.GetGameFrame() - runStartFrame))
+		removeAllSpawnedUnits()
+		SendToUnsynced("fightersynctest_synchash_end")
+	end
+
+	local function toggleRun(words)
+		if active then endRun() else startRun(words) end
+	end
+
+	function gadget:Initialize()
+		checkStartPlayers()
+	end
+
+	function gadget:RecvLuaMsg(msg, playerID)
+		if string.sub(msg, 1, PACKET_HEADER_LENGTH) ~= PACKET_HEADER then
+			return
+		end
+		msg = string.sub(msg, PACKET_HEADER_LENGTH)
+		local words = {}
+		for word in msg:gmatch("[%-_%w%.]+") do
+			table.insert(words, word)
+		end
+		if words[1] ~= "fightersynctest" then return end
+		if not isAuthorized(playerID, "terrain") then return end
+		toggleRun(words)
+	end
+
+	function gadget:FeatureCreated(featureID, allyTeam)
+		if not active then return end
+		local fdID = Spring.GetFeatureDefID(featureID)
+		if fdID and featureDefsToRemove[fdID] then
+			featurestoremove[featureID] = Spring.GetGameFrame() + cleanupFeatureLife
+		end
+	end
+
+	function gadget:GameFrame(n)
+		if not active then return end
+
+		local runFrame = n - runStartFrame
+
+		if n % feedMod == 0 then
+			for _, cat in ipairs(enabledCats) do
+				spawnBurstForCategory(cat)
+			end
+		end
+
+		if n % cleanupMod == 1 then
+			for featureID, deathtime in pairs(featurestoremove) do
+				if deathtime < n then
+					if Spring.ValidFeatureID(featureID) then
+						Spring.DestroyFeature(featureID)
+					end
+					featurestoremove[featureID] = nil
+				end
+			end
+		end
+
+		if runFrame >= totalFrames then
+			endRun()
+		end
+	end
+
+
+else	-- UNSYNCED
+
+
+	local vsx, vsy = Spring.GetViewGeometry()
+	local uiScale = vsy / 1080
+
+	local synchashBuffer = {}
+	local synchashFirstFrame, synchashLastFrame
+
+	local hudActive = false
+	local hudTotalFrames = 0
+	local hudRunStartFrame = nil
+
+	local function onSynchashBegin(_, totalFrames)
+		synchashBuffer = {}
+		synchashFirstFrame, synchashLastFrame = nil, nil
+		hudActive = true
+		hudTotalFrames = tonumber(totalFrames) or 0
+		hudRunStartFrame = Spring.GetGameFrame()
+	end
+
+	function gadget:GameFrame(n)
+		if not hudActive then return end
+		if not Engine.hasSyncChecksums then return end
+		local checksum = tostring(Spring.GetPrevFrameSyncChecksum() or "")
+		synchashBuffer[#synchashBuffer + 1] = string.format("%d:%s", n, checksum)
+		if not synchashFirstFrame then synchashFirstFrame = n end
+		synchashLastFrame = n
+	end
+
+	local function onSynchashEnd()
+		hudActive = false
+		local count = #synchashBuffer
+		if count == 0 then
+			Spring.Echo("[fightersynctest] sync-hash: no frames collected (engine may lack Spring.GetPrevFrameSyncChecksum)")
+			return
+		end
+		local blob = table.concat(synchashBuffer, "\n")
+		local digest = VFS.CalculateHash(blob, 0)
+
+		local path = "fightersynctest_synchash.txt"
+		local content = digest .. "\n"
+			.. string.format("frames=%d first=%d last=%d\n",
+				count, synchashFirstFrame or -1, synchashLastFrame or -1)
+			.. blob .. "\n"
+
+		local f, err = io.open(path, "w")
+		if not f then
+			Spring.Echo("[fightersynctest] sync-hash: failed to open " .. tostring(path) .. ": " .. tostring(err))
+			return
+		end
+		f:write(content)
+		f:close()
+		Spring.Echo(string.format(
+			"[fightersynctest] sync-hash: wrote %s (md5=%s, %d frames %d..%d)",
+			path, digest, count, synchashFirstFrame or -1, synchashLastFrame or -1))
+		synchashBuffer = {}
+	end
+
+	local function fightersynctest(_, line, words, playerID, action)
+		if playerID ~= Spring.GetMyPlayerID() then return end
+		Spring.Echo("[fightersynctest]", line, playerID, action)
+		if not isAuthorized(playerID, "terrain") then return end
+		local msg = PACKET_HEADER .. ':fightersynctest'
+		for i = 1, 6 do
+			if words[i] then msg = msg .. " " .. tostring(words[i]) end
+		end
+		Spring.SendLuaRulesMsg(msg)
+	end
+
+	function gadget:ViewResize()
+		vsx, vsy = Spring.GetViewGeometry()
+		uiScale = vsy / 1080
+	end
+
+	function gadget:DrawScreen()
+		if not hudActive then return end
+		local gameFrame = Spring.GetGameFrame()
+		local runFrame = hudRunStartFrame and (gameFrame - hudRunStartFrame) or 0
+		gl.Color(1, 1, 1, 1)
+		gl.Text(string.format("Fightertest Synctest  frame %d / %d", runFrame, hudTotalFrames),
+			600 * uiScale, 600 * uiScale, 16 * uiScale)
+	end
+
+	function gadget:Initialize()
+		gadgetHandler:AddChatAction('fightersynctest', fightersynctest, "")
+		gadgetHandler:AddSyncAction('fightersynctest_synchash_begin', onSynchashBegin)
+		gadgetHandler:AddSyncAction('fightersynctest_synchash_end',   onSynchashEnd)
+	end
+
+	function gadget:Shutdown()
+		gadgetHandler:RemoveChatAction('fightersynctest')
+		gadgetHandler:RemoveSyncAction('fightersynctest_synchash_begin')
+		gadgetHandler:RemoveSyncAction('fightersynctest_synchash_end')
+	end
+
+end

--- a/luarules/gadgets/dbg_fightersynctest.lua
+++ b/luarules/gadgets/dbg_fightersynctest.lua
@@ -68,12 +68,12 @@ if gadgetHandler:IsSyncedCode() then
 	local areaFraction = 1.0
 	local areaOffsetX = 0.0
 	local areaOffsetZ = 0.0
-	local unitMultiplier = 2.0
+	local unitMultiplier = 1.0
 
 	local seededrand = {}
 	local randindex = 1
 
-	local anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
+	local anchorsByClass = { land = {}, water = {}, air = {} }
 
 	-- TODO: add `cons` (with mex-build onSpawn) and `transports` (with
 	-- load/unload onSpawn).
@@ -83,7 +83,7 @@ if gadgetHandler:IsSyncedCode() then
 		{ name = "fighters",   t1 = "corvamp",  t2 = "armhawk",  max = 280, step = 14, class = "air" },
 		{ name = "bombers",    t1 = "armpnix",  t2 = "corshad",  max = 140, step = 7,  class = "air" },
 		{ name = "hover",      t1 = "armanac",  t2 = "corsh",    max = 200, step = 14, class = "land" },
-		{ name = "subs",       t1 = "armsub",   t2 = "corsub",   max = 200, step = 14, class = "deepwater" },
+		{ name = "subs",       t1 = "armsub",   t2 = "corsub",   max = 200, step = 14, class = "water" },
 		{ name = "ships",      t1 = "armpt",    t2 = "corpt",    max = 200, step = 14, class = "water" },
 		{ name = "spiders",    t1 = "armspid",  t2 = "armflea",  max = 200, step = 14, class = "land" },
 		{ name = "commanders", t1 = "armcom",   t2 = "corcom",   max = 3,   step = 1,  class = "land",
@@ -102,7 +102,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	local initrandom, getrandom
 	local scanAnchors
-	local filterCategories
+	local initCategoriesForRun
 	local spawnBurstForCategory, spawnBurstForCategoryAtAnchor
 	local computeFeatureDefsToRemove, removeAllSpawnedUnits
 
@@ -110,6 +110,13 @@ if gadgetHandler:IsSyncedCode() then
 	-- Run lifecycle
 	--------------------------------------------------------------------
 
+	-- Supported positional arguments (all optional, parsed from the chat command):
+	--   words[2] totalFrames    how many frames to run        integer, >= 60      (default 2000)
+	--   words[3] areaFraction   fraction of the map used      number in (0, 1]    (default 1.0)
+	--   words[4] areaOffsetX    normalized x start of area    number in [0, 1]    (default 0.0)
+	--   words[5] areaOffsetZ    normalized z start of area    number in [0, 1]    (default 0.0)
+	--   words[6] unitMultiplier scales nuymber of units       number in (0, 8]    (default 1.0)
+	-- areaOffsetX/Z are clamped so offset + areaFraction <= 1.
 	local function startRun(words)
 		if words[2] then
 			local f = tonumber(words[2])
@@ -137,14 +144,14 @@ if gadgetHandler:IsSyncedCode() then
 		runStartFrame = Spring.GetGameFrame()
 		initrandom(RUN_SEED)
 		scanAnchors()
-		filterCategories()
+		initCategoriesForRun()
 		computeFeatureDefsToRemove()
 		featurestoremove = {}
 
 		Spring.Echo(string.format(
-			"[fightersynctest] starting: totalframes=%d area=%.2f offset=%.2f,%.2f mult=%.2f categories=%d anchors land/water/deep/air=%d/%d/%d/%d",
+			"[fightersynctest] starting: totalframes=%d area=%.2f offset=%.2f,%.2f mult=%.2f categories=%d anchors land/water/air=%d/%d/%d",
 			totalFrames, areaFraction, areaOffsetX, areaOffsetZ, unitMultiplier, #enabledCats,
-			#anchorsByClass.land, #anchorsByClass.water, #anchorsByClass.deepwater, #anchorsByClass.air))
+			#anchorsByClass.land, #anchorsByClass.water, #anchorsByClass.air))
 		SendToUnsynced("fightersynctest_synchash_begin", totalFrames, runStartFrame)
 		active = true
 	end
@@ -175,6 +182,8 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 
+		-- remove wreckage left behind by unit deaths after a delay
+		-- this keeps the map from getting too cluttered
 		if runFrame % cleanupMod == 1 then
 			for featureID, deathtime in pairs(featurestoremove) do
 				if deathtime < runFrame then
@@ -196,7 +205,7 @@ if gadgetHandler:IsSyncedCode() then
 	--------------------------------------------------------------------
 
 	function scanAnchors()
-		anchorsByClass = { land = {}, water = {}, deepwater = {}, air = {} }
+		anchorsByClass = { land = {}, water = {}, air = {} }
 		local stride = 256
 		local originX = mapSX * areaOffsetX
 		local originZ = mapSZ * areaOffsetZ
@@ -206,7 +215,7 @@ if gadgetHandler:IsSyncedCode() then
 		local regionH = areaZ / anchorRegions
 		for rz = 0, anchorRegions - 1 do
 			for rx = 0, anchorRegions - 1 do
-				local pickedLand, pickedWater, pickedDeep = false, false, false
+				local pickedLand, pickedWater = false, false
 				local z0 = originZ + rz * regionH + stride * 0.5
 				local x0 = originX + rx * regionW + stride * 0.5
 				for z = z0, originZ + (rz + 1) * regionH, stride do
@@ -216,17 +225,13 @@ if gadgetHandler:IsSyncedCode() then
 							anchorsByClass.land[#anchorsByClass.land + 1] = { x = x, z = z }
 							pickedLand = true
 						end
-						if not pickedWater and h < -16 then
+						if not pickedWater and h < -15 then
 							anchorsByClass.water[#anchorsByClass.water + 1] = { x = x, z = z }
 							pickedWater = true
 						end
-						if not pickedDeep and h < -48 then
-							anchorsByClass.deepwater[#anchorsByClass.deepwater + 1] = { x = x, z = z }
-							pickedDeep = true
-						end
-						if pickedLand and pickedWater and pickedDeep then break end
+						if pickedLand and pickedWater then break end
 					end
-					if pickedLand and pickedWater and pickedDeep then break end
+					if pickedLand and pickedWater then break end
 				end
 			end
 		end
@@ -265,6 +270,8 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 
+		-- Give some randomized orders to the new units, to mix up the execution paths and
+		-- make sure they actually do something instead of just sitting idle.
 		if #newUnitIDs > 0 then
 			Spring.GiveOrderToUnitArray(newUnitIDs, CMD.REPEAT, { 1 }, 0)
 			local classAnchors = anchorsByClass[cat.class]
@@ -285,15 +292,17 @@ if gadgetHandler:IsSyncedCode() then
 		if not anchors or #anchors == 0 then return end
 		cat.anchorCounter = cat.anchorCounter + 1
 		local anchor = anchors[((cat.anchorCounter - 1) % #anchors) + 1]
+		
+		-- make sure we spawn for both teams
 		spawnBurstForCategoryAtAnchor(cat, 0, cat.t1id, anchor)
 		spawnBurstForCategoryAtAnchor(cat, 1, cat.t2id, anchor)
 	end
 
 	--------------------------------------------------------------------
-	-- Unit categories
+	-- Unit category setup
 	--------------------------------------------------------------------
 
-	function filterCategories()
+	function initCategoriesForRun()
 		enabledCats = {}
 		allTeamUnitDefNames = {}
 		for _, cat in ipairs(categoryDefs) do
@@ -389,6 +398,11 @@ if gadgetHandler:IsSyncedCode() then
 		recordStartPlayers()
 	end
 
+	-- Entry point for the `/fightersynctest` chat command, relayed from unsynced
+	-- via Spring.SendLuaRulesMsg. Expected packet format:
+	--   "$fts$:fightersynctest [totalFrames] [areaFraction] [areaOffsetX] [areaOffsetZ] [unitMultiplier]"
+	-- See startRun() above for per-argument meaning, ranges, and defaults.
+	-- Toggles a run: starts if idle, ends if already active.
 	function gadget:RecvLuaMsg(msg, playerID)
 		if string.sub(msg, 1, PACKET_HEADER_LENGTH) ~= PACKET_HEADER then
 			return

--- a/luarules/gadgets/dbg_fightersynctest.lua
+++ b/luarules/gadgets/dbg_fightersynctest.lua
@@ -469,11 +469,13 @@ else	-- UNSYNCED
 	-- Sync-hash capture
 	--------------------------------------------------------------------
 
-	local synchashBuffer = {}
+	local frameBuffer = {}
+	local checksumBuffer = {}
 	local synchashFirstFrame, synchashLastFrame
 
 	local function onSynchashBegin(_, totalFrames, runStartFrame)
-		synchashBuffer = {}
+		frameBuffer = {}
+		checksumBuffer = {}
 		synchashFirstFrame, synchashLastFrame = nil, nil
 		hudActive = true
 		hudTotalFrames = tonumber(totalFrames) or 0
@@ -485,26 +487,38 @@ else	-- UNSYNCED
 		if not Engine.hasSyncChecksums then return end
 		local checksum = Spring.GetPrevFrameSyncChecksum()
 		local runFrame = n - hudRunStartFrame
-		synchashBuffer[#synchashBuffer + 1] = string.format("%d:%s", runFrame, checksum)
+		local i = #checksumBuffer + 1
+		frameBuffer[i] = runFrame
+		checksumBuffer[i] = checksum
 		if not synchashFirstFrame then synchashFirstFrame = runFrame end
 		synchashLastFrame = runFrame
 	end
 
 	local function onSynchashEnd()
 		hudActive = false
-		local count = #synchashBuffer
+		local count = #checksumBuffer
 		if count == 0 then
 			Spring.Echo("[fightersynctest] sync-hash: no frames collected (Engine.hasSyncChecksums is false — engine built without SYNCCHECK)")
 			return
 		end
-		local blob = table.concat(synchashBuffer, "\n")
-		local digest = VFS.CalculateHash(blob, 0)
 
-		local path = "fightersynctest_synchash.txt"
-		local content = digest .. "\n"
-			.. string.format("frames=%d first=%d last=%d\n",
-				count, synchashFirstFrame or -1, synchashLastFrame or -1)
-			.. blob .. "\n"
+		-- Digest is computed purely over the checksum values in frame order, so it
+		-- stays stable across any future change to the file format.
+		local digest = VFS.CalculateHash(table.concat(checksumBuffer, "\n"), 0)
+
+		local checksums = {}
+		for i = 1, count do
+			checksums[i] = { frame = frameBuffer[i], checksum = checksumBuffer[i] }
+		end
+
+		local path = "fightersynctest_synchash.json"
+		local content = Json.encode({
+			digest = digest,
+			frameCount = count,
+			firstFrame = synchashFirstFrame or -1,
+			lastFrame = synchashLastFrame or -1,
+			checksums = checksums,
+		})
 
 		local f, err = io.open(path, "w")
 		if not f then
@@ -516,7 +530,8 @@ else	-- UNSYNCED
 		Spring.Echo(string.format(
 			"[fightersynctest] sync-hash: wrote %s (md5=%s, %d frames %d..%d)",
 			path, digest, count, synchashFirstFrame or -1, synchashLastFrame or -1))
-		synchashBuffer = {}
+		frameBuffer = {}
+		checksumBuffer = {}
 	end
 
 	--------------------------------------------------------------------


### PR DESCRIPTION
## Work Done
Adds dbg_fightersynctest.lua covering bots, tanks, fighters, bombers, hover, subs, ships, spiders to exercise more engine code paths compared to the fightertest benchmarks.

New bevahiour: collect per-frame engine sync checksums during fightertest runs, fold them into a single MD5, and write the result to fightersynctest_synchash.txt in the Spring write directory. This gives engine CI a deterministic artifact to diff across platforms/builds for sync testing.
- Synced GameFrame reads Spring.GetPrevFrameSyncChecksum() (gated by Engine.hasSyncChecksums) and forwards each frame's checksum to unsynced via SendToUnsynced
- Unsynced collector folds all checksums via VFS.CalculateHash (MD5) on toggle-off

## Addresses Issue(s)
- https://github.com/beyond-all-reason/RecoilEngine/issues/2910

## Setup
* Requires engine with Spring.GetPrevFrameChecksum() and Engine.FeatureSupport.hasChecksums (RecoilEngine#2922). So needs to wait for merge on this engine PR.
                                                                                   
## Test steps                                            
- [x] Run a seeded fightersynctest with the patched engine. Confirm fightertest_synchash.txt appears in write dir with MD5 on line 1 and per-frame entries below.
- [x] Run twice on same build/platform — output files should be byte-identical.

## Screenshot
<img width="650" height="231" alt="image" src="https://github.com/user-attachments/assets/750e3039-6d1e-42f8-8bbd-30efac5681f2" />


## AI Disclosure
This PR was created with heavy help from claude code; so it is not wholly my own. I have tested and read every line!