### PR TITLE
fix: make press-only widget actions reachable from mouse-button binds

### DIFF
--- a/luaui/Widgets/camera_flip.lua
+++ b/luaui/Widgets/camera_flip.lua
@@ -72,5 +72,5 @@ local function cameraFlipHandler()
 end
 
 function widget:Initialize()
-	widgetHandler:AddAction("cameraflip", cameraFlipHandler, nil, "p")
+	widgetHandler:AddAction("cameraflip", cameraFlipHandler, nil, "pt")
 end

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -1215,12 +1215,12 @@ function widget:Initialize()
 	loadBlueprintsFromFile()
 	loadedBlueprints = true
 
-	widgetHandler.actionHandler:AddAction(self, "blueprint_create", handleBlueprintCreateAction, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "blueprint_next", handleBlueprintNextAction, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "blueprint_prev", handleBlueprintPrevAction, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "blueprint_delete", handleBlueprintDeleteAction, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "buildfacing", handleFacingAction, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "buildspacing", handleSpacingAction, nil, "p")
+	widgetHandler.actionHandler:AddAction(self, "blueprint_create", handleBlueprintCreateAction, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "blueprint_next", handleBlueprintNextAction, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "blueprint_prev", handleBlueprintPrevAction, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "blueprint_delete", handleBlueprintDeleteAction, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "buildfacing", handleFacingAction, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "buildspacing", handleSpacingAction, nil, "pt")
 
 	widget:SelectionChanged(spGetSelectedUnits())
 end

--- a/luaui/Widgets/cmd_chainactions.lua
+++ b/luaui/Widgets/cmd_chainactions.lua
@@ -85,5 +85,5 @@ local function chainHandler(_, extra, bOpts, _, isRepeat, isRelease)
 end
 
 function widget:Initialize()
-	widgetHandler.actionHandler:AddAction(self, "chain", chainHandler, nil, "p")
+	widgetHandler.actionHandler:AddAction(self, "chain", chainHandler, nil, "pt")
 end

--- a/luaui/Widgets/cmd_commandq_manager.lua
+++ b/luaui/Widgets/cmd_commandq_manager.lua
@@ -14,8 +14,8 @@ end
 
 -- Handlers
 function widget:Initialize()
-	widgetHandler:AddAction("command_skip_current", SkipCurrentCommand, nil, "p")
-	widgetHandler:AddAction("command_cancel_last", CancelLastCommand, nil, "p")
+	widgetHandler:AddAction("command_skip_current", SkipCurrentCommand, nil, "pt")
+	widgetHandler:AddAction("command_cancel_last", CancelLastCommand, nil, "pt")
 end
 
 -- Locals

--- a/luaui/Widgets/cmd_comselect.lua
+++ b/luaui/Widgets/cmd_comselect.lua
@@ -124,5 +124,5 @@ function widget:Initialize()
 
 	myTeamID = spGetMyTeamID()
 
-	widgetHandler:AddAction("selectcomm", handleSelectComm, nil, "p")
+	widgetHandler:AddAction("selectcomm", handleSelectComm, nil, "pt")
 end

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -746,7 +746,7 @@ function widget:Initialize()
 
 	curModId = string.upper(Game.gameShortName or "")
 
-	widgetHandler:AddAction("factory_preset", factoryPresetKeyHandler, nil, "p")
+	widgetHandler:AddAction("factory_preset", factoryPresetKeyHandler, nil, "pt")
 	widgetHandler:AddAction("factory_preset_show", factoryPresetRender, {true}, "p")
 	widgetHandler:AddAction("factory_preset_show", factoryPresetRender, {false}, "r")
 end

--- a/luaui/Widgets/cmd_onoff.lua
+++ b/luaui/Widgets/cmd_onoff.lua
@@ -47,5 +47,5 @@ local function onoff(_, _, args)
 end
 
 function widget:Initialize()
-	widgetHandler:AddAction("onoff", onoff, nil, "p")
+	widgetHandler:AddAction("onoff", onoff, nil, "pt")
 end

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -995,9 +995,9 @@ function widget:Initialize()
 		unitToggles[i] = v
 	end
 
-	widgetHandler:AddAction("cursor_range_toggle", toggleCursorRange, nil, "p")
-	widgetHandler:AddAction("attack_range_inc", cycleUnitDisplayHandler, {direction = 1}, "p")
-	widgetHandler:AddAction("attack_range_dec", cycleUnitDisplayHandler, {direction = -1}, "p")
+	widgetHandler:AddAction("cursor_range_toggle", toggleCursorRange, nil, "pt")
+	widgetHandler:AddAction("attack_range_inc", cycleUnitDisplayHandler, {direction = 1}, "pt")
+	widgetHandler:AddAction("attack_range_dec", cycleUnitDisplayHandler, {direction = -1}, "pt")
 
 	myAllyTeam = Spring.GetMyAllyTeamID()
 	myTeamID = spGetMyTeamID()

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1390,9 +1390,9 @@ function widget:Initialize()
 
 
 	widgetHandler.actionHandler:AddAction(self, "gridmenu_key", gridmenuKeyHandler, nil, "pR")
-	widgetHandler.actionHandler:AddAction(self, "gridmenu_category", gridmenuCategoryHandler, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "gridmenu_next_page", nextPageHandler, nil, "p")
-	widgetHandler.actionHandler:AddAction(self, "gridmenu_cycle_builder", cycleBuilder, nil, "p")
+	widgetHandler.actionHandler:AddAction(self, "gridmenu_category", gridmenuCategoryHandler, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "gridmenu_next_page", nextPageHandler, nil, "pt")
+	widgetHandler.actionHandler:AddAction(self, "gridmenu_cycle_builder", cycleBuilder, nil, "pt")
 
 	reloadBindings()
 

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -247,10 +247,10 @@ end
 ---               INIT                 ---
 ------------------------------------------
 function widget:Initialize()
-	widgetHandler:AddAction("stop", clearPregameBuildQueue, nil, "p")
-	widgetHandler:AddAction("buildfacing", buildFacingHandler, nil, "p")
-	widgetHandler:AddAction("buildspacing", buildSpacingHandler, nil, "p")
-	widgetHandler:AddAction("buildmenu_pregame_deselect", buildmenuPregameDeselectHandler, nil, "p")
+	widgetHandler:AddAction("stop", clearPregameBuildQueue, nil, "pt")
+	widgetHandler:AddAction("buildfacing", buildFacingHandler, nil, "pt")
+	widgetHandler:AddAction("buildspacing", buildSpacingHandler, nil, "pt")
+	widgetHandler:AddAction("buildmenu_pregame_deselect", buildmenuPregameDeselectHandler, nil, "pt")
 
 	Spring.Log(widget:GetInfo().name, LOG.INFO, "Pregame Queue Initializing. Local SubLogic is assumed available.")
 

--- a/luaui/Widgets/gui_teamstats.lua
+++ b/luaui/Widgets/gui_teamstats.lua
@@ -268,7 +268,7 @@ local function closeHandler()
 end
 
 function widget:Initialize()
-	widgetHandler:AddAction("teamstatus_close", closeHandler, nil, "p")
+	widgetHandler:AddAction("teamstatus_close", closeHandler, nil, "pt")
 
 	refreshHeaders()
 	guiData.mainPanel.visible = false

--- a/luaui/Widgets/minimap_rotation_manager.lua
+++ b/luaui/Widgets/minimap_rotation_manager.lua
@@ -243,7 +243,7 @@ function widget:Initialize()
 
 	Spring.SetConfigInt("MiniMapCanFlip", 0)
 
-	widgetHandler:AddAction("minimap_rotate", minimapRotateHandler, nil, "p")
+	widgetHandler:AddAction("minimap_rotate", minimapRotateHandler, nil, "pt")
 
 	-- Apply the current camera heading immediately so the minimap starts in the
 	-- correct orientation on game start/reload, without waiting for the first

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -251,10 +251,10 @@ function widget:Initialize()
 
 	widget:PlayerChanged()
 
-	widgetHandler:AddAction("add_to_autogroup", changeUnitTypeAutogroupHandler, nil, "p") -- With a parameter, adds all units of this type to a specific autogroup
-	widgetHandler:AddAction("remove_from_autogroup", changeUnitTypeAutogroupHandler, { removeAll = true }, "p") -- Without a parameter, removes all units of this type from autogroups
-	widgetHandler:AddAction("remove_one_unit_from_group", removeOneUnitFromGroupHandler, nil, "p") -- Removes the closest of selected units from groups and selects only it
-	widgetHandler:AddAction("load_autogroup_preset", loadAutogroupPresetHandler, nil, "p") -- Changes the autogroup preset
+	widgetHandler:AddAction("add_to_autogroup", changeUnitTypeAutogroupHandler, nil, "pt") -- With a parameter, adds all units of this type to a specific autogroup
+	widgetHandler:AddAction("remove_from_autogroup", changeUnitTypeAutogroupHandler, { removeAll = true }, "pt") -- Without a parameter, removes all units of this type from autogroups
+	widgetHandler:AddAction("remove_one_unit_from_group", removeOneUnitFromGroupHandler, nil, "pt") -- Removes the closest of selected units from groups and selects only it
+	widgetHandler:AddAction("load_autogroup_preset", loadAutogroupPresetHandler, nil, "pt") -- Changes the autogroup preset
 
 	WG['autogroup'] = {}
 	WG['autogroup'].getImmediate = function()

--- a/luaui/Widgets/unit_key_select.lua
+++ b/luaui/Widgets/unit_key_select.lua
@@ -22,7 +22,7 @@ local function handleSetCommand(_, commandDef)
 end
 
 function widget:Initialize()
-	widgetHandler:AddAction("select", handleSetCommand, nil, "p")
+	widgetHandler:AddAction("select", handleSetCommand, nil, "pt")
 end
 
 function widget:Shutdown()

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -167,7 +167,7 @@ function widget:Initialize()
 	widgetHandler:AddAction("stateprefs_record", onRecordRelease, nil, "r")
 	widgetHandler:AddAction("stateprefs_clear", onClearPress, nil, "p")
 	widgetHandler:AddAction("stateprefs_clear", onClearRelease, nil, "r")
-	widgetHandler:AddAction("stateprefs_clearunit", doClearUnit, nil, "p")
+	widgetHandler:AddAction("stateprefs_clearunit", doClearUnit, nil, "pt")
 
 	priorUserFirestateFunction = WG['firestate'].userFirestateChanged
 	WG['firestate'].userFirestateChanged = recordUserFirestateChanged


### PR DESCRIPTION
### Work done

Follow-up to #7952, which fixed the `chain` action and flipped its
registration from `"p"` to `"pt"` so it could be triggered from mouse-button
binds. Reviewer feedback on that PR asked for a **separate PR** to audit the
other cases where the same `"p"` → `"pt"` change is appropriate. This is that
audit.

**Background.** Widget actions are registered with `actionHandler:AddAction(self, name, fn, data, types)`,
where `types` selects the dispatch sets the action lives in:
- `"p"` (key-press) → `keyPressActions`, reached by **keyboard** binds via `actionHandler:KeyAction`.
- `"t"` (text) → `textActions`, reached by **mouse-button** binds and the console via `actionHandler:TextAction`.

An action registered `"p"`-only is invisible to the text path, so binding it to
a mouse button silently does nothing. On the text path the handler is invoked
exactly like a press (`isRepeat = false`, `release = nil`), so making a one-shot
press action `"pt"` is safe and simply extends it to mouse binds and the console.

**Change.** Converted **30 one-shot press actions across 14 widgets** from `"p"`
to `"pt"`:

| Widget | Actions |
|---|---|
| `camera_flip` | `cameraflip` |
| `cmd_blueprint` | `blueprint_create`, `blueprint_next`, `blueprint_prev`, `blueprint_delete`, `buildfacing`, `buildspacing` |
| `cmd_commandq_manager` | `command_skip_current`, `command_cancel_last` |
| `cmd_comselect` | `selectcomm` |
| `cmd_onoff` | `onoff` |
| `cmd_factoryqmanager` | `factory_preset` |
| `gui_attackrange_gl4` | `cursor_range_toggle`, `attack_range_inc`, `attack_range_dec` |
| `gui_teamstats` | `teamstatus_close` |
| `minimap_rotation_manager` | `minimap_rotate` |
| `gui_gridmenu` | `gridmenu_category`, `gridmenu_next_page`, `gridmenu_cycle_builder` |
| `gui_pregame_build` | `stop`, `buildfacing`, `buildspacing`, `buildmenu_pregame_deselect` |
| `unit_auto_group` | `add_to_autogroup`, `remove_from_autogroup`, `remove_one_unit_from_group`, `load_autogroup_preset` |
| `unit_key_select` | `select` |
| `unit_stateprefs` | `stateprefs_clearunit` |

**Deliberately left as `"p"` (hold-to-activate).** Every action that registers a
`"p"` press paired with an `"r"` release — the modifier is set true on press and
false on release — is **not** converted. A mouse/text bind cannot fire the
release, so adding `"t"` would leave the modifier stuck on. These are:
`buildsplit`, `commandinsert`, `factory_preset_show`, `reclaim_highlight`,
`unit_stats`, `selectloop`/`selectloop_deselect`/`selectloop_add`,
`selectbox`/`selectbox_<modifier>`, `stateprefs_record`, `stateprefs_clear`.
(Note `stateprefs_clearunit` **is** converted — it is one-shot and has no paired
release, unlike its siblings.)

No handler logic changed; only the `types` string on the `AddAction` calls.

#### Addresses Issue(s)
- Review feedback on #7952

#### Test steps

**1. Widget load / no errors (all conversions)**
- [ ] Start a skirmish and let all default widgets load.
- [ ] Confirm no Lua errors in `infolog.txt`. All converted widgets that are
  enabled by default (CameraFlip, TeamStats, Attack Range GL4, Commander
  Selector, Onoff, Minimap Rotation Manager, Grid menu, Auto Group, Blueprint,
  Command Queue Manager, Pregame Queue, State Prefs V2) loaded cleanly with no
  error following their load line. A bad `types` string would throw during
  `widget:Initialize()` — none did. (`cmd_factoryqmanager` and `unit_key_select`
  are disabled by default and were not loaded; their change is inert until
  enabled.)

**2. Mouse-button bind now works (the fix)**
- [ ] `/bind mouse5 cameraflip` in the console, then press **mouse5** → camera
  flips 180°. On `master` the identical bind does nothing. This before/after
  difference confirms the fix.
- [ ] Spot-checked additional converted actions from separate widgets via mouse
  bind (e.g. `/bind mouse4 attack_range_inc` cycles the range display;
  `/bind mouse5 minimap_rotate` steps minimap rotation) — all now respond to the
  mouse button.

**3. Keyboard binds still work (regression)**
- [ ] The same actions bound to a keyboard key behave exactly as before the
  change — no double-dispatch, no change in keyboard behaviour.

**4. Hold-to-activate actions untouched (regression)**
- [ ] Verified an excluded action (`buildsplit`, kept `"p"`) still activates on
  keyboard hold and releases cleanly — no stuck modifier. Confirmed none of the
  paired press/release actions were converted.

### AI / LLM usage statement:
The audit and code changes were produced with Claude (Opus 4.8); the human
contribution was identifying the follow-up scope, reviewing each candidate, and
validating the fixes in-game.
