### PR TITLE
cmd_undo: restore killed units to their original teams

### DIFF
--- a/luarules/gadgets/cmd_undo.lua
+++ b/luarules/gadgets/cmd_undo.lua
@@ -159,7 +159,8 @@ if gadgetHandler:IsSyncedCode() then
 					end
 				end
 
-				local unitID = Spring.CreateUnit(params[2], unitX, Spring.GetGroundHeight(unitX, unitZ), unitZ, params[7], toTeamID)
+				local restoreTeamID = params[11] or toTeamID
+				local unitID = Spring.CreateUnit(params[2], unitX, Spring.GetGroundHeight(unitX, unitZ), unitZ, params[7], restoreTeamID)
 				if unitID ~= nil then
 					Spring.SetUnitHealth(unitID, params[3])
 					Spring.SetUnitDirection(unitID, params[8], params[9], params[10])
@@ -291,6 +292,7 @@ if gadgetHandler:IsSyncedCode() then
 			local health, maxHealth = Spring.GetUnitHealth(unitID)
 			local buildFacing = Spring.GetUnitBuildFacing(unitID)
 			local dx, dy, dz = Spring.GetUnitDirection(unitID)
+			local originalTeamID = teamID  -- capture before potential overwrite below
 			if attackerID ~= nil then
 				teamID = attackerTeamID or Spring.GetUnitTeam(attackerID) or teamID
 				health = maxHealth -- health only applicable to actual selfd units
@@ -299,7 +301,7 @@ if gadgetHandler:IsSyncedCode() then
 			if teamSelfdUnits[teamID] == nil then
 				teamSelfdUnits[teamID] = {}
 			end
-			teamSelfdUnits[teamID][unitID] = {Spring.GetGameFrame(), unitDefID, health, ux, uy, uz, buildFacing, dx, dy, dz}
+			teamSelfdUnits[teamID][unitID] = {Spring.GetGameFrame(), unitDefID, health, ux, uy, uz, buildFacing, dx, dy, dz, originalTeamID}
 		end
 
 		selfdCmdUnits[unitID] = nil


### PR DESCRIPTION
When a selfd kills units belonging to multiple allied teams, restoreUnits previously sent everything to a single toTeamID. This change stores each unit's original teamID as params[11] in the log entry at UnitDestroyed, captured before teamID is overwritten for chain kills. restoreUnits then uses params[11] or toTeamID so each unit is returned to its correct owner. Falls back to toTeamID for backward compatibility.


### AI / LLM usage statement:
Visual Studio with Claude Code

