### PR TITLE
Map projects: save and load full map state as git-friendly project folders

### DIFF
--- a/luarules/gadgets/cmd_terraform_brush.lua
+++ b/luarules/gadgets/cmd_terraform_brush.lua
@@ -83,6 +83,14 @@ local undoStack = {}
 local redoStack = {}
 local totalVertexCount = 0  -- track approximate memory usage
 
+-- Monotonic import-completion counter published as a game rules param. The map
+-- project load driver gates on it: draw frames say nothing about whether the
+-- SIM has processed the streamed columns (startpos slope validation and feature
+-- ground-snap read the unsynced height mirror, which only updates as the sim
+-- applies the import). A rules param — unlike SendToUnsynced — survives
+-- /luaui reload, so a mid-load widget reload can still observe completion.
+local importDoneCounter = 0
+
 -- Active drag session: all pushSnapshot/pushSnapshotFromFlat calls merge into mergeSnapshot until
 -- MERGE_END is received (sent by widget on mouse release).  No time window — MERGE_END is authoritative.
 local mergeSnapshot = nil      -- the active snapshot being merged into; nil = no drag in progress
@@ -1979,6 +1987,8 @@ function gadget:RecvLuaMsg(msg, playerID)
 		-- engine to mark every heightmap chunk dirty, so the GPU mesh, normals,
 		-- shadow pass and minimap all refresh without needing a local edit.
 		Spring.AdjustHeightMap(0, 0, Game.mapSizeX, Game.mapSizeZ, 0)
+		importDoneCounter = importDoneCounter + 1
+		Spring.SetGameRulesParam("tfb_import_done", importDoneCounter)
 		return true
 	end
 

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1662,11 +1662,19 @@ end
 -- current session's _script.txt (preserving players/teams/modoptions) and
 -- injecting the engine blank-map-generator keys. Returns (scriptText) or
 -- (nil, errorMessage).
-local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skyboxPath)
+-- opts (all optional; defaults preserve the New Map behavior):
+--   baseHeight   number  blank_map_height (project manifests record theirs)
+--   baseColor    {r,g,b} 0..255 blank_map_color
+-- dntsSet.rawPaths: texture entries are full VFS paths already (project-local
+-- assets/) instead of names under the library DNTS_DIR.
+local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skyboxPath, opts)
 	local base = VFS.LoadFile("_script.txt")
 	if not base or base == "" then
 		return nil, "no _script.txt available (not in a game?)"
 	end
+	opts = opts or {}
+	local baseHeight = tonumber(opts.baseHeight) or NEWMAP_BASE_HEIGHT
+	local baseColor = opts.baseColor or NEWMAP_COLOR
 
 	local mapName = string.format("Editor Flat %dx%d", widthUnits, heightUnits)
 	local seed = math.random(1, 2000000000)
@@ -1682,6 +1690,11 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	script = script:gsub("[Ii][Nn][Ii][Tt][Bb][Ll][Aa][Nn][Kk]%s*=[^;\r\n]*;?", "")
 	script = script:gsub("[Mm][Aa][Pp][Ss][Ee][Ee][Dd]%s*=[^;\r\n]*;?", "")
 
+	-- An inherited disablemapdamage modoption would make the blank canvas
+	-- read-only (no terraform, no import replay) — strip it for both New Map
+	-- and project loads.
+	script = script:gsub("[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Mm][Aa][Pp][Dd][Aa][Mm][Aa][Gg][Ee]%s*=[^;\r\n]*;?", "")
+
 	-- Swap the map name (the generator uses it as the generated map's label).
 	if script:find("[Mm][Aa][Pp][Nn][Aa][Mm][Ee]%s*=") then
 		script = (script:gsub("[Mm][Aa][Pp][Nn][Aa][Mm][Ee]%s*=[^;\r\n]*;?", "mapname=" .. mapName .. ";", 1))
@@ -1690,10 +1703,10 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	local opt = {
 		"blank_map_x=" .. widthUnits .. ";",
 		"blank_map_y=" .. heightUnits .. ";",
-		"blank_map_height=" .. NEWMAP_BASE_HEIGHT .. ";",
-		"blank_map_color_r=" .. NEWMAP_COLOR[1] .. ";",
-		"blank_map_color_g=" .. NEWMAP_COLOR[2] .. ";",
-		"blank_map_color_b=" .. NEWMAP_COLOR[3] .. ";",
+		"blank_map_height=" .. baseHeight .. ";",
+		"blank_map_color_r=" .. baseColor[1] .. ";",
+		"blank_map_color_g=" .. baseColor[2] .. ";",
+		"blank_map_color_b=" .. baseColor[3] .. ";",
 	}
 
 	-- Bake a skybox into the generated map's mapinfo. A non-empty atmosphere.skyBox
@@ -1709,9 +1722,10 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	-- the blank-map generator must honour these blank_map_splat* keys.
 	if dntsSet and dntsSet.textures then
 		local t, sc, mu = dntsSet.textures, dntsSet.scales or {}, dntsSet.mults or {}
+		local prefix = dntsSet.rawPaths and "" or DNTS_DIR
 		for ch = 1, 4 do
 			if t[ch] then
-				opt[#opt + 1] = "blank_map_splatdetailnormaltex" .. ch .. "=" .. DNTS_DIR .. t[ch] .. ";"
+				opt[#opt + 1] = "blank_map_splatdetailnormaltex" .. ch .. "=" .. prefix .. t[ch] .. ";"
 				opt[#opt + 1] = "blank_map_splattexscale" .. ch .. "=" .. (sc[ch] or 0.01) .. ";"
 				opt[#opt + 1] = "blank_map_splattexmult" .. ch .. "=" .. (mu[ch] or 1.0) .. ";"
 			end
@@ -1720,7 +1734,7 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 		-- present, even when DNTS normals are the actual source. Feed a compatible
 		-- placeholder so old gates don't silently disable splats on blank maps.
 		if t[1] then
-			opt[#opt + 1] = "blank_map_splatdetailtex=" .. DNTS_DIR .. t[1] .. ";"
+			opt[#opt + 1] = "blank_map_splatdetailtex=" .. prefix .. t[1] .. ";"
 		end
 		-- Do not force blank_map_splatdistr here. New engine builds can synthesize
 		-- an empty distribution when absent; forcing a missing filename causes load
@@ -1745,6 +1759,65 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	end
 	script = script:sub(1, e) .. "\n" .. inject .. "\n" .. script:sub(e + 1)
 	return script
+end
+
+-- Start script for OPENING a map project (cmd_map_project.lua calls this via
+-- WG before restarting): blank map at the manifest's recorded size/height/color,
+-- DNTS keys pointing at the project's own assets/dnts/ copies (self-contained —
+-- the library may have mutated since the save), skybox resolved from the
+-- library by basename. Returns (scriptText) or (nil, errorMessage).
+widgetState.buildProjectStartScript = function(manifest, slug)
+	if type(manifest) ~= "table" or type(manifest.map) ~= "table" then
+		return nil, "invalid manifest"
+	end
+	local m = manifest.map
+	local sizeX, sizeZ = tonumber(m.size_x), tonumber(m.size_z)
+	if not sizeX or not sizeZ then
+		return nil, "manifest has no map size"
+	end
+
+	local dntsSet = nil
+	if type(m.dnts) == "table" and type(m.dnts.textures) == "table" then
+		local textures = {}
+		local any = false
+		for ch = 1, 4 do
+			local rel = m.dnts.textures[ch]
+			if type(rel) == "string" and rel ~= "" then
+				textures[ch] = "MapProjects/" .. slug .. "/" .. rel
+				any = true
+			end
+		end
+		if any then
+			dntsSet = {
+				rawPaths = true,
+				textures = textures,
+				scales = m.dnts.scales or {},
+				mults = m.dnts.mults or {},
+				diffuseAlpha = (tonumber(m.dnts.diffuse_alpha) == 1) and 1 or 0,
+			}
+		end
+	end
+
+	-- The manifest records the skybox basename; find it in the library so the
+	-- engine bakes a real cubemap sky (runtime swaps need a CSkyBox).
+	local skyboxPath = nil
+	if type(m.skybox) == "string" and m.skybox ~= "" then
+		for _, thumb in ipairs(widgetState.envSkyboxThumbs or {}) do
+			local base = (thumb.path or ""):match("([^/\\]+)$")
+			if base == m.skybox then
+				skyboxPath = thumb.path
+				break
+			end
+		end
+		if not skyboxPath then
+			Spring.Echo("[Terraform Brush] Project skybox '" .. m.skybox .. "' not found in the skybox library; using none.")
+		end
+	end
+
+	return buildBlankMapStartScript(sizeX, sizeZ, dntsSet, skyboxPath, {
+		baseHeight = m.base_height,
+		baseColor = m.base_color,
+	})
 end
 
 -- ---- Procedural terrain controls for New Map ----
@@ -1844,6 +1917,9 @@ local initialModel = {
 	-- Save Project dialog (FILE > Save Project, backed by WG.MapProject)
 	projectSaveOpen = false,
 	projectSaveHint = "",
+	-- Open Project dialog (FILE > Open Project, backed by WG.MapProject)
+	projectOpenOpen = false,
+	projectOpenHint = "",
 	newMapWidthStr = "12",
 	newMapHeightStr = "12",
 	newMapElmoStr = "6144 x 6144 elmos",
@@ -4497,6 +4573,64 @@ local initialModel = {
 		else
 			if d then d.projectSaveHint = "Save could not start (see console)." end
 		end
+	end,
+	-- ===== Open Project dialog handlers (backed by WG.MapProject) =====
+	onFileOpenProject = function(_event)
+		playSound("click")
+		local d = widgetState.dmHandle
+		if d then
+			d.fileMenuOpen = false
+			d.projectOpenOpen = true
+			d.projectOpenHint = ""
+		end
+		-- Imperative DOM list build (same justification as the feature placer's
+		-- save list: rows are dynamic, data-model arrays are not used here).
+		local doc = widgetState.document
+		local listEl = doc and doc:GetElementById("tf-project-open-list")
+		if not listEl then return end
+		listEl.inner_rml = ""
+		if not (WG.MapProject and WG.MapProject.listDetailed) then
+			if d then d.projectOpenHint = "Map Project widget is not enabled (Settings > Widgets)." end
+			return
+		end
+		local projects = WG.MapProject.listDetailed()
+		if #projects == 0 then
+			listEl.inner_rml = '<div style="padding: 4dp 6dp; font-size: 0.9rem; color: #6b7280;">'
+				.. 'No projects found in MapProjects/. Projects saved this session may need an engine restart to appear (VFS folder cache).</div>'
+			return
+		end
+		for _, p in ipairs(projects) do
+			local label = string.format("%s&nbsp;&nbsp;<span style=\"color: #6b7280;\">%sx%s&nbsp;&nbsp;%s</span>",
+				p.name or p.slug, tostring(p.size_x or "?"), tostring(p.size_z or "?"),
+				(p.modified or ""):gsub("T", " "):gsub("Z", ""))
+			local item = doc:CreateElement("div")
+			item:SetAttribute("style", "padding: 4dp 6dp; font-size: 0.95rem; color: #9ca3af; cursor: pointer; border-radius: 3dp;")
+			item.inner_rml = label
+			local slug = p.slug
+			item:AddEventListener("click", function(ev)
+				playSound("apply")
+				local dm = widgetState.dmHandle
+				if not (WG.MapProject and WG.MapProject.open) then
+					if dm then dm.projectOpenHint = "Map Project widget is not enabled (Settings > Widgets)." end
+				elseif WG.MapProject.isBusy and WG.MapProject.isBusy() then
+					if dm then dm.projectOpenHint = "A save or load is already running (see console)." end
+				elseif not WG.MapProject.open(slug) then
+					if dm then dm.projectOpenHint = "Could not open '" .. slug .. "' — see console for the reason." end
+				end
+				ev:StopPropagation()
+			end, false)
+			item:AddEventListener("mouseover", function()
+				item:SetAttribute("style", "padding: 4dp 6dp; font-size: 0.95rem; color: #d1d5db; cursor: pointer; border-radius: 3dp; background-color: #2a2a3a;")
+			end, false)
+			item:AddEventListener("mouseout", function()
+				item:SetAttribute("style", "padding: 4dp 6dp; font-size: 0.95rem; color: #9ca3af; cursor: pointer; border-radius: 3dp;")
+			end, false)
+			listEl:AppendChild(item)
+		end
+	end,
+	onProjectOpenClose = function(_event)
+		playSound("click")
+		local d = widgetState.dmHandle; if d then d.projectOpenOpen = false end
 	end,
 	-- GENERATE TERRAIN toggle: off (default) creates a dead-flat map; on reveals
 	-- the procedural terrain/water/resources/layout controls and the randomizer.
@@ -8914,6 +9048,7 @@ local function attachEventListeners()
 		makeWindowDraggable("tf-settings-handle", widgetState.settingsRootEl)
 		makeWindowDraggable("tf-newmap-handle", getCachedEl(doc, "tf-newmap-root"))
 		makeWindowDraggable("tf-project-handle", getCachedEl(doc, "tf-project-root"))
+		makeWindowDraggable("tf-project-open-handle", getCachedEl(doc, "tf-project-open-root"))
 	end
 
 	-- ===== Transport (auto-scroll) button listeners =====
@@ -9044,6 +9179,11 @@ function widget:Initialize()
 		end,
 		applyEnvConfig = function(d)
 			return widgetState.applyEnvConfig(d)
+		end,
+		-- Start script for opening a map project (blank map at the manifest's
+		-- size with project-local DNTS assets); called by WG.MapProject.open.
+		buildProjectStartScript = function(manifest, slug)
+			return widgetState.buildProjectStartScript(manifest, slug)
 		end,
 		isCapturingKey = function()
 			return widgetState.settingsCapturing ~= nil

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1738,10 +1738,13 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 			end
 		end
 		-- Legacy SMFReadMap codepaths gate splat activation on splatDetailTex being
-		-- present, even when DNTS normals are the actual source. Feed a compatible
-		-- placeholder so old gates don't silently disable splats on blank maps.
-		if t[1] then
-			opt[#opt + 1] = "blank_map_splatdetailtex=" .. prefix .. t[1] .. ";"
+		-- present, even when DNTS normals are the actual source. Prefer a real
+		-- captured detail texture (compiled-map projects record one); else feed
+		-- ch1 as a compatible placeholder so old gates don't silently disable
+		-- splats on blank maps.
+		local detailTex = dntsSet.detail or t[1]
+		if detailTex then
+			opt[#opt + 1] = "blank_map_splatdetailtex=" .. prefix .. detailTex .. ";"
 		end
 		-- Do not force blank_map_splatdistr here. New engine builds can synthesize
 		-- an empty distribution when absent; forcing a missing filename causes load
@@ -1784,20 +1787,30 @@ widgetState.buildProjectStartScript = function(manifest, slug)
 	end
 
 	local dntsSet = nil
-	if type(m.dnts) == "table" and type(m.dnts.textures) == "table" then
+	if type(m.dnts) == "table" then
 		local textures = {}
 		local any = false
-		for ch = 1, 4 do
-			local rel = m.dnts.textures[ch]
-			if type(rel) == "string" and rel ~= "" then
-				textures[ch] = "MapProjects/" .. slug .. "/" .. rel
-				any = true
+		if type(m.dnts.textures) == "table" then
+			for ch = 1, 4 do
+				local rel = m.dnts.textures[ch]
+				if type(rel) == "string" and rel ~= "" then
+					textures[ch] = "MapProjects/" .. slug .. "/" .. rel
+					any = true
+				end
 			end
+		end
+		-- A captured detail texture alone (legacy SSMF map) still warrants a set:
+		-- blank_map_splatdetailtex is what old activation gates key on.
+		local detail = nil
+		if type(m.dnts.detail) == "string" and m.dnts.detail ~= "" then
+			detail = "MapProjects/" .. slug .. "/" .. m.dnts.detail
+			any = true
 		end
 		if any then
 			dntsSet = {
 				rawPaths = true,
 				textures = textures,
+				detail = detail,
 				scales = m.dnts.scales or {},
 				mults = m.dnts.mults or {},
 				diffuseAlpha = (tonumber(m.dnts.diffuse_alpha) == 1) and 1 or 0,

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1481,6 +1481,131 @@ widgetState.applyEnvConfig = function(d)
 	end
 end
 
+-- Serialize the live environment state into the env-config Lua format (the same
+-- format onEnvSave writes and applyEnvConfig consumes). Shared by the env editor's
+-- SAVE button and the map-project orchestrator (cmd_map_project.lua).
+-- opts.nodate suppresses the date comment: repeated project saves of unchanged
+-- state must serialize identically (project files live in git).
+widgetState.buildEnvConfigContent = function(opts)
+	local sX, sY, sZ = gl.GetSun("pos")
+	local grA = { gl.GetSun("ambient") }
+	local grD = { gl.GetSun("diffuse") }
+	local grS = { gl.GetSun("specular") }
+	local unA = { gl.GetSun("ambient", "unit") }
+	local unD = { gl.GetSun("diffuse", "unit") }
+	local unS = { gl.GetSun("specular", "unit") }
+	local gShadow = gl.GetSun("shadowDensity", "ground")
+	local uShadow = gl.GetSun("shadowDensity", "unit")
+	local fgS = gl.GetAtmosphere("fogStart")
+	local fgE = gl.GetAtmosphere("fogEnd")
+	local fgC = { gl.GetAtmosphere("fogColor") }
+	local snC = { gl.GetAtmosphere("sunColor") }
+	local skC = { gl.GetAtmosphere("skyColor") }
+	local skAA = { gl.GetAtmosphere("skyAxisAngle") }
+	local clC = { gl.GetAtmosphere("cloudColor") }
+	local sunIntensity = widgetState.envSunIntensity or 1.0
+	local smR, smG, smB, smA = gl.GetMapRendering("splatTexMults")
+	local ssR, ssG, ssB, ssA = gl.GetMapRendering("splatTexScales")
+	local sdnda = gl.GetMapRendering("splatDetailNormalDiffuseAlpha")
+	local vW = gl.GetMapRendering("voidWater")
+	local vG = gl.GetMapRendering("voidGround")
+	local fmt3 = function(t) return string.format("{ %.4f, %.4f, %.4f }", t[1] or 0, t[2] or 0, t[3] or 0) end
+	local fmt4 = function(t) return string.format("{ %.4f, %.4f, %.4f, %.4f }", t[1] or 0, t[2] or 0, t[3] or 0, t[4] or 0) end
+	local bstr = function(v) return v and "true" or "false" end
+	local outLines = {
+		"-- Environment config exported from BAR Terraform Brush",
+		"-- Map: " .. (Game.mapName or "unknown"),
+	}
+	if not (opts and opts.nodate) then
+		outLines[#outLines + 1] = "-- Date: " .. os.date("%Y-%m-%d %H:%M:%S")
+	end
+	local body = {
+		"return {",
+		"\tversion = 1,",
+		"\tmapName = \"" .. (Game.mapName or "unknown") .. "\",",
+		"",
+		"\t-- Sun direction",
+		"\tsunDir = " .. fmt3({sX, sY, sZ}) .. ",",
+		"",
+		"\t-- Shadow density",
+		"\tgroundShadowDensity = " .. string.format("%.4f", gShadow) .. ",",
+		"\tmodelShadowDensity = " .. string.format("%.4f", uShadow) .. ",",
+		"",
+		"\t-- Ground lighting",
+		"\tgroundAmbientColor = " .. fmt3(grA) .. ",",
+		"\tgroundDiffuseColor = " .. fmt3(grD) .. ",",
+		"\tgroundSpecularColor = " .. fmt3(grS) .. ",",
+		"",
+		"\t-- Unit lighting",
+		"\tunitAmbientColor = " .. fmt3(unA) .. ",",
+		"\tunitDiffuseColor = " .. fmt3(unD) .. ",",
+		"\tunitSpecularColor = " .. fmt3(unS) .. ",",
+		"",
+		"\t-- Fog",
+		"\tfogStart = " .. string.format("%.4f", fgS) .. ",",
+		"\tfogEnd = " .. string.format("%.4f", fgE) .. ",",
+		"\tfogColor = " .. fmt4(fgC) .. ",",
+		"",
+		"\t-- Atmosphere colors",
+		"\tsunColor = " .. fmt3(snC) .. ",",
+		"\tskyColor = " .. fmt3(skC) .. ",",
+		"\tcloudColor = " .. fmt3(clC) .. ",",
+		"",
+		"\t-- Sun intensity",
+		"\tsunIntensity = " .. string.format("%.4f", sunIntensity) .. ",",
+		"",
+		"\t-- Skybox rotation",
+		"\tskyAxisAngle = " .. fmt4(skAA) .. ",",
+		"",
+		"\t-- Map rendering",
+		"\tsplatDetailNormalDiffuseAlpha = " .. bstr(sdnda) .. ",",
+		"\tsplatTexMults = " .. fmt4({smR, smG, smB, smA}) .. ",",
+		"\tsplatTexScales = " .. fmt4({ssR, ssG, ssB, ssA}) .. ",",
+		"\tvoidWater = " .. bstr(vW) .. ",",
+		"\tvoidGround = " .. bstr(vG) .. ",",
+		"",
+		"\t-- Water",
+		"\twater = {",
+	}
+	for i = 1, #body do
+		outLines[#outLines + 1] = body[i]
+	end
+	local wParams = {
+		"shoreWaves", "hasWaterPlane", "forceRendering",
+		"repeatX", "repeatY", "surfaceAlpha",
+		"ambientFactor", "diffuseFactor", "specularFactor", "specularPower",
+		"fresnelMin", "fresnelMax", "fresnelPower",
+		"perlinStartFreq", "perlinLacunarity", "perlinAmplitude", "numTiles",
+		"blurBase", "blurExponent", "reflectionDistortion",
+		"waveOffsetFactor", "waveLength", "waveFoamDistortion", "waveFoamIntensity",
+		"causticsResolution", "causticsStrength",
+	}
+	local boolParams = { shoreWaves = true, hasWaterPlane = true, forceRendering = true }
+	for _, p in ipairs(wParams) do
+		local val = gl.GetWaterRendering(p)
+		if boolParams[p] then
+			outLines[#outLines + 1] = "\t\t" .. p .. " = " .. bstr(val) .. ","
+		else
+			outLines[#outLines + 1] = "\t\t" .. p .. " = " .. string.format("%.4f", val or 0) .. ","
+		end
+	end
+	outLines[#outLines + 1] = "\t},"
+	outLines[#outLines + 1] = ""
+	outLines[#outLines + 1] = "\t-- Water colors"
+	local waterColorExport = {
+		{"absorb", "absorb"}, {"baseColor", "baseColor"}, {"minColor", "minColor"},
+		{"surfaceColor", "surfaceColor"}, {"planeColor", "planeColor"},
+		{"diffuseColor", "diffuseColor"}, {"specularColor", "specularColor"},
+	}
+	for _, wce in ipairs(waterColorExport) do
+		local c = { gl.GetWaterRendering(wce[2]) }
+		outLines[#outLines + 1] = "\twaterColors_" .. wce[1] .. " = " .. fmt3(c) .. ","
+	end
+	outLines[#outLines + 1] = "}"
+	outLines[#outLines + 1] = ""
+	return table.concat(outLines, "\n")
+end
+
 -- Resolve the env preset to apply after a New Map reload (nil = Default/none).
 widgetState._nmCurrentEnvPreset = function()
 	local idx = widgetState.newMapEnvIdx or 0
@@ -1716,6 +1841,9 @@ local initialModel = {
 	-- FILE menu + New Map dialog
 	fileMenuOpen = false,
 	newMapOpen = false,
+	-- Save Project dialog (FILE > Save Project, backed by WG.MapProject)
+	projectSaveOpen = false,
+	projectSaveHint = "",
 	newMapWidthStr = "12",
 	newMapHeightStr = "12",
 	newMapElmoStr = "6144 x 6144 elmos",
@@ -4313,6 +4441,63 @@ local initialModel = {
 		playSound("click")
 		local d = widgetState.dmHandle; if d then d.newMapOpen = false end
 	end,
+	-- ===== Save Project dialog handlers (backed by WG.MapProject) =====
+	onFileSaveProject = function(_event)
+		playSound("click")
+		local d = widgetState.dmHandle
+		if d then
+			d.fileMenuOpen = false
+			d.projectSaveOpen = true
+			d.projectSaveHint = ""
+		end
+		-- Prefill: last used name, else the slugified map name.
+		local doc = widgetState.document
+		local inp = doc and doc:GetElementById("input-project-name")
+		if inp then
+			local name = widgetState.projectNameStr
+			if not name or name == "" then
+				name = (Game.mapName or "map"):lower():gsub("[^%w_%-]+", "-"):gsub("^%-+", ""):gsub("%-+$", "")
+			end
+			widgetState.projectNameStr = name
+			inp:SetAttribute("value", name)
+		end
+	end,
+	onProjectSaveClose = function(_event)
+		playSound("click")
+		local d = widgetState.dmHandle; if d then d.projectSaveOpen = false end
+	end,
+	onProjectSaveConfirm = function(_event)
+		local d = widgetState.dmHandle
+		-- Read the input at click time (the change listener also tracks it, but
+		-- typed-and-not-yet-blurred text must not be lost).
+		local doc = widgetState.document
+		local inp = doc and doc:GetElementById("input-project-name")
+		local name = (inp and inp:GetAttribute("value")) or widgetState.projectNameStr or ""
+		name = name:gsub("^%s+", ""):gsub("%s+$", "")
+		if name == "" then
+			if d then d.projectSaveHint = "Enter a project name first." end
+			return
+		end
+		if not name:match("^[A-Za-z0-9_%-]+$") then
+			if d then d.projectSaveHint = "Only letters, digits, - and _ (no spaces)." end
+			return
+		end
+		if not (WG.MapProject and WG.MapProject.save) then
+			if d then d.projectSaveHint = "Map Project widget is not enabled (Settings > Widgets)." end
+			return
+		end
+		if WG.MapProject.isBusy and WG.MapProject.isBusy() then
+			if d then d.projectSaveHint = "A save is already running (see console)." end
+			return
+		end
+		widgetState.projectNameStr = name
+		if WG.MapProject.save(name) then
+			playSound("save")
+			if d then d.projectSaveHint = "Saving to MapProjects/" .. name .. "/ — progress in console." end
+		else
+			if d then d.projectSaveHint = "Save could not start (see console)." end
+		end
+	end,
 	-- GENERATE TERRAIN toggle: off (default) creates a dead-flat map; on reveals
 	-- the procedural terrain/water/resources/layout controls and the randomizer.
 	onNewMapGenToggle = function(_event)
@@ -5356,116 +5541,7 @@ local initialModel = {
 	end,
 	onEnvSave = function(_event)
 		playSound("save")
-		local sX, sY, sZ = gl.GetSun("pos")
-		local grA = { gl.GetSun("ambient") }
-		local grD = { gl.GetSun("diffuse") }
-		local grS = { gl.GetSun("specular") }
-		local unA = { gl.GetSun("ambient", "unit") }
-		local unD = { gl.GetSun("diffuse", "unit") }
-		local unS = { gl.GetSun("specular", "unit") }
-		local gShadow = gl.GetSun("shadowDensity", "ground")
-		local uShadow = gl.GetSun("shadowDensity", "unit")
-		local fgS = gl.GetAtmosphere("fogStart")
-		local fgE = gl.GetAtmosphere("fogEnd")
-		local fgC = { gl.GetAtmosphere("fogColor") }
-		local snC = { gl.GetAtmosphere("sunColor") }
-		local skC = { gl.GetAtmosphere("skyColor") }
-		local skAA = { gl.GetAtmosphere("skyAxisAngle") }
-		local clC = { gl.GetAtmosphere("cloudColor") }
-		local sunIntensity = widgetState.envSunIntensity or 1.0
-		local smR, smG, smB, smA = gl.GetMapRendering("splatTexMults")
-		local ssR, ssG, ssB, ssA = gl.GetMapRendering("splatTexScales")
-		local sdnda = gl.GetMapRendering("splatDetailNormalDiffuseAlpha")
-		local vW = gl.GetMapRendering("voidWater")
-		local vG = gl.GetMapRendering("voidGround")
-		local fmt3 = function(t) return string.format("{ %.4f, %.4f, %.4f }", t[1] or 0, t[2] or 0, t[3] or 0) end
-		local fmt4 = function(t) return string.format("{ %.4f, %.4f, %.4f, %.4f }", t[1] or 0, t[2] or 0, t[3] or 0, t[4] or 0) end
-		local bstr = function(v) return v and "true" or "false" end
-		local outLines = {
-			"-- Environment config exported from BAR Terraform Brush",
-			"-- Map: " .. (Game.mapName or "unknown"),
-			"-- Date: " .. os.date("%Y-%m-%d %H:%M:%S"),
-			"return {",
-			"\tversion = 1,",
-			"\tmapName = \"" .. (Game.mapName or "unknown") .. "\",",
-			"",
-			"\t-- Sun direction",
-			"\tsunDir = " .. fmt3({sX, sY, sZ}) .. ",",
-			"",
-			"\t-- Shadow density",
-			"\tgroundShadowDensity = " .. string.format("%.4f", gShadow) .. ",",
-			"\tmodelShadowDensity = " .. string.format("%.4f", uShadow) .. ",",
-			"",
-			"\t-- Ground lighting",
-			"\tgroundAmbientColor = " .. fmt3(grA) .. ",",
-			"\tgroundDiffuseColor = " .. fmt3(grD) .. ",",
-			"\tgroundSpecularColor = " .. fmt3(grS) .. ",",
-			"",
-			"\t-- Unit lighting",
-			"\tunitAmbientColor = " .. fmt3(unA) .. ",",
-			"\tunitDiffuseColor = " .. fmt3(unD) .. ",",
-			"\tunitSpecularColor = " .. fmt3(unS) .. ",",
-			"",
-			"\t-- Fog",
-			"\tfogStart = " .. string.format("%.4f", fgS) .. ",",
-			"\tfogEnd = " .. string.format("%.4f", fgE) .. ",",
-			"\tfogColor = " .. fmt4(fgC) .. ",",
-			"",
-			"\t-- Atmosphere colors",
-			"\tsunColor = " .. fmt3(snC) .. ",",
-			"\tskyColor = " .. fmt3(skC) .. ",",
-			"\tcloudColor = " .. fmt3(clC) .. ",",
-			"",
-			"\t-- Sun intensity",
-			"\tsunIntensity = " .. string.format("%.4f", sunIntensity) .. ",",
-			"",
-			"\t-- Skybox rotation",
-			"\tskyAxisAngle = " .. fmt4(skAA) .. ",",
-			"",
-			"\t-- Map rendering",
-			"\tsplatDetailNormalDiffuseAlpha = " .. bstr(sdnda) .. ",",
-			"\tsplatTexMults = " .. fmt4({smR, smG, smB, smA}) .. ",",
-			"\tsplatTexScales = " .. fmt4({ssR, ssG, ssB, ssA}) .. ",",
-			"\tvoidWater = " .. bstr(vW) .. ",",
-			"\tvoidGround = " .. bstr(vG) .. ",",
-			"",
-			"\t-- Water",
-			"\twater = {",
-		}
-		local wParams = {
-			"shoreWaves", "hasWaterPlane", "forceRendering",
-			"repeatX", "repeatY", "surfaceAlpha",
-			"ambientFactor", "diffuseFactor", "specularFactor", "specularPower",
-			"fresnelMin", "fresnelMax", "fresnelPower",
-			"perlinStartFreq", "perlinLacunarity", "perlinAmplitude", "numTiles",
-			"blurBase", "blurExponent", "reflectionDistortion",
-			"waveOffsetFactor", "waveLength", "waveFoamDistortion", "waveFoamIntensity",
-			"causticsResolution", "causticsStrength",
-		}
-		local boolParams = { shoreWaves = true, hasWaterPlane = true, forceRendering = true }
-		for _, p in ipairs(wParams) do
-			local val = gl.GetWaterRendering(p)
-			if boolParams[p] then
-				outLines[#outLines + 1] = "\t\t" .. p .. " = " .. bstr(val) .. ","
-			else
-				outLines[#outLines + 1] = "\t\t" .. p .. " = " .. string.format("%.4f", val or 0) .. ","
-			end
-		end
-		outLines[#outLines + 1] = "\t},"
-		outLines[#outLines + 1] = ""
-		outLines[#outLines + 1] = "\t-- Water colors"
-		local waterColorExport = {
-			{"absorb", "absorb"}, {"baseColor", "baseColor"}, {"minColor", "minColor"},
-			{"surfaceColor", "surfaceColor"}, {"planeColor", "planeColor"},
-			{"diffuseColor", "diffuseColor"}, {"specularColor", "specularColor"},
-		}
-		for _, wce in ipairs(waterColorExport) do
-			local c = { gl.GetWaterRendering(wce[2]) }
-			outLines[#outLines + 1] = "\twaterColors_" .. wce[1] .. " = " .. fmt3(c) .. ","
-		end
-		outLines[#outLines + 1] = "}"
-		outLines[#outLines + 1] = ""
-		local content = table.concat(outLines, "\n")
+		local content = widgetState.buildEnvConfigContent()
 		local mapSafe = (Game.mapName or "unknown"):gsub("[^%w_%-]", "_")
 		local timestamp = os.date("%Y%m%d_%H%M%S")
 		local LIGHTMAPS_DIR = "Terraform Brush/Lightmaps/"
@@ -8538,6 +8614,26 @@ local function attachEventListeners()
 		end, false)
 	end
 
+	-- Save Project name input (FILE > Save Project): same SDL text-input capture
+	-- as the preset input, plus a change listener mirroring into widgetState so
+	-- the confirm handler has the value even if GetAttribute lags the keystroke.
+	local projectNameInput = getCachedEl(doc, "input-project-name")
+	if projectNameInput then
+		projectNameInput:AddEventListener("focus", function(event)
+			WG.TerraformBrushInputFocused = true
+			Spring.SDLStartTextInput()
+			widgetState.focusedRmlInput = projectNameInput
+		end, false)
+		projectNameInput:AddEventListener("blur", function(event)
+			WG.TerraformBrushInputFocused = false
+			Spring.SDLStopTextInput()
+			widgetState.focusedRmlInput = nil
+		end, false)
+		projectNameInput:AddEventListener("change", function(event)
+			widgetState.projectNameStr = projectNameInput:GetAttribute("value") or ""
+		end, false)
+	end
+
 	local function setDropdownOpen(open)
 		dropdownOpen = open
 		if presetDropdown then
@@ -8817,6 +8913,7 @@ local function attachEventListeners()
 		makeWindowDraggable("tf-light-library-handle", widgetState.lightLibraryRootEl)
 		makeWindowDraggable("tf-settings-handle", widgetState.settingsRootEl)
 		makeWindowDraggable("tf-newmap-handle", getCachedEl(doc, "tf-newmap-root"))
+		makeWindowDraggable("tf-project-handle", getCachedEl(doc, "tf-project-root"))
 	end
 
 	-- ===== Transport (auto-scroll) button listeners =====
@@ -8940,6 +9037,14 @@ function widget:Initialize()
 
 	-- Expose UI-side API for key capture and badge refresh
 	WG.TerraformBrushUI = {
+		-- Environment snapshot/apply, for the map-project orchestrator
+		-- (cmd_map_project.lua). Indirect so it tracks widgetState assignments.
+		buildEnvConfigContent = function(opts)
+			return widgetState.buildEnvConfigContent(opts)
+		end,
+		applyEnvConfig = function(d)
+			return widgetState.applyEnvConfig(d)
+		end,
 		isCapturingKey = function()
 			return widgetState.settingsCapturing ~= nil
 		end,

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1695,6 +1695,13 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	-- and project loads.
 	script = script:gsub("[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Mm][Aa][Pp][Dd][Aa][Mm][Aa][Gg][Ee]%s*=[^;\r\n]*;?", "")
 
+	-- Inherited startboxes (startrectleft/right/top/bottom in the allyteam
+	-- blocks) confine pregame commander placement to a sliver of the blank
+	-- canvas — every click outside a startrect is silently ignored before the
+	-- game starts, which reads as a dead mouse. The editor canvas allows
+	-- placement anywhere.
+	script = script:gsub("[Ss][Tt][Aa][Rr][Tt][Rr][Ee][Cc][Tt][A-Za-z]*%s*=[^;\r\n]*;?", "")
+
 	-- Swap the map name (the generator uses it as the generated map's label).
 	if script:find("[Mm][Aa][Pp][Nn][Aa][Mm][Ee]%s*=") then
 		script = (script:gsub("[Mm][Aa][Pp][Nn][Aa][Mm][Ee]%s*=[^;\r\n]*;?", "mapname=" .. mapName .. ";", 1))

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -27,6 +27,7 @@
 					<div id="btn-file" class="tf-header-btn tf-file-btn" data-class-active="fileMenuOpen" data-event-mousedown="onFileMenuToggle()"><img class="tf-header-icon" src="/luaui/images/terraform_brush/folder.png" /></div>
 					<div id="tf-file-menu" class="tf-file-menu" data-if="fileMenuOpen">
 						<div id="btn-file-newmap" class="tf-file-menu-item" data-event-mousedown="onFileNewMap()">New Map...</div>
+						<div id="btn-file-openproject" class="tf-file-menu-item" data-event-mousedown="onFileOpenProject()">Open Project...</div>
 						<div id="btn-file-saveproject" class="tf-file-menu-item" data-event-mousedown="onFileSaveProject()">Save Project...</div>
 					</div>
 				</div>
@@ -6893,6 +6894,20 @@
 				<div class="tf-action-btn-text">SAVE PROJECT</div>
 			</div>
 		</div>
+	</div>
+
+	<!-- ============ OPEN PROJECT WINDOW (floating, opened from FILE menu) ============ -->
+	<div id="tf-project-open-root" class="tf-newmap-window widget-shadow rounded-md bg-darkest p-2-5" style="left: 38vw; top: 26vh;" data-if="projectOpenOpen">
+		<div class="flex flex-row justify-between items-center mb-2">
+			<div id="tf-project-open-handle" class="tf-drag-handle text-xl font-bold text-light text-outline-darker" style="flex: 1;">Open Project</div>
+			<div id="btn-project-open-close" class="tf-quit-btn" data-event-mousedown="onProjectOpenClose()"><img class="tf-icon-sm" src="/luaui/images/terraform_brush/close.png" /></div>
+		</div>
+
+		<div class="text-base text-keybind mb-2">Load a saved project from MapProjects/. This restarts the session onto a blank map of the project's size and replays every section. Unsaved changes on the current map will be lost.</div>
+
+		<div id="tf-project-open-list" class="mb-2" style="max-height: 40vh; overflow-y: auto;"></div>
+
+		<div class="text-base text-keybind mb-1" data-if="projectOpenHint != ''">{{projectOpenHint}}</div>
 	</div>
 
 	<!-- ============ NEW MAP WINDOW (floating, opened from FILE menu) ============ -->

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -27,6 +27,7 @@
 					<div id="btn-file" class="tf-header-btn tf-file-btn" data-class-active="fileMenuOpen" data-event-mousedown="onFileMenuToggle()"><img class="tf-header-icon" src="/luaui/images/terraform_brush/folder.png" /></div>
 					<div id="tf-file-menu" class="tf-file-menu" data-if="fileMenuOpen">
 						<div id="btn-file-newmap" class="tf-file-menu-item" data-event-mousedown="onFileNewMap()">New Map...</div>
+						<div id="btn-file-saveproject" class="tf-file-menu-item" data-event-mousedown="onFileSaveProject()">Save Project...</div>
 					</div>
 				</div>
 				<div class="tf-rail-spacer"></div>
@@ -6864,6 +6865,32 @@
 					<div class="tf-dj-activate-desc">Hides the pulsing blue notification dots on collapsed section headers.</div>
 				</div>
 				<div id="pill-ui-disable-tips" class="tf-dj-toggle-pill">{{disableTipsStr}}</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- ============ SAVE PROJECT WINDOW (floating, opened from FILE menu) ============ -->
+	<div id="tf-project-root" class="tf-newmap-window widget-shadow rounded-md bg-darkest p-2-5" style="left: 38vw; top: 30vh;" data-if="projectSaveOpen">
+		<div class="flex flex-row justify-between items-center mb-2">
+			<div id="tf-project-handle" class="tf-drag-handle text-xl font-bold text-light text-outline-darker" style="flex: 1;">Save Project</div>
+			<div id="btn-project-close" class="tf-quit-btn" data-event-mousedown="onProjectSaveClose()"><img class="tf-icon-sm" src="/luaui/images/terraform_brush/close.png" /></div>
+		</div>
+
+		<div class="text-base text-keybind mb-2">Save this map's full state (terrain, metal, features, decals, lights, environment, weather, grass, start positions) into one folder: MapProjects/&lt;name&gt;. Re-saving the same name updates it.</div>
+
+		<div class="flex flex-row justify-between items-center mb-1">
+			<div class="text-lg text-light">NAME</div>
+			<div class="text-sm text-keybind">letters, digits, - and _</div>
+		</div>
+		<div class="flex flex-row gap-1 mb-2">
+			<input type="text" id="input-project-name" class="tf-preset-input" maxlength="64" value="" />
+		</div>
+
+		<div class="text-base text-keybind mb-2" data-if="projectSaveHint != ''">{{projectSaveHint}}</div>
+
+		<div class="flex flex-row gap-1 items-center">
+			<div id="btn-project-save" class="tf-action-btn tf-save-btn" style="flex: 1;" data-event-mousedown="onProjectSaveConfirm()">
+				<div class="tf-action-btn-text">SAVE PROJECT</div>
 			</div>
 		</div>
 	</div>

--- a/luaui/Widgets/cmd_decal_placer.lua
+++ b/luaui/Widgets/cmd_decal_placer.lua
@@ -111,6 +111,10 @@ local dp = {
 	-- Undo/Redo
 	undoStack     = {},      -- each entry = { decalIDs = {id1,id2,...} }
 	redoStack     = {},
+	-- Registry of decals this tool placed (set of ids). GetAllGroundDecals() also
+	-- returns engine decals (unit tracks, scars, building plates); project export
+	-- must only serialize our own placements.
+	projectIDs    = {},
 	undoCount     = 0,
 	redoCount     = 0,
 }
@@ -341,6 +345,7 @@ local function applyDecal(tex, wx, wz, sizeX, sizeZ, rotRad)
 	if dp.alignToNormal and SetGroundDecalNormal then
 		SetGroundDecalNormal(id, 0, 0, 0)
 	end
+	dp.projectIDs[id] = true
 	return id
 end
 
@@ -406,7 +411,10 @@ local function placeRemove(cx, cz)
 			local ddx = dx - cx
 			local ddz = dz - cz
 			if ddx * ddx + ddz * ddz <= r2 then
-				if DestroyGroundDecal(id) then removed = removed + 1 end
+				if DestroyGroundDecal(id) then
+					removed = removed + 1
+					dp.projectIDs[id] = nil
+				end
 			end
 		end
 	end
@@ -443,6 +451,7 @@ local function decalUndo()
 	dp.undoStack[#dp.undoStack] = nil
 	for _, id in ipairs(entry.decalIDs) do
 		DestroyGroundDecal(id)
+		dp.projectIDs[id] = nil
 	end
 	dp.undoCount = #dp.undoStack
 	-- redoStack would need re-creation info; skip redo for destructive ops
@@ -454,6 +463,7 @@ local function decalClearAll()
 	for _, id in ipairs(GetAllGroundDecals()) do
 		if DestroyGroundDecal(id) then n = n + 1 end
 	end
+	dp.projectIDs = {}
 	dp.undoStack = {}
 	dp.redoStack = {}
 	dp.undoCount = 0
@@ -624,6 +634,38 @@ local function decalSave()
 	Echo("[Decal Placer] Saved " .. n .. " decals to " .. filename)
 end
 
+-- Project-mode save: only decals placed by this tool (dp.projectIDs), stable order,
+-- no timestamp comment — repeated saves of the same scene must serialize identically
+-- (project files live in git). Returns the decal count written, or nil on error.
+local function decalSaveProject(explicitPath)
+	if not GetAllGroundDecals then return nil end
+	-- "wb": project files must be byte-identical across OSes (no CRLF translation)
+	local f = io.open(explicitPath, "wb")
+	if not f then Echo("[Decal Placer] Cannot write " .. explicitPath); return nil end
+	local lines = {}
+	for _, id in ipairs(GetAllGroundDecals()) do
+		if dp.projectIDs[id] then
+			local dx, dz = GetGroundDecalMiddlePos(id)
+			local sx, sz = GetGroundDecalSizeAndHeight(id)
+			local rot = Spring.GetGroundDecalRotation and Spring.GetGroundDecalRotation(id) or 0
+			local tex = Spring.GetGroundDecalTexture and Spring.GetGroundDecalTexture(id, true) or ""
+			if dx and tex and tex ~= "" then
+				lines[#lines + 1] = string.format('\t{tex=%q, x=%.1f, z=%.1f, sx=%.1f, sz=%.1f, rot=%.4f},',
+					tex, dx, dz, sx or 64, sz or 64, rot)
+			end
+		end
+	end
+	-- Sorting the fully serialized lines gives a total order over every field, so
+	-- ties can never reorder entries between sessions (files live in git).
+	table.sort(lines)
+	f:write("return {\n")
+	f:write(table.concat(lines, "\n"))
+	if #lines > 0 then f:write("\n") end
+	f:write("}\n")
+	f:close()
+	return #lines
+end
+
 local function decalLoad(filename)
 	if not filename or filename == "" then
 		local saves = VFS.DirList(SAVE_DIR, "*.lua", VFS.RAW) or {}
@@ -785,10 +827,40 @@ function widget:Initialize()
 		undo                  = decalUndo,
 		clearAll              = decalClearAll,
 		save                  = decalSave,
+		saveProject           = decalSaveProject,
 		load                  = decalLoad,
 		listSaves             = listSavedDecalMaps,
 		deactivate            = deactivate,
 	}
+end
+
+-- Persist the placement registry across /luaui reload: placed ground decals are
+-- engine objects that survive a widget reload, but dp.projectIDs would not —
+-- a project save right after a reload would then see zero owned decals and
+-- delete the project's decals section. Guards: ids are only re-adopted in the
+-- same session (game frame is monotonic within one) and are re-validated
+-- against GetAllGroundDecals() at save time anyway.
+function widget:GetConfigData()
+	local ids = {}
+	for id in pairs(dp.projectIDs) do
+		ids[#ids + 1] = id
+	end
+	table.sort(ids)
+	return {
+		projectIDs = ids,
+		savedAtFrame = Spring.GetGameFrame(),
+		mapName = Game.mapName,
+	}
+end
+
+function widget:SetConfigData(data)
+	if not (data and data.projectIDs) then return end
+	if data.mapName ~= Game.mapName then return end
+	local frame = Spring.GetGameFrame()
+	if not data.savedAtFrame or data.savedAtFrame > frame then return end
+	for _, id in ipairs(data.projectIDs) do
+		dp.projectIDs[id] = true
+	end
 end
 
 function widget:Shutdown()

--- a/luaui/Widgets/cmd_diffuse_painter.lua
+++ b/luaui/Widgets/cmd_diffuse_painter.lua
@@ -233,6 +233,12 @@ local pendingInit       = false
 local pendingFullBake   = false  -- re-bake already-allocated squares
 local pendingFullCover  = false  -- allocate every map square + bake (heavy)
 local pendingExport     = false  -- /diffusepaintexport queued; runs in DrawWorld (GL context)
+local pendingProjectSave = nil   -- map-project save job (chunked in DrawWorld); see projectSaveTick
+local projectSaveResult  = nil   -- result table once the save job finished
+local pendingProjectLoad = nil   -- map-project load job (chunked in DrawWorld); see projectLoadTick
+local projectLoadResult  = nil   -- result table once the load job finished
+local PROJECT_SAVE_SQUARES_PER_TICK = 4  -- 1024^2 readback+PNG encode each; full-map capture must not freeze
+local PROJECT_LOAD_SQUARES_PER_TICK = 8
 local libraryScanned    = false  -- material library VFS walk done (deferred to first activate)
 local pendingPaintStrokes = {}   -- array of {wx, wz, layerId, erase}
 local dirtySquares      = {}     -- squareKey -> true; consumed each Draw
@@ -2079,6 +2085,33 @@ function widget:Initialize()
 		rescanMaterialLibrary = scanMaterialLibrary,
 		bakeAll        = function() pendingFullCover = true end,
 		exportSquares  = function() pendingExport = true end,
+		-- Map project (cmd_map_project.lua): chunked DrawWorld jobs saving/loading
+		-- baked square diffuse + channel textures; poll the pending flags.
+		saveProject = function(dir, allSquares)
+			if pendingProjectSave or pendingProjectLoad then return false end
+			pendingProjectSave = { dir = dir, allSquares = allSquares and true or false, sx = 0, sy = 0, written = {} }
+			projectSaveResult = nil
+			return true
+		end,
+		isProjectSavePending = function() return pendingProjectSave ~= nil end,
+		getProjectSaveResult = function() return projectSaveResult end,
+		loadProject = function(squareList, channelMap)
+			if pendingProjectSave or pendingProjectLoad then return false end
+			pendingProjectLoad = { squares = squareList or {}, channels = channelMap or {}, i = 1 }
+			projectLoadResult = nil
+			return true
+		end,
+		isProjectLoadPending = function() return pendingProjectLoad ~= nil end,
+		getProjectLoadResult = function() return projectLoadResult end,
+		hasProjectState = function()
+			for _, s in pairs(squares) do
+				if s.compositeTex then return true end
+			end
+			for key, ch in pairs(channels) do
+				if channelsEnabled[key] and ch.tex then return true end
+			end
+			return false
+		end,
 		getBrush       = function() return brushRadius, brushStrength, brushCurve, eraseMode end,
 		setRadius        = function(r) brushRadius = max(MIN_RADIUS, min(MAX_RADIUS, floor(r))) end,
 		setStrength      = function(v) brushStrength = max(MIN_STRENGTH, min(MAX_STRENGTH, v)) end,
@@ -2251,6 +2284,230 @@ function widget:MouseWheel(up, value)
 	return false
 end
 
+-- ============================================================================
+-- Map project save/load (cmd_map_project.lua) — chunked in DrawWorld
+-- ============================================================================
+
+-- Save one square to <dir>sq_<sx>_<sy>.png. Painted squares save their baked
+-- composite; untouched squares (full capture) read the engine's own diffuse
+-- through a transient texture, so a compiled map's shipped art (e.g. World
+-- Machine output) rides along in the project. Returns true on success.
+local function projectSaveSquare(dir, sx, sy)
+	local fname = dir .. "sq_" .. sx .. "_" .. sy .. ".png"
+	local s = squares[squareKey(sx, sy)]
+	if s and s.compositeTex then
+		local ok
+		glRenderToTexture(s.compositeTex, function()
+			ok = gl.SaveImage(0, 0, TILE_PX, TILE_PX, fname, { yflip = false })
+		end)
+		return ok and true or false
+	end
+	local tmp = glCreateTexture(TILE_PX, TILE_PX, {
+		border = false, min_filter = GL.LINEAR, mag_filter = GL.LINEAR,
+		wrap_s = GL.CLAMP_TO_EDGE, wrap_t = GL.CLAMP_TO_EDGE,
+		fbo = false, format = GL.RGBA8,
+	})
+	if not tmp then return false end
+	if not GetMapSquareTextureFn(sx, sy, 0, tmp, 0) then
+		glDeleteTexture(tmp)
+		return false
+	end
+	local scratch = getScratchTex(TILE_PX)
+	if not scratch then
+		glDeleteTexture(tmp)
+		return false
+	end
+	local ok
+	glRenderToTexture(scratch, function()
+		glBlending(false)
+		glUseShader(copyShader)
+		glTexture(0, tmp)
+		glTexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+		glTexture(0, false)
+		glUseShader(0)
+		glBlending(true)
+		ok = gl.SaveImage(0, 0, TILE_PX, TILE_PX, fname, { yflip = false })
+	end)
+	glDeleteTexture(tmp)
+	return ok and true or false
+end
+
+local function projectSaveTick()
+	local req = pendingProjectSave
+	if not copyShader then
+		if not createShaders() then
+			projectSaveResult = { error = "shader creation failed" }
+			pendingProjectSave = nil
+			return
+		end
+	end
+	local done = 0
+	while req.sy < numSqZ and done < PROJECT_SAVE_SQUARES_PER_TICK do
+		local k = squareKey(req.sx, req.sy)
+		local s = squares[k]
+		if req.allSquares or (s and s.compositeTex) then
+			-- The bake pass drains dirtySquares in hash order at its own rate; a
+			-- square still dirty when the save cursor reaches it would capture a
+			-- stale composite (e.g. mid-save layer tweak). Bake it now.
+			if dirtySquares[k] and s and s.seedTex then
+				bakeSquare(s)
+				dirtySquares[k] = nil
+			end
+			if projectSaveSquare(req.dir, req.sx, req.sy) then
+				req.written[#req.written + 1] = "sq_" .. req.sx .. "_" .. req.sy .. ".png"
+			else
+				req.failed = (req.failed or 0) + 1
+			end
+			done = done + 1
+		end
+		req.sx = req.sx + 1
+		if req.sx >= numSqX then
+			req.sx = 0
+			req.sy = req.sy + 1
+		end
+	end
+	if req.sy < numSqZ then return end
+	-- Channels: enabled + allocated only (a disabled channel means the engine's
+	-- own texture is showing — not ours to record).
+	local chans = {}
+	for key, ch in pairs(channels) do
+		if channelsEnabled[key] and ch.tex then
+			local fname = req.dir .. "channel_" .. key .. ".png"
+			local ok
+			glRenderToTexture(ch.tex, function()
+				ok = gl.SaveImage(0, 0, ch.w, ch.h, fname, { yflip = false })
+			end)
+			if ok then
+				chans[#chans + 1] = key
+			else
+				req.failed = (req.failed or 0) + 1
+			end
+		end
+	end
+	table.sort(chans)
+	projectSaveResult = {
+		squares = req.written,
+		channels = chans,
+		-- Coverage fact, not capture mode: a loaded full project re-saves from a
+		-- blank session with every square painted — recording the mode would
+		-- flip this field and break save->load->save byte-idempotence.
+		full = (#req.written == numSqX * numSqZ),
+		failed = req.failed or 0,
+		squareSize = TILE_PX,
+	}
+	pendingProjectSave = nil
+end
+
+local function projectLoadTick()
+	local req = pendingProjectLoad
+	if not copyShader then
+		if not createShaders() then
+			projectLoadResult = { error = "shader creation failed" }
+			pendingProjectLoad = nil
+			return
+		end
+	end
+	-- A load replaces the entire diffuse state: stale hand-paint masks would be
+	-- double-applied by the next bake (the strokes are already baked into the
+	-- loaded PNGs), and undoing a pre-load snapshot would resurrect old paint.
+	if not req.cleared then
+		req.cleared = true
+		clearHistory()
+		for _, layerMasks in pairs(masks) do
+			for _, maskTex in pairs(layerMasks) do
+				clearMaskTex(maskTex)
+			end
+		end
+	end
+	local done = 0
+	while req.i <= #req.squares and done < PROJECT_LOAD_SQUARES_PER_TICK do
+		local e = req.squares[req.i]
+		req.i = req.i + 1
+		done = done + 1
+		local s = getOrAllocSquare(e.sx, e.sy)
+		local texName = ":l:" .. e.path
+		if s and gl.Texture(texName) then
+			gl.Texture(false)
+			-- Recreate both textures FBO-capable: an engine-seeded seedTex is not
+			-- renderable, and the loaded PNG must become the square's new SEED so
+			-- later layer bakes composite over it instead of the engine texture.
+			freeSquare(s)
+			s.allocFailed = nil
+			s.seedTex = glCreateTexture(TILE_PX, TILE_PX, {
+				border = false, min_filter = GL.LINEAR, mag_filter = GL.LINEAR,
+				wrap_s = GL.CLAMP_TO_EDGE, wrap_t = GL.CLAMP_TO_EDGE,
+				fbo = true, format = GL.RGBA8,
+			})
+			s.compositeTex = s.seedTex and glCreateTexture(TILE_PX, TILE_PX, {
+				border = false, min_filter = GL.LINEAR, mag_filter = GL.LINEAR,
+				wrap_s = GL.CLAMP_TO_EDGE, wrap_t = GL.CLAMP_TO_EDGE,
+				fbo = true, format = GL.RGBA8,
+			}) or nil
+			if s.seedTex and s.compositeTex then
+				local targets = { s.seedTex, s.compositeTex }
+				for t = 1, 2 do
+					glRenderToTexture(targets[t], function()
+						glBlending(false)
+						glUseShader(copyShader)
+						glTexture(0, texName)
+						glTexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+						glTexture(0, false)
+						glUseShader(0)
+						glBlending(true)
+					end)
+				end
+				s.dirty = false
+				bindSquare(s)
+				req.loaded = (req.loaded or 0) + 1
+			else
+				if s.seedTex then
+					glDeleteTexture(s.seedTex)
+					s.seedTex = nil
+				end
+				req.failed = (req.failed or 0) + 1
+			end
+			gl.DeleteTexture(texName)
+		else
+			req.failed = (req.failed or 0) + 1
+		end
+	end
+	if req.i <= #req.squares then return end
+	local chLoaded = 0
+	for key, path in pairs(req.channels or {}) do
+		if channelsEnabled[key] ~= nil then
+			-- Verify the PNG loads BEFORE flipping the enabled flag: an enabled
+			-- but unbound channel would accept strokes the engine never shows.
+			local texName = ":l:" .. path
+			if gl.Texture(texName) then
+				gl.Texture(false)
+				channelsEnabled[key] = true
+				local ch = ensureChannel(key)
+				if ch then
+					glRenderToTexture(ch.tex, function()
+						glBlending(false)
+						glUseShader(copyShader)
+						glTexture(0, texName)
+						glTexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+						glTexture(0, false)
+						glUseShader(0)
+						glBlending(true)
+					end)
+					bindChannel(ch)
+					chLoaded = chLoaded + 1
+				else
+					channelsEnabled[key] = false
+					req.failed = (req.failed or 0) + 1
+				end
+				gl.DeleteTexture(texName)
+			else
+				req.failed = (req.failed or 0) + 1
+			end
+		end
+	end
+	projectLoadResult = { loaded = req.loaded or 0, failed = req.failed or 0, channels = chLoaded }
+	pendingProjectLoad = nil
+end
+
 function widget:DrawWorld()
 	-- Lazy init: NO bulk alloc. Squares are allocated on first paint stroke
 	-- (executeStroke) or on explicit /diffusepaintbake (which will allocate
@@ -2354,6 +2611,15 @@ function widget:DrawWorld()
 			end
 		end
 		Echo("[Diffuse Painter] exported " .. count .. " square textures to " .. folder .. "/")
+	end
+
+	-- Deferred map-project save/load: after the bake section so painted squares
+	-- are fresh; chunked so a full-map capture cannot freeze the session.
+	if pendingProjectSave then
+		projectSaveTick()
+	end
+	if pendingProjectLoad and not pendingProjectSave then
+		projectLoadTick()
 	end
 
 	-- Brush ring

--- a/luaui/Widgets/cmd_diffuse_painter.lua
+++ b/luaui/Widgets/cmd_diffuse_painter.lua
@@ -2298,7 +2298,7 @@ local function projectSaveSquare(dir, sx, sy)
 	if s and s.compositeTex then
 		local ok
 		glRenderToTexture(s.compositeTex, function()
-			ok = gl.SaveImage(0, 0, TILE_PX, TILE_PX, fname, { yflip = false })
+			ok = gl.SaveImage(0, 0, TILE_PX, TILE_PX, fname, { yflip = false, alpha = true })
 		end)
 		return ok and true or false
 	end
@@ -2326,7 +2326,7 @@ local function projectSaveSquare(dir, sx, sy)
 		glTexture(0, false)
 		glUseShader(0)
 		glBlending(true)
-		ok = gl.SaveImage(0, 0, TILE_PX, TILE_PX, fname, { yflip = false })
+		ok = gl.SaveImage(0, 0, TILE_PX, TILE_PX, fname, { yflip = false, alpha = true })
 	end)
 	glDeleteTexture(tmp)
 	return ok and true or false
@@ -2375,7 +2375,8 @@ local function projectSaveTick()
 			local fname = req.dir .. "channel_" .. key .. ".png"
 			local ok
 			glRenderToTexture(ch.tex, function()
-				ok = gl.SaveImage(0, 0, ch.w, ch.h, fname, { yflip = false })
+				-- alpha=true: normal-channel alpha carries the diffuse-blend weight
+				ok = gl.SaveImage(0, 0, ch.w, ch.h, fname, { yflip = false, alpha = true })
 			end)
 			if ok then
 				chans[#chans + 1] = key

--- a/luaui/Widgets/cmd_light_placer.lua
+++ b/luaui/Widgets/cmd_light_placer.lua
@@ -608,7 +608,7 @@ local function getMapName()
 	return mapName:gsub("[^%w_%-]", "_")
 end
 
-local function save()
+local function save(explicitPath)
 	local lightList = {}
 	for _, rec in pairs(placedLights) do
 		lightList[#lightList + 1] = {
@@ -631,35 +631,43 @@ local function save()
 		}
 	end
 
-	local data = {
-		version = 1,
-		mapName = Game.mapName,
-		lights  = lightList,
-	}
+	local filename = explicitPath
+	if not filename then
+		local timestamp = os.date("%Y%m%d_%H%M%S")
+		Spring.CreateDir(SAVE_DIR)
+		filename = SAVE_DIR .. getMapName() .. "_lights_" .. timestamp .. ".lua"
+	end
 
-	local timestamp = os.date("%Y%m%d_%H%M%S")
-	Spring.CreateDir(SAVE_DIR)
-	local filename = SAVE_DIR .. getMapName() .. "_lights_" .. timestamp .. ".lua"
+	-- placedLights is keyed by transient instanceID (pairs = hash order): build
+	-- each light's serialized block, then sort the blocks. Lexicographic order
+	-- over the full serialization is a total order, so repeated saves of the same
+	-- scene produce identical bytes (project files are diffed in git).
+	local blocks = {}
+	for _, l in ipairs(lightList) do
+		local b = { "\t\t{\n" }
+		b[#b + 1] = string.format('\t\t\ttype = "%s",\n', l.type)
+		b[#b + 1] = string.format("\t\t\tpos = { %.1f, %.1f, %.1f },\n", l.pos[1], l.pos[2], l.pos[3])
+		b[#b + 1] = string.format("\t\t\tradius = %.1f,\n", l.radius)
+		b[#b + 1] = string.format("\t\t\tcolor = { %.3f, %.3f, %.3f },\n", l.color[1], l.color[2], l.color[3])
+		b[#b + 1] = string.format("\t\t\tbrightness = %.2f,\n", l.brightness)
+		b[#b + 1] = string.format("\t\t\tmodelfactor = %.2f,\n", l.modelfactor)
+		b[#b + 1] = string.format("\t\t\tspecular = %.2f,\n", l.specular)
+		b[#b + 1] = string.format("\t\t\tscattering = %.2f,\n", l.scattering)
+		b[#b + 1] = string.format("\t\t\tlensflare = %.2f,\n", l.lensflare)
+		if l.pitch then b[#b + 1] = string.format("\t\t\tpitch = %.1f,\n", l.pitch) end
+		if l.yaw   then b[#b + 1] = string.format("\t\t\tyaw = %.1f,\n", l.yaw) end
+		if l.roll  then b[#b + 1] = string.format("\t\t\troll = %.1f,\n", l.roll) end
+		if l.theta then b[#b + 1] = string.format("\t\t\ttheta = %.3f,\n", l.theta) end
+		if l.beamLength then b[#b + 1] = string.format("\t\t\tbeamLength = %.1f,\n", l.beamLength) end
+		if l.elevation then b[#b + 1] = string.format("\t\t\televation = %.1f,\n", l.elevation) end
+		b[#b + 1] = "\t\t},\n"
+		blocks[#blocks + 1] = table.concat(b)
+	end
+	table.sort(blocks)
 
 	local lines = { "return {\n", "\tversion = 1,\n", '\tmapName = "' .. (Game.mapName or "unknown") .. '",\n', "\tlights = {\n" }
-	for _, l in ipairs(lightList) do
-		lines[#lines + 1] = "\t\t{\n"
-		lines[#lines + 1] = string.format('\t\t\ttype = "%s",\n', l.type)
-		lines[#lines + 1] = string.format("\t\t\tpos = { %.1f, %.1f, %.1f },\n", l.pos[1], l.pos[2], l.pos[3])
-		lines[#lines + 1] = string.format("\t\t\tradius = %.1f,\n", l.radius)
-		lines[#lines + 1] = string.format("\t\t\tcolor = { %.3f, %.3f, %.3f },\n", l.color[1], l.color[2], l.color[3])
-		lines[#lines + 1] = string.format("\t\t\tbrightness = %.2f,\n", l.brightness)
-		lines[#lines + 1] = string.format("\t\t\tmodelfactor = %.2f,\n", l.modelfactor)
-		lines[#lines + 1] = string.format("\t\t\tspecular = %.2f,\n", l.specular)
-		lines[#lines + 1] = string.format("\t\t\tscattering = %.2f,\n", l.scattering)
-		lines[#lines + 1] = string.format("\t\t\tlensflare = %.2f,\n", l.lensflare)
-		if l.pitch then lines[#lines + 1] = string.format("\t\t\tpitch = %.1f,\n", l.pitch) end
-		if l.yaw   then lines[#lines + 1] = string.format("\t\t\tyaw = %.1f,\n", l.yaw) end
-		if l.roll  then lines[#lines + 1] = string.format("\t\t\troll = %.1f,\n", l.roll) end
-		if l.theta then lines[#lines + 1] = string.format("\t\t\ttheta = %.3f,\n", l.theta) end
-		if l.beamLength then lines[#lines + 1] = string.format("\t\t\tbeamLength = %.1f,\n", l.beamLength) end
-		if l.elevation then lines[#lines + 1] = string.format("\t\t\televation = %.1f,\n", l.elevation) end
-		lines[#lines + 1] = "\t\t},\n"
+	for _, b in ipairs(blocks) do
+		lines[#lines + 1] = b
 	end
 	lines[#lines + 1] = "\t},\n"
 	lines[#lines + 1] = "}\n"

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
 	return {
 		name    = "Map Project",
-		desc    = "Save map projects: one git-friendly folder bundling heightmap, splat, metal, features, decals, lights, environment, weather, grass and start positions",
+		desc    = "Save and load map projects: one git-friendly folder bundling heightmap, splat, metal, features, decals, lights, environment, weather, grass and start positions",
 		author  = "PtaQ",
 		date    = "2026",
 		license = "GNU GPL, v2 or later",
@@ -22,21 +22,42 @@ end
 -- context for gl.Get*): heightmap sampling is millions of GetGroundHeight calls
 -- (chunked here), and the splat PNG is written by the splat painter inside its
 -- own draw pump (requested, then polled).
+--
+-- LOAD: opening a project restarts the engine into a blank map of the project's
+-- recorded size (the UI builds the start script and writes a pointer file),
+-- then a post-restart driver here replays every section in phase order. The
+-- pointer file carries a phase journal: it is updated after each completed
+-- phase and only deleted when the load finishes (or is aborted), so a
+-- /luaui reload mid-load RESUMES instead of dying — every phase is an
+-- idempotent replay. The driver consumes the pointer ONLY when the session
+-- matches the recorded map (blank-map name, exact size, map damage enabled,
+-- local singleplayer); on mismatch it deletes the pointer and explains itself.
 
 local Echo = Spring.Echo
 
 local PROJECTS_DIR   = "MapProjects/"
 local FORMAT_VERSION = 1
 local ELMOS_PER_UNIT = 512
+local POINTER_PATH   = "Terraform Brush/pending_project.lua"
+local ACK_PARAM      = "tfb_import_done"  -- rules param set by the terraform gadget after $terraform_import_end$
 
 -- Chunk budgets per Update tick (keep the UI responsive during save)
 local HEIGHT_ROWS_PER_TICK = 32
 local METAL_ROWS_PER_TICK  = 128
 local SPLAT_TIMEOUT_TICKS  = 300
 
+-- Load driver pacing (all in draw-frame ticks unless noted)
+local CHEAT_RESEND_TICKS   = 150  -- min gap between /cheat sends ("cheat" TOGGLES — never double-send)
+local CHEAT_MAX_SENDS      = 8    -- then abort loudly
+local DNTS_WAIT_TICKS      = 300  -- wait for splat normals to appear before splat load
+local SPLAT_LOAD_TIMEOUT   = 600
+local IMPORT_START_TICKS   = 300  -- import never went in-flight => decode failed
+local ACK_TIMEOUT_FRAMES   = 120  -- GAME frames after stream end without sim ack => failed
+
 local heightmapPNG = nil  -- lazy VFS.Include of the shared 16-bit PNG codec
 
-local job = nil  -- active save job, nil when idle
+local job = nil      -- active save job, nil when idle
+local loadJob = nil  -- active load job, nil when idle (never both at once)
 
 ----------------------------------------------------------------
 -- Small helpers
@@ -107,7 +128,7 @@ end
 
 -- Read a previously saved manifest (created timestamp + canonical height range
 -- must survive re-saves). Raw io.open, never VFS: fresh files can be invisible
--- or stale in the VFS view within a session.
+-- or stale in the VFS view within a session. Also the load-side manifest reader.
 local function readPrevManifest(dir)
 	local f = io.open(dir .. "project.lua", "r")
 	if not f then return nil end
@@ -118,6 +139,34 @@ local function readPrevManifest(dir)
 	local ok, data = pcall(chunk)
 	if not ok or type(data) ~= "table" then return nil end
 	return data
+end
+
+-- Generic `return {...}` section file reader (raw io, same VFS-staleness rule).
+local function readLuaFile(path)
+	local f = io.open(path, "rb")
+	if not f then return nil, "cannot open" end
+	local raw = f:read("*a")
+	f:close()
+	local chunk, err = loadstring(raw)
+	if not chunk then return nil, "parse error: " .. tostring(err) end
+	local ok, data = pcall(chunk)
+	if not ok then return nil, "run error: " .. tostring(data) end
+	if type(data) ~= "table" then return nil, "not a table" end
+	return data
+end
+
+-- TGA header dims (18-byte header: width LE at offset 12, height LE at 14).
+-- Used to validate the grass grid against the session before it can misplace
+-- every patch.
+local function readTGADims(path)
+	local f = io.open(path, "rb")
+	if not f then return nil end
+	local header = f:read(18)
+	f:close()
+	if not header or #header < 18 then return nil end
+	local w = header:byte(13) + header:byte(14) * 256
+	local h = header:byte(15) + header:byte(16) * 256
+	return w, h
 end
 
 ----------------------------------------------------------------
@@ -803,6 +852,10 @@ local function startSave(slug)
 		echoP("a save is already running")
 		return false
 	end
+	if loadJob then
+		echoP("cannot save while a project load is running")
+		return false
+	end
 	local ok, err = validateSlug(slug)
 	if not ok then
 		echoP("cannot save: " .. err)
@@ -824,25 +877,716 @@ local function startSave(slug)
 	return true
 end
 
-local function listProjects()
+-- Enumerate projects with manifest details for the Open Project dialog.
+-- VFS.SubDirs sees the folders; manifests are read via raw io (same-session
+-- folders may be invisible/stale in the VFS view — SubDirs RAW semantics for
+-- folders created THIS session are unpinned, so a just-saved project may need
+-- an engine restart to appear; the dialog says so when the list is empty).
+local function listProjectsDetailed()
+	local out = {}
 	local dirs = VFS.SubDirs(PROJECTS_DIR, "*", VFS.RAW) or {}
-	local found = 0
 	for _, d in ipairs(dirs) do
-		-- Raw io read: same-session folders may be invisible/stale in the VFS view
-		local f = io.open(d .. "project.lua", "r")
-		if f then
-			f:close()
-			found = found + 1
-			echoP("  " .. (d:match("([^/\\]+)[/\\]*$") or d))
+		local slug = d:match("([^/\\]+)[/\\]*$")
+		if slug then
+			local manifest = readPrevManifest(PROJECTS_DIR .. slug .. "/")
+			if manifest and manifest.kind == "bar-map-project" then
+				local m = manifest.map or {}
+				out[#out + 1] = {
+					slug = slug,
+					name = manifest.name or slug,
+					size_x = tonumber(m.size_x),
+					size_z = tonumber(m.size_z),
+					modified = manifest.modified,
+					format_version = tonumber(manifest.format_version),
+				}
+			end
 		end
 	end
-	if found == 0 then
+	table.sort(out, function(a, b)
+		if (a.modified or "") ~= (b.modified or "") then return (a.modified or "") > (b.modified or "") end
+		return a.slug < b.slug
+	end)
+	return out
+end
+
+local function listProjects()
+	local found = listProjectsDetailed()
+	for _, p in ipairs(found) do
+		echoP(string.format("  %-24s %sx%s  modified %s", p.slug,
+			tostring(p.size_x), tostring(p.size_z), tostring(p.modified)))
+	end
+	if #found == 0 then
 		echoP("no projects in " .. PROJECTS_DIR)
 	end
-	return found
+	return #found
+end
+
+----------------------------------------------------------------
+-- Load: pointer file (restart survivor with phase journal)
+----------------------------------------------------------------
+
+-- Raw io ONLY for the pointer: VFS caches stale content for files created or
+-- rewritten within a session (the reason pending_newmap.lua does the same).
+local function writePointer(t)
+	Spring.CreateDir("Terraform Brush")
+	local content = string.format(
+		"return { path = %q, size_x = %d, size_z = %d, phase = %d }\n",
+		t.path, t.size_x, t.size_z, t.phase or 0)
+	return writeFile(POINTER_PATH, content) ~= nil
+end
+
+local function readPointer()
+	local f = io.open(POINTER_PATH, "r")
+	if not f then return nil end
+	local raw = f:read("*a")
+	f:close()
+	if not raw or raw == "" then return nil end
+	local chunk = loadstring(raw)
+	if not chunk then return nil end
+	local ok, t = pcall(chunk)
+	if ok and type(t) == "table" and type(t.path) == "string" then return t end
+	return nil
+end
+
+local function deletePointer()
+	os.remove(POINTER_PATH)
+end
+
+----------------------------------------------------------------
+-- Load: manifest validation
+----------------------------------------------------------------
+
+local function validateManifest(manifest)
+	if type(manifest) ~= "table" then return nil, "manifest is not a table" end
+	if manifest.kind ~= "bar-map-project" then
+		return nil, "not a map project (kind=" .. tostring(manifest.kind) .. ")"
+	end
+	local fv = tonumber(manifest.format_version)
+	if not fv then return nil, "manifest has no format_version" end
+	if fv > FORMAT_VERSION then
+		return nil, string.format(
+			"project format_version %d is NEWER than this tool understands (%d) — update the game before opening it (re-saving with an older tool would silently lose data)",
+			fv, FORMAT_VERSION)
+	end
+	local m = manifest.map
+	if type(m) ~= "table" then return nil, "manifest has no map block" end
+	local sx, sz = tonumber(m.size_x), tonumber(m.size_z)
+	if not sx or not sz then return nil, "manifest has no map size" end
+	if sx < 2 or sx > 64 or sz < 2 or sz > 64 or sx % 2 ~= 0 or sz % 2 ~= 0 then
+		return nil, string.format("implausible map size %sx%s (need even map units in 2..64)",
+			tostring(m.size_x), tostring(m.size_z))
+	end
+	if type(manifest.sections) ~= "table" then return nil, "manifest has no sections table" end
+	-- The format is git-managed and hand-editable: type-check every section
+	-- entry (and normalize bytes to a number) so a merge artifact fails with a
+	-- clean refusal instead of a raw Lua error mid-open.
+	for name, sec in pairs(manifest.sections) do
+		if type(sec) ~= "table" then
+			return nil, "section '" .. tostring(name) .. "' is not a table"
+		end
+		if sec.file ~= nil and type(sec.file) ~= "string" then
+			return nil, "section '" .. tostring(name) .. "' has a non-string file"
+		end
+		sec.bytes = tonumber(sec.bytes)
+	end
+	return true
+end
+
+----------------------------------------------------------------
+-- Load: phase machinery
+----------------------------------------------------------------
+
+local function loadOk(name, detail)
+	loadJob.loaded[#loadJob.loaded + 1] = { name = name, detail = detail }
+	echoP("loaded " .. name .. (detail and (" (" .. detail .. ")") or ""))
+end
+
+local function loadSkip(name, reason)
+	loadJob.skipped[#loadJob.skipped + 1] = { name = name, reason = reason }
+	echoP("SKIPPED " .. name .. ": " .. reason)
+end
+
+-- Resolve a section to its on-disk file. Absent from the manifest => nil,nil
+-- (section legitimately empty — silent). Listed but missing on disk => loud
+-- skip, ONCE (multi-tick phases re-poll every tick). Byte mismatch => warn,
+-- load best-effort (incomplete-save policy).
+local function sectionFile(key)
+	local sec = loadJob.manifest.sections and loadJob.manifest.sections[key]
+	if not (sec and sec.file) then return nil end
+	local path = loadJob.dir .. sec.file
+	local size = fileSize(path)
+	if not size then
+		if not loadJob.missingWarned[key] then
+			loadJob.missingWarned[key] = true
+			loadSkip(key, "file missing: " .. sec.file)
+		end
+		return nil
+	end
+	if sec.bytes and sec.bytes > 0 and size ~= sec.bytes and not loadJob.byteWarned[key] then
+		loadJob.byteWarned[key] = true
+		echoP(string.format("WARNING: %s is %d bytes but the manifest recorded %d (incomplete save?) — loading best-effort", sec.file, size, sec.bytes))
+	end
+	return path, sec
+end
+
+-- Phase 1: heightmap. Stream via the terraform importer, then BLOCK on the
+-- gadget's sim-side ack (rules param): draw frames say nothing about whether
+-- the sim applied the columns, and startpos slope validation + feature ground
+-- snap in later phases read the sim-fed height mirror. Pause-aware: while the
+-- game frame does not advance the timeout clock does not run.
+local function phaseHeightmap(c)
+	local path = sectionFile("heightmap")
+	if not path then return true end
+	local tb = WG.TerraformBrush
+	if not (tb and tb.getImportStatus) then
+		loadSkip("heightmap", "terraform brush widget not loaded")
+		return true
+	end
+	if not c.sent then
+		if tb.getImportStatus() then return false end  -- another import in flight; wait
+		c.ackBase = Spring.GetGameRulesParam(ACK_PARAM) or 0
+		c.frameAtSend = Spring.GetGameFrame()
+		Spring.SendCommands("terraformimport " .. path)
+		c.sent = true
+		c.ticks = 0
+		echoP("heightmap: importing " .. path .. " ...")
+		return false
+	end
+	c.ticks = c.ticks + 1
+	local busy, colsDone, colsTotal = tb.getImportStatus()
+	if busy then
+		c.sawBusy = true
+		c.frameAtEnd = nil
+		if c.ticks % 180 == 0 and colsTotal and colsTotal > 0 then
+			echoP(string.format("heightmap: %d%% streamed", math.floor(colsDone / colsTotal * 100)))
+		end
+		return false
+	end
+	local ack = Spring.GetGameRulesParam(ACK_PARAM) or 0
+	if ack > c.ackBase then
+		loadOk("heightmap", "sim-acknowledged")
+		return true
+	end
+	if not c.sawBusy then
+		-- Import never observed in-flight: the importer rejected the file
+		-- before streaming (decode failure — its own console message says
+		-- why). Only conclude that once game frames have advanced past the
+		-- send, so a frozen sim can never journal a false skip.
+		if c.ticks > IMPORT_START_TICKS and Spring.GetGameFrame() > (c.frameAtSend or 0) then
+			loadSkip("heightmap", "import never started (see the terraform brush messages above)")
+			return true
+		end
+		return false
+	end
+	local frame = Spring.GetGameFrame()
+	if not c.frameAtEnd then
+		c.frameAtEnd = frame
+		c.ticksAtEnd = c.ticks
+	end
+	if frame > c.frameAtEnd + ACK_TIMEOUT_FRAMES then
+		loadSkip("heightmap", "sim never acknowledged the import (was /cheat disabled mid-stream?)")
+		return true
+	end
+	if frame == c.frameAtEnd and ((c.ticks - c.ticksAtEnd) % 300) == 299 then
+		echoP("heightmap: waiting for the sim to apply the import — unpause the game to continue")
+	end
+	return false
+end
+
+-- Phase 2: DNTS + splat. DNTS binding comes from the start script's
+-- blank_map_splat* keys plus the terraform widget's force-bind fallback; we
+-- only poll for the result because splat distribution is meaningless without
+-- the detail normals bound first.
+local function phaseDntsSplat(c)
+	local m = loadJob.manifest.map or {}
+	local hasDnts = type(m.dnts) == "table"
+	local splatPath = sectionFile("splat")
+	if not splatPath and not hasDnts then return true end
+	if hasDnts and not c.dntsChecked then
+		c.ticks = (c.ticks or 0) + 1
+		local info = gl.TextureInfo("$ssmf_splat_normals:0")
+		if info and info.xsize and info.xsize > 0 then
+			c.dntsChecked = true
+			loadOk("dnts", "splat normals bound")
+		elseif c.ticks > DNTS_WAIT_TICKS then
+			c.dntsChecked = true
+			loadSkip("dnts", "splat normals never appeared (engine honoring blank_map_splat* keys?) — splat visuals may be missing")
+		else
+			return false
+		end
+	end
+	if not splatPath then return true end
+	if not hasDnts and not c.noDntsWarned then
+		c.noDntsWarned = true
+		echoP("WARNING: project has splat.png but no DNTS record — the splat data will load with no textures to modulate")
+	end
+	local sp = WG.SplatPainter
+	if not (sp and sp.loadSplats) then
+		loadSkip("splat", "splat painter widget not loaded")
+		return true
+	end
+	if not c.splatRequested then
+		if not sp.loadSplats(splatPath) then
+			loadSkip("splat", "load request rejected")
+			return true
+		end
+		c.splatRequested = true
+		c.splatTicks = 0
+		return false
+	end
+	if sp.isLoadPending() then
+		c.splatTicks = c.splatTicks + 1
+		if c.splatTicks > SPLAT_LOAD_TIMEOUT then
+			loadSkip("splat", "timed out waiting for the painter draw pump")
+			return true
+		end
+		return false
+	end
+	local result = sp.getLoadResult and sp.getLoadResult()
+	if result == "ok" then
+		loadOk("splat", nil)
+	else
+		loadSkip("splat", tostring(result or "no result reported"))
+	end
+	return true
+end
+
+-- Phase 3: metal. Direct $metal_clear$/$metal_load$ batching (mirrors the
+-- save side: no dependency on the metal brush widget being enabled).
+local function phaseMetal(c)
+	local path = sectionFile("metal")
+	if not path then return true end
+	if not c.spots then
+		local data, err = readLuaFile(path)
+		if not (data and type(data.spots) == "table") then
+			loadSkip("metal", "unreadable metal.lua (" .. tostring(err) .. ")")
+			return true
+		end
+		c.spots = data.spots
+		c.i = 1
+		Spring.SendLuaRulesMsg("$metal_clear$")
+		return false
+	end
+	local parts = {}
+	local format = string.format
+	local processed = 0
+	while c.i <= #c.spots and processed < 400 do
+		local s = c.spots[c.i]
+		if s.mx and s.mz and s.amount then
+			parts[#parts + 1] = s.mx
+			parts[#parts + 1] = s.mz
+			parts[#parts + 1] = format("%.3f", s.amount)
+			if #parts >= 300 then
+				Spring.SendLuaRulesMsg("$metal_load$" .. table.concat(parts, " "))
+				parts = {}
+			end
+		end
+		c.i = c.i + 1
+		processed = processed + 1
+	end
+	if #parts > 0 then
+		Spring.SendLuaRulesMsg("$metal_load$" .. table.concat(parts, " "))
+	end
+	if c.i > #c.spots then
+		loadOk("metal", #c.spots .. " spots")
+		return true
+	end
+	return false
+end
+
+-- Phase 4: features. Clear-all first so a resumed replay cannot duplicate.
+local function phaseFeatures(c)
+	local path = sectionFile("features")
+	if not path then return true end
+	local fp = WG.FeaturePlacer
+	if not (fp and fp.load) then
+		loadSkip("features", "feature placer widget not loaded")
+		return true
+	end
+	Spring.SendLuaRulesMsg("$feature_clearall$")
+	fp.load(path)
+	loadOk("features", "replaying (applies over the next frames)")
+	return true
+end
+
+-- Phase 5: decals + lights (client-side; need final heights for light Y).
+local function phaseDecalsLights(c)
+	local decalPath = sectionFile("decals")
+	if decalPath then
+		local dp = WG.DecalPlacer
+		if dp and dp.load then
+			for _, a in ipairs((loadJob.manifest.assets and loadJob.manifest.assets.decals) or {}) do
+				if a.name and not VFS.FileExists("bitmaps/decals/" .. a.name .. ".png", VFS.MOD) then
+					echoP("WARNING: decal capture '" .. a.name .. "' is not installed in the game archive — copy "
+						.. loadJob.dir .. tostring(a.file) .. " into bitmaps/decals/ and restart to see it")
+				end
+			end
+			if dp.clearAll then dp.clearAll() end
+			dp.load(decalPath)
+			loadOk("decals", nil)
+		else
+			loadSkip("decals", "decal placer widget not loaded")
+		end
+	end
+	local lightPath = sectionFile("lights")
+	if lightPath then
+		local lp = WG.LightPlacer
+		if lp and lp.load then
+			if lp.load(lightPath) then
+				loadOk("lights", nil)
+			else
+				loadSkip("lights", "light placer rejected the file")
+			end
+		else
+			loadSkip("lights", "light placer widget not loaded")
+		end
+	end
+	return true
+end
+
+-- Phase 6: environment. Short settle countdown mirrors the New Map env-preset
+-- pattern (the water renderer needs a few draw frames after map changes).
+local function phaseEnvironment(c)
+	local path = sectionFile("environment")
+	if not path then return true end
+	local ui = WG.TerraformBrushUI
+	if not (ui and ui.applyEnvConfig) then
+		loadSkip("environment", "terraform UI widget not loaded")
+		return true
+	end
+	if not c.cfg then
+		local data, err = readLuaFile(path)
+		if type(data) ~= "table" then
+			loadSkip("environment", "unreadable environment.lua (" .. tostring(err) .. ")")
+			return true
+		end
+		c.cfg = data
+		c.countdown = 15
+		return false
+	end
+	c.countdown = c.countdown - 1
+	if c.countdown > 0 then return false end
+	ui.applyEnvConfig(c.cfg)
+	loadOk("environment", nil)
+	return true
+end
+
+-- Phase 7: weather. Clear persistent spawners first (idempotent replay), then
+-- rebuild each from its serialized entry with rebased timing.
+local function phaseWeather(c)
+	local path = sectionFile("weather")
+	if not path then return true end
+	local wb = WG.WeatherBrush
+	if not (wb and wb.addSpawnerRaw) then
+		loadSkip("weather", "weather brush widget not loaded (or too old — needs addSpawnerRaw)")
+		return true
+	end
+	local data, err = readLuaFile(path)
+	if not (data and type(data.spawners) == "table") then
+		loadSkip("weather", "unreadable weather.lua (" .. tostring(err) .. ")")
+		return true
+	end
+	if wb.clearAllPersistent then wb.clearAllPersistent() end
+	local added = 0
+	for _, s in ipairs(data.spawners) do
+		if wb.addSpawnerRaw(s) then added = added + 1 end
+	end
+	loadOk("weather", added .. " of " .. #data.spawners .. " spawners")
+	return true
+end
+
+-- Phase 8: startpos + startboxes + grass (all need sim-acked terrain: slope
+-- validation and patch ground-snap read final heights).
+local function phaseStartposGrass(c)
+	local st = WG.StartPosTool
+	local posPath = sectionFile("startpos")
+	if posPath then
+		if st and st.loadStartPositions then
+			if st.loadStartPositions(nil, posPath) then
+				loadOk("startpos", nil)
+			else
+				loadSkip("startpos", "startpos tool rejected the file")
+			end
+		else
+			loadSkip("startpos", "startpos tool widget not loaded")
+		end
+	end
+	local boxPath = sectionFile("startboxes")
+	if boxPath then
+		if st and st.loadStartboxes then
+			if st.loadStartboxes(nil, boxPath) then
+				loadOk("startboxes", nil)
+			else
+				loadSkip("startboxes", "startpos tool rejected the file")
+			end
+		else
+			loadSkip("startboxes", "startpos tool widget not loaded")
+		end
+	end
+	local grassPath, grassSec = sectionFile("grass")
+	if grassPath then
+		local api = WG["grassgl4"]
+		if not (api and api.loadGrass) then
+			loadSkip("grass", "grass widget not loaded")
+		else
+			local cfg = (api.getConfig and api.getConfig()) or {}
+			local sessionRes = tonumber(cfg.patchResolution) or 32
+			local savedRes = tonumber(grassSec and grassSec.patch_resolution)
+			local tw, th = readTGADims(grassPath)
+			local ew = math.floor(Game.mapSizeX / sessionRes)
+			local eh = math.floor(Game.mapSizeZ / sessionRes)
+			if savedRes and savedRes ~= sessionRes then
+				loadSkip("grass", string.format(
+					"patch resolution mismatch (project %d, session %d) — a mismatched grid would misplace every patch", savedRes, sessionRes))
+			elseif not tw then
+				loadSkip("grass", "cannot read grass_dist.tga header")
+			elseif tw ~= ew or th ~= eh then
+				loadSkip("grass", string.format("grass grid is %dx%d but this map needs %dx%d", tw, th, ew, eh))
+			else
+				-- loadGrass side effect: it enters grass dev placement mode,
+				-- whose MousePress swallows EVERY world click (no commander
+				-- placement, no terraform). Restore the prior mode.
+				local wasEdit = api.isEditMode and api.isEditMode() or false
+				api.loadGrass(grassPath)
+				if not wasEdit and api.disableEditMode then
+					api.disableEditMode()
+				end
+				loadOk("grass", tw .. "x" .. th .. " patches grid")
+			end
+		end
+	end
+	return true
+end
+
+local LOAD_PHASES = {
+	{ name = "heightmap",       run = phaseHeightmap },
+	{ name = "dnts+splat",      run = phaseDntsSplat },
+	{ name = "metal",           run = phaseMetal },
+	{ name = "features",        run = phaseFeatures },
+	{ name = "decals+lights",   run = phaseDecalsLights },
+	{ name = "environment",     run = phaseEnvironment },
+	{ name = "weather",         run = phaseWeather },
+	{ name = "startpos+grass",  run = phaseStartposGrass },
+}
+
+local function finishLoad()
+	echoP("PROJECT LOAD COMPLETE: '" .. loadJob.slug .. "'")
+	for _, s in ipairs(loadJob.loaded) do
+		echoP(string.format("  %-12s %s", s.name, s.detail or "ok"))
+	end
+	for _, s in ipairs(loadJob.skipped) do
+		echoP(string.format("  %-12s SKIPPED: %s", s.name, s.reason))
+	end
+	if #loadJob.skipped > 0 then
+		echoP(#loadJob.skipped .. " section(s) skipped — reasons above")
+	end
+	deletePointer()
+	loadJob = nil
+end
+
+local function abortLoad(reason)
+	echoP("PROJECT LOAD ABORTED: " .. reason)
+	deletePointer()
+	loadJob = nil
+end
+
+-- One pump tick. The cheat gate is a PRECONDITION, not a journaled phase: the
+-- synced gadgets ($terraform_import$, $metal_load$, $feature_load$) all require
+-- live cheat outside replays ($c$ certification is replay-only), and cheat
+-- resets across engine restart AND can be toggled off by the user mid-load, so
+-- it is re-verified on every tick. "cheat" TOGGLES — only (re)send while
+-- observed OFF, with a generous gap so an in-flight send cannot be doubled.
+local function runLoadTick()
+	if not Spring.IsCheatingEnabled() then
+		local c = loadJob
+		c.cheatTicks = (c.cheatTicks or 0) + 1
+		if not c.cheatLastSend or (c.cheatTicks - c.cheatLastSend) >= CHEAT_RESEND_TICKS then
+			c.cheatSends = (c.cheatSends or 0) + 1
+			if c.cheatSends > CHEAT_MAX_SENDS then
+				abortLoad("could not enable /cheat (required for terrain/metal/feature replay); enable cheats and open the project again")
+				return
+			end
+			c.cheatLastSend = c.cheatTicks
+			Spring.SendCommands("cheat")
+			echoP("enabling /cheat for the load (attempt " .. c.cheatSends .. ")...")
+		end
+		return
+	end
+	loadJob.cheatTicks, loadJob.cheatLastSend, loadJob.cheatSends = nil, nil, nil
+
+	local phaseIdx = loadJob.phase + 1
+	local phase = LOAD_PHASES[phaseIdx]
+	if not phase then
+		finishLoad()
+		return
+	end
+	if not loadJob.announced then
+		loadJob.announced = true
+		echoP(string.format("phase %d/%d: %s", phaseIdx, #LOAD_PHASES, phase.name))
+	end
+	local ok, done = pcall(phase.run, loadJob.cursor)
+	if not ok then
+		echoP("ERROR in load phase '" .. phase.name .. "': " .. tostring(done))
+		loadSkip(phase.name, "error: " .. tostring(done))
+		done = true
+	end
+	if done then
+		loadJob.phase = phaseIdx
+		loadJob.cursor = {}
+		loadJob.announced = nil
+		-- Journal progress so /luaui reload mid-load resumes here.
+		writePointer({ path = loadJob.dir, size_x = loadJob.sizeX, size_z = loadJob.sizeZ, phase = loadJob.phase })
+		if not LOAD_PHASES[loadJob.phase + 1] then
+			finishLoad()
+		end
+	end
+end
+
+-- Consume the pointer at widget init — but ONLY when this session actually is
+-- the blank map the restart was supposed to produce. Anything else (restart
+-- failed, user aborted, joined a multiplayer game, plain /luaui reload on an
+-- unrelated map) deletes the pointer with a loud explanation and touches
+-- nothing (critique blocker: a stale pointer must never replay onto the wrong
+-- session, and must not survive to ambush a future matching one).
+local function maybeStartLoad()
+	local ptr = readPointer()
+	if not ptr then return end
+	local reasons = {}
+	if not (ptr.size_x and ptr.size_z
+		and Game.mapSizeX == ptr.size_x * ELMOS_PER_UNIT
+		and Game.mapSizeZ == ptr.size_z * ELMOS_PER_UNIT) then
+		reasons[#reasons + 1] = string.format("map size is %dx%d units, pointer wants %sx%s",
+			Game.mapSizeX / ELMOS_PER_UNIT, Game.mapSizeZ / ELMOS_PER_UNIT,
+			tostring(ptr.size_x), tostring(ptr.size_z))
+	end
+	if not (Game.mapName or ""):match("^Editor Flat %d+x%d+") then
+		reasons[#reasons + 1] = "map is '" .. tostring(Game.mapName) .. "', not an editor blank map"
+	end
+	if Game.mapDamage == false then
+		reasons[#reasons + 1] = "map damage is disabled (terrain cannot be replayed)"
+	end
+	if Spring.IsReplay() then
+		reasons[#reasons + 1] = "this is a replay"
+	end
+	local gt = Spring.Utilities and Spring.Utilities.Gametype
+	if gt and gt.IsSinglePlayer and not gt.IsSinglePlayer() then
+		reasons[#reasons + 1] = "not a local singleplayer session"
+	end
+	if #reasons > 0 then
+		deletePointer()
+		echoP("PENDING PROJECT LOAD CANCELLED — session mismatch: " .. table.concat(reasons, "; ")
+			.. ". Pointer removed; open the project again from the FILE menu.")
+		return
+	end
+	local manifest = readPrevManifest(ptr.path)
+	if not manifest then
+		deletePointer()
+		echoP("PENDING PROJECT LOAD CANCELLED: cannot read " .. ptr.path .. "project.lua. Pointer removed.")
+		return
+	end
+	local vok, verr = validateManifest(manifest)
+	if not vok then
+		deletePointer()
+		echoP("PENDING PROJECT LOAD CANCELLED: " .. verr .. ". Pointer removed.")
+		return
+	end
+	loadJob = {
+		slug = ptr.path:match("([^/\\]+)[/\\]*$") or ptr.path,
+		dir = ptr.path,
+		sizeX = ptr.size_x,
+		sizeZ = ptr.size_z,
+		manifest = manifest,
+		phase = tonumber(ptr.phase) or 0,
+		cursor = {},
+		loaded = {},
+		skipped = {},
+		byteWarned = {},
+		missingWarned = {},
+	}
+	if loadJob.phase > 0 then
+		echoP(string.format("resuming project load '%s' at phase %d/%d",
+			loadJob.slug, loadJob.phase + 1, #LOAD_PHASES))
+	else
+		echoP(string.format("loading project '%s' (%d phases)...", loadJob.slug, #LOAD_PHASES))
+	end
+end
+
+----------------------------------------------------------------
+-- Load: open (validate + restart), callable from UI and console
+----------------------------------------------------------------
+
+local function openProject(slug)
+	if job then
+		echoP("cannot open a project while a save is running")
+		return false
+	end
+	if loadJob then
+		echoP("cannot open a project while a load is running")
+		return false
+	end
+	local ok, err = validateSlug(slug)
+	if not ok then
+		echoP("cannot open: " .. err)
+		return false
+	end
+	local gt = Spring.Utilities and Spring.Utilities.Gametype
+	if gt and gt.IsSinglePlayer and not gt.IsSinglePlayer() then
+		echoP("cannot open: project loading needs a local singleplayer session")
+		return false
+	end
+	local dir = PROJECTS_DIR .. slug .. "/"
+	local manifest = readPrevManifest(dir)
+	if not manifest then
+		echoP("cannot open '" .. slug .. "': no readable project.lua in " .. dir)
+		return false
+	end
+	local vok, verr = validateManifest(manifest)
+	if not vok then
+		echoP("cannot open '" .. slug .. "': " .. verr)
+		return false
+	end
+	local ui = WG.TerraformBrushUI
+	if not (ui and ui.buildProjectStartScript) then
+		echoP("cannot open: the Terraform Brush UI widget is required (it builds the blank-map start script)")
+		return false
+	end
+	local script, serr = ui.buildProjectStartScript(manifest, slug)
+	if not script then
+		echoP("cannot open '" .. slug .. "': " .. tostring(serr))
+		return false
+	end
+	-- Cheap pre-restart integrity report (sections load best-effort regardless).
+	for name, sec in pairs(manifest.sections) do
+		if sec.file then
+			local size = fileSize(dir .. sec.file)
+			if size == nil then
+				echoP("WARNING: section '" .. name .. "' file is missing (" .. sec.file .. ") — it will be skipped")
+			elseif sec.bytes and sec.bytes > 0 and size ~= sec.bytes then
+				echoP("WARNING: section '" .. name .. "' size differs from the manifest (incomplete save?)")
+			end
+		end
+	end
+	-- Stale New Map recipes must not fire on the fresh session. REMOVE the
+	-- files rather than blanking them: the terraform UI reads an EXISTING but
+	-- empty pending_newmap_env.lua as "New Map with Default environment" and
+	-- would stomp the project's baked skybox with the first library one.
+	Spring.CreateDir("Terraform Brush")
+	os.remove("Terraform Brush/pending_newmap.lua")
+	os.remove("Terraform Brush/pending_newmap_env.lua")
+	local m = manifest.map
+	if not writePointer({ path = dir, size_x = m.size_x, size_z = m.size_z, phase = 0 }) then
+		echoP("cannot open: failed to write " .. POINTER_PATH)
+		return false
+	end
+	echoP(string.format("restarting into a blank %dx%d map for project '%s'...", m.size_x, m.size_z, slug))
+	Spring.Restart("", script)
+	return true
 end
 
 function widget:DrawScreen()
+	if loadJob then
+		runLoadTick()
+	end
 	if not job then return end
 	local step = STEPS[job.step]
 	if not step then
@@ -876,10 +1620,12 @@ local function mapProjectAction(_, optLine, params)
 	local sub = params and params[1]
 	if sub == "save" then
 		startSave(params[2])
+	elseif sub == "open" then
+		openProject(params[2])
 	elseif sub == "list" then
 		listProjects()
 	else
-		echoP("usage: /mapproject save <name>  |  /mapproject list")
+		echoP("usage: /mapproject save <name>  |  /mapproject open <name>  |  /mapproject list")
 	end
 end
 
@@ -887,9 +1633,13 @@ function widget:Initialize()
 	widgetHandler:AddAction("mapproject", mapProjectAction, nil, "t")
 	WG.MapProject = {
 		save = startSave,
+		open = openProject,
 		list = listProjects,
-		isBusy = function() return job ~= nil end,
+		listDetailed = listProjectsDetailed,
+		isBusy = function() return job ~= nil or loadJob ~= nil end,
+		isLoading = function() return loadJob ~= nil end,
 	}
+	maybeStartLoad()
 end
 
 function widget:Shutdown()
@@ -898,5 +1648,9 @@ function widget:Shutdown()
 	if job then
 		echoP("save aborted by widget shutdown — project may be incomplete (no manifest written)")
 		job = nil
+	end
+	if loadJob then
+		echoP("project load interrupted by widget shutdown — it will resume from the phase journal on reload")
+		loadJob = nil
 	end
 end

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -701,6 +701,35 @@ local function stepGrass()
 	return true
 end
 
+-- Read a live engine texture into a PNG (GL context required — the save pump
+-- runs in DrawScreen). Plain fixed-function blit, alpha preserved (DNTS normal
+-- alpha carries the diffuse-blend weight).
+local function captureLiveTexture(texName, destPath)
+	local info = gl.TextureInfo(texName)
+	if not (info and info.xsize and info.xsize > 1) then return nil end
+	local w, h = info.xsize, info.ysize
+	local fbo = gl.CreateTexture(w, h, {
+		border = false,
+		min_filter = GL.NEAREST,
+		mag_filter = GL.NEAREST,
+		wrap_s = GL.CLAMP_TO_EDGE,
+		wrap_t = GL.CLAMP_TO_EDGE,
+		fbo = true,
+	})
+	if not fbo then return nil end
+	local ok
+	gl.RenderToTexture(fbo, function()
+		gl.Blending(false)
+		gl.Texture(0, texName)
+		gl.TexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+		gl.Texture(0, false)
+		gl.Blending(true)
+		ok = gl.SaveImage(0, 0, w, h, destPath, { yflip = false, alpha = true })
+	end)
+	gl.DeleteTexture(fbo)
+	return ok and true or false
+end
+
 local function stepAssets()
 	local mo = job.mapOptions
 	-- DNTS set: copy the resolved textures INTO the project (libraries mutate
@@ -736,6 +765,40 @@ local function stepAssets()
 		-- Provenance: the library set folder name, if the path reveals one
 		local firstTex = mo.blank_map_splatdetailnormaltex1 or ""
 		dnts.set = firstTex:match("([^/\\]+)[/\\][^/\\]+$")
+	end
+
+	-- Compiled maps carry no blank_map_splat* options — their splat setup lives
+	-- in mapinfo. Capture the LIVE engine textures instead, so the project is
+	-- self-contained and the saved splat.png has textures to modulate on load
+	-- (without a dnts record, a splat section saved from a compiled map is
+	-- unloadable on the blank canvas).
+	if not dnts then
+		local scR, scG, scB, scA = gl.GetMapRendering("splatTexScales")
+		local muR, muG, muB, muA = gl.GetMapRendering("splatTexMults")
+		local scales = { scR, scG, scB, scA }
+		local mults = { muR, muG, muB, muA }
+		for ch = 1, 4 do
+			local name = "capture_normals" .. ch .. ".png"
+			if captureLiveTexture("$ssmf_splat_normals:" .. (ch - 1), job.dir .. "assets/dnts/" .. name) then
+				dnts = dnts or { textures = {}, scales = {}, mults = {} }
+				dnts.textures[ch] = "assets/dnts/" .. name
+				dnts.scales[ch] = tonumber(scales[ch]) or 0
+				dnts.mults[ch] = tonumber(mults[ch]) or 0
+			end
+		end
+		-- Legacy SSMF maps modulate a single grayscale detail texture instead of
+		-- (or in addition to) DNTS normals — capture it too.
+		if captureLiveTexture("$ssmf_splat_detail", job.dir .. "assets/dnts/capture_detail.png") then
+			dnts = dnts or { textures = {}, scales = scales, mults = mults }
+			dnts.detail = "assets/dnts/capture_detail.png"
+		end
+		if dnts then
+			dnts.set = "live-capture"
+			dnts.diffuse_alpha = gl.GetMapRendering("splatDetailNormalDiffuseAlpha") and 1 or 0
+			echoP("captured the map's live splat textures into assets/dnts/")
+		elseif findSection("splat") then
+			warn("map has a splat distribution but no capturable splat textures — splat.png may not load onto a blank canvas")
+		end
 	end
 	job.dnts = dnts
 
@@ -866,6 +929,9 @@ local function stepManifest()
 			end
 		end
 		add("\t\t\t},")
+		if job.dnts.detail then
+			add(string.format("\t\t\tdetail = %q,", job.dnts.detail))
+		end
 		local function quad(name, t)
 			add(string.format("\t\t\t%s = { %s, %s, %s, %s },", name,
 				fmtNum(t[1] or 0), fmtNum(t[2] or 0), fmtNum(t[3] or 0), fmtNum(t[4] or 0)))

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -1,0 +1,902 @@
+function widget:GetInfo()
+	return {
+		name    = "Map Project",
+		desc    = "Save map projects: one git-friendly folder bundling heightmap, splat, metal, features, decals, lights, environment, weather, grass and start positions",
+		author  = "PtaQ",
+		date    = "2026",
+		license = "GNU GPL, v2 or later",
+		layer   = 1000000,
+		enabled = false,
+	}
+end
+
+-- Save orchestration for map projects (see doc: map-project-format-draft.md).
+-- One project = one folder under MapProjects/<slug>/ with a versioned manifest
+-- (project.lua, written LAST as the commit marker) plus per-section files in the
+-- existing tools' formats. Filenames are fixed and serialization is deterministic:
+-- git history is the versioning, so a re-save of unchanged state must produce a
+-- zero diff except the manifest's `modified` field.
+--
+-- The save runs as a small state machine pumped from widget:DrawScreen (the
+-- codebase's pattern for deferred work, and the env snapshot needs a draw
+-- context for gl.Get*): heightmap sampling is millions of GetGroundHeight calls
+-- (chunked here), and the splat PNG is written by the splat painter inside its
+-- own draw pump (requested, then polled).
+
+local Echo = Spring.Echo
+
+local PROJECTS_DIR   = "MapProjects/"
+local FORMAT_VERSION = 1
+local ELMOS_PER_UNIT = 512
+
+-- Chunk budgets per Update tick (keep the UI responsive during save)
+local HEIGHT_ROWS_PER_TICK = 32
+local METAL_ROWS_PER_TICK  = 128
+local SPLAT_TIMEOUT_TICKS  = 300
+
+local heightmapPNG = nil  -- lazy VFS.Include of the shared 16-bit PNG codec
+
+local job = nil  -- active save job, nil when idle
+
+----------------------------------------------------------------
+-- Small helpers
+----------------------------------------------------------------
+
+local function echoP(msg)
+	Echo("[Map Project] " .. msg)
+end
+
+-- Windows reserved device names make CreateDir fail or produce unusable paths.
+local RESERVED_NAMES = {
+	con = true, prn = true, aux = true, nul = true,
+	com1 = true, com2 = true, com3 = true, com4 = true, com5 = true,
+	com6 = true, com7 = true, com8 = true, com9 = true,
+	lpt1 = true, lpt2 = true, lpt3 = true, lpt4 = true, lpt5 = true,
+	lpt6 = true, lpt7 = true, lpt8 = true, lpt9 = true,
+}
+
+local function validateSlug(slug)
+	if type(slug) ~= "string" or slug == "" then
+		return nil, "missing project name"
+	end
+	if #slug > 64 then
+		return nil, "project name too long (max 64)"
+	end
+	if not slug:match("^[A-Za-z0-9_%-]+$") then
+		return nil, "project name may only contain letters, digits, _ and - (no spaces)"
+	end
+	if RESERVED_NAMES[slug:lower()] then
+		return nil, "'" .. slug .. "' is a reserved Windows device name"
+	end
+	return slug
+end
+
+local function isoNow()
+	return os.date("!%Y-%m-%dT%H:%M:%SZ")
+end
+
+-- Always binary mode: Windows text mode would write CRLF, making project bytes
+-- differ across OSes and desync the manifest's recorded sizes from #content.
+-- All orchestrator-written text uses LF.
+local function writeFile(path, content)
+	local f = io.open(path, "wb")
+	if not f then return nil end
+	f:write(content)
+	f:close()
+	return #content
+end
+
+local function fileSize(path)
+	local f = io.open(path, "rb")
+	if not f then return nil end
+	local size = f:seek("end")
+	f:close()
+	return size
+end
+
+-- Numbers in the manifest: integers stay integers, floats get fixed precision
+-- (deterministic serialization).
+local function fmtNum(v)
+	if v == math.floor(v) then return string.format("%d", v) end
+	return string.format("%.4f", v)
+end
+
+local function basename(path)
+	return path:match("([^/\\]+)$") or path
+end
+
+-- Read a previously saved manifest (created timestamp + canonical height range
+-- must survive re-saves). Raw io.open, never VFS: fresh files can be invisible
+-- or stale in the VFS view within a session.
+local function readPrevManifest(dir)
+	local f = io.open(dir .. "project.lua", "r")
+	if not f then return nil end
+	local raw = f:read("*a")
+	f:close()
+	local chunk = loadstring(raw)
+	if not chunk then return nil end
+	local ok, data = pcall(chunk)
+	if not ok or type(data) ~= "table" then return nil end
+	return data
+end
+
+----------------------------------------------------------------
+-- Section reporting
+----------------------------------------------------------------
+
+local function sectionOk(name, file, bytes, extra)
+	job.sections[#job.sections + 1] = { name = name, file = file, bytes = bytes or 0, extra = extra }
+end
+
+local function sectionSkip(name, reason)
+	job.skipped[#job.skipped + 1] = { name = name, reason = reason }
+end
+
+local function warn(msg)
+	job.warnings[#job.warnings + 1] = msg
+	echoP("WARNING: " .. msg)
+end
+
+local function findSection(name)
+	for _, s in ipairs(job.sections) do
+		if s.name == name then return s end
+	end
+	return nil
+end
+
+----------------------------------------------------------------
+-- Save steps (each returns true when finished; job.cursor holds chunk state)
+----------------------------------------------------------------
+
+local function stepPrepare()
+	Spring.CreateDir(job.dir .. "assets/decals")
+	Spring.CreateDir(job.dir .. "assets/dnts")
+	Spring.CreateDir(job.dir .. "mission")
+
+	job.prev = readPrevManifest(job.dir)
+	job.mapOptions = Spring.GetMapOptions() or {}
+
+	local mo = job.mapOptions
+	if not (mo.blank_map_x or mo.blank_map_y) then
+		warn("current map is not an editor blank map; project will record its state, but loading will replay it onto a flat canvas")
+	end
+	return true
+end
+
+-- Sampling is chunked over ticks; the encode runs in the same step's final tick
+-- (one step — the pump resets job.cursor between steps, so sample state must
+-- not cross a step boundary).
+local function stepHeightmap()
+	local sq = Game.squareSize
+	local c = job.cursor
+	if not c.z then
+		c.z = 0
+		c.idx = 0
+		c.heights = {}
+		c.minH, c.maxH = math.huge, -math.huge
+		c.w = Game.mapSizeX / sq + 1
+		c.h = Game.mapSizeZ / sq + 1
+	end
+	if c.z <= Game.mapSizeZ then
+		local rows = 0
+		local heights, idx = c.heights, c.idx
+		local minH, maxH = c.minH, c.maxH
+		local GetGroundHeight = Spring.GetGroundHeight
+		while c.z <= Game.mapSizeZ and rows < HEIGHT_ROWS_PER_TICK do
+			local z = c.z
+			for x = 0, Game.mapSizeX, sq do
+				local gh = GetGroundHeight(x, z)
+				if gh < minH then minH = gh end
+				if gh > maxH then maxH = gh end
+				idx = idx + 1
+				heights[idx] = gh
+			end
+			c.z = c.z + sq
+			rows = rows + 1
+		end
+		c.idx, c.minH, c.maxH = idx, minH, maxH
+		if c.z <= Game.mapSizeZ then return false end
+		-- Sampling complete; encode next tick (known hitch: the codec's per-pixel
+		-- loop is one synchronous call — announce it so the freeze is explained).
+		echoP("encoding heightmap PNG (" .. c.w .. "x" .. c.h .. ")...")
+		return false
+	end
+	-- Canonical range: previous manifest range auto-widened to live extremes,
+	-- rounded outward to integers so an unchanged terrain re-quantizes to the
+	-- exact same PNG bytes. Never clip terrain (silent data loss).
+	local minH = math.floor(c.minH)
+	local maxH = math.ceil(c.maxH)
+	local prevRange = job.prev and job.prev.map and job.prev.map.height_range
+	if prevRange and prevRange.min and prevRange.max then
+		local widened = minH < prevRange.min or maxH > prevRange.max
+		minH = math.min(minH, prevRange.min)
+		maxH = math.max(maxH, prevRange.max)
+		if widened then
+			warn(string.format("terrain exceeded the recorded height range; widened to %d..%d (full heightmap diff this save)", minH, maxH))
+		end
+	end
+	if maxH - minH < 1 then maxH = minH + 1 end
+
+	local range = maxH - minH
+	local samples = {}
+	local floor = math.floor
+	for i = 1, c.idx do
+		local norm = (c.heights[i] - minH) / range
+		if norm < 0 then norm = 0 elseif norm > 1 then norm = 1 end
+		samples[i] = floor(norm * 65535 + 0.5)
+	end
+
+	local png = heightmapPNG.encodeGray16(c.w, c.h, samples, minH, maxH)
+	if not png then
+		warn("heightmap PNG encode failed; section skipped")
+		sectionSkip("heightmap", "encode failed")
+		return true
+	end
+	local bytes = writeFile(job.dir .. "heightmap.png", png)
+	if not bytes then
+		warn("could not write heightmap.png")
+		sectionSkip("heightmap", "write failed")
+		return true
+	end
+	job.heightRange = { min = minH, max = maxH }
+	sectionOk("heightmap", "heightmap.png", bytes)
+	return true
+end
+
+local function stepSplat()
+	local sp = WG.SplatPainter
+	local c = job.cursor
+	if not c.requested then
+		if not (sp and sp.hasSplatState and sp.hasSplatState()) then
+			sectionSkip("splat", "no splat paint state (painter inactive or blank map without DNTS)")
+			return true
+		end
+		sp.saveSplats(job.dir .. "splat.png")
+		c.requested = true
+		c.ticks = 0
+		return false
+	end
+	c.ticks = c.ticks + 1
+	if sp.isSavePending() then
+		if c.ticks > SPLAT_TIMEOUT_TICKS then
+			warn("splat save timed out (painter draw pump never ran)")
+			sectionSkip("splat", "timeout")
+			return true
+		end
+		return false
+	end
+	local bytes = fileSize(job.dir .. "splat.png")
+	if bytes then
+		sectionOk("splat", "splat.png", bytes)
+	else
+		sectionSkip("splat", "painter reported done but file missing")
+	end
+	return true
+end
+
+local function stepMetal()
+	local METAL_SQ = Game.metalMapSquareSize or 16
+	local mmX = math.floor(Game.mapSizeX / METAL_SQ)
+	local mmZ = math.floor(Game.mapSizeZ / METAL_SQ)
+	local c = job.cursor
+	if not c.mz then
+		c.mz = 0
+		c.spots = 0
+		c.lines = {
+			"-- Metal map data for map project",
+			"-- Generated by Map Project (Metal Brush format)",
+			"-- Metalmap size: " .. mmX .. " x " .. mmZ .. "  squareSize: " .. METAL_SQ,
+			"return {",
+			"  squareSize = " .. METAL_SQ .. ",",
+			"  width = " .. mmX .. ",",
+			"  height = " .. mmZ .. ",",
+			"  spots = {",
+		}
+	end
+	local rows = 0
+	local lines = c.lines
+	local GetMetalAmount = Spring.GetMetalAmount
+	local format = string.format
+	while c.mz < mmZ and rows < METAL_ROWS_PER_TICK do
+		local mz = c.mz
+		for mx = 0, mmX - 1 do
+			local amount = GetMetalAmount(mx, mz)
+			if amount > 0.001 then
+				local wx = mx * METAL_SQ + METAL_SQ * 0.5
+				local wz = mz * METAL_SQ + METAL_SQ * 0.5
+				lines[#lines + 1] = format("    {x=%.0f,z=%.0f,mx=%d,mz=%d,amount=%.3f},", wx, wz, mx, mz, amount)
+				c.spots = c.spots + 1
+			end
+		end
+		c.mz = c.mz + 1
+		rows = rows + 1
+	end
+	if c.mz < mmZ then return false end
+
+	if c.spots == 0 then
+		sectionSkip("metal", "no metal on map")
+		return true
+	end
+	lines[#lines + 1] = "  },"
+	lines[#lines + 1] = "}"
+	local bytes = writeFile(job.dir .. "metal.lua", table.concat(lines, "\n"))
+	if bytes then
+		sectionOk("metal", "metal.lua", bytes, c.spots .. " spots")
+	else
+		sectionSkip("metal", "write failed")
+	end
+	return true
+end
+
+local function stepFeatures()
+	-- Serialized unsynced straight from the engine: the feature placer's own save
+	-- is an async gadget round-trip with no completion signal, and the data is
+	-- fully readable from here. Output format = FeaturePlacer setcfg (unchanged),
+	-- so the existing loader consumes it as-is.
+	local featureIDs = Spring.GetAllFeatures()
+	local entries = {}
+	for i = 1, #featureIDs do
+		local fid = featureIDs[i]
+		local defID = Spring.GetFeatureDefID(fid)
+		local def = defID and FeatureDefs[defID]
+		local x, _, z = Spring.GetFeaturePosition(fid)
+		if def and x then
+			entries[#entries + 1] = {
+				name = def.name,
+				x = x,
+				z = z,
+				rot = Spring.GetFeatureHeading(fid) or 0,
+			}
+		end
+	end
+	if #entries == 0 then
+		sectionSkip("features", "no features on map")
+		return true
+	end
+	-- Feature IDs are transient (re-assigned every load), so order by content.
+	table.sort(entries, function(a, b)
+		if a.name ~= b.name then return a.name < b.name end
+		if a.x ~= b.x then return a.x < b.x end
+		if a.z ~= b.z then return a.z < b.z end
+		return a.rot < b.rot
+	end)
+	local lines = {
+		"local setcfg = {",
+		"\tunitlist = {},",
+		"\tbuildinglist = {},",
+		"\tobjectlist = {",
+	}
+	local format = string.format
+	for _, e in ipairs(entries) do
+		lines[#lines + 1] = format("\t\t{ name = %q, x = %.1f, z = %.1f, rot = %d },", e.name, e.x, e.z, e.rot)
+	end
+	lines[#lines + 1] = "\t},"
+	lines[#lines + 1] = "}"
+	lines[#lines + 1] = "return setcfg"
+	local bytes = writeFile(job.dir .. "features.lua", table.concat(lines, "\n"))
+	if bytes then
+		sectionOk("features", "features.lua", bytes, #entries .. " features")
+	else
+		sectionSkip("features", "write failed")
+	end
+	return true
+end
+
+local function stepDecals()
+	local dp = WG.DecalPlacer
+	if not (dp and dp.saveProject) then
+		sectionSkip("decals", "decal placer not loaded")
+		return true
+	end
+	local path = job.dir .. "decals.lua"
+	local n = dp.saveProject(path)
+	if not n then
+		sectionSkip("decals", "save failed")
+	elseif n == 0 then
+		os.remove(path)
+		sectionSkip("decals", "no placed decals")
+	else
+		sectionOk("decals", "decals.lua", fileSize(path), n .. " decals")
+	end
+	return true
+end
+
+local function stepLights()
+	local lp = WG.LightPlacer
+	if not lp then
+		sectionSkip("lights", "light placer not loaded")
+		return true
+	end
+	local count = lp.getPlacedCount and lp.getPlacedCount() or 0
+	if count == 0 then
+		sectionSkip("lights", "no placed lights")
+		return true
+	end
+	local path = job.dir .. "lights.lua"
+	lp.save(path)
+	local bytes = fileSize(path)
+	if bytes then
+		sectionOk("lights", "lights.lua", bytes, count .. " lights")
+	else
+		sectionSkip("lights", "write failed")
+	end
+	return true
+end
+
+local function stepStartPos()
+	local st = WG.StartPosTool
+	if not st then
+		sectionSkip("startpos", "startpos tool not loaded")
+		sectionSkip("startboxes", "startpos tool not loaded")
+		return true
+	end
+	local posPath = job.dir .. "startpos.lua"
+	if st.saveStartPositions(nil, posPath) then
+		sectionOk("startpos", "startpos.lua", fileSize(posPath))
+	else
+		sectionSkip("startpos", "write failed")
+	end
+	local boxPath = job.dir .. "startboxes.lua"
+	if st.saveStartboxes(nil, boxPath) then
+		sectionOk("startboxes", "startboxes.lua", fileSize(boxPath))
+	else
+		sectionSkip("startboxes", "write failed")
+	end
+	return true
+end
+
+local function stepEnvironment()
+	local ui = WG.TerraformBrushUI
+	if not (ui and ui.buildEnvConfigContent) then
+		sectionSkip("environment", "terraform UI not loaded")
+		return true
+	end
+	local content = ui.buildEnvConfigContent({ nodate = true })
+	if type(content) ~= "string" then
+		sectionSkip("environment", "snapshot failed")
+		return true
+	end
+	local bytes = writeFile(job.dir .. "environment.lua", content)
+	if bytes then
+		sectionOk("environment", "environment.lua", bytes)
+	else
+		sectionSkip("environment", "write failed")
+	end
+	return true
+end
+
+local function stepWeather()
+	local wb = WG.WeatherBrush
+	if not (wb and wb.getPersistentSpawners) then
+		sectionSkip("weather", "weather brush not loaded")
+		return true
+	end
+	local spawners = wb.getPersistentSpawners()
+	if #spawners == 0 then
+		sectionSkip("weather", "no persistent weather spawners")
+		return true
+	end
+	-- Absolute frame fields are session-local; persist remaining lifetime in
+	-- seconds (-1 = permanent) and rebase at load. NOTE: finite spawners recompute
+	-- persistence against the current frame, so re-saves churn weather.lua by
+	-- design; permanent spawners (the common case) are stable.
+	local now = Spring.GetGameFrame()
+	local gameSpeed = Game.gameSpeed or 30
+	local format = string.format
+	-- Serialize each spawner to its full text block, then sort the blocks:
+	-- lexicographic order over ALL fields is a total order, so ties in any
+	-- individual field cannot flip entries between sessions.
+	local blocks = {}
+	for _, s in ipairs(spawners) do
+		local persistence = -1
+		if s.expireFrame then
+			persistence = math.max(1, math.floor((s.expireFrame - now) / gameSpeed + 0.5))
+		end
+		local cegParts = {}
+		for i = 1, #s.cegs do cegParts[i] = format("%q", s.cegs[i]) end
+		blocks[#blocks + 1] = table.concat({
+			"\t\t{",
+			format("\t\t\tx = %s, z = %s,", fmtNum(s.x), fmtNum(s.z)),
+			"\t\t\tcegs = { " .. table.concat(cegParts, ", ") .. " },",
+			format("\t\t\tradius = %s,", fmtNum(s.radius)),
+			format("\t\t\tcount = %d,", s.count),
+			format("\t\t\tshape = %q,", s.shape or "circle"),
+			format("\t\t\tangleDeg = %s,", fmtNum(s.angleDeg or 0)),
+			format("\t\t\tlengthScale = %s,", fmtNum(s.lengthScale or 1)),
+			format("\t\t\taltitude = %s,", fmtNum(s.altitude or 0)),
+			format("\t\t\tinterval = %d,", s.interval),
+			format("\t\t\trefreshInterval = %d,", s.refreshInterval),
+			format("\t\t\tpersistence = %d,", persistence),
+			"\t\t},",
+		}, "\n")
+	end
+	table.sort(blocks)
+	local lines = {
+		"return {",
+		"\tversion = 1,",
+		"\tspawners = {",
+	}
+	for _, b in ipairs(blocks) do
+		lines[#lines + 1] = b
+	end
+	lines[#lines + 1] = "\t},"
+	lines[#lines + 1] = "}"
+	local bytes = writeFile(job.dir .. "weather.lua", table.concat(lines, "\n"))
+	if bytes then
+		sectionOk("weather", "weather.lua", bytes, #spawners .. " spawners")
+	else
+		sectionSkip("weather", "write failed")
+	end
+	return true
+end
+
+local function stepGrass()
+	local api = WG["grassgl4"]
+	if not api then
+		sectionSkip("grass", "grass widget not loaded")
+		return true
+	end
+	if not (api.hasGrass and api.hasGrass()) then
+		sectionSkip("grass", "no grass on map")
+		return true
+	end
+	local tgaPath = job.dir .. "grass_dist.tga"
+	if not api.saveGrassTGA(tgaPath) then
+		sectionSkip("grass", "TGA write failed")
+		return true
+	end
+	api.saveGrassConfig(job.dir .. "grass_config.lua", { nodate = true })
+	local cfg = api.getConfig and api.getConfig() or {}
+	sectionOk("grass", "grass_dist.tga", fileSize(tgaPath), "patchResolution " .. tostring(cfg.patchResolution))
+	job.grassPatchResolution = cfg.patchResolution
+	return true
+end
+
+local function stepAssets()
+	local mo = job.mapOptions
+	-- DNTS set: copy the resolved textures INTO the project (libraries mutate
+	-- over months; projects must stay self-contained) and record the resolved
+	-- scales/mults so load does not depend on the library.
+	local dnts = nil
+	local seenSource = {}  -- dest name -> source path (detects basename collisions across sets)
+	for ch = 1, 4 do
+		local tex = mo["blank_map_splatdetailnormaltex" .. ch]
+		if tex and tex ~= "" then
+			dnts = dnts or { textures = {}, scales = {}, mults = {} }
+			local name = basename(tex)
+			if seenSource[name] and seenSource[name] ~= tex then
+				-- Same filename from a different source: keep both, disambiguated
+				name = "ch" .. ch .. "_" .. name
+			end
+			if not seenSource[name] then
+				seenSource[name] = tex
+				local data = VFS.LoadFile(tex, VFS.RAW_FIRST)
+				if data then
+					writeFile(job.dir .. "assets/dnts/" .. name, data)
+				else
+					warn("DNTS texture not readable, not copied: " .. tex)
+				end
+			end
+			dnts.textures[ch] = "assets/dnts/" .. name
+			dnts.scales[ch] = tonumber(mo["blank_map_splattexscale" .. ch]) or 0
+			dnts.mults[ch] = tonumber(mo["blank_map_splattexmult" .. ch]) or 0
+		end
+	end
+	if dnts then
+		dnts.diffuse_alpha = tonumber(mo.blank_map_splatdetailnormaldiffusealpha) or 1
+		-- Provenance: the library set folder name, if the path reveals one
+		local firstTex = mo.blank_map_splatdetailnormaltex1 or ""
+		dnts.set = firstTex:match("([^/\\]+)[/\\][^/\\]+$")
+	end
+	job.dnts = dnts
+
+	-- Decal captures: copy captures REFERENCED by this project's placements into
+	-- the project so they survive archive resets. Reference check is a substring
+	-- match of the capture name against the serialized decals.lua (placement tex
+	-- strings carry the capture name). Install state is whether the capture also
+	-- lives in the game archive's decal atlas source.
+	job.assetDecals = {}
+	local decalsContent = nil
+	do
+		local f = io.open(job.dir .. "decals.lua", "rb")
+		if f then
+			decalsContent = f:read("*a")
+			f:close()
+		end
+	end
+	if decalsContent then
+		local captures = VFS.DirList("LuaUI/Cache/decal_captures/", "*.png", VFS.RAW) or {}
+		for _, path in ipairs(captures) do
+			local name = basename(path)
+			local nameNoExt = name:gsub("%.png$", "")
+			if decalsContent:find(nameNoExt, 1, true) then
+				local data = VFS.LoadFile(path, VFS.RAW_FIRST)
+				if data then
+					writeFile(job.dir .. "assets/decals/" .. name, data)
+					job.assetDecals[#job.assetDecals + 1] = {
+						name = nameNoExt,
+						file = "assets/decals/" .. name,
+						installed = VFS.FileExists("bitmaps/decals/" .. name, VFS.MOD) and true or false,
+					}
+				end
+			end
+		end
+	end
+	table.sort(job.assetDecals, function(a, b) return a.name < b.name end)
+	return true
+end
+
+-- Canonical section files: anything present on disk but NOT written this save is
+-- stale state from a previous save (e.g. metal cleared since) and must go, or a
+-- file-presence loader would resurrect deleted state.
+local SECTION_FILES = {
+	heightmap   = { "heightmap.png" },
+	splat       = { "splat.png" },
+	metal       = { "metal.lua" },
+	features    = { "features.lua" },
+	decals      = { "decals.lua" },
+	startpos    = { "startpos.lua" },
+	startboxes  = { "startboxes.lua" },
+	lights      = { "lights.lua" },
+	environment = { "environment.lua" },
+	weather     = { "weather.lua" },
+	grass       = { "grass_dist.tga", "grass_config.lua" },
+}
+
+local function stepCleanupStale()
+	for name, files in pairs(SECTION_FILES) do
+		if not findSection(name) then
+			for _, file in ipairs(files) do
+				local path = job.dir .. file
+				if fileSize(path) then
+					os.remove(path)
+					echoP("removed stale " .. file .. " (section now empty)")
+				end
+			end
+		end
+	end
+	return true
+end
+
+local function stepManifest()
+	local mo = job.mapOptions
+	local prev = job.prev
+	local created = (prev and prev.created) or isoNow()
+
+	local lines = {
+		"return {",
+		'\tkind = "bar-map-project",',
+		"\tformat_version = " .. FORMAT_VERSION .. ",",
+		string.format("\tname = %q,", (prev and prev.name) or job.slug),
+		string.format("\tcreated = %q,", created),
+		string.format("\tmodified = %q,", isoNow()),
+		string.format("\tgame_version = %q,", Game.gameVersion or "unknown"),
+		"",
+		"\tmap = {",
+		string.format("\t\tsize_x = %d, size_z = %d,", Game.mapSizeX / ELMOS_PER_UNIT, Game.mapSizeZ / ELMOS_PER_UNIT),
+	}
+	local function add(line) lines[#lines + 1] = line end
+
+	local baseHeight = tonumber(mo.blank_map_height)
+	if baseHeight then
+		add(string.format("\t\tbase_height = %s,", fmtNum(baseHeight)))
+	end
+	local cr, cg, cb = tonumber(mo.blank_map_color_r), tonumber(mo.blank_map_color_g), tonumber(mo.blank_map_color_b)
+	if cr and cg and cb then
+		add(string.format("\t\tbase_color = { %s, %s, %s },", fmtNum(cr), fmtNum(cg), fmtNum(cb)))
+	end
+	if job.heightRange then
+		add(string.format("\t\theight_range = { min = %d, max = %d },", job.heightRange.min, job.heightRange.max))
+	end
+	if mo.blank_map_skybox and mo.blank_map_skybox ~= "" then
+		add(string.format("\t\tskybox = %q,", basename(mo.blank_map_skybox)))
+	end
+	add(string.format("\t\tsource_map = %q,", Game.mapName or "unknown"))
+	if job.dnts then
+		add("\t\tdnts = {")
+		if job.dnts.set then
+			add(string.format("\t\t\tset = %q,", job.dnts.set))
+		end
+		add("\t\t\ttextures = {")
+		for ch = 1, 4 do
+			if job.dnts.textures[ch] then
+				add(string.format("\t\t\t\t[%d] = %q,", ch, job.dnts.textures[ch]))
+			end
+		end
+		add("\t\t\t},")
+		local function quad(name, t)
+			add(string.format("\t\t\t%s = { %s, %s, %s, %s },", name,
+				fmtNum(t[1] or 0), fmtNum(t[2] or 0), fmtNum(t[3] or 0), fmtNum(t[4] or 0)))
+		end
+		quad("scales", job.dnts.scales)
+		quad("mults", job.dnts.mults)
+		add(string.format("\t\t\tdiffuse_alpha = %s,", fmtNum(job.dnts.diffuse_alpha)))
+		add("\t\t},")
+	end
+	add("\t},")
+	add("")
+	add("\tsections = {")
+	-- Fixed emission order (deterministic diffs); only sections actually written.
+	local order = { "heightmap", "splat", "metal", "features", "decals", "startpos", "startboxes", "lights", "environment", "weather", "grass" }
+	for _, name in ipairs(order) do
+		local s = findSection(name)
+		if s then
+			local extraFields = ""
+			if name == "grass" then
+				if job.grassPatchResolution then
+					extraFields = string.format(" patch_resolution = %d,", job.grassPatchResolution)
+				end
+				extraFields = extraFields .. ' config = "grass_config.lua",'
+			end
+			add(string.format("\t\t%s = { file = %q, version = 1, bytes = %d,%s },", name, s.file, s.bytes, extraFields))
+		end
+	end
+	add("\t},")
+	add("")
+	add("\tassets = {")
+	add("\t\tdecals = {")
+	for _, d in ipairs(job.assetDecals or {}) do
+		add(string.format("\t\t\t{ name = %q, file = %q, installed = %s },", d.name, d.file, tostring(d.installed)))
+	end
+	add("\t\t},")
+	add("\t},")
+	add("")
+	add("\t-- Reserved for mission tooling (zones/markers/placeholders); additive only.")
+	add("\tmission = {")
+	add("\t\tzones = {},")
+	add("\t\tmarkers = {},")
+	add("\t\tplaceholders = {},")
+	add('\t\tnotes = "",')
+	add("\t},")
+	add("}")
+	add("")
+
+	local bytes = writeFile(job.dir .. "project.lua", table.concat(lines, "\n"))
+	if not bytes then
+		job.failed = "could not write project.lua (the manifest is the commit marker — this save is INVALID)"
+	end
+	return true
+end
+
+local STEPS = {
+	{ name = "prepare",     run = stepPrepare },
+	{ name = "heightmap",   run = stepHeightmap },
+	{ name = "splat",       run = stepSplat },
+	{ name = "metal",       run = stepMetal },
+	{ name = "features",    run = stepFeatures },
+	{ name = "decals",      run = stepDecals },
+	{ name = "lights",      run = stepLights },
+	{ name = "startpos",    run = stepStartPos },
+	{ name = "environment", run = stepEnvironment },
+	{ name = "weather",     run = stepWeather },
+	{ name = "grass",       run = stepGrass },
+	{ name = "assets",      run = stepAssets },
+	{ name = "cleanup",     run = stepCleanupStale },
+	{ name = "manifest",    run = stepManifest },
+}
+
+----------------------------------------------------------------
+-- Job control
+----------------------------------------------------------------
+
+local function finishSave()
+	if job.failed then
+		echoP("SAVE FAILED for project '" .. job.slug .. "': " .. job.failed)
+		job = nil
+		return
+	end
+	echoP("saved project '" .. job.slug .. "' to " .. job.dir)
+	for _, s in ipairs(job.sections) do
+		echoP(string.format("  %-12s %s (%d bytes%s)", s.name, s.file, s.bytes, s.extra and (", " .. s.extra) or ""))
+	end
+	for _, s in ipairs(job.skipped) do
+		echoP(string.format("  %-12s skipped: %s", s.name, s.reason))
+	end
+	if #job.warnings > 0 then
+		echoP(#job.warnings .. " warning(s) above")
+	end
+	job = nil
+end
+
+local function startSave(slug)
+	if job then
+		echoP("a save is already running")
+		return false
+	end
+	local ok, err = validateSlug(slug)
+	if not ok then
+		echoP("cannot save: " .. err)
+		return false
+	end
+	if not heightmapPNG then
+		heightmapPNG = VFS.Include("luaui/Widgets/cmd_terraform_brush_png.lua")
+	end
+	job = {
+		slug = slug,
+		dir = PROJECTS_DIR .. slug .. "/",
+		step = 1,
+		cursor = {},
+		sections = {},
+		skipped = {},
+		warnings = {},
+	}
+	echoP("saving project '" .. slug .. "'...")
+	return true
+end
+
+local function listProjects()
+	local dirs = VFS.SubDirs(PROJECTS_DIR, "*", VFS.RAW) or {}
+	local found = 0
+	for _, d in ipairs(dirs) do
+		-- Raw io read: same-session folders may be invisible/stale in the VFS view
+		local f = io.open(d .. "project.lua", "r")
+		if f then
+			f:close()
+			found = found + 1
+			echoP("  " .. (d:match("([^/\\]+)[/\\]*$") or d))
+		end
+	end
+	if found == 0 then
+		echoP("no projects in " .. PROJECTS_DIR)
+	end
+	return found
+end
+
+function widget:DrawScreen()
+	if not job then return end
+	local step = STEPS[job.step]
+	if not step then
+		finishSave()
+		return
+	end
+	local ok, done = pcall(step.run)
+	if not ok then
+		echoP("ERROR in step '" .. step.name .. "': " .. tostring(done))
+		if step.name == "manifest" then
+			job.failed = "manifest step errored: " .. tostring(done)
+		else
+			sectionSkip(step.name, "error: " .. tostring(done))
+		end
+		done = true
+	end
+	if done then
+		job.step = job.step + 1
+		job.cursor = {}
+		if not STEPS[job.step] then
+			finishSave()
+		end
+	end
+end
+
+----------------------------------------------------------------
+-- Widget interface
+----------------------------------------------------------------
+
+local function mapProjectAction(_, optLine, params)
+	local sub = params and params[1]
+	if sub == "save" then
+		startSave(params[2])
+	elseif sub == "list" then
+		listProjects()
+	else
+		echoP("usage: /mapproject save <name>  |  /mapproject list")
+	end
+end
+
+function widget:Initialize()
+	widgetHandler:AddAction("mapproject", mapProjectAction, nil, "t")
+	WG.MapProject = {
+		save = startSave,
+		list = listProjects,
+		isBusy = function() return job ~= nil end,
+	}
+end
+
+function widget:Shutdown()
+	WG.MapProject = nil
+	widgetHandler:RemoveAction("mapproject")
+	if job then
+		echoP("save aborted by widget shutdown — project may be incomplete (no manifest written)")
+		job = nil
+	end
+end

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -53,6 +53,7 @@ local DNTS_WAIT_TICKS      = 300  -- wait for splat normals to appear before spl
 local SPLAT_LOAD_TIMEOUT   = 600
 local IMPORT_START_TICKS   = 300  -- import never went in-flight => decode failed
 local ACK_TIMEOUT_FRAMES   = 120  -- GAME frames after stream end without sim ack => failed
+local DIFFUSE_TIMEOUT_TICKS = 3600  -- full-map diffuse capture/load is many chunked GL ticks
 
 local heightmapPNG = nil  -- lazy VFS.Include of the shared 16-bit PNG codec
 
@@ -319,6 +320,105 @@ local function stepSplat()
 		sectionOk("splat", "splat.png", bytes)
 	else
 		sectionSkip("splat", "painter reported done but file missing")
+	end
+	return true
+end
+
+-- Baked diffuse capture (per-square PNGs + enabled shading channels).
+-- On real (compiled) maps EVERY square is captured, so a map whose diffuse was
+-- generated externally (World Machine workflow) carries its full texture in
+-- the project; blank canvases save only painted squares. Layers/masks are NOT
+-- serialized — the project records the baked result, and post-load painting
+-- extends it (same ownership semantics as the splat section).
+-- Failure skips (widget missing, busy, timeout, all captures failed) must NOT
+-- delete the diffuse dir or drop the section — hours of paint could live
+-- there. Carry the previous manifest section forward so the loader still sees
+-- the old files; only a genuine "no paint state" marks the dir as deletable.
+local function diffuseFailSkip(reason)
+	local prev = job.prev and job.prev.sections and job.prev.sections.diffuse
+	if prev and prev.dir then
+		warn("diffuse capture failed (" .. reason .. "); keeping the previous save's diffuse files")
+		job.diffuse = {
+			full = prev.full or false,
+			channels = prev.channels or {},
+			squareSize = tonumber(prev.square_size) or 1024,
+			count = tonumber(prev.squares) or 0,
+		}
+		sectionOk("diffuse", "diffuse/", tonumber(prev.bytes) or 0, "carried forward from previous save")
+	else
+		sectionSkip("diffuse", reason)
+	end
+	return true
+end
+
+local function stepDiffuse()
+	local dp = WG.DiffusePainter
+	local c = job.cursor
+	if not c.requested then
+		if not (dp and dp.saveProject) then
+			return diffuseFailSkip("diffuse painter widget not loaded")
+		end
+		local mo = job.mapOptions
+		local isBlank = (mo.blank_map_x or mo.blank_map_y) and true or false
+		if isBlank and not (dp.hasProjectState and dp.hasProjectState()) then
+			sectionSkip("diffuse", "no diffuse paint state")
+			job.diffuseStateEmpty = true  -- the ONE case where cleanup may wipe diffuse/
+			return true
+		end
+		Spring.CreateDir(job.dir .. "diffuse")
+		if not dp.saveProject(job.dir .. "diffuse/", not isBlank) then
+			return diffuseFailSkip("painter is busy")
+		end
+		echoP("capturing diffuse squares" .. ((not isBlank) and " (full map)" or "") .. "...")
+		c.requested = true
+		c.ticks = 0
+		return false
+	end
+	c.ticks = c.ticks + 1
+	if dp.isProjectSavePending() then
+		if c.ticks > DIFFUSE_TIMEOUT_TICKS then
+			return diffuseFailSkip("timed out (painter draw pump never finished)")
+		end
+		return false
+	end
+	local res = dp.getProjectSaveResult and dp.getProjectSaveResult()
+	if not res or res.error or #(res.squares or {}) == 0 then
+		return diffuseFailSkip((res and res.error) or "no squares captured")
+	end
+	-- Stale files inside diffuse/ from a previous save would be resurrected by
+	-- the loader's glob — remove anything this save did not write. (VFS listing
+	-- of files created earlier THIS session is unpinned; cross-session staleness
+	-- is what this reliably covers.)
+	local writtenSet = {}
+	for _, f in ipairs(res.squares) do
+		writtenSet[f] = true
+	end
+	for _, key in ipairs(res.channels) do
+		writtenSet["channel_" .. key .. ".png"] = true
+	end
+	local existing = VFS.DirList(job.dir .. "diffuse/", "*.png", VFS.RAW) or {}
+	for _, p in ipairs(existing) do
+		local name = basename(p)
+		if not writtenSet[name] then
+			os.remove(job.dir .. "diffuse/" .. name)
+			echoP("removed stale diffuse/" .. name)
+		end
+	end
+	local bytes = 0
+	for name in pairs(writtenSet) do
+		bytes = bytes + (fileSize(job.dir .. "diffuse/" .. name) or 0)
+	end
+	job.diffuse = {
+		full = res.full,
+		channels = res.channels,
+		squareSize = res.squareSize or 1024,
+		count = #res.squares,
+		bytes = bytes,
+	}
+	sectionOk("diffuse", "diffuse/", bytes, #res.squares .. " squares"
+		.. (#res.channels > 0 and (", channels: " .. table.concat(res.channels, " ")) or ""))
+	if (res.failed or 0) > 0 then
+		warn(res.failed .. " diffuse square(s) failed to capture")
 	end
 	return true
 end
@@ -704,6 +804,19 @@ local function stepCleanupStale()
 			end
 		end
 	end
+	-- Dir-based diffuse section: clear its folder ONLY when the state is
+	-- genuinely empty (paint deleted). Failure skips carry the previous section
+	-- forward instead — wiping a dir of up to thousands of square PNGs because
+	-- the painter widget happened to be disabled would be data loss.
+	if not findSection("diffuse") and job.diffuseStateEmpty then
+		local existing = VFS.DirList(job.dir .. "diffuse/", "*.png", VFS.RAW) or {}
+		for _, p in ipairs(existing) do
+			os.remove(job.dir .. "diffuse/" .. basename(p))
+		end
+		if #existing > 0 then
+			echoP("removed " .. #existing .. " stale diffuse square(s) (section now empty)")
+		end
+	end
 	return true
 end
 
@@ -766,18 +879,29 @@ local function stepManifest()
 	add("")
 	add("\tsections = {")
 	-- Fixed emission order (deterministic diffs); only sections actually written.
-	local order = { "heightmap", "splat", "metal", "features", "decals", "startpos", "startboxes", "lights", "environment", "weather", "grass" }
+	local order = { "heightmap", "splat", "diffuse", "metal", "features", "decals", "startpos", "startboxes", "lights", "environment", "weather", "grass" }
 	for _, name in ipairs(order) do
 		local s = findSection(name)
 		if s then
-			local extraFields = ""
-			if name == "grass" then
-				if job.grassPatchResolution then
-					extraFields = string.format(" patch_resolution = %d,", job.grassPatchResolution)
+			if name == "diffuse" then
+				-- Dir-based section: per-square PNGs, discovered by glob at load.
+				local d = job.diffuse or {}
+				local chParts = {}
+				for i, key in ipairs(d.channels or {}) do
+					chParts[i] = string.format("%q", key)
 				end
-				extraFields = extraFields .. ' config = "grass_config.lua",'
+				add(string.format('\t\tdiffuse = { dir = "diffuse/", version = 1, bytes = %d, square_size = %d, squares = %d, full = %s, channels = { %s } },',
+					s.bytes, d.squareSize or 1024, d.count or 0, tostring(d.full or false), table.concat(chParts, ", ")))
+			else
+				local extraFields = ""
+				if name == "grass" then
+					if job.grassPatchResolution then
+						extraFields = string.format(" patch_resolution = %d,", job.grassPatchResolution)
+					end
+					extraFields = extraFields .. ' config = "grass_config.lua",'
+				end
+				add(string.format("\t\t%s = { file = %q, version = 1, bytes = %d,%s },", name, s.file, s.bytes, extraFields))
 			end
-			add(string.format("\t\t%s = { file = %q, version = 1, bytes = %d,%s },", name, s.file, s.bytes, extraFields))
 		end
 	end
 	add("\t},")
@@ -811,6 +935,7 @@ local STEPS = {
 	{ name = "prepare",     run = stepPrepare },
 	{ name = "heightmap",   run = stepHeightmap },
 	{ name = "splat",       run = stepSplat },
+	{ name = "diffuse",     run = stepDiffuse },
 	{ name = "metal",       run = stepMetal },
 	{ name = "features",    run = stepFeatures },
 	{ name = "decals",      run = stepDecals },
@@ -930,8 +1055,8 @@ end
 local function writePointer(t)
 	Spring.CreateDir("Terraform Brush")
 	local content = string.format(
-		"return { path = %q, size_x = %d, size_z = %d, phase = %d }\n",
-		t.path, t.size_x, t.size_z, t.phase or 0)
+		"return { path = %q, size_x = %d, size_z = %d, phase = %d, phases = %d }\n",
+		t.path, t.size_x, t.size_z, t.phase or 0, t.phases or 0)
 	return writeFile(POINTER_PATH, content) ~= nil
 end
 
@@ -1151,7 +1276,80 @@ local function phaseDntsSplat(c)
 	return true
 end
 
--- Phase 3: metal. Direct $metal_clear$/$metal_load$ batching (mirrors the
+-- Phase 3: diffuse. Per-square PNGs blitted into painter-owned seed+composite
+-- textures (later paint bakes over the loaded state), channel PNGs into the
+-- painter's channel textures. Files discovered by glob — the save side keeps
+-- the diffuse/ dir exact.
+local function phaseDiffuse(c)
+	local sec = loadJob.manifest.sections and loadJob.manifest.sections.diffuse
+	if not (sec and sec.dir) then return true end
+	local dp = WG.DiffusePainter
+	if not (dp and dp.loadProject) then
+		loadSkip("diffuse", "diffuse painter widget not loaded")
+		return true
+	end
+	if not c.requested then
+		local dir = loadJob.dir .. sec.dir
+		local files = VFS.DirList(dir, "*.png", VFS.RAW) or {}
+		local sqs, chans, nChans = {}, {}, 0
+		for _, p in ipairs(files) do
+			local name = p:match("([^/\\]+)$")
+			-- NOT `name and name:match(...)`: `and` truncates a multi-return to
+			-- its first value, which would silently drop sy.
+			local sx, sy
+			if name then
+				sx, sy = name:match("^sq_(%d+)_(%d+)%.png$")
+			end
+			if sx and sy then
+				sqs[#sqs + 1] = { sx = tonumber(sx), sy = tonumber(sy), path = dir .. name }
+			else
+				local key = name and name:match("^channel_(%w+)%.png$")
+				if key then
+					chans[key] = dir .. name
+					nChans = nChans + 1
+				end
+			end
+		end
+		if #sqs == 0 and nChans == 0 then
+			loadSkip("diffuse", "no PNGs found in " .. sec.dir)
+			return true
+		end
+		table.sort(sqs, function(a, b)
+			if a.sy ~= b.sy then return a.sy < b.sy end
+			return a.sx < b.sx
+		end)
+		if not dp.loadProject(sqs, chans) then
+			loadSkip("diffuse", "painter is busy")
+			return true
+		end
+		echoP(string.format("diffuse: loading %d squares%s...", #sqs,
+			nChans > 0 and (" + " .. nChans .. " channel(s)") or ""))
+		c.requested = true
+		c.ticks = 0
+		return false
+	end
+	c.ticks = c.ticks + 1
+	if dp.isProjectLoadPending() then
+		if c.ticks > DIFFUSE_TIMEOUT_TICKS then
+			loadSkip("diffuse", "timed out (painter draw pump never finished)")
+			return true
+		end
+		return false
+	end
+	local res = dp.getProjectLoadResult and dp.getProjectLoadResult()
+	if not res or res.error or ((res.loaded or 0) == 0 and (res.channels or 0) == 0) then
+		loadSkip("diffuse", (res and (res.error or ((res.failed or 0) .. " square(s) failed"))) or "no result reported")
+	else
+		loadOk("diffuse", (res.loaded or 0) .. " squares"
+			.. ((res.channels or 0) > 0 and (", " .. res.channels .. " channel(s)") or ""))
+		if (res.failed or 0) > 0 then
+			echoP("WARNING: " .. res.failed .. " diffuse square(s) failed to load")
+		end
+	end
+	return true
+end
+
+-- Phase 4: metal. Direct $metal_clear$/$metal_load$ batching (mirrors the
 -- save side: no dependency on the metal brush widget being enabled).
 local function phaseMetal(c)
 	local path = sectionFile("metal")
@@ -1194,7 +1392,7 @@ local function phaseMetal(c)
 	return false
 end
 
--- Phase 4: features. Clear-all first so a resumed replay cannot duplicate.
+-- Phase 5: features. Clear-all first so a resumed replay cannot duplicate.
 local function phaseFeatures(c)
 	local path = sectionFile("features")
 	if not path then return true end
@@ -1209,7 +1407,7 @@ local function phaseFeatures(c)
 	return true
 end
 
--- Phase 5: decals + lights (client-side; need final heights for light Y).
+-- Phase 6: decals + lights (client-side; need final heights for light Y).
 local function phaseDecalsLights(c)
 	local decalPath = sectionFile("decals")
 	if decalPath then
@@ -1244,7 +1442,7 @@ local function phaseDecalsLights(c)
 	return true
 end
 
--- Phase 6: environment. Short settle countdown mirrors the New Map env-preset
+-- Phase 7: environment. Short settle countdown mirrors the New Map env-preset
 -- pattern (the water renderer needs a few draw frames after map changes).
 local function phaseEnvironment(c)
 	local path = sectionFile("environment")
@@ -1271,7 +1469,7 @@ local function phaseEnvironment(c)
 	return true
 end
 
--- Phase 7: weather. Clear persistent spawners first (idempotent replay), then
+-- Phase 8: weather. Clear persistent spawners first (idempotent replay), then
 -- rebuild each from its serialized entry with rebased timing.
 local function phaseWeather(c)
 	local path = sectionFile("weather")
@@ -1295,7 +1493,7 @@ local function phaseWeather(c)
 	return true
 end
 
--- Phase 8: startpos + startboxes + grass (all need sim-acked terrain: slope
+-- Phase 9: startpos + startboxes + grass (all need sim-acked terrain: slope
 -- validation and patch ground-snap read final heights).
 local function phaseStartposGrass(c)
 	local st = WG.StartPosTool
@@ -1361,6 +1559,7 @@ end
 local LOAD_PHASES = {
 	{ name = "heightmap",       run = phaseHeightmap },
 	{ name = "dnts+splat",      run = phaseDntsSplat },
+	{ name = "diffuse",         run = phaseDiffuse },
 	{ name = "metal",           run = phaseMetal },
 	{ name = "features",        run = phaseFeatures },
 	{ name = "decals+lights",   run = phaseDecalsLights },
@@ -1435,7 +1634,7 @@ local function runLoadTick()
 		loadJob.cursor = {}
 		loadJob.announced = nil
 		-- Journal progress so /luaui reload mid-load resumes here.
-		writePointer({ path = loadJob.dir, size_x = loadJob.sizeX, size_z = loadJob.sizeZ, phase = loadJob.phase })
+		writePointer({ path = loadJob.dir, size_x = loadJob.sizeX, size_z = loadJob.sizeZ, phase = loadJob.phase, phases = #LOAD_PHASES })
 		if not LOAD_PHASES[loadJob.phase + 1] then
 			finishLoad()
 		end
@@ -1490,13 +1689,21 @@ local function maybeStartLoad()
 		echoP("PENDING PROJECT LOAD CANCELLED: " .. verr .. ". Pointer removed.")
 		return
 	end
+	-- A journal written by a different code version counts phases on a different
+	-- list; resuming would silently skip the wrong ones. Phases are idempotent,
+	-- so restart from the beginning instead.
+	local startPhase = tonumber(ptr.phase) or 0
+	if startPhase > 0 and tonumber(ptr.phases) ~= #LOAD_PHASES then
+		echoP("phase journal was written by a different version; restarting the load from the beginning")
+		startPhase = 0
+	end
 	loadJob = {
 		slug = ptr.path:match("([^/\\]+)[/\\]*$") or ptr.path,
 		dir = ptr.path,
 		sizeX = ptr.size_x,
 		sizeZ = ptr.size_z,
 		manifest = manifest,
-		phase = tonumber(ptr.phase) or 0,
+		phase = startPhase,
 		cursor = {},
 		loaded = {},
 		skipped = {},
@@ -1574,7 +1781,7 @@ local function openProject(slug)
 	os.remove("Terraform Brush/pending_newmap.lua")
 	os.remove("Terraform Brush/pending_newmap_env.lua")
 	local m = manifest.map
-	if not writePointer({ path = dir, size_x = m.size_x, size_z = m.size_z, phase = 0 }) then
+	if not writePointer({ path = dir, size_x = m.size_x, size_z = m.size_z, phase = 0, phases = #LOAD_PHASES }) then
 		echoP("cannot open: failed to write " .. POINTER_PATH)
 		return false
 	end

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -735,7 +735,9 @@ local function executeSaveSplats(explicitPath)
 	end
 
 	glRenderToTexture(fboTex, function()
-		glSaveImage(0, 0, splatTexWidth, splatTexHeight, filename, { yflip = false })
+		-- alpha=true: the distribution is 4 channels — without it the A channel
+		-- (splat 4) is silently dropped from the export.
+		glSaveImage(0, 0, splatTexWidth, splatTexHeight, filename, { yflip = false, alpha = true })
 	end)
 
 	Echo("[Splat Painter] Saved splat distribution to: " .. filename .. " (" .. splatTexWidth .. "x" .. splatTexHeight .. ")")

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -161,6 +161,7 @@ local lastPaintZ = nil
 local pendingInit = false
 local pendingPaintStrokes = {}
 local pendingSave = false
+local pendingSavePath = nil  -- explicit target (project save); nil = default export dir
 
 -- Undo/redo history (texture snapshots per drag)
 local MAX_UNDO_SPLAT = 20
@@ -720,13 +721,16 @@ end
 -- ============ SAVE / EXPORT ============
 
 -- Execute the actual save (must be called from a Draw call-in)
-local function executeSaveSplats()
+local function executeSaveSplats(explicitPath)
 	if not fboTex then return end
 
-	local ext = EXPORT_FORMATS[exportFormatIndex] or "png"
-	local SPLATS_DIR = "Terraform Brush/Splats/"
-	Spring.CreateDir(SPLATS_DIR)
-	local filename = SPLATS_DIR .. "splat_export_" .. Game.mapName .. "." .. ext
+	local filename = explicitPath
+	if not filename then
+		local ext = EXPORT_FORMATS[exportFormatIndex] or "png"
+		local SPLATS_DIR = "Terraform Brush/Splats/"
+		Spring.CreateDir(SPLATS_DIR)
+		filename = SPLATS_DIR .. "splat_export_" .. Game.mapName .. "." .. ext
+	end
 
 	glRenderToTexture(fboTex, function()
 		glSaveImage(0, 0, splatTexWidth, splatTexHeight, filename, { yflip = false })
@@ -736,11 +740,12 @@ local function executeSaveSplats()
 end
 
 -- Public API: always defers to DrawWorld
-local function requestSaveSplats()
+local function requestSaveSplats(explicitPath)
 	if not fboTex and not active then
 		Echo("[Splat Painter] No splat texture to save")
 		return
 	end
+	pendingSavePath = explicitPath
 	pendingSave = true
 end
 
@@ -985,6 +990,8 @@ function widget:Initialize()
 		setSmartEnabled = setSmartEnabled,
 		setSmartFilter = setSmartFilter,
 		saveSplats = requestSaveSplats,
+		isSavePending = function() return pendingSave end,
+		hasSplatState = function() return fboTex ~= nil end,
 		cycleExportFormat = cycleExportFormat,
 		setExportFormat = setExportFormat,
 		setGeoDecalMode = setGeoDecalMode,
@@ -1507,6 +1514,15 @@ function widget:DrawWorld()
 		glDepthTest(false)
 	end
 
+	-- Deferred save: before the active guard, so a project save requested while
+	-- the tool is deactivated (fboTex still alive) still executes.
+	if pendingSave and fboTex then
+		pendingSave = false
+		local savePath = pendingSavePath
+		pendingSavePath = nil
+		executeSaveSplats(savePath)
+	end
+
 	if not active then return end
 
 	-- Deferred GL initialization (must happen inside a Draw call-in)
@@ -1559,11 +1575,6 @@ function widget:DrawWorld()
 		pendingPaintStrokes = {}
 	end
 
-	-- Deferred save
-	if pendingSave and fboTex then
-		pendingSave = false
-		executeSaveSplats()
-	end
 
 	local worldX, worldZ = getWorldMousePosition()
 	do

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -162,6 +162,8 @@ local pendingInit = false
 local pendingPaintStrokes = {}
 local pendingSave = false
 local pendingSavePath = nil  -- explicit target (project save); nil = default export dir
+local pendingLoadPath = nil  -- deferred project load (executes in DrawWorld)
+local lastLoadResult = nil   -- "ok" or "failed: <reason>" after the deferred load ran
 
 -- Undo/redo history (texture snapshots per drag)
 local MAX_UNDO_SPLAT = 20
@@ -749,6 +751,72 @@ local function requestSaveSplats(explicitPath)
 	pendingSave = true
 end
 
+-- ============ PROJECT LOAD ============
+
+-- Blit a saved splat distribution PNG INTO the painter's own fboTex (must be
+-- called from a Draw call-in). Ownership rule: fboTex stays the single owner of
+-- the splat state — a loader-owned texture would be clobbered by the first
+-- paint stroke and dangle on widget reload. Because the PNG lands inside
+-- fboTex, a paint stroke after load extends the loaded state.
+local function executeLoadSplats(path)
+	if not paintShader then
+		if not createShaders() then
+			return "failed: shader creation failed"
+		end
+	end
+	if not fboTex then
+		if not initSplatTexture() then
+			return "failed: map exposes no splat distribution texture (DNTS not bound?)"
+		end
+	end
+
+	local texName = ":l:" .. path
+	if not gl.Texture(texName) then
+		return "failed: could not load " .. path
+	end
+	gl.Texture(false)
+	local info = gl.TextureInfo(texName)
+	if not info or not info.xsize or info.xsize <= 0 then
+		return "failed: could not read texture info for " .. path
+	end
+	if info.xsize > splatTexWidth or info.ysize > splatTexHeight then
+		Echo(string.format(
+			"[Splat Painter] Warning: loaded splat PNG (%dx%d) is larger than the edit texture (%dx%d); downscaling.",
+			info.xsize, info.ysize, splatTexWidth, splatTexHeight))
+	end
+
+	glRenderToTexture(fboTex, function()
+		glBlending(false)
+		glUseShader(copyShader)
+		glTexture(0, texName)
+		glTexRect(-1, -1, 1, 1, 0, 0, 1, 1)
+		glTexture(0, false)
+		glUseShader(0)
+		glBlending(true)
+	end)
+	gl.DeleteTexture(texName)
+
+	-- Rebind through the painter's own path so the engine points at fboTex and
+	-- the binding inherits the painter's reload lifecycle.
+	SetMapShadingTexture(SPLAT_TEX_NAME, fboTex)
+	texApplied = true
+
+	Echo(string.format("[Splat Painter] Loaded splat distribution from %s (%dx%d into %dx%d)",
+		path, info.xsize, info.ysize, splatTexWidth, splatTexHeight))
+	return "ok"
+end
+
+-- Public API: defers to DrawWorld (GL work). Poll isLoadPending / getLoadResult.
+local function requestLoadSplats(path)
+	if not path or path == "" then
+		Echo("[Splat Painter] loadSplats: no path given")
+		return false
+	end
+	pendingLoadPath = path
+	lastLoadResult = nil
+	return true
+end
+
 -- ============ GEO DECAL PLACEMENT ============
 
 local function placeGeoDecal(worldX, worldZ)
@@ -992,6 +1060,9 @@ function widget:Initialize()
 		saveSplats = requestSaveSplats,
 		isSavePending = function() return pendingSave end,
 		hasSplatState = function() return fboTex ~= nil end,
+		loadSplats = requestLoadSplats,
+		isLoadPending = function() return pendingLoadPath ~= nil end,
+		getLoadResult = function() return lastLoadResult end,
 		cycleExportFormat = cycleExportFormat,
 		setExportFormat = setExportFormat,
 		setGeoDecalMode = setGeoDecalMode,
@@ -1521,6 +1592,22 @@ function widget:DrawWorld()
 		local savePath = pendingSavePath
 		pendingSavePath = nil
 		executeSaveSplats(savePath)
+	end
+
+	-- Deferred project load: also before the active guard — the map project
+	-- orchestrator loads splats without the paint tool being active.
+	if pendingLoadPath then
+		local loadPath = pendingLoadPath
+		pendingLoadPath = nil
+		lastLoadResult = executeLoadSplats(loadPath)
+		if lastLoadResult ~= "ok" then
+			Echo("[Splat Painter] Splat load " .. tostring(lastLoadResult))
+		end
+		-- The load may have created fboTex; a still-queued activation init would
+		-- rebuild it and clobber (and leak) the freshly loaded state.
+		if fboTex then
+			pendingInit = false
+		end
 	end
 
 	if not active then return end

--- a/luaui/Widgets/cmd_startpos_tool.lua
+++ b/luaui/Widgets/cmd_startpos_tool.lua
@@ -893,8 +893,8 @@ local function saveStartPositions(name, explicitPath)
 	end
 end
 
-local function loadStartPositions(name)
-	local filename = SAVE_DIR .. (name or getMapName()) .. ".lua"
+local function loadStartPositions(name, explicitPath)
+	local filename = explicitPath or (SAVE_DIR .. (name or getMapName()) .. ".lua")
 	local ok, data = pcall(function()
 		return VFS.Include(filename, nil, VFS.RAW_FIRST)
 	end)
@@ -961,8 +961,8 @@ local function saveStartboxes(name, explicitPath)
 	end
 end
 
-local function loadStartboxes(name)
-	local filename = STARTBOX_SAVE_DIR .. (name or getMapName()) .. ".lua"
+local function loadStartboxes(name, explicitPath)
+	local filename = explicitPath or (STARTBOX_SAVE_DIR .. (name or getMapName()) .. ".lua")
 	local ok, data = pcall(function()
 		return VFS.Include(filename, nil, VFS.RAW_FIRST)
 	end)

--- a/luaui/Widgets/cmd_startpos_tool.lua
+++ b/luaui/Widgets/cmd_startpos_tool.lua
@@ -861,9 +861,12 @@ local function getMapName()
 	return Game.mapName or "unknown"
 end
 
-local function saveStartPositions(name)
-	Spring.CreateDir(SAVE_DIR)
-	local filename = SAVE_DIR .. (name or getMapName()) .. ".lua"
+local function saveStartPositions(name, explicitPath)
+	local filename = explicitPath
+	if not filename then
+		Spring.CreateDir(SAVE_DIR)
+		filename = SAVE_DIR .. (name or getMapName()) .. ".lua"
+	end
 	local lines = {}
 	lines[#lines + 1] = "-- Start Positions Config"
 	lines[#lines + 1] = "-- Map: " .. getMapName()
@@ -919,9 +922,12 @@ local function listSavedConfigs()
 	return names
 end
 
-local function saveStartboxes(name)
-	Spring.CreateDir(STARTBOX_SAVE_DIR)
-	local filename = STARTBOX_SAVE_DIR .. (name or getMapName()) .. ".lua"
+local function saveStartboxes(name, explicitPath)
+	local filename = explicitPath
+	if not filename then
+		Spring.CreateDir(STARTBOX_SAVE_DIR)
+		filename = STARTBOX_SAVE_DIR .. (name or getMapName()) .. ".lua"
+	end
 	local lines = {}
 	lines[#lines + 1] = "-- Startbox Config"
 	lines[#lines + 1] = "-- Map: " .. getMapName()

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -2316,6 +2316,15 @@ local function doImportHeightmapSend()
 	end
 end
 
+-- Heightmap import progress probe for the map project load orchestrator
+-- (cmd_map_project.lua): (busy, columnsSent, columnsTotal). busy covers both the
+-- queued file (not yet decoded) and an in-flight column stream. Attached to
+-- extraState so it can read the file-locals as upvalues (200-local ceiling).
+extraState._importStatus = function()
+	local total = importHeightRows and #importHeightRows or 0
+	return (pendingImportFile ~= nil) or (importHeightRows ~= nil), importRowIndex or 0, total
+end
+
 -- Pre-bundle noise setters into extraState to keep widget:Initialize under the 60-upvalue limit
 -- without adding a new chunk-level local (which would breach the 200-local limit).
 extraState._noiseSetters = {
@@ -2362,6 +2371,7 @@ function widget:Initialize()
 	end
 
 	WG.TerraformBrush = {
+		getImportStatus = extraState._importStatus,
 		setMode = setMode,
 		setShape = setShape,
 		rotate = rotateBy,

--- a/luaui/Widgets/cmd_weather_brush.lua
+++ b/luaui/Widgets/cmd_weather_brush.lua
@@ -982,6 +982,36 @@ local function clearAllPersistent()
 	end
 end
 
+-- Raw copies of all persistent spawners, for project serialization.
+-- Frame fields (startFrame/expireFrame/nextFrame) are absolute game frames and
+-- NOT portable across sessions; callers must convert to relative durations.
+local function getPersistentSpawners()
+	local out = {}
+	for _, s in pairs(wb.persistentSpawners) do
+		local cegs = {}
+		for i = 1, #s.cegs do cegs[i] = s.cegs[i] end
+		out[#out + 1] = {
+			cegs = cegs,
+			x = s.x,
+			z = s.z,
+			radius = s.radius,
+			count = s.count,
+			shape = s.shape,
+			angleDeg = s.angleDeg,
+			lengthScale = s.lengthScale,
+			altitude = s.altitude,
+			interval = s.interval,
+			refreshInterval = s.refreshInterval,
+			startFrame = s.startFrame,
+			expireFrame = s.expireFrame,
+			nextFrame = s.nextFrame,
+			spawnCycles = s.spawnCycles,
+			saturationCycles = s.saturationCycles,
+		}
+	end
+	return out
+end
+
 -- ===========================================================================
 -- State Export (for UI)
 -- ===========================================================================
@@ -1327,6 +1357,7 @@ function widget:Initialize()
 		getWeatherLibrary = getWeatherLibrary,
 		applyWeatherPreset = applyWeatherPreset,
 		clearAllPersistent = clearAllPersistent,
+		getPersistentSpawners = getPersistentSpawners,
 	}
 end
 

--- a/luaui/Widgets/cmd_weather_brush.lua
+++ b/luaui/Widgets/cmd_weather_brush.lua
@@ -1012,6 +1012,50 @@ local function getPersistentSpawners()
 	return out
 end
 
+-- Reconstruct a persistent spawner from a serialized project entry, honoring
+-- the saved interval/refreshInterval instead of deriving them from the live UI
+-- cadence (which addPersistentSpawner does). Synthesizes every runtime field
+-- the Update loop dereferences — a missing one crashes the widget on the next
+-- tick. entry.persistence: -1 = permanent, else remaining seconds.
+local function addSpawnerRaw(entry)
+	if type(entry) ~= "table" or type(entry.cegs) ~= "table" or #entry.cegs == 0 then
+		Echo("[Weather Brush] addSpawnerRaw: entry has no cegs, skipped")
+		return nil
+	end
+	local frameRate = Game.gameSpeed
+	local now = GetGameFrame()
+	local cegs = {}
+	for i = 1, #entry.cegs do cegs[i] = tostring(entry.cegs[i]) end
+	local interval = max(1, floor(tonumber(entry.interval) or frameRate))
+	local refreshInterval = max(interval, floor(tonumber(entry.refreshInterval) or interval))
+	local persistence = tonumber(entry.persistence) or PERSIST_PERMANENT
+	local expireFrame = nil
+	if persistence >= 0 then
+		expireFrame = now + max(1, floor(persistence * frameRate))
+	end
+	local id = wb.nextSpawnerId
+	wb.nextSpawnerId = id + 1
+	wb.persistentSpawners[id] = {
+		cegs = cegs,
+		x = tonumber(entry.x) or 0,
+		z = tonumber(entry.z) or 0,
+		radius = tonumber(entry.radius) or 100,
+		count = max(1, floor(tonumber(entry.count) or 1)),
+		shape = entry.shape or "circle",
+		angleDeg = tonumber(entry.angleDeg) or 0,
+		lengthScale = tonumber(entry.lengthScale) or 1.0,
+		altitude = tonumber(entry.altitude) or 0,
+		interval = interval,
+		refreshInterval = refreshInterval,
+		startFrame = now,
+		expireFrame = expireFrame, -- nil = permanent
+		nextFrame = now,
+		spawnCycles = 0,
+		saturationCycles = max(1, floor(refreshInterval / interval)),
+	}
+	return id
+end
+
 -- ===========================================================================
 -- State Export (for UI)
 -- ===========================================================================
@@ -1358,6 +1402,7 @@ function widget:Initialize()
 		applyWeatherPreset = applyWeatherPreset,
 		clearAllPersistent = clearAllPersistent,
 		getPersistentSpawners = getPersistentSpawners,
+		addSpawnerRaw = addSpawnerRaw,
 	}
 end
 

--- a/luaui/Widgets/map_grass_gl4.lua
+++ b/luaui/Widgets/map_grass_gl4.lua
@@ -1130,7 +1130,7 @@ local function savegrassCmd(_, _, params)
 	if saveError then spEcho("Saving grass map image failed", filename, saveError) end
 end
 
-local function exportGrassConfig(filename)
+local function exportGrassConfig(filename, opts)
 	local function fmtVal(v)
 		local t = type(v)
 		if t == "number" then
@@ -1160,7 +1160,13 @@ local function exportGrassConfig(filename)
 	local out = {
 		"-- Grass config export from Map Grass GL4",
 		"-- Map: " .. (Game.mapName or "unknown"),
-		"-- Date: " .. os.date("%Y-%m-%d %H:%M:%S"),
+	}
+	-- Project saves suppress the date comment: repeated saves of unchanged state
+	-- must serialize identically (project files live in git).
+	if not (opts and opts.nodate) then
+		out[#out + 1] = "-- Date: " .. os.date("%Y-%m-%d %H:%M:%S")
+	end
+	local body = {
 		"-- Paste mapinfo.custom = mapinfo.custom or {} and then mapinfo.custom.grassConfig = (this file table).custom.grassConfig",
 		"return {",
 		"\tcustom = {",
@@ -1182,6 +1188,9 @@ local function exportGrassConfig(filename)
 		"",
 		"\t\t\tgrassShaderParams = {",
 	}
+	for i = 1, #body do
+		out[#out + 1] = body[i]
+	end
 
 	for i = 1, #shaderKeys do
 		local k = shaderKeys[i]
@@ -1457,8 +1466,8 @@ function widget:Initialize()
 		spEcho("[Grass] Saved grass map: " .. filename)
 		return true
 	end
-	WG['grassgl4'].saveGrassConfig = function(filename)
-		local ok = exportGrassConfig(filename)
+	WG['grassgl4'].saveGrassConfig = function(filename, opts)
+		local ok = exportGrassConfig(filename, opts)
 		return ok
 	end
 	WG['grassgl4'].getVisualConfig = function()


### PR DESCRIPTION
### Work done
Adds map projects to the terraformer: FILE > Save Project bundles the full editable map state into one folder under `MapProjects/<name>/`, and FILE > Open Project restarts into a blank map of the recorded size and replays every section onto it.

A project folder contains a versioned Lua manifest plus per-section files in the existing tools' formats: 16-bit heightmap PNG, splat distribution PNG, baked per-square diffuse PNGs, metal spots, features, decals, lights, environment snapshot, weather spawners, grass grid and start positions/boxes.

Serialization is deterministic (stable ordering, fixed float precision, binary-mode LF), so a re-save of unchanged state diffs only in the manifest's `modified` field and project folders can live in git.

Projects are self-contained: DNTS splat textures and referenced decal captures are copied into `assets/`, and compiled maps capture their live splat textures and full diffuse (every map square), so a map whose diffuse was generated externally (World Machine workflow) carries its texture through the round trip.

The load driver survives interruption: a pointer file with a phase journal is written before the restart, each completed phase updates it, and `/luaui reload` mid-load resumes instead of dying.

A session mismatch (wrong size, wrong map, multiplayer, replay, map damage off) deletes the pointer with an explanation instead of replaying onto the wrong map.

Terrain replay gates on live `/cheat` (observed, with bounded retries) and on a sim-side ack published by the terraform gadget as a rules param, not on draw-frame waits, so a paused or pregame session cannot mis-journal a phase.

The blank-map start script builder now strips inherited `disablemapdamage` and `startrect*` keys; leftover startboxes confined pregame commander placement to a sliver of the canvas, which read as a dead mouse after load.

Fixed along the way: `gl.SaveImage` exports now pass `alpha=true` (the fourth splat channel and DNTS blend weights were silently dropped), and grass loading no longer leaves the grass widget in placement mode (which swallowed every world click).

Known limitations: diffuse persists the baked result only (layers/masks are tool state); decal captures referenced by a project must be manually installed into the archive for the atlas; splat/DNTS visuals on loaded blank maps additionally require the engine to honor `blank_map_splat*` keys (RecoilEngine#3086, still open) — the data saves and rides along regardless.

#### Setup
Enable the Map Project widget (Settings > Widgets) alongside the terraformer suite.
Loading needs a local singleplayer session; splat/DNTS visuals on load need an engine build with RecoilEngine#3086.

#### Test steps
- [ ] On any map, sculpt terrain, place metal/features/lights and paint splat/diffuse, then FILE > Save Project — expect a `MapProjects/<name>/` folder with a manifest and one file per non-empty section, and a second save to diff only in `modified`.
- [ ] FILE > Open Project on the saved entry — expect a restart into a blank map of the same size, a per-phase console log ending in `PROJECT LOAD COMPLETE`, and heightmap/metal/features/decals/lights/environment/weather/grass/startpos matching the source.
- [ ] Paint a splat or diffuse stroke after loading — expect it to extend the loaded state, and a re-save to diff only the touched squares.
- [ ] `/luaui reload` while a load is running — expect the load to resume from the journaled phase instead of aborting.
- [ ] Open a project, then abort the restart (or join a different game) — expect a loud "load cancelled" message and no state changes.

### AI / LLM usage statement:
Implemented with Claude Fable 5 driving the design, code and review passes, per the design docs and evaluation criteria I wrote and against my in-game verification of each increment. Smaller tasks were delegated to lighter Sonnet 5 agent) 

All code was human-directed and verified in-game by me; the adversarial review passes (which caught several real bugs pre-merge) were also AI-assisted.
