### PR TITLE
Fix issue with Hold Fire/Return Fire icons appearing on constructors

### DIFF
--- a/luaui/Widgets/gui_unit_firestate_icons.lua
+++ b/luaui/Widgets/gui_unit_firestate_icons.lua
@@ -45,9 +45,11 @@ local popElementInstance  = InstanceVBOTable.popElementInstance
 --------------------------------------------------------------------------------
 local unitConf = {}
 for udid, unitDef in pairs(UnitDefs) do
-	local xsize, zsize = unitDef.xsize, unitDef.zsize
-	local scale = 2.5 * (xsize*xsize + zsize*zsize)^0.5
-	unitConf[udid] = {11 + (scale / 2.2), unitDef.height}
+    if unitDef.weapons and #unitDef.weapons > 0 then
+        local xsize, zsize = unitDef.xsize, unitDef.zsize
+        local scale = 2.5 * (xsize*xsize + zsize*zsize)^0.5
+        unitConf[udid] = {11 + (scale / 2.2), unitDef.height}
+    end
 end
 
 -- All visible units: [unitID] = unitDefID
@@ -104,6 +106,7 @@ local function pushToVBO(vbo, unitID, unitDefID, gf)
 	if vbo.instanceIDtoIndex[unitID] then return end
 	if not spValidUnitID(unitID) or spGetUnitIsDead(unitID) then return end
 	local conf = unitConf[unitDefID]
+	if not conf then return end
 	instanceData[1] = conf[1]  -- width
 	instanceData[2] = conf[1]  -- height
 	instanceData[4] = conf[2]  -- unit height offset


### PR DESCRIPTION
### Work done
Fix issue with Hold Fire/Return Fire icons appearing on constructors and other units that don't have a firestate.

### Screenshots:
#### BEFORE:
<img width="1920" height="1080" alt="screen_2026-05-10_18-31-11-609" src="https://github.com/user-attachments/assets/66f3bff5-6307-4e1a-a264-7d5736a3c1ac" />

#### AFTER:
<img width="1920" height="1080" alt="screen_2026-05-10_18-27-44-137" src="https://github.com/user-attachments/assets/5bd1831a-d867-42d9-a82b-b36610295951" />

### AI / LLM usage statement:
Help from Claude - Sonnet 4.6