### PR TITLE
fix: raptor unitdefs post missing a var

### DIFF
--- a/unitbasedefs/raptor_unitdefs_post.lua
+++ b/unitbasedefs/raptor_unitdefs_post.lua
@@ -1,4 +1,5 @@
 local function processRaptorUnitDef(uDef)
+	local customparams = uDef.customparams
 	local raptorHealth = uDef.health
 	uDef.activatewhenbuilt = true
 	uDef.metalcost = raptorHealth * 0.5


### PR DESCRIPTION
### Work done

Fixes an issue from the modoptions migration to data files.