### PR TITLE
April Community Balance Patch

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1618,7 +1618,7 @@ local options = {
     {
         key     = "community_balance_corjamt",
         name    = "(CBP) Castro",
-        desc    = "(New)\nBuild time, energy, upkeep, health, metal, and jam range match Sneaky Pete (armjamt)\nBuild time: 9950 (from 4000)\nEnergy cost: 8500 (from 4500)\nEnergy upkeep: 40 (from 25)\nHealth: 790 (from 1070)\nMetal cost: 240 (from 100)\nJammer range: 500 (from 360)",
+        desc    = "(New)\nMatches the stats of Sneaky Pete.",
         type    = "bool",
         def     = false,
         section = "options_experimental",
@@ -1645,7 +1645,7 @@ local options = {
     {
         key     = "community_balance_corjamt",
         name    = "(CBP) Castro",
-        desc    = "Build time: 9950 (from 4000)\nEnergy cost: 8500 (from 4500)\nEnergy upkeep: 40 (from 25)\nHealth: 790 (from 1070)\nMetal cost: 240 (from 100)\nJammer range: 500 (from 360)",
+        desc    = "Matches the stats of Sneaky Pete.",
         type    = "bool",
         def     = false,
         section = "options_experimental",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1565,13 +1565,13 @@ local options = {
         section = "options_experimental",
         items   = {
             { key = "disabled", name = "Disabled", desc = "No community balance changes",
-            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armfast","community_balance_armcroc","community_balance_corkorg","community_balance_corspy"} },
+            lock = {"community_balance_commando","community_balance_corkorg","community_balance_corspy","community_balance_corjamt","community_balance_armmav","community_balance_corcan"} },
 
-            { key = "enabled",  name = "Enabled",  desc = "Enable all community balance changes\nCommando\nTermite\nSprinter\nTurtle\nJuggernaut\nSpectre",
-            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armfast","community_balance_armcroc","community_balance_corkorg","community_balance_corspy"} },
+            { key = "enabled",  name = "Enabled",  desc = "Enable all community balance changes\nCommando\nJuggernaut\nSpectre\nCastro\nGunslinger\nSumo",
+            lock = {"community_balance_commando","community_balance_corkorg","community_balance_corspy","community_balance_corjamt","community_balance_armmav","community_balance_corcan"} },
 
             { key = "custom",   name = "Custom",   desc = "Customize individual community balance changes",
-            unlock = {"community_balance_commando", "community_balance_cortermite", "community_balance_armfast", "community_balance_armcroc", "community_balance_corkorg", "community_balance_corspy"} },
+            unlock = {"community_balance_commando", "community_balance_corkorg", "community_balance_corspy", "community_balance_corjamt", "community_balance_armmav", "community_balance_corcan"} },
         }
     },
 
@@ -1598,33 +1598,6 @@ local options = {
     },
 
     {
-        key     = "community_balance_cortermite",
-        name    = "(CBP) Termite",
-        desc    = "(From January)\nAdded stealth",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_armfast",
-        name    = "(CBP) Sprinter",
-        desc    = "(From January)\nEnergy cost: 3500 (from 4140)\nAcceleration: 0.37 (from 0.414)\nSpeed: 115 (from 111.3)\nTurn-in-place angle: 115° (from 90°)\nTurn-in-place speed: 2.75 (from 2.4486)\nTurn rate: 1320 (from 1644.5)\nSight distance: 380 (from 351)\nWeapon: 18 AoE (from 16), 230 range (from 220), 15/5 damage (from 12/4)",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_armcroc",
-        name    = "(CBP) Turtle",
-        desc    = "(New)\nHealth: 5250 (from 5000)\nMain gun AoE: 80 (from 64), impulse factor: 0.50 (from 0.123)",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
         key     = "community_balance_corkorg",
         name    = "(CBP) Juggernaut",
         desc    = "(New)\nAir LOS: 1600 (from 1260)\nMetal cost: 26000 (from 29000)",
@@ -1637,6 +1610,33 @@ local options = {
         key     = "community_balance_corspy",
         name    = "(CBP) Spectre",
         desc    = "(New)\nEnergy cost: 8800 (from 12500)\nMetal cost: 135 (from 165)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_corjamt",
+        name    = "(CBP) Castro",
+        desc    = "Build time: 9950 (from 4000)\nEnergy cost: 8500 (from 4500)\nEnergy upkeep: 40 (from 25)\nHealth: 790 (from 1070)\nMetal cost: 240 (from 100)\nJammer range: 500 (from 360)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_armmav",
+        name    = "(CBP) Gunslinger",
+        desc    = "Metal cost: 520 (from 650)\nEnergy cost: 6500 (from 11000)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_corcan",
+        name    = "(CBP) Sumo",
+        desc    = "Main laser range: 300 (from 275)\nMain laser beam time: 0.24 (from 0.16)",
         type    = "bool",
         def     = false,
         section = "options_experimental",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1558,20 +1558,20 @@ local options = {
 
     {
         key     = "community_balance_patch",
-        name    = "Community Balance Patch Feb '26",
+        name    = "Community Balance Patch April '26",
         desc    = "Enable community balance patch changes\n(overwrites changes in official seasonal balance test)",
         type    = "list",
         def     = "disabled",
         section = "options_experimental",
         items   = {
             { key = "disabled", name = "Disabled", desc = "No community balance changes",
-            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armfast","community_balance_armcroc","community_balance_corkorg","community_balance_corspy"} },
+            lock = {"community_balance_commando","community_balance_corkorg","community_balance_corspy","community_balance_corjamt","community_balance_armmav","community_balance_corcan"} },
 
-            { key = "enabled",  name = "Enabled",  desc = "Enable all community balance changes\nCommando\nTermite\nSprinter\nTurtle\nJuggernaut\nSpectre",
-            lock = {"community_balance_commando","community_balance_cortermite","community_balance_armfast","community_balance_armcroc","community_balance_corkorg","community_balance_corspy"} },
+            { key = "enabled",  name = "Enabled",  desc = "Enable all community balance changes\nCommando\nJuggernaut\nSpectre\nCastro\nGunslinger\nSumo",
+            lock = {"community_balance_commando","community_balance_corkorg","community_balance_corspy","community_balance_corjamt","community_balance_armmav","community_balance_corcan"} },
 
             { key = "custom",   name = "Custom",   desc = "Customize individual community balance changes",
-            unlock = {"community_balance_commando", "community_balance_cortermite", "community_balance_armfast", "community_balance_armcroc", "community_balance_corkorg", "community_balance_corspy"} },
+            unlock = {"community_balance_commando", "community_balance_corkorg", "community_balance_corspy", "community_balance_corjamt", "community_balance_armmav", "community_balance_corcan"} },
         }
     },
 
@@ -1581,7 +1581,7 @@ local options = {
         desc    = "Community Balance Patch changelog",
         section = "options_experimental",
         type    = "link",
-        link    = "https://discord.com/channels/549281623154229250/1462625474344783872/1462625474344783872",
+        link    = "https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7571",
         width   = 235,
         column  = 2.025,
         linkheight = 325,
@@ -1598,36 +1598,9 @@ local options = {
     },
 
     {
-        key     = "community_balance_cortermite",
-        name    = "(CBP) Termite",
-        desc    = "(From January)\nAdded stealth",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_armfast",
-        name    = "(CBP) Sprinter",
-        desc    = "(From January)\nEnergy cost: 3500 (from 4140)\nAcceleration: 0.37 (from 0.414)\nSpeed: 115 (from 111.3)\nTurn-in-place angle: 115° (from 90°)\nTurn-in-place speed: 2.75 (from 2.4486)\nTurn rate: 1320 (from 1644.5)\nSight distance: 380 (from 351)\nWeapon: 18 AoE (from 16), 230 range (from 220), 15/5 damage (from 12/4)",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_armcroc",
-        name    = "(CBP) Turtle",
-        desc    = "(New)\nHealth: 5250 (from 5000)\nMain gun AoE: 80 (from 64), impulse factor: 0.50 (from 0.123)",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
         key     = "community_balance_corkorg",
         name    = "(CBP) Juggernaut",
-        desc    = "(New)\nAir LOS: 1600 (from 1260)\nMetal cost: 26000 (from 29000)",
+        desc    = "(From February)\nAir LOS: 1600 (from 1260)\nMetal cost: 26000 (from 29000)",
         type    = "bool",
         def     = false,
         section = "options_experimental",
@@ -1636,7 +1609,34 @@ local options = {
     {
         key     = "community_balance_corspy",
         name    = "(CBP) Spectre",
-        desc    = "(New)\nEnergy cost: 8800 (from 12500)\nMetal cost: 135 (from 165)",
+        desc    = "(From February)\nEnergy cost: 8800 (from 12500)\nMetal cost: 135 (from 165)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_corjamt",
+        name    = "(CBP) Castro",
+        desc    = "(New)\nBuild time, energy, upkeep, health, metal, and jam range match Sneaky Pete (armjamt)\nBuild time: 9950 (from 4000)\nEnergy cost: 8500 (from 4500)\nEnergy upkeep: 40 (from 25)\nHealth: 790 (from 1070)\nMetal cost: 240 (from 100)\nJammer range: 500 (from 360)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_armmav",
+        name    = "(CBP) Gunslinger",
+        desc    = "(New)\nMetal cost: 520 (from 650)\nEnergy cost: 6500 (from 11000)",
+        type    = "bool",
+        def     = false,
+        section = "options_experimental",
+    },
+
+    {
+        key     = "community_balance_corcan",
+        name    = "(CBP) Sumo",
+        desc    = "(New)\nMain laser range: 300 (from 275)\nMain laser beam time: 0.24 (from 0.16)",
         type    = "bool",
         def     = false,
         section = "options_experimental",

--- a/unitbasedefs/community_balance_patch_defs.lua
+++ b/unitbasedefs/community_balance_patch_defs.lua
@@ -101,6 +101,7 @@ local function communityBalanceTweaks(name, uDef, modOptions)
 				uDef.health = 790
 				uDef.metalcost = 240
 				uDef.radardistancejam = 500
+				uDef.sightdistance = 195
 			end
 		end
 

--- a/unitbasedefs/community_balance_patch_defs.lua
+++ b/unitbasedefs/community_balance_patch_defs.lua
@@ -79,46 +79,6 @@ local function communityBalanceTweaks(name, uDef, modOptions)
 			end
 		end
 
-		if all or (custom and modOptions.community_balance_cortermite) then
-			if name == "cortermite" then
-				uDef.stealth = true
-			end
-		end
-
-		if all or (custom and modOptions.community_balance_armfast) then
-			if name == "armfast" then
-				uDef.energycost = 3500
-				uDef.maxacc = 0.37
-				uDef.speed = 115
-				uDef.turninplaceanglelimit = 115
-				uDef.turninplacespeedlimit = 2.75
-				uDef.turnrate = 1320
-				uDef.sightdistance = 380
-				if uDef.weapondefs then
-					for weaponName, weaponDef in pairs(uDef.weapondefs) do
-						if weaponName == "arm_fast" then
-							weaponDef.areaofeffect = 18
-							weaponDef.range = 230
-							weaponDef.damage = {
-								default = 15,
-								vtol = 5
-							}
-						end
-					end
-				end
-			end
-		end
-
-		if all or (custom and modOptions.community_balance_armcroc) then
-			if name == "armcroc" then
-				uDef.health = 5250
-				if uDef.weapondefs and uDef.weapondefs.arm_triton then
-					uDef.weapondefs.arm_triton.areaofeffect = 80
-					uDef.weapondefs.arm_triton.impulsefactor = 0.5
-				end
-			end
-		end
-
 		if all or (custom and modOptions.community_balance_corkorg) then
 			if name == "corkorg" then
 				uDef.airsightdistance = 1600
@@ -130,6 +90,33 @@ local function communityBalanceTweaks(name, uDef, modOptions)
 			if name == "corspy" then
 				uDef.energycost = 8800
 				uDef.metalcost = 135
+			end
+		end
+
+		if all or (custom and modOptions.community_balance_corjamt) then
+			if name == "corjamt" then
+				uDef.buildtime = 9950
+				uDef.energycost = 8500
+				uDef.energyupkeep = 40
+				uDef.health = 790
+				uDef.metalcost = 240
+				uDef.radardistancejam = 500
+			end
+		end
+
+		if all or (custom and modOptions.community_balance_armmav) then
+			if name == "armmav" then
+				uDef.metalcost = 520
+				uDef.energycost = 6500
+			end
+		end
+
+		if all or (custom and modOptions.community_balance_corcan) then
+			if name == "corcan" then
+				if uDef.weapondefs and uDef.weapondefs.cor_canlaser then
+					uDef.weapondefs.cor_canlaser.range = 300
+					uDef.weapondefs.cor_canlaser.beamtime = 0.24
+				end
 			end
 		end
 	end


### PR DESCRIPTION
## **Commando**
*From January '26 (3 wins)*
- +130 jammer range (150 → 280)
- +300 radar (900 → **1200**) and LoS (600 → **900**)
- add light and hvy mines to build options
- 80% EMP resistance
- allow build in amphib complex
- 2s self-d timer
- x2 autoheal (9 → **18**)
- **Cannon → Laser**
- **100** dmg, **50** vs air (w/ laser damage falloff)
- 2 shots/s (**unchanged**)
- 100% accuracy
- **8** AoE, **20** E/shot
- **300 → 450** range
- targets air
## Juggernaut
*From February '26 (2 wins)*
- **Air LOS:** 1260 → **1600**
- **Metal cost:** 29 000 → **26 000**
## Spectre
*From February '26 (2 wins)*
- **Energy cost:** 12 500 → **8800**
- **Metal cost:** 165 → **135**
## Castro
*New*
- **Build time:** 4000 → **9950**
- **Energy cost:** 4500 → **8500**
- **Energy upkeep:** 25 → **40**
- **Health:** 1070 → **790**
- **Metal cost:** 100 → **240**
- **Jammer range:** 360 → **500**
- **Sight distance:** 104 → **195**
## Gunslinger
*New*
- **Metal cost:** 650 → **520**
- **Energy cost:** 11 000 → **6500**
## Cortex — Sumo
*New*
- **Main laser range:** 275 → **300**
- **Main laser beam time:** 0.16 → **0.24**
