### PR TITLE
Fix formation dots drawn on rotated minimap

### DIFF
--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -8644,11 +8644,22 @@ local function DrawFormationDotsOverlay()
 		glFunc.TexRect(sx - dotSize, sy - dotSize, sx + dotSize, sy + dotSize)
 	end
 
+	-- Prevent displaying formation dots outside of the minimap
+	gl.Scissor(render.dim.l, render.dim.b, render.dim.r - render.dim.l, render.dim.t - render.dim.b)
+
+	-- Handle minimap rotation when displaying formation dots
+	if render.minimapRotation ~= 0 then
+		local centerX = render.dim.l + (render.dim.r - render.dim.l) / 2
+		local centerY = render.dim.b + (render.dim.t - render.dim.b) / 2
+		glFunc.PushMatrix()
+		glFunc.Translate(centerX, centerY, 0)
+		glFunc.Rotate(render.minimapRotation * 180 / math.pi, 0, 0, 1)
+		glFunc.Translate(-centerX, -centerY, 0)
+	end
+
 	-- Draw first dot
 	local sx, sy = WorldToPipCoords(formationNodes[1][1], formationNodes[1][3])
-	if sx >= render.dim.l and sx <= render.dim.r and sy >= render.dim.b and sy <= render.dim.t then
-		DrawScreenDot(sx, sy)
-	end
+	DrawScreenDot(sx, sy)
 
 	-- Draw dots along the line
 	if #formationNodes > 2 then
@@ -8668,9 +8679,7 @@ local function DrawFormationDotsOverlay()
 				local wz = node1[3] + (node2[3] - node1[3]) * factor
 
 				sx, sy = WorldToPipCoords(wx, wz)
-				if sx >= render.dim.l and sx <= render.dim.r and sy >= render.dim.b and sy <= render.dim.t then
-					DrawScreenDot(sx, sy)
-				end
+				DrawScreenDot(sx, sy)
 
 				lengthUnitNext = lengthUnitNext + lengthPerUnit
 			end
@@ -8680,10 +8689,13 @@ local function DrawFormationDotsOverlay()
 
 	-- Draw last dot
 	sx, sy = WorldToPipCoords(formationNodes[#formationNodes][1], formationNodes[#formationNodes][3])
-	if sx >= render.dim.l and sx <= render.dim.r and sy >= render.dim.b and sy <= render.dim.t then
-		DrawScreenDot(sx, sy)
+	DrawScreenDot(sx, sy)
+
+	if render.minimapRotation ~= 0 then
+		glFunc.PopMatrix()
 	end
 
+	gl.Scissor(false)
 	glFunc.Texture(false)
 end
 


### PR DESCRIPTION
I found a visual bug (only visual no other impact) when using the minimap to command units while the minimap is rotated using the rotation mode setting.

The formation dots displayed on the minimap that should match the user's drawing aren't rotated with minimap rotation and so they don't appear at the right place (see video/screenshot below for better understanding).

Depending on the rotation applied, vertical lines drawn could be displayed as horizontal and vice versa or the line could be display on the other side of the map. Moreover, on non-square maps, some dots near the borders were not displayed because the boundary checks did not account for the map rotation.

### Work done
I did two things in the `DrawFormationDotsOverlay` function:

1. Added the rotation when `render.minimapRotation` is not 0. I used the same lines of code that does the rotation for other components (`glFunc.Rotate`).
2. I removed the conditions to check if the dots are in the minimap (that were the reason why some dots were not displayed in non-square map) and used `gl.Scissor` to prevent dots from being drawn outside (but I'm not sure if it is mandatory as this shouldn't happen or maybe it is done at an other level and I don't need to do it here?). 

#### Setup
The setting **Interface > Minimap > rotation mode** must be set to auto flip 180, auto rotate 90 or auto-landscape.
And a rotation must be applied so the minimap is rotated.

#### Test steps
- Set rotation mode to auto flip 180, auto rotate 90 or auto-landscape
- Rotate the view until the minimap rotate
- Select multiple units
- Make a move command on the minimap (using right click and draw the formation line)
- The formation dots appearing in the minimap are not rotated (or rotated if you're running this fix)

If testing on a non-square map and trying to drawn the line near the border, the dots might not appear.


### Screenshots:
Here is a video I recorded to better understand the visual bug and see the fix working: https://youtu.be/er3W9zLsCu0

#### BEFORE:
We can see the minimap below, the cursor is at the end of a horizontal line but the formation dots appear vertical:
<img width="413" height="244" alt="image" src="https://github.com/user-attachments/assets/a678d85b-01db-4d75-8a73-67dfa396fd06" />

#### AFTER:
We can see the minimap below, the cursor is at the end of the horizontal line and the formation dots appear horizontal:
<img width="407" height="237" alt="image" src="https://github.com/user-attachments/assets/8f9b8159-116a-43e8-a3cb-ea33cce33917" />