### PR TITLE
Fix spectators being able to run /give command 🤯 

### DIFF
--- a/luarules/gadgets/cmd_give.lua
+++ b/luarules/gadgets/cmd_give.lua
@@ -100,7 +100,7 @@ if gadgetHandler:IsSyncedCode() then
 			authorized = true
 			givenSomethingAtFrame = Spring.GetGameFrame()
 		end
-		if authorized == nil then
+		if not authorized then
 			Spring.SendMessageToPlayer(playerID, "You are not authorized to give units")
 			return
 		elseif not spec then

--- a/luarules/gadgets/cmd_sendcommand.lua
+++ b/luarules/gadgets/cmd_sendcommand.lua
@@ -47,7 +47,7 @@ if gadgetHandler:IsSyncedCode() then
 		if _G.permissions.cmd[accountID] then
 			authorized = true
 		end
-		if authorized == nil then
+		if not authorized then
 			Spring.SendMessageToPlayer(playerID, "You are not authorized to send commands for a player")
 			return
 		elseif not spec then


### PR DESCRIPTION
## Summary

Fixes an auth bypass in the spectator-only LuaRules admin commands for `/give` and `/cmd`. I have a widget that exploits this but will for obvious reasons not attach that to this PR. I think the git diff speaks for itself.

Both gadgets initialized `authorized` to `false`, but only rejected when `authorized == nil`, allowing unauthorized spectators who had never been players to pass the permission check.

## Changes

- Reject unauthorized `/give` requests with `if not authorized`
- Reject unauthorized `/cmd` requests with `if not authorized`

## Testing

I manually tested this with Damgam in multiplayer, and holy fuck it works.

### AI / LLM usage statement:

Codex was used to find and create the widget to exploit this bug. 