### PR TITLE
Add modoption for slowing Comm trans

### DIFF
--- a/luarules/gadgets/unit_transports_air_speed.lua
+++ b/luarules/gadgets/unit_transports_air_speed.lua
@@ -8,7 +8,7 @@ function gadget:GetInfo()
 		date = "2015",
 		license = "PD",
 		layer = 0,
-		enabled = false,
+		enabled = Spring.GetModOptions().comm_trans_slow,
 	}
 end
 
@@ -45,6 +45,32 @@ local spGetUnitIsTransporting = Spring.GetUnitIsTransporting
 -- update allowed speed for transport
 local function updateAllowedSpeed(transportId)
 	local uDefID = spGetUnitDefID(transportId)
+	local units = spGetUnitIsTransporting(transportId)
+	local tunitdefid
+	local tunitdefcustom
+	local iscom = false
+	if units then
+		for _,tUnitId in pairs(units) do
+			tunitdefid = spGetUnitDefID(tUnitId)
+			tunitdefcustom = UnitDefs[tunitdefid].customParams		
+			if tunitdefcustom and tunitdefcustom.iscommander == '1' then
+				iscom = true
+			end
+		end
+
+		if (iscom) then
+			allowedSpeed =  120 / FRAMES_PER_SECOND
+		else
+			allowedSpeed = unitSpeed[uDefID] / FRAMES_PER_SECOND
+		end
+			airTransportMaxSpeeds[transportId] = allowedSpeed
+	end
+end
+
+
+--Old complex weight calc for posterity:
+--[[local function updateAllowedSpeed(transportId)
+	local uDefID = spGetUnitDefID(transportId)
 
 	-- get sum of mass and size for all transported units
 	currentMassUsage = 0
@@ -53,8 +79,7 @@ local function updateAllowedSpeed(transportId)
 	local tunitdefcustom
 	local iscom = false
 	local transportspeedmult = 0.0
-	if 1 == 2 then --stops the gadget from doing anything. CHANGE TO GET ACTUAL SLOWDOWN -- This gadget has done nothing for one year
-		if units then
+	if units then
 			for _,tUnitId in pairs(units) do
 				tunitdefid = spGetUnitDefID(tUnitId)
 				tunitdefcustom = UnitDefs[tunitdefid].customParams		
@@ -75,9 +100,9 @@ local function updateAllowedSpeed(transportId)
 				--Spring.Echo("unit "..transportUnitDef.name.." is air transport at  "..(massUsageFraction*100).."%".." load, curSpeed="..vw.." allowedSpeed="..allowedSpeed)
 			end
 			airTransportMaxSpeeds[transportId] = allowedSpeed
-		end
 	end
-end
+end]]
+
 
 
 -- add transports to table when they load a unit

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -276,6 +276,15 @@ local options = {
 		def		= false,
 	},
 
+    {
+        key 	= "comm_trans_slow",
+        name 	= "Slow Commander Transport",
+        desc 	= "T2 transports carrying a Commander, move at speed 120. A temporary option available, until bigger transport changes get finished.",
+        type 	= "bool",
+        section = "options_main",
+        def 	= false,
+    },
+
 	{
 		key		= "sub_header",
 		section	= "options_main",


### PR DESCRIPTION
T2 transports carrying a Commander, move at speed 120. A temporary option available, until bigger transport changes get finished.