### PR TITLE
Feature/expand defs export

### DIFF
--- a/luaui/Widgets/export_defs.lua
+++ b/luaui/Widgets/export_defs.lua
@@ -28,10 +28,116 @@ local function TableToFile(tbl, filename)
 	file:close()
 end
 
+local function BuildSoundIndex()
+	-- Index keyed by lowercased basename; engine sound-name resolution is case-insensitive
+	-- (e.g. unitdefs reference "Rockhvy1" but the file on disk is sounds/weapons/rockhvy1.wav).
+	local index = {}
+	local function scanDir(dir)
+		for _, ext in ipairs({ "wav", "ogg" }) do
+			for _, file in ipairs(VFS.DirList(dir, "*." .. ext) or {}) do
+				local basename = file:match("([^/\\]+)%.[^.]+$")
+				if basename then
+					local key = basename:lower()
+					if not index[key] then index[key] = file end
+				end
+			end
+		end
+		for _, sub in ipairs(VFS.SubDirs(dir) or {}) do
+			scanDir(sub)
+		end
+	end
+	scanDir("sounds/")
+	local ok, soundsModule = pcall(VFS.Include, "gamedata/sounds.lua")
+	if ok and type(soundsModule) == "table" and type(soundsModule.SoundItems) == "table" then
+		for name, def in pairs(soundsModule.SoundItems) do
+			if type(def) == "table" and type(def.file) == "string" then
+				index[name:lower()] = def.file
+			end
+		end
+	end
+	return index
+end
+
+local function BuildIconTypeIndex()
+	local ok, result = pcall(VFS.Include, "gamedata/icontypes.lua")
+	if ok and type(result) == "table" then return result end
+	return {}
+end
+
+local function ResolveSoundPath(soundIndex, name)
+	if type(name) ~= "string" or name == "" then return nil end
+	return soundIndex[name:lower()]
+end
+
+local function ResolveBuildPicPath(buildPic)
+	if type(buildPic) ~= "string" or buildPic == "" then return nil end
+	for _, candidate in ipairs({ "unitpics/" .. buildPic, "unitpics/" .. buildPic:lower() }) do
+		if VFS.FileExists(candidate) then return candidate end
+	end
+	return nil
+end
+
+local function AnnotateSoundArray(soundArray, soundIndex)
+	if type(soundArray) ~= "table" then return end
+	for _, entry in ipairs(soundArray) do
+		if type(entry) == "table" then
+			entry.path = ResolveSoundPath(soundIndex, entry.name)
+		end
+	end
+end
+
+local function AnnotateWeaponDefAssets(wd, soundIndex)
+	AnnotateSoundArray(wd.fireSound, soundIndex)
+	AnnotateSoundArray(wd.hitSound, soundIndex)
+end
+
+local function AnnotateUnitDefAssets(ud, soundIndex, iconTypeIndex)
+	ud.buildPicPath = ResolveBuildPicPath(ud.buildPic)
+	local iconEntry = iconTypeIndex[ud.iconType]
+	ud.iconTypePath = (type(iconEntry) == "table" and type(iconEntry.bitmap) == "string") and iconEntry.bitmap or nil
+	if type(ud.sounds) == "table" then
+		for _, soundArr in pairs(ud.sounds) do
+			AnnotateSoundArray(soundArr, soundIndex)
+		end
+	end
+end
+
+local function FlattenWeaponDef(weaponDef)
+	local tbl = {}
+	for field_name, value in pairs(weaponDef) do
+		if type(value) ~= "table" and type(value) ~= "function" then
+			tbl[field_name] = value
+		end
+	end
+	for k, v in weaponDef:pairs() do
+		tbl[k] = v
+	end
+	return tbl
+end
+
+local function ExportWeaponDefs(soundIndex)
+	local subdir = export_folder_path .. "/weaponDefs"
+	Spring.CreateDir(subdir)
+	for _, weaponDef in pairs(WeaponDefs) do
+		spEcho(string.format("Exporting weapondef: %s", weaponDef.name))
+		local flattened = FlattenWeaponDef(weaponDef)
+		AnnotateWeaponDefAssets(flattened, soundIndex)
+		TableToFile(flattened, string.format("%s/%s.json", subdir, weaponDef.name))
+	end
+end
+
 local function ExportDefs()
 	if not VFS.FileExists(export_folder_path) then
 		Spring.CreateDir(export_folder_path)
 	end
+	local unit_subdir = export_folder_path .. "/unitDefs"
+	Spring.CreateDir(unit_subdir)
+
+	spEcho("Building asset indices")
+	local soundIndex = BuildSoundIndex()
+	local iconTypeIndex = BuildIconTypeIndex()
+
+	ExportWeaponDefs(soundIndex)
 
 	for id, unitDef in pairs(UnitDefs) do
 		spEcho(string.format("Exporting unitdef: %s", unitDef.name))
@@ -39,7 +145,7 @@ local function ExportDefs()
 
 		-- embed higher-level "computed" fields like translatedHumanName, translatedTooltip, etc.
 		for field_name, value in pairs(unitDef) do
-			if type(value) ~= "table" or type(value) ~= "function" then
+			if type(value) ~= "table" and type(value) ~= "function" then
 				tbl[field_name] = value
 			end
 		end
@@ -49,16 +155,27 @@ local function ExportDefs()
 			tbl[k] = v
 		end
 
-		-- parse wDefs, a list of weaponDef metatables
+		-- wDefs is a parallel array of weapondef names indexed by mount slot
+		-- (matches unit.weapons[i]); full weapondef data lives in weaponDefs.json
 		tbl["wDefs"] = {}
 		for i, weaponDef in pairs(unitDef.wDefs) do
-			tbl["wDefs"][weaponDef.id] = {}
-			for field_name, value in weaponDef:pairs() do
-				tbl["wDefs"][weaponDef.id][field_name] = value
+			tbl["wDefs"][i] = weaponDef.name
+		end
+
+		-- annotate each weapons[] mount entry with its weapondef name so consumers
+		-- can dereference into weaponDefs.json without needing the parallel wDefs array
+		if type(tbl.weapons) == "table" then
+			for _, weapon in pairs(tbl.weapons) do
+				if type(weapon) == "table" then
+					local wd = type(weapon.weaponDef) == "number" and WeaponDefs[weapon.weaponDef] or nil
+					if wd then weapon.weaponDefName = wd.name end
+				end
 			end
 		end
 
-		TableToFile(tbl, string.format("%s/%s.json", export_folder_path, unitDef.name))
+		AnnotateUnitDefAssets(tbl, soundIndex, iconTypeIndex)
+
+		TableToFile(tbl, string.format("%s/%s.json", unit_subdir, unitDef.name))
 	end
 end
 

--- a/luaui/Widgets/export_defs.lua
+++ b/luaui/Widgets/export_defs.lua
@@ -115,6 +115,40 @@ local function FlattenWeaponDef(weaponDef)
 	return tbl
 end
 
+local function FlattenUnitDef(unitDef)
+	local tbl = {}
+	-- embed higher-level "computed" fields like translatedHumanName, translatedTooltip, etc.
+	for field_name, value in pairs(unitDef) do
+		if type(value) ~= "table" and type(value) ~= "function" then
+			tbl[field_name] = value
+		end
+	end
+	-- flatten the UnitDef metatable data into plain table
+	for k, v in unitDef:pairs() do
+		tbl[k] = v
+	end
+
+	-- wDefs is a parallel array of weapondef names indexed by mount slot
+	-- (matches unit.weapons[i]); full weapondef data lives in weaponDefs/<name>.json
+	tbl["wDefs"] = {}
+	for i, weaponDef in pairs(unitDef.wDefs) do
+		tbl["wDefs"][i] = weaponDef.name
+	end
+
+	-- annotate each weapons[] mount entry with its weapondef name so consumers
+	-- can dereference into weaponDefs/ without needing the parallel wDefs array
+	if type(tbl.weapons) == "table" then
+		for _, weapon in pairs(tbl.weapons) do
+			if type(weapon) == "table" then
+				local wd = type(weapon.weaponDef) == "number" and WeaponDefs[weapon.weaponDef] or nil
+				if wd then weapon.weaponDefName = wd.name end
+			end
+		end
+	end
+
+	return tbl
+end
+
 local function ExportWeaponDefs(soundIndex)
 	local subdir = export_folder_path .. "/weaponDefs"
 	Spring.CreateDir(subdir)
@@ -126,57 +160,28 @@ local function ExportWeaponDefs(soundIndex)
 	end
 end
 
+local function ExportUnitDefs(soundIndex, iconTypeIndex)
+	local subdir = export_folder_path .. "/unitDefs"
+	Spring.CreateDir(subdir)
+	for _, unitDef in pairs(UnitDefs) do
+		spEcho(string.format("Exporting unitdef: %s", unitDef.name))
+		local flattened = FlattenUnitDef(unitDef)
+		AnnotateUnitDefAssets(flattened, soundIndex, iconTypeIndex)
+		TableToFile(flattened, string.format("%s/%s.json", subdir, unitDef.name))
+	end
+end
+
 local function ExportDefs()
 	if not VFS.FileExists(export_folder_path) then
 		Spring.CreateDir(export_folder_path)
 	end
-	local unit_subdir = export_folder_path .. "/unitDefs"
-	Spring.CreateDir(unit_subdir)
 
 	spEcho("Building asset indices")
 	local soundIndex = BuildSoundIndex()
 	local iconTypeIndex = BuildIconTypeIndex()
 
 	ExportWeaponDefs(soundIndex)
-
-	for id, unitDef in pairs(UnitDefs) do
-		spEcho(string.format("Exporting unitdef: %s", unitDef.name))
-		local tbl = {}
-
-		-- embed higher-level "computed" fields like translatedHumanName, translatedTooltip, etc.
-		for field_name, value in pairs(unitDef) do
-			if type(value) ~= "table" and type(value) ~= "function" then
-				tbl[field_name] = value
-			end
-		end
-
-		-- flatten the UnitDef metatable data into plain table
-		for k, v in unitDef:pairs() do
-			tbl[k] = v
-		end
-
-		-- wDefs is a parallel array of weapondef names indexed by mount slot
-		-- (matches unit.weapons[i]); full weapondef data lives in weaponDefs.json
-		tbl["wDefs"] = {}
-		for i, weaponDef in pairs(unitDef.wDefs) do
-			tbl["wDefs"][i] = weaponDef.name
-		end
-
-		-- annotate each weapons[] mount entry with its weapondef name so consumers
-		-- can dereference into weaponDefs.json without needing the parallel wDefs array
-		if type(tbl.weapons) == "table" then
-			for _, weapon in pairs(tbl.weapons) do
-				if type(weapon) == "table" then
-					local wd = type(weapon.weaponDef) == "number" and WeaponDefs[weapon.weaponDef] or nil
-					if wd then weapon.weaponDefName = wd.name end
-				end
-			end
-		end
-
-		AnnotateUnitDefAssets(tbl, soundIndex, iconTypeIndex)
-
-		TableToFile(tbl, string.format("%s/%s.json", unit_subdir, unitDef.name))
-	end
+	ExportUnitDefs(soundIndex, iconTypeIndex)
 end
 
 function widget:TextCommand(command)

--- a/luaui/Widgets/export_defs.lua
+++ b/luaui/Widgets/export_defs.lua
@@ -18,15 +18,6 @@ local spEcho = Spring.Echo
 
 local export_folder_path = "json_export"
 
--- Deep-copy values pulled from unitDef:pairs() / weaponDef:pairs() so the widget
--- owns its data and never mutates engine-shared tables, even additively.
-local function deepCopy(value)
-	if type(value) ~= "table" then return value end
-	local copy = {}
-	for k, v in pairs(value) do copy[k] = deepCopy(v) end
-	return copy
-end
-
 local function TableToFile(tbl, filename)
 	local file, err = io.open(filename, "w")
 	if not file then
@@ -118,8 +109,10 @@ local function FlattenWeaponDef(weaponDef)
 			tbl[field_name] = value
 		end
 	end
+	-- Each access via weaponDef:pairs() builds fresh Lua tables (engine LuaWeaponDefs
+	-- getters call lua_createtable per access), so later mutating these is safe.
 	for k, v in weaponDef:pairs() do
-		tbl[k] = deepCopy(v)
+		tbl[k] = v
 	end
 	return tbl
 end
@@ -132,9 +125,10 @@ local function FlattenUnitDef(unitDef)
 			tbl[field_name] = value
 		end
 	end
-	-- flatten the UnitDef metatable data into plain table
+	-- Each access via unitDef:pairs() builds fresh Lua tables (engine LuaUnitDefs
+	-- getters call lua_createtable per access), so later mutating these is safe.
 	for k, v in unitDef:pairs() do
-		tbl[k] = deepCopy(v)
+		tbl[k] = v
 	end
 
 	-- wDefs is a parallel array of weapondef names indexed by mount slot

--- a/luaui/Widgets/export_defs.lua
+++ b/luaui/Widgets/export_defs.lua
@@ -18,6 +18,15 @@ local spEcho = Spring.Echo
 
 local export_folder_path = "json_export"
 
+-- Deep-copy values pulled from unitDef:pairs() / weaponDef:pairs() so the widget
+-- owns its data and never mutates engine-shared tables, even additively.
+local function deepCopy(value)
+	if type(value) ~= "table" then return value end
+	local copy = {}
+	for k, v in pairs(value) do copy[k] = deepCopy(v) end
+	return copy
+end
+
 local function TableToFile(tbl, filename)
 	local file, err = io.open(filename, "w")
 	if not file then
@@ -110,7 +119,7 @@ local function FlattenWeaponDef(weaponDef)
 		end
 	end
 	for k, v in weaponDef:pairs() do
-		tbl[k] = v
+		tbl[k] = deepCopy(v)
 	end
 	return tbl
 end
@@ -125,7 +134,7 @@ local function FlattenUnitDef(unitDef)
 	end
 	-- flatten the UnitDef metatable data into plain table
 	for k, v in unitDef:pairs() do
-		tbl[k] = v
+		tbl[k] = deepCopy(v)
 	end
 
 	-- wDefs is a parallel array of weapondef names indexed by mount slot


### PR DESCRIPTION
### Work done

Expands `export_defs.lua` so its JSON is a complete picture of unit and weapon data, no longer requiring fallback scraping of the BAR git tree to fill in gaps.

#### What changed

- **Top-level weapondef export.** Every `WeaponDefs` entry is now written to `weaponDefs/<name>.json`. This includes weaponless defs the previous version skipped: cluster fragments (`customParams.cluster_def`), shared explosion defs (`mine_light` etc.), self-destruct/death defs referenced by string from `selfDExplosion`/`deathExplosion`/`explodeAs`/`selfDestructAs`/`customParams.speceffect_def`. Previously mines and crawling-bombs exported with zero damage because the real damage lived in an unexported explosion def.
- **Per-unit `wDefs` is now an array of weapondef names**, indexed by mount slot. Full weapondef bodies are no longer duplicated into each unit file -- consumers dereference into `weaponDefs/<name>.json`. Each `weapons[i]` mount entry also gets a `weaponDefName` field for direct lookup without the parallel array.
- **Asset path resolution.** Sound names resolve against the `sounds/` VFS tree and `gamedata/sounds.lua` `SoundItems` (case-insensitive); resolved paths land in `entry.path` next to `entry.name`. `buildPic` and `iconType` resolve to `buildPicPath` and `iconTypePath` on each unit.
- **Output split into `unitDefs/` and `weaponDefs/`** subdirs for a symmetric layout.
- **Bug fix.** The type filter at line 42 was tautological (`or` should have been `and`). Harmless in practice but no reason to leave it broken.

Engine-side gaps (transport-compatibility relationships, `ownerExpAccWeight` and similar unitdef fields not exposed via `LuaUnitDefs.cpp`) are out of scope here -- those need C++ changes upstream.

#### Setup

Widget is disabled by default. Enable via `/luaui enablewidget Unitdefs JSON Export`, then run `/exportdefs` in chat. Output lands at `<write-dir>/json_export/`.

#### Test steps

- [ ] Enable the widget and run `/exportdefs`.
- [ ] Verify `<write-dir>/json_export/` has both `unitDefs/` and `weaponDefs/` subdirs populated.
- [ ] Open `unitDefs/armmine1.json`; confirm `deathExplosion: "mine_light"` resolves to a non-empty `weaponDefs/mine_light.json` with positive `damages`.
- [ ] Open a cluster weapon's weapondef (e.g. `weaponDefs/legacluster_plasma_high.json`); confirm `customParams.cluster_def` resolves to an existing file under `weaponDefs/`.
- [ ] Spot-check `path` fields on weapon sounds and unit `buildPicPath` / `iconTypePath` resolve to real files under `sounds/` / `unitpics/` / `icons/`.

### AI / LLM usage statement

Developed with Claude Code (Claude Opus 4.7). Used for codebase analysis and verification via the headless test harness in `tools/headless_testing/`. All code was reviewed, directed, and tested by the contributor.
