### PR TITLE
Dispatch the DrawGround map shader callins to widgets

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -154,6 +154,10 @@ local flexCallIns = {
 	'StockpileChanged',
 	'SelectionChanged',
 	'DrawGenesis',
+	'DrawGroundPreForward',
+	'DrawGroundPostForward',
+	'DrawGroundPreDeferred',
+	'DrawGroundPostDeferred',
 	'DrawGroundDeferred',
 	'DrawWorld',
 	'DrawWorldPreUnit',
@@ -1631,6 +1635,46 @@ function widgetHandler:DrawGenesis()
 		tracy.ZoneBeginN(w._tracyDrawGenesisName)
 		w:DrawGenesis()
 		tracy.ZoneEnd()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function widgetHandler:DrawGroundPreForward()
+	tracy.ZoneBeginN("W:DrawGroundPreForward")
+	local list = self.DrawGroundPreForwardList
+	for i = #list, 1, -1 do
+		list[i]:DrawGroundPreForward()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function widgetHandler:DrawGroundPostForward()
+	tracy.ZoneBeginN("W:DrawGroundPostForward")
+	local list = self.DrawGroundPostForwardList
+	for i = #list, 1, -1 do
+		list[i]:DrawGroundPostForward()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function widgetHandler:DrawGroundPreDeferred()
+	tracy.ZoneBeginN("W:DrawGroundPreDeferred")
+	local list = self.DrawGroundPreDeferredList
+	for i = #list, 1, -1 do
+		list[i]:DrawGroundPreDeferred()
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function widgetHandler:DrawGroundPostDeferred()
+	tracy.ZoneBeginN("W:DrawGroundPostDeferred")
+	local list = self.DrawGroundPostDeferredList
+	for i = #list, 1, -1 do
+		list[i]:DrawGroundPostDeferred()
 	end
 	tracy.ZoneEnd()
 	return


### PR DESCRIPTION
### Work done

The engine fires four callins around the map draw passes — `DrawGroundPreForward`, `DrawGroundPostForward`, `DrawGroundPreDeferred`, `DrawGroundPostDeferred` — but our widget handler only dispatched `DrawGroundDeferred`.
Widgets therefore could never hook the Lua map shader draw passes, which is exactly where a `Spring.SetMapShader` program needs its textures bound and per-frame uniforms set.
This adds the four names to `flexCallIns` and the matching dispatch methods in `luaui/barwidgets.lua`; the callin names were already listed in `luaui/callins.lua`, they just never reached widgets.

#### Why now / context

I'm prototyping a shader-driven terrain pipeline for BAR (slope/height-based auto-texturing with triplanar cliffs, live re-texturing under terraform) as a Lua map shader widget.
That work needs these callins to feed the shader each frame, and it also surfaced two engine bugs that made `Spring.SetMapShader` unusable in practice — fixed in beyond-all-reason/RecoilEngine#3127 together with a new `Engine.FeatureSupport.reliableLuaMapShaders` flag the prototype gates on.
This dispatch change is deliberately split out because it is independent of both the prototype and the engine PR: it's a tiny, generally useful piece that lets any widget hook the map draw passes, and merging it early keeps the future prototype branch purely additive.

There is no cost for existing play: flex callins are only routed to widgets that actually implement them, and the engine does not even fire these events unless a Lua map shader render state is active or `AlwaysSendDrawGroundEvents=1` is set (`SMFGroundDrawer.cpp:294-305`).

#### Setup

Normal play needs no setup (the change is inert without a consumer widget).
To see the callins fire on a current stock engine, set `AlwaysSendDrawGroundEvents = 1` in `springsettings.cfg` and install the probe widget below; the deferred pair additionally needs `AllowDeferredMapRendering = 1`.

<details>
<summary>Probe widget</summary>

```lua
function widget:GetInfo()
	return {
		name    = "DrawGround callin probe",
		desc    = "Echoes when each DrawGround map draw callin first fires",
		author  = "PtaQ",
		license = "GNU GPL, v2 or later",
		layer   = 0,
		enabled = false,
	}
end

local seen = {}
for _, cb in ipairs({ "DrawGroundPreForward", "DrawGroundPostForward", "DrawGroundPreDeferred", "DrawGroundPostDeferred" }) do
	widget[cb] = function()
		if not seen[cb] then
			seen[cb] = true
			Spring.Echo("[probe] " .. cb .. " fired")
		end
	end
end
```

</details>

#### Test steps
- [ ] Play a normal game with an unmodified widget set: no behavior or performance change (no widget implements the callins, and the engine doesn't fire them without a Lua map shader).
- [ ] Set `AlwaysSendDrawGroundEvents = 1`, enable the probe widget: infolog shows `[probe] DrawGroundPreForward fired` and `[probe] DrawGroundPostForward fired`. On master the echoes never appear because the handler drops the events.
- [ ] With `AllowDeferredMapRendering = 1` as well: the `PreDeferred`/`PostDeferred` echoes also appear.

### AI / LLM usage statement:
GitHub Copilot (Claude) was used extensively throughout development. All changes were human-reviewed. 

