### PR TITLE
Fix: Add handling of quotas and alt queue units to FactoryQ

### DIFF
--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -1,5 +1,5 @@
 include("keysym.h.lua")
-local versionNumber = 1.5
+local versionNumber = 1.6
 
 local widget = widget ---@type Widget
 
@@ -29,6 +29,7 @@ local spGetViewGeometry = Spring.GetViewGeometry
 local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
 
 --Changelog
+--1.6: added: support of quotas and 'alt' queued priority units in preset
 --1.5: added repeat icon and bindable keybind actions to activate
 --1.4: fixed text alignment, changed layer cause other widgets are eating events otherwise (e.g. smartselect)
 --1.3: fixed for 0.83
@@ -64,7 +65,7 @@ local idrawY = 650
 local igroupLabelXOff = 17
 local igroupLabelYOff = 10
 
-local drawFadeTime = 0.15
+local drawFadeTime = 0.10
 local loadedBorderDisplayTime = 1.0
 
 local repeatIcon = "LuaUI/Images/repeat.png"
@@ -81,6 +82,8 @@ local defaultScreenResY = 960  --dont change it, its just to keep the same absol
 local savedQueues = {}
 local drawX = nil
 local facRepeatIdx = "facq_repeat"
+local facQuotaIdx = "facq_quotaMode"
+local facQuota = "facq_quota"
 local lastBoxX = nil
 local lastBoxY = nil
 local boxCoords = {}
@@ -312,13 +315,6 @@ function getSingleFactory()
 end
 
 function saveQueue(unitId, unitDef, groupNo)
-	local unitQ = Spring.GetFactoryCommands(unitId, -1)
-	if #unitQ <= 0 then
-		--queue is empty -> signal to delete preset
-		savedQueues[curModId][unitDef.id][groupNo] = nil
-		return
-	end
-
 	if savedQueues[curModId] == nil then
 		savedQueues[curModId] = {}
 	end
@@ -326,8 +322,33 @@ function saveQueue(unitId, unitDef, groupNo)
 		savedQueues[curModId][unitDef.id] = {}
 	end
 
-	savedQueues[curModId][unitDef.id][groupNo] = unitQ
-	savedQueues[curModId][unitDef.id][groupNo][facRepeatIdx] = select(4, Spring.GetUnitStates(unitId, false, true))    -- 4=repeat
+	local unitQ = Spring.GetFactoryCommands(unitId, -1)
+	local unitQuota = {}
+	local unitQuotaIdx = false
+
+	if WG.Quotas then
+		local quotas = WG.Quotas.getQuotas()
+		local quota = quotas[unitId]
+		if quota then
+			unitQuota = table.copy(quota)
+		end
+		unitQuotaIdx = WG.Quotas.isOnQuotaMode(unitId)
+	end
+
+	for i = #unitQ, 1, -1 do
+		if unitQ[i].id == CMD.WAIT or unitQ[i].options.internal and not unitQ[i].options.alt then -- We don't want to save these commands
+			table.remove(unitQ, i)
+		end
+	end
+	if #unitQ <= 0 and next(unitQuota) == nil then
+		--queue is empty -> signal to delete preset
+		savedQueues[curModId][unitDef.id][groupNo] = nil
+	else
+		savedQueues[curModId][unitDef.id][groupNo] = unitQ
+		savedQueues[curModId][unitDef.id][groupNo][facQuota] = unitQuota
+		savedQueues[curModId][unitDef.id][groupNo][facRepeatIdx] = select(4, Spring.GetUnitStates(unitId, false, true))    -- 4=repeat
+		savedQueues[curModId][unitDef.id][groupNo][facQuotaIdx] = unitQuotaIdx
+	end
 
 	modifiedGroup = groupNo
 	modifiedGroupTime = Spring.GetGameSeconds()
@@ -345,11 +366,22 @@ function loadQueue(unitId, unitDef, groupNo)
 	end
 
 	local queue = savedQueues[curModId][unitDef.id][groupNo]
-	if queue ~= nil and #queue > 0 then
-		ClearFactoryQueues()
+	if queue ~= nil then
 		modifiedGroup = groupNo
 		modifiedGroupTime = Spring.GetGameSeconds()
 		modifiedSaved = false
+
+		if WG.Quotas and queue[facQuota] then
+			local quotas = WG.Quotas.getQuotas()
+			quotas[unitId] = queue[facQuota]
+
+			--set factory to quota mode on/off
+			local quotaVal = 1
+			if queue[facQuotaIdx] == false then
+				quotaVal = 0
+			end
+			spGiveOrderToUnit(unitId, GameCMD.QUOTA_BUILD_TOGGLE, { quotaVal }, 0)
+		end
 
 		--set factory to repeat on/off
 		local repVal = 1
@@ -357,14 +389,20 @@ function loadQueue(unitId, unitDef, groupNo)
 			repVal = 0
 		end
 		spGiveOrderToUnit(unitId, CMD.REPEAT, { repVal }, 0)
-
-		for i = 1, #queue do
-			local cmd = queue[i]
-			if not cmd.options.internal then
+		if #queue > 0 then
+			ClearFactoryQueues()
+			for i = 1, #queue do
+				local cmd = queue[i]
 				local opts = {}
-				spGiveOrderToUnit(unitId, cmd.id, cmd.params, opts)
+				if cmd.options.alt then
+					opts = { "alt" }
+				end
+				if cmd.id then
+					spGiveOrderToUnit(unitId, cmd.id, cmd.params, opts)
+				end
 			end
-		end
+		end 	
+
 	end
 end
 
@@ -464,6 +502,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 
 	--if units == nil then
 	local units = SortQueueToUnits(queue)
+	local quota = queue[facQuota] or {} -- already in a sorted table
 	--end
 	--Draw "loaded" border
 	if modifiedGroup == groupNo and modifiedGroupTime > Spring.GetGameSeconds() - loadedBorderDisplayTime then
@@ -489,7 +528,9 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 
 	font:Begin()
 	--Draw group Label
-	if  queue[facRepeatIdx] == nil or queue[facRepeatIdx] == true then
+	if queue[facQuotaIdx] and queue[facQuotaIdx] == true then
+		font:SetTextColor(1, 0.51, 0.745, alpha or 1)
+	elseif  queue[facRepeatIdx] == nil or queue[facRepeatIdx] == true then
 		font:SetTextColor(0, 1, 0, alpha or 1)
 	else
 		font:SetTextColor(1, 1, 1, alpha or 1)
@@ -519,7 +560,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 		xOff = xOff + boxHeight - boxIconBorder - boxIconBorder + unitIconSpacing
 	end
 
-	if queue[facRepeatIdx] == nil or queue[facRepeatIdx] == true then
+	if queue[facRepeatIdx] and queue[facRepeatIdx] == true then
 		if x + boxHeight + boxIconBorder + xOff + boxHeight + unitIconSpacing > x + boxWidth then
 			font:SetTextColor(1, 1, 1, alpha)
 			font:Print("...", x + xOff + unitCountXOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "nd")
@@ -534,7 +575,32 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 				repeatIcon
 			)
 		end
+		xOff = xOff + boxHeight - boxIconBorder - boxIconBorder + unitIconSpacing
 	end
+
+	for k, unitQuotaCount in pairs(quota) do
+		if k ~= 0 then
+			if x + boxHeight + boxIconBorder + xOff + boxHeight + unitIconSpacing > x + boxWidth then
+				font:SetTextColor(1, 1, 1, alpha)
+				font:Print("...", x + xOff + unitCountXOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "nd")
+				break
+			else
+				gl.Color(0.8,0.8,0.8 ,1)
+				UiUnit(
+					x + boxIconBorder + xOff, y - boxHeight + boxIconBorder, x + boxHeight - boxIconBorder + xOff, y - boxIconBorder,
+					nil,
+					1,1,1,1,
+					0.08,
+					nil, nil,
+					'#'..k
+				)
+				font:SetTextColor(1, 0.51, 0.745, alpha)
+				font:Print(unitQuotaCount, x + (boxHeight*0.5) - boxIconBorder + xOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "cndo")
+			end
+			xOff = xOff + boxHeight - boxIconBorder - boxIconBorder + unitIconSpacing
+		end
+	end
+
 
 	--draw "loaded" text
 	if modifiedGroup == groupNo and modifiedGroupTime > Spring.GetGameSeconds() - loadedBorderDisplayTime then
@@ -590,7 +656,7 @@ function DrawBoxes()
 				height = boxHeightTitle
 			end
 			yOffset = yOffset - height
-			DrawBoxGroup(x, y + yOffset, yOffset, unitDef, selUnit, alpha, k, savedQueues[curModId][unitDef.id][k])
+			DrawBoxGroup(x, y + yOffset, yOffset, unitDef, selUnit, alpha, k, q)
 			first = false
 		end
 


### PR DESCRIPTION
Fix factoryQ Manager to add handling of quotas and alt queue units.

### Work done
Added saving and loading of the factory quota if quotas are used. 

Also added the ability to pass on `alt` queued units so a mix of repeat + alt (non repeat) units can be saved. It does drop the `shift` option to keep the queue in a more expected order, only using shift for the number of units, i.e.:

User input: 

`alt z, alt v, alt v, alt z, shift alt v, shift c`

result saved queue

`z, v, v, z, v, v, v, v, v, c, c, c, c, c`

as opposed to:

`z, v, v, v, v, v, z, v, v, c, c, c, c, c` - with repeat
`v, v, v, v, v, z, v, v, z, c, c, c, c, c` - without repeat

Some other minor bug fixes when saving empty queues. 

#### Setup
Have the factory Q Manager widget enabled:
```
/togglewidget FactoryQ Manager
```

#### Test steps
- Save various Queues with and without repeat state enabled, alt queued units, quotas, and quota mode (currently) enabled


### Screenshots:
Added the quota pink colour to the group label (if quota mode will be enabled on the lab). Quota unit cards are added and same pink colour for the number of the quotas. 

#### BEFORE:
<img width="838" height="576" alt="image" src="https://github.com/user-attachments/assets/cf9f74ea-7132-45a2-b073-8045d59300b0" />


#### AFTER:
Number indicates lab state. Pink = will be in quota mode, Green in repeat mode (if not quota). Shows the queue, then the repeat icon (if repeating) and then the quotas. Alt and regular/repeat units are condensed for space so it just indicates the sum(alt+repeat) then (quota). 

<img width="1749" height="957" alt="image" src="https://github.com/user-attachments/assets/3deb34d2-3194-4905-96ee-33a70d3d54ee" />


### AI / LLM usage statement:
No AI code