### PR TITLE
feat(stats): add lua stats api to capture metrics and events

### DIFF
--- a/luarules/gadgets/api_stats.lua
+++ b/luarules/gadgets/api_stats.lua
@@ -1,0 +1,393 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Stats API",
+		desc    = "Counters/gauges/events stats API; aggregates time-series and writes a zlib-compressed JSONL sidecar at GameOver",
+		author  = "bruno-dasilva",
+		date    = "May 2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+--[[----------------------------------------------------------------------------
+GG.Stats — public API for emitting counters, gauges, and events.
+
+Exposed in both synced and unsynced gadgets with the same surface.
+Counters and gauges are snapshot-sampled into a "reporting period" every
+REPORTING_PERIOD_FRAMES frames (default 450 = 15s); events are emitted as
+they happen.
+
+  GG.Stats.IncCounter(name, delta, labels)
+    Add `delta` to a cumulative-total counter. Use when the producer naturally
+    yields per-event increments (e.g. one kill, N damage).
+
+  GG.Stats.OverrideCounter(name, total, labels)
+    Replace the cumulative total directly. Only use when the producer already
+    owns a monotonic running total (e.g. polling Spring.GetTeamStatsHistory).
+    Bypasses the additive contract — non-monotonic writes will produce a
+    counter series that goes backwards, which most consumers don't expect.
+
+  GG.Stats.SetGauge(name, value, labels)
+    Latest-wins sample of a value that can move freel up and down (e.g. unit count).
+
+  GG.Stats.EmitEvent(name, labels)
+    One-shot occurrence, written through immediately (e.g. commander killed).
+
+`labels` is a free-form table of dimension keys (e.g. {team_id=1, weapon="laser"});
+a stable serialization is used internally to merge writes with identical labels.
+
+Records are accumulated column-oriented in unsynced gadget memory and shipped
+to the LuaUI file-sink widget in a single compressed blob at GameOver. Each
+unique (type, name, labels) tuple becomes one series row, with parallel
+`frames` and `values` arrays appended over the game:
+  { type="meta",    schemaVersion=N, frameRate=N }
+  { type="counter", name=..., labels={...}, frames=[N,...], values=[N,...] }
+  { type="gauge",   name=..., labels={...}, frames=[N,...], values=[N,...] }
+  { type="event",   name=..., labels={...}, frames=[N,...] }
+  { type="end",     totalFrames=N }
+------------------------------------------------------------------------------]]
+
+local REPORTING_PERIOD_FRAMES = 450
+local SCHEMA_VERSION          = 1
+local SYNC_ACTION             = "stats_flush"
+
+local function makeLabelKey(labels)
+	if not labels then return "" end
+	local keys = {}
+	for k in pairs(labels) do
+		keys[#keys+1] = tostring(k)
+	end
+	table.sort(keys)
+	for i = 1, #keys do
+		keys[i] = keys[i] .. "=" .. tostring(labels[keys[i]])
+	end
+	return table.concat(keys, "|")
+end
+
+if gadgetHandler:IsSyncedCode() then
+	------------------------------------------------------------------ SYNCED
+    --- in synced code we try and do as little as possible.
+	--- at most we aggregate things that happen within a single frame,
+	--- then pass a lightweight final value to unsynced at end of frame
+	------------------------------------------------------------------
+
+	local counterDeltas    = {}
+	local counterOverrides = {}
+	local gaugeChanges     = {}
+	local events           = {}
+	local hasWork          = false
+
+	---@param name string  counter metric name (e.g. "units_built")
+	---@param value number  positive delta to add to the cumulative total
+	---@param labels table?  free-form label dimensions; identical labels merge
+	local function incCounter(name, value, labels)
+		if value == 0 then return end
+		local labelKey = makeLabelKey(labels)
+		counterDeltas[name] = counterDeltas[name] or {}
+		local entry = counterDeltas[name][labelKey]
+		if entry then
+			entry.delta = entry.delta + value
+		else
+			counterDeltas[name][labelKey] = { labels = labels or {}, delta = value }
+		end
+		hasWork = true
+	end
+
+	--- Replace the cumulative total directly. Caller is responsible for keeping
+	--- the value monotonically increasing — most consumers assume counters never
+	--- decrease. Use only when wrapping an external monotonic source.
+	---@param name string  counter metric name
+	---@param value number  cumulative monotonic total
+	---@param labels table?  free-form label dimensions
+	local function overrideCounter(name, value, labels)
+		local labelKey = makeLabelKey(labels)
+		counterOverrides[name] = counterOverrides[name] or {}
+		counterOverrides[name][labelKey] = { labels = labels or {}, value = value }
+		hasWork = true
+	end
+
+	---@param name string  gauge metric name (e.g. "live_unit_count")
+	---@param value number  latest-wins sample value
+	---@param labels table?  free-form label dimensions
+	local function setGauge(name, value, labels)
+		local labelKey = makeLabelKey(labels)
+		gaugeChanges[name] = gaugeChanges[name] or {}
+		gaugeChanges[name][labelKey] = { labels = labels or {}, value = value }
+		hasWork = true
+	end
+
+	---@param name string  event name (e.g. "building_constructed")
+	---@param labels table?  free-form label dimensions
+	local function emitEvent(name, labels)
+		events[#events+1] = { name = name, labels = labels or {} }
+		hasWork = true
+	end
+
+	GG.Stats = {
+		IncCounter      = incCounter,
+		OverrideCounter = overrideCounter,
+		SetGauge        = setGauge,
+		EmitEvent       = emitEvent,
+	}
+
+	function gadget:GameFrame(frame)
+		if not hasWork then return end
+		local payload = Json.encode({
+			frame            = frame,
+			counters         = counterDeltas,
+			counterOverrides = counterOverrides,
+			gauges           = gaugeChanges,
+			events           = events,
+		})
+		SendToUnsynced(SYNC_ACTION, payload)
+		counterDeltas    = {}
+		counterOverrides = {}
+		gaugeChanges     = {}
+		events           = {}
+		hasWork          = false
+	end
+
+	function gadget:Shutdown()
+		GG.Stats = nil
+	end
+
+	return
+end
+
+------------------------------------------------------------------ UNSYNCED
+
+local lastReportFrame = -REPORTING_PERIOD_FRAMES
+
+local metaRecord = {
+	type          = "meta",
+	schemaVersion = SCHEMA_VERSION,
+	frameRate     = Game.gameSpeed or 30,
+}
+
+-- Column-oriented series store: one entry per unique (type, name, labelKey).
+-- Counters/gauges have a `runningValue` updated as records arrive; the periodic
+-- flush appends a (frame, runningValue) sample to the series's frames/values.
+-- Events skip the running value and append a frame on every occurrence.
+local seriesByKey = {} -- "<type>:<name>:<labelKey>" → series table
+local seriesOrder = {} -- ordered list for stable serialization
+
+local function getOrCreateSeries(stype, name, labels, labelKey, withValues)
+	local key = stype .. "\0" .. name .. "\0" .. labelKey
+	local s = seriesByKey[key]
+	if not s then
+		s = { type = stype, name = name, labels = labels or {}, frames = {} }
+		if withValues then
+			s.values = {}
+			s.runningValue = 0
+		end
+		seriesByKey[key] = s
+		seriesOrder[#seriesOrder+1] = s
+	end
+	return s
+end
+
+local function appendSample(s, frame)
+	local frames = s.frames
+	local values = s.values
+	if values then
+		local n = #values
+		local v = s.runningValue
+		-- Collapse a run of identical samples by sliding the trailing frame forward:
+		-- (fA,V),(fB,V) + (fC,V) → (fA,V),(fC,V). Keeps both endpoints of the flat
+		-- region so consumers can still see when V started and when it ended.
+		if n >= 2 and values[n] == v and values[n - 1] == v then
+			frames[n] = frame
+			return
+		end
+		frames[n + 1] = frame
+		values[n + 1] = v
+	else
+		frames[#frames + 1] = frame
+	end
+end
+
+-- forward-declared for organization
+local maybeFlushReportingPeriod
+
+------------------------------------
+-- helpers called by both synced 
+--         and unsynced code paths
+------------------------------------
+local function addCounterDelta(name, labels, delta)
+	if delta == 0 then return end
+	local labelKey = makeLabelKey(labels)
+	local s = getOrCreateSeries("counter", name, labels, labelKey, true)
+	s.runningValue = s.runningValue + delta
+end
+
+local function overrideCounterTotal(name, labels, value)
+	local labelKey = makeLabelKey(labels)
+	local s = getOrCreateSeries("counter", name, labels, labelKey, true)
+	s.runningValue = value
+end
+
+local function setGaugeLatest(name, labels, value)
+	local labelKey = makeLabelKey(labels)
+	local s = getOrCreateSeries("gauge", name, labels, labelKey, true)
+	s.runningValue = value
+end
+
+local function appendEventAt(name, labels, frame)
+	local lbl = labels or {}
+	local labelKey = makeLabelKey(lbl)
+	local s = getOrCreateSeries("event", name, lbl, labelKey, false)
+	appendSample(s, frame)
+end
+------------------------------------
+
+------------------------------------
+--- public unsynced API
+------------------------------------
+---@param name string  counter metric name (e.g. "units_built")
+---@param value number  positive delta to add to the cumulative total
+---@param labels table?  free-form label dimensions; identical labels merge
+local function incCounter(name, value, labels)
+	addCounterDelta(name, labels, value)
+	maybeFlushReportingPeriod(Spring.GetGameFrame())
+end
+
+---@param name string  counter metric name
+---@param value number  cumulative monotonic total
+---@param labels table?  free-form label dimensions
+local function overrideCounter(name, value, labels)
+	overrideCounterTotal(name, labels, value)
+	maybeFlushReportingPeriod(Spring.GetGameFrame())
+end
+
+---@param name string  gauge metric name (e.g. "live_unit_count")
+---@param value number  latest-wins sample value
+---@param labels table?  free-form label dimensions
+local function setGauge(name, value, labels)
+	setGaugeLatest(name, labels, value)
+	maybeFlushReportingPeriod(Spring.GetGameFrame())
+end
+
+---@param name string  event name (e.g. "building_constructed")
+---@param labels table?  free-form label dimensions
+local function emitEvent(name, labels)
+	appendEventAt(name, labels, Spring.GetGameFrame())
+end
+
+GG.Stats = {
+	IncCounter      = incCounter,
+	OverrideCounter = overrideCounter,
+	SetGauge        = setGauge,
+	EmitEvent       = emitEvent,
+}
+------------------------------------
+
+------------------------------------
+-- synced -> unsynced
+------------------------------------
+local function handleSyncedFlush(_, payloadStr)
+	local payload = Json.decode(payloadStr)
+	if not payload then return end
+	local frame = payload.frame or Spring.GetGameFrame()
+
+	if payload.counters then
+		for name, byKey in pairs(payload.counters) do
+			for _, entry in pairs(byKey) do
+				addCounterDelta(name, entry.labels, entry.delta)
+			end
+		end
+	end
+
+	if payload.counterOverrides then
+		for name, byKey in pairs(payload.counterOverrides) do
+			for _, entry in pairs(byKey) do
+				overrideCounterTotal(name, entry.labels, entry.value)
+			end
+		end
+	end
+
+	if payload.gauges then
+		for name, byKey in pairs(payload.gauges) do
+			for _, entry in pairs(byKey) do
+				setGaugeLatest(name, entry.labels, entry.value)
+			end
+		end
+	end
+
+	if payload.events then
+		for _, ev in ipairs(payload.events) do
+			appendEventAt(ev.name, ev.labels, frame)
+		end
+	end
+
+	maybeFlushReportingPeriod(frame)
+end
+------------------------------------
+
+------------------------------------
+-- snapshot metric data periodically
+------------------------------------
+local function flushReportingPeriod(frame)
+	for i = 1, #seriesOrder do
+		local s = seriesOrder[i]
+		if s.type == "counter" or s.type == "gauge" then
+			appendSample(s, frame)
+		end
+	end
+end
+
+maybeFlushReportingPeriod = function(frame)
+	if frame - lastReportFrame < REPORTING_PERIOD_FRAMES then return end
+	flushReportingPeriod(frame)
+	lastReportFrame = frame
+end
+------------------------------------
+
+------------------------------------
+-- send final data to widgets
+------------------------------------
+local function serializeAll(endFrame)
+	local lines = { Json.encode(metaRecord) }
+	for i = 1, #seriesOrder do
+		local s = seriesOrder[i]
+		local entry = { type = s.type, name = s.name, labels = s.labels, frames = s.frames }
+		if s.values then entry.values = s.values end
+		lines[#lines+1] = Json.encode(entry)
+	end
+	lines[#lines+1] = Json.encode({ type = "end", totalFrames = endFrame })
+	return table.concat(lines, "\n") .. "\n"
+end
+
+local function flushBufferToLuaUI(endFrame)
+	local plain = serializeAll(endFrame)
+	local compressed = VFS.ZlibCompress(plain)
+	if not compressed then
+		Spring.Echo("[Stats] Compression failed; stats file not written")
+		return
+	end
+	if not Script.LuaUI("OnStatsBlob") then
+		Spring.Echo("[Stats] No OnStatsBlob widget handler; stats file not written")
+		return
+	end
+	Script.LuaUI.OnStatsBlob(compressed)
+	Spring.Echo(("[Stats] Stats file shipped: %d series, %d B plain → %d B zlib"):format(
+		#seriesOrder, #plain, #compressed))
+end
+------------------------------------
+
+function gadget:Initialize()
+	gadgetHandler:AddSyncAction(SYNC_ACTION, handleSyncedFlush)
+end
+
+function gadget:GameOver()
+	local frame = Spring.GetGameFrame()
+	flushReportingPeriod(frame)
+	flushBufferToLuaUI(frame)
+end
+
+function gadget:Shutdown()
+	gadgetHandler:RemoveSyncAction(SYNC_ACTION)
+	GG.Stats = nil
+end

--- a/luarules/gadgets/api_stats.lua
+++ b/luarules/gadgets/api_stats.lua
@@ -241,7 +241,6 @@ local function appendEventAt(name, labels, frame)
 	local s = getOrCreateSeries("event", name, lbl, labelKey, false)
 	appendSample(s, frame)
 end
-------------------------------------
 
 ------------------------------------
 --- public unsynced API
@@ -282,7 +281,6 @@ GG.Stats = {
 	SetGauge        = setGauge,
 	EmitEvent       = emitEvent,
 }
-------------------------------------
 
 ------------------------------------
 -- synced -> unsynced
@@ -324,7 +322,6 @@ local function handleSyncedFlush(_, payloadStr)
 
 	maybeFlushReportingPeriod(frame)
 end
-------------------------------------
 
 ------------------------------------
 -- snapshot metric data periodically
@@ -343,7 +340,6 @@ maybeFlushReportingPeriod = function(frame)
 	flushReportingPeriod(frame)
 	lastReportFrame = frame
 end
-------------------------------------
 
 ------------------------------------
 -- send final data to widgets
@@ -375,7 +371,6 @@ local function flushBufferToLuaUI(endFrame)
 	Spring.Echo(("[Stats] Stats file shipped: %d series, %d B plain → %d B zlib"):format(
 		#seriesOrder, #plain, #compressed))
 end
-------------------------------------
 
 function gadget:Initialize()
 	gadgetHandler:AddSyncAction(SYNC_ACTION, handleSyncedFlush)

--- a/luarules/gadgets/stats_building_events.lua
+++ b/luarules/gadgets/stats_building_events.lua
@@ -1,0 +1,47 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Stats API - Building events",
+		desc    = "Emits building_constructed{team_id, allyteam_id, unit_type, pos_x, pos_y, pos_z} when a building is finished",
+		author  = "bruno-dasilva",
+		date    = "May 2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local buildingName = {}
+local allyTeamFor  = {}
+
+local function getAllyTeam(teamID)
+	local cached = allyTeamFor[teamID]
+	if cached then return cached end
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID)
+	allyTeamFor[teamID] = allyTeamID
+	return allyTeamID
+end
+
+function gadget:Initialize()
+	for unitDefID, ud in pairs(UnitDefs) do
+		if ud.isBuilding then
+			buildingName[unitDefID] = ud.name
+		end
+	end
+end
+
+function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+	local name = buildingName[unitDefID]
+	if not name then return end
+	if not GG.Stats then return end
+	GG.Stats.EmitEvent("building_constructed", {
+		team_id     = unitTeam,
+		allyteam_id = getAllyTeam(unitTeam),
+		unit_type   = name,
+	})
+end

--- a/luarules/gadgets/stats_engine_metrics.lua
+++ b/luarules/gadgets/stats_engine_metrics.lua
@@ -1,0 +1,65 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Stats API - Engine metrics",
+		desc    = "Mirrors per-team engine stats (metal/energy/damage/units) into counters by polling Spring.GetTeamStatsHistory once per reporting period",
+		author  = "bruno-dasilva",
+		date    = "May 2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local POLL_FRAMES = 450
+
+local TRACKED_FIELDS = {
+	metalProduced  = "metal_produced",
+	metalUsed      = "metal_used",
+	energyProduced = "energy_produced",
+	energyUsed     = "energy_used",
+	damageDealt    = "damage_dealt",
+	damageReceived = "damage_received",
+	unitsProduced  = "units_produced",
+	unitsKilled    = "units_killed",
+	unitsDied      = "units_died",
+}
+
+local teams
+local allyTeamFor = {}
+
+local function getAllyTeam(teamID)
+	local cached = allyTeamFor[teamID]
+	if cached then return cached end
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID)
+	allyTeamFor[teamID] = allyTeamID
+	return allyTeamID
+end
+
+function gadget:GameFrame(frame)
+	if frame % POLL_FRAMES ~= 0 then return end
+	if not GG.Stats then return end
+	teams = teams or Spring.GetTeamList() or {}
+	for i = 1, #teams do
+		local teamID = teams[i]
+		local cur_max = Spring.GetTeamStatsHistory(teamID)
+		if cur_max and cur_max > 0 then
+			local statsArr = Spring.GetTeamStatsHistory(teamID, cur_max, cur_max)
+			local stats = statsArr and statsArr[1]
+			if stats then
+				local labels = {
+					team_id     = teamID,
+					allyteam_id = getAllyTeam(teamID),
+				}
+				for engineField, counterName in pairs(TRACKED_FIELDS) do
+					GG.Stats.OverrideCounter(counterName, stats[engineField] or 0, labels)
+				end
+			end
+		end
+	end
+end

--- a/luarules/gadgets/stats_live_unit_count.lua
+++ b/luarules/gadgets/stats_live_unit_count.lua
@@ -1,0 +1,43 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Stats API - Live unit count",
+		desc    = "Records live_unit_count{team_id, allyteam_id} by polling Spring.GetTeamUnitCount once per reporting period",
+		author  = "bruno-dasilva",
+		date    = "May 2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local POLL_FRAMES = 450
+
+local teams
+local allyTeamFor = {}
+
+local function getAllyTeam(teamID)
+	local cached = allyTeamFor[teamID]
+	if cached then return cached end
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID)
+	allyTeamFor[teamID] = allyTeamID
+	return allyTeamID
+end
+
+function gadget:GameFrame(frame)
+	if frame % POLL_FRAMES ~= 0 then return end
+	if not GG.Stats then return end
+	teams = teams or Spring.GetTeamList() or {}
+	for i = 1, #teams do
+		local teamID = teams[i]
+		GG.Stats.SetGauge("live_unit_count", Spring.GetTeamUnitCount(teamID) or 0, {
+			team_id     = teamID,
+			allyteam_id = getAllyTeam(teamID),
+		})
+	end
+end

--- a/luarules/gadgets/stats_units_built.lua
+++ b/luarules/gadgets/stats_units_built.lua
@@ -1,0 +1,43 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Stats API - Units built",
+		desc    = "Counts completed units per team and unit type (units_built{team_id, allyteam_id, unit_type})",
+		author  = "bruno-dasilva",
+		date    = "May 2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local unitDefName = {}
+local allyTeamFor = {}
+
+local function getAllyTeam(teamID)
+	local cached = allyTeamFor[teamID]
+	if cached then return cached end
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID)
+	allyTeamFor[teamID] = allyTeamID
+	return allyTeamID
+end
+
+function gadget:Initialize()
+	for unitDefID, ud in pairs(UnitDefs) do
+		unitDefName[unitDefID] = ud.name
+	end
+end
+
+function gadget:UnitFinished(_, unitDefID, unitTeam)
+	if not GG.Stats then return end
+	GG.Stats.IncCounter("units_built", 1, {
+		team_id     = unitTeam,
+		allyteam_id = getAllyTeam(unitTeam),
+		unit_type   = unitDefName[unitDefID] or "unknown",
+	})
+end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -5417,6 +5417,8 @@ function init()
 
 		{ id = "startboxeditor", group = "dev", category = types.dev, widget = "Startbox Editor", name = Spring.I18N('ui.settings.option.startboxeditor'), type = "bool", value = GetWidgetToggleValue("Startbox Editor"), description = Spring.I18N('ui.settings.option.startboxeditor_descr') },
 
+		{ id = "stats_jsonl_sink", group = "dev", category = types.dev, widget = "Stats API - JSONL file sink", name = "Write stats JSONL file", type = "bool", value = GetWidgetToggleValue("Stats API - JSONL file sink"), description = "Writes a zlib-compressed stats sidecar next to the replay at game over" },
+
 		{ id = "language_dev", group = "dev", category = types.dev, name = Spring.I18N('ui.settings.option.language'), type = "select", options = devLanguageNames, value = devLanguageCodes[Spring.I18N.getLocale()],
 			onchange = function(i, value)
 				local devLanguage = devLanguageCodes[value]

--- a/luaui/Widgets/stats_jsonl_sink.lua
+++ b/luaui/Widgets/stats_jsonl_sink.lua
@@ -1,0 +1,65 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name    = "Stats API - JSONL file sink",
+		desc    = "Writes a zlib-compressed stats JSONL file alongside the replay at GameOver",
+		author  = "bruno-dasilva",
+		date    = "May 2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = false,
+	}
+end
+
+-- This widget consumes a single compressed blob shipped by the api_stats gadget
+-- on GameOver, then writes it to disk. Lives in widget land (rather than as a
+-- gadget) only because the engine version we ship does not yet expose `io` to
+-- luarules. Records are buffered inside the gadget until GameOver so they
+-- never cross into widget land mid-game; that prevents a malicious widget from
+-- intercepting live enemy-team stats by hooking the same global.
+
+if not io then
+	Spring.Echo("[StatsJsonlSink] IO library not available, disabling widget")
+	return false
+end
+
+-- Prefer Spring.GetReplayRecordingFilePath so the file lands next to the
+-- replay's .sdfz. That API isn't exposed in our current engine version yet, so
+-- we fall back to a gameID-based filename in the engine working dir; pair with
+-- a replay later via the gameID embedded inside the file's meta record.
+local function deriveStatsFilePath()
+	if Spring.GetReplayRecordingFilePath then
+		local recPath = Spring.GetReplayRecordingFilePath()
+		if recPath and recPath ~= "" then
+			local path = recPath:gsub("%.sdfz$", ".stats.jsonl.zz")
+			if path == recPath then
+				path = recPath .. ".stats.jsonl.zz"
+			end
+			return path
+		end
+	end
+	local gameID = Game.gameID or Spring.GetGameRulesParam("GameID") or tostring(os.time())
+	local mapName = (Game.mapName or "unknown"):gsub("[^%w%-_]", "_")
+	return ("stats_%s_%s.jsonl.zz"):format(mapName, gameID)
+end
+
+local function onStatsBlob(data)
+	local path = deriveStatsFilePath()
+	local f, err = io.open(path, "wb")
+	if not f then
+		Spring.Echo("[StatsJsonlSink] Could not open stats file: " .. tostring(err))
+		return
+	end
+	f:write(data)
+	f:close()
+	Spring.Echo("[StatsJsonlSink] Stats file written: " .. path)
+end
+
+function widget:Initialize()
+	widgetHandler:RegisterGlobal('OnStatsBlob', onStatsBlob)
+end
+
+function widget:Shutdown()
+	widgetHandler:DeregisterGlobal('OnStatsBlob')
+end


### PR DESCRIPTION
### Work Done

Added a new gadget-facing (synced AND unsynced) API for collecting metrics and events. Intended to be as simple as possible, and follow the general conventions of a [prometheus](https://prometheus.io/)-like system. 

Metrics are shaped as:
`metric_name {label1key=label1value, label2key=label2value} [frame1, frame2] [value1, value2]`
Events are shaped as:
`event_name {label1key=label1value, label2key=label2value} [frame1, frame2, frame3]`

I've exported all current engine metrics, as well as tacked on a couple example collector gadgets (eg. live_unit_count. At end of game, these stats are sent as a blob over to widget-land where any widget can consume and use them.

### Addresses Issue(s)
- API, baseline stats, file format as part of #7584 

### Future Work
1. Enable by default(?) in follow up PR (needs dedicated discussion)
2. Implement stats file uploading to bar servers at end of game
3. More stats collected as needed
4. Possibly add a histogram metric type

### Testing
1. in dev section, enable the stats jsonl sink widget
5. play a game or watch a replay
6. look for stats file in your bar datadir

### Performance (TODO)
Stats memory usage and cumulative cpu time spent by a VERY large 13v13 late game:
`[Stats] f=50401 series=1391 points=31745 plain=519.8KB heap=33.6MB | append=226.0ms probe=35.0ms`
`[Stats] f=75151 series=1609 points=46397 plain=717.0KB heap=33.3MB | append=454.0ms probe=47.0ms`
`[Stats] f=115201 series=1751 points=64291 plain=955.1KB heap=65.3MB | append=832.0ms probe=64.0ms`
^ only ~1 MiB used and less than 900ms total cpu time by 65 mins, so pretty light.


### File size
samples from 5 weekends of games (25k games):
| game_type   | n      | mean       | p50        | p95        | max        |
  |-------------|--------|------------|------------|------------|------------|
  | Large Team  | 11,400 | 150.1 KiB  | 141.9 KiB  | 270.5 KiB  | 505.5 KiB  |
  | Small Team  |  5,352 |  46.3 KiB  |  39.7 KiB  |  98.4 KiB  | 277.4 KiB  |
  | Bots        |  5,049 | 147.4 KiB  | 131.4 KiB  | 321.6 KiB  | 515.9 KiB  |
  | Duel        |  4,812 |  13.8 KiB  |  11.3 KiB  |  32.1 KiB  | 135.4 KiB  |
  | FFA         |    711 |  48.1 KiB  |  39.1 KiB  | 109.8 KiB  | 255.7 KiB  |
  | Team FFA    |    419 | 101.5 KiB  |  89.4 KiB  | 218.9 KiB  | 465.4 KiB  |
  | Raptors     |    392 | 122.6 KiB  | 112.7 KiB  | 241.4 KiB  | 422.3 KiB  |
  | Scavengers  |    239 | 134.0 KiB  | 123.9 KiB  | 247.8 KiB  | 413.0 KiB  |

Example stats file from a 15min duel: 
https://bar-rts.com/replays/48affe691cca5484fe50507e2bee5123
[stats_48affe69.jsonl.zip](https://github.com/user-attachments/files/28173754/stats_48affe69.jsonl.zip)

Example stats file from a 120 minute 8v8: 
https://bar-rts.com/replays/a174ee69fd99e0d8cf58f53fea33c256
[stats_a174ee69.jsonl.zip](https://github.com/user-attachments/files/28173735/stats_a174ee69.jsonl.zip)

### AI Disclosure
Designed and tested by human, code-assisted by claude code.