### PR TITLE
fix: nuke units use "nuke", nuke weapons use "nuclear"

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -112,11 +112,11 @@ if gadgetHandler:IsSyncedCode() then
 			return false
 		end
 
-		-- FIXME: We don't know which weaponDefs have submissile. We can check `nuke`, for now.
+		-- FIXME: We don't know which weaponDefs have submissile. We can check `nuclear`, for now.
 		local function getWeaponType(weapon)
 			if hasTargeting(weapon) then
 				local weaponDef = WeaponDefs[weapon.weaponDef]
-				return weaponDef.waterWeapon and not weaponDef.customParams.nuke and WATERWEAPON or 1
+				return weaponDef.waterWeapon and not weaponDef.customParams.nuclear and WATERWEAPON or 1
 			else
 				return false
 			end


### PR DESCRIPTION
Fixes the Set Target behavior for nuclear missile-armed submarines, since we can't detect the submissile property via Lua, atm.