### PR TITLE
fix: use spherical test for mine detonation range

### DIFF
--- a/scripts/mines_lus.lua
+++ b/scripts/mines_lus.lua
@@ -61,7 +61,7 @@ end
 function EnemyDetect()
 	SetSignalMask(stop_detect)
 	while true do
-		if spGetUnitNearestEnemy(unitID, triggerRange) ~= nil then
+		if spGetUnitNearestEnemy(unitID, triggerRange, true) ~= nil then
 			StartThread(Detonate) -- Makes sure detonation is not cancellable
 			break
 		else


### PR DESCRIPTION
### Work done

Mine detonation range was changed to a cylindrical test in the new mines LUS. The switch is a boolean flag to GetUnitNearestEnemy so is not obvious behavior and would slip by in a test for typical gameplay.

Resolves #8320. Bombers and gunships were detonating mines while flying safely (more or less) overhead.