### PR TITLE
Allow single target load commands on enemy nano

### DIFF
--- a/luarules/gadgets/unit_transportable_nanos.lua
+++ b/luarules/gadgets/unit_transportable_nanos.lua
@@ -56,10 +56,10 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 	if cmdID == CMD_LOAD_UNITS then
 		if #cmdParams == 1 then -- if unit is target
 			local targetId = cmdParams[1]
-			local isvalidId = spValidUnitID(targetId)
-			local isTeamTarget = isvalidId and spGetUnitTeam(targetId) == teamID
-			local isEnemyTarget = isvalidId and spGetUnitAllyTeam(targetId) ~= spGetUnitAllyTeam(unitID)
-			if isvalidId and not isEnemyTarget and not isTeamTarget and Nanos[spGetUnitDefID(targetId)] then
+			local isValidId = spValidUnitID(targetId)
+			local isTeamTarget = isValidId and spGetUnitTeam(targetId) == teamID
+			local isEnemyTarget = isValidId and spGetUnitAllyTeam(targetId) ~= spGetUnitAllyTeam(unitID)
+			if isValidId and not isEnemyTarget and not isTeamTarget and Nanos[spGetUnitDefID(targetId)] then
 				return false
 			end
 		end

--- a/luarules/gadgets/unit_transportable_nanos.lua
+++ b/luarules/gadgets/unit_transportable_nanos.lua
@@ -3,8 +3,8 @@ local gadget = gadget ---@type Gadget
 function gadget:GetInfo()
     return {
         name      = "Unit transportable nanos",
-        desc      = "Prevent loading of ally and enemy nanos, prevent unloading onto cliffs and underwater",
-        author    = "Beherith",
+        desc      = "Prevent loading of ally nanos, prevent unloading onto cliffs and underwater",
+        author    = "Beherith, Chronographer",
         date      = "Jul 2012",
         license   = "GNU GPL, v2 or later",
         layer     = 0,
@@ -16,11 +16,12 @@ if not gadgetHandler:IsSyncedCode() then
     return false
 end
 
-local GetUnitTeam = Spring.GetUnitTeam
-local GetUnitDefID = Spring.GetUnitDefID
-local GetGroundNormal = Spring.GetGroundNormal
-local GetUnitIsTransporting = Spring.GetUnitIsTransporting
-local ValidUnitID = Spring.ValidUnitID
+local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitIsTransporting = Spring.GetUnitIsTransporting
+local spValidUnitID = Spring.ValidUnitID
+local spGetGroundNormal = Spring.GetGroundNormal
 local stringFind = string.find
 
 local CMD_LOAD_UNITS = CMD.LOAD_UNITS
@@ -51,19 +52,24 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 	if not UnitDefs[unitDefID].isTransport then
 		return false
 	end
+	
 	if cmdID == CMD_LOAD_UNITS then
 		if #cmdParams == 1 then -- if unit is target
-			if ValidUnitID(cmdParams[1]) and GetUnitTeam(cmdParams[1]) ~= teamID and Nanos[GetUnitDefID(cmdParams[1])] then
+			local targetId = cmdParams[1]
+			local isvalidId = spValidUnitID(targetId)
+			local isTeamTarget = isvalidId and spGetUnitTeam(targetId) == teamID
+			local isEnemyTarget = isvalidId and spGetUnitAllyTeam(targetId) ~= spGetUnitAllyTeam(unitID)
+			if isvalidId and not isEnemyTarget and not isTeamTarget and Nanos[spGetUnitDefID(targetId)] then
 				return false
 			end
 		end
 	else	 -- CMD_UNLOAD_UNITS
-		if cmdParams[1] and cmdParams[3] and GetUnitIsTransporting(unitID) then
-			local intrans = GetUnitIsTransporting(unitID)
+		if cmdParams[1] and cmdParams[3] and spGetUnitIsTransporting(unitID) then
+			local intrans = spGetUnitIsTransporting(unitID)
 			if #intrans >= 1 then
 				-- no unloading underwater
-				local _,y,_ = GetGroundNormal(cmdParams[1], cmdParams[3])
-				if Nanos[GetUnitDefID(intrans[1])] and (cmdParams[2] < 0 or y < 0.9) then
+				local _,y,_ = spGetGroundNormal(cmdParams[1], cmdParams[3])
+				if Nanos[spGetUnitDefID(intrans[1])] and (cmdParams[2] < 0 or y < 0.9) then
 					return false
 				end
 			end


### PR DESCRIPTION
Allows enemy nano turrets (immobile builders) to be transported with a targeted load command. Loading has been possible for at least 14 years with an untargeted load command so this is more about consistency than a change in mechanics.

The blocking of targeting ally non towers is left to prevent griefing, but suffers from a similar bug that area commands are not yet blocked.

### Work done

#### Addresses Issue(s)

[Issue URL](https://discord.com/channels/549281623154229250/1490748818306896144/1490748818306896144)
[Issue URL](https://discord.com/channels/549281623154229250/1272635021144096839/1272712752045232148)

#### Test steps
- Transporting of nano with single left click is allowed on enemy
- Transporting of nano with single left click is blocked on ally

- Transporting of nano with area commands is allowed on enemy

#### To do
- Block all area loads of ally nanos
- Consider right click default command on enemy nanos, currently NOT load. 