### PR TITLE
Fix: State prefs not saving

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -42,7 +42,7 @@ for udid, ud in pairs(UnitDefs) do
 end
 
 local unitSet = {}
-local chunk, err = loadfile("LuaUI/config/StatesPrefs.lua")
+local chunk, err = loadfile("LuaUI/Config/StatesPrefs.lua")
 if chunk then
 	local tmp = {}
 	setfenv(chunk, tmp)
@@ -120,7 +120,7 @@ function onClearRelease()
 end
 
 function saveStatePrefs()
-	table.save(unitSet, "LuaUI/config/StatesPrefs.lua", "--States prefs")
+	table.save(unitSet, "LuaUI/Config/StatesPrefs.lua", "--States prefs")
 end
 
 function doClearUnit()
@@ -191,6 +191,8 @@ function widget:GameOver()
 end
 
 function widget:Shutdown()
+	spEcho("Recorded States Prefs")
+	saveStatePrefs()
 	widgetHandler:RemoveAction("stateprefs_record")
 	widgetHandler:RemoveAction("stateprefs_clear")
 	widgetHandler:RemoveAction("stateprefs_clearunit")

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -185,13 +185,10 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 end
 
 function widget:GameOver()
-	spEcho("Recorded States Prefs")
-	saveStatePrefs()
 	widgetHandler:RemoveWidget()
 end
 
 function widget:Shutdown()
-	spEcho("Recorded States Prefs")
 	saveStatePrefs()
 	widgetHandler:RemoveAction("stateprefs_record")
 	widgetHandler:RemoveAction("stateprefs_clear")


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
State prefs used to not save on linux due to the file location being `LuaUI/config/StatesPrefs.lua` instead of `LuaUI/Config/StatesPrefs.lua`. I assume the folder is called `Config` for everyone. If not, the PR will break state prefs for linux users with folders called `config`. 

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->
<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
