### PR TITLE
Add warn before forcing resign on a player

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -1,6 +1,7 @@
 {
 	"ui": {
-		"forceResignMessage": "You have been force-resigned: Self-destructing all your units is considered unwanted behavior when you still have teammates playing.",
+		"forceResignWarn": "Self-destructing all your units is considered unwanted behavior when you still have teammates playing.",
+		"forceResignMessage": "You have been force-resigned due to self-destructing all your units.",
 		"factoryqmanager": {
 			"saved": "Saved",
 			"loaded": "Loaded"

--- a/luarules/gadgets/game_selfd_resign.lua
+++ b/luarules/gadgets/game_selfd_resign.lua
@@ -9,7 +9,7 @@ local gadget = gadget ---@type Gadget
 function gadget:GetInfo()
     return {
         name	= "Self-Destruct Resign",
-        desc	= "Cancel the order and resign player when he tries to self-destruct all his units",
+        desc	= "Cancel the order and resign players which try to self-destruct all their units",
         author	= "Floris",
         date	= "October 2021",
         license	= "GNU GPL, v2 or later",
@@ -21,11 +21,12 @@ end
 local spGetTeamInfo = Spring.GetTeamInfo
 local spGetTeamList = Spring.GetTeamList
 local spGetAllyTeamList = Spring.GetAllyTeamList
+local spGetTeamAllyTeamID = Spring.GetTeamAllyTeamID
 local gaiaTeamID = Spring.GetGaiaTeamID()
-local gaiaAllyTeamID = select(6, spGetTeamInfo(gaiaTeamID, false))
+local gaiaAllyTeamID = spGetTeamAllyTeamID(gaiaTeamID)
 
 local function isLastAliveNonGaiaAllyTeam(teamID)
-	local teamAllyTeamID = select(6, spGetTeamInfo(teamID, false))
+	local teamAllyTeamID = spGetTeamAllyTeamID(teamID)
 	if not teamAllyTeamID then
 		return false
 	end
@@ -50,7 +51,7 @@ local function isLastAliveNonGaiaAllyTeam(teamID)
 end
 
 local function hasActiveHumanTeammate(teamID)
-	local allyTeamID = select(6, spGetTeamInfo(teamID, false))
+	local allyTeamID = spGetTeamAllyTeamID(teamID)
 	for _, tID in ipairs(spGetTeamList(allyTeamID) or {}) do
 		local luaAI = Spring.GetTeamLuaAI(tID)
 		if tID ~= teamID and not select(4, spGetTeamInfo(tID, false)) and (not luaAI or luaAI == "") and Spring.GetTeamRulesParam(tID, "numActivePlayers") > 0 then

--- a/luarules/gadgets/game_selfd_resign.lua
+++ b/luarules/gadgets/game_selfd_resign.lua
@@ -9,7 +9,7 @@ local gadget = gadget ---@type Gadget
 function gadget:GetInfo()
     return {
         name	= "Self-Destruct Resign",
-        desc	= "Converts a self-destruct to resign",
+        desc	= "Cancel the order and resign player when he tries to self-destruct all his units",
         author	= "Floris",
         date	= "October 2021",
         license	= "GNU GPL, v2 or later",
@@ -18,48 +18,60 @@ function gadget:GetInfo()
     }
 end
 
+local spGetTeamInfo = Spring.GetTeamInfo
+local spGetTeamList = Spring.GetTeamList
+local spGetAllyTeamList = Spring.GetAllyTeamList
+local gaiaTeamID = Spring.GetGaiaTeamID()
+local gaiaAllyTeamID = select(6, spGetTeamInfo(gaiaTeamID, false))
+
+local function isLastAliveNonGaiaAllyTeam(teamID)
+	local teamAllyTeamID = select(6, spGetTeamInfo(teamID, false))
+	if not teamAllyTeamID then
+		return false
+	end
+
+	local aliveNonGaiaAllyTeams = 0
+	for _, allyTeamID in ipairs(spGetAllyTeamList()) do
+		if allyTeamID ~= gaiaAllyTeamID then
+			local teams = spGetTeamList(allyTeamID) or {}
+			for _, tID in ipairs(teams) do
+				if not select(4, spGetTeamInfo(tID, false)) then -- skip AIs
+					aliveNonGaiaAllyTeams = aliveNonGaiaAllyTeams + 1
+					break
+				end
+			end
+			if aliveNonGaiaAllyTeams > 1 then
+				return false
+			end
+		end
+	end
+
+	return aliveNonGaiaAllyTeams == 1 and teamAllyTeamID ~= gaiaAllyTeamID
+end
+
+local function hasActiveHumanTeammate(teamID)
+	local allyTeamID = select(6, spGetTeamInfo(teamID, false))
+	for _, tID in ipairs(spGetTeamList(allyTeamID) or {}) do
+		local luaAI = Spring.GetTeamLuaAI(tID)
+		if tID ~= teamID and not select(4, spGetTeamInfo(tID, false)) and (not luaAI or luaAI == "") and Spring.GetTeamRulesParam(tID, "numActivePlayers") > 0 then
+			return true
+		end
+	end
+	return false
+end
+
 if gadgetHandler:IsSyncedCode() then
 
 	local thresholdPercentage = 0.95
+	local allowedStrikes = 3
 
 	local CMD_SELFD = CMD.SELFD
 	local selfdCheckTeamUnits = {}
+	local forceResignStrikesByTeamID = {}
 	local spGetUnitSelfDTime = Spring.GetUnitSelfDTime
 	local spGetTeamUnits = Spring.GetTeamUnits
-	local spGetTeamList = Spring.GetTeamList
-	local spGetTeamInfo = Spring.GetTeamInfo
-	local spGetAllyTeamList = Spring.GetAllyTeamList
-	local gaiaTeamID = Spring.GetGaiaTeamID()
-	local gaiaAllyTeamID = select(6, spGetTeamInfo(gaiaTeamID, false))
 
-	local function isLastAliveNonGaiaAllyTeam(teamID)
-		local teamAllyTeamID = select(6, spGetTeamInfo(teamID, false))
-		if not teamAllyTeamID then
-			return false
-		end
-
-		local aliveNonGaiaAllyTeams = 0
-		for _, allyTeamID in ipairs(spGetAllyTeamList()) do
-			if allyTeamID ~= gaiaAllyTeamID then
-				local teams = spGetTeamList(allyTeamID) or {}
-				for _, tID in ipairs(teams) do
-					if not select(4, spGetTeamInfo(tID, false)) then
-						aliveNonGaiaAllyTeams = aliveNonGaiaAllyTeams + 1
-						break
-					end
-				end
-				if aliveNonGaiaAllyTeams > 1 then
-					return false
-				end
-			end
-		end
-
-		return aliveNonGaiaAllyTeams == 1 and teamAllyTeamID ~= gaiaAllyTeamID
-	end
-
-	local function forceResignTeam(teamID)
-
-		-- cancel self-d orders
+	local function cancelSelfDestructOrders(teamID)
 		local units = spGetTeamUnits(teamID)
 		for i=1, #units do
 			local unitID = units[i]
@@ -67,16 +79,30 @@ if gadgetHandler:IsSyncedCode() then
 				Spring.GiveOrderToUnit(unitID, CMD_SELFD, {}, 0)
 			end
 		end
+	end
 
-		Spring.KillTeam(teamID)
-
-		-- notify players in this team
+	local function notifyTeamPlayers(teamID, message)
 		local players = Spring.GetPlayerList()
 		for _, playerID in pairs(players) do
 			if teamID == select(4, Spring.GetPlayerInfo(playerID, false)) then
-				SendToUnsynced('forceResignMessage', playerID)
+				SendToUnsynced(message, playerID)
 			end
 		end
+	end
+
+	local function forceResignTeam(teamID)
+		cancelSelfDestructOrders(teamID)
+
+		local strikes = (forceResignStrikesByTeamID[teamID] or 0) + 1
+		forceResignStrikesByTeamID[teamID] = strikes
+
+		if strikes < allowedStrikes then
+			notifyTeamPlayers(teamID, 'forceResignWarn')
+			return
+		end
+
+		notifyTeamPlayers(teamID, 'forceResignMessage')
+		Spring.KillTeam(teamID)
 	end
 
 	function gadget:Initialize()
@@ -87,43 +113,29 @@ if gadgetHandler:IsSyncedCode() then
 		if n % 15 == 1 then
 			for teamID, _ in pairs(selfdCheckTeamUnits) do
 				if not isLastAliveNonGaiaAllyTeam(teamID) then
-					-- check first if player has team players... that could possibly take
-					--local numActiveTeamPlayers = 0
-					--local allyTeamID = select(6, Spring.GetTeamInfo(teamID,false))
-					--local teamList = Spring.GetTeamList(allyTeamID)
-					--for _,tID in ipairs(teamList) do
-					--	local luaAI = Spring.GetTeamLuaAI(tID)
-					--	if tID ~= teamID and not select(4, Spring.GetTeamInfo(tID,false)) and (not luaAI or luaAI == "") and Spring.GetTeamRulesParam(tID, "numActivePlayers") > 0 then
-					--		numActiveTeamPlayers = numActiveTeamPlayers + 1
-					--	end
-					--end
-
-					-- players has teammates
-					--if numActiveTeamPlayers > 1 then
-						local units = spGetTeamUnits(teamID)
-						local unitCount = #units
-						local triggerResignAmount = math.ceil(unitCount * thresholdPercentage)
-						local skipResignAmount = unitCount - triggerResignAmount
-						local selfdUnitCount = 0
-						local skippedUnitCount = 0
-						for i=1, unitCount do
-							local unitID = units[i]
-							if spGetUnitSelfDTime(unitID) > 0 then
-								selfdUnitCount = selfdUnitCount + 1
-							else
-								skippedUnitCount = skippedUnitCount + 1
-							end
-							if skippedUnitCount >= skipResignAmount then
-								break
-							elseif selfdUnitCount >= triggerResignAmount then
-								local LuaAI = Spring.GetTeamLuaAI(teamID)
-								if not LuaAI or not ( string.find(LuaAI, "Scavengers") or string.find(LuaAI, "Raptors") ) then
-									forceResignTeam(teamID)
-								end
-								break
-							end
+					local units = spGetTeamUnits(teamID)
+					local unitCount = #units
+					local triggerResignAmount = math.ceil(unitCount * thresholdPercentage)
+					local skipResignAmount = unitCount - triggerResignAmount
+					local selfdUnitCount = 0
+					local skippedUnitCount = 0
+					for i=1, unitCount do
+						local unitID = units[i]
+						if spGetUnitSelfDTime(unitID) > 0 then
+							selfdUnitCount = selfdUnitCount + 1
+						else
+							skippedUnitCount = skippedUnitCount + 1
 						end
-					--end
+						if skippedUnitCount > skipResignAmount then
+							break
+						elseif selfdUnitCount >= triggerResignAmount then
+							local LuaAI = Spring.GetTeamLuaAI(teamID)
+							if not LuaAI or not ( string.find(LuaAI, "Scavengers") or string.find(LuaAI, "Raptors") ) then
+								forceResignTeam(teamID)
+							end
+							break
+						end
+					end
 				end
 			end
 			selfdCheckTeamUnits = {}
@@ -143,62 +155,35 @@ else -- UNSYNCED
 
 	local myPlayerID = Spring.GetMyPlayerID()
 	local myTeamID = Spring.GetMyTeamID()
-	local gaiaTeamID = Spring.GetGaiaTeamID()
-	local gaiaAllyTeamID = select(6, Spring.GetTeamInfo(gaiaTeamID, false))
-	local spGetTeamList = Spring.GetTeamList
 
-	local function isLastAliveNonGaiaAllyTeam(teamID)
-		local teamAllyTeamID = select(6, Spring.GetTeamInfo(teamID, false))
-		if not teamAllyTeamID then
-			return false
+	local function showForceResignNotification(playerID, messageKey)
+		if playerID ~= myPlayerID or Spring.GetSpectatingState() then
+			return
+		end
+		if isLastAliveNonGaiaAllyTeam(myTeamID) then
+			return
 		end
 
-		local aliveNonGaiaAllyTeams = 0
-		for _, allyTeamID in ipairs(Spring.GetAllyTeamList()) do
-			if allyTeamID ~= gaiaAllyTeamID then
-				for _, tID in ipairs(spGetTeamList(allyTeamID) or {}) do
-					if not select(4, Spring.GetTeamInfo(tID, false)) then
-						aliveNonGaiaAllyTeams = aliveNonGaiaAllyTeams + 1
-						break
-					end
-				end
-				if aliveNonGaiaAllyTeams > 1 then
-					return false
-				end
-			end
+		if hasActiveHumanTeammate(myTeamID) and Script.LuaUI('GadgetMessageProxy') then
+			Spring.Echo("\255\255\166\166" .. Script.LuaUI.GadgetMessageProxy(messageKey))
 		end
+	end
 
-		return aliveNonGaiaAllyTeams == 1 and teamAllyTeamID ~= gaiaAllyTeamID
+	local function forceResignWarn(_, playerID)
+		showForceResignNotification(playerID, 'ui.forceResignWarn')
 	end
 
 	local function forceResignMessage(_, playerID)
-		if playerID == myPlayerID then
-		if not Spring.GetSpectatingState() then
-			if isLastAliveNonGaiaAllyTeam(myTeamID) then
-				return
-			end
-			-- check first if player has team players
-			local numActiveTeamPlayers = 0
-			local allyID = select(6, Spring.GetTeamInfo(myTeamID, false))
-			local teamList = Spring.GetTeamList(allyID)
-			for _,tID in ipairs(teamList) do
-					local luaAI = Spring.GetTeamLuaAI(tID)
-					if tID ~= myTeamID and not select(4, Spring.GetTeamInfo(tID,false)) and (not luaAI or luaAI == "") and Spring.GetTeamRulesParam(tID, "numActivePlayers") > 0 then
-						numActiveTeamPlayers = numActiveTeamPlayers + 1
-					end
-				end
-				if numActiveTeamPlayers > 0 and Script.LuaUI('GadgetMessageProxy') then
-					Spring.Echo("\255\255\166\166" .. Script.LuaUI.GadgetMessageProxy('ui.forceResignMessage'))
-				end
-			end
-		end
+		showForceResignNotification(playerID, 'ui.forceResignMessage')
 	end
 
 	function gadget:Initialize()
+		gadgetHandler:AddSyncAction('forceResignWarn', forceResignWarn)
 		gadgetHandler:AddSyncAction('forceResignMessage', forceResignMessage)
 	end
 
 	function gadget:Shutdown()
+		gadgetHandler:RemoveSyncAction('forceResignWarn')
 		gadgetHandler:RemoveSyncAction('forceResignMessage')
 	end
 end


### PR DESCRIPTION
### Work done
Add a 3-strikes system to force-resign gadget. Player will get warned twice before they get resigned due to mass-selfd command.
The main goal is to prevent instant resign when selfd was triggered by accident

#### Test steps
Gadget isn't active in single player but you can easily modify it to test it in AI match:
1. comment out `if Spring.Utilities.Gametype.IsSinglePlayer()` check
2. comment out `if not select(4, spGetTeamInfo(tID, false)) then -- skip AIs` check
3. comment out `hasActiveHumanTeammate(myTeamID)` check

#### VIDEO:
https://streamable.com/hhzlax

### AI / LLM usage statement:
Refactored and reviewed with codex