### PR TITLE
Fix syntax error in unit_cloak_firestate widget

### DIFF
--- a/luaui/Widgets/unit_cloak_firestate.lua
+++ b/luaui/Widgets/unit_cloak_firestate.lua
@@ -34,7 +34,7 @@ local myTeam = spGetMyTeamID()
 
 local cloakFireState = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	if unitDef.canCloak and unitDef.customParams.firestateoncloak and not unitDef.customParams.isscavenger) then
+	if unitDef.canCloak and unitDef.customParams.firestateoncloak and not unitDef.customParams.isscavenger then
 		cloakFireState[unitDefID] = tonumber(unitDef.customParams.firestateoncloak) or FIRESTATE_HOLDFIRE
 	end
 end


### PR DESCRIPTION
The if-condition added in #7708 has an unbalanced closing paren after
`isscavenger`, which is a Lua syntax error that stops the widget from
loading. Remove the stray `)`.
