### PR TITLE
Fix: Prevent void nukes

### DIFF
--- a/luarules/gadgets/cmd_place_target_on_ground.lua
+++ b/luarules/gadgets/cmd_place_target_on_ground.lua
@@ -4,7 +4,7 @@ function gadget:GetInfo()
 	return {
 		name      = 'Place Target On Ground',
 		desc      = 'Make some units, like nukes, target ground instead of units',
-		author    = 'Itanthias',
+		author    = 'Itanthias, Chronographer',
 		date      = 'August 2023',
 		license   = 'GNU GPL, v2 or later',
 		layer     = -12,
@@ -35,12 +35,22 @@ local spEditUnitCmdDesc = Spring.EditUnitCmdDesc
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetGroundHeight = Spring.GetGroundHeight
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local mapx = Game.mapSizeX
+local mapz = Game.mapSizeZ
 
 local CMD_ATTACK = CMD.ATTACK
 local CMD_UNIT_SET_TARGET = GameCMD.UNIT_SET_TARGET
 local CMD_UNIT_SET_TARGET_NO_GROUND = GameCMD.UNIT_SET_TARGET_NO_GROUND
 local CMD_UNIT_SET_TARGET_RECTANGLE = GameCMD.UNIT_SET_TARGET_RECTANGLE 
 local CMDTYPE_ICON_MAP = CMDTYPE.ICON_MAP
+
+local success, mapinfo = pcall(VFS.Include,"mapinfo.lua") -- load mapinfo.lua confs
+local hasVoid = false
+if success and type(mapinfo) == "table" and mapinfo.voidwater then
+  hasVoid = true
+elseif not success then
+  Spring.Echo("Place Target On Ground failed to load the mapinfo.lua")
+end
 
 function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD_ATTACK)
@@ -98,10 +108,18 @@ function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdO
 	-- usually from user side DefaultCommand widget function
 	if place_target_on_ground[unitDefID] then
 		-- no need to check cmdID due to RegisterAllowCommand above
-		if (#cmdParams == 1) then -- give an attack command at the ground, and deny the intial attack unit command
+		if hasVoid and (#cmdParams == 3 or #cmdParams == 4) then 
+			local x,y,z = cmdParams[1], cmdParams[2], cmdParams[3]
+			if x ~= nil and (y < 0) and ( x >= 0 and x <= mapx ) and (z >= 0 and z <= mapz) then
+				return false
+			end
+		elseif (#cmdParams == 1) then -- give an attack command at the ground, and deny the intial attack unit command
 			local basePointX, basePointY, basePointZ = spGetUnitPosition(cmdParams[1])
 			if basePointX and basePointZ then
 				local yGround = spGetGroundHeight(basePointX, basePointZ)
+				if hasVoid and (yGround < 0) then
+					return false
+				end 
 				spGiveOrderToUnit(unitID, cmdID, {basePointX, yGround, basePointZ}, cmdOptions)
 				return false
 			end


### PR DESCRIPTION
Prevents attack commands for nukes aimed at void water to prevent clipping into the map and not triggering anti-nuke response. 

This is a much easier fix than changing nuke trajectory, can be considered a interim measure until that is implemented. 

#### Addresses Issue(s)
- Issue URL
https://discord.com/channels/549281623154229250/1485735758567571630/1486619744542130329

#### Test steps
- Fire nukes at the void on space maps using attack
- Fire nukes at the void using set target
- fire nukes at aircraft flying over the void using attack/set target

### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
Nukes can hit void
<img width="1627" height="1016" alt="image" src="https://github.com/user-attachments/assets/cc5eba76-3564-4325-8923-af6fc069138b" />
<img width="1508" height="846" alt="image" src="https://github.com/user-attachments/assets/48311b26-dda1-4ea4-aa80-4f04a0ce68fa" />


#### AFTER:
Nukes do not fire at void
<img width="1370" height="1157" alt="image" src="https://github.com/user-attachments/assets/6bea3812-d4d5-412a-93bc-db993dfb7aa9" />

<img width="1190" height="1134" alt="image" src="https://github.com/user-attachments/assets/e7075591-7fbd-4c86-97d2-edc577ee4ab2" />

### AI / LLM usage statement:
No AI code