### PR TITLE
Fix "State Prefs v2" widget not saving properly on Linux

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -182,8 +182,7 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 			if cmdID == 115 then
 				return
 			end -- we're skipping "repeat" command here for now
-			local success = Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, cmdOpts)
-			--spEcho("".. name .. ", " .. tostring(cmdID) .. ", " .. tostring(cmdParam) .. " success: ".. tostring(success))
+			Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, cmdOpts)
 		end
 	end
 end

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -54,18 +54,16 @@ local function migrateOldConfig()
 	end
 
 	setfenv(chunk, {})
-	-- in case a widgetHandler config exists, we want those to take preference, since they are definitely newer,
-	-- but we still want to use the old ones if there's no entry for that unit
 	local merged = chunk()
-	for i, v in pairs(unitSet) do
-		merged[i] = v
-	end
+	-- in case a widgetHandler config exists, we want those to take preference, since they are definitely newer, but we still want to use
+	-- the old ones if there's no entry for that unit. This is mainly just for users that move config files, for example from an old backup.
+	table.mergeInPlace(merged, unitSet)
 	os.remove(oldConfigPath)
 	return merged
 end
 
 function widget:GetConfigData()
-	unitSet = migrateOldConfig() or unitSet
+	unitSet = migrateOldConfig() or unitSet -- remove this line and the migration function once sufficient time has passed (implemented 2026-06-03)
 	return unitSet
 end
 

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -35,18 +35,42 @@ bind ctrl 	stateprefs_record
 bind sc_\ 	stateprefs_clearunit
 
 --]]------------------------------------------------------------------------------
-local unitArray = {}
+
 local unitName = {}
 for udid, ud in pairs(UnitDefs) do
 	unitName[udid] = ud.name
 end
 
 local unitSet = {}
-local chunk, err = loadfile("LuaUI/config/StatesPrefs.lua")
-if chunk then
-	local tmp = {}
-	setfenv(chunk, tmp)
-	unitArray = chunk()
+
+-- The config was previously using a seperate file, but after a bug with this file
+-- it was decided to simply use the widgetHandler shared config instead.
+local function migrateOldConfig()
+	local oldConfigPath = "LuaUI/config/StatesPrefs.lua"
+	local chunk = loadfile(oldConfigPath)
+	if not chunk then
+		-- no old config/already migrated
+		return nil
+	end
+
+	setfenv(chunk, {})
+	-- in case a widgetHandler config exists, we want those to take preference, since they are definitely newer,
+	-- but we still want to use the old ones if there's no entry for that unit
+	local merged = chunk()
+	for i, v in pairs(unitSet) do
+		merged[i] = v
+	end
+	os.remove(oldConfigPath)
+	return merged
+end
+
+function widget:GetConfigData()
+	unitSet = migrateOldConfig() or unitSet
+	return unitSet
+end
+
+function widget:SetConfigData(data)
+	unitSet = data
 end
 
 local clearSound = 'LuaUI/Sounds/switchoff.wav'
@@ -90,10 +114,6 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:Initialize()
-	unitArray = unitArray or {}
-	for i, v in pairs(unitArray) do
-		unitSet[i] = v
-	end
 	if Spring.IsReplay() then
 		widgetHandler:RemoveWidget()
 		return
@@ -123,9 +143,6 @@ function onClearRelease()
   isClearPressed = false
 end
 
-function saveStatePrefs()
-	table.save(unitSet, "LuaUI/config/StatesPrefs.lua", "--States prefs")
-end
 
 function doClearUnit()
 	local selectedUnits = spGetSelectedUnits()
@@ -137,7 +154,6 @@ function doClearUnit()
 		spEcho("All state prefs removed for unit: " .. name)
 	end
 	Spring.PlaySoundFile(clearSound , 0.6, 'ui')
-	saveStatePrefs()
 end
 
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
@@ -162,11 +178,9 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 		if #cmdParams == 1 and isClearPressed then
 			unitSet[name][cmdID] = nil
 			spEcho("State pref removed: " .. name .. ", " .. command.name)
-			saveStatePrefs()
 		elseif #cmdParams == 1 and not (unitSet[name][cmdID] == cmdParams[1]) then
 			unitSet[name][cmdID] = cmdParams[1]
 			spEcho("State pref changed:  " .. name .. ",  " .. command.name .. " " .. cmdParams[1])
-			saveStatePrefs()
 		end
 	end
 end
@@ -213,8 +227,6 @@ function widget:GameFrame(n)
 end
 
 function widget:GameOver()
-	spEcho("Recorded States Prefs")
-	saveStatePrefs()
 	widgetHandler:RemoveWidget()
 end
 

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -95,7 +95,8 @@ function widget:Initialize()
 		unitSet[i] = v
 	end
 	if Spring.IsReplay() then
-		widget:GameOver()
+		widgetHandler:RemoveWidget()
+		return
 	end
 
 	widgetHandler:AddAction("stateprefs_record", onRecordPress, nil, "p")


### PR DESCRIPTION
### Work done

This mainly fixes the state prefs v2 widget not correctly saving its preferences on Linux, because the game creates the `Config` (capital C) folder, but not the `config` (small c) folder, which the widget uses.

Instead of working with this separate file, this PR moves the settings completely out of that file and into the widgetHandler general config file by using `widget:GetConfigData` and `widget:SetConfigData`. The old file is read in case it exists, the settings moved over to the general config file, and then it is deleted.

I think that the usage of this separate file is not in the spirit of the rest of the code and shouldn't have been done in the first place. There is no real reason to have a separate settings file here if we already use a central config location for most other widgets.

I also did 2 small refactorings, one that makes the disabling of the widget explicit instead of calling `widget:GameOver()` (which is not correct since it's not actually GameOver, in case in future something else would happen on GameOver), and the other one removes some debug code.

#### Addresses Issue(s)
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3915

#### Test steps
- [ ] State prefs save correctly on Linux
- [ ] Old state prefs are correctly imported into the general widgetHandler config

### AI / LLM usage statement:
All human.