### PR TITLE
assign anti-air priorities to non-dedicated AA weapons

### DIFF
--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -22,6 +22,38 @@ if gadgetHandler:IsSyncedCode() then
 	local PRIORITY_FIGHTERS = 20
 	local PRIORITY_SCOUTS = 1000
 
+	local isAirCategory = {
+		vtol = true,
+		mobile = true,
+		nothover = true,
+		notship = true,
+		notsub = true,
+	}
+
+	local nonAntiAirTypes = {
+		AircraftBomb    = true,
+		Shield          = true,
+		TorpedoLauncher = true,
+	}
+
+	local function hasAntiAirPriority(weapon)
+		local weaponDef = WeaponDefs[weapon.weaponDef]
+		if nonAntiAirTypes[weaponDef.type] or weaponDef.manualFire or weaponDef.range < 100 then
+			return false
+		end
+		if not table.any(weapon.onlyTargets, function(v, k) return isAirCategory[k] end) then
+			return false
+		end
+		if table.any(weapon.badTargets, function(v, k) return isAirCategory[k] end) then
+			return false
+		end
+		local damages = weaponDef.damages
+		if damages[Game.armorTypes.vtol] <= damages[Game.armorTypes.default] * 0.5 then
+			return false
+		end
+		return true
+	end
+
 	-- Pre-compute direct unitDefID → priority multiplier for all air units
 	local airPriorityMultiplier = {}
 	for unitDefID, unitDef in pairs(UnitDefs) do
@@ -47,14 +79,9 @@ if gadgetHandler:IsSyncedCode() then
 
 		-- Set watch on vtol-targeting weapons so AllowWeaponTarget gets called
 		for i = 1, #weapons do
-			if weapons[i].onlyTargets.vtol then
-				for wid = 1, #weapons do
-					local weapon = weapons[wid]
-					if weapon.onlyTargets and weapon.onlyTargets.vtol then
-						Script.SetWatchAllowTarget(weapon.weaponDef, true)
-					end
-				end
-				break
+			local weapon = weapons[i]
+			if weapon.slavedTo == 0 and hasAntiAirPriority(weapon) then
+				Script.SetWatchAllowTarget(weapon.weaponDef, true)
 			end
 		end
 	end

--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -17,10 +17,10 @@ if gadgetHandler:IsSyncedCode() then
 	local spGetUnitDefID = Spring.GetUnitDefID
 	local stringFind = string.find
 
-	local PRIORITY_BOMBERS = 1
-	local PRIORITY_VTOLS = 10
-	local PRIORITY_FIGHTERS = 20
-	local PRIORITY_SCOUTS = 1000
+	local PRIORITY_BOMBERS = 0.1
+	local PRIORITY_VTOLS = 1
+	local PRIORITY_FIGHTERS = 2
+	local PRIORITY_SCOUTS = 100
 
 	local isAirCategory = {
 		vtol = true,

--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -90,10 +90,13 @@ if gadgetHandler:IsSyncedCode() then
 	-- so the attacker always has AA priority — no need to check hasPriorityAir or call
 	-- spGetUnitDefID on the attacker.
 	function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
+		if not defPriority then
+			return true
+		end
 		local mult = airPriorityMultiplier[spGetUnitDefID(targetID)]
 		if mult then
-			return true, (defPriority or 1.0) * mult
+			defPriority = defPriority * mult
 		end
-		return true, defPriority or 1.0
+		return true, defPriority
 	end
 end


### PR DESCRIPTION
### Work done

Add weapons that are not dedicated anti-air but nevertheless target air units to the unit_aa_targeting_priority gadget. This mostly includes railguns but also commander weapons (exceptions to design) and a couple random units with oddly good AA (Bulwark, Triton).

Ideally, railguns would continue to prioritize ground units while serving as an AA deterrent, so this change causes them to prioritize bombers, treat transports/gunships neutrally, and deprioritizes fighters and scouts.

The intention was to waste fewer shots into fighters/scouts with units with long reload times, at least when better targets are available. So a long reload could be added as a prereq for non-dedicated AA, though I haven't done so.