### PR TITLE
feat(gadget): add metal resource check before energy conversion

### DIFF
--- a/luarules/gadgets/game_energy_conversion.lua
+++ b/luarules/gadgets/game_energy_conversion.lua
@@ -314,8 +314,12 @@ function gadget:GameFrame(n)
 				tID = teamList[tpos]
 
 				local eCur, eStor = spGetTeamResources(tID, 'energy')
+				local mCur, mStor = spGetTeamResources(tID, 'metal')
 				local mmLevel = spGetTeamRulesParam(tID, mmLevelParamName)
 				local convertAmount = eCur - eStor * mmLevel
+				if mCur >= mStor then
+					convertAmount = 0
+				end
 				local eConverted, mConverted, teamUsages = 0, 0, 0
 
 				local teamCaps = teamCapacities[tID]


### PR DESCRIPTION
### Work done
Made metal converters stop when they would waste the metal (allyteam is full).

### Screenshots:


https://github.com/user-attachments/assets/cd354db8-c8d3-4fd9-8b54-37a9d82f5345

