### PR TITLE
Add modmarker: moderator broadcast map marker visible to all players

### DIFF
--- a/luarules/configs/powerusers.lua
+++ b/luarules/configs/powerusers.lua
@@ -10,6 +10,7 @@ local everything = {
 	-- devhelpers_test = true,	-- desync
 	playerdata = true,
 	waterlevel = true,
+	modmarker = true,
 	sysinfo = true,
 	volcano = true,
 }
@@ -20,6 +21,7 @@ local moderator = {
 	devhelpers = false,
 	playerdata = true,
 	waterlevel = false,
+	modmarker = true,
 	sysinfo = true,
 	volcano = true,
 }
@@ -32,6 +34,7 @@ local eventmanager = {
 	devhelpers_teams = true,	-- playertoteam, killteam
 	playerdata = false,
 	waterlevel = true,
+	modmarker = true,
 	sysinfo = false,
 	volcano = true,
 }
@@ -41,6 +44,7 @@ local singleplayer = {		-- note: these permissions override others when singlepl
 	cmd = true,
 	devhelpers = true,
 	waterlevel = true,
+	modmarker = true,
 	playerdata = true,
 	sysinfo = false,
 	volcano = true,

--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -38,12 +38,16 @@ function isAuthorized(playerID, subPermission)
 	   (SYNCED and SYNCED.permissions.devhelpers and (SYNCED.permissions.devhelpers[accountID] or (playername and SYNCED.permissions.devhelpers[playername]))) then
 		hasPermission = true
 	end
-	-- check specific sub-permission
+	-- check the devhelpers_<name> sub-permission OR a matching top-level permission
+	-- of the same name (e.g. modmarker), so roles without the devhelpers catch-all
+	-- (moderators/event managers) are authorized too
 	if not hasPermission and subPermission then
-		local permKey = "devhelpers_" .. subPermission
-		if (_G and _G.permissions[permKey] and (_G.permissions[permKey][accountID] or (playername and _G.permissions[permKey][playername]))) or
-		   (SYNCED and SYNCED.permissions[permKey] and (SYNCED.permissions[permKey][accountID] or (playername and SYNCED.permissions[permKey][playername]))) then
-			hasPermission = true
+		for _, permKey in ipairs({ "devhelpers_" .. subPermission, subPermission }) do
+			if (_G and _G.permissions[permKey] and (_G.permissions[permKey][accountID] or (playername and _G.permissions[permKey][playername]))) or
+			   (SYNCED and SYNCED.permissions[permKey] and (SYNCED.permissions[permKey][accountID] or (playername and SYNCED.permissions[permKey][playername]))) then
+				hasPermission = true
+				break
+			end
 		end
 	end
 	if hasPermission then
@@ -456,6 +460,8 @@ if gadgetHandler:IsSyncedCode() then
 			subPermission = "teams"
 		elseif cmd == "globallos" or cmd == "clearwrecks" or cmd == "reducewrecks" then
 			subPermission = "terrain"
+		elseif cmd == "modmarker" then
+			subPermission = "modmarker"
 		end
 
 		if not isAuthorized(playerID, subPermission) then
@@ -511,6 +517,19 @@ if gadgetHandler:IsSyncedCode() then
 			playertoteam(words)
 		elseif cmd == "killteam" then
 			killteam(words)
+		elseif cmd == "modmarker" then
+			-- split on ':' so a multi-word label ("Rule Violation") keeps its spaces;
+			-- the gmatch words[] above would truncate it to the first token. After the
+			-- header strip msg is "$:modmarker:x:y:z:label", so parts =
+			-- {"$","modmarker",x,y,z,label}.
+			local parts = string.split(msg, ':')
+			local x = tonumber(parts[3])
+			local y = tonumber(parts[4])
+			local z = tonumber(parts[5])
+			local label = parts[6] or ""
+			if x and y and z then
+				SendToUnsynced("modmarker", x, y, z, label)
+			end
 		end
 	end
 
@@ -764,6 +783,12 @@ else	-- UNSYNCED
 		gadgetHandler:AddChatAction('playertoteam', playertoteam, "") -- /luarules playertoteam [playerID] [teamID] -- playerID+teamID are optional, no playerID given = your own playerID, no teamID = selected unit team or hovered unit team
 		gadgetHandler:AddChatAction('killteam', killteam, "") -- /luarules killteam [teamID] -- kills the team
 		gadgetHandler:AddChatAction('desync', desync) -- /luarules desync
+		gadgetHandler:AddChatAction('modmarker', modmarker, "") -- /luarules modmarker [label] -- places a broadcast marker at cursor visible to all players
+		-- Moderator broadcast ping: the synced modmarker handler relays here, and
+		-- every client draws it locally (localOnly=true) so ALL players see it.
+		gadgetHandler:AddSyncAction("modmarker", function(_, x, y, z, label)
+			Spring.MarkerAddPoint(x, y, z, label or "", true)
+		end)
 	end
 
 	function gadget:Shutdown()
@@ -786,6 +811,8 @@ else	-- UNSYNCED
 		gadgetHandler:RemoveChatAction('playertoteam')
 		gadgetHandler:RemoveChatAction('killteam')
 		gadgetHandler:RemoveChatAction('desync')
+		gadgetHandler:RemoveChatAction('modmarker')
+		gadgetHandler:RemoveSyncAction("modmarker")
 	end
 
 	function xpUnits(_, line, words, playerID)
@@ -1303,8 +1330,27 @@ else	-- UNSYNCED
 		end
 	end
 
+	function modmarker(_, line, words, playerID)
+		-- /luarules modmarker          -- places broadcast marker at cursor with no label
+		-- /luarules modmarker My text  -- places broadcast marker at cursor with label
+		if playerID ~= Spring.GetMyPlayerID() then
+			return
+		end
+		if not isAuthorized(playerID, "modmarker") then
+			return
+		end
+		local mx, my = Spring.GetMouseState()
+		local t, pos = Spring.TraceScreenRay(mx, my, true)
+		if type(pos) == 'table' then
+			local x = math.floor(pos[1])
+			local y = math.floor(pos[2])
+			local z = math.floor(pos[3])
+			local label = words[1] and table.concat(words, " ", 1) or ""
+			Spring.SendLuaRulesMsg(PACKET_HEADER .. ':modmarker:' .. x .. ':' .. y .. ':' .. z .. ':' .. label)
+		end
+	end
+
 	function spawnunitexplosion(_, line, words, playerID)
-		--spawnunitexplosion usage:
 		--/luarules spawnunitexplosion armbull --spawns at cursor
 		if playerID ~= Spring.GetMyPlayerID() then
 			return


### PR DESCRIPTION
Adds a new `$dev$:modmarker` command to cmd_dev_helpers that places a map marker visible to all players (including enemies), gated behind a new modmarker permission in powerusers.lua.

Motivation:
Moderators / Event Managers need a way to visually mark rule violation incidents on the map in a way that all players can see, including the offending player and their teammates. The existing Spring.MarkerAddPoint is ally-team scoped, meaning enemy players never see it. During moderation actions (unit removal, commander selfd incidents) the current marker only reaches spectators and allied players, leaving the offending team unaware of why the action was taken. A broadcast marker improves transparency and serves as a visible deterrent.

This command has the same functionality as the normal in-game map ping, but unlike a standard ping which is scoped to your ally-team, modmarker broadcasts to all players including enemies. Access is gated behind powerusers.lua so only authorized moderators, admins, and event managers can use it,  regular players cannot trigger a broadcast marker.

Normal Spring.MarkerAddPoint is ally-team scoped — enemies never see it. This uses the existing $dev$ packet infrastructure to broadcast via SendToUnsynced, where each client draws the marker locally with localOnly=true, making it visible to everyone.

Changes:
- cmd_dev_helpers.lua: adds modmarker command handler (synced RecvLuaMsg dispatch + unsynced AddSyncAction/RemoveSyncAction)
- cmd_dev_helpers.lua: fixes isAuthorized to support top-level permissions (e.g. modmarker) in addition to the existing devhelpers_* sub-permissions — without this fix roles with modmarker=true but devhelpers=false (moderators) would be incorrectly denied
- powerusers.lua: adds modmarker = true to everything, moderator, and singleplayer permission sets

Update:
- cmd_dev_helpers.lua: adds /luarules modmarker chat action so the command is self-contained and usable without a widget trigger. Usage: /luarules modmarker [optional label] — places a broadcast marker at the cursor position visible to all players. Follows the same pattern as /luarules spawnceg.

Usage:
Spring.SendLuaRulesMsg("$dev$:modmarker:x:y:z:label")
Update:
Usage:
Via widget: Spring.SendLuaRulesMsg("$dev$:modmarker:x:y:z:label")
Via chat:   /luarules modmarker [optional label]  (places at cursor position)

The marker label supports color escape strings. Multi-word labels are preserved via string.split(msg, ':') parsing.

AI / LLM usage statement:
VStudio with Claude Code extension, Lua language Server by sumneko and XLM Language Support by Red Hat were used to make this PR
