### PR TITLE
fix: set target state inits with nil currentIndex

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -343,6 +343,7 @@ if gadgetHandler:IsSyncedCode() then
 					teamID = spGetUnitTeam(unitID),
 					allyTeam = spGetUnitAllyTeam(unitID),
 					weapons = unitWeapons[unitDefID],
+					currentIndex = 1,
 				}
 			end
 			if not append then


### PR DESCRIPTION
We need this when removing targets during the Stop cancel. May as well also keep this table const-sized by adding this field at creation.