### PR TITLE
stop flanking yourself

### DIFF
--- a/luarules/gadgets/map_lava.lua
+++ b/luarules/gadgets/map_lava.lua
@@ -170,7 +170,7 @@ if gadgetHandler:IsSyncedCode() then
 							lavaUnits[unitID].currentSlow = unitSlow
 						end
 					end
-				spAddUnitDamage(unitID, lavaDamage, 0, gaiaTeamID, 1)
+				spAddUnitDamage(unitID, lavaDamage, nil, nil)
 				spSpawnCEG(lavaEffectDamage, x, y+5, z)
 				elseif lavaUnits[unitID] then -- unit exited lava
 					if lavaUnits[unitID].slowed then
@@ -187,7 +187,7 @@ if gadgetHandler:IsSyncedCode() then
 				if not geoThermal[FeatureDefID] then
 					x,y,z = spGetFeaturePosition(featureID)
 					if (y and y < lavaLevel) then
-						spAddFeatureDamage(featureID, lavaDamage, 0, gaiaTeamID)
+						spAddFeatureDamage(featureID, lavaDamage, nil, nil)
 						spSpawnCEG(lavaEffectDamage, x, y+5, z)
 					end
 				end

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -419,7 +419,8 @@ local function damageTargetsInAreas(timedAreas, gameFrame)
 						spSpawnCEG(area.damageCeg, hitX, hitY, hitZ)
 					end
 					data.damageTaken = damageTaken + damage
-					spAddUnitDamage(unitID, damage, nil, area.owner, area.weapon)
+					-- GetFlankingBonus evaluates the zero-vector to 50% flanking bonus, so conditionally remove:
+					spAddUnitDamage(unitID, damage, nil, area.owner ~= unitID and area.owner or nil, area.weapon)
 				end
             end
         end

--- a/luarules/gadgets/unit_water_depth_damage.lua
+++ b/luarules/gadgets/unit_water_depth_damage.lua
@@ -111,7 +111,7 @@ function gadget:UnitEnteredWater(unitID, unitDefID, unitTeam)
 				if damage >= health then
 					spDestroyUnit(unitID) --this ensures a wreck is left behind. If damage is too great, it destroys the heap.
 				else
-					spAddUnitDamage(unitID, damage, 0, gaiaTeamID, waterDamageDefID)
+					spAddUnitDamage(unitID, damage, 0, nil, waterDamageDefID)
 				end
 			end
 		else
@@ -170,7 +170,7 @@ function gadget:GameFrame(frame)
 					if math.random(1, 6) == 1 then
 						spPlaySoundFile('alien_electric', 0.50, posX, posY, posZ, 'sfx')
 					end
-					spAddUnitDamage(unitID, data.drowningDamage, 0, gaiaTeamID, waterDamageDefID)
+					spAddUnitDamage(unitID, data.drowningDamage, 0, nil, waterDamageDefID)
 				end
 			else
 				drowningUnitsWatch[unitID] = nil --dead unit


### PR DESCRIPTION
### Work done

Remove self-flanking damage bonus from AddUnitDamage calls pending any good reason to reenable it.

#### Addresses Issue(s)

The engine evaluates the zero-vector resulting from self-damage (dir = self.pos - self.pos) to the average flanking bonus (+50%) in all cases.

- Relevantish, this is more about parsing defs: https://github.com/beyond-all-reason/RecoilEngine/issues/1964