### PR TITLE
Fix screenshot request executing on all authorized clients

### DIFF
--- a/luarules/gadgets/cmd_get_player_data.lua
+++ b/luarules/gadgets/cmd_get_player_data.lua
@@ -135,8 +135,14 @@ else
 		return nil
 	end
 
-	local function requestScreenshot(targetPlayerName, width)
+	local function requestScreenshot(targetPlayerName, width, callerID)
 		if not isAuthorized() then
+			return
+		end
+		-- Only the client whose playerID matches the caller should send the request.
+		-- AddChatAction fires on every client, so without this guard every authorized
+		-- client would send a duplicate screenshot request.
+		if callerID ~= myPlayerID then
 			return
 		end
 		if screenshotRequestInProgress then
@@ -162,15 +168,15 @@ else
 	end
 
 	function GetScreenshot(_, line, words, player)
-		requestScreenshot(words[1], screenshotWidth)
+		requestScreenshot(words[1], screenshotWidth, player)
 	end
 
 	function GetScreenshotLq(_, line, words, player)
-		requestScreenshot(words[1], screenshotWidthLq)
+		requestScreenshot(words[1], screenshotWidthLq, player)
 	end
 
 	function GetScreenshotHq(_, line, words, player)
-		requestScreenshot(words[1], screenshotWidthHq)
+		requestScreenshot(words[1], screenshotWidthHq, player)
 	end
 
 	-- Optimized encoding using base64 charset (6 bits per char)


### PR DESCRIPTION
## Problem
When a poweruser requests a screenshot from a player via /luarules getscreenshot <playername>, the 
screenshot would appear on other authorized clients instead of (or as well as) 
the requester.

## Root Cause
`gadgetHandler:AddChatAction` registers the handler on every client that loads 
the gadget, not just the client that issued the command. This meant that when 
`/luarules getscreenshot <name>` was sent, every authorized client ran 
`GetScreenshot` and fired their own `SendLuaRulesMsg("ss...")` request — each 
with their own playerID as the requester. The screenshot would then be routed 
back to whichever client sent the last request, which in practice meant another 
admin saw it instead of the one who clicked the button.

## Fix
Thread the `player` parameter (already provided by `AddChatAction` but 
previously ignored) through to `requestScreenshot` as `callerID`. Add a guard 
at the top of `requestScreenshot`:

    if callerID ~= myPlayerID then return end

This ensures only the client whose local playerID matches the command issuer 
proceeds with the request. All other authorized clients exit immediately.

## What Was Already Correct
- `StartScreenshot` already guarded `targetPlayerID ~= myPlayerID` — only the 
  target player captures
- `ReceiveScreenshot` already guarded `requestingPlayerID ~= myPlayerID` — only 
  the requester displays and saves
- The existing 60-second timeout mechanism (`screenshotRequestInProgress`) is 
  fully preserved
- The fix closes the one missing guard in the chain

## Files Changed
- `LuaRules/Gadgets/cmd_get_player_data.lua`

### AI / LLM usage statement:
Visual Studio and Claude Code
