### PR TITLE
Fix sporadic gui_selfd_icons integration test failures

### DIFF
--- a/luaui/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
+++ b/luaui/Tests/gui_selfd_icons/test_gui_selfd_icons_armpw.lua
@@ -8,6 +8,7 @@ function setup()
 	Test.clearMap()
 
 	Test.prepareWidget(widgetName)
+	Test.expectCallin("UnitCommand")
 end
 
 function cleanup()
@@ -34,26 +35,27 @@ function test()
 
 	-- standard selfd command
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
-	Test.waitFrames(1)
+	Test.waitUntilCallinArgs("UnitCommand", { unitID, nil, nil, CMD.SELFD })
 	assert(table.count(widget.activeSelfD) == 1)
 	assert(table.count(widget.queuedSelfD) == 0)
 
 	-- cancel selfd order
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
-	Test.waitFrames(1)
+	Test.waitUntilCallinArgs("UnitCommand", { unitID, nil, nil, CMD.SELFD })
 	assert(table.count(widget.activeSelfD) == 0)
 	assert(table.count(widget.queuedSelfD) == 0)
 
 	-- queued selfd order
 	Spring.GiveOrderToUnit(unitID, CMD.MOVE, { 1, 1, 1 }, 0)
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, { "shift" })
-	Test.waitFrames(1)
+	Test.waitUntilCallinArgs("UnitCommand", { unitID, nil, nil, CMD.SELFD })
 	assert(table.count(widget.activeSelfD) == 0)
 	assert(table.count(widget.queuedSelfD) == 1)
 
 	-- remove move order
 	Spring.GiveOrderToUnit(unitID, CMD.REMOVE, { CMD.MOVE }, { "alt" })
-	Test.waitFrames(1)
-	assert(table.count(widget.activeSelfD) == 1)
-	assert(table.count(widget.queuedSelfD) == 0)
+	Test.waitUntil(function()
+		return table.count(widget.activeSelfD) == 1
+			and table.count(widget.queuedSelfD) == 0
+	end, 10)
 end

--- a/luaui/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
+++ b/luaui/Tests/gui_selfd_icons/test_gui_selfd_icons_armvp.lua
@@ -8,6 +8,7 @@ function setup()
 	Test.clearMap()
 
 	Test.prepareWidget(widgetName)
+	Test.expectCallin("UnitCommand")
 end
 
 function cleanup()
@@ -34,13 +35,13 @@ function test()
 
 	-- standard selfd command
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
-	Test.waitFrames(1)
+	Test.waitUntilCallinArgs("UnitCommand", { unitID, nil, nil, CMD.SELFD })
 	assert(table.count(widget.activeSelfD) == 1)
 	assert(table.count(widget.queuedSelfD) == 0)
 
 	-- cancel selfd order
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
-	Test.waitFrames(1)
+	Test.waitUntilCallinArgs("UnitCommand", { unitID, nil, nil, CMD.SELFD })
 	assert(table.count(widget.activeSelfD) == 0)
 	assert(table.count(widget.queuedSelfD) == 0)
 


### PR DESCRIPTION
### Summary

The gui_selfd_icons integration tests fail sporadically in CI due to a race condition. After Spring.GiveOrderToUnit, the tests used Test.waitFrames(1) before asserting widget state — but the UnitCommand callin isn't guaranteed to fire within a single frame under load.

Replaced waitFrames(1) with waitUntilCallinArgs("UnitCommand", ...) to wait for the actual event, matching the pattern already used in the cmd_stop_selfd tests.

### Changes

- 	est_gui_selfd_icons_armpw.lua: Added Test.expectCallin("UnitCommand") in setup, replaced 3x waitFrames(1) with callin-based waits, final block uses waitUntil on observable state
- 	est_gui_selfd_icons_armvp.lua: Same fix for its 2 SELFD command blocks

### AI Disclosure

Developed with GitHub Copilot (Claude). Used for investigation, implementation, and test validation. All changes reviewed and verified by the contributor.
