### PR TITLE
[macOS] Guard Ecostats empty allyteam slots

### DIFF
--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -244,6 +244,9 @@ local function refreshIsTeamRealCache()
 end
 
 local function isTeamReal(allyID)
+	if allyID == nil then
+		return false
+	end
 	local cached = eco.isTeamRealCache[allyID]
 	if cached ~= nil then return cached end
 	local result = isTeamRealUncached(allyID)


### PR DESCRIPTION
## Summary

Add a nil guard to `gui_ecostats.lua` before indexing `eco.isTeamRealCache`.

## Why

Some start scripts can contain empty allyteam slots. During Ecostats initialization/update, those placeholder allyteam entries can reach `isTeamReal(data.aID)` with `data.aID == nil`, which then tries to index `eco.isTeamRealCache[nil]` and raises:

```text
gui_ecostats.lua:250: table index is nil
```

Returning `false` for a nil allyteam id matches the existing intent: an empty allyteam slot is not a real drawable team.

## Validation

- `luac -p luaui/Widgets/gui_ecostats.lua`
- `git diff --check`
- Prior BAR.app runtime overlay checks showed the `gui_ecostats.lua:250 table index is nil` initialize/shutdown errors absent after this guard.
