### PR TITLE
[macOS] Guard Scav and Raptor boss health percentages

### DIFF
--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -984,9 +984,13 @@ if gadgetHandler:IsSyncedCode() then
 			SetGameRulesParam("raptorQueenStaggerActive", queenStagger.currentlyStaggered)
 		end
 
-		SetGameRulesParam("raptorQueenHealth", math.floor(0.5 + ((totalHealth / totalMaxHealth) * 100)))
+		local queenHealthPercentage = 0
+		if totalMaxHealth > 0 then
+			queenHealthPercentage = math.floor(0.5 + ((totalHealth / totalMaxHealth) * 100))
+		end
+		SetGameRulesParam("raptorQueenHealth", queenHealthPercentage)
 		SetGameRulesParam("pveBossInfo", Json.encode(bosses))
-		RaptorQueenHealthPercentage = math.floor(0.5 + ((totalHealth / totalMaxHealth) * 100))
+		RaptorQueenHealthPercentage = queenHealthPercentage
 	end
 
 	function SpawnQueen()

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1133,9 +1133,13 @@ if gadgetHandler:IsSyncedCode() then
 			SetGameRulesParam("scavBossStaggerActive", bossStagger.currentlyStaggered)
 		end
 
-		SetGameRulesParam("scavBossHealth", math.floor(0.5 + ((totalHealth / totalMaxHealth) * 100)))
+		local bossHealthPercentage = 0
+		if totalMaxHealth > 0 then
+			bossHealthPercentage = math.floor(0.5 + ((totalHealth / totalMaxHealth) * 100))
+		end
+		SetGameRulesParam("scavBossHealth", bossHealthPercentage)
 		SetGameRulesParam("pveBossInfo", Json.encode(bosses))
-		ScavBossHealthPercentage = math.floor(0.5 + ((totalHealth / totalMaxHealth) * 100))
+		ScavBossHealthPercentage = bossHealthPercentage
 	end
 
 	function SpawnBoss()

--- a/luaui/Widgets/snd_notifications_addon_scavraptorstatus.lua
+++ b/luaui/Widgets/snd_notifications_addon_scavraptorstatus.lua
@@ -15,6 +15,11 @@ end
 
 local PlayedMessages = {}
 
+local function NumParam(name)
+	local value = Spring.GetGameRulesParam(name)
+	return tonumber(value)
+end
+
 UpdateTimer = 0
 function widget:Update(dt)
     UpdateTimer = UpdateTimer+dt
@@ -22,9 +27,9 @@ function widget:Update(dt)
         UpdateTimer = UpdateTimer - 1
 
         if Spring.Utilities.Gametype.IsRaptors() then
-            FinalBossProgress = Spring.GetGameRulesParam("raptorQueenAnger")
-            FinalBossHealth = Spring.GetGameRulesParam("raptorQueenHealth")
-            TechProgress = Spring.GetGameRulesParam("raptorTechAnger")
+            FinalBossProgress = NumParam("raptorQueenAnger")
+            FinalBossHealth = NumParam("raptorQueenHealth")
+            TechProgress = NumParam("raptorTechAnger")
 
             if TechProgress and TechProgress >= 50 and not PlayedMessages["AntiNukeReminder1"] then
                 WG['notifications'].queueNotification("PvE/AntiNukeReminder")
@@ -105,9 +110,9 @@ function widget:Update(dt)
             end
 
         elseif Spring.Utilities.Gametype.IsScavengers() then
-            FinalBossProgress = Spring.GetGameRulesParam("scavBossAnger")
-            FinalBossHealth = Spring.GetGameRulesParam("scavBossHealth")
-            TechProgress = Spring.GetGameRulesParam("scavTechAnger")
+            FinalBossProgress = NumParam("scavBossAnger")
+            FinalBossHealth = NumParam("scavBossHealth")
+            TechProgress = NumParam("scavTechAnger")
 
             if TechProgress and TechProgress >= 50 and not PlayedMessages["AntiNukeReminder1"] then
                 WG['notifications'].queueNotification("PvE/AntiNukeReminder")


### PR DESCRIPTION
## Summary
- guard Scav and Raptor boss health percentage calculations while no boss max health has been accumulated
- publish 0 before the denominator is available, preserving the existing rounded percentage once it is available
- normalize PvE notification GameRulesParams through tonumber before numeric comparisons

## Why
Observed Scav and Raptor Defense sessions can call SetGameRulesParam with +-NaN when totalHealth / totalMaxHealth is evaluated while totalMaxHealth is 0. This starts early in the match before boss max health exists yet.

## Validation
- luac -p LuaRules/Gadgets/scav_spawner_defense.lua LuaRules/Gadgets/raptor_spawner_defense.lua LuaUI/Widgets/snd_notifications_addon_scavraptorstatus.lua
- git diff --check