### PR TITLE
Support rebindable mouse select and command

### DIFF
--- a/luaui/Include/mouse_roles.lua
+++ b/luaui/Include/mouse_roles.lua
@@ -1,0 +1,26 @@
+-- Resolve which physical mouse button currently carries an engine mouse-role action
+-- (mouseprimary = select/confirm, mousesecondary = default command), so widgets follow
+-- a rebound/swapped mouse setup instead of hardcoding button 1/3.
+
+local spGetKeyBindings = Spring.GetKeyBindings
+
+local function isButtonBoundTo(button, action)
+	local binds = spGetKeyBindings("mouse" .. button)
+	if binds then
+		for i = 1, #binds do
+			if binds[i].command == action then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+return {
+	isPrimaryButton = function(button)
+		return isButtonBoundTo(button, "mouseprimary")
+	end,
+	isSecondaryButton = function(button)
+		return isButtonBoundTo(button, "mousesecondary")
+	end,
+}

--- a/luaui/Include/mouse_roles.lua
+++ b/luaui/Include/mouse_roles.lua
@@ -2,10 +2,8 @@
 -- (mouseprimary = select/confirm, mousesecondary = default command), so widgets follow
 -- a rebound/swapped mouse setup instead of hardcoding button 1/3.
 
-local spGetKeyBindings = Spring.GetKeyBindings
-
 local function isButtonBoundTo(button, action)
-	local binds = spGetKeyBindings("mouse" .. button)
+	local binds = Spring.GetKeyBindings("mouse" .. button)
 	if binds then
 		for i = 1, #binds do
 			if binds[i].command == action then

--- a/luaui/Widgets/cmd_attack_no_ally.lua
+++ b/luaui/Widgets/cmd_attack_no_ally.lua
@@ -1,5 +1,7 @@
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 function widget:GetInfo()
 	return {
 		name         = "Attack no Ally",
@@ -54,7 +56,7 @@ end
 	-- Right mouse button
 function widget:MousePress(x, y, button)
 
-	if button ~= 3 then
+	if not mouseRoles.isSecondaryButton(button) then
 		return false
 	end
 
@@ -72,7 +74,7 @@ function widget:MousePress(x, y, button)
 	return false
 end
 function widget:MouseMove(x, y, dx, dy, button)
-	if not rmbDragTracking or button ~= 3 then
+	if not rmbDragTracking or not mouseRoles.isSecondaryButton(button) then
 		return false
 	end
 
@@ -84,7 +86,7 @@ function widget:MouseMove(x, y, dx, dy, button)
 end
 
 function widget:MouseRelease(x, y, button)
-	if button ~= 3 then
+	if not mouseRoles.isSecondaryButton(button) then
 		return false
 	end
 

--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -41,6 +41,26 @@ local function fallbackToDefault(currentKeys)
 end
 
 
+-- back-fill the engine mouse-role binds when a config (e.g. a Custom snapshot) lacks them
+local function isActionBound(action)
+	for _, b in ipairs(Spring.GetKeyBindings()) do
+		if b.command == action then
+			return true
+		end
+	end
+	return false
+end
+
+local function ensureMouseRoleBinds()
+	if not isActionBound("mouseprimary") then
+		Spring.SendCommands("bind Any+mouse1 mouseprimary")
+	end
+	if not isActionBound("mousesecondary") then
+		Spring.SendCommands("bind Any+mouse3 mousesecondary")
+	end
+end
+
+
 local function reloadBindings()
 	-- Second parameter here is just a fallback if this config is undefined
 	currentLayout = Spring.GetConfigString("KeyboardLayout", 'qwerty')
@@ -57,6 +77,8 @@ local function reloadBindings()
 	else
 		spEcho("BAR Hotkeys: No hotkey file found")
 	end
+
+	ensureMouseRoleBinds()
 
 	reloadWidgetsBindings()
 end

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -1,5 +1,7 @@
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 -- makes the intent of our usage of Spring.Echo clear
 local FeedbackForUser = Spring.Echo
 
@@ -920,7 +922,7 @@ function widget:MousePress(x, y, button)
 		return true
 	end
 
-	if button ~= 1 or not blueprintPlacementActive or not getSelectedBlueprint() then
+	if not mouseRoles.isPrimaryButton(button) or not blueprintPlacementActive or not getSelectedBlueprint() then
 		return
 	end
 

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -30,6 +30,7 @@ local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
 
 local getCurrentMiniMapRotationOption = VFS.Include("luaui/Include/minimap_utils.lua").getCurrentMiniMapRotationOption
 local ROTATION = VFS.Include("luaui/Include/minimap_utils.lua").ROTATION
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
 
 local dotImage			= "LuaUI/Images/formationDot.dds"
 
@@ -143,7 +144,6 @@ local glLoadIdentity = gl.LoadIdentity
 local spGetActiveCommand = Spring.GetActiveCommand
 local spSetActiveCommand = Spring.SetActiveCommand
 local spGetDefaultCommand = Spring.GetDefaultCommand
-local spGetKeyBindings = Spring.GetKeyBindings
 local spFindUnitCmdDesc = Spring.FindUnitCmdDesc
 local spGetModKeyState = Spring.GetModKeyState
 local spGetInvertQueueKey = Spring.GetInvertQueueKey
@@ -400,31 +400,19 @@ end
 -- Mouse/keyboard Callins
 --------------------------------------------------------------------------------
 
-local function isSecondaryMouseButton(button)
-    local binds = spGetKeyBindings("mouse" .. button)
-    if binds then
-        for i = 1, #binds do
-            if binds[i].command == "mousesecondary" then
-                return true
-            end
-        end
-    end
-    return false
-end
-
 function widget:MousePress(mx, my, mButton)
     lineLength = 0 --for linestipple
     -- Where did we click
     inMinimap = spIsAboveMiniMap(mx, my)
     if inMinimap and not MiniMapFullProxy then return false end
 
-    if not isSecondaryMouseButton(mButton) and usingRMB then
+    if not mouseRoles.isSecondaryButton(mButton) and usingRMB then
         fNodes = {}
         fDists = {}
         usingRMB = false
     end
 
-    if not isSecondaryMouseButton(mButton) then return false end --formations run on the mouse-secondary (default right-click) button
+    if not mouseRoles.isSecondaryButton(mButton) then return false end --formations run on the mouse-secondary (default right-click) button
 
     -- Get command that would've been issued
     local _, activeCmdID = spGetActiveCommand()

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -143,6 +143,7 @@ local glLoadIdentity = gl.LoadIdentity
 local spGetActiveCommand = Spring.GetActiveCommand
 local spSetActiveCommand = Spring.SetActiveCommand
 local spGetDefaultCommand = Spring.GetDefaultCommand
+local spGetKeyBindings = Spring.GetKeyBindings
 local spFindUnitCmdDesc = Spring.FindUnitCmdDesc
 local spGetModKeyState = Spring.GetModKeyState
 local spGetInvertQueueKey = Spring.GetInvertQueueKey
@@ -399,19 +400,31 @@ end
 -- Mouse/keyboard Callins
 --------------------------------------------------------------------------------
 
+local function isSecondaryMouseButton(button)
+    local binds = spGetKeyBindings("mouse" .. button)
+    if binds then
+        for i = 1, #binds do
+            if binds[i].command == "mousesecondary" then
+                return true
+            end
+        end
+    end
+    return false
+end
+
 function widget:MousePress(mx, my, mButton)
     lineLength = 0 --for linestipple
     -- Where did we click
     inMinimap = spIsAboveMiniMap(mx, my)
     if inMinimap and not MiniMapFullProxy then return false end
 
-    if mButton ~= 3 and usingRMB then
+    if not isSecondaryMouseButton(mButton) and usingRMB then
         fNodes = {}
         fDists = {}
         usingRMB = false
     end
 
-    if mButton ~= 3 then return false end --all formation commands are done using right click & drag
+    if not isSecondaryMouseButton(mButton) then return false end --formations run on the mouse-secondary (default right-click) button
 
     -- Get command that would've been issued
     local _, activeCmdID = spGetActiveCommand()

--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -1,5 +1,7 @@
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 function widget:GetInfo()
 	return {
 		name      = "Extractor Snap (mex/geo)",
@@ -290,7 +292,7 @@ function widget:MousePress(x, y, button)
 		return
 	end
 
-	if button == 1 and buildCmd and buildCmd[1] then
+	if mouseRoles.isPrimaryButton(button) and buildCmd and buildCmd[1] then
 		local alt, ctrl, meta, shift = Spring.GetModKeyState()
 		shift = Spring.GetInvertQueueKey() and (not shift) or shift
 		if selectedMex then

--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -1,5 +1,7 @@
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 function widget:GetInfo()
 	return {
 		name = "Quick Build (mex/geo)",
@@ -295,7 +297,7 @@ function widget:MousePress(x, y, button)
 		return
 	end
 
-	if (button == 3) then
+	if mouseRoles.isSecondaryButton(button) then
 		local _, _, _, shift = spGetModKeyState()
 		if selectedMex then
 			spotBuilder.ApplyPreviewCmds(buildCmd, mexConstructors, shift)

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -1,5 +1,7 @@
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 -- Include the substitution logic directly with a shorter alias
 local SubLogic = VFS.Include("luaui/Include/blueprint_substitution/logic.lua")
 
@@ -781,14 +783,14 @@ function widget:MousePress(mx, my, button)
 	end
 	local _, _, meta, shift = Spring.GetModKeyState()
 
-	if button == 3 and selBuildQueueDefID then
+	if mouseRoles.isSecondaryButton(button) and selBuildQueueDefID then
 		setPreGamestartDefID(nil)
 		buildModeState.startPosition = nil
 		buildModeState.buildPositions = {}
 		return true
 	end
 
-	if button == 3 and shift then
+	if mouseRoles.isSecondaryButton(button) and shift then
 		local x, y, _ = spGetMouseState()
 		local _, pos = spTraceScreenRay(x, y, true, false, false, true)
 		if pos and pos[1] then
@@ -804,7 +806,7 @@ function widget:MousePress(mx, my, button)
 	end
 
 	local alt, ctrl = Spring.GetModKeyState()
-	if button == 1 and shift and ctrl then
+	if mouseRoles.isPrimaryButton(button) and shift and ctrl then
 		local buildAroundTarget = getGhostBuildingUnderCursor(mx, my)
 		if buildAroundTarget then
 			local buildFacing = Spring.GetBuildFacing()
@@ -891,7 +893,7 @@ function widget:MousePress(mx, my, button)
 	end
 
 	local _, pos = spTraceScreenRay(mx, my, true, false, false, isUnderwater(selBuildQueueDefID))
-	if button == 1 then
+	if mouseRoles.isPrimaryButton(button) then
 		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
 		if WG.ExtractorSnap then
 			local snapPos = WG.ExtractorSnap.position
@@ -987,7 +989,7 @@ function widget:MousePress(mx, my, button)
 		return true
 	end
 
-	if button == 1 and #buildQueue > 0 and buildQueue[1][1]>0 then
+	if mouseRoles.isPrimaryButton(button) and #buildQueue > 0 and buildQueue[1][1]>0 then
 		local _, pos = spTraceScreenRay(mx, my, true, false, false, isUnderwater(startDefID))
 		if not pos then
 			return
@@ -999,7 +1001,7 @@ function widget:MousePress(mx, my, button)
 		end
 	end
 
-	if button == 3 and #buildQueue > 0 then
+	if mouseRoles.isSecondaryButton(button) and #buildQueue > 0 then
 		tableRemove(buildQueue, #buildQueue)
 
 		return true

--- a/luaui/Widgets/unit_loop_select.lua
+++ b/luaui/Widgets/unit_loop_select.lua
@@ -1,6 +1,8 @@
 
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 function widget:GetInfo()
 	return {
 		name      = "Loop Select",
@@ -128,7 +130,7 @@ end
 function widget:MousePress(mx, my, mButton)
 
 	-- Only left click
-	if (mButton ~= 1) then return false end
+	if not mouseRoles.isPrimaryButton(mButton) then return false end
 
 	-- Only handle if there is no active command
 	local _, actCmdID = spGetActiveCommand()

--- a/luaui/Widgets/unit_waypoint_dragger_2.lua
+++ b/luaui/Widgets/unit_waypoint_dragger_2.lua
@@ -1,5 +1,7 @@
 local widget = widget ---@type Widget
 
+local mouseRoles = VFS.Include("luaui/Include/mouse_roles.lua")
+
 function widget:GetInfo()
 	return {
 		name      = "Waypoint Dragger",
@@ -257,7 +259,7 @@ function widget:MousePress(mx, my, mb)
 	local _, _, _, shift = spGetModKeyState()
 	local numWayPts              = 0
 	if not shift then return false end
-	if mb ~= 1 then return false end
+	if not mouseRoles.isPrimaryButton(mb) then return false end
 	numWayPts = GetWayPointsNearCursor(selWayPtsTbl, mx, my)
 	if numWayPts == 0 then
 		return false

--- a/luaui/configs/hotkeys/chat_and_ui_keys.txt
+++ b/luaui/configs/hotkeys/chat_and_ui_keys.txt
@@ -12,6 +12,10 @@ bind                esc  customgameinfo_close
 bind                esc  buildmenu_pregame_deselect
 bind      Alt+backspace  fullscreen
 
+// core mouse action buttons (engine select/command roles; rebindable)
+bind          Any+mouse1  mouseprimary
+bind          Any+mouse3  mousesecondary
+
 // common selectbox keys
 bind           Any+sc_z  selectbox_same     // select only units that share type with current selection modifier | Smart Select Widget
 bind          Any+space  selectbox_idle     // select only idle units modifier | Smart Select Widget


### PR DESCRIPTION
Companion to the engine PR beyond-all-reason/RecoilEngine#3116, which turns hardcoded left-click select / right-click command into rebindable `mouseprimary` / `mousesecondary` actions.

The engine change relocates the built-in behaviors, but BAR's own input widgets hardcode button 1/3, so under a rebind or LMB<->RMB swap they'd shadow the engine. This makes them read the bind instead, through a small shared `luaui/Include/mouse_roles.lua` helper. Widgets updated: CustomFormations2, Extractor Snap, Quick Build, Waypoint Dragger, Blueprint, Pregame Queue, Attack no Ally, Loop Select. SmartSelect needs no change - it already rides the engine selection box.

Also ships the defaults so no one loses select/command: `Any+mouse1 mouseprimary` / `Any+mouse3 mousesecondary` in the shared preset include (covers Grid/Legacy/60%), plus an add-if-missing backfill in cmd_bar_hotkeys for existing custom keybind configs, which otherwise get no automatic propagation of new defaults.

Draft: depends on the engine PR, and the build-placement widgets beyond CustomFormations2 aren't individually play-tested yet.

Implemented and tested with Claude Code.