### PR TITLE
[macOS] Stabilize screen-space UI overlays

### DIFF
--- a/luaui/Widgets/gui_pausescreen.lua
+++ b/luaui/Widgets/gui_pausescreen.lua
@@ -102,7 +102,7 @@ local fragmentShaderSource = [[
 	}
 
 	void main() {
-	  vec2 texCoord = vec2(gl_TextureMatrix[0] * gl_TexCoord[0]);
+	  vec2 texCoord = gl_TexCoord[0].st;
 	  vec4 origColor = texture2D(screencopy, texCoord);
 	  float intensity = getIntensity(origColor);
 	  intensity = intensity * 1.15;

--- a/luaui/Widgets/gui_selectionbox.lua
+++ b/luaui/Widgets/gui_selectionbox.lua
@@ -43,6 +43,15 @@ function widget:Shutdown()
 	Spring.LoadCmdColorsConfig('mouseBoxLineWidth 1.5')
 end
 
+local function DrawLineLoopRect(x1, y1, x2, y2)
+	gl.BeginEnd(GL.LINE_LOOP, function()
+		gl.Vertex(x1, y1)
+		gl.Vertex(x2, y1)
+		gl.Vertex(x2, y2)
+		gl.Vertex(x1, y2)
+	end)
+end
+
 function widget:DrawScreen() -- This blurs the UI elements obscured by other UI elements (only unit stats so far!)
 	local x1, y1, x2, y2 = Spring.GetSelectionBox()
 	if y2 then
@@ -72,10 +81,9 @@ function widget:DrawScreen() -- This blurs the UI elements obscured by other UI 
 		gl.Texture(false)
 
 		-- black selection outline
-		gl.PolygonMode(GL.FRONT_AND_BACK, GL.LINE)
 		gl.LineWidth(lineWidth + 2.5)
 		gl.Color(0,0,0,0.12)
-		gl.Rect(x1, y1, x2, y2)
+		DrawLineLoopRect(x1, y1, x2, y2)
 
 		-- colored selection outline based on modifier keys
 		gl.LineStipple(true)	-- animated stipplelines!
@@ -93,8 +101,7 @@ function widget:DrawScreen() -- This blurs the UI elements obscured by other UI 
 			gl.Color(1, 1, 1, 1)
 		end
 
-		gl.Rect(x1, y1, x2, y2)
-		gl.PolygonMode(GL.FRONT_AND_BACK, GL.FILL)
+		DrawLineLoopRect(x1, y1, x2, y2)
 		gl.LineStipple(false)
 
 		gl.PopMatrix()


### PR DESCRIPTION
## Summary

This keeps two screen-space UI overlays away from legacy fixed-function paths that exposed rendering artifacts on the macOS Zink/MoltenVK path:

- Pause Screen samples its copied screen texture directly from `gl_TexCoord[0].st` instead of going through `gl_TextureMatrix[0] * gl_TexCoord[0]`.
- Selectionbox draws the screen-space outline with an explicit `GL.LINE_LOOP` instead of `gl.PolygonMode(..., GL.LINE)` plus `gl.Rect(...)`.

The changes are intentionally local to the affected widgets. They do not rewrite `gl.TexRect`, `gl.Texture`, `gl.CopyToTexture`, R2T helpers, FlowUI rounded rectangles, or broader quad helpers.

## Why

On the BAR Apple Silicon runtime, the Settings/Quit pause overlay could smear or show a diagonal/mottled screen-copy artifact after commander spawn. Separately, dragging a selection rectangle could expose the internal diagonal from the rectangle primitive while line polygon mode was active.

Both paths already operate in screen coordinates and do not need the more fragile fixed-function compatibility state.

## Validation

- `luac -p luaui/Widgets/gui_pausescreen.lua luaui/Widgets/gui_selectionbox.lua`
- `git diff --check`
- Prior BAR.app user-path diagnostics confirmed the direct texcoord Pause Screen path and explicit Selectionbox line-loop path removed the observed artifacts.
