### PR TITLE
Factories canReclaim = false

### DIFF
--- a/units/ArmBuildings/LandFactories/armaap.lua
+++ b/units/ArmBuildings/LandFactories/armaap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMAAP.DDS",
 		buildtime = 32000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 4 0",
 		collisionvolumescales = "144 70 144",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armalab.lua
+++ b/units/ArmBuildings/LandFactories/armalab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMALAB.DDS",
 		buildtime = 25000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "124 75 140",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armap.lua
+++ b/units/ArmBuildings/LandFactories/armap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMAP.DDS",
 		buildtime = 5450,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "134 49 82",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armavp.lua
+++ b/units/ArmBuildings/LandFactories/armavp.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMAVP.DDS",
 		buildtime = 27000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "130 86 140",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armhaap.lua
+++ b/units/ArmBuildings/LandFactories/armhaap.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMAAP.DDS",
 		buildtime = 85000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armhaapuw.lua
+++ b/units/ArmBuildings/LandFactories/armhaapuw.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMPLAT.DDS",
 		buildtime = 42000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 4 0",
 		collisionvolumescales = "144 70 144",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armhalab.lua
+++ b/units/ArmBuildings/LandFactories/armhalab.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMSHLTX.DDS",
 		buildtime = 85000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armhavp.lua
+++ b/units/ArmBuildings/LandFactories/armhavp.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMHAVP.DDS",
 		buildtime = 85000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armhp.lua
+++ b/units/ArmBuildings/LandFactories/armhp.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMHP.DDS",
 		buildtime = 8700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumescales = "100 40 90",
 		collisionvolumetype = "Box",
 		corpse = "DEAD",

--- a/units/ArmBuildings/LandFactories/armlab.lua
+++ b/units/ArmBuildings/LandFactories/armlab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMLAB.DDS",
 		buildtime = 5000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 -1 0",
 		collisionvolumescales = "84 22 84",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armsaap.lua
+++ b/units/ArmBuildings/LandFactories/armsaap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "LEGAAP.DDS",
 		buildtime = 52000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 4 0",
 		collisionvolumescales = "144 70 144",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armsalab.lua
+++ b/units/ArmBuildings/LandFactories/armsalab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "LEGALAB.DDS",
 		buildtime = 51000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "124 75 140",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armsavp.lua
+++ b/units/ArmBuildings/LandFactories/armsavp.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "LEGAVP.DDS",
 		buildtime = 51000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "130 86 140",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armshltx.lua
+++ b/units/ArmBuildings/LandFactories/armshltx.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMSHLTX.DDS",
 		buildtime = 62000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/LandFactories/armvp.lua
+++ b/units/ArmBuildings/LandFactories/armvp.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMVP.DDS",
 		buildtime = 5700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumescales = "120 34 92",
 		collisionvolumetype = "Box",
 		corpse = "DEAD",

--- a/units/ArmBuildings/SeaFactories/armamsub.lua
+++ b/units/ArmBuildings/SeaFactories/armamsub.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMAMSUB.DDS",
 		buildtime = 11100,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 16 0",
 		collisionvolumescales = "96 42 96",
 		collisionvolumetype = "CylY",

--- a/units/ArmBuildings/SeaFactories/armasy.lua
+++ b/units/ArmBuildings/SeaFactories/armasy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMASY.DDS",
 		buildtime = 24000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 -9 -2",
 		collisionvolumescales = "192 60 192",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/SeaFactories/armfhp.lua
+++ b/units/ArmBuildings/SeaFactories/armfhp.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMFHP.DDS",
 		buildtime = 8700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumescales = "100 40 90",
 		collisionvolumetype = "Box",
 		corpse = "DEAD",

--- a/units/ArmBuildings/SeaFactories/armhasy.lua
+++ b/units/ArmBuildings/SeaFactories/armhasy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMSHLTXUW.DDS",
 		buildtime = 85000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "256 80 221",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/SeaFactories/armplat.lua
+++ b/units/ArmBuildings/SeaFactories/armplat.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "ARMPLAT.DDS",
 		buildtime = 12000,
 		canmove = true,
+		canReclaim = false,
 		category = "SURFACE UNDERWATER",
 		corpse = "DEAD",
 		energycost = 5000,

--- a/units/ArmBuildings/SeaFactories/armsasy.lua
+++ b/units/ArmBuildings/SeaFactories/armsasy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMASY.DDS",
 		buildtime = 30000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 -9 -2",
 		collisionvolumescales = "192 60 192",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/SeaFactories/armshltxuw.lua
+++ b/units/ArmBuildings/SeaFactories/armshltxuw.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMSHLTXUW.DDS",
 		buildtime = 62000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",

--- a/units/ArmBuildings/SeaFactories/armsy.lua
+++ b/units/ArmBuildings/SeaFactories/armsy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "ARMSY.DDS",
 		buildtime = 5160,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 16 0",
 		collisionvolumescales = "90 60 90",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/coraap.lua
+++ b/units/CorBuildings/LandFactories/coraap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORAAP.DDS",
 		buildtime = 32000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 4 0",
 		collisionvolumescales = "142 64 142",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/coralab.lua
+++ b/units/CorBuildings/LandFactories/coralab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORALAB.DDS",
 		buildtime = 26000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 2 0",
 		collisionvolumescales = "144 56 144",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corap.lua
+++ b/units/CorBuildings/LandFactories/corap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORAP.DDS",
 		buildtime = 5380,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "128 33 96",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/coravp.lua
+++ b/units/CorBuildings/LandFactories/coravp.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORAVP.DDS",
 		buildtime = 28000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 8 0",
 		collisionvolumescales = "144 70 144",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corgant.lua
+++ b/units/CorBuildings/LandFactories/corgant.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORGANT.DDS",
 		buildtime = 68000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 110 196",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corhaap.lua
+++ b/units/CorBuildings/LandFactories/corhaap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORAAP.DDS",
 		buildtime = 92000,
 		canmove = true,
+		canReclaim = false,
 		corpse = "DEAD",
 		energycost = 65000,
 		energystorage = 1400,

--- a/units/CorBuildings/LandFactories/corhaapuw.lua
+++ b/units/CorBuildings/LandFactories/corhaapuw.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORPLAT.DDS",
 		buildtime = 42000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 4 0",
 		collisionvolumescales = "142 64 142",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corhalab.lua
+++ b/units/CorBuildings/LandFactories/corhalab.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORGANT.DDS",
 		buildtime = 92000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 110 196",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corhavp.lua
+++ b/units/CorBuildings/LandFactories/corhavp.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORHAVP.DDS",
 		buildtime = 92000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 110 196",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corhp.lua
+++ b/units/CorBuildings/LandFactories/corhp.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORHP.DDS",
 		buildtime = 8700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 5 0",
 		collisionvolumescales = "96 32 96",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corlab.lua
+++ b/units/CorBuildings/LandFactories/corlab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORLAB.DDS",
 		buildtime = 5000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "93 92 87",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corsaap.lua
+++ b/units/CorBuildings/LandFactories/corsaap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "LEGAAP.DDS",
 		buildtime = 51000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 4 0",
 		collisionvolumescales = "142 64 142",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corsalab.lua
+++ b/units/CorBuildings/LandFactories/corsalab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "LEGALAB.DDS",
 		buildtime = 51000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 2 0",
 		collisionvolumescales = "144 56 144",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corsavp.lua
+++ b/units/CorBuildings/LandFactories/corsavp.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "LEGAVP.DDS",
 		buildtime = 51000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 8 0",
 		collisionvolumescales = "144 70 144",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/corvp.lua
+++ b/units/CorBuildings/LandFactories/corvp.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORVP.DDS",
 		buildtime = 5650,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 5 0",
 		collisionvolumescales = "96 40 96",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/LandFactories/leghaap.lua
+++ b/units/CorBuildings/LandFactories/leghaap.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORHAAP.DDS",
 		buildtime = 92000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 110 196",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/coramsub.lua
+++ b/units/CorBuildings/SeaFactories/coramsub.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORAMSUB.DDS",
 		buildtime = 11400,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 -6",
 		collisionvolumescales = "96 30 96",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corasy.lua
+++ b/units/CorBuildings/SeaFactories/corasy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORASY.DDS",
 		buildtime = 24000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 10 -2",
 		collisionvolumescales = "186 78 183",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corfhp.lua
+++ b/units/CorBuildings/SeaFactories/corfhp.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORFHP.DDS",
 		buildtime = 8700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 5 0",
 		collisionvolumescales = "96 32 96",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corgantuw.lua
+++ b/units/CorBuildings/SeaFactories/corgantuw.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORGANTUW.DDS",
 		buildtime = 68000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 110 196",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corhasy.lua
+++ b/units/CorBuildings/SeaFactories/corhasy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORGANTUW.DDS",
 		buildtime = 92000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "260 146 260",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corplat.lua
+++ b/units/CorBuildings/SeaFactories/corplat.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "CORPLAT.DDS",
 		buildtime = 11800,
 		canmove = true,
+		canReclaim = false,
 		category = "SURFACE UNDERWATER",
 		corpse = "DEAD",
 		energycost = 5500,

--- a/units/CorBuildings/SeaFactories/corsasy.lua
+++ b/units/CorBuildings/SeaFactories/corsasy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORASY.DDS",
 		buildtime = 51000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 10 -2",
 		collisionvolumescales = "186 78 183",
 		collisionvolumetype = "Box",

--- a/units/CorBuildings/SeaFactories/corsy.lua
+++ b/units/CorBuildings/SeaFactories/corsy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "CORSY.DDS",
 		buildtime = 5100,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "96 59 96",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legaap.lua
+++ b/units/Legion/Labs/legaap.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "LEGAAP.DDS",
 		buildtime = 31050,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "142 50 142",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legadvshipyard.lua
+++ b/units/Legion/Labs/legadvshipyard.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "legadvshipyard.DDS",
 		buildtime = 23550,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 10 -2",
 		collisionvolumescales = "186 78 183",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legalab.lua
+++ b/units/Legion/Labs/legalab.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "LEGALAB.DDS",
 		buildtime = 25200,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "140 52 140",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legamphlab.lua
+++ b/units/Legion/Labs/legamphlab.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "legamphlab.DDS",
 		buildtime = 11400,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 5 0",
 		collisionvolumescales = "98 60 91",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legap.lua
+++ b/units/Legion/Labs/legap.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "LEGAP.DDS",
 		buildtime = 6380,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "96 45 96",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legavp.lua
+++ b/units/Legion/Labs/legavp.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "LEGAVP.DDS",
 		buildtime = 27750,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 5",
 		collisionvolumescales = "144 70 144",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legfhp.lua
+++ b/units/Legion/Labs/legfhp.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGFHP.DDS",
 		buildtime = 8700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "96 35 96",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/leggant.lua
+++ b/units/Legion/Labs/leggant.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGGANT.DDS",
 		buildtime = 67300,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 105 196",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/leggantuw.lua
+++ b/units/Legion/Labs/leggantuw.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGGANTUW.DDS",
 		buildtime = 67300,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 105 196",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/leghalab.lua
+++ b/units/Legion/Labs/leghalab.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGGANT.DDS",
 		buildtime = 67300,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 105 196",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/leghavp.lua
+++ b/units/Legion/Labs/leghavp.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGHAVP.DDS",
 		buildtime = 67300,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 12 0",
 		collisionvolumescales = "196 105 196",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/leghp.lua
+++ b/units/Legion/Labs/leghp.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGHP.DDS",
 		buildtime = 8700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "96 35 96",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/leglab.lua
+++ b/units/Legion/Labs/leglab.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "LEGLAB.DDS",
 		buildtime = 5000,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 5 0",
 		collisionvolumescales = "100 45 100",
 		collisionvolumetype = "CylY",

--- a/units/Legion/Labs/legsplab.lua
+++ b/units/Legion/Labs/legsplab.lua
@@ -5,6 +5,7 @@ return {
 		buildpic = "legsplab.DDS",
 		buildtime = 11800,
 		canmove = true,
+		canReclaim = false,
 		category = "SURFACE UNDERWATER",
 		corpse = "DEAD",
 		energycost = 5500,

--- a/units/Legion/Labs/legsy.lua
+++ b/units/Legion/Labs/legsy.lua
@@ -4,6 +4,7 @@ return {
 		buildpic = "legsy.DDS",
 		buildtime = 5100,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "96 42 96",
 		collisionvolumetype = "Box",

--- a/units/Legion/Labs/legvp.lua
+++ b/units/Legion/Labs/legvp.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "LEGVP.DDS",
 		buildtime = 5700,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 19 0",
 		collisionvolumescales = "101 53 106",
 		collisionvolumetype = "Box",

--- a/units/Scavengers/Buildings/Factories/armapt3.lua
+++ b/units/Scavengers/Buildings/Factories/armapt3.lua
@@ -9,6 +9,7 @@ return {
 		buildpic = "ARMAP.DDS",
 		buildtime = 72400,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 8 1",
 		collisionvolumescales = "268 98 164",
 		collisionvolumetype = "Box",

--- a/units/Scavengers/Buildings/Factories/corapt3.lua
+++ b/units/Scavengers/Buildings/Factories/corapt3.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "CORAP.DDS",
 		buildtime = 72400,
 		canmove = true,
+		canReclaim = false,
 		collisionvolumeoffsets = "0 -14 -23",
 		collisionvolumescales = "220 66 100",
 		collisionvolumetype = "Box",

--- a/units/Scavengers/Buildings/Factories/legapt3.lua
+++ b/units/Scavengers/Buildings/Factories/legapt3.lua
@@ -8,6 +8,7 @@ return {
 		buildpic = "LEGAP.DDS",
 		buildtime = 72400,
 		canmove = true,
+		canReclaim = false,
 		category = "ALL NOTLAND NOWEAPON NOTSUB NOTSHIP NOTAIR NOTHOVER SURFACE EMPABLE",
 		collisionvolumeoffsets = "0 -14 -23",
 		collisionvolumescales = "220 66 100",


### PR DESCRIPTION
Since they're builders and canReclaim is undefined, it seems the engine considers them as able to reclaim things. This is impossible for them to actually do as factories. This messes up the WIP FireState Defend I'm working on. https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8139

Merge this with it.