### PR TITLE
feat(stateprefs): transform widget into API and setup default F9 hotkey

### DIFF
--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -6,8 +6,8 @@ local widget = widget ---@type Widget
 function widget:GetInfo()
 	return {
 		name = "State Prefs V2",
-		desc = "Sets pre-defined units states. Hold bindable action 'stateprefs_record' while clicking a unit's state commands to define the preferred state for newly produced units of its type. V2 fixes bug, improves console output to show unit and state change details.",
-		author = "Errrrrrr, quantum + Doo, sneyed, Chronographer",
+		desc = "Sets pre-defined units states. Hold bindable action 'stateprefs_record' while clicking a unit's state commands to define the preferred state for newly produced units of its type. V2 fixes bug, improves console output, and exposes a comprehensive WG.StatePrefs API for other widgets.",
+		author = "Errrrrrr, quantum + Doo, sneyed, Chronographer, uBdead",
 		date = "April 21, 2023",
 		license = "GNU GPL, v2 or later",
 		layer = 1000,
@@ -19,45 +19,102 @@ end
 -- Localized Spring API for performance
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetSelectedUnits = Spring.GetSelectedUnits
+local spGetUnitCmdDescs = Spring.GetUnitCmdDescs
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spGetMyTeamID = Spring.GetMyTeamID
+local spGetTeamUnits = Spring.GetTeamUnits
+local spGetAllUnits = Spring.GetAllUnits
+local spGetUnitTeam = Spring.GetUnitTeam
 local spEcho = Spring.Echo
 
 --[[------------------------------------------------------------------------------
 
-Usage:
+Usage (key bindings):
 Bind actions to a key of your choice in /Beyond-All-Reason/data/uikeys.txt
 stateprefs_record 		will save the preferred state for the selected unit/units for the selected command.
 stateprefs_clear 		will clears the preferred state for the selected unit/units for the selected command.
 stateprefs_clearunit 	will clears all saved states for the selected unit/units for all commands.
+stateprefs_savecurrent	will snapshot ALL current states of the selected unit/units as their prefs.
 
-e.g. 
+e.g.
 bind alt 	stateprefs_clear
 bind ctrl 	stateprefs_record
 bind sc_\ 	stateprefs_clearunit
 
+Usage (WG.StatePrefs API, for other widgets):
+	local api = WG.StatePrefs
+	-- queries
+	api.getAllPrefs()                      -> { [unitName] = { [cmdID] = stateIndex } }  (copy)
+	api.getUnitPrefs(unitDefID|unitName)   -> { [cmdID] = stateIndex }                   (copy or nil)
+	api.hasPrefs(unitDefID|unitName)       -> boolean
+	-- live capture
+	api.captureUnitStates(unitID)          -> { [cmdID] = stateIndex }
+	api.saveSelected()                     -> number of unit types saved
+	api.saveUnits(unitIDs)                 -> number of unit types saved
+	-- granular mutation (persisted)
+	api.setState(unitDefID|unitName, cmdID, stateIndex)
+	api.clearState(unitDefID|unitName, cmdID)
+	api.clearUnit(unitDefID|unitName)
+	api.clearAll()                         -- wipe all saved prefs for every unit type
+	api.recordSelected(cmdID, stateIndex)  -- like the record key action
+	api.clearStateSelected(cmdID)          -- like the clear key action
+	api.clearSelected()                    -- like the clearunit key action
+	-- persistence / application
+	api.save()                             -- force-write the config to disk
+	api.reload()                           -- reload the config from disk
+	api.applyToUnit(unitID[, unitDefID])   -- apply stored prefs to one unit
+	api.applyToTeam([teamID])              -- apply stored prefs to all of a team's units
+
 --]]------------------------------------------------------------------------------
-local unitArray = {}
-local unitName = {}
-for udid, ud in pairs(UnitDefs) do
-	unitName[udid] = ud.name
-end
 
-local unitSet = {}
-local chunk, err = loadfile("LuaUI/config/StatesPrefs.lua")
-if chunk then
-	local tmp = {}
-	setfenv(chunk, tmp)
-	unitArray = chunk()
-end
-
-local clearSound = 'LuaUI/Sounds/switchoff.wav'
 local CMDTYPE_ICON_MODE = CMDTYPE.ICON_MODE
+local CMD_REPEAT = CMD.REPEAT -- skipped when applying (handled by repeat command itself)
+
+local CONFIG_PATH = "LuaUI/config/StatesPrefs.lua"
+local CONFIG_HEADER = "--States prefs"
+local clearSound = 'LuaUI/Sounds/switchoff.wav'
+local saveSound = 'LuaUI/Sounds/switchon.wav'
+
+-- unitDefID -> internal name (used as unitSet key), human name (used for display)
+local unitName = {}
+local unitHumanName = {}
+local validName = {}
+for udid, ud in pairs(UnitDefs) do
+	unitName[udid] = ud.name or ("unitDefID_" .. udid)
+	unitHumanName[udid] = ud.translatedHumanName or unitName[udid]
+	validName[ud.name] = true
+end
+
+-- name -> { [cmdID] = stateIndex }
+local unitSet = {}
+
+local wasRecordPressed = false
 local isRecordPressed = false
 local isClearPressed = false
 local spawnInitialFrame = Game.spawnInitialFrame
-local spawnWarpInFrame = Game.spawnWarpInFrame
 local spectatingState = select(1, Spring.GetSpectatingState())
 
 --------------------------------------------------------------------------------
+-- Config persistence
+--------------------------------------------------------------------------------
+local function loadStatePrefs()
+	local chunk = loadfile(CONFIG_PATH)
+	if chunk then
+		setfenv(chunk, {})
+		local ok, result = pcall(chunk)
+		if ok and type(result) == "table" then
+			return result
+		end
+	end
+	return {}
+end
+
+local function saveStatePrefs()
+	table.save(unitSet, CONFIG_PATH, CONFIG_HEADER)
+end
+
+--------------------------------------------------------------------------------
+-- Helpers
 --------------------------------------------------------------------------------
 local function GetCmdOpts(alt, ctrl, meta, shift, right)
 	local opts = { alt = alt, ctrl = ctrl, meta = meta, shift = shift, right = right }
@@ -83,17 +140,307 @@ local function GetCmdOpts(alt, ctrl, meta, shift, right)
 	return opts
 end
 
+local applyCmdOpts = GetCmdOpts(false, false, false, true, false)
+
+-- Accepts a unitDefID (number) or a unit name (string), returns a valid name or nil.
+local function resolveName(unitDefIDorName)
+	local t = type(unitDefIDorName)
+	if t == "number" then
+		return unitName[unitDefIDorName]
+	elseif t == "string" and validName[unitDefIDorName] then
+		return unitDefIDorName
+	end
+	return nil
+end
+
+local function copyStates(states)
+	local out = {}
+	for cmdID, value in pairs(states) do
+		out[cmdID] = value
+	end
+	return out
+end
+
+-- Snapshots every ICON_MODE state command (fire state, move state, repeat,
+-- on/off, cloak, trajectory, ...) of a unit into a { [cmdID] = stateIndex } table.
+local function captureUnitStates(unitID)
+	local states = {}
+	local cmdDescs = spGetUnitCmdDescs(unitID)
+	if cmdDescs then
+		for i = 1, #cmdDescs do
+			local cmd = cmdDescs[i]
+			if cmd.type == CMDTYPE_ICON_MODE and cmd.params then
+				local current = tonumber(cmd.params[1])
+				if current then
+					states[cmd.id] = current
+				end
+			end
+		end
+	end
+	return states
+end
+
+local function applyToUnit(unitID, unitDefID, unitTeam)
+	unitDefID = unitDefID or spGetUnitDefID(unitID)
+	if not unitDefID then
+		return
+	end
+	unitTeam = unitTeam or spGetUnitTeam(unitID)
+	if spectatingState or unitTeam ~= spGetMyTeamID() then
+		return
+	end
+	local name = unitName[unitDefID]
+	local states = name and unitSet[name]
+	if not states then
+		return
+	end
+	for cmdID, stateIndex in pairs(states) do
+		if cmdID ~= CMD_REPEAT then
+			spGiveOrderToUnit(unitID, cmdID, { stateIndex }, applyCmdOpts)
+		end
+	end
+end
+
+local function applyToTeam(teamID)
+	teamID = teamID or ((not spectatingState) and spGetMyTeamID())
+	local units = (teamID and spGetTeamUnits(teamID)) or spGetAllUnits()
+	if units then
+		for i = 1, #units do
+			local unitID = units[i]
+			applyToUnit(unitID, spGetUnitDefID(unitID), teamID or spGetUnitTeam(unitID))
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Core mutation operations (update in-memory + persist)
+--------------------------------------------------------------------------------
+local function setState(unitDefIDorName, cmdID, stateIndex)
+	local name = resolveName(unitDefIDorName)
+	if not name or type(cmdID) ~= "number" then
+		return false
+	end
+	unitSet[name] = unitSet[name] or {}
+	if unitSet[name][cmdID] == stateIndex then
+		return false
+	end
+	unitSet[name][cmdID] = stateIndex
+	saveStatePrefs()
+	return true
+end
+
+local function clearState(unitDefIDorName, cmdID)
+	local name = resolveName(unitDefIDorName)
+	if not name or not unitSet[name] then
+		return false
+	end
+	if unitSet[name][cmdID] == nil then
+		return false
+	end
+	unitSet[name][cmdID] = nil
+	saveStatePrefs()
+	return true
+end
+
+local function clearUnit(unitDefIDorName)
+	local name = resolveName(unitDefIDorName)
+	if not name then
+		return false
+	end
+	unitSet[name] = {}
+	saveStatePrefs()
+	return true
+end
+
+-- Wipes every saved state pref for all unit types, restoring defaults.
+local function clearAll()
+	unitSet = {}
+	saveStatePrefs()
+	spEcho("All state prefs reset to defaults")
+	return true
+end
+
+-- Saves the full current state snapshot of each selected unit type.
+local function saveUnits(units)
+	if not units or #units == 0 then
+		return 0
+	end
+	local savedNames = {}
+	local saved = 0
+	for i = 1, #units do
+		local unitID = units[i]
+		local udid = spGetUnitDefID(unitID)
+		local name = unitName[udid]
+		if name and not savedNames[name] then
+			unitSet[name] = captureUnitStates(unitID)
+			savedNames[name] = true
+			saved = saved + 1
+			spEcho("State prefs saved for unit: " .. unitHumanName[udid])
+		end
+	end
+	if saved > 0 then
+		saveStatePrefs()
+		Spring.PlaySoundFile(saveSound, 0.6, 'ui')
+	end
+	return saved
+end
+
+local function saveSelected()
+	return saveUnits(spGetSelectedUnits())
+end
+
+--------------------------------------------------------------------------------
+-- Selection-based operations (mirror the original key actions)
+--------------------------------------------------------------------------------
+local function recordSelectedState(cmdID, command, value)
+	local selectedUnits = spGetSelectedUnits()
+	local changed = false
+	for i = 1, #selectedUnits do
+		local udid = spGetUnitDefID(selectedUnits[i])
+		local name = unitName[udid]
+		if name then
+			unitSet[name] = unitSet[name] or {}
+			if unitSet[name][cmdID] ~= value then
+				unitSet[name][cmdID] = value
+				spEcho("State pref changed:  " .. unitHumanName[udid] .. ",  " .. (command or cmdID) .. " " .. tostring(value))
+				changed = true
+			end
+		end
+	end
+	if changed then
+		saveStatePrefs()
+	end
+end
+
+local function clearSelectedState(cmdID, command)
+	local selectedUnits = spGetSelectedUnits()
+	for i = 1, #selectedUnits do
+		local udid = spGetUnitDefID(selectedUnits[i])
+		local name = unitName[udid]
+		if name and unitSet[name] then
+			unitSet[name][cmdID] = nil
+			spEcho("State pref removed: " .. unitHumanName[udid] .. ", " .. (command or cmdID))
+		end
+	end
+	saveStatePrefs()
+end
+
+local function clearSelectedUnits()
+	local selectedUnits = spGetSelectedUnits()
+	for i = 1, #selectedUnits do
+		local udid = spGetUnitDefID(selectedUnits[i])
+		local name = unitName[udid]
+		if name then
+			unitSet[name] = {}
+			spEcho("All state prefs removed for unit: " .. unitHumanName[udid])
+		end
+	end
+	Spring.PlaySoundFile(clearSound, 0.6, 'ui')
+	saveStatePrefs()
+end
+
+--------------------------------------------------------------------------------
+-- Public WG API
+--------------------------------------------------------------------------------
+local function buildAPI()
+	return {
+		-- queries
+		getAllPrefs = function()
+			local out = {}
+			for name, states in pairs(unitSet) do
+				out[name] = copyStates(states)
+			end
+			return out
+		end,
+		getUnitPrefs = function(unitDefIDorName)
+			local name = resolveName(unitDefIDorName)
+			local states = name and unitSet[name]
+			return states and copyStates(states) or nil
+		end,
+		hasPrefs = function(unitDefIDorName)
+			local name = resolveName(unitDefIDorName)
+			local states = name and unitSet[name]
+			return states ~= nil and next(states) ~= nil
+		end,
+
+		-- live capture
+		captureUnitStates = captureUnitStates,
+		saveSelected = saveSelected,
+		saveUnits = saveUnits,
+
+		-- granular mutation
+		setState = setState,
+		clearState = clearState,
+		clearUnit = clearUnit,
+		clearAll = clearAll,
+		recordSelected = function(cmdID, value)
+			recordSelectedState(cmdID, nil, value)
+		end,
+		clearStateSelected = function(cmdID)
+			clearSelectedState(cmdID, nil)
+		end,
+		clearSelected = clearSelectedUnits,
+
+		-- persistence / application
+		save = saveStatePrefs,
+		reload = function()
+			unitSet = loadStatePrefs()
+		end,
+		applyToUnit = applyToUnit,
+		applyToTeam = applyToTeam,
+	}
+end
+
+--------------------------------------------------------------------------------
+-- Action callbacks
+--------------------------------------------------------------------------------
+function onRecordPress()
+	if not wasRecordPressed then
+		wasRecordPressed = true
+		Spring.PlaySoundFile("LuaUI/Sounds/buildbar_add.wav", 1, 'ui')
+		Spring.Echo("State Prefs: Record mode ON - click a state command (e.g. fire state)")
+	end
+
+	isRecordPressed = true
+end
+
+function onRecordRelease()
+	isRecordPressed = false
+	wasRecordPressed = false
+	Spring.PlaySoundFile("LuaUI/Sounds/buildbar_rem.wav", 1, 'ui')
+	Spring.Echo("State Prefs: Record mode OFF")
+end
+
+function onClearPress()
+	isClearPressed = true
+end
+
+function onClearRelease()
+	isClearPressed = false
+end
+
+function doClearUnit()
+	clearSelectedUnits()
+end
+
+function doSaveCurrent()
+	saveSelected()
+end
+
+--------------------------------------------------------------------------------
+-- Widget call-ins
+--------------------------------------------------------------------------------
 function widget:PlayerChanged(playerID)
-	if Spring.GetSpectatingState() then
+	spectatingState = select(1, Spring.GetSpectatingState())
+	if spectatingState then
 		widget:GameOver()
 	end
 end
 
 function widget:Initialize()
-	unitArray = unitArray or {}
-	for i, v in pairs(unitArray) do
-		unitSet[i] = v
-	end
+	unitSet = loadStatePrefs()
+	spectatingState = select(1, Spring.GetSpectatingState())
+
 	if Spring.IsReplay() then
 		widget:GameOver()
 	end
@@ -103,45 +450,14 @@ function widget:Initialize()
 	widgetHandler:AddAction("stateprefs_clear", onClearPress, nil, "p")
 	widgetHandler:AddAction("stateprefs_clear", onClearRelease, nil, "r")
 	widgetHandler:AddAction("stateprefs_clearunit", doClearUnit, nil, "p")
-	
-end
+	widgetHandler:AddAction("stateprefs_savecurrent", doSaveCurrent, nil, "p")
 
-function onRecordPress()
-  isRecordPressed = true
-end
-
-function onRecordRelease()
-  isRecordPressed = false
-end
-
-function onClearPress()
-  isClearPressed = true
-end
-
-function onClearRelease()
-  isClearPressed = false
-end
-
-function saveStatePrefs()
-	table.save(unitSet, "LuaUI/config/StatesPrefs.lua", "--States prefs")
-end
-
-function doClearUnit()
-	local selectedUnits = spGetSelectedUnits()
-	for i = 1, #selectedUnits do
-		local unitID = selectedUnits[i]
-		local unitDefID = spGetUnitDefID(unitID)
-		local name = unitName[unitDefID]
-		unitSet[name] = {}
-		spEcho("All state prefs removed for unit: " .. name)
-	end
-	Spring.PlaySoundFile(clearSound , 0.6, 'ui')
-	saveStatePrefs()
+	WG.StatePrefs = buildAPI()
 end
 
 function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
-	if not isRecordPressed and not isClearPressed then 
-		return false 
+	if not isRecordPressed and not isClearPressed then
+		return false
 	end
 
 	local index = Spring.GetCmdDescIndex(cmdID)
@@ -151,50 +467,17 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 		return
 	end
 
-	local selectedUnits = spGetSelectedUnits()
-	for i = 1, #selectedUnits do
-		local unitID = selectedUnits[i]
-		local unitDefID = spGetUnitDefID(unitID)
-		local name = unitName[unitDefID]
-		unitSet[name] = unitSet[name] or {}
-		
-		if #cmdParams == 1 and isClearPressed then
-			unitSet[name][cmdID] = nil
-			spEcho("State pref removed: " .. name .. ", " .. command.name)
-			saveStatePrefs()
-		elseif #cmdParams == 1 and not (unitSet[name][cmdID] == cmdParams[1]) then
-			unitSet[name][cmdID] = cmdParams[1]
-			spEcho("State pref changed:  " .. name .. ",  " .. command.name .. " " .. cmdParams[1])
-			saveStatePrefs()
+	if #cmdParams == 1 then
+		if isClearPressed then
+			clearSelectedState(cmdID, command.name)
+		else
+			recordSelectedState(cmdID, command.name, cmdParams[1])
 		end
 	end
 end
 
 function widget:UnitFinished(unitID, unitDefID, unitTeam)
-	local cmdOpts = GetCmdOpts(false, false, false, true, false)
-
-	local name = unitName[unitDefID]
-
-	unitSet[name] = unitSet[unitName[unitDefID]] or {}
-	if unitTeam == Spring.GetMyTeamID() then
-		for cmdID, cmdParam in pairs(unitSet[name]) do
-			if cmdID == 115 then
-				return
-			end -- we're skipping "repeat" command here for now
-			local success = Spring.GiveOrderToUnit(unitID, cmdID, { cmdParam }, cmdOpts)
-			--spEcho("".. name .. ", " .. tostring(cmdID) .. ", " .. tostring(cmdParam) .. " success: ".. tostring(success))
-		end
-	end
-end
-
-local function ApplyUnitStates()
-	local teamID = (not spectatingState) and Spring.GetMyTeamID()
-	local units = (teamID and Spring.GetTeamUnits(teamID)) or Spring.GetAllUnits()
-	if units then
-		for i = 1, #units do
-			widget:UnitFinished(units[i], Spring.GetUnitDefID(units[i]), teamID or Spring.GetUnitTeam(units[i]))
-		end
-	end
+	applyToUnit(unitID, unitDefID, unitTeam)
 end
 
 function widget:GameFrame(n)
@@ -208,7 +491,7 @@ function widget:GameFrame(n)
 	if n <= spawnInitialFrame then
 		return
 	end
-	ApplyUnitStates()
+	applyToTeam()
 	widgetHandler:RemoveCallIn("GameFrame", self)
 end
 
@@ -219,9 +502,11 @@ function widget:GameOver()
 end
 
 function widget:Shutdown()
+	WG.StatePrefs = nil
 	widgetHandler:RemoveAction("stateprefs_record")
 	widgetHandler:RemoveAction("stateprefs_clear")
 	widgetHandler:RemoveAction("stateprefs_clearunit")
+	widgetHandler:RemoveAction("stateprefs_savecurrent")
 end
 
 --------------------------------------------------------------------------------

--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -120,6 +120,9 @@ bind             Any+f6  ShowPathTraversability
 bind             Any+f7  ShowMetalMap
 bind             Any+f8  ShowElevation
 
+bind                 f9  stateprefs_record
+bind             Alt+f9  stateprefs_clearunit
+bind            Ctrl+f9  stateprefs_savecurrent
 bind                f10  options
 bind                f11  luaui selector
 bind            Any+f12  screenshot png

--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -96,6 +96,9 @@ bind Any+f4 ShowMetalMap
 bind Any+f5 HideInterface
 bind Any+f6 MuteSound
 bind Any+f7 DynamicSky
+bind f9      stateprefs_record
+bind Alt+f9  stateprefs_clearunit
+bind Ctrl+f9 stateprefs_savecurrent
 bind f10 options
 bind f11 luaui selector
 bind Any+f12 screenshot png


### PR DESCRIPTION
### Work done
Refactored `unit_stateprefs.lua` to be a WG API so it is future ready to be used by other widgets. Also added SFX for the recording state to make it more clear for the user what is going on.

#### Test steps
- [ ] Use stateprefs as before, using the new default F9 hotkey. Hold down F9 to enter "recording mode" allowing to set specific states of the unit. Use CTRL+F9 to one click fully record the whole state of the unit(s). Use ALT+F9 to clear all unitprefs for the unit(s).

### Screenshots:

https://github.com/user-attachments/assets/4882babc-5cbd-4b1a-8cce-054795854359


### AI / LLM usage statement:
Concept and structure by me, API refactoring done by Claude 4.8 Opus. 
