### PR TITLE
fix: ambiguity on BAR install directory (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ In order to develop the game (this repository) you first need a working install 
 
 Once you have a working install of BAR you need a local development copy of the game code to work with. This code will live in the BAR install directory.
 
-1. To find the BAR install directory simply open the launcher (not full game) and click the "Open install directory" button. This is one of the 3 buttons (`Toggle log` and `Upload log` are the other 2). For Windows installs this might be your user's `AppData/Local/Programs/Beyond-All-Reason/data` directory.
+1. To find the BAR install directory simply open the launcher (not full game) and click the "Open install directory" button. This is one of the 3 buttons (`Toggle log` and `Upload log` are the other 2). For Windows installs this might be your user's `AppData/Local/Programs/Beyond-All-Reason/data` directory, for Linux it might be your user's `.local/state/Beyond All Reason/` directory.
 
-2. In the BAR install directory create the empty file `devmode.txt`. E.g: `AppData/Local/Programs/Beyond-All-Reason/data/devmode.txt`
+2. In the BAR install directory create the empty file `devmode.txt`. E.g: `AppData/Local/Programs/Beyond-All-Reason/data/devmode.txt` or `.local/state/Beyond All Reason/devmode.txt`.
 
-3. In the BAR install directory in the `data` folder in the `games` sub-directory (create `games` if it doesn't exist) clone the code for this repository into a directory with a name ending in `.sdd`. For example:
+3. In the BAR install directory (inside the `data` folder on Windows) in the `games` sub-directory (create `games` if it doesn't exist) clone the code for this repository into a directory with a name ending in `.sdd`. For example:
 
 ```
 git clone --recurse-submodules https://github.com/beyond-all-reason/Beyond-All-Reason.git BAR.sdd
 ```
 
-Ensure that you have the correct path by looking for the file `Beyond-All-Reason/data/games/BAR.sdd/modinfo.lua`
+Ensure that you have the correct path by looking for the file `Beyond-All-Reason/data/games/BAR.sdd/modinfo.lua` on Windows, or `.local/state/Beyond All Reason/games/BAR.sdd/modinfo.lua` on Linux.
 
 4. Now you have the game code launch the full game from the launcher as normal. Then go to `Settings > Developer > Singleplayer` and select `Beyond All Reason Dev`.
 


### PR DESCRIPTION
### Work done
The BAR install directory is platform-specific. Added clarification for Windows/Linux distinction.