### PR TITLE
[Types] LLM-driven type-error transform capstone

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,18 @@
+# gen(stylua): initial formatting of entire codebase
+d7553dbdcbcd7e4c4702a140a1a3ad6da12897a8
+
+# gen(bar_codemod): bracket-to-dot
+f184455f9b34c7f821a4ea056f47cd87fad95a1b
+
+# gen(bar_codemod): rename-aliases
+7bf6c10a79c64ecdf9ab0cd60574d38c0cf05754
+
+# gen(bar_codemod): detach-bar-modules
+a1b8a8abe997bcf626401dd017232799942f9aa2
+
+# gen(hand): integration tests return-table shape
+a1b8a8abe997bcf626401dd017232799942f9aa2
+
+# gen(hand): inline luassert and busted LuaCATS types
+a1b8a8abe997bcf626401dd017232799942f9aa2
+

--- a/luarules/gadgets/api_enemyunitdestroyed.lua
+++ b/luarules/gadgets/api_enemyunitdestroyed.lua
@@ -28,7 +28,7 @@ if not gadgetHandler:IsSyncedCode() then
 
 	function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID, weaponDefID)
 		local allyTeam = spGetUnitAllyTeam(unitID)
-		if (spec and fullview) or (allyTeam and allyTeam ~= myAllyTeamID) then
+		if (spec and fullView) or (allyTeam and allyTeam ~= myAllyTeamID) then
 			local losstate = Spring.GetUnitLosState(unitID, myAllyTeamID)
 			if losstate and losstate.los and Script.LuaUI("EnemyUnitDestroyed") then
 				Script.LuaUI.EnemyUnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID, weaponDefID)

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1048,7 +1048,7 @@ if gadgetHandler:IsSyncedCode() then
 			--if bestBurrowID then
 			--	DestroyUnit(bestBurrowID, true, false)
 			--end
-			return CreateUnit(config.queenName, sx, sy, sz, mRandom(0, 3), raptorTeamID), burrowID
+			return CreateUnit(config.queenName, sx, sy, sz, mRandom(0, 3), raptorTeamID), bestBurrowID
 		end
 
 		local x, z, y

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1181,7 +1181,7 @@ if gadgetHandler:IsSyncedCode() then
 			--if bestBurrowID then
 			--	Spring.DestroyUnit(bestBurrowID, true, false)
 			--end
-			return CreateUnit(config.bossName, sx, sy, sz, mRandom(0, 3), scavTeamID), burrowID
+			return CreateUnit(config.bossName, sx, sy, sz, mRandom(0, 3), scavTeamID), bestBurrowID
 		end
 
 		local x, z, y

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -20,12 +20,12 @@ end
 --------------------------------------------------------------------------------
 -- Configuration ---------------------------------------------------------------
 
-local damageInterval = 0.7333 ---@type number in seconds, time between procs
-local damageLimit = 120 ---@type number in damage per second, soft-cap across multiple areas
-local damageExcessRate = 0.2 ---@type number %damage dealt above limit [0, 1)
-local damageCegMinScalar = 30 ---@type number in damage, minimum to show hit CEG
-local damageCegMinMultiple = 1 / 3 ---@type number in %damage, minimum to show hit CEG
-local factoryWaitTime = damageInterval ---@type number in seconds, immunity period for factory-built units
+local damageInterval = 0.7333 ---@type number # in seconds, time between procs
+local damageLimit = 120 ---@type number # in damage per second, soft-cap across multiple areas
+local damageExcessRate = 0.2 ---@type number # %damage dealt above limit [0, 1)
+local damageCegMinScalar = 30 ---@type number # in damage, minimum to show hit CEG
+local damageCegMinMultiple = 1 / 3 ---@type number # in %damage, minimum to show hit CEG
+local factoryWaitTime = damageInterval ---@type number # in seconds, immunity period for factory-built units
 
 -- Since I couldn't figure out totally arbitrary-radius variable CEGs for fire,
 -- we're left with this static list, which is repeated in the expgen def files:

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -421,7 +421,7 @@ local function CobDroneSpawnSequenceFinished(unitID, unitDefID, team, subUnitID)
 		return
 	else
 		local dockingPiece = carrierMetaList[unitID].subUnitsList[subUnitID].dockingPiece
-		local _, pieceAngle = spCallCOBScript(unitID, "DroneDocked", 5, pieceAngle, dockingPiece)
+		local _, pieceAngle = spCallCOBScript(unitID, "DroneDocked", 5, nil, dockingPiece)
 		spCallCOBScript(subUnitID, "Docked", 0, carrierMetaList[unitID].cobdockparam, dockingPiece, pieceAngle)
 		return
 	end
@@ -475,7 +475,7 @@ local function spawnUnit(spawnData)
 							energyCost = carrierData.energyCost[dronetypeIndex]
 						else
 							local subUnitDef = UnitDefNames[dronename]
-							if subunitDef then
+							if subUnitDef then
 								metalCost = subUnitDef.metalCost
 								energyCost = subUnitDef.energyCost
 							else
@@ -617,7 +617,7 @@ local function spawnUnit(spawnData)
 								droneSpawnSequence(ownerID, subUnitID)
 								droneMetaData.activeSpawnSequence = true
 							else
-								local _, pieceAngle = spCallCOBScript(ownerID, "DroneDocked", 5, pieceAngle, droneMetaData.dockingPiece)
+								local _, pieceAngle = spCallCOBScript(ownerID, "DroneDocked", 5, nil, droneMetaData.dockingPiece)
 								spCallCOBScript(subUnitID, "Docked", 0, carrierData.cobdockparam, droneMetaData.dockingPiece, pieceAngle)
 							end
 						else
@@ -1578,7 +1578,7 @@ local function dockUnits(dockingqueue, queuestart, queueend)
 								if carrierMetaList[unitID].dockArmor then
 									spSetUnitArmored(subUnitID, true, carrierMetaList[unitID].dockArmor)
 								end
-								local _, pieceAngle = spCallCOBScript(unitID, "DroneDocked", 5, pieceAngle, pieceNumber)
+								local _, pieceAngle = spCallCOBScript(unitID, "DroneDocked", 5, nil, pieceNumber)
 								spCallCOBScript(subUnitID, "Docked", 0, carrierMetaList[unitID].cobdockparam, pieceNumber, pieceAngle)
 
 								if dronetype == "abductor" then

--- a/luarules/gadgets/unit_stomp.lua
+++ b/luarules/gadgets/unit_stomp.lua
@@ -31,7 +31,7 @@ end
 local stompableDefs = {}
 for udid, ud in pairs(UnitDefs) do
 	if stompable[ud.name] then
-		stompableDefs[udid] = v
+		stompableDefs[udid] = ud
 	end
 end
 

--- a/luaui/Include/AtlasOnDemand.lua
+++ b/luaui/Include/AtlasOnDemand.lua
@@ -529,7 +529,7 @@ local function MakeAtlasOnDemand(config)
 		if id then
 			self.uvcoords[id] = nil
 		end
-		local drawblanktask = { id = self.blankimg, w = xmax - xmin * self.xresolution, h = ymax - ymin * yresolution, x = xmin * self.xresolution, y = ymin * self.yresolution }
+		local drawblanktask = { id = self.blankimg, w = xmax - xmin * self.xresolution, h = ymax - ymin * self.yresolution, x = xmin * self.xresolution, y = ymin * self.yresolution }
 		self.renderImageTaskList[#self.renderImageTaskList + 1] = drawblanktask
 		self.hastasks = true
 	end

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -11100,6 +11100,7 @@ local function attachEventListeners()
 	local defaultsBtn = getCachedEl(doc, "btn-defaults")
 	if defaultsBtn then
 		defaultsBtn:AddEventListener("click", function(event)
+			local dm = widgetState.dmHandle
 			playSound("reset")
 			if WG.TerraformBrush then
 				WG.TerraformBrush.setRadius(100)
@@ -12885,12 +12886,12 @@ function widget:Update()
 		if fillBtn then
 			fillBtn:SetClass("disabled", mbActive or fpActive or gbActive or wbActive or lpActive or noiseActive or (tfActive and tfState and tfState.mode == "lower") or false)
 		end
+
+		local doc = widgetState.document
 		local clayBtn = doc and getCachedEl(doc, "btn-clay-mode")
 		if clayBtn then
 			clayBtn:SetClass("disabled", mbActive or lpActive or false)
 		end
-
-		local doc = widgetState.document
 
 		-- Blue-dot hint gating: hide dots already seen or when tips disabled,
 		-- and handle chip 2-pulse animations scheduled by tf_environment listeners.
@@ -13277,6 +13278,7 @@ function widget:Update()
 						widgetState.dmHandle.tfRestoreStrengthStr = v
 					end
 				end
+				local dm = widgetState.dmHandle
 
 				local sliderCapMax = getCachedEl(doc, "slider-cap-max")
 				if sliderCapMax and ds ~= "capmax" then
@@ -13496,6 +13498,7 @@ function widget:Update()
 						setDm("tfSymHasAxis", (state.symmetryRadial or state.symmetryMirrorX or state.symmetryMirrorY) and true or false)
 					end
 				end
+				local dustEl = getCachedEl(doc, "btn-dust-effects")
 				if dustEl then
 					dustEl:SetClass("active", state.dustEffects == true)
 					if dm then

--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -137,7 +137,7 @@ local function Scream(reason, unitID) -- This will pause the game and play some 
 		local unitDefID = spGetUnitDefID(unitID)
 		local unitTeam = spGetUnitTeam(unitID)
 		local ux, uy, uz = spGetUnitPosition(unitID)
-		spEcho("API Unit Tracker error unitID", unitID, unitDefID and UnitDefs[unitDefID].name or "nil", unitTeam, px, pz)
+		spEcho("API Unit Tracker error unitID", unitID, unitDefID and UnitDefs[unitDefID].name or "nil", unitTeam, ux, uz)
 	end
 	if lastknownunitpos[unitID] then
 		Spring.MarkerAddPoint(lastknownunitpos[unitID][1], lastknownunitpos[unitID][2], lastknownunitpos[unitID][3], lastknownunitpos[unitID][4], true)

--- a/luaui/Widgets/cmd_area_commands_filter.lua
+++ b/luaui/Widgets/cmd_area_commands_filter.lua
@@ -56,8 +56,6 @@ local myAllyTeamID
 --- Target sorting logic (pick the closest first)
 ---------------------------------------------------------------------------------------
 
----@field position1 table {x, y, z}
----@field position2 table {x, y, z}
 local function distanceSq(position1, position2)
 	local dx = position1.x - position2.x
 	local dz = position1.z - position2.z

--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -27,7 +27,7 @@ local tableInsert = table.insert
 -- Localized Spring API for performance
 local spGetGameFrame = Spring.GetGameFrame
 
-local isPregame = spGetGameFrame() == 0 and not isSpec
+local isPregame = spGetGameFrame() == 0 and not Spring.GetSpectatingState()
 
 local uDefNames = UnitDefNames
 

--- a/luaui/Widgets/dbg_frame_grapher.lua
+++ b/luaui/Widgets/dbg_frame_grapher.lua
@@ -435,6 +435,6 @@ function widget:DrawScreen()
 	glColor(1, 1, 1, 1)
 
 	wasgameframe = 0
-	prevframems = lastframeduration
+	prevframems = lastframems
 	gameFrameHappened = false
 end

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1419,8 +1419,8 @@ function widget:UnitCreated(unitID, unitDefID, teamID)
 	eventLightSpawner("UnitCreated", unitID, unitDefID, teamID)
 end
 function widget:UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)
-	eventLightSpawner("UnitFromFactory", unitID, unitDefID, teamID) -- i have no idea of the differences here
-	eventLightSpawner("UnitFromFactoryBuilder", factID, factDefID, teamID)
+	eventLightSpawner("UnitFromFactory", unitID, unitDefID, unitTeam) -- i have no idea of the differences here
+	eventLightSpawner("UnitFromFactoryBuilder", factID, factDefID, unitTeam)
 end
 function widget:UnitDestroyed(unitID, unitDefID, teamID) -- dont do piece-attached lights here!
 	eventLightSpawner("UnitDestroyed", unitID, unitDefID, teamID)

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -1001,8 +1001,8 @@ function widget:UnitCreated(unitID, unitDefID, teamID)
 	eventDistortionSpawner("UnitCreated", unitID, unitDefID, teamID)
 end
 function widget:UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)
-	eventDistortionSpawner("UnitFromFactory", unitID, unitDefID, teamID) -- i have no idea of the differences here
-	eventDistortionSpawner("UnitFromFactoryBuilder", factID, factDefID, teamID)
+	eventDistortionSpawner("UnitFromFactory", unitID, unitDefID, unitTeam) -- i have no idea of the differences here
+	eventDistortionSpawner("UnitFromFactoryBuilder", factID, factDefID, unitTeam)
 end
 function widget:UnitDestroyed(unitID, unitDefID, teamID) -- dont do piece-attached distortions here!
 	eventDistortionSpawner("UnitDestroyed", unitID, unitDefID, teamID)

--- a/luaui/Widgets/gfx_norush_timer_gl4.lua
+++ b/luaui/Widgets/gfx_norush_timer_gl4.lua
@@ -23,6 +23,7 @@ local pveAllyTeamID = BAR.Utilities.GetScavAllyTeamID() or BAR.Utilities.GetRapt
 local autoReload = false -- refresh shader code every second (disable in production!)
 
 local StartBoxes = {} -- list of xXyY
+local NUM_BOXES = 0
 local noRushTime = Spring.GetModOptions().norushtimer * 60 * 30
 if noRushTime == 0 then
 	return

--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -2052,7 +2052,7 @@ function CreateBackground()
 	if absRight > vsx + margin then -- lazy bugfix needed when playerScale < 1 is in effect
 		absRight = vsx + margin
 	end
-	apiAbsPosition = { absTop, absLeft, absBottom, absRight, widgetScale, right, false }
+	apiAbsPosition = { absTop, absLeft, absBottom, absRight, widgetScale, absRight, false }
 
 	local paddingBottom = bgpadding
 	local paddingRight = bgpadding
@@ -2865,6 +2865,7 @@ function DrawState(playerID, posX, posY)
 	-- note that adv pl list uses a phantom pID for absent players, so this will always show unready for players not ingame
 	local ready = (playerReadyState[playerID] == 1) or (playerReadyState[playerID] == 2) or (playerReadyState[playerID] == -1)
 	local hasStartPoint = (playerReadyState[playerID] == 4)
+	local _, _, _, ai = spGetPlayerInfo(playerID)
 	if ai then
 		gl_Color(0.1, 0.1, 0.97, 1)
 	else

--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -30,7 +30,7 @@ local config = {
 local waterLevel = Spring.GetWaterPlaneLevel and Spring.GetWaterPlaneLevel() or 0
 
 local cmdShowForUnitDefID
-local isPregame = Spring.GetGameFrame() == 0 and not isSpec
+local isPregame = Spring.GetGameFrame() == 0 and not Spring.GetSpectatingState()
 
 local gridVBO = nil -- the vertex buffer object, an array of vec2 coords
 local gridVAO = nil -- the vertex array object, a way of collecting buffer objects for submission to opengl

--- a/luaui/Widgets/gui_ground_ao_plates_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_gl4.lua
@@ -180,7 +180,7 @@ end
 
 function widget:VisibleUnitRemoved(unitID) -- remove the corresponding ground plate if it exists
 	if debugmode then
-		BAR.Debug.TraceEcho("remove", unitID, reason)
+		BAR.Debug.TraceEcho("remove", unitID)
 	end
 	if groundPlateVBO.instanceIDtoIndex[unitID] then
 		popElementInstance(groundPlateVBO, unitID)

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -671,7 +671,7 @@ local function addBarForUnit(unitID, unitDefID, barname, reason)
 
 	if unitDefID == nil or Spring.ValidUnitID(unitID) == false or Spring.GetUnitIsDead(unitID) == true then -- dead or invalid
 		if debugmode then
-			BAR.Debug.TraceEcho("Tried to add a bar to dead/invalid/nounitdef unit", unitID, unitdefID, barname)
+			BAR.Debug.TraceEcho("Tried to add a bar to dead/invalid/nounitdef unit", unitID, unitDefID, barname)
 		end
 		return nil
 	end

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -229,7 +229,7 @@ local function drawContent()
 				end
 
 				local texSize = floor(iconSize * 1.33)
-				local zoom = i == hoveredIcon and (b and 0.15 or 0.105) or 0.05
+				local zoom = i == hoveredIcon and (showStack and 0.15 or 0.105) or 0.05
 				local highlightOpacity = 0
 				if i == hoveredIcon then
 					highlightOpacity = 0.22

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -1,6 +1,7 @@
 local widget = widget ---@type Widget
 
 local customPresetOptions -- forward-decl: read in options export
+local customPresets = {}
 
 function widget:GetInfo()
 	return {
@@ -1271,6 +1272,7 @@ local function checkQuitscreen()
 	end
 	quitscreen = (WG.topbar and WG.topbar.showingQuit() or false)
 	if prevQuitscreen ~= quitscreen then
+		local _, _, isClientPaused, _ = Spring.GetGameState()
 		if quitscreen and isClientPaused and not showToggledOff then
 			skipUnpauseOnHide = true
 		end

--- a/luaui/Widgets/gui_pregameui_draft.lua
+++ b/luaui/Widgets/gui_pregameui_draft.lua
@@ -213,6 +213,7 @@ local function DrawState(playerID, posX, posY)
 	-- note that adv pl list uses a phantom pID for absent players, so this will always show unready for players not ingame
 	local ready = (playerReadyState[playerID] == 1) or (playerReadyState[playerID] == 2) or (playerReadyState[playerID] == -1)
 	local hasStartPoint = (playerReadyState[playerID] == 4)
+	local _, _, _, _, _, _, _, ai = Spring.GetPlayerInfo(playerID, false)
 	if ai then
 		gl_Color(0.1, 0.1, 0.97, 1)
 	else
@@ -995,6 +996,7 @@ function widget:Initialize()
 	end
 
 	local xn, zn, xp, zp = Spring.GetAllyTeamStartBox(myAllyTeamID)
+	local msx, msz = Game.mapSizeX, Game.mapSizeZ
 	if xn and (xn ~= 0 or zn ~= 0 or xp ~= msx or zp ~= msz) then
 		hasStartbox = true
 	end

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -295,7 +295,7 @@ local function buildUnitDefs()
 
 	local function isArmyUnit(unitDefID, unitDef)
 		local isArmyUnit = #unitDef.weapons > 0 and unitDef.speed > 0
-		return isArmyUnit and not isCommander(unitDefId, unitDef)
+		return isArmyUnit and not isCommander(unitDefID, unitDef)
 	end
 
 	local function isDefenseUnit(unitDefID, unitDef)

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -1035,7 +1035,7 @@ local function InitStartPolygons()
 	)
 	startConeVBOTable.numVertices = numConeVertices
 	if startConeVBOTable == nil then
-		goodbye("Failed to create StartConeVBO")
+		Spring.Echo("Failed to create StartConeVBO")
 		widgetHandler:RemoveWidget()
 		return
 	end

--- a/mapgenerator/mapinfo_template.lua
+++ b/mapgenerator/mapinfo_template.lua
@@ -214,7 +214,7 @@ local mapinfo = {
 	},
 
 	teams = {
-		${START_POSITIONS}
+		-- START_POSITIONS placeholder filled by map generator
 	},
 
 	terrainTypes = {

--- a/modules/graphics/LuaShader.lua
+++ b/modules/graphics/LuaShader.lua
@@ -1116,7 +1116,7 @@ local function isUpdateRequiredNoTable(uniform, u1, u2, u3, u4)
 
 	if u1 and cachedValues[1] ~= u1 then
 		update = true
-		cachedValues[1] = val
+		cachedValues[1] = u1
 	end
 	if u2 and cachedValues[2] ~= u2 then
 		update = true

--- a/modules/graphics/instancevboidtable.lua
+++ b/modules/graphics/instancevboidtable.lua
@@ -92,7 +92,7 @@ local function makeVAOandAttach(vertexVBO, instanceVBO, indexVBO) -- Attach a ve
 	local newVAO = nil
 	newVAO = gl.GetVAO()
 	if newVAO == nil then
-		goodbye("Failed to create newVAO")
+		Spring.Echo("Failed to create newVAO")
 	end
 	if vertexVBO == nil then -- the special case where are using 'vertices' as 'instances'
 		newVAO:AttachVertexBuffer(instanceVBO)
@@ -639,5 +639,6 @@ return {
 	dumpAndCompareInstanceData = dumpAndCompareInstanceData,
 	uploadAllElements = uploadAllElements,
 	validateInstanceVBOIDTable = validateInstanceVBOIDTable,
+	---@diagnostic disable-next-line: undefined-global
 	uploadElementRange = uploadElementRange,
 }

--- a/modules/graphics/instancevbotable.lua
+++ b/modules/graphics/instancevbotable.lua
@@ -68,7 +68,7 @@ local function makeInstanceVBOTable(layout, maxElements, myName, unitIDattribID)
 		local newVAO = nil
 		newVAO = gl.GetVAO()
 		if newVAO == nil then
-			goodbye("Failed to create newVAO")
+			Spring.Echo("Failed to create newVAO")
 		end
 		self.VAO = newVAO
 		if vertexVBO == nil then -- the special case where are using 'vertices' as 'instances'
@@ -226,7 +226,7 @@ local function makeVAOandAttach(vertexVBO, instanceVBO, indexVBO) -- Attach a ve
 	local newVAO = nil
 	newVAO = gl.GetVAO()
 	if newVAO == nil then
-		goodbye("Failed to create newVAO")
+		Spring.Echo("Failed to create newVAO")
 	end
 	if vertexVBO == nil then -- the special case where are using 'vertices' as 'instances'
 		newVAO:AttachVertexBuffer(instanceVBO)

--- a/scripts/Units/armmar_lus/weapons.lua
+++ b/scripts/Units/armmar_lus/weapons.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: undefined-global
+
 function DrawWeapon(id)
 	Turn(torso, 2, ang(0), ang(300.00))
 	Turn(luparm, 1, ang(0), ang(300.000000))

--- a/scripts/headers/common_includes_lus.lua
+++ b/scripts/headers/common_includes_lus.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: undefined-global
+
 common = {
 
 	CustomEmitter = function(pieceName, effectName)

--- a/scripts/include/walk.lua
+++ b/scripts/include/walk.lua
@@ -3,6 +3,8 @@
 -- Author:	Nemo, Smoth
 -- Date:	3/18/2011
 -------------------------------------------------------
+---@diagnostic disable: undefined-global
+
 local inStance = false
 local gravFactor = Game.gravity / 120
 


### PR DESCRIPTION
> [!WARNING]
> **Superseded — this PR was an earlier mint of the stack.** The type-error cleanup
> now lands via the current stack tip [`fmt-llm` #8398](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8398).
> This slice's current counterpart is [#8398](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8398).
> Kept closed for review history; nothing here merges.

Part of [BAR type-error cleanup](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/7408). Final stage: deterministic transforms + env layer + LLM type-fix pass.

LLM workers apply the categorized fix recipes in [`SKILL.md`](https://github.com/beyond-all-reason/BAR-Devtools/pull/17/changes#diff-03a30b0197306b790f86b384d585b6d1aff0f23cc38a8545e73c027e3d090ddf) — each category maps an `emmylua_check` error pattern to an idempotent recipe.

### Triage run

```
baseline_errors=109
final_errors=0
chunks=5
model=gpt-5.4
timestamp=2026-07-22T19:27:27Z
```

### Branch Topology

All branches in the [BAR type-error cleanup](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/7408) stack — see [Bulk Migrations](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8237) for the migration log and how to run `just bar::migrate::stylua-cleanup`. Regenerated deterministically by [`just bar::migrate::stylua-cleanup-generate`](https://github.com/beyond-all-reason/BAR-Devtools/pull/17). *Generated 2026-07-22 19:34:38 UTC.*

**Leaves** — each isolates one transform's diff vs `fmt`:

| Branch | Command | Diff vs parent | Units |
|--------|---------|------|-------|
| [fmt](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7199) | `stylua` | 1425 files, +196955 −195449 | ✅ pass |
| [mig-bracket](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7287) | `bar-lua-codemod bracket-to-dot` | 351 files, +7779 −7779 | ✅ pass |
| [mig-rename-aliases](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7288) | `bar-lua-codemod rename-aliases` | 177 files, +376 −376 | ✅ pass |
| [mig-detach-bar-modules](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7289) | `bar-lua-codemod detach-bar-modules` | 181 files, +1702 −1573 | ✅ pass |
| [mig-integration-tests](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7437) | `<hand curated>` | 20 files, +134 −81 | ✅ pass |
| [mig-busted-types](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7438) | `<hand curated>` | 12 files, +1501 −0 | ✅ pass |

**Rollups** — composite branches stacking the leaves and (for `fmt-llm`) the env + LLM layers:

| Branch | Diff vs `master` | Diff vs parent | Units |
|--------|------|------|-------|
| [mig](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7229) | 1449 files, +201211 −198022 | 528 files, +11446 −9763 | ✅ pass |
| [fmt-llm-source](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7447) | 1454 files, +201680 −198185 | 61 files, +523 −217 | ✅ pass |
| 👉 **[fmt-llm](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8235)** — you are here | 1456 files, +201733 −198206 | 32 files, +70 −38 | ✅ pass |

