### PR TITLE
Fix UI bug regarding unit_stats being displayed

### DIFF
--- a/luaui/Widgets/gui_tooltip.lua
+++ b/luaui/Widgets/gui_tooltip.lua
@@ -425,6 +425,9 @@ function widget:DrawScreen()
 	if WG['topbar'] and WG['topbar'].showingQuit() then
 		return
 	end
+	if WG['unitstats'] and WG['unitstats'].isShowing() then
+		return
+	end
 	local x, y = spGetMouseState()
 	local now = os.clock()
 

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -9,7 +9,7 @@ function widget:GetInfo()
 		date      = "Jan 11, 2009",
 		version   = 1.7,
 		license   = "GNU GPL, v2 or later",
-		layer     = -999990,
+		layer     = 0,
 		enabled   = true,
 	}
 end

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -417,7 +417,7 @@ function widget:Initialize()
 
 	WG['unitstats'] = {}
 	WG['unitstats'].showUnit = function(unitID)
-    		showUnitID = unitID
+		showUnitID = unitID
 	end
 	WG['unitstats'].isShowing = function()
 		return showStats

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -9,7 +9,7 @@ function widget:GetInfo()
 		date      = "Jan 11, 2009",
 		version   = 1.7,
 		license   = "GNU GPL, v2 or later",
-		layer     = 0,
+		layer     = -999990,
 		enabled   = true,
 	}
 end
@@ -417,7 +417,10 @@ function widget:Initialize()
 
 	WG['unitstats'] = {}
 	WG['unitstats'].showUnit = function(unitID)
-		showUnitID = unitID
+    		showUnitID = unitID
+	end
+	WG['unitstats'].isShowing = function()
+		return showStats
 	end
 
 	widgetHandler:AddAction("unit_stats", enableStats, nil, "p")


### PR DESCRIPTION
### Work done
Added visibility flag for unit_stats, so that the unit tooltip with name and description will disappear to not cover it up

#### Addresses Issue(s)
https://discord.com/channels/549281623154229250/1498079574540423259

### Screenshots:
#### BEFORE:
<img width="1920" height="1080" alt="Στιγμιότυπο οθόνης (114)" src="https://github.com/user-attachments/assets/87256cd3-fe88-4ff5-a224-4f2fda4ab25d" />

#### AFTER:
<img width="1920" height="1080" alt="Στιγμιότυπο οθόνης (116)" src="https://github.com/user-attachments/assets/1c81a3fc-bb86-43a3-8b88-d882edf1d362" />
<img width="1920" height="1080" alt="Στιγμιότυπο οθόνης (115)" src="https://github.com/user-attachments/assets/9d9adb06-9e98-4f0d-b810-61c393736d23" />

### AI / LLM usage statement:
Slight use of Claude - Sonnet 4.6