### PR TITLE
Prevent waypoint dragging from blocking area dragging commands

### DIFF
--- a/luaui/Widgets/unit_waypoint_dragger_2.lua
+++ b/luaui/Widgets/unit_waypoint_dragger_2.lua
@@ -47,15 +47,16 @@ local cmdColorsTbl = {
 }
 
 local cmdAreaBlockDragging = {
-	[CMD.RECLAIM]      = true,
-	[CMD.REPAIR]       = true,
-	[CMD.RESURRECT]    = true,
-	[CMD.RESTORE]      = true,
-	[CMD.CAPTURE]      = true,
-	[CMD.ATTACK]       = true,
-	[CMD.AREA_ATTACK]  = true,
-	[CMD.LOAD_UNITS]   = true,
-	[CMD.UNLOAD_UNITS] = true,
+	[CMD.RECLAIM]                = true,
+	[CMD.REPAIR]                 = true,
+	[CMD.RESURRECT]              = true,
+	[CMD.RESTORE]                = true,
+	[CMD.CAPTURE]                = true,
+	[CMD.ATTACK]                 = true,
+	[CMD.AREA_ATTACK]            = true,
+	[CMD.LOAD_UNITS]             = true,
+	[CMD.UNLOAD_UNITS]			 = true,
+	[GameCMD.AREA_ATTACK_GROUND] = true,
 }
 
 local wayPtSelDist = 15

--- a/luaui/Widgets/unit_waypoint_dragger_2.lua
+++ b/luaui/Widgets/unit_waypoint_dragger_2.lua
@@ -46,6 +46,18 @@ local cmdColorsTbl = {
 	[CMD.RESTORE]      = {0.0, 1.0, 0.0, 0.55},
 }
 
+local cmdAreaBlockDragging = {
+	[CMD.RECLAIM]      = true,
+	[CMD.REPAIR]       = true,
+	[CMD.RESURRECT]    = true,
+	[CMD.RESTORE]      = true,
+	[CMD.CAPTURE]      = true,
+	[CMD.ATTACK]       = true,
+	[CMD.AREA_ATTACK]  = true,
+	[CMD.LOAD_UNITS]   = true,
+	[CMD.UNLOAD_UNITS] = true,
+}
+
 local wayPtSelDist = 15
 local wayPtSelDistSqr = wayPtSelDist * wayPtSelDist
 local selWayPtsTbl = {}
@@ -237,7 +249,11 @@ function widget:MousePress(mx, my, mb)
 	if actCmdID and actCmdID < 0 then
 		return false
 	end
-	local alt, ctrl, meta, shift = spGetModKeyState()
+	-- stop waypoint dragging from hijacking area dragging
+	if actCmdID and cmdAreaBlockDragging[actCmdID] then
+		return false
+	end
+	local _, _, _, shift = spGetModKeyState()
 	local numWayPts              = 0
 	if not shift then return false end
 	if mb ~= 1 then return false end


### PR DESCRIPTION
### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Stopped waypoints from hijacking shift+drag with area commands by detecting active command. This makes queuing commands like area reclaim easier since you don't have to avoid waypoints when selecting the center of the area reclaim.


#### Addresses Issue(s)
- Fixes #6651

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] create a waypoint
- [ ] select an area command like area reclaim
- [ ] hold shift and drag mouse starting from the waypoint position
- [ ] waypoint should not move and command should be queued
- [ ] with no selected command waypoint should be moveable

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->


### AI / LLM usage statement:
ChatGPT was used to help determine the commands to avoid hijacking. Changes have been tested.
