### PR TITLE
feat(gui-options): implement scroll functionality for dropdown options

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -153,7 +153,7 @@ local math_isInRect = math.isInRect
 local chobbyInterface, font, font2, font3, backgroundGuishader, currentGroupTab, windowList, optionButtonBackward, optionButtonForward
 local groupRect, titleRect, countDownOptionID, countDownOptionClock, sceduleOptionApply, checkedForWaterAfterGamestart, checkedWidgetDataChanges
 local savedConfig, forceUpdate, sliderValueChanged, selectOptionsList, showSelectOptions, prevSelectHover
-local fontOption, draggingSlider, lastSliderSound, selectClickAllowHide
+local fontOption, draggingSlider, lastSliderSound, selectClickAllowHide, selectScrollOffset
 local guishaderWasActive = false
 
 local glColor = gl.Color
@@ -1473,13 +1473,19 @@ function widget:DrawScreen()
 				local oHeight = optionButtons[showSelectOptions][4] - optionButtons[showSelectOptions][2]
 				local oPadding = math.floor(4 * widgetScale)
 				local y = optionButtons[showSelectOptions][4] - oPadding
-				local yPos = y
 				optionSelect = {}
-				local i = 0
-				for k, option in pairs(options[showSelectOptions].options) do
-					i = i + 1
-					yPos = y - (((oHeight + oPadding + oPadding) * i) - oPadding)
+
+				-- count total items and clamp scroll offset
+				local numItems = 0
+				for _ in pairs(options[showSelectOptions].options) do
+					numItems = numItems + 1
 				end
+				local maxVisible = math.min(numItems, 16)
+				if selectScrollOffset == nil then selectScrollOffset = 0 end
+				selectScrollOffset = math.max(0, math.min(selectScrollOffset, numItems - maxVisible))
+
+				-- yPos at bottom of last visible item
+				local yPos = y - (((oHeight + oPadding + oPadding) * maxVisible) - oPadding)
 
 				-- get max text option width
 				local fontSize = oHeight * 0.85
@@ -1500,29 +1506,52 @@ function widget:DrawScreen()
 					UiSelector(optionButtons[showSelectOptions][1], optionButtons[showSelectOptions][2], optionButtons[showSelectOptions][3], optionButtons[showSelectOptions][4])
 
 					local i = 0
+					local vi = 0
 					for k, option in pairs(options[showSelectOptions].options) do
 						i = i + 1
-						yPos = math.floor(y - (((oHeight + oPadding + oPadding) * i) - oPadding))
-						optionSelect[#optionSelect + 1] = { math.floor(optionButtons[showSelectOptions][1]), math.floor(yPos - oHeight - oPadding), math.floor(optionButtons[showSelectOptions][1] + maxWidth), math.floor(yPos + oPadding) - 1, k }
+						if i > selectScrollOffset and vi < maxVisible then
+							vi = vi + 1
+							local itemYPos = math.floor(y - (((oHeight + oPadding + oPadding) * vi) - oPadding))
+							optionSelect[#optionSelect + 1] = { math.floor(optionButtons[showSelectOptions][1]), math.floor(itemYPos - oHeight - oPadding), math.floor(optionButtons[showSelectOptions][1] + maxWidth), math.floor(itemYPos + oPadding) - 1, k }
 
-						if math_isInRect(mx, my, optionSelect[#optionSelect][1], optionSelect[#optionSelect][2], optionSelect[#optionSelect][3], optionSelect[#optionSelect][4]) then
-							UiSelectHighlight(optionButtons[showSelectOptions][1], math.floor(yPos - oHeight - oPadding), optionButtons[showSelectOptions][1] + maxWidth, math.floor(yPos + oPadding))
-							if playSounds and (prevSelectHover == nil or prevSelectHover ~= i) then
-								Spring.PlaySoundFile(sounds.selectHoverClick, 0.04, 'ui')
+							if math_isInRect(mx, my, optionSelect[#optionSelect][1], optionSelect[#optionSelect][2], optionSelect[#optionSelect][3], optionSelect[#optionSelect][4]) then
+								UiSelectHighlight(optionButtons[showSelectOptions][1], math.floor(itemYPos - oHeight - oPadding), optionButtons[showSelectOptions][1] + maxWidth, math.floor(itemYPos + oPadding))
+								if playSounds and (prevSelectHover == nil or prevSelectHover ~= i) then
+									Spring.PlaySoundFile(sounds.selectHoverClick, 0.04, 'ui')
+								end
+								prevSelectHover = k
 							end
-							prevSelectHover = k
+							if options[showSelectOptions].optionsFont and fontOption and fontOption[i] then
+								fontOption[i]:Begin()
+								fontOption[i]:SetOutlineColor(0,0,0,0.4)
+								fontOption[i]:Print(optionColor .. option, optionButtons[showSelectOptions][1] + 7, itemYPos - (oHeight / 2) - oPadding, fontSize, "no")
+								fontOption[i]:End()
+							else
+								font:Begin()
+								font:SetOutlineColor(0,0,0,0.4)
+								font:Print(optionColor .. option, optionButtons[showSelectOptions][1] + 7, itemYPos - (oHeight / 2) - oPadding, fontSize, "no")
+								font:End()
+							end
 						end
-						if options[showSelectOptions].optionsFont and fontOption and fontOption[i] then
-							fontOption[i]:Begin()
-							fontOption[i]:SetOutlineColor(0,0,0,0.4)
-							fontOption[i]:Print(optionColor .. option, optionButtons[showSelectOptions][1] + 7, yPos - (oHeight / 2) - oPadding, fontSize, "no")
-							fontOption[i]:End()
-						else
-							font:Begin()
-							font:SetOutlineColor(0,0,0,0.4)
-							font:Print(optionColor .. option, optionButtons[showSelectOptions][1] + 7, yPos - (oHeight / 2) - oPadding, fontSize, "no")
-							font:End()
-						end
+					end
+					-- scrollbar
+					if numItems > 16 then
+						local sbWidth = math.max(3, math.floor(4 * widgetScale))
+						local dropY1 = yPos - oHeight - oPadding
+						local dropY2 = optionButtons[showSelectOptions][2]
+						local dropH = dropY2 - dropY1
+						local sbX1 = optionButtons[showSelectOptions][1] + maxWidth - sbWidth
+						local sbX2 = optionButtons[showSelectOptions][1] + maxWidth
+						-- track
+						gl.Color(0.15, 0.15, 0.15, 0.85)
+						gl.Rect(sbX1, dropY1, sbX2, dropY2)
+						-- thumb
+						local thumbH = math.max(dropH * maxVisible / numItems, sbWidth * 2)
+						local thumbY2 = dropY2 - (selectScrollOffset / (numItems - maxVisible)) * (dropH - thumbH)
+						local thumbY1 = thumbY2 - thumbH
+						gl.Color(0.65, 0.65, 0.65, 0.9)
+						gl.Rect(sbX1, thumbY1, sbX2, thumbY2)
+						gl.Color(1, 1, 1, 1)
 					end
 				end)
 				if WG['guishader'] then
@@ -1733,6 +1762,17 @@ end
 function widget:MouseWheel(up, value)
 	local x, y = Spring.GetMouseState()
 	if show then
+		if showSelectOptions ~= nil then
+			local numItems = 0
+			for _ in pairs(options[showSelectOptions].options) do numItems = numItems + 1 end
+			local maxVisible = math.min(numItems, 16)
+			if selectScrollOffset == nil then selectScrollOffset = 0 end
+			if up then
+				selectScrollOffset = math.max(0, selectScrollOffset - 1)
+			else
+				selectScrollOffset = math.min(numItems - maxVisible, selectScrollOffset + 1)
+			end
+		end
 		return true
 	end
 end
@@ -1899,6 +1939,7 @@ function mouseEvent(mx, my, button, release)
 								end
 								if showSelectOptions == nil then
 									showSelectOptions = i
+									selectScrollOffset = 0
 								elseif showSelectOptions == i then
 									--showSelectOptions = nil
 								end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -1506,7 +1506,7 @@ function widget:DrawScreen()
 					UiSelector(optionButtons[showSelectOptions][1], optionButtons[showSelectOptions][2], optionButtons[showSelectOptions][3], optionButtons[showSelectOptions][4])
 
 					local i = 0
-					local vi = 0
+					local vi = 0 -- visible index in the current scrollbar  
 					for k, option in pairs(options[showSelectOptions].options) do
 						i = i + 1
 						if i > selectScrollOffset and vi < maxVisible then


### PR DESCRIPTION
For really long dropdowns it's possible they are actually going offscreen, this PR limit the items in a dropdown to 16 and add a scrollbar if more are needed to be presented.

PR:
<img width="429" height="612" alt="image" src="https://github.com/user-attachments/assets/87ff7da9-96f5-4890-8f5b-86ee6ae44f1c" />

Before:
<img width="429" height="776" alt="image" src="https://github.com/user-attachments/assets/e0b5fa5c-fd94-4658-88a7-7aa25104b0ff" />

LLM: Claude, human brain checked

Note that we are the limit for available variables in this file... (wontfix in this PR)