### PR TITLE
fix: guard for invalid units receiving Set Target commands

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -750,7 +750,9 @@ if gadgetHandler:IsSyncedCode() then
 		--tracy.ZoneBeginN(string.format("AllowCommand %s %s", tostring(fromSynced), tostring(fromLua)))
 		--tracy.Message(string.format("Allowcommand params %s %s", table.toString(cmdOptions), table.toString(cmdParams)))
 		if isSetTargetCommand[cmdID] then
-			processCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
+			if validUnits[unitDefID] then
+				processCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
+			end
 			--tracy.ZoneEnd()
 			return false -- consume command
 		end


### PR DESCRIPTION
### Work done

Replace the guard that was removed here. It didn't need to be in both places -- but shouldn't have been removed from both places.