### PR TITLE
disable the construction of naval units on lava maps as per the game design document

### DIFF
--- a/common/configs/unit_restrictions_config.lua
+++ b/common/configs/unit_restrictions_config.lua
@@ -36,7 +36,10 @@ local function shouldShowWaterUnits()
 		voidWater = mapinfo.voidwater
 	end
 
-	if voidWater then
+	local lava = Spring.Lava
+	local isLava = lava and lava.isLavaMap
+
+	if voidWater or isLava then
 		return false
 	end
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Disabled the placement of naval units in lava maps since it seems like this was a planned feature and the game design document states that construction is forbidden in lava. 

#### Addresses Issue(s)
- Issue #5486

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Naval units disabled on lava maps
- [ ] Naval units working on normal water maps


### Screenshots:
<img width="713" height="481" alt="image" src="https://github.com/user-attachments/assets/d53b0923-cf88-4779-8601-3ac9c6bb0c25" />


### AI / LLM usage statement:
Not used.
