### PR TITLE
cosmetics: remove Nation Wars cosmetics

### DIFF
--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -99,24 +99,13 @@ local kings = {
 	[82263] = true,  -- TM_autopilot
 }
 
-local goldMedals = { -- Nation Wars 1st place, last season top1 finishers
-	[64215] = true,  -- Darth_Revan
-	[116414] = true, -- [SG]random_variable
-	[3778] = true,   -- PRO_che
-	[9361] = true,   -- [DmE]ChickenDinner
-	[1422] = true,   -- ZaRxT4
+local goldMedals = { -- last season top1 finishers
 	[50820] = true,  -- Emre
 
 	-- BAR Pro League
 	[151863] = true,  -- Blodir
 }
-local silverMedals = { -- Nation Wars 2nd place, last season top2 finishers
-	[63960] = true,  -- Delfea
-	[59916] = true,  -- Kuchy
-	[137454] = true, -- Chronopolize
-	[44807] = true,  -- Ezreal
-	[97867] = true,  -- [KILL]SirIcecream55
-	[119832] = true, -- Darkclone
+local silverMedals = { -- last season top2 finishers
 	[151863] = true,  -- Blodir
 	[1332] = true,  -- Flash
 	[915] = true,  -- PRO_rANDY
@@ -124,11 +113,7 @@ local silverMedals = { -- Nation Wars 2nd place, last season top2 finishers
 	-- BAR Pro League
 	[915] = true,  -- PRO_rANDY
 }
-local bronzeMedals = { -- Nation Wars 3rd place, last season top3 finishers
-	[82811] = true,   -- [DmE]SlickLikeVik
-	[134499] = true,  -- Archangels
-	[60841] = true,   -- Alhazred
-	[8069] = true,    -- Grumpy
+local bronzeMedals = { -- last season top3 finishers
 	[82263] = true, -- TM_autopilot
 	[70311] = true, -- PRO_BTCV
 	[142011] = true, -- [BAC]OutlawElite


### PR DESCRIPTION
We are switching away from medals to shiny new pauldrons with flags. Removing last year's medals with this commit, the new pauldrons will come later when they are ready.