### PR TITLE
feat: add frametime broadcast gadget to save into replays

### DIFF
--- a/luarules/gadgets/game_frametime_broadcast.lua
+++ b/luarules/gadgets/game_frametime_broadcast.lua
@@ -1,0 +1,51 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Frame Time Broadcast",
+		desc    = "Broadcasts per-client sim and draw frame times into the demo packet stream",
+		author  = "bruno-dasilva",
+		date    = "2026-04",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if gadgetHandler:IsSyncedCode() then return end
+
+local sendPacketEverySeconds = 2
+
+local GetLastUpdateSeconds  = Spring.GetLastUpdateSeconds
+local GetProfilerTimeRecord = Spring.GetProfilerTimeRecord
+local SendLuaRulesMsg       = Spring.SendLuaRulesMsg
+
+local updateTimer = 0
+local simN,  simSum,  simPeak  = 0, 0, 0
+local drawN, drawSum, drawPeak = 0, 0, 0
+
+function gadget:GameFrame(_)
+	local _, simCurrent = GetProfilerTimeRecord("Sim", false)
+	simN   = simN + 1
+	simSum = simSum + simCurrent
+	if simCurrent > simPeak then simPeak = simCurrent end
+end
+
+function gadget:Update()
+	updateTimer = updateTimer + GetLastUpdateSeconds()
+
+	local _, drawCurrent = GetProfilerTimeRecord("Draw", false)
+	drawN   = drawN + 1
+	drawSum = drawSum + drawCurrent
+	if drawCurrent > drawPeak then drawPeak = drawCurrent end
+
+	if updateTimer > sendPacketEverySeconds then
+		local avgSim  = simN  > 0 and (simSum  / simN)  or 0
+		local avgDraw = drawN > 0 and (drawSum / drawN) or 0
+		SendLuaRulesMsg(string.format("#ft%d/%d/%.1f/%.1f/%.1f/%.1f",
+			simN, drawN, avgSim, simPeak, avgDraw, drawPeak))
+		updateTimer = 0
+		simN,  simSum,  simPeak  = 0, 0, 0
+		drawN, drawSum, drawPeak = 0, 0, 0
+	end
+end


### PR DESCRIPTION
### Work done
Added game_frametime_broadcast.lua gadget to periodically send average/peak sim+draw frame times into the packet stream so they get saved into demos.

This way, demos contain information about how slowly clients were running at any given time.

Very useful for post-hoc investigations to determine why all or a specific player's performance is bad, as well as to track how performance behaves over time (if aggregated).

#### Related Issue(s)
- https://github.com/beyond-all-reason/RecoilEngine/issues/2929
    - looking to combine this with live unit count numbers to aggregate into a "perf per unit" number to track game performance over time.

### Screenshots:
TODO

### AI / LLM usage statement:
Claude code assisted