### PR TITLE
Fix: Remove unwanted saved commands in factory presets

### DIFF
--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -340,7 +340,7 @@ function saveQueue(unitId, unitDef, groupNo)
 	end
 
 	for i = #unitQ, 1, -1 do
-		if unitQ[i].id == CMD.WAIT or unitQ[i].options.internal and not unitQ[i].options.alt then -- We don't want to save these commands
+		if unitQ[i].id >= 0 or unitQ[i].options.internal and not unitQ[i].options.alt then -- We don't want to save these commands
 			table.remove(unitQ, i)
 		end
 	end


### PR DESCRIPTION
A whole bunch of stop (cmd.id = 0) commands were being saved. Let's just get rid of all non-build commands.

[Issue URL](https://discord.com/channels/549281623154229250/1499196343921410238/1508499712599134369)