### PR TITLE
New Airplants set to most recent Land/Fly Preference

### DIFF
--- a/luarules/gadgets/unit_air_plants.lua
+++ b/luarules/gadgets/unit_air_plants.lua
@@ -67,7 +67,6 @@ local landCmd = {
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 	if isAirplant[unitDefID] then
-		landCmd.params[1] = 1
 		plantList[unitID] = 1
 		InsertUnitCmdDesc(unitID, 500, landCmd)
 	elseif plantList[builderID] then


### PR DESCRIPTION
Now when building a new Airplant it will do whichever Land/Fly Setting the player most recently set. Better sticks to player's preference they set for that battle. Less hassle for the player overall.
Only lasts in the battle, so not sticky.

### Work done
Removed the hard set of the Land/Fly setting to Land.
It now uses the Global variable it is setting so that it will use whatever the player set most recently

#### Setup/Test steps
Build an Airplant, change the setting, then build another Airplant and check if it remembered your preference.

