### PR TITLE
Update armassimilator and armmeatball energycost and buildtime

### DIFF
--- a/units/Scavengers/Bots/armassimilator.lua
+++ b/units/Scavengers/Bots/armassimilator.lua
@@ -2,10 +2,10 @@ return {
 	armassimilator = {
 		maxacc = 0.2369,
 		maxdec = 0.9039,
-		energycost = 25000,
+		energycost = 49000,
 		metalcost = 2500,
 		buildpic = "ARMASSIMILATOR.DDS",
-		buildtime = 25000,
+		buildtime = 80000,
 		canmove = true,
 		collisionvolumeoffsets = "0.0 -2.0 -5",
 		collisionvolumescales = "50.0 60.0 50.0",

--- a/units/Scavengers/Bots/armmeatball.lua
+++ b/units/Scavengers/Bots/armmeatball.lua
@@ -2,10 +2,10 @@ return {
 	armmeatball = {
 		maxacc = 0.253,
 		maxdec = 0.8211,
-		energycost = 30000,
+		energycost = 54000,
 		metalcost = 3000,
 		buildpic = "ARMMEATBALL.DDS",
-		buildtime = 30000,
+		buildtime = 94000,
 		canmove = true,
 		collisionvolumeoffsets = "0 -2 -1",
 		collisionvolumescales = "34 68 38",


### PR DESCRIPTION


### Work done
Armada's Assimilator and Meatball from the Extra Units Pack still have Scavengers' Metal, Energy and Build time ratios.
This results in T3 Gantries jumping to a 180/1800 metal/energy usage instead of the usual 50~60/~1000 metal/energy that other T3 units require.
Building these units in your Gantry require taking in consideration the brief periods of extra resource usage.
They are the only units in the Extra Units Pack that have such a drastic resource drain.

Proposed Changes:

 Armassimilator:

- Energy cost 25000 -> 49000
- Build time 25000 -> 80000

 Armmeatball:

- Energy cost 30000 -> 54000
- Build time 30000 ->94000

Metal cost remains unchanged.
This makes both units' resource usage and build time line up with other T3 units.

I don't believe these adjustments meaningfully change the balance of the Scavengers mode.