### PR TITLE
fix: a bunch of minor Set Target bugs

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -528,7 +528,9 @@ if gadgetHandler:IsSyncedCode() then
 								elseif target[2] < 0 and spGetUnitWeaponTestTarget(unitID, weaponID, target[1], 1, target[3]) then
 									target[2] = 1 -- clip to waterlevel +1
 									validTarget = spGetUnitWeaponTestTarget(unitID, weaponID, target[1], target[2], target[3])
-									break
+									if validTarget then
+										break
+									end
 								end
 							end
 						end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -722,6 +722,7 @@ if gadgetHandler:IsSyncedCode() then
 		if n % 5 == 4 then
 			for unitID, unitData in pairsNext, unitTargets do
 				local targetIndex
+				local targetOffset = 0
 				local targets = unitData.targets
 				-- Check each target and find first valid one
 				for index = 1, #targets do
@@ -729,8 +730,9 @@ if gadgetHandler:IsSyncedCode() then
 					if not checkTarget(unitID, targetData.target) then
 						-- Mark for removal, but don't remove during iteration
 						targetData.invalid = true
+						targetOffset = targetOffset + 1
 					elseif not targetData.invalid and setTarget(unitID, targetData) then
-						targetIndex = index
+						targetIndex = index - targetOffset
 						break
 					end
 				end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -349,7 +349,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			sendTargetsToUnsynced(unitID)
 			SendToUnsynced("targetList", unitID, #unitTargets[unitID].targets + 1) -- ask to clear the last element since we made the table smaller
-			local currentIndex = index == unitTargets[unitID].currentIndex
+			local currentIndex = unitTargets[unitID].currentIndex
 			if index == currentIndex then
 				unitTargets[unitID].currentIndex = 1
 			elseif index < currentIndex then

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -438,7 +438,7 @@ if gadgetHandler:IsSyncedCode() then
 
 				-- Checks if the command is a valid area command {x,y,z,r} with radius more than 0:
 				if #cmdParams > 3 and not (#cmdParams == 4 and cmdParams[4] == 0) then
-					local targets = {}
+					local targets
 					if #cmdParams == 6 then
 						--rectangle
 						local top, bot, left, right

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -86,7 +86,7 @@ if gadgetHandler:IsSyncedCode() then
 
 		if #weapons > 0 then
 			-- filter this down to only the params that actually get used, weapons is an array full of stuff!
-			unitWeapons[unitDefID] = weapons
+			unitWeapons[unitDefID] = {}
 			for i=1, #weapons do
 				unitWeapons[unitDefID][i] = true
 			end
@@ -102,6 +102,7 @@ if gadgetHandler:IsSyncedCode() then
 	local unitTargets = {} -- data holds all unitID data
 	local pausedTargets = {}
 	--local needSend = {}
+
 	--------------------------------------------------------------------------------
 	-- Commands
 

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -349,6 +349,12 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			sendTargetsToUnsynced(unitID)
 			SendToUnsynced("targetList", unitID, #unitTargets[unitID].targets + 1) -- ask to clear the last element since we made the table smaller
+			local currentIndex = index == unitTargets[unitID].currentIndex
+			if index == currentIndex then
+				unitTargets[unitID].currentIndex = 1
+			elseif index < currentIndex then
+				unitTargets[unitID].currentIndex = currentIndex - 1
+			end
 		end
 	end
 


### PR DESCRIPTION
### Work done

A few bugs from reading through the file for #7601.

- Removing specific targets from a target list was bugged.
- Units with mixed above/under water weapons could exit too early without success when trying to place a target at a world position.
- Failure to acquire new targets in append-mode would still clear targets.