### PR TITLE
[Types] LLM-driven type-error transform capstone

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,15 @@
+# gen(stylua): initial formatting of entire codebase
+b955520aab3c0b71bdaa7198a5a480acaeb7f406
+
+# gen(stylua): initial formatting of entire codebase
+f44c947f7e94f5f96c757ea85d860814d4e29131
+
+# gen(bar_codemod): bracket-to-dot
+68acd60c4199212f22339edb1636a6a8a0da54c8
+
+# gen(bar_codemod): rename-aliases
+ce9c4a0a1da5ee00143225694fa9a1411ee2263b
+
+# gen(bar_codemod): detach-bar-modules
+422b41057ef05cfaa3332c5c29c64b92cb4a6719
+

--- a/luarules/gadgets/api_enemyunitdestroyed.lua
+++ b/luarules/gadgets/api_enemyunitdestroyed.lua
@@ -28,7 +28,7 @@ if not gadgetHandler:IsSyncedCode() then
 
 	function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID, weaponDefID)
 		local allyTeam = spGetUnitAllyTeam(unitID)
-		if (spec and fullview) or (allyTeam and allyTeam ~= myAllyTeamID) then
+		if (spec and fullView) or (allyTeam and allyTeam ~= myAllyTeamID) then
 			local losstate = Spring.GetUnitLosState(unitID, myAllyTeamID)
 			if losstate and losstate.los and Script.LuaUI("EnemyUnitDestroyed") then
 				Script.LuaUI.EnemyUnitDestroyed(

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -1214,7 +1214,7 @@ if gadgetHandler:IsSyncedCode() then
 			--if bestBurrowID then
 			--	DestroyUnit(bestBurrowID, true, false)
 			--end
-			return CreateUnit(config.queenName, sx, sy, sz, mRandom(0, 3), raptorTeamID), burrowID
+			return CreateUnit(config.queenName, sx, sy, sz, mRandom(0, 3), raptorTeamID), bestBurrowID
 		end
 
 		local x, z, y

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1472,7 +1472,7 @@ if gadgetHandler:IsSyncedCode() then
 			--if bestBurrowID then
 			--	Spring.DestroyUnit(bestBurrowID, true, false)
 			--end
-			return CreateUnit(config.bossName, sx, sy, sz, mRandom(0, 3), scavTeamID), burrowID
+			return CreateUnit(config.bossName, sx, sy, sz, mRandom(0, 3), scavTeamID), bestBurrowID
 		end
 
 		local x, z, y

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -20,12 +20,12 @@ end
 --------------------------------------------------------------------------------
 -- Configuration ---------------------------------------------------------------
 
-local damageInterval = 0.7333 ---@type number in seconds, time between procs
-local damageLimit = 120 ---@type number in damage per second, soft-cap across multiple areas
-local damageExcessRate = 0.2 ---@type number %damage dealt above limit [0, 1)
-local damageCegMinScalar = 30 ---@type number in damage, minimum to show hit CEG
-local damageCegMinMultiple = 1 / 3 ---@type number in %damage, minimum to show hit CEG
-local factoryWaitTime = damageInterval ---@type number in seconds, immunity period for factory-built units
+local damageInterval = 0.7333 ---@type number # in seconds, time between procs
+local damageLimit = 120 ---@type number # in damage per second, soft-cap across multiple areas
+local damageExcessRate = 0.2 ---@type number # %damage dealt above limit [0, 1)
+local damageCegMinScalar = 30 ---@type number # in damage, minimum to show hit CEG
+local damageCegMinMultiple = 1 / 3 ---@type number # in %damage, minimum to show hit CEG
+local factoryWaitTime = damageInterval ---@type number # in seconds, immunity period for factory-built units
 
 -- Since I couldn't figure out totally arbitrary-radius variable CEGs for fire,
 -- we're left with this static list, which is repeated in the expgen def files:

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -451,8 +451,9 @@ local function CobDroneSpawnSequenceFinished(unitID, unitDefID, team, subUnitID)
 		return
 	else
 		local dockingPiece = carrierMetaList[unitID].subUnitsList[subUnitID].dockingPiece
-		local _, pieceAngle = spCallCOBScript(unitID, "DroneDocked", 5, pieceAngle, dockingPiece)
-		spCallCOBScript(subUnitID, "Docked", 0, carrierMetaList[unitID].cobdockparam, dockingPiece, pieceAngle)
+		local pieceAngle = nil
+		local _, pieceAngleResult = spCallCOBScript(unitID, "DroneDocked", 5, pieceAngle, dockingPiece)
+		spCallCOBScript(subUnitID, "Docked", 0, carrierMetaList[unitID].cobdockparam, dockingPiece, pieceAngleResult)
 		return
 	end
 end
@@ -509,7 +510,7 @@ local function spawnUnit(spawnData)
 							energyCost = carrierData.energyCost[dronetypeIndex]
 						else
 							local subUnitDef = UnitDefNames[dronename]
-							if subunitDef then
+							if subUnitDef then
 								metalCost = subUnitDef.metalCost
 								energyCost = subUnitDef.energyCost
 							else
@@ -664,7 +665,8 @@ local function spawnUnit(spawnData)
 								droneSpawnSequence(ownerID, subUnitID)
 								droneMetaData.activeSpawnSequence = true
 							else
-								local _, pieceAngle =
+								local pieceAngle = nil
+								local _, pieceAngleResult =
 									spCallCOBScript(ownerID, "DroneDocked", 5, pieceAngle, droneMetaData.dockingPiece)
 								spCallCOBScript(
 									subUnitID,
@@ -672,7 +674,7 @@ local function spawnUnit(spawnData)
 									0,
 									carrierData.cobdockparam,
 									droneMetaData.dockingPiece,
-									pieceAngle
+									pieceAngleResult
 								)
 							end
 						else
@@ -1815,14 +1817,16 @@ local function dockUnits(dockingqueue, queuestart, queueend)
 								if carrierMetaList[unitID].dockArmor then
 									spSetUnitArmored(subUnitID, true, carrierMetaList[unitID].dockArmor)
 								end
-								local _, pieceAngle = spCallCOBScript(unitID, "DroneDocked", 5, pieceAngle, pieceNumber)
+								local pieceAngle = nil
+								local _, pieceAngleResult =
+									spCallCOBScript(unitID, "DroneDocked", 5, pieceAngle, pieceNumber)
 								spCallCOBScript(
 									subUnitID,
 									"Docked",
 									0,
 									carrierMetaList[unitID].cobdockparam,
 									pieceNumber,
-									pieceAngle
+									pieceAngleResult
 								)
 
 								if dronetype == "abductor" then

--- a/luarules/gadgets/unit_stomp.lua
+++ b/luarules/gadgets/unit_stomp.lua
@@ -31,7 +31,7 @@ end
 local stompableDefs = {}
 for udid, ud in pairs(UnitDefs) do
 	if stompable[ud.name] then
-		stompableDefs[udid] = v
+		stompableDefs[udid] = ud
 	end
 end
 

--- a/luaui/Include/AtlasOnDemand.lua
+++ b/luaui/Include/AtlasOnDemand.lua
@@ -597,7 +597,7 @@ local function MakeAtlasOnDemand(config)
 		local drawblanktask = {
 			id = self.blankimg,
 			w = xmax - xmin * self.xresolution,
-			h = ymax - ymin * yresolution,
+			h = ymax - ymin * self.yresolution,
 			x = xmin * self.xresolution,
 			y = ymin * self.yresolution,
 		}

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -12406,6 +12406,7 @@ local function attachEventListeners()
 			capMaxValue = 0
 			capAbsolute = true
 			capEnabled = true
+			local dm = widgetState.dmHandle
 			if dm then
 				dm.tfCapAbsoluteSrc = "/luaui/images/terraform_brush/check_on.png"
 			end
@@ -14691,12 +14692,12 @@ function widget:Update()
 					or false
 			)
 		end
+
+		local doc = widgetState.document
 		local clayBtn = doc and getCachedEl(doc, "btn-clay-mode")
 		if clayBtn then
 			clayBtn:SetClass("disabled", mbActive or lpActive or false)
 		end
-
-		local doc = widgetState.document
 
 		-- Blue-dot hint gating: hide dots already seen or when tips disabled,
 		-- and handle chip 2-pulse animations scheduled by tf_environment listeners.
@@ -15145,6 +15146,7 @@ function widget:Update()
 				if sliderCapMin and ds ~= "capmin" then
 					sliderCapMin:SetAttribute("value", tostring(capMinValue))
 				end
+				local dm = widgetState.dmHandle
 				if dm then
 					dm.tfCapAbsoluteSrc = capAbsolute and "/luaui/images/terraform_brush/check_on.png"
 						or "/luaui/images/terraform_brush/check_off.png"
@@ -15371,6 +15373,7 @@ function widget:Update()
 						)
 					end
 				end
+				local dustEl = getCachedEl(doc, "btn-dust-effects")
 				if dustEl then
 					dustEl:SetClass("active", state.dustEffects == true)
 					if dm then

--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -142,8 +142,8 @@ local function Scream(reason, unitID) -- This will pause the game and play some 
 			unitID,
 			unitDefID and UnitDefs[unitDefID].name or "nil",
 			unitTeam,
-			px,
-			pz
+			ux,
+			uz
 		)
 	end
 	if lastknownunitpos[unitID] then

--- a/luaui/Widgets/cmd_area_commands_filter.lua
+++ b/luaui/Widgets/cmd_area_commands_filter.lua
@@ -56,8 +56,8 @@ local myAllyTeamID
 --- Target sorting logic (pick the closest first)
 ---------------------------------------------------------------------------------------
 
----@field position1 table {x, y, z}
----@field position2 table {x, y, z}
+---@param position1 table {x, y, z}
+---@param position2 table {x, y, z}
 local function distanceSq(position1, position2)
 	local dx = position1.x - position2.x
 	local dz = position1.z - position2.z

--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -26,6 +26,7 @@ local tableInsert = table.insert
 
 -- Localized Spring API for performance
 local spGetGameFrame = Spring.GetGameFrame
+local isSpec = nil
 
 local isPregame = spGetGameFrame() == 0 and not isSpec
 

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -928,6 +928,8 @@ function widget:Shutdown()
 	widgetHandler:RemoveAction("factory_preset_show")
 end
 
+local spEcho = Spring.Echo
+
 function printDebug(value)
 	if debug then
 		if type(value) == "boolean" then

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1853,8 +1853,8 @@ function widget:UnitCreated(unitID, unitDefID, teamID)
 	eventLightSpawner("UnitCreated", unitID, unitDefID, teamID)
 end
 function widget:UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)
-	eventLightSpawner("UnitFromFactory", unitID, unitDefID, teamID) -- i have no idea of the differences here
-	eventLightSpawner("UnitFromFactoryBuilder", factID, factDefID, teamID)
+	eventLightSpawner("UnitFromFactory", unitID, unitDefID, unitTeam) -- i have no idea of the differences here
+	eventLightSpawner("UnitFromFactoryBuilder", factID, factDefID, unitTeam)
 end
 function widget:UnitDestroyed(unitID, unitDefID, teamID) -- dont do piece-attached lights here!
 	eventLightSpawner("UnitDestroyed", unitID, unitDefID, teamID)

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -1082,8 +1082,8 @@ function widget:UnitCreated(unitID, unitDefID, teamID)
 	eventDistortionSpawner("UnitCreated", unitID, unitDefID, teamID)
 end
 function widget:UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)
-	eventDistortionSpawner("UnitFromFactory", unitID, unitDefID, teamID) -- i have no idea of the differences here
-	eventDistortionSpawner("UnitFromFactoryBuilder", factID, factDefID, teamID)
+	eventDistortionSpawner("UnitFromFactory", unitID, unitDefID, unitTeam) -- i have no idea of the differences here
+	eventDistortionSpawner("UnitFromFactoryBuilder", factID, factDefID, unitTeam)
 end
 function widget:UnitDestroyed(unitID, unitDefID, teamID) -- dont do piece-attached distortions here!
 	eventDistortionSpawner("UnitDestroyed", unitID, unitDefID, teamID)

--- a/luaui/Widgets/gfx_norush_timer_gl4.lua
+++ b/luaui/Widgets/gfx_norush_timer_gl4.lua
@@ -32,6 +32,7 @@ local LuaShader = gl.LuaShader
 local InstanceVBOTable = gl.InstanceVBOTable
 
 local minY, maxY = Spring.GetGroundExtremes()
+local NUM_BOXES = 0
 
 local shaderSourceCache = {
 	vssrcpath = "LuaUI/Shaders/norush_timer.vert.glsl",

--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -2118,7 +2118,7 @@ function CreateBackground()
 	if absRight > vsx + margin then -- lazy bugfix needed when playerScale < 1 is in effect
 		absRight = vsx + margin
 	end
-	apiAbsPosition = { absTop, absLeft, absBottom, absRight, widgetScale, right, false }
+	apiAbsPosition = { absTop, absLeft, absBottom, absRight, widgetScale, absRight, false }
 
 	local paddingBottom = bgpadding
 	local paddingRight = bgpadding
@@ -3241,6 +3241,7 @@ function DrawState(playerID, posX, posY)
 		or (playerReadyState[playerID] == 2)
 		or (playerReadyState[playerID] == -1)
 	local hasStartPoint = (playerReadyState[playerID] == 4)
+	local _, _, _, _, _, _, _, _, _, ai = spGetPlayerInfo(playerID)
 	if ai then
 		gl_Color(0.1, 0.1, 0.97, 1)
 	else

--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -30,6 +30,7 @@ local config = {
 local waterLevel = Spring.GetWaterPlaneLevel and Spring.GetWaterPlaneLevel() or 0
 
 local cmdShowForUnitDefID
+local isSpec = nil
 local isPregame = Spring.GetGameFrame() == 0 and not isSpec
 
 local gridVBO = nil -- the vertex buffer object, an array of vec2 coords

--- a/luaui/Widgets/gui_ground_ao_plates_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_gl4.lua
@@ -181,7 +181,7 @@ end
 
 function widget:VisibleUnitRemoved(unitID) -- remove the corresponding ground plate if it exists
 	if debugmode then
-		BAR.Debug.TraceEcho("remove", unitID, reason)
+		BAR.Debug.TraceEcho("remove", unitID)
 	end
 	if groundPlateVBO.instanceIDtoIndex[unitID] then
 		popElementInstance(groundPlateVBO, unitID)

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -674,7 +674,7 @@ local function addBarForUnit(unitID, unitDefID, barname, reason)
 
 	if unitDefID == nil or Spring.ValidUnitID(unitID) == false or Spring.GetUnitIsDead(unitID) == true then -- dead or invalid
 		if debugmode then
-			BAR.Debug.TraceEcho("Tried to add a bar to dead/invalid/nounitdef unit", unitID, unitdefID, barname)
+			BAR.Debug.TraceEcho("Tried to add a bar to dead/invalid/nounitdef unit", unitID, unitDefID, barname)
 		end
 		return nil
 	end

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -311,7 +311,7 @@ local function drawContent()
 				end
 
 				local texSize = floor(iconSize * 1.33)
-				local zoom = i == hoveredIcon and (b and 0.15 or 0.105) or 0.05
+				local zoom = i == hoveredIcon and (showStack and 0.15 or 0.105) or 0.05
 				local highlightOpacity = 0
 				if i == hoveredIcon then
 					highlightOpacity = 0.22

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -1672,7 +1672,7 @@ end
 local showToggledOff = false
 local function checkPause()
 	-- pause/unpause when the options/quitscreen interface shows
-	local _, _, isClientPaused, _ = Spring.GetGameState()
+	_, _, isClientPaused, _ = Spring.GetGameState()
 	if not isClientPaused then
 		skipUnpauseOnHide = false
 		skipUnpauseOnLobbyHide = false
@@ -1695,6 +1695,7 @@ local prevQuitscreen = false
 local pauseCheckTimer = 0
 local lastPauseCheckClock = os_clock()
 local canPauseGame = (isSinglePlayer or isReplay) and pauseGameWhenSingleplayer
+local isClientPaused = false
 local function checkQuitscreen()
 	if not canPauseGame then
 		return
@@ -12895,7 +12896,7 @@ function widget:GetConfigData()
 		currentGroupTab = currentGroupTab,
 		show = show,
 		waterDetected = waterDetected,
-		customPresets = customPresets,
+		customPresets = customPresetOptions,
 		changesRequireRestart = changesRequireRestart,
 		requireRestartDefaults = requireRestartDefaults,
 

--- a/luaui/Widgets/gui_pregameui_draft.lua
+++ b/luaui/Widgets/gui_pregameui_draft.lua
@@ -1,7 +1,5 @@
 local widget = widget ---@type Widget
 
-local isAI = false -- forward-decl: read in DrawState
-
 function widget:GetInfo()
 	return {
 		name = "Pregame UI - Draft Spawn Order",
@@ -220,6 +218,7 @@ local function DrawState(playerID, posX, posY)
 		or (playerReadyState[playerID] == 2)
 		or (playerReadyState[playerID] == -1)
 	local hasStartPoint = (playerReadyState[playerID] == 4)
+	local _, _, _, _, _, _, _, _, _, ai = Spring.GetPlayerInfo(playerID, false)
 	if ai then
 		gl_Color(0.1, 0.1, 0.97, 1)
 	else
@@ -1143,6 +1142,7 @@ function widget:Initialize()
 	end
 
 	local xn, zn, xp, zp = Spring.GetAllyTeamStartBox(myAllyTeamID)
+	local msx, msz = Game.mapSizeX, Game.mapSizeZ
 	if xn and (xn ~= 0 or zn ~= 0 or xp ~= msx or zp ~= msz) then
 		hasStartbox = true
 	end

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -295,7 +295,7 @@ local function buildUnitDefs()
 
 	local function isArmyUnit(unitDefID, unitDef)
 		local isArmyUnit = #unitDef.weapons > 0 and unitDef.speed > 0
-		return isArmyUnit and not isCommander(unitDefId, unitDef)
+		return isArmyUnit and not isCommander(unitDefID, unitDef)
 	end
 
 	local function isDefenseUnit(unitDefID, unitDef)

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -2938,7 +2938,7 @@ function widget:DrawScreen()
 						{ 0, 0, 0, 0.06 }
 					)
 					glBlending(GL.SRC_ALPHA, GL.ONE)
-					---@diagnostic disable-next-line: undefined-global
+					local mb = buttonsArea.buttons[button][9]
 					RectRound(
 						buttonsArea.buttons[button][1],
 						buttonsArea.buttons[button][2],

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -1046,7 +1046,7 @@ local function InitStartPolygons()
 	)
 	startConeVBOTable.numVertices = numConeVertices
 	if startConeVBOTable == nil then
-		goodbye("Failed to create StartConeVBO")
+		Spring.Echo("Failed to create StartConeVBO")
 		widgetHandler:RemoveWidget()
 		return
 	end

--- a/luaui/system.lua
+++ b/luaui/system.lua
@@ -39,6 +39,7 @@ if System == nil then
 		--
 		--  Custom LuaUI variables
 		--
+		---@diagnostic disable-next-line: undefined-global
 		Commands = Commands,
 		fontHandler = fontHandler,
 		LUAUI_DIRNAME = LUAUI_DIRNAME,

--- a/modules/graphics/LuaShader.lua
+++ b/modules/graphics/LuaShader.lua
@@ -1236,7 +1236,7 @@ local function isUpdateRequiredNoTable(uniform, u1, u2, u3, u4)
 
 	if u1 and cachedValues[1] ~= u1 then
 		update = true
-		cachedValues[1] = val
+		cachedValues[1] = u1
 	end
 	if u2 and cachedValues[2] ~= u2 then
 		update = true

--- a/modules/graphics/instancevboidtable.lua
+++ b/modules/graphics/instancevboidtable.lua
@@ -92,7 +92,7 @@ local function makeVAOandAttach(vertexVBO, instanceVBO, indexVBO) -- Attach a ve
 	local newVAO = nil
 	newVAO = gl.GetVAO()
 	if newVAO == nil then
-		goodbye("Failed to create newVAO")
+		Spring.Echo("Failed to create newVAO")
 	end
 	if vertexVBO == nil then -- the special case where are using 'vertices' as 'instances'
 		newVAO:AttachVertexBuffer(instanceVBO)
@@ -746,5 +746,6 @@ return {
 	dumpAndCompareInstanceData = dumpAndCompareInstanceData,
 	uploadAllElements = uploadAllElements,
 	validateInstanceVBOIDTable = validateInstanceVBOIDTable,
+	---@diagnostic disable-next-line: undefined-global
 	uploadElementRange = uploadElementRange,
 }

--- a/modules/graphics/instancevbotable.lua
+++ b/modules/graphics/instancevbotable.lua
@@ -68,7 +68,7 @@ local function makeInstanceVBOTable(layout, maxElements, myName, unitIDattribID)
 		local newVAO = nil
 		newVAO = gl.GetVAO()
 		if newVAO == nil then
-			goodbye("Failed to create newVAO")
+			Spring.Echo("Failed to create newVAO")
 		end
 		self.VAO = newVAO
 		if vertexVBO == nil then -- the special case where are using 'vertices' as 'instances'
@@ -226,7 +226,7 @@ local function makeVAOandAttach(vertexVBO, instanceVBO, indexVBO) -- Attach a ve
 	local newVAO = nil
 	newVAO = gl.GetVAO()
 	if newVAO == nil then
-		goodbye("Failed to create newVAO")
+		Spring.Echo("Failed to create newVAO")
 	end
 	if vertexVBO == nil then -- the special case where are using 'vertices' as 'instances'
 		newVAO:AttachVertexBuffer(instanceVBO)

--- a/scripts/Units/armmar_lus/weapons.lua
+++ b/scripts/Units/armmar_lus/weapons.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: undefined-global
+
 function DrawWeapon(id)
 	Turn(torso, 2, ang(0), ang(300.00))
 	Turn(luparm, 1, ang(0), ang(300.000000))

--- a/scripts/headers/common_includes_lus.lua
+++ b/scripts/headers/common_includes_lus.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: undefined-global
+
 common = {
 
 	CustomEmitter = function(pieceName, effectName)

--- a/scripts/include/walk.lua
+++ b/scripts/include/walk.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: undefined-global
+
 ------------------------------------------------------
 -- License:	Public Domain
 -- Author:	Nemo, Smoth

--- a/spec/fixtures/reentrant_include.lua
+++ b/spec/fixtures/reentrant_include.lua
@@ -1,8 +1,10 @@
 -- Includes itself once, under a different environment, and reads its own global
 -- again afterwards. A shared compiled chunk would have had its environment
 -- retargeted by the nested call, so the second read would come back "inner".
+---@diagnostic disable-next-line: undefined-global
 local before = marker
 
+---@diagnostic disable-next-line: undefined-global
 if not alreadyNested then
 	local nested = setmetatable({ marker = "inner", alreadyNested = true }, { __index = _G })
 	VFS.Include("spec/fixtures/reentrant_include.lua", nested)
@@ -10,5 +12,6 @@ end
 
 return {
 	before = before,
+	---@diagnostic disable-next-line: undefined-global
 	after = marker,
 }


### PR DESCRIPTION
> [!WARNING]
> **This is the stack tip.** Merging this PR lands the entire type-error
> cleanup — every branch below it. Do **not** merge the intermediate PRs on
> their own; that breaks the stack topology.

Part of [BAR type-error cleanup](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/7408). Final stage: deterministic transforms + env layer + LLM type-fix pass.

LLM workers apply the categorized fix recipes in [`SKILL.md`](https://github.com/beyond-all-reason/BAR-Devtools/pull/17/changes#diff-03a30b0197306b790f86b384d585b6d1aff0f23cc38a8545e73c027e3d090ddf) — each category maps an `emmylua_check` error pattern to an idempotent recipe.

### Triage run

```
baseline_errors=127
final_errors=0
chunks=5
model=gpt-5.4
timestamp=2026-08-13T02:39:19Z
```

### Branch Topology

All branches in the [BAR type-error cleanup](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/7408) stack — see [Bulk Migrations](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8410) for the migration log and how to run `just bar::migrate::stylua-cleanup`. Regenerated deterministically by [`just bar::migrate::stylua-cleanup-generate`](https://github.com/keithharvey/BAR-Devtools/pull/4). *Generated 2026-08-13 02:40:15 UTC.*

**Leaves** — each isolates one transform's diff vs `fmt`:

| Branch | Command | Diff vs parent | Units |
|--------|---------|------|-------|
| [fmt](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8395) | `stylua` | 1434 files, +311150 −196670 | ✅ pass |
| [mig-bracket](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8401) | `bar-lua-codemod bracket-to-dot` | 356 files, +8337 −8337 | ✅ pass |
| [mig-rename-aliases](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8402) | `bar-lua-codemod rename-aliases` | 179 files, +379 −379 | ✅ pass |
| [mig-detach-bar-modules](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8403) | `bar-lua-codemod detach-bar-modules` | 206 files, +3203 −3203 | ✅ pass |
| [mig-integration-tests](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8404) | `<hand curated>` | 61 files, +1439 −1548 | ✅ pass |
| [mig-busted-types](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8405) | `<hand curated>` | 52 files, +2804 −1467 | ✅ pass |

**Rollups** — composite branches stacking the leaves and (for `fmt-llm`) the env + LLM layers:

| Branch | Diff vs `master` | Diff vs parent | Units |
|--------|------|------|-------|
| [mig](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8396) | 1454 files, +315808 −199943 | 541 files, +13441 −12056 | ✅ pass |
| [fmt-llm-source](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8397) | 1460 files, +316186 −200090 | 56 files, +420 −189 | ✅ pass |
| 👉 **[fmt-llm](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8398)** — you are here | 1462 files, +316246 −200110 | 34 files, +83 −43 | ✅ pass |
