### PR TITLE
Adjust the auto mapmark eraser times to be more "round"

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3903,7 +3903,7 @@ function init()
 		--  end,
 		--},
 		{ id = "autoeraser", group = "ui", category = types.basic, widget = "Auto mapmark eraser", name = Spring.I18N('ui.settings.option.autoeraser'), type = "bool", value = GetWidgetToggleValue("Auto mapmark eraser"), description = Spring.I18N('ui.settings.option.autoeraser_descr') },
-		{ id = "autoeraser_erasetime", group = "ui", category = types.advanced, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.autoeraser_erasetime'), type = "slider", min = 10, max = 200, step = 1, value = 60, description = Spring.I18N('ui.settings.option.autoeraser_erasetime_descr'),
+		{ id = "autoeraser_erasetime", group = "ui", category = types.advanced, name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.autoeraser_erasetime'), type = "slider", min = 5, max = 600, step = 5, value = 60, description = Spring.I18N('ui.settings.option.autoeraser_erasetime_descr'),
 		  onload = function(i)
 			  loadWidgetData("Auto mapmark eraser", "autoeraser_erasetime", { 'eraseTime' })
 		  end,


### PR DESCRIPTION
I adjusted a single line in the options / settings widget so that times for the "auto mapmark eraser" are more round and pleasing.

By default, map marks are auto erased after 60 seconds. This is a nice "round" number.

Some people might want the marks erased after 30 seconds, they can set that option.

Some people might want the marks erased after 120 seconds (2 minutes), they can set that option.

I would like the marks erased after 5 minutes. That setting cannot be set currently.

I have adjusted the slider in the settings widget so that a wider range of times may be chosen for the auto erase time.

This is a trivial 1 line change.