### PR TITLE
Remove Duplicate CBP modoption entries

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1643,33 +1643,6 @@ local options = {
     },
 
     {
-        key     = "community_balance_corjamt",
-        name    = "(CBP) Castro",
-        desc    = "Matches the stats of Sneaky Pete.",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_armmav",
-        name    = "(CBP) Gunslinger",
-        desc    = "Metal cost: 520 (from 650)\nEnergy cost: 6500 (from 11000)",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
-        key     = "community_balance_corcan",
-        name    = "(CBP) Sumo",
-        desc    = "Main laser range: 300 (from 275)\nMain laser beam time: 0.24 (from 0.16)",
-        type    = "bool",
-        def     = false,
-        section = "options_experimental",
-    },
-
-    {
         key    	= "experimentallegionfaction",
         name   	= "Legion Faction",
         desc   	= "3rd experimental faction",


### PR DESCRIPTION
Somehow the entries got duplicated causing them to show up when they're supposed to be hidden in the modoptions menu. For the community balance patch.