### PR TITLE
Decal placer: declarative RML/data-model refactor + extracted preview bake

### DIFF
--- a/luaui/RmlWidgets/gui_decal_placer/dp_preview_bake.lua
+++ b/luaui/RmlWidgets/gui_decal_placer/dp_preview_bake.lua
@@ -1,0 +1,343 @@
+--------------------------------------------------------------------------------
+-- Decal preview bake module
+--
+-- Channel-encoded source bitmaps (mainscars: red filler + green mask;
+-- tracks/footprints: red-on-dark) have no alpha and don't render usefully via
+-- a raw <img>. We pre-bake them through a one-shot fragment shader into RGBA
+-- PNGs in a writable cache dir, then the widget renders the cached PNG via
+-- plain <img data-attr-src="...">.
+--
+-- Spring restricts gl.RenderToTexture to draw callbacks, so the widget can't
+-- bake inline from syncDecals/Initialize. The flow is:
+--   1. widget calls M.enqueueAll(categories, fallbackResolver) once after
+--      first sync — module enumerates and queues every mask-encoded decal.
+--   2. widget calls M.drainQueue(N) every frame from widget:DrawScreen — the
+--      module bakes up to N decals per frame and writes their PNGs.
+--   3. widget calls M.consumeResync() in widget:Update — true means at least
+--      one bake completed since the last consume, and the queue is now
+--      empty, so the widget should re-run its sync to pick up new srcPaths.
+--   4. widget calls M.resolve(name, sourcePath, maskMode) per row in its
+--      sync — returns the "/vfs/path" once the decal is baked (or
+--      immediately for PNG/TGA sources that don't need baking), or nil.
+--
+-- STARTUP OVERHEAD (deliberate trade-off): we do NOT trust on-disk cache
+-- between sessions. Every widget startup re-bakes every mask-encoded decal.
+-- ~60 bakes × 4 per frame ≈ 0.25s of startup work, spread across DrawScreen
+-- ticks (no single-frame stutter). Tiles render blank for ~0.25s on first
+-- open, then populate as bakes complete.
+--
+-- Why no cache? While the shader is being iterated, trusting cached PNGs
+-- meant stale baked output survived shader edits — cost hours of debugging.
+-- When the shader stabilises, switch to versioned cache filenames keyed off
+-- a CACHE_VERSION constant; that's a 5-line change to invalidate cleanly
+-- on shader edits and keep instant reloads otherwise.
+--------------------------------------------------------------------------------
+
+local M = {}
+
+local PREVIEW_SIZE     = 64
+local BAKES_PER_FRAME  = 4
+
+local cacheDir         -- set by M.init(); caller is responsible for Spring.CreateDir
+local previewShader    ---@type any?
+local uniMaskMode
+
+-- { [decalName] = "/vfs/path" or false (resolution failed). nil = unknown }
+local previewResolveCache = {}
+
+-- Enumerated upfront once; drained from DrawScreen.
+local bakeQueue        = {}    -- array of { name, sourcePath, maskMode }
+local bakePending      = {}    -- { [name] = true } dedupe
+local resyncRequested  = false
+local bakesEnqueued    = false
+
+--------------------------------------------------------------------------------
+-- Shader (lazy-init on first bake)
+--------------------------------------------------------------------------------
+local function initPreviewShader()
+	if previewShader ~= nil then return previewShader and true or false end
+	previewShader = gl.CreateShader({
+		vertex = [[
+			#version 150 compatibility
+			void main() {
+				gl_TexCoord[0] = gl_MultiTexCoord0;
+				gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;
+			}
+		]],
+		-- OPAQUE composite (matches the original GL renderer that visibly
+		-- worked pre-refactor): mix a "ground" color with a "decal tint" by
+		-- the channel-derived mask. The cached PNG is fully opaque so it
+		-- always renders something visible regardless of how the underlying
+		-- tile bg is styled.
+		fragment = [[
+			#version 150 compatibility
+			uniform sampler2D tex0;
+			uniform int maskMode;
+			uniform vec3 groundColor;
+			uniform vec3 decalTint;
+			void main() {
+				vec4 c = texture2D(tex0, gl_TexCoord[0].st);
+				float mask;
+				if (maskMode == 1) {
+					// mainscar atlas: red is filler, green encodes shape
+					mask = clamp(c.g - c.r * 0.5, 0.0, 1.0);
+				} else if (maskMode == 2) {
+					// tracks / footprints: dark mark on red background
+					mask = clamp(1.0 - c.r, 0.0, 1.0);
+					mask = smoothstep(0.05, 0.6, mask);
+				} else {
+					// generic luminance fallback for unclassified BMPs
+					mask = dot(c.rgb, vec3(0.299, 0.587, 0.114));
+				}
+				vec3 scarred = mix(groundColor, decalTint, mask);
+				gl_FragColor = vec4(scarred, 1.0);
+			}
+		]],
+		uniformInt   = { tex0 = 0, maskMode = 1 },
+		-- groundColor matches .dp-thumb-footprints rgb(96, 72, 56) so the
+		-- baked previews blend visually with the category-tinted tile bg.
+		uniformFloat = { groundColor = { 96/255, 72/255, 56/255 }, decalTint = { 0.12, 0.08, 0.06 } },
+	})
+	if not previewShader or previewShader == 0 then
+		Spring.Echo("[DecalPlacer.bake] shader compile failed: " .. tostring(gl.GetShaderLog()))
+		previewShader = false
+		return false
+	end
+	uniMaskMode = gl.GetUniformLocation(previewShader, "maskMode")
+	return true
+end
+
+--------------------------------------------------------------------------------
+-- Path helpers
+--------------------------------------------------------------------------------
+local function bakedPreviewPath(decalName)
+	-- Sanitize for filesystem
+	local safe = decalName:gsub("[^%w_-]", "_")
+	return cacheDir .. safe .. ".png"
+end
+
+--------------------------------------------------------------------------------
+-- Bake one decal. Must be called inside a draw callback (gl.RenderToTexture
+-- restriction). Writes the cached PNG and returns true on success.
+--------------------------------------------------------------------------------
+local function bakeDecalPreview(decalName, sourceTexPath, maskMode)
+	if not initPreviewShader() then return false end
+
+	local cachePath = bakedPreviewPath(decalName)
+	local fboTex = gl.CreateTexture(PREVIEW_SIZE, PREVIEW_SIZE, {
+		border     = false,
+		min_filter = GL.LINEAR,
+		mag_filter = GL.LINEAR,
+		wrap_s     = GL.CLAMP_TO_EDGE,
+		wrap_t     = GL.CLAMP_TO_EDGE,
+		fbo        = true,
+	})
+	if not fboTex then return false end
+
+	local saved = false
+	gl.RenderToTexture(fboTex, function()
+		gl.Blending(false)
+		gl.DepthTest(false)
+		gl.Clear(GL.COLOR_BUFFER_BIT, 0, 0, 0, 0)
+
+		gl.MatrixMode(GL.PROJECTION)
+		gl.PushMatrix()
+		gl.LoadIdentity()
+		gl.MatrixMode(GL.MODELVIEW)
+		gl.PushMatrix()
+		gl.LoadIdentity()
+
+		if gl.Texture(0, sourceTexPath) then
+			gl.UseShader(previewShader)
+			if uniMaskMode then gl.Uniform(uniMaskMode, maskMode) end
+
+			gl.BeginEnd(GL.QUADS, function()
+				gl.TexCoord(0, 1); gl.Vertex(-1, -1, 0)
+				gl.TexCoord(1, 1); gl.Vertex( 1, -1, 0)
+				gl.TexCoord(1, 0); gl.Vertex( 1,  1, 0)
+				gl.TexCoord(0, 0); gl.Vertex(-1,  1, 0)
+			end)
+
+			gl.UseShader(0)
+			gl.Texture(0, false)
+
+			-- Save inside the FBO callback — proven-required pattern from
+			-- cmd_terraform_brush.lua heightmap export.
+			gl.SaveImage(0, 0, PREVIEW_SIZE, PREVIEW_SIZE, cachePath, { yflip = false })
+			saved = true
+		end
+
+		gl.MatrixMode(GL.PROJECTION)
+		gl.PopMatrix()
+		gl.MatrixMode(GL.MODELVIEW)
+		gl.PopMatrix()
+
+		gl.Blending(true)
+	end)
+
+	gl.DeleteTexture(fboTex)
+	return saved
+end
+
+--------------------------------------------------------------------------------
+-- Public API
+--------------------------------------------------------------------------------
+
+-- Set the cache directory (e.g. "Terraform Brush/DecalPreviews/"). Caller
+-- should Spring.CreateDir() it themselves before calling.
+function M.init(cachePathStr)
+	cacheDir = cachePathStr
+end
+
+-- TODO: filename-pattern heuristic. Works for the known decal set but isn't
+-- robust to new decals or non-conforming names. Two cleaner paths exist:
+--
+--   (A) Metadata path — WG.DecalPlacer (or the engine API it wraps) exposes
+--       the encoding/maskMode per entry. We pass it through to M.resolve
+--       and delete this function. Cheap; just needs a few lines added to
+--       cmd_decal_placer.lua and the engine query.
+--
+--   (B) Standardization path — re-author / convert the channel-encoded BMP
+--       atlases (mainscars, tracks, footprints) into RGBA PNG/TGA with
+--       proper alpha. Then EVERY decal becomes maskMode 0 (alpha-as-mask),
+--       no shader bake needed at all, this whole module collapses to ~30
+--       lines of pure path resolution. This is the "real" fix and how
+--       modern game asset pipelines do it; the legacy encodings are a
+--       holdover from older Spring engine days.
+--
+-- (B) is more work (asset-pipeline change, ~60 source files, possibly
+-- overriding via BAR.sdd VFS shadowing of engine-archive files), but it's
+-- the end state worth aiming for. Until then, this heuristic + the bake
+-- machinery is the engineering compromise.
+--
+-- Returns:
+--   -1  normal map — skip preview entirely
+--    0  PNG/TGA — has alpha already, use source as-is, no bake needed
+--    1  mainscar atlas BMP — green-channel-minus-red-filler mask
+--    2  tracks / footprints BMP — inverse-red mask
+--    3  generic BMP — luminance fallback
+function M.classifyMaskMode(sourcePath)
+	local lower = sourcePath:lower():gsub("\\", "/")
+	if lower:find("/normscar") or lower:find("_normal") or lower:find("/normals?/") then
+		return -1
+	end
+	local ext = lower:match("%.([^%.]+)$") or ""
+	if ext == "png" or ext == "tga" then
+		return 0
+	elseif lower:find("/mainscar") then
+		return 1
+	elseif lower:find("tracks") or lower:find("track") or lower:find("footprint") or lower:find("bigfoot") then
+		return 2
+	end
+	return 3
+end
+
+-- Returns the VFS path (with leading slash) to use as <img src>, or nil if
+-- no preview is available yet. For mask-encoded sources not yet baked,
+-- returns nil — the upfront enqueueAll + DrawScreen drain handles them; the
+-- widget will re-derive once the bake completes (signaled via consumeResync).
+function M.resolve(decalName, sourcePath, maskMode)
+	if previewResolveCache[decalName] ~= nil then
+		return previewResolveCache[decalName] or nil
+	end
+
+	if maskMode == -1 then
+		previewResolveCache[decalName] = false
+		return nil
+	end
+
+	if maskMode == 0 then
+		local result = "/" .. sourcePath
+		previewResolveCache[decalName] = result
+		return result
+	end
+
+	-- Mask-encoded BMP. Will be baked from DrawScreen.
+	return nil
+end
+
+-- One-shot enumeration: walk every category entry, queue every mask-encoded
+-- source. Idempotent (only enumerates once per session). Pass categories as
+-- returned by WG.DecalPlacer.getDecalCategories(), and a fallback resolver
+-- (typically findPreviewPath) for entries with empty filename.
+function M.enqueueAll(categories, getFallbackPath)
+	if bakesEnqueued or not categories then return 0 end
+
+	for _, items in pairs(categories) do
+		for _, entry in ipairs(items) do
+			local fname = entry.filename
+			if (not fname or fname == "") and getFallbackPath then
+				fname = getFallbackPath(entry.name)
+			end
+			if fname and fname ~= "" then
+				local sourcePath = fname:gsub("\\", "/"):gsub("^/+", "")
+				local maskMode = M.classifyMaskMode(sourcePath)
+				if maskMode > 0 and not bakePending[entry.name] then
+					bakePending[entry.name] = true
+					bakeQueue[#bakeQueue + 1] = {
+						name = entry.name,
+						sourcePath = sourcePath,
+						maskMode = maskMode,
+					}
+				end
+			end
+		end
+	end
+	bakesEnqueued = true
+
+	if #bakeQueue > 0 then
+		Spring.Echo(string.format("[Decal Placer] queued %d decal previews to bake", #bakeQueue))
+	end
+	return #bakeQueue
+end
+
+-- Drain up to BAKES_PER_FRAME bakes from the queue. MUST be called from a
+-- draw callback (Spring restricts gl.RenderToTexture). Sets the internal
+-- resync flag if any bakes succeeded; widget polls via consumeResync.
+function M.drainQueue()
+	if #bakeQueue == 0 then return end
+	local processed = 0
+	while #bakeQueue > 0 and processed < BAKES_PER_FRAME do
+		local item = table.remove(bakeQueue, 1)
+		bakePending[item.name] = nil
+		if bakeDecalPreview(item.name, item.sourcePath, item.maskMode) then
+			previewResolveCache[item.name] = "/" .. bakedPreviewPath(item.name)
+			resyncRequested = true
+		else
+			previewResolveCache[item.name] = false
+		end
+		processed = processed + 1
+	end
+end
+
+-- Number of bakes still pending. Useful if the widget wants to gate its
+-- re-sync on full drain (avoid syncing partway through bake batches).
+function M.queueLen()
+	return #bakeQueue
+end
+
+-- True once the queue is empty AND at least one bake completed since the
+-- last call. Atomic: clears the internal flag. Widget should re-run its
+-- sync when this returns true.
+function M.consumeResync()
+	if resyncRequested and #bakeQueue == 0 then
+		resyncRequested = false
+		return true
+	end
+	return false
+end
+
+function M.shutdown()
+	if previewShader and previewShader ~= false then
+		gl.DeleteShader(previewShader)
+	end
+	previewShader = nil
+	uniMaskMode = nil
+	previewResolveCache = {}
+	bakeQueue = {}
+	bakePending = {}
+	resyncRequested = false
+	bakesEnqueued = false
+end
+
+return M

--- a/luaui/RmlWidgets/gui_decal_placer/gui_decal_placer.lua
+++ b/luaui/RmlWidgets/gui_decal_placer/gui_decal_placer.lua
@@ -24,54 +24,161 @@ local GetViewGeometry = Spring.GetViewGeometry
 
 local INITIAL_LEFT_VW = 60
 local INITIAL_TOP_VH  = 10
-local BASE_WIDTH_DP   = 162
-local TILE_COLUMNS    = 3
-local TILE_GAP_DP     = 2
 
+----------------------------------------------------------------
+-- Type definitions (Lua LS only — strip at compile time, no runtime cost)
+----------------------------------------------------------------
+
+---One row in the dm_handle.currentDecals array. Drives one tile via
+---data-for="d, i : currentDecals" in the RML template.
+---@class DecalRow
+---@field name string         -- engine texture name
+---@field displayName string  -- name truncated to 22 chars for tile label
+---@field category string     -- one of CATEGORY_ORDER (scars, tracks, ...)
+---@field selected boolean    -- true iff in WG.DecalPlacer state.selectedSet
+---@field hasImg boolean      -- true iff srcPath resolves to a file
+---@field srcPath string      -- VFS path with leading slash, "" if no image
+
+---Shape of the data model bound to the RML document. Every field is mirrored
+---into RmlUi for declarative binding.
+---@class DecalPlacerModel
+---@field search string               -- data-value on #dp-search
+---@field activeCategory string       -- data-class-active on each fp-cat-btn
+---@field currentDecals DecalRow[]    -- data-for source for tile grid
+---@field selectedCount integer       -- {{selectedCount}} in tile header
+---@field onDecalClick fun(event: any, name: string)         -- data-event-click on tile (passes d.name)
+---@field onCategorySelect fun(event: any, key: string)       -- data-event-click on category button
+---@field onSearchFocus fun(event: any)                       -- data-event-focus on search input
+---@field onSearchBlur fun(event: any)                        -- data-event-blur on search input
+---@field onSearchChange fun(event: any)                      -- data-event-change on search input
+---@field onSearchClear fun(event: any)                       -- data-event-click on clear button
+-- Note: panel visibility is NOT a model field. Show/hide is controlled at the
+-- document level via document:Show() / document:Hide() so RmlUi drops the
+-- whole document from its active set when off — no layout/draw cost when
+-- closed. Class-toggle visibility (data-class-hidden) keeps the document live
+-- and is the wrong tool for "this panel is closed".
+
+---@class WidgetState
+---@field rmlContext any
+---@field document any
+---@field dm_handle DecalPlacerModel? -- nil until widget:Initialize() opens the data model
+---@field rootElement any
+
+---@type WidgetState
 local widgetState = {
-	rmlContext   = nil,
-	document     = nil,
-	dmHandle     = nil,
-	rootElement  = nil,
-	-- Logical (dp) width used for tile layout math. Actual rendered width
-	-- lives in RCSS (.dp-root) which applies dp_ratio + min-width floor.
-	panelWidthDp = BASE_WIDTH_DP,
+	rmlContext  = nil,
+	document    = nil,
+	dm_handle   = nil,
+	rootElement = nil,
 }
 
-local initialModel = {
-	-- Root panel visibility (data-class-hidden on #dp-root)
-	hidden = true,
-	-- Two-way-bound search filter (data-value on #dp-search)
-	search = "",
-}
-
+-- Hoisted above initialModel so model-resident handlers can capture them
+-- as upvalues. Reassignments work because Lua closures bind to the local
+-- slot, not the value at definition time.
+local syncDecals          -- forward decl, assigned further down
 local lastSearchFilter = ""
-local activeCategory   = "all"
-local categoryButtons  = {}
-local decalElements    = {}    -- { [name] = element }
-local thumbDivs        = {}    -- { [name] = thumb element }
-local manuallyHidden   = false
-local lastActive       = false
-local lastBuildInnerPx = 0  -- dp-list client_width at last rebuild, for resize detection
 
-local function getDpRatio()
-	return (WG.RmlContextManager and WG.RmlContextManager.getDpRatio
-		and WG.RmlContextManager.getDpRatio()) or 1.0
-end
+---@type DecalPlacerModel
+local initialModel = {
+	search = "",
+	activeCategory = "all",
+	currentDecals = {},
+	selectedCount = 0,
 
-local function getListInnerPx()
+	-- RmlUi convention: data-event-click passes the Event as the implicit
+	-- first arg; explicit args from the RML expression follow.
+	-- The RML passes d.name directly so we don't need a Lua-side index→row
+	-- lookup table — the master decal list lives in WG.DecalPlacer.
+	onDecalClick = function(_event, name)
+		if not WG.DecalPlacer or not name then return end
+		local _, _, _, shift = Spring.GetModKeyState()
+		if shift then
+			WG.DecalPlacer.toggleDecal(name)
+		else
+			WG.DecalPlacer.selectDecal(name)
+		end
+		-- Re-derive the visible array so each row's `selected` flag updates.
+		-- Cheap (~200 entries, runs only on click).
+		syncDecals()
+	end,
+
+	onCategorySelect = function(_event, key)
+		local dm = widgetState.dm_handle
+		if not dm or dm.activeCategory == key then return end
+		dm.activeCategory = key
+		-- syncDecals is defined below; forward declared via the closure since
+		-- this whole table is the model and `syncDecals` is in module scope.
+		syncDecals()
+	end,
+
+	onSearchFocus = function(_event)
+		Spring.SDLStartTextInput()
+	end,
+
+	onSearchBlur = function(_event)
+		Spring.SDLStopTextInput()
+	end,
+
+	-- data-value="search" updates dm.search AFTER the change event fires
+	-- (RmlUi quirk, see rmlui_data_value_race memory note). So we read the
+	-- input element's value directly rather than dm.search.
+	onSearchChange = function(_event)
+		local doc = widgetState.document
+		local el = doc and doc:GetElementById("dp-search")
+		local val = el and el:GetAttribute("value") or ""
+		if val == lastSearchFilter then return end
+		lastSearchFilter = val
+		syncDecals()
+	end,
+
+	onSearchClear = function(_event)
+		local dm = widgetState.dm_handle
+		if not dm then return end
+		dm.search = ""
+		lastSearchFilter = ""
+		syncDecals()
+	end,
+}
+
+-- Tracks document:Show/Hide state so we don't issue redundant calls every frame.
+-- See setVisible() below.
+local documentVisible  = false
+
+-- One-shot guard for the lazy first sync. WG.DecalPlacer may not be ready in
+-- widget:Initialize (engine resources still loading), so widget:Update retries
+-- until categories arrive. After that — never. State changes (category click,
+-- filter change) drive subsequent syncs explicitly; Update does NOT poll.
+local firstSyncDone = false
+
+local userDragged = false
+
+----------------------------------------------------------------
+-- Document-level visibility. document:Show()/Hide() takes the whole document
+-- in/out of the RmlUi context's active set — when hidden, NO layout/draw/event
+-- cost. This is the right primitive for "panel is closed" (vs CSS class
+-- toggling, which keeps the document live).
+----------------------------------------------------------------
+local function setVisible(visible)
+	if visible == documentVisible then return end
 	local doc = widgetState.document
-	local listEl = doc and doc:GetElementById("dp-list")
-	if listEl then
-		local cw = listEl.client_width or 0
-		if cw > 0 then return cw, listEl end
-	end
-	local dpRatio = getDpRatio()
-	local pwPx = (widgetState.rootElement and widgetState.rootElement.offset_width) or 0
-	if pwPx <= 0 then pwPx = widgetState.panelWidthDp * dpRatio end
-	return pwPx - (4 + 4 + 1 + 1) * dpRatio - 12, listEl
+	if not doc then return end
+	documentVisible = visible
+	if visible then doc:Show() else doc:Hide() end
 end
-local userDragged      = false
+
+-- Polls WG.DecalPlacer.state.active once per Update tick. The X button
+-- deactivates the tool directly (see widget:OnQuit), so there's no separate
+-- "manually closed" concept — tool active state is the single source of
+-- truth for whether the panel is shown.
+-- TODO: replace with an event-driven WG.DecalPlacer.onActiveChanged hook
+-- when the WG layer grows callbacks; until then we poll.
+-- Returns whether the tool is currently engaged so callers can early-bail.
+local function syncVisibilityFromTool()
+	local state = WG.DecalPlacer and WG.DecalPlacer.getState()
+	local toolActive = state and state.active or false
+	setVisible(toolActive)
+	return toolActive
+end
 
 local DP_SNAP_THRESHOLD = 30
 local dpDragState = {
@@ -81,67 +188,6 @@ local dpDragState = {
 	vsx = 0, vsy = 0,
 	lastX = -1, lastY = -1,
 }
-
--- Per-tile decal texture entries, populated as tiles are built.
--- Each entry: { div = thumbEl, texPath = "string path or engine texture name" }
-local thumbOverlays = {}
-
--- Preview compositing shader (lazy-init on first DrawScreenPost).
-local previewShader
-local uniMaskMode, uniGround, uniDecalTint
-local function initPreviewShader()
-	if previewShader ~= nil then return previewShader and true or false end
-	previewShader = gl.CreateShader({
-		vertex = [[
-			#version 150 compatibility
-			void main() {
-				gl_TexCoord[0] = gl_MultiTexCoord0;
-				gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;
-			}
-		]],
-		fragment = [[
-			#version 150 compatibility
-			uniform sampler2D tex0;
-			uniform int maskMode;     // 0=alpha, 1=green-red, 2=1-red, 3=luminance, -1=raw
-			uniform vec3 groundColor;
-			uniform vec3 decalTint;
-			void main() {
-				vec4 c = texture2D(tex0, gl_TexCoord[0].st);
-				if (maskMode < 0) {
-					gl_FragColor = vec4(c.rgb, 1.0);
-					return;
-				}
-				float mask;
-				if (maskMode == 0) {
-					mask = c.a;
-				} else if (maskMode == 1) {
-					// Atlas BMP scars: red is filler, green encodes shape
-					mask = clamp(c.g - c.r * 0.5, 0.0, 1.0);
-				} else if (maskMode == 2) {
-					// Red-filler BMPs (tracks/footprints): dark on red background
-					mask = clamp(1.0 - c.r, 0.0, 1.0);
-					mask = smoothstep(0.05, 0.6, mask);
-				} else {
-					// Generic luminance fallback
-					mask = dot(c.rgb, vec3(0.299, 0.587, 0.114));
-				}
-				vec3 scarred = mix(groundColor, decalTint, mask);
-				gl_FragColor = vec4(scarred, 1.0);
-			}
-		]],
-		uniformInt   = { tex0 = 0, maskMode = 3 },
-		uniformFloat = { groundColor = { 0.42, 0.32, 0.22 }, decalTint = { 0.12, 0.08, 0.06 } },
-	})
-	if not previewShader or previewShader == 0 then
-		Spring.Echo("[DecalPlacer.preview] shader compile failed: " .. tostring(gl.GetShaderLog()))
-		previewShader = false
-		return false
-	end
-	uniMaskMode  = gl.GetUniformLocation(previewShader, "maskMode")
-	uniGround    = gl.GetUniformLocation(previewShader, "groundColor")
-	uniDecalTint = gl.GetUniformLocation(previewShader, "decalTint")
-	return true
-end
 
 ----------------------------------------------------------------
 -- Decal preview texture lookup
@@ -181,6 +227,15 @@ local function findPreviewPath(decalName)
 end
 
 ----------------------------------------------------------------
+-- Mask-shader pre-bake module — channel-encoded BMP atlases (mainscars,
+-- tracks, footprints) have no alpha. Module composites them through a one-
+-- shot shader into RGBA PNGs cached on disk, then <img> renders the cached
+-- PNG normally. See dp_preview_bake.lua for the full API + design notes.
+----------------------------------------------------------------
+local Bake = VFS.Include("luaui/RmlWidgets/gui_decal_placer/dp_preview_bake.lua")
+local PREVIEW_CACHE_DIR = "Terraform Brush/DecalPreviews/"
+
+----------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------
 local function buildRootStyle()
@@ -189,285 +244,71 @@ local function buildRootStyle()
 		INITIAL_LEFT_VW, INITIAL_TOP_VH)
 end
 
-local function setLabel(id, text)
-	local el = widgetState.document and widgetState.document:GetElementById(id)
-	if el then el.inner_rml = text end
-end
-
-local function setSliderValue(id, val)
-	local el = widgetState.document and widgetState.document:GetElementById(id)
-	if el then el:SetAttribute("value", tostring(val)) end
-end
-
-local function getModeButtons()
-	local doc = widgetState.document
-	if not doc then return nil end
-	return {
-		scatter = doc:GetElementById("btn-dp-mode-scatter"),
-		point   = doc:GetElementById("btn-dp-mode-point"),
-		remove  = doc:GetElementById("btn-dp-mode-remove"),
-	}
-end
-
-local function getShapeButtons()
-	local doc = widgetState.document
-	if not doc then return nil end
-	return {
-		circle   = doc:GetElementById("btn-dp-shape-circle"),
-		square   = doc:GetElementById("btn-dp-shape-square"),
-		hexagon  = doc:GetElementById("btn-dp-shape-hexagon"),
-		octagon  = doc:GetElementById("btn-dp-shape-octagon"),
-		triangle = doc:GetElementById("btn-dp-shape-triangle"),
-	}
-end
-
-local function refreshUIFromState()
-	if not WG.DecalPlacer then return end
-	local state = WG.DecalPlacer.getState()
-	if not state then return end
-
-	local mb = getModeButtons()
-	if mb then
-		for k, el in pairs(mb) do el:SetClass("active", state.mode == k) end
-	end
-	local sb = getShapeButtons()
-	if sb then
-		for k, el in pairs(sb) do el:SetClass("active", state.shape == k) end
-	end
-
-	setLabel("dp-radius-label",   tostring(state.radius))
-	setLabel("dp-rotation-label", tostring(math.floor(state.rotation)) .. "°")
-	setLabel("dp-rotrand-label",  tostring(state.rotRandom))
-	setLabel("dp-count-label",    tostring(state.decalCount))
-	setLabel("dp-cadence-label",  tostring(state.cadence))
-	setLabel("dp-sizemin-label",  tostring(state.sizeMin))
-	setLabel("dp-sizemax-label",  tostring(state.sizeMax))
-	setLabel("dp-alpha-label",    tostring(math.floor(state.alpha * 100)))
-	setLabel("dp-tint-r-label",   string.format("%.2f", state.tintR))
-	setLabel("dp-tint-g-label",   string.format("%.2f", state.tintG))
-	setLabel("dp-tint-b-label",   string.format("%.2f", state.tintB))
-
-	setSliderValue("dp-slider-radius",   state.radius)
-	setSliderValue("dp-slider-rotation", math.floor(state.rotation))
-	setSliderValue("dp-slider-rotrand",  state.rotRandom)
-	setSliderValue("dp-slider-count",    state.decalCount)
-	setSliderValue("dp-slider-cadence",  state.cadence)
-	setSliderValue("dp-slider-sizemin",  state.sizeMin)
-	setSliderValue("dp-slider-sizemax",  state.sizeMax)
-	setSliderValue("dp-slider-alpha",    math.floor(state.alpha * 100))
-	setSliderValue("dp-slider-tint-r",   math.floor(state.tintR * 100))
-	setSliderValue("dp-slider-tint-g",   math.floor(state.tintG * 100))
-	setSliderValue("dp-slider-tint-b",   math.floor(state.tintB * 100))
-
-	local doc = widgetState.document
-	if doc then
-		local cnt = doc:GetElementById("dp-selected-count")
-		if cnt then cnt.inner_rml = tostring(#state.selectedDecals) end
-		local alignBtn = doc:GetElementById("btn-dp-align-toggle")
-		if alignBtn then
-			alignBtn:SetAttribute("src", state.alignToNormal
-				and "/luaui/images/terraform_brush/check_on.png"
-				or  "/luaui/images/terraform_brush/check_off.png")
-		end
-		local smartBtn = doc:GetElementById("btn-dp-smart-toggle")
-		if smartBtn then
-			smartBtn:SetAttribute("src", state.smartEnabled
-				and "/luaui/images/terraform_brush/check_on.png"
-				or  "/luaui/images/terraform_brush/check_off.png")
-		end
-		local smartOpts = doc:GetElementById("dp-smart-options")
-		if smartOpts then smartOpts:SetClass("hidden", not state.smartEnabled) end
-		local waterBtn = doc:GetElementById("btn-dp-smart-water")
-		if waterBtn then
-			waterBtn:SetAttribute("src", state.smartFilters.avoidWater
-				and "/luaui/images/terraform_brush/check_on.png"
-				or  "/luaui/images/terraform_brush/check_off.png")
-		end
-		local cliffsBtn = doc:GetElementById("btn-dp-smart-cliffs")
-		if cliffsBtn then
-			cliffsBtn:SetAttribute("src", state.smartFilters.avoidCliffs
-				and "/luaui/images/terraform_brush/check_on.png"
-				or  "/luaui/images/terraform_brush/check_off.png")
-		end
-	end
-end
-
 ----------------------------------------------------------------
--- Build decal list (tile grid)
+-- Derive the visible decal rows from WG state + active filter/category and
+-- sync them into the data model (which drives the tile grid via data-for).
+-- Idempotent — same call shape for initial population and for refresh after
+-- filter/category change.
+-- (Forward-declared above so initialModel handlers can capture it.)
 ----------------------------------------------------------------
-local function rebuildDecalList(filter)
-	local doc = widgetState.document
-	local listEl = doc and doc:GetElementById("dp-list")
-	if not listEl or not WG.DecalPlacer then return end
-
-	listEl.inner_rml = ""
-	decalElements = {}
-	thumbDivs = {}
-	thumbOverlays = {}
-	_dp_debug_logged = false
-
+syncDecals = function()
+	local dm = widgetState.dm_handle
+	if not WG.DecalPlacer or not dm then return end
 	local categories = WG.DecalPlacer.getDecalCategories()
 	local order = WG.DecalPlacer.getCategoryOrder()
 	if not categories or not order then return end
 
 	local state = WG.DecalPlacer.getState()
 	local selectedSet = state and state.selectedSet or {}
-	local lowerFilter = filter and filter:lower() or ""
-	local cat = activeCategory
+	local lowerFilter = (lastSearchFilter or ""):lower()
+	local cat = dm.activeCategory or "all"
 
-	local toShow = {}
-	if cat == "all" then
-		for _, catName in ipairs(order) do
-			local items = categories[catName]
-			if items then
-				for _, entry in ipairs(items) do toShow[#toShow + 1] = entry end
-			end
-		end
-	else
-		local items = categories[cat]
+	local catOrder = (cat == "all") and order or { cat }
+	local newArray = {}
+	for _, catName in ipairs(catOrder) do
+		local items = categories[catName]
 		if items then
-			for _, entry in ipairs(items) do toShow[#toShow + 1] = entry end
+			for _, entry in ipairs(items) do
+				local name = entry.name
+				if lowerFilter == "" or name:lower():find(lowerFilter, 1, true) then
+					local displayName = (#name > 22) and (name:sub(1, 20) .. "..") or name
+					-- Resolve a VFS path for <img>. Spring may not return a filename
+					-- for atlas-packed textures, so fall back to scanning bitmaps/
+					-- by basename. Bake.resolve handles the bake step for mask-
+					-- encoded BMPs (mainscars / tracks / footprints) so the <img>
+					-- always gets a real RGBA file with proper alpha.
+					local fname = entry.filename
+					if not fname or fname == "" then
+						fname = findPreviewPath(name)
+					end
+					local srcPath = ""
+					local hasImg = false
+					if fname and fname ~= "" then
+						local sourcePath = fname:gsub("\\", "/"):gsub("^/+", "")
+						local resolved = Bake.resolve(name, sourcePath, Bake.classifyMaskMode(sourcePath))
+						if resolved then
+							srcPath = resolved
+							hasImg = true
+						end
+					end
+					newArray[#newArray + 1] = {
+						name = name,
+						displayName = displayName,
+						category = entry.category or "other",
+						selected = selectedSet[name] or false,
+						hasImg = hasImg,
+						srcPath = srcPath,
+					}
+				end
+			end
 		end
 	end
 
-	-- ALWAYS 3 columns. Real dp-list client_width with safety margin so
-	-- flex-wrap never promotes/demotes us due to sub-pixel rounding or a
-	-- scrollbar popping in after rebuild.
-	local dpRatio = getDpRatio()
-	local rawInnerPx = getListInnerPx()
-	-- RmlUI client_width includes padding. fp-feature-list has 4dp padding
-	-- each side (8dp total) — subtract so tile math uses the real content box.
-	-- Always reserve scrollbar (8dp from RCSS) even when not visible yet.
-	local innerPx = rawInnerPx - 8 * dpRatio - 8 * dpRatio
-	local gapPx = TILE_GAP_DP * dpRatio
-	local tileBorderPx = 4 * dpRatio
-	local safetyPx = 6 * dpRatio
-	local tileW = math.floor((innerPx - (TILE_COLUMNS - 1) * gapPx - TILE_COLUMNS * tileBorderPx - safetyPx) / TILE_COLUMNS)
-	if tileW < 24 then tileW = 24 end
-	-- Store the RAW getListInnerPx() value for resize comparison in Update();
-	-- Update() samples getListInnerPx() unadjusted, so storing the adjusted
-	-- innerPx here caused a constant 16dp mismatch → rebuild every frame →
-	-- new click listeners overwriting old ones → decal library tiles
-	-- impossible to click.
-	lastBuildInnerPx = rawInnerPx
-
-	for _, entry in ipairs(toShow) do
-		local name = entry.name
-		if lowerFilter == "" or name:lower():find(lowerFilter, 1, true) then
-			local itemEl = doc:CreateElement("div")
-			itemEl:SetClass("fp-feature-item", true)
-			itemEl:SetAttribute("style", string.format("width: %dpx; height: %dpx;", tileW, tileW))
-			if selectedSet[name] then itemEl:SetClass("selected", true) end
-
-			local thumbEl = doc:CreateElement("div")
-			thumbEl:SetClass("fp-feature-thumb", true)
-			thumbEl:SetClass("dp-thumb-" .. (entry.category or "other"), true)
-			-- Register the tile for GL overlay rendering. We bind the decal's
-			-- real texture and draw it via DrawScreen with alpha blending so the
-			-- shape shows through against the category-tinted backing.
-			local texPath = entry.filename
-			if not texPath or texPath == "" then
-				texPath = findPreviewPath(name)
-			end
-			if texPath and texPath ~= "" then
-				local tp = texPath:gsub("\\", "/")
-				-- gl.Texture wants a VFS path without leading slash
-				if tp:sub(1, 1) == "/" then tp = tp:sub(2) end
-				-- Choose mask channel heuristically from filename so the preview
-				-- can composite the decal shape onto a ground-like background.
-				-- 0 = alpha, 1 = green-minus-red, 2 = 1-red (red-filler), 3 = luminance
-				-- negative = skip compositing (render raw, used for normal maps).
-				local lower = tp:lower()
-				local ext = lower:match("%.([^%.]+)$") or ""
-				local maskMode = 3
-				local isNormal = lower:find("/normscar")
-					or lower:find("_normal")
-					or lower:find("/normals?/")
-				if isNormal then
-					maskMode = -1
-				elseif ext == "png" or ext == "tga" then
-					maskMode = 0
-				elseif lower:find("/mainscar") then
-					maskMode = 1
-				elseif lower:find("tracks") or lower:find("track") or lower:find("footprint") or lower:find("bigfoot") then
-					maskMode = 2
-				end
-				thumbOverlays[name] = {
-					div = thumbEl,
-					texPath = tp,
-					maskMode = maskMode,
-				}
-			end
-			itemEl:AppendChild(thumbEl)
-			thumbDivs[name] = thumbEl
-
-			local nameEl = doc:CreateElement("div")
-			nameEl:SetClass("fp-feature-name", true)
-			-- Trim long names for display
-			local displayName = #name > 22 and (name:sub(1, 20) .. "..") or name
-			nameEl.inner_rml = displayName
-			nameEl:SetAttribute("title", name)
-			itemEl:AppendChild(nameEl)
-
-			itemEl:AddEventListener("click", function(event)
-				if not WG.DecalPlacer then return end
-				local _, _, _, shift = Spring.GetModKeyState()
-				if shift then
-					WG.DecalPlacer.toggleDecal(name)
-				else
-					WG.DecalPlacer.selectDecal(name)
-				end
-				local st = WG.DecalPlacer.getState()
-				local ss = st and st.selectedSet or {}
-				for n, el in pairs(decalElements) do
-					el:SetClass("selected", ss[n] or false)
-				end
-				local cnt = doc:GetElementById("dp-selected-count")
-				if cnt then cnt.inner_rml = tostring(#st.selectedDecals) end
-				event:StopPropagation()
-			end, false)
-
-			decalElements[name] = itemEl
-			listEl:AppendChild(itemEl)
-		end
-	end
-end
-
-----------------------------------------------------------------
--- Slider helper: parse range value, call setter, refresh UI
-----------------------------------------------------------------
-local function bindSlider(sliderId, numboxId, setter, transform)
-	local doc = widgetState.document
-	local slider  = doc and doc:GetElementById(sliderId)
-	local numbox  = doc and doc:GetElementById(numboxId)
-	if not slider then return end
-	local function applyFromValue(s)
-		local v = tonumber(s)
-		if not v then return end
-		if transform then v = transform(v) end
-		setter(v)
-		refreshUIFromState()
-	end
-	slider:AddEventListener("change", function()
-		applyFromValue(slider:GetAttribute("value"))
-	end, false)
-	if numbox then
-		numbox:AddEventListener("focus", function() Spring.SDLStartTextInput() end, false)
-		numbox:AddEventListener("blur",  function() Spring.SDLStopTextInput() end, false)
-		numbox:AddEventListener("change", function()
-			applyFromValue(numbox:GetAttribute("value"))
-		end, false)
-	end
-end
-
-local function bindButton(id, fn)
-	local doc = widgetState.document
-	local el = doc and doc:GetElementById(id)
-	if el then
-		el:AddEventListener("click", function(event)
-			fn()
-			event:StopPropagation()
-		end, false)
+	dm.currentDecals = newArray
+	dm.selectedCount = #(state and state.selectedDecals or {})
+	if not firstSyncDone then
+		firstSyncDone = true
+		Bake.enqueueAll(WG.DecalPlacer.getDecalCategories(), findPreviewPath)
 	end
 end
 
@@ -475,244 +316,107 @@ end
 -- Declarative event handlers (called from RML via onclick="widget:Foo()")
 ----------------------------------------------------------------
 function widget:OnQuit()
-	manuallyHidden = true
-	if widgetState.dmHandle then
-		widgetState.dmHandle.hidden = true
-	end
-end
-
-function widget:OnSearchFocus()
-	Spring.SDLStartTextInput()
-end
-
-function widget:OnSearchBlur()
-	Spring.SDLStopTextInput()
-end
-
-function widget:OnSearchClear()
-	if widgetState.dmHandle then
-		widgetState.dmHandle.search = ""
-	end
-	lastSearchFilter = ""
-	rebuildDecalList("")
+	-- Closing the panel disengages the tool — this is the panel's whole UI,
+	-- so closing it without deactivating leaves the main terraform brush
+	-- still highlighting DECALS as active. Deactivating cascades through
+	-- WG.DecalPlacer.getState().active → syncVisibilityFromTool hides the
+	-- document on the next Update tick.
+	if WG.DecalPlacer then WG.DecalPlacer.deactivate() end
 end
 
 function widget:OnClearSelection()
-	if WG.DecalPlacer then
-		WG.DecalPlacer.clearSelectedDecals()
-		for _, el in pairs(decalElements) do el:SetClass("selected", false) end
-		refreshUIFromState()
-	end
+	if not WG.DecalPlacer then return end
+	WG.DecalPlacer.clearSelectedDecals()
+	syncDecals()
 end
 
+
 ----------------------------------------------------------------
--- Wire all controls
+-- Drag handle wiring (the only imperative event listener left — everything
+-- else lives declaratively in the RML).
 ----------------------------------------------------------------
-local function attachEventListeners()
+local function wireDragHandle()
 	local doc = widgetState.document
-	if not doc then return end
-
-	-- Categories
-	local catKeys = { "all", "scars", "explosions", "tracks", "builds", "footprints", "scorch", "groundplates", "other" }
-	for _, key in ipairs(catKeys) do
-		local btn = doc:GetElementById("btn-dp-cat-" .. key)
-		if btn then
-			categoryButtons[key] = btn
-			btn:AddEventListener("click", function(event)
-				activeCategory = key
-				for k, el in pairs(categoryButtons) do
-					el:SetClass("active", k == key)
-				end
-				rebuildDecalList(lastSearchFilter)
-				event:StopPropagation()
-			end, false)
-		end
-	end
-
-	-- Quit
-	-- Quit button click lives in RML (onclick="widget:OnQuit()").
-
-	-- Mode buttons
-	local mb = getModeButtons()
-	if mb then
-		for key, btn in pairs(mb) do
-			btn:AddEventListener("click", function(event)
-				if WG.DecalPlacer then WG.DecalPlacer.setMode(key) end
-				refreshUIFromState()
-				event:StopPropagation()
-			end, false)
-		end
-	end
-
-	-- Shape buttons
-	local sb = getShapeButtons()
-	if sb then
-		for key, btn in pairs(sb) do
-			btn:AddEventListener("click", function(event)
-				if WG.DecalPlacer then WG.DecalPlacer.setShape(key) end
-				refreshUIFromState()
-				event:StopPropagation()
-			end, false)
-		end
-	end
-
-	-- Search focus/blur/clear + clear selection + search input value all live
-	-- declaratively in the RML (data-value="search", onclick, onfocus, onblur).
-	-- Only the filter-change → rebuild sync is done from widget:Update().
-
-	-- Sliders
-	local DP = WG.DecalPlacer
-	if DP then
-		bindSlider("dp-slider-radius",   "dp-slider-radius-numbox",   DP.setRadius)
-		bindSlider("dp-slider-rotation", "dp-slider-rotation-numbox", DP.setRotation)
-		bindSlider("dp-slider-rotrand",  "dp-slider-rotrand-numbox",  DP.setRotRandom)
-		bindSlider("dp-slider-count",    "dp-slider-count-numbox",    DP.setDecalCount)
-		bindSlider("dp-slider-cadence",  "dp-slider-cadence-numbox",  DP.setCadence)
-		bindSlider("dp-slider-sizemin",  "dp-slider-sizemin-numbox",  DP.setSizeMin)
-		bindSlider("dp-slider-sizemax",  "dp-slider-sizemax-numbox",  DP.setSizeMax)
-		bindSlider("dp-slider-alpha",    "dp-slider-alpha-numbox",    DP.setAlpha, function(v) return v / 100 end)
-
-		-- Tint sliders share helper but call setTint
-		local function tintFromUI()
-			local s = DP.getState()
-			if not s then return 0.5, 0.5, 0.5 end
-			local r = doc:GetElementById("dp-slider-tint-r")
-			local g = doc:GetElementById("dp-slider-tint-g")
-			local b = doc:GetElementById("dp-slider-tint-b")
-			local rv = (tonumber(r and r:GetAttribute("value")) or 50) / 100
-			local gv = (tonumber(g and g:GetAttribute("value")) or 50) / 100
-			local bv = (tonumber(b and b:GetAttribute("value")) or 50) / 100
-			return rv, gv, bv
-		end
-		local function applyTint()
-			local r, g, b = tintFromUI()
-			DP.setTint(r, g, b, 0.5)
-			refreshUIFromState()
-		end
-		for _, sid in ipairs({"dp-slider-tint-r","dp-slider-tint-g","dp-slider-tint-b"}) do
-			local el = doc:GetElementById(sid)
-			if el then el:AddEventListener("change", applyTint, false) end
-		end
-	end
-
-	-- +/- buttons for radius/rotation/rotrand/count/cadence/sizemin/sizemax/alpha
-	local function bindStep(btnId, getCur, setter, step)
-		bindButton(btnId, function() setter(getCur() + step); refreshUIFromState() end)
-	end
-	if DP then
-		bindStep("btn-dp-radius-down",   function() return DP.getState().radius end,     DP.setRadius,    -8)
-		bindStep("btn-dp-radius-up",     function() return DP.getState().radius end,     DP.setRadius,     8)
-		bindStep("btn-dp-rot-ccw",       function() return DP.getState().rotation end,   DP.setRotation,  -5)
-		bindStep("btn-dp-rot-cw",        function() return DP.getState().rotation end,   DP.setRotation,   5)
-		bindStep("btn-dp-rotrand-down",  function() return DP.getState().rotRandom end,  DP.setRotRandom, -5)
-		bindStep("btn-dp-rotrand-up",    function() return DP.getState().rotRandom end,  DP.setRotRandom,  5)
-		bindStep("btn-dp-count-down",    function() return DP.getState().decalCount end, DP.setDecalCount,-1)
-		bindStep("btn-dp-count-up",      function() return DP.getState().decalCount end, DP.setDecalCount, 1)
-		bindStep("btn-dp-cadence-down",  function() return DP.getState().cadence end,    DP.setCadence,   -5)
-		bindStep("btn-dp-cadence-up",    function() return DP.getState().cadence end,    DP.setCadence,    5)
-		bindStep("btn-dp-sizemin-down",  function() return DP.getState().sizeMin end,    DP.setSizeMin,   -4)
-		bindStep("btn-dp-sizemin-up",    function() return DP.getState().sizeMin end,    DP.setSizeMin,    4)
-		bindStep("btn-dp-sizemax-down",  function() return DP.getState().sizeMax end,    DP.setSizeMax,   -4)
-		bindStep("btn-dp-sizemax-up",    function() return DP.getState().sizeMax end,    DP.setSizeMax,    4)
-		bindStep("btn-dp-alpha-down",    function() return math.floor(DP.getState().alpha*100) end, function(v) DP.setAlpha(v/100) end, -5)
-		bindStep("btn-dp-alpha-up",      function() return math.floor(DP.getState().alpha*100) end, function(v) DP.setAlpha(v/100) end,  5)
-	end
-
-	-- Toggles
-	bindButton("btn-dp-align-toggle", function()
-		local s = WG.DecalPlacer and WG.DecalPlacer.getState()
-		if s then WG.DecalPlacer.setAlignToNormal(not s.alignToNormal); refreshUIFromState() end
-	end)
-	bindButton("btn-dp-smart-toggle", function()
-		local s = WG.DecalPlacer and WG.DecalPlacer.getState()
-		if s then WG.DecalPlacer.setSmartEnabled(not s.smartEnabled); refreshUIFromState() end
-	end)
-	bindButton("btn-dp-smart-water", function()
-		local s = WG.DecalPlacer and WG.DecalPlacer.getState()
-		if s then WG.DecalPlacer.setSmartFilter("avoidWater", not s.smartFilters.avoidWater); refreshUIFromState() end
-	end)
-	bindButton("btn-dp-smart-cliffs", function()
-		local s = WG.DecalPlacer and WG.DecalPlacer.getState()
-		if s then WG.DecalPlacer.setSmartFilter("avoidCliffs", not s.smartFilters.avoidCliffs); refreshUIFromState() end
-	end)
-
-	-- Action buttons
-	bindButton("btn-dp-undo",     function() if WG.DecalPlacer then WG.DecalPlacer.undo()     end end)
-	bindButton("btn-dp-clearall", function() if WG.DecalPlacer then WG.DecalPlacer.clearAll() end end)
-	bindButton("btn-dp-save",     function() if WG.DecalPlacer then WG.DecalPlacer.save()     end end)
-	bindButton("btn-dp-load",     function()
-		if not WG.DecalPlacer then return end
-		local saves = WG.DecalPlacer.listSaves()
-		if not saves or #saves == 0 then Spring.Echo("[Decal Placer] No saved files"); return end
-		WG.DecalPlacer.load(saves[#saves])  -- load most recent
-		Spring.Echo("[Decal Placer] Loaded " .. saves[#saves])
-	end)
-
-	-- Initial population
-	rebuildDecalList("")
-	refreshUIFromState()
-
-	-- Drag handle
+	local rootEl = widgetState.rootElement
+	if not doc or not rootEl then return end
 	local handleEl = doc:GetElementById("dp-handle")
-	if handleEl and widgetState.rootElement then
-		local rootEl = widgetState.rootElement
-		local ds = dpDragState
-		handleEl:AddEventListener("mousedown", function(event)
-			local p = event.parameters
-			if not p or (p.button and p.button ~= 0) then return end
-			local mx, my = Spring.GetMouseState()
-			local vsx, vsy = GetViewGeometry()
-			ds.active = true
-			userDragged = true
-			ds.rootEl = rootEl
-			ds.offsetX = mx - rootEl.offset_left
-			ds.offsetY = (vsx > 0 and vsy > 0) and ((vsy - my) - rootEl.offset_top) or 0
-			ds.ew = rootEl.offset_width
-			ds.eh = rootEl.offset_height
-			ds.vsx = vsx
-			ds.vsy = vsy
-			ds.lastX = -1
-			ds.lastY = -1
-			event:StopPropagation()
-		end, false)
-		doc:AddEventListener("mouseup", function()
-			if ds.active then ds.active = false; ds.rootEl = nil end
-		end, false)
-	end
+	if not handleEl then return end
+
+	local ds = dpDragState
+	handleEl:AddEventListener("mousedown", function(event)
+		local p = event.parameters
+		if not p or (p.button and p.button ~= 0) then return end
+		local mx, my = Spring.GetMouseState()
+		local vsx, vsy = GetViewGeometry()
+		ds.active = true
+		userDragged = true
+		ds.rootEl = rootEl
+		ds.offsetX = mx - rootEl.offset_left
+		ds.offsetY = (vsx > 0 and vsy > 0) and ((vsy - my) - rootEl.offset_top) or 0
+		ds.ew = rootEl.offset_width
+		ds.eh = rootEl.offset_height
+		ds.vsx = vsx
+		ds.vsy = vsy
+		ds.lastX = -1
+		ds.lastY = -1
+		event:StopPropagation()
+	end, false)
+	doc:AddEventListener("mouseup", function()
+		if ds.active then ds.active = false; ds.rootEl = nil end
+	end, false)
 end
 
 ----------------------------------------------------------------
 -- Lifecycle
 ----------------------------------------------------------------
 function widget:Initialize()
+	Spring.Echo("[Decal Placer UI] Initializing")
+	Spring.CreateDir(PREVIEW_CACHE_DIR)
+	Bake.init(PREVIEW_CACHE_DIR)
 	widgetState.rmlContext = RmlUi.GetContext("shared")
 	if not widgetState.rmlContext then return false end
+	Spring.Echo("[Decal Placer UI] RmlContext obtained")
 
-	local dm = widgetState.rmlContext:OpenDataModel(MODEL_NAME, initialModel, self)
-	if not dm then return false end
-	widgetState.dmHandle = dm
+	widgetState.dm_handle = widgetState.rmlContext:OpenDataModel(MODEL_NAME, initialModel, self)
+	if not widgetState.dm_handle then return false end
 
-	local document = widgetState.rmlContext:LoadDocument(RML_PATH, self)
-	if not document then
+	widgetState.document = widgetState.rmlContext:LoadDocument(RML_PATH, self)
+	if not widgetState.document then
 		widget:Shutdown()
 		return false
 	end
-	widgetState.document = document
 
 	if WG.RmlContextManager and WG.RmlContextManager.registerDocument then
 		WG.RmlContextManager.registerDocument("decal_placer", document)
 	end
-	document:Show()
 
-	widgetState.rootElement = document:GetElementById("dp-root")
-	-- hidden state is driven via data-class-hidden; initial model starts hidden.
+	widgetState.document:ReloadStyleSheet()
+
+	-- Document starts hidden. widget:Update() calls setVisible() based on
+	-- whether the DECALS tool is active, so the panel appears the first time
+	-- the user picks the tool — never paying layout cost in between.
+	widgetState.document:Hide()
+	documentVisible = false
+
+	widgetState.rootElement = widgetState.document:GetElementById("dp-root")
 
 	widgetState.rootElement:SetAttribute("style", buildRootStyle())
 
-	attachEventListeners()
+	wireDragHandle()
+	syncDecals()
+end
+
+-- Drain bake queue. Spring restricts gl.RenderToTexture to draw callbacks,
+-- so this is where the bake module's per-frame work happens.
+function widget:DrawScreen()
+	Bake.drainQueue()
 end
 
 function widget:Update()
+	-- After a batch of bakes completes, re-push the model so newly-cached
+	-- srcPaths land on their tiles.
+	if Bake.consumeResync() then syncDecals() end
+
 	-- Window drag
 	local ds = dpDragState
 	if ds.active and ds.rootEl then
@@ -760,33 +464,7 @@ function widget:Update()
 		end
 	end
 
-	local function setHidden(v)
-		if widgetState.dmHandle and widgetState.dmHandle.hidden ~= v then
-			widgetState.dmHandle.hidden = v
-		end
-	end
-
-	if not WG.DecalPlacer then
-		setHidden(true)
-		return
-	end
-
-	local state = WG.DecalPlacer.getState()
-	if not state then return end
-	local isActive = state.active
-	if isActive and not lastActive then manuallyHidden = false end
-	lastActive = isActive
-	setHidden((not isActive) or manuallyHidden)
-	if not isActive then return end
-
-	-- Sync two-way-bound search filter back to internal state
-	if widgetState.dmHandle then
-		local searchVal = widgetState.dmHandle.search or ""
-		if searchVal ~= lastSearchFilter then
-			lastSearchFilter = searchVal
-			rebuildDecalList(searchVal)
-		end
-	end
+	if not syncVisibilityFromTool() then return end
 
 	-- Auto-position next to terraform main panel until user drags
 	local mainPanel = WG.RmlContextManager and WG.RmlContextManager.getElementRect
@@ -801,19 +479,13 @@ function widget:Update()
 		end
 	end
 
-	-- Lazy build decal list (Spring.GetGroundDecalTextures may not be ready in Initialize)
-	if WG.DecalPlacer and not next(decalElements) then
+	-- Lazy FIRST build only — WG.DecalPlacer's category data may not be ready
+	-- in widget:Initialize. After firstSyncDone, syncDecals is only ever called
+	-- in response to actual state changes (category click, filter change), never
+	-- from this Update tick.
+	if not firstSyncDone then
 		local cats = WG.DecalPlacer.getDecalCategories()
-		if cats and next(cats) then rebuildDecalList(lastSearchFilter) end
-	end
-
-	-- Relayout: if dp-list client_width changed since last rebuild, rebuild
-	-- so tile widths re-derive (handles window resize + scrollbar appearance).
-	if widgetState.document and next(decalElements) then
-		local curInner = getListInnerPx()
-		if curInner > 0 and math.abs(curInner - lastBuildInnerPx) >= 2 then
-			rebuildDecalList(lastSearchFilter)
-		end
+		if cats and next(cats) then syncDecals() end
 	end
 end
 
@@ -822,86 +494,20 @@ function widget:Shutdown()
 	if WG.RmlContextManager and WG.RmlContextManager.unregisterDocument then
 		WG.RmlContextManager.unregisterDocument("decal_placer")
 	end
+
+	if widgetState.rmlContext and widgetState.dm_handle then
+		widgetState.rmlContext:RemoveDataModel(MODEL_NAME)
+		widgetState.dm_handle = nil
+	end
+
 	if widgetState.document then
 		widgetState.document:Close()
 		widgetState.document = nil
 	end
-	if widgetState.rmlContext then
-		widgetState.rmlContext:RemoveDataModel(MODEL_NAME)
-	end
-	widgetState.dmHandle = nil
+
+	widgetState.rmlContext = nil
 	widgetState.rootElement = nil
-	decalElements = {}
-	thumbDivs = {}
-	thumbOverlays = {}
-	categoryButtons = {}
-	activeCategory = "all"
-	if previewShader and previewShader ~= false then
-		gl.DeleteShader(previewShader)
-	end
-	previewShader = nil
+
+	Bake.shutdown()
 end
 
-----------------------------------------------------------------
--- DrawScreen: overlay each decal tile with its real texture.
--- RmlUi handles layout/borders/labels; we render the actual image content
--- on top of each thumb div with alpha blending so transparent shape textures
--- (tracks, scars, footprints) display their silhouette rather than raw channel
--- data.
-----------------------------------------------------------------
-function widget:DrawScreenPost()
-	if widgetState.rootElement and widgetState.rootElement:IsClassSet("hidden") then return end
-	if not next(thumbOverlays) then return end
-	local doc = widgetState.document
-	if not doc then return end
-	local listEl = doc:GetElementById("dp-list")
-	if not listEl then return end
-	if not initPreviewShader() then return end
-
-	local vsx, vsy = Spring.GetViewGeometry()
-
-	-- Clip to the scrollable list region so thumbs don't bleed outside on scroll.
-	local clipX = listEl.absolute_left
-	local clipH = listEl.client_height
-	local clipY = vsy - listEl.absolute_top - clipH
-	local clipW = listEl.client_width
-	if clipW <= 0 or clipH <= 0 then return end
-
-	gl.Scissor(clipX, clipY, clipW, clipH)
-	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
-	gl.Color(1, 1, 1, 1)
-	gl.UseShader(previewShader)
-
-	for _, entry in pairs(thumbOverlays) do
-		local div = entry.div
-		local tex = entry.texPath
-		if div and tex and not entry.failed then
-			local x = div.absolute_left
-			local y = div.absolute_top
-			local w = div.offset_width
-			local h = div.offset_height
-			if w > 0 and h > 0 then
-				-- Skip tiles scrolled outside the list viewport
-				if y + h > listEl.absolute_top - 4 and y < listEl.absolute_top + clipH + 4 then
-					local ok = gl.Texture(0, tex)
-					if ok then
-						if uniMaskMode then
-							gl.Uniform(uniMaskMode, entry.maskMode or 3)
-						end
-						local glY2 = vsy - y
-						local glY1 = vsy - y - h
-						gl.TexRect(x, glY1, x + w, glY2, 0, 0, 1, 1)
-					else
-						entry.failed = true
-					end
-				end
-			end
-		end
-	end
-
-	gl.UseShader(0)
-	gl.Texture(0, false)
-	gl.Scissor(false)
-	gl.Blending(true)
-	gl.Color(1, 1, 1, 1)
-end

--- a/luaui/RmlWidgets/gui_decal_placer/gui_decal_placer.rcss
+++ b/luaui/RmlWidgets/gui_decal_placer/gui_decal_placer.rcss
@@ -1,19 +1,37 @@
 /* Decal Placer Library — extends fp- styles from gui_feature_placer */
 
-/*
- * Width uses `vw` so the panel scales proportionally across 1080p / 1440p
- * / 4k. `min-width: px` keeps it readable on small windows; `max-width: px`
- * caps it on ultrawide / 4k.
- */
 .dp-root {
 	width: 13vw;
-	min-width: 220px;
+	min-width: 220dp;
 	z-index: 901;
 }
 
-/* Decal tile thumbnail — when no decorator is set, show name centered on a
-   subtle diagonal-stripe pattern so engine-packed atlas textures still look
-   intentional rather than blank */
+/* Decal tiles — the .dp-tile-host wrapper is what flex-wrap sees; sizing
+   lives on the wrapper so the visible .fp-feature-item just fills it.
+   The wrapper exists to keep per-row data bindings off the outer data-for
+   element — see the RML comment for why */
+.dp-root .dp-tile-host {
+	width: 84dp;
+	height: 84dp;
+	margin: 4dp;
+}
+
+.dp-root .dp-tile-host > .fp-feature-item {
+	width: 100%;
+	height: 100%;
+}
+
+/* The decal preview img fills its thumb container. Decals with a real alpha
+   channel (PNG/TGA) show the per-category tint behind through transparent
+   pixels. Channel-encoded BMP atlases (mainscars / tracks / footprints) are
+   fully opaque RGB so the tint is hidden — those need a pre-bake pass to
+   convert the mask channels to alpha (separate workitem). */
+.dp-root .fp-feature-thumb img {
+	width: 100%;
+	height: 100%;
+}
+
+/* Category tints — visible on alpha-channel decals (PNG/TGA). */
 .dp-thumb-scars        { background-color: #6b4838; }
 .dp-thumb-explosions   { background-color: #b04030; }
 .dp-thumb-tracks       { background-color: #4a4a52; }
@@ -22,30 +40,3 @@
 .dp-thumb-scorch       { background-color: #2a2018; }
 .dp-thumb-groundplates { background-color: #506060; }
 .dp-thumb-other        { background-color: #4a4a4a; }
-
-.dp-mode-btn {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 26dp;
-	background-color: #2a2a32;
-	border: 1dp #3a3a4a80;
-	border-radius: 4dp;
-	cursor: pointer;
-	transition: background-color 0.15s;
-}
-.dp-mode-btn:hover {
-	background-color: #3a3a4a;
-}
-.dp-mode-btn.active {
-	background-color: #1a3a2a;
-	border-color: #22c55e80;
-}
-.dp-mode-btn.active .dp-btn-text {
-	color: #22c55e;
-}
-.dp-btn-text {
-	font-size: 1.0rem;
-	color: #d1d5db;
-	font-weight: bold;
-}

--- a/luaui/RmlWidgets/gui_decal_placer/gui_decal_placer.rml
+++ b/luaui/RmlWidgets/gui_decal_placer/gui_decal_placer.rml
@@ -3,51 +3,73 @@
 	<link type="text/rcss" href="../styles.rcss" />
 	<link type="text/rcss" href="../rml-utility-classes.rcss" />
 	<link type="text/rcss" href="../palette-standard-global.rcss" />
-	<link type="text/rcss" href="../themes/theme-base.rcss" />
-	<link type="text/rcss" href="../themes/theme-armada.rcss" />
-	<link type="text/rcss" href="../themes/theme-cortex.rcss" />
-	<link type="text/rcss" href="../themes/theme-legion.rcss" />
 	<link type="text/rcss" href="../gui_feature_placer/gui_feature_placer.rcss" />
 	<link type="text/rcss" href="gui_decal_placer.rcss" />
 </head>
 <body data-model="decal_placer_model">
-	<div id="dp-root" class="fp-root dp-root widget-shadow rounded-md bg-darkest p-2" data-class-hidden="hidden">
+	<div id="dp-root" class="fp-root dp-root widget-shadow rounded-md bg-darkest p-2">
 		<div class="flex flex-row justify-between items-center mb-2">
 			<div id="dp-handle" class="fp-drag-handle text-2xl font-bold text-light text-outline-darker" style="flex: 1;">Decal Library</div>
-			<div id="btn-quit" class="fp-quit-btn" onclick="widget:OnQuit()"><img class="fp-icon-sm" src="/luaui/images/terraform_brush/close.png" /></div>
+			<div class="fp-quit-btn" onclick="widget:OnQuit()"><img class="fp-icon-sm" src="/luaui/images/terraform_brush/close.png" /></div>
 		</div>
 
 		<div class="flex flex-row justify-between items-center mb-1">
 			<div class="text-lg text-light">DECALS</div>
 			<div class="text-sm text-keybind">
-				<span id="dp-selected-count">0</span> selected
+				<span>{{selectedCount}}</span> selected
 			</div>
 		</div>
 		<div class="text-sm text-keybind mb-1" style="text-align: right;">Shift+Click to select multiple</div>
 
-		<div id="dp-category-buttons" class="fp-cat-row">
-			<div id="btn-dp-cat-all" class="fp-cat-btn active"><span class="fp-cat-label">All</span></div>
-			<div id="btn-dp-cat-scars" class="fp-cat-btn"><span class="fp-cat-label">Scars</span></div>
-			<div id="btn-dp-cat-explosions" class="fp-cat-btn"><span class="fp-cat-label">Explos.</span></div>
-			<div id="btn-dp-cat-tracks" class="fp-cat-btn"><span class="fp-cat-label">Tracks</span></div>
-			<div id="btn-dp-cat-builds" class="fp-cat-btn"><span class="fp-cat-label">Builds</span></div>
-			<div id="btn-dp-cat-footprints" class="fp-cat-btn"><span class="fp-cat-label">Foot</span></div>
-			<div id="btn-dp-cat-scorch" class="fp-cat-btn"><span class="fp-cat-label">Scorch</span></div>
-			<div id="btn-dp-cat-groundplates" class="fp-cat-btn"><span class="fp-cat-label">Plates</span></div>
-			<div id="btn-dp-cat-other" class="fp-cat-btn"><span class="fp-cat-label">Other</span></div>
+		<div class="fp-cat-row">
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'all'"          data-event-click="onCategorySelect('all')"><span class="fp-cat-label">All</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'scars'"        data-event-click="onCategorySelect('scars')"><span class="fp-cat-label">Scars</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'explosions'"   data-event-click="onCategorySelect('explosions')"><span class="fp-cat-label">Explos.</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'tracks'"       data-event-click="onCategorySelect('tracks')"><span class="fp-cat-label">Tracks</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'builds'"       data-event-click="onCategorySelect('builds')"><span class="fp-cat-label">Builds</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'footprints'"   data-event-click="onCategorySelect('footprints')"><span class="fp-cat-label">Foot</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'scorch'"       data-event-click="onCategorySelect('scorch')"><span class="fp-cat-label">Scorch</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'groundplates'" data-event-click="onCategorySelect('groundplates')"><span class="fp-cat-label">Plates</span></div>
+			<div class="fp-cat-btn" data-class-active="activeCategory == 'other'"        data-event-click="onCategorySelect('other')"><span class="fp-cat-label">Other</span></div>
 		</div>
 
 		<div class="fp-search-wrapper mb-1">
-			<input type="text" id="dp-search" class="fp-search-input" placeholder="Search decals..." data-value="search" onfocus="widget:OnSearchFocus()" onblur="widget:OnSearchBlur()" />
-			<div id="btn-dp-search-clear" class="fp-search-clear-btn" onclick="widget:OnSearchClear()"><img class="fp-search-clear-icon" src="/luaui/images/terraform_brush/close.png" /></div>
+			<input type="text" id="dp-search" class="fp-search-input" placeholder="Search decals..."
+				data-value="search"
+				data-event-focus="onSearchFocus()"
+				data-event-blur="onSearchBlur()"
+				data-event-change="onSearchChange()" />
+			<div class="fp-search-clear-btn" data-event-click="onSearchClear()">
+				<img class="fp-search-clear-icon" src="/luaui/images/terraform_brush/close.png" />
+			</div>
 		</div>
 
-		<div id="btn-dp-clear-selection" class="fp-clr-btn mb-1" onclick="widget:OnClearSelection()">
+		<div class="fp-clr-btn mb-1" onclick="widget:OnClearSelection()">
 			<div class="fp-btn-text">CLR</div>
 		</div>
 
-		<div id="dp-list" class="fp-feature-list">
-			<!-- Populated dynamically by Lua -->
+		<div class="fp-feature-list gap-2">
+			<!--
+				The outer .dp-tile-host carries ONLY data-for. All per-row d.X
+				bindings (including the click handler) live on the inner tile.
+				RmlUi re-evaluates outer (data-for) element bindings against
+				indices the new array no longer has during shrinks, producing
+				"Could not get value from data variable" warnings. Inner bindings
+				empirically don't trigger this — including data-event-click,
+				which only fires on actual user click anyway.
+				Passing d.name (instead of a loop index) lets the handler
+				dispatch directly without a Lua-side index→row lookup table.
+			-->
+			<div class="dp-tile-host" data-for="d : currentDecals">
+				<div class="fp-feature-item"
+					data-class-selected="d.selected"
+					data-event-click="onDecalClick(d.name)">
+					<div data-attr-class="'fp-feature-thumb dp-thumb-' + d.category">
+						<img data-if="d.hasImg" data-attr-src="d.srcPath" />
+					</div>
+					<div class="fp-feature-name">{{d.displayName}}</div>
+				</div>
+			</div>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
Hey PtaQ — I've been deep-diving the new RML widgets on your branch and ended up doing a declarative refactor of `gui_decal_placer`. Putting it up as a PR against your branch so you can see exactly what changed and decide if any of it is worth pulling in. Zero pressure either way: take it whole, cherry-pick parts, or close this and ignore.

## What changed

**Tile grid**: imperative `doc:CreateElement` / `AddEventListener` loops in `rebuildDecalList` replaced with `data-for` over `dm.currentDecals`. All event handlers moved into the data model (`onDecalClick`, `onCategorySelect`, `onSearchFocus/Blur/Change/Clear`). `widget:OnFoo()` reduced to `OnQuit` and `OnClearSelection`.

**Search**: filter is now event-driven via `data-event-change` on the input, reading the element value directly. The old `widget:Update` polling loop on `dm.search` is gone.

**Visibility**: panel show/hide runs through `document:Show()/Hide()` instead of `data-class-hidden`. The document drops out of the RmlUi context's active set when closed (no layout/draw cost), the hiding of elements should not be done with css, we have data-if and the removal of documents from the context.

**Decal previews**: the `DrawScreenPost` GL overlay is gone. Channel-encoded BMP atlases (mainscars / tracks / footprints) are now baked through a one-shot mask shader into RGBA PNGs in `Terraform Brush/DecalPreviews/`, and tiles render via plain `<img data-attr-src="d.srcPath">`. No more z-order punch-through above other RML panels. The bake machinery is extracted into `dp_preview_bake.lua` so the widget proper stays readable. If you want to see this existing issue for yourself, drag any rml widget over the features widget.

**Dead code purges**: `refreshUIFromState` and its helpers (~70 lines pointing at element IDs that don't exist in this widget — looked like leftovers from when brush controls lived here), 4 unused IDs in the RML, several unreachable RCSS rules.

Net: ~908 → ~487 lines in `gui_decal_placer.lua`, plus a new ~340-line `dp_preview_bake.lua`. Every line that's left does something visible.

## Patterns I had to learn the hard way

A few RmlUi gotchas in this engine build — flagging in case they're useful for the other widgets too:

- `data-for` on this build emits `Could not get value from data variable` warnings if `d.X` bindings live on the outer `data-for` element. Bindings on **inner** children are silent. The `.dp-tile-host` wrapper exists for that reason: outer carries `data-for` only, inner carries all the `d.X` bindings.
- `data-event-X` passes the Event object as the implicit first arg, then your explicit args. So `data-event-click="onDecalClick(d.name)"` calls `onDecalClick(event, name)`.
- `data-for="d, i : items"` 0-indexes the loop variable. Add 1 if you're using it as a Lua array index.
- `data-value="search"` updates the model AFTER the change event fires, so onchange handlers reading the model see the previous value. Read `element:GetAttribute("value")` directly.

## Caveats

- This branches off your `realtime-terraformer`, so the PR includes your commits. Cleanest review is the diff under `luaui/RmlWidgets/gui_decal_placer/` (4 files: 1 new, 3 modified).
- The bake step has a deliberate startup cost (~0.25s spread across DrawScreen ticks on first open of the panel) and currently re-bakes every session. Comments in `dp_preview_bake.lua` explain why (shader still in flux, didn't want stale cache hiding shader edits) and how to flip to a versioned cache once the shader stabilises.
- The mask-mode classifier is a filename-pattern heuristic that works for the known decal set but isn't robust. Cleaner: have `WG.DecalPlacer` expose `maskMode` per entry. Cleanest: standardise the source decals as RGBA-with-alpha and the whole bake module collapses to ~30 lines of pure path resolution. Both noted in TODO.
- I left the drag handle as `AddEventListener` because the document-level mouseup pattern needed for drag-end isn't trivially expressible declaratively here.

Happy to walk through any of it on Discord if useful, or just close this if you'd rather come back to declarative patterns yourself when you have time.