### PR TITLE
lua tooling: extensions hint + .emmyrc.json + descriptive type stubs

### DIFF
--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -1,0 +1,82 @@
+{
+	"$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/main/crates/emmylua_code_analysis/resources/schema.json",
+	"completion": {
+		"autoRequireSeparator": "/"
+	},
+	"diagnostics": {
+		"disable": ["duplicate-set-field"],
+		"globals": [
+			"Turn",
+			"Move",
+			"Spin",
+			"StopSpin",
+			"WaitForTurn",
+			"WaitForMove",
+			"Hide",
+			"Show",
+			"Explode",
+			"EmitSfx",
+			"StartThread",
+			"SetSignalMask",
+			"Signal",
+			"Sleep",
+			"GetUnitValue",
+			"SetUnitValue",
+			"piece",
+			"script",
+			"UnitScript",
+			"x_axis",
+			"y_axis",
+			"z_axis",
+			"SIG_WALK",
+			"UNITSCRIPT_DIR",
+
+			"widgetHandler",
+			"gadgetHandler",
+			"fontHandler",
+			"LUAUI_DIRNAME",
+			"socket",
+			"pairsByKeys",
+			"SendToUnsynced",
+			"CallAsTeam",
+			"handler",
+			"lowerkeys",
+			"addon",
+			"gcinfo",
+			"loadlib",
+
+			"_G",
+			"self",
+			"widget",
+			"gadget",
+			"GG",
+			"ghInfo",
+			"include",
+
+			"GameCMD",
+			"Scenario",
+			"game_engine",
+			"SG",
+			"CMD_AREA_MEX",
+			"CMD_WANT_CLOAK",
+			"CMD_WANTED_SPEED",
+			"GadgetCrashingAircraft",
+			"ExplosionDefs",
+			"GL_TEXTURE_2D"
+		]
+	},
+	"runtime": {
+		"version": "Lua5.1",
+		"requirePattern": ["?", "?.lua"],
+		"requireLikeFunction": ["VFS.Include", "include", "shard_include"]
+	},
+	"workspace": {
+		"ignoreDir": [
+			".vscode",
+			".lux"
+		],
+		"ignoreGlobs": [
+			"**/.lux/**"
+		]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.db
 /.git
 /.svn
-.vscode/
+.vscode/*
+!.vscode/extensions.json
 .idea/
 *.iml
 .project

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,36 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "completion.requireSeparator": "/",
-  "diagnostics": {
-    "type": {
-      "definition": [
-        ".lux/",
-        "types/",
-        "recoil-lua-library/library/"
-      ]
-    }
-  },
-  "runtime.path": [
-    "?",
-    "?.lua"
-  ],
-  "runtime.special": {
-    "VFS.Include": "require",
-    "include": "require",
-    "shard_include": "require"
-  },
-  "runtime.version": "Lua 5.1",
-  "semantic": {
-    "enable": true
-  },
   "workspace": {
-    "ignoreDir": [
-      ".vscode",
-      "luaui/Tests",
-      "luaui/TestsExamples"
-    ],
     "library": [
       "recoil-lua-library",
+      "recoil-lua-library/library",
       "luarules",
       "luaui",
       "spec",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "tangzx.emmylua",
+    "JohnnyMorganz.stylua",
+    "llvm-vs-code-extensions.vscode-clangd"
+  ],
+  "unwantedRecommendations": [
+    "sumneko.lua"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,8 @@
   "recommendations": [
     "tangzx.emmylua",
     "JohnnyMorganz.stylua",
-    "llvm-vs-code-extensions.vscode-clangd"
+    "llvm-vs-code-extensions.vscode-clangd",
+    "Soulcode.vscode-unwanted-extensions"
   ],
   "unwantedRecommendations": [
     "sumneko.lua"

--- a/types/Addon.lua
+++ b/types/Addon.lua
@@ -1,6 +1,7 @@
 ---@meta
 
 ---@class Addon
+---@field [string] any
 local Addon = {}
 
 ---Get info about an addon.
@@ -15,3 +16,7 @@ function Addon:GetInfo() end
 ---@field license string?
 ---@field layer number?
 ---@field enabled boolean?
+
+---@type Addon
+---@diagnostic disable-next-line: lowercase-global
+addon = nil

--- a/types/BarLuaShader.lua
+++ b/types/BarLuaShader.lua
@@ -1,0 +1,10 @@
+---@meta
+
+---@class BarLuaShader
+---@field Activate fun(self)
+---@field Deactivate fun(self)
+---@field SetUniform fun(self, name: string, ...: number|boolean)
+---@field SetUniformInt fun(self, name: string, ...: integer)
+---@field Initialize fun(self): boolean
+---@field Finalize fun(self)
+---@field [string] any

--- a/types/BarLuaShaderModule.lua
+++ b/types/BarLuaShaderModule.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class BarLuaShaderModule
+---@field [string] any

--- a/types/Callins.lua
+++ b/types/Callins.lua
@@ -1,0 +1,22 @@
+---@meta
+
+-- Callin type overrides to accept BAR's routing extra args pattern.
+-- BAR passes internal routing strings (e.g. "UnitFinished", "UnitGiven") as extra
+-- args through callins. Lua silently ignores them, but LuaLS warns about arity.
+-- Adding `...: any` makes these pass type checking.
+
+---@class Callins
+---@field UnitCreated fun(self, unitID: integer, unitDefID: integer, unitTeam: integer, builderID: integer?, ...: any)?
+---@field UnitDestroyed fun(self, unitID: integer, unitDefID: integer, unitTeam: integer, attackerID: integer?, attackerDefID: integer?, attackerTeam: integer?, weaponDefID: integer?, ...: any)?
+---@field UnitGiven fun(self, unitID: integer, unitDefID: integer, newTeam: integer, oldTeam: integer, ...: any)?
+---@field UnitTaken fun(self, unitID: integer, unitDefID: integer, newTeam: integer, oldTeam: integer, ...: any)?
+---@field GameFrame fun(self, frame: integer, ...: any)?
+---@field PlayerChanged fun(self, playerID: integer, ...: any)?
+---@field ViewResize fun(self, viewSizeX: integer, viewSizeY: integer, ...: any)?
+---@field MouseMove fun(self, x: number, y: number, dx: number, dy: number, button: number, ...: any): boolean?
+---@field MousePress fun(self, x: number, y: number, button: number, ...: any): boolean?
+---@field MouseRelease fun(self, x: number, y: number, button: number, ...: any): boolean|integer
+---@field TextInput fun(self, utf8: string, ...: any): boolean?
+---@field UnitFinished fun(self, unitID: integer, unitDefID: integer, unitTeam: integer, ...: any)?
+---@field FeatureCreated fun(self, featureID: integer, allyTeamID: integer, ...: any)?
+---@field FeatureDestroyed fun(self, featureID: integer, allyTeamID: integer|boolean?, ...: any)?

--- a/types/CommandQueueAugment.lua
+++ b/types/CommandQueueAugment.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class CommandQueueAugment
+---@field [string] any

--- a/types/CommandsFxGl4.lua
+++ b/types/CommandsFxGl4.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class CommandsFxGl4
+---@field [string] any

--- a/types/Extensions.lua
+++ b/types/Extensions.lua
@@ -1,0 +1,15 @@
+---@meta
+
+-- Type extensions for classes that BAR injects fields into at runtime.
+-- These prevent inject-field warnings without losing type safety on known fields.
+
+---@class Command
+---@field tx number?
+---@field ty number?
+---@field tz number?
+---@field tag integer?
+---@field [string] any
+
+---@class BuildCommandEntry
+---@field builderCount integer?
+---@field [string] any

--- a/types/GL.lua
+++ b/types/GL.lua
@@ -1,0 +1,4 @@
+---@meta
+---OpenGL enums are integer constants at runtime. Engine stubs name the parameter type `GL`
+---which otherwise resolves to the `GL` enum table and rejects raw integers.
+---@alias GL integer

--- a/types/Gadget.lua
+++ b/types/Gadget.lua
@@ -1,31 +1,12 @@
 ---@meta
 
 ---@class Gadget : Addon, RulesSyncedCallins
----
----Gadgets can control game logic and receive synced and unsynced callins.
----
----**Attention:** Callins from `SyncedCallins` will only work on the unsynced
----portion of the gadget.
----
----**Attention:** To prevent complaints from Lua Language Server, e.g.
----
----> ```md
----> Duplicate field `CommandNotify` (duplicate-set-field)
----> ```
----
----Add this line at the top of your gadget script:
----
----```lua
----local gadget = gadget ---@type Gadget
----```
----
+---@field [string] any
+---@field ghInfo FullGadgetInfo
 ---@see Callins
 ---@see SyncedCallins
 ---@see UnsyncedCallins
 ---@see Spring.IsSyncedCode
----
----@field ghInfo FullGadgetInfo
-local Gadget = {}
 
 ---@class FullGadgetInfo : AddonInfo
 ---@field filename string

--- a/types/InstanceVBOModule.lua
+++ b/types/InstanceVBOModule.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class InstanceVBOModule
+---@field [string] any

--- a/types/InstanceVBOTable.lua
+++ b/types/InstanceVBOTable.lua
@@ -1,0 +1,31 @@
+---@meta
+
+--- Instance VBO table from `gl.InstanceVBOTable` / `InstanceVBOTable.makeInstanceVBOTable`.
+--- Single merged definition (see `modules/graphics/instancevbotable.lua` implementation).
+
+---@class InstanceVBOTable
+---@field instanceVBO VBO|any
+---@field instanceData number[]
+---@field instanceStep integer
+---@field usedElements integer
+---@field maxElements integer
+---@field myName string
+---@field instanceIDtoIndex table<any, integer>
+---@field indextoInstanceID table<integer, any>
+---@field indextoUnitID table<integer, integer>?
+---@field unitIDattribID integer?
+---@field layout table
+---@field dirty boolean
+---@field numVertices integer
+---@field primitiveType integer
+---@field VAO VAO?
+---@field vertexVBO VBO|any?
+---@field indexVBO VBO|any?
+---@field clearInstanceTable fun(self: InstanceVBOTable)
+---@field makeVAOandAttach fun(self: InstanceVBOTable, vertexVBO: any?, instanceVBO: any?, indexVBO: any?): any
+---@field Draw fun(self: InstanceVBOTable)
+---@field draw fun(self: InstanceVBOTable, primitiveType: integer?)
+---@field compact fun(self: InstanceVBOTable)
+---@field Delete fun(self: InstanceVBOTable)
+---@field debug boolean?
+---@field [string] any

--- a/types/LuaFont.lua
+++ b/types/LuaFont.lua
@@ -1,0 +1,15 @@
+---@meta
+
+--- Engine font object from `gl.LoadFont` (subset for LuaUI/LuaRules).
+
+---@class LuaFont
+---@field Begin fun(self: LuaFont, userDefinedBlending: boolean?)
+---@field End fun(self: LuaFont)
+---@field Print fun(self: LuaFont, text: string, x: number, y: number, size: number?, options: string?)
+---@field PrintWorld fun(self: LuaFont, text: string, x: number, y: number, z: number, size: number?, options: string?)
+---@field SetTextColor fun(self: LuaFont, color: table|number, g: number?, b: number?, a: number?)
+---@field SetOutlineColor fun(self: LuaFont, color: table|number, g: number?, b: number?, a: number?)
+---@field GetTextWidth fun(self: LuaFont, text: string): number
+---@field GetTextHeight fun(self: LuaFont, text: string): number, number, number
+---@field WrapText fun(self: LuaFont, text: string, maxWidth: number, maxHeight: number?, size: number?): string, number
+---@field [string] any

--- a/types/LuaShader.lua
+++ b/types/LuaShader.lua
@@ -1,0 +1,23 @@
+---@meta
+
+--- BAR `modules/graphics/LuaShader.lua` instance (compiled shader wrapper).
+
+---@class LuaShader
+---@field shaderObj integer?
+---@field shaderName string?
+---@field Activate fun(self: LuaShader): boolean?
+---@field Deactivate fun(self: LuaShader)
+---@field ActivateWith fun(self: LuaShader, func: function, ...: any)
+---@field SetUniform fun(self: LuaShader, name: string, u1?: number|string, u2?: number, u3?: number, u4?: number): boolean?
+---@field SetUniformInt fun(self: LuaShader, name: string, u1?: integer, u2?: integer, u3?: integer, u4?: integer): boolean?
+---@field SetUniformFloat fun(self: LuaShader, name: string, u1?: number, u2?: number, u3?: number, u4?: number): boolean?
+---@field SetUniformAlways fun(self: LuaShader, name: string, u1?: number|string, u2?: number, u3?: number, u4?: number): boolean?
+---@field SetUniformIntAlways fun(self: LuaShader, name: string, u1?: integer, u2?: integer, u3?: integer, u4?: integer): boolean?
+---@field SetUniformMatrix fun(self: LuaShader, name: string, ...: any): boolean?
+---@field Finalize fun(self: LuaShader)
+---@field Delete fun(self: LuaShader)
+---@field Compile fun(self: LuaShader, ...: any): boolean?
+---@field Initialize fun(self: LuaShader, ...: any): boolean?
+---@field GetHandle fun(self: LuaShader): integer?
+---@field DrawPrintf fun(self: LuaShader?, xoffset?: number, yoffset?: number)?
+---@field [string] any

--- a/types/LuaShaderInstance.lua
+++ b/types/LuaShaderInstance.lua
@@ -1,0 +1,3 @@
+---@meta
+
+---@alias LuaShaderInstance LuaShader

--- a/types/RmlUiElementPtr.lua
+++ b/types/RmlUiElementPtr.lua
@@ -1,0 +1,5 @@
+---@meta
+
+-- Document/Context-created nodes are typed as ElementPtr in generated stubs but expose
+-- the full Element API at runtime.
+---@class RmlUi.ElementPtr : RmlUi.Element

--- a/types/ScenarioTeamStatsRow.lua
+++ b/types/ScenarioTeamStatsRow.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class ScenarioTeamStatsRow
+---@field [string] any

--- a/types/Shader.lua
+++ b/types/Shader.lua
@@ -1,0 +1,5 @@
+---@meta
+
+-- gl.CreateShader() returns an integer program ID. BAR LuaShader wrapper objects
+-- should be annotated as `LuaShaderInstance` (see types/LuaShaderInstance.lua).
+---@alias Shader integer

--- a/types/SpectatorHudKnobVAO.lua
+++ b/types/SpectatorHudKnobVAO.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class SpectatorHudKnobVAO
+---@field [string] any

--- a/types/Spring.lua
+++ b/types/Spring.lua
@@ -1,15 +1,18 @@
--- TODO: delete when recoil-lua-library publishes SpringSynced types
----@class SpringSynced
----@field CMD table
----@field Log fun(section: string, level: number, ...: any)
----@field GetModOptions fun(): table
----@field GetGameFrame fun(): number
----@field IsCheatingEnabled fun(): boolean
----@field GetTeamRulesParam fun(teamID: number, key: string): any
----@field SetTeamRulesParam fun(teamID: number, key: string, value: any)
----@field GetUnitDefID fun(unitID: number): number?
----@field ValidUnitID fun(unitID: number): boolean
----@field GetTeamLuaAI fun(teamID: number): string
+---@class UnitScriptTable
+---@field CallAsUnit fun(unitID: integer, fn: function, ...: any): any
+---@field WaitForMove fun(pieceNum: integer, axis: integer)
+---@field WaitForTurn fun(pieceNum: integer, axis: integer)
+---@field WaitForScale fun(pieceNum: integer)
+---@field GetUnitCOBValue fun(unitID: integer, cobVal: integer, ...: any): integer
+---@field SetUnitCOBValue fun(unitID: integer, cobVal: integer, param: integer|boolean): nil
+---@field Sleep fun(ms: number)
+---@field StartThread fun(fn: function, ...: any)
+---@field SetSignalMask fun(mask: integer)
+---@field Signal fun(mask: integer)
+---@field Hide fun(pieceNum: integer)
+---@field Show fun(pieceNum: integer)
+---@field GetScriptEnv fun(unitID: integer): table
+---@field GetLongestReloadTime fun(unitID: integer): number
 
 -- Engine types (temporary -- will move to recoil-lua-library when eco branch merges)
 ---@class ResourceData
@@ -57,4 +60,9 @@
 ---@field unitDefId string
 ---@field unitDef table?
 ---@field [string] any
+
+--- BAR extends engine `ObjectRenderingTable` in `luarules/Utilities/unitrendering.lua`.
+---@class ObjectRenderingTable
+---@field ActivateMaterial fun(objectID: integer, lod: integer)
+---@field DeactivateMaterial fun(objectID: integer, lod: integer)
 

--- a/types/SyncedGadgetSandbox.lua
+++ b/types/SyncedGadgetSandbox.lua
@@ -1,0 +1,8 @@
+---@meta
+-- Synced gadget environment entries wired in `luarules/system.lua` (engine provides implementation).
+
+---@param ... any
+function SendToUnsynced(...) end
+
+---@param ... any
+function CallAsTeam(...) end

--- a/types/TeamStatsHistoryAugment.lua
+++ b/types/TeamStatsHistoryAugment.lua
@@ -1,0 +1,4 @@
+---@meta
+
+---@class TeamStatsHistoryAugment
+---@field [string] any

--- a/types/UnitDef.lua
+++ b/types/UnitDef.lua
@@ -1,0 +1,6 @@
+---@meta
+
+--- Minimal unit definition stub for widget code paths that only need stable fields.
+---@class UnitDef
+---@field id integer
+---@field name string?

--- a/types/VAO.lua
+++ b/types/VAO.lua
@@ -1,0 +1,18 @@
+---@meta
+
+--- Engine vertex array object (`gl.GetVAO`).
+
+---@class VAO
+---@field Delete fun(self: VAO)
+---@field AttachVertexBuffer fun(self: VAO, vbo: VBO)
+---@field AttachInstanceBuffer fun(self: VAO, vbo: VBO)
+---@field AttachIndexBuffer fun(self: VAO, vbo: VBO)
+---@field DrawArrays fun(self: VAO, glEnum: number, vertexCount: number?, vertexFirst: number?, instanceCount: number?, instanceFirst: number?)
+---@field DrawElements fun(self: VAO, ...: any)
+---@field ClearSubmission fun(self: VAO)
+---@field AddUnitsToSubmission fun(self: VAO, ...: any)
+---@field AddUnitDefsToSubmission fun(self: VAO, ...: any)
+---@field AddFeaturesToSubmission fun(self: VAO, ...: any)
+---@field AddFeatureDefsToSubmission fun(self: VAO, ...: any)
+---@field BindBufferRange fun(self: VAO, ...: any)
+---@field [string] any

--- a/types/VBO.lua
+++ b/types/VBO.lua
@@ -1,0 +1,16 @@
+---@meta
+
+--- Engine GL buffer object (`gl.GetVBO`). Declared in `types/` so LuaLS resolves methods
+--- when `types/` is ordered before generated stubs.
+
+---@class VBO
+---@field Define fun(self: VBO, size: number, attribs?: number|table)
+---@field Upload fun(self: VBO, vboData: number[], attributeIndex: integer?, elemOffset: integer?, luaStartIndex: integer?, luaFinishIndex: integer?): any
+---@field Delete fun(self: VBO)
+---@field BindBufferRange fun(self: VBO, ...: any)
+---@field ModelsVBO fun(self: VBO): (nil|number)
+---@field InstanceDataFromUnitIDs fun(self: VBO, ...: any)
+---@field InstanceDataFromUnitDefIDs fun(self: VBO, ...: any)
+---@field InstanceDataFromFeatureIDs fun(self: VBO, ...: any)
+---@field InstanceDataFromFeatureDefIDs fun(self: VBO, ...: any)
+---@field [string] any

--- a/types/Widget.lua
+++ b/types/Widget.lua
@@ -1,20 +1,8 @@
 ---@meta
 
 ---@class Widget : Addon, RulesUnsyncedCallins
----
----Widgets cannot control game logic and receive only unsynced callins.
----
----**Attention:** To prevent complaints from Lua Language Server, e.g.
----
----> ```md
----> Duplicate field `CommandNotify` (duplicate-set-field)
----> ```
----
----Add this line at the top of your widget script:
----
----```lua
----local widget = widget ---@type Widget
----```
+---@field [string] any
+---@field MousePress fun(self, x: number, y: number, button: number, ...: any): (boolean|integer)?
 ---@see Callins
 ---@see UnsyncedCallins
 
@@ -22,5 +10,5 @@
 ---@diagnostic disable-next-line: lowercase-global
 widget = nil
 
----Shared table for widets.
+---Shared table for widgets.
 WG = {}


### PR DESCRIPTION
Three things that ride together because separately they don't do much:

1. **`.vscode/extensions.json`** — workspace recommendations for VS Code / Cursor / VSCodium. First time you open BAR the editor offers to install EmmyLua, StyLua, clangd. Also flags `sumneko.lua` as `unwantedRecommended` because it's slow as caramelized molasses on our bindings and conflicts with EmmyLua. `.gitignore` switched from `.vscode/` to `.vscode/*` +  `!extensions.json` so this one file is allowed through; everything else in `.vscode/` stays personal.

2. **`.emmyrc.json`** — sandbox globals (UnitScript, gadget/widget handler, engine sandbox, BAR-specific). Read by `emmylua_check` (the CLI that `just bar::check` runs) and `emmylua_ls` (the LSP). Without this file every line of every gadget is an undefined-global storm.

3. **`.luarc.json` trimmed to lux library paths only** + **22 type stubs in `types/`** for engine/BAR API surfaces (VBO/VAO/Shader/LuaFont/Callins/Widget/Gadget/Addon/Extensions/etc., plus enrichments to existing Spring/Addon/Gadget/Widget). Pure type info, no runtime code.

Functionally these are one unit. The recommendation file is useless without the config, the config is useless without the types, and the types are useless without the recommendation telling the editor what's reading them.

## Heads up — this raises the visible problem count

`just bar::check` (and EmmyLua's in-editor diagnostics) will report more problems against master after this lands than they did before. That's because globals/types are now actually defined, so identifiers resolve and real errors surface. They were always there — sumneko was just quietly shrugging at them. Make it work first, report real, fix the real in the next PR.

The fix-up itself (the [BAR transform issue](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/7408) that drives the count back to 0) rides on `fmt-llm-source` and lands separately when the broader bar-fmt stack is ready.

## What's not in this PR (intentionally)

- **`Utilities` / `Debug` / `Lava` / `GetModOptionsCopy` / `I18N` globals
  + their type stubs** — these only exist as bare globals after the
  `detach-bar-modules` codemod runs (today they're `Spring.Utilities`
  etc.). They ride with the `detach-bar-modules-env` branch instead, so
  the .emmyrc.json claims match codebase reality at every step.
- **`.github/workflows/type_check.yml`** — CI gate would fail until the
  source fix-ups land. Stays on `fmt-llm-source`.
- **`types/Test.lua`** (integration-test DSL) — split to
  `mig-integration-tests`.
- **Source-code fix-ups** in `luarules/`, `luaui/`, `gamedata/`, etc. —
  those are the LLM rollout, separate PR.

## Test plan

- [X] Open BAR in a fresh VS Code / Cursor — get the "install recommended
      extensions?" prompt
<img width="920" height="211" alt="image" src="https://github.com/user-attachments/assets/e2760079-b76a-4d38-9b67-1d2767a32698" />
- [X] If sumneko.lua is installed, get the "unwanted extension" notice.

<img width="916" height="214" alt="image" src="https://github.com/user-attachments/assets/f53ead1b-bf26-4006-974f-2c3491824452" />

- [X] Had to add ["Unwanted extensions"](https://marketplace.visualstudio.com/items?itemName=Soulcode.vscode-unwanted-extensions) to the recommended list to get this one to work
- [X] `settings.json`, `launch.json`, etc. still gitignored
- [X] `emmylua_check -c .emmyrc.json .` runs without crashing
- [X] EmmyLua in the editor reads `.emmyrc.json` (sandbox globals no longer
      flagged)
<img width="1201" height="249" alt="image" src="https://github.com/user-attachments/assets/34f0e437-3d13-44a1-a40b-955d8ea828dd" />

      

## LLMs
yes