### PR TITLE
Gadget to reduce DGun griefing

### DIFF
--- a/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
+++ b/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
@@ -24,6 +24,7 @@ local spGetUnitsInSphere = Spring.GetUnitsInSphere
 local spGetTeamInfo = Spring.GetTeamInfo
 local spGetUnitLosState = Spring.GetUnitLosState
 local spGetGaiaTeamID = Spring.GetGaiaTeamID
+local spPlaySoundFile = Spring.PlaySoundFile
 local spEcho = Spring.Echo
 
 local CMD_DGUN = CMD.DGUN
@@ -97,11 +98,12 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
 			local ux, uy, uz = spGetUnitPosition(unitID)
 			if ux then
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
-				if d < DGUN_WIDTH then
-					dangerCount = dangerCount + 1
-					spEcho("WARNING: an attempt to d-gun allies was recorded. Griefing your team is a violation of the Code of Conduct." .. dangerCount)
-					return true
-				end
+					if d < DGUN_WIDTH then
+						dangerCount = dangerCount + 1
+						spPlaySoundFile("sounds/ui/warning2.wav", 1, "ui")
+						spEcho("WARNING: we have recorded an attempt to D-Gun your allies. Griefing your team is a violation of the Code of Conduct!" .. dangerCount)
+						return true
+					end
 			end
 		end
 	end

--- a/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
+++ b/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
@@ -33,6 +33,10 @@ local ENEMY_SCAN_RADIUS = 1500
 local dangerCount = 0
 local gaiaTeamID = spGetGaiaTeamID()
 
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_DGUN)
+end
+
 local function GetAllyTeamID(teamID)
 	local _, _, _, _, _, allyTeamID = spGetTeamInfo(teamID)
 	return allyTeamID
@@ -95,7 +99,7 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
 				if d < DGUN_WIDTH then
 					dangerCount = dangerCount + 1
-					spEcho("DANGER " .. dangerCount)
+					spEcho("WARNING: an attempt to d-gun allies was recorded. Griefing your team is a violation of the Code of Conduct." .. dangerCount)
 					return true
 				end
 			end
@@ -120,7 +124,6 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 				local unitDef = unitDefID and UnitDefs[unitDefID]
 				local unitName = unitDef and (unitDef.translatedHumanName or unitDef.name) or "unknown"
 				local dist = (ex and math.sqrt((ex - ux) * (ex - ux) + (ey - uy) * (ey - uy) + (ez - uz) * (ez - uz))) or ENEMY_SCAN_RADIUS
-				spEcho(string.format("Enemy nearby: %s (unitID=%d, teamID=%d, dist=%.0f)", unitName, unitID, unitTeam, dist))
 				return true
 			end
 		end
@@ -129,23 +132,23 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	return false
 end
 
-function gadget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams)
+function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if cmdID ~= CMD_DGUN then
-		return
+		return true
 	end
 
 	local uDef = UnitDefs[unitDefID]
 	if not (uDef and uDef.customParams and uDef.customParams.iscommander) then
-		return
+		return true
 	end
 
 	local ux, uy, uz = spGetUnitPosition(unitID)
 	if not ux then
-		return
+		return true
 	end
 
 	if HasKnownEnemyNearby(teamID, ux, uy, uz) then
-		return
+		return true
 	end
 
 	local tx, ty, tz
@@ -156,9 +159,9 @@ function gadget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams)
 	end
 
 	if not tx then
-		return
+		return true
 	end
 
 	local sx, sy, sz, ex, ey, ez = BuildDGunSegment(ux, uy, uz, tx, ty, tz)
-	HandleDGunAllyRisk(teamID, unitID, sx, sy, sz, ex, ey, ez)
+	return not HandleDGunAllyRisk(teamID, unitID, sx, sy, sz, ex, ey, ez)
 end

--- a/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
+++ b/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
@@ -1,0 +1,130 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "DGun Ally Danger Echo",
+		desc    = "Echoes DANGER when an ally's DGun path intersects allied units",
+		author  = "Codex",
+		date    = "2026-05-01",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitsInBox = Spring.GetUnitsInBox
+local spGetTeamInfo = Spring.GetTeamInfo
+local spEcho = Spring.Echo
+
+local CMD_DGUN = CMD.DGUN
+local DGUN_RANGE = 280
+local DGUN_WIDTH = 60
+local dangerCount = 0
+
+local function GetAllyTeamID(teamID)
+	local _, _, _, _, _, allyTeamID = spGetTeamInfo(teamID)
+	return allyTeamID
+end
+
+local function BuildDGunSegment(ux, uy, uz, tx, ty, tz)
+	local dx, dy, dz = tx - ux, ty - uy, tz - uz
+	local dist = math.sqrt(dx * dx + dy * dy + dz * dz)
+	if dist == 0 then
+		dist = 1
+	end
+
+	local nx, ny, nz = dx / dist, dy / dist, dz / dist
+	if dist <= DGUN_RANGE then
+		return ux, uy, uz, ux + nx * DGUN_RANGE, uy + ny * DGUN_RANGE, uz + nz * DGUN_RANGE
+	end
+
+	return tx - nx * DGUN_RANGE, ty - ny * DGUN_RANGE, tz - nz * DGUN_RANGE, tx, ty, tz
+end
+
+local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
+	local vx, vy, vz = bx - ax, by - ay, bz - az
+	local wx, wy, wz = px - ax, py - ay, pz - az
+
+	local c1 = vx * wx + vy * wy + vz * wz
+	if c1 <= 0 then
+		local dx, dy, dz = px - ax, py - ay, pz - az
+		return math.sqrt(dx * dx + dy * dy + dz * dz)
+	end
+
+	local c2 = vx * vx + vy * vy + vz * vz
+	if c2 <= c1 then
+		local dx, dy, dz = px - bx, py - by, pz - bz
+		return math.sqrt(dx * dx + dy * dy + dz * dz)
+	end
+
+	local b = c1 / c2
+	local bx2, by2, bz2 = ax + b * vx, ay + b * vy, az + b * vz
+	local dx, dy, dz = px - bx2, py - by2, pz - bz2
+	return math.sqrt(dx * dx + dy * dy + dz * dz)
+end
+
+local function HandleDGunAllyRisk(teamID, sx, sy, sz, ex, ey, ez)
+	local minx = math.min(sx, ex) - DGUN_WIDTH
+	local maxx = math.max(sx, ex) + DGUN_WIDTH
+	local miny = math.min(sy, ey) - DGUN_WIDTH
+	local maxy = math.max(sy, ey) + DGUN_WIDTH
+	local minz = math.min(sz, ez) - DGUN_WIDTH
+	local maxz = math.max(sz, ez) + DGUN_WIDTH
+
+	local candidates = spGetUnitsInBox(minx, miny, minz, maxx, maxy, maxz)
+	local myAllyTeam = GetAllyTeamID(teamID)
+
+	for i = 1, #candidates do
+		local unitID = candidates[i]
+		local unitTeam = spGetUnitTeam(unitID)
+		if unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
+			local ux, uy, uz = spGetUnitPosition(unitID)
+			if ux then
+				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
+				if d < DGUN_WIDTH then
+					dangerCount = dangerCount + 1
+					spEcho("DANGER " .. dangerCount)
+					return true
+				end
+			end
+		end
+	end
+
+	return false
+end
+
+function gadget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams)
+	if cmdID ~= CMD_DGUN then
+		return
+	end
+
+	local uDef = UnitDefs[unitDefID]
+	if not (uDef and uDef.customParams and uDef.customParams.iscommander) then
+		return
+	end
+
+	local ux, uy, uz = spGetUnitPosition(unitID)
+	if not ux then
+		return
+	end
+
+	local tx, ty, tz
+	if #cmdParams == 1 and cmdParams[1] > 0 then
+		tx, ty, tz = spGetUnitPosition(cmdParams[1])
+	else
+		tx, ty, tz = cmdParams[1], cmdParams[2], cmdParams[3]
+	end
+
+	if not tx then
+		return
+	end
+
+	local sx, sy, sz, ex, ey, ez = BuildDGunSegment(ux, uy, uz, tx, ty, tz)
+	HandleDGunAllyRisk(teamID, sx, sy, sz, ex, ey, ez)
+end

--- a/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
+++ b/luarules/gadgets/cmd_dgun_ally_danger_echo.lua
@@ -18,14 +18,20 @@ end
 
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitsInBox = Spring.GetUnitsInBox
+local spGetUnitsInSphere = Spring.GetUnitsInSphere
 local spGetTeamInfo = Spring.GetTeamInfo
+local spGetUnitLosState = Spring.GetUnitLosState
+local spGetGaiaTeamID = Spring.GetGaiaTeamID
 local spEcho = Spring.Echo
 
 local CMD_DGUN = CMD.DGUN
 local DGUN_RANGE = 280
 local DGUN_WIDTH = 60
+local ENEMY_SCAN_RADIUS = 1500
 local dangerCount = 0
+local gaiaTeamID = spGetGaiaTeamID()
 
 local function GetAllyTeamID(teamID)
 	local _, _, _, _, _, allyTeamID = spGetTeamInfo(teamID)
@@ -69,7 +75,7 @@ local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
 	return math.sqrt(dx * dx + dy * dy + dz * dz)
 end
 
-local function HandleDGunAllyRisk(teamID, sx, sy, sz, ex, ey, ez)
+local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
 	local minx = math.min(sx, ex) - DGUN_WIDTH
 	local maxx = math.max(sx, ex) + DGUN_WIDTH
 	local miny = math.min(sy, ey) - DGUN_WIDTH
@@ -83,7 +89,7 @@ local function HandleDGunAllyRisk(teamID, sx, sy, sz, ex, ey, ez)
 	for i = 1, #candidates do
 		local unitID = candidates[i]
 		local unitTeam = spGetUnitTeam(unitID)
-		if unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
+		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
 			local ux, uy, uz = spGetUnitPosition(unitID)
 			if ux then
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
@@ -92,6 +98,30 @@ local function HandleDGunAllyRisk(teamID, sx, sy, sz, ex, ey, ez)
 					spEcho("DANGER " .. dangerCount)
 					return true
 				end
+			end
+		end
+	end
+
+	return false
+end
+
+local function HasKnownEnemyNearby(teamID, ux, uy, uz)
+	local myAllyTeam = GetAllyTeamID(teamID)
+	local candidates = spGetUnitsInSphere(ux, uy, uz, ENEMY_SCAN_RADIUS)
+
+	for i = 1, #candidates do
+		local unitID = candidates[i]
+		local unitTeam = spGetUnitTeam(unitID)
+		if unitTeam and unitTeam ~= gaiaTeamID and GetAllyTeamID(unitTeam) ~= myAllyTeam then
+			local losState = spGetUnitLosState(unitID, myAllyTeam, true)
+			if losState and (losState % 4) > 0 then
+				local ex, ey, ez = spGetUnitPosition(unitID)
+				local unitDefID = spGetUnitDefID(unitID)
+				local unitDef = unitDefID and UnitDefs[unitDefID]
+				local unitName = unitDef and (unitDef.translatedHumanName or unitDef.name) or "unknown"
+				local dist = (ex and math.sqrt((ex - ux) * (ex - ux) + (ey - uy) * (ey - uy) + (ez - uz) * (ez - uz))) or ENEMY_SCAN_RADIUS
+				spEcho(string.format("Enemy nearby: %s (unitID=%d, teamID=%d, dist=%.0f)", unitName, unitID, unitTeam, dist))
+				return true
 			end
 		end
 	end
@@ -114,6 +144,10 @@ function gadget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams)
 		return
 	end
 
+	if HasKnownEnemyNearby(teamID, ux, uy, uz) then
+		return
+	end
+
 	local tx, ty, tz
 	if #cmdParams == 1 and cmdParams[1] > 0 then
 		tx, ty, tz = spGetUnitPosition(cmdParams[1])
@@ -126,5 +160,5 @@ function gadget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams)
 	end
 
 	local sx, sy, sz, ex, ey, ez = BuildDGunSegment(ux, uy, uz, tx, ty, tz)
-	HandleDGunAllyRisk(teamID, sx, sy, sz, ex, ey, ez)
+	HandleDGunAllyRisk(teamID, unitID, sx, sy, sz, ex, ey, ez)
 end

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -4,10 +4,11 @@ function gadget:GetInfo()
 	return {
 		name    = "DGun Griefing Prevention",
 		desc    = "Prevents players from firing DGuns that intersect ally units and gives them both text and audio warning. Note that DGuns are always allowed if the commander is on the frontline.",
-		author  = "TheDujin, with Codex",
+		author  = "TheDujin, with Codex. DGun ally detection code by kroIya/Color",
 		date    = "2026-05-01",
 		license = "GNU GPL, v2 or later",
 		layer   = 0,
+        version = "0.2",
 		enabled = true,
 	}
 end
@@ -18,22 +19,30 @@ end
 
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitsInBox = Spring.GetUnitsInBox
 local spGetUnitsInSphere = Spring.GetUnitsInSphere
 local spGetTeamInfo = Spring.GetTeamInfo
 local spGetUnitLosState = Spring.GetUnitLosState
 local spGetGaiaTeamID = Spring.GetGaiaTeamID
+local spGetPlayerInfo = Spring.GetPlayerInfo
+local spGetGameFrame = Spring.GetGameFrame
 local spPlaySoundFile = Spring.PlaySoundFile
 local spEcho = Spring.Echo
 
 local CMD_DGUN = CMD.DGUN
 local DGUN_RANGE = 280
-local DGUN_WIDTH = 60
+-- Excessively large dgun safety range to acount for some units, such as behemoths, being quite large
+local DGUN_SAFETY_RANGE = 100
+-- Approximate actual width of the dgun projectile
+local DGUN_WIDTH = 20
 -- 1500 is a bit more than the range of a Vanguard
 -- In my opinion, there is never a reason to even fire a DGun if there are no enemies within VANGUARD distance
 -- We can tweak this smaller as needed
 local ENEMY_SCAN_RADIUS = 1500
+local SEISMIC_PING_DURATION = 5 * 30 -- five seconds at 30 gameframes per second
 local gaiaTeamID = spGetGaiaTeamID()
+local seismicPings = {}
 
 function gadget:Initialize()
 	-- Hook DGun commands into allow/disallow interface
@@ -43,6 +52,35 @@ end
 local function GetAllyTeamID(teamID)
 	local _, _, _, _, _, allyTeamID = spGetTeamInfo(teamID)
 	return allyTeamID
+end
+
+local function GetPlayerName(playerID)
+	local name = playerID and select(1, spGetPlayerInfo(playerID, false))
+	return name or "unknown player"
+end
+
+local function GetApproxUnitRadius(unitDefID)
+	local unitDef = unitDefID and UnitDefs[unitDefID]
+	if not unitDef then
+		return 0 -- If unknown unit, then we pretend it is tiny. This is to minimize false positives
+	end
+
+	if unitDef.radius and unitDef.radius > 0 then
+		return unitDef.radius
+	end
+
+	local footprintX = unitDef.xsize or 0
+	local footprintZ = unitDef.zsize or 0
+	local approxRadius = math.min(footprintX, footprintZ) * 4
+	return approxRadius
+end
+
+local function PruneExpiredSeismicPings(currentFrame)
+	for i = #seismicPings, 1, -1 do
+		if seismicPings[i].expiresFrame <= currentFrame then
+			table.remove(seismicPings, i)
+		end
+	end
 end
 
 -- Convert a DGun target into a line segment representing the beam path
@@ -84,29 +122,44 @@ local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
 	return math.sqrt(dx * dx + dy * dy + dz * dz)
 end
 
-local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
+local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex, ey, ez)
 	-- Build a cheap box around the beam first, then do the precise segment test
-	local minx = math.min(sx, ex) - DGUN_WIDTH
-	local maxx = math.max(sx, ex) + DGUN_WIDTH
-	local miny = math.min(sy, ey) - DGUN_WIDTH
-	local maxy = math.max(sy, ey) + DGUN_WIDTH
-	local minz = math.min(sz, ez) - DGUN_WIDTH
-	local maxz = math.max(sz, ez) + DGUN_WIDTH
+	local minx = math.min(sx, ex) - DGUN_SAFETY_RANGE
+	local maxx = math.max(sx, ex) + DGUN_SAFETY_RANGE
+	local miny = math.min(sy, ey) - DGUN_SAFETY_RANGE
+	local maxy = math.max(sy, ey) + DGUN_SAFETY_RANGE
+	local minz = math.min(sz, ez) - DGUN_SAFETY_RANGE
+	local maxz = math.max(sz, ez) + DGUN_SAFETY_RANGE
 
 	local candidates = spGetUnitsInBox(minx, miny, minz, maxx, maxy, maxz)
 	local myAllyTeam = GetAllyTeamID(teamID)
+	spEcho(string.format("DGun coarse box candidates: %d", #candidates))
 
 	for i = 1, #candidates do
 		local unitID = candidates[i]
 		local unitTeam = spGetUnitTeam(unitID)
+		local unitDefID = spGetUnitDefID(unitID)
+		local unitDef = unitDefID and UnitDefs[unitDefID]
+		local unitName = unitDef and (unitDef.translatedHumanName or unitDef.name) or "unknown"
+		local unitRadius = GetApproxUnitRadius(unitDefID)
+		spEcho(string.format(
+			"DGun coarse candidate: %s (unitID=%d, teamID=%s, radius=%.0f)",
+			unitName,
+			unitID,
+			tostring(unitTeam),
+			unitRadius
+		))
 		-- Skip the firing commander itself; only warn on other units in the path
 		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
 			local ux, uy, uz = spGetUnitPosition(unitID)
 			if ux then
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
-				if d < DGUN_WIDTH then
+				if d < unitRadius + DGUN_WIDTH / 2 then
 					spPlaySoundFile("sounds/ui/warning2.wav")
-					spEcho("WARNING: we have recorded an attempt to D-Gun your allies. Griefing your team is a violation of the Code of Conduct!")
+					spEcho(string.format(
+						"WARNING: %s attempted to D-Gun allies. Griefing your team is a violation of the Code of Conduct!",
+						GetPlayerName(playerID)
+					))
 					return true
 				end
 			end
@@ -119,6 +172,9 @@ end
 local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	-- If the commander is already near a visible enemy, we leave the order alone
 	local myAllyTeam = GetAllyTeamID(teamID)
+	local currentFrame = spGetGameFrame()
+	PruneExpiredSeismicPings(currentFrame)
+
 	local candidates = spGetUnitsInSphere(ux, uy, uz, ENEMY_SCAN_RADIUS)
 
 	for i = 1, #candidates do
@@ -132,7 +188,30 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 		end
 	end
 
+	-- Treat recent seismic pings as temporarily visible enemy presence.
+	for i = 1, #seismicPings do
+		local ping = seismicPings[i]
+		if ping.allyTeam ~= myAllyTeam then
+			local dx, dy, dz = ping.x - ux, ping.y - uy, ping.z - uz
+			if (dx * dx + dy * dy + dz * dz) <= (ENEMY_SCAN_RADIUS * ENEMY_SCAN_RADIUS) then
+				return true
+			end
+		end
+	end
+
 	return false
+end
+
+function gadget:UnitSeismicPing(x, y, z, strength, allyTeam, unitID, unitDefID)
+	-- Cache seismic detections briefly so they count as visible enemy presence.
+	local currentFrame = spGetGameFrame()
+	seismicPings[#seismicPings + 1] = {
+		x = x,
+		y = y,
+		z = z,
+		allyTeam = Spring.GetUnitAllyTeam(unitID), -- The allyTeam parameter is the team of the PING, not the team of the unit causing the ping
+		expiresFrame = currentFrame + SEISMIC_PING_DURATION,
+	}
 end
 
 -- Allow normal DGuns, block only ally-targeted hits. If an enemy is visibly nearby, DGuns are always allowed.
@@ -167,5 +246,5 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 	end
 
 	local sx, sy, sz, ex, ey, ez = BuildDGunSegment(ux, uy, uz, tx, ty, tz)
-	return not HandleDGunAllyRisk(teamID, unitID, sx, sy, sz, ex, ey, ez)
+	return not HandleDGunAllyRisk(teamID, unitID, playerID, sx, sy, sz, ex, ey, ez)
 end

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -8,7 +8,7 @@ function gadget:GetInfo()
 		date    = "2026-05-01",
 		license = "GNU GPL, v2 or later",
 		layer   = 0,
-        version = "0.3",
+        version = "1.0",
 		enabled = true,
 	}
 end
@@ -44,6 +44,8 @@ local gaiaTeamID = spGetGaiaTeamID()
 local contactsCache = {}
 -- Tracks enemy contacts briefly so that dguns are allowed for a few seconds even after contact is lost
 local CONTACT_WINDOW_DURATION = 5 * 30 -- five seconds at 30 gameframes per second
+local CONTACT_PRUNE_INTERVAL = 60 * 30 -- prune expired contacts every minute
+local nextContactPruneFrame = CONTACT_PRUNE_INTERVAL
 
 function gadget:Initialize()
 	-- Hook DGun commands into allow/disallow interface
@@ -76,7 +78,7 @@ local function GetApproxUnitRadius(unitDefID)
 	return approxRadius
 end
 
-local function PruneExpiredSeismicPings(currentFrame)
+local function PruneExpiredContacts(currentFrame)
 	for i = #contactsCache, 1, -1 do
 		if contactsCache[i].expiresFrame <= currentFrame then
 			table.remove(contactsCache, i)
@@ -174,7 +176,7 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	-- If the commander is already near a visible enemy, we leave the order alone
 	local myAllyTeam = GetAllyTeamID(teamID)
 	local currentFrame = spGetGameFrame()
-	PruneExpiredSeismicPings(currentFrame)
+	PruneExpiredContacts(currentFrame)
 
 	local candidates = spGetUnitsInSphere(ux, uy, uz, ENEMY_SCAN_RADIUS)
 
@@ -227,6 +229,20 @@ end
 function gadget:UnitSeismicPing(x, y, z, strength, allyTeam, unitID, unitDefID)
 	-- Cache seismic detections briefly so they count as visible enemy presence.
 	AddExpiringUnitContact(x, y, z, allyTeam, spGetGameFrame())
+end
+
+function gadget:GameFrame(currentFrame)
+	if currentFrame < nextContactPruneFrame then
+		return
+	end
+
+	if #contactsCache > 0 then
+		PruneExpiredContacts(currentFrame)
+	end
+
+	while nextContactPruneFrame <= currentFrame do
+		nextContactPruneFrame = nextContactPruneFrame + CONTACT_PRUNE_INTERVAL
+	end
 end
 
 -- Allow normal DGuns, block only ally-targeted hits. If an enemy is visibly nearby, DGuns are always allowed.

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -53,6 +53,29 @@ local CONTACT_WINDOW_DURATION = 5 * 30 -- five seconds at 30 gameframes per seco
 local CONTACT_PRUNE_INTERVAL = 60 * 30 -- prune expired contacts every minute
 local nextContactPruneFrame = CONTACT_PRUNE_INTERVAL
 
+-- These units are ignored for ally-DGun checks.
+local IGNORED_UNIT_NAMES = {
+	armdrag = true, -- Wall
+	armclaw = true, -- Dragon's claw
+	armfdrag = true, -- Naval wall
+	armfort = true, -- T2 wall
+	armwin = true, -- Wind
+	armwint2 = true, -- T2 wind
+	armdf = true, -- Decoy fusion
+	cordrag = true, -- Wall
+	cormaw = true, -- Dragon's maw
+	corfdrag = true, -- Naval wall
+	corfort = true, --T2 wall
+	corwin = true, -- Wind
+	corwint2 = true, -- T2 wind
+	legdrag = true, -- Wall
+	legdtr = true, -- Dragon's jaw
+	legfdrag = true, -- Naval wall
+	legforti = true, -- T2 wall
+	legwin = true, -- Wind
+	legwint2 = true, -- T2 wind
+}
+
 -- Hook DGun commands into allow/disallow interface
 function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD_DGUN)
@@ -82,6 +105,15 @@ local function GetApproxUnitRadius(unitDefID)
 	local footprintZ = unitDef.zsize or 0
 	local approxRadius = math.min(footprintX, footprintZ) * 4
 	return approxRadius
+end
+
+-- Check if the unit being targeted by DGun is a whitelisted unit.
+-- Cheap units that are commonly used to block pathfinding (walls, decoy fusions, winds, etc) are whitelisted.
+-- This means players are always allowed to dgun allied walls (etc) in the event they need to urgently escape through
+-- an otherwise blocked path (e.g. there is an incoming gunship snipe and allied walls are blocking the fastest escape route)
+local function IsIgnoredUnit(unitDefID)
+	local unitDef = unitDefID and UnitDefs[unitDefID]
+	return unitDef and IGNORED_UNIT_NAMES[unitDef.name] == true
 end
 
 local function PruneExpiredContacts(currentFrame)
@@ -159,7 +191,7 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 		local unitDefID = spGetUnitDefID(unitID)
 		local unitRadius = GetApproxUnitRadius(unitDefID)
 		-- Skip the firing commander itself; only warn on other units in the path
-		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
+		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam and not IsIgnoredUnit(unitDefID) then
 			local ux, uy, uz = spGetUnitPosition(unitID)
 			if ux then
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -33,7 +33,9 @@ local spEcho = Spring.Echo
 local CMD_DGUN = CMD.DGUN
 local DGUN_RANGE = 280
 
--- Excessively large dgun safety width to acount for some units, such as behemoths, being quite large
+-- Excessively large dgun safety width to acount for some units, such as behemoths, being quite large.
+-- Note that this safety width is only used to find allies that could be POTENTIALLY hit by the DGun.
+-- A more precise check is used to evaluated whether a potential ally target is actually in danger.
 local DGUN_SAFETY_WIDTH = 100
 
 -- Approximate actual width of the dgun projectile
@@ -90,7 +92,7 @@ local function PruneExpiredContacts(currentFrame)
 	end
 end
 
--- Caches a brief unit contact. This can be checked for the sake of allowing/disallowing DGun later
+-- Caches a unit contact briefly. This can be checked for the sake of allowing/disallowing DGun later
 local function AddExpiringUnitContact(x, y, z, contactTeam, currentFrame)
 	contactsCache[#contactsCache + 1] = {
 		x = x,
@@ -140,8 +142,8 @@ local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
 	return math.sqrt(dx * dx + dy * dy + dz * dz)
 end
 
--- Build a cheap box around the beam first, then do the precise segment test
 local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex, ey, ez)
+	-- Build a cheap box around the beam first, then do the precise segment test
 	local minx = math.min(sx, ex) - DGUN_SAFETY_WIDTH
 	local maxx = math.max(sx, ex) + DGUN_SAFETY_WIDTH
 	local miny = math.min(sy, ey) - DGUN_SAFETY_WIDTH
@@ -195,7 +197,7 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 		end
 	end
 
-	-- Treat recent seismic pings as temporarily visible enemy presence.
+	-- Treat recent contacts as visible enemy presence.
 	for i = 1, #contactsCache do
 		local ping = contactsCache[i]
 		if ping.contactTeam ~= myAllyTeam then
@@ -249,7 +251,7 @@ function gadget:GameFrame(currentFrame)
 	end
 end
 
--- Allow normal DGuns, block only ally-targeted hits. If an enemy is visibly nearby, DGuns are always allowed.
+-- Allow normal DGuns, block only ally-targeted hits. If an enemy is visible nearby, DGuns are always allowed.
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if cmdID ~= CMD_DGUN then
 		return true

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -18,7 +18,6 @@ end
 
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitTeam = Spring.GetUnitTeam
-local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitsInBox = Spring.GetUnitsInBox
 local spGetUnitsInSphere = Spring.GetUnitsInSphere
 local spGetTeamInfo = Spring.GetTeamInfo
@@ -30,11 +29,14 @@ local spEcho = Spring.Echo
 local CMD_DGUN = CMD.DGUN
 local DGUN_RANGE = 280
 local DGUN_WIDTH = 60
+-- 1500 is a bit more than the range of a Vanguard
+-- In my opinion, there is never a reason to even fire a DGun if there are no enemies within VANGUARD distance
+-- We can tweak this smaller as needed
 local ENEMY_SCAN_RADIUS = 1500
-local dangerCount = 0
 local gaiaTeamID = spGetGaiaTeamID()
 
 function gadget:Initialize()
+	-- Hook DGun commands into allow/disallow interface
 	gadgetHandler:RegisterAllowCommand(CMD_DGUN)
 end
 
@@ -43,6 +45,7 @@ local function GetAllyTeamID(teamID)
 	return allyTeamID
 end
 
+-- Convert a DGun target into a line segment representing the beam path
 local function BuildDGunSegment(ux, uy, uz, tx, ty, tz)
 	local dx, dy, dz = tx - ux, ty - uy, tz - uz
 	local dist = math.sqrt(dx * dx + dy * dy + dz * dz)
@@ -58,6 +61,7 @@ local function BuildDGunSegment(ux, uy, uz, tx, ty, tz)
 	return tx - nx * DGUN_RANGE, ty - ny * DGUN_RANGE, tz - nz * DGUN_RANGE, tx, ty, tz
 end
 
+-- Measure the shortest distance from a unit position to the DGun beam segment
 local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
 	local vx, vy, vz = bx - ax, by - ay, bz - az
 	local wx, wy, wz = px - ax, py - ay, pz - az
@@ -81,6 +85,7 @@ local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
 end
 
 local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
+	-- Build a cheap box around the beam first, then do the precise segment test
 	local minx = math.min(sx, ex) - DGUN_WIDTH
 	local maxx = math.max(sx, ex) + DGUN_WIDTH
 	local miny = math.min(sy, ey) - DGUN_WIDTH
@@ -94,16 +99,16 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
 	for i = 1, #candidates do
 		local unitID = candidates[i]
 		local unitTeam = spGetUnitTeam(unitID)
+		-- Skip the firing commander itself; only warn on other units in the path
 		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
 			local ux, uy, uz = spGetUnitPosition(unitID)
 			if ux then
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
-					if d < DGUN_WIDTH then
-						dangerCount = dangerCount + 1
-						spPlaySoundFile("sounds/ui/warning2.wav")
-						spEcho("WARNING: we have recorded an attempt to D-Gun your allies. Griefing your team is a violation of the Code of Conduct!" .. dangerCount)
-						return true
-					end
+				if d < DGUN_WIDTH then
+					spPlaySoundFile("sounds/ui/warning2.wav")
+					spEcho("WARNING: we have recorded an attempt to D-Gun your allies. Griefing your team is a violation of the Code of Conduct!")
+					return true
+				end
 			end
 		end
 	end
@@ -112,6 +117,7 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
 end
 
 local function HasKnownEnemyNearby(teamID, ux, uy, uz)
+	-- If the commander is already near a visible enemy, we leave the order alone
 	local myAllyTeam = GetAllyTeamID(teamID)
 	local candidates = spGetUnitsInSphere(ux, uy, uz, ENEMY_SCAN_RADIUS)
 
@@ -121,11 +127,6 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 		if unitTeam and unitTeam ~= gaiaTeamID and GetAllyTeamID(unitTeam) ~= myAllyTeam then
 			local losState = spGetUnitLosState(unitID, myAllyTeam, true)
 			if losState and (losState % 4) > 0 then
-				local ex, ey, ez = spGetUnitPosition(unitID)
-				local unitDefID = spGetUnitDefID(unitID)
-				local unitDef = unitDefID and UnitDefs[unitDefID]
-				local unitName = unitDef and (unitDef.translatedHumanName or unitDef.name) or "unknown"
-				local dist = (ex and math.sqrt((ex - ux) * (ex - ux) + (ey - uy) * (ey - uy) + (ez - uz) * (ez - uz))) or ENEMY_SCAN_RADIUS
 				return true
 			end
 		end
@@ -134,6 +135,7 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	return false
 end
 
+-- Allow normal DGuns, block only ally-targeted hits. If an enemy is visibly nearby, DGuns are always allowed.
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if cmdID ~= CMD_DGUN then
 		return true

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -84,13 +84,13 @@ local function PruneExpiredSeismicPings(currentFrame)
 	end
 end
 
-local function AddEnemyPing(x, y, z, allyTeam, currentFrame)
-	-- Caches an enemy contact so that dguns are allowed briefly after contact is lost
+local function AddExpiringUnitContact(x, y, z, contactTeam, currentFrame)
+	-- Caches a brief unit contact. This can be checked for the sake of allowing/disallowing DGun later
 	contactsCache[#contactsCache + 1] = {
 		x = x,
 		y = y,
 		z = z,
-		allyTeam = allyTeam,
+		contactTeam = contactTeam,
 		expiresFrame = currentFrame + CONTACT_WINDOW_DURATION,
 	}
 end
@@ -149,8 +149,6 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 		local unitID = candidates[i]
 		local unitTeam = spGetUnitTeam(unitID)
 		local unitDefID = spGetUnitDefID(unitID)
-		local unitDef = unitDefID and UnitDefs[unitDefID]
-		local unitName = unitDef and (unitDef.translatedHumanName or unitDef.name) or "unknown"
 		local unitRadius = GetApproxUnitRadius(unitDefID)
 		-- Skip the firing commander itself; only warn on other units in the path
 		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
@@ -194,7 +192,7 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	-- Treat recent seismic pings as temporarily visible enemy presence.
 	for i = 1, #contactsCache do
 		local ping = contactsCache[i]
-		if ping.allyTeam ~= myAllyTeam then
+		if ping.contactTeam ~= myAllyTeam then
 			local dx, dy, dz = ping.x - ux, ping.y - uy, ping.z - uz
 			if (dx * dx + dy * dy + dz * dz) <= (ENEMY_SCAN_RADIUS * ENEMY_SCAN_RADIUS) then
 				return true
@@ -221,12 +219,14 @@ function gadget:UnitLeftRadar(unitID, unitTeam, allyTeam, unitDefID)
 		return
 	end
 
-	AddEnemyPing(x, y, z, unitTeam, spGetGameFrame())
+	-- Note: we want to track the team of the unit that left radar.
+	-- 'allyTeam' in this context is actually which team that lost track of a radar contact
+	AddExpiringUnitContact(x, y, z, unitTeam, spGetGameFrame())
 end
 
 function gadget:UnitSeismicPing(x, y, z, strength, allyTeam, unitID, unitDefID)
 	-- Cache seismic detections briefly so they count as visible enemy presence.
-	AddEnemyPing(x, y, z, allyTeam, spGetGameFrame())
+	AddExpiringUnitContact(x, y, z, allyTeam, spGetGameFrame())
 end
 
 -- Allow normal DGuns, block only ally-targeted hits. If an enemy is visibly nearby, DGuns are always allowed.

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -20,6 +20,7 @@ end
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitTeam = Spring.GetUnitTeam
 local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitHealth = Spring.GetUnitHealth
 local spGetUnitsInBox = Spring.GetUnitsInBox
 local spGetUnitsInSphere = Spring.GetUnitsInSphere
 local spGetTeamInfo = Spring.GetTeamInfo
@@ -59,6 +60,8 @@ local IGNORED_UNIT_NAMES = {
 	armclaw = true, -- Dragon's claw
 	armfdrag = true, -- Naval wall
 	armfort = true, -- T2 wall
+	armmakr = true, -- T1 converter
+	armfmkr = true, -- T1 naval converter
 	armwin = true, -- Wind
 	armwint2 = true, -- T2 wind
 	armdf = true, -- Decoy fusion
@@ -66,12 +69,16 @@ local IGNORED_UNIT_NAMES = {
 	cormaw = true, -- Dragon's maw
 	corfdrag = true, -- Naval wall
 	corfort = true, --T2 wall
+	cormakr = true, -- T1 converter
+	corfmkr = true, -- T1 naval converter
 	corwin = true, -- Wind
 	corwint2 = true, -- T2 wind
 	legdrag = true, -- Wall
 	legdtr = true, -- Dragon's jaw
 	legfdrag = true, -- Naval wall
 	legforti = true, -- T2 wall
+	legeconv = true, -- T1 converter
+	legfeconv = true, -- T1 sea converter
 	legwin = true, -- Wind
 	legwint2 = true, -- T2 wind
 }
@@ -111,9 +118,19 @@ end
 -- Cheap units that are commonly used to block pathfinding (walls, decoy fusions, winds, etc) are whitelisted.
 -- This means players are always allowed to dgun allied walls (etc) in the event they need to urgently escape through
 -- an otherwise blocked path (e.g. there is an incoming gunship snipe and allied walls are blocking the fastest escape route)
-local function IsIgnoredUnit(unitDefID)
+local function IsIgnoredUnit(unitID, unitDefID)
 	local unitDef = unitDefID and UnitDefs[unitDefID]
-	return unitDef and IGNORED_UNIT_NAMES[unitDef.name] == true
+	if not unitDef then
+		return false
+	end
+
+	local _, _, _, _, buildProgress = spGetUnitHealth(unitID)
+	if buildProgress and buildProgress < 1 then
+		-- Ignore partially built buildings to prevent players from being intentionally boxed in by blueprints
+		return true
+	end
+
+	return IGNORED_UNIT_NAMES[unitDef.name] == true
 end
 
 local function PruneExpiredContacts(currentFrame)
@@ -191,7 +208,7 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 		local unitDefID = spGetUnitDefID(unitID)
 		local unitRadius = GetApproxUnitRadius(unitDefID)
 		-- Skip the firing commander itself; only warn on other units in the path
-		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam and not IsIgnoredUnit(unitDefID) then
+		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam and not IsIgnoredUnit(unitID, unitDefID) then
 			local ux, uy, uz = spGetUnitPosition(unitID)
 			if ux then
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -2,9 +2,9 @@ local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
 	return {
-		name    = "DGun Ally Danger Echo",
-		desc    = "Echoes DANGER when an ally's DGun path intersects allied units",
-		author  = "Codex",
+		name    = "DGun Griefing Prevention",
+		desc    = "Prevents players from firing DGuns that intersect ally units and gives them both text and audio warning. Note that DGuns are always allowed if the commander is on the frontline.",
+		author  = "TheDujin, with Codex",
 		date    = "2026-05-01",
 		license = "GNU GPL, v2 or later",
 		layer   = 0,
@@ -100,7 +100,7 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, sx, sy, sz, ex, ey, ez)
 				local d = DistPointToSegment(ux, uy, uz, sx, sy, sz, ex, ey, ez)
 					if d < DGUN_WIDTH then
 						dangerCount = dangerCount + 1
-						spPlaySoundFile("sounds/ui/warning2.wav", 1, "ui")
+						spPlaySoundFile("sounds/ui/warning2.wav")
 						spEcho("WARNING: we have recorded an attempt to D-Gun your allies. Griefing your team is a violation of the Code of Conduct!" .. dangerCount)
 						return true
 					end

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -32,23 +32,27 @@ local spEcho = Spring.Echo
 
 local CMD_DGUN = CMD.DGUN
 local DGUN_RANGE = 280
+
 -- Excessively large dgun safety width to acount for some units, such as behemoths, being quite large
 local DGUN_SAFETY_WIDTH = 100
+
 -- Approximate actual width of the dgun projectile
 local DGUN_WIDTH = 20
+
 -- 1500 is a bit more than the range of a Vanguard
 -- In my opinion, there is never a reason to even fire a DGun if there are no enemies within VANGUARD distance
 -- We can tweak this smaller as needed
 local ENEMY_SCAN_RADIUS = 1500
 local gaiaTeamID = spGetGaiaTeamID()
-local contactsCache = {}
+
 -- Tracks enemy contacts briefly so that dguns are allowed for a few seconds even after contact is lost
+local contactsCache = {}
 local CONTACT_WINDOW_DURATION = 5 * 30 -- five seconds at 30 gameframes per second
 local CONTACT_PRUNE_INTERVAL = 60 * 30 -- prune expired contacts every minute
 local nextContactPruneFrame = CONTACT_PRUNE_INTERVAL
 
+-- Hook DGun commands into allow/disallow interface
 function gadget:Initialize()
-	-- Hook DGun commands into allow/disallow interface
 	gadgetHandler:RegisterAllowCommand(CMD_DGUN)
 end
 
@@ -86,8 +90,8 @@ local function PruneExpiredContacts(currentFrame)
 	end
 end
 
+-- Caches a brief unit contact. This can be checked for the sake of allowing/disallowing DGun later
 local function AddExpiringUnitContact(x, y, z, contactTeam, currentFrame)
-	-- Caches a brief unit contact. This can be checked for the sake of allowing/disallowing DGun later
 	contactsCache[#contactsCache + 1] = {
 		x = x,
 		y = y,
@@ -136,8 +140,8 @@ local function DistPointToSegment(px, py, pz, ax, ay, az, bx, by, bz)
 	return math.sqrt(dx * dx + dy * dy + dz * dz)
 end
 
+-- Build a cheap box around the beam first, then do the precise segment test
 local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex, ey, ez)
-	-- Build a cheap box around the beam first, then do the precise segment test
 	local minx = math.min(sx, ex) - DGUN_SAFETY_WIDTH
 	local maxx = math.max(sx, ex) + DGUN_SAFETY_WIDTH
 	local miny = math.min(sy, ey) - DGUN_SAFETY_WIDTH
@@ -172,8 +176,8 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 	return false
 end
 
+-- If the commander is already near a visible enemy, we leave the order alone
 local function HasKnownEnemyNearby(teamID, ux, uy, uz)
-	-- If the commander is already near a visible enemy, we leave the order alone
 	local myAllyTeam = GetAllyTeamID(teamID)
 	local currentFrame = spGetGameFrame()
 	PruneExpiredContacts(currentFrame)
@@ -205,9 +209,9 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	return false
 end
 
+-- Cache units that leave radar briefly so they count as visible enemy presence
+-- This allows players to attempt dguns even if radar contact is lost.
 function gadget:UnitLeftRadar(unitID, unitTeam, allyTeam, unitDefID)
-	-- Cache units that leave radar briefly so they count as visible enemy presence
-	-- This allows players to attempt dguns even if radar contact is lost.
 	if not unitTeam or unitTeam == gaiaTeamID then
 		return
 	end
@@ -226,8 +230,8 @@ function gadget:UnitLeftRadar(unitID, unitTeam, allyTeam, unitDefID)
 	AddExpiringUnitContact(x, y, z, unitTeam, spGetGameFrame())
 end
 
+-- Cache seismic detections briefly so they count as visible enemy presence.
 function gadget:UnitSeismicPing(x, y, z, strength, allyTeam, unitID, unitDefID)
-	-- Cache seismic detections briefly so they count as visible enemy presence.
 	AddExpiringUnitContact(x, y, z, allyTeam, spGetGameFrame())
 end
 

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -8,7 +8,7 @@ function gadget:GetInfo()
 		date    = "2026-05-01",
 		license = "GNU GPL, v2 or later",
 		layer   = 0,
-        version = "0.2",
+        version = "0.3",
 		enabled = true,
 	}
 end
@@ -32,17 +32,18 @@ local spEcho = Spring.Echo
 
 local CMD_DGUN = CMD.DGUN
 local DGUN_RANGE = 280
--- Excessively large dgun safety range to acount for some units, such as behemoths, being quite large
-local DGUN_SAFETY_RANGE = 100
+-- Excessively large dgun safety width to acount for some units, such as behemoths, being quite large
+local DGUN_SAFETY_WIDTH = 100
 -- Approximate actual width of the dgun projectile
 local DGUN_WIDTH = 20
 -- 1500 is a bit more than the range of a Vanguard
 -- In my opinion, there is never a reason to even fire a DGun if there are no enemies within VANGUARD distance
 -- We can tweak this smaller as needed
 local ENEMY_SCAN_RADIUS = 1500
-local SEISMIC_PING_DURATION = 5 * 30 -- five seconds at 30 gameframes per second
 local gaiaTeamID = spGetGaiaTeamID()
-local seismicPings = {}
+local contactsCache = {}
+-- Tracks enemy contacts briefly so that dguns are allowed for a few seconds even after contact is lost
+local CONTACT_WINDOW_DURATION = 5 * 30 -- five seconds at 30 gameframes per second
 
 function gadget:Initialize()
 	-- Hook DGun commands into allow/disallow interface
@@ -76,11 +77,22 @@ local function GetApproxUnitRadius(unitDefID)
 end
 
 local function PruneExpiredSeismicPings(currentFrame)
-	for i = #seismicPings, 1, -1 do
-		if seismicPings[i].expiresFrame <= currentFrame then
-			table.remove(seismicPings, i)
+	for i = #contactsCache, 1, -1 do
+		if contactsCache[i].expiresFrame <= currentFrame then
+			table.remove(contactsCache, i)
 		end
 	end
+end
+
+local function AddEnemyPing(x, y, z, allyTeam, currentFrame)
+	-- Caches an enemy contact so that dguns are allowed briefly after contact is lost
+	contactsCache[#contactsCache + 1] = {
+		x = x,
+		y = y,
+		z = z,
+		allyTeam = allyTeam,
+		expiresFrame = currentFrame + CONTACT_WINDOW_DURATION,
+	}
 end
 
 -- Convert a DGun target into a line segment representing the beam path
@@ -124,17 +136,15 @@ end
 
 local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex, ey, ez)
 	-- Build a cheap box around the beam first, then do the precise segment test
-	local minx = math.min(sx, ex) - DGUN_SAFETY_RANGE
-	local maxx = math.max(sx, ex) + DGUN_SAFETY_RANGE
-	local miny = math.min(sy, ey) - DGUN_SAFETY_RANGE
-	local maxy = math.max(sy, ey) + DGUN_SAFETY_RANGE
-	local minz = math.min(sz, ez) - DGUN_SAFETY_RANGE
-	local maxz = math.max(sz, ez) + DGUN_SAFETY_RANGE
+	local minx = math.min(sx, ex) - DGUN_SAFETY_WIDTH
+	local maxx = math.max(sx, ex) + DGUN_SAFETY_WIDTH
+	local miny = math.min(sy, ey) - DGUN_SAFETY_WIDTH
+	local maxy = math.max(sy, ey) + DGUN_SAFETY_WIDTH
+	local minz = math.min(sz, ez) - DGUN_SAFETY_WIDTH
+	local maxz = math.max(sz, ez) + DGUN_SAFETY_WIDTH
 
 	local candidates = spGetUnitsInBox(minx, miny, minz, maxx, maxy, maxz)
 	local myAllyTeam = GetAllyTeamID(teamID)
-	spEcho(string.format("DGun coarse box candidates: %d", #candidates))
-
 	for i = 1, #candidates do
 		local unitID = candidates[i]
 		local unitTeam = spGetUnitTeam(unitID)
@@ -142,13 +152,6 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 		local unitDef = unitDefID and UnitDefs[unitDefID]
 		local unitName = unitDef and (unitDef.translatedHumanName or unitDef.name) or "unknown"
 		local unitRadius = GetApproxUnitRadius(unitDefID)
-		spEcho(string.format(
-			"DGun coarse candidate: %s (unitID=%d, teamID=%s, radius=%.0f)",
-			unitName,
-			unitID,
-			tostring(unitTeam),
-			unitRadius
-		))
 		-- Skip the firing commander itself; only warn on other units in the path
 		if unitID ~= firingUnitID and unitTeam and GetAllyTeamID(unitTeam) == myAllyTeam then
 			local ux, uy, uz = spGetUnitPosition(unitID)
@@ -157,9 +160,10 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 				if d < unitRadius + DGUN_WIDTH / 2 then
 					spPlaySoundFile("sounds/ui/warning2.wav")
 					spEcho(string.format(
-						"WARNING: %s attempted to D-Gun allies. Griefing your team is a violation of the Code of Conduct!",
+						"WARNING: %s attempted to D-Gun allies. Please remember that the Code of Conduct prohibits griefing.",
 						GetPlayerName(playerID)
 					))
+					Spring.Log("dgun_grief_attempts", LOG.INFO, string.format("%s attempted to D-Gun allies.", GetPlayerName(playerID)))
 					return true
 				end
 			end
@@ -189,8 +193,8 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	end
 
 	-- Treat recent seismic pings as temporarily visible enemy presence.
-	for i = 1, #seismicPings do
-		local ping = seismicPings[i]
+	for i = 1, #contactsCache do
+		local ping = contactsCache[i]
 		if ping.allyTeam ~= myAllyTeam then
 			local dx, dy, dz = ping.x - ux, ping.y - uy, ping.z - uz
 			if (dx * dx + dy * dy + dz * dz) <= (ENEMY_SCAN_RADIUS * ENEMY_SCAN_RADIUS) then
@@ -202,16 +206,28 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	return false
 end
 
+function gadget:UnitLeftRadar(unitID, unitTeam, allyTeam, unitDefID)
+	-- Cache units that leave radar briefly so they count as visible enemy presence
+	-- This allows players to attempt dguns even if radar contact is lost.
+	if not unitTeam or unitTeam == gaiaTeamID then
+		return
+	end
+
+	if allyTeam and GetAllyTeamID(unitTeam) == allyTeam then
+		return
+	end
+
+	local x, y, z = spGetUnitPosition(unitID)
+	if not x then
+		return
+	end
+
+	AddEnemyPing(x, y, z, unitTeam, spGetGameFrame())
+end
+
 function gadget:UnitSeismicPing(x, y, z, strength, allyTeam, unitID, unitDefID)
 	-- Cache seismic detections briefly so they count as visible enemy presence.
-	local currentFrame = spGetGameFrame()
-	seismicPings[#seismicPings + 1] = {
-		x = x,
-		y = y,
-		z = z,
-		allyTeam = Spring.GetUnitAllyTeam(unitID), -- The allyTeam parameter is the team of the PING, not the team of the unit causing the ping
-		expiresFrame = currentFrame + SEISMIC_PING_DURATION,
-	}
+	AddEnemyPing(x, y, z, allyTeam, spGetGameFrame())
 end
 
 -- Allow normal DGuns, block only ally-targeted hits. If an enemy is visibly nearby, DGuns are always allowed.

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -210,13 +210,13 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 	return false
 end
 
--- If the commander is already near a visible enemy, we leave the order alone
-local function HasKnownEnemyNearby(teamID, ux, uy, uz)
+-- If DGun target location is near a visible enemy, we leave the order alone
+local function HasKnownEnemyNearby(teamID, targetX, targetY, targetZ)
 	local myAllyTeam = GetAllyTeamID(teamID)
 	local currentFrame = spGetGameFrame()
 	PruneExpiredContacts(currentFrame)
 
-	local candidates = spGetUnitsInSphere(ux, uy, uz, ENEMY_SCAN_RADIUS)
+	local candidates = spGetUnitsInSphere(targetX, targetY, targetZ, ENEMY_SCAN_RADIUS)
 
 	for i = 1, #candidates do
 		local unitID = candidates[i]
@@ -233,7 +233,7 @@ local function HasKnownEnemyNearby(teamID, ux, uy, uz)
 	for i = 1, #contactsCache do
 		local ping = contactsCache[i]
 		if ping.contactTeam ~= myAllyTeam then
-			local dx, dy, dz = ping.x - ux, ping.y - uy, ping.z - uz
+			local dx, dy, dz = ping.x - targetX, ping.y - targetY, ping.z - targetZ
 			if (dx * dx + dy * dy + dz * dz) <= (ENEMY_SCAN_RADIUS * ENEMY_SCAN_RADIUS) then
 				return true
 			end
@@ -294,26 +294,26 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		return true
 	end
 
-	local ux, uy, uz = spGetUnitPosition(unitID)
-	if not ux then
+	local unitX, unitY, unitZ = spGetUnitPosition(unitID)
+	if not unitX then
 		return true
 	end
-
-	if HasKnownEnemyNearby(teamID, ux, uy, uz) then
-		return true
-	end
-
-	local tx, ty, tz
+	
+	local targetX, targetY, targetZ
 	if #cmdParams == 1 and cmdParams[1] > 0 then
-		tx, ty, tz = spGetUnitPosition(cmdParams[1])
+		targetX, targetY, targetZ = spGetUnitPosition(cmdParams[1])
 	else
-		tx, ty, tz = cmdParams[1], cmdParams[2], cmdParams[3]
+		targetX, targetY, targetZ = cmdParams[1], cmdParams[2], cmdParams[3]
 	end
-
-	if not tx then
+	if HasKnownEnemyNearby(teamID, targetX, targetY, targetZ) then
 		return true
 	end
 
-	local sx, sy, sz, ex, ey, ez = BuildDGunSegment(ux, uy, uz, tx, ty, tz)
+
+	if not targetX then
+		return true
+	end
+
+	local sx, sy, sz, ex, ey, ez = BuildDGunSegment(unitX, unitY, unitZ, targetX, targetY, targetZ)
 	return not HandleDGunAllyRisk(teamID, unitID, playerID, sx, sy, sz, ex, ey, ez)
 end

--- a/luarules/gadgets/cmd_dgun_griefing_prevention.lua
+++ b/luarules/gadgets/cmd_dgun_griefing_prevention.lua
@@ -163,7 +163,6 @@ local function HandleDGunAllyRisk(teamID, firingUnitID, playerID, sx, sy, sz, ex
 						"WARNING: %s attempted to D-Gun allies. Please remember that the Code of Conduct prohibits griefing.",
 						GetPlayerName(playerID)
 					))
-					Spring.Log("dgun_grief_attempts", LOG.INFO, string.format("%s attempted to D-Gun allies.", GetPlayerName(playerID)))
 					return true
 				end
 			end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

**This gadget idea was proposed and discussed in Overwatch channels.**
**The gadget prototype has been briefly reviewed by OW members and Moderators, including OW Tech members**

Adds a new gadget that seeks to reduce the number of griefing DGuns that can be fired. Note that the DGun griefing check is intentionally very conservative, as we want to avoid having any false positives whatsoever (see discussion below).

When a DGun is fired, this gadget checks:

- Does the DGun intersect an allied unit/structure (including self-owned)? If no, DGun is allowed
  - **edit:** Cheap pathfinding-blocking units (walls, decoy fusions, winds) are whitelisted from this check: the gadget will never prevent a player from dgunning walls in order to create an emergency escape path, for example
- If yes:
  - Are there any visible enemies within 1500 distance of the ~~commander~~ DGun target location (adjustable parameter; approximately Vanguard range)?
  - Were there any seismic pings or visible enemies within 1500 distance in the past few seconds?
  - If yes to either, Dgun is allowed (i.e, it's worthwhile to allow someone to hit an allied LLT in an attempt to hit enemy T3/enemy Gremlins/etc)
  - **If the DGun intersects an allied unit/structure and there are no enemies recently visible within 1500 distance of the ~~commander~~ targeted location, the DGun command is prevented and a text+audio notification is issued to the player who attempted to grief**

Note that 1500 distance is likely an excessive range to allow DGuns in. I chose this overkill number  because I consider false positives by this gadget to be much worse than false negatives. Players are already used to getting griefed sometimes, but they would get VERY ANGRY if a legitimate attempt to DGun something important (hit enemy T3, deny reclaim, etc) was prevented due to an anti-griefing gadget. Choosing this overkill parameter is intended to reduce false positive rate to zero.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

#### Video demonstration:
https://drive.google.com/file/d/1pI3dcsLRguIFJJwKMA03ZXdEoWqRN7Gb/view?usp=sharing
**Explanation**
* When red's grunts are not visible and within 1500 distance of blue's targeted location, then blue cannot fire dguns at either allied or self-owned units/buildings
* When red's grunts become visible and within 1500 range of blue's targeted location, then all dguns are allowed (friendly fire is acceptable for the greater good)

### AI / LLM usage statement:
Codex was used in part to create, debug, and "peer review" the gadget.

Manual testing in skirmish was performed to ensure the gadget works in edge cases (e.g., seismic signatures).