### PR TITLE
Disable Juno Pulse 1 Dmg Notification

### DIFF
--- a/luarules/gadgets/sfx_notifications.lua
+++ b/luarules/gadgets/sfx_notifications.lua
@@ -197,6 +197,10 @@ else
 	local commanderLastDamaged = {}
 
 	function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+		-- suppress under-attack notifications for trivial damage (Juno's 1 dmg pulse)
+		if damage < 5 then
+			return
+		end
 		if unitTeam == myTeamID and isLrpc[attackerDefID] and attackerTeam and GetAllyTeamID(attackerTeam) ~= myAllyTeamID then
 			GG["notifications"].queueNotification('LrpcTargetUnits', "playerID", tostring(myPlayerID))
 		end


### PR DESCRIPTION
### Work Done
Added a Minimum Damage Requirement for "Under Attack" Notification due to the New AI will be firing a lot of Juno Missiles.

### Testing
1v1 AI - Cheats on - Godmode - Join Team 1 - Add a Juno - Fire at Team 0 Commander Starting Spot - Will not Trigger Damaged Notification (Even if it hits more then 5 Targets)