### PR TITLE
fix: remove queued self-destruct orders from shared units

### DIFF
--- a/luarules/gadgets/unit_prevent_share_self_d.lua
+++ b/luarules/gadgets/unit_prevent_share_self_d.lua
@@ -21,31 +21,33 @@ local monitorPlayers = {}
 local spGetPlayerInfo = Spring.GetPlayerInfo
 
 function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
-	if Spring.GetUnitSelfDTime(unitID) > 0 then
-		Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
-	end
+	removeSelfDOrders(unitID)
 	return true
 end
 
-local function removeSelfdOrders(teamID)
-	-- check team is empty
-	--local team = Spring.GetPlayerList(teamID)
-	--if team then
-	--	for _,pID in pairs(team) do
-	--		local _,active,spec = Spring.GetPlayerInfo(pID,false)
-	--		if active and not spec then
-	--			return
-	--		end
-	--	end
-	--end
+local function removeSelfDOrders(unitID)
+	-- cancel any current self-D orders
+	if Spring.GetUnitSelfDTime(unitID) > 0 then
+		Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	end
 
-	-- cancel any self d orders
-	local units = Spring.GetTeamUnits(teamID)
-	for i=1,#units do
-		local unitID = units[i]
-		if Spring.GetUnitSelfDTime(unitID) > 0 then
-			Spring.GiveOrderToUnit(unitID, CMD.SELFD, {}, 0)
+	-- for queued self-D orders, remove them from queue
+	local selfdTags = {}
+	for index = 1, Spring.GetUnitCommandCount(unitID) do
+		local cmd, _, tag = Spring.GetUnitCurrentCommand(unitID, index)
+		if cmd == CMD.SELFD then
+			selfdTags[#selfdTags + 1] = tag
 		end
+	end
+	if #selfdTags > 0 then
+		Spring.GiveOrderToUnit(unitID, CMD.REMOVE, selfdTags, 0)
+	end
+end
+
+local function removeTeamSelfDOrders(teamID)
+	local units = Spring.GetTeamUnits(teamID)
+	for i = 1, #units do
+		removeSelfDOrders(units[i])
 	end
 end
 
@@ -68,11 +70,11 @@ function gadget:GameFrame(gameFrame)
 	for playerID, prevActive in pairs(monitorPlayers) do
 		_,active,spec,teamID = spGetPlayerInfo(playerID,false)
 		if spec then
-			removeSelfdOrders(teamID)
+			removeTeamSelfDOrders(teamID)
 			monitorPlayers[playerID] = nil
 		elseif active ~= prevActive then
 			if not active then
-				removeSelfdOrders(teamID)
+				removeTeamSelfDOrders(teamID)
 			end
 			monitorPlayers[playerID] = active	-- dont nil cause player could reconnect
 		end


### PR DESCRIPTION
### Work done

We have a gadget that stops self-destruction on unit sharing. However, there's an easy way to bypass that:

1. shift
2. move
3. self-d
4. move
5. release shift
6. share during move from step 2

As the gadget currently checks only whether the unit *currently* has a self-d timer and not whether it has any self-d timers queued, it will happily accept the unit transfer.

Thanks to KroIya for helping me debug this [here](https://discord.com/channels/549281623154229250/1523190210102296606).

Also slightly refactored to deduplicate the code.

### Video

For comparison, I spawned two commanders to show the difference between shared and unshared self-D.

#### Before


https://github.com/user-attachments/assets/6ba54993-f04f-4dd9-a9c3-d292942d7737

I'm not sure why the share used to introduce a slight delay in the explosion.

#### After

https://github.com/user-attachments/assets/4bbd1c8b-4238-4c76-8013-bf2b775bb067


#### With both current and queued self-d orders

https://github.com/user-attachments/assets/77f949c0-38c5-45dc-b574-70d4476bf010



### AI / LLM usage statement:

I'm not great at Lua so I implemented the fix using Qwen3.6-27b.
