### PR TITLE
fix unit test CI

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -9,16 +9,20 @@ on:
 jobs:
   busted:
     runs-on: ubuntu-latest
-    env:
-      FEDORA_VERSION: '43'
     container:
-      # NOTE: keep this in sync with env.FEDORA_VERSION below. The `env`
-      # context is not available in `container.image` (evaluated too early),
-      # so the version must be hardcoded here.
+      # The `env`/`steps` contexts are not available in `container.image`
+      # (it's evaluated before the job's steps run), so the version is the
+      # one literal here. The cache key derives its version from the running
+      # container instead (see the "Detect Fedora version" step), so the two
+      # can never disagree.
       image: fedora:43
 
     steps:
     - uses: actions/checkout@v5
+
+    - name: Detect Fedora version
+      id: fedora
+      run: echo "version=$(rpm -E %fedora)" >> "$GITHUB_OUTPUT"
 
     - name: Install build deps + Lua 5.1
       run: |
@@ -47,9 +51,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .lux
-        key: lux-5.1-fedora${{ env.FEDORA_VERSION }}-${{ hashFiles('lux.lock') }}
+        key: lux-5.1-fedora${{ steps.fedora.outputs.version }}-${{ hashFiles('lux.lock') }}
         restore-keys: |
-          lux-5.1-fedora${{ env.FEDORA_VERSION }}-
+          lux-5.1-fedora${{ steps.fedora.outputs.version }}-
 
     - name: Run busted
       run: lx --lua-version 5.1 test

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -12,7 +12,10 @@ jobs:
     env:
       FEDORA_VERSION: '43'
     container:
-      image: fedora:${{ env.FEDORA_VERSION }}
+      # NOTE: keep this in sync with env.FEDORA_VERSION below. The `env`
+      # context is not available in `container.image` (evaluated too early),
+      # so the version must be hardcoded here.
+      image: fedora:43
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
The env context isn't available that early. It was a good idea to remove duplication but I broke unit tests in the CI for a few weeks by being inattentive. :( Luckily I'm the only one using them atm and they're still green.

Broken by: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7616