### PR TITLE
Fix destroyunits explosion/wreck and wreckunits resurrectible wreck

### DIFF
--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -614,7 +614,7 @@ if gadgetHandler:IsSyncedCode() then
 			if unitID and Spring.ValidUnitID(unitID) then
 				local h, mh = Spring.GetUnitHealth(unitID)
 				if not action then
-					Spring.DestroyUnit(unitID, false, false, unitID)
+					Spring.DestroyUnit(unitID)  -- bare call: engine handles explosion + resurrectible wreck naturally
 				elseif action == 'xp' and params then
 					--Spring.SetUnitExperience(unitID, select(1, Spring.GetUnitExperience(unitID)) + tonumber(params))
 					if type(tonumber(params)) == 'number' then
@@ -636,12 +636,18 @@ if gadgetHandler:IsSyncedCode() then
 					Spring.AddTeamResource(teamID, 'energy', UnitDefs[unitDefID].energyCost)
 				elseif action == 'wreck' then
 					local unitDefID = Spring.GetUnitDefID(unitID)
-					local x, y, z = Spring.GetUnitPosition(unitID)
+					local ux, uy, uz = Spring.GetUnitPosition(unitID)
 					local heading = Spring.GetUnitHeading(unitID)
 					local unitTeam = Spring.GetUnitTeam(unitID)
+					local uDef = UnitDefs[unitDefID]
+					-- Destroy silently (no explosion, no natural wreck), then manually create a resurrectible wreck
 					Spring.DestroyUnit(unitID, false, true)
-					if UnitDefs[unitDefID] and UnitDefs[unitDefID].corpse and FeatureDefNames[UnitDefs[unitDefID].corpse] then
-						Spring.CreateFeature(FeatureDefNames[UnitDefs[unitDefID].corpse].id, x, y, z, heading, unitTeam)
+					if uDef and uDef.corpse and FeatureDefNames[uDef.corpse] then
+						local fDefID = FeatureDefNames[uDef.corpse].id
+						local fID = Spring.CreateFeature(fDefID, ux, uy, uz, heading, unitTeam)
+						if fID then
+							Spring.SetFeatureResurrect(fID, unitDefID, heading)
+						end
 					end
 				end
 			end


### PR DESCRIPTION
Problem:
destroyunits and wreckunits were functionally and visually identical — both produced no explosion and neither left a resurrectible wreck. This made the two commands indistinguishable and broke their intended use case of leaving wrecks that builders could resurrect.

Fix:
destroyunits previously used Spring.DestroyUnit(unitID, false, false, unitID) which suppressed the natural death sequence. Reverted to bare Spring.DestroyUnit(unitID) to restore natural death behavior — explosion + resurrectible wreck.

wreckunits previously used DestroyUnit + CreateFeature which left a non-resurrectible static wreck. Updated to use DestroyUnit(reclaimed=true) for silent removal + CreateFeature + SetFeatureResurrect(fID, unitDefID, heading) so the wreck is correctly marked as resurrectible.

The Gaia unit fix (explicit unit ID targeting to prevent unintended destruction of other players' selected units) is preserved — only the per-unit action handlers were changed.

Result:
- destroyunits: explosion + resurrectible wreck
- wreckunits: no explosion + resurrectible wreck
- removeunits: instant removal, no wreck

Note:
Known issue (pre-existing, not introduced by this PR):
Both destroyunits and wreckunits leave wrecks with no collision — live units can pass through them as if they are ghosts. This was present before this fix and appears to be a limitation of how the engine handles unit death in this context. The natural death path (Spring.DestroyUnit bare call) does not appear to restore collision to the resulting wreck. Investigation into whether Spring.SetFeatureCollision or a similar API can address this would be appreciated.

### AI / LLM usage statement:
Visual Studio with Claude Code
