### PR TITLE
Fix: FactoryQ Manager use unitName not unitDefID

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1776,6 +1776,8 @@
 				"factory": "Factory",
 				"factoryguard": "guard (builders)",
 				"factoryguard_descr": "Sets factory guard to on by default, builders will automatically guard the factory that produced them",
+				"factorypreset": "Factory Presets",
+				"factorypreset_descr": "Save and load factory build queues\nSelect a single factory and press space to open the preset menu",
 				"factoryholdpos": "hold position",
 				"factoryholdpos_descr": "Sets factories and units they produce, to hold position automatically (not aircraft)",
 				"factoryrepeat": "auto-repeat",

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -1,5 +1,5 @@
 include("keysym.h.lua")
-local versionNumber = 1.6
+local versionNumber = 1.7
 
 local widget = widget ---@type Widget
 
@@ -27,8 +27,17 @@ local spGetGameFrame = Spring.GetGameFrame
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGetViewGeometry = Spring.GetViewGeometry
 local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
+local spGetModKeyState = Spring.GetModKeyState
+local lastGameSeconds = Spring.GetGameSeconds()
+local CMD_REPEAT = CMD.REPEAT
+local CMD_REMOVE = CMD.REMOVE
+local CMD_WAIT = CMD.WAIT
+local CMD_OPT_INTERNAL = CMD.OPT_INTERNAL
+local CMD_OPT_CTRL = CMD.OPT_CTRL
+local CMD_OPT_ALT = CMD.OPT_ALT
 
 --Changelog
+--1.7: fixed: save unit presets by unit name not unitDefId
 --1.6: added: support of quotas and 'alt' queued priority units in preset
 --1.5: added repeat icon and bindable keybind actions to activate
 --1.4: fixed text alignment, changed layer cause other widgets are eating events otherwise (e.g. smartselect)
@@ -53,7 +62,7 @@ local ifontSizeTitle = 16
 local ifontSizeGroup = 16
 local ifontSizeUnitCount = 12
 local ifontSizeModifed = 28
-local iunitIconSpacing = 5
+local iunitIconSpacing = 1
 local ifontModifiedYOff = 16
 local igroupLabelMargin = 30
 local ititleTextXOff = 10
@@ -137,17 +146,14 @@ local SortQueueToUnits
 local CalcDrawCoords
 local UiUnit, UiElement
 
-local spEcho = Spring.Echo
-local spGetModKeyState = Spring.GetModKeyState
-local lastGameSeconds = Spring.GetGameSeconds()
-
 local font, gameStarted, selUnits
 
 local udefTab = {}
 local isFactory = {}
+local unitName = {}
 --local unitId = {}
 for udid, ud in pairs(UnitDefs) do
-	--unitId[udid] = ud.id
+	unitName[udid] = ud.name
 	if ud.isFactory then
 		isFactory[udid] = true
 		udefTab[udid] = ud
@@ -214,6 +220,21 @@ end
 
 function widget:PlayerChanged(playerID)
 	maybeRemoveSelf()
+end
+
+function migratePresets(presets)
+	if not presets then return end
+	local toDelete = {}
+
+	for key, defID in pairs(presets) do
+		if type(key) == "number" then
+			toDelete[#toDelete+1] = key
+		end
+	end
+
+	for _, oldKey in ipairs(toDelete) do
+		presets[oldKey] = nil
+	end
 end
 
 -- Included FactoryClear Lua widget
@@ -318,12 +339,24 @@ function getSingleFactory()
 	end
 end
 
+function orderToName(orderId)
+	if orderId >= 0 then
+		return nil
+	else
+		return unitName[-1*orderId] or nil
+	end
+end
+
+function nameToOrder(name)
+	return UnitDefNames[name] and -1 * UnitDefNames[name].id or nil
+end
+
 function saveQueue(unitId, unitDef, groupNo)
 	if savedQueues[curModId] == nil then
 		savedQueues[curModId] = {}
 	end
-	if savedQueues[curModId][unitDef.id] == nil then
-		savedQueues[curModId][unitDef.id] = {}
+	if savedQueues[curModId][unitDef.name] == nil then
+		savedQueues[curModId][unitDef.name] = {}
 	end
 
 	local unitQ = Spring.GetFactoryCommands(unitId, -1)
@@ -334,7 +367,14 @@ function saveQueue(unitId, unitDef, groupNo)
 		local quotas = WG.Quotas.getQuotas()
 		local quota = quotas[unitId]
 		if quota then
-			unitQuota = table.copy(quota)
+			for quotaDefID, quotaCount in pairs(quota) do
+				if quotaCount ~= 0 then
+					name = unitName[quotaDefID]
+					if name then
+						unitQuota[name] = quotaCount
+					end
+				end
+			end
 		end
 		unitQuotaIdx = WG.Quotas.isOnQuotaMode(unitId)
 	end
@@ -342,16 +382,19 @@ function saveQueue(unitId, unitDef, groupNo)
 	for i = #unitQ, 1, -1 do
 		if unitQ[i].id >= 0 or unitQ[i].options.internal and not unitQ[i].options.alt then -- We don't want to save these commands
 			table.remove(unitQ, i)
+		else
+			unitQ[i].name = orderToName(unitQ[i].id)
+			unitQ[i].id = nil
 		end
 	end
 	if #unitQ <= 0 and next(unitQuota) == nil then
 		--queue is empty -> signal to delete preset
-		savedQueues[curModId][unitDef.id][groupNo] = nil
+		savedQueues[curModId][unitDef.name][groupNo] = nil
 	else
-		savedQueues[curModId][unitDef.id][groupNo] = unitQ
-		savedQueues[curModId][unitDef.id][groupNo][facQuota] = unitQuota
-		savedQueues[curModId][unitDef.id][groupNo][facRepeatIdx] = select(4, Spring.GetUnitStates(unitId, false, true))    -- 4=repeat
-		savedQueues[curModId][unitDef.id][groupNo][facQuotaIdx] = unitQuotaIdx
+		savedQueues[curModId][unitDef.name][groupNo] = unitQ
+		savedQueues[curModId][unitDef.name][groupNo][facQuota] = unitQuota
+		savedQueues[curModId][unitDef.name][groupNo][facRepeatIdx] = select(4, Spring.GetUnitStates(unitId, false, true))    -- 4=repeat
+		savedQueues[curModId][unitDef.name][groupNo][facQuotaIdx] = unitQuotaIdx
 	end
 
 	modifiedGroup = groupNo
@@ -364,20 +407,52 @@ function saveQueue(unitId, unitDef, groupNo)
 end
 
 function loadQueue(unitId, unitDef, groupNo)
-	if savedQueues[curModId][unitDef.id] == nil then
+	if savedQueues[curModId][unitDef.name] == nil then
 		--there are no queus for this factory type
 		return
 	end
 
-	local queue = savedQueues[curModId][unitDef.id][groupNo]
+	local queue = savedQueues[curModId][unitDef.name][groupNo]
 	if queue ~= nil then
 		modifiedGroup = groupNo
 		modifiedGroupTime = Spring.GetGameSeconds()
 		modifiedSaved = false
+		ClearFactoryQueues()
+
+		if #queue > 0 then
+			local insertPos = 0
+			for i = 1, #queue do
+				local opts = 0
+				local cmd = queue[i]
+				cmd.id = nameToOrder(cmd.name)
+				if cmd.id and cmd.options.alt then
+					insertPos = insertPos + 1 
+					opts = CMD_OPT_ALT + CMD_OPT_INTERNAL
+					spGiveOrderToUnit(unitId, CMD.INSERT, {insertPos - 1, cmd.id, opts, unpack(cmd.params)}, CMD_OPT_ALT + CMD_OPT_CTRL  )
+				else 
+					spGiveOrderToUnit(unitId, cmd.id, cmd.params, opts)
+				end
+			end
+		end
+		spGiveOrderToUnit(unitId, CMD_REMOVE, CMD_WAIT, CMD_OPT_ALT + CMD_OPT_CTRL )
+
+		--set factory to repeat on/off
+		local repVal = 1
+		if queue[facRepeatIdx] == false then
+			repVal = 0
+		end
+		spGiveOrderToUnit(unitId, CMD_REPEAT, { repVal }, 0)
 
 		if WG.Quotas and queue[facQuota] then
 			local quotas = WG.Quotas.getQuotas()
-			quotas[unitId] = queue[facQuota]
+			local quotaTable = {}
+			for quotaNames, quotaCount in pairs(queue[facQuota]) do
+				local udid = UnitDefNames[quotaNames] and UnitDefNames[quotaNames].id or nil
+				if udid then
+					quotaTable[udid] = quotaCount
+				end
+			end
+			quotas[unitId] = quotaTable
 
 			--set factory to quota mode on/off
 			local quotaVal = 1
@@ -386,26 +461,6 @@ function loadQueue(unitId, unitDef, groupNo)
 			end
 			spGiveOrderToUnit(unitId, GameCMD.QUOTA_BUILD_TOGGLE, { quotaVal }, 0)
 		end
-
-		--set factory to repeat on/off
-		local repVal = 1
-		if queue[facRepeatIdx] == false then
-			repVal = 0
-		end
-		spGiveOrderToUnit(unitId, CMD.REPEAT, { repVal }, 0)
-		if #queue > 0 then
-			ClearFactoryQueues()
-			for i = 1, #queue do
-				local cmd = queue[i]
-				local opts = {}
-				if cmd.options.alt then
-					opts = { "alt" }
-				end
-				if cmd.id then
-					spGiveOrderToUnit(unitId, cmd.id, cmd.params, opts)
-				end
-			end
-		end 	
 
 	end
 end
@@ -487,24 +542,38 @@ function SortQueueToUnits(queue)
 	for i = 1, #queue do
 		local entity = queue[i]
 		if type(entity) == "table" then
-			if entity.id < 0 then
-				local idx = -1 * entity.id
-				local queuedunit = units[idx]
-				if not queuedunit then
-                	queuedunit = { alt = 0, normal = 0 }
-                	units[idx] = queuedunit
+			if entity.name then
+				local idx = UnitDefNames[entity.name] and UnitDefNames[entity.name].id or nil
+				if idx then 
+					local queuedunit = units[idx]
+					if not queuedunit then
+						queuedunit = { alt = 0, normal = 0 }
+						units[idx] = queuedunit
+					end
+					local isAlt = entity.options and entity.options.alt
+					if isAlt then
+						queuedunit.alt = queuedunit.alt + 1
+					else
+						queuedunit.normal = queuedunit.normal + 1
+					end
 				end
-				local isAlt = entity.options and entity.options.alt
-				if isAlt then
-                	queuedunit.alt = queuedunit.alt + 1
-            	else
-                	queuedunit.normal = queuedunit.normal + 1
-            	end
-            end
-
+			end
 		end
 	end
 	return units
+end
+
+function quotaByID(quota)
+	local quotaIDs = {}
+	for unitQuotaName, unitQuotaCount in pairs(quota) do
+		if unitQuotaCount ~= 0 then
+			local defID = UnitDefNames[unitQuotaName] and UnitDefNames[unitQuotaName].id or nil
+			if defID then 
+				quotaIDs[defID] = unitQuotaCount
+			end
+		end
+	end
+	return quotaIDs
 end
 
 function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
@@ -513,7 +582,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 
 	--if units == nil then
 	local units = SortQueueToUnits(queue)
-	local quota = queue[facQuota] or {} -- already in a sorted table
+	local quota = quotaByID(queue[facQuota]) -- already in a sorted table
 	--end
 	--Draw "loaded" border
 	if modifiedGroup == groupNo and modifiedGroupTime > Spring.GetGameSeconds() - loadedBorderDisplayTime then
@@ -555,7 +624,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 			local normalCount = unitCounts.normal
 			local unitCount = altCount + normalCount
 			if unitCount == 0 then break end
-			if x + boxHeight + boxIconBorder + xOff + boxHeight + unitIconSpacing > x + boxWidth then
+			if x + boxHeight + boxIconBorder + xOff + unitCountXOff + unitIconSpacing > x + boxWidth then
 				font:SetTextColor(1, 1, 1, alpha)
 				font:Print("...", x + xOff + unitCountXOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "nd")
 				break
@@ -578,7 +647,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 		for k, unitCounts in pairs(units) do
 			local altCount = unitCounts.alt
 			if altCount ~= 0 then 
-				if x + boxHeight + boxIconBorder + xOff + boxHeight + unitIconSpacing > x + boxWidth then
+				if x + boxHeight + boxIconBorder + xOff + unitCountXOff + unitIconSpacing > x + boxWidth then
 					font:SetTextColor(1, 1, 1, alpha)
 					font:Print("...", x + xOff + unitCountXOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "nd")
 					break
@@ -601,7 +670,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 		for k, unitCounts in pairs(units) do
 			local normalCount = unitCounts.normal
 			if normalCount ~= 0 then 
-				if x + boxHeight + boxIconBorder + xOff + boxHeight + unitIconSpacing > x + boxWidth then
+				if x + boxHeight + boxIconBorder + xOff + unitCountXOff + unitIconSpacing > x + boxWidth then
 					font:SetTextColor(1, 1, 1, alpha)
 					font:Print("...", x + xOff + unitCountXOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "nd")
 					break
@@ -636,8 +705,8 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 		end
 	end
 
-	for k, unitQuotaCount in pairs(quota) do
-		if k ~= 0 then
+	for unitQuotaID, unitQuotaCount in pairs(quota) do
+		if unitQuotaCount ~= 0 then
 			if x + boxHeight + boxIconBorder + xOff + boxHeight + unitIconSpacing > x + boxWidth then
 				font:SetTextColor(1, 1, 1, alpha)
 				font:Print("...", x + xOff + unitCountXOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "nd")
@@ -650,7 +719,7 @@ function DrawBoxGroup(x, y, yOffset, unitDef, selUnit, alpha, groupNo, queue)
 					1,1,1,1,
 					0.08,
 					nil, nil,
-					'#'..k
+					'#'..unitQuotaID
 				)
 				font:SetTextColor(1, 0.51, 0.745, alpha)
 				font:Print(unitQuotaCount, x + (boxHeight*0.5) - boxIconBorder + xOff, y - boxHeight + unitCountYOff, fontSizeUnitCount, "cndo")
@@ -680,8 +749,8 @@ function DrawBoxes()
 	end
 
 	local itemCount = 0
-	if savedQueues[curModId] ~= nil and savedQueues[curModId][unitDef.id] ~= nil then
-		itemCount = #savedQueues[curModId][unitDef.id]
+	if savedQueues[curModId] ~= nil and savedQueues[curModId][unitDef.name] ~= nil then
+		itemCount = #savedQueues[curModId][unitDef.name]
 	end
 	local heightAll = boxHeightTitle + itemCount * (boxHeight + boxOuterMargin)
 
@@ -696,7 +765,7 @@ function DrawBoxes()
 
 	DrawBoxTitle(x, y, alpha, unitDef, selUnit)
 
-	if savedQueues[curModId] == nil or savedQueues[curModId][unitDef.id] == nil then
+	if savedQueues[curModId] == nil or savedQueues[curModId][unitDef.name] == nil then
 		return
 	end
 
@@ -707,7 +776,7 @@ function DrawBoxes()
 	local k = 1
 	local first = true
 	while (k < 10) do
-		local q = savedQueues[curModId][unitDef.id][k]
+		local q = savedQueues[curModId][unitDef.name][k]
 		if q ~= nil then
 			local height = boxHeight
 			if first == true then
@@ -745,6 +814,7 @@ function widget:Initialize()
 	widget:ViewResize()
 
 	curModId = string.upper(Game.gameShortName or "")
+	migratePresets(savedQueues[curModId]) -- remove old presets that were saved by version < 1.7 which used numeric unitDefID instead of names
 
 	widgetHandler:AddAction("factory_preset", factoryPresetKeyHandler, nil, "p")
 	widgetHandler:AddAction("factory_preset_show", factoryPresetRender, {true}, "p")

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -27,9 +27,9 @@ local spGetGameFrame = Spring.GetGameFrame
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGetViewGeometry = Spring.GetViewGeometry
 local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
-local spGetModKeyState = Spring.GetModKeyState
 local lastGameSeconds = Spring.GetGameSeconds()
 local CMD_REPEAT = CMD.REPEAT
+local CMD_INSERT = CMD.INSERT
 local CMD_REMOVE = CMD.REMOVE
 local CMD_WAIT = CMD.WAIT
 local CMD_OPT_INTERNAL = CMD.OPT_INTERNAL
@@ -428,7 +428,7 @@ function loadQueue(unitId, unitDef, groupNo)
 				if cmd.id and cmd.options.alt then
 					insertPos = insertPos + 1 
 					opts = CMD_OPT_ALT + CMD_OPT_INTERNAL
-					spGiveOrderToUnit(unitId, CMD.INSERT, {insertPos - 1, cmd.id, opts, unpack(cmd.params)}, CMD_OPT_ALT + CMD_OPT_CTRL  )
+					spGiveOrderToUnit(unitId, CMD_INSERT, {insertPos - 1, cmd.id, opts, unpack(cmd.params)}, CMD_OPT_ALT + CMD_OPT_CTRL  )
 				else 
 					spGiveOrderToUnit(unitId, cmd.id, cmd.params, opts)
 				end

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -228,7 +228,7 @@ function migratePresets(presets)
 
 	for key, defID in pairs(presets) do
 		if type(key) == "number" then
-			toDelete[#toDelete+1] = key
+			toDelete[#toDelete + 1] = key
 		end
 	end
 
@@ -426,9 +426,9 @@ function loadQueue(unitId, unitDef, groupNo)
 				local cmd = queue[i]
 				cmd.id = nameToOrder(cmd.name)
 				if cmd.id and cmd.options.alt then
-					insertPos = insertPos + 1 
+					insertPos = insertPos + 1
 					opts = CMD_OPT_ALT + CMD_OPT_INTERNAL
-					spGiveOrderToUnit(unitId, CMD_INSERT, {insertPos - 1, cmd.id, opts, unpack(cmd.params)}, CMD_OPT_ALT + CMD_OPT_CTRL  )
+					spGiveOrderToUnit(unitId, CMD_INSERT, { insertPos - 1, cmd.id, opts, unpack(cmd.params) }, CMD_OPT_ALT + CMD_OPT_CTRL )
 				else 
 					spGiveOrderToUnit(unitId, cmd.id, cmd.params, opts)
 				end

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -231,7 +231,8 @@ function migratePresets(presets)
 			toDelete[#toDelete + 1] = key
 		end
 	end
-
+	if #toDelete == 0 then return end
+	Spring.Echo("FactoryQ Manager: Warning - Removed old presets. Newly saved presets will persist between games.")
 	for _, oldKey in ipairs(toDelete) do
 		presets[oldKey] = nil
 	end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -5204,6 +5204,7 @@ function init()
 		{ id = "factoryguard", group = "game", category = types.basic, widget = "Factory Guard Default On", name = Spring.I18N('ui.settings.option.factory') .. widgetOptionColor .. "  " .. Spring.I18N('ui.settings.option.factoryguard'), type = "bool", value = GetWidgetToggleValue("Factory Guard Default On"), description = Spring.I18N('ui.settings.option.factoryguard_descr') },
 		{ id = "factoryholdpos", group = "game", category = types.basic, widget = "Factory hold position", name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.factoryholdpos'), type = "bool", value = GetWidgetToggleValue("Factory hold position"), description = Spring.I18N('ui.settings.option.factoryholdpos_descr') },
 		{ id = "factoryrepeat", group = "game", category = types.basic, widget = "Factory Auto-Repeat", name = widgetOptionColor .. "   " .. Spring.I18N('ui.settings.option.factoryrepeat'), type = "bool", value = GetWidgetToggleValue("Factory Auto-Repeat"), description = Spring.I18N('ui.settings.option.factoryrepeat_descr') },
+		{ id = "factorypreset", group = "game", category = types.basic, widget = "FactoryQ Manager", name = Spring.I18N('ui.settings.option.factorypreset'), type = "bool", value = GetWidgetToggleValue("Factory Presets"), description = Spring.I18N('ui.settings.option.factorypreset_descr') },
 
 		{ id = "transportOrderedUnits",
 		group = "game",


### PR DESCRIPTION
And other bug fixes. 

### Work done
Main change here is migrating the factory presets to use unit names instead of unit defIDs. DefIDs move around as experimental options Legion, modded units, etc. are added to the unitdefs table and therefore unstable. Disappearing at best and pulling the wrong preset at worst. 

This update will therefore also clear all the old presets on first load for current users. I tried migrating but that could cause conflicts too. As the option has been hidden for a long time this will affect only those few users who were familiar with the widget and used to presets disappearing due to above bug. 

Other bug fixes include:
- Stable handling of the Alt Q. Uses the actual queue order that the saved lab had
- Un-waiting factories when a new preset is loaded
- Reduced Icon spacing and fixed an arithmetic error to allow more icons per preset to be displayed before cut off by '...'

Finally, have added it as an option in the GUI options to toggle on with appropriate language support. 

Only remaining addition I can think of is updating the tooltip in gui_options with the LIVE keybind for `factory_presets_show` but I noticed that no options currectly draw the live keys (unlike the gui_ordermenu or gui_keybind_info) so I'll leave that a TODO another PR. 

#### Test steps
- Toggle option in settings
- select a single factory and queue units
- save the current build queue
- load the saved queue into the existing or a new factory

### Screenshots:

#### BEFORE:
<img width="901" height="696" alt="image" src="https://github.com/user-attachments/assets/732d28fe-cad0-4620-9813-fe5142c99360" />


#### AFTER:
<img width="1063" height="645" alt="image" src="https://github.com/user-attachments/assets/a72e6023-41fb-4aca-86c9-77d4c1577bd2" />

### AI / LLM usage statement:
No AI
