### PR TITLE
Allow Vesuvius Missile Launchers to target Air.

### DIFF
--- a/units/Scavengers/Vehicles/corves.lua
+++ b/units/Scavengers/Vehicles/corves.lua
@@ -247,14 +247,14 @@ return {
 			[2] = {
 				badtargetcategory = "VTOL",
 				def = "banisher",
-				onlytargetcategory = "SURFACE",
+				onlytargetcategory = "NOTSUB",
 				maindir = "-1 0 0",
 				maxangledif = 180,
 			},
 			[3] = {
 				badtargetcategory = "VTOL",
 				def = "banisher",
-				onlytargetcategory = "SURFACE",
+				onlytargetcategory = "NOTSUB",
 				maindir = "1 0 0",
 				maxangledif = 180,
 			},


### PR DESCRIPTION
Allow Vesuvius Missile Launchers to target Air, to properly replicate Banisher behaviour.