### PR TITLE
feat(camera-startup): add Camera Startup widget to initialize camera …

### DIFF
--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -1,27 +1,32 @@
 local widget = widget ---@type Widget
 
 function widget:GetInfo()
-	return {
-		name = "Camera Startup",
-		desc = "Organize the camera to point at the startbox at the start of the game",
-		author = "uBdead",
-		date = "June 2026",
-		license = "GNU LGPL, v2.1 or later",
-		layer = 1,
-		enabled = true
-	}
+    return {
+        name = "Camera Startup",
+        desc = "Organize the camera to point at the startbox at the start of the game",
+        author = "uBdead",
+        date = "June 2026",
+        license = "GNU LGPL, v2.1 or later",
+        layer = 1,
+        enabled = true
+    }
 end
 
 function widget:Initialize()
-    -- this is not accidental, we need to get the camera state twice
+    if Spring.GetGameFrame() > 0 then
+        Spring.Echo("Camera Startup: Game already started, skipping camera setup")
+        return
+    end
+
     local nameCameraState = Spring.GetCameraState(true)
     if nameCameraState.name ~= "ta" and nameCameraState.name ~= "spring" then
-        Spring.Echo("Camera Startup: Unsupported camera mode, expected 'ta' or 'spring', got '" .. nameCameraState.name .. "'")
+        Spring.Echo("Camera Startup: Unsupported camera mode, expected 'ta' or 'spring', got '" .. nameCameraState.name
+                .. "'")
         return
     end
 
     -- Calculate the center of the startbox
-    local xMin,zMin,xMax,zMax = Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
+    local xMin, zMin, xMax, zMax = Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
     if not xMin or not zMin or not xMax or not zMax then
         Spring.Echo("Camera Startup: Failed to get startbox coordinates")
         return
@@ -33,6 +38,7 @@ function widget:Initialize()
     Spring.SetCameraTarget(centerX, 0, centerZ, 0.0000001)
 
     -- Set a reasonable zoom level
+    -- We need to get the camera state again due to the earlier SetCameraTarget call changed it
     local currentCameraState = Spring.GetCameraState(true)
     currentCameraState.height = 5000
     currentCameraState.dist = 5000

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -13,6 +13,13 @@ function widget:GetInfo()
 end
 
 function widget:Initialize()
+    -- this is not accidental, we need to get the camera state twice
+    local nameCameraState = Spring.GetCameraState(true)
+    if nameCameraState.name ~= "ta" and nameCameraState.name ~= "spring" then
+        Spring.Echo("Camera Startup: Unsupported camera mode, expected 'ta' or 'spring', got '" .. nameCameraState.name .. "'")
+        return
+    end
+
     -- Calculate the center of the startbox
     local xMin,zMin,xMax,zMax = Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
     if not xMin or not zMin or not xMax or not zMax then

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -14,21 +14,17 @@ end
 
 function widget:Initialize()
     if Spring.GetGameFrame() > 0 then
-        Spring.Echo("Camera Startup: Game already started, skipping camera setup")
         return
     end
 
     local nameCameraState = Spring.GetCameraState(true)
     if nameCameraState.name ~= "ta" and nameCameraState.name ~= "spring" then
-        Spring.Echo("Camera Startup: Unsupported camera mode, expected 'ta' or 'spring', got '" .. nameCameraState.name
-                .. "'")
         return
     end
 
     -- Calculate the center of the startbox
     local xMin, zMin, xMax, zMax = Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
     if not xMin or not zMin or not xMax or not zMax then
-        Spring.Echo("Camera Startup: Failed to get startbox coordinates")
         return
     end
 
@@ -44,4 +40,6 @@ function widget:Initialize()
     currentCameraState.dist = 5000
 
     Spring.SetCameraState(currentCameraState)
+
+    widgetHandler:RemoveWidget()
 end

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -1,0 +1,34 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Camera Startup",
+		desc = "Organize the camera to point at the startbox at the start of the game",
+		author = "uBdead",
+		date = "June 2026",
+		license = "GNU LGPL, v2.1 or later",
+		layer = 1,
+		enabled = true
+	}
+end
+
+function widget:Initialize()
+    -- Calculate the center of the startbox
+    local xMin,zMin,xMax,zMax = Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
+    if not xMin or not zMin or not xMax or not zMax then
+        Spring.Echo("Camera Startup: Failed to get startbox coordinates")
+        return
+    end
+
+    local centerX = (xMin + xMax) / 2
+    local centerZ = (zMin + zMax) / 2
+
+    Spring.SetCameraTarget(centerX, 0, centerZ, 0.0000001)
+
+    -- Set a reasonable zoom level
+    local currentCameraState = Spring.GetCameraState(true)
+    currentCameraState.height = 5000
+    currentCameraState.dist = 5000
+
+    Spring.SetCameraState(currentCameraState)
+end

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -7,23 +7,40 @@ function widget:GetInfo()
         author = "uBdead",
         date = "June 2026",
         license = "GNU LGPL, v2.1 or later",
-        layer = 1,
+        layer = 1, -- hypothetical stuff in layer = 0 could be doing things to boxes
         enabled = true
     }
 end
 
+function byeBye()
+    widgetHandler:RemoveWidget()
+end
+
 function widget:Initialize()
     if Spring.GetGameFrame() > 0 then
+        byeBye()
         return
     end
 
     local nameCameraState = Spring.GetCameraState(true)
     if nameCameraState.name ~= "ta" and nameCameraState.name ~= "spring" then
+        byeBye()
         return
     end
 
-    -- Calculate the center of the startbox
-    local xMin, zMin, xMax, zMax = Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
+    -- Calculate the center of the startbox (or map for spectators)
+    local xMin, zMin, xMax, zMax
+
+    local isSpectator = select(1, Spring.GetSpectatingState())
+    if isSpectator then
+        xMin = 0
+        zMin = 0
+        xMax = Game.mapSizeX
+        zMax = Game.mapSizeZ
+    else
+        xMin, zMin, xMax, zMax= Spring.GetAllyTeamStartBox(Spring.GetMyAllyTeamID())
+    end
+
     if not xMin or not zMin or not xMax or not zMax then
         return
     end
@@ -41,5 +58,5 @@ function widget:Initialize()
 
     Spring.SetCameraState(currentCameraState)
 
-    widgetHandler:RemoveWidget()
+    byeBye()
 end

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -12,19 +12,19 @@ function widget:GetInfo()
     }
 end
 
-function byeBye()
+function removeSelf()
     widgetHandler:RemoveWidget()
 end
 
 function widget:Initialize()
     if Spring.GetGameFrame() > 0 then
-        byeBye()
+        removeSelf()
         return
     end
 
     local nameCameraState = Spring.GetCameraState(true)
     if nameCameraState.name ~= "ta" and nameCameraState.name ~= "spring" then
-        byeBye()
+        removeSelf()
         return
     end
 
@@ -58,5 +58,5 @@ function widget:Initialize()
 
     Spring.SetCameraState(currentCameraState)
 
-    byeBye()
+    removeSelf()
 end

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -1,3 +1,5 @@
+local STARTUP_CAMERA_INITIAL_ZOOM_DISTANCE = 5000
+
 local widget = widget ---@type Widget
 
 function widget:GetInfo()
@@ -53,8 +55,8 @@ function widget:Initialize()
     -- Set a reasonable zoom level
     -- We need to get the camera state again due to the earlier SetCameraTarget call changed it
     local currentCameraState = Spring.GetCameraState(true)
-    currentCameraState.height = 5000
-    currentCameraState.dist = 5000
+    currentCameraState.height = STARTUP_CAMERA_INITIAL_ZOOM_DISTANCE
+    currentCameraState.dist = STARTUP_CAMERA_INITIAL_ZOOM_DISTANCE
 
     Spring.SetCameraState(currentCameraState)
 


### PR DESCRIPTION
- no animation/transition (instant at first frame)
- fixed zoom level
- doesn't touch camera rotation
- positions start box in center


https://github.com/user-attachments/assets/52f2e184-e6b8-4d2c-b57a-58a47f4dd5e5

works with pretty extreme angles
https://github.com/user-attachments/assets/8ecf5e2e-1cee-41ee-a7a9-3c45f8741894



