### PR TITLE
display lightning-spark damages as bonus damage

### DIFF
--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -438,11 +438,12 @@ local function refreshUnitInfo()
 					local splitd = WeaponDefNames[weaponDef.customParams.speceffect_def].damages[0]
 					local splitn = weaponDef.customParams.number or 1
 					addDPS(calculateWeaponDPS(weaponDef, splitd * splitn))
-				elseif weaponDef.customParams.spark_basedamage then -- Lightning
+				elseif weaponDef.customParams.spark_forkdamage then -- Lightning
 					unitExempt = true
-					local forkd = weaponDef.customParams.spark_forkdamage
-					local forkn = weaponDef.customParams.spark_maxunits or 1
-					addDPS(calculateWeaponDPS(weaponDef, weaponDef.damages[0] * (1 + forkd * forkn)))
+					addDPS(calculateWeaponDPS(weaponDef, weaponDef.damages[0]))
+					-- Sparks cannot retarget the original unit they hit, so add them as secondary damages.
+					local forkDamageRate = weaponDef.customParams.spark_forkdamage
+					addSecondaryDPS(calculateWeaponDPS(weaponDef, weaponDef.damages[0] * forkDamageRate))
 					if unitExempt and weaponDef.paralyzer then -- DPS => EMP
 						unitDefInfo[unitDefID].minemp = unitDefInfo[unitDefID].mindps
 						unitDefInfo[unitDefID].maxemp = unitDefInfo[unitDefID].maxdps

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -749,8 +749,9 @@ local function computeContent(uDefID, uID, shiftBool)
 
 		local custom = uWep.customParams
 
-		if custom.spark_basedamage then
-			local spDamage = custom.spark_basedamage * custom.spark_forkdamage
+		if custom.spark_forkdamage then
+			-- Sparks are hardcoded to target the default armor type:
+			local spDamage = custom.spark_basedamage * defaultArmorDamage
 			local spCount = custom.spark_maxunits
 			baseArmorDamage = baseArmorDamage + spDamage * spCount
 


### PR DESCRIPTION
### Work done

- Remove multi-target damage from lightning sparks.
- Fix the base damage done by lightning weapons to use their (hardcoded) default damage.
- Remove spark damage from primary DPS (mindps) in damage ranges.

#### Addresses issue(s)

DPS is always single-target; e.g., weapons with a large area of effect don't gain +damage% for potential extra targets.

The display intent for damage ranges is to show guaranteed damages at the lowest end and guaranteed + conditional damages in the upper range. Spark damage doesn't fit neatly as conditional damage since it does not contribute toward single-target DPS.

I went with a compromise position to show the extra damage as bonus without having to show a separate bonus field, like "mindps–maxdps (+bonusdps)". That is a bit much just to be technically correct.