### PR TITLE
feat: add platform architecture to system_info gadget

### DIFF
--- a/luarules/gadgets/system_info.lua
+++ b/luarules/gadgets/system_info.lua
@@ -233,6 +233,9 @@ else
 		if s_os ~= nil then
 			system = system..'\nOS:  '..s_os
 		end
+		if Platform and Platform.architecture then
+			system = system..'\nArchitecture:  '..Platform.architecture
+		end
 
 		if chobbyLoaded then
 			system = system..'\nLobby:  Chobby'


### PR DESCRIPTION
### Work done
Add "Architecture" to the system info gadget, which will include "x86_64" or "arm64".

### Engine PR
Needs this engine PR to actually function, so this will no-op on nil until this an engine version supports this https://github.com/beyond-all-reason/RecoilEngine/pull/2825