### PR TITLE
Fix race condition between track change and fade

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -1503,7 +1503,7 @@ function widget:GameFrame(n)
 						fadeDirection = -1
 					end
 				end
-			elseif totalTime == 0 and not fadeDirection then -- there's no music and not mid-transition
+			elseif totalTime == 0 and (not fadeDirection or Spring.GetConfigInt("UseSoundtrackFades", 1) ~= 1) then -- there's no music and not mid-transition (or fades are disabled)
 				PlayNewTrack()
 			end
 		end

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -1503,7 +1503,7 @@ function widget:GameFrame(n)
 						fadeDirection = -1
 					end
 				end
-			elseif totalTime == 0 then -- there's no music
+			elseif totalTime == 0 and not fadeDirection then -- there's no music and not mid-transition
 				PlayNewTrack()
 			end
 		end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Added conditional check to prevent track change if fade is happening. fadeDirection being non-nil means a track transition is already in progress (either fading in or fading out into a new track). There is no reason to re-trigger PlayNewTrack() in that state.

This resolves a race condition which results in a problem where the loading music does not transition properly to the next song, and a low, repeating sound is heard instead.
<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps

- [ ] When a game starts, loading music should transition properly to next song without hiccups.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

### AI / LLM usage statement:

Claude and Gemini were used to help identify the race condition.
The simplest solution was implemented and manually tested.