### PR TITLE
fix comparison to multivalue return in Set Target

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -1045,7 +1045,7 @@ else	-- UNSYNCED
 		local result
 		repeat
 			weaponNum = weaponNum + 1
-			local _, currentTarget = spGetUnitWeaponTarget(unitID, weaponNum)
+			local _, _, currentTarget = spGetUnitWeaponTarget(unitID, weaponNum)
 			if currentTarget then
 				result = currentTarget == target
 			else
@@ -1060,7 +1060,7 @@ else	-- UNSYNCED
 		local result
 		repeat
 			weaponNum = weaponNum + 1
-			local _, currentTarget = spGetUnitWeaponTarget(unitID, weaponNum)
+			local _, _, currentTarget = spGetUnitWeaponTarget(unitID, weaponNum)
 			if currentTarget then
 				result = currentTarget[1] == x
 					and currentTarget[2] == y


### PR DESCRIPTION
### Work done

Fixes comparison against the wrong value in the multivalue return from GetUnitWeaponTarget (targetType, isUserTarget, target).

This check is used as a fallback in the Set Target target list UI to make it appear snappier in multiplayer so players might experience this as "lag".

I tested this in single player by sending a ton of junk messages to unsynced up to the point of crashing. That might be a useful method to use in general actually.