### PR TITLE
Fix: Allow Minelayers to assist build

### DIFF
--- a/units/ArmVehicles/armmlv.lua
+++ b/units/ArmVehicles/armmlv.lua
@@ -5,7 +5,6 @@ return {
 		builder = true,
 		buildpic = "ARMMLV.DDS",
 		buildtime = 3520,
-		canassist = false,
 		canmove = true,
 		canreclaim = false,
 		canrepair = true,

--- a/units/CorVehicles/cormlv.lua
+++ b/units/CorVehicles/cormlv.lua
@@ -5,7 +5,6 @@ return {
 		builder = true,
 		buildpic = "CORMLV.DDS",
 		buildtime = 3640,
-		canassist = false,
 		canmove = true,
 		canreclaim = false,
 		canrepair = true,

--- a/units/Legion/Vehicles/legmlv.lua
+++ b/units/Legion/Vehicles/legmlv.lua
@@ -5,7 +5,6 @@ return {
 		builder = true,
 		buildpic = "legmlv.DDS",
 		buildtime = 3640,
-		canassist = false,
 		canmove = true,
 		canreclaim = false,
 		canrepair = true,


### PR DESCRIPTION
### Work done
Allows mine layer vehicles to assist build. 

Very minor balance decision? But minelayers are terrible builders regardless, and there already exists jammed builders who can assist (commando) so the risk is low. 

#### Addresses Issue(s)
Mostly addresses: https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3210
https://discord.com/channels/549281623154229250/1472259243997663418
Except the underlying issue with unit_clear_builder_queue and lag in multiplayer games. But alleviates it a lot. 

#### Test steps
- Start building a mine, stop building a mine, restart building the mine. 

### AI / LLM usage statement:
No AI