### PR TITLE
Fix: Bombers not respecting option to hold fire

### DIFF
--- a/units/ArmAircraft/T2/armpnix.lua
+++ b/units/ArmAircraft/T2/armpnix.lua
@@ -22,7 +22,6 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 230,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMPNIX.s3o",
 		script = "Units/ARMPNIX.cob",

--- a/units/ArmAircraft/armthund.lua
+++ b/units/ArmAircraft/armthund.lua
@@ -8,7 +8,6 @@ return {
 		cruisealtitude = 165,
 		energycost = 4400,
 		explodeas = "mediumexplosiongeneric",
-		firestate = 0,
 		footprintx = 3,
 		footprintz = 3,
 		health = 670,

--- a/units/ArmSeaplanes/armsb.lua
+++ b/units/ArmSeaplanes/armsb.lua
@@ -22,7 +22,6 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 255,
 		metalcost = 240,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/ARMSB.s3o",
 		script = "Units/ARMSB.cob",

--- a/units/CorAircraft/T2/corhurc.lua
+++ b/units/CorAircraft/T2/corhurc.lua
@@ -22,7 +22,6 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 310,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORHURC.s3o",
 		script = "Units/CORHURC.cob",

--- a/units/CorAircraft/corshad.lua
+++ b/units/CorAircraft/corshad.lua
@@ -22,7 +22,6 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 0,
 		metalcost = 150,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORSHAD.s3o",
 		script = "Units/CORSHAD.cob",

--- a/units/CorSeaplanes/corsb.lua
+++ b/units/CorSeaplanes/corsb.lua
@@ -23,7 +23,6 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 255,
 		metalcost = 200,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/CORSB.s3o",
 		script = "Units/CORSB.cob",

--- a/units/Legion/Air/T2 Air/legmineb.lua
+++ b/units/Legion/Air/T2 Air/legmineb.lua
@@ -24,7 +24,6 @@ return {
 		maxslope = 10,
 		speed = 210.0,
 		maxwaterdepth = 0,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/legmineb.s3o",
 		script = "Units/legmineb.cob",

--- a/units/Legion/Air/T2 Air/legnap.lua
+++ b/units/Legion/Air/T2 Air/legnap.lua
@@ -25,7 +25,6 @@ return {
 		maxslope = 10,
 		speed = 215,
 		maxwaterdepth = 0,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/LEGNAP.s3o",
 		script = "Units/CORHURC.cob",

--- a/units/Legion/Air/T2 Air/legphoenix.lua
+++ b/units/Legion/Air/T2 Air/legphoenix.lua
@@ -25,7 +25,6 @@ return {
 		maxslope = 10,
 		speed = 270,
 		maxwaterdepth = 0,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/legphoenix.s3o",
 		script = "Units/legphoenix.cob",

--- a/units/Legion/SeaPlanes/legspbomber.lua
+++ b/units/Legion/SeaPlanes/legspbomber.lua
@@ -22,7 +22,6 @@ return {
 		maxslope = 10,
 		maxwaterdepth = 255,
 		metalcost = 240,
-		firestate = 0,
 		nochasecategory = "VTOL",
 		objectname = "Units/legspbomber.s3o",
 		script = "Units/legspbomber.cob",


### PR DESCRIPTION
They should not have been given `firestate = 0 ` in the unitdef. They should remain the default firestate = -1 which means inheriting lab state. With `firestate = 0 ` the setting toggle does nothing and the widget is superfluous  

### Work done
Fixes bombers not respecting the lab state when built with the bombers hold fire setting off. 

#### Addresses Issue(s)
https://discord.com/channels/549281623154229250/1511122764466098447

#### Setup

<img width="1049" height="143" alt="image" src="https://github.com/user-attachments/assets/ee8fd575-d5a6-469e-b49b-0ccb1891207e" />

#### AFTER:
Setting off: 

<img width="883" height="543" alt="image" src="https://github.com/user-attachments/assets/f145cdd4-3bbc-4514-88c5-c8ffa8bff316" />

Setting on: 

<img width="602" height="372" alt="image" src="https://github.com/user-attachments/assets/86f517cc-21ca-4269-9cd8-2e58e97a4d1a" />

#### Note:
This setting should one day be rolled into stateprefs. 

### AI / LLM usage statement:
No AI
