### PR TITLE
macOS Apple Silicon: NoGS widget paths + minor Lua fixes

### DIFF
--- a/luaui/Include/DrawPrimitiveAtUnitNoGS.lua
+++ b/luaui/Include/DrawPrimitiveAtUnitNoGS.lua
@@ -1,0 +1,135 @@
+-------------------------------------------------
+-- Alternative shader path for the DrawPrimitiveAtUnit pattern that does not
+-- use a geometry-shader stage. Useful for backends that lack a geometry-
+-- shader stage. Each instance is expanded into the target primitive via
+-- gl_VertexID in an instanced vertex shader, drawn as GL_TRIANGLES.
+--
+-- The per-unit data is bound as an INSTANCE buffer (divisor 1) and the
+-- vertex shader expands each instance into the target primitive (triangle,
+-- quad, cornerrect, or circle) via gl_VertexID. Widgets draw with:
+--   VBO.VAO:DrawArrays(GL.TRIANGLES, VBO.numVerts, 0, VBO.usedElements)
+--
+-- Same public surface as DrawPrimitiveAtUnit.lua so a widget can opt in at
+-- load time by switching the VFS.Include path (and its draw call). Widgets
+-- that do not opt in continue using the geometry-shader-based
+-- DrawPrimitiveAtUnit infrastructure unchanged.
+-- License: GNU GPL V2
+-------------------------------------------------
+
+local DrawPrimitiveAtUnit = {}
+
+-- shaderConfig: per-key documentation. Keys mirror DrawPrimitiveAtUnit.lua so
+-- a widget can move between the two paths by changing only the VFS.Include
+-- path. Differences from the GS variant are called out below.
+local shaderConfig = {
+	TRANSPARENCY = 0.2, -- transparency of the stuff drawn
+	HEIGHTOFFSET = 1, -- Additional height added to everything
+	ANIMATION = 1, -- set to 0 if you dont want animation
+	INITIALSIZE = 0.66, -- What size the stuff starts off at when spawned
+	GROWTHRATE = 4, -- How fast it grows to full size
+	BREATHERATE = 30.0, -- how fast it periodicly grows
+	BREATHESIZE = 0.05, -- how much it periodicly grows
+	TEAMCOLORIZATION = 1.0, -- not used yet
+	CLIPTOLERANCE = 1.1, -- At 1.0 it wont draw at units just outside of view (may pop in), 1.1 is a good safe amount
+	USETEXTURE = 1, -- 1 if you want to use textures (atlasses too!), 0 if not
+	BILLBOARD = 0, -- 1 if you want camera facing billboards, 0 is flat on ground
+	-- POST_ANIM / POST_VERTEX / PRE_OFFSET / POST_GEOMETRY: GLSL injection
+	-- points inside the vertex shader, identical to the GS variant by name and
+	-- by the locals they may read/write (v_color, v_lengthwidthcornerheight,
+	-- v_parameters, v_centerpos, v_uvoffsets, v_numvertices, ...).
+	-- IMPORTANT SEMANTIC DIFFERENCE: in the GS variant these run ONCE per
+	-- instance (inside the VS, which then feeds the GS). In this NoGS variant
+	-- the expansion is inside the VS itself, so each injection runs ONCE per
+	-- OUTPUT VERTEX (up to (MAXVERTICES-2)*3 times per instance). All injection
+	-- bodies must be idempotent pure writes; do not put counters, RNG advances
+	-- or accumulators here.
+	POST_ANIM = " ", -- what you want to do in the animation post function (glsl snippet, see shader source)
+	POST_VERTEX = " ", -- noop
+	ZPULL = 256.0, -- how much to pull the z (depth) value towards the camera, 256 is about 16 elmos
+	POST_GEOMETRY = "", -- per-vertex post-emit snippet; in the GS variant this was per-emit inside the GS, here it is per output vertex inside the VS
+	POST_SHADING = "fragColor.rgba = fragColor.rgba;", -- noop
+	-- MAXVERTICES: max number of strip vertices a primitive can have (tris 3,
+	-- quads 4, cornerrect 8, circle up to 64). In this NoGS variant it ALSO
+	-- determines the fixed per-instance draw count: (MAXVERTICES-2)*3 vertices
+	-- are emitted via glDrawArraysInstanced and unused ones become degenerate
+	-- (off-screen) vertices. Keep it as low as your largest primitive needs.
+	MAXVERTICES = 64,
+	USE_CIRCLES = 1, -- set to nil if you dont want circles
+	USE_CORNERRECT = 1, -- set to nil if you dont want cornerrect
+	USE_TRIANGLES = 1, -- set to nil if you dont want to use tris
+	USE_QUADS = 1, -- set to nil if you dont want to use quads
+	FULL_ROTATION = 0, -- the primitive is fully rotated in the units plane
+	DISCARD = 0, -- Enable alpha threshold to discard fragments below 0.01
+	ROTATE_CIRCLES = 1, -- Set to 0 if you dont want circles to be rotated
+	PRE_OFFSET = "", -- vertex-shader snippet run just before the gl_Position write; same name as in the GS variant, but per-output-vertex here
+	USEQUATERNIONS = Engine.FeatureSupport.transformsInGL4 and "1" or "0", -- use quaternion-based unit transforms when supported by the engine
+}
+
+---- GL4 Backend Stuff----
+local DrawPrimitiveAtUnitVBO = nil
+local DrawPrimitiveAtUnitShader = nil
+
+local LuaShader = gl.LuaShader
+local InstanceVBOTable = gl.InstanceVBOTable
+
+local vsSrcPath = "LuaUI/Shaders/DrawPrimitiveAtUnitNoGS.vert.glsl"
+local fsSrcPath = "LuaUI/Shaders/DrawPrimitiveAtUnitNoGS.frag.glsl"
+
+local shaderSourceCache = {
+		vssrcpath = vsSrcPath,
+		fssrcpath = fsSrcPath,
+		shaderName = "DrawPrimitiveAtUnitNoGS",
+		uniformInt = {},
+		uniformFloat = {
+			addRadius = 0.0,
+			iconDistance = 20000.0,
+		  },
+		shaderConfig = shaderConfig,
+	}
+
+local function InitDrawPrimitiveAtUnit(shaderConfig, DPATname)
+	if shaderConfig.USETEXTURE then
+		shaderSourceCache.uniformInt = {DrawPrimitiveAtUnitTexture = 0,}
+	end
+
+	shaderSourceCache.shaderName = DPATname .. "Shader GL4"
+
+	DrawPrimitiveAtUnitShader =  LuaShader.CheckShaderUpdates(shaderSourceCache) or DrawPrimitiveAtUnitShader
+
+	if not DrawPrimitiveAtUnitShader then
+		Spring.Echo("Failed to compile shader for ", DPATname)
+		return nil
+	end
+
+	DrawPrimitiveAtUnitVBO = InstanceVBOTable.makeInstanceVBOTable(
+		{
+			{id = 0, name = 'lengthwidthcorner', size = 4},
+			{id = 1, name = 'teamID', size = 1, type = GL.UNSIGNED_INT},
+			{id = 2, name = 'numvertices', size = 1, type = GL.UNSIGNED_INT},
+			{id = 3, name = 'parameters', size = 4},
+			{id = 4, name = 'uvoffsets', size = 4},
+			{id = 5, name = 'instData', size = 4, type = GL.UNSIGNED_INT},
+		},
+		64, -- maxelements
+		DPATname .. "VBO", -- name
+		5  -- unitIDattribID (instData)
+	)
+	if DrawPrimitiveAtUnitVBO == nil then
+		Spring.Echo("Failed to create DrawPrimitiveAtUnitVBO for ", DPATname)
+		return nil
+	end
+
+	local DrawPrimitiveAtUnitVAO = gl.GetVAO()
+	-- NoGS: per-unit data advances per INSTANCE (divisor 1), and the VS emits
+	-- (MAXVERTICES-2)*3 vertices/instance via gl_VertexID. (The GS variant
+	-- uses AttachVertexBuffer + GL.POINTS instead.)
+	DrawPrimitiveAtUnitVAO:AttachInstanceBuffer(DrawPrimitiveAtUnitVBO.instanceVBO)
+	DrawPrimitiveAtUnitVBO.VAO = DrawPrimitiveAtUnitVAO
+	-- Vertices per instance = the triangle-list size of a (MAXVERTICES)-vertex
+	-- triangle strip. Widgets draw with:
+	--   VBO.VAO:DrawArrays(GL.TRIANGLES, VBO.numVerts, 0, VBO.usedElements)
+	DrawPrimitiveAtUnitVBO.numVerts = (math.max(3, shaderConfig.MAXVERTICES or 4) - 2) * 3
+	return  DrawPrimitiveAtUnitVBO, DrawPrimitiveAtUnitShader
+end
+
+return {InitDrawPrimitiveAtUnit = InitDrawPrimitiveAtUnit, shaderConfig = shaderConfig}

--- a/luaui/Shaders/DrawPrimitiveAtUnitNoGS.frag.glsl
+++ b/luaui/Shaders/DrawPrimitiveAtUnitNoGS.frag.glsl
@@ -1,0 +1,39 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Beherith (mysterme@gmail.com)
+// This shader is part of the Beyond All Reason repository.
+//
+// Fragment stage for the geometry-shader-free DrawPrimitiveAtUnit variant,
+// an alternative shader path for backends without a geometry-shader stage.
+// Identical shading to the GS variant; only the interface block it reads
+// from changed (now fed by the VS directly instead of a geometry shader).
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+#line 30000
+uniform float addRadius = 0.0;
+uniform float iconDistance = 20000.0;
+in PrimData {
+	vec4 g_color;
+	vec4 g_uv;
+};
+
+uniform sampler2D DrawPrimitiveAtUnitTexture;
+out vec4 fragColor;
+
+void main(void)
+{
+	vec4 texcolor = vec4(1.0);
+	#if (USETEXTURE == 1)
+		texcolor = texture(DrawPrimitiveAtUnitTexture, g_uv.xy);
+	#endif
+	fragColor.rgba = vec4(g_color.rgb * texcolor.rgb + addRadius, texcolor.a * TRANSPARENCY + addRadius);
+	POST_SHADING
+	#if (DISCARD == 1)
+		if (fragColor.a < 0.01) discard;
+	#endif
+}

--- a/luaui/Shaders/DrawPrimitiveAtUnitNoGS.vert.glsl
+++ b/luaui/Shaders/DrawPrimitiveAtUnitNoGS.vert.glsl
@@ -1,0 +1,266 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Beherith (mysterme@gmail.com)
+// This shader is part of the Beyond All Reason repository.
+//
+// Alternative shader path for DrawPrimitiveAtUnit that does not use a
+// geometry-shader stage, for backends without a GS stage. The per-unit data
+// is bound as an INSTANCE buffer (divisor 1) and this VS expands each
+// instance into the same primitive the GS would have, using gl_VertexID.
+// The instance is drawn as a fixed triangle LIST of (MAXVERTICES-2)*3
+// vertices via glDrawArraysInstanced(GL_TRIANGLES, 0, (MAXVERTICES-2)*3, N).
+//
+// The GS variant emits triangle_strips of a variable count K (triangle=3,
+// quad=4, cornerrect=8, circle=numvertices). We reproduce that strip as a
+// triangle list: for triangle t, strip indices are (t,t+1,t+2) with the
+// first two swapped on odd t to keep winding. getStripVertex() returns the
+// i-th strip vertex for the active primitive (selected at compile time by
+// the USE_* defines and at runtime by numvertices); it returns false past
+// the primitive's own vertex count, and we emit a degenerate (off-screen)
+// vertex for those (and for culled instances).
+
+#line 5000
+
+// Per-instance attributes (divisor 1; attached via VAO:AttachInstanceBuffer).
+layout (location = 0) in vec4 lengthwidthcornerheight;
+layout (location = 1) in uint teamID;
+layout (location = 2) in uint numvertices;
+layout (location = 3) in vec4 parameters; // lifestart, ismine
+layout (location = 4) in vec4 uvoffsets;  // optional atlas slice
+layout (location = 5) in uvec4 instData;
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+struct SUniformsBuffer {
+    uint composite; //     u8 drawFlag; u8 unused1; u16 id;
+    uint unused2;
+    uint unused3;
+    uint unused4;
+    float maxHealth;
+    float health;
+    float unused5;
+    float unused6;
+    vec4 drawPos;
+    vec4 speed;
+    vec4[4] userDefined;
+};
+
+layout(std140, binding=1) readonly buffer UniformsBuffer {
+    SUniformsBuffer uni[];
+};
+
+#define UNITID (uni[instData.y].composite >> 16)
+
+#line 10000
+
+uniform float addRadius = 0.0;
+uniform float iconDistance = 20000.0;
+
+out PrimData {
+	vec4 g_color;
+	vec4 g_uv;
+};
+
+#if USEQUATERNIONS == 0
+	layout(std140, binding=0) readonly buffer MatrixBuffer {
+		mat4 UnitPieces[];
+	};
+#else
+	//__QUATERNIONDEFS__
+#endif
+
+bool vertexClipped(vec4 clipspace, float tolerance) {
+  return any(lessThan(clipspace.xyz, -clipspace.www * tolerance)) ||
+         any(greaterThan(clipspace.xyz, clipspace.www * tolerance));
+}
+
+// Atlas UV remap, identical to the GS transformUV().
+vec2 transformUV(vec4 uvoff, float u, float v){
+	float a = uvoff.t - uvoff.s;
+	float b = uvoff.q - uvoff.p;
+	return vec2(uvoff.s + a * u, uvoff.p + b * v);
+}
+
+// Returns the si-th triangle-strip vertex (position offset, UV, radius
+// correction) for the primitive selected by nverts. Returns false when si is
+// past this primitive's strip length. Mirrors DrawPrimitiveAtUnit.geom.glsl.
+bool getStripVertex(int si, uint nverts, float w, float l, float cs,
+                    out vec3 off, out vec2 uv, out float corr) {
+	off = vec3(0.0); uv = vec2(0.0); corr = 1.0;
+
+#ifdef USE_TRIANGLES
+	if (nverts == 3u) {
+		corr = 2.0;
+		if (si == 0) { off = vec3(0.0, 0.0, l);            uv = vec2(0.5, 1.0); return true; }
+		if (si == 1) { off = vec3(-0.866 * w, 0.0, -0.5 * l); uv = vec2(0.0, 0.0); return true; }
+		if (si == 2) { off = vec3( 0.866 * w, 0.0, -0.5 * l); uv = vec2(1.0, 0.0); return true; }
+		return false;
+	}
+#endif
+#ifdef USE_QUADS
+	if (nverts == 4u) {
+		corr = 1.414;
+		if (si == 0) { off = vec3( w * 0.5, 0.0,  l * 0.5); uv = vec2(0.0, 1.0); return true; }
+		if (si == 1) { off = vec3( w * 0.5, 0.0, -l * 0.5); uv = vec2(0.0, 0.0); return true; }
+		if (si == 2) { off = vec3(-w * 0.5, 0.0,  l * 0.5); uv = vec2(1.0, 1.0); return true; }
+		if (si == 3) { off = vec3(-w * 0.5, 0.0, -l * 0.5); uv = vec2(1.0, 0.0); return true; }
+		return false;
+	}
+#endif
+#ifdef USE_CORNERRECT
+	if (nverts == 2u) {
+		float csuv = (cs / (l + w)) * 2.0;
+		corr = 1.1;
+		if (si == 0) { off = vec3(-w * 0.5,      0.0, -l * 0.5 + cs); uv = vec2(0.0, csuv);       return true; }
+		if (si == 1) { off = vec3(-w * 0.5,      0.0,  l * 0.5 - cs); uv = vec2(0.0, 1.0 - csuv); return true; }
+		if (si == 2) { off = vec3(-w * 0.5 + cs, 0.0, -l * 0.5);      uv = vec2(csuv, 0.0);       return true; }
+		if (si == 3) { off = vec3(-w * 0.5 + cs, 0.0,  l * 0.5);      uv = vec2(csuv, 1.0);       return true; }
+		if (si == 4) { off = vec3( w * 0.5 - cs, 0.0, -l * 0.5);      uv = vec2(1.0 - csuv, 0.0); return true; }
+		if (si == 5) { off = vec3( w * 0.5 - cs, 0.0,  l * 0.5);      uv = vec2(1.0 - csuv, 1.0); return true; }
+		if (si == 6) { off = vec3( w * 0.5,      0.0, -l * 0.5 + cs); uv = vec2(1.0, csuv);       return true; }
+		if (si == 7) { off = vec3( w * 0.5,      0.0,  l * 0.5 - cs); uv = vec2(1.0 - csuv, 1.0); return true; }
+		return false;
+	}
+#endif
+#ifdef USE_CIRCLES
+	if (nverts > 5u) {
+		uint nv = min(nverts, 64u);
+		int numSides = int(nv) / 2;
+		float internalAngle = float(nv - 2u) * radians(180.0) / float(nv);
+		corr = 1.0 / sin(internalAngle / 2.0);
+		if (si == 0)            { off = vec3(-w * 0.5, 0.0, 0.0); uv = vec2(0.0, 0.5); return true; }
+		if (si == int(nv) - 1)  { off = vec3( w * 0.5, 0.0, 0.0); uv = vec2(1.0, 0.5); return true; }
+		if (si >= 1 && si <= 2 * (numSides - 1)) {
+			int i = (si + 1) / 2;            // pair index 1..numSides-1
+			bool first = ((si & 1) == 1);    // odd si: first of pair (+cos)
+			float phi = ((float(i) * 3.141592) / float(numSides)) - 1.5707963;
+			float sinphi = sin(phi);
+			float cosphi = cos(phi);
+			if (first) { off = vec3(w * 0.5 * sinphi, 0.0,  l * 0.5 * cosphi); uv = vec2(sinphi * 0.5 + 0.5, cosphi * 0.5 + 0.5); }
+			else       { off = vec3(w * 0.5 * sinphi, 0.0, -l * 0.5 * cosphi); uv = vec2(sinphi * 0.5 + 0.5, cosphi * (-0.5) + 0.5); }
+			return true;
+		}
+		return false;
+	}
+#endif
+	return false;
+}
+
+void main()
+{
+	// ---- per-unit setup (mirrors DrawPrimitiveAtUnit.vert.glsl). The GS
+	// variant's VS->GS varyings are kept as locals (v_color, v_rotationY, ...)
+	// so that widget-injected GLSL (POST_ANIM/POST_VERTEX/PRE_OFFSET/
+	// POST_GEOMETRY), which references those names, compiles here unchanged.
+	// ----
+	//
+	// SEMANTIC CHANGE vs the VS+GS pipeline: in the GS pipeline these
+	// injection points ran ONCE per instance (in the VS) and the result was
+	// passed to the GS via VS->GS varyings. Here they run ONCE per OUTPUT VERTEX
+	// (up to (MAXVERTICES-2)*3 times per instance), because the expansion is
+	// inside this VS. All current injection bodies in BAR are idempotent pure
+	// writes (e.g. `v_lengthwidthcornerheight.xy *= scale`, `v_parameters.w = x`)
+	// so the per-vertex re-evaluation is harmless. DO NOT add an injection that
+	// has side effects (counter increment, RNG advance, accumulator) without
+	// either making it idempotent or hoisting it out of main(); it will run N
+	// times per instance and produce wrong results.
+	uint baseIndex = instData.x;
+	#if USEQUATERNIONS == 0
+		mat4 modelMatrix = UnitPieces[baseIndex];
+	#else
+		Transform modelWorldTX = GetModelWorldTransform(instData.x);
+		mat4 modelMatrix = TransformToMatrix(modelWorldTX);
+	#endif
+
+	float v_rotationY = atan(modelMatrix[0][2], modelMatrix[0][0]);
+	vec4  v_uvoffsets = uvoffsets;
+	vec4  v_parameters = parameters;
+	vec4  v_color = teamColor[teamID];
+	vec4  v_centerpos = vec4(modelMatrix[3].xyz, 1.0);
+	vec4  v_lengthwidthcornerheight = lengthwidthcornerheight;
+	#if (ANIMATION == 1)
+		float animation = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, INITIALSIZE, 1.0) + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE;
+		v_lengthwidthcornerheight.xy *= animation;
+	#endif
+	POST_ANIM
+
+	uint v_numvertices = numvertices;
+	vec4 centerClip = cameraViewProj * vec4(v_centerpos.xyz, 1.0);
+	if (vertexClipped(centerClip, CLIPTOLERANCE)) v_numvertices = 0u;
+
+	float cameraDistance = length((cameraViewInv[3]).xyz - v_centerpos.xyz);
+	if (cameraDistance > iconDistance) v_numvertices = 0u;
+
+	if (dot(v_centerpos.xyz, v_centerpos.xyz) < 1.0) v_numvertices = 0u;
+
+	v_centerpos.y += HEIGHTOFFSET;
+	v_centerpos.y += lengthwidthcornerheight.w;
+
+	#if (FULL_ROTATION == 1)
+		mat3 v_fullrotation = mat3(modelMatrix);
+	#endif
+
+	if ((uni[instData.y].composite & 0x00000003u) < 1u) v_numvertices = 0u;
+	POST_VERTEX
+
+	// ---- orientation (mirrors the GS) ----
+	mat3 rotY;
+	#if (BILLBOARD == 1)
+		rotY = mat3(cameraViewInv[0].xyz, cameraViewInv[2].xyz, cameraViewInv[1].xyz);
+	#else
+		#if (FULL_ROTATION == 1)
+			rotY = v_fullrotation;
+		#else
+			#if (ROTATE_CIRCLES == 1)
+				rotY = rotation3dY(-1.0 * v_rotationY);
+			#else
+				if (v_numvertices > 5u) rotY = mat3(1.0);
+				else rotY = rotation3dY(-1.0 * v_rotationY);
+			#endif
+		#endif
+	#endif
+
+	// ---- strip(K) -> triangle-list expansion via gl_VertexID ----
+	int v = gl_VertexID;
+	int t = v / 3;       // triangle index within the instance
+	int k = v % 3;       // corner within the triangle
+	int si;              // strip-vertex index
+	if ((t & 1) == 0) {
+		si = t + k;
+	} else {
+		si = (k == 0) ? (t + 1) : ((k == 1) ? (t + 0) : (t + 2));
+	}
+
+	float w  = v_lengthwidthcornerheight.x;
+	float l  = v_lengthwidthcornerheight.y;
+	float cs = v_lengthwidthcornerheight.z;
+
+	vec3 primitiveCoords;
+	vec2 uv;
+	float addRadiusCorr;
+	bool ok = (v_numvertices >= 2u) && getStripVertex(si, v_numvertices, w, l, cs, primitiveCoords, uv, addRadiusCorr);
+
+	if (!ok) {
+		// culled, past this primitive's strip, or unsupported count: degenerate.
+		gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+		g_color = vec4(0.0);
+		g_uv = vec4(0.0);
+		return;
+	}
+
+	// ---- per-vertex body (mirrors the GS offsetVertex4()) ----
+	g_color = v_color;
+	g_uv.xy = transformUV(v_uvoffsets, uv.x, uv.y);
+	vec3 vecnorm = normalize(primitiveCoords);
+	PRE_OFFSET
+	gl_Position = cameraViewProj * vec4(v_centerpos.xyz + rotY * (addRadius * addRadiusCorr * vecnorm + primitiveCoords), 1.0);
+	#ifdef ZPULL
+		gl_Position.z = gl_Position.z - ZPULL / gl_Position.w;
+	#endif
+	g_uv.zw = v_parameters.zw;
+	POST_GEOMETRY
+}

--- a/luaui/Shaders/HealthbarsGL4NoGS.vert.glsl
+++ b/luaui/Shaders/HealthbarsGL4NoGS.vert.glsl
@@ -1,0 +1,383 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Beherith (mysterme@gmail.com)
+// This shader is part of the Beyond All Reason repository.
+//
+// Geometry-shader-free Healthbars GL4 vertex shader. For backends without a
+// GS stage, this VS folds HealthbarsGL4.geom.glsl's point->bars expansion
+// into the vertex shader. The per-unit data is bound as an INSTANCE buffer
+// (divisor 1) and each instance is drawn as a fixed triangle LIST of
+// VERTSPERINSTANCE verts via gl_VertexID:
+//   VAO:DrawArrays(GL.TRIANGLES, 90, 0, usedElements)
+//
+// Vertex budget per instance (must match the widget's draw count):
+//   3 octagons (background, colored background, foreground bar)
+//     = 3 * (8-vertex triangle_strip -> 6 triangles) = 3 * 18 = 54 verts
+//   6 glyph slots (icon, stockpile lsb/msb, percent-or-time sign/lsb/msb)
+//     = 6 * (4-vertex quad strip -> 2 triangles)      = 6 *  6 = 36 verts
+//   total = 90 verts. Inactive sub-primitives emit degenerate (off-screen)
+//   vertices, exactly mirroring the GS's conditional EmitVertex/return paths.
+
+#line 5000
+
+layout (location = 0) in vec4 height_timers;
+layout (location = 1) in uvec4 bartype_index_ssboloc;
+layout (location = 2) in vec4 mincolor;
+layout (location = 3) in vec4 maxcolor;
+layout (location = 4) in uvec4 instData;
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+struct SUniformsBuffer {
+    uint composite; //     u8 drawFlag; u8 unused1; u16 id;
+    uint unused2;
+    uint unused3;
+    uint unused4;
+    float maxHealth;
+    float health;
+    float unused5;
+    float unused6;
+    vec4 drawPos;
+    vec4 speed;
+    vec4[4] userDefined;
+};
+
+layout(std140, binding=1) readonly buffer UniformsBuffer {
+    SUniformsBuffer uni[];
+};
+
+#line 10000
+
+uniform float iconDistance;
+uniform float cameraDistanceMult;
+uniform float cameraDistanceMultGlyph;
+uniform float skipGlyphsNumbers; // <0.5 all, <1.5 numbers only, >1.5 just bars
+
+out DataGS {
+	vec4 g_color;
+	vec4 g_uv;
+};
+
+bool vertexClipped(vec4 clipspace, float tolerance) {
+  return any(lessThan(clipspace.xyz, -clipspace.www * tolerance)) ||
+         any(greaterThan(clipspace.xyz, clipspace.www * tolerance));
+}
+
+#define UNITUNIFORMS uni[instData.y]
+
+#define BITUSEOVERLAY 1u
+#define BITSHOWGLYPH 2u
+#define BITPERCENTAGE 4u
+#define BITTIMELEFT 8u
+#define BITINTEGERNUMBER 16u
+#define BITGETPROGRESS 32u
+#define BITFLASHBAR 64u
+#define BITCOLORCORRECT 128u
+
+#define HALFPIXEL 0.0019765625
+
+// Layout (must match the DrawArrays count in the widget).
+const int OCT_TRIS    = 6;   // 8-vertex strip -> 6 triangles
+const int OCT_VERTS   = 18;  // OCT_TRIS * 3
+const int NUM_OCT     = 3;
+const int GLYPH_VERTS = 6;   // 4-vertex strip -> 2 triangles
+const int NUM_GLYPHS  = 6;
+const int OCT_TOTAL   = NUM_OCT * OCT_VERTS; // 54
+
+// strip(8) -> triangle-list strip index for octagons.
+int octStripIndex(int local) {
+	int to = local / 3;
+	int k  = local % 3;
+	if ((to & 1) == 0) return to + k;
+	return (k == 0) ? (to + 1) : ((k == 1) ? to : (to + 2));
+}
+
+// strip(4) -> triangle-list strip index for quad glyphs.
+int quadStripIndex(int local) {
+	int qt = local / 3; // 0 or 1
+	int k  = local % 3;
+	if (qt == 0) return k;                                // (0,1,2)
+	return (k == 0) ? 2 : ((k == 1) ? 1 : 3);             // (2,1,3)
+}
+
+void degenerate() {
+	gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+	g_color = vec4(0.0);
+	g_uv = vec4(0.0);
+}
+
+void main()
+{
+	// =========================================================================
+	// Per-unit setup (mirrors HealthbarsGL4.vert.glsl). Recomputed per output
+	// vertex; cheap relative to the GS interface it replaces.
+	// =========================================================================
+	vec4 drawPos = vec4(UNITUNIFORMS.drawPos.xyz, 1.0);
+	vec4 centerpos = drawPos;
+
+	uint v_numvertices = 4u;
+	if (vertexClipped(cameraViewProj * drawPos, CLIPTOLERANCE)) v_numvertices = 0u;
+
+	float cameraDistance = length((cameraViewInv[3]).xyz - centerpos.xyz);
+
+	float BARALPHA = (clamp(cameraDistance * cameraDistanceMult, BARFADESTART, BARFADEEND) - BARFADESTART) / (BARFADEEND - BARFADESTART);
+	BARALPHA = 1.0 - clamp(BARALPHA, 0.0, 1.0);
+
+	float GLYPHALPHA = (clamp(cameraDistance * cameraDistanceMult * cameraDistanceMultGlyph, BARFADESTART, BARFADEEND) - BARFADESTART) / (BARFADEEND - BARFADESTART);
+	GLYPHALPHA = 1.0 - clamp(GLYPHALPHA, 0.0, 1.0);
+
+	#ifdef DEBUGSHOW
+		BARALPHA = 1.0;
+		GLYPHALPHA = 1.0;
+	#endif
+
+	float UVOFFSET = height_timers.w;
+	float sizemultiplier = height_timers.y;
+
+	if (dot(centerpos.xyz, centerpos.xyz) < 1.0) v_numvertices = 0u;
+
+	centerpos.y += HEIGHTOFFSET;
+	centerpos.y += height_timers.x;
+
+	uint BARTYPE   = bartype_index_ssboloc.x;
+	uint UNIFORMLOC = bartype_index_ssboloc.z;
+
+	float relativehealth = UNITUNIFORMS.health / UNITUNIFORMS.maxHealth;
+	float health = relativehealth;
+	if (UNIFORMLOC < 20u) {
+		health = UNITUNIFORMS.userDefined[0].y;
+	} else {
+		float buildprogress = UNITUNIFORMS.userDefined[0].x;
+		#ifndef DEBUGSHOW
+			if (abs(buildprogress - relativehealth) < 0.03) v_numvertices = 0u;
+		#endif
+	}
+	if (UNIFORMLOC < 4u) health = UNITUNIFORMS.userDefined[0][UNIFORMLOC];
+	if (UNIFORMLOC == 1u) health = UNITUNIFORMS.userDefined[0].y;
+	if (UNIFORMLOC == 2u) health = UNITUNIFORMS.userDefined[0].z;
+	if (UNIFORMLOC == 4u) health = UNITUNIFORMS.userDefined[1].x;
+	if (UNIFORMLOC == 5u) health = UNITUNIFORMS.userDefined[1].y;
+
+	if ((BARTYPE & BITGETPROGRESS) > 0u) {
+		health =
+			((timeInfo.x + timeInfo.w) - UNITUNIFORMS.userDefined[0].z) /
+			(UNITUNIFORMS.userDefined[0].w - UNITUNIFORMS.userDefined[0].z);
+		health = clamp(health, 0.0, 1.0);
+	}
+
+	vec4 v_mincolor = mincolor;
+	vec4 v_maxcolor = maxcolor;
+
+	// =========================================================================
+	// GS main() scope: billboard, bail conditions, stockpile decode.
+	// =========================================================================
+	float zoffset = 1.15 * BARHEIGHT * float(bartype_index_ssboloc.y);
+	mat3 rotY = mat3(cameraViewInv[0].xyz, cameraViewInv[2].xyz, cameraViewInv[1].xyz); // billboard (xz swizzle)
+
+	bool mainBail = (v_numvertices == 0u);
+	if (BARALPHA < MINALPHA) mainBail = true;
+	#ifndef DEBUGSHOW
+		if (health < 0.00001) mainBail = true;
+		if ((BARTYPE & BITPERCENTAGE) > 0u) {
+			if (health > 0.999) mainBail = true;
+		} else {
+			if ((BARTYPE & BITGETPROGRESS) > 0u) {
+				if (health > 0.999) mainBail = true;
+			}
+		}
+	#endif
+
+	// STOCKPILE decode (mutates health for INTEGERNUMBER bars, like the GS).
+	uint numStockpiled = 0u;
+	if ((BARTYPE & BITINTEGERNUMBER) > 0u) {
+		float oldhealth = health;
+		health = fract(oldhealth);
+		oldhealth = floor(oldhealth);
+		numStockpiled = uint(floor(mod(oldhealth, 128.0)));
+	}
+
+	int gid = gl_VertexID;
+
+	// =========================================================================
+	// OCTAGONS (gid 0..53): background, colored background, foreground bar.
+	// =========================================================================
+	if (gid < OCT_TOTAL) {
+		if (mainBail) { degenerate(); return; }
+
+		int oct   = gid / OCT_VERTS;       // 0,1,2
+		int local = gid - oct * OCT_VERTS; // 0..17
+		int si    = octStripIndex(local);  // 0..7
+
+		bool odd = (si & 1) == 1;
+
+		vec2 pos;
+		vec4 color;
+		float bartextureoffset = 0.0;
+		float depthbuffermod = 0.0;
+		int uvmode = 0; // 0 = BG (flat color), 1 = bar (atlas uv)
+
+		if (oct == 0) {
+			// ---- background octagon (emitVertexBG) ----
+			depthbuffermod = 0.001;
+			uvmode = 0;
+			if      (si == 0) pos = vec2(-BARWIDTH,             BARCORNER);
+			else if (si == 1) pos = vec2(-BARWIDTH,             BARHEIGHT - BARCORNER);
+			else if (si == 2) pos = vec2(-BARWIDTH + BARCORNER, 0.0);
+			else if (si == 3) pos = vec2(-BARWIDTH + BARCORNER, BARHEIGHT);
+			else if (si == 4) pos = vec2( BARWIDTH - BARCORNER, 0.0);
+			else if (si == 5) pos = vec2( BARWIDTH - BARCORNER, BARHEIGHT);
+			else if (si == 6) pos = vec2( BARWIDTH,             BARCORNER);
+			else              pos = vec2( BARWIDTH,             BARHEIGHT - BARCORNER);
+
+			float extracolor = (((BARTYPE & BITFLASHBAR) > 0u) && (mod(timeInfo.x, 10.0) > 4.0)) ? 0.5 : 0.0;
+			color = mix(BGBOTTOMCOLOR + extracolor, BGTOPCOLOR + extracolor, pos.y);
+		} else {
+			// shared colour for the two bar octagons
+			vec4 truecolor = mix(v_mincolor, v_maxcolor, health);
+			truecolor.a = 0.2;
+			uvmode = 1;
+
+			if (oct == 1) {
+				// ---- colored background octagon (truecolor/topcolor) ----
+				depthbuffermod = 0.0;
+				vec4 topcolor = truecolor;
+				topcolor.rgb *= BOTTOMDARKENFACTOR;
+				color = odd ? topcolor : truecolor;
+
+				if      (si == 0) pos = vec2(-BARWIDTH + BARCORNER,                 SMALLERCORNER + BARCORNER);
+				else if (si == 1) pos = vec2(-BARWIDTH + BARCORNER,                 BARHEIGHT - SMALLERCORNER - BARCORNER);
+				else if (si == 2) pos = vec2(-BARWIDTH + SMALLERCORNER + BARCORNER, BARCORNER);
+				else if (si == 3) pos = vec2(-BARWIDTH + SMALLERCORNER + BARCORNER, BARHEIGHT - BARCORNER);
+				else if (si == 4) pos = vec2( BARWIDTH - SMALLERCORNER - BARCORNER, BARCORNER);
+				else if (si == 5) pos = vec2( BARWIDTH - SMALLERCORNER - BARCORNER, BARHEIGHT - BARCORNER);
+				else if (si == 6) pos = vec2( BARWIDTH - BARCORNER,                 SMALLERCORNER + BARCORNER);
+				else              pos = vec2( BARWIDTH - BARCORNER,                 BARHEIGHT - SMALLERCORNER - BARCORNER);
+			} else {
+				// ---- foreground bar octagon (botcolor/truecolor, health-scaled) ----
+				depthbuffermod = -0.001;
+				float healthbasedpos = (2.0 * (BARWIDTH - BARCORNER) - 2.0 * SMALLERCORNER) * health;
+				if ((BARTYPE & BITTIMELEFT) > 0u) healthbasedpos = (2.0 * (BARWIDTH - BARCORNER) - 2.0 * SMALLERCORNER);
+				if ((BARTYPE & BITCOLORCORRECT) > 0u) truecolor.rgb = truecolor.rgb / max(truecolor.r, truecolor.g);
+				truecolor.a = 1.0;
+				vec4 botcolor = truecolor;
+				botcolor.rgb *= BOTTOMDARKENFACTOR;
+				color = odd ? truecolor : botcolor;
+				if ((BARTYPE & BITUSEOVERLAY) > 0u) bartextureoffset = UVOFFSET;
+
+				if      (si == 0) pos = vec2(-BARWIDTH + BARCORNER,                                    SMALLERCORNER + BARCORNER);
+				else if (si == 1) pos = vec2(-BARWIDTH + BARCORNER,                                    BARHEIGHT - BARCORNER - SMALLERCORNER);
+				else if (si == 2) pos = vec2(-BARWIDTH + BARCORNER + SMALLERCORNER,                    BARCORNER);
+				else if (si == 3) pos = vec2(-BARWIDTH + BARCORNER + SMALLERCORNER,                    BARHEIGHT - BARCORNER);
+				else if (si == 4) pos = vec2(-BARWIDTH + BARCORNER + SMALLERCORNER + healthbasedpos,   BARCORNER);
+				else if (si == 5) pos = vec2(-BARWIDTH + BARCORNER + SMALLERCORNER + healthbasedpos,   BARHEIGHT - BARCORNER);
+				else if (si == 6) pos = vec2(-BARWIDTH + BARCORNER + 2.0 * SMALLERCORNER + healthbasedpos, BARCORNER + SMALLERCORNER);
+				else              pos = vec2(-BARWIDTH + BARCORNER + 2.0 * SMALLERCORNER + healthbasedpos, BARHEIGHT - BARCORNER - SMALLERCORNER);
+			}
+		}
+
+		// ---- shading (emitVertexBG / emitVertexBarBG) ----
+		if (uvmode == 0) {
+			g_uv = vec4(0.0);
+		} else {
+			float ux = pos.x * (1.0 / (2.0 * (BARWIDTH - BARCORNER))) + 0.5;
+			float uy = (pos.y - BARCORNER) / (BARHEIGHT - 2.0 * BARCORNER);
+			vec2 uvxy = vec2(ux, uy) * vec2(ATLASSTEP * 9.0, ATLASSTEP) + vec2(3.0 * ATLASSTEP, bartextureoffset);
+			uvxy.y = -uvxy.y;
+			g_uv = vec4(uvxy, clamp(10000.0 * bartextureoffset, 0.0, 1.0), 0.0);
+		}
+		color.a *= BARALPHA;
+		g_color = color;
+
+		vec3 primitiveCoords = vec3(pos.x, 0.0, pos.y - zoffset) * BARSCALE * sizemultiplier;
+		gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * primitiveCoords, 1.0);
+		gl_Position.z += depthbuffermod;
+		return;
+	}
+
+	// =========================================================================
+	// GLYPHS (gid 54..89): 6 fixed slots. Mirrors the GS glyph emit order.
+	//   slot 0 icon, 1 stockpile-lsb, 2 stockpile-msb,
+	//   3 percent/time sign, 4 percent/time lsb, 5 percent/time msb.
+	// =========================================================================
+	int glocal = gid - OCT_TOTAL;
+	int slot   = glocal / GLYPH_VERTS;     // 0..5
+	int gsi    = quadStripIndex(glocal % GLYPH_VERTS); // 0..3
+
+	// glyph-wide bail conditions (mirror the GS returns before the glyph block)
+	if (mainBail || (GLYPHALPHA < MINALPHA) || (skipGlyphsNumbers > 1.5)) { degenerate(); return; }
+
+	float currentglyphpos = (skipGlyphsNumbers < 0.5) ? 1.0 : 0.0;
+
+	bool glyphActive = false; // note: 'active' is a reserved word in GLSL
+	vec2 bottomleft = vec2(0.0);
+	vec2 uvbl = vec2(0.0);
+	vec2 uvsizes = vec2(ATLASSTEP, ATLASSTEP);
+
+	if (slot == 0) {
+		// icon
+		glyphActive = (skipGlyphsNumbers < 0.5) && ((BARTYPE & BITSHOWGLYPH) > 0u);
+		bottomleft = vec2(-BARWIDTH - currentglyphpos * BARHEIGHT, 0.0);
+		uvbl = vec2(ATLASSTEP, UVOFFSET);
+	} else if (slot == 1 || slot == 2) {
+		// stockpile xx
+		vec4 numbers = vec4(numStockpiled) * vec4(1.0, 0.1, 1.0, 0.1);
+		numbers = floor(mod(numbers, 10.0)) * ATLASSTEP;
+		if (slot == 1) {
+			glyphActive = ((BARTYPE & BITINTEGERNUMBER) > 0u);
+			bottomleft = vec2(-BARWIDTH - (currentglyphpos + 1.0) * BARHEIGHT, 0.0);
+			uvbl = vec2(0.0, numbers.x);
+		} else {
+			glyphActive = ((BARTYPE & BITINTEGERNUMBER) > 0u) && (numbers.y > 0.0);
+			bottomleft = vec2(-BARWIDTH - (currentglyphpos + 2.0) * BARHEIGHT + BARHEIGHT * 0.4, 0.0);
+			uvbl = vec2(0.0, numbers.y);
+		}
+	} else {
+		// percent / time-left digits
+		bool wantNumber = ((BARTYPE & (BITTIMELEFT | BITPERCENTAGE)) > 0u);
+		float lsb, msb, glyphpctsecatlas;
+		if ((BARTYPE & BITTIMELEFT) > 0u) {
+			float h = (health - 1.0) / (1.0 / 40.0);
+			lsb = abs(floor(mod(h, 10.0)));
+			msb = abs(floor(mod(h * 0.1, 10.0)));
+			glyphpctsecatlas = 14.0;
+		} else {
+			lsb = floor(mod(health * 100.0, 10.0));
+			msb = floor(mod(health * 10.0, 10.0));
+			glyphpctsecatlas = 11.0;
+		}
+		if (slot == 3) {
+			glyphActive = wantNumber;
+			bottomleft = vec2(-BARWIDTH - (currentglyphpos + 1.0) * BARHEIGHT, 0.0);
+			uvbl = vec2(0.0, glyphpctsecatlas * ATLASSTEP);
+		} else if (slot == 4) {
+			glyphActive = wantNumber;
+			bottomleft = vec2(-BARWIDTH - (currentglyphpos + 2.0) * BARHEIGHT + BARHEIGHT * 0.2, 0.0);
+			uvbl = vec2(0.0, lsb * ATLASSTEP);
+		} else {
+			glyphActive = wantNumber && (msb > 0.0);
+			bottomleft = vec2(-BARWIDTH - (currentglyphpos + 3.0) * BARHEIGHT + BARHEIGHT * 0.5, 0.0);
+			uvbl = vec2(0.0, msb * ATLASSTEP);
+		}
+	}
+
+	if (!glyphActive) { degenerate(); return; }
+
+	// emitGlyph strip vertex -> (pos, uv)
+	vec2 pos;
+	vec2 uv;
+	if      (gsi == 0) { pos = vec2(bottomleft.x,             bottomleft.y);             uv = vec2(uvbl.x + HALFPIXEL,             uvbl.y + HALFPIXEL); }
+	else if (gsi == 1) { pos = vec2(bottomleft.x,             bottomleft.y + BARHEIGHT); uv = vec2(uvbl.x + HALFPIXEL,             uvbl.y + uvsizes.y - HALFPIXEL); }
+	else if (gsi == 2) { pos = vec2(bottomleft.x + BARHEIGHT, bottomleft.y);             uv = vec2(uvbl.x + uvsizes.x - HALFPIXEL, uvbl.y + HALFPIXEL); }
+	else               { pos = vec2(bottomleft.x + BARHEIGHT, bottomleft.y + BARHEIGHT); uv = vec2(uvbl.x + uvsizes.x - HALFPIXEL, uvbl.y + uvsizes.y - HALFPIXEL); }
+
+	g_uv = vec4(uv.x, 1.0 - uv.y, 1.0, 0.0); // z=1 -> sample texture
+	g_color = vec4(1.0);
+	g_color.a *= GLYPHALPHA;
+
+	vec3 primitiveCoords = vec3(pos.x, 0.0, pos.y - zoffset) * BARSCALE * sizemultiplier;
+	gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * primitiveCoords, 1.0);
+}

--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -95,9 +95,19 @@ local unitTrackerVBO = nil
 local unitTrackerShader = nil
 local luaShaderDir = "LuaUI/Include/"
 local texture = "luaui/images/solid.png"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. Other platforms continue to use
+-- the original geometry-shader path unchanged. Only the internal shader path
+-- is affected; the widget's WG['unittrackerapi'] surface (visibleUnits,
+-- visibleUnitsTeam, alliedUnits, alliedUnitsTeam, and the Script.LuaUI
+-- VisibleUnit* / AlliedUnit* hooks) is unchanged.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local function initGL4()
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.TRANSPARENCY = 0.5
@@ -554,7 +564,11 @@ function widget:DrawWorldPreUnit()
 			unitTrackerShader:SetUniform("addRadius", 0)
 			gl.DepthTest(true)
 			gl.DepthMask(false)
-			unitTrackerVBO.VAO:DrawArrays(GL.POINTS, unitTrackerVBO.usedElements)
+			if UseNoGS then
+				unitTrackerVBO.VAO:DrawArrays(GL.TRIANGLES, unitTrackerVBO.numVerts, 0, unitTrackerVBO.usedElements)
+			else
+				unitTrackerVBO.VAO:DrawArrays(GL.POINTS, unitTrackerVBO.usedElements)
+			end
 			unitTrackerShader:Deactivate()
 			gl.Texture(0, false)
 		end

--- a/luaui/Widgets/flowui_gl4.lua
+++ b/luaui/Widgets/flowui_gl4.lua
@@ -1263,6 +1263,11 @@ local atlasID = nil
 local atlassedImages = {}
 --local rectRoundVBO = nil
 
+-- Select GS-based or GS-free pipeline. On backends without a geometry-shader
+-- stage (e.g. Metal via Zink) the NoGS path folds the GS body into the VS and
+-- per-rect attribs become INSTANCE-rate (divisor 1) instead of vertex-rate.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
+
 local vsSrc = [[
 #version 420
 #line 5000
@@ -1540,6 +1545,232 @@ void main() {
 
 ]]
 
+-- NoGS variant of the VS: the GS body (slot decoding + corner-size gating +
+-- progress mask + addvertexflowui packing) is folded into the VS and per-rect
+-- attribs become INSTANCE-rate. Each instance is drawn as a 27-vertex triangle
+-- list (9 slots × 3 verts); inactive slots emit a degenerate (off-screen)
+-- vertex. Used when no geometry-shader stage is available.
+local vsSrcNoGS = [[
+#version 420
+#line 5000
+
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+//__ENGINEUNIFORMBUFFERDEFS__
+
+layout (location = 0) in vec4 screenpos; // left, bottom, right, top, in pixels
+layout (location = 1) in vec4 cornersizes; // tl, tr, br, bl
+layout (location = 2) in vec4 color1; // rgba
+layout (location = 3) in vec4 color2; // rgba
+layout (location = 4) in vec4 uvoffsets; // uvrect, bottom left, top right
+layout (location = 5) in vec4 fronttexture_edge_z_progress; //  textured, edgewidth, z,progress
+layout (location = 6) in vec4 hide_blendmode_globalbackground;
+
+uniform vec4 scrollScale = vec4(0,0,1,1);
+
+out DataGS {
+	vec4 g_screenpos;
+	vec4 g_uv;
+	vec4 g_color;
+	vec4 g_color2;
+	vec4 g_fronttex_edge_backtex_hide;
+};
+
+#define HALFPI 1.570796326794896
+#define PI 3.1415926535897932384626433832795
+#define TWOPI 6.283185307179586476925286766559
+
+// Folded copy of the old GS's addvertexflowui(). Reads per-instance locals
+// computed at the top of main() (v_screenpos etc.), produces per-vertex
+// outputs g_screenpos / g_uv / g_color / g_color2 / g_fronttex_edge_backtex_hide
+// + gl_Position.
+void emitVertexFlowUI(float spx, float spy, float distfromside,
+                      vec4 v_screenpos, vec4 v_color1, vec4 v_color2,
+                      vec4 v_uvoffsets, vec4 v_fronttexture_edge_z_progress,
+                      vec4 v_hide_blendmode_globalbackground) {
+	#define LEFT_   v_screenpos.x
+	#define BOTTOM_ v_screenpos.y
+	#define RIGHT_  v_screenpos.z
+	#define TOP_    v_screenpos.w
+	#define UV_     v_uvoffsets
+	#define DEPTH_  v_fronttexture_edge_z_progress.z
+	#define EDGE_   v_fronttexture_edge_z_progress.y
+	#define HIDE_   v_hide_blendmode_globalbackground.x
+	#define BLENDMODE_  v_hide_blendmode_globalbackground.y
+
+	g_screenpos = vec4(spx, spy, DEPTH_, 1.0);
+	g_uv.x = UV_.x + (UV_.z - UV_.x) * ((spx - LEFT_) / (RIGHT_ - LEFT_));
+	g_uv.y = UV_.y + (UV_.w - UV_.y) * ((spy - BOTTOM_) / (TOP_ - BOTTOM_));
+	g_screenpos.xy = (g_screenpos.xy / viewGeometry.xy) * 2.0 - 1.0;
+	g_uv.z = spx;
+	g_uv.w = spy;
+
+	float topness = (spy - BOTTOM_) / (TOP_ - BOTTOM_);
+	g_color = mix(v_color1, v_color2, topness);
+	g_fronttex_edge_backtex_hide = v_fronttexture_edge_z_progress;
+
+	float future_feather = 200.0;
+	if (EDGE_ > 0.5) {
+		float borderwidth1_0 = distfromside - EDGE_;
+		future_feather = distfromside / borderwidth1_0;
+		if (distfromside > 1.0) {
+			future_feather = -1.0 * distfromside / EDGE_;
+		} else {
+			future_feather = 1.0;
+		}
+		g_color2 = mix(v_color1, v_color2, future_feather);
+	} else {
+		g_color2 = vec4(1.0, 0.0, 1.0, 1.0);
+	}
+	g_fronttex_edge_backtex_hide.y = future_feather;
+
+	// mouse-hover/click packing into z
+	g_fronttex_edge_backtex_hide.z = 0.0;
+	bvec2 righttopmouse   = lessThanEqual(mouseScreenPos.xy, vec2(RIGHT_, TOP_));
+	bvec2 leftbottommouse = greaterThanEqual(mouseScreenPos.xy, vec2(LEFT_, BOTTOM_));
+	if (all(bvec4(righttopmouse, leftbottommouse))) {
+		g_fronttex_edge_backtex_hide.z = BLENDMODE_ + 0.5;
+		if ((mouseStatus & 1u) > 0u) {
+			g_fronttex_edge_backtex_hide.z += BLENDMODE_ + 0.5;
+		}
+	}
+	g_fronttex_edge_backtex_hide.w = HIDE_;
+
+	gl_Position = vec4(g_screenpos.x, g_screenpos.y, DEPTH_, 1.0);
+	g_screenpos = vec4(spx, spy, DEPTH_, 1.0);
+}
+
+void degenerate() {
+	g_screenpos = vec4(0.0);
+	g_uv = vec4(0.0);
+	g_color = vec4(0.0);
+	g_color2 = vec4(0.0);
+	g_fronttex_edge_backtex_hide = vec4(0.0);
+	gl_Position = vec4(2.0, 2.0, 2.0, 1.0); // off-screen NDC
+}
+
+#line 5100
+void main() {
+	// per-instance setup (mirrors the old VS) ---------------------------------
+	vec4 v_screenpos = screenpos * scrollScale.zwzw + scrollScale.xyxy;
+	vec4 v_cornersizes = cornersizes * scrollScale.zwzw + scrollScale.xyxy;
+	v_cornersizes = min(v_cornersizes, vec4(v_screenpos.z - v_screenpos.x) * 0.5);
+	v_cornersizes = min(v_cornersizes, vec4(v_screenpos.w - v_screenpos.y) * 0.5);
+	vec4 v_color1 = color1;
+	vec4 v_color2 = color2;
+	vec4 v_uvoffsets = uvoffsets;
+	vec4 v_fronttexture_edge_z_progress = fronttexture_edge_z_progress;
+	vec4 v_hide_blendmode_globalbackground = hide_blendmode_globalbackground;
+
+	// hidden rects: every vertex degenerates ----------------------------------
+	if (v_hide_blendmode_globalbackground.x > 0.5) {
+		degenerate();
+		return;
+	}
+
+	#define TL_CORNERSIZE v_cornersizes.x
+	#define TR_CORNERSIZE v_cornersizes.y
+	#define BR_CORNERSIZE v_cornersizes.z
+	#define BL_CORNERSIZE v_cornersizes.w
+	#define LEFT   v_screenpos.x
+	#define BOTTOM v_screenpos.y
+	#define RIGHT  v_screenpos.z
+	#define TOP    v_screenpos.w
+	#define PROGRESS v_fronttexture_edge_z_progress.w
+
+	float invprogress = 1.0 - PROGRESS;
+	float centery = (TOP + BOTTOM) * 0.5;
+	float centerx = (LEFT + RIGHT) * 0.5;
+	float distfromsideCenter = (TOP - BOTTOM) * 0.5;
+
+	// slot decoding (gl_VertexID layout: 9 slots × 3 verts) -------------------
+	int vid = gl_VertexID;
+	int slot = vid / 3;
+	int slotVert = vid - slot * 3;
+
+	bool slotActive = false;
+	float spx = 0.0, spy = 0.0, distfromside = 0.0;
+
+	// slot 0: TOPRIGHT side  (invprogress < 0.125)
+	if (slot == 0) {
+		slotActive = invprogress < 0.125;
+		float progress_offset = (RIGHT - LEFT - TR_CORNERSIZE) * clamp((invprogress - 0.0) * 4.0, 0.0, 1.0);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = RIGHT - TR_CORNERSIZE; spy = TOP; }
+		else { spx = centerx + progress_offset; spy = TOP; }
+	}
+	// slot 1: TR corner  (invprogress < 0.125 AND TR_CORNERSIZE > 0.1)
+	else if (slot == 1) {
+		slotActive = (invprogress < 0.125) && (TR_CORNERSIZE > 0.1);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = RIGHT; spy = TOP - TR_CORNERSIZE; }
+		else { spx = RIGHT - TR_CORNERSIZE; spy = TOP; }
+	}
+	// slot 2: RIGHT side  (invprogress < 0.375)
+	else if (slot == 2) {
+		slotActive = invprogress < 0.375;
+		float progress_offset = (TOP - BOTTOM - TR_CORNERSIZE - BR_CORNERSIZE) * clamp((invprogress - 0.125) * 4.0, 0.0, 1.0);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = RIGHT; spy = BOTTOM + BR_CORNERSIZE; }
+		else { spx = RIGHT; spy = TOP - TR_CORNERSIZE - progress_offset; }
+	}
+	// slot 3: BR corner  (invprogress < 0.375 AND BR_CORNERSIZE > 0.1)
+	else if (slot == 3) {
+		slotActive = (invprogress < 0.375) && (BR_CORNERSIZE > 0.1);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = RIGHT - BR_CORNERSIZE; spy = BOTTOM; }
+		else { spx = RIGHT; spy = BOTTOM + BR_CORNERSIZE; }
+	}
+	// slot 4: BOTTOM side  (invprogress < 0.625)
+	else if (slot == 4) {
+		slotActive = invprogress < 0.625;
+		float progress_offset = (RIGHT - LEFT - BL_CORNERSIZE - BR_CORNERSIZE) * clamp((invprogress - 0.375) * 4.0, 0.0, 1.0);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = LEFT + BL_CORNERSIZE; spy = BOTTOM; }
+		else { spx = RIGHT - BR_CORNERSIZE - progress_offset; spy = BOTTOM; }
+	}
+	// slot 5: BL corner  (invprogress < 0.625 AND BL_CORNERSIZE > 0.01)
+	else if (slot == 5) {
+		slotActive = (invprogress < 0.625) && (BL_CORNERSIZE > 0.01);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = LEFT; spy = BOTTOM + BL_CORNERSIZE; }
+		else { spx = LEFT + BL_CORNERSIZE; spy = BOTTOM; }
+	}
+	// slot 6: LEFT side  (invprogress < 0.875)
+	else if (slot == 6) {
+		slotActive = invprogress < 0.875;
+		float progress_offset = (TOP - BOTTOM - BL_CORNERSIZE - TL_CORNERSIZE) * clamp((invprogress - 0.625) * 4.0, 0.0, 1.0);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = LEFT; spy = TOP - TL_CORNERSIZE; }
+		else { spx = LEFT; spy = BOTTOM + BL_CORNERSIZE + progress_offset; }
+	}
+	// slot 7: TL corner  (invprogress < 0.875 AND TL_CORNERSIZE > 0.01)
+	else if (slot == 7) {
+		slotActive = (invprogress < 0.875) && (TL_CORNERSIZE > 0.01);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = LEFT + TL_CORNERSIZE; spy = TOP; }
+		else { spx = LEFT; spy = TOP - TL_CORNERSIZE; }
+	}
+	// slot 8: TOPLEFT side  (always)
+	else {
+		slotActive = true;
+		float progress_offset = (RIGHT - LEFT - TL_CORNERSIZE) * clamp((invprogress - 0.875) * 4.0, 0.0, 1.0);
+		if (slotVert == 0) { spx = centerx; spy = centery; distfromside = distfromsideCenter; }
+		else if (slotVert == 1) { spx = centerx; spy = TOP; }
+		else { spx = LEFT + TL_CORNERSIZE + progress_offset; spy = TOP; }
+	}
+
+	if (!slotActive) {
+		degenerate();
+		return;
+	}
+
+	emitVertexFlowUI(spx, spy, distfromside,
+	                 v_screenpos, v_color1, v_color2, v_uvoffsets,
+	                 v_fronttexture_edge_z_progress, v_hide_blendmode_globalbackground);
+}
+]]
+
 local fsSrc = [[
 #version 330
 
@@ -1643,7 +1874,13 @@ local function makeRectRoundVBO(name)
 	end
 
 	rectRoundVAO = gl.GetVAO()
-	rectRoundVAO:AttachVertexBuffer(rectRoundVBO.instanceVBO)
+	if UseNoGS then
+		-- NoGS path: per-rect attribs run at instance rate (divisor 1) so the VS
+		-- can be invoked once per (instance × vertex-in-quad-fan) via gl_VertexID.
+		rectRoundVAO:AttachInstanceBuffer(rectRoundVBO.instanceVBO)
+	else
+		rectRoundVAO:AttachVertexBuffer(rectRoundVBO.instanceVBO)
+	end
 	rectRoundVBO.instanceVAO = rectRoundVAO
 	return rectRoundVBO
 end
@@ -1653,13 +1890,14 @@ GetNewVBO = makeRectRoundVBO
 local function makeShaders()
 	local engineUniformBufferDefs = LuaShader.GetEngineUniformBufferDefs()
 	vsSrc = vsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+	vsSrcNoGS = vsSrcNoGS:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 	gsSrc = gsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 	fsSrc = fsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 	rectRoundShader =  LuaShader(
 		{
-			vertex = vsSrc,
+			vertex = UseNoGS and vsSrcNoGS or vsSrc,
 			fragment = fsSrc,
-			geometry = gsSrc,
+			geometry = (not UseNoGS) and gsSrc or nil,
 
 			uniformInt = {
 				bgTex = 0,
@@ -2480,7 +2718,12 @@ local function DrawLayer(layername)
 	--spEcho(Layer.name, Layer.VBO.usedElements)
 	rectRoundShader:SetUniformFloat("scissorLayer", Layer.scissorLayer[1], Layer.scissorLayer[2], Layer.scissorLayer[3], Layer.scissorLayer[4])
 	rectRoundShader:SetUniformFloat("scrollScale", Layer.scrollScale[1], Layer.scrollScale[2], Layer.scrollScale[3], Layer.scrollScale[4])
-	Layer.VBO.instanceVAO:DrawArrays(GL.POINTS,Layer.VBO.usedElements, 0, nil, 0)
+	if UseNoGS then
+		-- NoGS path: each instance expands into 27 vertices (9 slots × 3 verts).
+		Layer.VBO.instanceVAO:DrawArrays(GL.TRIANGLES, 27, 0, Layer.VBO.usedElements)
+	else
+		Layer.VBO.instanceVAO:DrawArrays(GL.POINTS,Layer.VBO.usedElements, 0, nil, 0)
+	end
 end
 
 function widget:DrawScreen()

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -159,6 +159,15 @@ local popElementInstance  = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 local compactInstanceVBO  = InstanceVBOTable.compactInstanceVBO
 
+-- Backends without a geometry-shader stage (e.g. Metal via Zink) cannot link the
+-- small-decal pipeline that uses decals_gl4.geom.glsl. On those platforms we
+-- route the small-decal path through the existing decals_large_gl4.vert.glsl
+-- with a 4x4 pre-tessellated plane VBO; that is geometrically identical to the
+-- GS's 4x4 subdivision (vertex x-positions {1, 0.5, 0, -0.5, -1} at strip z-rows
+-- match makePlaneVBO(1, 1, 4, 4) exactly, and the large VS's per-vertex
+-- transform is line-by-line equivalent to the GS's offsetVertex4).
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
+
 local vsSrcPath = "LuaUI/Shaders/decals_gl4.vert.glsl"
 local fsSrcPath = "LuaUI/Shaders/decals_gl4.frag.glsl"
 local gsSrcPath = "LuaUI/Shaders/decals_gl4.geom.glsl"
@@ -210,27 +219,59 @@ end
 local function initGL4( DPATname)
 	hasBadCulling = ((Platform.gpuVendor == "AMD" and Platform.osFamily == "Linux") == true)
 	if hasBadCulling then spEcho("Decals GL4 detected AMD + Linux platform, attempting to fix culling") end
-	decalShader = LuaShader.CheckShaderUpdates(shaderSourceCache)
+	if not UseNoGS then
+		decalShader = LuaShader.CheckShaderUpdates(shaderSourceCache)
+	end
 	decalLargeShader = LuaShader.CheckShaderUpdates(shaderLargeSourceCache)
 
-	if (not decalShader) or (not decalLargeShader) then goodbye("Failed to compile ".. DPATname .." GL4 ") end
+	if (not UseNoGS and not decalShader) or (not decalLargeShader) then goodbye("Failed to compile ".. DPATname .." GL4 ") end
 
-	decalVBO = InstanceVBOTable.makeInstanceVBOTable(
-		{
+	-- On the GS path the small-decal VBO uses attribute IDs 0..4 (no per-vertex
+	-- attribute, since the GS expands a single point). On the NoGS path the
+	-- small-decal VBO is paired with a 4x4 pre-tessellated plane vertex VBO, so
+	-- per-vertex xyworld_xyfract must live at location 0 and per-instance attribs
+	-- shift to locations 1..5 (matching the large VBO layout).
+	local smallDecalAttrs
+	if UseNoGS then
+		smallDecalAttrs = {
+			{id = 1, name = 'lengthwidthrotation', size = 4},
+			{id = 2, name = 'uv_atlaspos', size = 4},
+			{id = 3, name = 'alphastart_alphadecay_heatstart_heatdecay', size = 4},
+			{id = 4, name = 'worldPos', size = 4},
+			{id = 5, name = 'parameters', size = 4},
+		}
+	else
+		smallDecalAttrs = {
 			{id = 0, name = 'lengthwidthrotation', size = 4},
 			{id = 1, name = 'uv_atlaspos', size = 4},
 			{id = 2, name = 'alphastart_alphadecay_heatstart_heatdecay', size = 4},
 			{id = 3, name = 'worldPos', size = 4},
 			{id = 4, name = 'parameters', size = 4},
-		},
+		}
+	end
+	decalVBO = InstanceVBOTable.makeInstanceVBOTable(
+		smallDecalAttrs,
 		64, -- maxelements
 		DPATname .. "VBO" -- name
 	)
 	if decalVBO == nil then goodbye("Failed to create decalVBO") end
 
-	local smallDecalVAO = gl.GetVAO()
-	smallDecalVAO:AttachVertexBuffer(decalVBO.instanceVBO)
-	decalVBO.VAO = smallDecalVAO
+	if UseNoGS then
+		-- Small decals: 4x4 pre-tessellated plane (matches the old GS's 4x4 subdivision).
+		local smallPlaneVBO, _ = InstanceVBOTable.makePlaneVBO(1, 1, 4, 4)
+		local smallPlaneIndexVBO, _ = InstanceVBOTable.makePlaneIndexVBO(4, 4)
+		decalVBO.vertexVBO = smallPlaneVBO
+		decalVBO.indexVBO = smallPlaneIndexVBO
+		decalVBO.VAO = InstanceVBOTable.makeVAOandAttach(
+			decalVBO.vertexVBO,
+			decalVBO.instanceVBO,
+			decalVBO.indexVBO
+		)
+	else
+		local smallDecalVAO = gl.GetVAO()
+		smallDecalVAO:AttachVertexBuffer(decalVBO.instanceVBO)
+		decalVBO.VAO = smallDecalVAO
+	end
 
 	local planeVBO, numVertices = InstanceVBOTable.makePlaneVBO(1,1,resolution,resolution)
 	local planeIndexVBO, numIndices =  InstanceVBOTable.makePlaneIndexVBO(resolution,resolution) --, true) -- add true to cull into a circle
@@ -388,7 +429,9 @@ local updatePositionX = 0
 local updatePositionZ = 0
 function widget:Update() -- this is pointlessly expensive!
 	if autoupdate then
-		decalShader = LuaShader.CheckShaderUpdates(shaderSourceCache) or decalShader
+		if not UseNoGS then
+			decalShader = LuaShader.CheckShaderUpdates(shaderSourceCache) or decalShader
+		end
 		decalLargeShader = LuaShader.CheckShaderUpdates(shaderLargeSourceCache) or		decalLargeShader
 	end
 
@@ -572,24 +615,41 @@ local function DrawDecals()
 		--glTexture(11, '$map_gbuffer_normtex')
 
 
-		if decalVBO.usedElements > 0  then
-			decalShader:Activate()
-			decalShader:SetUniform("fadeDistance",disticon * 1000)
-			decalVBO.VAO:DrawArrays(GL.POINTS, decalVBO.usedElements)
-			decalShader:Deactivate()
-		end
+		if UseNoGS then
+			-- NoGS path: small decals share the large shader + a 4x4 pre-tessellated plane.
+			if decalVBO.usedElements > 0 or decalLargeVBO.usedElements > 0 or decalExtraLargeVBO.usedElements > 0 then
+				decalLargeShader:Activate()
+				if decalVBO.usedElements > 0 then
+					decalVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalVBO.usedElements, 0)
+				end
+				if decalLargeVBO.usedElements > 0 then
+					decalLargeVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalLargeVBO.usedElements, 0)
+				end
+				if decalExtraLargeVBO.usedElements > 0 then
+					decalExtraLargeVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalExtraLargeVBO.usedElements, 0)
+				end
+				decalLargeShader:Deactivate()
+			end
+		else
+			if decalVBO.usedElements > 0  then
+				decalShader:Activate()
+				decalShader:SetUniform("fadeDistance",disticon * 1000)
+				decalVBO.VAO:DrawArrays(GL.POINTS, decalVBO.usedElements)
+				decalShader:Deactivate()
+			end
 
-		if decalLargeVBO.usedElements > 0 or decalExtraLargeVBO.usedElements > 0 then
-			--spEcho("large elements:", decalLargeVBO.usedElements)
-			decalLargeShader:Activate()
-			--decalLargeShader:SetUniform("fadeDistance",disticon * 1000)
-			if decalLargeVBO.usedElements > 0 then
-				decalLargeVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalLargeVBO.usedElements, 0)
+			if decalLargeVBO.usedElements > 0 or decalExtraLargeVBO.usedElements > 0 then
+				--spEcho("large elements:", decalLargeVBO.usedElements)
+				decalLargeShader:Activate()
+				--decalLargeShader:SetUniform("fadeDistance",disticon * 1000)
+				if decalLargeVBO.usedElements > 0 then
+					decalLargeVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalLargeVBO.usedElements, 0)
+				end
+				if decalExtraLargeVBO.usedElements > 0 then
+					decalExtraLargeVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalExtraLargeVBO.usedElements, 0)
+				end
+				decalLargeShader:Deactivate()
 			end
-			if decalExtraLargeVBO.usedElements > 0 then
-				decalExtraLargeVBO.VAO:DrawElements(GL.TRIANGLES, nil, 0, decalExtraLargeVBO.usedElements, 0)
-			end
-			decalLargeShader:Deactivate()
 		end
 
 		-- Restore the GL state

--- a/luaui/Widgets/gfx_limit_idle_fps.lua
+++ b/luaui/Widgets/gfx_limit_idle_fps.lua
@@ -61,6 +61,15 @@ end
 
 local sec = 0
 function widget:Update(dt)
+	-- TODO: SDL_WINDOWEVENT_LEAVE is not delivered reliably on the surfaceless
+	-- EGL + drawable-layer setup used by some GL backends, which causes this
+	-- widget to clamp the VSync interval to the idle divider (~15 fps) during
+	-- active play. Short-circuit Update() on those backends until the engine-
+	-- side SDL mouse-leave behavior is fixed. See <engine-issue-link>.
+	if Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX") then
+		return
+	end
+
 	sec = sec + dt
 	if sec > 2 then
 		sec = 0

--- a/luaui/Widgets/gfx_unit_stencil_gl4.lua
+++ b/luaui/Widgets/gfx_unit_stencil_gl4.lua
@@ -37,12 +37,25 @@ local addRadius = 10
 -----------------------------------------------------------------
 -- GL4 Backend Stuff
 
+-- Select the no-GS expansion path on platforms whose GL backend does not
+-- expose a geometry-shader stage (currently macOS/Metal). Other platforms
+-- continue to use the original GS pipeline unchanged. The no-GS path folds
+-- the 3-face box silhouette expansion into the vertex shader and draws each
+-- unit as a 18-vert GL.TRIANGLES instance using gl_VertexID.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
+
+-- Verts emitted per instance by the no-GS VS (3 quads * 6 list verts).
+local stencilVertsPerInstance = 18
+
 local LuaShader = gl.LuaShader
 local InstanceVBOTable = gl.InstanceVBOTable
 local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 
-local vsSrc =  [[
+-- Original geometry-shader-based vertex shader. Emits one point per instance
+-- with the per-unit min/max bounds and centerpos carried in DataVS; the
+-- geometry shader (gsSrc) expands that point into the silhouette quads.
+local vsSrcGS =  [[
 #version 420
 #extension GL_ARB_uniform_buffer_object : require
 #extension GL_ARB_shader_storage_buffer_object : require
@@ -108,7 +121,7 @@ void main()
 }
 ]]
 
-local gsSrc = [[
+local gsSrcGS = [[
 #version 330
 #extension GL_ARB_uniform_buffer_object : require
 #extension GL_ARB_shading_language_420pack: require
@@ -176,10 +189,123 @@ void main(){
         offsetVertex4( Maxs.x, Maxs.y,  frontback);
         offsetVertex4( Mins.x, Mins.y,  frontback);
         offsetVertex4( Maxs.x, Mins.y,  frontback);
-    
+
     EndPrimitive();
 }
 ]]
+
+-- Geometry-shader-free vertex shader. The original VS emitted one point per
+-- unit (carrying min/max/centerpos in DataVS) and the GS expanded that point
+-- into the 3-face silhouette. Here the per-unit data is bound as an INSTANCE
+-- buffer (divisor 1) and this VS emits the 3 quads as a triangle LIST of 18
+-- verts/instance via gl_VertexID. Used only when UseNoGS is true.
+local vsSrcNoGS = [[
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+
+#line 5000
+
+layout (location = 0) in vec4 unitModelMinXYZ;
+layout (location = 1) in vec4 unitModelMaxXYZ;
+layout (location = 2) in uvec4 instData;
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+struct SUniformsBuffer {
+    uint composite; //   u8 drawFlag; u8 unused1; u16 id;
+
+    uint unused2;
+    uint unused3;
+    uint unused4;
+
+    float maxHealth;
+    float health;
+    float unused5;
+    float unused6;
+
+    vec4 drawPos;
+    vec4 speed;
+    vec4[4] userDefined; //can't use float[16] because float in arrays occupies 4 * float space
+};
+
+layout(std140, binding=1) readonly buffer UniformsBuffer {
+    SUniformsBuffer uni[];
+};
+
+#line 10000
+
+uniform float addRadius = 10;
+
+// The original GS expanded each point into a 3-face box silhouette (top +
+// nearest side + nearest front/back), 3 quads = 12 strip verts. Here we
+// emit those 3 quads as a triangle LIST of 18 verts/instance via gl_VertexID:
+//   VAO:DrawArrays(GL.TRIANGLES, 18, 0, usedElements)
+
+void main()
+{
+    vec4 Mins = unitModelMinXYZ;
+    vec4 Maxs = unitModelMaxXYZ;
+    vec4 centerpos = uni[instData.y].drawPos;
+
+    // ---- per-unit cull (mirrors the old VS flag + GS bail on Maxs.w<0.5) ----
+    bool culled = false;
+    if (isSphereVisibleXY(vec4(centerpos.xyz, 1.0), addRadius + Maxs.x + Maxs.z)) culled = true;
+    if ((uni[instData.y].composite & 0x00000003u) < 1u) culled = true; // drawFlag
+    if (culled) {
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0); // degenerate / off-screen
+        return;
+    }
+
+    vec3 camPos = cameraViewInv[3].xyz;
+    vec3 camDir = normalize(camPos - centerpos.xyz);
+    float s = sin(centerpos.w);
+    float c = cos(centerpos.w);
+    mat3 rotY = mat3(c, 0.0, -s,  0.0, 1.0, 0.0,  s, 0.0, c);
+
+    float leftright = (dot(vec3(c, 0, -s), camDir) < 0.0) ? Mins.x : Maxs.x;
+    float frontback = (dot(vec3(s, 0,  c), camDir) > 0.0) ? Maxs.z : Mins.z;
+
+    // ---- pick face (0=top,1=side,2=front/back) and its strip vertex ----
+    int vid  = gl_VertexID;
+    int face = vid / 6;        // 3 faces, 6 list verts (2 tris) each
+    int fv   = vid % 6;
+    int ft   = fv / 3;         // triangle 0 or 1 within the face
+    int kk   = fv % 3;
+    int si;                    // 4-vert strip index 0..3
+    if (ft == 0) si = kk;                                  // (0,1,2)
+    else         si = (kk == 0) ? 2 : ((kk == 1) ? 1 : 3); // (2,1,3)
+
+    vec3 p;
+    if (face == 0) {            // top face
+        if      (si == 0) p = vec3(Mins.x, Maxs.y, Mins.z);
+        else if (si == 1) p = vec3(Maxs.x, Maxs.y, Mins.z);
+        else if (si == 2) p = vec3(Mins.x, Maxs.y, Maxs.z);
+        else              p = vec3(Maxs.x, Maxs.y, Maxs.z);
+    } else if (face == 1) {     // nearest left/right face
+        if      (si == 0) p = vec3(leftright, Maxs.y, Mins.z);
+        else if (si == 1) p = vec3(leftright, Maxs.y, Maxs.z);
+        else if (si == 2) p = vec3(leftright, Mins.y, Mins.z);
+        else              p = vec3(leftright, Mins.y, Maxs.z);
+    } else {                    // nearest front/back face
+        if      (si == 0) p = vec3(Mins.x, Maxs.y, frontback);
+        else if (si == 1) p = vec3(Maxs.x, Maxs.y, frontback);
+        else if (si == 2) p = vec3(Mins.x, Mins.y, frontback);
+        else              p = vec3(Maxs.x, Mins.y, frontback);
+    }
+
+    vec3 vecnorm = sign(p);
+    gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * (vec3(addRadius, 0, addRadius) * vecnorm + p), 1.0);
+}
+]]
+
+-- Pick the active VS source based on the backend's GS support. The GS
+-- variant (vsSrcGS + gsSrcGS) is used on all non-macOS platforms; the
+-- NoGS variant (vsSrcNoGS, no GS) is used on macOS/Metal.
+local vsSrc = UseNoGS and vsSrcNoGS or vsSrcGS
+local gsSrc = UseNoGS and nil       or gsSrcGS
 
 local fsSrc =
 [[
@@ -218,20 +344,24 @@ local function InitDrawPrimitiveAtUnit(modifiedShaderConf, DPATname)
 	local engineUniformBufferDefs = LuaShader.GetEngineUniformBufferDefs()
 	vsSrc = vsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 	fsSrc = fsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
-	gsSrc = gsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
-	local DrawPrimitiveAtUnitShader =  LuaShader(
-		{
-			vertex = vsSrc,
-			fragment = fsSrc,
-			geometry = gsSrc,
-			uniformInt = {
-				--DrawPrimitiveAtUnitTexture = 0;
-			},
-			uniformFloat = {
-				addRadius = 1,
-                stencilColor = 1,
-			},
+	local shaderStages = {
+		vertex = vsSrc,
+		fragment = fsSrc,
+		uniformInt = {
+			--DrawPrimitiveAtUnitTexture = 0;
 		},
+		uniformFloat = {
+			addRadius = 1,
+            stencilColor = 1,
+		},
+	}
+	if not UseNoGS then
+		-- GS path only: substitute defs and attach the geometry stage.
+		gsSrc = gsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+		shaderStages.geometry = gsSrc
+	end
+	local DrawPrimitiveAtUnitShader =  LuaShader(
+		shaderStages,
 		DPATname .. "Shader GL4"
 	  )
 	local shaderCompiled = DrawPrimitiveAtUnitShader:Initialize()
@@ -252,7 +382,13 @@ local function InitDrawPrimitiveAtUnit(modifiedShaderConf, DPATname)
 	)
 
 	unitStencilVBO.VAO  = gl.GetVAO()
-	unitStencilVBO.VAO:AttachVertexBuffer(unitStencilVBO.instanceVBO)
+	if UseNoGS then
+		-- NoGS: per-unit data advances per instance (divisor 1); the VS uses
+		-- gl_VertexID to fan out a 18-vert triangle list per instance.
+		unitStencilVBO.VAO:AttachInstanceBuffer(unitStencilVBO.instanceVBO)
+	else
+		unitStencilVBO.VAO:AttachVertexBuffer(unitStencilVBO.instanceVBO)
+	end
 
     featureStencilVBO = InstanceVBOTable.makeInstanceVBOTable(
 		{
@@ -264,9 +400,13 @@ local function InitDrawPrimitiveAtUnit(modifiedShaderConf, DPATname)
 		"featurestencil VBO", -- name
 		2  -- unitIDattribID (instData)
 	)
-    
+
 	featureStencilVBO.VAO  = gl.GetVAO()
-	featureStencilVBO.VAO:AttachVertexBuffer(featureStencilVBO.instanceVBO)
+	if UseNoGS then
+		featureStencilVBO.VAO:AttachInstanceBuffer(featureStencilVBO.instanceVBO)
+	else
+		featureStencilVBO.VAO:AttachVertexBuffer(featureStencilVBO.instanceVBO)
+	end
     featureStencilVBO.featureIDs = true
 
 	return DrawPrimitiveAtUnitShader
@@ -359,11 +499,19 @@ local function DrawMe() -- about 0.025 ms
 		unitStencilShader:SetUniform("addRadius", addRadius)
         if featureStencilVBO.usedElements > 0 then
             unitStencilShader:SetUniform("stencilColor", 0.5)
-            featureStencilVBO.VAO:DrawArrays(GL.POINTS, featureStencilVBO.usedElements)
+            if UseNoGS then
+                featureStencilVBO.VAO:DrawArrays(GL.TRIANGLES, stencilVertsPerInstance, 0, featureStencilVBO.usedElements)
+            else
+                featureStencilVBO.VAO:DrawArrays(GL.POINTS, featureStencilVBO.usedElements)
+            end
         end
-        if unitStencilVBO.usedElements > 0 then 
+        if unitStencilVBO.usedElements > 0 then
             unitStencilShader:SetUniform("stencilColor", 1.0)
-	    	unitStencilVBO.VAO:DrawArrays(GL.POINTS, unitStencilVBO.usedElements)
+            if UseNoGS then
+                unitStencilVBO.VAO:DrawArrays(GL.TRIANGLES, stencilVertsPerInstance, 0, unitStencilVBO.usedElements)
+            else
+                unitStencilVBO.VAO:DrawArrays(GL.POINTS, unitStencilVBO.usedElements)
+            end
         end
 		unitStencilShader:Deactivate()
 		gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)

--- a/luaui/Widgets/gui_allySelectedUnits.lua
+++ b/luaui/Widgets/gui_allySelectedUnits.lua
@@ -42,6 +42,12 @@ local popElementInstance  = InstanceVBOTable.popElementInstance
 local selectionVBO = nil
 local selectShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. Other platforms continue to use
+-- the original geometry-shader path unchanged. Only POST_SHADING (fragment
+-- shader injection) is customized here, which is identical between the two
+-- paths.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local glStencilFunc         = gl.StencilFunc
 local glStencilOp           = gl.StencilOp
@@ -324,7 +330,10 @@ function widget:Update(dt)
 end
 
 local function init()
-	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DPatUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
 	shaderConfig.BILLBOARD = 0
@@ -400,14 +409,22 @@ function widget:DrawWorldPreUnit()
 			glStencilMask(1)
 
 			selectShader:SetUniform("addRadius", 0)
-			selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+			if UseNoGS then
+				selectionVBO.VAO:DrawArrays(GL.TRIANGLES, selectionVBO.numVerts, 0, selectionVBO.usedElements)
+			else
+				selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+			end
 
 			glStencilFunc(GL_NOTEQUAL, 1, 1)
 			glStencilMask(0)
 			glDepthTest(true)
 
 			selectShader:SetUniform("addRadius", lineSize)
-			selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+			if UseNoGS then
+				selectionVBO.VAO:DrawArrays(GL.TRIANGLES, selectionVBO.numVerts, 0, selectionVBO.usedElements)
+			else
+				selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+			end
 
 			glStencilMask(1)
 			glStencilFunc(GL_ALWAYS, 1, 1)

--- a/luaui/Widgets/gui_enemy_spotter.lua
+++ b/luaui/Widgets/gui_enemy_spotter.lua
@@ -28,6 +28,10 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 local enemyspotterVBO = nil
 local enemyspotterShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. Other platforms continue to use
+-- the original geometry-shader path unchanged.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 -- Localize for speedups:
 local glDepthTest           = gl.DepthTest
@@ -100,7 +104,11 @@ function widget:DrawWorldPreUnit()
 		glDepthTest(true)
 
 		enemyspotterShader:SetUniform("addRadius", 0)
-		enemyspotterVBO.VAO:DrawArrays(GL_POINTS, enemyspotterVBO.usedElements)
+		if UseNoGS then
+			enemyspotterVBO.VAO:DrawArrays(GL.TRIANGLES, enemyspotterVBO.numVerts, 0, enemyspotterVBO.usedElements)
+		else
+			enemyspotterVBO.VAO:DrawArrays(GL_POINTS, enemyspotterVBO.usedElements)
+		end
 
 		enemyspotterShader:Deactivate()
 		glTexture(0, false)
@@ -140,7 +148,10 @@ function widget:CrashingAircraft(unitID, unitDefID, teamID)
 end
 
 local function init()
-	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DPatUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
 	shaderConfig.TRANSPARENCY = opacity

--- a/luaui/Widgets/gui_flanking_icons.lua
+++ b/luaui/Widgets/gui_flanking_icons.lua
@@ -30,6 +30,13 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 local flankingVBO = nil
 local flankingShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. Other platforms continue to use
+-- the original geometry-shader path unchanged. The widget's POST_ANIM
+-- snippet is a pure assignment to v_color / v_rotationY from constants and
+-- per-instance attribs; it has no accumulator or RNG state, so it is safe
+-- under the per-output-vertex execution model of the no-GS path.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local glTexture             = gl.Texture
 
 local udefHasFlankingIcon = {}
@@ -93,7 +100,11 @@ function widget:DrawWorldPreUnit()
 		flankingShader:Activate()
 		flankingShader:SetUniform("iconDistance",disticon)
 		flankingShader:SetUniform("addRadius",0)
-		flankingVBO.VAO:DrawArrays(GL.POINTS,flankingVBO.usedElements)
+		if UseNoGS then
+			flankingVBO.VAO:DrawArrays(GL.TRIANGLES, flankingVBO.numVerts, 0, flankingVBO.usedElements)
+		else
+			flankingVBO.VAO:DrawArrays(GL.POINTS,flankingVBO.usedElements)
+		end
 		flankingShader:Deactivate()
 		glTexture(0, false)
 	end
@@ -126,7 +137,10 @@ local function init()
 end
 
 function widget:Initialize()
-	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DPatUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 0

--- a/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
@@ -88,6 +88,9 @@ local groundPlateVBO = nil
 local groundPlateShader = nil
 
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local InstanceVBOTable = gl.InstanceVBOTable
 
 local pushElementInstance = InstanceVBOTable.pushElementInstance
@@ -155,7 +158,11 @@ function widget:DrawWorldPreUnit()
 		groundPlateShader:Activate()
 		groundPlateShader:SetUniform("iconDistance",disticon) 
 		groundPlateShader:SetUniform("addRadius",0) 
-		groundPlateVBO.VAO:DrawArrays(GL.POINTS,groundPlateVBO.usedElements)
+		if UseNoGS then
+			groundPlateVBO.VAO:DrawArrays(GL.TRIANGLES, groundPlateVBO.numVerts, 0, groundPlateVBO.usedElements)
+		else
+			groundPlateVBO.VAO:DrawArrays(GL.POINTS,groundPlateVBO.usedElements)
+		end
 		groundPlateShader:Deactivate()
 		glTexture(0, false)
 		glCulling(false)
@@ -233,7 +240,10 @@ function widget:Initialize()
 			end
 		end
 	end
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 0

--- a/luaui/Widgets/gui_ground_ao_plates_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_gl4.lua
@@ -29,6 +29,9 @@ local groundPlateVBO = nil
 local groundPlateShader = nil
 
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local InstanceVBOTable = gl.InstanceVBOTable
 
 local pushElementInstance = InstanceVBOTable.pushElementInstance
@@ -86,7 +89,11 @@ function widget:DrawWorldPreUnit()
 		glDepthMask(false) --"BK OpenGL state resets", default is already false, could remove
 		glTexture(0, atlas.atlasimage)
 		groundPlateShader:Activate()
-		groundPlateVBO.VAO:DrawArrays(GL_POINTS,groundPlateVBO.usedElements)
+		if UseNoGS then
+			groundPlateVBO.VAO:DrawArrays(GL.TRIANGLES, groundPlateVBO.numVerts, 0, groundPlateVBO.usedElements)
+		else
+			groundPlateVBO.VAO:DrawArrays(GL_POINTS,groundPlateVBO.usedElements)
+		end
 		groundPlateShader:Deactivate()
 		glTexture(0, false)
 		glCulling(false)
@@ -119,7 +126,10 @@ function widget:Initialize()
 	end
 
 	-- Init GL4 things
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 0
@@ -129,7 +139,17 @@ function widget:Initialize()
 	-- MATCH CUS position as seed to sin, then pass it through geoshader into fragshader
 	shaderConfig.POST_VERTEX = "v_parameters.w = max(-0.2, sin((timeInfo.x + timeInfo.w) * 2.0/30.0 + float(UNITID) * 0.1)) + 0.2; // match CUS glow rate"
 	shaderConfig.ZPULL = 512.0 -- send 16 elmos forward in depth buffer"
-	shaderConfig.POST_GEOMETRY = "g_uv.w = dataIn[0].v_parameters.w;" -- pass the glow rate to the frag shader
+	-- pass the glow rate to the frag shader. In the GS backend this snippet runs
+	-- inside the geometry shader where the VS outputs are visible as
+	-- dataIn[VERTEX]. In the no-GS backend the same injection runs per output
+	-- vertex inside the VS itself, where v_parameters is a VS-local that has
+	-- already been populated by the POST_VERTEX snippet above; both forms are
+	-- pure per-vertex writes of the same value.
+	if UseNoGS then
+		shaderConfig.POST_GEOMETRY = "g_uv.w = v_parameters.w;"
+	else
+		shaderConfig.POST_GEOMETRY = "g_uv.w = dataIn[0].v_parameters.w;"
+	end
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(texcolor.rgb* (1.0 + g_uv.w), texcolor.a * g_uv.z);"
 	shaderConfig.MAXVERTICES = 4
 	shaderConfig.USE_CIRCLES = nil

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -407,6 +407,18 @@ local variableBarSizes = true -- Option 'healthbarsvariable'
 local healthBarVBO = nil
 local healthBarShader = nil
 
+-- Select the no-GS expansion path on platforms whose GL backend does not
+-- expose a geometry-shader stage (currently macOS/Metal). Other platforms
+-- continue to use the original GS pipeline (HealthbarsGL4.geom.glsl)
+-- unchanged. The no-GS path folds the GS bar/glyph expansion into a fixed
+-- 90-verts-per-instance VS (HealthbarsGL4NoGS.vert.glsl) drawn via
+-- gl_VertexID as a GL.TRIANGLES list.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
+
+-- Fixed verts/instance emitted by HealthbarsGL4NoGS.vert.glsl
+-- (3 octagons * 18 + 6 glyph slots * 6 = 90). Must match the shader layout.
+local healthbarVertsPerInstance = 90
+
 local LuaShader = gl.LuaShader
 local InstanceVBOTable = gl.InstanceVBOTable
 
@@ -455,14 +467,18 @@ if debugmode then
 	shaderConfig.DEBUGSHOW = 1 -- comment this to always show all bars
 end
 
-local vsSrcPath = "LuaUI/Shaders/HealthbarsGL4.vert.glsl"
-local gsSrcPath = "LuaUI/Shaders/HealthbarsGL4.geom.glsl"
+-- The no-GS path uses a combined instanced VS (HealthbarsGL4NoGS.vert.glsl)
+-- and omits the geometry stage. The GS path uses the original VS + GS pair.
+local vsSrcPath = UseNoGS
+	and "LuaUI/Shaders/HealthbarsGL4NoGS.vert.glsl"
+	or  "LuaUI/Shaders/HealthbarsGL4.vert.glsl"
+local gsSrcPath = (not UseNoGS) and "LuaUI/Shaders/HealthbarsGL4.geom.glsl" or nil
 local fsSrcPath = "LuaUI/Shaders/HealthbarsGL4.frag.glsl"
 
 local shaderSourceCache = {
 		vssrcpath = vsSrcPath,
 		fssrcpath = fsSrcPath,
-		gssrcpath = gsSrcPath,
+		gssrcpath = gsSrcPath, -- nil on macOS/Metal: no geometry-shader stage
 		shaderName = "Health Bars Shader GL4",
 		uniformInt = {
 			healthbartexture = 0;
@@ -549,7 +565,13 @@ local function initializeInstanceVBOTable(myName, usesFeatures)
 	if newVBOTable == nil then goodbye("Failed to create " .. myName) end
 
 	local newVAO = gl.GetVAO()
-	newVAO:AttachVertexBuffer(newVBOTable.instanceVBO)
+	if UseNoGS then
+		-- NoGS: per-unit data advances per instance (divisor 1); the VS uses
+		-- gl_VertexID to fan out a 90-vert triangle list per instance.
+		newVAO:AttachInstanceBuffer(newVBOTable.instanceVBO)
+	else
+		newVAO:AttachVertexBuffer(newVBOTable.instanceVBO)
+	end
 	newVBOTable.VAO = newVAO
 	if usesFeatures then newVBOTable.featureIDs = true end
 	return newVBOTable
@@ -1269,21 +1291,37 @@ function widget:DrawScreenEffects()
 		healthBarShader:SetUniform("cameraDistanceMultGlyph", glphydistmult)
 		healthBarShader:SetUniform("skipGlyphsNumbers",skipGlyphsNumbers)  --0.0 is everything,  1.0 means only numbers, 2.0 means only bars,
 		if healthBarVBO.usedElements > 0 then
-			healthBarVBO.VAO:DrawArrays(GL.POINTS,healthBarVBO.usedElements)
+			if UseNoGS then
+				healthBarVBO.VAO:DrawArrays(GL.TRIANGLES, healthbarVertsPerInstance, 0, healthBarVBO.usedElements)
+			else
+				healthBarVBO.VAO:DrawArrays(GL.POINTS,healthBarVBO.usedElements)
+			end
 		end
 		-- below its the feature bars being drawn:
 			healthBarShader:SetUniform("cameraDistanceMultGlyph", glyphdistmultfeatures)
 			if featureHealthVBO.usedElements > 0 then
 				if not debugmode then healthBarShader:SetUniform("cameraDistanceMult",featureHealthDistMult)  end
-				featureHealthVBO.VAO:DrawArrays(GL.POINTS,featureHealthVBO.usedElements)
+				if UseNoGS then
+					featureHealthVBO.VAO:DrawArrays(GL.TRIANGLES, healthbarVertsPerInstance, 0, featureHealthVBO.usedElements)
+				else
+					featureHealthVBO.VAO:DrawArrays(GL.POINTS,featureHealthVBO.usedElements)
+				end
 			end
 			if featureResurrectVBO.usedElements > 0 then
 				if not debugmode then healthBarShader:SetUniform("cameraDistanceMult",featureResurrectDistMult)  end
-				featureResurrectVBO.VAO:DrawArrays(GL.POINTS,featureResurrectVBO.usedElements)
+				if UseNoGS then
+					featureResurrectVBO.VAO:DrawArrays(GL.TRIANGLES, healthbarVertsPerInstance, 0, featureResurrectVBO.usedElements)
+				else
+					featureResurrectVBO.VAO:DrawArrays(GL.POINTS,featureResurrectVBO.usedElements)
+				end
 			end
 			if featureReclaimVBO.usedElements > 0 then
 				if not debugmode then healthBarShader:SetUniform("cameraDistanceMult",featureReclaimDistMult)  end
-				featureReclaimVBO.VAO:DrawArrays(GL.POINTS,featureReclaimVBO.usedElements)
+				if UseNoGS then
+					featureReclaimVBO.VAO:DrawArrays(GL.TRIANGLES, healthbarVertsPerInstance, 0, featureReclaimVBO.usedElements)
+				else
+					featureReclaimVBO.VAO:DrawArrays(GL.POINTS,featureReclaimVBO.usedElements)
+				end
 			end
 
 		healthBarShader:Deactivate()

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -1427,6 +1427,14 @@ local CMD_MAX_CHAIN_UNITS = 6
 -- GPU-driven icon rendering: replaces the CPU-heavy DrawUnit+DrawIcons pipeline with a single
 -- instanced draw call via a texture atlas + VBO + geometry shader.
 -- Benefits: eliminates per-icon texture switches, per-icon draw calls, and most per-unit API calls.
+
+-- Select the GS-based or GS-free pipeline. On backends without a geometry-
+-- shader stage (e.g. Metal via Zink) the 4 inline GS programs in this widget
+-- (decal, icon, circle, quad) cannot link; the NoGS shader variants fold each
+-- GS body into its VS via gl_VertexID -> [0,1,2,2,1,3] strip-to-list decoding,
+-- per-rect attribs become instance-rate (divisor 1), and the 5 affected VAOs
+-- switch to AttachInstanceBuffer + 6-vert-per-instance triangle draws.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local gl4Icons = {
 	INSTANCE_STEP = 12,       -- floats per icon instance (3 x vec4)
 	MAX_INSTANCES = 16384,    -- pre-allocated capacity (covers 16k units without resize)
@@ -2525,6 +2533,87 @@ void main() {
 			atlasTex = 0,
 		},
 	},
+	-- NoGS variant of decalCode: per-instance attribs at divisor 1; each instance
+	-- draws as a 6-vertex triangle list (1 quad = 2 tris). gl_VertexID 0..5 decodes
+	-- via the strip-to-list map [0,1,2,2,1,3] into the original GS strip vertices
+	-- (BL, BR, TL, TR). The rotation-then-NDC-conversion math is folded into the VS.
+	decalCodeNoGS = {
+		vertex = [[
+#version 330
+// Per-instance decal data (one INSTANCE = one decal, divisor 1)
+layout(location = 0) in vec4 posRot;        // worldX, worldZ, rotation (rad), maxalpha
+layout(location = 1) in vec4 sizeAlpha;     // halfLengthX, halfWidthZ, alphastart, alphadecay
+layout(location = 2) in vec4 uvCoords;      // p, q, s, t (atlas UV rect)
+layout(location = 3) in vec4 spawnParams;   // spawnframe, 0, 0, 0
+
+uniform float gameFrame;
+uniform vec2 invMapSize;  // 2/mapSizeX, 2/mapSizeZ (factor of 2 because NDC spans -1..1)
+
+out vec2 f_texCoord;
+out float f_alpha;
+
+void main() {
+	float lifetonow = gameFrame - spawnParams.x;
+	float currentAlpha = sizeAlpha.z - lifetonow * sizeAlpha.w;
+	currentAlpha = clamp(currentAlpha, 0.0, posRot.w);
+
+	if (currentAlpha < 0.01) {
+		f_alpha = 0.0;
+		f_texCoord = vec2(0.0);
+		gl_Position = vec4(2.0, 2.0, 0.0, 1.0);  // off-screen degenerate
+		return;
+	}
+
+	f_alpha = currentAlpha;
+	vec2 ndc = posRot.xy * invMapSize - 1.0;
+
+	float ca = cos(posRot.z);
+	float sa = sin(posRot.z);
+	vec2 hs = sizeAlpha.xy;
+	vec2 dx = vec2(ca,  sa) * hs.x * invMapSize;
+	vec2 dy = vec2(-sa, ca) * hs.y * invMapSize;
+
+	// Strip ABCD = BL,BR,TL,TR  ->  triangle list [0,1,2,2,1,3].
+	int sIdx;
+	int vid = gl_VertexID;
+	if      (vid == 0) sIdx = 0;
+	else if (vid == 1) sIdx = 1;
+	else if (vid == 2) sIdx = 2;
+	else if (vid == 3) sIdx = 2;
+	else if (vid == 4) sIdx = 1;
+	else               sIdx = 3;
+
+	vec2 offset;
+	if      (sIdx == 0) { offset = -dx - dy; f_texCoord = vec2(uvCoords.x, uvCoords.z); } // BL
+	else if (sIdx == 1) { offset =  dx - dy; f_texCoord = vec2(uvCoords.y, uvCoords.z); } // BR
+	else if (sIdx == 2) { offset = -dx + dy; f_texCoord = vec2(uvCoords.x, uvCoords.w); } // TL
+	else                { offset =  dx + dy; f_texCoord = vec2(uvCoords.y, uvCoords.w); } // TR
+
+	gl_Position = vec4(ndc + offset, 0.0, 1.0);
+}
+		]],
+		fragment = [[
+#version 330
+uniform sampler2D atlasTex;
+in vec2 f_texCoord;
+in float f_alpha;
+out vec4 fragColor;
+
+void main() {
+	vec4 tex = texture(atlasTex, f_texCoord);
+	// Square alpha to match world decal shader (soft edge falloff)
+	float a = tex.a * tex.a * 0.999 * f_alpha;
+	// Brighten scar color toward mid-gray (world does tex * minimap * 2 + lighting)
+	vec3 scarColor = mix(tex.rgb, vec3(0.5), 0.35);
+	// Lerp from white toward scar color
+	vec3 result = mix(vec3(1.0), scarColor, a);
+	fragColor = vec4(result, 1.0);
+}
+		]],
+		uniformInt = {
+			atlasTex = 0,
+		},
+	},
 	-- Water overlay: renders water/lava tinting based on heightmap
 	water = nil,
 	waterCode = {
@@ -2998,6 +3087,139 @@ v_halfSizeNDC = vec2(iconBaseSize * worldPos_size.z * sizeExpand) * ndcScale;
 	},
 }
 
+-- NoGS variant of icon shaderCode: per-instance attribs at divisor 1; each
+-- instance draws as a 6-vertex triangle list via gl_VertexID -> [0,1,2,2,1,3]
+-- strip-to-list mapping. The quad expansion (BL,BR,TL,TR) that the GS did is
+-- folded into the VS using the pre-computed iconBaseSize * worldPos_size.z *
+-- sizeExpand half-size in NDC. The `flat` qualifier on f_flash is preserved.
+gl4Icons.shaderCodeNoGS = {
+	vertex = [[
+#version 330
+layout(location = 0) in vec4 worldPos_size;  // worldX, worldZ, iconSizeScale, flags (bitfield)
+layout(location = 1) in vec4 atlasUV;         // u0, v0, u1, v1
+layout(location = 2) in vec4 colorFlags;      // r, g, b, wobblePhase + flashFactor*100*7
+
+uniform vec2 wtp_scale;
+uniform vec2 wtp_offset;
+uniform vec2 ndcScale;
+uniform vec2 rotSC;
+uniform vec2 rotCenter;
+uniform float iconBaseSize;
+uniform float gameTime;
+uniform float wallClockTime;
+uniform float outlinePass;
+uniform float healthDarkenMax;
+
+out vec2 f_texCoord;
+out vec4 f_color;
+flat out float f_flash;
+
+void main() {
+float flags = worldPos_size.w;
+float bitFlags = mod(flags, 32.0);
+float healthPct = floor(flags / 32.0);
+float healthFrac = clamp(healthPct / 100.0, 0.0, 1.0);
+float isRadar    = mod(floor(bitFlags      ), 2.0);
+float isTakeable = mod(floor(bitFlags / 2.0 ), 2.0);
+float isStunned  = mod(floor(bitFlags / 4.0 ), 2.0);
+float isTracked  = mod(floor(bitFlags / 8.0 ), 2.0);
+float isSelfD    = mod(floor(bitFlags / 16.0), 2.0);
+
+float packedW = colorFlags.w;
+float flashFactor = floor(packedW / 7.0) / 100.0;
+float phase = mod(packedW, 7.0);
+
+vec2 pipPos;
+pipPos.x = wtp_offset.x + worldPos_size.x * wtp_scale.x;
+pipPos.y = wtp_offset.y + worldPos_size.y * wtp_scale.y;
+
+float wobbleAmp = iconBaseSize * sqrt(abs(wtp_scale.x)) * 0.03 * isRadar;
+pipPos.x += sin(gameTime * 3.0 + phase) * wobbleAmp;
+pipPos.y += cos(gameTime * 2.7 + phase * 1.3) * wobbleAmp;
+
+vec2 d = pipPos - rotCenter;
+pipPos = rotCenter + vec2(
+d.x * rotSC.y - d.y * rotSC.x,
+d.x * rotSC.x + d.y * rotSC.y
+);
+
+gl_Position = vec4(pipPos * ndcScale - 1.0, 0.0, 1.0);
+
+vec3 col = colorFlags.rgb;
+float alpha = 1.0 - 0.25 * isRadar;
+
+float takeableBlink = step(0.0, sin(wallClockTime * 9.42));
+alpha *= mix(1.0, mix(0.3, 1.0, takeableBlink), isTakeable);
+
+float damage = 1.0 - healthFrac;
+col = max(col - vec3(damage * healthDarkenMax), vec3(0.0));
+
+float stunnedPulse = 0.5 + 0.5 * sin(wallClockTime * 12.57);
+col = mix(col, vec3(0.82, 0.85, 1.0), 0.45 * stunnedPulse * isStunned);
+
+float selfDPulse = 0.55 + 0.45 * sin(wallClockTime * 18.85);
+col = mix(col, vec3(1.0, 0.25, 0.0), 0.7 * selfDPulse * isSelfD);
+
+if (outlinePass > 0.5) {
+  float hasOutline = max(isTracked, isSelfD);
+  if (hasOutline < 0.5) {
+    alpha = 0.0;
+  } else if (isSelfD > 0.5) {
+    float selfDOutlinePulse = 0.5 + 0.5 * sin(wallClockTime * 18.85);
+    col = vec3(1.0, 0.3, 0.0);
+    alpha = 0.4 + 0.4 * selfDOutlinePulse;
+  } else {
+    col = vec3(1.0, 1.0, 1.0);
+    alpha = 0.5;
+  }
+}
+
+f_color = vec4(col, alpha);
+f_flash = flashFactor;
+float hasOutline = max(isTracked, isSelfD);
+float sizeExpand = 1.0 + 0.12 * outlinePass * hasOutline;
+vec2 hs = vec2(iconBaseSize * worldPos_size.z * sizeExpand) * ndcScale;
+
+// Strip ABCD = BL,BR,TL,TR -> triangle list [0,1,2,2,1,3].
+int vid = gl_VertexID;
+int sIdx;
+if      (vid == 0) sIdx = 0;
+else if (vid == 1) sIdx = 1;
+else if (vid == 2) sIdx = 2;
+else if (vid == 3) sIdx = 2;
+else if (vid == 4) sIdx = 1;
+else               sIdx = 3;
+
+vec2 off;
+if      (sIdx == 0) { off = vec2(-hs.x, -hs.y); f_texCoord = vec2(atlasUV.x, atlasUV.y); }
+else if (sIdx == 1) { off = vec2( hs.x, -hs.y); f_texCoord = vec2(atlasUV.z, atlasUV.y); }
+else if (sIdx == 2) { off = vec2(-hs.x,  hs.y); f_texCoord = vec2(atlasUV.x, atlasUV.w); }
+else                { off = vec2( hs.x,  hs.y); f_texCoord = vec2(atlasUV.z, atlasUV.w); }
+
+gl_Position = vec4(gl_Position.xy + off, gl_Position.z, 1.0);
+}
+	]],
+	fragment = [[
+		#version 330
+		uniform sampler2D iconAtlas;
+		in vec2 f_texCoord;
+		in vec4 f_color;
+		flat in float f_flash;
+		out vec4 fragColor;
+
+		void main() {
+			vec4 texColor = texture(iconAtlas, f_texCoord);
+			vec4 result = texColor * f_color;
+			result.rgb += f_color.rgb * f_flash * (1.0 - texColor.rgb);
+			if (result.a < 0.01) discard;
+			fragColor = result;
+		}
+	]],
+	uniformInt = {
+		iconAtlas = 0,
+	},
+}
+
 ----------------------------------------------------------------------------------------------------
 -- GL4 Primitive Shaders (circles, quads, lines)
 ----------------------------------------------------------------------------------------------------
@@ -3088,6 +3310,76 @@ gl4Prim.circleShaderCode = {
 	]],
 }
 
+-- NoGS variant of circleShaderCode: VS expands each instance into 6 verts via
+-- gl_VertexID -> [0,1,2,2,1,3] strip-to-list mapping. f_blendMode is `flat` on
+-- both VS->FS sides (matching the FS, which always had `flat in`); the
+-- original VS->GS->FS chain had a smooth VS->GS hop that the GS upgraded to
+-- flat, which is preserved by the collapse.
+gl4Prim.circleShaderCodeNoGS = {
+	vertex = [[
+		#version 330
+		layout(location = 0) in vec4 posRadius;    // worldX, worldZ, radius, alpha
+		layout(location = 1) in vec4 coreColor;    // coreR, coreG, coreB, edgeAlpha
+		layout(location = 2) in vec4 edgeColor;    // edgeR, edgeG, edgeB, blendMode (0=normal, 1=additive)
+
+		uniform vec2 wtp_scale;
+		uniform vec2 wtp_offset;
+		uniform vec2 ndcScale;
+		uniform vec2 rotSC;
+		uniform vec2 rotCenter;
+
+		out vec2 f_localCoord;
+		out vec4 f_coreColor;
+		out vec4 f_edgeColor;
+		flat out float f_blendMode;
+
+		void main() {
+			vec2 pipPos = wtp_offset + posRadius.xy * wtp_scale;
+			vec2 d = pipPos - rotCenter;
+			pipPos = rotCenter + vec2(d.x*rotSC.y - d.y*rotSC.x, d.x*rotSC.x + d.y*rotSC.y);
+			vec2 centerNDC = pipPos * ndcScale - 1.0;
+
+			float radiusPIP = posRadius.z * abs(wtp_scale.x);
+			vec2 hs = vec2(radiusPIP) * ndcScale;
+			f_coreColor = vec4(coreColor.rgb, posRadius.w);
+			f_edgeColor = vec4(edgeColor.rgb, coreColor.w);
+			f_blendMode = edgeColor.w;
+
+			int vid = gl_VertexID;
+			int sIdx;
+			if      (vid == 0) sIdx = 0;
+			else if (vid == 1) sIdx = 1;
+			else if (vid == 2) sIdx = 2;
+			else if (vid == 3) sIdx = 2;
+			else if (vid == 4) sIdx = 1;
+			else               sIdx = 3;
+
+			vec2 off;
+			if      (sIdx == 0) { off = vec2(-hs.x, -hs.y); f_localCoord = vec2(-1.0, -1.0); }
+			else if (sIdx == 1) { off = vec2( hs.x, -hs.y); f_localCoord = vec2( 1.0, -1.0); }
+			else if (sIdx == 2) { off = vec2(-hs.x,  hs.y); f_localCoord = vec2(-1.0,  1.0); }
+			else                { off = vec2( hs.x,  hs.y); f_localCoord = vec2( 1.0,  1.0); }
+
+			gl_Position = vec4(centerNDC + off, 0.0, 1.0);
+		}
+	]],
+	fragment = [[
+		#version 330
+		in vec2 f_localCoord;
+		in vec4 f_coreColor;
+		in vec4 f_edgeColor;
+		flat in float f_blendMode;
+		out vec4 fragColor;
+
+		void main() {
+			float dist = length(f_localCoord);
+			if (dist > 1.0) discard;
+			float t = smoothstep(0.0, 1.0, dist);
+			fragColor = mix(f_coreColor, f_edgeColor, t);
+		}
+	]],
+}
+
 -- Quad shader: point → rotated quad
 gl4Prim.quadShaderCode = {
 	vertex = [[
@@ -3159,6 +3451,70 @@ gl4Prim.quadShaderCode = {
 			gl_Position = vec4(c.xy + (-dx + dy) * ndc, 0, 1); EmitVertex();
 			gl_Position = vec4(c.xy + ( dx + dy) * ndc, 0, 1); EmitVertex();
 			EndPrimitive();
+		}
+	]],
+	fragment = [[
+		#version 330
+		in vec4 f_color;
+		out vec4 fragColor;
+		void main() {
+			fragColor = f_color;
+		}
+	]],
+}
+
+-- NoGS variant of quadShaderCode: VS expands each instance into 6 verts via
+-- gl_VertexID -> [0,1,2,2,1,3] strip-to-list mapping. Quad-rotation-combined-
+-- with-map-rotation math from the GS (sa*cos(m) + ca*sin(m) etc.) is folded
+-- into the VS, then pixel-space rotation is converted to NDC.
+gl4Prim.quadShaderCodeNoGS = {
+	vertex = [[
+		#version 330
+		layout(location = 0) in vec4 posSizeIn;     // worldX, worldZ, halfWidth, halfHeight
+		layout(location = 1) in vec4 colorIn;        // r, g, b, a
+		layout(location = 2) in vec4 angleFlags;     // angleDeg, 0, 0, 0
+
+		uniform vec2 wtp_scale;
+		uniform vec2 wtp_offset;
+		uniform vec2 ndcScale;
+		uniform vec2 rotSC;
+		uniform vec2 rotCenter;
+
+		out vec4 f_color;
+
+		void main() {
+			vec2 pipPos = wtp_offset + posSizeIn.xy * wtp_scale;
+			vec2 d = pipPos - rotCenter;
+			pipPos = rotCenter + vec2(d.x*rotSC.y - d.y*rotSC.x, d.x*rotSC.x + d.y*rotSC.y);
+			vec2 centerNDC = pipPos * ndcScale - 1.0;
+
+			float scalePIP = abs(wtp_scale.x);
+			vec2 hs = vec2(posSizeIn.z * scalePIP, posSizeIn.w * scalePIP);
+			f_color = colorIn;
+
+			float a = radians(angleFlags.x);
+			float sa = sin(a), ca = cos(a);
+			float sT = sa * rotSC.y + ca * rotSC.x;
+			float cT = ca * rotSC.y - sa * rotSC.x;
+			vec2 dx = vec2(cT, sT) * hs.x;
+			vec2 dy = vec2(-sT, cT) * hs.y;
+
+			int vid = gl_VertexID;
+			int sIdx;
+			if      (vid == 0) sIdx = 0;
+			else if (vid == 1) sIdx = 1;
+			else if (vid == 2) sIdx = 2;
+			else if (vid == 3) sIdx = 2;
+			else if (vid == 4) sIdx = 1;
+			else               sIdx = 3;
+
+			vec2 offPx;
+			if      (sIdx == 0) offPx = -dx - dy;
+			else if (sIdx == 1) offPx =  dx - dy;
+			else if (sIdx == 2) offPx = -dx + dy;
+			else                offPx =  dx + dy;
+
+			gl_Position = vec4(centerNDC + offPx * ndcScale, 0.0, 1.0);
 		}
 	]],
 	fragment = [[
@@ -3281,7 +3637,7 @@ local function InitGL4Icons()
 		gl4Icons.vbo = nil
 		return
 	end
-	vao:AttachVertexBuffer(vbo)
+	if UseNoGS then vao:AttachInstanceBuffer(vbo) else vao:AttachVertexBuffer(vbo) end
 	gl4Icons.vao = vao
 
 	-- Building VBO/VAO: separate buffer for building+ghost icons.
@@ -3308,7 +3664,7 @@ local function InitGL4Icons()
 		gl4Icons.vao = nil
 		return
 	end
-	bldgVao:AttachVertexBuffer(bldgVbo)
+	if UseNoGS then bldgVao:AttachInstanceBuffer(bldgVbo) else bldgVao:AttachVertexBuffer(bldgVbo) end
 	gl4Icons.bldgVbo = bldgVbo
 	gl4Icons.bldgVao = bldgVao
 
@@ -3351,7 +3707,7 @@ local function InitGL4Icons()
 		gl4Icons.bldgVao = nil
 		return
 	end
-	slowVao:AttachVertexBuffer(slowVbo)
+	if UseNoGS then slowVao:AttachInstanceBuffer(slowVbo) else slowVao:AttachVertexBuffer(slowVbo) end
 	gl4Icons.slowVbo = slowVbo
 	gl4Icons.slowVao = slowVao
 
@@ -3363,7 +3719,7 @@ local function InitGL4Icons()
 	gl4Icons.slowInstanceData = slowInstanceData
 
 	-- Compile shader
-	local shader = gl.CreateShader(gl4Icons.shaderCode)
+	local shader = gl.CreateShader(UseNoGS and gl4Icons.shaderCodeNoGS or gl4Icons.shaderCode)
 	if not shader then
 		Spring.Echo("[PIP] GL4 icons: Shader compilation failed: " .. tostring(gl.GetShaderLog()))
 		vao:Delete()
@@ -3469,7 +3825,7 @@ local function InitGL4Primitives()
 	cVbo:Define(gl4Prim.CIRCLE_MAX, circleLayout)
 	local cVao = gl.GetVAO()
 	if not cVao then cVbo:Delete(); return end
-	cVao:AttachVertexBuffer(cVbo)
+	if UseNoGS then cVao:AttachInstanceBuffer(cVbo) else cVao:AttachVertexBuffer(cVbo) end
 	local cData = {}
 	for i = 1, gl4Prim.CIRCLE_MAX * gl4Prim.CIRCLE_STEP do cData[i] = 0 end
 	gl4Prim.circles.vbo = cVbo
@@ -3487,7 +3843,7 @@ local function InitGL4Primitives()
 	qVbo:Define(gl4Prim.QUAD_MAX, quadLayout)
 	local qVao = gl.GetVAO()
 	if not qVao then qVbo:Delete(); cVao:Delete(); cVbo:Delete(); return end
-	qVao:AttachVertexBuffer(qVbo)
+	if UseNoGS then qVao:AttachInstanceBuffer(qVbo) else qVao:AttachVertexBuffer(qVbo) end
 	local qData = {}
 	for i = 1, gl4Prim.QUAD_MAX * gl4Prim.QUAD_STEP do qData[i] = 0 end
 	gl4Prim.quads.vbo = qVbo
@@ -3515,7 +3871,7 @@ local function InitGL4Primitives()
 	gl4Prim.normLines.vbo, gl4Prim.normLines.vao, gl4Prim.normLines.data = nlVbo, nlVao, nlData
 
 	-- Compile shaders
-	local cShader = gl.CreateShader(gl4Prim.circleShaderCode)
+	local cShader = gl.CreateShader(UseNoGS and gl4Prim.circleShaderCodeNoGS or gl4Prim.circleShaderCode)
 	if not cShader then
 		Spring.Echo("[PIP] GL4 circle shader failed: " .. tostring(gl.GetShaderLog()))
 		-- cleanup all
@@ -3526,7 +3882,7 @@ local function InitGL4Primitives()
 	end
 	gl4Prim.circles.shader = cShader
 
-	local qShader = gl.CreateShader(gl4Prim.quadShaderCode)
+	local qShader = gl.CreateShader(UseNoGS and gl4Prim.quadShaderCodeNoGS or gl4Prim.quadShaderCode)
 	if not qShader then
 		Spring.Echo("[PIP] GL4 quad shader failed: " .. tostring(gl.GetShaderLog()))
 		gl.DeleteShader(cShader)
@@ -3659,7 +4015,11 @@ local function GL4FlushEffects()
 		local c = gl4Prim.circles
 		c.vbo:Upload(c.data, nil, 0, 1, c.count * gl4Prim.CIRCLE_STEP)
 		GL4SetPrimUniforms(c.shader, c.uniformLocs)
-		c.vao:DrawArrays(GL.POINTS, c.count)
+		if UseNoGS then
+			c.vao:DrawArrays(GL.TRIANGLES, 6, 0, c.count)
+		else
+			c.vao:DrawArrays(GL.POINTS, c.count)
+		end
 		gl.UseShader(0)
 	end
 
@@ -3668,7 +4028,11 @@ local function GL4FlushEffects()
 		local q = gl4Prim.quads
 		q.vbo:Upload(q.data, nil, 0, 1, q.count * gl4Prim.QUAD_STEP)
 		GL4SetPrimUniforms(q.shader, q.uniformLocs)
-		q.vao:DrawArrays(GL.POINTS, q.count)
+		if UseNoGS then
+			q.vao:DrawArrays(GL.TRIANGLES, 6, 0, q.count)
+		else
+			q.vao:DrawArrays(GL.POINTS, q.count)
+		end
 		gl.UseShader(0)
 	end
 
@@ -3714,7 +4078,11 @@ local function GL4FlushCirclesOnly()
 	local c = gl4Prim.circles
 	c.vbo:Upload(c.data, nil, 0, 1, c.count * gl4Prim.CIRCLE_STEP)
 	GL4SetPrimUniforms(c.shader, c.uniformLocs)
-	c.vao:DrawArrays(GL.POINTS, c.count)
+	if UseNoGS then
+		c.vao:DrawArrays(GL.TRIANGLES, 6, 0, c.count)
+	else
+		c.vao:DrawArrays(GL.POINTS, c.count)
+	end
 	gl.UseShader(0)
 end
 
@@ -7320,7 +7688,7 @@ function widget:Initialize()
 	end
 
 	-- Initialize decal overlay shader + GL4 VBO/VAO
-	shaders.decal = gl.CreateShader(shaders.decalCode)
+	shaders.decal = gl.CreateShader(UseNoGS and shaders.decalCodeNoGS or shaders.decalCode)
 	if not shaders.decal then
 		Spring.Echo("PIP: Failed to compile decal shader")
 		Spring.Echo("PIP: Shader log: " .. (gl.GetShaderLog() or "no log"))
@@ -9103,7 +9471,11 @@ local function DrawCommandQueuesOverlay(cachedSelectedUnits)
 				local c = gl4Prim.circles
 				c.vbo:Upload(c.data, nil, 0, 1, c.count * gl4Prim.CIRCLE_STEP)
 				GL4SetPrimUniforms(c.shader, c.uniformLocs)
-				c.vao:DrawArrays(GL.POINTS, c.count)
+				if UseNoGS then
+					c.vao:DrawArrays(GL.TRIANGLES, 6, 0, c.count)
+				else
+					c.vao:DrawArrays(GL.POINTS, c.count)
+				end
 				gl.UseShader(0)
 			end
 
@@ -10791,30 +11163,54 @@ local function GL4DrawIcons(checkAllyTeamID, selectedSet, trackingSet)
 		if bldgUsedElements > 0 then
 			if hasOutlines then
 				gl.UniformFloat(ul.outlinePass, 1.0)
-				gl4Icons.bldgVao:DrawArrays(GL.POINTS, bldgUsedElements)
+				if UseNoGS then
+					gl4Icons.bldgVao:DrawArrays(GL.TRIANGLES, 6, 0, bldgUsedElements)
+				else
+					gl4Icons.bldgVao:DrawArrays(GL.POINTS, bldgUsedElements)
+				end
 			end
 			gl.UniformFloat(ul.outlinePass, 0.0)
-			gl4Icons.bldgVao:DrawArrays(GL.POINTS, bldgUsedElements)
+			if UseNoGS then
+				gl4Icons.bldgVao:DrawArrays(GL.TRIANGLES, 6, 0, bldgUsedElements)
+			else
+				gl4Icons.bldgVao:DrawArrays(GL.POINTS, bldgUsedElements)
+			end
 		end
 
 		-- Slow mobile (ground units, above buildings)
 		if slowMobileUsedElements > 0 then
 			if hasOutlines then
 				gl.UniformFloat(ul.outlinePass, 1.0)
-				gl4Icons.slowVao:DrawArrays(GL.POINTS, slowMobileUsedElements)
+				if UseNoGS then
+					gl4Icons.slowVao:DrawArrays(GL.TRIANGLES, 6, 0, slowMobileUsedElements)
+				else
+					gl4Icons.slowVao:DrawArrays(GL.POINTS, slowMobileUsedElements)
+				end
 			end
 			gl.UniformFloat(ul.outlinePass, 0.0)
-			gl4Icons.slowVao:DrawArrays(GL.POINTS, slowMobileUsedElements)
+			if UseNoGS then
+				gl4Icons.slowVao:DrawArrays(GL.TRIANGLES, 6, 0, slowMobileUsedElements)
+			else
+				gl4Icons.slowVao:DrawArrays(GL.POINTS, slowMobileUsedElements)
+			end
 		end
 
 		-- Fast mobile (aircraft, commanders — always on top)
 		if mobileUsedElements > 0 then
 			if hasOutlines then
 				gl.UniformFloat(ul.outlinePass, 1.0)
-				gl4Icons.vao:DrawArrays(GL.POINTS, mobileUsedElements)
+				if UseNoGS then
+					gl4Icons.vao:DrawArrays(GL.TRIANGLES, 6, 0, mobileUsedElements)
+				else
+					gl4Icons.vao:DrawArrays(GL.POINTS, mobileUsedElements)
+				end
 			end
 			gl.UniformFloat(ul.outlinePass, 0.0)
-			gl4Icons.vao:DrawArrays(GL.POINTS, mobileUsedElements)
+			if UseNoGS then
+				gl4Icons.vao:DrawArrays(GL.TRIANGLES, 6, 0, mobileUsedElements)
+			else
+				gl4Icons.vao:DrawArrays(GL.POINTS, mobileUsedElements)
+			end
 		end
 
 		glFunc.Texture(0, false)
@@ -14838,7 +15234,7 @@ InitGL4Decals = function()
 		vbo:Delete()
 		return
 	end
-	vao:AttachVertexBuffer(vbo)
+	if UseNoGS then vao:AttachInstanceBuffer(vbo) else vao:AttachVertexBuffer(vbo) end
 
 	-- Pre-allocate instance data array
 	local instanceData = {}
@@ -14952,7 +15348,11 @@ local function decalR2TDraw()
 			local ul = decalGL4.uniformLocs
 			gl.UniformFloat(ul.gameFrame, decalGL4.renderFrame)
 			gl.UniformFloat(ul.invMapSize, 2.0 / mapInfo.mapSizeX, 2.0 / mapInfo.mapSizeZ)
-			decalGL4.vao:DrawArrays(GL.POINTS, decalGL4.instanceCount)
+			if UseNoGS then
+				decalGL4.vao:DrawArrays(GL.TRIANGLES, 6, 0, decalGL4.instanceCount)
+			else
+				decalGL4.vao:DrawArrays(GL.POINTS, decalGL4.instanceCount)
+			end
 			gl.UseShader(0)
 			glFunc.Texture(false)
 		end

--- a/luaui/Widgets/gui_rank_icons_gl4.lua
+++ b/luaui/Widgets/gui_rank_icons_gl4.lua
@@ -54,6 +54,13 @@ local atlasSize = 2048
 local rankVBO = nil
 local rankShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. The POST_VERTEX snippet used by
+-- this widget (a compound multiply on v_lengthwidthcornerheight.xy) is safe
+-- under per-output-vertex execution because v_lengthwidthcornerheight is a
+-- VS-local that is freshly initialized from the per-instance attribute on
+-- every shader invocation; each output vertex multiplies its own fresh base.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local debugmode = false
 
@@ -187,7 +194,10 @@ local function RemovePrimitive(unitID,reason)
 end
 
 local function initGL4()
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 1
 	shaderConfig.HEIGHTOFFSET = 0
@@ -381,7 +391,11 @@ function widget:DrawScreenEffects()
 		rankShader:Activate()
 		rankShader:SetUniform("iconDistance",usedCutoffDistance)
 		rankShader:SetUniform("addRadius",0)
-		rankVBO.VAO:DrawArrays(GL.POINTS,rankVBO.usedElements)
+		if UseNoGS then
+			rankVBO.VAO:DrawArrays(GL.TRIANGLES, rankVBO.numVerts, 0, rankVBO.usedElements)
+		else
+			rankVBO.VAO:DrawArrays(GL.POINTS,rankVBO.usedElements)
+		end
 		rankShader:Deactivate()
 		glTexture(0, false)
 		--gl.Culling(false)

--- a/luaui/Widgets/gui_resurrection_halos_gl4.lua
+++ b/luaui/Widgets/gui_resurrection_halos_gl4.lua
@@ -15,6 +15,9 @@ end
 local resurrectionHalosVBO = nil
 local resurrectionHalosShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local InstanceVBOTable = gl.InstanceVBOTable
 
@@ -41,7 +44,10 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 end
 
 local function initGL4()
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.TRANSPARENCY = 0.5
@@ -118,7 +124,11 @@ function widget:DrawWorld()
 		resurrectionHalosShader:SetUniform("addRadius", 0)
 		gl.DepthTest(true)
 		gl.DepthMask(false) --"BK OpenGL state resets", default is already false, could remove
-		resurrectionHalosVBO.VAO:DrawArrays(GL.POINTS, resurrectionHalosVBO.usedElements)
+		if UseNoGS then
+			resurrectionHalosVBO.VAO:DrawArrays(GL.TRIANGLES, resurrectionHalosVBO.numVerts, 0, resurrectionHalosVBO.usedElements)
+		else
+			resurrectionHalosVBO.VAO:DrawArrays(GL.POINTS, resurrectionHalosVBO.usedElements)
+		end
 		resurrectionHalosShader:Deactivate()
 		gl.Texture(0, false)
 	end

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -47,6 +47,12 @@ local mapHasWater = (Spring.GetGroundExtremes() < 0)
 
 local selectShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. Other platforms continue to use
+-- the original geometry-shader path unchanged. Only POST_SHADING (fragment
+-- shader injection) is customized by this widget, which is identical between
+-- both paths.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local InstanceVBOTable = gl.InstanceVBOTable
 
@@ -218,14 +224,22 @@ local function DrawSelections(selectionVBO, isAir)
 		glStencilMask(1)
 
 		selectShader:SetUniform("addRadius", 0)
-		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+		if UseNoGS then
+			selectionVBO.VAO:DrawArrays(GL.TRIANGLES, selectionVBO.numVerts, 0, selectionVBO.usedElements)
+		else
+			selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+		end
 
 		glStencilFunc(GL_NOTEQUAL, 1, 1)
 		glStencilMask(0)
 		glDepthTest(true)
 
 		selectShader:SetUniform("addRadius", 1.3)
-		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+		if UseNoGS then
+			selectionVBO.VAO:DrawArrays(GL.TRIANGLES, selectionVBO.numVerts, 0, selectionVBO.usedElements)
+		else
+			selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+		end
 
 		glStencilMask(1)
 		glStencilFunc(GL_ALWAYS, 1, 1)
@@ -423,7 +437,10 @@ end
 local function init()
 	updateSelection = true
 	selUnits = {}
-	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DPatUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
 	shaderConfig.BILLBOARD = 0

--- a/luaui/Widgets/gui_team_platter.lua
+++ b/luaui/Widgets/gui_team_platter.lua
@@ -26,6 +26,10 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 local teamplatterVBO = nil
 local teamplatterShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage. Other platforms continue to use
+-- the original geometry-shader path unchanged.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 -- Localize for speedups:
 local glStencilFunc         = gl.StencilFunc
@@ -135,7 +139,11 @@ function widget:DrawWorldPreUnit()
 		end
 
 		teamplatterShader:SetUniform("addRadius", 0)
-		teamplatterVBO.VAO:DrawArrays(GL_POINTS, teamplatterVBO.usedElements)
+		if UseNoGS then
+			teamplatterVBO.VAO:DrawArrays(GL.TRIANGLES, teamplatterVBO.numVerts, 0, teamplatterVBO.usedElements)
+		else
+			teamplatterVBO.VAO:DrawArrays(GL_POINTS, teamplatterVBO.usedElements)
+		end
 
 		--[[ -- this second draw pass is only needed if we actually want to draw the unit's radius
 		glStencilFunc(GL_NOTEQUAL, 1, 1)
@@ -143,7 +151,11 @@ function widget:DrawWorldPreUnit()
 		glDepthTest(true)
 
 		teamplatterShader:SetUniform("addRadius", 0.15)
-		teamplatterVBO.VAO:DrawArrays(GL_POINTS, teamplatterVBO.usedElements)
+		if UseNoGS then
+			teamplatterVBO.VAO:DrawArrays(GL.TRIANGLES, teamplatterVBO.numVerts, 0, teamplatterVBO.usedElements)
+		else
+			teamplatterVBO.VAO:DrawArrays(GL_POINTS, teamplatterVBO.usedElements)
+		end
 		]]--
 
 		glStencilMask(1)
@@ -182,7 +194,10 @@ function widget:CrashingAircraft(unitID, unitDefID, teamID)
 end
 
 local function init()
-	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DPatUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
 	shaderConfig.TRANSPARENCY = opacity

--- a/luaui/Widgets/gui_unit_energy_icons.lua
+++ b/luaui/Widgets/gui_unit_energy_icons.lua
@@ -94,6 +94,9 @@ local energyIconVBO = nil
 local energyIconShader = nil
 
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local InstanceVBOTable = gl.InstanceVBOTable
 
 local uploadAllElements   = InstanceVBOTable.uploadAllElements
@@ -102,7 +105,10 @@ local popElementInstance  = InstanceVBOTable.popElementInstance
 
 
 local function initGL4()
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 1
@@ -254,7 +260,11 @@ function widget:DrawScreenEffects()
 		energyIconShader:Activate()
 		energyIconShader:SetUniform("iconDistance",disticon)
 		energyIconShader:SetUniform("addRadius",0)
-		energyIconVBO.VAO:DrawArrays(GL.POINTS,energyIconVBO.usedElements)
+		if UseNoGS then
+			energyIconVBO.VAO:DrawArrays(GL.TRIANGLES, energyIconVBO.numVerts, 0, energyIconVBO.usedElements)
+		else
+			energyIconVBO.VAO:DrawArrays(GL.POINTS,energyIconVBO.usedElements)
+		end
 		energyIconShader:Deactivate()
 		gl.Texture(false)
 		gl.DepthTest(false)

--- a/luaui/Widgets/gui_unit_firestate_icons.lua
+++ b/luaui/Widgets/gui_unit_firestate_icons.lua
@@ -35,6 +35,9 @@ local returnFireVBO  = nil
 local fireIconShader = nil
 
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local InstanceVBOTable    = gl.InstanceVBOTable
 local uploadAllElements   = InstanceVBOTable.uploadAllElements
 local pushElementInstance = InstanceVBOTable.pushElementInstance
@@ -74,7 +77,10 @@ local instanceData = {0, 0, 0, 0,  0,  4,  0, 0, 0.85, 0,  0, 1, 0, 1,  0, 0, 0,
 -- GL4 Initialization
 --------------------------------------------------------------------------------
 local function initGL4()
-	local DrawPrimitiveAtUnit    = VFS.Include(luaShaderDir .. "DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir .. "DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir .. "DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit    = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig           = DrawPrimitiveAtUnit.shaderConfig
 
@@ -292,7 +298,11 @@ function widget:DrawScreenEffects()
 		fireIconShader:Activate()
 		fireIconShader:SetUniform("iconDistance", disticon)
 		fireIconShader:SetUniform("addRadius", 0)
-		holdFireVBO.VAO:DrawArrays(GL.POINTS, holdFireVBO.usedElements)
+		if UseNoGS then
+			holdFireVBO.VAO:DrawArrays(GL.TRIANGLES, holdFireVBO.numVerts, 0, holdFireVBO.usedElements)
+		else
+			holdFireVBO.VAO:DrawArrays(GL.POINTS, holdFireVBO.usedElements)
+		end
 		fireIconShader:Deactivate()
 		gl.Texture(false)
 	end
@@ -302,7 +312,11 @@ function widget:DrawScreenEffects()
 		fireIconShader:Activate()
 		fireIconShader:SetUniform("iconDistance", disticon)
 		fireIconShader:SetUniform("addRadius", 0)
-		returnFireVBO.VAO:DrawArrays(GL.POINTS, returnFireVBO.usedElements)
+		if UseNoGS then
+			returnFireVBO.VAO:DrawArrays(GL.TRIANGLES, returnFireVBO.numVerts, 0, returnFireVBO.usedElements)
+		else
+			returnFireVBO.VAO:DrawArrays(GL.POINTS, returnFireVBO.usedElements)
+		end
 		fireIconShader:Deactivate()
 		gl.Texture(false)
 	end

--- a/luaui/Widgets/gui_unit_group_number.lua
+++ b/luaui/Widgets/gui_unit_group_number.lua
@@ -52,6 +52,9 @@ end
 local unitGroupVBO = nil
 local unitGroupShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local vbocachetables = {} -- A table of tables for speed
 
 local function initGL4()
@@ -84,7 +87,10 @@ local function initGL4()
 		vbocachetables[i] = vbocachetable
 	end
 
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir .. "DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir .. "DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir .. "DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 1
 	shaderConfig.HEIGHTOFFSET = 0
@@ -248,7 +254,11 @@ function widget:DrawScreenEffects()
 		-- note that unitGroupVBO.VAO:DrawArrays can be display-list wrapped, but then the #usedElements doesnt update :/
 		gl.Texture(0, healthbartexture)
 		unitGroupShader:Activate()
-		unitGroupVBO.VAO:DrawArrays(GL.POINTS, unitGroupVBO.usedElements)
+		if UseNoGS then
+			unitGroupVBO.VAO:DrawArrays(GL.TRIANGLES, unitGroupVBO.numVerts, 0, unitGroupVBO.usedElements)
+		else
+			unitGroupVBO.VAO:DrawArrays(GL.POINTS, unitGroupVBO.usedElements)
+		end
 		unitGroupShader:Deactivate()
 		gl.Texture(0, false)
 	end

--- a/luaui/Widgets/gui_unit_idlebuilder_icons.lua
+++ b/luaui/Widgets/gui_unit_idlebuilder_icons.lua
@@ -62,9 +62,15 @@ local popElementInstance  = InstanceVBOTable.popElementInstance
 local iconVBO = nil
 local energyIconShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local function initGL4()
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 1
@@ -188,7 +194,11 @@ function widget:DrawScreenEffects()
 		energyIconShader:Activate()
 		energyIconShader:SetUniform("iconDistance",disticon)
 		energyIconShader:SetUniform("addRadius",0)
-		iconVBO.VAO:DrawArrays(GL.POINTS,iconVBO.usedElements)
+		if UseNoGS then
+			iconVBO.VAO:DrawArrays(GL.TRIANGLES, iconVBO.numVerts, 0, iconVBO.usedElements)
+		else
+			iconVBO.VAO:DrawArrays(GL.POINTS,iconVBO.usedElements)
+		end
 		energyIconShader:Deactivate()
 		gl.Texture(false)
 		gl.DepthTest(false)

--- a/luaui/Widgets/gui_unit_repeat_icon.lua
+++ b/luaui/Widgets/gui_unit_repeat_icon.lua
@@ -29,6 +29,9 @@ local repeatVBO       = nil
 local repeatShader    = nil
 
 local luaShaderDir        = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 local InstanceVBOTable    = gl.InstanceVBOTable
 local uploadAllElements   = InstanceVBOTable.uploadAllElements
 local pushElementInstance = InstanceVBOTable.pushElementInstance
@@ -71,7 +74,10 @@ local instanceData = {0, 0, 0, 0,  0,  4,  0, 0, 0.85, 0,  0, 1, 0, 1,  0, 0, 0,
 -- GL4 Initialization
 --------------------------------------------------------------------------------
 local function initGL4()
-	local DrawPrimitiveAtUnit     = VFS.Include(luaShaderDir .. "DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir .. "DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir .. "DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit     = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig            = DrawPrimitiveAtUnit.shaderConfig
 
@@ -213,7 +219,11 @@ function widget:DrawScreenEffects()
 	repeatShader:Activate()
 	repeatShader:SetUniform("iconDistance", disticon)
 	repeatShader:SetUniform("addRadius", 0)
-	repeatVBO.VAO:DrawArrays(GL.POINTS, repeatVBO.usedElements)
+	if UseNoGS then
+		repeatVBO.VAO:DrawArrays(GL.TRIANGLES, repeatVBO.numVerts, 0, repeatVBO.usedElements)
+	else
+		repeatVBO.VAO:DrawArrays(GL.POINTS, repeatVBO.usedElements)
+	end
 	repeatShader:Deactivate()
 	gl.Texture(false)
 	gl.DepthTest(false)

--- a/luaui/Widgets/gui_unit_wait_icons.lua
+++ b/luaui/Widgets/gui_unit_wait_icons.lua
@@ -59,9 +59,15 @@ local uploadAllElements   = InstanceVBOTable.uploadAllElements
 local iconVBO = nil
 local energyIconShader = nil
 local luaShaderDir = "LuaUI/Include/"
+-- Select the no-GS DrawPrimitiveAtUnit backend on platforms whose GL backend
+-- does not expose a geometry-shader stage.
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
 
 local function initGL4()
-	local DrawPrimitiveAtUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local primitivesInclude = UseNoGS
+		and luaShaderDir.."DrawPrimitiveAtUnitNoGS.lua"
+		or  luaShaderDir.."DrawPrimitiveAtUnit.lua"
+	local DrawPrimitiveAtUnit = VFS.Include(primitivesInclude)
 	local InitDrawPrimitiveAtUnit = DrawPrimitiveAtUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DrawPrimitiveAtUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE in DrawPrimitiveAtUnit.lua
 	shaderConfig.BILLBOARD = 1
@@ -234,7 +240,11 @@ function widget:DrawScreenEffects()
 		energyIconShader:Activate()
 		energyIconShader:SetUniform("iconDistance",disticon)
 		energyIconShader:SetUniform("addRadius",0)
-		iconVBO.VAO:DrawArrays(GL.POINTS,iconVBO.usedElements)
+		if UseNoGS then
+			iconVBO.VAO:DrawArrays(GL.TRIANGLES, iconVBO.numVerts, 0, iconVBO.usedElements)
+		else
+			iconVBO.VAO:DrawArrays(GL.POINTS,iconVBO.usedElements)
+		end
 		energyIconShader:Deactivate()
 		gl.Texture(false)
 		gl.DepthTest(false)

--- a/luaui/Widgets/map_edge_extension2.lua
+++ b/luaui/Widgets/map_edge_extension2.lua
@@ -82,6 +82,14 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+-- Select the GS-based or GS-free forward pipeline. The deferred pass below was
+-- always GS-free; only the forward pass has two paths. On backends without a
+-- geometry-shader stage (e.g. Metal via Zink) the NoGS path folds the GS body
+-- into the VS and the draw call switches from POINTS (one per cell, expanded
+-- by the GS) to TRIANGLES (6 list verts per cell, expanded by gl_VertexID
+-- decoding).
+local UseNoGS = (Platform and (Platform.osFamily == "MacOS" or Platform.osFamily == "MacOSX"))
+
 local vsSrc = [[
 #version 330
 
@@ -109,7 +117,7 @@ void main() {
 
 		float X = mapSize.x / gridSize;
 
-		float modX = mod(vID, X); 
+		float modX = mod(vID, X);
 		//this is sometimes true in the magic land of amd drivers!
 		if (modX >= X) 	modX=0;
 
@@ -120,7 +128,186 @@ void main() {
 		gl_Position = vec4(x, 0.0, y, 1.0);
 
 		vMirrorParams = aMirrorParams;
-	
+
+}
+]]
+
+-- NoGS forward VS: the original VS emitted one point per grid cell (driven by
+-- gl_VertexID) and a GS expanded each point into a quad — either a vertical
+-- seam at the map edge (when aMirrorParams == vec4(0)) or a flat mirrored map
+-- tile. This VS does both the cell-position decoding AND the quad expansion;
+-- each "old point" becomes 6 vertices (2 tris in triangle-list form). Caller
+-- draws numPoints*6 vertices per instance.
+local vsSrcNoGS = [[
+#version 330
+
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+
+#line 10077
+
+layout (location = 0) in vec4 aMirrorParams;
+
+//__DEFINES__
+//__ENGINEUNIFORMBUFFERDEFS__
+
+uniform sampler2D heightTex;
+
+uniform vec4 shaderParams;
+
+#define gridSize shaderParams.x
+#define curvature shaderParams.z
+#define edgeFog shaderParams.w
+
+out DataGS {
+	vec2 alphaFog;
+	vec2 uv;
+	vec2 mirrorParams;
+};
+
+#define NORM2SNORM(value) (value * 2.0 - 1.0)
+#define SNORM2NORM(value) (value * 0.5 + 0.5)
+
+#define WF 0.0
+#define SEAMHEIGHT -128.0
+
+// Strip ABCD -> triangle list [A, B, C, C, B, D] = indices [0,1,2,2,1,3].
+// Returns 0..3 telling which strip vertex this list index refers to.
+int stripVertexFromListIndex(int li) {
+	if (li == 0) return 0;
+	if (li == 1) return 1;
+	if (li == 2) return 2;
+	if (li == 3) return 2;
+	if (li == 4) return 1;
+	return 3;
+}
+
+// Per-vertex transform: mirrors what the GS's MyEmitTestVertex did, minus the
+// "testme" sphere visibility cull (a perf optimization — dropped here because
+// the VS can't return-skip; the alpha<0.05 case still self-discards via degenerate).
+void transformVertex(vec4 basePos, vec3 vertexOffset, vec4 mp,
+                     out vec4 outClipPos, out vec2 outAlphaFog, out vec2 outUV, out vec2 outMirror) {
+	vec4 worldPos = basePos + vec4(vertexOffset.x, vertexOffset.y, vertexOffset.z, 0.0);
+	outUV = worldPos.xz / mapSize.xy;
+	outMirror = mp.xy;
+
+	vec2 UVHM = heightmapUVatWorldPos(worldPos.xz);
+	worldPos.y = textureLod(heightTex, UVHM, 0.0).x + vertexOffset.y;
+
+	const vec2 edgeTightening = vec2(0.0);
+	worldPos.xz = abs(mp.xy * mapSize.xy - worldPos.xz);
+	worldPos.xz += mp.zw * (mapSize.xy - edgeTightening);
+
+	float alpha = 1.0;
+	if (curvature == 1.0) {
+		const float curvatureBend = 150.0;
+		alpha = 0.0;
+		vec2 refPoint = SNORM2NORM(mp.zw) * mapSize.xy;
+		if (mp.x != 0.0) {
+			worldPos.y -= pow((worldPos.x - refPoint.x) / curvatureBend, 2.0);
+			alpha -= pow((worldPos.x - refPoint.x) / mapSize.x, 2.0);
+		}
+		if (mp.y != 0.0) {
+			worldPos.y -= pow((worldPos.z - refPoint.y) / curvatureBend, 2.0);
+			alpha -= pow((worldPos.z - refPoint.y) / mapSize.y, 2.0);
+		}
+		alpha = 1.0 + (6.0 * (alpha + 0.18));
+		alpha = clamp(alpha, 0.0, 1.0);
+	}
+
+	float fogFactor = 1.0;
+	if (edgeFog == 1.0) {
+		vec4 forCoord = cameraView * worldPos;
+		float fogDist = length(forCoord.xyz);
+		fogFactor = (fogParams.y - fogDist) * fogParams.w;
+		fogFactor = clamp(fogFactor, 0.0, 1.0);
+	}
+
+	outAlphaFog = vec2(alpha, fogFactor);
+	outClipPos = cameraViewProj * worldPos;
+}
+
+void main() {
+	int vid = gl_VertexID;
+	int cellID = vid / 6;
+	int listIdx = vid - cellID * 6;
+	int stripIdx = stripVertexFromListIndex(listIdx);
+
+	// Decode cellID -> grid cell (x, z) in world space.
+	float fCell = float(cellID);
+	float X = mapSize.x / gridSize;
+	float modX = mod(fCell, X);
+	if (modX >= X) modX = 0.0; // AMD-driver guard from the original VS
+	float cellX = modX * gridSize;
+	float cellZ = ((fCell - modX) / X) * gridSize;
+	vec4 basePos = vec4(cellX, 0.0, cellZ, 1.0);
+
+	vec4 mp = aMirrorParams;
+	vec3 corners[4];   // 4 strip vertices ABCD
+	bool skipQuad = false;
+
+	if (all(equal(mp, vec4(0.0)))) {
+		// Seam-only pass: emit a vertical seam quad only if this cell is on the
+		// map edge; interior cells degenerate.
+		vec2 localPos = basePos.xz;
+		vec2 mapCenterHPG = (mapSize.xy - vec2(gridSize)) * 0.5;
+		vec2 disttoMapCenter = abs(localPos - mapCenterHPG) + vec2(gridSize) * 0.5;
+		if (all(lessThan(disttoMapCenter, mapCenterHPG))) {
+			skipQuad = true;
+		} else if (localPos.x == 0.0) {
+			// west edge
+			corners[0] = vec3(WF,           0.0, gridSize);
+			corners[1] = vec3(WF,    SEAMHEIGHT, gridSize);
+			corners[2] = vec3(WF,           0.0, 0.0);
+			corners[3] = vec3(WF,    SEAMHEIGHT, 0.0);
+		} else if (localPos.y == 0.0) {
+			// north edge (localPos.y is cellZ since localPos = basePos.xz)
+			corners[0] = vec3(gridSize,           0.0, WF);
+			corners[1] = vec3(0.0,                0.0, WF);
+			corners[2] = vec3(gridSize,    SEAMHEIGHT, WF);
+			corners[3] = vec3(0.0,         SEAMHEIGHT, WF);
+		} else if (localPos.x >= mapSize.x - gridSize) {
+			// east edge
+			corners[0] = vec3(gridSize - WF,           0.0, gridSize);
+			corners[1] = vec3(gridSize - WF,           0.0, 0.0);
+			corners[2] = vec3(gridSize - WF,    SEAMHEIGHT, gridSize);
+			corners[3] = vec3(gridSize - WF,    SEAMHEIGHT, 0.0);
+		} else {
+			// south edge (z >= mapSize.z - gridSize)
+			corners[0] = vec3(gridSize,           0.0, gridSize - WF);
+			corners[1] = vec3(gridSize,    SEAMHEIGHT, gridSize - WF);
+			corners[2] = vec3(0.0,                0.0, gridSize - WF);
+			corners[3] = vec3(0.0,         SEAMHEIGHT, gridSize - WF);
+		}
+	} else if (all(equal(mp.xy, vec2(1.0)))) {
+		// Diagonal mirror: TR, TL, BR, BL strip
+		corners[0] = vec3(gridSize, 0.0,      0.0);
+		corners[1] = vec3(0.0,      0.0,      0.0);
+		corners[2] = vec3(gridSize, 0.0, gridSize);
+		corners[3] = vec3(0.0,      0.0, gridSize);
+	} else {
+		// Axis-mirror: BL, TL, BR, TR strip (opposite winding)
+		corners[0] = vec3(0.0,      0.0, gridSize);
+		corners[1] = vec3(0.0,      0.0,      0.0);
+		corners[2] = vec3(gridSize, 0.0, gridSize);
+		corners[3] = vec3(gridSize, 0.0,      0.0);
+	}
+
+	if (skipQuad) {
+		gl_Position = vec4(2.0, 2.0, 2.0, 1.0); // off-screen NDC degenerate
+		alphaFog = vec2(0.0);
+		uv = vec2(0.0);
+		mirrorParams = vec2(0.0);
+		return;
+	}
+
+	vec4 clipPos;
+	vec2 _alphaFog, _uv, _mirror;
+	transformVertex(basePos, corners[stripIdx], mp, clipPos, _alphaFog, _uv, _mirror);
+	gl_Position = clipPos;
+	alphaFog = _alphaFog;
+	uv = _uv;
+	mirrorParams = _mirror;
 }
 ]]
 
@@ -607,12 +794,13 @@ function widget:Initialize()
 	--spEcho(gsSrc)
 	local engineUniformBufferDefs = LuaShader.GetEngineUniformBufferDefs()
 	vsSrc = vsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+	vsSrcNoGS = vsSrcNoGS:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 	gsSrc = gsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 	fsSrc = fsSrc:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
 
 	mapExtensionShader = LuaShader({
-		vertex = vsSrc,
-		geometry = gsSrc,
+		vertex = UseNoGS and vsSrcNoGS or vsSrc,
+		geometry = (not UseNoGS) and gsSrc or nil,
 		fragment = fsSrc,
 		uniformInt = {
 			colorTex = 0,
@@ -879,7 +1067,12 @@ function widget:DrawWorldPreUnit()
 	mapExtensionShader:Activate()
 	mapExtensionShader:SetUniform("shaderParams", gridSize, brightness * nightFactor, (curvature and 1.0) or 0.0, (fogEffect and 1.0) or 0.0)
 	--gl.RunQuery(q, function()
-		terrainVAO:DrawArrays(GL.POINTS, numPoints, 0, #mirrorParams / 4)
+		if UseNoGS then
+			-- NoGS forward path: VS emits 6 list verts per grid cell (2 tris = 1 quad).
+			terrainVAO:DrawArrays(GL.TRIANGLES, numPoints * 6, 0, #mirrorParams / 4)
+		else
+			terrainVAO:DrawArrays(GL.POINTS, numPoints, 0, #mirrorParams / 4)
+		end
 	--end)
 	mapExtensionShader:Deactivate()
 	gl.Texture(0, false)


### PR DESCRIPTION
## Summary

Adds geometry-shader-free shader paths for ~22 widgets, selected at widget load when `Platform.osFamily` matches `"MacOS"` or `"MacOSX"`. Linux/Windows users continue to take the existing GS path; no behavior change on those platforms.

Background: Metal (via Mesa Zink → KosmicKrisp on Apple Silicon) does not expose a geometry-shader stage. The engine strips GS programs at link time, so widgets that depend on point→quad expansion in a GS fail to link. The NoGS path expands instances via `gl_VertexID` from instanced vertex shaders instead.

> ⚠️ **Companion engine PR required**: this PR makes BAR widgets opt in to NoGS paths on macOS, but the engine-side `__APPLE__`-gated GS stripping in `LuaShaders.cpp` lives in the companion RecoilEngine PR. This BAR PR is safe to land on its own (it adds opt-in code paths that are inert without the engine support), but the macOS Apple Silicon experience requires both PRs.

## Scope

**Dual-path widgets (10 quad-family + 6 circle/cornerrect + 2 own-GS + 4 specialty = ~22 widgets):**

- Quad-family DrawPrimitiveAtUnit widgets: `gui_unit_energy_icons`, `gui_unit_firestate_icons`, `gui_unit_repeat_icon`, `gui_unit_idlebuilder_icons`, `gui_rank_icons_gl4`, `gui_unit_wait_icons`, `gui_unit_group_number`, `gui_ground_ao_plates_gl4`, `gui_ground_ao_plates_features_gl4`, `gui_resurrection_halos_gl4`
- Circle/cornerrect DPAT widgets: `gui_selectedunits_gl4`, `gui_allySelectedUnits`, `gui_team_platter`, `gui_enemy_spotter`, `gui_flanking_icons`, `api_unit_tracker_gl4`
- Own-GS widgets (inline GS folded into VS on Mac): `gfx_unit_stencil_gl4`, `gui_healthbars_gl4`
- Specialty widgets: `gfx_decals_gl4`, `map_edge_extension2`, `flowui_gl4`, `gui_pip`

**Other Lua changes:**

- `gfx_limit_idle_fps`: platform-gated short-circuit on Mac (workaround for unreliable SDL mouse-leave events on surfaceless EGL + CAMetalLayer setup; engine-side issue tracked separately)

## Cross-platform safety

- All GS shader files and GS-path widget code remain in-tree, unmodified except for the addition of a `Platform.osFamily` branch.
- The `Platform.osFamily == "MacOS" or == "MacOSX"` dual check accommodates both the engine's runtime value (`"MacOS"`) and the docs claim in `LuaConstPlatform.cpp` (`"MacOSX"`); robust against either being fixed later.
- Every widget edit was verified to preserve the existing GS code path bit-for-bit when `UseNoGS == false`.

## Test plan

- [x] macOS Apple Silicon: every refactored widget compiles + renders (smoke-tested via skirmish)
- [ ] Linux: relies on this CI matrix — every refactored widget should take the unchanged GS path
- [ ] Windows: same

## Notes for reviewers

- `Platform.osFamily == "MacOSX"` is a proxy for "no GS support". Every Linux/Windows GL driver supports GS in practice; the check can be replaced with a runtime feature query later if one becomes available.
- Widget injection points (`POST_VERTEX`, `POST_GEOMETRY`, `PRE_OFFSET`, `POST_ANIM`) execute **once per instance** on the GS path but **once per output vertex** on the NoGS path. Where this matters (e.g. `gui_rank_icons_gl4`'s compound multiply on `v_lengthwidthcornerheight`), I verified that the affected locals are freshly initialized per VS invocation and the operation is therefore idempotent. Documented in the NoGS include's docstring.