### PR TITLE
Fix: Apply stateprefs at load

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -53,6 +53,9 @@ local clearSound = 'LuaUI/Sounds/switchoff.wav'
 local CMDTYPE_ICON_MODE = CMDTYPE.ICON_MODE
 local isRecordPressed = false
 local isClearPressed = false
+local spawnInitialFrame = Game.spawnInitialFrame
+local spawnWarpInFrame = Game.spawnWarpInFrame
+local spectatingState = select(1, Spring.GetSpectatingState())
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -182,6 +185,31 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			--spEcho("".. name .. ", " .. tostring(cmdID) .. ", " .. tostring(cmdParam) .. " success: ".. tostring(success))
 		end
 	end
+end
+
+local function ApplyUnitStates()
+	local teamID = (not spectatingState) and Spring.GetMyTeamID()
+	local units = (teamID and Spring.GetTeamUnits(teamID)) or Spring.GetAllUnits()
+	if units then
+		for i = 1, #units do
+			widget:UnitFinished(units[i], Spring.GetUnitDefID(units[i]), teamID or Spring.GetUnitTeam(units[i]))
+		end
+	end
+end
+
+function widget:GameFrame(n)
+	if Spring.GetGameState then
+		local finishedLoading, loadedFromSave, locallyPaused, lagging = Spring.GetGameState()
+		if loadedFromSave then
+			widgetHandler:RemoveCallIn("GameFrame", self)
+			return
+		end
+	end
+	if n <= spawnInitialFrame then
+		return
+	end
+	ApplyUnitStates()
+	widgetHandler:RemoveCallIn("GameFrame", self)
 end
 
 function widget:GameOver()


### PR DESCRIPTION
### Work done
Catch the commander spawn after spawnInitialFrame and apply the saved states.

#### Setup
```bind 	       Ctrl  stateprefs_record```

#### Test steps
- [ ] Save a state for commander (e.g. low priority)
- [ ] Start a new game and see the saved state apply after spawn


### Screenshots:

#### BEFORE:
Spawned in commander does not remember states (return fire, low priority), created commander does. 

<img width="1138" height="901" alt="image" src="https://github.com/user-attachments/assets/aead6144-20ef-42e4-ad1e-73f4392526bc" />

#### AFTER:
Spawn in commander does remember states. 
<img width="1250" height="692" alt="image" src="https://github.com/user-attachments/assets/78e750cd-fd54-4a27-ac12-7515b1b17759" />


### AI / LLM usage statement:
No AI used. Just good old steal from ZK. 