### PR TITLE
Add tooltip for reclaim time

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1021,6 +1021,7 @@
 			"footprint": "size",
 			"speed": "speed",
 			"reversespeed": "reverse speed",
+			"reclaimtime": "Reclaim time",
 			"buildpower": "buildpower",
 			"buildoptions": "buildoptions",
 			"unparalyzable": "unparalyzable",

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -1903,7 +1903,7 @@ local function drawEngineTooltip()
 				font:SetTextColor(1, 1, 1, 1)
 				font:SetOutlineColor(0.1, 0.1, 0.1, 1)
 				text = ''
-				local metal, _, energy, _ = Spring.GetFeatureResources(hoverData)
+				local metal, _, energy, _, _, reclaimTime = Spring.GetFeatureResources(hoverData)
 				if energy > 0 then
 					height = height + heightStep
 					text = tooltipLabelTextColor..Spring.I18N('ui.info.energy').."  \255\255\255\000"..string.formatSI(energy)
@@ -1912,6 +1912,11 @@ local function drawEngineTooltip()
 				if metal > 0 then
 					height = height + heightStep
 					text = tooltipLabelTextColor..Spring.I18N('ui.info.metal').."  "..tooltipValueColor..string.formatSI(metal)
+					font:Print(text, backgroundRect[1] + contentPadding, backgroundRect[4] - contentPadding - (fontSize * 0.8) - height, fontSize, "o")
+				end
+				if reclaimTime > 0 then
+					height = height + heightStep
+					text = tooltipLabelTextColor..Spring.I18N('ui.info.reclaimtime') .. ": " .. tooltipValueColor .. string.formatSI(reclaimTime)
 					font:Print(text, backgroundRect[1] + contentPadding, backgroundRect[4] - contentPadding - (fontSize * 0.8) - height, fontSize, "o")
 				end
 				font:End()


### PR DESCRIPTION
### Work done
Adds reclaim time to the feature hover tooltip in `gui_info.lua`, so reclaimables like trees, wrecks, etc, show how long they take to reclaim alongside their metal/energy values. The reason for implementing this is because the reclaim time for trees differ on some maps. For example on Supreme, reclaiming trees with a Lazarus gives 58E/s while  doing the same on All That Simmers results in just 35E/s. There is currently no way to tell which of the two it is for the map you are playing without just knowing.

Had to add the english i18n string for the new tooltip label. I didn't touch any other languages. Will this be translated later?

#### Test steps
- Hover over a reclaimable feature/wreck like a tree and see it's displaying the `Reclaim time`

### Screenshots:
All screenshots from the bottom left corner tooltip.

#### BEFORE:
<img width="392" height="152" alt="image" src="https://github.com/user-attachments/assets/77844ceb-c711-4ed8-879f-f4f19a08cb3f" />
<img width="385" height="147" alt="image" src="https://github.com/user-attachments/assets/9e6ca500-fd7a-44c2-8f95-256d7e9ace80" />
<img width="391" height="153" alt="image" src="https://github.com/user-attachments/assets/ee21d21f-919d-42bb-8219-27b6bcbfdd94" />


#### AFTER:
<img width="378" height="152" alt="image" src="https://github.com/user-attachments/assets/731c9de6-d1e0-4c42-8035-9b1eccb73672" />
<img width="377" height="143" alt="image" src="https://github.com/user-attachments/assets/4e6c9eba-89e2-4476-927c-c1522baa9042" />
<img width="391" height="148" alt="image" src="https://github.com/user-attachments/assets/f11a31e4-f4be-48f2-886d-4606eba79ed2" />



### AI / LLM usage statement:
Used Codex to navigate the codebase and implement the bulk of the changes.