### PR TITLE
fix firestate > gridmenu keybind ordering since defend firestate

### DIFF
--- a/luaui/Include/ordermenu_firestate.lua
+++ b/luaui/Include/ordermenu_firestate.lua
@@ -193,11 +193,13 @@ local function hotkeyHandler(cmd, optLine, optWords, data, isRepeat, release)
 		if targetIndex < 1 or targetIndex > DIRECT_BIND_MAX then
 			return false
 		end
-		return giveVirtualIndex(targetIndex, 0)
+		giveVirtualIndex(targetIndex, 0)
+		return false
 	end
 	local _, _, shift = spGetModKeyState()
 	local nextIndex = nextCycledVirtualIndex(virtualIndex, shift)
-	return giveVirtualIndex(nextIndex, 0)
+	giveVirtualIndex(nextIndex, 0)
+	return false
 end
 
 local function commandNotify(cmdID, cmdParams, cmdOptions)

--- a/luaui/Include/ordermenu_firestate.lua
+++ b/luaui/Include/ordermenu_firestate.lua
@@ -175,8 +175,18 @@ local function nextCycledVirtualIndex(virtualIndex, reverse)
 	return virtualIndex + 1
 end
 
+local function shouldDeferToGridMenu()
+	if not WG.gridmenu or not WG.gridmenu.getActiveBuilder then
+		return false
+	end
+	return WG.gridmenu.getActiveBuilder() ~= nil
+end
+
 local function hotkeyHandler(cmd, optLine, optWords, data, isRepeat, release)
 	if release then
+		return false
+	end
+	if shouldDeferToGridMenu() then
 		return false
 	end
 	local selectedUnits = spGetSelectedUnits()

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1346,6 +1346,9 @@ function widget:Initialize()
 		widget:SelectionChanged(Spring.GetSelectedUnits())
 	end
 
+	WG["gridmenu"].getActiveBuilder = function()
+		return activeBuilder
+	end
 	WG["gridmenu"].getAlwaysReturn = function()
 		return alwaysReturn
 	end


### PR DESCRIPTION
since update firestate in gui_ordermenu's firestate toggle would eat a keybind before it could affect gridmenu. It used to be the reverse. This reverses the reversal universally.

Works as it did pre-update now.