### PR TITLE
Adding range check to construction turrets on single target commands

### DIFF
--- a/luaui/Widgets/cmd_nanoturrets_assist_range.lua
+++ b/luaui/Widgets/cmd_nanoturrets_assist_range.lua
@@ -22,11 +22,34 @@ local spGetUnitBuildeeRadius = Spring.GetUnitBuildeeRadius
 local spGetFeaturePosition = Spring.GetFeaturePosition
 local maxUnits = Game.maxUnits
 
-local nanoDefs = {}
+local nanoBuildDistances = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
 	if unitDef.isBuilder and not unitDef.canMove and not unitDef.isFactory then
-		nanoDefs[unitDefID] = unitDef.buildDistance
+		nanoBuildDistances[unitDefID] = unitDef.buildDistance
 	end
+end
+
+local function isWithinBuildDistance(unitID, buildDistance, targetX, targetZ, targetRadius)
+	local nanoX, _, nanoZ = spGetUnitPosition(unitID)
+	-- nanoX is nil if nano died before the command was processed
+	if nanoX then
+		local adjustedRange = buildDistance + targetRadius
+		local dx = nanoX - targetX
+		local dz = nanoZ - targetZ
+		if dx * dx + dz * dz <= adjustedRange * adjustedRange then
+			return true
+		end
+	end
+	return false
+end
+
+local function hasNano(selectedUnits)
+	for _, unitID in ipairs(selectedUnits) do
+		if nanoBuildDistances[spGetUnitDefID(unitID)] then
+			return true
+		end
+	end
+	return false
 end
 
 function widget:CommandNotify(id, params, options)
@@ -37,41 +60,28 @@ function widget:CommandNotify(id, params, options)
 
 	local selectedUnits = spGetSelectedUnits()
 
-	local hasNano = false
-	for _, unitID in ipairs(selectedUnits) do
-		if nanoDefs[spGetUnitDefID(unitID)] then
-			hasNano = true
-			break
-		end
-	end
-	if not hasNano then return false end
+	if not hasNano(selectedUnits) then return false end
 
-	local tx, tz, targetRadius
+	local targetX, targetZ, targetRadius
 
 	if params[1] < maxUnits then
-		tx, _, tz = spGetUnitPosition(params[1])
+		targetX, _, targetZ = spGetUnitPosition(params[1])
 		targetRadius = spGetUnitBuildeeRadius(params[1]) or 0
 	else
-		tx, _, tz = spGetFeaturePosition(params[1] - maxUnits)
+		targetX, _, targetZ = spGetFeaturePosition(params[1] - maxUnits)
 		targetRadius = 0
 	end
 
-	-- tx is nil if target died before the command was processed
-	if not tx then return false end
+	-- targetX is nil if target died before the command was processed
+	if not targetX then return false end
 
 	for _, unitID in ipairs(selectedUnits) do
-		local unitDefID = spGetUnitDefID(unitID)
+		local buildDistance = nanoBuildDistances[spGetUnitDefID(unitID)]
 
-		if nanoDefs[unitDefID] ~= nil then
-			local nx, _, nz = spGetUnitPosition(unitID)
-			-- nx is nil if nano died before the command was processed
-			if nx then
-				local adjustedRange = nanoDefs[unitDefID] + targetRadius
-				local dx = nx - tx
-				local dz = nz - tz
-				if dx * dx + dz * dz <= adjustedRange * adjustedRange then
-					spGiveOrderToUnit(unitID, id, params, options)
-				end
+		-- buildDistance is nil when the unit is not a nano
+		if buildDistance ~= nil then
+			if isWithinBuildDistance(unitID, buildDistance, targetX, targetZ, targetRadius) then
+				spGiveOrderToUnit(unitID, id, params, options)
 			end
 		else
 			spGiveOrderToUnit(unitID, id, params, options)

--- a/luaui/Widgets/cmd_nanoturrets_assist_range.lua
+++ b/luaui/Widgets/cmd_nanoturrets_assist_range.lua
@@ -1,0 +1,82 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name    = "Construction Turrets range assist",
+		desc    = "When a command is given to nanos, this widget will check if each nanos is in range to execute it. If not the command will not be given to the out of range nanos. Use CTRL to skip this widget.",
+		author  = "mreasyfrag",
+		date    = "30/05/2026",
+		license = "GNU GPL, v2 or later",
+		layer   = -1,
+		-- -1 to be executed before cmd_no_duplicate_orders.lua that break the behavior when using right click to repair on the second click
+		enabled = true,
+	}
+end
+
+local spGetSelectedUnits = Spring.GetSelectedUnits
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local UnitDefs = UnitDefs
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetUnitBuildeeRadius = Spring.GetUnitBuildeeRadius
+local spGetFeaturePosition = Spring.GetFeaturePosition
+local maxUnits = Game.maxUnits
+
+local nanoDefs = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.isBuilder and not unitDef.canMove and not unitDef.isFactory then
+		nanoDefs[unitDefID] = unitDef.buildDistance
+	end
+end
+
+function widget:CommandNotify(id, params, options)
+	if options.ctrl then return false end
+	if #params ~= 1 then return false end
+
+	if id ~= CMD.REPAIR and id ~= CMD.RECLAIM and id ~= CMD.GUARD then return false end
+
+	local selectedUnits = spGetSelectedUnits()
+
+	local hasNano = false
+	for _, unitID in ipairs(selectedUnits) do
+		if nanoDefs[spGetUnitDefID(unitID)] then
+			hasNano = true
+			break
+		end
+	end
+	if not hasNano then return false end
+
+	local tx, tz, targetRadius
+
+	if params[1] < maxUnits then
+		tx, _, tz = spGetUnitPosition(params[1])
+		targetRadius = spGetUnitBuildeeRadius(params[1]) or 0
+	else
+		tx, _, tz = spGetFeaturePosition(params[1] - maxUnits)
+		targetRadius = 0
+	end
+
+	-- tx is nil if target died before the command was processed
+	if not tx then return false end
+
+	for _, unitID in ipairs(selectedUnits) do
+		local unitDefID = spGetUnitDefID(unitID)
+
+		if nanoDefs[unitDefID] ~= nil then
+			local nx, _, nz = spGetUnitPosition(unitID)
+			-- nx is nil if nano died before the command was processed
+			if nx then
+				local adjustedRange = nanoDefs[unitDefID] + targetRadius
+				local dx = nx - tx
+				local dz = nz - tz
+				if dx * dx + dz * dz <= adjustedRange * adjustedRange then
+					spGiveOrderToUnit(unitID, id, params, options)
+				end
+			end
+		else
+			spGiveOrderToUnit(unitID, id, params, options)
+		end
+	end
+
+	return true
+end

--- a/luaui/Widgets/cmd_nanoturrets_assist_range.lua
+++ b/luaui/Widgets/cmd_nanoturrets_assist_range.lua
@@ -60,7 +60,7 @@ local function getPositionAndRadius(id)
 		r = spGetUnitBuildeeRadius(id)
 	else
 		x, y, z = spGetFeaturePosition(id)
-		r = spGetFeaturePosition(id)
+		r = spGetFeatureRadius(id)
 	end
 	return x, y, z, r
 end
@@ -75,7 +75,7 @@ function widget:CommandNotify(id, params, options)
 
 	if not hasNano(selectedUnits) then return false end
 
-	local targetX, targetY, targetZ, targetRadius = getPositionAndRadius(params[1])
+	local targetX, _, targetZ, targetRadius = getPositionAndRadius(params[1])
 
 	-- targetX is nil if target died before the command was processed
 	if not targetX then return false end

--- a/luaui/Widgets/cmd_nanoturrets_assist_range.lua
+++ b/luaui/Widgets/cmd_nanoturrets_assist_range.lua
@@ -20,6 +20,7 @@ local UnitDefs = UnitDefs
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitBuildeeRadius = Spring.GetUnitBuildeeRadius
 local spGetFeaturePosition = Spring.GetFeaturePosition
+local spGetFeatureRadius = Spring.GetFeatureRadius
 local maxUnits = Game.maxUnits
 
 local nanoBuildDistances = {}
@@ -52,6 +53,18 @@ local function hasNano(selectedUnits)
 	return false
 end
 
+local function getPositionAndRadius(id)
+	local x, y, z, r
+	if id < maxUnits then
+		x, y, z = spGetUnitPosition(id)
+		r = spGetUnitBuildeeRadius(id)
+	else
+		x, y, z = spGetFeaturePosition(id)
+		r = spGetFeaturePosition(id)
+	end
+	return x, y, z, r
+end
+
 function widget:CommandNotify(id, params, options)
 	if options.ctrl then return false end
 	if #params ~= 1 then return false end
@@ -62,15 +75,7 @@ function widget:CommandNotify(id, params, options)
 
 	if not hasNano(selectedUnits) then return false end
 
-	local targetX, targetZ, targetRadius
-
-	if params[1] < maxUnits then
-		targetX, _, targetZ = spGetUnitPosition(params[1])
-		targetRadius = spGetUnitBuildeeRadius(params[1]) or 0
-	else
-		targetX, _, targetZ = spGetFeaturePosition(params[1] - maxUnits)
-		targetRadius = 0
-	end
+	local targetX, targetY, targetZ, targetRadius = getPositionAndRadius(params[1])
 
 	-- targetX is nil if target died before the command was processed
 	if not targetX then return false end

--- a/luaui/Widgets/cmd_nanoturrets_assist_range.lua
+++ b/luaui/Widgets/cmd_nanoturrets_assist_range.lua
@@ -16,7 +16,6 @@ end
 local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
-local UnitDefs = UnitDefs
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitBuildeeRadius = Spring.GetUnitBuildeeRadius
 local spGetFeaturePosition = Spring.GetFeaturePosition


### PR DESCRIPTION
### Work done

Adding a new widget that intercepts single target guard, repair and reclaim commands given to construction turrets to check if they are in range to perform the command. The command will only be given to turrets that are in range.

This only applies to single target commands for guard, repair and reclaim if at least one construction turret is included in the selected units and if CTRL key is not pressed.

If CTRL key is pressed it will skip the widget to give the command to all unit (current behavior).

If selection contains units that are not construction turrets the command will be given to them as is.

Layer is -1 to be executed before cmd_no_duplicate_orders widget, which breaks the behavior when using right click to repair if some construction turrets selected (but not necessary all) are already following the order.

Why only single target? The engine already performs a range check for area commands and trying to include area commands in this widget just create multiple conflicts with other widget handling such commands.

I tried to look for other potential conflict with other widget handling single target command but except the one describe above with cmd_no_duplicate_orders I didn't find any.

Images before and after repair command was given to all construction turrets:
<img width="1000" height="431" alt="image" src="https://github.com/user-attachments/assets/5f53ac84-fc73-4442-9b64-f9d7fe30f77f" />
<img width="1000" height="431" alt="image" src="https://github.com/user-attachments/assets/98e0c835-034a-4812-9367-08e20531a689" />

#### Addresses Issue(s)
Not an issue but relevent post on BAR discord where this feature was discussed : https://discord.com/channels/549281623154229250/1497634147370270790

#### Test steps
- Build multiple construction turrets and other unit in range and outside of range of the turrets
- Select all
- Give guard, repair or reclaim order targeting a unit that is in range of some turrets and outside of range of other
- Only turrets in range will get the order, other will kept their previous order
