### PR TITLE
Terraform Brush: smoother smooth tool using local blur instead of full area mean height

### DIFF
--- a/luarules/gadgets/cmd_terraform_brush.lua
+++ b/luarules/gadgets/cmd_terraform_brush.lua
@@ -100,6 +100,7 @@ local currentStrokeId = 0      -- incremented on each STROKE_END; tags all entri
 local lastUndoFrame = -1       -- throttle: only one undo per game frame
 local MAX_RADIUS = 2000
 local MIN_RADIUS = 8
+local MAX_BLUR_STEP = 6  -- smooth mode: widest neighbor spacing (grid cells) at max intensity
 
 -- ── Diagnostics ──────────────────────────────────────────────────────────────
 local DIAG = false  -- set false to silence
@@ -111,6 +112,7 @@ local ringInnerRatio = 0.6
 local scratchHeightData = {}
 local scratchHeightDataMax = 0  -- high-water mark for reliable trimming (avoids # on reused table)
 local scratchSnapFlat = {}  -- flat buffer: x,z,h,x,z,h,... (no sub-table allocation)
+local scratchBlurHeights = {}  -- padded (sw+2)x(sh+2) height grid for smooth-mode local blur
 local scratchParts = {}
 
 -- Parse a space-separated payload into scratchParts, reusing the table
@@ -678,7 +680,7 @@ local function getFalloffStamp(radius, shape, angleDeg, curve, lengthScale, ring
 	return stamp
 end
 
-local function applyTerraform(centerX, centerZ, radius, direction, shape, angleDeg, curve, heightMin, heightMax, intensity, lengthScale, clayMode, opacity, flattenHeight, instant)
+local function applyTerraform(centerX, centerZ, radius, direction, shape, angleDeg, curve, heightMin, heightMax, intensity, lengthScale, clayMode, opacity, flattenHeight, instant, localBlur)
 	local squareSize = Game.squareSize
 	local mapSizeX = Game.mapSizeX
 	local mapSizeZ = Game.mapSizeZ
@@ -694,7 +696,7 @@ local function applyTerraform(centerX, centerZ, radius, direction, shape, angleD
 	opacity = opacity or 0.3
 	local dirStep = direction * HEIGHT_STEP
 	local levelTarget
-	if direction == 0 then
+	if direction == 0 and not localBlur then
 		-- Heights are only written after the loop, so this matches the
 		-- per-cell read it replaces.
 		levelTarget = flattenHeight or GetGroundHeight(centerX, centerZ)
@@ -714,6 +716,36 @@ local function applyTerraform(centerX, centerZ, radius, direction, shape, angleD
 	local centerCellX = floor(centerX / squareSize + 0.5)
 	local centerCellZ = floor(centerZ / squareSize + 0.5)
 
+	-- Smooth mode (localBlur): each cell blends toward the mean of its OWN 3x3
+	-- neighborhood instead of one flat target for the whole stamp, so a cell at
+	-- the falloff edge blends toward a value close to its own height (most of
+	-- its neighbors are untouched terrain) -- no plateau-vs-untouched seam.
+	-- Neighbor spacing (blurStep, in grid cells) scales with intensity: at low
+	-- intensity it stays tight (fine-detail smoothing only, gentle), so at high
+	-- intensity a single pass reaches wide enough to actually flatten broad
+	-- bumps instead of forever only erasing single-cell noise. Capped at half
+	-- the brush's own radius so small brushes don't sample past themselves.
+	-- Read the padded rect once; the main loop below reuses it for both the
+	-- cell's own height and all 8 neighbor samples.
+	local blurBuf, blurStride, blurStep
+	if localBlur then
+		local intensityT = max(0, min(1, math.log(intensity / 0.1) / math.log(100.0 / 0.1)))
+		blurStep = floor(1 + intensityT * (MAX_BLUR_STEP - 1) + 0.5)
+		blurStep = max(1, min(blurStep, floor(radius / squareSize / 2)))
+		blurStride = sw + 2 * blurStep
+		blurBuf = scratchBlurHeights
+		for pz = 0, sh - 1 + 2 * blurStep do
+			local zCell = centerCellZ + (pz - blurStep - sCz)
+			local bz = max(0, min(mapSizeZ, zCell * squareSize))
+			local rowBase = pz * blurStride
+			for px = 0, sw - 1 + 2 * blurStep do
+				local xCell = centerCellX + (px - blurStep - sCx)
+				local bx = max(0, min(mapSizeX, xCell * squareSize))
+				blurBuf[rowBase + px + 1] = GetGroundHeight(bx, bz)
+			end
+		end
+	end
+
 	-- Reuse scratch tables to reduce per-frame allocation
 	local heightData = scratchHeightData
 	local snapFlat = scratchSnapFlat
@@ -731,7 +763,25 @@ local function applyTerraform(centerX, centerZ, radius, direction, shape, angleD
 					local xCell = centerCellX + (ix - sCx)
 					local x = xCell * squareSize
 					if x >= 0 and x <= mapSizeX then
-						local current = GetGroundHeight(x, z)
+						local current
+						local blurTarget
+						if localBlur then
+							local rowN = iz * blurStride
+							local rowC = (iz + blurStep) * blurStride
+							local rowS = (iz + 2 * blurStep) * blurStride
+							local colW = ix + 1
+							local colC = ix + blurStep + 1
+							local colE = ix + 2 * blurStep + 1
+							current = blurBuf[rowC + colC]
+							blurTarget = (
+								blurBuf[rowN + colW] + blurBuf[rowN + colC] + blurBuf[rowN + colE] +
+								blurBuf[rowC + colW]                       + blurBuf[rowC + colE] +
+								blurBuf[rowS + colW] + blurBuf[rowS + colC] + blurBuf[rowS + colE] +
+								current
+							) / 9
+						else
+							current = GetGroundHeight(x, z)
+						end
 						-- Write to flat scratch buffer (no sub-table allocation)
 						local base = sCount * 3
 						snapFlat[base + 1] = x
@@ -748,7 +798,8 @@ local function applyTerraform(centerX, centerZ, radius, direction, shape, angleD
 							elseif direction < 0 and heightMin then
 								newHeight = current + (heightMin - current) * falloff
 							elseif direction == 0 then
-								newHeight = current + (levelTarget - current) * falloff
+								local target = localBlur and blurTarget or levelTarget
+								newHeight = current + (target - current) * falloff
 								if heightMin then newHeight = max(heightMin, newHeight) end
 								if heightMax then newHeight = min(heightMax, newHeight) end
 							else
@@ -762,7 +813,8 @@ local function applyTerraform(centerX, centerZ, radius, direction, shape, angleD
 							local delta = (random() * 2 - 1) * HEIGHT_STEP * falloff * intensity * opacity
 							newHeight = current + delta
 						elseif direction == 0 then
-							local diff = levelTarget - current
+							local target = localBlur and blurTarget or levelTarget
+							local diff = target - current
 							local blend = min(1.0, falloff * opacity * intensity)
 							newHeight = current + diff * blend
 						else
@@ -2269,6 +2321,9 @@ function gadget:RecvLuaMsg(msg, playerID)
 	local dustMode = parts[13] == "1"
 	local opacity = tonumber(parts[14]) or 0.3
 	local instant = parts[15] == "1"
+	-- "smooth" is a sentinel (not a number): smooth mode has no single flatten
+	-- target, the gadget computes one locally per cell instead.
+	local localBlur = parts[16] == "smooth"
 	local flattenHeight = tonumber(parts[16])
 	if parts[17] then
 		ringInnerRatio = max(0.05, min(0.95, tonumber(parts[17]) or 0.6))
@@ -2284,7 +2339,7 @@ function gadget:RecvLuaMsg(msg, playerID)
 	lengthScale = max(0.2, min(5.0, lengthScale))
 	opacity = max(0.01, min(1.0, opacity))
 
-	applyTerraform(centerX, centerZ, radius, direction, shape, angleDeg, curve, heightMin, heightMax, intensity, lengthScale, clayMode, opacity, flattenHeight, instant)
+	applyTerraform(centerX, centerZ, radius, direction, shape, angleDeg, curve, heightMin, heightMax, intensity, lengthScale, clayMode, opacity, flattenHeight, instant, localBlur)
 	if dustMode then
 		spawnDust(centerX, centerZ, radius, intensity)
 	end

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -966,7 +966,11 @@ local function sendTerraformMessage(direction, worldX, worldZ, radius, shape, ro
 		absCapMax = (heightCapMax and lockedGroundY) and string.format("%.0f", lockedGroundY + heightCapMax) or "nil"
 	end
 	local instant = isStampMode() and "1" or "0"
-	local flattenStr = flattenHeight and string.format("%.0f", flattenHeight) or "nil"
+	-- Smooth mode has no single flatten target: the gadget computes a local
+	-- per-cell blur target instead. "smooth" rides the same wire slot as a
+	-- non-numeric sentinel (tonumber() on it is nil, same as the "no target"
+	-- case), so recordLinkedStroke/replay need no changes to carry it.
+	local flattenStr = (activeMode == "smooth") and "smooth" or (flattenHeight and string.format("%.0f", flattenHeight) or "nil")
 	local penPressureFactor = 1
 	if extraState.penPressureEnabled and extraState.penPressureModulateIntensity and not extraState.penOverUI then
 		local pm = extraState.penPressureMapped or extraState.penPressure or 0
@@ -3425,22 +3429,12 @@ function widget:Update(dt)
 			stampApplied = true
 		end
 
-		-- For level/smooth mode (direction=0): pass the flatten target height.
-		-- level: first-click height (pinned target). smooth: live mean of brush area.
+		-- Level mode (direction=0) passes the flatten target height (first-click,
+		-- pinned). Smooth mode needs none: the gadget computes a local per-cell
+		-- blur target itself (see the "smooth" sentinel in sendTerraformMessage).
 		local fh = nil
-		if activeDirection == 0 then
-			if activeMode == "smooth" then
-				local sum = 0
-				local step = activeRadius * 0.4
-				for ix = -2, 2 do
-					for iz = -2, 2 do
-						sum = sum + GetGroundHeight(lockedWorldX + ix * step, lockedWorldZ + iz * step)
-					end
-				end
-				fh = sum / 25
-			else
-				fh = lockedGroundY
-			end
+		if activeDirection == 0 and activeMode ~= "smooth" then
+			fh = lockedGroundY
 		end
 
 		-- Interpolated stamps: bridge the gap between last applied position and
@@ -3473,18 +3467,7 @@ function widget:Update(dt)
 				local t = i / steps
 				local ix = prevX + (lockedWorldX - prevX) * t
 				local iz = prevZ + (lockedWorldZ - prevZ) * t
-				local fhi = fh
-				if activeMode == "smooth" and activeDirection == 0 then
-					local sum = 0
-					local step = activeRadius * 0.4
-					for jx = -2, 2 do
-						for jz = -2, 2 do
-							sum = sum + GetGroundHeight(ix + jx * step, iz + jz * step)
-						end
-					end
-					fhi = sum / 25
-				end
-				sendTerraformMessage(activeDirection, ix, iz, activeRadius, activeShape, activeRotation, activeCurve, fhi)
+				sendTerraformMessage(activeDirection, ix, iz, activeRadius, activeShape, activeRotation, activeCurve, fh)
 			end
 			extraState.interpIntensityScale = 1
 		end


### PR DESCRIPTION
### Work done

Smooth mode blended every cell in the brush toward a single mean height sampled at the cursor, so the inside of the stroke leveled out while untouched terrain just past the falloff edge didn't move at all — a hard seam, independent of intensity.
Each cell now blends toward the average of its own local neighbors instead (classic box-blur smoothing), so a cell near the edge moves by an amount close to zero — no seam regardless of dwell time or intensity.

Neighbor spacing scales with intensity: tight at low settings (fine-detail smoothing only), wider at max intensity so a single pass can flatten broad bumps instead of forever only erasing single-cell noise. Capped at half the brush radius so small brushes can't sample past themselves.

Falloff/curve is unchanged — still shapes the edge decay exactly as before.

#### Test steps
- [ ] Smooth over rough terrain at low intensity: no ring/seam at the brush boundary no matter how long you hold it.
- [ ] Smooth at max intensity: noticeably flattens broader bumps in one or two strokes, not just fine noise.
- [ ] Level mode: unaffected, still snaps to the first-click height.

### AI / LLM usage statement:
Written with Claude Code (Claude Sonnet 5) under my direction; all changes tested and verified manually. 
