### PR TITLE
improvements to gfx diag fog lines + radarjammer red

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1218,6 +1218,7 @@
 				"lineofsight": "Fog of war",
 				"losopacity": "opacity",
 				"fogdiaglines": "diagonal lines",
+				"fogdiaglines_blur": "diagonal lines blur",
 				"water": "Water quality",
 				"decals": "Unit tracks",
 				"decals_descr": "0 = Off\nNOTE: Changes might require a restart (if you turn it On/Off)",

--- a/luaui/Shaders/fog_diaglines.frag.glsl
+++ b/luaui/Shaders/fog_diaglines.frag.glsl
@@ -10,6 +10,9 @@ uniform float lineFreq;     // elmos per line cycle (world-space; lines anchor t
 uniform float lineWidth;    // 0..1 fraction of cycle that is line vs gap (0.5 = equal)
 uniform float lineSharpness;// smoothstep half-width at the edge (smaller = sharper)
 uniform float scrollSpeed;  // animation speed in cycles per second
+uniform float noiseScale;   // elmos per noise cell; larger = bigger, softer blotches
+uniform float noiseAmount;  // 0 = lines untouched, 1 = noise can fully fade lines out
+uniform float noiseSpeed;   // how fast the noise field drifts/evolves
 
 //__DEFINES__
 //__ENGINEUNIFORMBUFFERDEFS__
@@ -19,6 +22,25 @@ in DataVS {
 };
 
 out vec4 fragColor;
+
+// Cheap 2D value noise: hash the integer grid corners and bilerp with a smooth
+// fade. One hash per corner, no octaves — deliberately low cost.
+float hash21(vec2 p) {
+    p = fract(p * vec2(123.34, 345.45));
+    p += dot(p, p + 34.345);
+    return fract(p.x * p.y);
+}
+
+float valueNoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    vec2 u = f * f * (3.0 - 2.0 * f); // smoothstep fade
+    float a = hash21(i + vec2(0.0, 0.0));
+    float b = hash21(i + vec2(1.0, 0.0));
+    float c = hash21(i + vec2(0.0, 1.0));
+    float d = hash21(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
 
 void main(void) {
     // Reconstruct world position from depth. This gives us a way to look up
@@ -51,7 +73,12 @@ void main(void) {
     // the behaviour players intuitively expect from a ground overlay).
     // Use a triangle wave (abs of fract) instead of sine so lineWidth maps
     // intuitively to the line-vs-gap fraction of one cycle.
-    float scrolled = (worldPos.x + worldPos.z) / lineFreq - timeInfo.x * scrollSpeed;
+    // lineDir is the (normalised) direction the pattern phase increases along,
+    // which sets the line angle: (cos a, sin a) for an angle a measured from the
+    // X axis. 36 degrees -> (0.809, 0.588). Keep it normalised so lineFreq stays
+    // an honest world-space spacing regardless of angle.
+    const vec2 lineDir = vec2(0.80901699, 0.58778525); // 36 degrees
+    float scrolled = dot(worldPos.xz, lineDir) / lineFreq - timeInfo.x * scrollSpeed;
     float tri = abs(fract(scrolled) * 2.0 - 1.0); // 0 at line center, 1 at gap center
 
     // Anti-alias against actual screen-space derivative of the pattern phase.
@@ -61,6 +88,17 @@ void main(void) {
     float aa = max(lineSharpness, pixelWidth);
     float threshold = clamp(lineWidth, 0.0, 1.0);
     float line = 1.0 - smoothstep(threshold - aa, threshold + aa, tri);
+
+    // Subtle animated noise over the fogged area: low-frequency world-space
+    // blotches that slowly drift, locally fading the lines so the pattern feels
+    // alive rather than perfectly static. The noise is anchored to the ground
+    // (world XZ) and the field itself evolves over time via the z-offset trick.
+    vec2 noiseUV = worldPos.xz / noiseScale + vec2(timeInfo.x * noiseSpeed);
+    float n = valueNoise(noiseUV);
+    // Remap so most of the area is untouched and only the darker patches fade:
+    // smoothstep keeps the effect from looking like uniform flicker.
+    float fade = 1.0 - noiseAmount * smoothstep(0.35, 0.65, n);
+    line *= fade;
 
     fragColor = vec4(lineColor.rgb, line * fogMask * lineColor.a);
 }

--- a/luaui/Widgets/gfx_fog_diaglines_gl4.lua
+++ b/luaui/Widgets/gfx_fog_diaglines_gl4.lua
@@ -20,10 +20,10 @@ local LuaShader = gl.LuaShader
 local InstanceVBOTable = gl.InstanceVBOTable
 
 -- Tunables
-local strength       = 0.30  -- 0 = lines off, 1 = full opacity
+local strength       = 0.25  -- 0 = lines off, 1 = full opacity
 local lineFreq       = 35.94 -- elmos per line cycle (world-space; lines anchor to ground and grow with zoom). Now a true spacing since the shader uses a normalised line direction; was visually ~29.7 before two +10% spacing bumps.
 local lineWidth      = 0.38  -- 0..1 fraction of cycle that is line; lower = thinner lines + bigger gaps
-local lineSharpness  = 0.19  -- smoothstep half-width at the edge (smaller = sharper, auto-widened when zoomed out)
+local lineSharpness  = 0.3725 -- smoothstep half-width at the edge (smaller = sharper, auto-widened when zoomed out). 0.3725 == blur slider 0.43 (see sharpnessMin/Max below)
 local scrollSpeed    = 0.0067  -- cycles per second
 
 -- Subtle animated noise that locally fades the lines for a dynamic feel.

--- a/luaui/Widgets/gfx_fog_diaglines_gl4.lua
+++ b/luaui/Widgets/gfx_fog_diaglines_gl4.lua
@@ -162,7 +162,9 @@ function widget:Initialize()
 		-- Blurriness slider: 0 = sharp edges, 1 = strongly blurred. Maps linearly
 		-- onto lineSharpness (the smoothstep half-width at each line edge).
 		getBlurriness = function()
-			return (lineSharpness - sharpnessMin) / (sharpnessMax - sharpnessMin)
+			local range = sharpnessMax - sharpnessMin
+			if range <= 0 then return 0 end -- guard against a degenerate (min == max) range
+			return (lineSharpness - sharpnessMin) / range
 		end,
 		setBlurriness = function(value)
 			local t = math.max(0, math.min(1, value or 0))

--- a/luaui/Widgets/gfx_fog_diaglines_gl4.lua
+++ b/luaui/Widgets/gfx_fog_diaglines_gl4.lua
@@ -21,10 +21,20 @@ local InstanceVBOTable = gl.InstanceVBOTable
 
 -- Tunables
 local strength       = 0.30  -- 0 = lines off, 1 = full opacity
-local lineFreq       = 42.0  -- elmos per line cycle (world-space; lines anchor to ground and grow with zoom)
+local lineFreq       = 35.94 -- elmos per line cycle (world-space; lines anchor to ground and grow with zoom). Now a true spacing since the shader uses a normalised line direction; was visually ~29.7 before two +10% spacing bumps.
 local lineWidth      = 0.38  -- 0..1 fraction of cycle that is line; lower = thinner lines + bigger gaps
 local lineSharpness  = 0.19  -- smoothstep half-width at the edge (smaller = sharper, auto-widened when zoomed out)
-local scrollSpeed    = 0.008  -- cycles per second
+local scrollSpeed    = 0.0067  -- cycles per second
+
+-- Subtle animated noise that locally fades the lines for a dynamic feel.
+local noiseScale     = 512.0  -- elmos per noise cell; larger = bigger, softer blotches
+local noiseAmount    = 0.46   -- 0 = off, 1 = noise can fully fade lines out
+local noiseSpeed     = 0.010  -- how fast the noise field drifts
+
+-- Range that the 0..1 "blurriness" settings slider maps lineSharpness onto.
+-- The default 0.19 above sits a little below the middle of this range.
+local sharpnessMin   = 0.05  -- slider at 0 = crisp lines
+local sharpnessMax   = 0.80  -- slider at 1 = strongly blurred
 
 -- Smoothing tunables (temporal blend toward live engine coverage)
 local accumUpdateRate = 2     -- update accumulator every N gameframes
@@ -56,6 +66,9 @@ local diagShaderSourceCache = {
 		lineWidth     = lineWidth,
 		lineSharpness = lineSharpness,
 		scrollSpeed   = scrollSpeed,
+		noiseScale    = noiseScale,
+		noiseAmount   = noiseAmount,
+		noiseSpeed    = noiseSpeed,
 	},
 	shaderName = "Fog Diagonal Lines GL4",
 	shaderConfig = {},
@@ -146,6 +159,15 @@ function widget:Initialize()
 	WG.fogdiaglines = {
 		getStrength = function() return strength end,
 		setStrength = function(value) strength = math.max(0, math.min(1, value or 0)) end,
+		-- Blurriness slider: 0 = sharp edges, 1 = strongly blurred. Maps linearly
+		-- onto lineSharpness (the smoothstep half-width at each line edge).
+		getBlurriness = function()
+			return (lineSharpness - sharpnessMin) / (sharpnessMax - sharpnessMin)
+		end,
+		setBlurriness = function(value)
+			local t = math.max(0, math.min(1, value or 0))
+			lineSharpness = sharpnessMin + t * (sharpnessMax - sharpnessMin)
+		end,
 	}
 end
 
@@ -201,6 +223,9 @@ function widget:DrawWorldPreUnit()
 	diagShader:SetUniformFloat("lineWidth", lineWidth)
 	diagShader:SetUniformFloat("lineSharpness", lineSharpness)
 	diagShader:SetUniformFloat("scrollSpeed", scrollSpeed)
+	diagShader:SetUniformFloat("noiseScale", noiseScale)
+	diagShader:SetUniformFloat("noiseAmount", noiseAmount)
+	diagShader:SetUniformFloat("noiseSpeed", noiseSpeed)
 	fullScreenQuadVAO:DrawArrays(GL.TRIANGLES)
 	diagShader:Deactivate()
 
@@ -209,9 +234,14 @@ function widget:DrawWorldPreUnit()
 end
 
 function widget:GetConfigData()
-	return { strength = strength }
+	return { strength = strength, blurriness = WG.fogdiaglines and WG.fogdiaglines.getBlurriness() or nil }
 end
 
 function widget:SetConfigData(data)
 	if data.strength ~= nil then strength = data.strength end
+	-- blurriness is the 0..1 slider value; map it back onto lineSharpness.
+	if data.blurriness ~= nil then
+		local t = math.max(0, math.min(1, data.blurriness))
+		lineSharpness = sharpnessMin + t * (sharpnessMax - sharpnessMin)
+	end
 end

--- a/luaui/Widgets/gfx_los_colors.lua
+++ b/luaui/Widgets/gfx_los_colors.lua
@@ -24,7 +24,7 @@ local losColors = {
 	fog =    {0.40, 0.40, 0.40},
 	los =    {0.60, 0.60, 0.60},
 	radar =  {0.00, 0.00, 0.00}, -- not used
-	jam =    {0.08, -0.08, -0.08},
+	jam =    {0.03, -0.03, -0.03}, -- additive tint: R-G/B spread sets how red jammed areas look (was 0.08)
 	radar2 = {0.40, 0.40, 0.40},
 }
 

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2950,6 +2950,15 @@ function init()
 		  end,
 		},
 
+		{ id = "fogdiaglines_blur", group = "gfx", category = types.advanced, name = Spring.I18N('ui.settings.option.lineofsight')..widgetOptionColor .. "  " .. Spring.I18N('ui.settings.option.fogdiaglines_blur'), type = "slider", min = 0, max = 1, step = 0.01, value = (WG.fogdiaglines ~= nil and WG.fogdiaglines.getBlurriness ~= nil and WG.fogdiaglines.getBlurriness()) or 0.187, description = '',
+		  onload = function(i)
+			  loadWidgetData("Fog Diagonal Lines GL4", "fogdiaglines_blur", { 'blurriness' })
+		  end,
+		  onchange = function(i, value)
+			  saveOptionValue('Fog Diagonal Lines GL4', 'fogdiaglines', 'setBlurriness', { 'blurriness' }, value)
+		  end,
+		},
+
 		{ id = "water", group = "gfx", category = types.basic, name = Spring.I18N('ui.settings.option.water'), type = "select", options = { Spring.I18N('ui.settings.option.select_low'), Spring.I18N('ui.settings.option.select_high') }, value = desiredWaterValue == 4 and 2 or 1,
 		  onload = function(i)
 		  end,


### PR DESCRIPTION
new no-radar-diagonal-lines:

- more blurry (configurable)
- a bit more space between lines
- slight change in angle (36 degrees instead of 45)
- reduced speed from 0.008 to 0.0067
- added a slight subtle noise effect so some parts are a bit less visible than others
- changed default 0.30 opacity to 0.25
- changed default blurry ness from 0.19 to 0.3725 (more blur)

Re-tinted jammer area from 0.08 to 0.03 values, so jammed areas don't get super red.

See https://discord.com/channels/549281623154229250/1510005538245705980/1511091062477947030