### PR TITLE
fix active command not cleared after formation drag on minimap

### DIFF
--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -20204,6 +20204,15 @@ function widget:MouseRelease(mx, my, mButton)
 				finalPos = {wx, wy, wz}
 			end
 			formationHandled = WG.customformations.EndFormation(finalPos)
+
+			if formationHandled then
+				local _, _, _, shift = Spring.GetModKeyState()
+				if not shift then
+					Spring.SetActiveCommand(0)
+				else
+					interactionState.commandIssuedWithShift = true
+				end
+			end
 		end
 
 		-- Clear the force shift flag


### PR DESCRIPTION
There is a bug when issuing command from the minimap (such as attack, or patrol) to multiple units using a formation line. The active command is not cleared after it was given.

### Work done
In `gui_pip.lua`, I copied the lines that reset the active command under the section that handle end formation dragging (found in other section of the file).

#### Test steps
- Select multiple units
- Issue an attack or patrol command from the minimap by drawing a formation line

If not fixed: the command is still active (cursor still blue or purple) until we draw the line on the map (not the minimap) or press escape or another command. 
If fixed: the command is not active anymore.