### PR TITLE
Add CI Workflow to export definition files as JSON

### DIFF
--- a/.github/workflows/export_defs.yml
+++ b/.github/workflows/export_defs.yml
@@ -1,4 +1,4 @@
-name: Export UnitDefs JSON
+name: Export Defs JSON
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   export:
-    name: Export UnitDefs
+    name: Export Defs
     runs-on: ubuntu-latest
     if: github.repository == 'beyond-all-reason/Beyond-All-Reason'
     steps:
@@ -52,7 +52,7 @@ jobs:
           path: |
             ${{ env.EXPORT_DIR }}/engine
             ${{ env.EXPORT_DIR }}/maps
-          key: unitdef-export-${{ steps.engine.outputs.version }}-quicksilver-1.24
+          key: defs-export-${{ steps.engine.outputs.version }}-quicksilver-1.24
 
       - name: Download engine
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/export_unitdefs.yml
+++ b/.github/workflows/export_unitdefs.yml
@@ -15,7 +15,8 @@ jobs:
   export:
     name: Export UnitDefs
     runs-on: ubuntu-latest
-    if: github.repository == 'beyond-all-reason/Beyond-All-Reason'
+    # TODO: restore repo guard before PR
+    # if: github.repository == 'beyond-all-reason/Beyond-All-Reason'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/export_unitdefs.yml
+++ b/.github/workflows/export_unitdefs.yml
@@ -96,13 +96,8 @@ jobs:
             exit 1
           fi
 
-      - name: Package
-        run: |
-          cd "$EXPORT_DIR/json_export"
-          zip -r "$GITHUB_WORKSPACE/unitdefs-export.zip" .
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: unitdefs-export-${{ github.sha }}
-          path: unitdefs-export.zip
+          path: ${{ env.EXPORT_DIR }}/json_export/

--- a/.github/workflows/export_unitdefs.yml
+++ b/.github/workflows/export_unitdefs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - stable
-      - feature/3039-ci-unit-defs-export  # TODO: remove before PR
   workflow_dispatch:
 
 env:
@@ -16,8 +15,7 @@ jobs:
   export:
     name: Export UnitDefs
     runs-on: ubuntu-latest
-    # TODO: restore repo guard before PR
-    # if: github.repository == 'beyond-all-reason/Beyond-All-Reason'
+    if: github.repository == 'beyond-all-reason/Beyond-All-Reason'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/export_unitdefs.yml
+++ b/.github/workflows/export_unitdefs.yml
@@ -1,0 +1,106 @@
+name: Export UnitDefs JSON
+
+on:
+  push:
+    branches:
+      - stable
+  workflow_dispatch:
+
+env:
+  EXPORT_DIR: /tmp/bar-export
+  MAP_NAME: quicksilver_remake_1.24.sd7
+  MAP_URL: https://springfiles.springrts.com/files/maps/quicksilver_remake_1.24.sd7
+
+jobs:
+  export:
+    name: Export UnitDefs
+    runs-on: ubuntu-latest
+    if: github.repository == 'beyond-all-reason/Beyond-All-Reason'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve engine version
+        id: engine
+        run: |
+          CONFIG=$(curl -fsSL https://launcher-config.beyondallreason.dev/config.json)
+          ENGINE_URL=$(echo "$CONFIG" | jq -r '
+            .setups[]
+            | select(.package.id == "manual-linux-test-engine")
+            | .downloads.resources[]
+            | select(.destination | contains("engine"))
+            | .url
+          ')
+          ENGINE_DEST=$(echo "$CONFIG" | jq -r '
+            .setups[]
+            | select(.package.id == "manual-linux-test-engine")
+            | .downloads.resources[]
+            | select(.destination | contains("engine"))
+            | .destination
+          ')
+          ENGINE_VERSION=$(basename "$ENGINE_DEST")
+          echo "url=$ENGINE_URL" >> "$GITHUB_OUTPUT"
+          echo "dest=$ENGINE_DEST" >> "$GITHUB_OUTPUT"
+          echo "version=$ENGINE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved engine: $ENGINE_VERSION"
+          echo "Engine URL: $ENGINE_URL"
+
+      - name: Cache engine and map
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.EXPORT_DIR }}/engine
+            ${{ env.EXPORT_DIR }}/maps
+          key: unitdef-export-${{ steps.engine.outputs.version }}-quicksilver-1.24
+
+      - name: Download engine
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$EXPORT_DIR/${{ steps.engine.outputs.dest }}"
+          curl -fsSL "${{ steps.engine.outputs.url }}" -o /tmp/engine.7z
+          7z x /tmp/engine.7z -o"$EXPORT_DIR/${{ steps.engine.outputs.dest }}"
+          rm /tmp/engine.7z
+
+      - name: Download map
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$EXPORT_DIR/maps"
+          curl -fsSL "$MAP_URL" -o "$EXPORT_DIR/maps/$MAP_NAME"
+
+      - name: Set up workspace
+        run: |
+          mkdir -p "$EXPORT_DIR/games"
+          ln -sf "$GITHUB_WORKSPACE" "$EXPORT_DIR/games/BAR.sdd"
+          cp tools/headless_testing/springsettings.cfg "$EXPORT_DIR/"
+          cp tools/headless_testing/startscript_export.txt "$EXPORT_DIR/"
+
+      - name: Run headless export
+        run: |
+          cd "$EXPORT_DIR"
+          rm -rf LuaUI/Config
+          engine/*/spring-headless \
+            --isolation \
+            --write-dir "$(pwd)" \
+            startscript_export.txt
+        timeout-minutes: 15
+
+      - name: Validate export
+        run: |
+          FILE_COUNT=$(find "$EXPORT_DIR/json_export" -name '*.json' | wc -l)
+          echo "Exported $FILE_COUNT unit definitions"
+          if [ "$FILE_COUNT" -lt 1 ]; then
+            echo "::error::No JSON files were exported"
+            exit 1
+          fi
+
+      - name: Package
+        run: |
+          cd "$EXPORT_DIR/json_export"
+          zip -r "$GITHUB_WORKSPACE/unitdefs-export.zip" .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: unitdefs-export-${{ github.sha }}
+          path: unitdefs-export.zip

--- a/.github/workflows/export_unitdefs.yml
+++ b/.github/workflows/export_unitdefs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - stable
+      - feature/3039-ci-unit-defs-export  # TODO: remove before PR
   workflow_dispatch:
 
 env:

--- a/.github/workflows/export_unitdefs.yml
+++ b/.github/workflows/export_unitdefs.yml
@@ -87,15 +87,16 @@ jobs:
 
       - name: Validate export
         run: |
-          FILE_COUNT=$(find "$EXPORT_DIR/json_export" -name '*.json' | wc -l)
-          echo "Exported $FILE_COUNT unit definitions"
-          if [ "$FILE_COUNT" -lt 1 ]; then
-            echo "::error::No JSON files were exported"
+          UNIT_COUNT=$(find "$EXPORT_DIR/json_export/unitDefs" -name '*.json' 2>/dev/null | wc -l)
+          WEAPON_COUNT=$(find "$EXPORT_DIR/json_export/weaponDefs" -name '*.json' 2>/dev/null | wc -l)
+          echo "Exported $UNIT_COUNT unit definitions and $WEAPON_COUNT weapon definitions"
+          if [ "$UNIT_COUNT" -lt 1 ] || [ "$WEAPON_COUNT" -lt 1 ]; then
+            echo "::error::Export incomplete (unitDefs=$UNIT_COUNT weaponDefs=$WEAPON_COUNT)"
             exit 1
           fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: unitdefs-export-${{ github.sha }}
+          name: defs-export-${{ github.sha }}
           path: ${{ env.EXPORT_DIR }}/json_export/

--- a/tools/headless_testing/.gitignore
+++ b/tools/headless_testing/.gitignore
@@ -1,1 +1,2 @@
 testlog
+json_export

--- a/tools/headless_testing/startscript_export.txt
+++ b/tools/headless_testing/startscript_export.txt
@@ -1,0 +1,29 @@
+[GAME]
+{
+	MapName=Quicksilver Remake 1.24;
+	GameType=Beyond All Reason $VERSION;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=TestRunner;
+	IsHost=1;
+	FixedRNGSeed = 1;
+  [MODOPTIONS]
+  {
+    debugcommands=1:luaui enablewidget Unitdefs JSON Export|2:exportdefs|3:quitforce;
+		deathmode=neverend;
+		experimentallegionfaction=1;
+  }
+  [ALLYTEAM0]
+  {
+  }
+  [TEAM0]
+  {
+    allyteam=0;
+    teamleader=0;
+  }
+  [PLAYER0]
+  {
+    team=0;
+  }
+}


### PR DESCRIPTION
Related to #3039 (though depending on if we want reshaping, may or may not close it)

### Work done

Adds a GitHub Actions workflow that exports fully-hydrated UnitDef and WeaponDef data as JSON using `spring-headless`, picking up where #1897 and #3039 left off. This is the CI automation that p2004a demonstrated manually back in 2023 — now it runs automatically on push to `stable` (or via manual dispatch).

#### How it works

The workflow resolves the current engine version from the launcher config, downloads `spring-headless` and a small map (Quicksilver Remake 1.24), then runs the existing `export_defs.lua` widget via `debugcommands`. The engine loads all game Lua, runs the full UnitDef post-processing pipeline, and the widget serializes each unit to an individual JSON file. The output is uploaded as a workflow artifact.

Engine and map are cached via `actions/cache` keyed on engine version — since the engine changes a few times a year and the map never changes, most runs skip the ~200 MB download entirely.

The performance of the run was much better than expected: https://github.com/burnhamrobertp/bar-Beyond-All-Reason/actions/runs/24936179408

(the changes I made to facilitate running the workflow on my fork were - as you can see - removed afterwards)

#### What's included

- `.github/workflows/export_defs.yml` — the workflow (checkout → resolve engine → cache → download → headless export → validate → upload)
- `tools/headless_testing/startscript_export.txt` — startscript with Legion enabled, Quicksilver map, debugcommands for export
- `tools/headless_testing/.gitignore` — added `json_export` to avoid polluting git status during local runs

#### Numbers from testing

- 820 units exported (Armada + Cortex + Legion), 253 fields per unit
- ~5 min total runtime (Lua init dominates; actual export is ~13s)
- Successful test run on fork: https://github.com/burnhamrobertp/bar-Beyond-All-Reason/actions/runs/24936179408

#### What this doesn't do (yet)

- No reshaping or field filtering — raw engine output. Reshaping can be iterated on separately per the discussion in #3039.
- No publishing to CDN or external storage — artifact only for now. Graduating to a release asset or CDN endpoint is a natural follow-up.

### AI / LLM usage statement

Developed with GitHub Copilot CLI (Claude). Used for workflow authoring, codebase analysis, and testing. All code was reviewed, directed, and verified by the contributor. Workflow execution was reviewed and tested by contributor.

