### PR TITLE
skip empty tables when saving to customparams/file

### DIFF
--- a/gamedata/post_save_to_customparams.lua
+++ b/gamedata/post_save_to_customparams.lua
@@ -20,14 +20,20 @@ function table.key_to_str ( k )
 	end
 end
 
+local function isEmptyTable(v)
+	return type(v) == "table" or next(v) == nil
+end
+
 function table.tostring( tbl )
 	local result, done = {}, {}
 	for k, v in ipairs( tbl ) do
-		table.insert( result, table.val_to_str( v ) )
-		done[ k ] = true
+		if not isEmptyTable(v) then
+			table.insert( result, table.val_to_str( v ) )
+			done[ k ] = true
+		end
 	end
 	for k, v in pairs( tbl ) do
-		if not done[ k ] then
+		if not done[ k ] and not isEmptyTable(v) then
 			table.insert( result,
 			table.key_to_str( k ) .. "=" .. table.val_to_str( v ) )
 		end

--- a/gamedata/post_save_to_customparams.lua
+++ b/gamedata/post_save_to_customparams.lua
@@ -21,7 +21,7 @@ function table.key_to_str ( k )
 end
 
 local function isEmptyTable(v)
-	return type(v) == "table" or next(v) == nil
+	return type(v) == "table" and next(v) == nil
 end
 
 function table.tostring( tbl )

--- a/luaui/Widgets/__defs_write.lua
+++ b/luaui/Widgets/__defs_write.lua
@@ -202,7 +202,9 @@ local spEcho = Spring.Echo
 			file:write(header..'\n')
 		end
 		file:write('return {\n')
-		if type(t)=="table" or type(t)=="metatable" then SaveTable(t, file, '') end
+		if (type(t)=="table" and next(t)~=nil) or type(t)=="metatable" then
+			SaveTable(t, file, '')
+		end
 		file:write('}\n')
 		file:close()
 		for k,v in pairs(savedTables) do


### PR DESCRIPTION
### Work done

Skips empty tables (generally buildoptions/weapons/weapondefs) when prebaking unitdefs to file.