### PR TITLE
Fix visual state of wait button #7659

### DIFF
--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -426,6 +426,8 @@ local function refreshCommands()
 
 	hasWaitCommand = (waitCommand ~= nil)
 
+	computeWaitState()
+
 	-- Fingerprint: detect if commands visually changed to skip redundant R2T redraws
 	commandsVisuallyChanged = false
 	local cmdCount = #commands
@@ -444,6 +446,11 @@ local function refreshCommands()
 					commandsVisuallyChanged = true
 					break
 				end
+			elseif cmd.id == CMD.WAIT then
+				if cachedWaitState ~= prevCmdStates[i] then
+					commandsVisuallyChanged = true
+					break
+				end
 			end
 		end
 	end
@@ -454,6 +461,8 @@ local function refreshCommands()
 			prevCmdIDs[i] = commands[i].id
 			if isStateCommand[commands[i].id] then
 				prevCmdStates[i] = commands[i].params and commands[i].params[1]
+			elseif commands[i].id == CMD.WAIT then
+				prevCmdStates[i] = cachedWaitState
 			else
 				prevCmdStates[i] = nil
 			end
@@ -470,7 +479,6 @@ local function refreshCommands()
 	end
 
 	setupCellGrid(false)
-	computeWaitState()
 end
 
 function widget:ViewResize()


### PR DESCRIPTION
First time any PR to this project :)

The wait toggle button in the order menu was not updating its visual state (red/green indicator) after being clicked. The button appeared correct only while the mouse was hovering over it, reverting to the old state when the cursor moved away.

### Work done
Move computeWaitState() to before the fingerprint check, and include CMD.WAIT in the fingerprint comparison so that toggling wait correctly invalidates the cached texture.

#### Addresses Issue(s)
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/7659

#### Test steps
 - Click the wait toggle button — the state indicator should immediately change color and stay changed after moving the mouse away
 - Toggle wait off — the indicator should again update correctly without requiring hover

AI / LLM usage statement:

Find place where is handle of this button. (Claude code).
