### PR TITLE
stop chat history / console from opening when using area commands while holding ctrl+shift

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -38,6 +38,7 @@ local cmdBlockChatHistory = {
 	[CMD.LOAD_UNITS]             = true,
 	[CMD.UNLOAD_UNITS]			 = true,
 	[GameCMD.AREA_ATTACK_GROUND] = true,
+	[GameCMD.AREA_MEX]           = true,
 }
 
 local LineTypes = {

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -25,6 +25,20 @@ local spGetMyTeamID = Spring.GetMyTeamID
 local spGetMouseState = Spring.GetMouseState
 local spEcho = Spring.Echo
 local spGetSpectatingState = Spring.GetSpectatingState
+local spGetActiveCommand = Spring.GetActiveCommand
+
+local cmdBlockChatHistory = {
+	[CMD.RECLAIM]                = true,
+	[CMD.REPAIR]                 = true,
+	[CMD.RESURRECT]              = true,
+	[CMD.RESTORE]                = true,
+	[CMD.CAPTURE]                = true,
+	[CMD.ATTACK]                 = true,
+	[CMD.AREA_ATTACK]            = true,
+	[CMD.LOAD_UNITS]             = true,
+	[CMD.UNLOAD_UNITS]			 = true,
+	[GameCMD.AREA_ATTACK_GROUND] = true,
+}
 
 local LineTypes = {
 	Console = -1,
@@ -1464,7 +1478,8 @@ function widget:Update(dt)
 		setCurrentChatLine(#chatLines)
 	elseif math_isInRect(x, y, activationArea[1], activationArea[2], activationArea[3], activationArea[4]) then
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
-		if showHistoryWhenCtrlShift and ctrl and shift then
+		local _, actCmdID, _, _      = spGetActiveCommand()
+		if showHistoryWhenCtrlShift and ctrl and shift and not (actCmdID and cmdBlockChatHistory[actCmdID]) then
 			if math_isInRect(x, y, consoleActivationArea[1], consoleActivationArea[2], consoleActivationArea[3], consoleActivationArea[4]) then
 				historyMode = 'console'
 			else

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -27,20 +27,6 @@ local spEcho = Spring.Echo
 local spGetSpectatingState = Spring.GetSpectatingState
 local spGetActiveCommand = Spring.GetActiveCommand
 
-local cmdBlockChatHistory = {
-	[CMD.RECLAIM]                = true,
-	[CMD.REPAIR]                 = true,
-	[CMD.RESURRECT]              = true,
-	[CMD.RESTORE]                = true,
-	[CMD.CAPTURE]                = true,
-	[CMD.ATTACK]                 = true,
-	[CMD.AREA_ATTACK]            = true,
-	[CMD.LOAD_UNITS]             = true,
-	[CMD.UNLOAD_UNITS]			 = true,
-	[GameCMD.AREA_ATTACK_GROUND] = true,
-	[GameCMD.AREA_MEX]           = true,
-}
-
 local LineTypes = {
 	Console = -1,
 	Player = 1,
@@ -1479,8 +1465,8 @@ function widget:Update(dt)
 		setCurrentChatLine(#chatLines)
 	elseif math_isInRect(x, y, activationArea[1], activationArea[2], activationArea[3], activationArea[4]) then
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
-		local _, actCmdID, _, _      = spGetActiveCommand()
-		if showHistoryWhenCtrlShift and ctrl and shift and not (actCmdID and cmdBlockChatHistory[actCmdID]) then
+		local _, actCmdID, _, _ = spGetActiveCommand()
+		if showHistoryWhenCtrlShift and ctrl and shift and not actCmdID then
 			if math_isInRect(x, y, consoleActivationArea[1], consoleActivationArea[2], consoleActivationArea[3], consoleActivationArea[4]) then
 				historyMode = 'console'
 			else


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Stops chat history / console ui from popping up when using area commands while holding ctrl+shift. 


#### Addresses Issue(s)
- Issue #6996

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] hold shift+ctrl and hover on chatbox / console history area and see them appear
- [ ] select area command then hold shift+ctrl and do the same, chatbox / console history should not appear

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

### AI / LLM usage statement:
Not used.
