### PR TITLE
Fix explodeAs typo, adding a largeExplosionGeneric to armmerl and legavroc

### DIFF
--- a/units/ArmVehicles/T2/armmerl.lua
+++ b/units/ArmVehicles/T2/armmerl.lua
@@ -8,7 +8,7 @@ return {
 		collisionvolumetype = "Box",
 		corpse = "DEAD",
 		energycost = 6500,
-		explodeas = "largexplosiongeneric",
+		explodeas = "largeExplosionGeneric",
 		footprintx = 3,
 		footprintz = 3,
 		health = 1220,

--- a/units/Legion/Vehicles/T2 Vehicles/legavroc.lua
+++ b/units/Legion/Vehicles/T2 Vehicles/legavroc.lua
@@ -11,7 +11,7 @@ return {
 		collisionvolumescales = "46 24 54",
 		collisionvolumetype = "Box",
 		corpse = "DEAD",
-		explodeas = "largexplosiongeneric",
+		explodeas = "largeExplosionGeneric",
 		footprintx = 3,
 		footprintz = 3,
 		leavetracks = true,


### PR DESCRIPTION
### Work done

This just fixes a typo, there is no [`largexplosiongeneric`](https://github.com/search?q=repo%3Abeyond-all-reason%2FBeyond-All-Reason%20largexplosiongeneric&type=code) (with camelcase: `largeXplosionGeneric`), there is only a [`largeExplosionGeneric`](https://github.com/search?q=repo%3Abeyond-all-reason%2FBeyond-All-Reason+largeExplosionGeneric&type=code) (two consecutive e's, larg**eE**xpl).

#### Test steps
- [ ] Observe units around taking slightly more damage/larger aoe than before
(The difference is very minimal, I don't know what the "default" explosion is if a definition can not be found, but it's smaller/less damage than `largeExplosionGeneric` apparently)