### PR TITLE
fix(i18n): add fallback proxy for table-level translations

### DIFF
--- a/modules/i18n/i18nlib/i18n/init.lua
+++ b/modules/i18n/i18nlib/i18n/init.lua
@@ -97,7 +97,7 @@ local function recursiveLoad(currentContext, data)
   end
 end
 
-local function localizedTranslate(key, locale, data)
+local function getNodeAtKey(key, locale)
   local path, length = dotSplit(locale .. "." .. key)
   local node = store
 
@@ -106,7 +106,28 @@ local function localizedTranslate(key, locale, data)
     if not node then return nil end
   end
 
+  return node
+end
+
+local function localizedTranslate(key, locale, data)
+  local node = getNodeAtKey(key, locale)
+  if not node then return nil end
   return treatNode(node, data)
+end
+
+local function makeFallbackTable(key, fallbacks, data)
+  return setmetatable({}, {
+    __index = function(_, subKey)
+      local fullKey = key .. '.' .. tostring(subKey)
+      for i=1, #fallbacks do
+        local node = getNodeAtKey(fullKey, fallbacks[i])
+        if node ~= nil then
+          return treatNode(node, data)
+        end
+      end
+      return nil
+    end
+  })
 end
 
 -- public interface
@@ -145,6 +166,9 @@ function i18n.translate(key, data)
     local fallback = fallbacks[i]
     local value = localizedTranslate(key, fallback, data)
     if value then
+      if type(value) == 'table' and not isPluralTable(value) then
+        return makeFallbackTable(key, fallbacks, data)
+      end
       return value
     else
       if missingTranslations[key] == nil then


### PR DESCRIPTION
Spring.I18N('ui.unitstats') returns a reference to the per-locale table store[locale].ui.unitstats. When a locale translation file is missing keys, those fields are nil because the i18n fallback mechanism only works for individual key lookups, not for table-level references.

The root cause is that tables are truthy in Lua, so the fallback loop in translate() exits on the first locale that has a non-nil table, even if that table is missing keys present in fallback locales.

This fix introduces a proxy table with __index metatable that lazily resolves each subkey through the full fallback chain. When translate() resolves to a plain table, it wraps it in a fallback proxy instead of returning the raw locale-specific table.

Key changes:
- getNodeAtKey(): extracts raw store traversal without treatNode processing
- makeFallbackTable(): creates a proxy table with __index that searches the fallback chain for each accessed subkey
- translate(): detects plain tables and returns fallback proxies

This eliminates the need for manual 'or' defaults at every call site (e.g. gui_unit_stats.lua) when requesting translated subtables.

Any thoughts, @WatchTheFort  ? Or should I avoid any edits to i18n? 