### PR TITLE
Fix: attack commands not working. 

### DIFF
--- a/luarules/gadgets/unit_areaattack_limiter.lua
+++ b/luarules/gadgets/unit_areaattack_limiter.lua
@@ -8,7 +8,7 @@ function gadget:GetInfo()
 		date = "2026",
 		license = "GNU GPL, v2 or later",
 		layer = -999999,
-		enabled = true
+		enabled = false
 	}
 end
 


### PR DESCRIPTION
### Work done
Disable area attack limiter until it is functioning. 

#### Addresses Issue(s)
Gadget seems to just block all attack commands when you select more than 25 units. 

Does not replace attack commands with fight or anything that functions. Units just stop responding. 

#### Test steps
35 bombers attack + left click drag = no command issued
<img width="1499" height="1148" alt="image" src="https://github.com/user-attachments/assets/51ba55e3-e25c-46e6-ab95-2d64fad0d250" />

No fight, no 25 units keeping the command. 

14 bombers attack + left click grad = unit targeted commands issued
<img width="1332" height="1175" alt="image" src="https://github.com/user-attachments/assets/ae00b36d-41c1-4ef7-a0ac-8ee2741e547e" />

14 bombers area attack + left click drag = area attack issued
<img width="1393" height="1125" alt="image" src="https://github.com/user-attachments/assets/af905eca-458c-4a95-b161-2ed1e63c6720" />

I tried on master, stable skirmish and online private games same problem. 