### PR TITLE
fix: set target comparing table to non-table

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -1121,7 +1121,7 @@ else	-- UNSYNCED
 		repeat
 			weaponNum = weaponNum + 1
 			local _, _, currentTarget = spGetUnitWeaponTarget(unitID, weaponNum)
-			if currentTarget then
+			if type(currentTarget) == "table" then
 				result = currentTarget[1] == x
 					and currentTarget[2] == y
 					and currentTarget[3] == z


### PR DESCRIPTION
### Work done

Check that the target type returned from Spring.GetUnitWeaponTarget is a table before comparing coordinates.

#### Addresses Issue(s)

Bug found when keeping a target list paused with an active ground target.