### PR TITLE
Clean up unnecessary build options Legion Commander

### DIFF
--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -84,13 +84,8 @@ return {
 			[23] = "legtl",
 			[24] = "legfrl",
 			[25] = "legfrad",
-			-- Experimental:
 			[26] = "leghp",
 			[27] = "legfhp",
-			--[28] = "armmg",
-			--[29] = "armclaw",
-			--[30] = "armferret",
-			--[31] = "legjam",
 		},
 		customparams = {
 			unitgroup = 'builder',


### PR DESCRIPTION
Removed experimental unit entries from the list that weren't used and were causing faulty information in the website.