### PR TITLE
remove math.round fill with wrong type signature

### DIFF
--- a/effects/raptors/raptor-effects.lua
+++ b/effects/raptors/raptor-effects.lua
@@ -2443,12 +2443,6 @@ local debugCircle = {
   },
 }
 
--- apparently math.round doesnt exist here yet
-if not math.round then
-	function math.round(num, idp)
-		return ("%." .. (((num == 0) and 0) or idp or 0) .. "f"):format(num)
-	end
-end
 local function count(radius)
   return math.round(2 + (radius - 75) / 84)
 end


### PR DESCRIPTION
### Work done

This was a temp shim for CEGs but has been polluting the type signatures of every use of math.round in code sense.