### PR TITLE
improve test messaging around failed tests, especially the ongoing failure with gui_pip/test_gui_pip_autostart_maximize.lua

### DIFF
--- a/luaui/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
+++ b/luaui/Tests/cmd_blueprint/test_cmd_blueprint_line.lua
@@ -126,5 +126,5 @@ function test()
 	local builderQueue = Spring.GetUnitCommands(builderUnitID, -1)
 
 	assert(#builderQueue == bpCount, #builderQueue)
-	assert(builderQueue[1].id == -blueprintUnitDefID)
+	assertEqual(builderQueue[1].id, -blueprintUnitDefID)
 end

--- a/luaui/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
+++ b/luaui/Tests/cmd_stop_selfd/test_cmd_stop_selfd.lua
@@ -14,7 +14,7 @@ end
 
 function test()
 	widget = widgetHandler:FindWidget("Stop means Stop")
-	assert(widget)
+	assert(widget, "Stop means Stop widget not found via FindWidget")
 
 	local myTeamID = Spring.GetMyTeamID()
 
@@ -27,21 +27,21 @@ function test()
 	-- issue selfd and then issue stop
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
 	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
-	assert(Spring.GetUnitSelfDTime(unitID) > 0)
+	assert(Spring.GetUnitSelfDTime(unitID) > 0, string.format("Expected GetUnitSelfDTime > 0 after selfd, got %d", Spring.GetUnitSelfDTime(unitID)))
 
 	Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
 	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
-	assert(Spring.GetUnitSelfDTime(unitID) == 0)
-	assert(Spring.GetUnitCommandCount(unitID) == 0)
+	assertEqual(Spring.GetUnitSelfDTime(unitID), 0, string.format("GetUnitSelfDTime after stop: expected 0, got %d", Spring.GetUnitSelfDTime(unitID)))
+	assertEqual(Spring.GetUnitCommandCount(unitID), 0, string.format("GetUnitCommandCount after stop: expected 0, got %d", Spring.GetUnitCommandCount(unitID)))
 
 	-- issue {move, selfd}, then issue stop
 	Spring.GiveOrderToUnit(unitID, CMD.MOVE, { 1, 1, 1 }, 0)
 	Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, { "shift" })
 	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.SELFD, nil, nil, nil })
-	assert(Spring.GetUnitSelfDTime(unitID) == 0)
+	assertEqual(Spring.GetUnitSelfDTime(unitID), 0, string.format("GetUnitSelfDTime for queued selfd: expected 0, got %d", Spring.GetUnitSelfDTime(unitID)))
 
 	Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, 0)
 	Test.waitUntilCallinArgs("UnitCommand", { nil, nil, nil, CMD.STOP, nil, nil, nil })
-	assert(Spring.GetUnitSelfDTime(unitID) == 0)
-	assert(Spring.GetUnitCommandCount(unitID) == 0)
+	assertEqual(Spring.GetUnitSelfDTime(unitID), 0, string.format("GetUnitSelfDTime after stop of queued selfd: expected 0, got %d", Spring.GetUnitSelfDTime(unitID)))
+	assertEqual(Spring.GetUnitCommandCount(unitID), 0, string.format("GetUnitCommandCount after stop of queued selfd: expected 0, got %d", Spring.GetUnitCommandCount(unitID)))
 end

--- a/luaui/Tests/gui_pip/test_gui_pip_autostart_maximize.lua
+++ b/luaui/Tests/gui_pip/test_gui_pip_autostart_maximize.lua
@@ -12,7 +12,7 @@ function setup()
 		return false, false
 	end
 	widget = Test.prepareWidget(widgetName)
-	assert(widget)
+	assert(widget, string.format("prepareWidget: widget %q returned nil from FindWidget after EnableWidgetRaw", widgetName))
 end
 
 function cleanup()
@@ -38,7 +38,7 @@ function test()
 	widget:Update(0.25)
 
 	local data = widget:GetConfigData()
-	assert(data)
+	assert(data, "widget:GetConfigData should not be nil")
 	assert(data.inMinMode == false, "PIP should exit minimized mode on GameStart auto-maximize")
 
 	local expandedWidth = (data.pr - data.pl) * vsx

--- a/luaui/Tests/mex-building/pregame_mex_queue.lua
+++ b/luaui/Tests/mex-building/pregame_mex_queue.lua
@@ -7,10 +7,10 @@ function setup()
 	Test.clearMap()
 
 	local widget_cmd_extractor_snap = widgetHandler:FindWidget("Extractor Snap (mex/geo)")
-	assert(widget_cmd_extractor_snap)
+	assert(widget_cmd_extractor_snap, "Extractor Snap (mex/geo) widget not found via FindWidget")
 
 	local widget_gui_pregame_build = widgetHandler:FindWidget("Pregame Queue")
-	assert(widget_gui_pregame_build)
+	assert(widget_gui_pregame_build, "Pregame Queue widget not found via FindWidget")
 
 	WG['pregame-build'].setBuildQueue({})
 	WG["pregame-build"].setPreGamestartDefID(nil)
@@ -61,15 +61,16 @@ function test()
 	Test.waitTime(10)
 
 	-- did it snap?
-	assert(WG.ExtractorSnap.position ~= nil)
+	assert(WG.ExtractorSnap.position ~= nil, "ExtractorSnap.position should not be nil after setting mex blueprint and waiting")
 
 	-- did it snap to the closest mex?
-	assert(math.distance2d(
-		WG.ExtractorSnap.position.x,
-		WG.ExtractorSnap.position.z,
-		targetMex.x,
-		targetMex.z
-	) < 100)
+	local snapDistance = math.distance2d(
+				WG.ExtractorSnap.position.x,
+				WG.ExtractorSnap.position.z,
+				targetMex.x,
+				targetMex.z
+			)
+		assert(snapDistance < 100, string.format("Extractor snap distance %.0f from target mex, expected < 100", snapDistance))
 
 	local snappedPosition = table.copy(WG.ExtractorSnap.position)
 

--- a/luaui/Tests/mex-building/pregame_mex_snap.lua
+++ b/luaui/Tests/mex-building/pregame_mex_snap.lua
@@ -77,7 +77,7 @@ function test()
 
 	-- did the mex get placed in the right spot?
 	buildQueue = WG['pregame-build'].getBuildQueue()
-	assert(#buildQueue == 1)
+	assertEqual(#buildQueue, 1)
 	assertTablesEqual(buildQueue[1], {
 		mexUnitDefId,
 		snappedPosition.x,

--- a/luaui/Tests/weapondefs/test_flighttime.lua
+++ b/luaui/Tests/weapondefs/test_flighttime.lua
@@ -84,8 +84,8 @@ function runDistanceTest(flightTime, shouldAlive)
 	local isAlive = Spring.ValidUnitID(unitNames["armsolar"])
 	local isAlive2 = Spring.ValidUnitID(unitNames["armpw"])
 
-	assert(isAlive == shouldAlive)
-	assert(isAlive2 == shouldAlive)
+	assertEqual(isAlive, shouldAlive)
+	assertEqual(isAlive2, shouldAlive)
 end
 
 function test()

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -815,7 +815,8 @@ Test = {
 	prepareWidget = function(widgetName)
 		-- Enable widget with locals access and store state for later restoring
 		-- through restoreWidget(s).
-		assert(widgetHandler.knownWidgets[widgetName] ~= nil)
+		assert(widgetHandler.knownWidgets[widgetName] ~= nil,
+			string.format("prepareWidget: unknown widget %q — not in widgetHandler.knownWidgets", widgetName))
 
 		initialWidgetActive[widgetName] = widgetHandler.knownWidgets[widgetName].active or false
 		if initialWidgetActive[widgetName] then
@@ -824,7 +825,8 @@ Test = {
 		widgetHandler:EnableWidgetRaw(widgetName, true)
 
 		local widget = widgetHandler:FindWidget(widgetName)
-		assert(widget)
+		assert(widget,
+			string.format("prepareWidget: widget %q returned nil from FindWidget after EnableWidgetRaw", widgetName))
 		return widget
 	end,
 	restoreWidget = function(widgetName)
@@ -832,7 +834,8 @@ Test = {
 		-- Otherwise testrunner will run it automatically through restoreWidgets.
 		local wasActive = initialWidgetActive[widgetName]
 		initialWidgetActive[widgetName] = nil
-		assert(wasActive ~= nil)
+		assert(wasActive ~= nil,
+			string.format("restoreWidget: widget %q was never prepared (no entry in initialWidgetActive)", widgetName))
 
 		widgetHandler:DisableWidgetRaw(widgetName)
 		if wasActive then


### PR DESCRIPTION
### Work done
Improves test messages regarding failing integration tests

It's a lot of one-line obvious test messages, and it's purely for quality-of-life. No game logic changes were made.
 
#### Test steps
1. Run `docker compose -f tools/headless_testing/docker-compose.yml up --no-build`
1. Review the log output marked with `[Test Runner] FAIL:`

 
#### BEFORE:
`[string "LuaUI/Widgets/dbg_test_runner.lua"]:827: assertion failed!`

#### AFTER:
```
prepareWidget: widget "Picture-in-Picture" returned nil from FindWidget after EnableWidgetRaw
[string "LuaUI/Widgets/dbg_test_runner.lua"]:828: prepareWidget: widget "Picture-in-Picture" returned nil from FindWidget after EnableWidgetRaw
```

 
### AI / LLM usage statement:
I guided Deepseek v4 Flash to find, diagnose, and write these messages. 