### PR TITLE
fix: i18n.interpolate tolerates leftover % and arg-count mismatch

### DIFF
--- a/modules/i18n/i18nlib/i18n/interpolate.lua
+++ b/modules/i18n/i18nlib/i18n/interpolate.lua
@@ -30,7 +30,19 @@ local function interpolate(str, vars)
   str = escapeDoublePercent(str)
   str = interpolateVariables(str, vars)
   str = interpolateFormattedVariables(str, vars)
-  str = string.format(str, unpack(vars))
+  -- format remaining positional placeholders (%s, %d, %5d, ...)
+  if str:find('%%') and not str:find('%%{') and not str:find('%%<') then
+    local scan = str:gsub('%%%%', '')
+    local _, percentCount = scan:gsub('%%[%-%d%.]*%a', '')
+    local args = {}
+    for i = 1, percentCount do
+      args[i] = vars[i] or vars[tostring(i)] or 'nil'
+    end
+    local ok, formatted = pcall(string.format, str, unpack(args))
+    if ok then
+      str = formatted
+    end
+  end
   str = unescapeDoublePercent(str)
   return str
 end

--- a/modules/i18n/i18nlib/i18n/interpolate.lua
+++ b/modules/i18n/i18nlib/i18n/interpolate.lua
@@ -24,13 +24,8 @@ local function unescapeDoublePercent(str)
   return str:gsub(ltDummy, "%%<"):gsub(bracketDummy, "%%{")
 end
 
-
-local function interpolate(str, vars)
-  vars = vars or {}
-  str = escapeDoublePercent(str)
-  str = interpolateVariables(str, vars)
-  str = interpolateFormattedVariables(str, vars)
-  -- format remaining positional placeholders (%s, %d, %5d, ...)
+-- formats remaining positional placeholders (%s, %d, %5d, ...); unconsumed args and lone % render raw instead of crashing
+local function interpolatePositionalVariables(str, vars)
   if str:find('%%') and not str:find('%%{') and not str:find('%%<') then
     local scan = str:gsub('%%%%', '')
     local _, percentCount = scan:gsub('%%[%-%d%.]*%a', '')
@@ -43,6 +38,16 @@ local function interpolate(str, vars)
       str = formatted
     end
   end
+  return str
+end
+
+
+local function interpolate(str, vars)
+  vars = vars or {}
+  str = escapeDoublePercent(str)
+  str = interpolateVariables(str, vars)
+  str = interpolateFormattedVariables(str, vars)
+  str = interpolatePositionalVariables(str, vars)
   str = unescapeDoublePercent(str)
   return str
 end


### PR DESCRIPTION
## What it does

Make the trailing positional `string.format` pass in `interpolate()` optional and non-fatal: run it only when the string still has real positional specs (`%d`, `%s`, … — ignoring escaped `%%`), pass one argument per spec, and `pcall`-guard it so a spec/argument mismatch falls back to the un-formatted string instead of erroring.

## Why

**TLDR:** callers can pass named variables freely without i18n blowing up.

`string.format(str, unpack(vars))` ran unconditionally after `%{name}` interpolation, so a leftover literal `%` (e.g. `50% off`) or a positional spec/arg mismatch threw an error — even when a translation only used named variables. That made it unsafe to pass a variable a given string doesn't consume.

**Intermediate systems need this.** In another branch, [gui_chat](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5704/files#diff-50e9e809ac9691ea91cf6bb0ce6b1cced195ea150a9fdcf978972faaf9970ab0R625) sits between my code and i18n and infers a field's color from the translation variable *key names* — fragile, and my keys are resource-agnostic now (`amountSendable`, not `energyAmount`). I wanted to pass it a `resourceType` hint, but any extra variable exploded translation. This unblocks that.

## Note

This is NOT fixed in the upstream kikito I18n, that's sad.
