### PR TITLE
Raptors/Scav spawn optimisation

### DIFF
--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1759,10 +1759,6 @@ if gadgetHandler:IsSyncedCode() then
 					end
 				end
 
-				GiveOrderToUnit(unitID, CMD.IDLEMODE, { 0 }, { "shift" })
-				GiveOrderToUnit(unitID, CMD.MOVE, { x + mRandom(-128, 128), y, z + mRandom(-128, 128) }, { "shift" })
-				GiveOrderToUnit(unitID, CMD.MOVE, { x + mRandom(-128, 128), y, z + mRandom(-128, 128) }, { "shift" })
-
 				setRaptorXP(unitID)
 			end
 			spawnQueue[i] = nil

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1986,11 +1986,6 @@ if gadgetHandler:IsSyncedCode() then
 					Spring.SetUnitAlwaysVisible(unitID, true)
 				end
 
-				GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
-				GiveOrderToUnit(unitID, CMD.IDLEMODE, { 0 }, 0)
-				GiveOrderToUnit(unitID, CMD.MOVE, { x + mRandom(-128, 128), y, z + mRandom(-128, 128) }, { "shift" })
-				GiveOrderToUnit(unitID, CMD.MOVE, { x + mRandom(-128, 128), y, z + mRandom(-128, 128) }, { "shift" })
-
 				setScavXP(unitID)
 			end
 			spawnQueue[i] = nil


### PR DESCRIPTION
- Disabled random spread move commands on spawn. Tested, doesn't seem like any units get forever stuck on spawn anymore, so it's hopefully not needed anymore.