### PR TITLE
Fix minimap build preview icon rotation

### DIFF
--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -13332,7 +13332,7 @@ local function DrawBuildCursorWithRotation()
 			glFunc.Rotate(-render.minimapRotation * 180 / math.pi, 0, 0, 1)
 		end
 		glFunc.Texture(texture)
-		glFunc.BeginEnd(glConst.QUADS, DrawTexturedQuad, -iconSize, -iconSize, iconSize, iconSize)
+		glFunc.TexRect(-iconSize, -iconSize, iconSize, iconSize)
 		glFunc.Texture(false)
 		glFunc.PopMatrix()
 	end


### PR DESCRIPTION
on minimap buildings now follow correct orientation before placing blueprint


fixes #8210 



<img width="196" height="262" alt="image" src="https://github.com/user-attachments/assets/8427d541-f787-4305-8f0c-238556ddb782" />
