### PR TITLE
Fix nondestructive respawn

### DIFF
--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -66,7 +66,7 @@ if gadgetHandler:IsSyncedCode() then
 
 		--	-- Has a default value, as indicated, if not chosen:
 		-- respawn_health_threshold = 0,				--The health value when the unit will initiate the respawn sequence.
-		-- destructive_respawn = true,					--If this is set to true, the effigy unit will be destroyed when the unit respawns.
+		-- destructive_respawn = true, 1,				-- If this is set to true, the effigy unit will be destroyed when the unit respawns, can also be set to a number to provide that n-1 respawns or n instances of that unit with 0 for infinite
 		-- respawn_health = 1,                          -- If this is set to a number set the respawned units health to that number when respawning.
         -- respawn_stun_duration = calculated by distance/maxHealth, -- Override the stun duration to a static value
 
@@ -93,7 +93,7 @@ if gadgetHandler:IsSyncedCode() then
 			GG.ComSpawnDefoliate(ex, ey, ez)
 
 			-- Mark effigy as used for respawning to prevent "lost" notifications
-			if meta.destructive_respawn then
+			if meta.destructive_respawn == 1 then
 				meta.effigyID = nil
 			end
 
@@ -108,7 +108,7 @@ if gadgetHandler:IsSyncedCode() then
 			-- could kill the commander and nil out respawnMetaList[unitID]
 			local stunDuration = maxHealth + ((maxHealth/30)*meta.minimum_respawn_stun) + (((maxHealth/30)*diag((x-ex), (z-ez))*meta.distance_stun_multiplier)/250)--250 is an arbitrary number that seems to produce desired results.
 
-			if meta.destructive_respawn then
+			if meta.destructive_respawn == 1 then
 			    if friendlyFire then
 			        destroyEffigy(effigyID, false, true)
 			    else
@@ -116,6 +116,8 @@ if gadgetHandler:IsSyncedCode() then
 				end
 				spSetUnitRulesParam(unitID, "unit_effigy", nil, PRIVATE)
 			end
+			-- decrement respawn count, when starting at 0 this just counts negatively forever
+			meta.destructive_respawn = meta.destructive_respawn - 1
 
 			local respawnHealth = 1
 			if meta.respawn_health then
@@ -174,7 +176,7 @@ if gadgetHandler:IsSyncedCode() then
 				effigy_offset = tonumber(udcp.effigy_offset) or 0,
 				minimum_respawn_stun = tonumber(udcp.minimum_respawn_stun) or 0,
 				distance_stun_multiplier = tonumber(udcp.distance_stun_multiplier) or 0,
-				destructive_respawn = ((udcp.destructive_respawn == true) or (udcp.destructive_respawn == nil)),
+				destructive_respawn = tonumber(udcp.destructive_respawn) or 1,
 				respawn_pad = udcp.respawn_pad or "false",
 				unitTeam = unitTeam,
 				respawnTimer = spGetGameSeconds(),

--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -6,8 +6,8 @@ function gadget:GetInfo()
 	return {
 		name = "Unit Respawning",
 		desc = "Prevents death and instead respawns elsewhere",
-		author = "Xehrath",
-		date = "2023-05-12",
+		author = "Xehrath, Chemdude8",
+		date = "2023-05-12, 2026",
 		license = "None",
 		layer = 49,
 		enabled = true
@@ -91,7 +91,9 @@ if gadgetHandler:IsSyncedCode() then
 			GG.ComSpawnDefoliate(ex, ey, ez)
 
 			-- Mark effigy as used for respawning to prevent "lost" notifications
-			meta.effigyID = nil
+			if meta.destructive_respawn then
+				meta.effigyID = nil
+			end
 
 			if meta.respawn_pad == "false" then
 				Spring.SetUnitPosition(effigyID, x, z, true)
@@ -113,9 +115,17 @@ if gadgetHandler:IsSyncedCode() then
 				spSetUnitRulesParam(unitID, "unit_effigy", nil, PRIVATE)
 			end
 
+			local respawnHealth = 1
+			if meta.respawn_healthy then
+				respawnHealth = maxHealth
+			end
+			
+			if meta.respawn_immediately == true then
+				stunDuration = 0
+			end
 			-- Only apply stun if the unit survived the effigy destruction
 			if respawnMetaList[unitID] then
-				spSetUnitHealth(unitID, {health = 1, capture = 0, paralyze = stunDuration,})
+				spSetUnitHealth(unitID, {health = respawnHealth, capture = 0, paralyze = stunDuration})
 				spGiveOrderToUnit(unitID, CMD.STOP, {}, 0)
 			end
 		end
@@ -162,11 +172,13 @@ if gadgetHandler:IsSyncedCode() then
 				effigy_offset = tonumber(udcp.effigy_offset) or 0,
 				minimum_respawn_stun = tonumber(udcp.minimum_respawn_stun) or 0,
 				distance_stun_multiplier = tonumber(udcp.distance_stun_multiplier) or 0,
-				destructive_respawn = udcp.destructive_respawn or true,
+				destructive_respawn = ((udcp.destructive_respawn == true) or (udcp.destructive_respawn == nil)),
 				respawn_pad = udcp.respawn_pad or "false",
 				unitTeam = unitTeam,
 				respawnTimer = spGetGameSeconds(),
 				effigyID = nil,
+				respawn_healthy = udcp.respawn_healthy or false,
+                respawn_immediately = udcp.respawn_immediately or false,
 			}
 
 			if respawnMetaList[unitID].effigy ~= "none" then

--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -67,6 +67,8 @@ if gadgetHandler:IsSyncedCode() then
 		--	-- Has a default value, as indicated, if not chosen:
 		-- respawn_health_threshold = 0,				--The health value when the unit will initiate the respawn sequence.
 		-- destructive_respawn = true,					--If this is set to true, the effigy unit will be destroyed when the unit respawns.
+		-- respawn_health = 1,                          -- If this is set to a number set the respawned units health to that number when respawning.
+        -- respawn_stun_duration = calculated by distance/maxHealth, -- Override the stun duration to a static value
 
 
 		-- },
@@ -116,12 +118,12 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			local respawnHealth = 1
-			if meta.respawn_healthy then
-				respawnHealth = maxHealth
+			if meta.respawn_health then
+				respawnHealth = meta.respawn_health
 			end
 			
-			if meta.respawn_immediately == true then
-				stunDuration = 0
+			if meta.respawn_stun_duration then
+				stunDuration = meta.respawn_stun_duration
 			end
 			-- Only apply stun if the unit survived the effigy destruction
 			if respawnMetaList[unitID] then
@@ -177,8 +179,8 @@ if gadgetHandler:IsSyncedCode() then
 				unitTeam = unitTeam,
 				respawnTimer = spGetGameSeconds(),
 				effigyID = nil,
-				respawn_healthy = udcp.respawn_healthy or false,
-                respawn_immediately = udcp.respawn_immediately or false,
+				respawn_health = tonumber(udcp.respawn_health),
+                respawn_stun_duration = tonumber(udcp.respawn_stun_duration),
 			}
 
 			if respawnMetaList[unitID].effigy ~= "none" then

--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -116,8 +116,10 @@ if gadgetHandler:IsSyncedCode() then
 				end
 				spSetUnitRulesParam(unitID, "unit_effigy", nil, PRIVATE)
 			end
-			-- decrement respawn count, when starting at 0 this just counts negatively forever
-			meta.destructive_respawn = meta.destructive_respawn - 1
+
+			if meta.destructive_respawn > 0 then
+				meta.destructive_respawn = meta.destructive_respawn - 1
+			end
 
 			local respawnHealth = 1
 			if meta.respawn_health then


### PR DESCRIPTION
### Work done
Updated existing effigy code to remove bug where destructive_respawn was always set to true. destructive_respawn=false case based on provided unitDef.customparams.  Current code and unitdefs can mislead unitdef creation into believing that non-destructive respawn is an option (which whenever the code was originally created it clearly was planning to support.  With this the notion of the respawn_pad becomes possible.  Separately, via unitdefs I have created a gun-game mode where your unit evolves based on experience and on-death is respawned for you to re-attempt (single unit control game to promote micro skill growth).


#### Setup
Can be tested with legion, 'kill all units' and the attached tweakdef (tweakdef is still subject to additional updates but it works to illustrate the non-destructive and respawn_pad functionality.

[gungametweakdef.txt](https://github.com/user-attachments/files/27503941/gungametweakdef.txt)


#### Test steps
- When a unitdef for a effigy provides destructive_respawn = false the effigy does not get destroyed on respawn
- The effigy also creates additional copies of the unit because in the case of destructive_respawn=false it does not clear the effigyId reference
- Small addition to enable min/max health setting
- Small addition to enable 0/existing paralyze setting
- In the case of the tweakdef, currently you must "stumble upon" enemy effigies to kill them, provided this PR gets accepted I plan to update the tweakdef such that the final unit can destroy the other effigies in an effective manner

### Screenshots:
Changes are only behavioral, as any visual changes are based on tweakdefs, happy to include a video, but want to make sure someone is willing to consider this PR before the extra effort (sorry, my second PR and first got closed with 'not asked for')

### AI / LLM usage statement:
No AI/LLM was used to create nor test this code.

