### PR TITLE
Un-hardcode the keybinds for FOV

### DIFF
--- a/luaui/Widgets/camera_fov_changer.lua
+++ b/luaui/Widgets/camera_fov_changer.lua
@@ -3,15 +3,14 @@ local widget = widget ---@type Widget
 function widget:GetInfo()
 	return {
 	name      = "FOV changer",
-	desc      = "shortcuts: keypad 1/7 or CTRL+O/P",
-	author    = "",
-	date      = "",
+	desc      = "Changes the camera's field of view, either by a relative amount or to a specific value",
+	author    = "Floris, Chronographer",
+	date      = "April 10, 2019",
 	license   = "GNU GPL, v2 or later",
 	layer     = 999999,
 	enabled   = false
 	}
 end
-
 
 -- Localized functions for performance
 local mathFloor = math.floor
@@ -19,28 +18,57 @@ local mathFloor = math.floor
 -- Localized Spring API for performance
 local spEcho = Spring.Echo
 
-local fovStep = 5
-local FOVminus = 111 -- CTRL+O
-local FOVplus = 112 -- CTRL+P
-local FOVminus2 = 257 --KP1
-local FOVplus2 = 263 --KP7
+--------------------------------------------------------------------------------
+-- Bindable actions:	fov [number] - Set Field of View to [number] or 45 degrees
+-- 						fov_inc [number] - Increase Field of View [number] or 5 degrees
+-- 						fov_dec [number] - Decrease Field of View [number] or 5 degrees	
+--------------------------------------------------------------------------------
+local FOV_DEFAULT = 40
+local STEP_DEFAULT = 5
 
-function widget:KeyRelease(key, modifier)
-	--spEcho(key)
-	if ((key == FOVplus and modifier.ctrl) or key == FOVplus2 or (key == FOVminus and modifier.ctrl) or key == FOVminus2) then
-		local current_cam_state = Spring.GetCameraState()
-		if key == FOVplus or key == FOVplus2 then
-			current_cam_state.fov = mathFloor(current_cam_state.fov + fovStep)
-			if current_cam_state.fov > 100 then	-- glitches beyond 100
-				current_cam_state.fov = 100
-			end
-		else
-			current_cam_state.fov = mathFloor(current_cam_state.fov - fovStep)
-			if current_cam_state.fov < 0 then
-				current_cam_state.fov = 0
-			end
-		end
-		spEcho('target FOV: '..current_cam_state.fov)
-		Spring.SetCameraState(current_cam_state, WG['options'] and WG['options'].getCameraSmoothness() or 2)
+local fovTarget
+local direction
+
+local function limitFieldOfView(fov)
+	if fov < 0 then
+		return 0
+	elseif fov > 100 then -- glitches beyond 100
+		return 100 
+	else
+		return fov
 	end
+end
+
+local function updateFieldOfView(fovTarget, direction)
+	local current_cam_state = Spring.GetCameraState()
+	if direction == 1 or direction == -1 then
+		current_cam_state.fov = mathFloor(current_cam_state.fov + direction * fovTarget)
+		current_cam_state.fov = limitFieldOfView(current_cam_state.fov)
+	elseif direction == 0 then
+		current_cam_state.fov = limitFieldOfView(fovTarget)
+	end
+
+	spEcho('FOV: '..current_cam_state.fov)
+	Spring.SetCameraState(current_cam_state, WG['options'] and WG['options'].getCameraSmoothness() or 2)
+end
+
+local function fieldOfViewHandler(_, _, args, data, isRepeat, isRelease)
+	local data = data or {}
+	direction = data["direction"]
+	local args = args or {}
+	fovTarget = (args[1] and tonumber(args[1])) or (direction == 0 and FOV_DEFAULT or STEP_DEFAULT)
+	updateFieldOfView(fovTarget, direction)
+	return true
+end
+
+function widget:Initialize()
+    widgetHandler:AddAction("fov_inc", fieldOfViewHandler, {direction = 1}, "pt")
+    widgetHandler:AddAction("fov_dec", fieldOfViewHandler, {direction = -1}, "pt")
+	widgetHandler:AddAction("fov", fieldOfViewHandler, {direction = 0}, "pt")
+end
+
+function widget:Shutdown()
+	widgetHandler:RemoveAction("fov_inc", "pt")
+	widgetHandler:RemoveAction("fov_dec", "pt")
+	widgetHandler:RemoveAction("fov", "pt")
 end

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -69,6 +69,12 @@ bind            Any+alt  movereset      // fast camera reset on mousewheel
 bind            Any+alt  moverotate     // rotate on x,y with mmb hold + move (Spring Camera)
 bind           Any+ctrl  movetilt       // rotate on x with mousewheel
 
+bind          ctrl+sc_o  fov_dec 5      // decrease field of view 5 degrees
+bind          ctrl+sc_p  fov_inc 5      // increase field of view 5 degrees
+bind         sc_numpad1  fov_dec 5      // decrease field of view 5 degrees
+bind         sc_numpad7  fov_inc 5      // increase field of view 5 degrees
+// bind                  fov 40         // set field of view to 40 degrees
+
 // picture in picture camera controls
 // bind                  pip0_activity      // Focus advanced minimap onto recently placed map markers
 // bind                  pip0_trackplayer   // Focus advanced minimap (while spectating)


### PR DESCRIPTION
### Work done
Un-hardcode the keybinds for the FOV changer widget. The step size is taken as an argument for relative changes `fov_inc` and `foc_dec`.  Also add an additional action `fov` that sets the FOV to the argument number directly.

These are also available as chat actions directly. 

#### Setup

- `/togglewidget FOV changer` if not enabled

#### Test steps
- Test out the default keybind behavior remains as previous hardcoded behavior:
```
bind          ctrl+sc_o  fov_dec 5      // decrease field of view 5 degrees
bind          ctrl+sc_p  fov_inc 5      // increase field of view 5 degrees
bind         sc_numpad1  fov_dec 5      // decrease field of view 5 degrees
bind         sc_numpad7  fov_inc 5      // increase field of view 5 degrees
// bind                  fov 40         // set field of view to 40 degrees
```

- Adjust to custom keybinds and ensure controls still work
- Adjust arguments (increment number) and ensure FOV changes by the specified amount
- Pass bad arguments like `/fov_inc FOO BAR` and see FOV changes only be the default amount 5 Degree steps

### AI / LLM usage statement:
No AI, still haven't got a local agent working. 
