### PR TITLE
fix: keep target order on Stop with Set Target

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -368,13 +368,13 @@ if gadgetHandler:IsSyncedCode() then
 
 
 	local function refreshSendList(unitID, unitData, minIndex)
-		for i, targetData in ipairs(unitData.targets) do
-			if i >= minIndex then
-				targetData.sent = nil
-			end
+		local targetList = unitData.targets
+		local n = #targetList
+		for i = (minIndex or 1), n do
+			targetList[i].sent = nil
 		end
 		sendTargetsToUnsynced(unitID)
-		SendToUnsynced("targetList", unitID, #unitData.targets + 1) -- ask to clear the last element when the table is smaller
+		SendToUnsynced("targetList", unitID, n + 1) -- clear the last element in case the list shrank
 	end
 
 	local function removeTarget(unitID, index)

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -390,29 +390,25 @@ if gadgetHandler:IsSyncedCode() then
 	local function removeWithStop(unitID)
 		local unitData = unitTargets[unitID] or pausedTargets[unitID]
 		local targetList = unitData.targets
-		local index = unitData.currentIndex
+		local currentIndex = unitData.currentIndex
+		local minIndex
 		local n = #targetList
-		local m = n
 		for i = n, 1, -1 do
 			if not targetList[i].ignoreStop then
-				targetList[i] = targetList[m]
-				targetList[m] = nil
-				m = m - 1
-				if i == index then
-					unitData.currentIndex = 1
+				tremove(targetList, i)
+				minIndex = i
+				if i == currentIndex then
+					currentIndex = 1
+				elseif i < currentIndex then
+					currentIndex = currentIndex - 1
 				end
 			end
 		end
-		if m == 0 then
+		if not targetList[1] then
 			removeUnit(unitID)
-		elseif m < n then
-			refreshSendList(unitID, unitData, m)
-			local currentIndex = unitTargets[unitID].currentIndex
-			if index == currentIndex then
-				unitTargets[unitID].currentIndex = 1
-			elseif index < currentIndex then
-				unitTargets[unitID].currentIndex = currentIndex - 1
-			end
+		elseif minIndex then
+			unitTargets[unitID].currentIndex = currentIndex
+			refreshSendList(unitID, unitData, minIndex)
 		end
 	end
 


### PR DESCRIPTION
### Work done

- Do not reorder the target list when removing targets during a Stop command.
- Since we can treat the list as stable, be a little smarter about the minIndex value.

#### Addresses Issue(s)

- Fixes priority targets sometimes visually remaining after issuing a Stop command though they were removed in synced code, bug introduced by #7601.
