### PR TITLE
chore: increase pre-aim distance from 10% to 20% of the unit's range

### DIFF
--- a/luarules/gadgets/unit_preaim.lua
+++ b/luarules/gadgets/unit_preaim.lua
@@ -36,7 +36,7 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 			if not weaponDef.customParams.exclude_preaim then
 				local range = weaponDef.range
 				local param = tonumber(weaponDef.customParams.preaim_range)
-				local boost = math.max(20, range * 0.10, (param or 0) - range)
+				local boost = math.max(20, range * 0.5, (param or 0) - range)
 				weaponBoost[i] = boost
 			end
 		end

--- a/luarules/gadgets/unit_preaim.lua
+++ b/luarules/gadgets/unit_preaim.lua
@@ -36,7 +36,7 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 			if not weaponDef.customParams.exclude_preaim then
 				local range = weaponDef.range
 				local param = tonumber(weaponDef.customParams.preaim_range)
-				local boost = math.max(20, range * 0.5, (param or 0) - range)
+				local boost = math.max(20, range * 0.2, (param or 0) - range)
 				weaponBoost[i] = boost
 			end
 		end


### PR DESCRIPTION
Let units pre-aim the target from a distance ~1.5~ 1.2 times their range instead of only 1.1

See the discussion here https://discord.com/channels/549281623154229250/1526284815463088128
10% longer distance plays no meaningful role for most units, while 20% seems more reasonable with a few exceptions (e.g. Janus and other short ranged units would likely benefit from longer rnages).

EDIT: udpated to reflect the latest changes
