### PR TITLE
Fix stuck hold-actions when modifiers change before key release

### DIFF
--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -17,7 +17,8 @@ local actionHandler = {
 	keyRepeatActions = {},
 	keyReleaseActions = {},
 	syncActions = {},
-	-- actions triggered by currently held physical key (keyed by scancode) captured at press time so their release can be dispatched reliably
+	-- Actions triggered by a currently held physical key, keyed by scancode and captured at press time.
+	-- The engine rebuilds the action list from the live modifier state at release time, so a modified bind (e.g. Shift+n) gets no matching release dispatch once the modifier is let go first. Capturing the press list is makes modified binds releasable.
 	pressedKeyActions = {},
 }
 
@@ -223,14 +224,16 @@ local function TryActionList(actionMap, actionsToTry, isRepeat, release, trigger
 end
 
 function actionHandler:KeyAction(press, key, _, isRepeat, scanCode, actions)
+	local hasActions = actions ~= nil and next(actions) ~= nil
+
 	if press then
-		if not (actions and next(actions)) then
-			return false
+		-- Remember which actions this physical key triggered, so their release can still be dispatched even when the modifier state no longer matches the bind at release time. Always written (nil included) so a press whose release never arrives cannot leave a stale list behind for the next press of the same key.
+		if scanCode and not isRepeat then
+			self.pressedKeyActions[scanCode] = hasActions and actions or nil
 		end
 
-		-- Remember which actions this physical key triggered, so their release can still be dispatched even when the modifier state no longer matches the bind at release time.
-		if scanCode and not isRepeat then
-			self.pressedKeyActions[scanCode] = actions
+		if not hasActions then
+			return false
 		end
 
 		local actionSet = isRepeat and self.keyRepeatActions or self.keyPressActions

--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -209,6 +209,19 @@ local function TryAction(actionMap, cmd, optLine, optWords, isRepeat, release, a
 	return false
 end
 
+local function TryActionList(actionMap, actionsToTry, isRepeat, release, triggeringActions, key, scanCode)
+	for _, bAction in ipairs(actionsToTry) do
+		local cmd = bAction.command
+		local extra = bAction.extra
+		local words = string.split(extra)
+
+		if TryAction(actionMap, cmd, extra, words, isRepeat, release, triggeringActions, key, scanCode) then
+			return true
+		end
+	end
+	return false
+end
+
 function actionHandler:KeyAction(press, key, _, isRepeat, scanCode, actions)
 	if press then
 		if not (actions and next(actions)) then
@@ -221,14 +234,8 @@ function actionHandler:KeyAction(press, key, _, isRepeat, scanCode, actions)
 		end
 
 		local actionSet = isRepeat and self.keyRepeatActions or self.keyPressActions
-		for _, bAction in ipairs(actions) do
-			local cmd = bAction.command
-			local extra = bAction.extra
-			local words = string.split(extra)
-
-			if TryAction(actionSet, cmd, extra, words, isRepeat, false, actions, key, scanCode) then
-				return true
-			end
+		if TryActionList(actionSet, actions, isRepeat, false, actions, key, scanCode) then
+			return true
 		end
 
 		return false
@@ -244,14 +251,8 @@ function actionHandler:KeyAction(press, key, _, isRepeat, scanCode, actions)
 		return false
 	end
 
-	for _, bAction in ipairs(releaseActions) do
-		local cmd = bAction.command
-		local extra = bAction.extra
-		local words = string.split(extra)
-
-		if TryAction(self.keyReleaseActions, cmd, extra, words, false, true, releaseActions, key, scanCode) then
-			return true
-		end
+	if TryActionList(self.keyReleaseActions, releaseActions, false, true, releaseActions, key, scanCode) then
+		return true
 	end
 
 	return false

--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -17,6 +17,8 @@ local actionHandler = {
 	keyRepeatActions = {},
 	keyReleaseActions = {},
 	syncActions = {},
+	-- actions triggered by currently held physical key (keyed by scancode) captured at press time so their release can be dispatched reliably
+	pressedKeyActions = {},
 }
 
 --------------------------------------------------------------------------------
@@ -208,23 +210,46 @@ local function TryAction(actionMap, cmd, optLine, optWords, isRepeat, release, a
 end
 
 function actionHandler:KeyAction(press, key, _, isRepeat, scanCode, actions)
-	if not (actions and next(actions)) then
+	if press then
+		if not (actions and next(actions)) then
+			return false
+		end
+
+		-- Remember which actions this physical key triggered, so their release can still be dispatched even when the modifier state no longer matches the bind at release time.
+		if scanCode and not isRepeat then
+			self.pressedKeyActions[scanCode] = actions
+		end
+
+		local actionSet = isRepeat and self.keyRepeatActions or self.keyPressActions
+		for _, bAction in ipairs(actions) do
+			local cmd = bAction.command
+			local extra = bAction.extra
+			local words = string.split(extra)
+
+			if TryAction(actionSet, cmd, extra, words, isRepeat, false, actions, key, scanCode) then
+				return true
+			end
+		end
+
 		return false
 	end
 
-	local actionSet
-	if press then
-		actionSet = isRepeat and self.keyRepeatActions or self.keyPressActions
-	else
-		actionSet = self.keyReleaseActions
+	-- Release: prefer the action list captured at press time.
+	local releaseActions = (scanCode and self.pressedKeyActions[scanCode]) or actions
+	if scanCode then
+		self.pressedKeyActions[scanCode] = nil
 	end
 
-	for _, bAction in ipairs(actions) do
+	if not (releaseActions and next(releaseActions)) then
+		return false
+	end
+
+	for _, bAction in ipairs(releaseActions) do
 		local cmd = bAction.command
 		local extra = bAction.extra
 		local words = string.split(extra)
 
-		if TryAction(actionSet, cmd, extra, words, isRepeat, not press, actions, key, scanCode) then
+		if TryAction(self.keyReleaseActions, cmd, extra, words, false, true, releaseActions, key, scanCode) then
 			return true
 		end
 	end

--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -18,7 +18,9 @@ local actionHandler = {
 	keyReleaseActions = {},
 	syncActions = {},
 	-- Actions triggered by a currently held physical key, keyed by scancode and captured at press time.
-	-- The engine rebuilds the action list from the live modifier state at release time, so a modified bind (e.g. Shift+n) gets no matching release dispatch once the modifier is let go first. Capturing the press list is makes modified binds releasable.
+	-- The engine rebuilds the action list at release time from a single key only with the live modifier state.
+	-- So a modified bind (e.g. Shift+n) gets no matching release dispatch once the modifier is let go first.
+	-- Capturing the press list makes chained or modified binds releasable.
 	pressedKeyActions = {},
 }
 

--- a/luaui/actions.lua
+++ b/luaui/actions.lua
@@ -263,6 +263,13 @@ function actionHandler:KeyAction(press, key, _, isRepeat, scanCode, actions)
 	return false
 end
 
+-- Drops a key's captured actions without dispatching them, for releases that never reach KeyAction: A textOwner can swallow the release of the key that installed it, which would otherwise leave the capture behind to be dispatched by some later release.
+function actionHandler:ClearPressedKey(scanCode)
+	if scanCode then
+		self.pressedKeyActions[scanCode] = nil
+	end
+end
+
 function actionHandler:TextAction(line)
 	local words = string.split(line)
 	local cmd = words[1]

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1992,6 +1992,8 @@ function widgetHandler:KeyRelease(key, mods, label, unicode, scanCode, actions)
 
 	if textOwner then
 		if (not textOwner.KeyRelease) or textOwner:KeyRelease(key, mods, label, unicode, scanCode, actions) then
+			-- the action handler (actions.lua) never sees this release, so let's forget the key itself
+			self.actionHandler:ClearPressedKey(scanCode)
 			tracy.ZoneEnd()
 			return true
 		end


### PR DESCRIPTION
`actionHandler:KeyAction` built its release dispatch from the engine-provided `actions` which the engine recomputes from the current modifier state at release time.  

Let's consider a modified bind (e.g. `Shift+n`): If I released `n` while still holding shift, the engine's release dispatch contained `shift+n` and the release handler ran since it was registered to `shift+n`.  
But if I released `Shift` first, only then released `n`, the engine's release dispatch contained only `n` and the release handler never ran since the handler was expecting shift+n.  
The action was stuck in its hold state.  
Same if we changed the modifiers for example by alt-tabbing away, or by simply holding ctrl then releasing shift, etc...

### Work done

Capture the action list each key triggers at press time(keyed by scancode), and use those on release.  
The engine's list is used only as a fallback when nothing was captured.  

#### Test steps
- [ ] Bind for example `Shift+sc_n commandinsert prepend_between`
- [ ] Queue commands whilel holding shift+n. 
- [ ] Release shift, then release n. Commandinsert mode should exit. Without this fix it would stay in insert mode.

I tested all widgets which register hold-style actions, the only issue I found was with `gui_overview_cam_tab_hold.lua` which doesn't work as expected but not because of this fix, it doesn't work correctly without the fix either (neither `gui_overview_keep_camera_position.lua` though that's unrelated). 

Relevant other PR: #7994

**I'm not 100% confident in this fix, I don't know if there are any other edge cases that could cause issues, or that I even understand the engine's behavior well enough to be sure this is a complete/correct fix.** 

### AI / LLM usage statement:

Claude Opus 4.8 validated my reasoning and fix. 