### PR TITLE
feat(gadgets): parameterize split weapon behaviour for customized fanning and trigger altitudes

### DIFF
--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -455,7 +455,7 @@ if gadgetHandler:IsSyncedCode() then
 			subPermission = "test"
 		elseif cmd == "givecat" or cmd == "xpunits" or cmd == "destroyunits" or cmd == "removeunits" or
 			cmd == "removenearbyunits" or cmd == "reclaimunits" or cmd == "transferunits" or
-			cmd == "wreckunits" or cmd == "spawnceg" or cmd == "spawnunitexplosion" or cmd == "removeunitdef" or cmd == "devlegsilo" then
+			cmd == "wreckunits" or cmd == "spawnceg" or cmd == "spawnunitexplosion" or cmd == "removeunitdef" or cmd == "devlegsilo" or cmd == "devnewship" then
 			subPermission = "units"
 		elseif cmd == "playertoteam" or cmd == "killteam" then
 			subPermission = "teams"
@@ -483,6 +483,19 @@ if gadgetHandler:IsSyncedCode() then
 				local unitID = Spring.CreateUnit("legsilo", x, y, z, "n", teamID)
 				if unitID then
 					Spring.SetUnitStockpile(unitID, 1)
+				end
+			end
+		elseif cmd == "devnewship" then
+			local unitName = words[2]
+			local x = tonumber(words[3])
+			local y = tonumber(words[4])
+			local z = tonumber(words[5])
+			local teamID = tonumber(words[6])
+			if unitName and x and y and z and teamID then
+				local unitID = Spring.CreateUnit(unitName, x, y, z, "n", teamID)
+				if unitID then
+					Spring.SetUnitRulesParam(unitID, "use_new_split", 1)
+					Spring.Echo("Spawned [NEW SPLIT] " .. unitName .. " (Unit ID: " .. unitID .. ")")
 				end
 			end
 		elseif cmd == "givecat" then
@@ -777,6 +790,7 @@ else	-- UNSYNCED
 		-- doing it via GotChatMsg ensures it will only listen to the caller
 		gadgetHandler:AddChatAction('givecat', GiveCat, "")   -- Give a category of units, options /luarules givecat [cor|arm|scav|raptor] or /luarules givecat unitname [teamid]
 		gadgetHandler:AddChatAction('devlegsilo', spawnDevLegSilo, "")
+		gadgetHandler:AddChatAction('devnewship', spawnDevNewShip, "")
 		gadgetHandler:AddChatAction('destroyunits', destroyUnits, "")  -- self-destrucs the selected units /luarules destroyunits
 		gadgetHandler:AddChatAction('wreckunits', wreckUnits, "")  -- turns the selected units into wrecks /luarules wreckunits
 		gadgetHandler:AddChatAction('reclaimunits', reclaimUnits, "")  -- reclaims and refunds the selected units /luarules reclaimUnits
@@ -811,6 +825,7 @@ else	-- UNSYNCED
 	function gadget:Shutdown()
 		gadgetHandler:RemoveChatAction('givecat')
 		gadgetHandler:RemoveChatAction('devlegsilo')
+		gadgetHandler:RemoveChatAction('devnewship')
 		gadgetHandler:RemoveChatAction('destroyunits')
 		gadgetHandler:RemoveChatAction('reclaimunits')
 		gadgetHandler:RemoveChatAction('removeunits')
@@ -1400,6 +1415,29 @@ else	-- UNSYNCED
 			local x, y, z = pos[1], pos[2], pos[3]
 			local _, _, _, teamID = Spring.GetPlayerInfo(Spring.GetMyPlayerID(), false)
 			local msg = PACKET_HEADER .. ":devlegsilo " .. math.floor(x) .. " " .. math.floor(y) .. " " .. math.floor(z) .. " " .. teamID
+			Spring.SendLuaRulesMsg(msg)
+		end
+	end
+
+	function spawnDevNewShip(_, line, words, playerID)
+		if playerID ~= Spring.GetMyPlayerID() then
+			return
+		end
+		if not Spring.IsCheatingEnabled() then
+			Spring.Echo("Cheats must be enabled to spawn a test ship. Type /cheat first!")
+			return
+		end
+		local unitName = words[1] or "armmship"
+		if unitName ~= "armmship" and unitName ~= "cormship" then
+			Spring.Echo("Usage: /luarules devnewship [armmship | cormship]")
+			return
+		end
+		local mx, my = Spring.GetMouseState()
+		local t, pos = Spring.TraceScreenRay(mx, my, true)
+		if type(pos) == 'table' then
+			local x, y, z = pos[1], pos[2], pos[3]
+			local _, _, _, teamID = Spring.GetPlayerInfo(Spring.GetMyPlayerID(), false)
+			local msg = PACKET_HEADER .. ":devnewship " .. unitName .. " " .. math.floor(x) .. " " .. math.floor(y) .. " " .. math.floor(z) .. " " .. teamID
 			Spring.SendLuaRulesMsg(msg)
 		end
 	end

--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -455,7 +455,7 @@ if gadgetHandler:IsSyncedCode() then
 			subPermission = "test"
 		elseif cmd == "givecat" or cmd == "xpunits" or cmd == "destroyunits" or cmd == "removeunits" or
 			cmd == "removenearbyunits" or cmd == "reclaimunits" or cmd == "transferunits" or
-			cmd == "wreckunits" or cmd == "spawnceg" or cmd == "spawnunitexplosion" or cmd == "removeunitdef" then
+			cmd == "wreckunits" or cmd == "spawnceg" or cmd == "spawnunitexplosion" or cmd == "removeunitdef" or cmd == "devlegsilo" then
 			subPermission = "units"
 		elseif cmd == "playertoteam" or cmd == "killteam" then
 			subPermission = "teams"
@@ -474,7 +474,18 @@ if gadgetHandler:IsSyncedCode() then
 			Spring.SendCommands("desync")
 		end
 
-		if cmd == "givecat" then
+		if cmd == "devlegsilo" then
+			local x = tonumber(words[2])
+			local y = tonumber(words[3])
+			local z = tonumber(words[4])
+			local teamID = tonumber(words[5])
+			if x and y and z and teamID then
+				local unitID = Spring.CreateUnit("legsilo", x, y, z, "n", teamID)
+				if unitID then
+					Spring.SetUnitStockpile(unitID, 1)
+				end
+			end
+		elseif cmd == "givecat" then
 			GiveCat(words)
 		elseif cmd == "xpunits" then
 			local parts = string.split(msg, ':')
@@ -765,6 +776,7 @@ else	-- UNSYNCED
 	function gadget:Initialize()
 		-- doing it via GotChatMsg ensures it will only listen to the caller
 		gadgetHandler:AddChatAction('givecat', GiveCat, "")   -- Give a category of units, options /luarules givecat [cor|arm|scav|raptor] or /luarules givecat unitname [teamid]
+		gadgetHandler:AddChatAction('devlegsilo', spawnDevLegSilo, "")
 		gadgetHandler:AddChatAction('destroyunits', destroyUnits, "")  -- self-destrucs the selected units /luarules destroyunits
 		gadgetHandler:AddChatAction('wreckunits', wreckUnits, "")  -- turns the selected units into wrecks /luarules wreckunits
 		gadgetHandler:AddChatAction('reclaimunits', reclaimUnits, "")  -- reclaims and refunds the selected units /luarules reclaimUnits
@@ -798,6 +810,7 @@ else	-- UNSYNCED
 
 	function gadget:Shutdown()
 		gadgetHandler:RemoveChatAction('givecat')
+		gadgetHandler:RemoveChatAction('devlegsilo')
 		gadgetHandler:RemoveChatAction('destroyunits')
 		gadgetHandler:RemoveChatAction('reclaimunits')
 		gadgetHandler:RemoveChatAction('removeunits')
@@ -1371,6 +1384,24 @@ else	-- UNSYNCED
 
 		--Spring.Echo('Spawning unit explosion:', line, playerID, msg)
 		Spring.SendLuaRulesMsg(PACKET_HEADER .. ':' .. msg)
+	end
+
+	function spawnDevLegSilo(_, line, words, playerID)
+		if playerID ~= Spring.GetMyPlayerID() then
+			return
+		end
+		if not Spring.IsCheatingEnabled() then
+			Spring.Echo("Cheats must be enabled to spawn a test launcher. Type /cheat first!")
+			return
+		end
+		local mx, my = Spring.GetMouseState()
+		local t, pos = Spring.TraceScreenRay(mx, my, true)
+		if type(pos) == 'table' then
+			local x, y, z = pos[1], pos[2], pos[3]
+			local _, _, _, teamID = Spring.GetPlayerInfo(Spring.GetMyPlayerID(), false)
+			local msg = PACKET_HEADER .. ":devlegsilo " .. math.floor(x) .. " " .. math.floor(y) .. " " .. math.floor(z) .. " " .. teamID
+			Spring.SendLuaRulesMsg(msg)
+		end
 	end
 
 	function GiveCat(_, line, words, playerID)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -538,7 +538,7 @@ specialEffectFunction.split = function(params, projectileID)
 		if px then
 			local groundHeight = spGetGroundHeight(px, pz)
 			local height = py - groundHeight
-			if height < 500 then
+			if height < 1000 then
 				split(params, projectileID)
 				return true
 			end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -527,11 +527,11 @@ local function split(params, projectileID)
 		if spawnedID and targetType and params.scatter then
 			if targetType == targetedGround then
 				-- Assign a randomized landing target coordinate within the scatter radius
-				local angle = math_random() * 2 * math.pi
+				local angle = math_random() * 2 * math_pi
 				local dist = math_random() * params.scatter
-				local tx = target[1] + math.cos(angle) * dist
-				local tz = target[3] + math.sin(angle) * dist
-				local ty = Spring.GetGroundHeight(tx, tz)
+				local tx = target[1] + math_cos(angle) * dist
+				local tz = target[3] + math_sin(angle) * dist
+				local ty = spGetGroundHeight(tx, tz)
 				spSetProjectileTarget(spawnedID, tx, ty, tz)
 			elseif targetType == targetedUnit then
 				spSetProjectileTarget(spawnedID, target, targetedUnit)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -493,9 +493,11 @@ weaponCustomParamKeys.split = {
 	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
 	cegtag            = tostring, -- as `projectileParams.cegTag`
 	model             = tostring, -- as `projectileParams.model`
+	scatter           = tonumber, -- scatter radius around target
 }
 
 local function split(params, projectileID)
+	local targetType, target = spGetProjectileTarget(projectileID)
 	local weaponDefID, projectileParams, parentSpeed = getProjectileArgs(params, projectileID)
 
 	spDeleteProjectile(projectileID)
@@ -507,13 +509,26 @@ local function split(params, projectileID)
 
 	local speed = projectileParams.speed
 	local velocityX, velocityY, velocityZ = speed[1], speed[2], speed[3]
+	local scatter = params.scatter or 400
 
 	for _ = 1, params.number do
-		speed[1] = velocityX + parentSpeed * (math_random(-100, 100) / 880)
-		speed[2] = velocityY + parentSpeed * (math_random(-100, 100) / 440)
-		speed[3] = velocityZ + parentSpeed * (math_random(-100, 100) / 880)
+		speed[1] = velocityX * 0.6 + parentSpeed * (math_random(-100, 100) / 200)
+		speed[2] = velocityY * 0.6 + parentSpeed * (math_random(-100, 100) / 150)
+		speed[3] = velocityZ * 0.6 + parentSpeed * (math_random(-100, 100) / 200)
 
-		spSpawnProjectile(weaponDefID, projectileParams)
+		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
+		if spawnedID and targetType then
+			if targetType == targetedGround then
+				local angle = math_random() * 2 * math.pi
+				local dist = math_random() * scatter
+				local tx = target[1] + math.cos(angle) * dist
+				local tz = target[3] + math.sin(angle) * dist
+				local ty = Spring.GetGroundHeight(tx, tz)
+				spSetProjectileTarget(spawnedID, tx, ty, tz)
+			elseif targetType == targetedUnit then
+				spSetProjectileTarget(spawnedID, target, targetedUnit)
+			end
+		end
 	end
 end
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -538,7 +538,7 @@ specialEffectFunction.split = function(params, projectileID)
 		if px then
 			local groundHeight = spGetGroundHeight(px, pz)
 			local height = py - groundHeight
-			if height < 1000 then
+			if height < 1500 then
 				split(params, projectileID)
 				return true
 			end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -56,6 +56,8 @@ local gravityPerFrame = -Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 local targetedGround = string.byte('g')
 local targetedUnit = string.byte('u')
 
+local metatables = {}
+
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
@@ -493,10 +495,47 @@ weaponCustomParamKeys.split = {
 	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
 	cegtag            = tostring, -- as `projectileParams.cegTag`
 	model             = tostring, -- as `projectileParams.model`
-	scatter           = tonumber, -- scatter radius around target
 }
 
 local function split(params, projectileID)
+	local weaponDefID, projectileParams, parentSpeed = getProjectileArgs(params, projectileID)
+
+	spDeleteProjectile(projectileID)
+
+	local pos = projectileParams.pos
+	spSpawnCEG(params.splitexplosionceg, pos[1], pos[2], pos[3])
+
+	projectileParams.gravity = gravityPerFrame
+
+	local speed = projectileParams.speed
+	local velocityX, velocityY, velocityZ = speed[1], speed[2], speed[3]
+
+	for _ = 1, params.number do
+		speed[1] = velocityX + parentSpeed * (math_random(-100, 100) / 880)
+		speed[2] = velocityY + parentSpeed * (math_random(-100, 100) / 440)
+		speed[3] = velocityZ + parentSpeed * (math_random(-100, 100) / 880)
+
+		spSpawnProjectile(weaponDefID, projectileParams)
+	end
+end
+
+specialEffectFunction.split = function(params, projectileID)
+	if isProjectileFalling(projectileID) then
+		split(params, projectileID)
+		return true
+	end
+end
+
+weaponCustomParamKeys.split_new = {
+	speceffect_def    = toWeaponDefID, -- name of spawned weapondef (weapon type must be non-hitscan)
+	number            = tonumber, -- count of projectiles to spawn
+	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
+	cegtag            = tostring, -- as `projectileParams.cegTag`
+	model             = tostring, -- as `projectileParams.model`
+	scatter           = tonumber, -- scatter radius around target
+}
+
+local function split_new(params, projectileID)
 	local targetType, target = spGetProjectileTarget(projectileID)
 	local weaponDefID, projectileParams, parentSpeed = getProjectileArgs(params, projectileID)
 
@@ -512,6 +551,7 @@ local function split(params, projectileID)
 	local scatter = params.scatter or 400
 
 	for _ = 1, params.number do
+		-- Damp inherited velocity by 40% to reduce forward overshoot, allowing wider fanning
 		speed[1] = velocityX * 0.6 + parentSpeed * (math_random(-100, 100) / 200)
 		speed[2] = velocityY * 0.6 + parentSpeed * (math_random(-100, 100) / 150)
 		speed[3] = velocityZ * 0.6 + parentSpeed * (math_random(-100, 100) / 200)
@@ -519,6 +559,7 @@ local function split(params, projectileID)
 		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
 		if spawnedID and targetType then
 			if targetType == targetedGround then
+				-- Assign a randomized landing target coordinate within the scatter radius
 				local angle = math_random() * 2 * math.pi
 				local dist = math_random() * scatter
 				local tx = target[1] + math.cos(angle) * dist
@@ -532,14 +573,15 @@ local function split(params, projectileID)
 	end
 end
 
-specialEffectFunction.split = function(params, projectileID)
+specialEffectFunction.split_new = function(params, projectileID)
 	if isProjectileFalling(projectileID) then
 		local px, py, pz = spGetProjectilePosition(projectileID)
 		if px then
 			local groundHeight = spGetGroundHeight(px, pz)
 			local height = py - groundHeight
+			-- Split when height above the ground is less than 1500 units during descent
 			if height < 1500 then
-				split(params, projectileID)
+				split_new(params, projectileID)
 				return true
 			end
 		end
@@ -643,7 +685,7 @@ end
 -- Engine call-ins -------------------------------------------------------------
 
 function gadget:Initialize()
-	local metatables = {}
+	metatables = {}
 
 	for effectName, effectFunction in pairs(specialEffectFunction) do
 		-- Add self-call syntax to weapondef special effects:
@@ -687,8 +729,18 @@ function gadget:Initialize()
 end
 
 function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
-	if weaponDefEffect[weaponDefID] then
-		projectiles[projectileID] = weaponDefEffect[weaponDefID]
+	local effect = weaponDefEffect[weaponDefID]
+	if effect then
+		local ownerID = spGetProjectileOwnerID(projectileID)
+		if ownerID and Spring.GetUnitRulesParam(ownerID, "use_new_split") == 1 then
+			if type(effect) == "table" then
+				projectiles[projectileID] = setmetatable(table.copy(effect), metatables.split_new)
+			else
+				projectiles[projectileID] = specialEffectFunction.split_new
+			end
+		else
+			projectiles[projectileID] = effect
+		end
 	end
 end
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -497,6 +497,7 @@ weaponCustomParamKeys.split = {
 	vmult             = tonumber, -- parent velocity multiplier (defaults to 1.0, or 0.6 if scatter is set)
 	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 880, or 200 if scatter is set)
 	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 440, or 150 if scatter is set)
+	splitheight       = tonumber, -- altitude above ground to trigger split (defaults to 1500 if scatter is set)
 }
 
 local function split(params, projectileID)
@@ -525,7 +526,7 @@ local function split(params, projectileID)
 
 		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
 		if spawnedID and targetType and params.scatter then
-			if targetType == targetedGround then
+			if targetType == targetedGround and target then
 				-- Assign a randomized landing target coordinate within the scatter radius
 				local angle = math_random() * 2 * math_pi
 				local dist = math_random() * params.scatter
@@ -533,7 +534,7 @@ local function split(params, projectileID)
 				local tz = target[3] + math_sin(angle) * dist
 				local ty = spGetGroundHeight(tx, tz)
 				spSetProjectileTarget(spawnedID, tx, ty, tz)
-			elseif targetType == targetedUnit then
+			elseif targetType == targetedUnit and target then
 				spSetProjectileTarget(spawnedID, target, targetedUnit)
 			end
 		end
@@ -543,12 +544,13 @@ end
 specialEffectFunction.split = function(params, projectileID)
 	if isProjectileFalling(projectileID) then
 		if params.scatter then
-			-- New split: split when height above the ground is less than 1500 units during descent
+			-- New split: split when height above the ground is less than splitheight units during descent
 			local px, py, pz = spGetProjectilePosition(projectileID)
 			if px then
 				local groundHeight = spGetGroundHeight(px, pz)
 				local height = py - groundHeight
-				if height < 1500 then
+				local splitHeight = params.splitheight or 1500
+				if height < splitHeight then
 					split(params, projectileID)
 					return true
 				end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -56,9 +56,6 @@ local gravityPerFrame = -Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 local targetedGround = string.byte('g')
 local targetedUnit = string.byte('u')
 
-local bypassedNukes = {}
-local legsilo_legicbm_id
-
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
@@ -669,8 +666,6 @@ end
 -- Engine call-ins -------------------------------------------------------------
 
 function gadget:Initialize()
-	legsilo_legicbm_id = WeaponDefNames.legsilo_legicbm and WeaponDefNames.legsilo_legicbm.id
-
 	local metatables = {}
 
 	for effectName, effectFunction in pairs(specialEffectFunction) do
@@ -718,23 +713,10 @@ function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
 	if weaponDefEffect[weaponDefID] then
 		projectiles[projectileID] = weaponDefEffect[weaponDefID]
 	end
-	if weaponDefID == legsilo_legicbm_id then
-		if math_random() < 0.05 then
-			bypassedNukes[projectileID] = true
-			Spring.Echo("MIRV Nuke bypassed primary anti-nuke shield!")
-		end
-	end
 end
 
 function gadget:ProjectileDestroyed(projectileID)
 	projectiles[projectileID] = nil
-	bypassedNukes[projectileID] = nil
-end
-
-function gadget:AllowWeaponInterceptTarget(interceptorUnitID, interceptorWeaponID, targetProjectileID)
-	if bypassedNukes[targetProjectileID] then
-		return false
-	end
 end
 
 function gadget:GameFrame(frame)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -56,24 +56,6 @@ local gravityPerFrame = -Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 local targetedGround = string.byte('g')
 local targetedUnit = string.byte('u')
 
-local initialDistances = {}
-
-local function getTargetPosition(projectileID)
-	local targetType, target = spGetProjectileTarget(projectileID)
-	if not targetType then
-		return nil
-	end
-	if targetType == targetedGround then
-		return target[1], target[2], target[3]
-	elseif targetType == targetedUnit then
-		local tx, ty, tz = spGetUnitPosition(target)
-		if tx then
-			return tx, ty, tz
-		end
-	end
-	return nil
-end
-
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
@@ -551,37 +533,15 @@ local function split(params, projectileID)
 end
 
 specialEffectFunction.split = function(params, projectileID)
-	local initialDist = initialDistances[projectileID]
-	if initialDist then
+	if isProjectileFalling(projectileID) then
 		local px, py, pz = spGetProjectilePosition(projectileID)
-		local tx, ty, tz = getTargetPosition(projectileID)
-		if px and tx then
-			local currentDist = math.sqrt((px - tx)^2 + (py - ty)^2 + (pz - tz)^2)
-			-- Split when 3/4 of the way to the target (remaining distance <= 25%)
-			if currentDist <= initialDist * 0.25 then
-				local vx, vy, vz = spGetProjectileVelocity(projectileID)
-				-- Fallback to split immediately if very close to the ground (within 350 height)
-				local groundHeight = spGetGroundHeight(px, pz)
-				local height = py - groundHeight
-				if height < 350 then
-					split(params, projectileID)
-					return true
-				end
-				-- Otherwise wait until it's mostly in a vertical descent (falling down at > 56 deg angle)
-				if vy and vy < 0 then
-					local horizSpeed = math.sqrt(vx^2 + vz^2)
-					if -vy > horizSpeed * 1.5 then
-						split(params, projectileID)
-						return true
-					end
-				end
+		if px then
+			local groundHeight = spGetGroundHeight(px, pz)
+			local height = py - groundHeight
+			if height < 500 then
+				split(params, projectileID)
+				return true
 			end
-		end
-	else
-		-- Fallback to original apogee behavior if initial distance was not recorded
-		if isProjectileFalling(projectileID) then
-			split(params, projectileID)
-			return true
 		end
 	end
 end
@@ -727,26 +687,13 @@ function gadget:Initialize()
 end
 
 function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
-	local effect = weaponDefEffect[weaponDefID]
-	if effect then
-		projectiles[projectileID] = effect
-		-- If this is a split projectile, store its initial distance to target
-		local cp = WeaponDefs[weaponDefID] and WeaponDefs[weaponDefID].customParams
-		local effectName = cp and cp.speceffect
-		if effectName == "split" then
-			local px, py, pz = spGetProjectilePosition(projectileID)
-			local tx, ty, tz = getTargetPosition(projectileID)
-			if px and tx then
-				local dist = math.sqrt((px - tx)^2 + (py - ty)^2 + (pz - tz)^2)
-				initialDistances[projectileID] = dist
-			end
-		end
+	if weaponDefEffect[weaponDefID] then
+		projectiles[projectileID] = weaponDefEffect[weaponDefID]
 	end
 end
 
 function gadget:ProjectileDestroyed(projectileID)
 	projectiles[projectileID] = nil
-	initialDistances[projectileID] = nil
 end
 
 function gadget:GameFrame(frame)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -56,6 +56,24 @@ local gravityPerFrame = -Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 local targetedGround = string.byte('g')
 local targetedUnit = string.byte('u')
 
+local initialDistances = {}
+
+local function getTargetPosition(projectileID)
+	local targetType, target = spGetProjectileTarget(projectileID)
+	if not targetType then
+		return nil
+	end
+	if targetType == targetedGround then
+		return target[1], target[2], target[3]
+	elseif targetType == targetedUnit then
+		local tx, ty, tz = spGetUnitPosition(target)
+		if tx then
+			return tx, ty, tz
+		end
+	end
+	return nil
+end
+
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
@@ -533,9 +551,38 @@ local function split(params, projectileID)
 end
 
 specialEffectFunction.split = function(params, projectileID)
-	if isProjectileFalling(projectileID) then
-		split(params, projectileID)
-		return true
+	local initialDist = initialDistances[projectileID]
+	if initialDist then
+		local px, py, pz = spGetProjectilePosition(projectileID)
+		local tx, ty, tz = getTargetPosition(projectileID)
+		if px and tx then
+			local currentDist = math.sqrt((px - tx)^2 + (py - ty)^2 + (pz - tz)^2)
+			-- Split when 3/4 of the way to the target (remaining distance <= 25%)
+			if currentDist <= initialDist * 0.25 then
+				local vx, vy, vz = spGetProjectileVelocity(projectileID)
+				-- Fallback to split immediately if very close to the ground (within 350 height)
+				local groundHeight = spGetGroundHeight(px, pz)
+				local height = py - groundHeight
+				if height < 350 then
+					split(params, projectileID)
+					return true
+				end
+				-- Otherwise wait until it's mostly in a vertical descent (falling down at > 56 deg angle)
+				if vy and vy < 0 then
+					local horizSpeed = math.sqrt(vx^2 + vz^2)
+					if -vy > horizSpeed * 1.5 then
+						split(params, projectileID)
+						return true
+					end
+				end
+			end
+		end
+	else
+		-- Fallback to original apogee behavior if initial distance was not recorded
+		if isProjectileFalling(projectileID) then
+			split(params, projectileID)
+			return true
+		end
 	end
 end
 
@@ -680,13 +727,26 @@ function gadget:Initialize()
 end
 
 function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
-	if weaponDefEffect[weaponDefID] then
-		projectiles[projectileID] = weaponDefEffect[weaponDefID]
+	local effect = weaponDefEffect[weaponDefID]
+	if effect then
+		projectiles[projectileID] = effect
+		-- If this is a split projectile, store its initial distance to target
+		local cp = WeaponDefs[weaponDefID] and WeaponDefs[weaponDefID].customParams
+		local effectName = cp and cp.speceffect
+		if effectName == "split" then
+			local px, py, pz = spGetProjectilePosition(projectileID)
+			local tx, ty, tz = getTargetPosition(projectileID)
+			if px and tx then
+				local dist = math.sqrt((px - tx)^2 + (py - ty)^2 + (pz - tz)^2)
+				initialDistances[projectileID] = dist
+			end
+		end
 	end
 end
 
 function gadget:ProjectileDestroyed(projectileID)
 	projectiles[projectileID] = nil
+	initialDistances[projectileID] = nil
 end
 
 function gadget:GameFrame(frame)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -56,6 +56,9 @@ local gravityPerFrame = -Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 local targetedGround = string.byte('g')
 local targetedUnit = string.byte('u')
 
+local bypassedNukes = {}
+local legsilo_legicbm_id
+
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
@@ -488,16 +491,18 @@ end
 -- Use with a weapon with a high firing arc, or it can cause strange behaviors, e.g. when firing down.
 
 weaponCustomParamKeys.split = {
-	speceffect_def    = toWeaponDefID, -- name of spawned weapondef (weapon type must be non-hitscan)
-	number            = tonumber, -- count of projectiles to spawn
-	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
-	cegtag            = tostring, -- as `projectileParams.cegTag`
-	model             = tostring, -- as `projectileParams.model`
-	scatter           = tonumber, -- scatter radius around target
-	vmult             = tonumber, -- parent velocity multiplier (defaults to 1.0, or 0.6 if scatter is set)
-	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 880, or 200 if scatter is set)
-	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 440, or 150 if scatter is set)
-	splitheight       = tonumber, -- altitude above ground to trigger split (defaults to 1500 if scatter is set)
+	speceffect_def            = toWeaponDefID, -- name of spawned weapondef (weapon type must be non-hitscan)
+	speceffect_def_targetable = toWeaponDefID, -- optional targetable submunition weapondef
+	number_targetable         = tonumber, -- count of targetable submunitions to spawn
+	number                    = tonumber, -- count of projectiles to spawn
+	splitexplosionceg         = tostring, -- name of spawned CEG (use a small puff, there is no damage)
+	cegtag                    = tostring, -- as `projectileParams.cegTag`
+	model                     = tostring, -- as `projectileParams.model`
+	scatter                   = tonumber, -- scatter radius around target
+	vmult                     = tonumber, -- parent velocity multiplier (defaults to 1.0, or 0.6 if scatter is set)
+	fanning_divisor           = tonumber, -- X/Z spread divisor (defaults to 880, or 200 if scatter is set)
+	fanning_divisor_y         = tonumber, -- Y spread divisor (defaults to 440, or 150 if scatter is set)
+	splitheight               = tonumber, -- altitude above ground to trigger split (defaults to 1500 if scatter is set)
 }
 
 local function split(params, projectileID)
@@ -519,12 +524,16 @@ local function split(params, projectileID)
 	local fanDiv = params.fanning_divisor or (params.scatter and 200 or 880)
 	local fanDivY = params.fanning_divisor_y or (params.scatter and 150 or 440)
 
-	for _ = 1, params.number do
+	local targetableWeaponDefID = params.speceffect_def_targetable
+	local numTargetable = params.number_targetable or 0
+
+	for i = 1, params.number do
 		speed[1] = velocityX * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 		speed[2] = velocityY * vMult + parentSpeed * (math_random(-100, 100) / fanDivY)
 		speed[3] = velocityZ * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 
-		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
+		local currentWeaponDefID = (i <= numTargetable and targetableWeaponDefID) and targetableWeaponDefID or weaponDefID
+		local spawnedID = spSpawnProjectile(currentWeaponDefID, projectileParams)
 		if spawnedID and targetType and params.scatter then
 			if targetType == targetedGround and target then
 				-- Assign a randomized landing target coordinate within the scatter radius
@@ -660,6 +669,8 @@ end
 -- Engine call-ins -------------------------------------------------------------
 
 function gadget:Initialize()
+	legsilo_legicbm_id = WeaponDefNames.legsilo_legicbm and WeaponDefNames.legsilo_legicbm.id
+
 	local metatables = {}
 
 	for effectName, effectFunction in pairs(specialEffectFunction) do
@@ -707,10 +718,23 @@ function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
 	if weaponDefEffect[weaponDefID] then
 		projectiles[projectileID] = weaponDefEffect[weaponDefID]
 	end
+	if weaponDefID == legsilo_legicbm_id then
+		if math_random() < 0.20 then
+			bypassedNukes[projectileID] = true
+			Spring.Echo("MIRV Nuke bypassed primary anti-nuke shield!")
+		end
+	end
 end
 
 function gadget:ProjectileDestroyed(projectileID)
 	projectiles[projectileID] = nil
+	bypassedNukes[projectileID] = nil
+end
+
+function gadget:AllowWeaponInterceptTarget(interceptorUnitID, interceptorWeaponID, targetProjectileID)
+	if bypassedNukes[targetProjectileID] then
+		return false
+	end
 end
 
 function gadget:GameFrame(frame)

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -489,8 +489,6 @@ end
 
 weaponCustomParamKeys.split = {
 	speceffect_def            = toWeaponDefID, -- name of spawned weapondef (weapon type must be non-hitscan)
-	speceffect_def_targetable = toWeaponDefID, -- optional targetable submunition weapondef
-	number_targetable         = tonumber, -- count of targetable submunitions to spawn
 	number                    = tonumber, -- count of projectiles to spawn
 	splitexplosionceg         = tostring, -- name of spawned CEG (use a small puff, there is no damage)
 	cegtag                    = tostring, -- as `projectileParams.cegTag`
@@ -521,16 +519,12 @@ local function split(params, projectileID)
 	local fanDiv = params.fanning_divisor or (params.scatter and 200 or 880)
 	local fanDivY = params.fanning_divisor_y or (params.scatter and 150 or 440)
 
-	local targetableWeaponDefID = params.speceffect_def_targetable
-	local numTargetable = params.number_targetable or 0
-
-	for i = 1, params.number do
+	for _ = 1, params.number do
 		speed[1] = velocityX * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 		speed[2] = velocityY * vMult + parentSpeed * (math_random(-100, 100) / fanDivY)
 		speed[3] = velocityZ * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 
-		local currentWeaponDefID = (i <= numTargetable and targetableWeaponDefID) and targetableWeaponDefID or weaponDefID
-		local spawnedID = spSpawnProjectile(currentWeaponDefID, projectileParams)
+		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
 		if spawnedID and targetType and params.scatter then
 			if targetType == targetedGround and target then
 				-- Assign a randomized landing target coordinate within the scatter radius

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -56,8 +56,6 @@ local gravityPerFrame = -Game.gravity / (Game.gameSpeed * Game.gameSpeed)
 local targetedGround = string.byte('g')
 local targetedUnit = string.byte('u')
 
-local metatables = {}
-
 --------------------------------------------------------------------------------
 -- Initialization --------------------------------------------------------------
 
@@ -495,56 +493,13 @@ weaponCustomParamKeys.split = {
 	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
 	cegtag            = tostring, -- as `projectileParams.cegTag`
 	model             = tostring, -- as `projectileParams.model`
-	vmult             = tonumber, -- parent velocity multiplier (defaults to 1.0)
-	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 880)
-	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 440)
+	scatter           = tonumber, -- scatter radius around target
+	vmult             = tonumber, -- parent velocity multiplier (defaults to 1.0, or 0.6 if scatter is set)
+	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 880, or 200 if scatter is set)
+	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 440, or 150 if scatter is set)
 }
 
 local function split(params, projectileID)
-	local weaponDefID, projectileParams, parentSpeed = getProjectileArgs(params, projectileID)
-
-	spDeleteProjectile(projectileID)
-
-	local pos = projectileParams.pos
-	spSpawnCEG(params.splitexplosionceg, pos[1], pos[2], pos[3])
-
-	projectileParams.gravity = gravityPerFrame
-
-	local speed = projectileParams.speed
-	local velocityX, velocityY, velocityZ = speed[1], speed[2], speed[3]
-	local vMult = params.vmult or 1.0
-	local fanDiv = params.fanning_divisor or 880
-	local fanDivY = params.fanning_divisor_y or 440
-
-	for _ = 1, params.number do
-		speed[1] = velocityX * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
-		speed[2] = velocityY * vMult + parentSpeed * (math_random(-100, 100) / fanDivY)
-		speed[3] = velocityZ * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
-
-		spSpawnProjectile(weaponDefID, projectileParams)
-	end
-end
-
-specialEffectFunction.split = function(params, projectileID)
-	if isProjectileFalling(projectileID) then
-		split(params, projectileID)
-		return true
-	end
-end
-
-weaponCustomParamKeys.split_new = {
-	speceffect_def    = toWeaponDefID, -- name of spawned weapondef (weapon type must be non-hitscan)
-	number            = tonumber, -- count of projectiles to spawn
-	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
-	cegtag            = tostring, -- as `projectileParams.cegTag`
-	model             = tostring, -- as `projectileParams.model`
-	scatter           = tonumber, -- scatter radius around target
-	vmult             = tonumber, -- parent velocity multiplier (defaults to 0.6)
-	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 200)
-	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 150)
-}
-
-local function split_new(params, projectileID)
 	local targetType, target = spGetProjectileTarget(projectileID)
 	local weaponDefID, projectileParams, parentSpeed = getProjectileArgs(params, projectileID)
 
@@ -557,23 +512,23 @@ local function split_new(params, projectileID)
 
 	local speed = projectileParams.speed
 	local velocityX, velocityY, velocityZ = speed[1], speed[2], speed[3]
-	local scatter = params.scatter or 400
-	local vMult = params.vmult or 0.6
-	local fanDiv = params.fanning_divisor or 200
-	local fanDivY = params.fanning_divisor_y or 150
+
+	-- If scatter is defined, we default to the new damped fanning physics. Otherwise, use base game physics.
+	local vMult = params.vmult or (params.scatter and 0.6 or 1.0)
+	local fanDiv = params.fanning_divisor or (params.scatter and 200 or 880)
+	local fanDivY = params.fanning_divisor_y or (params.scatter and 150 or 440)
 
 	for _ = 1, params.number do
-		-- Damp inherited velocity to reduce forward overshoot, allowing wider fanning
 		speed[1] = velocityX * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 		speed[2] = velocityY * vMult + parentSpeed * (math_random(-100, 100) / fanDivY)
 		speed[3] = velocityZ * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 
 		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
-		if spawnedID and targetType then
+		if spawnedID and targetType and params.scatter then
 			if targetType == targetedGround then
 				-- Assign a randomized landing target coordinate within the scatter radius
 				local angle = math_random() * 2 * math.pi
-				local dist = math_random() * scatter
+				local dist = math_random() * params.scatter
 				local tx = target[1] + math.cos(angle) * dist
 				local tz = target[3] + math.sin(angle) * dist
 				local ty = Spring.GetGroundHeight(tx, tz)
@@ -585,17 +540,23 @@ local function split_new(params, projectileID)
 	end
 end
 
-specialEffectFunction.split_new = function(params, projectileID)
+specialEffectFunction.split = function(params, projectileID)
 	if isProjectileFalling(projectileID) then
-		local px, py, pz = spGetProjectilePosition(projectileID)
-		if px then
-			local groundHeight = spGetGroundHeight(px, pz)
-			local height = py - groundHeight
-			-- Split when height above the ground is less than 1500 units during descent
-			if height < 1500 then
-				split_new(params, projectileID)
-				return true
+		if params.scatter then
+			-- New split: split when height above the ground is less than 1500 units during descent
+			local px, py, pz = spGetProjectilePosition(projectileID)
+			if px then
+				local groundHeight = spGetGroundHeight(px, pz)
+				local height = py - groundHeight
+				if height < 1500 then
+					split(params, projectileID)
+					return true
+				end
 			end
+		else
+			-- Original split: split immediately at apogee
+			split(params, projectileID)
+			return true
 		end
 	end
 end
@@ -697,7 +658,7 @@ end
 -- Engine call-ins -------------------------------------------------------------
 
 function gadget:Initialize()
-	metatables = {}
+	local metatables = {}
 
 	for effectName, effectFunction in pairs(specialEffectFunction) do
 		-- Add self-call syntax to weapondef special effects:
@@ -741,18 +702,8 @@ function gadget:Initialize()
 end
 
 function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
-	local effect = weaponDefEffect[weaponDefID]
-	if effect then
-		local ownerID = spGetProjectileOwnerID(projectileID)
-		if ownerID and Spring.GetUnitRulesParam(ownerID, "use_new_split") == 1 then
-			if type(effect) == "table" then
-				projectiles[projectileID] = setmetatable(table.copy(effect), metatables.split_new)
-			else
-				projectiles[projectileID] = specialEffectFunction.split_new
-			end
-		else
-			projectiles[projectileID] = effect
-		end
+	if weaponDefEffect[weaponDefID] then
+		projectiles[projectileID] = weaponDefEffect[weaponDefID]
 	end
 end
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -719,7 +719,7 @@ function gadget:ProjectileCreated(projectileID, proOwnerID, weaponDefID)
 		projectiles[projectileID] = weaponDefEffect[weaponDefID]
 	end
 	if weaponDefID == legsilo_legicbm_id then
-		if math_random() < 0.20 then
+		if math_random() < 0.05 then
 			bypassedNukes[projectileID] = true
 			Spring.Echo("MIRV Nuke bypassed primary anti-nuke shield!")
 		end

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -495,6 +495,9 @@ weaponCustomParamKeys.split = {
 	splitexplosionceg = tostring, -- name of spawned CEG (use a small puff, there is no damage)
 	cegtag            = tostring, -- as `projectileParams.cegTag`
 	model             = tostring, -- as `projectileParams.model`
+	vmult             = tonumber, -- parent velocity multiplier (defaults to 1.0)
+	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 880)
+	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 440)
 }
 
 local function split(params, projectileID)
@@ -509,11 +512,14 @@ local function split(params, projectileID)
 
 	local speed = projectileParams.speed
 	local velocityX, velocityY, velocityZ = speed[1], speed[2], speed[3]
+	local vMult = params.vmult or 1.0
+	local fanDiv = params.fanning_divisor or 880
+	local fanDivY = params.fanning_divisor_y or 440
 
 	for _ = 1, params.number do
-		speed[1] = velocityX + parentSpeed * (math_random(-100, 100) / 880)
-		speed[2] = velocityY + parentSpeed * (math_random(-100, 100) / 440)
-		speed[3] = velocityZ + parentSpeed * (math_random(-100, 100) / 880)
+		speed[1] = velocityX * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
+		speed[2] = velocityY * vMult + parentSpeed * (math_random(-100, 100) / fanDivY)
+		speed[3] = velocityZ * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 
 		spSpawnProjectile(weaponDefID, projectileParams)
 	end
@@ -533,6 +539,9 @@ weaponCustomParamKeys.split_new = {
 	cegtag            = tostring, -- as `projectileParams.cegTag`
 	model             = tostring, -- as `projectileParams.model`
 	scatter           = tonumber, -- scatter radius around target
+	vmult             = tonumber, -- parent velocity multiplier (defaults to 0.6)
+	fanning_divisor   = tonumber, -- X/Z spread divisor (defaults to 200)
+	fanning_divisor_y = tonumber, -- Y spread divisor (defaults to 150)
 }
 
 local function split_new(params, projectileID)
@@ -549,12 +558,15 @@ local function split_new(params, projectileID)
 	local speed = projectileParams.speed
 	local velocityX, velocityY, velocityZ = speed[1], speed[2], speed[3]
 	local scatter = params.scatter or 400
+	local vMult = params.vmult or 0.6
+	local fanDiv = params.fanning_divisor or 200
+	local fanDivY = params.fanning_divisor_y or 150
 
 	for _ = 1, params.number do
-		-- Damp inherited velocity by 40% to reduce forward overshoot, allowing wider fanning
-		speed[1] = velocityX * 0.6 + parentSpeed * (math_random(-100, 100) / 200)
-		speed[2] = velocityY * 0.6 + parentSpeed * (math_random(-100, 100) / 150)
-		speed[3] = velocityZ * 0.6 + parentSpeed * (math_random(-100, 100) / 200)
+		-- Damp inherited velocity to reduce forward overshoot, allowing wider fanning
+		speed[1] = velocityX * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
+		speed[2] = velocityY * vMult + parentSpeed * (math_random(-100, 100) / fanDivY)
+		speed[3] = velocityZ * vMult + parentSpeed * (math_random(-100, 100) / fanDiv)
 
 		local spawnedID = spSpawnProjectile(weaponDefID, projectileParams)
 		if spawnedID and targetType then


### PR DESCRIPTION
# Pull Request Title
`feat(gadgets): parameterize split weapon behaviour for customized fanning and trigger altitudes`

---

### Work done
This PR parameterizes the `split` weapon effect in `unit_custom_weapons_behaviours.lua` to allow highly configurable fanning profiles without modifying or breaking the base game's default `split` behavior.

Specifically, it introduces the following enhancements to the `split` weapon custom parameters:
- **`splitheight`**: Allows overriding the hardcoded apogee split to trigger the split terminally at a specific altitude during descent.
- **`vmult`**: A parent velocity multiplier for the submunitions.
- **`fanning_divisor` & `fanning_divisor_y`**: X/Y/Z fanning divisors to allow tighter or wider scatter arcs.
- **Target Retention & Scattering**: When `scatter` is defined, the engine now actively passes the parent's target down to the submunitions:
  - **Ground Targets**: Submunitions are assigned a randomized sub-target within the scatter radius. This allows the engine's native guidance to smoothly track distinct spread impacts.
  - **Unit Targets**: Submunitions directly inherit the parent's targeted unit ID so they can seamlessly continue homing in on moving units.
- **Performance & Safety**: Implemented robust nil-checks for targeting edge cases and localized math/Spring engine API calls (`math_cos`, `spGetGroundHeight`, etc.) to minimize lookup overhead inside the projectile spawning loop.

**Why it's necessary:**
Currently, the `split` effect is strictly hardcoded to break apart at the trajectory's apogee with a fixed fanning spread. This change enables the creation of custom units, mods, and new factions (such as a MIRV ICBM) that can deploy submunitions terminally with tailored spread trajectories.

**Backwards compatibility (Does it break existing items?):**
Absolutely not. The updated `split` function dynamically branches based on the presence of the `scatter` parameter in the weapon's `customParams`. 
Existing base-game units that utilize the `split` effect do not supply a `scatter` parameter, so they automatically default to the original apogee split logic and the original fanning multipliers (`vmult=1.0`, `fanDiv=880`, `fanDivY=440`). This guarantees zero impact on existing game balance or units.

#### Test steps
- [x] Launch the game and fire any existing unit that uses the `split` effect (e.g., standard split missiles). Verify they behave identically to the master branch.
- [x] Define a custom weapon with `scatter`, `splitheight`, and custom `fanning_divisor` parameters in its `customParams`.
- [x] Fire the custom weapon and verify it waits until the specified `splitheight` during its descent to trigger the split, and that the submunitions fan out properly based on the provided divisors.

### AI / LLM usage statement:
LLM assistance was utilized to refactor the localized math function caching, parameter fallback syntax, and edge-case nil checks within the `split` loop.
