### PR TITLE
fix: iter for stale or canceled targets in set target

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -955,7 +955,7 @@ else	-- UNSYNCED
 		end
 		local targets = unitData.targets
 		if removeFromIndex then
-			for i = #targets, removeFromIndex, 1 do
+			for i = #targets, removeFromIndex, -1 do
 				targets[i] = nil
 			end
 			if removeFromIndex <= unitData.targetIndex then

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -622,7 +622,7 @@ if gadgetHandler:IsSyncedCode() then
 						if allowTargetUnit(unitID, weaponList, target) then
 							count = count + 1
 							targetList[count] = {
-								alwaysSeen = true,
+								alwaysSeen = unitAlwaysSeen[spGetUnitDefID(target)],
 								ignoreStop = ignoreStop,
 								userTarget = userTarget,
 								target = target,


### PR DESCRIPTION
### Work done

Typo in a reverse iter made it a foward iter, and some units were not being checked for stale targeting. This caused the drawn target list not to clear correctly after Cancel Target w/ extra params and would leave stale targets for one extra sim frame.