### PR TITLE
warn when map is missing sun direction info

### DIFF
--- a/luarules/gadgets/unit_sunfacing.lua
+++ b/luarules/gadgets/unit_sunfacing.lua
@@ -18,16 +18,14 @@ end
 
 local spCallCOBScript = Spring.CallCOBScript
 local mathAtan2 = math.atan2
-local mathDeg = math.deg
-local mathTau = math.tau
-local mathPi = math.pi
+local COBSCALE_HEADING = (COBSCALE / math.deg(math.tau)) / math.pi
 
 local sundir, mapinfo
 local success = false
 
 local function solarpoint(unitID, unitDefID, team)
 	if success then
-		local sunheading = mathAtan2(sundir[1], sundir[3]) * ((COBSCALE / mathDeg(mathTau)) / mathPi) -- WIZARDRY INTENSIFIES (182.04)
+		local sunheading = mathAtan2(sundir[1], sundir[3]) * COBSCALE_HEADING -- WIZARDRY INTENSIFIES (182.04)
 		spCallCOBScript(unitID, "solarreturn", 3, 1, sunheading)
 	else
 		spCallCOBScript(unitID, "solarreturn", 3, 0, 0)

--- a/luarules/gadgets/unit_sunfacing.lua
+++ b/luarules/gadgets/unit_sunfacing.lua
@@ -40,6 +40,11 @@ function gadget:Initialize()
 
 	success, mapinfo = pcall(VFS.Include,"mapinfo.lua")
 	if success and mapinfo then
-		sundir = mapinfo.lighting.sundir
+		if mapinfo.lighting and mapinfo.lighting.sundir then
+			sundir = mapinfo.lighting.sundir
+		else
+			Spring.Log(gadget:GetInfo().name, LOG.WARNING, "Missing sun facing for " .. Game.mapName)
+			gadgetHandler:RemoveGadget()
+		end
 	end
 end


### PR DESCRIPTION
### Work done

Handles nil errors when mapinfo.lua does not contain sunfacing info (missing lighting.sundir value). We have an uptick in these errors so maybe a new map is missing something.

Also pulled out an invariant expression into the scale constant. It's just nice.

#### Addresses Issue(s)

Handles this nil err:

```
[f=-000001] Error: [LuaRules::RunCallInTraceback] error=2 (LUA_ERRRUN) callin=LoadCode trace=[Internal Lua error: Call failure] [LuaVFS::Include(synced=true)][pcall] file=LuaRules/gadgets.lua error=2 ([string "LuaRules/Gadgets/unit_sunfacing.lua"]:43: attempt to index field 'lighting' (a nil value)) ptop=3 cenv=false vfsmode=Mmb
```

But does also lower the severity for missing this map info field.