### PR TITLE
Idle repair is idle

### DIFF
--- a/luaui/Include/select_api.lua
+++ b/luaui/Include/select_api.lua
@@ -95,8 +95,10 @@ local function checkCmd(uid, cmdId, indexTemp)
 	return false
 end
 
+local inIdleWorkerTask = table.ensureTable(WG, "InIdleWorkerTask")
+
 local function isIdle(udef, _udefid, uid)
-	return spGetUnitCommandCount(uid) == 0
+	return spGetUnitCommandCount(uid) == 0 or inIdleWorkerTask[uid]
 end
 
 local function stringContains(mainString, searchString)

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -88,6 +88,7 @@ local clicks = {}
 local unitList = {}
 
 local idleList = {}
+local inIdleWorkerTask = table.ensureTable(WG, "InIdleWorkerTask")
 
 local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, backgroundRect, ordermenuPosY
 local guishaderWasActive = false
@@ -104,7 +105,7 @@ local function refreshUnitDefs()
 			end
 			if unitDef.buildSpeed > 0 and not string.find(unitDef.name, 'spy') and not string.find(unitDef.name, 'infestor') and (unitDef.canAssist or unitDef.buildOptions[1] or (showRez and unitDef.canResurrect)) and not unitDef.customParams.isairbase then
 				unitConf[unitDefID] = unitDef.isFactory
-		end
+			end
 		end
 	end
 end

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -293,13 +293,16 @@ local function drawContent()
 	end
 end
 
+local function isWorkerUnitIdle(unitID, unitDefID)
+	return inIdleWorkerTask[unitID]
+		or (unitConf[unitDefID] and spGetFactoryCommandCount(unitID) or spGetUnitCommandCount(unitID)) == 0
+end
+
 local function updateList(force)
 	local prevIdleList = idleList
 	idleList = {}
-	local queue
 	for unitID, unitDefID in pairs(unitList) do
-		queue = unitConf[unitDefID] and spGetFactoryCommandCount(unitID) or spGetUnitCommandCount(unitID)
-		if queue == 0 then
+		if isWorkerUnitIdle(unitID, unitDefID) then
 			if spValidUnitID(unitID) and not spGetUnitIsDead(unitID) and not spGetUnitIsBeingBuilt(unitID) then
 				if idleList[unitDefID] then
 					idleList[unitDefID][#idleList[unitDefID] + 1] = unitID

--- a/luaui/Widgets/gui_unit_idlebuilder_icons.lua
+++ b/luaui/Widgets/gui_unit_idlebuilder_icons.lua
@@ -26,6 +26,7 @@ local iconSequenceFrametime = 0.02	-- duration per frame
 
 local unitScope = {} -- table of teamid to table of stallable unitID : unitDefID
 local idleUnitList = {}
+local inIdleWorkerTask = table.ensureTable(WG, "InIdleWorkerTask")
 
 local spGetUnitCommandCount = Spring.GetUnitCommandCount
 local spGetFactoryCommandCount = Spring.GetFactoryCommandCount
@@ -115,13 +116,16 @@ function widget:Initialize()
 end
 
 
+local function isWorkerUnitIdle(unitID, unitDefID)
+	return inIdleWorkerTask[unitID]
+		or (unitConf[unitDefID][3] and spGetFactoryCommandCount(unitID) or spGetUnitCommandCount(unitID)) == 0
+end
+
 local function updateIcons()
 	local gf = spGetGameFrame()
-	local queue
 	for unitID, unitDefID in pairs(unitScope) do
-		queue = unitConf[unitDefID][3] and spGetFactoryCommandCount(unitID) or spGetUnitCommandCount(unitID)
-		if queue == 0 then
-			if iconVBO.instanceIDtoIndex[unitID] == nil then -- not already being drawn
+		if isWorkerUnitIdle(unitID, unitDefID) then
+			if not iconVBO.instanceIDtoIndex[unitID] then -- not already being drawn
 				if spValidUnitID(unitID) and not spGetUnitIsDead(unitID) and not spGetUnitIsBeingBuilt(unitID) then
 					if not idleUnitList[unitID] then
 						idleUnitList[unitID] = os.clock()

--- a/luaui/Widgets/unit_auto_repair_idle_builders.lua
+++ b/luaui/Widgets/unit_auto_repair_idle_builders.lua
@@ -82,7 +82,7 @@ local myTeam = spGetMyTeamID()
 local idleBuilders = {}
 
 -- [builderID] = { targetID, homeX, homeY, homeZ }
-local activeRepairs = {}
+local activeRepairs = table.ensureTable(WG, "InIdleWorkerTask")
 
 -- [unitID] = expiryFrame
 local reclaimBlacklist = {}
@@ -162,6 +162,8 @@ function widget:Initialize()
 		return
 	end
 
+	activeRepairs = table.ensureTable(WG, "InIdleWorkerTask")
+
 	for _, unitID in ipairs(spGetTeamUnits(myTeam)) do
 		local unitDefID = spGetUnitDefID(unitID) 
 		if isMobileBuilder[unitDefID] and spGetUnitCommandCount(unitID) == 0 then
@@ -172,6 +174,9 @@ function widget:Initialize()
 end
 
 function widget:Shutdown()
+	for unitID in pairs(WG.InIdleWorkerTask) do
+		WG.InIdleWorkerTask[unitID] = nil
+	end
 	idleBuilders = {}
 	activeRepairs = {}
 	reclaimBlacklist = {}

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -169,8 +169,6 @@ local function handleSetModifier(_, _, _, data)
 	mods[data[1]] = data[2]
 end
 
-
-
 local function handleSetCustomFilter(_, ruleDef)
 	customFilter = selectApi.getFilter(ruleDef)
 	customFilterDef = ruleDef
@@ -179,6 +177,12 @@ end
 local function handleClearCustomFilter(_, _, _)
 	customFilter = {}
 	customFilterDef = ""
+end
+
+local inIdleWorkerTask = table.ensureTable(WG, "InIdleWorkerTask")
+
+local function isUnitIdle(unitID)
+	return inIdleWorkerTask[unitID] or spGetUnitCommandCount(unitID) == 0
 end
 
 
@@ -369,7 +373,7 @@ function widget:Update(dt)
 		for i = 1, #mouseSelection do
 			uid = mouseSelection[i]
 			udid = spGetUnitDefID(uid)
-			if spGetUnitCommandCount(uid) == 0 then
+			if isUnitIdle(unitID) then
 				included[#included + 1] = uid
 			end
 		end
@@ -597,7 +601,7 @@ function widget:Initialize()
 			included = {}
 			for i = 1, #mouseSelection do
 				uid = mouseSelection[i]
-				if spGetUnitCommandCount(uid) == 0 then
+				if isUnitIdle(unitID) then
 					included[#included + 1] = uid
 				end
 			end


### PR DESCRIPTION
### Work done

Workers that are performing an idle worker task (for now, they can only repair) are considered idle to the GUI and to the unit selection API (including smart select). They are excluded from sound notifications re: idleness, however.