### PR TITLE
fix: commandInsert getting stuck in insert-mode after a missed key-release

### DIFF
--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -6,6 +6,7 @@ local widget = widget ---@type Widget
 function widget:GetInfo()
   return {
     name = "CommandInsert",
+    version = 2,
     desc = "When pressing spacebar and shift, you can insert commands to arbitrary places in queue. When pressing spacebar alone, commands are inserted on front of queue. Based on FrontInsert by jK",
     author = "dizekat",
     date = "Jan,2008",
@@ -34,6 +35,94 @@ local modifiers = {
 
 -- Current position in prepend queue for prepend_queue mode
 local prependPos = 0
+
+-- [v2] Failsafe for a lost key-release: if the insert action's key-release is never
+-- delivered (the window losing focus while the key is held -- e.g. alt-tab or a
+-- compositor key-grab on Wayland), the mode flag stays set and every subsequent order
+-- silently becomes a CMD.INSERT. Re-validate the held state against the bound key(s).
+local STUCK_GRACE_FRAMES = 3 -- not configurable; frames the key must read released before clearing (avoids a single-frame state race)
+
+local spGetModKeyState = Spring.GetModKeyState
+local spGetKeyState = Spring.GetKeyState
+
+local insertKeyCodes -- resolved once, then cached
+local insertModifiers
+local stuckFrames = 0
+
+-- The keys are bound to the action+arg combinations, not the bare "commandinsert"
+-- action, so each combination must be queried for its hotkey(s).
+local INSERT_ACTIONS = { "commandinsert prepend_between", "commandinsert prepend_queue" }
+
+local function cacheInsertKeys()
+	insertKeyCodes, insertModifiers = {}, {}
+	for a = 1, #INSERT_ACTIONS do
+		local hotkeys = Spring.GetActionHotKeys(INSERT_ACTIONS[a])
+		if hotkeys then
+			for i = 1, #hotkeys do
+				local baseKey = hotkeys[i]:match("[^+]+$") -- strip modifier prefixes like "Any+"
+				if baseKey then
+					baseKey = baseKey:lower()
+					if baseKey == "alt" or baseKey == "ctrl" or baseKey == "meta" or baseKey == "shift" then
+						insertModifiers[baseKey] = true
+					else
+						local keyCode = Spring.GetKeyCode(baseKey)
+						if keyCode then
+							insertKeyCodes[#insertKeyCodes + 1] = keyCode
+						end
+					end
+				end
+			end
+		end
+	end
+
+end
+
+local function isInsertKeyHeld()
+	if not insertKeyCodes then
+		cacheInsertKeys()
+	end
+
+	-- Could not resolve a bound key (e.g. queried before keybinds were loaded): fail safe by
+	-- reporting held, so the insert feature is never broken, and retry the lookup next time.
+	if not next(insertModifiers) and insertKeyCodes[1] == nil then
+		insertKeyCodes = nil
+		return true
+	end
+
+	if next(insertModifiers) then
+		local alt, ctrl, meta, shift = spGetModKeyState()
+		if (insertModifiers.alt and alt) or (insertModifiers.ctrl and ctrl)
+			or (insertModifiers.meta and meta) or (insertModifiers.shift and shift) then
+			return true
+		end
+	end
+
+	for i = 1, #insertKeyCodes do
+		if spGetKeyState(insertKeyCodes[i]) then
+			return true
+		end
+	end
+
+	return false
+end
+
+function widget:Update()
+	if modifiers.prepend_between or modifiers.prepend_queue then
+		if isInsertKeyHeld() then
+			stuckFrames = 0
+		else
+			stuckFrames = stuckFrames + 1
+			if stuckFrames >= STUCK_GRACE_FRAMES then
+				modifiers.prepend_between = false
+				modifiers.prepend_queue = false
+				prependPos = 0
+				stuckFrames = 0
+			end
+		end
+	else
+		stuckFrames = 0
+	end
+end
 
 function widget:GameStart()
   widget:PlayerChanged()

--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -55,11 +55,11 @@ local INSERT_ACTIONS = { "commandinsert prepend_between", "commandinsert prepend
 
 local function cacheInsertKeys()
 	insertKeyCodes, insertModifiers = {}, {}
-	for a = 1, #INSERT_ACTIONS do
-		local hotkeys = Spring.GetActionHotKeys(INSERT_ACTIONS[a])
+	for _, action in ipairs(INSERT_ACTIONS) do
+		local hotkeys = Spring.GetActionHotKeys(action)
 		if hotkeys then
-			for i = 1, #hotkeys do
-				local baseKey = hotkeys[i]:match("[^+]+$") -- strip modifier prefixes like "Any+"
+			for _, hotkey in ipairs(hotkeys) do
+				local baseKey = hotkey:match("[^+]+$") -- strip modifier prefixes like "Any+"
 				if baseKey then
 					baseKey = baseKey:lower()
 					if baseKey == "alt" or baseKey == "ctrl" or baseKey == "meta" or baseKey == "shift" then
@@ -74,7 +74,6 @@ local function cacheInsertKeys()
 			end
 		end
 	end
-
 end
 
 local function isInsertKeyHeld()


### PR DESCRIPTION
### Work done

`cmd_commandinsert.lua` turns insert-mode on while its action key is held: the key-press sets `modifiers.prepend_between` / `modifiers.prepend_queue`, and the key-release clears them. If that release is never delivered to the widget — which happens when the window loses focus while the key is still held (alt-tab, or a compositor key-grab; common on Wayland) — the flag stays set. From then on `CommandNotify` converts every order into a `CMD.INSERT` and returns `true`, so right-clicks stop issuing direct orders and box-select misbehaves, until a `/luaui reload`.

This adds a `widget:Update` failsafe that re-validates insert-mode against the real held state of the bound key(s) and clears it when none are held. Bound keys are resolved via `GetActionHotKeys` for the action+arg combinations (`commandinsert prepend_between` / `commandinsert prepend_queue`), so it works for any binding — modifier keys via `GetModKeyState`, regular keys (e.g. the default `space`) via `GetKeyState`.

**Efficiency:** the per-frame check early-outs unless a flag is set (two table reads, no engine call, no allocation). Engine state is polled only while insert-mode is actually active; the bound keys are resolved once and cached; there is no per-frame heap allocation. If the binding can't be resolved yet it fails safe (treats the key as held, so the feature is never broken, and retries). `version` bumped to 2.

#### Test steps
- [ ] Hold the insert key (default `space`), alt-tab to another window, release the key there, return to the game → right-clicks issue **direct** orders. (Before: every order is inserted/queued until `/luaui reload`.)
- [ ] Normal use still works: hold the insert key and click → the command is inserted into the queue as before (the failsafe only clears when the key is genuinely released).

#### Testing done
Verified in live games on Linux/Wayland with an instrumented build of this exact logic (a gated log line on each auto-clear). It correctly resolved the bound key (`space`) and, over a single ~3.5 h session, auto-cleared **17** genuine stuck-insert-mode occurrences — each of which would previously have required a manual `/luaui reload`. It did **not** fire during normal insert use (it only triggers while the bound key reads released), so the insert feature is unaffected. (An earlier build that polled the wrong key was discarded.)

### AI / LLM usage statement
Root cause was diagnosed and the fix drafted with the assistance of Claude Code (Anthropic). All code was reviewed, edited, and verified in-game by me; the testing described above is from my own play sessions.
