### PR TITLE
feat(barwidgets): enable first seen user widgets by default

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -605,7 +605,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 			order = nil
 		end
 	else
-		if info.enabled and (knownInfo.fromZip or (self.allowUserWidgets and not allowuserwidgets)) then
+		if info.enabled and (knownInfo.fromZip or self.allowUserWidgets) then
 			order = 12345
 		end
 	end


### PR DESCRIPTION
Users installing a new widget most likely expectation is that the  widget will be enabled in the next game after installing. This is not the case however due to an odd looking check.

It actually also looks like the intended behavior was that user custom widgets are loaded when first seen, using their `enabled = true` property. However the original if statement leads to an unreachable line: on line 404 there is a check `if self.allowUserWidgets and allowuserwidgets then` so in the old code `not allowuserwidgets` is always false, never loading the new widget.

I'd really appriate any pair of extra eyes also verifying this.
