### PR TITLE
sharing 3/7: Policies (context → policy → policy_result → action)

### DIFF
--- a/common/luaUtilities/sharing/context_factory.lua
+++ b/common/luaUtilities/sharing/context_factory.lua
@@ -1,0 +1,174 @@
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local TeamResourceData = VFS.Include("common/luaUtilities/sharing/team_resource_data.lua")
+
+---@alias PolicyContextEnricher fun(ctx: PolicyContext, springRepo: EngineSynced, senderTeamID: integer, receiverTeamID: integer)
+
+---@class ContextFactory
+---@field create fun(springRepo: EngineSynced): ContextFactory
+---@field registerPolicyContextEnricher fun(fn: PolicyContextEnricher)
+---@field policy fun(senderTeamID: integer, receiverTeamID: integer): PolicyContext
+---@field action fun(senderTeamId: integer, receiverTeamId: integer, policyType: string): PolicyActionContext
+---@field resourceTransfer fun(senderTeamId: integer, receiverTeamId: integer, resourceType: ResourceName, desiredAmount: number, policyResult: ResourcePolicyResult): ResourceTransferContext
+---@field unitTransfer fun(senderTeamId: integer, receiverTeamId: integer, unitIds: integer[], given: boolean, policyResult: UnitPolicyResult, unitValidationResult: UnitValidationResult): UnitTransferContext
+local ContextFactory = {}
+
+-- shared via GG because VFS.Include re-runs per call; a module-local list would split registrar and consumer into separate registries
+GG = GG or {}
+GG.policyContextEnrichers = GG.policyContextEnrichers or {}
+---@type PolicyContextEnricher[]
+local enrichers = GG.policyContextEnrichers
+
+---@param fn PolicyContextEnricher
+function ContextFactory.registerPolicyContextEnricher(fn)
+	enrichers[#enrichers + 1] = fn
+end
+
+function ContextFactory.getEnrichers()
+	local copy = {}
+	for i = 1, #enrichers do
+		copy[i] = enrichers[i]
+	end
+	return copy
+end
+
+-- mutate in place so the shared reference (and create()'s closures) stay valid
+function ContextFactory.setEnrichers(list)
+	for i = #enrichers, 1, -1 do
+		enrichers[i] = nil
+	end
+	if list then
+		for i = 1, #list do
+			enrichers[i] = list[i]
+		end
+	end
+end
+
+---@param springRepo EngineSynced
+---@return table Context factory with closures
+function ContextFactory.create(springRepo)
+	-- per-snapshot resource memo so a refresh pass reads each team once, not once per pair; caller clears it at pass start
+	local resourceCache = {}
+
+	local function getResource(teamID, resourceType)
+		local perTeam = resourceCache[teamID]
+		if not perTeam then
+			perTeam = {}
+			resourceCache[teamID] = perTeam
+		end
+		local data = perTeam[resourceType]
+		if not data then
+			data = TeamResourceData.Get(springRepo, teamID, resourceType)
+			perTeam[resourceType] = data
+		end
+		return data
+	end
+
+	local function clearResourceCache()
+		resourceCache = {}
+	end
+
+	---@param senderTeamID integer
+	---@param receiverTeamID integer
+	---@param extensions? table
+	---@return PolicyContext
+	local function buildContext(senderTeamID, receiverTeamID, extensions)
+		---@type TeamResources
+		local senderResources = {
+			metal = getResource(senderTeamID, TransferEnums.ResourceType.METAL),
+			energy = getResource(senderTeamID, TransferEnums.ResourceType.ENERGY),
+		}
+
+		---@type TeamResources
+		local receiverResources = {
+			metal = getResource(receiverTeamID, TransferEnums.ResourceType.METAL),
+			energy = getResource(receiverTeamID, TransferEnums.ResourceType.ENERGY),
+		}
+
+		---@type PolicyContext
+		local ctx = {
+			senderTeamId = senderTeamID,
+			receiverTeamId = receiverTeamID,
+			sender = senderResources,
+			receiver = receiverResources,
+			springRepo = springRepo,
+			areAlliedTeams = springRepo.AreTeamsAllied(senderTeamID, receiverTeamID) == true,
+			isCheatingEnabled = springRepo.IsCheatingEnabled(),
+			ext = {},
+		}
+
+		for _, enricher in ipairs(enrichers) do
+			enricher(ctx, springRepo, senderTeamID, receiverTeamID)
+		end
+
+		if extensions then
+			for k, v in pairs(extensions) do
+				ctx[k] = v
+			end
+		end
+
+		return ctx
+	end
+
+	---@param senderTeamID integer
+	---@param receiverTeamID integer
+	---@param commandType? string
+	---@return PolicyContext
+	local function policy(senderTeamID, receiverTeamID, commandType)
+		return buildContext(senderTeamID, receiverTeamID, {
+			commandType = commandType,
+		})
+	end
+
+	---@param policyType string
+	---@param senderTeamId integer
+	---@param receiverTeamId integer
+	---@return PolicyActionContext
+	local function policyAction(senderTeamId, receiverTeamId, policyType)
+		return buildContext(senderTeamId, receiverTeamId, {
+			policyType = policyType,
+		}) --[[@as PolicyActionContext]]
+	end
+
+	---@param senderTeamId integer
+	---@param receiverTeamId integer
+	---@param resourceType ResourceName
+	---@param desiredAmount number
+	---@param policyResult ResourcePolicyResult
+	---@return ResourceTransferContext
+	local function resourceTransfer(senderTeamId, receiverTeamId, resourceType, desiredAmount, policyResult)
+		local policyType = resourceType == TransferEnums.ResourceType.METAL and TransferEnums.PolicyType.MetalTransfer or TransferEnums.PolicyType.EnergyTransfer
+		return buildContext(senderTeamId, receiverTeamId, {
+			policyType = policyType,
+			resourceType = resourceType,
+			desiredAmount = desiredAmount,
+			policyResult = policyResult,
+		}) --[[@as ResourceTransferContext]]
+	end
+
+	---@param senderTeamId integer
+	---@param receiverTeamId integer
+	---@param unitIds integer[]
+	---@param given boolean?
+	---@param policyResult UnitPolicyResult
+	---@param validationResult UnitValidationResult
+	---@return UnitTransferContext
+	local function unitTransfer(senderTeamId, receiverTeamId, unitIds, given, policyResult, validationResult)
+		return buildContext(senderTeamId, receiverTeamId, {
+			policyType = TransferEnums.PolicyType.UnitTransfer,
+			unitIds = unitIds,
+			given = given,
+			policyResult = policyResult,
+			validationResult = validationResult,
+		}) --[[@as UnitTransferContext]]
+	end
+
+	return {
+		policy = policy,
+		action = policyAction,
+		resourceTransfer = resourceTransfer,
+		unitTransfer = unitTransfer,
+		clearResourceCache = clearResourceCache,
+	}
+end
+
+return ContextFactory

--- a/common/luaUtilities/sharing/resource_transfer_shared.lua
+++ b/common/luaUtilities/sharing/resource_transfer_shared.lua
@@ -1,0 +1,151 @@
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local PolicyShared = VFS.Include("common/luaUtilities/sharing/serialization.lua")
+local Comms = VFS.Include("common/luaUtilities/sharing/resource_transfer_comms.lua")
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+
+local Shared = Comms
+
+local FieldTypes = PolicyShared.FieldTypes
+
+-- Schema for the GUI's flattened per-player policy packing (gui_advplayerlist/policy.lua).
+Shared.ResourcePolicyFields = {
+	resourceType = FieldTypes.string,
+	canShare = FieldTypes.boolean,
+	amountSendable = FieldTypes.number,
+	amountReceivable = FieldTypes.number,
+	taxedPortion = FieldTypes.number,
+	taxRate = FieldTypes.number,
+}
+
+-- one factor record per (team, resource), O(teams); GetCachedPolicyResult rebuilds any pair on read via min(taxedSendable(sender), capacity(receiver))
+Shared.ResourceFactorFields = {
+	taxedSendable = FieldTypes.number,
+	taxRate = FieldTypes.number,
+	capacity = FieldTypes.number,
+	isNonPlayer = FieldTypes.boolean,
+	active = FieldTypes.boolean,
+}
+
+---Rules-param key for a team's resource factor record (owner team = the rules-param team).
+---@param resourceType ResourceName
+---@return string
+function Shared.MakeFactorKey(resourceType)
+	local policyType = resourceType == TransferEnums.ResourceType.METAL and TransferEnums.PolicyType.MetalTransfer or TransferEnums.PolicyType.EnergyTransfer
+	return policyType .. "_factor"
+end
+
+---@param factor table
+---@return string
+function Shared.SerializeResourceFactor(factor)
+	return PolicyShared.Serialize(Shared.ResourceFactorFields, factor)
+end
+
+---@param serialized string
+---@return table
+function Shared.DeserializeResourceFactor(serialized)
+	return PolicyShared.Deserialize(Shared.ResourceFactorFields, serialized)
+end
+
+---combine sender + receiver factors into a ResourcePolicyResult (same math as CalcResourcePolicy)
+---@param taxedSendable number sender factor
+---@param taxRate number sender factor
+---@param capacity number receiver factor
+---@param senderTeamId integer
+---@param receiverTeamId integer
+---@param resourceType ResourceName
+---@param result table? optional reusable result table
+---@return ResourcePolicyResult
+function Shared.CombineResourcePolicy(taxedSendable, taxRate, capacity, senderTeamId, receiverTeamId, resourceType, result)
+	result = result or {}
+	local taxedPortion = math.min(taxedSendable, capacity)
+	local amountSendable = taxedPortion
+	result.senderTeamId = senderTeamId
+	result.receiverTeamId = receiverTeamId
+	result.canShare = capacity > 0 and amountSendable > 0
+	result.amountSendable = amountSendable
+	result.amountReceivable = capacity
+	result.taxedPortion = taxedPortion
+	result.taxRate = taxRate
+	result.resourceType = resourceType
+	return result
+end
+
+---@param senderTeamId integer
+---@param receiverTeamId integer
+---@param resourceType ResourceName
+---@param springApi EngineSynced?
+---@return ResourcePolicyResult
+function Shared.CreateDenyPolicy(senderTeamId, receiverTeamId, resourceType, springApi)
+	---@type ResourcePolicyResult
+	local result = {
+		senderTeamId = senderTeamId,
+		receiverTeamId = receiverTeamId,
+		canShare = false,
+		amountSendable = 0,
+		amountReceivable = 0,
+		taxedPortion = 0,
+		taxRate = 0,
+		resourceType = resourceType,
+	}
+	return result
+end
+
+---@param policyResult ResourcePolicyResult
+---@param desired number
+---@return number received, number sent
+function Shared.CalculateSenderTaxedAmount(policyResult, desired)
+	if desired <= 0 then
+		return 0, 0
+	end
+	local r = policyResult.taxRate
+	if r >= 1.0 then
+		-- 100% tax means the resource cannot be sent (infinite cost)
+		return 0, 0
+	end
+	local sent = desired / (1 - r)
+	return desired, sent
+end
+
+---@param spring EngineSynced
+---@param teamId integer
+---@param resourceType ResourceName
+---@return table|nil factor record, or nil if not cached
+local function readFactor(spring, teamId, resourceType)
+	local serialized = spring.GetTeamRulesParam(teamId, Shared.MakeFactorKey(resourceType))
+	if serialized == nil then
+		return nil
+	end
+	return Shared.DeserializeResourceFactor(serialized)
+end
+
+---rebuild (sender,receiver) policy from cached factors + live gates (gate order mirrors TryDenyPolicy); absent factors deny
+---@param senderId integer
+---@param receiverId integer
+---@param resourceType ResourceName
+---@param springApi EngineSynced?
+---@return ResourcePolicyResult
+function Shared.GetCachedPolicyResult(senderId, receiverId, resourceType, springApi)
+	local spring = springApi or (Spring --[[@as EngineSynced]])
+	if not SharedConfig.isResourceSharingEnabled(spring) then
+		return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+	end
+
+	local senderFactor = readFactor(spring, senderId, resourceType)
+	local receiverFactor = readFactor(spring, receiverId, resourceType)
+	if not senderFactor or not receiverFactor then
+		return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+	end
+
+	if not spring.IsCheatingEnabled() then
+		if not spring.AreTeamsAllied(senderId, receiverId) and not senderFactor.isNonPlayer then
+			return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+		end
+		if not receiverFactor.active then
+			return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+		end
+	end
+
+	return Shared.CombineResourcePolicy(senderFactor.taxedSendable, senderFactor.taxRate, receiverFactor.capacity, senderId, receiverId, resourceType)
+end
+
+return Shared

--- a/common/luaUtilities/sharing/resource_transfer_synced.lua
+++ b/common/luaUtilities/sharing/resource_transfer_synced.lua
@@ -1,0 +1,203 @@
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local Comms = VFS.Include("common/luaUtilities/sharing/resource_transfer_comms.lua")
+local Shared = VFS.Include("common/luaUtilities/sharing/resource_transfer_shared.lua")
+local WaterfillSolver = VFS.Include("common/luaUtilities/economy/economy_waterfill_solver.lua")
+local PolicyEvents = VFS.Include("common/luaUtilities/sharing/policy_events.lua")
+
+local ResourceType = TransferEnums.ResourceType
+local METAL = ResourceType.METAL
+local ENERGY = ResourceType.ENERGY
+
+local Gadgets = {
+	SendTransferChatMessages = Comms.SendTransferChatMessages,
+}
+
+local function isNonPlayerTeam(springRepo, teamId)
+	if teamId == springRepo.GetGaiaTeamID() then
+		return true
+	end
+	local _name, _active, _spec, isAiTeam = springRepo.GetTeamInfo(teamId, false)
+	if isAiTeam then
+		return true
+	end
+	-- Spring.GetTeamLuaAI returns "" (not nil) for teams without a LuaAI, so guard both.
+	local luaAI = springRepo.GetTeamLuaAI and springRepo.GetTeamLuaAI(teamId)
+	return luaAI ~= nil and luaAI ~= ""
+end
+
+-- Encapsulate legacy AllowResourceTransfer gate rules
+---@param ctx PolicyContext
+---@param resourceType ResourceName
+---@return ResourcePolicyResult|nil
+local function TryDenyPolicy(ctx, resourceType)
+	if not SharedConfig.isResourceSharingEnabled(ctx.springRepo) then
+		return Shared.CreateDenyPolicy(ctx.senderTeamId, ctx.receiverTeamId, resourceType, ctx.springRepo)
+	end
+
+	if ctx.isCheatingEnabled then
+		return nil
+	end
+
+	if not ctx.areAlliedTeams and not isNonPlayerTeam(ctx.springRepo, ctx.senderTeamId) then
+		return Shared.CreateDenyPolicy(ctx.senderTeamId, ctx.receiverTeamId, resourceType, ctx.springRepo)
+	end
+
+	local numActivePlayers = ctx.springRepo.GetTeamRulesParam(ctx.receiverTeamId, "numActivePlayers")
+	if numActivePlayers ~= nil and tonumber(numActivePlayers) == 0 then
+		return Shared.CreateDenyPolicy(ctx.senderTeamId, ctx.receiverTeamId, resourceType, ctx.springRepo)
+	end
+	return nil
+end
+
+--- Execute a resource transfer using received-unit desiredAmount capped by policy limits
+---@param ctx ResourceTransferContext
+---@return ResourceTransferResult
+function Gadgets.ResourceTransfer(ctx)
+	local policyResult = ctx.policyResult
+	local desiredAmount = ctx.desiredAmount
+	if (not policyResult or not policyResult.canShare) or (not desiredAmount or desiredAmount <= 0) then
+		---@type ResourceTransferResult
+		return {
+			success = false,
+			sent = 0,
+			received = 0,
+			senderTeamId = ctx.senderTeamId,
+			receiverTeamId = ctx.receiverTeamId,
+			policyResult = policyResult,
+		}
+	end
+
+	local received, sent = Shared.CalculateSenderTaxedAmount(policyResult, desiredAmount)
+
+	local springRepo = ctx.springRepo
+	local resourceType = policyResult.resourceType
+	-- deduct via SetTeamResource; AddTeamResource clamps its amount to >= 0
+	local senderCurrent = springRepo.GetTeamResources(ctx.senderTeamId, resourceType) or 0
+	springRepo.SetTeamResource(ctx.senderTeamId, resourceType, math.max(0, senderCurrent - sent))
+	springRepo.AddTeamResource(ctx.receiverTeamId, resourceType, received)
+
+	---@type ResourceTransferResult
+	local result = {
+		success = true,
+		sent = sent,
+		received = received,
+		senderTeamId = ctx.senderTeamId,
+		receiverTeamId = ctx.receiverTeamId,
+		policyResult = policyResult,
+	}
+
+	return result
+end
+
+local policyResultPool = {} ---@type table<ResourceName, ResourcePolicyResult>
+
+---resolve a context's effective resource tax rate in [0,1] (sender tech tax, else base)
+---@param ctx PolicyContext
+---@return number
+local function resolveEffectiveRate(ctx)
+	local taxRate = (ctx.taxRate or SharedConfig.getTaxConfig(ctx.springRepo)) --[[@as number]]
+	return math.min(taxRate, 1)
+end
+
+---@param ctx PolicyContext
+---@param resourceType ResourceName
+---@return ResourcePolicyResult
+function Gadgets.CalcResourcePolicy(ctx, resourceType)
+	local rejected = TryDenyPolicy(ctx, resourceType)
+	if rejected then
+		return rejected
+	end
+
+	local effectiveRate = resolveEffectiveRate(ctx)
+
+	local senderData, receiverData
+	if resourceType == METAL then
+		senderData = ctx.sender.metal
+		receiverData = ctx.receiver.metal
+	else
+		senderData = ctx.sender.energy
+		receiverData = ctx.receiver.energy
+	end
+
+	local taxedSendable = math.max(0, senderData.current) * (1 - effectiveRate)
+	local capacity = receiverData.storage - receiverData.current
+
+	local result = policyResultPool[resourceType]
+	if not result then
+		result = {} --[[@as ResourcePolicyResult]] -- filled by CombineResourcePolicy below
+		policyResultPool[resourceType] = result
+	end
+
+	Shared.CombineResourcePolicy(taxedSendable, effectiveRate, capacity, ctx.senderTeamId, ctx.receiverTeamId, resourceType, result)
+	result.techBlocking = ctx.ext and ctx.ext.techBlocking or nil
+
+	return result
+end
+
+---@param springRepo EngineSynced
+---@param teamId integer
+---@return boolean
+local function teamActive(springRepo, teamId)
+	local n = springRepo.GetTeamRulesParam(teamId, "numActivePlayers")
+	if n == nil then
+		return true
+	end
+	return tonumber(n) ~= 0
+end
+
+---Compute and cache one team's resource factor record for a single resource.
+---@param springRepo EngineSynced
+---@param teamId integer
+---@param resourceType ResourceName
+---@param ctx PolicyContext self-context (sender==receiver==teamId) so the enricher resolves the team's tax
+function Gadgets.CacheTeamFactor(springRepo, teamId, resourceType, ctx)
+	local data = (resourceType == METAL) and ctx.sender.metal or ctx.sender.energy
+	local effectiveRate = resolveEffectiveRate(ctx)
+	local isNonPlayer = isNonPlayerTeam(springRepo, teamId)
+	local active = teamActive(springRepo, teamId)
+	local factor = {
+		taxedSendable = math.max(0, data.current) * (1 - effectiveRate),
+		taxRate = effectiveRate,
+		capacity = data.storage - data.current,
+		isNonPlayer = isNonPlayer,
+		active = active,
+	}
+	springRepo.SetTeamRulesParam(teamId, Shared.MakeFactorKey(resourceType), Shared.SerializeResourceFactor(factor))
+	-- Policy fields only; live amounts (taxedSendable/capacity) would fire every economy tick.
+	local signature = string.format("%s|%s|%s", tostring(effectiveRate), tostring(active), tostring(isNonPlayer))
+	local category = (resourceType == METAL) and TransferEnums.PolicyType.MetalTransfer or TransferEnums.PolicyType.EnergyTransfer
+	PolicyEvents.NotifyIfChanged(teamId, category, signature)
+end
+
+---refresh the per-team resource factor cache (O(teams), factors are independent); pairs reconstructed on read
+---@param springRepo EngineSynced
+---@param frame number
+---@param lastUpdate number
+---@param updateRate number
+---@param contextFactory table
+---@return number lastUpdate New last update frame
+function Gadgets.UpdatePolicyCache(springRepo, frame, lastUpdate, updateRate, contextFactory)
+	if frame < lastUpdate + updateRate then
+		return lastUpdate
+	end
+
+	contextFactory.clearResourceCache()
+
+	local allTeams = springRepo.GetTeamList()
+	for _, teamId in ipairs(allTeams) do
+		local ctx = contextFactory.policy(teamId, teamId)
+		Gadgets.CacheTeamFactor(springRepo, teamId, METAL, ctx)
+		Gadgets.CacheTeamFactor(springRepo, teamId, ENERGY, ctx)
+	end
+
+	return frame
+end
+
+---@param springRepo EngineSynced
+---@param teamsList TeamResourceData[]
+function Gadgets.WaterfillSolve(springRepo, teamsList)
+	return WaterfillSolver.Solve(springRepo, teamsList)
+end
+
+return Gadgets

--- a/common/luaUtilities/sharing/unit_transfer_shared.lua
+++ b/common/luaUtilities/sharing/unit_transfer_shared.lua
@@ -1,0 +1,343 @@
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local PolicyShared = VFS.Include("common/luaUtilities/sharing/serialization.lua")
+local UnitSharingCategories = VFS.Include("common/luaUtilities/sharing/unit_sharing_categories.lua")
+local Comms = VFS.Include("common/luaUtilities/sharing/unit_transfer_comms.lua")
+
+local Shared = Comms
+
+local FieldTypes = PolicyShared.FieldTypes
+Shared.UnitPolicyFields = {
+	canShare = FieldTypes.boolean,
+	sharingModes = FieldTypes.string,
+	-- carried to the widget so the share tooltip can surface the share-time effects
+	buildDelaySeconds = FieldTypes.number,
+	stunSeconds = FieldTypes.number,
+	stunCategory = FieldTypes.string,
+}
+
+-- cached per-team factors; GetCachedPolicyResult rebuilds any pair on read (alliance + active stay live)
+Shared.UnitFactorFields = {
+	sharingModes = FieldTypes.string,
+	active = FieldTypes.boolean,
+}
+
+---Rules-param key for a team's unit factor record (owner team = the rules-param team).
+---@return string
+function Shared.MakeFactorKey()
+	return TransferEnums.PolicyType.UnitTransfer .. "_factor"
+end
+
+---@param factor table {sharingModes: string[], active: boolean}
+---@return string
+function Shared.SerializeUnitFactor(factor)
+	return PolicyShared.Serialize(Shared.UnitFactorFields, {
+		sharingModes = table.concat(factor.sharingModes or { ModeEnums.UnitFilterCategory.None }, ","),
+		active = factor.active,
+	})
+end
+
+---@param serialized string
+---@return table {sharingModes: string[], active: boolean}
+function Shared.DeserializeUnitFactor(serialized)
+	local raw = PolicyShared.Deserialize(Shared.UnitFactorFields, serialized)
+	local modes = {}
+	for m in (raw.sharingModes or "none"):gmatch("[^,]+") do
+		modes[#modes + 1] = m
+	end
+	return { sharingModes = modes, active = raw.active }
+end
+
+---@param unitDefID integer
+---@param stunCategory string?
+---@param defs table
+---@return boolean
+local function wouldBeStunned(unitDefID, stunCategory, defs)
+	if not stunCategory then
+		return false
+	end
+	return Shared.IsShareableDef(unitDefID, stunCategory, defs)
+end
+
+---clear an array in place so a lifted result table can be reused without churning garbage
+---@param arr table
+local function resetArray(arr)
+	for i = #arr, 1, -1 do
+		arr[i] = nil
+	end
+end
+
+---Validate a list of unitIds under current mode
+---@param policyResult UnitPolicyResult
+---@param unitIds integer[]
+---@param springApi EngineSynced?
+---@param unitDefs table?
+---@param out UnitValidationResult? optional pre-allocated result to fill in place (table lifting)
+---@return UnitValidationResult
+function Shared.ValidateUnits(policyResult, unitIds, springApi, unitDefs, out)
+	local spring = springApi or Spring
+	local defs = unitDefs or UnitDefs or (spring.GetUnitDefs and spring.GetUnitDefs()) or {}
+
+	-- reuse caller's table when supplied; scalars reassigned and arrays cleared so stale entries never leak
+	out = out or ({} --[[@as UnitValidationResult]]) -- every field is (re)assigned below
+	out.status = TransferEnums.UnitValidationOutcome.Failure
+	out.validUnitCount = 0
+	out.invalidUnitCount = 0
+	out.buildDelayedUnitCount = 0 -- valid units that will receive the constructor build delay
+	out.stunnedUnitCount = 0 -- valid units that will be stunned (stun category)
+	out.validUnitNames = out.validUnitNames or {}
+	out.validUnitIds = out.validUnitIds or {}
+	out.invalidUnitNames = out.invalidUnitNames or {}
+	out.invalidUnitIds = out.invalidUnitIds or {}
+	resetArray(out.validUnitNames)
+	resetArray(out.validUnitIds)
+	resetArray(out.invalidUnitNames)
+	resetArray(out.invalidUnitIds)
+
+	if (not policyResult.canShare) or (not unitIds or #unitIds == 0) then
+		return out
+	end
+
+	local modes = policyResult.sharingModes or { "none" }
+	local stunSeconds = tonumber(policyResult.stunSeconds) or 0
+	local stunCategory = policyResult.stunCategory
+
+	-- dedupe sets stay call-local; a shared one would leak keys across rotating `out` tables
+	local validUnitNamesSet = {} ---@type table<string, boolean>
+	local invalidUnitNamesSet = {} ---@type table<string, boolean>
+	for _, unitId in ipairs(unitIds) do
+		local unitDefID = spring.GetUnitDefID(unitId)
+		if not unitDefID then
+			-- LOG.ERROR must stay numeric: the engine rejects numeric *strings* as log levels
+			spring.Log("unit_transfer_shared", LOG.ERROR, string.format("ValidateUnits: unitId %d not found", unitId))
+			out.invalidUnitCount = out.invalidUnitCount + 1
+			table.insert(out.invalidUnitIds, unitId)
+			if not invalidUnitNamesSet["Unknown Unit"] then
+				invalidUnitNamesSet["Unknown Unit"] = true
+				table.insert(out.invalidUnitNames, "Unknown Unit")
+			end
+		else
+			local ok = Shared.IsShareableDef(unitDefID, modes, defs)
+			local def = defs[unitDefID] or defs[tostring(unitDefID)]
+			local unitName = (def and (def.translatedHumanName or def.name)) or tostring(unitDefID)
+
+			-- Block nanoframes for units that would be stunned (prevents tax bypass)
+			if ok and stunSeconds > 0 and wouldBeStunned(unitDefID, stunCategory, defs) then
+				local beingBuilt, buildProgress = spring.GetUnitIsBeingBuilt(unitId)
+				if beingBuilt and buildProgress > 0 then
+					ok = false
+				end
+			end
+
+			if ok then
+				out.validUnitCount = out.validUnitCount + 1
+				table.insert(out.validUnitIds, unitId)
+				if UnitSharingCategories.isMobileBuilderDef(def) then
+					out.buildDelayedUnitCount = out.buildDelayedUnitCount + 1
+				end
+				if wouldBeStunned(unitDefID, stunCategory, defs) then
+					out.stunnedUnitCount = out.stunnedUnitCount + 1
+				end
+				if not validUnitNamesSet[unitName] then
+					validUnitNamesSet[unitName] = true
+					table.insert(out.validUnitNames, unitName)
+				end
+			else
+				out.invalidUnitCount = out.invalidUnitCount + 1
+				table.insert(out.invalidUnitIds, unitId)
+				if not invalidUnitNamesSet[unitName] then
+					invalidUnitNamesSet[unitName] = true
+					table.insert(out.invalidUnitNames, unitName)
+				end
+			end
+		end
+	end
+
+	if out.validUnitCount > 0 and out.invalidUnitCount == 0 then
+		out.status = TransferEnums.UnitValidationOutcome.Success
+	elseif out.validUnitCount > 0 and out.invalidUnitCount > 0 then
+		out.status = TransferEnums.UnitValidationOutcome.PartialSuccess
+	else
+		out.status = TransferEnums.UnitValidationOutcome.Failure
+	end
+
+	return out
+end
+
+---rebuild (sender,receiver) unit policy from cached factors + live gates (mirrors Synced.GetPolicy); missing factors fall back to global unit_sharing_mode
+---@param senderTeamId integer
+---@param receiverTeamId integer
+---@param springApi EngineSynced?
+---@return UnitPolicyResult
+function Shared.GetCachedPolicyResult(senderTeamId, receiverTeamId, springApi)
+	local spring = springApi or Spring
+	local modOptions = spring.GetModOptions()
+	local stunSeconds = tonumber(modOptions[ModeEnums.ModOptions.UnitShareStunSeconds]) or 0
+	local stunCategory = modOptions[ModeEnums.ModOptions.UnitStunCategory] or ModeEnums.UnitFilterCategory.Resource
+	local buildDelaySeconds = tonumber(modOptions[ModeEnums.ModOptions.ConstructorBuildDelay]) or 0
+
+	local areAllied = (spring.AreTeamsAllied and spring.AreTeamsAllied(senderTeamId, receiverTeamId)) == true
+
+	local factorKey = Shared.MakeFactorKey()
+	local senderSerialized = spring.GetTeamRulesParam(senderTeamId, factorKey)
+	local receiverSerialized = spring.GetTeamRulesParam(receiverTeamId, factorKey)
+
+	if senderSerialized == nil or receiverSerialized == nil then
+		-- Pre-cache fallback: global mode + alliance only (matches legacy behaviour).
+		local category = modOptions.unit_sharing_mode or ModeEnums.UnitFilterCategory.None
+		---@type UnitPolicyResult
+		return {
+			senderTeamId = senderTeamId,
+			receiverTeamId = receiverTeamId,
+			canShare = areAllied and category ~= ModeEnums.UnitFilterCategory.None,
+			sharingModes = { category },
+			stunSeconds = stunSeconds,
+			stunCategory = stunCategory,
+			buildDelaySeconds = buildDelaySeconds,
+		}
+	end
+
+	local senderFactor = Shared.DeserializeUnitFactor(senderSerialized)
+	local receiverFactor = Shared.DeserializeUnitFactor(receiverSerialized)
+	local modes = senderFactor.sharingModes
+	local modeNotNone = not (#modes == 1 and modes[1] == ModeEnums.UnitFilterCategory.None)
+
+	local canShare = areAllied and modeNotNone
+	if canShare and not (spring.IsCheatingEnabled and spring.IsCheatingEnabled()) then
+		if not receiverFactor.active then
+			canShare = false
+		end
+	end
+
+	---@type UnitPolicyResult
+	return {
+		senderTeamId = senderTeamId,
+		receiverTeamId = receiverTeamId,
+		canShare = canShare,
+		sharingModes = modes,
+		stunSeconds = stunSeconds,
+		stunCategory = stunCategory,
+		buildDelaySeconds = buildDelaySeconds,
+	}
+end
+
+local allUnitTypes = {
+	TransferEnums.UnitType.Combat,
+	TransferEnums.UnitType.Commander,
+	TransferEnums.UnitType.Constructor,
+	TransferEnums.UnitType.Factory,
+	TransferEnums.UnitType.Resource,
+	TransferEnums.UnitType.Utility,
+}
+
+function Shared.GetModeUnitTypes(category)
+	if category == ModeEnums.UnitFilterCategory.None then
+		return {}
+	end
+
+	if category == ModeEnums.UnitFilterCategory.All then
+		return allUnitTypes
+	end
+
+	if category == ModeEnums.UnitFilterCategory.Combat then
+		return { TransferEnums.UnitType.Combat, TransferEnums.UnitType.Commander }
+	end
+
+	if category == ModeEnums.UnitFilterCategory.Buildings then
+		return { TransferEnums.UnitType.Factory, TransferEnums.UnitType.Resource, TransferEnums.UnitType.Utility }
+	end
+
+	if category == ModeEnums.UnitFilterCategory.Constructors then
+		return { TransferEnums.UnitType.Constructor }
+	end
+
+	if category == ModeEnums.UnitFilterCategory.Resource then
+		return { TransferEnums.UnitType.Resource }
+	end
+
+	if category == ModeEnums.UnitFilterCategory.NonCombat then
+		return {
+			TransferEnums.UnitType.Constructor,
+			TransferEnums.UnitType.Factory,
+			TransferEnums.UnitType.Resource,
+			TransferEnums.UnitType.Utility,
+		}
+	end
+
+	return {}
+end
+
+local function UnitTypeMatchesCategory(unitDef, category)
+	local unitType = UnitSharingCategories.classifyUnitDef(unitDef)
+	local categoryUnitTypes = Shared.GetModeUnitTypes(category)
+	return table.contains(categoryUnitTypes, unitType)
+end
+
+---@param unitDef table
+---@param category string
+---@return boolean
+local function EvaluateUnitForSharing(unitDef, category)
+	if not unitDef then
+		return false
+	end
+
+	if category == ModeEnums.UnitFilterCategory.None then
+		return false
+	end
+
+	if category == ModeEnums.UnitFilterCategory.All then
+		return true
+	end
+
+	return UnitTypeMatchesCategory(unitDef, category)
+end
+
+local allowedByCategory = setmetatable({}, { __mode = "k" })
+
+local function BuildAllowedCacheForCategory(category, unitDefs)
+	local defs = unitDefs or UnitDefs
+	if not defs then
+		return nil
+	end
+	local cacheByDefs = allowedByCategory[defs]
+	if not cacheByDefs then
+		cacheByDefs = {}
+		allowedByCategory[defs] = cacheByDefs
+	end
+	if cacheByDefs[category] then
+		return cacheByDefs[category]
+	end
+	local cache = {}
+	for unitDefID, unitDef in pairs(defs) do
+		if EvaluateUnitForSharing(unitDef, category) then
+			cache[unitDefID] = true
+		end
+	end
+	cacheByDefs[category] = cache
+	return cache
+end
+
+---@param unitDefId number
+---@param categories string|string[]
+---@param unitDefs table?
+---@return boolean
+function Shared.IsShareableDef(unitDefId, categories, unitDefs)
+	if not unitDefId or not categories then
+		return false
+	end
+	if type(categories) == "string" then
+		categories = { categories }
+	end
+	for _, category in ipairs(categories) do
+		if category == ModeEnums.UnitFilterCategory.All then
+			return true
+		end
+		local cache = BuildAllowedCacheForCategory(category, unitDefs)
+		if cache and cache[unitDefId] then
+			return true
+		end
+	end
+	return false
+end
+
+return Shared

--- a/common/luaUtilities/sharing/unit_transfer_synced.lua
+++ b/common/luaUtilities/sharing/unit_transfer_synced.lua
@@ -1,0 +1,98 @@
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local Shared = VFS.Include("common/luaUtilities/sharing/unit_transfer_shared.lua")
+local PolicyEvents = VFS.Include("common/luaUtilities/sharing/policy_events.lua")
+
+local Synced = {
+	ValidateUnits = Shared.ValidateUnits,
+	GetModeUnitTypes = Shared.GetModeUnitTypes,
+}
+
+---Build per-pair policy (expose) from context
+---@param ctx PolicyContext
+---@return UnitPolicyResult
+function Synced.GetPolicy(ctx)
+	local modOptions = ctx.springRepo.GetModOptions()
+	local modes = ctx.unitSharingModes or { modOptions.unit_sharing_mode or ModeEnums.UnitFilterCategory.None }
+	local canShare = ctx.areAlliedTeams and not (#modes == 1 and modes[1] == ModeEnums.UnitFilterCategory.None)
+	if canShare and not ctx.isCheatingEnabled then
+		local numActivePlayers = ctx.springRepo.GetTeamRulesParam(ctx.receiverTeamId, "numActivePlayers")
+		if numActivePlayers ~= nil and tonumber(numActivePlayers) == 0 then
+			canShare = false
+		end
+	end
+	local stunSeconds = tonumber(modOptions[ModeEnums.ModOptions.UnitShareStunSeconds]) or 0
+	local stunCategory = modOptions[ModeEnums.ModOptions.UnitStunCategory] or ModeEnums.UnitFilterCategory.Resource
+	local buildDelaySeconds = tonumber(modOptions[ModeEnums.ModOptions.ConstructorBuildDelay]) or 0
+	return {
+		canShare = canShare,
+		senderTeamId = ctx.senderTeamId,
+		receiverTeamId = ctx.receiverTeamId,
+		sharingModes = modes,
+		stunSeconds = stunSeconds,
+		stunCategory = stunCategory,
+		buildDelaySeconds = buildDelaySeconds,
+		techBlocking = ctx.ext and ctx.ext.techBlocking or nil,
+	}
+end
+
+---Execute unit transfer with pre-validated units
+---@param ctx UnitTransferContext
+---@return UnitTransferResult
+function Synced.UnitTransfer(ctx)
+	local policyResult = ctx.policyResult
+
+	if not policyResult.canShare then
+		---@type UnitTransferResult
+		return {
+			success = false,
+			outcome = TransferEnums.UnitValidationOutcome.Failure,
+			senderTeamId = ctx.senderTeamId,
+			receiverTeamId = ctx.receiverTeamId,
+			validationResult = ctx.validationResult,
+			policyResult = ctx.policyResult,
+		}
+	end
+
+	for _, unitId in ipairs(ctx.validationResult.validUnitIds) do
+		-- ctx.given should always be false here because we short-circuit inside AllowResourceTransfer
+		ctx.springRepo.TransferUnit(unitId, ctx.receiverTeamId, ctx.given)
+	end
+
+	---@type UnitTransferResult
+	return {
+		success = true,
+		outcome = ctx.validationResult.status,
+		senderTeamId = ctx.senderTeamId,
+		receiverTeamId = ctx.receiverTeamId,
+		validationResult = ctx.validationResult,
+		policyResult = ctx.policyResult,
+	}
+end
+
+---@param springRepo EngineSynced
+---@param teamId integer
+---@return boolean
+local function teamActive(springRepo, teamId)
+	local n = springRepo.GetTeamRulesParam(teamId, "numActivePlayers")
+	if n == nil then
+		return true
+	end
+	return tonumber(n) ~= 0
+end
+
+---Compute and cache one team's unit factor: its tech-resolved sharing modes + active flag.
+---@param springRepo EngineSynced
+---@param teamId integer
+---@param ctx PolicyContext self-context (sender==receiver==teamId) so the enricher resolves the team's modes
+function Synced.CacheTeamFactor(springRepo, teamId, ctx)
+	local modes = ctx.unitSharingModes or { springRepo.GetModOptions().unit_sharing_mode or ModeEnums.UnitFilterCategory.None }
+	local serialized = Shared.SerializeUnitFactor({
+		sharingModes = modes,
+		active = teamActive(springRepo, teamId),
+	})
+	springRepo.SetTeamRulesParam(teamId, Shared.MakeFactorKey(), serialized)
+	PolicyEvents.NotifyIfChanged(teamId, TransferEnums.PolicyType.UnitTransfer, serialized)
+end
+
+return Synced

--- a/spec/builders/mode_test_helpers.lua
+++ b/spec/builders/mode_test_helpers.lua
@@ -1,0 +1,73 @@
+local ContextFactoryModule = VFS.Include("common/luaUtilities/sharing/context_factory.lua")
+local ResourceTransfer = VFS.Include("common/luaUtilities/sharing/resource_transfer_synced.lua")
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+
+local M = {}
+
+function M.modeModOpts(modeConfig)
+	local opts = {}
+	for key, entry in pairs(modeConfig.modOptions) do
+		local value = entry.value
+		if type(value) == "boolean" then
+			opts[key] = value and "1" or "0"
+		else
+			opts[key] = tostring(value)
+		end
+	end
+	return opts
+end
+
+function M.buildModeResult(spring, modeConfig, sender, receiver, resourceType, enricherFn)
+	local springApi = spring:Build()
+	springApi.GetModOptions = function()
+		return M.modeModOpts(modeConfig)
+	end
+	SharedConfig.resetCache()
+
+	local saved = ContextFactoryModule.getEnrichers()
+	ContextFactoryModule.setEnrichers(enricherFn and { enricherFn } or {})
+
+	local ctx = ContextFactoryModule.create(springApi).policy(sender.id, receiver.id)
+	local result = ResourceTransfer.CalcResourcePolicy(ctx, resourceType)
+
+	ContextFactoryModule.setEnrichers(saved)
+	return result
+end
+
+function M.snapshotResult(result)
+	local snap = {}
+	for k, v in pairs(result) do
+		if type(v) == "table" then
+			local copy = {}
+			for k2, v2 in pairs(v) do
+				copy[k2] = v2
+			end
+			snap[k] = copy
+		else
+			snap[k] = v
+		end
+	end
+	return snap
+end
+
+function M.buildModeTransfer(spring, modeConfig, sender, receiver, resourceType, desiredAmount, enricherFn)
+	local springApi = spring:Build()
+	springApi.GetModOptions = function()
+		return M.modeModOpts(modeConfig)
+	end
+	SharedConfig.resetCache()
+
+	local saved = ContextFactoryModule.getEnrichers()
+	ContextFactoryModule.setEnrichers(enricherFn and { enricherFn } or {})
+
+	local policyCtx = ContextFactoryModule.create(springApi).policy(sender.id, receiver.id)
+	local policyResult = M.snapshotResult(ResourceTransfer.CalcResourcePolicy(policyCtx, resourceType))
+
+	local transferCtx = ContextFactoryModule.create(springApi).resourceTransfer(sender.id, receiver.id, resourceType, desiredAmount, policyResult)
+	local result = ResourceTransfer.ResourceTransfer(transferCtx)
+
+	ContextFactoryModule.setEnrichers(saved)
+	return result, policyResult
+end
+
+return M

--- a/spec/common/luaUtilities/sharing/resource_policy_cache_spec.lua
+++ b/spec/common/luaUtilities/sharing/resource_policy_cache_spec.lua
@@ -1,0 +1,87 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local ContextFactoryModule = VFS.Include("common/luaUtilities/sharing/context_factory.lua")
+local ResourceTransfer = VFS.Include("common/luaUtilities/sharing/resource_transfer_synced.lua")
+local ResourceShared = VFS.Include("common/luaUtilities/sharing/resource_transfer_shared.lua")
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+
+local METAL = TransferEnums.ResourceType.METAL
+
+-- The cache stores one per-team factor record per resource; GetCachedPolicyResult
+-- reconstructs any (sender,receiver) pair from those factors plus live gates.
+describe("resource policy cache (per-team factors) #policy", function()
+	local sender, receiver, enemy ---@type TeamBuilder, TeamBuilder, TeamBuilder
+	local spring ---@type EngineSyncedBuilder
+
+	before_each(function()
+		SharedConfig.resetCache()
+		sender = Builders.Team:new():Human():WithMetal(500):WithEnergy(500)
+		receiver = Builders.Team:new():Human():WithMetal(0):WithEnergy(0)
+		enemy = Builders.Team:new():Human():WithMetal(0):WithEnergy(0)
+		spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithTeam(enemy):WithAlliance(sender.id, receiver.id, true):WithAlliance(receiver.id, sender.id, true):WithModOption(ModeEnums.ModOptions.TaxResourceSharingAmount, 0):WithTeamRulesParam(sender.id, "numActivePlayers", 1):WithTeamRulesParam(receiver.id, "numActivePlayers", 1):WithTeamRulesParam(enemy.id, "numActivePlayers", 1)
+	end)
+
+	-- Build the mock and populate the factor cache for all teams.
+	local function populate()
+		local springApi = spring:Build()
+		local contextFactory = ContextFactoryModule.create(springApi)
+		ResourceTransfer.UpdatePolicyCache(springApi, 1000, -1000, 30, contextFactory)
+		return springApi, contextFactory
+	end
+
+	it("reconstructs an allied pair identically to a direct CalcResourcePolicy", function()
+		local springApi, contextFactory = populate()
+		local cached = ResourceShared.GetCachedPolicyResult(sender.id, receiver.id, METAL, springApi)
+		local direct = ResourceTransfer.CalcResourcePolicy(contextFactory.policy(sender.id, receiver.id), METAL)
+		assert.equal(direct.canShare, cached.canShare)
+		assert.equal(direct.amountSendable, cached.amountSendable)
+		assert.equal(direct.amountReceivable, cached.amountReceivable)
+		assert.equal(direct.taxedPortion, cached.taxedPortion)
+		assert.equal(direct.taxRate, cached.taxRate)
+	end)
+
+	it("stores per-team factor records, not per-pair entries", function()
+		local springApi = populate()
+		local metalKey = ResourceShared.MakeFactorKey(METAL)
+		assert.is_not_nil(springApi.GetTeamRulesParam(sender.id, metalKey))
+		assert.is_not_nil(springApi.GetTeamRulesParam(receiver.id, metalKey))
+		assert.is_not_nil(springApi.GetTeamRulesParam(enemy.id, metalKey))
+	end)
+
+	it("denies a cross-alliance pair via the live gate (no cached deny entry)", function()
+		local springApi = populate()
+		local cached = ResourceShared.GetCachedPolicyResult(sender.id, enemy.id, METAL, springApi)
+		assert.equal(false, cached.canShare)
+	end)
+
+	it("denies when the receiver has no active players", function()
+		spring:WithTeamRulesParam(receiver.id, "numActivePlayers", 0)
+		local springApi = populate()
+		local cached = ResourceShared.GetCachedPolicyResult(sender.id, receiver.id, METAL, springApi)
+		assert.equal(false, cached.canShare)
+	end)
+
+	it("allows a cross-alliance pair when cheating is enabled", function()
+		local springApi = populate()
+		springApi.IsCheatingEnabled = function()
+			return true
+		end
+		local cached = ResourceShared.GetCachedPolicyResult(sender.id, enemy.id, METAL, springApi)
+		assert.equal(true, cached.canShare)
+	end)
+
+	it("denies when factors are absent (cache not yet populated)", function()
+		local springApi = spring:Build()
+		local cached = ResourceShared.GetCachedPolicyResult(sender.id, receiver.id, METAL, springApi)
+		assert.equal(false, cached.canShare)
+	end)
+
+	it("denies every pair when resource sharing is disabled", function()
+		spring:WithModOption(ModeEnums.ModOptions.ResourceSharingEnabled, false)
+		local springApi = populate()
+		local cached = ResourceShared.GetCachedPolicyResult(sender.id, receiver.id, METAL, springApi)
+		assert.equal(false, cached.canShare)
+	end)
+end)

--- a/spec/common/luaUtilities/sharing/resource_transfer_synced_spec.lua
+++ b/spec/common/luaUtilities/sharing/resource_transfer_synced_spec.lua
@@ -1,0 +1,510 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local ContextFactoryModule = VFS.Include("common/luaUtilities/sharing/context_factory.lua")
+local ResourceTransfer = VFS.Include("common/luaUtilities/sharing/resource_transfer_synced.lua")
+local ResourceShared = VFS.Include("common/luaUtilities/sharing/resource_transfer_shared.lua")
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+
+local sender = Builders.Team:new():Human()
+local receiver = Builders.Team:new():Human()
+
+local function buildResourceResult(spring, taxRate, sender, receiver, resourceType)
+	local springApi = spring:Build()
+	springApi.GetModOptions = function()
+		return {
+			tax_resource_sharing_amount = tostring(taxRate),
+		}
+	end
+	SharedConfig.resetCache()
+	local ctx = ContextFactoryModule.create(springApi).policy(sender.id, receiver.id)
+	return ResourceTransfer.CalcResourcePolicy(ctx, resourceType)
+end
+
+local spring = Builders
+	.Spring
+	.new()
+	:WithTeam(sender)
+	:WithTeam(receiver)
+	:WithAlliance(sender.id, receiver.id, true)
+	-- set in-game by cmd_idle_players.lua
+	:WithTeamRulesParam(receiver.id, "numActivePlayers", 1)
+	:WithTeamRulesParam(sender.id, "numActivePlayers", 1)
+
+describe(ModeEnums.ModOptions.TaxResourceSharingAmount .. " #policy", function()
+	local taxRate = 0.5
+
+	describe("simple taxation", function()
+		---@type ResourcePolicyResult
+		local metalResult
+		---@type ResourcePolicyResult
+		local energyResult
+
+		before_each(function()
+			sender:WithEnergy(500):WithMetal(500)
+			receiver:WithEnergy(0):WithMetal(0)
+
+			spring:WithModOption(ModeEnums.ModOptions.TaxResourceSharingAmount, taxRate)
+
+			metalResult = buildResourceResult(spring, taxRate, sender, receiver, TransferEnums.ResourceType.METAL)
+			energyResult = buildResourceResult(spring, taxRate, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should ALLOW sharing of both METAL and ENERGY", function()
+			assert.equal(metalResult.canShare, true)
+			assert.equal(energyResult.canShare, true)
+		end)
+
+		it("should cap amount sendable (in receivable units) and account for tax overhead", function()
+			assert.equal(250, metalResult.amountSendable)
+			assert.equal(250, energyResult.amountSendable)
+		end)
+
+		it("should cap the amount receivable by the receivers storage capacity", function()
+			assert.equal(1000, metalResult.amountReceivable)
+			assert.equal(1000, energyResult.amountReceivable)
+		end)
+
+		it("should expose the tax rate", function()
+			assert.equal(taxRate, metalResult.taxRate)
+			assert.equal(taxRate, energyResult.taxRate)
+		end)
+	end)
+
+	describe("when receiver is full", function()
+		---@type ResourcePolicyResult
+		local metalResult
+		---@type ResourcePolicyResult
+		local energyResult
+
+		before_each(function()
+			sender:WithEnergy(500):WithMetal(500)
+			receiver:WithEnergy(1000):WithMetal(1000)
+
+			metalResult = buildResourceResult(spring, taxRate, sender, receiver, TransferEnums.ResourceType.METAL)
+			energyResult = buildResourceResult(spring, taxRate, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should NOT allow sharing when receiver is full", function()
+			assert.equal(metalResult.canShare, false)
+			assert.equal(energyResult.canShare, false)
+		end)
+
+		it("should set amount sendable to 0", function()
+			assert.equal(0, metalResult.amountSendable)
+			assert.equal(0, energyResult.amountSendable)
+		end)
+	end)
+
+	describe("when receiver capacity is below the taxed sendable amount", function()
+		it("should cap amount sendable to the receiver capacity", function()
+			sender:WithMetal(1000)
+			receiver:WithMetal(980)
+			local metalResult = buildResourceResult(spring, taxRate, sender, receiver, TransferEnums.ResourceType.METAL)
+			assert.equal(metalResult.amountSendable, 20)
+		end)
+	end)
+
+	describe("rate = 0.7, receiver capacity 300, sender 1000", function()
+		---@type ResourcePolicyResult
+		local energyResult
+		local testTaxRate = 0.7
+
+		before_each(function()
+			spring:WithModOption(ModeEnums.ModOptions.TaxResourceSharingAmount, testTaxRate)
+			sender:WithEnergy(1000)
+			receiver:WithEnergyStorage(1000):WithEnergy(700)
+
+			energyResult = buildResourceResult(spring, testTaxRate, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should have amountReceivable set to receiver capacity and amountSendable == 300", function()
+			assert.equal(300, energyResult.amountReceivable)
+			assert.equal(300, energyResult.amountSendable)
+		end)
+	end)
+
+	describe("sender 1000, rate = 0.7, receiver capacity 300", function()
+		---@type ResourcePolicyResult
+		local energyResult
+		local testTaxRate = 0.7
+
+		before_each(function()
+			spring:WithModOption(ModeEnums.ModOptions.TaxResourceSharingAmount, testTaxRate)
+			sender:WithEnergy(1000)
+			receiver:WithEnergyStorage(1000):WithEnergy(700)
+
+			energyResult = buildResourceResult(spring, testTaxRate, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should enable sharing", function()
+			assert.equal(true, energyResult.canShare)
+		end)
+
+		it("should have a receivable amount set to the receiver's capacity and amountSendable == 300", function()
+			assert.equal(300, energyResult.amountReceivable)
+			assert.equal(300, energyResult.amountSendable)
+		end)
+	end)
+
+	describe("when taxation is disabled", function()
+		---@type ResourcePolicyResult
+		local metalResult
+		---@type ResourcePolicyResult
+		local energyResult
+
+		before_each(function()
+			spring:WithModOption(ModeEnums.ModOptions.TaxResourceSharingAmount, 0)
+			receiver:WithEnergyStorage(1000):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithMetal(0)
+		end)
+
+		it("should not tax metal transfers", function()
+			sender:WithMetal(100)
+			metalResult = buildResourceResult(spring, 0, sender, receiver, TransferEnums.ResourceType.METAL)
+			assert.equal(1000, metalResult.amountReceivable)
+			assert.equal(100, metalResult.amountSendable)
+
+			sender:WithMetal(500)
+			metalResult = buildResourceResult(spring, 0, sender, receiver, TransferEnums.ResourceType.METAL)
+			assert.equal(1000, metalResult.amountReceivable)
+			assert.equal(500, metalResult.amountSendable)
+		end)
+
+		it("should not tax energy transfers", function()
+			sender:WithEnergy(100)
+			energyResult = buildResourceResult(spring, 0, sender, receiver, TransferEnums.ResourceType.ENERGY)
+			assert.equal(1000, energyResult.amountReceivable)
+			assert.equal(100, energyResult.amountSendable)
+
+			sender:WithEnergy(500)
+			energyResult = buildResourceResult(spring, 0, sender, receiver, TransferEnums.ResourceType.ENERGY)
+			assert.equal(1000, energyResult.amountReceivable)
+			assert.equal(500, energyResult.amountSendable)
+		end)
+	end)
+end)
+
+describe("ResourceTransfer #action", function()
+	local sender = Builders.Team:new():Human()
+	local receiver = Builders.Team:new():Human()
+	local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):Build()
+
+	describe("basic resource transfer", function()
+		it("should transfer metal without overhead when the tax rate is zero", function()
+			---@type ResourceTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.MetalTransfer,
+				resourceType = TransferEnums.ResourceType.METAL,
+				desiredAmount = 100,
+				isCheatingEnabled = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				ext = {},
+				sender = {
+					metal = {
+						resourceType = "metal",
+						excess = 0,
+						current = 1000,
+						storage = 1000,
+						pull = 0,
+						income = 0,
+						expense = 0,
+						shareSlider = 0,
+						sent = 0,
+						received = 0,
+					},
+					energy = {
+						resourceType = "energy",
+						excess = 0,
+						current = 1000,
+						storage = 1000,
+						pull = 0,
+						income = 0,
+						expense = 0,
+						shareSlider = 0,
+						sent = 0,
+						received = 0,
+					},
+				},
+				receiver = {
+					metal = {
+						resourceType = "metal",
+						excess = 0,
+						current = 500,
+						storage = 1000,
+						pull = 0,
+						income = 0,
+						expense = 0,
+						shareSlider = 0,
+						sent = 0,
+						received = 0,
+					},
+					energy = {
+						resourceType = "energy",
+						excess = 0,
+						current = 500,
+						storage = 1000,
+						pull = 0,
+						income = 0,
+						expense = 0,
+						shareSlider = 0,
+						sent = 0,
+						received = 0,
+					},
+				},
+				policyResult = {
+					canShare = true,
+					resourceType = TransferEnums.ResourceType.METAL,
+					amountSendable = 500,
+					amountReceivable = 500,
+					taxRate = 0,
+					taxedPortion = 500,
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			local result = ResourceTransfer.ResourceTransfer(ctx)
+
+			assert.is_true(result.success)
+			assert.equal(100, result.sent)
+			assert.equal(100, result.received)
+		end)
+
+		it("debits the sender and credits the receiver in engine team state", function()
+			local s = Builders.Team:new():Human():WithMetal(1000):WithMetalStorage(1000)
+			local r = Builders.Team:new():Human():WithMetal(500):WithMetalStorage(1000)
+			local spr = Builders.Spring.new():WithTeam(s):WithTeam(r):Build()
+
+			---@type ResourceTransferContext
+			local ctx = {
+				senderTeamId = s.id,
+				receiverTeamId = r.id,
+				policyType = TransferEnums.PolicyType.MetalTransfer,
+				resourceType = TransferEnums.ResourceType.METAL,
+				desiredAmount = 100,
+				isCheatingEnabled = false,
+				springRepo = spr,
+				areAlliedTeams = true,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 500, storage = 1000, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 500, storage = 1000, shareSlider = 0, sent = 0, received = 0 },
+				},
+				policyResult = {
+					canShare = true,
+					resourceType = TransferEnums.ResourceType.METAL,
+					amountSendable = 500,
+					amountReceivable = 500,
+					taxRate = 0,
+					taxedPortion = 100,
+					senderTeamId = s.id,
+					receiverTeamId = r.id,
+				},
+			}
+
+			local result = ResourceTransfer.ResourceTransfer(ctx)
+
+			assert.is_true(result.success)
+			assert.equal(100, result.sent)
+			assert.equal(100, result.received)
+			assert.equal(900, (spr.GetTeamResources(s.id, TransferEnums.ResourceType.METAL)))
+			assert.equal(600, (spr.GetTeamResources(r.id, TransferEnums.ResourceType.METAL)))
+		end)
+
+		it("should apply tax overhead to the sender cost", function()
+			---@type ResourceTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.MetalTransfer,
+				resourceType = TransferEnums.ResourceType.METAL,
+				desiredAmount = 200,
+				isCheatingEnabled = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 500, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 500, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				policyResult = {
+					canShare = true,
+					resourceType = TransferEnums.ResourceType.METAL,
+					amountSendable = 500,
+					amountReceivable = 500,
+					taxRate = 0.3,
+					taxedPortion = 500,
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			local result = ResourceTransfer.ResourceTransfer(ctx)
+
+			assert.is_true(result.success)
+			-- sent = 200/0.7 = 285.71
+			assert.is_near(285.71, result.sent, 0.1)
+			assert.is_near(200, result.received, 0.1)
+		end)
+
+		it("should handle 100% tax rate", function()
+			---@type ResourceTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.MetalTransfer,
+				resourceType = TransferEnums.ResourceType.METAL,
+				desiredAmount = 200,
+				isCheatingEnabled = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 500, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 500, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				policyResult = {
+					canShare = true,
+					resourceType = TransferEnums.ResourceType.METAL,
+					amountSendable = 500,
+					amountReceivable = 500,
+					taxRate = 1.0,
+					taxedPortion = 500,
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			local result = ResourceTransfer.ResourceTransfer(ctx)
+
+			assert.is_true(result.success)
+			-- nothing is sendable at 100% tax (infinite cost)
+			assert.equal(0, result.sent)
+			assert.equal(0, result.received)
+		end)
+
+		it("should limit transfer to amountSendable", function()
+			--- @type ResourceTransferContext
+			local ctx = {
+				desiredAmount = 300,
+				policyType = TransferEnums.PolicyType.MetalTransfer,
+				isCheatingEnabled = false,
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				resourceType = TransferEnums.ResourceType.METAL,
+				ext = {},
+				policyResult = {
+					canShare = true,
+					resourceType = TransferEnums.ResourceType.METAL,
+					amountSendable = 300,
+					amountReceivable = 9999,
+					taxRate = 0.2,
+					taxedPortion = 300,
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+				springRepo = spring,
+				areAlliedTeams = true,
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 500, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 500, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+			}
+
+			local result = ResourceTransfer.ResourceTransfer(ctx)
+
+			assert.is_true(result.success)
+			-- sent = 300/0.8 = 375
+			assert.is_near(375, result.sent, 0.1)
+			assert.is_near(300, result.received, 0.1)
+		end)
+	end)
+
+	describe("CalculateSenderTaxedAmount helper", function()
+		it("caps by amountSendable and amountReceivable and computes sender cost", function()
+			local policyResult = {
+				resourceType = TransferEnums.ResourceType.ENERGY,
+				amountSendable = 820,
+				amountReceivable = 1000,
+				taxRate = 0.3,
+			}
+
+			local desired = 820
+			local desiredCapped = math.min(desired, policyResult.amountSendable, policyResult.amountReceivable)
+			local received, sent = ResourceShared.CalculateSenderTaxedAmount(policyResult, desiredCapped)
+			-- cost = 820/0.7 = 1171.43
+			assert.is_near(1171.43, sent, 0.01)
+			assert.equal(820, received)
+		end)
+
+		it("caps desired by amountReceivable when it is lower", function()
+			local policyResult = {
+				resourceType = TransferEnums.ResourceType.ENERGY,
+				amountSendable = 500,
+				amountReceivable = 300,
+				taxRate = 0.7,
+			}
+			local desiredCapped = math.min(999, policyResult.amountSendable, policyResult.amountReceivable)
+			local received, sent = ResourceShared.CalculateSenderTaxedAmount(policyResult, desiredCapped)
+			assert.equal(300, received)
+			assert.is_near(1000, sent, 0.01) -- 300/(1-0.7)
+		end)
+	end)
+end)
+
+describe("Resource comms #comms", function()
+	describe("DecideCommunicationCase", function()
+		it("should return OnSelf when sender equals receiver", function()
+			local policy = { senderTeamId = 1, receiverTeamId = 1, canShare = true, taxRate = 0.3 }
+			assert.equal(TransferEnums.ResourceCommunicationCase.OnSelf, ResourceShared.DecideCommunicationCase(policy))
+		end)
+
+		it("should return OnTaxFree when tax rate is zero", function()
+			local policy = { senderTeamId = 1, receiverTeamId = 2, canShare = true, taxRate = 0 }
+			assert.equal(TransferEnums.ResourceCommunicationCase.OnTaxFree, ResourceShared.DecideCommunicationCase(policy))
+		end)
+
+		it("should return OnTaxed when taxed", function()
+			local policy = { senderTeamId = 1, receiverTeamId = 2, canShare = true, taxRate = 0.3 }
+			assert.equal(TransferEnums.ResourceCommunicationCase.OnTaxed, ResourceShared.DecideCommunicationCase(policy))
+		end)
+
+		it("should return OnDisabled when canShare is false", function()
+			local policy = { senderTeamId = 1, receiverTeamId = 2, canShare = false, taxRate = 0 }
+			assert.equal(TransferEnums.ResourceCommunicationCase.OnDisabled, ResourceShared.DecideCommunicationCase(policy))
+		end)
+	end)
+
+	describe("FormatNumberForUI", function()
+		it("should floor numbers to whole values", function()
+			assert.equal("285", ResourceShared.FormatNumberForUI(285.71))
+			assert.equal("100", ResourceShared.FormatNumberForUI(100.99))
+			assert.equal("0", ResourceShared.FormatNumberForUI(0.5))
+		end)
+
+		it("should pass through non-number values", function()
+			assert.equal("hello", ResourceShared.FormatNumberForUI("hello"))
+		end)
+	end)
+end)

--- a/spec/common/luaUtilities/sharing/unit_policy_cache_spec.lua
+++ b/spec/common/luaUtilities/sharing/unit_policy_cache_spec.lua
@@ -1,0 +1,87 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local ContextFactoryModule = VFS.Include("common/luaUtilities/sharing/context_factory.lua")
+local UnitTransfer = VFS.Include("common/luaUtilities/sharing/unit_transfer_synced.lua")
+local UnitShared = VFS.Include("common/luaUtilities/sharing/unit_transfer_shared.lua")
+
+local ALL = ModeEnums.UnitFilterCategory.All
+local NONE = ModeEnums.UnitFilterCategory.None
+
+-- The unit cache stores one factor record per team (sharing modes + active flag);
+-- GetCachedPolicyResult reconstructs any pair from those plus live alliance/cheat gates.
+describe("unit policy cache (per-team factors) #policy", function()
+	local sender, receiver, enemy ---@type TeamBuilder, TeamBuilder, TeamBuilder
+	local spring ---@type EngineSyncedBuilder
+
+	before_each(function()
+		sender = Builders.Team:new():Human()
+		receiver = Builders.Team:new():Human()
+		enemy = Builders.Team:new():Human()
+		spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithTeam(enemy):WithAlliance(sender.id, receiver.id, true):WithAlliance(receiver.id, sender.id, true):WithModOption(ModeEnums.ModOptions.UnitSharingMode, ALL):WithTeamRulesParam(sender.id, "numActivePlayers", 1):WithTeamRulesParam(receiver.id, "numActivePlayers", 1):WithTeamRulesParam(enemy.id, "numActivePlayers", 1)
+	end)
+
+	-- Build the mock and populate each team's unit factor.
+	local function populate()
+		local springApi = spring:Build()
+		local contextFactory = ContextFactoryModule.create(springApi)
+		for _, teamId in ipairs(springApi.GetTeamList()) do
+			UnitTransfer.CacheTeamFactor(springApi, teamId, contextFactory.policy(teamId, teamId))
+		end
+		return springApi, contextFactory
+	end
+
+	it("reconstructs an allied pair identically to a direct GetPolicy", function()
+		local springApi, contextFactory = populate()
+		local cached = UnitShared.GetCachedPolicyResult(sender.id, receiver.id, springApi)
+		local direct = UnitTransfer.GetPolicy(contextFactory.policy(sender.id, receiver.id))
+		assert.equal(direct.canShare, cached.canShare)
+		assert.same(direct.sharingModes, cached.sharingModes)
+	end)
+
+	it("allows an allied pair under a shareable mode", function()
+		local springApi = populate()
+		assert.equal(true, UnitShared.GetCachedPolicyResult(sender.id, receiver.id, springApi).canShare)
+	end)
+
+	it("denies a cross-alliance pair", function()
+		local springApi = populate()
+		assert.equal(false, UnitShared.GetCachedPolicyResult(sender.id, enemy.id, springApi).canShare)
+	end)
+
+	it("denies when the sharing mode is None", function()
+		spring:WithModOption(ModeEnums.ModOptions.UnitSharingMode, NONE)
+		local springApi = populate()
+		assert.equal(false, UnitShared.GetCachedPolicyResult(sender.id, receiver.id, springApi).canShare)
+	end)
+
+	it("denies when the receiver has no active players", function()
+		spring:WithTeamRulesParam(receiver.id, "numActivePlayers", 0)
+		local springApi = populate()
+		assert.equal(false, UnitShared.GetCachedPolicyResult(sender.id, receiver.id, springApi).canShare)
+	end)
+
+	it("cheating bypasses the inactive-receiver gate", function()
+		spring:WithTeamRulesParam(receiver.id, "numActivePlayers", 0)
+		local springApi = populate()
+		springApi.IsCheatingEnabled = function()
+			return true
+		end
+		assert.equal(true, UnitShared.GetCachedPolicyResult(sender.id, receiver.id, springApi).canShare)
+	end)
+
+	it("cheating does NOT bypass the alliance gate (units, unlike resources)", function()
+		local springApi = populate()
+		springApi.IsCheatingEnabled = function()
+			return true
+		end
+		assert.equal(false, UnitShared.GetCachedPolicyResult(sender.id, enemy.id, springApi).canShare)
+	end)
+
+	it("falls back to the global mode + alliance when factors are absent", function()
+		local springApi = spring:Build()
+		-- no populate(): allied pair under a shareable global mode is still allowed
+		assert.equal(true, UnitShared.GetCachedPolicyResult(sender.id, receiver.id, springApi).canShare)
+		assert.equal(false, UnitShared.GetCachedPolicyResult(sender.id, enemy.id, springApi).canShare)
+	end)
+end)

--- a/spec/common/luaUtilities/sharing/unit_transfer_synced_spec.lua
+++ b/spec/common/luaUtilities/sharing/unit_transfer_synced_spec.lua
@@ -1,0 +1,782 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local UnitTransfer = VFS.Include("common/luaUtilities/sharing/unit_transfer_synced.lua")
+local ContextFactoryModule = VFS.Include("common/luaUtilities/sharing/context_factory.lua")
+
+local Units = {
+	AdvancedConstructor = "coracv",
+	Pawn = "armpw",
+	Fusion = "armfus",
+	Constructor = "corcv",
+}
+
+---@class UnitSharingTestConfig
+---@field mode string The sharing mode to test
+---@field canShareUnits boolean Expected canShareUnits result
+---@field testUnits table<string, boolean> Map of unit names to expected outcomes
+
+---@type table<string, UnitSharingTestConfig>
+local testConfigs = {
+	[ModeEnums.UnitFilterCategory.None] = {
+		mode = ModeEnums.UnitFilterCategory.None,
+		canShareUnits = false,
+		testUnits = {
+			[Units.AdvancedConstructor] = false,
+			[Units.Fusion] = false,
+		},
+	},
+	[ModeEnums.UnitFilterCategory.All] = {
+		mode = ModeEnums.UnitFilterCategory.All,
+		canShareUnits = true,
+		testUnits = {
+			[Units.AdvancedConstructor] = true,
+			[Units.Fusion] = true,
+		},
+	},
+	[ModeEnums.UnitFilterCategory.Combat] = {
+		mode = ModeEnums.UnitFilterCategory.Combat,
+		canShareUnits = true,
+		testUnits = {
+			[Units.Pawn] = true,
+			[Units.Constructor] = false,
+			[Units.AdvancedConstructor] = false,
+			[Units.Fusion] = false,
+		},
+	},
+	[ModeEnums.UnitFilterCategory.Constructors] = {
+		mode = ModeEnums.UnitFilterCategory.Constructors,
+		canShareUnits = true,
+		testUnits = {
+			[Units.Constructor] = true,
+			[Units.AdvancedConstructor] = true,
+			[Units.Fusion] = false,
+			[Units.Pawn] = false,
+		},
+	},
+	[ModeEnums.UnitFilterCategory.Buildings] = {
+		mode = ModeEnums.UnitFilterCategory.Buildings,
+		canShareUnits = true,
+		testUnits = {
+			[Units.Fusion] = true,
+			[Units.Constructor] = false,
+			[Units.AdvancedConstructor] = false,
+			[Units.Pawn] = false,
+		},
+	},
+	[ModeEnums.UnitFilterCategory.Resource] = {
+		mode = ModeEnums.UnitFilterCategory.Resource,
+		canShareUnits = true,
+		testUnits = {
+			[Units.Fusion] = true,
+			[Units.Constructor] = false,
+			[Units.Pawn] = false,
+		},
+	},
+	[ModeEnums.UnitFilterCategory.NonCombat] = {
+		mode = ModeEnums.UnitFilterCategory.NonCombat,
+		canShareUnits = true,
+		testUnits = {
+			[Units.Constructor] = true,
+			[Units.AdvancedConstructor] = true,
+			[Units.Fusion] = true,
+			[Units.Pawn] = false,
+		},
+	},
+}
+
+describe(ModeEnums.ModOptions.UnitSharingMode .. " #policy", function()
+	local sender = Builders.Team:new():Human()
+	local receiver = Builders.Team:new():Human()
+
+	local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithAlliance(sender.id, receiver.id, true)
+
+	for modeKey, config in pairs(testConfigs) do
+		describe("WHEN unit sharing mode is set to " .. config.mode, function()
+			spring:WithModOption(ModeEnums.ModOptions.UnitSharingMode, config.mode)
+			local result ---@type UnitPolicyResult
+			local unitIds = {} ---@type table<string, integer>
+			local api ---@type EngineSyncedMock
+
+			before_each(function()
+				unitIds = {}
+				sender.units = {}
+				for unitDefName, _ in pairs(config.testUnits) do
+					sender:WithUnit(unitDefName, function(id)
+						unitIds[unitDefName] = id
+					end)
+				end
+				spring:WithRealUnitDefs()
+				api = spring:Build()
+				local defsByKey = {}
+				local defs = api.GetUnitDefs()
+				for key, def in pairs(defs or {}) do
+					defsByKey[key] = def
+					if def.id then
+						defsByKey[def.id] = def
+					end
+					if def.name then
+						defsByKey[def.name] = def
+					end
+				end
+				---@diagnostic disable-next-line: global-in-non-module
+				_G.UnitDefs = defsByKey
+				local ctx = ContextFactoryModule.create(api).policy(sender.id, receiver.id)
+				result = UnitTransfer.GetPolicy(ctx)
+			end)
+
+			after_each(function()
+				---@diagnostic disable-next-line: global-in-non-module
+				_G.UnitDefs = nil
+			end)
+
+			it("should have correct sharing permissions", function()
+				assert.equal(config.canShareUnits, result.canShare)
+			end)
+
+			for unitDefName, shouldAllow in pairs(config.testUnits) do
+				it("should " .. (shouldAllow and "allow" or "not allow") .. " validating transfer of " .. unitDefName, function()
+					local unitId = unitIds[unitDefName]
+					assert.is_not_nil(unitId)
+					local validation = UnitTransfer.ValidateUnits(result, { unitId }, api, _G.UnitDefs)
+					if not config.canShareUnits then
+						-- Disabled mode short-circuits validation
+						assert.equal(0, validation.validUnitCount)
+						assert.equal(0, validation.invalidUnitCount)
+					else
+						if shouldAllow then
+							assert.equal(1, validation.validUnitCount)
+							assert.equal(0, validation.invalidUnitCount)
+						else
+							assert.equal(0, validation.validUnitCount)
+							assert.equal(1, validation.invalidUnitCount)
+						end
+					end
+				end)
+			end
+		end)
+	end
+end)
+
+describe("UnitTransfer #action", function()
+	local sender = Builders.Team:new():Human()
+	local receiver = Builders.Team:new():Human()
+	local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):Build()
+
+	describe("when unit sharing is allowed", function()
+		local unitIds ---@type integer[]
+		local result
+		local spring ---@type EngineSyncedMock
+
+		before_each(function()
+			unitIds = {}
+			sender:WithUnit("armpw", function(unitId)
+				table.insert(unitIds, unitId)
+			end)
+			sender:WithUnit("armck", function(unitId)
+				table.insert(unitIds, unitId)
+			end)
+
+			-- Rebuild spring repo after adding units
+			spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):Build()
+		end)
+
+		it("should successfully transfer all units when sharing is allowed", function()
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = unitIds,
+				given = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.Success,
+					validUnitIds = unitIds,
+					validUnitCount = #unitIds,
+					validUnitNames = {},
+					invalidUnitIds = {},
+					invalidUnitCount = 0,
+					invalidUnitNames = {},
+				},
+				policyResult = {
+					canShare = true,
+					sharingModes = { ModeEnums.UnitFilterCategory.All },
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			local transferSpy = spy.on(spring, "TransferUnit")
+			result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(TransferEnums.UnitValidationOutcome.Success, result.outcome)
+			assert.equal(#unitIds, result.validationResult.validUnitCount)
+			assert.equal(0, result.validationResult.invalidUnitCount)
+			assert.spy(transferSpy).was.called(#unitIds)
+			assert.spy(transferSpy).was.called_with(unitIds[1], receiver.id, false)
+		end)
+
+		it("should handle mixed success/failure scenarios", function()
+			local mixedUnitIds = { assert(unitIds[1]), 9999, assert(unitIds[2]) }
+
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = mixedUnitIds,
+				given = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.PartialSuccess,
+					validUnitIds = { mixedUnitIds[1], mixedUnitIds[3] },
+					validUnitCount = 2,
+					validUnitNames = {},
+					invalidUnitIds = { mixedUnitIds[2] },
+					invalidUnitCount = 1,
+					invalidUnitNames = {},
+				},
+				policyResult = {
+					canShare = true,
+					sharingModes = { ModeEnums.UnitFilterCategory.All },
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(TransferEnums.UnitValidationOutcome.PartialSuccess, result.outcome)
+			assert.equal(2, result.validationResult.validUnitCount)
+			assert.equal(1, result.validationResult.invalidUnitCount)
+			assert.equal(9999, result.validationResult.invalidUnitIds[1])
+		end)
+
+		it("should set given parameter correctly", function()
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = { unitIds[1] },
+				given = true,
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.Success,
+					validUnitIds = { unitIds[1] },
+					validUnitCount = 1,
+					validUnitNames = {},
+					invalidUnitIds = {},
+					invalidUnitCount = 0,
+					invalidUnitNames = {},
+				},
+				policyResult = {
+					canShare = true,
+					sharingModes = { ModeEnums.UnitFilterCategory.All },
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(TransferEnums.UnitValidationOutcome.Success, result.outcome)
+			assert.equal(1, result.validationResult.validUnitCount)
+			assert.equal(0, result.validationResult.invalidUnitCount)
+		end)
+	end)
+
+	describe("when unit sharing is not allowed", function()
+		local unitIds ---@type integer[]
+		local result
+		local spring ---@type EngineSyncedMock
+
+		before_each(function()
+			unitIds = {}
+			sender:WithUnit("armpw", function(unitId)
+				table.insert(unitIds, unitId)
+			end)
+			sender:WithUnit("armck", function(unitId)
+				table.insert(unitIds, unitId)
+			end)
+
+			-- Rebuild spring repo after adding units
+			spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):Build()
+		end)
+
+		it("should fail to transfer any units when sharing is disabled", function()
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = unitIds,
+				given = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.Success,
+					validUnitIds = unitIds,
+					validUnitCount = #unitIds,
+					validUnitNames = {},
+					invalidUnitIds = {},
+					invalidUnitCount = 0,
+					invalidUnitNames = {},
+				},
+				policyResult = {
+					canShare = false,
+					sharingModes = { ModeEnums.UnitFilterCategory.None },
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(TransferEnums.UnitValidationOutcome.Success, result.validationResult.status)
+			assert.equal(TransferEnums.UnitValidationOutcome.Failure, result.outcome)
+			assert.equal(#unitIds, result.validationResult.validUnitCount)
+		end)
+
+		it("should include policy result in response", function()
+			local policyResult = {
+				canShare = false,
+				sharingModes = { ModeEnums.UnitFilterCategory.None },
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+			}
+
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = unitIds,
+				given = false,
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.Success,
+					validUnitIds = unitIds,
+					validUnitCount = #unitIds,
+					validUnitNames = {},
+					invalidUnitIds = {},
+					invalidUnitCount = 0,
+					invalidUnitNames = {},
+				},
+				policyResult = policyResult,
+			}
+
+			result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(policyResult, result.policyResult)
+		end)
+	end)
+
+	describe("edge cases", function()
+		it("should handle empty unit list", function()
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = {},
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.Failure,
+					validUnitIds = {},
+					validUnitCount = 0,
+					validUnitNames = {},
+					invalidUnitIds = {},
+					invalidUnitCount = 0,
+					invalidUnitNames = {},
+				},
+				given = false,
+				policyResult = {
+					canShare = true,
+					sharingModes = { ModeEnums.UnitFilterCategory.All },
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			local result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(TransferEnums.UnitValidationOutcome.Failure, result.outcome)
+			assert.equal(0, result.validationResult.validUnitCount)
+			assert.equal(0, result.validationResult.invalidUnitCount)
+		end)
+
+		it("should handle invalid unit IDs gracefully", function()
+			---@type UnitTransferContext
+			local ctx = {
+				senderTeamId = sender.id,
+				receiverTeamId = receiver.id,
+				policyType = TransferEnums.PolicyType.UnitTransfer,
+				unitIds = { -1, 0, 9999 },
+				springRepo = spring,
+				areAlliedTeams = true,
+				isCheatingEnabled = false,
+				ext = {},
+				sender = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				receiver = {
+					metal = { resourceType = "metal", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+					energy = { resourceType = "energy", excess = 0, current = 1000, storage = 1000, pull = 0, income = 0, expense = 0, shareSlider = 0, sent = 0, received = 0 },
+				},
+				validationResult = {
+					status = TransferEnums.UnitValidationOutcome.Failure,
+					validUnitIds = {},
+					validUnitCount = 0,
+					validUnitNames = {},
+					invalidUnitIds = { -1, 0, 9999 },
+					invalidUnitCount = 3,
+					invalidUnitNames = {},
+				},
+				given = false,
+				policyResult = {
+					canShare = true,
+					sharingModes = { ModeEnums.UnitFilterCategory.All },
+					senderTeamId = sender.id,
+					receiverTeamId = receiver.id,
+				},
+			}
+
+			local result = UnitTransfer.UnitTransfer(ctx)
+
+			assert.equal(TransferEnums.UnitValidationOutcome.Failure, result.outcome)
+			assert.equal(0, result.validationResult.validUnitCount)
+			assert.equal(3, result.validationResult.invalidUnitCount)
+		end)
+	end)
+end)
+
+describe("Easy Tax stun mechanics #stun", function()
+	local easyTaxMode = VFS.Include("modes/sharing/easy_tax.lua")
+
+	local function modeModOpts(modeConfig)
+		local opts = {}
+		for key, entry in pairs(modeConfig.modOptions) do
+			local value = entry.value
+			if type(value) == "boolean" then
+				opts[key] = value and "1" or "0"
+			else
+				opts[key] = tostring(value)
+			end
+		end
+		return opts
+	end
+
+	local sender = Builders.Team:new():Human()
+	local receiver = Builders.Team:new():Human()
+	local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithAlliance(sender.id, receiver.id, true):WithTeamRulesParam(receiver.id, "numActivePlayers", 1):WithTeamRulesParam(sender.id, "numActivePlayers", 1)
+
+	local mockDefs = {
+		[1] = { id = 1, name = "mockfusion", customParams = { unitgroup = "energy" } },
+		[2] = { id = 2, name = "mockcon", canAssist = true, buildOptions = {}, customParams = { techlevel = "1" } },
+		[3] = { id = 3, name = "mockpawn", customParams = { unitgroup = "weapon" }, weapons = { "gun" } },
+		[4] = { id = 4, name = "mockbuilder", isBuilder = true, customParams = { techlevel = "1" } },
+	}
+
+	describe("GetPolicy", function()
+		it("should expose stunSeconds, stunCategory and buildDelaySeconds from Easy Tax config", function()
+			local api = spring:Build()
+			api.GetModOptions = function()
+				return modeModOpts(easyTaxMode)
+			end
+
+			local ctx = ContextFactoryModule.create(api).policy(sender.id, receiver.id)
+			local policy = UnitTransfer.GetPolicy(ctx)
+
+			assert.equal(30, policy.stunSeconds)
+			assert.equal(ModeEnums.UnitFilterCategory.Resource, policy.stunCategory)
+			assert.equal(30, policy.buildDelaySeconds)
+		end)
+
+		it("should default stunSeconds and buildDelaySeconds to 0 when not configured", function()
+			local api = spring:Build()
+			api.GetModOptions = function()
+				return { unit_sharing_mode = "all" }
+			end
+
+			local ctx = ContextFactoryModule.create(api).policy(sender.id, receiver.id)
+			local policy = UnitTransfer.GetPolicy(ctx)
+
+			assert.equal(0, policy.stunSeconds)
+			assert.equal(0, policy.buildDelaySeconds)
+		end)
+	end)
+
+	describe("ValidateUnits nanoframe blocking", function()
+		it("should block nanoframes of stun-category units (resource building)", function()
+			local nanoframeId = 901
+			sender.units = {}
+			sender.units[nanoframeId] = { unitDefId = 1, beingBuilt = true, buildProgress = 0.5 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { nanoframeId }, api, mockDefs)
+			assert.equal(0, result.validUnitCount)
+			assert.equal(1, result.invalidUnitCount)
+		end)
+
+		it("should allow nanoframes of production units when stun category is resource", function()
+			local nanoframeId = 902
+			sender.units = {}
+			sender.units[nanoframeId] = { unitDefId = 2, beingBuilt = true, buildProgress = 0.3 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { nanoframeId }, api, mockDefs)
+			assert.equal(1, result.validUnitCount)
+			assert.equal(0, result.invalidUnitCount)
+		end)
+
+		it("should allow completed stun-category units", function()
+			local completedId = 903
+			sender.units = {}
+			sender.units[completedId] = { unitDefId = 1, beingBuilt = false, buildProgress = 1.0 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { completedId }, api, mockDefs)
+			assert.equal(1, result.validUnitCount)
+			assert.equal(0, result.invalidUnitCount)
+		end)
+
+		it("should allow combat nanoframes (not in EconomicPlusBuildings stun category)", function()
+			local combatNanoId = 904
+			sender.units = {}
+			sender.units[combatNanoId] = { unitDefId = 3, beingBuilt = true, buildProgress = 0.3 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { combatNanoId }, api, mockDefs)
+			assert.equal(1, result.validUnitCount)
+			assert.equal(0, result.invalidUnitCount)
+		end)
+
+		it("should allow all nanoframes when stunSeconds is 0", function()
+			local nanoframeId = 905
+			sender.units = {}
+			sender.units[nanoframeId] = { unitDefId = 1, beingBuilt = true, buildProgress = 0.5 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 0,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { nanoframeId }, api, mockDefs)
+			assert.equal(1, result.validUnitCount)
+			assert.equal(0, result.invalidUnitCount)
+		end)
+
+		it("should handle mixed nanoframes and completed units", function()
+			local nanoId = 906
+			local completedId = 907
+			sender.units = {}
+			sender.units[nanoId] = { unitDefId = 1, beingBuilt = true, buildProgress = 0.5 }
+			sender.units[completedId] = { unitDefId = 1, beingBuilt = false, buildProgress = 1.0 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { nanoId, completedId }, api, mockDefs)
+			assert.equal(1, result.validUnitCount)
+			assert.equal(1, result.invalidUnitCount)
+			assert.equal(TransferEnums.UnitValidationOutcome.PartialSuccess, result.status)
+		end)
+
+		it("should block nanoframes with Combat stun category", function()
+			local combatNanoId = 908
+			sender.units = {}
+			sender.units[combatNanoId] = { unitDefId = 3, beingBuilt = true, buildProgress = 0.4 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 15,
+				stunCategory = ModeEnums.UnitFilterCategory.Combat,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { combatNanoId }, api, mockDefs)
+			assert.equal(0, result.validUnitCount)
+			assert.equal(1, result.invalidUnitCount)
+		end)
+	end)
+
+	describe("ValidateUnits build-delay tally", function()
+		it("counts mobile builders among the valid units", function()
+			local builderId, fusionId = 910, 911
+			sender.units = {}
+			sender.units[builderId] = { unitDefId = 4, beingBuilt = false, buildProgress = 1.0 }
+			sender.units[fusionId] = { unitDefId = 1, beingBuilt = false, buildProgress = 1.0 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 0,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { builderId, fusionId }, api, mockDefs)
+			assert.equal(2, result.validUnitCount)
+			assert.equal(1, result.buildDelayedUnitCount)
+		end)
+
+		it("counts zero when the selection has no mobile builders", function()
+			local fusionId = 912
+			sender.units = {}
+			sender.units[fusionId] = { unitDefId = 1, beingBuilt = false, buildProgress = 1.0 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 0,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { fusionId }, api, mockDefs)
+			assert.equal(0, result.buildDelayedUnitCount)
+		end)
+	end)
+
+	describe("ValidateUnits stun tally", function()
+		it("counts stun-category units among the valid units", function()
+			local fusionId, builderId = 920, 921
+			sender.units = {}
+			sender.units[fusionId] = { unitDefId = 1, beingBuilt = false, buildProgress = 1.0 }
+			sender.units[builderId] = { unitDefId = 4, beingBuilt = false, buildProgress = 1.0 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { fusionId, builderId }, api, mockDefs)
+			assert.equal(2, result.validUnitCount)
+			assert.equal(1, result.stunnedUnitCount)
+		end)
+
+		it("counts zero when the selection has no stun-category units", function()
+			local builderId = 922
+			sender.units = {}
+			sender.units[builderId] = { unitDefId = 4, beingBuilt = false, buildProgress = 1.0 }
+			local api = spring:Build()
+
+			local policy = {
+				canShare = true,
+				sharingModes = { ModeEnums.UnitFilterCategory.All },
+				stunSeconds = 30,
+				stunCategory = ModeEnums.UnitFilterCategory.Resource,
+			}
+
+			local result = UnitTransfer.ValidateUnits(policy, { builderId }, api, mockDefs)
+			assert.equal(0, result.stunnedUnitCount)
+		end)
+	end)
+end)

--- a/spec/modes/easy_tax_spec.lua
+++ b/spec/modes/easy_tax_spec.lua
@@ -1,0 +1,137 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local H = Builders.Mode
+
+local easyTaxMode = VFS.Include("modes/sharing/easy_tax.lua")
+
+local sender = Builders.Team:new():Human()
+local receiver = Builders.Team:new():Human()
+local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithAlliance(sender.id, receiver.id, true):WithTeamRulesParam(receiver.id, "numActivePlayers", 1):WithTeamRulesParam(sender.id, "numActivePlayers", 1)
+
+describe("Easy Tax mode #policy", function()
+	describe("with default settings (30% tax)", function()
+		---@type ResourcePolicyResult
+		local metalResult
+		---@type ResourcePolicyResult
+		local energyResult
+
+		before_each(function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			metalResult = H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.METAL)
+			energyResult = H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should ALLOW sharing of both resources", function()
+			assert.equal(true, metalResult.canShare)
+			assert.equal(true, energyResult.canShare)
+		end)
+
+		it("should apply 30% tax rate", function()
+			assert.equal(0.30, metalResult.taxRate)
+			assert.equal(0.30, energyResult.taxRate)
+		end)
+
+		it("should compute sendable amount with 30% tax overhead", function()
+			-- sender=500, rate=0.30: 500 * 0.70 = 350
+			assert.equal(350, metalResult.amountSendable)
+			assert.equal(350, energyResult.amountSendable)
+		end)
+	end)
+
+	describe("when receiver is full", function()
+		---@type ResourcePolicyResult
+		local metalResult
+		---@type ResourcePolicyResult
+		local energyResult
+
+		before_each(function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(1000):WithEnergy(1000)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			metalResult = H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.METAL)
+			energyResult = H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should NOT allow sharing", function()
+			assert.equal(false, metalResult.canShare)
+			assert.equal(false, energyResult.canShare)
+		end)
+
+		it("should set amount sendable to 0", function()
+			assert.equal(0, metalResult.amountSendable)
+			assert.equal(0, energyResult.amountSendable)
+		end)
+	end)
+
+	describe("when sender is empty", function()
+		it("should NOT allow sharing", function()
+			sender:WithMetal(0):WithEnergy(0)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local metalResult = H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.METAL)
+			local energyResult = H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.ENERGY)
+
+			assert.equal(false, metalResult.canShare)
+			assert.equal(false, energyResult.canShare)
+		end)
+	end)
+
+	describe("when sender has less than desired", function()
+		it("should cap sendable amount to sender budget after tax", function()
+			sender:WithMetal(50):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local policy = H.snapshotResult(H.buildModeResult(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.METAL))
+
+			assert.equal(true, policy.canShare)
+			-- sender=50, rate=0.30: 50 * 0.70 = 35
+			assert.equal(35, policy.amountSendable)
+		end)
+	end)
+
+	describe("transfer action with 30% tax", function()
+		it("should deduct more from sender than receiver gets", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.METAL, 100)
+
+			assert.is_true(result.success)
+			assert.equal(100, result.received)
+			assert.is_true(result.sent > result.received)
+		end)
+
+		it("should transfer energy with tax overhead", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.ENERGY, 200)
+
+			assert.is_true(result.success)
+			assert.equal(200, result.received)
+			-- 30% tax: sender pays 200 / 0.7 ≈ 285.71
+			assert.is_near(285.71, result.sent, 0.1)
+		end)
+
+		it("should not transfer when receiver is full", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(1000):WithEnergy(1000)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, easyTaxMode, sender, receiver, TransferEnums.ResourceType.METAL, 100)
+
+			assert.equal(false, result.success)
+			assert.equal(0, result.sent)
+			assert.equal(0, result.received)
+		end)
+	end)
+end)

--- a/spec/modes/sharing_disabled_spec.lua
+++ b/spec/modes/sharing_disabled_spec.lua
@@ -1,0 +1,60 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local H = Builders.Mode
+
+local noSharingMode = VFS.Include("modes/sharing/disabled.lua")
+
+local sender = Builders.Team:new():Human()
+local receiver = Builders.Team:new():Human()
+local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithAlliance(sender.id, receiver.id, true):WithTeamRulesParam(receiver.id, "numActivePlayers", 1):WithTeamRulesParam(sender.id, "numActivePlayers", 1)
+
+describe("Sharing Disabled mode #policy", function()
+	describe("resource policy", function()
+		it("should deny metal sharing", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local metalResult = H.buildModeResult(spring, noSharingMode, sender, receiver, TransferEnums.ResourceType.METAL)
+
+			assert.equal(false, metalResult.canShare)
+		end)
+
+		it("should deny energy sharing", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local energyResult = H.buildModeResult(spring, noSharingMode, sender, receiver, TransferEnums.ResourceType.ENERGY)
+
+			assert.equal(false, energyResult.canShare)
+		end)
+	end)
+
+	describe("transfer action", function()
+		it("should fail metal transfer with zero sent and received", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, noSharingMode, sender, receiver, TransferEnums.ResourceType.METAL, 100)
+
+			assert.equal(false, result.success)
+			assert.equal(0, result.sent)
+			assert.equal(0, result.received)
+		end)
+
+		it("should fail energy transfer with zero sent and received", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, noSharingMode, sender, receiver, TransferEnums.ResourceType.ENERGY, 100)
+
+			assert.equal(false, result.success)
+			assert.equal(0, result.sent)
+			assert.equal(0, result.received)
+		end)
+	end)
+end)

--- a/spec/modes/sharing_enabled_spec.lua
+++ b/spec/modes/sharing_enabled_spec.lua
@@ -1,0 +1,100 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/sharing/transfer_enums.lua")
+local H = Builders.Mode
+
+local enabledMode = VFS.Include("modes/sharing/enabled.lua")
+
+local sender = Builders.Team:new():Human()
+local receiver = Builders.Team:new():Human()
+local spring = Builders.Spring.new():WithTeam(sender):WithTeam(receiver):WithAlliance(sender.id, receiver.id, true):WithTeamRulesParam(receiver.id, "numActivePlayers", 1):WithTeamRulesParam(sender.id, "numActivePlayers", 1)
+
+describe("Sharing Enabled mode #policy", function()
+	describe("with default settings (zero tax, zero thresholds)", function()
+		---@type ResourcePolicyResult
+		local metalResult
+		---@type ResourcePolicyResult
+		local energyResult
+
+		before_each(function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			metalResult = H.buildModeResult(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.METAL)
+			energyResult = H.buildModeResult(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.ENERGY)
+		end)
+
+		it("should ALLOW sharing of both resources", function()
+			assert.equal(true, metalResult.canShare)
+			assert.equal(true, energyResult.canShare)
+		end)
+
+		it("should have zero tax rate", function()
+			assert.equal(0, metalResult.taxRate)
+			assert.equal(0, energyResult.taxRate)
+		end)
+
+		it("should have sendable equal to full sender budget (no tax overhead)", function()
+			assert.equal(500, metalResult.amountSendable)
+			assert.equal(500, energyResult.amountSendable)
+		end)
+
+		it("should have receivable equal to full receiver capacity", function()
+			assert.equal(1000, metalResult.amountReceivable)
+			assert.equal(1000, energyResult.amountReceivable)
+		end)
+	end)
+
+	describe("when receiver is full", function()
+		it("should NOT allow sharing", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(1000):WithEnergy(1000)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local metalResult = H.buildModeResult(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.METAL)
+			local energyResult = H.buildModeResult(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.ENERGY)
+
+			assert.equal(false, metalResult.canShare)
+			assert.equal(false, energyResult.canShare)
+		end)
+	end)
+
+	describe("transfer action (untaxed)", function()
+		it("should transfer with sent == received (no tax deducted)", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.METAL, 200)
+
+			assert.is_true(result.success)
+			assert.equal(200, result.received)
+			assert.equal(200, result.sent)
+		end)
+
+		it("should transfer energy with sent == received", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(0):WithEnergy(0)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.ENERGY, 300)
+
+			assert.is_true(result.success)
+			assert.equal(300, result.received)
+			assert.equal(300, result.sent)
+		end)
+
+		it("should not transfer when receiver is full", function()
+			sender:WithMetal(500):WithEnergy(500)
+			receiver:WithMetal(1000):WithEnergy(1000)
+			receiver:WithMetalStorage(1000):WithEnergyStorage(1000)
+
+			local result = H.buildModeTransfer(spring, enabledMode, sender, receiver, TransferEnums.ResourceType.METAL, 100)
+
+			assert.equal(false, result.success)
+			assert.equal(0, result.sent)
+			assert.equal(0, result.received)
+		end)
+	end)
+end)


### PR DESCRIPTION
### 📚 The sharing stack — review bottom-up

- 1/7 · Transfer library (enums, comms, serialization, test infra) (#8125)
- 2/7 · Modes & economy boundary (presets, waterfill, share ledger) (#8126)
- **3/7 · Policies (context -> policy -> policy_result -> action) (#8407)** ← you are here
- 4/7 · Transfer runtime (controllers, economy boundary, gadget swap) (#8062)
- 5/7 · Tech Core / Keystone (#8063)
- 6/7 · Sharing Tab UI (#8064)
- 7/7 · Game modes export (export widget, headless startscript, CI workflow) (#8095)

> [!NOTE]
> Part of native stack #8411 (feature tracking: #8412). Merges bottom-up through the GitHub stacked-PR UI once the type-migration stack (#8398) is in.

Each PR is file-partitioned: every file appears in exactly one PR in its final `sharing_tab` form, so each PR's diff is byte-identical to that branch. Regenerated deterministically by `just bar::sharing-split`.

#### Summary (LLM-generated, claude-opus-4-6)

Adds the policy evaluation layer: `ContextFactory` builds a `PolicyContext` (team resources, alliance, cheating state, extensible via `PolicyContextEnricher` hooks), which feeds into `CalcResourcePolicy` / `GetPolicy` to produce a `ResourcePolicyResult` or `UnitPolicyResult`. Transfer actions (`ResourceTransfer`, `UnitTransfer`) consume those policy results to execute the actual engine calls. A per-team factor cache (`CacheTeamFactor` / `UpdatePolicyCache`) stores O(teams) records that `GetCachedPolicyResult` reconstructs into any sender-receiver pair on read, keeping the widget side in sync without O(pairs) storage. Unit validation (`ValidateUnits`) enforces sharing modes, blocks nanoframes of stun-category units, and tallies build-delay and stun counts. Tests cover resource and unit policies, the factor cache, and three concrete modes (enabled, disabled, easy_tax).


