### PR TITLE
Fix music transition stuttering during catch-up

### DIFF
--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -97,6 +97,7 @@ local serverFrame = 0
 local bossHasSpawned = false
 local playInterlude = false
 local isChangingTrack = false
+local lastTrackAttemptTime = Spring.GetTimer()
 
 local function ReloadMusicPlaylists()
 	-----------------------------------SETTINGS---------------------------------------
@@ -1224,6 +1225,7 @@ end
 function PlayNewTrack(paused)
 	if isChangingTrack then return end
 	isChangingTrack = true
+	lastTrackAttemptTime = Spring.GetTimer()
 
 	if Spring.GetConfigInt('music', 1) ~= 1 then
 		isChangingTrack = false
@@ -1503,7 +1505,7 @@ function widget:GameFrame(n)
 						fadeDirection = -1
 					end
 				end
-			elseif totalTime == 0 and (not fadeDirection or Spring.GetConfigInt("UseSoundtrackFades", 1) ~= 1) then -- there's no music and not mid-transition (or fades are disabled)
+			elseif totalTime == 0 and (Spring.DiffTimers(Spring.GetTimer(), lastTrackAttemptTime) > 2.0) and (not fadeDirection or Spring.GetConfigInt("UseSoundtrackFades", 1) ~= 1) then -- there's no music and not mid-transition (or fades are disabled)
 				PlayNewTrack()
 			end
 		end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->
### Work done

When joining a match mid-game, the simulation fast-forwards through frames at high speed to catch up.

Issue: The widget relied on game frames (30 frames) to throttle its track-checking logic. During catch-up, the frames are processed much faster than at normal game speed. This sometimes causes the automatic music track change to fail during the transition to the next song: after the first song fades out, a repeating 'stuttering' sound is heard.

<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Solution: Decouple the track transition fallback from the game simulation speed by introducing a 2-second cooldown using Spring.GetTimer() and Spring.DiffTimers.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps

Spectate join an ongoing game. The game should be catching up after loading. During the catch-up, automatic music track transitions may occur.

- Expected good result: The music track should transition properly to the next track.
- Previous bad result: The music track sometimes fails to transition to the next track after fading out the first track. A repeating, 'stuttering' sound heard.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
An LLM was used to troubleshoot and implement this change.