### PR TITLE
fix: check command params in Area Attack (Ground)

### DIFF
--- a/luarules/gadgets/unit_areaattack.lua
+++ b/luarules/gadgets/unit_areaattack.lua
@@ -61,11 +61,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 		-- accepts: CMD_AREA_ATTACK_GROUND
-		if canAreaAttack[unitDefID] then
-			return true
-		else
-			return false
-		end
+		return canAreaAttack[unitDefID] and #cmdParams == 4
 	end
 
 	function gadget:CommandFallback(u,ud,team,cmd,param,opt)

--- a/luarules/gadgets/unit_areaattack.lua
+++ b/luarules/gadgets/unit_areaattack.lua
@@ -27,6 +27,9 @@ if gadgetHandler:IsSyncedCode() then
 	local math_cos = math.cos
 	local math_sin = math.sin
 
+	local CMD_ATTACK = CMD.ATTACK
+	local reissueOrder = Game.Commands.ReissueOrder
+
 	local canAreaAttack = {}
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		if #unitDef.weapons > 0 and unitDef.customParams.canareaattack then
@@ -59,9 +62,16 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua, fromInsert)
 		-- accepts: CMD_AREA_ATTACK_GROUND
-		return canAreaAttack[unitDefID] and #cmdParams == 4
+		if canAreaAttack[unitDefID] and #cmdParams == 4 then
+			if cmdParams[4] > 1 then
+				return true
+			end
+			cmdParams[4] = nil
+			reissueOrder(unitID, CMD_ATTACK, cmdParams, cmdOptions, cmdTag, fromInsert)
+		end
+		return false
 	end
 
 	function gadget:CommandFallback(u,ud,team,cmd,param,opt)


### PR DESCRIPTION
### Work done

- Allow the custom command Area Attack (Ground) only when it has the correct parameter count.
- Replace areas with minuscule or negative radius with regular Attack orders targeting a map position.

#### Addresses Issue(s)

- Handles a nil error from users/widgets passing improper params.
