### PR TITLE
pause Set Target during Attack orders

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -39,9 +39,9 @@ end
 
 if gadgetHandler:IsSyncedCode() then
 
-	-- Unseen targets will be removed after max USEEN_UPDATE_FREQUENCY frames.
-	-- Should be small enough to not be evident, and big enough to save perf.
-	local USEEN_UPDATE_FREQUENCY = 15
+	-- The rate of removing unseen/untracked units from the unit target lists.
+	-- Done once per N target list update passes to reduce the overhead costs.
+	local unseenUpdatePasses = 3
 
 	local spInsertUnitCmdDesc = Spring.InsertUnitCmdDesc
 	local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
@@ -708,7 +708,9 @@ if gadgetHandler:IsSyncedCode() then
 	--------------------------------------------------------------------------------
 	-- Target update
 
-	function gadget:GameFrame(n)
+	local updateUnseenUnits = unseenUpdatePasses
+
+	function gadget:GameFrame(frame)
 		-- ideally timing would be synced with slow update to reduce attack jittering
 		-- SlowUpdate+ causes attack command to override target command
 		-- unfortunately since 103 that's not possible, attempt to override every frame
@@ -716,7 +718,30 @@ if gadgetHandler:IsSyncedCode() then
 		-- a set target command, howrever a quick test with 300 fidos only increased by 1%
 		-- sim here
 
-		if n % 5 == 4 then
+		teamQueryCaches = {}
+
+		local offset = frame % 5
+
+		if offset == 0 then
+
+			if updateUnseenUnits ~= 1 then
+				updateUnseenUnits = updateUnseenUnits - 1
+				return
+			end
+
+			updateUnseenUnits = unseenUpdatePasses
+
+			for unitID, unitData in pairsNext, activeTargets do
+				local targets = unitData.targets
+				for index = #targets, 1, -1 do
+					if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
+						removeTarget(unitID, index)
+					end
+				end
+			end
+
+		elseif offset == 1 then
+
 			for unitID, unitData in pairsNext, activeTargets do
 				local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
 				local length, targetIndex, countRemoved = #targets, 0, 0
@@ -758,32 +783,24 @@ if gadgetHandler:IsSyncedCode() then
 					setTargetPassive(unitID, unitData, 1)
 				end
 			end
-		end
 
-		if n % USEEN_UPDATE_FREQUENCY == 0 then
-			for unitID, unitData in pairsNext, activeTargets do
-				local targets = unitData.targets
-				for index = #targets, 1, -1 do
-					if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
-						removeTarget(unitID, index)
-					end
-				end
-			end
-		end
+		elseif offset == 2 or offset == 4 then
 
-		for unitID in pairs(setTargetData) do
-			if activeTargets[unitID] then
+			for unitID in pairs(activeTargets) do
 				if inAttackCommand(unitID) then
 					pauseTargetting(unitID)
 				end
-			else
+			end
+
+		else -- once per update cycle:
+
+			for unitID in pairs(pausedTargets) do
 				if not inAttackCommand(unitID) then
 					unpauseTargetting(unitID)
 				end
 			end
-		end
 
-		teamQueryCaches = {}
+		end
 	end
 
 

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -73,6 +73,8 @@ if gadgetHandler:IsSyncedCode() then
 
 	local CMD_STOP = CMD.STOP
 	local CMD_ATTACK = CMD.ATTACK
+	local CMD_FIGHT = CMD.FIGHT
+	local CMD_GUARD = CMD.GUARD
 	local CMD_WAIT = CMD.WAIT
 
 	local isAttackCommand = {
@@ -223,6 +225,46 @@ if gadgetHandler:IsSyncedCode() then
 			inCommand = spGetUnitCurrentCommand(unitID, 2)
 		end
 		return inCommand and isAttackCommand[inCommand]
+	end
+
+	-- Target precedence goes before target priority and ideally after target visibility, in range, unblocked, etc.
+	-- Autotargeting "target priority" is then a weighted value, and Set Target priority uses the order of the list.
+	local function hasTargetPrecedence(unitID)
+		local index = 1
+		local inCommand, _, _, param1, param2 = spGetUnitCurrentCommand(unitID, index)
+		if inCommand == CMD_WAIT then
+			index = index + 1
+			inCommand, _, _, param1, param2 = spGetUnitCurrentCommand(unitID, index)
+		end
+
+		if not inCommand or not isAttackCommand[inCommand] then
+			return true
+		end
+
+		-- Only Attack commands against units are emplaced/internal.
+		if param2 or inCommand ~= CMD_ATTACK then
+			return false
+		end
+
+		local nextCommand, _, _, nextParam1 = spGetUnitCurrentCommand(unitID, index + 1)
+
+		if not nextCommand then
+			return false
+		elseif nextCommand == CMD_FIGHT then
+			-- Set Target does not violate an active Fight command by prioritizing the user's target.
+			-- ! FIXME: We assume the Attack command originated from within Fight but cannot be sure.
+			return true
+		elseif nextCommand == CMD_GUARD then
+			-- Guard and Return Fire have an automatic retaliation behavior that precedes Set Target.
+			-- The user intent is to protect either the guardee unit or the unit itself from damages.
+			if spValidUnitID(param1) then
+				local _, _, target = spGetUnitWeaponTarget(param1, 1)
+				if target ~= nextParam1 then -- flimsy
+					return true
+				end
+			end
+		end
+		return false
 	end
 
 	local function setTargetActive(unitID, unitData, targetIndex)
@@ -720,6 +762,18 @@ if gadgetHandler:IsSyncedCode() then
 
 		teamQueryCaches = {}
 
+		for unitID in pairs(setTargetData) do
+			if activeTargets[unitID] then
+				if not hasTargetPrecedence(unitID) then
+					pauseTargetting(unitID)
+				end
+			else
+				if hasTargetPrecedence(unitID) then
+					unpauseTargetting(unitID)
+				end
+			end
+		end
+
 		local offset = frame % 5
 
 		if offset == 0 then
@@ -783,23 +837,6 @@ if gadgetHandler:IsSyncedCode() then
 					setTargetPassive(unitID, unitData, 1)
 				end
 			end
-
-		elseif offset == 2 or offset == 4 then
-
-			for unitID in pairs(activeTargets) do
-				if inAttackCommand(unitID) then
-					pauseTargetting(unitID)
-				end
-			end
-
-		else -- once per update cycle:
-
-			for unitID in pairs(pausedTargets) do
-				if not inAttackCommand(unitID) then
-					unpauseTargetting(unitID)
-				end
-			end
-
 		end
 	end
 

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -20,13 +20,6 @@ local CMD_UNIT_SET_TARGET = GameCMD.UNIT_SET_TARGET
 local CMD_UNIT_CANCEL_TARGET = GameCMD.UNIT_CANCEL_TARGET
 local CMD_UNIT_SET_TARGET_RECTANGLE = GameCMD.UNIT_SET_TARGET_RECTANGLE
 
-local isSetTargetCommand = {
-	[CMD_UNIT_SET_TARGET_NO_GROUND] = true,
-	[CMD_UNIT_SET_TARGET]           = true,
-	[CMD_UNIT_CANCEL_TARGET]        = true,
-	[CMD_UNIT_SET_TARGET_RECTANGLE] = true,
-}
-
 local spGetUnitRulesParam = Spring.GetUnitRulesParam
 
 function GG.GetUnitTarget(unitID)
@@ -78,12 +71,16 @@ if gadgetHandler:IsSyncedCode() then
 	local pairsNext = next
 	local type = type
 
-	local isEnqueuedFirst = Game.Commands.IsEnqueuedFirst
-
 	local CMD_STOP = CMD.STOP
-	local CMD_DGUN = CMD.DGUN
 	local CMD_ATTACK = CMD.ATTACK
 	local CMD_WAIT = CMD.WAIT
+
+	local isAttackCommand = {
+		[CMD_ATTACK]      = true,
+		[CMD.MANUALFIRE]  = true,
+		[CMD.AREA_ATTACK] = true,
+		[GameCMD.AREA_ATTACK_GROUND] = true,
+	}
 
 	local validUnits = {}
 	local unitWeapons = {}
@@ -136,10 +133,9 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	local unitTargets = {} -- data holds all unitID data
+	local setTargetData = {} -- holds all unit data
+	local activeTargets = {}
 	local pausedTargets = {}
-	local waitForCommandDone = {}
-	local checkForManualFire = {}
 
 	--------------------------------------------------------------------------------
 	-- Commands
@@ -226,7 +222,7 @@ if gadgetHandler:IsSyncedCode() then
 		if inCommand == CMD_WAIT then
 			inCommand = spGetUnitCurrentCommand(unitID, 2)
 		end
-		return inCommand == CMD_ATTACK
+		return inCommand and isAttackCommand[inCommand]
 	end
 
 	local function setTargetActive(unitID, unitData, targetIndex)
@@ -275,7 +271,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function sendTargetsToUnsynced(unitID)
 		--tracy.ZoneBeginN(string.format("sendTargetsToUnsynced %d", unitID))
-		for index, targetData in ipairs(unitTargets[unitID].targets) do
+		for index, targetData in ipairs(setTargetData[unitID].targets) do
 			if not targetData.sent then
 				targetData.sent = true
 				local target = targetData.target
@@ -290,12 +286,12 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function addUnitTargets(unitID, unitDefID, targetList, append)
-		--tracy.ZoneBeginN(string.format("addUnitTargets:%s %d %d",tostring(reason), unitID, unitDefID))
+		--tracy.ZoneBeginN(string.format("addUnitTargets:%s %d %d", unitID, unitDefID))
 		if not spValidUnitID(unitID) then
 			--tracy.ZoneEnd()
 			return
 		end
-		local data = unitTargets[unitID] or pausedTargets[unitID]
+		local data = setTargetData[unitID]
 		if not data then
 			data = {
 				targets = {},
@@ -335,11 +331,9 @@ if gadgetHandler:IsSyncedCode() then
 			--tracy.ZoneEnd()
 			return
 		end
-		unitTargets[unitID] = data
+		setTargetData[unitID] = data
+		activeTargets[unitID] = data
 		pausedTargets[unitID] = nil
-		if waitForCommandDone[unitID] then
-			checkForManualFire[unitID] = true
-		end
 		sendTargetsToUnsynced(unitID)
 		if not data.activeTarget and testTarget(unitID, data.teamID, data.weapons, targets[1].target) then
 			setTargetActive(unitID, data, 1)
@@ -348,19 +342,21 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function removeUnit(unitID, keeptrack)
-		if unitTargets[unitID] then
-			spSetUnitTarget(unitID, nil)
-			spSetUnitRulesParam(unitID, "targetID", -1)
-			spSetUnitRulesParam(unitID, "targetCoordX", -1)
-			spSetUnitRulesParam(unitID, "targetCoordY", -1)
-			spSetUnitRulesParam(unitID, "targetCoordZ", -1)
-			unitTargets[unitID] = nil
+		if activeTargets[unitID] then
+			activeTargets[unitID] = nil
+			spSetUnitRulesParam(unitID, "targetID", nil)
+			spSetUnitRulesParam(unitID, "targetCoordX", nil)
+			spSetUnitRulesParam(unitID, "targetCoordY", nil)
+			spSetUnitRulesParam(unitID, "targetCoordZ", nil)
+			if not inAttackCommand(unitID) then
+				spSetUnitTarget(unitID, nil)
+			end
 		elseif pausedTargets[unitID] then
-			SendToUnsynced("targetList", unitID, 0)
 			pausedTargets[unitID] = nil
+			SendToUnsynced("targetList", unitID, 0)
 		end
-		waitForCommandDone[unitID] = nil
 		if not keeptrack then
+			setTargetData[unitID] = nil
 			SendToUnsynced("targetList", unitID, 0)
 		end
 	end
@@ -388,7 +384,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function removeTarget(unitID, index)
-		local unitData = unitTargets[unitID] or pausedTargets[unitID]
+		local unitData = setTargetData[unitID]
 		local removed = tremove(unitData.targets, index)
 		if removed then
 			if not unitData.targets[1] then
@@ -404,7 +400,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function removeWithStop(unitID)
-		local unitData = unitTargets[unitID] or pausedTargets[unitID]
+		local unitData = setTargetData[unitID]
 		local targetList = unitData.targets
 		local currentTargets = unitData.currentTargets
 		local currentIndex = unitData.currentIndex
@@ -416,7 +412,7 @@ if gadgetHandler:IsSyncedCode() then
 				tremove(targetList, i)
 				minIndex = i
 				if i == currentIndex then
-					currentIndex = 0
+					currentIndex = 0 -- invalid, see below
 				elseif currentIndex > i then
 					currentIndex = currentIndex - 1
 				end
@@ -436,34 +432,28 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function GG.getUnitTargetList(unitID)
-		return unitTargets[unitID] and unitTargets[unitID].targets
+		return activeTargets[unitID] and activeTargets[unitID].targets
 	end
 
 	function GG.getUnitTargetIndex(unitID)
-		return unitTargets[unitID] and unitTargets[unitID].currentIndex
+		return activeTargets[unitID] and activeTargets[unitID].currentIndex
 	end
 
 	function gadget:Initialize()
-		-- register command
 		gadgetHandler:RegisterCMDID(CMD_UNIT_SET_TARGET)
 		gadgetHandler:RegisterCMDID(CMD_UNIT_CANCEL_TARGET)
 		gadgetHandler:RegisterCMDID(CMD_UNIT_SET_TARGET_RECTANGLE)
 		gadgetHandler:RegisterCMDID(CMD_UNIT_SET_TARGET_NO_GROUND)
-		-- register allowcommand callin
-		gadgetHandler:RegisterAllowCommand(CMD_STOP)
-		gadgetHandler:RegisterAllowCommand(CMD_DGUN)
 		gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET_NO_GROUND)
 		gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET)
 		gadgetHandler:RegisterAllowCommand(CMD_UNIT_SET_TARGET_RECTANGLE)
 		gadgetHandler:RegisterAllowCommand(CMD_UNIT_CANCEL_TARGET)
 
-		-- load active units
 		local allUnits = spGetAllUnits()
 		for i = 1, #allUnits do
 			local unitID = allUnits[i]
 			gadget:UnitCreated(unitID, spGetUnitDefID(unitID), spGetUnitTeam(unitID))
 		end
-
 	end
 
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
@@ -471,8 +461,8 @@ if gadgetHandler:IsSyncedCode() then
 			spInsertUnitCmdDesc(unitID, unitSetTargetNoGroundCmdDesc)
 			spInsertUnitCmdDesc(unitID, unitSetTargetCircleCmdDesc)
 			spInsertUnitCmdDesc(unitID, unitCancelTargetCmdDesc)
-			if unitTargets[builderID] then
-				addUnitTargets(unitID, unitDefID, unitTargets[builderID].targets, false, "UnitCreated")
+			if setTargetData[builderID] and validUnits[unitDefID] then
+				addUnitTargets(unitID, unitDefID, setTargetData[builderID].targets, false)
 			end
 		end
 	end
@@ -529,7 +519,7 @@ if gadgetHandler:IsSyncedCode() then
 	local function processCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
 		--tracy.ZoneBeginN(string.format("processCommand %d %d %d %d %s %s", unitID, unitDefID, teamID, cmdID, tostring(cmdParams), tostring(cmdOptions)))
 		--tracy.Message(string.format("processCommand params=%s oprt=%s", Json.encode(cmdParams), Json.encode(cmdOptions)))
-		local unitData = unitTargets[unitID] or pausedTargets[unitID]
+		local unitData = setTargetData[unitID]
 		local nParams = #cmdParams
 
 		if nParams == 4 and cmdParams[4] < 1 then
@@ -678,77 +668,32 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function pauseTargetting(unitID)
-		if unitTargets[unitID] and not pausedTargets[unitID] then
-			local data = unitTargets[unitID]
+		if activeTargets[unitID] and not pausedTargets[unitID] then
+			local data = activeTargets[unitID]
 			removeUnit(unitID, true)
 			pausedTargets[unitID] = data
 		end
 	end
 
 	local function unpauseTargetting(unitID)
-		addUnitTargets(unitID, Spring.GetUnitDefID(unitID), pausedTargets[unitID].targets, true, "unpauseTargetting")
+		addUnitTargets(unitID, Spring.GetUnitDefID(unitID), pausedTargets[unitID].targets, true)
 	end
 
 	function gadget:UnitCmdDone(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag)
-		local hasTargetData = unitTargets[unitID] or pausedTargets[unitID]
-		if not hasTargetData then
-			return
-		end
-
-		if cmdID == CMD_STOP then
+		if cmdID == CMD_STOP and setTargetData[unitID] then
 			removeWithStop(unitID)
-		end
-
-		if not waitForCommandDone[unitID] then
-			return
-		end
-
-		-- We do not know if we are coming from ExecuteInsert or FinishCommand.
-		-- So we do not know whether the below command is starting or finished.
-		local inCommandID = spGetUnitCurrentCommand(unitID)
-		local inManualFire = inCommandID == CMD_DGUN or cmdID == CMD_DGUN -- So, check in either case.
-
-		if inManualFire then
-			if not pausedTargets[unitID] then
-				checkForManualFire[unitID] = true
-			end
-		else
-			if pausedTargets[unitID] then
-				checkForManualFire[unitID] = true
-			end
 		end
 	end
 
 	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua, fromInsert)
-		-- Accepts: CMD_STOP, CMD_DGUN, CMD_UNIT_SET_TARGET_NO_GROUND, CMD_UNIT_SET_TARGET, CMD_UNIT_SET_TARGET_RECTANGLE, CMD_UNIT_CANCEL_TARGET.
+		-- Accepts: CMD_UNIT_SET_TARGET_NO_GROUND, CMD_UNIT_SET_TARGET, CMD_UNIT_SET_TARGET_RECTANGLE, CMD_UNIT_CANCEL_TARGET.
 		--tracy.ZoneBeginN(string.format("AllowCommand %s %s", tostring(fromSynced), tostring(fromLua)))
 		--tracy.Message(string.format("Allowcommand params %s %s", table.toString(cmdOptions), table.toString(cmdParams)))
-		if isSetTargetCommand[cmdID] then
-			if validUnits[unitDefID] then
-				processCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
-			end
-			--tracy.ZoneEnd()
-			return false -- consume command
+		if validUnits[unitDefID] then
+			processCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
 		end
-
-		if unitTargets[unitID] or pausedTargets[unitID] then
-			if not isEnqueuedFirst(unitID, cmdID, cmdTag, cmdOptions, fromInsert) then
-				if cmdID == CMD_DGUN then
-					waitForCommandDone[unitID] = true
-					checkForManualFire[unitID] = true
-				end
-			elseif cmdID == CMD_DGUN then
-				pauseTargetting(unitID)
-				waitForCommandDone[unitID] = true
-				checkForManualFire[unitID] = true
-			elseif cmdID == CMD_STOP then
-				removeWithStop(unitID)
-				waitForCommandDone[unitID] = nil
-			end
-		end
-
 		--tracy.ZoneEnd()
-		return true
+		return false -- consume command
 	end
 
 	function gadget:RecvLuaMsg(msg, playerID)
@@ -772,7 +717,7 @@ if gadgetHandler:IsSyncedCode() then
 		-- sim here
 
 		if n % 5 == 4 then
-			for unitID, unitData in pairsNext, unitTargets do
+			for unitID, unitData in pairsNext, activeTargets do
 				local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
 				local length, targetIndex, countRemoved = #targets, 0, 0
 
@@ -816,7 +761,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 
 		if n % USEEN_UPDATE_FREQUENCY == 0 then
-			for unitID, unitData in pairsNext, unitTargets do
+			for unitID, unitData in pairsNext, activeTargets do
 				local targets = unitData.targets
 				for index = #targets, 1, -1 do
 					if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
@@ -826,20 +771,15 @@ if gadgetHandler:IsSyncedCode() then
 			end
 		end
 
-		for unitID in pairs(checkForManualFire) do
-			if unitTargets[unitID] then
-				if spGetUnitCurrentCommand(unitID) == CMD_DGUN then
+		for unitID in pairs(setTargetData) do
+			if activeTargets[unitID] then
+				if inAttackCommand(unitID) then
 					pauseTargetting(unitID)
 				end
-				checkForManualFire[unitID] = nil
-			elseif pausedTargets[unitID] then
-				if spGetUnitCurrentCommand(unitID) ~= CMD_DGUN then
+			else
+				if not inAttackCommand(unitID) then
 					unpauseTargetting(unitID)
 				end
-				-- continue checking for manual fire
-			else
-				checkForManualFire[unitID] = nil
-				waitForCommandDone[unitID] = nil
 			end
 		end
 


### PR DESCRIPTION
### Work done

- Checks the active command, replacing manual command tracking for DGun and Stop.
- Checks more command types: Attack, Attack Area, and Attack Area (Ground). These now pause Set Target when they are active instead of fighting for priority.
    - Updated: There was almost no performance overhead for the next attack checks, so I made it respect a couple more rules re: user intent.
- Finish unifying the active/paused target lists. While targeting is paused, correctly updates drawn targets, inherits the target lists of the builder, etc.

#### Addresses Issue(s)

- Attack orders compete with target lists for precedence over the current unit target. Many units have trouble switching targets due to animation wait times. Flapping their target(s) can cause them to hold fire or lose damage against otherwise reachable targets.
- Some target updates while DGunning with the Commander would not be sent to unsynced. This issue was way more severe after adding the pause on Attack orders so needed to be remediated together with that change.
