### PR TITLE
process target lists in an incremental queue

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -39,10 +39,6 @@ end
 
 if gadgetHandler:IsSyncedCode() then
 
-	-- The rate of removing unseen/untracked units from the unit target lists.
-	-- Done once per N target list update passes to reduce the overhead costs.
-	local unseenUpdatePasses = 3
-
 	local spInsertUnitCmdDesc = Spring.InsertUnitCmdDesc
 	local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
 	local spSetUnitTarget = Spring.SetUnitTarget
@@ -68,6 +64,8 @@ if gadgetHandler:IsSyncedCode() then
 	local ensureTable = table.ensureTable
 
 	local max = math.max
+	local min = math.min
+	local clamp = math.clamp
 	local diag = math.diag
 	local pairsNext = next
 	local type = type
@@ -138,6 +136,44 @@ if gadgetHandler:IsSyncedCode() then
 	local setTargetData = {} -- holds all unit data
 	local activeTargets = {}
 	local pausedTargets = {}
+
+	-- Unlike the physical sim, unit, command, and "AI" AI respond to performance bottlenecks.
+	-- Use a work queue with a sliding index to process target lists in chunks on every frame.
+	local updateWorkQueue = {} -- unitID[] for target updates
+	local workQueueLookup = {} -- unitID => queue index lookup -- TODO: shadows activeTargets
+	local workQueueLength = 0
+	local workQueueIndex = 1
+	-- At most chunkSizeMin units will be processed on every frame except slow update frames.
+	-- So the update interval below is matched only from (updateFrames x chunkSizeMin) units,
+	-- and up to (updateFrames x chunkSizeMax) units, and could be lower or higher otherwise.
+	local updateFrames = 0.1667 * Game.gameSpeed
+	local chunkSizeMin = 32
+	local chunkSizeMax = 1024
+
+	local function addToQueue(unitID)
+		if not workQueueLookup[unitID] then
+			workQueueLength = workQueueLength + 1
+			updateWorkQueue[workQueueLength] = unitID
+			workQueueLookup[unitID] = workQueueLength
+		end
+	end
+
+	local function removeFromQueue(unitID)
+		local index = workQueueLookup[unitID]
+		if index then
+			if index ~= workQueueLength then
+				local moveID = updateWorkQueue[workQueueLength]
+				updateWorkQueue[index] = moveID
+				workQueueLookup[moveID] = index
+			end
+			updateWorkQueue[workQueueLength] = nil
+			workQueueLength = workQueueLength - 1
+			workQueueLookup[unitID] = nil
+			if workQueueIndex > index then
+				workQueueIndex = workQueueIndex - 1
+			end
+		end
+	end
 
 	--------------------------------------------------------------------------------
 	-- Commands
@@ -287,9 +323,9 @@ if gadgetHandler:IsSyncedCode() then
 		SendToUnsynced("targetIndex", unitID, targetIndex, true)
 	end
 
-	local function setTargetPassive(unitID, unitData, targetIndex)
+	local function setTargetPassive(unitID, unitData)
 		unitData.activeTarget = false
-		unitData.currentIndex = targetIndex
+		unitData.currentIndex = 1
 		if not inAttackCommand(unitID) then
 			spSetUnitTarget(unitID, nil)
 		end
@@ -297,7 +333,7 @@ if gadgetHandler:IsSyncedCode() then
 		spSetUnitRulesParam(unitID, "targetCoordX", nil)
 		spSetUnitRulesParam(unitID, "targetCoordY", nil)
 		spSetUnitRulesParam(unitID, "targetCoordZ", nil)
-		SendToUnsynced("targetIndex", unitID, targetIndex, false)
+		SendToUnsynced("targetIndex", unitID, 1, false)
 	end
 
 	local function isUnseenEnemyUnit(targetData, allyTeam)
@@ -376,6 +412,7 @@ if gadgetHandler:IsSyncedCode() then
 		setTargetData[unitID] = data
 		activeTargets[unitID] = data
 		pausedTargets[unitID] = nil
+		addToQueue(unitID)
 		sendTargetsToUnsynced(unitID)
 		if not data.activeTarget and testTarget(unitID, data.teamID, data.weapons, targets[1].target) then
 			setTargetActive(unitID, data, 1)
@@ -397,6 +434,7 @@ if gadgetHandler:IsSyncedCode() then
 			pausedTargets[unitID] = nil
 			SendToUnsynced("targetList", unitID, 0)
 		end
+		removeFromQueue(unitID)
 		if not keeptrack then
 			setTargetData[unitID] = nil
 			SendToUnsynced("targetList", unitID, 0)
@@ -750,9 +788,30 @@ if gadgetHandler:IsSyncedCode() then
 	--------------------------------------------------------------------------------
 	-- Target update
 
-	local updateUnseenUnits = unseenUpdatePasses
+	local function processSlowListUpdates()
+		for unitID, unitData in pairsNext, setTargetData do
+			local targets = unitData.targets
+			for index = #targets, 1, -1 do
+				if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
+					removeTarget(unitID, index)
+				end
+			end
+			if not targets[1] then
+				removeUnit(unitID)
+			elseif activeTargets[unitID] then
+				if not hasTargetPrecedence(unitID) then
+					pauseTargetting(unitID)
+				end
+			else
+				if hasTargetPrecedence(unitID) then
+					unpauseTargetting(unitID)
+				end
+			end
+		end
+	end
 
-	local function updateTargetList(unitID, unitData)
+	local function updateTargetList(unitID)
+		local unitData = activeTargets[unitID]
 		local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
 		local targetCount = #targets
 		local activeIndex = 0
@@ -804,56 +863,31 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	function gadget:GameFrame(frame)
-		-- ideally timing would be synced with slow update to reduce attack jittering
-		-- SlowUpdate+ causes attack command to override target command
-		-- unfortunately since 103 that's not possible, attempt to override every frame
-		-- it might create a slight increase of cpu usage when hundreds of units gets
-		-- a set target command, howrever a quick test with 300 fidos only increased by 1%
-		-- sim here
-
-		teamQueryCaches = {}
-
-		for unitID in pairs(setTargetData) do
-			if activeTargets[unitID] then
-				if not hasTargetPrecedence(unitID) then
-					pauseTargetting(unitID)
-				end
-			else
-				if hasTargetPrecedence(unitID) then
-					unpauseTargetting(unitID)
-				end
-			end
+	local function processTargetListChunk()
+		if workQueueLength == 0 then
+			return
 		end
-
-		local offset = frame % 5
-
-		if offset == 0 then
-
-			if updateUnseenUnits ~= 1 then
-				updateUnseenUnits = updateUnseenUnits - 1
-				return
+		local processCount = clamp(workQueueLength / updateFrames, min(workQueueLength, chunkSizeMin), chunkSizeMax)
+		for _ = 1, processCount do
+			if workQueueIndex > workQueueLength then
+				workQueueIndex = 1
 			end
-
-			updateUnseenUnits = unseenUpdatePasses
-
-			for unitID, unitData in pairsNext, activeTargets do
-				local targets = unitData.targets
-				for index = #targets, 1, -1 do
-					if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
-						removeTarget(unitID, index)
-					end
-				end
-			end
-
-		elseif offset == 1 then
-
-			for unitID, unitData in pairsNext, activeTargets do
-				updateTargetList(unitID, unitData)
-			end
+			local unitID = updateWorkQueue[workQueueIndex]
+			workQueueIndex = workQueueIndex + 1
+			updateTargetList(unitID)
 		end
 	end
 
+	-- Since v103 Attack commands override the unit target on any frame, not just slow updates.
+	-- So we try to override the target again, every single frame, to prevent target jittering.
+	function gadget:GameFrame(frame)
+		teamQueryCaches = {}
+		if frame % 15 == 0 then
+			processSlowListUpdates()
+		else
+			processTargetListChunk()
+		end
+	end
 
 
 else	-- UNSYNCED

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -752,6 +752,48 @@ if gadgetHandler:IsSyncedCode() then
 
 	local updateUnseenUnits = unseenUpdatePasses
 
+	local function updateTargetList(unitID, unitData)
+		local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
+		local length, targetIndex, countRemoved = #targets, 0, 0
+
+		-- Target priority is in list-order on the target list.
+		for index = 1, length do
+			local targetData = targets[index]
+			if not checkTarget(teamID, targetData.target) then
+				targetData.invalid = true
+				countRemoved = countRemoved + 1
+			elseif testTarget(unitID, teamID, weapons, targetData.target) then
+				targetIndex = index - countRemoved
+				break
+			end
+		end
+
+		-- But we remove in reverse to minimize shifted entries.
+		local isEmptyList = false
+		if countRemoved > 0 then
+			local maxIndex = targetIndex == 0 and length or targetIndex + countRemoved
+			for index = maxIndex, 1, -1 do
+				if targets[index].invalid then
+					-- TODO: Some duplicated effort. This updates the activeTarget/currentIndex.
+					-- TODO: We need that in the unseen loop, below, but this is redundant here.
+					removeTarget(unitID, index)
+				end
+			end
+			isEmptyList = not targets[1]
+			if not isEmptyList then
+				sendTargetsToUnsynced(unitID)
+			end
+		end
+
+		if isEmptyList then
+			--
+		elseif targetIndex ~= 0 then
+			setTargetActive(unitID, unitData, targetIndex)
+		elseif unitData.activeTarget then
+			setTargetPassive(unitID, unitData, 1)
+		end
+	end
+
 	function gadget:GameFrame(frame)
 		-- ideally timing would be synced with slow update to reduce attack jittering
 		-- SlowUpdate+ causes attack command to override target command
@@ -797,45 +839,7 @@ if gadgetHandler:IsSyncedCode() then
 		elseif offset == 1 then
 
 			for unitID, unitData in pairsNext, activeTargets do
-				local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
-				local length, targetIndex, countRemoved = #targets, 0, 0
-
-				-- Target priority is in list-order on the target list.
-				for index = 1, length do
-					local targetData = targets[index]
-					if not checkTarget(teamID, targetData.target) then
-						targetData.invalid = true
-						countRemoved = countRemoved + 1
-					elseif testTarget(unitID, teamID, weapons, targetData.target) then
-						targetIndex = index - countRemoved
-						break
-					end
-				end
-
-				-- But we remove in reverse to minimize shifted entries.
-				local isEmptyList = false
-				if countRemoved > 0 then
-					local maxIndex = targetIndex == 0 and length or targetIndex + countRemoved
-					for index = maxIndex, 1, -1 do
-						if targets[index].invalid then
-							-- TODO: Some duplicated effort. This updates the activeTarget/currentIndex.
-							-- TODO: We need that in the unseen loop, below, but this is redundant here.
-							removeTarget(unitID, index)
-						end
-					end
-					isEmptyList = not targets[1]
-					if not isEmptyList then
-						sendTargetsToUnsynced(unitID)
-					end
-				end
-
-				if isEmptyList then
-					--
-				elseif targetIndex ~= 0 then
-					setTargetActive(unitID, unitData, targetIndex)
-				elseif unitData.activeTarget then
-					setTargetPassive(unitID, unitData, 1)
-				end
+				updateTargetList(unitID, unitData)
 			end
 		end
 	end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -463,8 +463,7 @@ if gadgetHandler:IsSyncedCode() then
 		unitData.activeTarget = active
 	end
 
-	local function removeTarget(unitID, index)
-		local unitData = setTargetData[unitID]
+	local function removeTarget(unitID, unitData, index)
 		local removed = tremove(unitData.targets, index)
 		if removed then
 			if not unitData.targets[1] then
@@ -473,9 +472,12 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			unitData.currentTargets[removed.target] = nil
 			if index == unitData.currentIndex then
-				updateTarget(unitID, unitData, 1)
+				unitData.currentIndex = 1
+				unitData.activeTarget = false
+			elseif index < unitData.currentIndex then
+				unitData.currentIndex = unitData.currentIndex - 1
 			end
-			refreshSendData(unitID, unitData, index)
+			SendToUnsynced("targetDrop", unitID, index)
 		end
 	end
 
@@ -723,12 +725,12 @@ if gadgetHandler:IsSyncedCode() then
 				elseif nParams == 1 then
 					if cmdOptions.alt then
 						local targetIndex = cmdParams[1]
-						removeTarget(unitID, targetIndex)
+						removeTarget(unitID, unitData, targetIndex)
 					else
 						local targetID = cmdParams[1]
 						for index, targetData in ipairs(unitData.targets) do
 							if targetData.target == targetID then
-								removeTarget(unitID, index)
+								removeTarget(unitID, unitData, index)
 								break
 							end
 						end
@@ -736,7 +738,7 @@ if gadgetHandler:IsSyncedCode() then
 				elseif nParams == 3 then
 					for index, targetData in ipairs(unitData.targets) do
 						if type(targetData.target) == "table" and inCancelDistance(targetData.target, cmdParams) then
-							removeTarget(unitID, index)
+							removeTarget(unitID, unitData, index)
 						end
 					end
 				end
@@ -793,7 +795,7 @@ if gadgetHandler:IsSyncedCode() then
 			local targets = unitData.targets
 			for index = #targets, 1, -1 do
 				if isUnseenEnemyUnit(targets[index], unitData.allyTeam) then
-					removeTarget(unitID, index)
+					removeTarget(unitID, unitData, index)
 				end
 			end
 			if not targets[1] then
@@ -834,8 +836,6 @@ if gadgetHandler:IsSyncedCode() then
 					targets[updateIndex] = targetData
 				end
 			else
-				-- ! FIXME: WE NEED THIS FOR UNSYNCED TO WORK
-				-- ! FIXME: AAAHHH BREAKING COMMIT NO MERGE!!
 				SendToUnsynced("targetDrop", unitID, index)
 			end
 		end
@@ -845,20 +845,27 @@ if gadgetHandler:IsSyncedCode() then
 			if unitData.activeTarget then
 				setTargetPassive(unitID, unitData)
 			end
-			-- Remove entries only once we are done shifting indices.
-			for index = updateIndex + 1, targetCount do
-				targets[index] = nil
+			if updateIndex + 1 <= targetCount then
+				-- Remove entries only once we are done shifting indices.
+				for index = updateIndex + 1, targetCount do
+					targets[index] = nil
+				end
+				SendToUnsynced("targetList", unitID, updateIndex + 1)
 			end
 		else
 			setTargetActive(unitID, unitData, activeIndex)
 			-- We broke iter early so have to finish shifting indices.
 			local removedCount = updateIndex - activeIndex
+			local removeFromIndex = targetCount - removedCount + 1
 			for index = activeIndex + 1, targetCount - removedCount do
 				updateIndex = updateIndex + 1
 				targets[index] = targets[updateIndex]
 			end
-			for index = targetCount - removedCount + 1, targetCount do
-				targets[index] = nil
+			if removeFromIndex <= targetCount then
+				for index = removeFromIndex, targetCount do
+					targets[index] = nil
+				end
+				SendToUnsynced("targetList", unitID, removeFromIndex)
 			end
 		end
 	end
@@ -903,6 +910,8 @@ else	-- UNSYNCED
 	-- 4k * 100 list length maximum is enough to assume target saturation with 32,000 unit cap.
 
 	local math_min = math.min
+	local table_remove = table.remove
+	local pairsNext = next
 
 	local glVertex = gl.Vertex
 	local glPushAttrib = gl.PushAttrib
@@ -929,7 +938,6 @@ else	-- UNSYNCED
 	local spGetUnitWeaponTarget = Spring.GetUnitWeaponTarget
 	local spSetCustomCommandDrawData = Spring.SetCustomCommandDrawData
 	local spAddWorldIcon = Spring.AddWorldIcon
-	local pairsNext = next
 
 	local myAllyTeam = spGetMyAllyTeamID()
 	local myTeam = spGetMyTeamID()
@@ -947,6 +955,7 @@ else	-- UNSYNCED
 		gadgetHandler:AddChatAction("targetdrawteam", handleTargetDrawEvent, "toggles drawing targets for units, params: teamID doDraw")
 		gadgetHandler:AddChatAction("targetdrawunit", handleUnitTargetDrawEvent, "toggles drawing targets for units, params: unitID")
 		gadgetHandler:AddSyncAction("targetList", handleTargetListEvent)
+		gadgetHandler:AddSyncAction("targetDrop", handleTargetDropEvent)
 		gadgetHandler:AddSyncAction("targetIndex", handleTargetIndexEvent)
 		gadgetHandler:AddSyncAction("failCommand", handleFailCommand)
 
@@ -968,6 +977,7 @@ else	-- UNSYNCED
 		gadgetHandler:RemoveChatAction("targetdrawteam")
 		gadgetHandler:RemoveChatAction("targetdrawunit")
 		gadgetHandler:RemoveSyncAction("targetList")
+		gadgetHandler:RemoveSyncAction("targetDrop")
 		gadgetHandler:RemoveSyncAction("targetIndex")
 		gadgetHandler:RemoveSyncAction("failCommand")
 	end
@@ -1001,8 +1011,8 @@ else	-- UNSYNCED
 			}
 			targetList[unitID] = unitData
 		end
-		local targets = unitData.targets
 		if removeFromIndex then
+			local targets = unitData.targets
 			for i = #targets, removeFromIndex, -1 do
 				targets[i] = nil
 			end
@@ -1027,6 +1037,13 @@ else	-- UNSYNCED
 			end
 		end
 		--tracy.ZoneEnd()
+	end
+
+	function handleTargetDropEvent(_, unitID, index)
+		local unitData = getUnitTargetList(unitID, false)
+		if unitData then
+			table_remove(unitData.targets, index)
+		end
 	end
 
 	function handleTargetIndexEvent(_, unitID, index, active)

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -754,43 +754,53 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function updateTargetList(unitID, unitData)
 		local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
-		local length, targetIndex, countRemoved = #targets, 0, 0
-
-		-- Target priority is in list-order on the target list.
-		for index = 1, length do
+		local targetCount = #targets
+		local activeIndex = 0
+		local updateIndex = 0 -- table.remove is slow, as is iterating forward then backward, so we do an erase-remove
+		for index = 1, targetCount do
 			local targetData = targets[index]
-			if not checkTarget(teamID, targetData.target) then
-				targetData.invalid = true
-				countRemoved = countRemoved + 1
-			elseif testTarget(unitID, teamID, weapons, targetData.target) then
-				targetIndex = index - countRemoved
-				break
-			end
-		end
-
-		-- But we remove in reverse to minimize shifted entries.
-		local isEmptyList = false
-		if countRemoved > 0 then
-			local maxIndex = targetIndex == 0 and length or targetIndex + countRemoved
-			for index = maxIndex, 1, -1 do
-				if targets[index].invalid then
-					-- TODO: Some duplicated effort. This updates the activeTarget/currentIndex.
-					-- TODO: We need that in the unseen loop, below, but this is redundant here.
-					removeTarget(unitID, index)
+			if checkTarget(teamID, targetData.target) then
+				updateIndex = updateIndex + 1
+				if testTarget(unitID, teamID, weapons, targetData.target) then
+					if updateIndex ~= index then
+						targets[updateIndex] = targetData
+					end
+					activeIndex = updateIndex
+					updateIndex = index
+					-- if moveToIndex == index then
+					break -- Avoid continuing tests for better performance.
+					-- end
 				end
-			end
-			isEmptyList = not targets[1]
-			if not isEmptyList then
-				sendTargetsToUnsynced(unitID)
+				if updateIndex ~= index then
+					targets[updateIndex] = targetData
+				end
+			else
+				-- ! FIXME: WE NEED THIS FOR UNSYNCED TO WORK
+				-- ! FIXME: AAAHHH BREAKING COMMIT NO MERGE!!
+				SendToUnsynced("targetDrop", unitID, index)
 			end
 		end
-
-		if isEmptyList then
-			--
-		elseif targetIndex ~= 0 then
-			setTargetActive(unitID, unitData, targetIndex)
-		elseif unitData.activeTarget then
-			setTargetPassive(unitID, unitData, 1)
+		if updateIndex == 0 then
+			removeUnit(unitID)
+		elseif activeIndex == 0 then
+			if unitData.activeTarget then
+				setTargetPassive(unitID, unitData)
+			end
+			-- Remove entries only once we are done shifting indices.
+			for index = updateIndex + 1, targetCount do
+				targets[index] = nil
+			end
+		else
+			setTargetActive(unitID, unitData, activeIndex)
+			-- We broke iter early so have to finish shifting indices.
+			local removedCount = updateIndex - activeIndex
+			for index = activeIndex + 1, targetCount - removedCount do
+				updateIndex = updateIndex + 1
+				targets[index] = targets[updateIndex]
+			end
+			for index = targetCount - removedCount + 1, targetCount do
+				targets[index] = nil
+			end
 		end
 	end
 


### PR DESCRIPTION
### Work done

- Increase Set Target update rates and remove frame hitching under heavy loads w/ large numbers of priority targets by moving the workload to a work queue.
- Support longer target lists by replacing table.remove with an erase-remove.
- Added the targetDrop event and handling to unsynced.

This adds per-frame updates for Set Target. The previous update rate was once every 5 frames, which waffles between any two competing targets (e.g. Set Target and Attack). After this change and in regular gameplay conditions, we are able to override the Attack via Set Target.

At moderate to high target counts, this reaches an update rate of 5 frames, again. At extremely high target counts, the update rate also becomes sliding.

#### Some considerations

While the simulation requires full calculation, we have buffers and delays e.g. in netmsg that express similar constraints at high load. These constraints are just properties of the context; they are not explicit e.g. in widget code. Some project docs on how we consider/approach soft-real-time would be useful for calibrating the exact degree of sliding allowed, though. I based this change on allowing sliding updates as priority target counts become large (>10k).

This slows down the pause/unpause check to each half a second. That is fast enough for almost all units and engagements except Commander DGuns (while targeting is active). Command tracking can be readded but I would rather not; maybe these units can use a faster poll rate similar to fast auto-retargeting.

#### Before merge

Another PR changes the args to a method that is moved here. Need to resolve the merge and retest to be sure.