### PR TITLE
[Deps] lux-recoil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .project
 *.code-workspace
 .lux/
+recoil-lua-library/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "recoil-lua-library"]
-	path = recoil-lua-library
-	url = https://github.com/beyond-all-reason/recoil-lua-library.git
-	branch = main

--- a/.luarc.json
+++ b/.luarc.json
@@ -6,7 +6,7 @@
       "definition": [
         ".lux/",
         "types/",
-        "recoil-lua-library/library/"
+        "recoil-lua-library/src/"
       ]
     }
   },

--- a/lux.toml
+++ b/lux.toml
@@ -2,6 +2,10 @@ package = "beyond-all-reason"
 version = "0.1.0"
 lua = "=5.1"
 
+[dependencies.recoil-lua-library]
+version = "0.1.0"
+git = "https://github.com/beyond-all-reason/recoil-lua-library"
+
 [description]
 summary = "Beyond All Reason Game Code."
 maintainer = "BAR Team"


### PR DESCRIPTION
Replace the `recoil-lua-library` Git submodule with a [Lux](https://github.com/nvim-neorocks/lux) git dependency.

This is a hand-maintained infrastructure branch. Dependent transforms cherry-pick it automatically.

### Branch Topology

All branches generated by [`just bar::fmt-mig-generate`](https://github.com/thvl3/BAR-Devtools).

*Generated 2026-03-31 03:27:38 UTC*

**Basal branches** (infrastructure — cherry-picked into dependent leaves):

| Branch | Description | Diff vs `master` |
|--------|-------------|------|
| lux-recoil | Replace the `recoil-lua-library` Git submodule with a [Lux](https://github.com/nvim-neorocks/lux) git dependency. | 5 files, +6 −6 |
| lux-i18n | Add [kikito/i18n.lua](https://github.com/kikito/i18n.lua) as a Lux dependency. | 1 files, +3 −0 |

**Standalone branches** (each targets `master`, can merge independently):

| Branch | Transform | Diff vs `master` |
|--------|-----------|------|
| [fmt](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7199) | `stylua .` | 1425 files, +178316 −183012 |
| mig-bracket | `bracket-to-dot` | 344 files, +7630 −7630 |
| mig-rename-aliases | `rename-aliases` | 161 files, +349 −349 |
| mig-detach-bar-modules | `detach-bar-modules` | 163 files, +1299 −1299 |
| mig-spring-split | `spring-split` (basal: `lux-recoil`) | 757 files, +9520 −9516 |
| mig-i18n | `i18n-kikito` (basal: `lux-i18n`) | 17 files, +46 −1187 |

**Combined branch** (stylua + all transforms — full preview):

| Branch | Diff vs `master` |
|--------|------|
| [mig](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7229) | 1436 files, +186318 −192169 |

