### PR TITLE
fix: Set Target active target color on target updates

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -295,55 +295,58 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function addUnitTargets(unitID, unitDefID, targetList, append)
 		--tracy.ZoneBeginN(string.format("addUnitTargets:%s %d %d",tostring(reason), unitID, unitDefID))
-		if spValidUnitID(unitID) then
-			local data = unitTargets[unitID] or pausedTargets[unitID]
-			if not data then
-				data = {
-					targets = {},
-					currentTargets = {},
-					teamID = spGetUnitTeam(unitID),
-					allyTeam = spGetUnitAllyTeam(unitID),
-					weapons = unitWeapons[unitDefID],
-					currentIndex = 1,
-					activeTarget = false,
-				}
-			elseif not append then
-				data.targets = {}
-				data.currentTargets = {}
-				SendToUnsynced("targetList", unitID, 0)
+		if not spValidUnitID(unitID) then
+			--tracy.ZoneEnd()
+			return
+		end
+		local data = unitTargets[unitID] or pausedTargets[unitID]
+		if not data then
+			data = {
+				targets = {},
+				currentTargets = {},
+				teamID = spGetUnitTeam(unitID),
+				allyTeam = spGetUnitAllyTeam(unitID),
+				weapons = unitWeapons[unitDefID],
+				currentIndex = 1,
+				activeTarget = false,
+			}
+		elseif not append then
+			data.targets = {}
+			data.currentTargets = {}
+			SendToUnsynced("targetList", unitID, 0)
+		end
+		local teamID = data.teamID
+		local targets, currentTargets = data.targets, data.currentTargets
+		local targetCount = #targets
+		local limitCount = targetListLengthMax - targetCount
+		for i = 1, #targetList do
+			if limitCount == 0 then
+				break
 			end
-			local teamID = data.teamID
-			local targets, currentTargets = data.targets, data.currentTargets
-			local targetCount = #targets
-			local limitCount = targetListLengthMax - targetCount
-			for i = 1, #targetList do
-				if limitCount == 0 then
-					break
+			local targetData = targetList[i]
+			local target = targetData.target
+			if not currentTargets[target] and checkTarget(teamID, target) then
+				limitCount = limitCount - 1
+				targetCount = targetCount + 1
+				targets[targetCount] = targetData
+				if type(target) == "number" then
+					currentTargets[target] = true
 				end
-				local targetData = targetList[i]
-				local target = targetData.target
-				if not currentTargets[target] and checkTarget(teamID, target) then
-					limitCount = limitCount - 1
-					targetCount = targetCount + 1
-					targets[targetCount] = targetData
-					if type(target) == "number" then
-						currentTargets[target] = true
-					end
-					targetData.sent = false
-				end
+				targetData.sent = false
 			end
-			if targetCount == 0 then
-				return
-			end
-			unitTargets[unitID] = data
-			pausedTargets[unitID] = nil
-			if waitForCommandDone[unitID] then
-				checkForManualFire[unitID] = true
-			end
-			sendTargetsToUnsynced(unitID)
-			if not data.activeTarget and testTarget(unitID, data.teamID, data.weapons, targets[1]) then
-				setTargetActive(unitID, data, 1)
-			end
+		end
+		if targetCount == 0 then
+			--tracy.ZoneEnd()
+			return
+		end
+		unitTargets[unitID] = data
+		pausedTargets[unitID] = nil
+		if waitForCommandDone[unitID] then
+			checkForManualFire[unitID] = true
+		end
+		sendTargetsToUnsynced(unitID)
+		if not data.activeTarget and testTarget(unitID, data.teamID, data.weapons, targets[1]) then
+			setTargetActive(unitID, data, 1)
 		end
 		--tracy.ZoneEnd()
 	end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -382,7 +382,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function updateTarget(unitID, unitData, index, active)
 		if active == nil then
-			active = testTarget(unitID, unitData.teamID, unitData.weapons, unitData.targets[1])
+			active = testTarget(unitID, unitData.teamID, unitData.weapons, unitData.targets[index])
 		end
 		unitData.currentIndex = index
 		unitData.activeTarget = active
@@ -947,7 +947,7 @@ else	-- UNSYNCED
 		end
 	end
 
-	local function getEventTargetList(unitID, removeFromIndex)
+	local function getUnitTargetList(unitID, removeFromIndex)
 		if removeFromIndex == 0 then
 			targetList[unitID] = nil
 			return
@@ -968,28 +968,33 @@ else	-- UNSYNCED
 			end
 			if removeFromIndex <= unitData.targetIndex then
 				unitData.targetIndex = 1
+				unitData.targetActive = false
 			end
 		end
-		return targets
+		return unitData
 	end
 
 	function handleTargetListEvent(_, unitID, index, userTarget, targetA, targetB, targetC)
 		--tracy.ZoneBeginN(string.format("handleTargetListEvent %d %d ", unitID, index))
-		local targets = getEventTargetList(unitID, not targetA and index)
-		if targets then
-			targets[index] = {
+		local unitData = getUnitTargetList(unitID, not targetA and index)
+		if unitData then
+			unitData.targets[index] = {
 				userTarget = userTarget,
 				target     = (not targetB and targetA) or { targetA, targetB, targetC },
 			}
+			if index == unitData.targetIndex then
+				unitData.targetActive = false
+			end
 		end
 		--tracy.ZoneEnd()
 	end
 
-	function handleTargetIndexEvent(_, unitID, index)
+	function handleTargetIndexEvent(_, unitID, index, active)
 		if not targetList[unitID] then
 			return
 		end
 		targetList[unitID].targetIndex = index
+		targetList[unitID].targetActive = active
 	end
 
 	function handleUnitTargetDrawEvent(_, _, params)
@@ -1141,8 +1146,8 @@ else	-- UNSYNCED
 		local skipSize, skipLeft = 0, 0
 		for unitID, unitData in pairsNext, targetList do
 			if fullview or spGetUnitAllyTeam(unitID) == myAllyTeam then
-				if skipLeft == 0 then
-					if shouldDrawDecorations(unitID) then
+				if shouldDrawDecorations(unitID) then
+					if skipLeft == 0 then
 						if not init then
 							init = initDrawing()
 						end
@@ -1157,9 +1162,9 @@ else	-- UNSYNCED
 							skipSize = math_min(16, 2 * (skipSize > 0 and skipSize or 1))
 						end
 						skipLeft = skipSize
+					else
+						skipLeft = skipLeft - 1
 					end
-				else
-					skipLeft = skipLeft - 1
 				end
 			end
 		end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -262,15 +262,12 @@ if gadgetHandler:IsSyncedCode() then
 		SendToUnsynced("targetIndex", unitID, targetIndex, false)
 	end
 
-	local function removeUnseenTarget(targetData, attackerAllyTeam)
-		local target = targetData.target
-		if not targetData.alwaysSeen and type(target) == "number" and spValidUnitID(target) then
-			local los = spGetUnitLosState(target, attackerAllyTeam, true)
-			if not los or (los % 4 == 0) then
-				return true
-			end
+	local function isUnseenEnemyUnit(targetData, allyTeam)
+		if targetData.alwaysSeen or not spValidUnitID(targetData.target) then
+			return false
 		end
-		return false
+		local los = spGetUnitLosState(targetData.target, allyTeam, true)
+		return not los or los % 4 == 0
 	end
 
 	local function distance(posA, posB)
@@ -821,7 +818,7 @@ if gadgetHandler:IsSyncedCode() then
 			for unitID, unitData in pairsNext, unitTargets do
 				local targets = unitData.targets
 				for index = #targets, 1, -1 do
-					if removeUnseenTarget(targets[index], unitData.allyTeam) then
+					if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
 						removeTarget(unitID, index)
 					end
 				end


### PR DESCRIPTION
### Work done

Fix for Set Target's command color when the active target changes.

This was displaying the yellow passive/queue color in some cases instead of the deeper orange color to show an active target.