### PR TITLE
feat: add per-callin profiling to the gadget profiler

### DIFF
--- a/luarules/gadgets/dbg_gadget_profiler.lua
+++ b/luarules/gadgets/dbg_gadget_profiler.lua
@@ -371,6 +371,16 @@ else
 
 	local running = false
 
+	-- Per-callin drill-down state (only populated for the gadget currently drilled into).
+	-- Declared here, above Start/Kill, so every function captures the same upvalues.
+	local selectedGadget = nil    -- plain prefixed gname currently drilled into, or nil
+	local selectedSynced = false  -- which list (unsynced/synced) the selection came from
+	local selectedCallinAvgs = {} -- { [cname] = { tLoad, sLoad } } smoothed, reset on selection
+	local clickableRows = {}      -- reused each frame: { {x1, y1, x2, y2, gname, synced}, ... }
+	local clickableRowCount = 0   -- how many entries of clickableRows are valid this frame
+	local columnReserve = 0       -- width reserved left of column 0 for the detail panel (0 when none)
+	local detailColour = "\255\255\255\255"
+
 	local timersSynced = {}
 	local startTickTimer
 	local memUsageSynced = {}
@@ -379,6 +389,12 @@ else
 		-- when the profiler isn't running, the profiler gadget should have *no* draw callin
 		gadget.DrawScreen = drawCallin
 		gadgetHandler:UpdateGadgetCallIn("DrawScreen", gadget)
+	end
+
+	local function SetMousePressCallin(mousePressCallin)
+		-- only claim mouse clicks while the profiler is drawn (for the drill-down)
+		gadget.MousePress = mousePressCallin
+		gadgetHandler:UpdateGadgetCallIn("MousePress", gadget)
 	end
 
 	local function SyncedCallinStarted(_, gname, cname)
@@ -425,6 +441,7 @@ else
 			startTickTimer = spGetTimer()
 
 			SetDrawCallin(gadget.DrawScreen_)
+			SetMousePressCallin(gadget.MousePress_)
 
 			Spring.Echo("luarules profiler started (player " .. pID .. ")")
 		end
@@ -436,7 +453,11 @@ else
 
 			Spring.Echo("Killing...")
 			SetDrawCallin(nil)
+			SetMousePressCallin(nil)
 			KillHook()
+
+			selectedGadget = nil
+			selectedCallinAvgs = {}
 
 			startTickTimer = nil
 			timersSynced = {}
@@ -560,13 +581,17 @@ else
 		return timeColourString, spaceColourString
 	end
 
-	local function ProcessCallinStats(stats, timeLoadAvgs, spaceloadAvgs, redStr, deltaTime)
+	local function ProcessCallinStats(stats, timeLoadAvgs, spaceloadAvgs, redStr, deltaTime, isSynced)
 		totalLoads = {}
 		local allOverTime = 0
 		local allOverSpace = 0
 		local n = 1
 
 		local sorted = {}
+
+		-- Only smooth the per-callin breakdown for the gadget being drilled into,
+		-- and only in the list (unsynced/synced) it was selected from.
+		local captureThisList = selectedGadget and (isSynced == selectedSynced)
 
 		local averageTime = Spring.GetConfigFloat("profiler_averagetime", 2)
 		local sortByLoad = Spring.GetConfigInt("profiler_sort_by_load", 1) == 1
@@ -583,6 +608,8 @@ else
 			local cmax_space = 0
 			local cmaxname_space = "-"
 
+			local captureGadget = captureThisList and gname == selectedGadget
+
 			for cname, c in pairs(callins) do
 				local c1, c2, c3, c4 = c[1], c[2], c[3], c[4]
 				t = t + c1
@@ -598,6 +625,18 @@ else
 					cmaxname_space = cname
 				end
 				c[3] = 0
+
+				if captureGadget then
+					local relT = 100 * c1 / deltaTime
+					local relS = c3 / deltaTime
+					local prev = selectedCallinAvgs[cname]
+					if prev then
+						prev[1] = CalcLoad(prev[1], relT, averageTime)
+						prev[2] = CalcLoad(prev[2], relS, averageTime)
+					else
+						selectedCallinAvgs[cname] = { relT, relS }
+					end
+				end
 			end
 
 			local relTime = 100 * t / deltaTime
@@ -689,10 +728,17 @@ else
 		end
 	end
 
+	-- Horizontal offset of the current column. When a gadget is drilled into, a
+	-- band is reserved immediately left of column 0 for the detail panel, so every
+	-- overflow column (index >= 1) is pushed further left to clear it.
+	local function ColumnShift()
+		return currentColumnIndex * colWidth + (currentColumnIndex >= 1 and columnReserve or 0)
+	end
+
 	local function Text(color, string, dataColIndex)
 		gl.Text(
 			color .. string,
-			initialX + dataColWidth * dataColIndex - currentColumnIndex * colWidth,
+			initialX + dataColWidth * dataColIndex - ColumnShift(),
 			initialY - lineSpace * currentLineIndex,
 			fontSize,
 			"no"
@@ -754,7 +800,7 @@ else
 		if gadgetName then
 			local gadgetColor = gadgetNameColors[gadgetName]
 			if gadgetColor then
-				local x = initialX - currentColumnIndex * colWidth
+				local x = initialX - ColumnShift()
 				local textY = initialY - lineSpace * currentLineIndex
 
 				-- Draw opaque colored square on the left
@@ -791,7 +837,7 @@ else
 	local noDataColor = "\255\200\200\200"
 	local maxnameColor = "\255\200\200\200"
 
-	local function DrawSortedList(list, name)
+	local function DrawSortedList(list, name, isSynced)
 		NewSection(name)
 
 		local listLen = #list
@@ -811,6 +857,9 @@ else
 			-- Draw line with background and dimmed zeros
 			RequireSpace(1)
 			currentLineIndex = currentLineIndex + 1
+
+			local x = initialX - ColumnShift()
+			local textY = initialY - lineSpace * currentLineIndex
 
 			-- Draw tinted background and colored square for gadget line
 			local gadgetColor = gadgetNameColors[v.name]
@@ -833,9 +882,6 @@ else
 			end
 
 			if gadgetColor then
-				local x = initialX - currentColumnIndex * colWidth
-				local textY = initialY - lineSpace * currentLineIndex
-
 				-- Draw opaque colored square on the left
 				gl.Color(gadgetColor[1], gadgetColor[2], gadgetColor[3], 1.0)
 				gl.Rect(x - 12, textY - 3, x - 5, textY + fontSize - 3)
@@ -847,17 +893,28 @@ else
 				gl.Color(1, 1, 1, 1)  -- Reset color
 			end
 
+			-- Highlight the row that is currently drilled into
+			if v.plainname == selectedGadget and isSynced == selectedSynced then
+				gl.Color(1, 1, 1, 0.18)
+				gl.Rect(x - 12, textY - 3, x + colWidth - 15, textY + fontSize - 3)
+				gl.Color(1, 1, 1, 1)
+			end
+
+			-- Record click target so MousePress can map a click back to this gadget.
+			-- Reuse the row tables across frames to avoid per-frame GC churn.
+			clickableRowCount = clickableRowCount + 1
+			local r = clickableRows[clickableRowCount]
+			if not r then
+				r = {}
+				clickableRows[clickableRowCount] = r
+			end
+			r[1], r[2], r[3], r[4], r[5], r[6] = x - 12, textY - 3, x + colWidth - 15, textY + fontSize - 3, v.plainname, isSynced
+
 			-- Draw percentage with dimmed zeros
-			DrawPercentWithDimmedZeros(tColour, tLoad,
-				initialX + dataColWidth * 0 - currentColumnIndex * colWidth,
-				initialY - lineSpace * currentLineIndex,
-				fontSize, 3)
+			DrawPercentWithDimmedZeros(tColour, tLoad, x + dataColWidth * 0, textY, fontSize, 3)
 
 			-- Draw memory with dimmed zeros
-			DrawMemoryWithDimmedZeros(sColour, sLoad,
-				initialX + dataColWidth * 1 - currentColumnIndex * colWidth,
-				initialY - lineSpace * currentLineIndex,
-				fontSize, 1, 'kB/s')
+			DrawMemoryWithDimmedZeros(sColour, sLoad, x + dataColWidth * 1, textY, fontSize, 1, 'kB/s')
 
 			-- Draw gadget name
 			Text(tColour, gname, 2)
@@ -868,16 +925,92 @@ else
 
 		-- Draw totals with dimmed zeros
 		DrawPercentWithDimmedZeros(totals_colour, list.allOverTime,
-			initialX + dataColWidth * 0 - currentColumnIndex * colWidth,
+			initialX + dataColWidth * 0 - ColumnShift(),
 			initialY - lineSpace * currentLineIndex,
 			fontSize, 3)
 
 		DrawMemoryWithDimmedZeros(totals_colour, list.allOverSpace,
-			initialX + dataColWidth * 1 - currentColumnIndex * colWidth,
+			initialX + dataColWidth * 1 - ColumnShift(),
 			initialY - lineSpace * currentLineIndex,
 			fontSize, 1, 'kB/s')
 
 		Text(totals_colour, "totals (" .. stringLower(name) .. ")", 2)
+	end
+
+	-- Drill-down view: every callin of the selected gadget, sorted by cpu time.
+	-- Absolutely positioned (outside the column flow) in the band reserved to the
+	-- left of column 0 by columnReserve.
+	local function DrawDetailPanel(x, y, panelWidth)
+		local avgs = selectedCallinAvgs
+
+		-- Hide a callin only when BOTH its cpu and alloc rate are negligible; hidden
+		-- callins still count towards the total so it stays accurate.
+		local minCallinPerc = 0.003 -- % of running time
+		local minCallinKB = 0.1     -- kB/s allocated
+
+		local list = {}
+		local hidden = 0
+		local total_t, total_s = 0, 0
+		for cname, a in pairs(avgs) do
+			total_t = total_t + a[1]
+			total_s = total_s + a[2]
+			if a[1] >= minCallinPerc or a[2] >= minCallinKB then
+				list[#list + 1] = { name = cname, tLoad = a[1], sLoad = a[2] }
+			else
+				hidden = hidden + 1
+			end
+		end
+		tableSort(list, function(a, b) return a.tLoad > b.tLoad end)
+
+		local colW = fontSize * 8 -- one column width, wide enough for "9999.9 kB/s"
+		local timeColX = x
+		local allocsColX = x + colW
+		local callinColX = x + colW * 2
+		local panelRight = x + panelWidth
+
+		-- Fixed lines: title, blank, header, total, blank, close-hint (+ optional hidden line)
+		local lineCount = #list + 6 + (hidden > 0 and 1 or 0)
+
+		-- translucent backdrop (drawn first so the text lands on top of it)
+		gl.Color(0, 0, 0, 0.55)
+		gl.Rect(x - 10, y - lineSpace * lineCount - 3, panelRight, y + lineSpace)
+		gl.Color(1, 1, 1, 1)
+
+		-- Line cursor: returns the current line's y, then advances past it plus any trailing blanks.
+		local cy = y
+		local function line(blanks)
+			local ly = cy
+			cy = cy - lineSpace * (1 + (blanks or 0))
+			return ly
+		end
+
+		local label = (selectedSynced and "\255\200\200\255[synced] " .. detailColour or "") .. (gname2name[selectedGadget] or selectedGadget)
+		gl.Text(title_colour .. "CALLIN BREAKDOWN  " .. detailColour .. label, x, line(1), fontSize, "no")
+
+		local hy = line()
+		gl.Text(totals_colour .. "time", timeColX, hy, fontSize, "no")
+		gl.Text(totals_colour .. "allocs", allocsColX, hy, fontSize, "no")
+		gl.Text(totals_colour .. "callin", callinColX, hy, fontSize, "no")
+
+		for i = 1, #list do
+			local v = list[i]
+			local ry = line()
+			DrawPercentWithDimmedZeros(detailColour, v.tLoad, timeColX, ry, fontSize, 3)
+			DrawMemoryWithDimmedZeros(detailColour, v.sLoad, allocsColX, ry, fontSize, 1, 'kB/s')
+			gl.Text(detailColour .. v.name, callinColX, ry, fontSize, "no")
+		end
+
+		local ty = line()
+		DrawPercentWithDimmedZeros(totals_colour, total_t, timeColX, ty, fontSize, 2)
+		DrawMemoryWithDimmedZeros(totals_colour, total_s, allocsColX, ty, fontSize, 0, 'kB/s')
+		gl.Text(totals_colour .. "total", callinColX, ty, fontSize, "no")
+
+		if hidden > 0 then
+			gl.Text(totals_colour .. '\255\140\140\140' .. stringFormat("(%d negligible callins hidden)", hidden), x, line(), fontSize, "no")
+		end
+
+		line() -- blank separator before the close hint
+		gl.Text(title_colour .. "click the gadget again to close", x, line(), fontSize, "no")
 	end
 
 	--------------------------------------------------------------------------------
@@ -899,8 +1032,8 @@ else
 		if deltaTime >= tick then
 			startTickTimer = spGetTimer()
 
-			sortedList = ProcessCallinStats(callinStats, timeLoadAverages, spaceLoadAverages, redStrength, deltaTime)
-			sortedListSYNCED = ProcessCallinStats(callinStatsSYNCED, timeLoadAveragesSYNCED, spaceLoadAveragesSYNCED, redStrengthSYNCED, deltaTime)
+			sortedList = ProcessCallinStats(callinStats, timeLoadAverages, spaceLoadAverages, redStrength, deltaTime, false)
+			sortedListSYNCED = ProcessCallinStats(callinStatsSYNCED, timeLoadAveragesSYNCED, spaceLoadAveragesSYNCED, redStrengthSYNCED, deltaTime, true)
 
 			luarulesMemory, _, globalMemory, _, unsyncedMemory, _, syncedMemory, _ = spGetLuaMemUsage()
 		end
@@ -908,11 +1041,24 @@ else
 		currentLineIndex = 0
 		currentColumnIndex = 0
 
+		clickableRowCount = 0 -- refilled below so MousePress hit-testing matches what is on screen
+
+		-- When a gadget is drilled into, reserve a band immediately left of column 0
+		-- for the detail panel; overflow columns then wrap to the left of it.
+		local panelGap = fontSize * 2 -- gutter between the panel and column 0
+		local panelWidth = mathMin(colWidth - panelGap, fontSize * 30)
+		columnReserve = selectedGadget and (panelWidth + panelGap) or 0
+
 		gl.Color(1, 1, 1, 1)
 		gl.BeginText()
 
-		DrawSortedList(sortedList, "UNSYNCED")
-		DrawSortedList(sortedListSYNCED, "SYNCED")
+		DrawSortedList(sortedList, "UNSYNCED", false)
+		DrawSortedList(sortedListSYNCED, "SYNCED", true)
+
+		if selectedGadget then
+			-- Fixed slot in the reserved band, just left of column 0.
+			DrawDetailPanel(initialX - panelGap - panelWidth, initialY, panelWidth)
+		end
 
 		NewSection("ALL")
 
@@ -946,10 +1092,33 @@ else
 
 		Line(1, title_colour, "All data excludes load from garbage collection & executing GL calls")
 		Line(0, title_colour, "Callins in brackets are heaviest per gadget for (time,allocs)")
+		Line(0, title_colour, "Click a gadget to break it down per-callin")
 
 		Line(1, title_colour, "Tick time: " .. tick .. "s")
 		Line(0, title_colour, "Smoothing time: " .. Spring.GetConfigFloat("profiler_averagetime", 2) .. "s")
 
 		gl.EndText()
+	end
+
+	-- Click a gadget row to drill into its per-callin breakdown; click it again to close.
+	-- Only attached while the profiler is running (see SetMousePressCallin).
+	function gadget:MousePress_(mx, my, button)
+		if not running or button ~= 1 or clickableRowCount == 0 then
+			return false
+		end
+		for i = 1, clickableRowCount do
+			local r = clickableRows[i]
+			if mx >= r[1] and mx <= r[3] and my >= r[2] and my <= r[4] then
+				if selectedGadget == r[5] and selectedSynced == r[6] then
+					selectedGadget = nil
+				else
+					selectedGadget = r[5]
+					selectedSynced = r[6]
+					selectedCallinAvgs = {} -- start a fresh smoothing window
+				end
+				return true -- consume the click so it doesn't fall through to the map
+			end
+		end
+		return false
 	end
 end


### PR DESCRIPTION
### Work done
Added a per-callin breakdown for any selected widget in the widget profiler `/luarules profile`. Just like with the widget profiler, the data was already being collected so its just a matter of displaying it.

<img width="1069" height="516" alt="image" src="https://github.com/user-attachments/assets/0a64428e-3c6a-437d-a2d2-535d9d0677c9" />

https://github.com/user-attachments/assets/1fd62fe8-e4f8-4507-81f5-2f6b5a8c2cbf




#### Test steps
- [ ] run `/laurules profile`, click a gadget - you should see the callin breakdown. Click the same gadget again to close.


### Screenshots:
<img width="1736" height="1174" alt="image" src="https://github.com/user-attachments/assets/a61ad60d-cd2a-450b-8a02-b0c2399e744a" />


### AI / LLM usage statement:
Had claude code do most of the heavy lifting, review and cleanup by me + manual iterative testing until I got the behaviour i wanted.