### PR TITLE
fix: air units with non-anti-air weapons are not fighters

### DIFF
--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -54,6 +54,10 @@ if gadgetHandler:IsSyncedCode() then
 		return weapon.slavedTo == 0 and hasAntiAirTargeting(weapon)
 	end
 
+	local function isNotFakeWeapon(weapon)
+		return not WeaponDefs[weapon.weaponDef].customParams.bogus
+	end
+
 	local function hasAntiAirPriority(unitDef, weapon)
 		if not hasTargeting(unitDef, weapon) or not hasAntiAirTargeting(weapon) then
 			return false
@@ -76,6 +80,7 @@ if gadgetHandler:IsSyncedCode() then
 			airPriorityMultiplier[unitDefID] = (unitDef.isTransport or unitDef.isBuilder) and PRIORITY_VTOLS
 				or table.any(weapons, isBomberWeapon) and PRIORITY_BOMBERS
 				or table.any(weapons, isFighterWeapon) and PRIORITY_FIGHTERS
+				or table.any(weapons, isNotFakeWeapon) and PRIORITY_VTOLS -- doubles as the PRIORITY_GUNSHIP
 				or PRIORITY_SCOUTS
 		end
 		for i = 1, #weapons do

--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -36,13 +36,30 @@ if gadgetHandler:IsSyncedCode() then
 		TorpedoLauncher = true,
 	}
 
-	local function hasAntiAirPriority(unitDef, weapon)
+	local function hasTargeting(unitDef, weapon)
+		return weapon.slavedTo == 0 and not (unitDef.canManualFire and WeaponDefs[weapon.weaponDef].manualFire)
+	end
+
+	local function hasAntiAirTargeting(weapon)
+		return table.any(weapon.onlyTargets, function(v, k) return isAirCategory[k] end) and not
+			   table.any(weapon.badTargets,  function(v, k) return isAirCategory[k] end)
+	end
+
+	local function isBomberWeapon(weapon)
 		local weaponDef = WeaponDefs[weapon.weaponDef]
-		if nonAntiAirTypes[weaponDef.type] or (unitDef.canManualFire and weaponDef.manualFire) or weaponDef.range < 100 then
+		return weaponDef.type == 'AircraftBomb' or weaponDef.type == 'TorpedoLauncher' or stringFind(weaponDef.name, 'arm_pidr', 1, true)
+	end
+
+	local function isFighterWeapon(weapon)
+		return weapon.slavedTo == 0 and hasAntiAirTargeting(weapon)
+	end
+
+	local function hasAntiAirPriority(unitDef, weapon)
+		if not hasTargeting(unitDef, weapon) or not hasAntiAirTargeting(weapon) then
 			return false
 		end
-		if not table.any(weapon.onlyTargets, function(v, k) return isAirCategory[k] end)
-			or table.any(weapon.badTargets,  function(v, k) return isAirCategory[k] end) then
+		local weaponDef = WeaponDefs[weapon.weaponDef]
+		if nonAntiAirTypes[weaponDef.type] or weaponDef.range < 100 then
 			return false
 		end
 		local damages = weaponDef.damages
@@ -52,34 +69,19 @@ if gadgetHandler:IsSyncedCode() then
 		return true
 	end
 
-	-- Pre-compute direct unitDefID → priority multiplier for all air units
 	local airPriorityMultiplier = {}
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		local weapons = unitDef.weapons
 		if unitDef.isAirUnit then
-			local mult = PRIORITY_SCOUTS
-			if unitDef.isTransport or unitDef.isBuilder then
-				mult = PRIORITY_VTOLS
-			else
-				for i = 1, #weapons do
-					local weaponDef = WeaponDefs[weapons[i].weaponDef]
-					if weaponDef.type == 'AircraftBomb' or weaponDef.type == 'TorpedoLauncher' or stringFind(weaponDef.name, 'arm_pidr', 1, true) then
-						mult = PRIORITY_BOMBERS
-					elseif weapons[i].onlyTargets.vtol then
-						mult = PRIORITY_FIGHTERS
-					else
-						mult = PRIORITY_VTOLS
-					end
-				end
-			end
-			airPriorityMultiplier[unitDefID] = mult
+			airPriorityMultiplier[unitDefID] = (unitDef.isHoveringAirUnit or unitDef.isTransport or unitDef.isBuilder) and PRIORITY_VTOLS
+				or table.any(weapons, isBomberWeapon) and PRIORITY_BOMBERS
+				or table.any(weapons, isFighterWeapon) and PRIORITY_FIGHTERS
+				or PRIORITY_SCOUTS
 		end
-
-		-- Set watch on vtol-targeting weapons so AllowWeaponTarget gets called
 		for i = 1, #weapons do
-			local weapon = weapons[i]
-			if weapon.slavedTo == 0 and hasAntiAirPriority(unitDef, weapon) then
-				Script.SetWatchAllowTarget(weapon.weaponDef, true)
+			if hasAntiAirPriority(unitDef, weapons[i]) then
+				-- Watch this weapon so AllowWeaponTarget gets called:
+				Script.SetWatchAllowTarget(weapons[i].weaponDef, true)
 			end
 		end
 	end

--- a/luarules/gadgets/unit_aa_targeting_priority.lua
+++ b/luarules/gadgets/unit_aa_targeting_priority.lua
@@ -73,7 +73,7 @@ if gadgetHandler:IsSyncedCode() then
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		local weapons = unitDef.weapons
 		if unitDef.isAirUnit then
-			airPriorityMultiplier[unitDefID] = (unitDef.isHoveringAirUnit or unitDef.isTransport or unitDef.isBuilder) and PRIORITY_VTOLS
+			airPriorityMultiplier[unitDefID] = (unitDef.isTransport or unitDef.isBuilder) and PRIORITY_VTOLS
 				or table.any(weapons, isBomberWeapon) and PRIORITY_BOMBERS
 				or table.any(weapons, isFighterWeapon) and PRIORITY_FIGHTERS
 				or PRIORITY_SCOUTS


### PR DESCRIPTION
### Work done

Remove the x2 target priority penalty from some units, including the Legion Tyrannus. These have a secondary AA weapon as their last weapon so are treated like fighters.

The torpedo gunships have the bomber-type priority both before and after this change. Everything else seems to be in its proper place.