### PR TITLE
Fix wreckunits to leave resurrectible wreck

### DIFF
--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -641,7 +641,11 @@ if gadgetHandler:IsSyncedCode() then
 					local unitTeam = Spring.GetUnitTeam(unitID)
 					Spring.DestroyUnit(unitID, false, true)
 					if UnitDefs[unitDefID] and UnitDefs[unitDefID].corpse and FeatureDefNames[UnitDefs[unitDefID].corpse] then
-						Spring.CreateFeature(FeatureDefNames[UnitDefs[unitDefID].corpse].id, x, y, z, heading, unitTeam)
+						local fDefID = FeatureDefNames[UnitDefs[unitDefID].corpse].id
+						local fID = Spring.CreateFeature(fDefID, x, y, z, heading, unitTeam)
+						if fID then
+							Spring.SetFeatureResurrect(fID, unitDefID, heading)
+						end
 					end
 				end
 			end


### PR DESCRIPTION
Problem:
wreckunits created a wreck via Spring.CreateFeature but did not mark it as resurrectible, leaving a static wreck that builders could not resurrect.

Fix:
Capture the return value of Spring.CreateFeature and pass it to Spring.SetFeatureResurrect(fID, unitDefID, heading) to mark the wreck as resurrectible back into the original unit type.

Before:
Spring.CreateFeature(FeatureDefNames[uDef.corpse].id, x, y, z, heading, unitTeam)

After:
local fDefID = FeatureDefNames[UnitDefs[unitDefID].corpse].id local fID = Spring.CreateFeature(fDefID, x, y, z, heading, unitTeam) if fID then
    Spring.SetFeatureResurrect(fID, unitDefID, heading)
end

Tested in a live multiplayer game — wrecks created by wreckunits are now resurrectible by builders.

<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Write the steps needed to test out the changes. Include the expected result.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
