### PR TITLE
Remove category field from leglob.lua

### DIFF
--- a/units/Legion/Bots/leglob.lua
+++ b/units/Legion/Bots/leglob.lua
@@ -7,7 +7,6 @@ return {
 		buildpic = "LEGLOB.DDS",
 		buildtime = 1100,
 		canmove = true,
-		category = "BOT MOBILE WEAPON ALL NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
 		collisionvolumeoffsets = "0 -1 0",
 		collisionvolumescales = "20 18 20",
 		collisionvolumetype = "CylY",


### PR DESCRIPTION
### Work done
Removed 'category' field as it was catching on the no_ships filter. It also seemed to be unnecessary.

### Addresses Issue
https://discord.com/channels/549281623154229250/1495407479616573542

### Credit
Credit for finding the issue goes to nougatbyte