### PR TITLE
fix: gfx_nano_particles_gl4: add no-GS fallback for AMD/Mesa false-negative

### DIFF
--- a/luarules/gadgets/gfx_energy_explosion_particles_gl4.lua
+++ b/luarules/gadgets/gfx_energy_explosion_particles_gl4.lua
@@ -218,11 +218,11 @@ local GL_FRONT_AND_BACK      = GL.FRONT_AND_BACK
 local GL_FILL                = GL.FILL
 local GL_LEQUAL              = GL.LEQUAL
 
-local LuaShader           = gl.LuaShader
-local InstanceVBOTable    = gl.InstanceVBOTable
-local pushElementInstance = InstanceVBOTable.pushElementInstance
-local popElementInstance  = InstanceVBOTable.popElementInstance
-local uploadElementRange  = InstanceVBOTable.uploadElementRange
+local LuaShader              = gl.LuaShader
+local InstanceVBOTable       = gl.InstanceVBOTable
+local pushElementInstance    = InstanceVBOTable.pushElementInstance
+local popElementInstance     = InstanceVBOTable.popElementInstance
+local uploadElementRange     = InstanceVBOTable.uploadElementRange
 
 local mathRandom = math.random
 local mathSqrt   = math.sqrt
@@ -698,6 +698,8 @@ local function goodbye(reason)
 	gadgetHandler:RemoveGadget()
 end
 
+local useGeometryShader = true
+
 -- Visual constants taken verbatim from gfx_nano_particles_gl4.lua
 -- (MODE_SETTINGS.shape) so the chunks look identical to nano spray.
 local SHAPE_ID         = 0    -- 0 = cube, 1 = octahedron
@@ -731,11 +733,7 @@ local ROT_VEL_BASE  = -40   local ROT_VEL_RANGE = 80
 local ROT_ACC_BASE  = -40 / (30*30)   local ROT_ACC_RANGE = 80 / (30*30)
 
 local function initGL4()
-	if not LuaShader.isGeometryShaderSupported then
-		goodbye("geometry shader not supported")
-		return false
-	end
-	local shaderCache = {
+	local shaderCacheGS = {
 		vsSrc = vsSrc,
 		fsSrc = fsSrc,
 		gsSrc = gsSrc,
@@ -770,39 +768,156 @@ local function initGL4()
 		shaderConfig = {},
 		forceupdate  = true,
 	}
-	particleShader = LuaShader.CheckShaderUpdates(shaderCache)
+
+	local shaderCacheNoGS = {
+		vssrcpath = "LuaUI/Shaders/energy_explosion_particles_gl4_nogs.vert.glsl",
+		fsSrc = fsSrc,
+		shaderName = "UnitEnergyExplosionParticlesGL4_NoGS",
+		uniformInt   = { u_shape = SHAPE_ID },
+		uniformFloat = shaderCacheGS.uniformFloat,
+		shaderConfig = {},
+		forceupdate  = true,
+	}
+
+	-- Try the geometry-shader path first; only fall back if compile actually
+	-- fails. LuaShader.isGeometryShaderSupported can report false negatives on
+	-- some drivers (e.g. AMD/Mesa), so we don't trust it alone.
+	useGeometryShader = true
+	particleShader = LuaShader.CheckShaderUpdates(shaderCacheGS)
+	if not particleShader then
+		spEcho("Energy Explosion Particles GL4: geometry shader compile failed; trying no-GS fallback.")
+		useGeometryShader = false
+		particleShader = LuaShader.CheckShaderUpdates(shaderCacheNoGS)
+	end
 	if not particleShader then
 		goodbye("Failed to compile shader")
 		return false
 	end
 
-	local quadVBO, numVertices = InstanceVBOTable.makeRectVBO(
-		-1, -1, 1, 1,
-		0, 0, 1, 1,
-		"eepQuadVBO"
-	)
-	-- Shape GS only needs ONE triangle per instance; use a 3-index VBO so the
-	-- GS doesn't get invoked twice per particle.
-	local indexVBO = gl.GetVBO(GL.ELEMENT_ARRAY_BUFFER, false)
-	indexVBO:Define(3)
-	indexVBO:Upload({0, 1, 2})
+	if useGeometryShader then
+		local quadVBO, numVertices = InstanceVBOTable.makeRectVBO(
+			-1, -1, 1, 1,
+			0, 0, 1, 1,
+			"eepQuadVBO"
+		)
+		-- Shape GS only needs ONE triangle per instance; use a 3-index VBO so the
+		-- GS doesn't get invoked twice per particle.
+		local indexVBO = gl.GetVBO(GL.ELEMENT_ARRAY_BUFFER, false)
+		indexVBO:Define(3)
+		indexVBO:Upload({0, 1, 2})
 
-	local layout = {
-		{ id = 1, name = "spawnPosAndSize",  size = 4 },
-		{ id = 2, name = "velAndSpawnFrame", size = 4 },
-		{ id = 3, name = "instColor",        size = 4 },
-		{ id = 4, name = "rotData",          size = 4 },
-	}
-	particleVBO = InstanceVBOTable.makeInstanceVBOTable(layout, MAX_PARTICLES_VBO, "eepParticleVBO")
-	if not particleVBO then
-		goodbye("Failed to create instance VBO")
-		return false
+		local layout = {
+			{ id = 1, name = "spawnPosAndSize",  size = 4 },
+			{ id = 2, name = "velAndSpawnFrame", size = 4 },
+			{ id = 3, name = "instColor",        size = 4 },
+			{ id = 4, name = "rotData",          size = 4 },
+		}
+		particleVBO = InstanceVBOTable.makeInstanceVBOTable(layout, MAX_PARTICLES_VBO, "eepParticleVBO")
+		if not particleVBO then
+			goodbye("Failed to create instance VBO")
+			return false
+		end
+		particleVBO.numVertices = numVertices
+		particleVBO.vertexVBO   = quadVBO
+		particleVBO.indexVBO    = indexVBO
+		particleVBO.VAO         = particleVBO:makeVAOandAttach(quadVBO, particleVBO.instanceVBO, indexVBO)
+		particleVBO.primitiveType = GL.TRIANGLES
+	else
+		-- No-GS fallback: build a template indexed mesh with one vertex per
+		-- geometry-shader emitted vertex.  Default cube: 6 quads * 4 verts = 24 verts.
+		-- Octahedron: 8 tris * 3 verts = 24 verts.  Plus a 4-vert glow billboard
+		-- quad.  We use independent triangles, so each template vertex is emitted
+		-- exactly once and indexed in GL order.
+		local NUM_SHAPE_VERTS = 24
+		local NUM_GLOW_VERTS  = 4
+		local NUM_VERTS = NUM_SHAPE_VERTS + NUM_GLOW_VERTS
+		local isOcta = (SHAPE_ID == 1)
+
+		local templateVBO = gl.GetVBO(GL.ARRAY_BUFFER, false)
+		templateVBO:Define(NUM_VERTS, {{ id = 0, name = "vertexSlot", size = 1 }}) -- float slot, cast to int in VS
+		local vertexData = {}
+		for i = 0, NUM_VERTS - 1 do
+			vertexData[#vertexData + 1] = i
+		end
+		templateVBO:Upload(vertexData)
+
+		-- Build indices matching the order the no-GS VS emits the template:
+		-- cube quads are split into two triangles (0,1,2 and 0,2,3);
+		-- octahedron triangles are a single tri (0,1,2); glow quad likewise.
+		local indexData = {}
+		if isOcta then
+			for shapeTri = 0, NUM_SHAPE_VERTS / 3 - 1 do
+				local base = shapeTri * 3
+				indexData[#indexData + 1] = base + 0
+				indexData[#indexData + 1] = base + 1
+				indexData[#indexData + 1] = base + 2
+			end
+		else
+			for quad = 0, NUM_SHAPE_VERTS / 4 - 1 do
+				local base = quad * 4
+				indexData[#indexData + 1] = base + 0
+				indexData[#indexData + 1] = base + 1
+				indexData[#indexData + 1] = base + 2
+				indexData[#indexData + 1] = base + 0
+				indexData[#indexData + 1] = base + 2
+				indexData[#indexData + 1] = base + 3
+			end
+		end
+		local glowBase = NUM_SHAPE_VERTS
+		indexData[#indexData + 1] = glowBase + 0
+		indexData[#indexData + 1] = glowBase + 1
+		indexData[#indexData + 1] = glowBase + 2
+		indexData[#indexData + 1] = glowBase + 0
+		indexData[#indexData + 1] = glowBase + 2
+		indexData[#indexData + 1] = glowBase + 3
+
+		local indexVBO = gl.GetVBO(GL.ELEMENT_ARRAY_BUFFER, false)
+		indexVBO:Define(#indexData)
+		indexVBO:Upload(indexData)
+
+		local layout = {
+			{ id = 1, name = "spawnPosAndSize",  size = 4 },
+			{ id = 2, name = "velAndSpawnFrame", size = 4 },
+			{ id = 3, name = "instColor",        size = 4 },
+			{ id = 4, name = "rotData",          size = 4 },
+		}
+		particleVBO = InstanceVBOTable.makeInstanceVBOTable(layout, MAX_PARTICLES_VBO, "eepParticleVBO_NoGS")
+		if not particleVBO then
+			goodbye("Failed to create instance VBO")
+			return false
+		end
+
+		local realVAO = particleVBO:makeVAOandAttach(templateVBO, particleVBO.instanceVBO, indexVBO)
+		if not realVAO then
+			goodbye("Failed to create no-GS VAO")
+			return false
+		end
+
+		-- Anchor the template/index VBOs so Lua GC cannot collect them while
+		-- the VAO is alive (same GC fix as DrawPrimitiveAtUnit, commit 2b51f6e863).
+		particleVBO.nogsTemplateVBO = templateVBO
+		particleVBO.nogsIndexVBO    = indexVBO
+
+		local indexCount = #indexData
+		particleVBO.VAO = {
+			realVAO = realVAO,
+			indexCount = indexCount,
+			DrawArrays = function(self, _primitiveType, instanceCount)
+				if instanceCount and instanceCount > 0 then
+					self.realVAO:DrawElements(GL.TRIANGLES, self.indexCount, 0, instanceCount)
+				end
+			end,
+			DrawElements = function(self, _primitiveType, _numVertices, _startIndex, instanceCount, _drawIndex)
+				if instanceCount and instanceCount > 0 then
+					self.realVAO:DrawElements(GL.TRIANGLES, self.indexCount, 0, instanceCount)
+				end
+			end,
+			Delete = function(self)
+				self.realVAO:Delete()
+			end,
+		}
+		particleVBO.primitiveType = GL.TRIANGLES
 	end
-	particleVBO.numVertices = numVertices
-	particleVBO.vertexVBO   = quadVBO
-	particleVBO.indexVBO    = indexVBO
-	particleVBO.VAO         = particleVBO:makeVAOandAttach(quadVBO, particleVBO.instanceVBO, indexVBO)
-	particleVBO.primitiveType = GL.TRIANGLES
 	return true
 end
 

--- a/luarules/gadgets/gfx_nano_particles_gl4.lua
+++ b/luarules/gadgets/gfx_nano_particles_gl4.lua
@@ -1150,11 +1150,9 @@ local function goodbye(reason)
 end
 
 local function initGL4()
-	if not LuaShader.isGeometryShaderSupported then
-		goodbye("geometry shader not supported")
-		return false
-	end
-	local shaderCache = {
+	local useGeometryShader = true
+
+	local shaderCacheGS = {
 		vsSrc = vsSrcCube,
 		fsSrc = fsSrcCube,
 		gsSrc = gsSrcCube,
@@ -1172,41 +1170,161 @@ local function initGL4()
 		shaderConfig = {},
 		forceupdate = true,
 	}
-	nanoShader = LuaShader.CheckShaderUpdates(shaderCache)
+
+	local shaderCacheNoGS = {
+		vssrcpath = "LuaUI/Shaders/nano_particles_gl4_nogs.vert.glsl",
+		fsSrc = fsSrcCube,
+		shaderName = "NanoParticlesGL4_Shape_NoGS",
+		uniformInt = { infoTex = 1, u_shape = U.SHAPE_ID },
+		uniformFloat = shaderCacheGS.uniformFloat,
+		shaderConfig = {},
+		forceupdate = true,
+	}
+
+	-- Try the geometry-shader path first; only fall back if compile actually
+	-- fails. LuaShader.isGeometryShaderSupported can report false negatives on
+	-- some drivers (e.g. AMD/Mesa), so we don't trust it alone.
+	useGeometryShader = true
+	nanoShader = LuaShader.CheckShaderUpdates(shaderCacheGS)
+	if not nanoShader then
+		spEcho("Nano Particles GL4: geometry shader compile failed; trying no-GS fallback.")
+		useGeometryShader = false
+		nanoShader = LuaShader.CheckShaderUpdates(shaderCacheNoGS)
+	end
 	if not nanoShader then
 		goodbye("Failed to compile shader")
 		return false
 	end
 
-	-- Quad: xy in [-1,1] (corner), uv in [0,1]
-	local quadVBO, numVertices = InstanceVBOTable.makeRectVBO(
-		-1, -1, 1, 1,
-		0, 0, 1, 1,
-		"nanoQuadVBO"
-	)
-	-- Shape GS only needs ONE triangle per instance; using the rect's 2-tri
-	-- index buffer would invoke the GS twice per particle. A 3-index VBO
-	-- (the rect's first triangle: bl,tl,tr) cuts GS work in half.
-	local indexVBO = gl.GetVBO(GL.ELEMENT_ARRAY_BUFFER, false)
-	indexVBO:Define(3)
-	indexVBO:Upload({0, 1, 2})
+	if useGeometryShader then
+		-- Quad: xy in [-1,1] (corner), uv in [0,1]
+		local quadVBO, numVertices = InstanceVBOTable.makeRectVBO(
+			-1, -1, 1, 1,
+			0, 0, 1, 1,
+			"nanoQuadVBO"
+		)
+		-- Shape GS only needs ONE triangle per instance; using the rect's 2-tri
+		-- index buffer would invoke the GS twice per particle. A 3-index VBO
+		-- (the rect's first triangle: bl,tl,tr) cuts GS work in half.
+		local indexVBO = gl.GetVBO(GL.ELEMENT_ARRAY_BUFFER, false)
+		indexVBO:Define(3)
+		indexVBO:Upload({0, 1, 2})
 
-	local layout = {
-		{ id = 1, name = "spawnPosAndSize",  size = 4 },
-		{ id = 2, name = "velAndSpawnFrame", size = 4 },
-		{ id = 3, name = "instColor",        size = 4 },
-		{ id = 4, name = "rotData",          size = 4 },
-	}
-	nanoVBO = InstanceVBOTable.makeInstanceVBOTable(layout, MAX_PARTICLES_VBO, "nanoParticleVBO")
-	if not nanoVBO then
-		goodbye("Failed to create instance VBO")
-		return false
+		local layout = {
+			{ id = 1, name = "spawnPosAndSize",  size = 4 },
+			{ id = 2, name = "velAndSpawnFrame", size = 4 },
+			{ id = 3, name = "instColor",        size = 4 },
+			{ id = 4, name = "rotData",          size = 4 },
+		}
+		nanoVBO = InstanceVBOTable.makeInstanceVBOTable(layout, MAX_PARTICLES_VBO, "nanoParticleVBO")
+		if not nanoVBO then
+			goodbye("Failed to create instance VBO")
+			return false
+		end
+		nanoVBO.numVertices = numVertices
+		nanoVBO.vertexVBO   = quadVBO
+		nanoVBO.indexVBO    = indexVBO
+		nanoVBO.VAO         = nanoVBO:makeVAOandAttach(quadVBO, nanoVBO.instanceVBO, indexVBO)
+		nanoVBO.primitiveType = GL.TRIANGLES
+	else
+		-- No-GS fallback: build a template indexed mesh with one vertex per
+		-- geometry-shader emitted vertex.  Default cube: 6 quads * 4 verts = 24 verts.
+		-- Octahedron: 8 tris * 3 verts = 24 verts.  Plus a 4-vert glow billboard
+		-- quad.  We use independent triangles, so each template vertex is emitted
+		-- exactly once and indexed in GL order.
+		local NUM_SHAPE_VERTS = 24
+		local NUM_GLOW_VERTS  = 4
+		local NUM_VERTS = NUM_SHAPE_VERTS + NUM_GLOW_VERTS
+		local isOcta = (U.SHAPE_ID == 1)
+
+		local templateVBO = gl.GetVBO(GL.ARRAY_BUFFER, false)
+		templateVBO:Define(NUM_VERTS, {{ id = 0, name = "vertexSlot", size = 1 }}) -- float slot, cast to int in VS
+		local vertexData = {}
+		for i = 0, NUM_VERTS - 1 do
+			vertexData[#vertexData + 1] = i
+		end
+		templateVBO:Upload(vertexData)
+
+		-- Build indices matching the order the no-GS VS emits the template:
+		-- cube quads are split into two triangles (0,1,2 and 0,2,3);
+		-- octahedron triangles are a single tri (0,1,2); glow quad likewise.
+		local indexData = {}
+		if isOcta then
+			for shapeTri = 0, NUM_SHAPE_VERTS / 3 - 1 do
+				local base = shapeTri * 3
+				indexData[#indexData + 1] = base + 0
+				indexData[#indexData + 1] = base + 1
+				indexData[#indexData + 1] = base + 2
+			end
+		else
+			for quad = 0, NUM_SHAPE_VERTS / 4 - 1 do
+				local base = quad * 4
+				indexData[#indexData + 1] = base + 0
+				indexData[#indexData + 1] = base + 1
+				indexData[#indexData + 1] = base + 2
+				indexData[#indexData + 1] = base + 0
+				indexData[#indexData + 1] = base + 2
+				indexData[#indexData + 1] = base + 3
+			end
+		end
+		local glowBase = NUM_SHAPE_VERTS
+		indexData[#indexData + 1] = glowBase + 0
+		indexData[#indexData + 1] = glowBase + 1
+		indexData[#indexData + 1] = glowBase + 2
+		indexData[#indexData + 1] = glowBase + 0
+		indexData[#indexData + 1] = glowBase + 2
+		indexData[#indexData + 1] = glowBase + 3
+
+		local indexVBO = gl.GetVBO(GL.ELEMENT_ARRAY_BUFFER, false)
+		indexVBO:Define(#indexData)
+		indexVBO:Upload(indexData)
+
+		local layout = {
+			{ id = 1, name = "spawnPosAndSize",  size = 4 },
+			{ id = 2, name = "velAndSpawnFrame", size = 4 },
+			{ id = 3, name = "instColor",        size = 4 },
+			{ id = 4, name = "rotData",          size = 4 },
+		}
+		nanoVBO = InstanceVBOTable.makeInstanceVBOTable(layout, MAX_PARTICLES_VBO, "nanoParticleVBO_NoGS")
+		if not nanoVBO then
+			goodbye("Failed to create instance VBO")
+			return false
+		end
+
+		local realVAO = nanoVBO:makeVAOandAttach(templateVBO, nanoVBO.instanceVBO, indexVBO)
+		if not realVAO then
+			goodbye("Failed to create no-GS VAO")
+			return false
+		end
+
+		-- Anchor the template and index VBOs to the VBO table so the Lua GC
+		-- cannot collect them while the VAO is alive.  OpenGL owns the buffer
+		-- objects via the VAO, but Lua does not know that; without a strong Lua
+		-- reference the GC can finalize the userdata and delete the GL buffers
+		-- (fixed in commit 2b51f6e863 for DrawPrimitiveAtUnit).
+		nanoVBO.nogsTemplateVBO = templateVBO
+		nanoVBO.nogsIndexVBO    = indexVBO
+
+		local indexCount = #indexData
+		nanoVBO.VAO = {
+			realVAO = realVAO,
+			indexCount = indexCount,
+			DrawArrays = function(self, _primitiveType, instanceCount)
+				if instanceCount and instanceCount > 0 then
+					self.realVAO:DrawElements(GL.TRIANGLES, self.indexCount, 0, instanceCount)
+				end
+			end,
+			DrawElements = function(self, _primitiveType, _numVertices, _startIndex, instanceCount, _drawIndex)
+				if instanceCount and instanceCount > 0 then
+					self.realVAO:DrawElements(GL.TRIANGLES, self.indexCount, 0, instanceCount)
+				end
+			end,
+			Delete = function(self)
+				self.realVAO:Delete()
+			end,
+		}
+		nanoVBO.primitiveType = GL.TRIANGLES
 	end
-	nanoVBO.numVertices = numVertices
-	nanoVBO.vertexVBO   = quadVBO
-	nanoVBO.indexVBO    = indexVBO
-	nanoVBO.VAO         = nanoVBO:makeVAOandAttach(quadVBO, nanoVBO.instanceVBO, indexVBO)
-	nanoVBO.primitiveType = GL.TRIANGLES
 
 	return true
 end

--- a/luaui/Shaders/energy_explosion_particles_gl4_nogs.vert.glsl
+++ b/luaui/Shaders/energy_explosion_particles_gl4_nogs.vert.glsl
@@ -1,0 +1,262 @@
+#version 430 core
+
+// Template mesh vertex carries one integer slot index (0..27), uploaded as a
+// float because the engine VBO API convention uses float template attributes.
+layout(location = 0) in float vertexSlot;
+
+layout(location = 1) in vec4 spawnPosAndSize;   // xyz=spawnPos, w=packed(sizeMult,fadeFrames)
+layout(location = 2) in vec4 velAndSpawnFrame;  // xyz=velocity (elmos/frame), w=spawnFrame
+layout(location = 3) in vec4 instColor;         // rgb + alpha
+layout(location = 4) in vec4 rotData;           // x=rotVal0, y=rotVel0, z=rotAcc (deg/frame²), w=deathFrame
+
+//__ENGINEUNIFORMBUFFERDEFS__
+
+uniform float drag;
+uniform vec3  gravity;
+uniform float fadeInFrames;
+uniform float wobbleAmp;
+uniform float wobbleFreq;
+uniform float wobbleVar;
+uniform float wobbleFreqVar;
+uniform float wobbleRampFrames;
+uniform float drawRadius;
+uniform int   u_shape;
+uniform float glowScale;
+uniform float glowIntensity;
+
+out vec4 g_color;
+out vec3 g_normal;
+out vec3 g_worldPos;
+out vec3 g_localPos;
+out vec3 g_noiseSeed;
+out vec2 g_glowUV;
+out float g_isGlow;
+out float g_seed;
+out float g_breathScale;
+
+float hash11(float x) {
+	return fract(sin(x) * 43758.5453);
+}
+
+mat3 rotXYZ(vec3 a) {
+	float cx = cos(a.x), sx = sin(a.x);
+	float cy = cos(a.y), sy = sin(a.y);
+	float cz = cos(a.z), sz = sin(a.z);
+	mat3 Rx = mat3(1,0,0, 0,cx,sx, 0,-sx,cx);
+	mat3 Ry = mat3(cy,0,-sy, 0,1,0, sy,0,cy);
+	mat3 Rz = mat3(cz,sz,0, -sz,cz,0, 0,0,1);
+	return Rz * Ry * Rx;
+}
+
+void emitShapeVertex(int slot, vec3 localPos, vec3 normal, vec3 center, vec4 col, vec3 noiseSeed, float seed, float breathScale) {
+	g_color = col;
+	g_normal = normal;
+	g_noiseSeed = noiseSeed;
+	g_isGlow = 0.0;
+	g_glowUV = vec2(0.0);
+	g_seed = seed;
+	g_breathScale = breathScale;
+	g_localPos = localPos;
+	g_worldPos = center + localPos;
+	gl_Position = cameraViewProj * vec4(g_worldPos, 1.0);
+}
+
+void emitGlowVertex(int slot, vec3 localPos, vec2 glowUV, vec3 center, vec4 col, float seed, float breathScale) {
+	g_color = col;
+	g_normal = vec3(0.0, 1.0, 0.0);
+	g_noiseSeed = vec3(0.0);
+	g_localPos = vec3(0.0);
+	g_isGlow = 1.0;
+	g_seed = seed;
+	g_breathScale = breathScale;
+	g_glowUV = glowUV;
+	g_worldPos = center + localPos;
+	gl_Position = cameraViewProj * vec4(g_worldPos, 1.0);
+}
+
+void main() {
+	float currentFrame = timeInfo.x + timeInfo.w;
+	float spawnFrame   = velAndSpawnFrame.w;
+	float deathFrame   = rotData.w;
+
+	if (currentFrame >= deathFrame) {
+		gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+		g_color = vec4(0.0);
+		g_normal = vec3(0.0);
+		g_worldPos = vec3(0.0);
+		g_localPos = vec3(0.0);
+		g_noiseSeed = vec3(0.0);
+		g_glowUV = vec2(0.0);
+		g_isGlow = 0.0;
+		g_seed = 0.0;
+		g_breathScale = 0.0;
+		return;
+	}
+
+	float t = max(currentFrame - spawnFrame, 0.0);
+
+	float tCap   = (drag > 0.0001) ? (1.0 / drag) : 1.0e6;
+	float tClamp = min(t, tCap);
+	vec3 worldPos = spawnPosAndSize.xyz
+	              + velAndSpawnFrame.xyz * tClamp * (1.0 - 0.5 * drag * tClamp)
+	              + 0.5 * gravity * t * t;
+
+	if (wobbleAmp > 0.0001) {
+		float wobbleT   = max(currentFrame - spawnFrame, 0.0);
+		float totalLife = max(deathFrame - spawnFrame, 1.0);
+		float bell      = sin(3.14159265 * wobbleT / totalLife);
+		if (wobbleRampFrames > 0.5)
+			bell *= min(1.0, wobbleT / wobbleRampFrames);
+		vec3 vdir = velAndSpawnFrame.xyz;
+		vec3 ref, axA, axB;
+		float refAngle = rotData.x * 0.01745329;
+		float s1 = sin(refAngle), c1 = cos(refAngle);
+		float s2 = sin(refAngle * 2.19), c2 = cos(refAngle * 2.19);
+		if (abs(vdir.y) < 0.95) {
+			ref = normalize(vec3(s1, c1, s2));
+		} else {
+			ref = normalize(vec3(c1, s2, c2));
+		}
+		float h1 = fract(sin(rotData.x * 12.9898 + rotData.y * 78.233) * 43758.5453);
+		float h2 = fract(sin(rotData.x * 23.1451 + rotData.y * 34.567) * 65432.0987);
+		axA = normalize(vec3(
+			sin(h1 * 6.28318),
+			sin(h2 * 6.28318),
+			cos(h1 * 3.14159 + h2 * 3.14159)
+		));
+		axB = cross(axA, ref);
+		if (dot(axB, axB) > 0.001) {
+			axB = normalize(axB);
+		} else {
+			axB = cross(axA, (abs(axA.x) < 0.9) ? vec3(1, 0, 0) : vec3(0, 1, 0));
+			axB = normalize(axB);
+		}
+		float phaseOff = radians(rotData.x);
+		float hash     = fract(sin(rotData.x * 12.9898 + rotData.y * 78.233) * 43758.5453);
+		float freqScale = max(0.0, 1.0 + wobbleFreqVar * (2.0 * hash - 1.0));
+		float dirSign  = (fract(hash * 7.31) < 0.5) ? -1.0 : 1.0;
+		float hash2    = fract(hash * 113.7 + 0.317);
+		float ampScale = max(0.0, 1.0 + wobbleVar * (2.0 * hash2 - 1.0));
+		float ph = currentFrame * wobbleFreq * freqScale * dirSign * (6.2831853 / 30.0) + phaseOff;
+		worldPos += (axA * cos(ph) + axB * sin(ph)) * (wobbleAmp * ampScale * bell);
+	}
+
+	float packedW    = abs(spawnPosAndSize.w);
+	float fadeFrames = floor(packedW / 1024.0);
+	float sizeMult   = (packedW - fadeFrames * 1024.0) / 256.0;
+
+	float fadeOut = (fadeFrames > 0.5)
+		? clamp((deathFrame - currentFrame) / fadeFrames, 0.0, 1.0)
+		: 1.0;
+	float fadeIn  = (fadeInFrames > 0.5)
+		? clamp(t / fadeInFrames, 0.0, 1.0)
+		: 1.0;
+	float fade    = fadeOut * fadeIn;
+
+	float rotVel = rotData.y;
+	float rotAcc = rotData.z;
+	float rotVal = rotData.x + rotVel * t + 0.5 * rotAcc * t * t;
+
+	vec3 center = worldPos;
+	vec4 col = instColor * fade;
+	float size  = drawRadius * sizeMult;
+
+	vec3 phaseSeed = vec3(rotData.x, rotData.y, rotData.x + rotData.y);
+	vec3 noiseSeed = phaseSeed * 137.0 + vec3(11.0, 47.0, 83.0);
+	float h  = dot(phaseSeed, vec3(0.123, 0.456, 0.789));
+	vec3 phase = vec3(hash11(h), hash11(h+1.7), hash11(h+3.3)) * 6.2831853;
+	float r = radians(rotVal);
+	vec3 ang = phase + vec3(r * 1.0, r * 1.3, r * 0.7);
+	mat3 R = rotXYZ(ang);
+	float seed = radians(phaseSeed.x);
+
+	float totalLifeBR = max(deathFrame - spawnFrame, 1.0);
+	float lifeFrac    = clamp(t / totalLifeBR, 0.0, 1.0);
+	float breathScale = 1.0 - smoothstep(0.5, 1.0, lifeFrac);
+
+	int slot = int(vertexSlot);
+
+	// The geometry shader only emits the glow quad when glow is actually enabled.
+	// The template mesh always contains the 4 glow slots, so move them off-screen
+	// when disabled to avoid wasted fragment shader work.
+	bool emitGlow = (glowIntensity > 0.001) && (glowScale > 1.001);
+	if (slot >= 24 && !emitGlow) {
+		gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+		g_color = vec4(0.0);
+		g_normal = vec3(0.0);
+		g_worldPos = vec3(0.0);
+		g_localPos = vec3(0.0);
+		g_noiseSeed = vec3(0.0);
+		g_glowUV = vec2(0.0);
+		g_isGlow = 0.0;
+		g_seed = 0.0;
+		g_breathScale = 0.0;
+		return;
+	}
+
+	if (u_shape == 1) {
+		if (slot < 24) {
+			vec3 X = R * vec3(size, 0, 0); vec3 nX = -X;
+			vec3 Y = R * vec3(0, size, 0); vec3 nY = -Y;
+			vec3 Z = R * vec3(0, 0, size); vec3 nZ = -Z;
+			float k = 0.57735027;
+			vec3 n[8];
+			n[0] = R * vec3( k,  k,  k);
+			n[1] = R * vec3(-k,  k,  k);
+			n[2] = R * vec3(-k,  k, -k);
+			n[3] = R * vec3( k,  k, -k);
+			n[4] = R * vec3( k, -k,  k);
+			n[5] = R * vec3(-k, -k,  k);
+			n[6] = R * vec3(-k, -k, -k);
+			n[7] = R * vec3( k, -k, -k);
+			vec3 corners[8][3];
+			corners[0][0] = Y;  corners[0][1] = Z;  corners[0][2] = X;
+			corners[1][0] = Y;  corners[1][1] = nX; corners[1][2] = Z;
+			corners[2][0] = Y;  corners[2][1] = nZ; corners[2][2] = nX;
+			corners[3][0] = Y;  corners[3][1] = X;  corners[3][2] = nZ;
+			corners[4][0] = nY; corners[4][1] = X;  corners[4][2] = Z;
+			corners[5][0] = nY; corners[5][1] = Z;  corners[5][2] = nX;
+			corners[6][0] = nY; corners[6][1] = nX; corners[6][2] = nZ;
+			corners[7][0] = nY; corners[7][1] = nZ; corners[7][2] = X;
+			int tri = slot / 3;
+			int ci  = slot - tri * 3;
+			emitShapeVertex(slot, corners[tri][ci], n[tri], center, col, noiseSeed, seed, breathScale);
+		} else {
+			vec3 right = cameraViewInv[0].xyz * (size * glowScale);
+			vec3 up    = cameraViewInv[1].xyz * (size * glowScale);
+			int gi = slot - 24;
+			if (gi == 0) emitGlowVertex(slot, -right - up, vec2(-1.0, -1.0), center, col, seed, breathScale);
+			else if (gi == 1) emitGlowVertex(slot,  right - up, vec2( 1.0, -1.0), center, col, seed, breathScale);
+			else if (gi == 2) emitGlowVertex(slot, -right + up, vec2(-1.0,  1.0), center, col, seed, breathScale);
+			else              emitGlowVertex(slot,  right + up, vec2( 1.0,  1.0), center, col, seed, breathScale);
+		}
+	} else {
+		if (slot < 24) {
+			vec3 X = R * vec3(size, 0, 0);
+			vec3 Y = R * vec3(0, size, 0);
+			vec3 Z = R * vec3(0, 0, size);
+			vec3 nXp =  R[0]; vec3 nXm = -R[0];
+			vec3 nYp =  R[1]; vec3 nYm = -R[1];
+			vec3 nZp =  R[2]; vec3 nZm = -R[2];
+			vec3 corners[6][4];
+			vec3 normals[6];
+			corners[0][0] =  X-Y-Z; corners[0][1] =  X+Y-Z; corners[0][2] =  X-Y+Z; corners[0][3] =  X+Y+Z; normals[0] = nXp;
+			corners[1][0] = -X-Y-Z; corners[1][1] = -X-Y+Z; corners[1][2] = -X+Y-Z; corners[1][3] = -X+Y+Z; normals[1] = nXm;
+			corners[2][0] = -X+Y-Z; corners[2][1] = -X+Y+Z; corners[2][2] =  X+Y-Z; corners[2][3] =  X+Y+Z; normals[2] = nYp;
+			corners[3][0] = -X-Y-Z; corners[3][1] =  X-Y-Z; corners[3][2] = -X-Y+Z; corners[3][3] =  X-Y+Z; normals[3] = nYm;
+			corners[4][0] = -X-Y+Z; corners[4][1] =  X-Y+Z; corners[4][2] = -X+Y+Z; corners[4][3] =  X+Y+Z; normals[4] = nZp;
+			corners[5][0] = -X-Y-Z; corners[5][1] = -X+Y-Z; corners[5][2] =  X-Y-Z; corners[5][3] =  X+Y-Z; normals[5] = nZm;
+			int quad = slot / 4;
+			int ci   = slot - quad * 4;
+			emitShapeVertex(slot, corners[quad][ci], normals[quad], center, col, noiseSeed, seed, breathScale);
+		} else {
+			vec3 right = cameraViewInv[0].xyz * (size * glowScale);
+			vec3 up    = cameraViewInv[1].xyz * (size * glowScale);
+			int gi = slot - 24;
+			if (gi == 0) emitGlowVertex(slot, -right - up, vec2(-1.0, -1.0), center, col, seed, breathScale);
+			else if (gi == 1) emitGlowVertex(slot,  right - up, vec2( 1.0, -1.0), center, col, seed, breathScale);
+			else if (gi == 2) emitGlowVertex(slot, -right + up, vec2(-1.0,  1.0), center, col, seed, breathScale);
+			else              emitGlowVertex(slot,  right + up, vec2( 1.0,  1.0), center, col, seed, breathScale);
+		}
+	}
+}

--- a/luaui/Shaders/nano_particles_gl4_nogs.vert.glsl
+++ b/luaui/Shaders/nano_particles_gl4_nogs.vert.glsl
@@ -1,0 +1,245 @@
+#version 430 core
+
+// Template mesh vertex carries one integer slot index (0..27), uploaded as a
+// float because the engine VBO API convention uses float template attributes.
+layout(location = 0) in float vertexSlot;
+
+// Instance attributes shifted up by one because the template uses location 0.
+layout(location = 1) in vec4 spawnPosAndSize;   // xyz=spawnPos, w=packed(sizeMult,fadeFrames)
+layout(location = 2) in vec4 velAndSpawnFrame;  // xyz=velocity, w=spawnFrame
+layout(location = 3) in vec4 instColor;
+layout(location = 4) in vec4 rotData;           // x=rotVal0, y=rotVel0, z=wobbleStartFrame, w=deathFrame
+
+//__ENGINEUNIFORMBUFFERDEFS__
+
+uniform float wobbleAmp;
+uniform float wobbleFreq;
+uniform float wobbleVar;
+uniform float wobbleFreqVar;
+uniform float wobbleRampFrames;
+uniform float drawRadius;
+uniform int   u_shape;
+uniform float glowScale;
+uniform float glowIntensity;
+
+out vec4 g_color;
+out vec3 g_normal;
+out vec3 g_worldPos;
+out vec3 g_localPos;
+out vec3 g_noiseSeed;
+out vec2 g_glowUV;
+out float g_isGlow;
+out float g_seed;
+
+float hash11(float x) {
+	return fract(sin(x) * 43758.5453);
+}
+
+mat3 rotXYZ(vec3 a) {
+	float cx = cos(a.x), sx = sin(a.x);
+	float cy = cos(a.y), sy = sin(a.y);
+	float cz = cos(a.z), sz = sin(a.z);
+	mat3 Rx = mat3(1,0,0, 0,cx,sx, 0,-sx,cx);
+	mat3 Ry = mat3(cy,0,-sy, 0,1,0, sy,0,cy);
+	mat3 Rz = mat3(cz,sz,0, -sz,cz,0, 0,0,1);
+	return Rz * Ry * Rx;
+}
+
+void emitShapeVertex(int slot, vec3 localPos, vec3 normal, vec3 center, vec4 col, vec3 noiseSeed, float seed) {
+	g_color = col;
+	g_normal = normal;
+	g_noiseSeed = noiseSeed;
+	g_isGlow = 0.0;
+	g_glowUV = vec2(0.0);
+	g_seed = seed;
+	g_localPos = localPos;
+	g_worldPos = center + localPos;
+	gl_Position = cameraViewProj * vec4(g_worldPos, 1.0);
+}
+
+void emitGlowVertex(int slot, vec3 localPos, vec2 glowUV, vec3 center, vec4 col, float seed) {
+	g_color = col;
+	g_normal = vec3(0.0, 1.0, 0.0);
+	g_noiseSeed = vec3(0.0);
+	g_localPos = vec3(0.0);
+	g_isGlow = 1.0;
+	g_seed = seed;
+	g_glowUV = glowUV;
+	g_worldPos = center + localPos;
+	gl_Position = cameraViewProj * vec4(g_worldPos, 1.0);
+}
+
+void main() {
+	float currentFrame = timeInfo.x + timeInfo.w;
+	float spawnFrame   = velAndSpawnFrame.w;
+	float deathFrame   = rotData.w;
+
+	if (currentFrame >= deathFrame) {
+		gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+		g_color = vec4(0.0);
+		g_normal = vec3(0.0);
+		g_worldPos = vec3(0.0);
+		g_localPos = vec3(0.0);
+		g_noiseSeed = vec3(0.0);
+		g_glowUV = vec2(0.0);
+		g_isGlow = 0.0;
+		g_seed = 0.0;
+		return;
+	}
+
+	float t = currentFrame - spawnFrame;
+	if (t < 0.0) t = 0.0;
+
+	vec3 worldPos = spawnPosAndSize.xyz + velAndSpawnFrame.xyz * t;
+
+	if (wobbleAmp > 0.0001) {
+		float wobbleT   = max(currentFrame - rotData.z, 0.0);
+		float totalLife = max(deathFrame - rotData.z, 1.0);
+		float bell      = sin(3.14159265 * wobbleT / totalLife);
+		if (wobbleRampFrames > 0.5)
+			bell *= min(1.0, wobbleT / wobbleRampFrames);
+		vec3 vdir = velAndSpawnFrame.xyz;
+		vec3 ref, axA, axB;
+		float refAngle = rotData.x * 0.01745329;
+		float s1 = sin(refAngle), c1 = cos(refAngle);
+		float s2 = sin(refAngle * 2.19), c2 = cos(refAngle * 2.19);
+		if (abs(vdir.y) < 0.95) {
+			ref = normalize(vec3(s1, c1, s2));
+		} else {
+			ref = normalize(vec3(c1, s2, c2));
+		}
+		float h1 = fract(sin(rotData.x * 12.9898 + rotData.y * 78.233) * 43758.5453);
+		float h2 = fract(sin(rotData.x * 23.1451 + rotData.y * 34.567) * 65432.0987);
+		axA = normalize(vec3(
+			sin(h1 * 6.28318),
+			sin(h2 * 6.28318),
+			cos(h1 * 3.14159 + h2 * 3.14159)
+		));
+		axB = cross(axA, ref);
+		if (dot(axB, axB) > 0.001) {
+			axB = normalize(axB);
+		} else {
+			axB = cross(axA, (abs(axA.x) < 0.9) ? vec3(1, 0, 0) : vec3(0, 1, 0));
+			axB = normalize(axB);
+		}
+		float phaseOff = radians(rotData.x);
+		float hash     = fract(sin(rotData.x * 12.9898 + rotData.y * 78.233) * 43758.5453);
+		float freqScale = max(0.0, 1.0 + wobbleFreqVar * (2.0 * hash - 1.0));
+		float dirSign  = (fract(hash * 7.31) < 0.5) ? -1.0 : 1.0;
+		float hash2    = fract(hash * 113.7 + 0.317);
+		float ampScale = max(0.0, 1.0 + wobbleVar * (2.0 * hash2 - 1.0));
+		float ph = currentFrame * wobbleFreq * freqScale * dirSign * (6.2831853 / 30.0) + phaseOff;
+		worldPos += (axA * cos(ph) + axB * sin(ph)) * (wobbleAmp * ampScale * bell);
+	}
+
+	float packedW    = abs(spawnPosAndSize.w);
+	float fadeFrames = floor(packedW / 1024.0);
+	float sizeMult   = (packedW - fadeFrames * 1024.0) / 256.0;
+
+	float fade = (fadeFrames > 0.5)
+		? clamp((deathFrame - currentFrame) / fadeFrames, 0.0, 1.0)
+		: 1.0;
+
+	float rotVel = rotData.y;
+	float rotVal = rotData.x + rotVel  * t;
+
+	vec3 center = worldPos;
+	vec4 col = instColor * fade;
+	float size  = drawRadius * sizeMult * (0.5 + 0.5 * fade);
+
+	vec3 phaseSeed = vec3(rotData.x, rotData.y, rotData.x + rotData.y);
+	vec3 noiseSeed = phaseSeed * 137.0 + vec3(11.0, 47.0, 83.0);
+	float h  = dot(phaseSeed, vec3(0.123, 0.456, 0.789));
+	vec3 phase = vec3(hash11(h), hash11(h+1.7), hash11(h+3.3)) * 6.2831853;
+	float r = radians(rotVal);
+	vec3 ang = phase + vec3(r * 1.0, r * 1.3, r * 0.7);
+	mat3 R = rotXYZ(ang);
+	float seed = radians(phaseSeed.x);
+
+	int slot = int(vertexSlot);
+
+	// The geometry shader only emits the glow quad when glow is actually enabled.
+	// The template mesh always contains the 4 glow slots, so move them off-screen
+	// when disabled to avoid wasted fragment shader work.
+	bool emitGlow = (glowIntensity > 0.001) && (glowScale > 1.001);
+	if (slot >= 24 && !emitGlow) {
+		gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+		g_color = vec4(0.0);
+		g_normal = vec3(0.0);
+		g_worldPos = vec3(0.0);
+		g_localPos = vec3(0.0);
+		g_noiseSeed = vec3(0.0);
+		g_glowUV = vec2(0.0);
+		g_isGlow = 0.0;
+		g_seed = 0.0;
+		return;
+	}
+
+	if (u_shape == 1) {
+		// ---- OCTAHEDRON ---- 24 shape verts (8 tris * 3) then 4 glow verts.
+		if (slot < 24) {
+			vec3 X = R * vec3(size, 0, 0); vec3 nX = -X;
+			vec3 Y = R * vec3(0, size, 0); vec3 nY = -Y;
+			vec3 Z = R * vec3(0, 0, size); vec3 nZ = -Z;
+			float k = 0.57735027;
+			vec3 n[8];
+			n[0] = R * vec3( k,  k,  k);
+			n[1] = R * vec3(-k,  k,  k);
+			n[2] = R * vec3(-k,  k, -k);
+			n[3] = R * vec3( k,  k, -k);
+			n[4] = R * vec3( k, -k,  k);
+			n[5] = R * vec3(-k, -k,  k);
+			n[6] = R * vec3(-k, -k, -k);
+			n[7] = R * vec3( k, -k, -k);
+			vec3 corners[8][3];
+			corners[0][0] = Y;  corners[0][1] = Z;  corners[0][2] = X;
+			corners[1][0] = Y;  corners[1][1] = nX; corners[1][2] = Z;
+			corners[2][0] = Y;  corners[2][1] = nZ; corners[2][2] = nX;
+			corners[3][0] = Y;  corners[3][1] = X;  corners[3][2] = nZ;
+			corners[4][0] = nY; corners[4][1] = X;  corners[4][2] = Z;
+			corners[5][0] = nY; corners[5][1] = Z;  corners[5][2] = nX;
+			corners[6][0] = nY; corners[6][1] = nX; corners[6][2] = nZ;
+			corners[7][0] = nY; corners[7][1] = nZ; corners[7][2] = X;
+			int tri = slot / 3;
+			int ci  = slot - tri * 3;
+			emitShapeVertex(slot, corners[tri][ci], n[tri], center, col, noiseSeed, seed);
+		} else {
+			vec3 right = cameraViewInv[0].xyz * (size * glowScale);
+			vec3 up    = cameraViewInv[1].xyz * (size * glowScale);
+			int gi = slot - 24;
+			if (gi == 0) emitGlowVertex(slot, -right - up, vec2(-1.0, -1.0), center, col, seed);
+			else if (gi == 1) emitGlowVertex(slot,  right - up, vec2( 1.0, -1.0), center, col, seed);
+			else if (gi == 2) emitGlowVertex(slot, -right + up, vec2(-1.0,  1.0), center, col, seed);
+			else              emitGlowVertex(slot,  right + up, vec2( 1.0,  1.0), center, col, seed);
+		}
+	} else {
+		// ---- CUBE (default) ---- 24 shape verts (6 quads * 4) then 4 glow verts.
+		if (slot < 24) {
+			vec3 X = R * vec3(size, 0, 0);
+			vec3 Y = R * vec3(0, size, 0);
+			vec3 Z = R * vec3(0, 0, size);
+			vec3 nXp =  R[0]; vec3 nXm = -R[0];
+			vec3 nYp =  R[1]; vec3 nYm = -R[1];
+			vec3 nZp =  R[2]; vec3 nZm = -R[2];
+			vec3 corners[6][4];
+			vec3 normals[6];
+			corners[0][0] =  X-Y-Z; corners[0][1] =  X+Y-Z; corners[0][2] =  X-Y+Z; corners[0][3] =  X+Y+Z; normals[0] = nXp;
+			corners[1][0] = -X-Y-Z; corners[1][1] = -X-Y+Z; corners[1][2] = -X+Y-Z; corners[1][3] = -X+Y+Z; normals[1] = nXm;
+			corners[2][0] = -X+Y-Z; corners[2][1] = -X+Y+Z; corners[2][2] =  X+Y-Z; corners[2][3] =  X+Y+Z; normals[2] = nYp;
+			corners[3][0] = -X-Y-Z; corners[3][1] =  X-Y-Z; corners[3][2] = -X-Y+Z; corners[3][3] =  X-Y+Z; normals[3] = nYm;
+			corners[4][0] = -X-Y+Z; corners[4][1] =  X-Y+Z; corners[4][2] = -X+Y+Z; corners[4][3] =  X+Y+Z; normals[4] = nZp;
+			corners[5][0] = -X-Y-Z; corners[5][1] = -X+Y-Z; corners[5][2] =  X-Y-Z; corners[5][3] =  X+Y-Z; normals[5] = nZm;
+			int quad = slot / 4;
+			int ci   = slot - quad * 4;
+			emitShapeVertex(slot, corners[quad][ci], normals[quad], center, col, noiseSeed, seed);
+		} else {
+			vec3 right = cameraViewInv[0].xyz * (size * glowScale);
+			vec3 up    = cameraViewInv[1].xyz * (size * glowScale);
+			int gi = slot - 24;
+			if (gi == 0) emitGlowVertex(slot, -right - up, vec2(-1.0, -1.0), center, col, seed);
+			else if (gi == 1) emitGlowVertex(slot,  right - up, vec2( 1.0, -1.0), center, col, seed);
+			else if (gi == 2) emitGlowVertex(slot, -right + up, vec2(-1.0,  1.0), center, col, seed);
+			else              emitGlowVertex(slot,  right + up, vec2( 1.0,  1.0), center, col, seed);
+		}
+	}
+}


### PR DESCRIPTION
## Problem

On the AMD/Linux reproduction setup (RX 7800 XT, Mesa 26.0.6, Flatpak BAR 1.2988.0.3) the GL4 nano-particle gadget exits with <code>geometry shader not supported</code> and falls back to the thin engine spray.

fall back - 

<img width="1242" height="1028" alt="image" src="https://github.com/user-attachments/assets/a2eb3513-7cda-4745-9ef3-0acbf47122be" />

post fix - 

<img width="656" height="573" alt="image" src="https://github.com/user-attachments/assets/5f2c5c65-c591-494a-a44c-1793fc25ebac" />

there were several other graphics that were not rendering also. fire, energy explosion. These all apear to be working as expected now. confirmed with a few friends (running flat-pak AMD on linux), we have never seen the new nano stream until now - we didnt know what we were missing. 

The root cause is a false-negative geometry-shader capability precheck in <code>modules/graphics/LuaShader.lua</code>: <code>LuaShader.isGeometryShaderSupported</code> only checks extension strings and the presence of <code>gl.SetShaderParameter</code> / <code>gl.SetGeometryShaderParameter</code>. On the affected driver the extension strings are not reported, so the precheck returns false even though the GS actually compiles and runs fine.

Other GL4 widgets already use a compile-first/fallback pattern:
- <code>luaui/Include/DrawPrimitiveAtUnit.lua</code>
- <code>luaui/Widgets/gui_healthbars_gl4.lua</code>
- <code>luaui/Widgets/gfx_decals_gl4.lua</code>
- <code>luaui/Widgets/gui_pip.lua</code>
- <code>luaui/Widgets/map_edge_extension2.lua</code> (post cecec80c16)

The nano gadget, however, had no no-GS fallback.

## What this PR changes

### gfx_nano_particles_gl4.lua
- Removes the early <code>geometry shader not supported</code> exit.
- Tries to compile the geometry-shader path first via <code>LuaShader.CheckShaderUpdates</code> / <code>LuaShader:Initialize()</code>.
- Falls back to a no-GS instanced template-mesh path only if the GS compile actually fails.
- Adds the template mesh VBO + index VBO setup, shifts instance attributes to locations 1-4 (template vertex at location 0), and anchors the template/index VBOs to the VBO table to avoid the GC issue fixed in commit 2b51f6e863.
- Fixes a fake-VAO <code>DrawElements</code> bug that would have crashed the fallback path on first render.

### gfx_energy_explosion_particles_gl4.lua
- Applies the same compile-first/fallback pattern.

### New shaders
- <code>luaui/Shaders/nano_particles_gl4_nogs.vert.glsl</code>
- <code>luaui/Shaders/energy_explosion_particles_gl4_nogs.vert.glsl</code>

Both replicate the cube/octahedron/glow expansion that previously lived in the geometry shader, moving the per-instance rotation/noise/glow expansion into the vertex shader and passing the same outputs to the existing fragment shader. The no-GS VS also moves glow verts off-screen when the glow uniform is disabled, so the fallback does not waste fragment work relative to the GS path.

## Testing

Tested on the AMD/Linux reproduction setup by running the engine against the repo via:

```bash
/path/to/spring \
  --write-dir /var/home/<me>/.var/app/info.beyondallreason.bar/data/ \
  --game <BAR.sdd>
```

Results:
- Both <code>Nano Particles GL4</code> and <code>Energy Explosion Particles GL4</code> now load successfully.
- The nano particles render as glowing 3D tumbling cubes instead of the old engine blue-square fallback spray.
- Before the fix the log showed: <code>Nano Particles GL4 exiting: geometry shader not supported</code>.
- After the fix the GS path compiles successfully: <code>NanoParticlesGL4_Shape, recompiled ... success, true</code>.
- The no-GS fallback path was also force-tested by setting temporary config flags and verified to compile and render correctly:
  - <code>NanoParticlesGL4_Shape_NoGS, recompiled ... success, true</code>
  - <code>UnitEnergyExplosionParticlesGL4_NoGS, recompiled ... success, true</code>
- A full game was played to check for regressions in other GL4 effects; no <code>exiting</code>, <code>removing self</code>, <code>Failed to compile</code>, or shader errors were observed.

## Linked issue

Closes #7974.
