### PR TITLE
[Style] stylua: ignore mapgenerator templates

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -1,3 +1,4 @@
 common/luaUtilities/
 .lux/
 recoil-lua-library/
+mapgenerator/


### PR DESCRIPTION
`mapgenerator/mapinfo_template.lua` is a substitution template, not valid Lua — it contains a `${START_POSITIONS}` placeholder that the map generator fills in. StyLua fails to parse it, which breaks any full-tree `stylua .` run:

```
error: could not format file ./mapgenerator/mapinfo_template.lua: error parsing:
 - unexpected character $ (217:3 to 217:4)
 ...
```

This adds `mapgenerator/` to `.styluaignore` alongside the other excluded trees. Verified with a full-tree `stylua --check .`: no parse errors remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)