### PR TITLE
cleanup after shields api hotfix/opts

### DIFF
--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -287,14 +287,13 @@ local function addToExplosions(explosions, area)
 	tableInsert(explosions, index, area)
 end
 
-local function getBlockingShieldUnits()
-	return nil, 0
-end
-
-local function initBlockingShieldUnits()
-	local shields = GG.Shields
-	if shields and shields.GetBlockingShieldUnits then
-		getBlockingShieldUnits = shields.GetBlockingShieldUnits
+local function getBlockingShieldUnits(x, y, z, radius, onlyAlive)
+	-- Replace function stub at time of first call:
+	if GG.Shields.GetCoveringShieldUnits and GG.Shields.GetCoveringShieldUnits then
+		getBlockingShieldUnits = GG.Shields.GetCoveringShieldUnits
+		return getBlockingShieldUnits(x, y, z, radius, onlyAlive)
+	else
+		return {}, 0
 	end
 end
 
@@ -333,7 +332,6 @@ local function addTimedExplosion(weaponDefID, px, py, pz, attackerID, projectile
 		-- and the explosion volume and resulting area volume have some discrepancy, as well.
 		local blockingShields
 		if not explosion.penetrates then
-			initBlockingShieldUnits()
 			local allyTeam = getAllyTeam(attackerID, projectileID)
 			local units, count = getBlockingShieldUnits(px, elevation, pz, areaRange, allyTeam, true)
 			if count and count > 0 then
@@ -547,8 +545,6 @@ end
 -- Gadget callins --------------------------------------------------------------
 
 function gadget:Initialize()
-	initBlockingShieldUnits()
-
 	areaDamageTypes = GG.EnvAreaWeapons or {}
 	inExplosion = GG.InTimedDamageArea or table.new(1, 0) -- lua trick for ref passing
 	GG.EnvAreaWeapons = areaDamageTypes

--- a/luarules/gadgets/unit_custom_weapons_cluster.lua
+++ b/luarules/gadgets/unit_custom_weapons_cluster.lua
@@ -249,6 +249,16 @@ DirectionsUtil.ProvisionDirections(maxDataNum)
 local customShieldDeflect = table.contains({"unchanged", "absorbeverything"}, Spring.GetModOptions().experimentalshields)
 local projectileHitShield = {}
 
+-- Metatable for lookup on projectiles, rather than on our weaponDefIDs.
+-- This is likely cheaper than keeping a projectiles cache table around.
+local projectiles = setmetatable({
+	[-1] = false, -- beam weapons use projectileID -1
+}, {
+	__index = function(tbl, key)
+		return clusterWeaponDefs[spGetProjectileDefID(key)]
+	end
+})
+
 --------------------------------------------------------------------------------
 -- Functions -------------------------------------------------------------------
 
@@ -533,15 +543,11 @@ function gadget:Initialize()
 	getBlockingShieldUnits = GG.Shields.GetBlockingShieldUnits
 	isInShield = GG.Shields.IsInShield
 
-	-- Metatable for lookup on projectiles, rather than on our weaponDefIDs.
-	-- This is likely cheaper than keeping a projectiles cache table around.
-	local projectiles = setmetatable({
-		[-1] = false, -- beam weapons use projectileID -1
-	}, {
-		__index = function(tbl, key)
-			return clusterWeaponDefs[spGetProjectileDefID(key)]
-		end
-	})
-
 	GG.Shields.RegisterShieldPreDamaged(projectiles, shieldPreDamaged)
+end
+
+function gadget:Shutdown()
+	if GG.Shields then
+		GG.Shields.RegisterShieldPreDamaged(projectiles, nil)
+	end
 end

--- a/luarules/gadgets/unit_custom_weapons_overpen.lua
+++ b/luarules/gadgets/unit_custom_weapons_overpen.lua
@@ -559,3 +559,9 @@ function gadget:Initialize()
 	getUnitShieldState = GG.Shields.GetUnitShieldState
 	GG.Shields.RegisterShieldPreDamaged(projectiles, shieldPreDamaged)
 end
+
+function gadget:Shutdown()
+	if GG.Shields then
+		GG.Shields.RegisterShieldPreDamaged(projectiles, nil)
+	end
+end

--- a/luarules/gadgets/unit_dgun_behaviour.lua
+++ b/luarules/gadgets/unit_dgun_behaviour.lua
@@ -212,3 +212,9 @@ function gadget:Initialize()
 	addShieldDamage = GG.Shields.AddShieldDamage
 	GG.Shields.RegisterShieldPreDamaged(dgunData, shieldPreDamaged)
 end
+
+function gadget:Shutdown()
+	if GG.Shields then
+		GG.Shields.RegisterShieldPreDamaged(dgunData, nil)
+	end
+end

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -36,8 +36,12 @@ local scriptedShieldEntries = {} ---@type [table, function][]
 local function registerScriptedShieldEntry(projectileTbl, callback)
 	local index = table.getKeyOf(scriptedShieldEntries, projectileTbl)
 	if index then
-		scriptedShieldEntries[index][2] = callback
-	else
+		if callback then
+			scriptedShieldEntries[index][2] = callback
+		else
+			table.remove(scriptedShieldEntries, index)
+		end
+	elseif callback then
 		scriptedShieldEntries[#scriptedShieldEntries + 1] = { projectileTbl, callback }
 	end
 end
@@ -88,7 +92,7 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 
 	---Add a scripted weapon type to be handled by the shield behaviour gadget.
 	---@param projectileTbl table [projectileID] := true
-	---@param callback ShieldPreDamagedCallback accepting the ShieldPreDamaged args (excluding self-ref), returning `true` when consuming the event
+	---@param callback ShieldPreDamagedCallback? accepting the ShieldPreDamaged args (excluding self-ref), returning `true` when consuming the event
 	local function registerShieldPreDamaged(projectileTbl, callback)
 		if #scriptedShieldEntries == 0 then
 			gadget.ShieldPreDamaged = doShieldPreDamaged
@@ -898,7 +902,7 @@ end
 
 ---Add a scripted weapon type to be handled by the shield behaviour gadget.
 ---@param projectileTbl table [projectileID] := true
----@param callback ShieldPreDamagedCallback accepting the ShieldPreDamaged args (excluding self-ref), returning `true` when consuming the event
+---@param callback ShieldPreDamagedCallback? accepting the ShieldPreDamaged args (excluding self-ref), returning `true` when consuming the event
 local function registerShieldPreDamaged(projectileTbl, callback)
 	registerScriptedShieldEntry(projectileTbl, callback)
 end

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -97,15 +97,22 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 		registerScriptedShieldEntry(projectileTbl, callback)
 	end
 
+	local function getEmptyResultSet()
+		return {}, 0
+	end
+
 	function gadget:Initialize()
 		GG.Shields = {}
 		GG.Shields.AddShieldDamage = addEngineShieldDamage
 		GG.Shields.DamageToShields = originalShieldDamages
-		GG.Shields.GetUnitShieldPosition = function() end -- TODO: parts of the api are not usable (nor needed)
-		GG.Shields.GetShieldUnitsInSphere = function() end -- TODO: parts of the api are not usable (nor needed)
-		GG.Shields.GetUnitShieldState = spGetUnitShieldState
-		GG.Shields.IsInShield = function() end -- TODO: parts of the api are not usable (nor needed)
 		GG.Shields.RegisterShieldPreDamaged = registerShieldPreDamaged
+		GG.Shields.GetUnitShieldState = spGetUnitShieldState
+		-- FIXME: The shields api does not have full coverage for engine/bounce shields.
+		GG.Shields.GetUnitShieldPosition = function() end
+		GG.Shields.GetShieldUnitsInSphere = getEmptyResultSet
+		GG.Shields.GetBlockingShieldUnits = getEmptyResultSet
+		GG.Shields.GetCoveringShieldUnits = getEmptyResultSet
+		GG.Shields.IsInShield = function() return false end -- unfortunate
 	end
 
 	return -- do not load custom shields gadget

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -31,20 +31,15 @@ local SHIELDSTATE_ENABLED = 1
 local armorTypeShields = Game.armorTypes.shields
 
 local originalShieldDamages = table.new(#WeaponDefs, 1) -- [0] goes into hash part
-local scriptedShieldDamages = {}
-local scriptedShieldEntries = {}
-local scriptedShieldEntryIndex = {}
+local scriptedShieldEntries = {} ---@type [table, function][]
 
 local function registerScriptedShieldEntry(projectileTbl, callback)
-	local index = scriptedShieldEntryIndex[projectileTbl]
+	local index = table.getKeyOf(scriptedShieldEntries, projectileTbl)
 	if index then
 		scriptedShieldEntries[index][2] = callback
 	else
 		scriptedShieldEntries[#scriptedShieldEntries + 1] = { projectileTbl, callback }
-		scriptedShieldEntryIndex[projectileTbl] = #scriptedShieldEntries
 	end
-
-	scriptedShieldDamages[projectileTbl] = callback
 end
 
 -- Some modoptions require engine shield behaviors (namely their bounce/repulsion effects):


### PR DESCRIPTION
### Work done

- Add two missing game-side shield api methods to engine-side shields api. These caused errors requiring a hotfix.
- Handle missing shield api method in timed areas code by doing init only once.
- Allow gadgets to unhook their registered shield callbacks and add Shutdown methods to do so.