### PR TITLE
Fix /luarules reclaimunits not refunding resources to unit owner

### DIFF
--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -484,7 +484,7 @@ if gadgetHandler:IsSyncedCode() then
 		elseif cmd == "removenearbyunits" then
 			ExecuteSelUnits(words, playerID, 'removenearbyunits')
 		elseif cmd == "reclaimunits" then
-			ExecuteSelUnits(words, playerID)
+			ExecuteSelUnits(words, playerID, 'reclaim')
 		elseif cmd == "transferunits" then
 			local parts = string.split(msg, ':')
 			local words = {}


### PR DESCRIPTION
/luarules reclaimunits was only destroying units without refunding resources.

ExecuteSelUnits was called without the 'reclaim' action parameter, causing it to fall through to default destroy behavior. Added missing 'reclaim' argument so the reclaim action handler correctly destroys the unit and refunds metal and energy to the owning team via Spring.AddTeamResource.

