### PR TITLE
fix: cortex decoy commanders able to fly in light transports

### DIFF
--- a/units/ArmBots/T2/armdecom.lua
+++ b/units/ArmBots/T2/armdecom.lua
@@ -26,6 +26,7 @@ return {
 		health = 3700,
 		hidedamage = true,
 		holdsteady = true,
+		mass = 2700, -- same as armcom's default mass (= metalcost)
 		maxacc = 0.18,
 		maxdec = 1.125,
 		maxslope = 20,

--- a/units/CorBots/T2/cordecom.lua
+++ b/units/CorBots/T2/cordecom.lua
@@ -31,6 +31,7 @@ return {
 		maxslope = 20,
 		maxwaterdepth = 35,
 		metalcost = 750,
+		mass = 2700, -- same as corcom's default mass (= metalcost)
 		mincloakdistance = 50,
 		movementclass = "COMMANDERBOT",
 		nochasecategory = "VTOL",

--- a/units/Legion/Bots/T2 Bots/legdecom.lua
+++ b/units/Legion/Bots/T2 Bots/legdecom.lua
@@ -28,7 +28,7 @@ return {
 		footprintz = 3,
 		hidedamage = true,
    		holdsteady = true,
-		mass = 4900,
+		mass = 2700, -- same as legcom's default mass (= metalcost)
 		health = 3700,
 		maxslope = 20,
 		speed = 37.5,

--- a/units/Legion/legcom.lua
+++ b/units/Legion/legcom.lua
@@ -30,7 +30,6 @@ return {
 		hidedamage = true,
     	holdsteady = true,
 		sightemitheight = 40,
-		mass = 4999,
 		health = 3700,
 		maxslope = 20,
 		speed = 37.5,


### PR DESCRIPTION
Mass (for transport purposes), if not set, uses the unit's metalcost
value. Decoy commanders for Armada and Cortex didn't have a mass set, so
their 20 metal cost difference made cordecom able to fly in a light transport.

### Work done
I'm setting the masses to be equal to the original commanders' metal
cost values - that's one less way you can figure out a decoy is a decoy!

While at it, I checked legion commander + decoy - those had some
insanely high masses, so I standardized them to the metal cost.

#### Addresses Issue(s)
As per bug report in https://discord.com/channels/549281623154229250/1521788180653932584 and GDT thread in
https://discord.com/channels/549281623154229250/1521801153367511121.


#### Setup
- spawn a light transport (`corvalk`, `armatlas`) and a `cordecom`

#### Test steps
- try to lift decoy
- decoy should not be lifted

<img width="923" height="557" alt="image" src="https://github.com/user-attachments/assets/0e85dc62-88fb-4985-ac11-93d49e01bd87" />


### AI / LLM usage statement:

Used Qwen to investigate, as I didn't immediately connect the dots on metal cost -> mass.
