### PR TITLE
map projects: unique generated map names

### DIFF
--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1685,7 +1685,9 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	-- disk) and the next restart dies with "Dependent archive not found". A
 	-- fresh name can never collide with a poisoned cache entry. All name
 	-- matchers use the "^Editor Flat %dx%d" PREFIX, never an exact match.
-	local mapName = string.format("Editor Flat %dx%d s%d", widthUnits, heightUnits, seed % 100000)
+	-- Wall-clock, not the terrain seed above: this widget never seeds math.random
+	-- with real entropy, so reusing it here risked non-unique "unique" names.
+	local mapName = string.format("Editor Flat %dx%d s%d", widthUnits, heightUnits, os.time())
 
 	local script = base
 

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1066,7 +1066,9 @@ end
 
 local function _isGeneratedBlankMap()
 	local mapName = Game.mapName or ""
-	if mapName:find("^Editor Flat %d+x%d+$") then return true end
+	-- Prefix match: generated names carry a per-session uniquifier suffix
+	-- (see buildBlankMapStartScript).
+	if mapName:find("^Editor Flat %d+x%d+") then return true end
 	local mapOpts = Spring.GetMapOptions()
 	if type(mapOpts) ~= "table" then return false end
 	return (tonumber(mapOpts.blank_map_x) or 0) > 0 or (tonumber(mapOpts.blank_map_y) or 0) > 0
@@ -1676,8 +1678,14 @@ local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skybox
 	local baseHeight = tonumber(opts.baseHeight) or NEWMAP_BASE_HEIGHT
 	local baseColor = opts.baseColor or NEWMAP_COLOR
 
-	local mapName = string.format("Editor Flat %dx%d", widthUnits, heightUnits)
 	local seed = math.random(1, 2000000000)
+	-- Unique name per restart: the engine's archive scanner (current master)
+	-- wrongly persists the generated map's VIRTUAL archive into ArchiveCache at
+	-- shutdown; a reused name then resolves to that stale entry (no file on
+	-- disk) and the next restart dies with "Dependent archive not found". A
+	-- fresh name can never collide with a poisoned cache entry. All name
+	-- matchers use the "^Editor Flat %dx%d" PREFIX, never an exact match.
+	local mapName = string.format("Editor Flat %dx%d s%d", widthUnits, heightUnits, seed % 100000)
 
 	local script = base
 


### PR DESCRIPTION
The engine archive scanner (current Recoil master) persists the generated map's virtual archive into ArchiveCache at shutdown; a reused name then resolves to the stale entry and the restart dies with Dependent archive not found.
A fresh name per restart can never collide.
All matchers use the ^Editor Flat %dx%d prefix.

### Work done

The current Recoil master's archive scanner persists a generated blank map's VIRTUAL archive (`Editor Flat NxN.sva`, `archivedata.name="generated"`, `modified="0"`) into ArchiveCache at engine shutdown.
On the next restart, that stale cache entry shadows the fresh in-session scan, so `AddArchiveWithDeps(mapName)` fails and the restart dies with `Dependent archive "editor flat nxn" not found` — on every subsequent New Map or project open, once poisoned. Deleting the cache file fixes it for exactly one run, then it re-poisons.
Generated blank map names now carry a per-session suffix (`Editor Flat WxH s<seed%100000>`), so a reused name can never collide with a stale cache entry — a fresh name each restart sidesteps the bug entirely rather than trying to work around the engine's cache-writing logic.
All name matchers (`_isGeneratedBlankMap` in the terraform brush GUI, plus New Map / Open Project detection) now use the `^Editor Flat %dx%d` PREFIX instead of an exact match, since the suffix is unpredictable per session.

#### Setup

Only reproducible on Recoil builds that persist virtual archives into ArchiveCache (seen on a current master-based custom build) — stock/released engines don't hit this, and the fix is inert there too (unique names still parse fine as `Editor Flat WxH`).
To reproduce the bug pre-fix: FILE > New Map twice with a restart between them (same size) on an affected build — the second restart fails with `Dependent archive not found` unless the ArchiveCache file is deleted first.

#### Test steps
- [ ] FILE > New Map (any size), let it restart; repeat FILE > New Map with the same size on the same run: no `Dependent archive not found`, both restarts succeed.
- [ ] Save a map project from a generated blank map, then FILE > Open Project it: the blank-map/session-guard detection still recognizes it (prefix match), load proceeds normally.
- [ ] Map name shown in-game now includes a numeric suffix (e.g. "Editor Flat 12x12 s58880") — confirm nothing that displays the map name breaks on the longer string.

### AI / LLM usage statement:

Per [AI_POLICY.md](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/AI_POLICY.md):
- **Tool used**: Claude Code (model: Claude Sonnet 5).
- **Extent**: the fix and this PR text were AI-written under my direction after diagnosing the ArchiveCache regression together; I reviewed the diff line by line.
- **Human verification**: reproduced the pre-fix failure and confirmed the fix resolves it on the affected custom engine build; not yet tested on stock/released engines (expected to be a no-op there).

Generated with [Claude Code](https://claude.com/claude-code)