### PR TITLE
Adding canareaattack tag to nuke building & sub

### DIFF
--- a/units/ArmBuildings/LandDefenceOffence/armsilo.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armsilo.lua
@@ -36,6 +36,7 @@ return {
 			techlevel = 2,
 			unitgroup = "nuke",
 			usebuildinggrounddecal = true,
+			canareaattack = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/ArmShips/T2/armseadragon.lua
+++ b/units/ArmShips/T2/armseadragon.lua
@@ -44,6 +44,7 @@ return {
 			subfolder = "ArmShips/T2",
 			techlevel = 2,
 			unitgroup = "nuke",
+			canareaattack = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorBuildings/LandDefenceOffence/corsilo.lua
+++ b/units/CorBuildings/LandDefenceOffence/corsilo.lua
@@ -36,6 +36,7 @@ return {
 			techlevel = 2,
 			unitgroup = "nuke",
 			usebuildinggrounddecal = true,
+			canareaattack = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/CorShips/T2/cordesolator.lua
+++ b/units/CorShips/T2/cordesolator.lua
@@ -45,6 +45,7 @@ return {
 			subfolder = "CorShips/T2",
 			techlevel = 2,
 			unitgroup = "nuke",
+			canareaattack = 1,
 		},
 		featuredefs = {
 			dead = {

--- a/units/Legion/Defenses/legsilo.lua
+++ b/units/Legion/Defenses/legsilo.lua
@@ -30,12 +30,13 @@ return {
 			buildinggrounddecalsizey = 10,
 			buildinggrounddecalsizex = 10,
 			buildinggrounddecaldecayspeed = 30,
-			unitgroup = 'nuke',
+			unitgroup = "nuke",
 			model_author = "Tharsy",
 			normaltex = "unittextures/leg_normal.dds",
 			removewait = true,
 			subfolder = "CorBuildings/LandDefenceOffence",
 			techlevel = 2,
+			canareaattack = 1,
 		},
 		featuredefs = {
 			dead = {


### PR DESCRIPTION
### Work done
Simply add the canareaattack tag (primarily used by bombers) to every nuke launcher.
This change is targeted towards the casual side of the game, it allows for player to easily spread multiple nukes in the selected area. More likely to be intercepted, but the cool factor of blanketing an area is made easier.

I'm aware that right click drag works for nuke launcher, but it is a more involved solution and the spread is less than perfect when done by human hands. Also it is not a very clearly indicated function, so newer player can miss it, compared to a clear cut command card option.

#### Test steps
- [ ] Build two or more nuke capable building/sub
- [ ] Use the Area Attack command card option or hotkey
