### PR TITLE
Remove keybinding default-to-legacy migration code

### DIFF
--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -32,16 +32,6 @@ local function reloadWidgetsBindings()
 end
 
 
-local function replaceDefaultWithLegacy(file)
-	if file == 'luaui/configs/hotkeys/default_keys.txt' then
-		return 'luaui/configs/hotkeys/legacy_keys.txt'
-	end
-	if file == 'luaui/configs/hotkeys/default_keys_60pct.txt' then
-		return 'luaui/configs/hotkeys/legacy_keys_60pct.txt'
-	end
-end
-
-
 -- if keybinds are missing, load default hotkeys
 local function fallbackToDefault(currentKeys)
 	local default = keyConfig.keybindingLayoutFiles[1]
@@ -57,13 +47,6 @@ local function reloadBindings()
 
 	currentKeybindingsFile = Spring.GetConfigString("KeybindingFile", keyConfig.keybindingLayoutFiles[1])
 
-	-- detect if old "default" settings are present, replace with "legacy"
-	local usingOldPreset = string.find(currentKeybindingsFile, "default") and true or false
-	if usingOldPreset then
-		currentKeybindingsFile = replaceDefaultWithLegacy(currentKeybindingsFile)
-		spEcho("BAR Hotkeys: Found old default key config, replacing with legacy", currentKeybindingsFile)
-	end
-
 	if not VFS.FileExists(currentKeybindingsFile) then
 		currentKeybindingsFile = fallbackToDefault(currentKeybindingsFile)
 	end
@@ -71,10 +54,6 @@ local function reloadBindings()
 	if VFS.FileExists(currentKeybindingsFile) then
 		Spring.SendCommands("keyreload " .. currentKeybindingsFile)
 		spEcho("BAR Hotkeys: Loaded hotkeys from " .. currentKeybindingsFile)
-		if usingOldPreset then
-			-- resolve upgrading from old "default" to "legacy"
-			Spring.SetConfigString("KeybindingFile", currentKeybindingsFile)
-		end
 	else
 		spEcho("BAR Hotkeys: No hotkey file found")
 	end

--- a/luaui/configs/hotkeys/default_keys.txt
+++ b/luaui/configs/hotkeys/default_keys.txt
@@ -1,4 +1,0 @@
-// This is a placeholder file to ease the transition to grid as default
-// lots of custom hotkey setups got broken by this namechange.
-// TODO: After 1 year (may 2025) delete these
-keyload luaui/configs/hotkeys/legacy_keys.txt

--- a/luaui/configs/hotkeys/default_keys_60pct.txt
+++ b/luaui/configs/hotkeys/default_keys_60pct.txt
@@ -1,4 +1,0 @@
-// This is a placeholder file to ease the transition to grid as default
-// lots of custom hotkey setups got broken by this namechange.
-// TODO: After 1 year (may 2025) delete these
-keyload luaui/configs/hotkeys/legacy_keys_60pct.txt


### PR DESCRIPTION
Closes #5010.

The default->grid keybind default switch happened over a year ago, and the placeholder configs were marked for deletion after May 2025, so this drops the leftover migration code. It removes the two placeholder files (default_keys.txt and default_keys_60pct.txt, which only redirected to the legacy configs) and the matching default->legacy remapping in cmd_bar_hotkeys.lua.

After this, anyone whose KeybindingFile still points at a default_keys*.txt would fall through to the grid keys fallback instead of being quietly redirected to legacy. Per the issue, those users should change any `keyload *default*.txt` in their own configs to `*legacy*.txt` - probably worth a heads-up on the #keybinding-support Discord channel and a ping to the Keybind Warrior role around when this merges.

I didn't find anything else referencing the removed files or functions. I haven't run the game to confirm the fallback path, just verified by reading the code.

AI disclosure: drafted with AI assistance (Claude).