### PR TITLE
Fix grid menu settings toggle needing two clicks

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -152,7 +152,7 @@ local math_isInRect = math.isInRect
 
 local chobbyInterface, font, font2, font3, backgroundGuishader, currentGroupTab, windowList, optionButtonBackward, optionButtonForward
 local groupRect, titleRect, countDownOptionID, countDownOptionClock, sceduleOptionApply, checkedForWaterAfterGamestart, checkedWidgetDataChanges
-local savedConfig, forceUpdate, sliderValueChanged, selectOptionsList, showSelectOptions, prevSelectHover
+local savedConfig, forceUpdate, sliderValueChanged, selectOptionsList, showSelectOptions, prevSelectHover, scheduleInit
 local fontOption, draggingSlider, lastSliderSound, selectClickAllowHide, selectScrollOffset
 local guishaderWasActive = false
 
@@ -1047,6 +1047,12 @@ function widget:Update(dt)
 
 	if not initialized then
 		return
+	end
+
+	-- widgetHandler:EnableWidget/DisableWidget are deferred but are used to change displayed options. This is a solution to update the options list after next frame.
+	if scheduleInit then
+		scheduleInit = nil
+		init()
 	end
 
 		-- disable ambient player widget, also doing this on initialize but hell... players somehow still have this enabled
@@ -2050,6 +2056,7 @@ function applyOptionValue(i, newValue, skipRedrawWindow, force)
 			end
 		end
 		forceUpdate = true
+		scheduleInit = true
 		if id == "teamcolors" then
 			Spring.SendCommands("luarules reloadluaui")    -- cause several widgets are still using old colors
 		end
@@ -3569,7 +3576,7 @@ function init()
 			  if WG['bar_hotkeys'] and WG['bar_hotkeys'].reloadBindings then
 				  WG['bar_hotkeys'].reloadBindings()
 			  end
-			  init()
+			  scheduleInit = true
 		  end,
 		},
 
@@ -3582,7 +3589,7 @@ function init()
 				  widgetHandler:DisableWidget('Grid menu')
 				  widgetHandler:EnableWidget('Build menu')
 			  end
-			  init()
+			  scheduleInit = true
 		  end,
 		},
 		{ id = "gridmenu_alwaysreturn", group = "control", category = types.advanced, name = Spring.I18N('ui.settings.option.gridmenu_alwaysreturn'), type = "bool", value = (WG['gridmenu'] ~= nil and WG['gridmenu'].getAlwaysReturn ~= nil and WG['gridmenu'].getAlwaysReturn()), description = Spring.I18N('ui.settings.option.gridmenu_alwaysreturn_descr'),


### PR DESCRIPTION
The Grid menu toggle in Settings > Control needed two clicks to update on screen. The first click actually switched the interface behind the settings window, but the toggle only caught up on the next click.

Goes back to #3941, which made widgetHandler:EnableWidget/DisableWidget deferred. The onchange enables/disables the widget and then rebuilds the options right away to re-read the state, but the swap hasn't landed yet at that point, so it reads the old state and the toggle ends up a click behind.

Baldric (@MadeByGabe) already fixed this generically over in #8045 with a scheduleInit flag that defers the options rebuild to the next frame, which also covers the same lag on the keybind-mode sub-options. Since that fix is unrelated to the widget work in his PR, I've cherry-picked just that commit here so it can land on its own with him as the author.

See https://discord.com/channels/549281623154229250/1527008762257477642
