### PR TITLE
Terraform Brush: enable splat tool on generated blank maps

### DIFF
--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1097,6 +1097,18 @@ end
 
 local function _splatToolUnavailable()
 	if _newMapSplatUnavailable() then return true end
+	-- Generated blank maps expose only a 1x1 fallback splat distribution; the
+	-- splat painter PROMOTES that to a map-sized editable target (see
+	-- cmd_splat_painter initSplatTexture), so the tool works as long as the DNTS
+	-- normals are actually bound (the engine blank-map DNTS path plus the widget
+	-- fallback do this). The strict >1x1 check below would wrongly reject that
+	-- promotable case, leaving the button greyed even though painting succeeds.
+	if _isGeneratedBlankMap() then
+		local distr = gl.TextureInfo("$ssmf_splat_distr")
+		local normals = gl.TextureInfo("$ssmf_splat_normals:0")
+		return not (distr and (distr.xsize or 0) > 0
+			and normals and (normals.xsize or 0) > 0)
+	end
 	return not _mapHasUsableSplatTexture()
 end
 


### PR DESCRIPTION
The splat button was greyed on generated blank maps because _splatToolUnavailable() required the $ssmf_splat_distr texture to be larger than 1x1. Generated maps only ever expose the engine 1x1 fallback distribution, so the gate never opened even though painting works: the splat painter (cmd_splat_painter initSplatTexture) promotes that 1x1 fallback to a map-sized editable target.

For generated blank maps, gate on the distribution AND the DNTS normals actually being bound (xsize > 0) instead of the strict >1x1 check. That matches the painter's real capability now that the blank-map DNTS path binds normals. Non-generated maps keep the _mapHasUsableSplatTexture path unchanged.

### AI / LLM usage statement:
Written with Claude Code; all changes tested and verified manually. 