### PR TITLE
ecostats: expose y position to other widgets

### DIFF
--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -661,6 +661,12 @@ function widget:Initialize()
 	WG['ecostats'].setReclaim = function(value)
 		cfgTrackReclaim = value
 	end
+	WG['ecostats'].isvisible = function()
+		return myFullview and inSpecMode
+	end
+	WG['ecostats'].getWidgetPosY = function()
+		return widgetPosY
+	end
 
 	Init()
 	widget:ViewResize()


### PR DESCRIPTION
### Work done
I want to write a widget which sits in the top right corner, just below the topbar buttons, or alternatively, if visible, below ecostats. While the topbar has `getShowButtons()` and `GetPosition()`, the ecostats has no methods to query the location or visibility of the widget. Thus I have added them in this pull request.

I did not implement `GetPosition()`, but just `getWidgetPosY()`, since this is all I need. If you prefer `GetPosition()`, I can try to change the pull request.

#### Test steps
- Install this (work in progress; don't judge me) widget: https://gist.github.com/codesoap/b7090227590ce3e1548bfb2a6223ed0f
- Open a replay of a game.
- Activate the "Live Leaderboard" widget.
- Observe the position of the widget below the ecostats.
- Maybe go into Player View to see what happens when ecostats is not visible.

### Screenshots:
Here is my widget, placed below the ecostats. **Unfortunately, there is still a ~3px gap**, that I cannot explain:

<img width="385" height="314" alt="gap" src="https://github.com/user-attachments/assets/11ebd186-6eb9-49dd-890f-c1f5f5a6e447" />
