### PR TITLE
Fix share tax exploit that gives free resources

### DIFF
--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -76,6 +76,10 @@ function gadget:AllowResourceTransfer(senderTeamId, receiverTeamId, resourceType
 
 	-- rShare is the share slider setting, don't exceed their share slider max when sharing
 	local maxShare = rStor * rShare - rCur
+	
+	if amount <= 0 or maxShare <= 0 then
+		return false
+	end
 
 	local taxedAmount = math_min((1-sharingTax)*amount, maxShare)
 	local totalAmount = taxedAmount / (1-sharingTax)


### PR DESCRIPTION
### Work done

Fixed an exploit in taxed resource sharing where sending resources to a player that was already above their share slider cap could apply negative resources to the sender.

Previously, when the receiver was above cap, `maxShare` became negative. The tax gadget then used that negative value as the transferred amount, reducing the receiver’s resources and crediting the sender. With sharing tax enabled, this could create extra resources for the sender.

Normally, you can't share resources with a player that has more than their share cap, but using a custom widget lets you exploit this.

#### Setup

Enable sharing tax, set to anything, like 30%
Have a friend on your team. With my setup I didn't have any friends, so I used an AI ally with a small code modification to set their share cap to 500 (since you can't normally change the share cap of an AI player)
Then, your teammate must be producing metal while you are full too, so they don't overflow metal to you.
This makes your teammate have more resources than their share-cap slider.
Then, all you need to do is share any amount of resources to them, like 1, which causes them to lose all metal above their share-cap, while you gain metal. If there's a share tax, you gain more metal than your ally loses.

In this video, you can see the bug in action with me sending a single metal to my ally using the custom widget, causing them to lose the 1200 metal above their share-cap and I gain 1700 metal due to the 30% share tax.

https://github.com/user-attachments/assets/ff656582-584e-454d-aeac-1b91472cccc2



### AI / LLM usage statement:

Codex was used to find and fix the bug. Ofcourse I manually verified the exploit itself and the fix.