### PR TITLE
Fix inconsistent SmartSelect deselect-box when another widget selects on press

### DIFF
--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -209,6 +209,17 @@ function widget:SelectionChanged(sel)
 	selectedUnits = sel
 end
 
+-- function mousePress is called after all widgets have had their chance with widget:MousePress. 
+-- If any of those widgets change the selection on mouse press, referenceSelection will not only become stale, it will be stale inconsistently because widget:SelectionChanged is deferred.
+-- So we make a snapshot of the selection before any widget has had a chance to change it (layer -999999), and use that as the reference for the selection box.
+-- This produces a consistent behavior for Ctrl+drag deselect, even if other widgets select on mouse press (e.g. Squad Selection on ctrl+left click).
+function widget:MousePress(x, y, button)
+	if button == 1 then
+		referenceSelection = spGetSelectedUnits()
+	end
+	return false
+end
+
 -- this widget gets called early due to its layer
 -- this function will get called after all widgets have had their chance with widget:MousePress
 local function mousePress(x, y, button, hasMouseOwner)  --function widget:MousePress(x, y, button)
@@ -219,7 +230,6 @@ local function mousePress(x, y, button, hasMouseOwner)  --function widget:MouseP
 
 	skipSel = false
 
-	referenceSelection = selectedUnits
 	referenceSelectionTypes = {}
 	for i = 1, #referenceSelection do
 		local udid = spGetUnitDefID(referenceSelection[i])


### PR DESCRIPTION
## Problem

When a widget selects units on mouse press (e.g. Squad Selection picking the closest squad on Ctrl+click), a following Ctrl+drag deselect box behaved inconsistently: sometimes it deselected from the selection you had before the click, sometimes from the newly-selected one.  
The outcome depended on frame timing because widget:SelectionChanged is deferred. 

## Root cause

SmartSelect does its real press handling in `SmartSelect_MousePress2`, which is called after the whole `MousePress` loop. At that point it read its reference (for the drag boxes) from the widget's own `selectedUnits` cache.

`selectedUnits` is only updated by the SelectionChanged callin, which the engine dispatches deferred.  
So by the time SmartSelect reads it, a 'select on press' widget might have already changed the live selection, but whether selectedUnits reflected that yet wasn't certain. 

### Work done

Capture the reference selection in a real widget:MousePress. 
SmartSelect has the lowest layer (-999999), so this runs first in the press loop before any other widget can change the selection. 

The fix improves Squad Selection widget's Ctrl+left click behavior (makes it more consistent) but the same fix is needed for any other widget that can select on press.

#### Test steps

Select units, then Ctrl+drag a deselect box over a selection.  
I'm not sure it's necessary, but I tested all other selection box behaviors (`selectbox_same`, `selectbox_idle`, `selectbox Weapons_Not_Aircraft`, etc.) and they all still work.

Relevant other PR: #8045