### PR TITLE
mouse buildspacing: only consume thumb mouse buttons when placing building

### DIFF
--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -893,6 +893,33 @@ local function handleSpacingAction(_, _, args)
 end
 
 function widget:MousePress(x, y, button)
+	-- We consume the presses so they can't trigger other bindings, which makes us the handler's mouseOwner.
+	-- But barwidgets.lua sends no MouseRelease for buttons 4/5 to clear it.
+	-- So we release any stale mouse capture left over from a previous button 4/5 press.
+	local wh = self.widgetHandler
+	if wh.DisownMouse then
+		wh:DisownMouse()
+	elseif wh.mouseOwner == self then
+		wh.mouseOwner = nil
+	end
+
+	-- mousebuttons 4 and 5 adjust blueprint spacing while placing
+	if button == 4 or button == 5 then
+		if not blueprintPlacementActive or not getSelectedBlueprint() then
+			return false
+		end
+
+		-- only when shift or shift+alt is held
+		local alt, ctrl, meta, shift = SpringGetModKeyState()
+		if not shift or ctrl or meta then
+			return false
+		end
+
+		handleSpacingAction(nil, nil, { button == 4 and "inc" or "dec" })
+
+		return true
+	end
+
 	if button ~= 1 or not blueprintPlacementActive or not getSelectedBlueprint() then
 		return
 	end

--- a/luaui/Widgets/gui_buildspacing.lua
+++ b/luaui/Widgets/gui_buildspacing.lua
@@ -4,7 +4,7 @@ function widget:GetInfo()
    return {
       name      = "Mouse Buildspacing",
       desc      = "Use mousebuttons 4 and 5 for buildspacing",
-      author    = "Auswaschbar",
+      author    = "Auswaschbar, Baldric",
       version   = "v1.0",
       date      = "Mar, 2010",
       license   = "GNU GPL, v3 or later",
@@ -14,14 +14,38 @@ function widget:GetInfo()
 end
 
 function widget:MousePress(mx, my, button)
-	--local alt,ctrl,meta,shift = Spring.GetModKeyState()
-	if button == 4 then
-		-- Spring.SetActiveCommand("selfd")
-		Spring.SendCommands("buildspacing inc")
-		return true
-	elseif button == 5 then
-		Spring.SendCommands("buildspacing dec")
-		return true
+	-- We consume the presses so they can't trigger other bindings, which makes us the handler's mouseOwner.
+	-- But barwidgets.lua sends no MouseRelease for buttons 4/5 to clear it.
+	-- So we release any stale mouse capture left over from a previous button 4/5 press.
+
+	local wh = self.widgetHandler
+	if wh.DisownMouse then
+		wh:DisownMouse()
+	elseif wh.mouseOwner == self then
+		wh.mouseOwner = nil
 	end
-	return false
+
+	-- Only act on mousebuttons 4 and 5
+	if button ~= 4 and button ~= 5 then
+		return false
+	end
+
+	-- Only while a build command is active (build commands have a negative cmdID)
+	local _, cmdID = Spring.GetActiveCommand()
+	if not (cmdID and cmdID < 0) then
+		return false
+	end
+
+	-- Only when shift or shift+alt is held
+	local alt, ctrl, meta, shift = Spring.GetModKeyState()
+	if not shift or ctrl or meta then
+		return false
+	end
+
+	if button == 4 then
+		Spring.SendCommands("buildspacing inc")
+	else
+		Spring.SendCommands("buildspacing dec")
+	end
+	return true
 end


### PR DESCRIPTION
### Work done

The Mouse Buildspacing widget used to consume every mouse button 4/5 press to change build spacing, regardless of context. 
That made `sc_mouse4`/`sc_mouse5` permanently unavailable for any other bind.

This changes Mouse Buildspacing so mouse4/5 is consumed and adjust spacing only when:
- a build command is actually active
- shift (or shift+alt) is held (the modifiers already needed for building lines/grids).

In every other case the press falls through, freeing mouse4/5 (and their modified variants) for other actions. 

Same feature is added to the blueprint widget, so mouse4/5 can be used to adjust blueprint spacing while placing a blueprint.

Both handlers also release any stale mouse capture, because `barwidgets.lua` never sends a MouseRelease for buttons 4/5:  
https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e7d11fd81b6a6ee8b73c5c8f27f690a40cb4894b/luaui/barwidgets.lua#L1913-L1933 grants ownership on any button that returns true including 4/5:
https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e7d11fd81b6a6ee8b73c5c8f27f690a40cb4894b/luaui/barwidgets.lua#L1945-L1959 only clears it based on Spring.GetMouseState(), which doesn't report mouse 4/5:


#### Test steps
- [ ] Bind mouse4/5 to some action: `bind sc_mouse4 say "mouse4 pressed"` (this didn't work before, now it should)
- [ ] Without building: press mouse4/5 → bound action should trigger.
- [ ] While placing a building, hold shift, press mouse4/5 → spacing inc/dec.
- [ ] While placing, press mouse4/5 with no modifier → spacing unchanged, bound action should trigger.
- [ ] While placing, hold ctrl or meta + mouse4/5 → spacing unchanged.
- [ ] Same checks while placing a blueprint (cmd_blueprint).
- [ ] Repeatedly press mouse4/5 then left-click to place, then another click to select or move: no stuck mouse capture / no swallowed clicks.
- [ ] At the start of the game placing building ghosts work differently, mouse4/5 won't do anything with their spacing but didn't do anything before either. 

### AI / LLM usage statement:
Claude Code was used to investigate the mouse capture issue and to draft the comments and commit message. 