### PR TITLE
add unit xp on juno damage dealt

### DIFF
--- a/luarules/gadgets/unit_juno_damage.lua
+++ b/luarules/gadgets/unit_juno_damage.lua
@@ -150,6 +150,7 @@ if gadgetHandler:IsSyncedCode() then
 	local SpGetUnitPosition = Spring.GetUnitPosition
 	local SpGetGroundHeight = Spring.GetGroundHeight
 	local SpSpawnCEG = Spring.SpawnCEG
+	local SpAddUnitExperience = Spring.AddUnitExperience
 	local Mmin = math.min
 	local Mfloor = math.floor
 	local Msqrt = math.sqrt
@@ -203,6 +204,8 @@ if gadgetHandler:IsSyncedCode() then
 	end
 	junoWeaponsNames = nil
 
+	local experienceMod = 0.3
+
 	function gadget:UnitDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, projID, aID, aDefID, aTeam)
 		if junoWeapons[weaponID] and tokillUnits[uDefID] then
 			if uID and SpValidUnitID(uID) then
@@ -211,6 +214,12 @@ if gadgetHandler:IsSyncedCode() then
 					SpawnJunoDamageEffects(px, py, pz, aTeam)
 				end
 				if aID and SpValidUnitID(aID) then
+					local health, healthMax = Spring.GetUnitHealth(uID)
+					local attackerPower = UnitDefs[aDefID].power
+					local defenderPower = UnitDefs[uDefID].power
+					local scaledExpMod = 0.1 * experienceMod * (defenderPower / attackerPower)
+					local scaledDamage = health / healthMax
+					SpAddUnitExperience(aID, scaledExpMod * scaledDamage)
 					SpDestroyUnit(uID, false, false, aID)
 				else
 					SpDestroyUnit(uID, false, false) -- leavewreck, makeselfdexplosion

--- a/luarules/gadgets/unit_juno_damage.lua
+++ b/luarules/gadgets/unit_juno_damage.lua
@@ -218,7 +218,7 @@ if gadgetHandler:IsSyncedCode() then
 					local attackerPower = UnitDefs[aDefID].power
 					local defenderPower = UnitDefs[uDefID].power
 					local scaledExpMod = 0.1 * experienceMod * (defenderPower / attackerPower)
-					local scaledDamage = health / healthMax
+					local scaledDamage = math.max(health / healthMax, 0)
 					SpAddUnitExperience(aID, scaledExpMod * scaledDamage)
 					SpDestroyUnit(uID, false, false, aID)
 				else

--- a/luarules/gadgets/unit_juno_damage_mini.lua
+++ b/luarules/gadgets/unit_juno_damage_mini.lua
@@ -148,6 +148,7 @@ if gadgetHandler:IsSyncedCode() then
 	local SpDestroyUnit = Spring.DestroyUnit
 	local SpGetUnitDefID = Spring.GetUnitDefID
 	local SpValidUnitID = Spring.ValidUnitID
+	local SpAddUnitExperience = Spring.AddUnitExperience
 	local Mmin = math.min
 
 
@@ -165,6 +166,8 @@ if gadgetHandler:IsSyncedCode() then
 	end
 	junoWeaponsNames = nil
 
+	local experienceMod = 0.3
+
 	function gadget:UnitDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, projID, aID, aDefID, aTeam)
 		if junoWeapons[weaponID] and tokillUnits[uDefID] then
 			if uID and SpValidUnitID(uID) then
@@ -173,6 +176,12 @@ if gadgetHandler:IsSyncedCode() then
 					Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
 				end
 				if aID and SpValidUnitID(aID) then
+					local health, healthMax = Spring.GetUnitHealth(uID)
+					local attackerPower = UnitDefs[aDefID].power
+					local defenderPower = UnitDefs[uDefID].power
+					local scaledExpMod = 0.1 * experienceMod * (defenderPower / attackerPower)
+					local scaledDamage = health / healthMax
+					SpAddUnitExperience(aID, scaledExpMod * scaledDamage)
 					SpDestroyUnit(uID, false, false, aID)
 				else
 					SpDestroyUnit(uID, false, false) -- leavewreck, makeselfdexplosion

--- a/luarules/gadgets/unit_juno_damage_mini.lua
+++ b/luarules/gadgets/unit_juno_damage_mini.lua
@@ -180,7 +180,7 @@ if gadgetHandler:IsSyncedCode() then
 					local attackerPower = UnitDefs[aDefID].power
 					local defenderPower = UnitDefs[uDefID].power
 					local scaledExpMod = 0.1 * experienceMod * (defenderPower / attackerPower)
-					local scaledDamage = health / healthMax
+					local scaledDamage = math.max(health / healthMax, 0)
 					SpAddUnitExperience(aID, scaledExpMod * scaledDamage)
 					SpDestroyUnit(uID, false, false, aID)
 				else


### PR DESCRIPTION
### Work done

Adds damage-to-xp handling for some scripted damages. Juno weapons actually destroy their targets outright, but we can translate that into "damage done" by taking the target's remaining health.