### PR TITLE
Fix non-legion BARb

### DIFF
--- a/luarules/configs/BARb/stable/script/common.as
+++ b/luarules/configs/BARb/stable/script/common.as
@@ -5,7 +5,7 @@ namespace Side {
  */
 	TypeMask ARMADA = aiSideMasker.GetTypeMask("armada");
 	TypeMask CORTEX = aiSideMasker.GetTypeMask("cortex");
-	TypeMask LEGION = aiSideMasker.GetTypeMask("legion");
+	TypeMask LEGION;
 
 }  // namespace Side
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->
Legion is a **fake** and such `side` doesn't exist, when legion option is not enabled.
Hence do not initialize `side` by irrelevant data.
It is initialized in each `init.as` if legion is enabled.

#### Test steps
In singleplayer Skirmish lobby:
- Add `Hard` BARb
- Add `Testing AI` BARb
- Start the game
Load-order is important. If `hard` loads first then `dev` meets unknown `side` data.
Expected outcome: all AI instances are loaded and doing something.