### PR TITLE
feat(gui_advplayerslist): implement take rendering outside widget bounds

### DIFF
--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -1904,6 +1904,25 @@ function widget:DrawScreen()
         gl.PushMatrix()
     end
 
+    -- Draw the take signal outside render-to-texture so it extends beyond widget bounds (and can blink)
+    if m_take.active and mySpecStatus == false and blink then
+        local scaleDiffX = -((widgetPosX * widgetScale) - widgetPosX) / widgetScale
+        local scaleDiffY = -((widgetPosY * widgetScale) - widgetPosY) / widgetScale
+        gl.Scale(widgetScale, widgetScale, 0)
+        gl.Translate(scaleDiffX, scaleDiffY, 0)
+        for i, drawObject in ipairs(drawList) do
+            if drawObject >= 0 then
+                local p = player[drawObject]
+                if p and not p.spec and p.allyteam == myAllyTeamID and p.totake then
+                    DrawTakeSignal(widgetPosY + widgetHeight - drawListOffset[i])
+                end
+            end
+        end
+        gl_Texture(false)
+        gl.PopMatrix()
+        gl.PushMatrix()
+    end
+
     local scaleDiffX = -((widgetPosX * widgetScale) - widgetPosX) / widgetScale
     local scaleDiffY = -((widgetPosY * widgetScale) - widgetPosY) / widgetScale
     gl.Scale(widgetScale, widgetScale, 0)
@@ -2476,7 +2495,8 @@ function DrawPlayer(playerID, leader, vOffset, mouseX, mouseY, onlyMainList, onl
                     if allyteam == myAllyTeamID then
                         if m_take.active then
                             if totake then
-                                DrawTakeSignal(posY)
+                                -- take signal is drawn live in DrawScreen (outside render-to-texture) so it can
+                                -- extend beyond the widget bounds and blink; here we only handle its tooltip
                                 if tipY then
                                     TakeTip(mouseX)
                                 end
@@ -2589,13 +2609,15 @@ end
 
 function DrawTakeSignal(posY)
     if blink then
-        -- Draws a blinking rectangle if the player of the same team left (/take option)
+        -- Draws a blinking arrow + "TAKE" label if a same-team player left (/take option)
         gl_Color(0.7, 0.7, 0.7)
         gl_Texture(pics["arrowPic"])
-        DrawRect(widgetPosX - 14, posY, widgetPosX, posY + 16)
+        DrawRect(widgetPosX - (14*playerScale), posY, widgetPosX, posY + (16*playerScale))
         gl_Color(1, 1, 1)
         gl_Texture(pics["takePic"])
-        DrawRect(widgetPosX - 57, posY - 15, widgetPosX - 12, posY + 32)
+        -- take.dds is a square image (90x90), so keep a 1:1 aspect to avoid distortion
+        DrawRect(widgetPosX - (57*playerScale), posY - (14*playerScale), widgetPosX - (12*playerScale), posY + (31*playerScale))
+        gl_Color(1, 1, 1, 1)
     end
 end
 

--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -2432,7 +2432,6 @@ function DrawPlayer(playerID, leader, vOffset, mouseX, mouseY, onlyMainList, onl
     local ping = p.ping
     local cpu = p.cpu
     local spec = p.spec
-    local totake = p.totake
     local needm = p.needm
     local neede = p.neede
     local dead = p.dead
@@ -2493,15 +2492,8 @@ function DrawPlayer(playerID, leader, vOffset, mouseX, mouseY, onlyMainList, onl
             if mySpecStatus == false then
                 if onlyMainList2 then
                     if allyteam == myAllyTeamID then
-                        if m_take.active then
-                            if totake then
-                                -- take signal is drawn live in DrawScreen (outside render-to-texture) so it can
-                                -- extend beyond the widget bounds and blink; here we only handle its tooltip
-                                if tipY then
-                                    TakeTip(mouseX)
-                                end
-                            end
-                        end
+                        -- take signal + its tooltip are handled live in DrawScreen/Update (outside the
+                        -- render-to-texture) so they can extend beyond the widget bounds and blink
                         if m_share.active and not dead and not hideShareIcons then
                             DrawShareButtons(posY, needm, neede)
                             if tipY then
@@ -3217,13 +3209,6 @@ function DrawEraser(posY, time)
     gl_Texture(pics["eraserPic"])
     DrawRect(m_indent.posX + widgetPosX -0.5, posY + (3*playerScale), m_indent.posX + widgetPosX + 1.5 + (8*playerScale), posY + (14*playerScale))
     gl_Color(1, 1, 1, 1)
-end
-
-function TakeTip(mouseX)
-    if mouseX >= widgetPosX - 57 * widgetScale and mouseX <= widgetPosX - 1 * widgetScale then
-        tipText = Spring.I18N('ui.playersList.takeUnits')
-        tipTextTime = osClock()
-    end
 end
 
 function NameTip(mouseX, playerID, accountID, nameIsAlias)
@@ -4102,6 +4087,28 @@ function widget:Update(delta)
     --handles takes & related messages
     local mx, my = spGetMouseState()
     hoverPlayerlist = false
+
+    -- the take icon is drawn to the left of the panel, so detect hovering it independently of the panel bounds
+    local overTakeIcon = false
+    if m_take.active and mySpecStatus == false
+        and mx >= widgetPosX - 57 * widgetScale and mx <= widgetPosX - 1 * widgetScale then
+        for i, drawObject in ipairs(drawList) do
+            if drawObject >= 0 then
+                local p = player[drawObject]
+                if p and not p.spec and p.allyteam == myAllyTeamID and p.totake then
+                    local posY = widgetPosY + ((widgetHeight - drawListOffset[i]) * widgetScale)
+                    if my >= posY and my <= posY + (16 * widgetScale * playerScale) then
+                        overTakeIcon = true
+                        tipText = Spring.I18N('ui.playersList.takeUnits')
+                        tipTextTitle = nil
+                        tipTextTime = osClock()
+                        break
+                    end
+                end
+            end
+        end
+    end
+
     if math_isInRect(mx, my, apiAbsPosition[2] - 1, apiAbsPosition[3] - 1, apiAbsPosition[4] + 1, apiAbsPosition[1] + 1 ) then
         hoverPlayerlist = true
 
@@ -4118,10 +4125,12 @@ function widget:Update(delta)
 				tipTextTime = osClock()
 			end
 		end
+    end
 
-        if tipText and WG['tooltip'] then
-            WG['tooltip'].ShowTooltip('advplayerlist', tipText, nil, nil, tipTextTitle)
-        end
+    if (hoverPlayerlist or overTakeIcon) and tipText and WG['tooltip'] then
+        WG['tooltip'].ShowTooltip('advplayerlist', tipText, nil, nil, tipTextTitle)
+    end
+    if hoverPlayerlist or overTakeIcon then
         Spring.SetMouseCursor('cursornormal')
     end
 


### PR DESCRIPTION
It has been broken for a while.

PR:
https://github.com/user-attachments/assets/e5795332-0d8e-4f04-bd12-a4dfe1298920

TODO:
- [x] probably need to improve mouse handling of tooltip

you can use this patch to test it, but ideally we'd test it in a real match somehow before it's deployed
```
diff --git a/luarules/gadgets/cmd_idle_players.lua b/luarules/gadgets/cmd_idle_players.lua
index df103085fa..6a7edc327b 100644
--- a/luarules/gadgets/cmd_idle_players.lua
+++ b/luarules/gadgets/cmd_idle_players.lua
@@ -1,8 +1,3 @@
-
-if Spring.Utilities.Gametype.IsSinglePlayer() then
-	return
-end
-
 local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
@@ -17,7 +12,7 @@ function gadget:GetInfo()
     }
 end
 
-local maxIdleTreshold = 80 --in seconds
+local maxIdleTreshold = 5 --in seconds
 local warningPeriod = 15
 local maxPing = 33 -- in seconds
 local finishedResumingPing = 2 --in seconds
@@ -399,6 +394,7 @@ else	-- UNSYNCED
 		mx = x
 
 		if timer-lastActionTime > maxIdleTreshold-warningPeriod then
+			wentIdle()
 			if not warningGiven then
 				warningGiven = true
 				local spectator = Spring.GetSpectatingState()
```

Recommended to test after deployment.

AI: verified solution using Claude, it told me to clean up and refactor, as such the structure of the calls have been adjusted a bit.