### PR TITLE
Ignore manual fire weapons when the unit cannot manual fire

### DIFF
--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -36,15 +36,13 @@ if gadgetHandler:IsSyncedCode() then
 		TorpedoLauncher = true,
 	}
 
-	local function hasAntiAirPriority(weapon)
+	local function hasAntiAirPriority(unitDef, weapon)
 		local weaponDef = WeaponDefs[weapon.weaponDef]
-		if nonAntiAirTypes[weaponDef.type] or weaponDef.manualFire or weaponDef.range < 100 then
+		if nonAntiAirTypes[weaponDef.type] or (unitDef.canManualFire and weaponDef.manualFire) or weaponDef.range < 100 then
 			return false
 		end
-		if not table.any(weapon.onlyTargets, function(v, k) return isAirCategory[k] end) then
-			return false
-		end
-		if table.any(weapon.badTargets, function(v, k) return isAirCategory[k] end) then
+		if not table.any(weapon.onlyTargets, function(v, k) return isAirCategory[k] end)
+			or table.any(weapon.badTargets,  function(v, k) return isAirCategory[k] end) then
 			return false
 		end
 		local damages = weaponDef.damages
@@ -80,7 +78,7 @@ if gadgetHandler:IsSyncedCode() then
 		-- Set watch on vtol-targeting weapons so AllowWeaponTarget gets called
 		for i = 1, #weapons do
 			local weapon = weapons[i]
-			if weapon.slavedTo == 0 and hasAntiAirPriority(weapon) then
+			if weapon.slavedTo == 0 and hasAntiAirPriority(unitDef, weapon) then
 				Script.SetWatchAllowTarget(weapon.weaponDef, true)
 			end
 		end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -91,20 +91,20 @@ if gadgetHandler:IsSyncedCode() then
 	local WATERWEAPON = 0
 	do
 		local allowNonAttackerUnit = { legpede = true } -- Fastpass for units that don't have an attack command for other reasons.
-		local allowCommandFireWeapon = { armstil_stiletto_bomb = true } -- TODO: Why is this commandfire = true?
 
-		local function hasTargeting(weapon)
+		local function hasTargeting(weapon, canManualFire)
 			local weaponDef = WeaponDefs[weapon.weaponDef]
 			return weapon.slavedTo == 0
 				and weaponDef.type ~= "Shield"
-				and (not weaponDef.manualFire or allowCommandFireWeapon[weaponDef.name])
+				and not (canManualFire and weaponDef.manualFire)
 				and weaponDef.range > 10
 		end
 
 		local function canSetTarget(unitDef)
 			if (unitDef.canAttack or allowNonAttackerUnit[unitDef.name]) and unitDef.maxWeaponRange > 0 then
+				local canManualFire = unitDef.canManualFire
 				for _, weapon in pairs(unitDef.weapons) do
-					if hasTargeting(weapon) then
+					if hasTargeting(weapon, canManualFire) then
 						return true
 					end
 				end
@@ -113,8 +113,8 @@ if gadgetHandler:IsSyncedCode() then
 		end
 
 		-- FIXME: We don't know which weaponDefs have submissile. We can check `nuclear`, for now.
-		local function getWeaponType(weapon)
-			if hasTargeting(weapon) then
+		local function getWeaponType(weapon, canManualFire)
+			if hasTargeting(weapon, canManualFire) then
 				local weaponDef = WeaponDefs[weapon.weaponDef]
 				return weaponDef.waterWeapon and not weaponDef.customParams.nuclear and WATERWEAPON or 1
 			else
@@ -127,7 +127,7 @@ if gadgetHandler:IsSyncedCode() then
 			if canSetTarget(unitDef) then
 				validUnits[unitDefID] = true
 				unitWeapons[unitDefID] = table.map(unitDef.weapons, function(weapon, index)
-					return getWeaponType(weapon), index
+					return getWeaponType(weapon, unitDef.canManualFire), index
 				end)
 			end
 			unitAlwaysSeen[unitDefID] = unitDef.isBuilding or unitDef.speed == 0


### PR DESCRIPTION
### Work done

Units without canManualFire ignore the manualFire property of their weapondefs, so check the unit property before checking the weapon property.

Removes a hardcoded exception for the armstil. The armstil was configured this way for some obscure purpose which caused it to be filtered out from Set Target.