### PR TITLE
fix bogus weapon on Neptune rendering a projectile

### DIFF
--- a/units/Legion/Ships/T2/leganavyflagship.lua
+++ b/units/Legion/Ships/T2/leganavyflagship.lua
@@ -126,6 +126,7 @@ return {
 				weapontype = "Cannon",
 				weaponvelocity = 360,
 				customparams = {
+					bogus = 1,
 					norangering = 1,
 				},
 				damage = {


### PR DESCRIPTION
### Work done

Set the targeting system's fake weapon to "bogus" on the leganavyflagship. This now shows a teeny tiny plasma projectile since the new projectile gfx went into place. Probably has some other odd effects as well that this will fix.