### PR TITLE
Fix reclaim area reclaiminfo widget outside map border

### DIFF
--- a/luaui/Widgets/gui_reclaiminfo.lua
+++ b/luaui/Widgets/gui_reclaiminfo.lua
@@ -128,7 +128,7 @@ function widget:DrawScreen()
 		UpdateMinimapGeometry()
 	end
 
-	if (cmd == CMD.RECLAIM and rangestart ~= nil and b1 and b1was == false) or (nonground == "Reclaim" and b1was == false and b2 and rangestart ~= nil) then
+	if rangestart ~= nil and not b1was and ((cmd == CMD.RECLAIM and b1) or (nonground == "Reclaim" and b2)) then
 		if rangestart[1] == 0 and rangestart[3] == 0 then
 			local inMinimap, rx, ry = InMinimap(x, y)
 			if inMinimap then
@@ -147,9 +147,7 @@ function widget:DrawScreen()
 		b1was = true
 	else
 		b1was = false
-		rangestart[1] = 0
-		rangestart[2] = 0
-		rangestart[3] = 0
+		rangestart = {0, 0, 0}
 	end
 	--bit more precise showing when mouse is moved by 4 pixels (start)
 	if (b1 and rangestart ~= nil and cmd == CMD.RECLAIM and start == false) or (nonground == "Reclaim" and rangestart ~= nil and start == false and b2) then


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Fix area reclaim outside of map border from giving an error. `rangestart` was being indexed as nil.

#### Addresses Issue(s)
- Issue #7958


<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] area reclaim outside map should not produce an error

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
