### PR TITLE
more bold line to active target in Set Target

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -871,7 +871,6 @@ else	-- UNSYNCED
 	-- 4k * 100 list length maximum is enough to assume target saturation with 32,000 unit cap.
 
 	local math_min = math.min
-	local ensureTable = table.ensureTable
 
 	local glVertex = gl.Vertex
 	local glPushAttrib = gl.PushAttrib
@@ -904,6 +903,7 @@ else	-- UNSYNCED
 	local mySpec, fullview = spGetSpectatingState()
 
 	local lineWidth = 1.4
+	local lineWidthActiveTarget = 3.4
 	local queueColour = { 1, 0.75, 0, 0.3 }
 	local commandColour = { 1, 0.5, 0, 0.3 }
 
@@ -963,8 +963,15 @@ else	-- UNSYNCED
 			return
 		end
 
-		local unitData = ensureTable(targetList, unitID)
-		local targets = ensureTable(unitData, "targets")
+		local unitData = targetList[unitID]
+		if not unitData then
+			unitData = {
+				targets = {},
+				targetIndex = 0,
+			}
+			targetList[unitID] = unitData
+		end
+		local targets = unitData.targets
 
 		if remove then
 			if index == 1 then
@@ -1061,18 +1068,30 @@ else	-- UNSYNCED
 		end
 	end
 
-	local function drawCurrentTarget(unitID, unitData, myTeam, myAllyTeam)
+	local function drawCurrentTarget(unitID, unitData)
 		local _, _, _, x1, y1, z1 = spGetUnitPosition(unitID, true)
 		glVertex(x1, y1, z1)
 		drawTargetCommand(unitData.targets[unitData.targetIndex])
 	end
 
-	local function drawTargetQueue(unitID, unitData, myTeam, myAllyTeam)
+	local function drawTargetQueue(unitID, unitData)
 		local _, _, _, x1, y1, z1 = spGetUnitPosition(unitID, true)
-		glVertex(x1, y1, z1)
+		if unitData.targetIndex == 0 then
+			glVertex(x1, y1, z1)
+		elseif not unitData.targets[2] then
+			return
+		end
 		for _, targetData in ipairs(unitData.targets) do
 			drawTargetCommand(targetData)
 		end
+	end
+
+	local function initDrawing()
+		glPushAttrib(GL.LINE_BITS)
+		glLineStipple("any") -- use spring's default line stipple pattern, moving
+		glDepthTest(false)
+		glLineWidth(lineWidth)
+		return true
 	end
 
 	local function drawDecorations()
@@ -1083,18 +1102,18 @@ else	-- UNSYNCED
 			if fullview or spGetUnitAllyTeam(unitID) == myAllyTeam then
 				if skipLeft == 0 and (drawTarget[unitID] or drawAllTargets[spGetUnitTeam(unitID)] or spIsUnitSelected(unitID)) then
 					if not init then
-						init = true
-						glPushAttrib(GL.LINE_BITS)
-						glLineStipple("any") -- use spring's default line stipple pattern, moving
-						glDepthTest(false)
+						init = initDrawing()
+					end
+
+					if unitData.targetIndex ~= 0 then
+						glColor(commandColour)
+						glLineWidth(lineWidthActiveTarget)
+						glBeginEnd(GL_LINES, drawCurrentTarget, unitID, unitData)
 						glLineWidth(lineWidth)
 					end
+
 					glColor(queueColour)
-					glBeginEnd(GL_LINE_STRIP, drawTargetQueue, unitID, unitData, myTeam, myAllyTeam)
-					if (unitData.targetIndex or 0) ~= 0 then
-						glColor(commandColour)
-						glBeginEnd(GL_LINES, drawCurrentTarget, unitID, unitData, myTeam, myAllyTeam)
-					end
+					glBeginEnd(GL_LINE_STRIP, drawTargetQueue, unitID, unitData)
 
 					-- Use a gradual backoff to skip drawing commands at high unit counts.
 					skipChunkLeft = skipChunkLeft - 1

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -247,9 +247,7 @@ if gadgetHandler:IsSyncedCode() then
 				return false
 			end
 		else
-			targetX = target[1]
-			targetY = target[2]
-			targetZ = target[3]
+			targetX, targetY, targetZ = target[1], target[2], target[3]
 			if not spSetUnitTarget(unitID, targetX, targetY, targetZ, false, targetData.userTarget) then
 				return false
 			end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -230,39 +230,36 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function setTarget(unitID, targetData)
 		local unitData = unitTargets[unitID]
-		if not TargetCanBeReached(unitID, unitData.teamID, unitData.weapons, targetData.target) then
-			local currentCmdID = spGetUnitCurrentCommand(unitID)
-			if currentCmdID == CMD.ATTACK then
-				return false
-			else
-				Spring.SetUnitTarget(unitID, nil)
-				return false
-			end
-		end
-		
 		local target = targetData.target
-		local isUnitTarget = type(target) == "number"
-		
-		if isUnitTarget then
-			if not spSetUnitTarget(unitID, target, false, targetData.userTarget) then
-				return false
+
+		if not TargetCanBeReached(unitID, unitData.teamID, unitData.weapons, target) then
+			if unitData.hasTarget and spGetUnitCurrentCommand(unitID) ~= CMD.ATTACK then
+				spSetUnitTarget(unitID, nil)
 			end
-
-			spSetUnitRulesParam(unitID, "targetID", target)
-			spSetUnitRulesParam(unitID, "targetCoordX", -1)
-			spSetUnitRulesParam(unitID, "targetCoordY", -1)
-			spSetUnitRulesParam(unitID, "targetCoordZ", -1)
-
-		else
-			if not spSetUnitTarget(unitID, target[1], target[2], target[3], false, targetData.userTarget) then
-				return false
-			end
-
-			spSetUnitRulesParam(unitID, "targetID", -1)
-			spSetUnitRulesParam(unitID, "targetCoordX", target[1])
-			spSetUnitRulesParam(unitID, "targetCoordY", target[2])
-			spSetUnitRulesParam(unitID, "targetCoordZ", target[3])
+			unitData.hasTarget = false
+			return false
 		end
+
+		local targetID, targetX, targetY, targetZ = -1, -1, -1, -1
+		if type(target) == "number" then
+			targetID = target
+			if not spSetUnitTarget(unitID, targetID, false, targetData.userTarget) then
+				return false
+			end
+		else
+			targetX = target[1]
+			targetY = target[2]
+			targetZ = target[3]
+			if not spSetUnitTarget(unitID, targetX, targetY, targetZ, false, targetData.userTarget) then
+				return false
+			end
+		end
+		spSetUnitRulesParam(unitID, "targetID",     targetID)
+		spSetUnitRulesParam(unitID, "targetCoordX", targetX)
+		spSetUnitRulesParam(unitID, "targetCoordY", targetY)
+		spSetUnitRulesParam(unitID, "targetCoordZ", targetZ)
+
+		unitData.hasTarget = true
 		return true
 	end
 
@@ -346,6 +343,7 @@ if gadgetHandler:IsSyncedCode() then
 					allyTeam = spGetUnitAllyTeam(unitID),
 					weapons = unitWeapons[unitDefID],
 					currentIndex = 0,
+					hasTarget = false,
 				}
 			end
 			if not append then
@@ -380,11 +378,10 @@ if gadgetHandler:IsSyncedCode() then
 				checkForManualFire[unitID] = true
 			end
 			sendTargetsToUnsyncedBatched(unitID)
-			if setTarget(unitID, data.targets[1]) then
-				if data.currentIndex ~= 1 then
-					data.currentIndex = 1
-					SendToUnsynced("targetIndex", unitID, 1)
-				end
+			if not data.hasTarget and setTarget(unitID, data.targets[1]) then
+				data.currentIndex = 1
+				data.hasTarget = true
+				SendToUnsynced("targetIndex", unitID, 1)
 			end
 		end
 		--tracy.ZoneEnd()
@@ -407,7 +404,6 @@ if gadgetHandler:IsSyncedCode() then
 		end
 		waitForCommandDone[unitID] = nil
 	end
-
 
 	local function refreshSendList(unitID, unitData, minIndex)
 		local targetList = unitData.targets
@@ -808,7 +804,7 @@ if gadgetHandler:IsSyncedCode() then
 						-- Mark for removal, but don't remove during iteration
 						targetData.invalid = true
 						targetOffset = targetOffset + 1
-					elseif not targetData.invalid and setTarget(unitID, targetData) then
+					elseif setTarget(unitID, targetData) then
 						targetIndex = index - targetOffset
 						break
 					end


### PR DESCRIPTION
### Work done

- Draw a bolder line to a currently active target. The orange is barely visible on a large number of maps with earthy tones.
- Remove overlap between the current target (orange) and the target queue (yellow) when drawing the target list.
- Made it obvious in Set Target code when an active target is being tracked, already apparent from `currentIndex`. Some repetitive checks can be skipped by first checking `hasTarget`.