### PR TITLE
Alt + Set Target mode opts

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -42,6 +42,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spGetAllUnits = Spring.GetAllUnits
 	local spGetPlayerInfo = Spring.GetPlayerInfo
 	local spGetUnitStates = Spring.GetUnitStates
+	local spSetUnitRulesParam = Spring.SetUnitRulesParam
 
 	local tremove = table.remove
 	local ensureTable = table.ensureTable
@@ -302,8 +303,10 @@ if gadgetHandler:IsSyncedCode() then
 		local target = targetData.target
 		if type(target) == "number" then
 			spSetUnitTarget(unitID, target, false, targetData.userTarget)
+			spSetUnitRulesParam(unitID, "unitTargetID", target)
 		else
 			spSetUnitTarget(unitID, target[1], target[2], target[3], false, targetData.userTarget)
+			spSetUnitRulesParam(unitID, "unitTargetID", nil)
 		end
 		SendToUnsynced("targetIndex", unitID, targetIndex, true)
 	end
@@ -311,6 +314,7 @@ if gadgetHandler:IsSyncedCode() then
 	local function setTargetPassive(unitID, unitData)
 		unitData.activeTarget = false
 		unitData.currentIndex = 1
+		spSetUnitRulesParam(unitID, "unitTargetID", nil)
 		if not inAttackCommand(unitID) then
 			spSetUnitTarget(unitID, nil)
 		end
@@ -361,6 +365,7 @@ if gadgetHandler:IsSyncedCode() then
 			setTargetData[unitID] = nil
 			SendToUnsynced("targetList", unitID, 0)
 		end
+		spSetUnitRulesParam(unitID, "unitTargetID", nil)
 	end
 
 	local function addUnitTargets(unitID, unitDefID, targetList, append)

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -180,6 +180,8 @@ local function handleSelectionLine()
 	end
 end
 
+local commandsToGiveCache = table.new(64, 0)
+
 function widget:GameFrame(frame)
 	handleSelectionLine()
 
@@ -189,17 +191,21 @@ function widget:GameFrame(frame)
 
 	for unitID, targetUnitDefID in pairs(trackedUnitsToUnitDefID) do
 		local candidateUnits = GetUnitsInAttackRangeWithDef(unitID, targetUnitDefID)
-		local commandsToGive = {}
-		for _, targetID in ipairs(candidateUnits) do
-			local newCmdOpts = {}
-			if #commandsToGive ~= 0  then
-				newCmdOpts = { "shift" }
+		if candidateUnits[1] then
+			local commandsToGive = commandsToGiveCache
+			commandsToGive[1] = { CMD_SET_TARGET, candidateUnits[1] }
+			local nextCmdOpts = { "shift" }
+			local candidateCount = #candidateUnits
+			for index = 2, candidateCount do
+				commandsToGive[index] = { CMD_SET_TARGET, candidateUnits[index], nextCmdOpts }
 			end
-
-			commandsToGive[#commandsToGive+1] = { CMD_SET_TARGET, { targetID }, newCmdOpts }
+			-- We can use a nil boundary to stop iter in ParseCommandTable because we are careful
+			-- not to introduce a new hash part. luaH_next jumps to the hash following the array.
+			commandsToGive[candidateCount + 1] = nil
+			spGiveOrderArrayToUnit(unitID, commandsToGive)
+		else -- TODO: only give order if unit has a target list:
+			Spring.GiveOrderToUnit(unitID, CMD_UNIT_CANCEL_TARGET)
 		end
-
-		spGiveOrderArrayToUnit(unitID, commandsToGive)
 	end
 end
 

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -23,6 +23,7 @@ local spGetUnitsInCylinder   = Spring.GetUnitsInCylinder
 local spAreTeamsAllied       = Spring.AreTeamsAllied
 local spGetUnitTeam          = Spring.GetUnitTeam
 local spGiveOrderArrayToUnit = Spring.GiveOrderArrayToUnit
+local spGiveOrderToUnit      = Spring.GiveOrderToUnit
 local spGetSelectedUnits     = Spring.GetSelectedUnits
 local spGetMyTeamID          = Spring.GetMyTeamID
 local spGetActiveCommand 	 = Spring.GetActiveCommand
@@ -135,6 +136,27 @@ local function FindNearestEnemyUnit(x, y, z, radius, myTeam)
 	return closestUnit
 end
 
+local commandsToGiveCache = table.new(64, 0)
+
+local function targetUnitsInRangeWithDef(unitID, targetUnitDefID)
+	local candidateUnits = GetUnitsInAttackRangeWithDef(unitID, targetUnitDefID)
+	if candidateUnits[1] then
+		local commandsToGive = commandsToGiveCache
+		commandsToGive[1] = { CMD_SET_TARGET, candidateUnits[1] }
+		local nextCmdOpts = { "shift" }
+		local candidateCount = #candidateUnits
+		for index = 2, candidateCount do
+			commandsToGive[index] = { CMD_SET_TARGET, candidateUnits[index], nextCmdOpts }
+		end
+		-- We can use a nil boundary to stop iter in ParseCommandTable because we are careful
+		-- not to introduce a new hash part. luaH_next jumps to the hash following the array.
+		commandsToGive[candidateCount + 1] = nil
+		spGiveOrderArrayToUnit(unitID, commandsToGive)
+	else -- TODO: only give order if unit has a target list:
+		spGiveOrderToUnit(unitID, CMD_UNIT_CANCEL_TARGET)
+	end
+end
+
 function widget:DrawWorld()
     if not cursorPos or not snappedPos then return end
     gl.DepthTest(false)
@@ -180,8 +202,6 @@ local function handleSelectionLine()
 	end
 end
 
-local commandsToGiveCache = table.new(64, 0)
-
 function widget:GameFrame(frame)
 	handleSelectionLine()
 
@@ -190,22 +210,7 @@ function widget:GameFrame(frame)
 	end
 
 	for unitID, targetUnitDefID in pairs(trackedUnitsToUnitDefID) do
-		local candidateUnits = GetUnitsInAttackRangeWithDef(unitID, targetUnitDefID)
-		if candidateUnits[1] then
-			local commandsToGive = commandsToGiveCache
-			commandsToGive[1] = { CMD_SET_TARGET, candidateUnits[1] }
-			local nextCmdOpts = { "shift" }
-			local candidateCount = #candidateUnits
-			for index = 2, candidateCount do
-				commandsToGive[index] = { CMD_SET_TARGET, candidateUnits[index], nextCmdOpts }
-			end
-			-- We can use a nil boundary to stop iter in ParseCommandTable because we are careful
-			-- not to introduce a new hash part. luaH_next jumps to the hash following the array.
-			commandsToGive[candidateCount + 1] = nil
-			spGiveOrderArrayToUnit(unitID, commandsToGive)
-		else -- TODO: only give order if unit has a target list:
-			Spring.GiveOrderToUnit(unitID, CMD_UNIT_CANCEL_TARGET)
-		end
+		targetUnitsInRangeWithDef(unitID, targetUnitDefID)
 	end
 end
 
@@ -278,6 +283,7 @@ function widget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	for _, unitID in ipairs(selectedUnits) do
 		cleanupUnitTargeting(unitID)
 		trackedUnitsToUnitDefID[unitID] = targetUnitDefID
+		targetUnitsInRangeWithDef(unitID, targetUnitDefID)
 	end
 
 	return true

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -13,10 +13,8 @@ function widget:GetInfo()
 	}
 end
 
-
 -- Localized Spring API for performance
 local spGetGameFrame = Spring.GetGameFrame
-
 local spGetUnitDefID         = Spring.GetUnitDefID
 local spGetUnitPosition      = Spring.GetUnitPosition
 local spGetUnitsInCylinder   = Spring.GetUnitsInCylinder
@@ -30,6 +28,9 @@ local spGetActiveCommand 	 = Spring.GetActiveCommand
 local spGetMouseState    	 = Spring.GetMouseState
 local spTraceScreenRay   	 = Spring.TraceScreenRay
 local spGetModKeyState   	 = Spring.GetModKeyState
+local spGetUnitRulesParam    = Spring.GetUnitRulesParam
+
+local table_insert = table.insert
 
 local trackedUnitsToUnitDefID = {}
 local unitRanges = {}
@@ -83,7 +84,7 @@ local function GetUnitsInAttackRangeWithDef(unitID, unitDefIDToTarget)
         if targetID ~= unitID and targetTeam ~= nil then
             local isAllied = spAreTeamsAllied(unitTeam, targetTeam)
 			if not isAllied and spGetUnitDefID(targetID) == unitDefIDToTarget then
-				table.insert(unitsInRange, targetID)
+				table_insert(unitsInRange, targetID)
             end
         end
     end
@@ -141,12 +142,20 @@ local commandsToGiveCache = table.new(64, 0)
 local function targetUnitsInRangeWithDef(unitID, targetUnitDefID)
 	local candidateUnits = GetUnitsInAttackRangeWithDef(unitID, targetUnitDefID)
 	if candidateUnits[1] then
+		local unitTargetID = spGetUnitRulesParam(unitID, "unitTargetID")
 		local commandsToGive = commandsToGiveCache
 		commandsToGive[1] = { CMD_SET_TARGET, candidateUnits[1] }
 		local nextCmdOpts = { "shift" }
 		local candidateCount = #candidateUnits
 		for index = 2, candidateCount do
-			commandsToGive[index] = { CMD_SET_TARGET, candidateUnits[index], nextCmdOpts }
+			local commandTable = { CMD_SET_TARGET, candidateUnits[index], nextCmdOpts }
+			-- Keep the active target at the front of the target list to avoid target flap.
+			if commandTable[2] == unitTargetID then
+				commandTable[3] = nil -- unshift the command
+				table_insert(commandsToGive, 1, commandTable)
+			else
+				commandsToGive[index] = commandTable
+			end
 		end
 		-- We can use a nil boundary to stop iter in ParseCommandTable because we are careful
 		-- not to introduce a new hash part. luaH_next jumps to the hash following the array.

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -45,6 +45,8 @@ local CMD_SET_TARGET = GameCMD.UNIT_SET_TARGET
 local UNIT_RANGE_MULTIPLIER = 1.5
 -- Radius in elmos to search for nearby enemy units when click misses
 local SNAP_RADIUS = 100
+-- Number of targets that can be assigned. Used to set up the table pools.
+local TARGET_BY_TYPE_COUNT_MAX = 128
 
 local gameStarted
 
@@ -137,29 +139,39 @@ local function FindNearestEnemyUnit(x, y, z, radius, myTeam)
 	return closestUnit
 end
 
-local commandsToGiveCache = table.new(64, 0)
+local commandsToGiveCache = table.new(TARGET_BY_TYPE_COUNT_MAX + 1, 0) -- can insert active target also
+local commandsToGivePool = table.new(TARGET_BY_TYPE_COUNT_MAX, 0)
+local nextCmdOpts = { "shift" }
+do
+	for i = 1, TARGET_BY_TYPE_COUNT_MAX do
+		commandsToGivePool[i] = { CMD_SET_TARGET, -1, nextCmdOpts }
+	end
+end
 
 local function targetUnitsInRangeWithDef(unitID, targetUnitDefID)
 	local candidateUnits = GetUnitsInAttackRangeWithDef(unitID, targetUnitDefID)
 	if candidateUnits[1] then
 		local unitTargetID = spGetUnitRulesParam(unitID, "unitTargetID")
+		local commandTarget = { CMD_SET_TARGET, unitTargetID }
 		local commandsToGive = commandsToGiveCache
 		commandsToGive[1] = { CMD_SET_TARGET, candidateUnits[1] }
-		local nextCmdOpts = { "shift" }
 		local candidateCount = #candidateUnits
 		for index = 2, candidateCount do
-			local commandTable = { CMD_SET_TARGET, candidateUnits[index], nextCmdOpts }
-			-- Keep the active target at the front of the target list to avoid target flap.
-			if commandTable[2] == unitTargetID then
-				commandTable[3] = nil -- unshift the command
-				table_insert(commandsToGive, 1, commandTable)
-			else
+			if candidateUnits[index] == unitTargetID then
+				-- Keep the active target at the front of the target list to avoid target flap.
+				commandsToGive[1][3] = nextCmdOpts -- First command gains shift modifier.
+				table_insert(commandsToGive, 1, commandTarget)
+			elseif index <= TARGET_BY_TYPE_COUNT_MAX then
+				local commandTable = commandsToGivePool[index]
+				commandTable[2] = candidateUnits[index]
 				commandsToGive[index] = commandTable
 			end
 		end
 		-- We can use a nil boundary to stop iter in ParseCommandTable because we are careful
 		-- not to introduce a new hash part. luaH_next jumps to the hash following the array.
-		commandsToGive[candidateCount + 1] = nil
+		if candidateCount < TARGET_BY_TYPE_COUNT_MAX then
+			commandsToGive[candidateCount + 1] = nil
+		end
 		spGiveOrderArrayToUnit(unitID, commandsToGive)
 	else -- TODO: only give order if unit has a target list:
 		spGiveOrderToUnit(unitID, CMD_UNIT_CANCEL_TARGET)

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -81,12 +81,14 @@ local function GetUnitsInAttackRangeWithDef(unitID, unitDefIDToTarget)
 	maxRange = maxRange * UNIT_RANGE_MULTIPLIER
 
     local candidateUnits = spGetUnitsInCylinder(ux, uz, maxRange)
-	for _, targetID in ipairs(candidateUnits) do
-		local targetTeam = spGetUnitTeam(targetID)
-        if targetID ~= unitID and targetTeam ~= nil then
-            local isAllied = spAreTeamsAllied(unitTeam, targetTeam)
-			if not isAllied and spGetUnitDefID(targetID) == unitDefIDToTarget then
-				table_insert(unitsInRange, targetID)
+	local count = 0
+	for index = 1, #candidateUnits do
+		local targetID = candidateUnits[index]
+        if targetID ~= unitID and spGetUnitDefID(targetID) == unitDefIDToTarget then
+			local targetTeam = spGetUnitTeam(targetID)
+			if targetTeam and not spAreTeamsAllied(unitTeam, targetTeam) then
+				count = count + 1
+				unitsInRange[count] = targetID
             end
         end
     end


### PR DESCRIPTION
### Work done

- Alt + set target _command_ immediately sweeps for target units. Previously, there could be up to a 0.5 second delay (on top of multiplayer delay) which looks like the command failed.
- Alt + set target _command + mode_ each keep the active target on each target list update. Switching away from a focused target also makes the command look like it does nothing.
- Readded some rules params for set target as a consequence.
- Optimizations after stress testing. This was not especially slow, though.

#### Addresses issue(s)

Unresponsive command felt "laggy" and slightly unreliable mode behavior was confusing to players.