### PR TITLE
perf: early exit on AllowWeaponTarget calls with no priority

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1699,8 +1699,13 @@ end
 return ((ignore and -1) or 1)
 end
 
-
 function gadgetHandler:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
+	-- Calls with no input priority are pure pass/fail tests.
+	-- These are common, and BAR never disallows any of them.
+	if not defPriority then
+		return true -- The second return value is never used.
+	end
+
 	local allowed = true
 	local result = 1.0
 
@@ -1712,14 +1717,10 @@ function gadgetHandler:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum
 		end
 		allowed, result = defPriority > 0, defPriority
 	else
+		-- The actual callin. BAR only uses AllowWeaponTarget for the target priority.
 		for _, g in ipairs(self.AllowWeaponTargetList) do
-			local targetAllowed, targetPriority = g:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
-
-			if not targetAllowed then
-				allowed = false;
-				break
-			end
-			if targetPriority > result then
+			local targetPriority = g:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
+			if targetPriority then
 				result = targetPriority
 			end
 		end
@@ -1728,6 +1729,10 @@ function gadgetHandler:AllowWeaponTarget(attackerID, targetID, attackerWeaponNum
 	return allowed, result
 end
 
+function gadgetHandler:UnitAutoTargetRange(attackerID, autoTargetRange)
+	-- Implementation stub for g:UnitAutoTargetRange. See g:AllowWeaponTarget, above.
+	-- This is needed for gadgetHandler to "see" this callin and build its call list.
+end
 
 function gadgetHandler:AllowWeaponInterceptTarget(interceptorUnitID, interceptorWeaponNum, interceptorTargetID)
 	for _, g in ipairs(self.AllowWeaponInterceptTargetList) do

--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -90,7 +90,6 @@ if gadgetHandler:IsSyncedCode() then
 	-- so the attacker always has AA priority — no need to check hasPriorityAir or call
 	-- spGetUnitDefID on the attacker.
 	function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
-		defPriority = defPriority or 1.0
 		local mult = airPriorityMultiplier[spGetUnitDefID(targetID)]
 		if mult then
 			defPriority = defPriority * mult


### PR DESCRIPTION
### Work done

- Short-circuit all calls to g:AllowWeaponTarget that do not set a meaningful targeting priority.
- Sets up a stub for g:UnitAutoTargetRange for disallowing weapon targets only during autotargeting sweeps. Gadgets now can use it like an ordinary callin.

We have an overloaded callin, AllowWeaponTarget, that is used both for allowing targeting as the name suggests and for target priority. We do not use it to reject any targets, however, only for priority. Its most frequent call site coming from the engine ignores priority entirely.

This has a large impact on massed fighter v fighter combat. This case almost always uses generated attack orders, either through autotargeting or the Fight command. It is impractical for the player to assign attacks, and Set Target is still impractical for mass targeting without crashing.

#### Addresses Issue(s)

- Deals with the overloading of the callin by removing one of its "extra" uses. It is just this again: https://github.com/beyond-all-reason/RecoilEngine/issues/1623
- 1k vs 1k fighters hits about 21% CPU time on my potato testing laptop (fairly average PC gaming equipment for 2026) due to the AA target priority gadget. FPS does not restore until almost no fighters remain due to heavy GC. Players have an understanding to go "hands off the keyboard" after issuing an order to full-send all fighters to avoid instability and crashes; this goes a long way to fixing that.