### PR TITLE
Add build split to area mex

### DIFF
--- a/luaui/Widgets/api_build_orders.lua
+++ b/luaui/Widgets/api_build_orders.lua
@@ -22,6 +22,11 @@ end
 ---@field side string
 ---@field buildSpeed number
 
+---@class BuildingInfo
+---@field unitDefID number
+---@field position number[] { x, y, z }
+---@field facing? number
+
 ---@param builderID number
 ---@return BuilderInfo
 local function getBuilderInfo(builderID)
@@ -45,8 +50,8 @@ local function getBuilderInfo(builderID)
 	}
 end
 
----@param builderGroup table
----@param building table
+---@param builderGroup BuilderInfo[]
+---@param building BuildingInfo
 ---@param side string
 ---@param allowSubstitution boolean
 ---@return boolean
@@ -112,9 +117,9 @@ end
 --- builders outnumber buildings, the extras have empty own-chunks and simply
 --- start helping (double-up). The engine skips orders whose positions are already
 --- built, so the redundant followups self-clean.
----@param builderGroups table<number, table> Builders grouped -- by unit type for
+---@param builderGroups table<number, BuilderInfo[]> Builders grouped -- by unit type for
 --- the linear path, or one-per-builder for split.
----@param allBuildings table The buildings to place, with positions.
+---@param allBuildings BuildingInfo[] The buildings to place, with positions.
 ---@param cmdOpts table Command options.
 ---@param peerFollowups boolean|nil If true, append peers' buildings as followups.
 local function distributeBuildOrders(builderGroups, allBuildings, cmdOpts, peerFollowups)
@@ -320,8 +325,8 @@ end
 --- Splits a blueprint across builders so each works its own fork first, then
 --- helps peers. Building-aware: each builder only receives buildings it can
 --- construct (with faction substitution), and extra builders double up.
----@param builders table A list of builder info objects.
----@param buildings table A list of building objects.
+---@param builders BuilderInfo[] A list of builder info objects.
+---@param buildings BuildingInfo[] A list of building objects.
 ---@param cmdOpts table Command options.
 local function splitBuildOrders(builders, buildings, cmdOpts)
 	if #builders == 0 or #buildings == 0 then

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -149,7 +149,7 @@ end
 ---@param shift boolean Whether shift was held (appending to existing queue)
 local function calculateCmdOrder(cmds, spots, shift)
 	local builderPos = getAvgPositionOfValidBuilders(selectedUnits, mexConstructors, selectedMex, shift)
-	if not builderPos then return end
+	if not builderPos then return {} end
 	local orderedCommands = {}
 	local pos = {}
 	while #cmds > 0 do
@@ -173,6 +173,30 @@ local function calculateCmdOrder(cmds, spots, shift)
 	return orderedCommands
 end
 
+local function getSelectedBuilderIDs()
+	local builders = {}
+	for i = 1, #selectedUnits do
+		local unitID = selectedUnits[i]
+		if mexConstructors[unitID] then
+			builders[#builders + 1] = unitID
+		end
+	end
+	return builders
+end
+
+---@return BuildingInfo[]
+local function mapCommandsToBuildingInfos(cmds)
+	local buildings = {}
+	for i = 1, #cmds do
+		local cmd = cmds[i]
+		buildings[#buildings + 1] = {
+			unitDefID = cmd[1],
+			position = { cmd[2], cmd[3], cmd[4] },
+		}
+	end
+	return buildings
+end
+
 
 function widget:CommandNotify(id, params, options)
 	if id ~= CMD_AREA_MEX then
@@ -193,7 +217,12 @@ function widget:CommandNotify(id, params, options)
 	local cmds = getCmdsForValidSpots(spots, shift)
 	local sortedCmds = calculateCmdOrder(cmds, spots, shift)
 
-	WG['resource_spot_builder'].ApplyPreviewCmds(sortedCmds, mexConstructors, shift)
+	local BuildSplit = WG["build_split"]
+	if options.shift and BuildSplit.isActive() and #sortedCmds > 0 then
+		BuildSplit.splitBuildings(getSelectedBuilderIDs(), mapCommandsToBuildingInfos(sortedCmds), { "shift" })
+	else
+		WG['resource_spot_builder'].ApplyPreviewCmds(sortedCmds, mexConstructors, shift)
+	end
 
 	selectedMex = nil
 

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -189,10 +189,12 @@ local function mapCommandsToBuildingInfos(cmds)
 	local buildings = {}
 	for i = 1, #cmds do
 		local cmd = cmds[i]
-		buildings[#buildings + 1] = {
-			unitDefID = cmd[1],
-			position = { cmd[2], cmd[3], cmd[4] },
-		}
+		---@type BuildingInfo
+		local buildingInfo = {}
+		buildingInfo.unitDefID = cmd[1]
+		buildingInfo.position = { cmd[2], cmd[3], cmd[4] }
+		buildingInfo.facing = cmd[5]
+		buildings[#buildings + 1] = buildingInfo
 	end
 	return buildings
 end
@@ -217,9 +219,10 @@ function widget:CommandNotify(id, params, options)
 	local cmds = getCmdsForValidSpots(spots, shift)
 	local sortedCmds = calculateCmdOrder(cmds, spots, shift)
 
-	local BuildSplit = WG["build_split"]
-	if options.shift and BuildSplit.isActive() and #sortedCmds > 0 then
-		BuildSplit.splitBuildings(getSelectedBuilderIDs(), mapCommandsToBuildingInfos(sortedCmds), { "shift" })
+	-- WG["build_split"] has to be guarded because it can be disabled in settings
+	local isBuildSplitActive = WG["build_split"] and WG["build_split"].isActive()
+	if options.shift and isBuildSplitActive and #sortedCmds > 0 then
+		WG["build_split"].splitBuildings(getSelectedBuilderIDs(), mapCommandsToBuildingInfos(sortedCmds), { "shift" })
 	else
 		WG['resource_spot_builder'].ApplyPreviewCmds(sortedCmds, mexConstructors, shift)
 	end

--- a/luaui/Widgets/cmd_buildsplit.lua
+++ b/luaui/Widgets/cmd_buildsplit.lua
@@ -15,15 +15,11 @@ end
 
 
 -- Localized Spring API for performance
-local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetSpectatingState = Spring.GetSpectatingState
 
-local floor = math.floor
 local spTestBuildOrder = Spring.TestBuildOrder
 local spGetSelUnitCount = Spring.GetSelectedUnitsCount
 local spGetSelUnitsSorted = Spring.GetSelectedUnitsSorted
-local spGiveOrderToUnit = Spring.GiveOrderToUnit
-local spGiveOrderToUnitArray = Spring.GiveOrderToUnitArray
 local activeModifier = false
 
 local unitBuildOptions = {}
@@ -62,6 +58,25 @@ local function handleSetModifier(_, _, _, data)
 	activeModifier = data[1]
 end
 
+local function getBuilderInfos(unitIDs)
+	local builders = {}
+	for _, unitID in ipairs(unitIDs) do
+		local builderInfo = WG["api_build_orders"].getBuilderInfo(unitID)
+		if builderInfo and unitBuildOptions[builderInfo.unitDefID] then
+			table.insert(builders, builderInfo)
+		end
+	end
+	return builders
+end
+
+---@param builderIDs number[]
+---@param buildings BuildingInfo[]
+---@param cmdOpts table
+local function splitBuildings(builderIDs, buildings, cmdOpts)
+	local builders = getBuilderInfos(builderIDs)
+	WG["api_build_orders"].splitBuildOrders(builders, buildings, cmdOpts or { "shift" })
+end
+
 function widget:Initialize()
 	gameStarted = Spring.GetGameFrame() > 0
 	isSpec = spGetSpectatingState()
@@ -75,6 +90,7 @@ function widget:Initialize()
 
 	WG['build_split'] = {
 		isActive = function() return activeModifier end,
+		splitBuildings = splitBuildings,
 	}
 end
 
@@ -83,7 +99,7 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts) -- 3 of 3 parameters
 	if cmdID == GameCMD.BLUEPRINT_PLACE or cmdID == GameCMD.BLUEPRINT_CREATE then
 		return false
 	end
-	
+
 	if not (cmdID < 0 and cmdOpts.shift and activeModifier) then
 		return false
 	end -- Note: All multibuilds require shift
@@ -115,30 +131,27 @@ function widget:Update()
 
 	local selUnits = spGetSelUnitsSorted()
 
-	local builders = {}
+	local builderIDs = {}
 	for uDefID, uIDs in pairs(selUnits) do
 		local uDef = UnitDefs[uDefID]
 		if uDef and uDef.buildOptions and #uDef.buildOptions > 0 then
 			for _, uID in ipairs(uIDs) do
-				local builderInfo = WG["api_build_orders"].getBuilderInfo(uID)
-				if builderInfo then
-					table.insert(builders, builderInfo)
-				end
+				table.insert(builderIDs, uID)
 			end
 		end
 	end
 
 	local buildings = {}
 	for i = 1, buildCount do
-		table.insert(buildings, {
-			unitDefID = buildID,
-			position = buildLocs[i],
-			facing = buildLocs[i][4],
-			originalName = UnitDefs[buildID].name,
-		})
+		---@type BuildingInfo
+		local buildingInfo = {}
+		buildingInfo.unitDefID = buildID
+		buildingInfo.position = { buildLocs[i][1], buildLocs[i][2], buildLocs[i][3] }
+		buildingInfo.facing = buildLocs[i][4]
+		table.insert(buildings, buildingInfo)
 	end
 
-	WG["api_build_orders"].splitBuildOrders(builders, buildings, { "shift" })
+	splitBuildings(builderIDs, buildings, { "shift" })
 
 	buildCount = 0
 end


### PR DESCRIPTION
### Work done
Added build split handling for area mex

https://github.com/user-attachments/assets/9355a574-1924-43bc-a9f0-f936583e3a4b

#### Test steps
- Select few builders and issue area mex command while holding shift+space


### AI / LLM usage statement:
Implemented by codex and then refactored by me
