### PR TITLE
Azrety tooltip fix

### DIFF
--- a/luaui/configs/keyboard_layouts.lua
+++ b/luaui/configs/keyboard_layouts.lua
@@ -19,22 +19,24 @@ scanToCode["qwertz"]["-"] = "-"
 scanToCode["qwertz"]["="] = "="
 scanToCode["qwertz"]["\\"] = "\\"
 	-- NEEDS CORRECTION ABOVE
-
-scanToCode["azerty"]["Z"] = "W"
-scanToCode["azerty"]["A"] = "Q"
-scanToCode["azerty"]["Q"] = "A"
-scanToCode["azerty"]["W"] = "Z"
-	-- NEEDS CORRECTION BELOW
-scanToCode["azerty"][";"] = ";"
-scanToCode["azerty"]["'"] = "'"
-scanToCode["azerty"][","] = ","
-scanToCode["azerty"]["."] = "."
-scanToCode["azerty"]["/"] = "/"
-scanToCode["azerty"]["`"] = "`"
-scanToCode["azerty"]["-"] = "-"
-scanToCode["azerty"]["="] = "="
-scanToCode["azerty"]["\\"] = "\\"
-	-- NEEDS CORRECTION ABOVE
+scanToCode["azerty"] = {
+	Q = "A",
+	W = "Z",
+	Z = "W",
+	A = "Q",
+	M = ",",
+	[";"] = "M",
+	[","] = ";",
+	["."] = ":",
+	["/"] = "!",
+	["["] = "^",
+	["]"] = "$",
+	["-"] = ")",
+	["="] = "=",
+	["'"] = "ù",
+	["`"] = "²",
+	["\\"] = "\\",	-- NEEDS CORRECTION
+}
 
 scanToCode["colemak"] = {
 	Q = "Q",

--- a/luaui/configs/keyboard_layouts.lua
+++ b/luaui/configs/keyboard_layouts.lua
@@ -35,7 +35,7 @@ scanToCode["azerty"] = {
 	["="] = "=",
 	["'"] = "ù",
 	["`"] = "²",
-	["\\"] = "\\",	-- NEEDS CORRECTION
+	["\\"] = "*",
 }
 
 scanToCode["colemak"] = {


### PR DESCRIPTION
### Work done
Added the key symbol translations for the azerty layout (ISO-FR-azerty)

#### Addresses Issue(s)
- [Issue URL](https://discord.com/channels/549281623154229250/1498002622915805285/1498513422818607249)

<img width="783" height="329" alt="image" src="https://github.com/user-attachments/assets/45a4d62d-5597-4887-9d54-544bd2ed7634" />

vs qwerty
<img width="782" height="330" alt="image" src="https://github.com/user-attachments/assets/7df3714c-f377-4974-b0a0-53091bc1496e" />
