### PR TITLE
fix: calculate timings from totals in frame time broadcast

### DIFF
--- a/luarules/gadgets/game_frametime_broadcast.lua
+++ b/luarules/gadgets/game_frametime_broadcast.lua
@@ -24,20 +24,32 @@ local updateTimer = 0
 local simN,  simSum,  simPeak  = 0, 0, 0
 local drawN, drawSum, drawPeak = 0, 0, 0
 
+-- `total` (1st return) is a monotonic accumulator of time spent in the zone,
+-- the per-frame cost is the delta between two reads.
+local prevSimTotal, prevDrawTotal
+
 function gadget:GameFrame(_)
-	local _, simCurrent = GetProfilerTimeRecord("Sim", false)
-	simN   = simN + 1
-	simSum = simSum + simCurrent
-	if simCurrent > simPeak then simPeak = simCurrent end
+    local simTotal = GetProfilerTimeRecord("Sim", false)
+	if prevSimTotal then
+			local simFrame = simTotal - prevSimTotal
+			simN   = simN + 1
+			simSum = simSum + simFrame
+			if simFrame > simPeak then simPeak = simFrame end
+	end
+	prevSimTotal = simTotal
 end
 
 function gadget:Update()
 	updateTimer = updateTimer + GetLastUpdateSeconds()
 
-	local _, drawCurrent = GetProfilerTimeRecord("Draw", false)
-	drawN   = drawN + 1
-	drawSum = drawSum + drawCurrent
-	if drawCurrent > drawPeak then drawPeak = drawCurrent end
+	local drawTotal = GetProfilerTimeRecord("Draw", false)
+	if prevDrawTotal then
+		local drawFrame = drawTotal - prevDrawTotal
+		drawN   = drawN + 1
+		drawSum = drawSum + drawFrame
+		if drawFrame > drawPeak then drawPeak = drawFrame end
+	end
+	prevDrawTotal = drawTotal
 
 	if updateTimer > sendPacketEverySeconds then
 		local avgSim  = simN  > 0 and (simSum  / simN)  or 0


### PR DESCRIPTION

### Work done
The first PR thought that the "current" value returned by the timing api was for the _current frame_, but its actually the total time for last 500ms. Not very useful.

So we switch to just using the "total" value returned and diffing. This gives us the per frame number we care about.


### Screenshots:
Here it is after parsing + graphing (before i was getting nonsense numbers):
<img width="1503" height="878" alt="Screenshot 2026-06-27 at 1 18 39 PM" src="https://github.com/user-attachments/assets/db05bbfd-8493-4f42-b2ba-61fda3e0ae43" />



### AI / LLM usage statement:
claude code assisted
