### PR TITLE
Max Population count transfer on kill

### DIFF
--- a/luarules/gadgets/unit_kill_population_transfer.lua
+++ b/luarules/gadgets/unit_kill_population_transfer.lua
@@ -24,13 +24,12 @@ local spTransferTeamMaxUnits = Spring.TransferTeamMaxUnits
 -- One-off spring calls
 local modOptions = Spring.GetModOptions()
 local GaiaTeamID = Spring.GetGaiaTeamID()
-local GaiaAllyTeamID = select(6, Spring.GetTeamInfo(GaiaTeamID))
 
 -- Local long running variables
 local killedTeamToCountTable = {} -- either the teamID of the killed player in gaia-mode, or killedTeam..attackerTeam to count in transfer mode
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-    if modOptions.population_transfer == "disabled" or modOptions.population_transfer == nil then
+    if modOptions.populationtransfer == "disabled" or modOptions.populationtransfer == nil or modOptions.populationtransferratio == 0 then
         return
     end
 
@@ -40,36 +39,37 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
     end
 
     local transferIncrement = nil
-    if modOptions.population_transfer == "reduce" then
-        killedTeamToCountTable[unitTeam] = (killedTeamToCountTable[unitTeam] == nil and modOptions.population_transfer_ratio) or killedTeamToCountTable[unitTeam] + modOptions.population_transfer_ratio;
-        if killedTeamToCountTable[unitTeam] / modOptions.population_transfer_ratio > 1 then
+    if modOptions.populationtransfer == "reduce" then
+        
+        killedTeamToCountTable[unitTeam] = (killedTeamToCountTable[unitTeam] == nil and modOptions.populationtransferratio) or killedTeamToCountTable[unitTeam] + modOptions.populationtransferratio;
+        if math.abs(killedTeamToCountTable[unitTeam]) >= 1 then
             transferIncrement = 1
             killedTeamToCountTable[unitTeam] = 0
         end
-    elseif modOptions.population_transfer == "transfer" then
-        killedTeamToCountTable[unitTeam..attackerTeam] = (killedTeamToCountTable[unitTeam..attackerTeam] == nil and 1) or killedTeamToCountTable[unitTeam..attackerTeam] + 1;
-        if killedTeamToCountTable[unitTeam..attackerTeam] / modOptions.population_transfer_ratio > 1 then
+    elseif modOptions.populationtransfer == "transfer" then
+        killedTeamToCountTable[unitTeam..attackerTeam] = (killedTeamToCountTable[unitTeam..attackerTeam] == nil and modOptions.populationtransferratio) or killedTeamToCountTable[unitTeam..attackerTeam] + modOptions.populationtransferratio;
+        if math.abs(killedTeamToCountTable[unitTeam..attackerTeam]) >= 1 then
             transferIncrement = 1
             killedTeamToCountTable[unitTeam..attackerTeam] = 0
         end
     end
 
-    if (transferIncrement < 1) then
+    if (transferIncrement == nil or math.abs(transferIncrement) < 1) then
         return
     end
 
-    if modOptions.population_transfer_ratio > 0 then
-        if modOptions.population_transfer == "reduce" then
+    if modOptions.populationtransferratio > 0 then
+        if modOptions.populationtransfer == "reduce" then
             spTransferTeamMaxUnits(unitTeam, GaiaTeamID, 1);
-        elseif modOptions.population_transfer == "transfer" then
+        elseif modOptions.populationtransfer == "transfer" then
             spTransferTeamMaxUnits(unitTeam, attackerTeam, 1);
         end
     else
-        -- is this legit? Can I reduce from Gaia?
-        if modOptions.population_transfer == "reduce" then
-            -- spTransferTeamMaxUnits(unitTeam, GaiaTeamID, -1);
-        elseif modOptions.population_transfer == "transfer" then
-            spTransferTeamMaxUnits(unitTeam, attackerTeam, -1);
+        -- is this legit? Can I reduce/take from Gaia? not allowing this for now.
+        if modOptions.populationtransfer == "reduce" then
+            -- spTransferTeamMaxUnits(GaiaTeamID, unitTeam, 1);
+        elseif modOptions.populationtransfer == "transfer" then
+            spTransferTeamMaxUnits(attackerTeam, unitTeam, 1);
         end
     end
 end

--- a/luarules/gadgets/unit_kill_population_transfer.lua
+++ b/luarules/gadgets/unit_kill_population_transfer.lua
@@ -1,0 +1,77 @@
+
+
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Unit Killed Population Count Transfer",
+		desc = "Allows modifying population count to or from killed units allyteam or to Gaia",
+		author = "Chemdude8",
+		date = "2026-05-06",
+		license = "None",
+		layer = 49,
+		enabled = true
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+-- Local copies of spring/recoil functions
+local spTransferTeamMaxUnits = Spring.TransferTeamMaxUnits
+
+-- One-off spring calls
+local modOptions = Spring.GetModOptions()
+local GaiaTeamID = Spring.GetGaiaTeamID()
+local GaiaAllyTeamID = select(6, Spring.GetTeamInfo(GaiaTeamID))
+
+-- Local long running variables
+local killedTeamToCountTable = {} -- either the teamID of the killed player in gaia-mode, or killedTeam..attackerTeam to count in transfer mode
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
+    if modOptions.population_transfer == "disabled" or modOptions.population_transfer == nil then
+        return
+    end
+
+    -- could argue in gaia mode you might not need an attackerTeam but lava cases could punish you unnecessarily then
+    if unitTeam == nil or attackerTeam == nil then
+        return
+    end
+
+    local transferIncrement = nil
+    if modOptions.population_transfer == "reduce" then
+        killedTeamToCountTable[unitTeam] = (killedTeamToCountTable[unitTeam] == nil and modOptions.population_transfer_ratio) or killedTeamToCountTable[unitTeam] + modOptions.population_transfer_ratio;
+        if killedTeamToCountTable[unitTeam] / modOptions.population_transfer_ratio > 1 then
+            transferIncrement = 1
+            killedTeamToCountTable[unitTeam] = 0
+        end
+    elseif modOptions.population_transfer == "transfer" then
+        killedTeamToCountTable[unitTeam..attackerTeam] = (killedTeamToCountTable[unitTeam..attackerTeam] == nil and 1) or killedTeamToCountTable[unitTeam..attackerTeam] + 1;
+        if killedTeamToCountTable[unitTeam..attackerTeam] / modOptions.population_transfer_ratio > 1 then
+            transferIncrement = 1
+            killedTeamToCountTable[unitTeam..attackerTeam] = 0
+        end
+    end
+
+    if (transferIncrement < 1) then
+        return
+    end
+
+    if modOptions.population_transfer_ratio > 0 then
+        if modOptions.population_transfer == "reduce" then
+            spTransferTeamMaxUnits(unitTeam, GaiaTeamID, 1);
+        elseif modOptions.population_transfer == "transfer" then
+            spTransferTeamMaxUnits(unitTeam, attackerTeam, 1);
+        end
+    else
+        -- is this legit? Can I reduce from Gaia?
+        if modOptions.population_transfer == "reduce" then
+            -- spTransferTeamMaxUnits(unitTeam, GaiaTeamID, -1);
+        elseif modOptions.population_transfer == "transfer" then
+            spTransferTeamMaxUnits(unitTeam, attackerTeam, -1);
+        end
+    end
+end
+
+

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1515,28 +1515,28 @@ local options = {
     },
 
     {
-        key 	= "population_transfer",
+        key 	= "populationtransfer",
         name 	= "Max Population Transfer On Kills",
         type 	= "list",
         def 	= "disabled",
         section = "options_extra",
         hidden  = false,
         items 	= {
-            { key = "disabled", name = "Disabled", desc = "Disabled"},
-            { key = "transfer", name = "Transfer", desc = "Transfer population to the killing player from the killed units player." },
-            { key = "reduce", name = "Reduce", desc = "Lower the population cap of the player whose unit was killed. Should not be used with Negative transfer ratio."},
+            { key = "disabled", name = "Disabled", desc = "Disabled", lock = {"populationtransferratio"} },
+            { key = "transfer", name = "Transfer", desc = "Transfer population to the killing player from the killed units player.", unlock = {"populationtransferratio"}  },
+            { key = "reduce", name = "Reduce", desc = "Lower the population cap of the player whose unit was killed. Should not be used with Negative transfer ratio.", unlock = {"populationtransferratio"} },
         }
     },
 
     {
-        key    	= "population_transfer_ratioronescount",
+        key    	= "populationtransferratio",
         name   	= "Population count transfer ratio",
         desc   	= "How many kills are required to transfer 1 population",
         type   	= "number",
         section	= "options_extra",
         def    	= 1,
-        min    	= 0,
-        max    	= -1,
+        min    	= -1,
+        max    	= 1,
         step   	= .05,
     },
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1508,6 +1508,38 @@ local options = {
         }
     },
 
+    {
+        key     = "sub_header",
+        section = "options_extra",
+        type    = "separator",
+    },
+
+    {
+        key 	= "population_transfer",
+        name 	= "Max Population Transfer On Kills",
+        type 	= "list",
+        def 	= "disabled",
+        section = "options_extra",
+        hidden  = false,
+        items 	= {
+            { key = "disabled", name = "Disabled", desc = "Disabled"},
+            { key = "transfer", name = "Transfer", desc = "Transfer population to the killing player from the killed units player." },
+            { key = "reduce", name = "Reduce", desc = "Lower the population cap of the player whose unit was killed. Should not be used with Negative transfer ratio."},
+        }
+    },
+
+    {
+        key    	= "population_transfer_ratioronescount",
+        name   	= "Population count transfer ratio",
+        desc   	= "How many kills are required to transfer 1 population",
+        type   	= "number",
+        section	= "options_extra",
+        def    	= 1,
+        min    	= 0,
+        max    	= -1,
+        step   	= .05,
+    },
+
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     -- Experimental Options


### PR DESCRIPTION
### Work done
Added a new Gadget for unitDeath to leverage new option setting to either transfer or reduce max population with an option for kill to transfer ratio.


#### Setup
In lobby -> extras -> Population transfer section at the bottom

#### Test steps
Tested positive, negative ratios, transfer, reduction, and disabled modes

### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

<img width="1566" height="845" alt="image" src="https://github.com/user-attachments/assets/753c65c5-4fa3-4a33-8745-3d785392b903" />

Video showing population decrease on unit death (.3 ratio iirc)
https://github.com/user-attachments/assets/2cb44a95-9311-44b6-8bde-d5baefa83403

