### PR TITLE
Fix: Cloak hold fire

### DIFF
--- a/luaui/Widgets/unit_cloak_firestate.lua
+++ b/luaui/Widgets/unit_cloak_firestate.lua
@@ -31,6 +31,13 @@ local CMD_WANT_CLOAK    = GameCMD.WANT_CLOAK
 --------------------------------------------------------------------------------
 local myTeam = spGetMyTeamID()
 
+local canCloakHoldFire = {}
+for udid, ud in pairs(UnitDefs) do
+	if ud.canCloak then
+		canCloakHoldFire[udid] = true
+	end
+end
+
 local exceptionList = { --add exempt units here
 	"armmine1",
 	"armmine2",
@@ -51,11 +58,10 @@ local exceptionList = { --add exempt units here
 	"armsnipe",
 }
 
-local exceptionArray = {}
 for _,name in pairs(exceptionList) do
 	local ud = UnitDefNames[name]
 	if ud then
-		exceptionArray[ud.id] = true
+		canCloakHoldFire[ud.id] = false
 	end
 end
 
@@ -65,7 +71,7 @@ function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts
 	if teamID ~= myTeam then return end
 
 	if cmdID == CMD_WANT_CLOAK and cmdParams[1] ~= nil then -- is cloak command
-		if exceptionArray[unitDefID] or string.find(UnitDefs[unitDefID].name, "_scav") then return end -- don't do anything for these units
+		if not canCloakHoldFire[unitDefID] or string.find(UnitDefs[unitDefID].name, "_scav") then return end -- don't do anything for these units
 
 		if cmdParams[1] == 1 then -- store current fire state and cloak
 			decloakFireState[unitID] = select(1, GetUnitStates(unitID, false)) --store last state

--- a/luaui/Widgets/unit_cloak_firestate.lua
+++ b/luaui/Widgets/unit_cloak_firestate.lua
@@ -61,7 +61,7 @@ local exceptionList = { --add exempt units here
 for _,name in pairs(exceptionList) do
 	local ud = UnitDefNames[name]
 	if ud then
-		canCloakHoldFire[ud.id] = false
+		canCloakHoldFire[ud.id] = nil
 	end
 end
 


### PR DESCRIPTION
Don't hold fire all units in selection, only those that can actually cloak.

### Work done
Switched the check from a positive exception list (that didn't include all units) to a negative 'unit will cloak hold fire' check. 


#### Addresses Issue(s)
- [Issue URL](https://discord.com/channels/549281623154229250/1505531950692302888/1505531950692302888)


#### Test steps
- Tell a unit to cloak (want cloak) while other units are in the selection. 


### Screenshots:

#### BEFORE:
Cloaking the commander would cause the other units (thugs) to hold fire. 

<img width="823" height="528" alt="image" src="https://github.com/user-attachments/assets/bd4edf5e-0df8-4198-a9e5-da4b36e4b232" />

#### AFTER:
Cloaking the selection will only hold fire the commander and the gremlin. Thugs unaffected as cannot cloak, and snipers and mines unaffected as in the explicit exception list. 

<img width="1340" height="1053" alt="image" src="https://github.com/user-attachments/assets/65c62729-abaf-4164-8eb6-7f920d242072" />


### AI / LLM usage statement:
No AI
