### PR TITLE
Fix Territorial Domination Scoring

### DIFF
--- a/luarules/gadgets/game_territorial_domination.lua
+++ b/luarules/gadgets/game_territorial_domination.lua
@@ -278,7 +278,10 @@ local function setAllyTeamRanks()
 	end
 	for allyID, scoreData in pairs(allyData) do
 		local securedScore = scoreData.score
-		local projectedPoints = projectedAllyTeamPoints[allyID] or 0
+		local projectedPoints = 0
+		if currentRound <= MAX_ROUNDS then
+			projectedPoints = projectedAllyTeamPoints[allyID] or 0
+		end
 		local rankingScore = securedScore + projectedPoints
 		local territoryCount = 0
 		for gridID, data in pairs(captureGrid) do
@@ -579,11 +582,11 @@ local function updateProjectedPoints()
 			end
 		end
 
-		projectedAllyTeamPoints[allyID] = projectedScore
-
-		if not gameOver and (currentRound <= MAX_ROUNDS) then
+		if currentRound <= MAX_ROUNDS then
+			projectedAllyTeamPoints[allyID] = projectedScore
 			Spring.SetGameRulesParam("territorialDomination_ally_" .. allyID .. "_projectedPoints", projectedScore)
 		else
+			projectedAllyTeamPoints[allyID] = 0
 			Spring.SetGameRulesParam("territorialDomination_ally_" .. allyID .. "_projectedPoints", 0)
 		end
 		Spring.SetGameRulesParam("territorialDomination_ally_" .. allyID .. "_territoryCount", territoryCount)


### PR DESCRIPTION
At the end of the final round, projected points weren't being ignored in Overtime. this caused players with an agressive comeback to sometimes be able to win against a team with more cumulative points than them in the final round.

What's more, this isn't shown in the points score in the UI but the rankings remained accurate causing the declaration of a false winner rarely.

https://cdn.discordapp.com/attachments/1398260748433494137/1506827382932111500/2026-05-20_20-05-36.mp4?ex=6a0faddb&is=6a0e5c5b&hm=5967c2458847a0fe25562ac73def371855d76867d895140c8c037be142db9028&