### PR TITLE
add assertEqual with expected and actual values for more enlightening integration test failure messages

### DIFF
--- a/common/testing/assertions.lua
+++ b/common/testing/assertions.lua
@@ -118,11 +118,11 @@ local function formatValueForAssert(value)
 end
 
 local function assertEqual(actual, expected, errorMsg)
-	local depthOffset = 2
 	if actual ~= expected then
 		local msg = (errorMsg or "assertEqual failed")
 			.. ": expected " .. formatValueForAssert(expected)
 			.. ", actual " .. formatValueForAssert(actual)
+		local depthOffset = 2
 		error(msg, depthOffset)
 	end
 end

--- a/common/testing/assertions.lua
+++ b/common/testing/assertions.lua
@@ -110,8 +110,8 @@ local function assertThrowsMessage(fn, testMsg, errorMsg, depthOffset)
 	end
 end
 
-local function assertEqual(actual, expected, errorMsg, depthOffset)
-	depthOffset = (depthOffset or 0) + 2
+local function assertEqual(actual, expected, errorMsg)
+	local depthOffset = 2
 	if actual ~= expected then
 		local msg = (errorMsg or "assertEqual failed")
 			.. ": expected " .. tostring(expected)

--- a/common/testing/assertions.lua
+++ b/common/testing/assertions.lua
@@ -110,12 +110,19 @@ local function assertThrowsMessage(fn, testMsg, errorMsg, depthOffset)
 	end
 end
 
+local function formatValueForAssert(value)
+	if type(value) == "string" then
+		return '"' .. tostring(value) .. '"'
+	end
+	return tostring(value)
+end
+
 local function assertEqual(actual, expected, errorMsg)
 	local depthOffset = 2
 	if actual ~= expected then
 		local msg = (errorMsg or "assertEqual failed")
-			.. ": expected " .. tostring(expected)
-			.. ", actual " .. tostring(actual)
+			.. ": expected " .. formatValueForAssert(expected)
+			.. ", actual " .. formatValueForAssert(actual)
 		error(msg, depthOffset)
 	end
 end

--- a/common/testing/assertions.lua
+++ b/common/testing/assertions.lua
@@ -110,9 +110,20 @@ local function assertThrowsMessage(fn, testMsg, errorMsg, depthOffset)
 	end
 end
 
+local function assertEqual(actual, expected, errorMsg, depthOffset)
+	depthOffset = (depthOffset or 0) + 2
+	if actual ~= expected then
+		local msg = (errorMsg or "assertEqual failed")
+			.. ": expected " .. tostring(expected)
+			.. ", actual " .. tostring(actual)
+		error(msg, depthOffset)
+	end
+end
+
 return {
 	assertTablesEqual = assertTablesEqual,
 	assertSuccessBefore = assertSuccessBefore,
 	assertThrows = assertThrows,
 	assertThrowsMessage = assertThrowsMessage,
+	assertEqual = assertEqual,
 }

--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua
@@ -57,7 +57,7 @@ function test()
 
 	widget:CommandNotify(GameCMD.BLUEPRINT_CREATE, {}, {})
 
-	assert(#(widget.blueprints) == 1)
+	assertEqual(#(widget.blueprints), 1)
 
 	Test.clearMap()
 
@@ -89,7 +89,7 @@ function test()
 
 	Test.waitFrames(delay)
 
-	assert(widget.blueprintPlacementActive)
+	assert(widget.blueprintPlacementActive, "blueprintPlacementActive was nil or false")
 
 	local sx, sy = Spring.WorldToScreenCoords(x, y, z)
 	Spring.WarpMouse(sx, sy)
@@ -102,6 +102,6 @@ function test()
 
 	local builderQueue = Spring.GetUnitCommands(builderUnitID, -1)
 
-	assert(#builderQueue == 1)
-	assert(builderQueue[1].id == -blueprintUnitDefID)
+	assertEqual(#builderQueue, 1)
+	assertEqual(builderQueue[1].id, -blueprintUnitDefID)
 end

--- a/luaui/Tests/selftests/test_assertions.lua
+++ b/luaui/Tests/selftests/test_assertions.lua
@@ -148,12 +148,35 @@ function testAssertThrowsMessage()
 	end, "error")
 end
 
+function testAssertEqual()
+	-- test numeric mismatch
+	assertThrowsMessage(function()
+		assertEqual(1, 2)
+	end, "assertEqual failed: expected 2, actual 1")
+
+	-- test string mismatch
+	assertThrowsMessage(function()
+		assertEqual("a", "b")
+	end, 'assertEqual failed: expected "b", actual "a"')
+
+	-- test numeric vs string mismatch
+	assertThrowsMessage(function()
+		assertEqual(0, "0")
+	end, 'assertEqual failed: expected "0", actual 0')
+
+	-- test success cases
+	assertEqual(1, 1)
+	assertEqual("hello", "hello")
+	assertEqual(nil, nil)
+end
+
 function test()
 	sanityChecks()
 	testWaitUntil()
 	testAssertThrows()
 	testAssertSuccessBefore()
 	testAssertThrowsMessage()
+	testAssertEqual()
 	--failingTests()
 	failingWhileSucceedingTests()
 end


### PR DESCRIPTION
 
### Work done
- Adds an assertEqual function that provides the expected and actual values when an integration test assertion fails
- e.g. `[string "LuaUI/Tests/cmd_blueprint/test_cmd_blueprint_single.lua"]:105: assertEqual failed: expected 0, actual 1`
- Previously you would only get 

```
assertion failed!
[string "LuaUI/Tests/cmd_blueprint/test_cmd_blueprint_single.lua"]:105: assertion failed!
```

- Switched one integration test to use this function, added a message to another assert statement
- Verified that this better error message makes it into `tools/headless_testing/testlog/results.json` in the same format, so it should appear in the integration test if it fails.


This was discovered as part of troubleshooting the test failures seen on https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7620 2 days ago (test run was https://github.com/beyond-all-reason/Beyond-All-Reason/runs/77514877914 ) 

If this works successfully without issue, I'll roll assertEqual out to other integration tests (unless you want me to roll it out in this PR, which would make it larger)


 
 

#### Test steps
1. edit line 105 of `luaui/Tests/cmd_blueprint/test_cmd_blueprint_single.lua`  to have an expected result different from what it currently is 
2. If running from the root directory of the repository, run `docker compose -f tools/headless_testing/docker-compose.yml up`
3. the infolog that results from that run should have a line that reads

```
bar-1  | [t=00:00:33.194118][f=0000077] [Test Runner] FAIL: cmd_blueprint/test_cmd_blueprint_single.lua [42 frames] [1398 ms] | [string "LuaUI/Tests/cmd_blueprint/test_cmd_blueprint_single.lua"]:105: assertEqual failed: expected 0, actual 1
```

(or whatever expected value you put in)

### Screenshots:

#### BEFORE:
(screenshot from master)

<img width="835" height="453" alt="image" src="https://github.com/user-attachments/assets/2b3cb05a-b7c7-421d-9b03-c48a7d168e11" />

#### AFTER:
The same failing test would read 

`[string "LuaUI/Tests/cmd_blueprint/test_cmd_blueprint_single.lua"]:105: assertEqual failed: expected 0, actual 1` or whatever the actual value from the test is.

 
### AI / LLM usage statement: 
I used Kimi K2.6 to generate **all** of this change. I manually tested the output using the above `docker compose` command and got the result I expected.
