### PR TITLE
Fix Shard AI loader letting any client command any unit

### DIFF
--- a/luarules/gadgets/AILoader.lua
+++ b/luarules/gadgets/AILoader.lua
@@ -43,11 +43,13 @@ local table_remove = table.remove
 
 
 
+local shardAITeams = {}
 for i = 1, #teamList do
 	local luaAI = spGetTeamLuaAI(teamList[i])
 	if luaAI ~= "" then
 		if type(luaAI) == "string" and (VFS.FileExists("luarules/gadgets/ai/" .. luaAI .. "/boot.lua")) then
 			shardEnabled = true
+			shardAITeams[teamList[i]] = true
 		end
 	end
 end
@@ -154,7 +156,40 @@ if gadgetHandler:IsSyncedCode() then
 		return StrToTbl
 	end
 
-	function gadget:RecvLuaMsg(msg)
+	-- A Shard AI may only be issued orders for units on its own team, and only by the
+	-- player that controls that AI team. The synced Spring.GiveOrderToUnit ignores team
+	-- ownership, so without this check any client could wrap a message in the STGO
+	-- envelope and drive ANY unit on the map (enemies, allies, other players, other AIs -
+	-- including the enemy AI in a PvE game).
+	local function isAuthorizedShardUnit(unitID, playerID)
+		if not spValidUnitID(unitID) then
+			return false
+		end
+		local unitTeam = spGetUnitTeam(unitID)
+		if not shardAITeams[unitTeam] then
+			return false
+		end
+		local _, leader = spGetTeamInfo(unitTeam, false)
+		return leader == playerID
+	end
+
+	-- order.id is a single unit (methods 1-1/2-1) or an array of units (methods 1-2/2-2).
+	local function orderTargetsAuthorized(id, playerID)
+		if type(id) == 'table' then
+			if #id == 0 then
+				return false
+			end
+			for i = 1, #id do
+				if not isAuthorizedShardUnit(id[i], playerID) then
+					return false
+				end
+			end
+			return true
+		end
+		return isAuthorizedShardUnit(id, playerID)
+	end
+
+	function gadget:RecvLuaMsg(msg, playerID)
 
 		if string_sub(msg,1,17) == 'StGiveOrderToSync' then
 			spEcho('warn:  Shard  receive a old give order protocol',msg)
@@ -175,7 +210,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 
 			if order.method == '1-1' then
-				if not spValidUnitID(order.id) then return end
+				if not orderTargetsAuthorized(order.id, playerID) then return end
 				--('Receiveluarulesmsg GiveOrder to:',UnitDefs[spGetUnitDefID ( order.id )].name,order.cmd)
 				local cmd = spGiveOrderTounit(order.id,order.cmd,order.parameters,order.options)
 				--spEcho(order.id,order.cmd,order.parameters,order.options,cmd)
@@ -192,7 +227,7 @@ if gadgetHandler:IsSyncedCode() then
 					spEcho('GiveOrderToUnit Error:',cmd)
 				end
 			elseif order.method == '2-1' then
-				if not spValidUnitID(order.id) then return end
+				if not orderTargetsAuthorized(order.id, playerID) then return end
 				local arrayOfCmd = gadget:RezTable()
 				for i in pairs(order.cmd) do
 					local row = gadget:RezTable()
@@ -210,12 +245,14 @@ if gadgetHandler:IsSyncedCode() then
 				gadget:KillTable(order)
 			elseif order.method == '1-2' then
 				--spEcho(type(order.id),type(order.cmd),type(order.parameters[1]),type(order.options))
+				if not orderTargetsAuthorized(order.id, playerID) then return end
 				local cmd = spGiveOrderTounitArray(order.id,order.cmd,order.parameters,order.options)
 				cmdCounter.iz = cmdCounter.iz + 1
 				if not cmd then
 					spEcho('GiveOrderToUnitArray Error:',cmd)
 				end
 			elseif order.method == '2-2' then
+				if not orderTargetsAuthorized(order.id, playerID) then return end
 				local arrayOfCmd = gadget:RezTable()
 				for i in pairs(order.cmd) do
 					local row = gadget:RezTable()


### PR DESCRIPTION
First of all, I want to be honest that this is a PR I do not fully understand myself due to AI doing the heavy lifting, which is why I want to leave this to the maintainers for any desired changes, if any. I have tested and verified myself that the exploit works in multiplayer, and that this patch prevents this exploit from being abused, with that one exception described below.

### Work done

The Shard AI loader's synced `RecvLuaMsg` handler (`luarules/gadgets/AILoader.lua`)
accepted "give order" messages wrapped in the `@Shard[STGO]...[STGO]Shard@` envelope
and passed the decoded order straight to `Spring.GiveOrderToUnit(order.id, ...)`. It
only validated that `order.id` was a valid unit ID, and it never checked **who** sent
the message.

Because `Spring.GiveOrderToUnit` from synced code ignores team ownership, any client
could forge that envelope (via a simple LuaUI widget calling `Spring.SendLuaRulesMsg`)
and issue arbitrary orders — move, self-destruct, reclaim, attack, etc. — to **any unit
on the map**: enemy units, allied units, other players' units, and other AIs. This was
exploitable in any game where a Shard AI was present (which is what activates the gadget),
from a normal player slot, with no host/lobby control required.

This fix restricts the handler so an order is only executed when:
- the target unit belongs to a team controlled by a Shard AI, **and**
- the message sender is that AI team's controlling (leader) player.

The check is applied uniformly across all four order methods (`1-1`, `2-1`, `1-2`, `2-2`).
Legitimate AI play is unaffected, because a Shard AI only ever issues orders to its own
units from its controlling client.

> **Caveat / scope:** A Shard AI you personally added and control (you are its team
> leader) will still obey orders sent from your client — this is the pre-existing,
> by-design "control your own Shard AI" behavior and cannot be distinguished at this
> layer, since the genuine AI's orders originate from the same player. This PR's fix is
> that you can no longer command units you don't control: other players' units, the
> enemy AI in a PvE game, non-Shard AIs (e.g. BarbarianAI), and other players' Shard AIs.

#### Setup
Here's the widget, rename to .lua because for some reason I can't upload lua files here. [exploit_shard_command_hijack.txt](https://github.com/user-attachments/files/28403803/exploit_shard_command_hijack.txt)

A skirmish/PvE game that includes at least one Shard AI (this is what loads the gadget).
For the clearest test, also add a second, non-Shard AI (e.g. BarbarianAI). Use the attached
proof-of-concept widget (`exploit_shard_command_hijack.lua`): drop it into `LuaUI/Widgets/`,
then enable "Exploit: Shard Command Hijack" in the widget list (F11). It forges the Shard
order envelope and issues a command to whatever unit is under your cursor via
`/luaui shardhijack` (`info` | `mark` | `move` | `selfd` | `stop`).

#### Test steps
- [ ] On **master**, start a game with yourself + a non-Shard AI (e.g. BarbarianAI) + a Shard AI, and load the attached widget.
- [ ] Hover an enemy/other unit and run `/luaui shardhijack selfd` (or `mark` over a spot, then hover a unit and `move`). Expected (bug): the BarbarianAI's units, the Shard AI's units, and your own units all obey — you can command units you don't own.
- [ ] Switch to this branch and repeat the same commands. Expected (fixed): orders to units you don't control (BarbarianAI, other players, enemy AI) are silently ignored. (A Shard AI you yourself lead will still obey — see caveat above.)
- [ ] Confirm the friendly Shard AI still plays normally on this branch (builds, moves, fights), verifying legitimate AI control is unaffected.

### AI / LLM usage statement
This bug was found and fixed by Opus 4.8. This is my third exploit found by AI today and I'm happy to announce it has ran for quite a while now and can't seem to find any more serious bugs! 🥳 