### PR TITLE
fix(factory guard): constructors guarding idle labs move to next queued target

### DIFF
--- a/modules/commands.lua
+++ b/modules/commands.lua
@@ -101,7 +101,7 @@ local function isQueueingCommand(cmdID)
 		local cmdDescription = spGetActiveCmdDesc(cmdIndex)
 		if cmdDescription then
 			return cmdDescription.queueing -- TODO: It should be sufficient to check this.
-				and cmdDescription.type == CMDTYPE_ICON_MODE -- But it is not so do this.
+				or cmdDescription.type ~= CMDTYPE_ICON_MODE -- But it is not so do this.
 		end
 	end
 	return false


### PR DESCRIPTION
### Work done

Fixes bug introduced in 3cae0db78dede11d4832fb22cf204a64aafff699, reverting the one particular line to the previous version. Chronographer claims the adjustment wasn't necessary and was most likely a typo made while moving the original code between modules.

#### Addresses Issue(s)
Discussed in https://discord.com/channels/549281623154229250/1507290302233444482


#### Setup
~~You might need to have factory guard on, I guess?~~ oh nevermind, that's not a widget anymore.

#### Test steps
1. Make a botlab and wait for it to finish
2. Assist the lab with commander
3. Shift-build another building with the commander

Expected behavior: Lab build queue is empty so the commander walks off to build the new thing

Actual behavior: Commander never stops assisting the lab

### AI / LLM usage statement:

After bisecting to find the problematic commit, I pointed Qwen3.6-27b at it to pinpoint the actual problematic line while multitasking, which matched what Actual Intelligence (Chronographer) came up with.

### Thanks to

- fritman1 for the reproducer
- Chronographer for advice