### PR TITLE
Changes attack cursor on emp only units when hovering emp immune targets

### DIFF
--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -12,9 +12,6 @@ function gadget:GetInfo()
 	}
 end
 
-local CMD_ATTACK = CMD.ATTACK
-local CMD_MOVE = CMD.MOVE
-
 local spGetSelectedUnitsCounts = Spring.GetSelectedUnitsCounts
 local spGetUnitDefID = Spring.GetUnitDefID
 local spIsUnitAllied = Spring.IsUnitAllied
@@ -45,11 +42,11 @@ end
 
 if gadgetHandler:IsSyncedCode() then
 	function gadget:Initialize()
-		gadgetHandler:RegisterAllowCommand(CMD_ATTACK)
+		gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
 	end
 
+
 	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-		-- accepts: CMD.ATTACK
 		if empUnits[unitDefID]
 			and cmdParams[2] == nil
 			and type(cmdParams[1]) == 'number'
@@ -71,6 +68,7 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 else
+	-- EMP restriction for the hovering icons
 	local function CanSelectionAttackTarget(targetDefID)
 		local targetIsEmpImmune = unEmpableUnits[targetDefID]
 		for unitDefID in pairs(spGetSelectedUnitsCounts()) do
@@ -83,13 +81,13 @@ else
 	end
 
 	function gadget:DefaultCommand(type, id, cmd)
-		if type ~= "unit" or cmd ~= CMD_ATTACK or not id or spIsUnitAllied(id) then
+		if type ~= "unit" or cmd ~= CMD.ATTACK or not id or spIsUnitAllied(id) then
 			return
 		end
 
 		local targetDefID = spGetUnitDefID(id)
 		if targetDefID and unEmpableUnits[targetDefID] and not CanSelectionAttackTarget(targetDefID) then
-			return CMD_MOVE
+			return CMD.MOVE --shows move instead of attack on the immune targets. potentially changed later
 		end
 	end
 end

--- a/luarules/gadgets/unit_onlytargetempable.lua
+++ b/luarules/gadgets/unit_onlytargetempable.lua
@@ -12,18 +12,30 @@ function gadget:GetInfo()
 	}
 end
 
+local CMD_ATTACK = CMD.ATTACK
+local CMD_MOVE = CMD.MOVE
+
+local spGetSelectedUnitsCounts = Spring.GetSelectedUnitsCounts
+local spGetUnitDefID = Spring.GetUnitDefID
+local spIsUnitAllied = Spring.IsUnitAllied
+
 local empUnits = {}
+local attackUnits = {}
 local unEmpableUnits = {}
 for udid = 1, #UnitDefs do
 	local unitDef = UnitDefs[udid]
 	local weapons = unitDef.weapons
 	empUnits[udid] = false
+	if #weapons > 0 then
+		empUnits[udid] = true
+	end
 	for i = 1, #weapons do
-		if WeaponDefs[weapons[i].weaponDef].paralyzer then
-			empUnits[udid] = true
-		else
+		local weaponDef = WeaponDefs[weapons[i].weaponDef]
+		if weaponDef and not weaponDef.isShield then
+			attackUnits[udid] = true
+		end
+		if not (weaponDef and weaponDef.paralyzer) then
 			empUnits[udid] = false
-			break
 		end
 	end
 	if not unitDef.modCategories.empable then
@@ -31,29 +43,53 @@ for udid = 1, #UnitDefs do
 	end
 end
 
-function gadget:Initialize()
-	gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
-end
+if gadgetHandler:IsSyncedCode() then
+	function gadget:Initialize()
+		gadgetHandler:RegisterAllowCommand(CMD_ATTACK)
+	end
 
-function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
-	-- accepts: CMD.ATTACK
-	if empUnits[unitDefID]
-		and cmdParams[2] == nil
-		and type(cmdParams[1]) == 'number'
-		and UnitDefs[Spring.GetUnitDefID(cmdParams[1])] ~= nil then
-		if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then --	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
-			return false
-		else
-			local _,_,_,_, y = Spring.GetUnitPosition(cmdParams[1], true)
-			local _, scaleY, _, _, offY = Spring.GetUnitCollisionVolumeData(cmdParams[1])
-			y = y + offY + (scaleY * 0.5)
-			if y and y >= 0 then
-				return true
-			else
+	function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
+		-- accepts: CMD.ATTACK
+		if empUnits[unitDefID]
+			and cmdParams[2] == nil
+			and type(cmdParams[1]) == 'number'
+			and UnitDefs[Spring.GetUnitDefID(cmdParams[1])] ~= nil then
+			if unEmpableUnits[Spring.GetUnitDefID(cmdParams[1])] then --	and UnitDefs[Spring.GetUnitDefID(cmdParams[1])].customParams.paralyzemultiplier == '0' then
 				return false
+			else
+				local _,_,_,_, y = Spring.GetUnitPosition(cmdParams[1], true)
+				local _, scaleY, _, _, offY = Spring.GetUnitCollisionVolumeData(cmdParams[1])
+				y = y + offY + (scaleY * 0.5)
+				if y and y >= 0 then
+					return true
+				else
+					return false
+				end
+			end
+		else
+			return true
+		end
+	end
+else
+	local function CanSelectionAttackTarget(targetDefID)
+		local targetIsEmpImmune = unEmpableUnits[targetDefID]
+		for unitDefID in pairs(spGetSelectedUnitsCounts()) do
+			if attackUnits[unitDefID] and (not targetIsEmpImmune or not empUnits[unitDefID]) then
+				return true
 			end
 		end
-	else
-		return true
+
+		return false
+	end
+
+	function gadget:DefaultCommand(type, id, cmd)
+		if type ~= "unit" or cmd ~= CMD_ATTACK or not id or spIsUnitAllied(id) then
+			return
+		end
+
+		local targetDefID = spGetUnitDefID(id)
+		if targetDefID and unEmpableUnits[targetDefID] and not CanSelectionAttackTarget(targetDefID) then
+			return CMD_MOVE
+		end
 	end
 end

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -1727,6 +1727,8 @@ local cache = {
 	unitCost = {},
 	-- Combat properties
 	canAttack = {},
+	empOnlyAttacker = {},
+	unEmpableUnit = {},
 	isAirAttacker = {},   -- Air units with ground/sea attack weapons (bombers, gunships)
 	isExpensiveEco = {},  -- Non-commander buildings with cost >= 1000 (T2 mexes, fusions, etc.)
 	maxIconShatters = 20,
@@ -7362,6 +7364,29 @@ local function CanTransportLoadUnit(transportUnitID, targetUnitID)
 	return true
 end
 
+local function CanSelectedUnitsAttackTarget(selectedUnits, targetUnitID)
+	if not selectedUnits or not targetUnitID then
+		return false
+	end
+
+	local targetDefID = spFunc.GetUnitDefID(targetUnitID)
+	if not targetDefID then
+		return false
+	end
+
+	local targetIsEmpImmune = cache.unEmpableUnit[targetDefID]
+	for i = 1, #selectedUnits do
+		local unitDefID = spFunc.GetUnitDefID(selectedUnits[i])
+		if unitDefID and cache.canAttack[unitDefID] then
+			if not targetIsEmpImmune or not cache.empOnlyAttacker[unitDefID] then
+				return true
+			end
+		end
+	end
+
+	return false
+end
+
 local function IssueCommandAtPoint(cmdID, wx, wz, usingRMB, forceQueue, radius)
 
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
@@ -7809,6 +7834,23 @@ function widget:Initialize()
 
 		-- Cache combat properties
 		local hasGroundAttack = false
+		local isEmpOnlyAttacker = false
+		if uDef.weapons and #uDef.weapons > 0 then
+			isEmpOnlyAttacker = true
+			for _, weapon in ipairs(uDef.weapons) do
+				local weaponDef = WeaponDefs[weapon.weaponDef]
+				if not (weaponDef and weaponDef.paralyzer) then
+					isEmpOnlyAttacker = false
+					break
+				end
+			end
+		end
+		if isEmpOnlyAttacker then
+			cache.empOnlyAttacker[uDefID] = true
+		end
+		if not (uDef.modCategories and uDef.modCategories.empable) then
+			cache.unEmpableUnit[uDefID] = true
+		end
 		if uDef.weapons and #uDef.weapons > 0 then
 			-- Check if unit has any non-shield weapons
 			for _, weapon in ipairs(uDef.weapons) do
@@ -16075,13 +16117,9 @@ local function HandleHoverAndCursor(mx, my)
 						local isVisibleOrRadar = losState and (losState.los or losState.radar)
 
 						if not isNeutral and isVisibleOrRadar then
-							-- Check if any selected unit can attack
-							for i = 1, #selectedUnits do
-								local uDefID = spFunc.GetUnitDefID(selectedUnits[i])
-								if uDefID and cache.canAttack[uDefID] then
-									Spring.SetMouseCursor('Attack')
-									return
-								end
+							if CanSelectedUnitsAttackTarget(selectedUnits, lastHoveredUnitID) then
+								Spring.SetMouseCursor('Attack')
+								return
 							end
 						end
 					end
@@ -16109,8 +16147,11 @@ local function HandleHoverAndCursor(mx, my)
 				end
 			elseif defaultCmd == CMD.ATTACK and lastHoveredUnitID and not Spring.IsUnitAllied(lastHoveredUnitID) then
 				-- Hovering over enemy unit with units that can attack
-				Spring.SetMouseCursor('Attack')
-				return
+				if not frameSel then frameSel = Spring.GetSelectedUnits() end
+				if CanSelectedUnitsAttackTarget(frameSel, lastHoveredUnitID) then
+					Spring.SetMouseCursor('Attack')
+					return
+				end
 			end
 		else
 			local cursorName = cmdCursors[activeCmdID]
@@ -17807,13 +17848,7 @@ function widget:Update(dt)
 				local isVisibleOrRadar = losState and (losState.los or losState.radar)
 
 				if not isNeutral and isVisibleOrRadar then
-					for i = 1, #selectedUnits do
-						local uDefID = spFunc.GetUnitDefID(selectedUnits[i])
-						if uDefID and cache.canAttack[uDefID] then
-							shouldHighlight = true
-							break
-						end
-					end
+					shouldHighlight = CanSelectedUnitsAttackTarget(selectedUnits, unitID)
 				end
 			end
 
@@ -19247,7 +19282,10 @@ function widget:DefaultCommand()
 			if Spring.IsUnitAllied(uID) then
 				return CMD.GUARD
 			else
-				return CMD.ATTACK
+				if CanSelectedUnitsAttackTarget(Spring.GetSelectedUnits(), uID) then
+					return CMD.ATTACK
+				end
+				return CMD.MOVE
 			end
 		end
 		local fID = GetFeatureAtPoint(wx, wz)
@@ -20282,8 +20320,12 @@ function widget:MousePress(mx, my, mButton)
 								overrideTarget = uID
 							end
 						else
-							cmdID = CMD.ATTACK
-							overrideTarget = uID
+							if CanSelectedUnitsAttackTarget(Spring.GetSelectedUnits(), uID) then
+								cmdID = CMD.ATTACK
+								overrideTarget = uID
+							else
+								cmdID = CMD.MOVE
+							end
 						end
 					else
 						local fID = GetFeatureAtPoint(wx, wz)
@@ -21227,7 +21269,11 @@ function widget:MouseRelease(mx, my, mButton)
 						cmdID = CMD.GUARD
 					end
 				else
-					cmdID = CMD.ATTACK
+					if CanSelectedUnitsAttackTarget(Spring.GetSelectedUnits(), uID) then
+						cmdID = CMD.ATTACK
+					else
+						cmdID = CMD.MOVE
+					end
 				end
 			else
 				local fID = GetFeatureAtPoint(wx, wz)


### PR DESCRIPTION
Removed the attack hover icon over enemy units which displays when EMP only units are selected. 
Fixes #8228 

EX. When units like the Shuriken are selected they currently show an attack cursor when an enemy unit such as the Sol Invictus is hovered. This attack icon is incorrect as these units cannot attack EMP immune units. Should show no cursor or some other sort of icon besides the attack one

### Work done

Can now track if the selected units only have EMP weapons.
Attack cursor no longer appears when hovering an emp immune attacker while selecting only EMP units. Regular move cursor now appears. 

Note: units with multiple weapons besides EMP, such as ``Thor`` continue to show the attack icon on hover.


When selecting only shurikens and hovering over an EMP immune enemy unit:
<img width="405" height="235" alt="image" src="https://github.com/user-attachments/assets/0cf5ef52-5ae5-4bfa-83de-0ab79db38ca8" />



Used codex to assist. 