### PR TITLE
docs: add Bulk Migrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ More on the `.sdd` directory to run raw LUA and the structure expected by Spring
 
 ---
 
+## Bulk Migrations
+
+Large, repo-wide mechanical changes (indexing style, deprecated API renames, module namespacing) are applied as automated codemods maintained in [BAR-Devtools](https://github.com/beyond-all-reason/BAR-Devtools). A migration lands as one transform + format commit, so open branches must be replayed through the same transforms to merge cleanly.
+
+**After a migration lands on `master`, replay it onto your branch:**
+
+```bash
+just bar::fmt-mig                        # apply the codemod transforms + stylua
+git commit -am "apply code transforms"   # throwaway commit, squashed on merge
+git merge origin/master                  # only real conflicts remain
+```
+
+Maintainers regenerate the stacked branches/PRs with `just bar::fmt-mig-generate --update-prs`; the stack lands by merging **only the tip (`fmt-llm`)**.
+
+### Log
+
+- **2026-07 — Type-safety cleanup** — `t["x"]` -> `t.x` (valid identifiers only), deprecated `Spring.*` alias renames, `Spring.{Utilities,I18N,Debug,Lava,...}` -> `BAR.*` namespace, vendored LuaCATS test types, and an LLM-assisted type-error triage. Turns on the EmmyLua type-check CI gate.
+
+---
+
 ## Automated Testing
 
 ### Prereqs

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ https://www.beyondallreason.info/guides
 
 ## Development Quick Start
 
+> **Fastest path — [BAR-Devtools](https://github.com/beyond-all-reason/BAR-Devtools):** one command sets up the engine, game repos, type checker, formatter, tests, and a local server in an isolated container.
+>
+> ```bash
+> git clone https://github.com/beyond-all-reason/BAR-Devtools.git
+> cd BAR-Devtools
+> just setup::init
+> ```
+>
+> Prefer to wire it up by hand? The manual steps below still work.
+
 Beyond All Reason (BAR), consists of 2 primary components, the lobby (Chobby - https://github.com/beyond-all-reason/BYAR-Chobby) and the game code itself (this repository).
 
 The game runs on top of the Recoil engine https://github.com/beyond-all-reason/spring.


### PR DESCRIPTION
> [!WARNING]
> **Superseded — this PR was an earlier mint of the stack.** The type-error cleanup
> now lands via the current stack tip [`fmt-llm` #8398](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8398).
> This slice's current counterpart is [#8410](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8410).
> Kept closed for review history; nothing here merges.

Adds a **Bulk Migrations** section to the README documenting the automated repo-wide codemods run via [BAR-Devtools](https://github.com/beyond-all-reason/BAR-Devtools):

- how to apply them locally: `just bar::fmt-mig`
- a dated log of migrations (starting with the 2026-07 type-safety cleanup)

Existing setup/testing docs are untouched. The type-cleanup PR stack references this section.
