### PR TITLE
fix: wrong data length for partially-sent target lists

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -323,11 +323,13 @@ if gadgetHandler:IsSyncedCode() then
 						data[length + 4] = target[2]
 						data[length + 5] = target[3]
 					end
+					length = length + 5
+					if length > 4000 then break end
 				end
-				length = length + 5
-				if length > 4000 then break end
 			end
-			SendToUnsynced("targetListBatched", unitID, length, data)
+			if length > 0 then
+				SendToUnsynced("targetListBatched", unitID, length, data)
+			end
 		end
 		--tracy.ZoneEnd()
 	end


### PR DESCRIPTION
### Work done

Fixes an issue with mixed sent/unsent target lists on the newer batched send method, and only sends data when any unsent data is found.