### PR TITLE
modules — mission api 1/5: hello pawns — the module runtime and the missions DSL

### DIFF
--- a/.busted
+++ b/.busted
@@ -12,7 +12,8 @@ return {
       "luarules/?.lua", "luarules/?/init.lua",
       "luaui/?.lua", "luaui/?/init.lua",
       "spec/?.lua", "spec/?/init.lua",
-    }, ";")
+    }, ";"),
+    helper = "spec/spec_helper.lua",
   },
   -- Default configuration
   verbose = true,

--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -61,7 +61,20 @@
       "CMD_WANTED_SPEED",
       "GadgetCrashingAircraft",
       "ExplosionDefs",
-      "GL_TEXTURE_2D"
+      "GL_TEXTURE_2D",
+      "When",
+      "Team",
+      "UnitDef",
+      "Objective",
+      "MatchFlow",
+      "Policies",
+      "Actions",
+      "describe",
+      "it",
+      "before_each",
+      "after_each",
+      "setup",
+      "teardown"
     ]
   },
   "runtime": {

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -510,6 +510,17 @@ function gadgetHandler:Initialize()
 	local gadgetFiles = VFS.DirList(GADGETS_DIR, "*.lua", VFSMODE)
 	--  table.sort(gadgetFiles)
 
+	-- Encapsulated modules ship their own gadgets (modules/<name>/gadgets/).
+	-- Game-side shim until the engine loads module subdirectories natively.
+	if Script.GetName():gsub("US$", "") == "LuaRules" then
+		local ModuleHandler = VFS.Include("modules/module_handler.lua", nil, VFSMODE)
+		for _, moduleGadgetDir in ipairs(ModuleHandler.GadgetDirs(VFSMODE)) do
+			for _, gf in ipairs(VFS.DirList(moduleGadgetDir, "*.lua", VFSMODE)) do
+				gadgetFiles[#gadgetFiles + 1] = gf
+			end
+		end
+	end
+
 	--  for k,gf in ipairs(gadgetFiles) do
 	--    Spring.Echo('gf1 = ' .. gf) -- FIXME
 	--  end

--- a/luaui/Tests/hello_pawns/test_win.lua
+++ b/luaui/Tests/hello_pawns/test_win.lua
@@ -1,0 +1,93 @@
+---@diagnostic disable: lowercase-global, undefined-field
+
+-- Plays the hello_pawns mission end to end: load it via the chat command,
+-- reach 3 Pawns, expect scripted victory through the matchflow verdict path.
+-- Fails if DSL registration breaks, the loader env is missing a verb, the
+-- condition never fires, or the verdict path is disconnected.
+--
+-- NOTE: this test really ends the game (Spring.GameOver). If it disturbs
+-- later tests in a full suite run, scope the run: `runtestsheadless hello_pawns`.
+
+local PAWN = "armpw"
+local PAWN_COUNT = 3
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	-- SyncedRun ships the caller's stack locals (not upvalues), so copy the
+	-- file-level config into locals for the spawn block below.
+	local pawnName = PAWN
+	local pawnCount = PAWN_COUNT
+	local teamID = Spring.GetLocalTeamID()
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+	local pawnDefID = UnitDefNames[PAWN].id
+
+	-- Arm the mission via the same chat command a player would use.
+	Spring.SendCommands("luarules mission hello_pawns")
+	Test.waitUntil(function()
+		return Spring.GetGameRulesParam("mission_active") == 1
+	end)
+
+	-- Buffer GameOver before anything can win.
+	Test.expectCallin("GameOver")
+
+	-- Cheat-spawn toward the objective instead of really building: two finished
+	-- Pawns plus one nanoframe. Has() means COMPLETED units — the nanoframe
+	-- must not win the mission (the factory-blueprint bug).
+	local x = Game.mapSizeX / 2
+	local z = Game.mapSizeZ / 2
+	local frameUnitID = SyncedRun(function(locals)
+		for i = 1, locals.pawnCount - 1 do
+			Spring.CreateUnit(locals.pawnName, locals.x + i * 32, Spring.GetGroundHeight(locals.x + i * 32, locals.z), locals.z, 0, locals.teamID)
+		end
+		-- The nanoframe needs a live builder: unit_prevent_lab_hax2 destroys
+		-- fresh under-construction units whose builder is dead/absent.
+		local builderID = Spring.CreateUnit("armck", locals.x - 64, Spring.GetGroundHeight(locals.x - 64, locals.z), locals.z, 0, locals.teamID)
+		local unitID = Spring.CreateUnit(locals.pawnName, locals.x, Spring.GetGroundHeight(locals.x, locals.z), locals.z, 0, locals.teamID, true, true, nil, builderID)
+		if unitID ~= nil then
+			-- Give it real progress so abandoned-nanoframe decay stays far away.
+			Spring.SetUnitHealth(unitID, { build = 0.8 })
+		end
+		return unitID
+	end)
+	assert(frameUnitID ~= nil, "failed to spawn the nanoframe Pawn")
+
+	Test.waitUntil(function()
+		return Spring.GetTeamUnitDefCount(teamID, pawnDefID) >= PAWN_COUNT
+	end)
+
+	-- Two evaluation cadences with the third Pawn still a nanoframe: no verdict.
+	Test.waitFrames(2 * 15 + 2)
+	assert(Spring.GetGameRulesParam("objective_build_pawns") ~= 1, "mission must not complete while the third Pawn is a nanoframe")
+
+	-- Finish the build; NOW the mission should be won.
+	SyncedRun(function(locals)
+		Spring.SetUnitHealth(locals.frameUnitID, { build = 1 })
+	end)
+
+	-- The mission's effect chain: objective completes, then scripted victory
+	-- for the player's ally team.
+	Test.waitUntilCallin("GameOver", function(winningAllyTeams)
+		if type(winningAllyTeams) ~= "table" then
+			return false
+		end
+		for _, winner in ipairs(winningAllyTeams) do
+			if winner == allyTeamID then
+				return true
+			end
+		end
+		return false
+	end, 10 * 30)
+
+	assert(Spring.GetGameRulesParam("objective_build_pawns") == 1, "objective build_pawns should be complete before victory")
+end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -1047,6 +1047,9 @@ local function initializeTestEnvironment()
 		type = type,
 		unpack = unpack,
 		select = select,
+		setmetatable = setmetatable,
+		getmetatable = getmetatable,
+		getfenv = getfenv,
 		Scenario = scenarioConfig,
 
 		Json = Json,

--- a/modules/matchflow/api.lua
+++ b/modules/matchflow/api.lua
@@ -1,0 +1,30 @@
+--- Synced contract of the matchflow module — DEMO-MINIMAL: the scripted-verdict
+--- path only, not the game_end extraction (that is matchflow_module_plan.md,
+--- later). The point of this file is the call shape: `MatchFlow.Victory(...)`
+--- survives unchanged when the real module lands underneath it.
+---
+--- The pending verdict lives in the verdict gadget (one owner); contract
+--- includes are per-consumer, so this file holds no state and forwards
+--- through the gadget's GG surface.
+
+---@param name string
+---@return table
+local function gadgetSurface(name)
+	local surface = GG.MatchFlow
+	assert(surface ~= nil, "MatchFlow." .. name .. " called before the matchflow_verdict gadget initialized")
+	return surface
+end
+
+return {
+	---Scripted victory: the given ally team wins on the next verdict tick.
+	---@param allyTeamID integer
+	Victory = function(allyTeamID)
+		gadgetSurface("Victory").Victory(allyTeamID)
+	end,
+
+	---Scripted defeat: every other ally team (bar Gaia) wins.
+	---@param allyTeamIDs integer[]
+	Defeat = function(allyTeamIDs)
+		gadgetSurface("Defeat").Defeat(allyTeamIDs)
+	end,
+}

--- a/modules/matchflow/gadgets/matchflow_verdict.lua
+++ b/modules/matchflow/gadgets/matchflow_verdict.lua
@@ -1,0 +1,68 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "MatchFlow Verdict",
+		desc = "Scripted-verdict path of the matchflow module: applies pending Victory/Defeat verdicts (demo-minimal; the game_end extraction comes later)",
+		author = "Beyond All Reason",
+		date = "July 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+-- DEMO-ONLY coexistence: game_end.lua still runs its own end conditions, the
+-- same way missions coexist with it today (the scenariooptions path). This
+-- gadget only ever ends the game when a mission scripted a verdict.
+
+-- Deferral is deliberate: Victory/Defeat are called from trigger evaluation
+-- INSIDE GameFrame, and calling Spring.GameOver reentrantly mid-callin risks
+-- undefined ordering. Deferring to the next GameFrame gives one idempotent
+-- application point — double verdicts in a frame collapse to one.
+---@type integer[]|nil winning ally team ids; applied on the next GameFrame
+local pendingWinners = nil
+
+---@param allyTeamID integer
+local function Victory(allyTeamID)
+	pendingWinners = { allyTeamID }
+end
+
+---@param losers integer[]
+local function Defeat(losers)
+	local losing = {}
+	for _, allyTeamID in ipairs(losers) do
+		losing[allyTeamID] = true
+	end
+	local gaiaAllyTeam = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
+	local winners = {}
+	for _, allyTeamID in ipairs(Spring.GetAllyTeamList()) do
+		if not losing[allyTeamID] and allyTeamID ~= gaiaAllyTeam then
+			winners[#winners + 1] = allyTeamID
+		end
+	end
+	pendingWinners = winners
+end
+
+function gadget:Initialize()
+	GG.MatchFlow = {
+		Victory = Victory,
+		Defeat = Defeat,
+	}
+end
+
+function gadget:Shutdown()
+	GG.MatchFlow = nil
+end
+
+function gadget:GameFrame()
+	if pendingWinners ~= nil then
+		local winners = pendingWinners
+		pendingWinners = nil
+		Spring.GameOver(winners)
+	end
+end

--- a/modules/matchflow/lib/ceremony.lua
+++ b/modules/matchflow/lib/ceremony.lua
@@ -1,0 +1,111 @@
+--- Game-over ceremony, extracted behavior-for-behavior from game_end.lua's
+--- GameFrame: the global-LOS reveal for winners, the delayed Spring.GameOver
+--- (letting everything blow up gradually first), and the commander dance
+--- animation. Effects only — the decision that produced `winners` is the
+--- policy pipeline's job.
+---
+--- Quirks preserved on purpose: in shared-dynamic-alliance mode the legacy
+--- code hands a winner COUNT (a number) around instead of a table; every
+--- type(winners) == 'table' guard below is that inheritance.
+
+local Ceremony = {}
+
+---@class CeremonySpringDeps
+---@field SetGlobalLos fun(allyTeamID: integer, value: boolean)
+---@field GameOver fun(winners: table|number)
+---@field GetAllUnits fun(): integer[]
+---@field GetUnitDefID fun(unitID: integer): integer?
+---@field GetUnitAllyTeam fun(unitID: integer): integer?
+---@field GiveOrderToUnit fun(unitID: integer, cmd: integer, params: number|table, opts: number|table)
+---@field ValidUnitID fun(unitID: integer): boolean
+---@field GetCOBScriptID fun(unitID: integer, name: string): integer?
+---@field CallCOBScript fun(unitID: integer, script: integer|string, retvals: integer, ...)
+---@field UnitScriptGetScriptEnv fun(unitID: integer): table?
+---@field UnitScriptCallAsUnit fun(unitID: integer, fn: function, ...)
+
+---@class CeremonyDeps
+---@field spring CeremonySpringDeps
+---@field isCommander table<integer, boolean> unitDefID -> is commander
+---@field cmdStop integer CMD.STOP
+---@field maxDeathFrame fun(): integer|nil GG.maxDeathFrame at Begin time
+
+---@class MatchCeremony
+---@field Begin fun(winners: table|number, gf: integer) schedule the gameover sequence
+---@field GameFrame fun(gf: integer)
+---@field IsStarted fun(): boolean
+
+---@param deps CeremonyDeps
+---@return MatchCeremony
+function Ceremony.New(deps)
+	local spring = deps.spring
+
+	local gameoverFrame
+	local gameoverWinners
+	local gameoverAnimFrame
+	local gameoverAnimUnits
+	local globalLosGranted = false
+
+	local ceremony = {}
+
+	ceremony.Begin = function(winners, gf)
+		-- delay gameover to let everything blow up gradually first
+		local delay = deps.maxDeathFrame() or 250
+		gameoverFrame = gf + delay + 70
+		gameoverWinners = winners
+
+		-- make all winner commanders dance!
+		gameoverAnimFrame = gf + 55		-- delay a bit because walking commanders need to stop walking + a delay look nice
+		gameoverAnimUnits = {}
+		if type(winners) == 'table' then
+			local winnerSet = {}
+			for u = 1, #winners do
+				winnerSet[winners[u]] = true
+			end
+			local units = spring.GetAllUnits()
+			for i = 1, #units do
+				local unitID = units[i]
+				if deps.isCommander[spring.GetUnitDefID(unitID)] and winnerSet[spring.GetUnitAllyTeam(unitID)] then
+					spring.GiveOrderToUnit(unitID, deps.cmdStop, 0, 0)	-- give stop cmd so commanders can animate in place
+					gameoverAnimUnits[unitID] = true
+				end
+			end
+		end
+	end
+
+	ceremony.GameFrame = function(gf)
+		if not globalLosGranted then
+			for _, allyTeamId in ipairs(gameoverWinners) do
+				spring.SetGlobalLos(allyTeamId, true)
+			end
+
+			globalLosGranted = true
+		end
+
+		if gf == gameoverFrame then
+			spring.GameOver(gameoverWinners)
+		end
+
+		if gf == gameoverAnimFrame then
+			for unitID, _ in pairs(gameoverAnimUnits) do
+				if spring.ValidUnitID(unitID) then
+					if spring.GetCOBScriptID(unitID, 'GameOverAnim') then
+						spring.CallCOBScript(unitID, 'GameOverAnim', 0, true)
+					else
+						local scriptEnv = spring.UnitScriptGetScriptEnv(unitID)
+						if scriptEnv and scriptEnv['GameOverAnim'] then
+							spring.UnitScriptCallAsUnit(unitID, scriptEnv['GameOverAnim'], true)
+						end
+					end
+				end
+			end
+		end
+	end
+
+	ceremony.IsStarted = function()
+		return gameoverFrame ~= nil
+	end
+
+	return ceremony
+end
+
+return Ceremony

--- a/modules/matchflow/lib/liveness.lua
+++ b/modules/matchflow/lib/liveness.lua
@@ -1,0 +1,306 @@
+--- Match liveness tracking, extracted behavior-for-behavior from
+--- luarules/gadgets/game_end.lua: the allyTeamInfos bookkeeping (controlled /
+--- resigned state, leader grace periods, AI-host tracking, decoration-unit
+--- counting, the savegame 60-frame active hack). State maintenance only — the
+--- end-condition DECISION stays with the caller, reading Infos().
+---
+--- Every hack is preserved on purpose; the original comments travel with the
+--- code. Dependencies are injected so the machine specs under busted; the
+--- gadget supplies Spring and GG.wipeoutAllyTeam.
+
+local Liveness = {}
+
+---@class LivenessSpringDeps engine reads/effects the machine needs
+---@field GetPlayerList fun(teamID?: integer): integer[]
+---@field GetTeamList fun(allyTeamID?: integer): integer[]
+---@field GetPlayerInfo fun(playerID: integer, getPlayerOpts: boolean): string?, boolean?, boolean?, integer?, integer?
+---@field GetTeamInfo fun(teamID: integer, getTeamKeys: boolean): integer?, integer?, integer?, boolean?, string?, integer?
+---@field GetTeamUnitCount fun(teamID: integer): integer?
+---@field GetTeamUnits fun(teamID: integer): integer[]?
+---@field GetUnitDefID fun(unitID: integer): integer?
+---@field GetAIInfo fun(teamID: integer): integer?, string?, integer?
+---@field GetTeamLuaAI fun(teamID: integer): string?
+---@field KillTeam fun(teamID: integer)
+---@field DestroyUnit fun(unitID: integer, selfd: boolean, reclaimed: boolean)
+
+---@class LivenessConfig
+---@field gaiaTeamID integer
+---@field gaiaAllyTeamID integer
+---@field isFFA boolean
+---@field playerQuitIsDead boolean false for 1v1/FFA (quit & rejoin allowed)
+---@field earlyDropGrace integer frames; FFA early-drop reclaim window
+---@field killGraceFrames integer frames of leaderless grace before KillTeam
+---@field ignoredTeams table<integer, boolean> teams excluded from unit counting (gaia, Raptors/Scavengers)
+---@field unitDecoration table<integer, boolean> unitDefID -> is decoration
+
+---@class LivenessDeps
+---@field spring LivenessSpringDeps
+---@field config LivenessConfig
+---@field wipeoutAllyTeam fun(allyTeamID: integer) GG.wipeoutAllyTeam in production
+
+---@class MatchLiveness
+---@field InitTeams fun(allyteamList: integer[])
+---@field CheckAllPlayers fun(gf: integer)
+---@field TeamDied fun(teamID: integer, gf: integer)
+---@field UnitCreated fun(unitDefID: integer, unitTeamID: integer)
+---@field UnitDestroyed fun(unitDefID: integer, unitTeam: integer)
+---@field Infos fun(): table read-only-by-convention allyTeamInfos view
+
+---@param deps LivenessDeps
+---@return MatchLiveness
+function Liveness.New(deps)
+	local spring = deps.spring
+	local config = deps.config
+	local wipeoutAllyTeam = deps.wipeoutAllyTeam
+
+	local EMPTY_TABLE = {}
+
+	local playerQuitIsDead = config.playerQuitIsDead
+	local teamToAllyTeam = { [config.gaiaTeamID] = config.gaiaAllyTeamID }
+	local playerIDtoAIs = {}
+	local playerInfoCache = {}
+	local teamEvalFrame = {}
+	local allyTeamEvalFrame = {}
+	local playerList = spring.GetPlayerList()
+	local killTeamQueue = {}
+	local isFFA = config.isFFA
+
+	local allyTeamInfos = {}
+	--[[
+	allyTeamInfos structure: (excluding gaia)
+	 allyTeamInfos = {
+		[allyTeamID] = {
+			teams = {
+				[teamID]= {
+					players = {
+						[playerID] = isControlling
+					},
+					unitCount,
+					dead,
+					isAI,
+					isControlled,
+				},
+			},
+			unitCount,
+			unitDecorationCount,
+			dead,
+		},
+	}
+	]]--
+
+	local function UpdateAllyTeamIsDead(allyTeamID, gf)
+		if gf == 0 then return end
+
+		local wipeout = true
+		local allyTeamInfo = allyTeamInfos[allyTeamID]
+		for teamID, team in pairs(allyTeamInfo.teams) do
+			wipeout = wipeout and (team.dead or (playerQuitIsDead and not team.isControlled or not team.hasLeader))
+		end
+		if wipeout and not allyTeamInfos[allyTeamID].dead then
+			if isFFA and gf < config.earlyDropGrace then
+				for teamID, team in pairs(allyTeamInfos[allyTeamID].teams) do
+					local teamUnits = spring.GetTeamUnits(teamID) or EMPTY_TABLE
+					for i = 1, #teamUnits do
+						spring.DestroyUnit(teamUnits[i], false, true)	-- reclaim, dont want to leave FFA comwreck for idling starts
+					end
+				end
+			else
+				wipeoutAllyTeam(allyTeamID)
+			end
+			allyTeamInfos[allyTeamID].dead = true
+		end
+	end
+
+	local function CheckPlayer(playerID, gf)
+		local cachedPlayerInfo = playerInfoCache[playerID]
+		local active = cachedPlayerInfo and cachedPlayerInfo.active
+		local spectator = cachedPlayerInfo and cachedPlayerInfo.spectator
+		local teamID = cachedPlayerInfo and cachedPlayerInfo.teamID
+		local allyTeamID = cachedPlayerInfo and cachedPlayerInfo.allyTeamID
+		if teamID == nil then
+			_, active, spectator, teamID, allyTeamID = spring.GetPlayerInfo(playerID, false)
+		end
+		local team = allyTeamInfos[allyTeamID].teams[teamID]
+
+		if not spectator and active then
+			team.players[playerID] = gf
+		end
+		if teamEvalFrame[teamID] ~= gf then
+			teamEvalFrame[teamID] = gf
+
+			team.hasLeader = select(2, spring.GetTeamInfo(teamID, false)) >= 0
+
+			local allResigned = true
+			if not team.dead then
+				if team.isAI then
+					allResigned = false
+				else
+					for trackedPlayerID in pairs(team.players) do
+						local trackedInfo = playerInfoCache[trackedPlayerID]
+						local spec = trackedInfo and trackedInfo.spectator
+						if spec == nil then
+							_, _, spec = spring.GetPlayerInfo(trackedPlayerID, false)
+						end
+						allResigned = allResigned and (spec == true)
+						if not allResigned then
+							break
+						end
+					end
+				end
+			end
+			if not team.dead and allResigned then
+				killTeamQueue[teamID] = gf
+			else
+				if not team.hasLeader and not team.dead then
+					if not killTeamQueue[teamID] then
+						killTeamQueue[teamID] = gf + config.killGraceFrames	-- add a grace period before killing the team
+					end
+				elseif killTeamQueue[teamID] then
+					killTeamQueue[teamID] = nil
+				end
+			end
+			if killTeamQueue[teamID] and gf >= killTeamQueue[teamID] then
+				spring.KillTeam(teamID)
+				killTeamQueue[teamID] = nil
+			end
+
+			-- if team isn't AI controlled, then we need to check if we have attached players
+			if not team.isAI then
+				team.isControlled = false
+				for _, isControlling in pairs(team.players) do
+					if isControlling and isControlling > (gf - 60) then -- this entire crap is needed because GetPlayerInfo returns active = false for the next 30 gameframes after savegame load, and results in immediate end of loaded games if > 1v1 game
+						team.isControlled = true
+						break
+					end
+				end
+			end
+		end
+
+		-- if player is an AI controller, then mark all hosted AIs as uncontrolled
+		for AITeam, AIAllyTeam in pairs(playerIDtoAIs[playerID] or EMPTY_TABLE) do
+			allyTeamInfos[AIAllyTeam].teams[AITeam].isControlled = active
+		end
+
+		if allyTeamEvalFrame[allyTeamID] ~= gf then
+			allyTeamEvalFrame[allyTeamID] = gf
+			UpdateAllyTeamIsDead(allyTeamID, gf)
+		end
+	end
+
+	local liveness = {}
+
+	liveness.CheckAllPlayers = function(gf)
+		playerList = spring.GetPlayerList()
+		for i = 1, #playerList do
+			local playerID = playerList[i]
+			local _, active, spectator, teamID, allyTeamID = spring.GetPlayerInfo(playerID, false)
+			local info = playerInfoCache[playerID] or {}
+			info.active = active
+			info.spectator = spectator
+			info.teamID = teamID
+			info.allyTeamID = allyTeamID
+			playerInfoCache[playerID] = info
+		end
+		for i = 1, #playerList do
+			CheckPlayer(playerList[i], gf)
+		end
+	end
+
+	-- at start, fill in the table of all alive allyteams
+	liveness.InitTeams = function(allyteamList)
+		for _, allyTeamID in ipairs(allyteamList) do
+			if allyTeamID ~= config.gaiaAllyTeamID then
+				local allyteamTeams = spring.GetTeamList(allyTeamID)
+				local allyTeamInfo = {
+					unitCount = 0,
+					unitDecorationCount = 0,
+					teams = {},
+					dead = (#allyteamTeams == 0),
+				}
+				for _, teamID in ipairs(allyteamTeams) do
+					teamToAllyTeam[teamID] = allyTeamID
+					local teamInfo = {
+						players = {},
+						hasLeader = select(2, spring.GetTeamInfo(teamID, false)) >= 0,
+					}
+					local teamPlayers = spring.GetPlayerList(teamID) or EMPTY_TABLE
+					for p = 1, #teamPlayers do
+						teamInfo.players[teamPlayers[p]] = false
+					end
+					-- engine AI
+					teamInfo.isAI = select(4, spring.GetTeamInfo(teamID, false))
+					if teamInfo.isAI then
+						-- store who hosts that engine AI
+						local AIHostPlayerID = select(3, spring.GetAIInfo(teamID))
+						playerIDtoAIs[AIHostPlayerID] = playerIDtoAIs[AIHostPlayerID] or {}
+						playerIDtoAIs[AIHostPlayerID][teamID] = allyTeamID
+					end
+					-- lua AI
+					local luaAi = spring.GetTeamLuaAI(teamID)
+					if luaAi and luaAi ~= '' then
+						teamInfo.isAI = true
+						teamInfo.isControlled = true
+					end
+
+					teamInfo.unitCount = spring.GetTeamUnitCount(teamID)
+					allyTeamInfo.unitCount = allyTeamInfo.unitCount + teamInfo.unitCount
+					local units = spring.GetTeamUnits(teamID) or EMPTY_TABLE
+					for u = 1, #units do
+						if config.unitDecoration[spring.GetUnitDefID(units[u])] then
+							allyTeamInfo.unitDecorationCount = allyTeamInfo.unitDecorationCount + 1
+						end
+					end
+					allyTeamInfo.teams[teamID] = teamInfo
+				end
+				allyTeamInfos[allyTeamID] = allyTeamInfo
+			end
+		end
+	end
+
+	liveness.TeamDied = function(teamID, gf)
+		local allyTeamID = teamToAllyTeam[teamID]
+		allyTeamInfos[allyTeamID].teams[teamID].dead = true
+		UpdateAllyTeamIsDead(allyTeamID, gf)
+		liveness.CheckAllPlayers(gf)
+	end
+
+	liveness.UnitCreated = function(unitDefID, unitTeamID)
+		if not config.ignoredTeams[unitTeamID] then
+			local allyTeamID = teamToAllyTeam[unitTeamID]
+			local allyTeamInfo = allyTeamInfos[allyTeamID]
+			allyTeamInfo.teams[unitTeamID].unitCount = allyTeamInfo.teams[unitTeamID].unitCount + 1
+			allyTeamInfo.unitCount = allyTeamInfo.unitCount + 1
+			if config.unitDecoration[unitDefID] then
+				allyTeamInfo.unitDecorationCount = allyTeamInfo.unitDecorationCount + 1
+			end
+		end
+	end
+
+	liveness.UnitDestroyed = function(unitDefID, unitTeam)
+		if not config.ignoredTeams[unitTeam] then
+			local allyTeamID = teamToAllyTeam[unitTeam]
+			local allyTeamInfo = allyTeamInfos[allyTeamID]
+			local teamUnitCount = allyTeamInfo.teams[unitTeam].unitCount - 1
+			local allyTeamUnitCount = allyTeamInfo.unitCount - 1
+			allyTeamInfo.teams[unitTeam].unitCount = teamUnitCount
+			allyTeamInfo.unitCount = allyTeamUnitCount
+			if config.unitDecoration[unitDefID] then
+				allyTeamInfo.unitDecorationCount = allyTeamInfo.unitDecorationCount - 1
+			end
+			if allyTeamUnitCount <= allyTeamInfo.unitDecorationCount then
+				for teamID in pairs(allyTeamInfo.teams) do
+					spring.KillTeam(teamID)
+					killTeamQueue[teamID] = nil
+				end
+			end
+		end
+	end
+
+	liveness.Infos = function()
+		return allyTeamInfos
+	end
+
+	return liveness
+end
+
+return Liveness

--- a/modules/matchflow/module.lua
+++ b/modules/matchflow/module.lua
@@ -1,0 +1,6 @@
+--- Manifest for the match-lifecycle module (demo-minimal: scripted verdicts).
+---@type ModuleManifestFile
+return {
+	name = "matchflow",
+	description = "Match lifecycle: scripted Victory/Defeat verdicts",
+}

--- a/modules/matchflow/policies/game_over.lua
+++ b/modules/matchflow/policies/game_over.lua
@@ -1,0 +1,105 @@
+--- The game-over decision, extracted from game_end.lua's CheckSingle/
+--- CheckSharedAllyVictoryEnd. Pure functions over the ctx the gadget hands in;
+--- first non-nil result wins; the terminal Compute always returns (explicit
+--- continue, the sharing-module precedent).
+---
+--- GameOverCtx (built by the game_end gadget per evaluation):
+---   infos                        liveness.Infos() — allyTeamInfos view
+---   scriptedWinners              pending MatchFlow.Victory/Defeat verdict, or nil
+---   fixedallies                  modoption; forces the single-ally check
+---   sharedDynamicAllianceVictory modoption; enables the alliance cross-check
+---   AreTeamsAllied               fun(teamA, teamB): boolean (engine read)
+---
+--- Legacy quirk preserved: the shared-alliance path returns a winner COUNT
+--- (a number), not a winner list — the original built the list, commented it
+--- out, and shipped the count. Bit-identical behavior first; fix later, once,
+--- here.
+
+local singleWinnerScratch = {}
+local sharedWinnerScratch = {}
+
+local function AreAllyTeamsDoubleAllied(ctx, firstAllyTeamID, secondAllyTeamID)
+	-- we need to check for both directions of alliance
+	for teamA in pairs(ctx.infos[firstAllyTeamID].teams) do
+		for teamB in pairs(ctx.infos[secondAllyTeamID].teams) do
+			if not ctx.AreTeamsAllied(teamA, teamB) or not ctx.AreTeamsAllied(teamB, teamA) then
+				return false
+			end
+		end
+	end
+	return true
+end
+
+-- find the last remaining allyteam
+local function CheckSingleAllyVictoryEnd(ctx)
+	for i = #singleWinnerScratch, 1, -1 do
+		singleWinnerScratch[i] = nil
+	end
+	local winnerCount = 0
+	for allyTeamID in pairs(ctx.infos) do
+		if not ctx.infos[allyTeamID].dead then
+			winnerCount = winnerCount + 1
+			singleWinnerScratch[winnerCount] = allyTeamID
+		end
+	end
+	if winnerCount > 1 then
+		return false
+	end
+	return singleWinnerScratch
+end
+
+-- we have to cross check all the alliances
+local function CheckSharedAllyVictoryEnd(ctx)
+	for allyTeamID in pairs(sharedWinnerScratch) do
+		sharedWinnerScratch[allyTeamID] = nil
+	end
+	local winnerCountSquared = 0
+	local aliveCount = 0
+	for allyTeamA in pairs(ctx.infos) do
+		if not ctx.infos[allyTeamA].dead then
+			aliveCount = aliveCount + 1
+			for allyTeamB in pairs(ctx.infos) do
+				if not ctx.infos[allyTeamB].dead and AreAllyTeamsDoubleAllied(ctx, allyTeamA, allyTeamB) then
+					-- store both check directions
+					-- since we're gonna check if we're allied against ourself, only secondAllyTeamID needs to be stored
+					sharedWinnerScratch[allyTeamB] = true
+					winnerCountSquared = winnerCountSquared + 1
+				end
+			end
+		end
+	end
+
+	if aliveCount * aliveCount ~= winnerCountSquared then
+		return false
+	end
+
+	-- all the allyteams alive are bidirectionally allied against eachother, they are all winners
+	local winnersCorrectFormatCount = 0
+	for _winner in pairs(sharedWinnerScratch) do
+		winnersCorrectFormatCount = winnersCorrectFormatCount + 1
+	end
+	return winnersCorrectFormatCount
+end
+
+Policies.Pipeline()
+	:Gate("MissionOverride", function(ctx)
+		-- scripted verdicts (CampaignAPI / MatchFlow.Victory) exit through the
+		-- same pipeline as every other end condition — not a bypass
+		if ctx.scriptedWinners ~= nil then
+			return { winners = ctx.scriptedWinners }
+		end
+		return nil
+	end)
+	:Compute("LastAllyStanding", function(ctx)
+		local winners
+		if not ctx.fixedallies and ctx.sharedDynamicAllianceVictory then
+			winners = CheckSharedAllyVictoryEnd(ctx)
+		else
+			winners = CheckSingleAllyVictoryEnd(ctx)
+		end
+		if winners then
+			return { winners = winners }
+		end
+		return { continue = true }
+	end)
+	:Register()

--- a/modules/missions/README.md
+++ b/modules/missions/README.md
@@ -1,0 +1,27 @@
+# The missions module
+
+Mission logic is authored as dot-only, closure-free, terminator-free trigger chains in
+missions/<name>/triggers/*.lua. The loader includes each file in an injected
+environment (the env IS the API surface), the DSL builds descriptors, and the
+trigger engine evaluates them — event-driven where conditions declare inputs,
+polling as the fallback. Effects are lazy objects executed when a condition
+fires; matchflow owns the game-over verdict.
+
+```mermaid
+flowchart TB
+    LUA["missions/&lt;name&gt;/triggers/*.lua<br/>dot-only, closure-free chains"]
+    subgraph SYNCED["synced runtime"]
+        LOADER["mission_loader gadget<br/>injected env = the API surface;<br/>wires only watched callins"]
+        DSL["DSL builder<br/>When/.When/Do/Once — no terminator;<br/>finalized at include → TriggerDescriptor"]
+        ENGINE["trigger engine<br/>input→watchers index · dirty marks<br/>state tables (the save pile)"]
+        BUS["event bus (engine.OnEvent)<br/>engine callins + module events<br/>('UnitFinished', 'mission.objective_changed')"]
+        MF["matchflow module<br/>Victory/Defeat → pending verdict"]
+        VG["verdict gadget<br/>deferred, idempotent Spring.GameOver"]
+    end
+    LUA -->|"VFS.Include per file<br/>(hot reload by identity)"| LOADER
+    LOADER --> DSL -->|"descriptors"| ENGINE
+    LOADER -->|"forward watched callins"| BUS --> ENGINE
+    ENGINE -->|"execute effects"| MF
+    ENGINE -->|"Objective(...).Complete() emits<br/>'mission.objective_changed'"| BUS
+    MF --> VG
+```

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -1,0 +1,254 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Mission Loader",
+		desc = "Loads mission trigger files (/luarules mission <name>) into the trigger engine and evaluates them on a cadence",
+		author = "Beyond All Reason",
+		date = "July 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local LOG_TAG = "mission_loader"
+
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local ChatGuard = VFS.Include("modules/missions/lib/chat_guard.lua")
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local MISSIONS_DIR = "modules/missions/"
+local EVALUATE_PERIOD = 15 -- frames
+
+local engine = TriggerEngine.New()
+local activeMission = nil ---@type string|nil
+
+--- The engine's view of the world. Built once; frame is updated per tick.
+---@type MissionContext
+local ctx = {
+	frame = 0,
+	GetUnitDefCount = function(teamID, unitDefName)
+		local unitDef = UnitDefNames[unitDefName]
+		if unitDef == nil then
+			return 0
+		end
+		-- GetTeamUnitDefCount includes nanoframes; Has() means finished units,
+		-- so filter out anything still being built.
+		local count = 0
+		for _, unitID in ipairs(Spring.GetTeamUnitsByDefs(teamID, unitDef.id)) do
+			if not Spring.GetUnitIsBeingBuilt(unitID) then
+				count = count + 1
+			end
+		end
+		return count
+	end,
+	IsObjectiveComplete = function(name)
+		return Spring.GetGameRulesParam("objective_" .. name) == 1
+	end,
+}
+
+---Demo rule (documented in hello_pawns_plan.md): Team.Player is the first
+---human team — lowest non-Gaia teamID with no Lua AI and not the AI-hosted kind.
+---@return MissionTeam|nil
+local function resolvePlayerTeam()
+	local gaiaTeamID = Spring.GetGaiaTeamID()
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaiaTeamID then
+			local _, _, _, isAiTeam, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+			if not isAiTeam and (Spring.GetTeamLuaAI(teamID) or "") == "" then
+				return Verbs.MakeTeam(teamID, allyTeamID)
+			end
+		end
+	end
+	return nil
+end
+
+---Objective verb, demo-minimal. Closure-free surface: Complete() is LAZY —
+---it builds an effect the engine executes when the trigger fires, so mission
+---files chain it with Do instead of wrapping it in a function. IsComplete()
+---is the condition side, so victory can be its own trigger driven by
+---objective state (the "all objectives complete -> win" shape in miniature).
+---Completion state lives in rulesparams (objective_<name>) —
+---engine-serialized, so it survives a savegame like the rest of the trigger
+---progress pile.
+---
+---Rulesparam changes have no callin, but this module is the thing that
+---completes objectives — so Complete() emits "mission.objective_changed" on
+---the mission bus, and IsComplete() declares it as its input (see
+---mission_authoring_dsl.md, "Conditions declare their inputs").
+---@param name string
+---@return MissionObjective
+local function Objective(name)
+	return {
+		Complete = function()
+			return {
+				execute = function()
+					Spring.SetGameRulesParam("objective_" .. name, 1)
+					Spring.Echo("[" .. LOG_TAG .. "] objective complete: " .. name)
+					engine.OnEvent("mission.objective_changed")
+				end,
+			}
+		end,
+		IsComplete = function()
+			return {
+				inputs = { "mission.objective_changed" },
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return ctx.IsObjectiveComplete(name)
+				end,
+			}
+		end,
+	}
+end
+
+-- Engine callins the bus can forward. The gadget hooks ONLY the callins some
+-- registered trigger actually watches (the don't-hook-what-you-don't-use
+-- rule, applied automatically per mission); everything else stays unhooked.
+local FORWARDABLE_CALLINS = { "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken" }
+
+---(Re)hook engine callins to match the engine's watched-input set. Called
+---after every mission (re)load, when the watch set may have changed.
+local function syncWatchedCallins()
+	local watched = engine.WatchedInputs()
+	for _, name in ipairs(FORWARDABLE_CALLINS) do
+		if watched[name] and gadget[name] == nil then
+			gadget[name] = function()
+				engine.OnEvent(name)
+			end
+			gadgetHandler:UpdateCallIn(name)
+		elseif not watched[name] and gadget[name] ~= nil then
+			gadget[name] = nil
+			gadgetHandler:UpdateCallIn(name)
+		end
+	end
+end
+
+---The MatchFlow verbs injected into mission files: same names as the module
+---api, but LAZY — Victory(team) builds an effect for a Do chain; the module's
+---imperative api fires only when the trigger does. Takes the Team handle, not
+---a raw allyTeam id, so the mission line reads as English.
+---@param matchflowApi table the matchflow module api (ModuleHandler.Get)
+---@return MissionMatchFlow
+local function makeMatchFlowVerbs(matchflowApi)
+	return {
+		---@param team MissionTeam
+		---@return MissionEffect
+		Victory = function(team)
+			assert(type(team) == "table" and type(team.allyTeam) == "number",
+				"MatchFlow.Victory expects a Team handle (e.g. Team.Player)")
+			return {
+				execute = function()
+					matchflowApi.Victory(team.allyTeam)
+				end,
+			}
+		end,
+		---@param team MissionTeam
+		---@return MissionEffect
+		Defeat = function(team)
+			assert(type(team) == "table" and type(team.allyTeam) == "number",
+				"MatchFlow.Defeat expects a Team handle (e.g. Team.Player)")
+			return {
+				execute = function()
+					matchflowApi.Defeat({ team.allyTeam })
+				end,
+			}
+		end,
+	}
+end
+
+---Load (or reload) a mission: run each triggers/*.lua through the injected
+---environment. The sandbox IS the API surface — trigger files see the five
+---verbs and nothing else. Unregister-by-identity first makes loading
+---idempotent and is the hot-reload path.
+---@param missionName string
+---@return boolean loaded
+local function loadMission(missionName)
+	local triggersDir = MISSIONS_DIR .. missionName .. "/triggers/"
+	local files = VFS.DirList(triggersDir, "*.lua")
+	if #files == 0 then
+		Spring.Log(LOG_TAG, LOG.ERROR, "no trigger files under " .. triggersDir)
+		return false
+	end
+	table.sort(files)
+
+	local playerTeam = resolvePlayerTeam()
+	if playerTeam == nil then
+		Spring.Log(LOG_TAG, LOG.ERROR, "no human team found for Team.Player")
+		return false
+	end
+
+	local matchFlow = makeMatchFlowVerbs(ModuleHandler.Get("matchflow"))
+
+	for _, filePath in ipairs(files) do
+		-- Identity is mission-relative so ids survive install-path differences.
+		local filename = filePath:sub(#MISSIONS_DIR + 1)
+		engine.UnregisterFile(filename)
+		local file = DSL.ForFile(filename, engine.Register)
+		local env = {
+			When = file.When,
+			Team = { Player = playerTeam },
+			UnitDef = Verbs.UnitDef,
+			Objective = Objective,
+			MatchFlow = matchFlow,
+		}
+		VFS.Include(filePath, env)
+		-- The commit point: statements register here, and a half-finished
+		-- chain (no Do) is a load error naming the file and statement.
+		file.Finalize()
+	end
+
+	syncWatchedCallins()
+	activeMission = missionName
+	Spring.SetGameRulesParam("mission_active", 1)
+	Spring.Echo("[" .. LOG_TAG .. "] mission armed: " .. missionName .. " (" .. #engine.Triggers() .. " trigger(s))")
+	return true
+end
+
+---@param cmd string
+---@param line string
+---@param words string[]
+local function missionChatAction(cmd, line, words, playerID)
+	-- Synced chat actions arrive from ANY player in multiplayer; arming or
+	-- reloading a mission is not an open verb (review point on PR #8375).
+	if not ChatGuard.IsAllowed(Spring.Utilities.Gametype.IsSinglePlayer(), Spring.IsCheatingEnabled()) then
+		Spring.Log(LOG_TAG, LOG.WARNING, "/mission refused: multiplayer without cheats (player " .. tostring(playerID) .. ")")
+		return true
+	end
+	local missionName = words[1]
+	if missionName == nil or missionName == "" then
+		Spring.Log(LOG_TAG, LOG.ERROR, "usage: /luarules mission <name> | reload")
+		return true
+	end
+	if missionName == "reload" then
+		if activeMission == nil then
+			Spring.Log(LOG_TAG, LOG.ERROR, "no active mission to reload")
+			return true
+		end
+		missionName = activeMission
+	end
+	loadMission(missionName)
+	return true
+end
+
+function gadget:Initialize()
+	gadgetHandler:AddChatAction("mission", missionChatAction, "load a mission: /luarules mission <name>")
+end
+
+function gadget:Shutdown()
+	gadgetHandler:RemoveChatAction("mission")
+end
+
+---@param frame integer
+function gadget:GameFrame(frame)
+	if activeMission ~= nil and frame % EVALUATE_PERIOD == 0 then
+		ctx.frame = frame
+		engine.Evaluate(ctx)
+	end
+end

--- a/modules/missions/hello_pawns/triggers/win.lua
+++ b/modules/missions/hello_pawns/triggers/win.lua
@@ -1,0 +1,5 @@
+When(Team.Player.Has(UnitDef("armpw"), 3))
+	.Do(Objective("build_pawns").Complete())
+
+When(Objective("build_pawns").IsComplete())
+	.Do(MatchFlow.Victory(Team.Player))

--- a/modules/missions/lib/chat_guard.lua
+++ b/modules/missions/lib/chat_guard.lua
@@ -1,0 +1,17 @@
+--- Who may drive mission chat commands. Pure — the gadget supplies the
+--- Spring facts — so the policy specs under busted.
+---
+--- Missions are a dev/campaign surface: in multiplayer, any player can send
+--- a synced chat action, so arming or reloading a mission must not be an
+--- open verb. Singleplayer is always allowed; elsewhere cheats must be on.
+
+local ChatGuard = {}
+
+---@param isSinglePlayer boolean
+---@param cheatsEnabled boolean
+---@return boolean
+function ChatGuard.IsAllowed(isSinglePlayer, cheatsEnabled)
+	return isSinglePlayer == true or cheatsEnabled == true
+end
+
+return ChatGuard

--- a/modules/missions/lib/dsl.lua
+++ b/modules/missions/lib/dsl.lua
@@ -1,0 +1,143 @@
+--- The mission authoring DSL builder: chain -> descriptor -> sink, the
+--- policy_builder idiom. Pure Lua, no Spring.
+---
+--- The surface is dot-only, closure-free, and terminator-free:
+---
+---     When(Team.Player.Has(UnitDef("armpw"), 3))
+---         .Do(Objective("build_pawns").Complete())
+---
+--- No colon methods, no metatables, no function bodies, no Register. A
+--- statement's identity is the chain object the When call creates — every
+--- .When/.Do returns it, so Lua's own parser attaches continuation lines and
+--- separates statements (they start with the name `When`; whitespace was
+--- never the delimiter). Repeated .When AND-composes. The loader calls
+--- Finalize after including the file: every chain registers in creation
+--- order, and a chain without a Do is a load error naming the file — the
+--- transaction check Register used to provide, without the ceremony.
+---
+--- Trigger identity = filename + declaration order (When-call order),
+--- stamped at Finalize — the key hot reload unregisters by.
+
+local DSL = {}
+
+---Build one trigger file's authoring surface: the `When` chain entry the
+---loader injects, and the Finalize the loader calls after the include.
+---@param filename string mission-relative path, e.g. "triggers/win.lua"
+---@param sink fun(descriptor: TriggerDescriptor)
+---@return { When: fun(condition: MissionCondition): TriggerChain, Finalize: fun(): integer }
+function DSL.ForFile(filename, sink)
+	local chains = {} ---@type table[] chain build-state, in When-call (declaration) order
+	local finalized = false
+
+	---@param condition MissionCondition
+	---@return TriggerChain
+	local When = function(condition)
+		assert(not finalized, filename .. ": When after Finalize — the file already loaded")
+		assert(type(condition) == "table" and type(condition.evaluate) == "function",
+			filename .. ": When expects a condition (a table with an evaluate function)")
+
+		local build = {
+			conditions = { condition }, ---@type MissionCondition[]
+			effects = {}, ---@type MissionEffect[]
+			once = true,
+		}
+		chains[#chains + 1] = build
+
+		local chain = {}
+
+		---Another condition on the same statement; all must hold (AND).
+		---@param another MissionCondition
+		---@return TriggerChain
+		chain.When = function(another)
+			assert(not finalized, filename .. ": When after Finalize — the file already loaded")
+			assert(type(another) == "table" and type(another.evaluate) == "function",
+				filename .. ": .When expects a condition (a table with an evaluate function)")
+			build.conditions[#build.conditions + 1] = another
+			return chain
+		end
+
+		---@param effect MissionEffect a lazy effect built by a named verb
+		---@return TriggerChain
+		chain.Do = function(effect)
+			assert(not finalized, filename .. ": Do after Finalize — the file already loaded")
+			assert(type(effect) == "table" and type(effect.execute) == "function",
+				filename .. ": Do expects an effect (a table with an execute function) — build one with a named verb like Objective(...).Complete()")
+			build.effects[#build.effects + 1] = effect
+			return chain
+		end
+
+		---@param flag boolean?
+		---@return TriggerChain
+		chain.Once = function(flag)
+			assert(not finalized, filename .. ": Once after Finalize — the file already loaded")
+			build.once = flag ~= false
+			return chain
+		end
+
+		return chain
+	end
+
+	---The commit point: called by the loader when the file's include
+	---returns. Registers every chain in declaration order; a chain without a
+	---Do is a load error here — half-finished statements cannot arm.
+	---@return integer registered count
+	local Finalize = function()
+		assert(not finalized, filename .. ": Finalize called twice")
+		finalized = true
+		-- Validate before committing anything: a failed load arms nothing.
+		for order, build in ipairs(chains) do
+			if #build.effects == 0 then
+				error(filename .. ": statement " .. order .. " has no Do — every trigger needs at least one effect")
+			end
+		end
+		for order, build in ipairs(chains) do
+			local combined = build.conditions[1]
+			if #build.conditions > 1 then
+				-- AND-composition. Inputs compose as the UNION of the parts';
+				-- any poll-only part (nil inputs) makes the whole trigger
+				-- poll. The closure captures the conditions list —
+				-- configuration, never progress (the savegame rule holds).
+				local conditions = build.conditions
+				local union = {}
+				local seen = {}
+				for _, part in ipairs(conditions) do
+					if part.inputs == nil then
+						union = nil
+						break
+					end
+					for _, input in ipairs(part.inputs) do
+						if not seen[input] then
+							seen[input] = true
+							union[#union + 1] = input
+						end
+					end
+				end
+				combined = {
+					inputs = union,
+					---@param ctx MissionContext
+					evaluate = function(ctx)
+						for _, part in ipairs(conditions) do
+							if not part.evaluate(ctx) then
+								return false
+							end
+						end
+						return true
+					end,
+				}
+			end
+			sink({
+				id = filename .. ":" .. order,
+				filename = filename,
+				order = order,
+				condition = combined,
+				effects = build.effects,
+				once = build.once,
+			})
+		end
+		return #chains
+	end
+
+	return { When = When, Finalize = Finalize }
+end
+
+return DSL

--- a/modules/missions/lib/trigger_engine.lua
+++ b/modules/missions/lib/trigger_engine.lua
@@ -1,0 +1,151 @@
+--- Mission trigger engine: holds registered triggers, evaluates their
+--- conditions on the caller's cadence, runs effects. Pure Lua — no Spring —
+--- so it specs under busted.
+---
+--- State discipline (the savegame rule, enforced from commit one): trigger
+--- progress — fired flags — lives in the engine's plain `state` table, never
+--- in closures. Definitions are the source pile; `state` is the save pile.
+---
+--- Conditions declare their inputs (mission_authoring_dsl.md): the engine
+--- indexes input -> watching triggers at Register; OnEvent marks watchers
+--- dirty; the evaluation cadence processes dirty triggers plus pollers
+--- (conditions with nil inputs). The watcher index and dirty flags are
+--- DERIVED — rebuilt from source at load, never serialized.
+
+local TriggerEngine = {}
+
+---@class MissionTriggerEngine
+---@field Register fun(descriptor: TriggerDescriptor)
+---@field UnregisterFile fun(filename: string): integer removed count
+---@field OnEvent fun(name: MissionEventName) mark the input's watchers dirty (the mission bus entry point)
+---@field WatchedInputs fun(): table<MissionEventName, boolean> input names some registered trigger watches
+---@field Evaluate fun(ctx: MissionContext)
+---@field Triggers fun(): TriggerDescriptor[] registration order, read-only by convention
+---@field GetState fun(): TriggerEngineState the serializable progress pile
+---@field SetState fun(state: TriggerEngineState) reapply saved progress over reloaded definitions
+
+---@return MissionTriggerEngine
+function TriggerEngine.New()
+	local triggers = {} ---@type TriggerDescriptor[]
+	local state = { fired = {} } ---@type TriggerEngineState
+	-- Derived, never serialized: input name -> { [id] = true } watchers;
+	-- poller ids (nil-inputs conditions); ids awaiting evaluation.
+	local watchers = {} ---@type table<string, table<string, boolean>>
+	local pollers = {} ---@type table<string, boolean>
+	local dirty = {} ---@type table<string, boolean>
+
+	local engine = {}
+
+	---@param descriptor TriggerDescriptor
+	engine.Register = function(descriptor)
+		assert(type(descriptor.id) == "string", "trigger descriptor needs an id")
+		assert(type(descriptor.condition) == "table" and type(descriptor.condition.evaluate) == "function",
+			descriptor.id .. ": condition must have an evaluate function")
+		assert(type(descriptor.effects) == "table" and #descriptor.effects > 0,
+			descriptor.id .. ": descriptor needs a non-empty effects list")
+		for _, effect in ipairs(descriptor.effects) do
+			assert(type(effect) == "table" and type(effect.execute) == "function",
+				descriptor.id .. ": every effect must have an execute function")
+		end
+		for _, existing in ipairs(triggers) do
+			if existing.id == descriptor.id then
+				error("duplicate trigger id: " .. descriptor.id)
+			end
+		end
+		triggers[#triggers + 1] = descriptor
+		local inputs = descriptor.condition.inputs
+		if inputs == nil then
+			pollers[descriptor.id] = true
+		else
+			for _, input in ipairs(inputs) do
+				watchers[input] = watchers[input] or {}
+				watchers[input][descriptor.id] = true
+			end
+		end
+		-- A trigger armed mid-game evaluates once immediately, whatever its
+		-- inputs — its condition may already hold.
+		dirty[descriptor.id] = true
+	end
+
+	---Remove every trigger registered from `filename`, and its progress —
+	---the hot-reload half of unregister-by-identity.
+	---@param filename string
+	---@return integer removed
+	engine.UnregisterFile = function(filename)
+		local kept, removed = {}, 0
+		for _, trigger in ipairs(triggers) do
+			if trigger.filename == filename then
+				removed = removed + 1
+				state.fired[trigger.id] = nil
+				pollers[trigger.id] = nil
+				dirty[trigger.id] = nil
+				for _, ids in pairs(watchers) do
+					ids[trigger.id] = nil
+				end
+			else
+				kept[#kept + 1] = trigger
+			end
+		end
+		for input, ids in pairs(watchers) do
+			if next(ids) == nil then
+				watchers[input] = nil
+			end
+		end
+		triggers = kept
+		return removed
+	end
+
+	---An event on the mission bus: engine callins and module events are the
+	---same kind of string here. Marks the input's watchers for evaluation on
+	---the next cadence.
+	---@param name MissionEventName
+	engine.OnEvent = function(name)
+		for id in pairs(watchers[name] or {}) do
+			dirty[id] = true
+		end
+	end
+
+	---@return table<string, boolean>
+	engine.WatchedInputs = function()
+		local out = {}
+		for input in pairs(watchers) do
+			out[input] = true
+		end
+		return out
+	end
+
+	---@param ctx MissionContext
+	engine.Evaluate = function(ctx)
+		for _, trigger in ipairs(triggers) do
+			local id = trigger.id
+			if pollers[id] or dirty[id] then
+				dirty[id] = nil
+				if not (trigger.once and state.fired[id]) and trigger.condition.evaluate(ctx) then
+					state.fired[id] = true
+					for _, effect in ipairs(trigger.effects) do
+						effect.execute(ctx)
+					end
+				end
+			end
+		end
+	end
+
+	---@return TriggerDescriptor[]
+	engine.Triggers = function()
+		return triggers
+	end
+
+	---@return TriggerEngineState
+	engine.GetState = function()
+		return state
+	end
+
+	---@param saved TriggerEngineState
+	engine.SetState = function(saved)
+		state = saved
+	end
+
+	return engine
+end
+
+return TriggerEngine

--- a/modules/missions/lib/verbs.lua
+++ b/modules/missions/lib/verbs.lua
@@ -1,0 +1,48 @@
+--- The three demo verbs' pure halves: UnitDef refs and the Team handle with
+--- its Has condition. No Spring here — conditions read counts from the ctx the
+--- engine is handed, so this specs under busted; the gadget supplies a ctx
+--- backed by Spring.GetTeamUnitDefCount.
+---
+--- Conditions capture configuration only (team id, unit name, threshold) —
+--- never progress. Dot-only surface, same rule as the chain DSL.
+
+local Verbs = {}
+
+---@param name string unit def name, e.g. "armpw"
+---@return MissionUnitDefRef
+function Verbs.UnitDef(name)
+	assert(type(name) == "string", "UnitDef expects a unit def name string")
+	return { name = name }
+end
+
+---Build a Team handle for one team.
+---@param teamID integer
+---@param allyTeam integer
+---@return MissionTeam
+function Verbs.MakeTeam(teamID, allyTeam)
+	local team = {
+		teamID = teamID,
+		allyTeam = allyTeam,
+	}
+
+	---@param unitDef MissionUnitDefRef
+	---@param count integer
+	---@return MissionCondition
+	team.Has = function(unitDef, count)
+		assert(type(unitDef) == "table" and type(unitDef.name) == "string",
+			"Team.Has expects a UnitDef(...) reference")
+		assert(type(count) == "number", "Team.Has expects a count")
+		return {
+			-- Transfers move counts too, hence Given/Taken.
+			inputs = { "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken" },
+			---@param ctx MissionContext
+			evaluate = function(ctx)
+				return ctx.GetUnitDefCount(teamID, unitDef.name) >= count
+			end,
+		}
+	end
+
+	return team
+end
+
+return Verbs

--- a/modules/missions/module.lua
+++ b/modules/missions/module.lua
@@ -1,0 +1,7 @@
+--- Manifest for the mission-runtime module (the CampaignAPI home).
+---@type ModuleManifestFile
+return {
+	name = "missions",
+	description = "Mission runtime: trigger engine, authoring DSL, mission loader",
+	requires = { "matchflow" },
+}

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -1,0 +1,92 @@
+--- Mission-runtime types: the trigger engine's descriptors and the authoring
+--- DSL's chain/condition/effect shapes. The DSL surface is dot-only AND
+--- closure-free: every chain step is a plain call with parens, no colon
+--- methods, no metatables, and no function bodies in mission files — effects
+--- are lazy objects built by named verbs. Mission files must load identically
+--- in the synced sandbox (which strips rawset) and in busted.
+
+--- The mission bus vocabulary, CLOSED BY TYPE: every event name that may
+--- cross the bus is a member of this alias. Engine callins are one producer,
+--- modules are another — same kind of string, one type. Adding an event
+--- means extending this alias; the checker then walks you to every consumer
+--- (inputs declarations, OnEvent emitters) and flags typos as type errors —
+--- the state heritage is tied together by the compiler, not convention.
+---@alias MissionEventName
+---| "UnitFinished"
+---| "UnitDestroyed"
+---| "UnitGiven"
+---| "UnitTaken"
+---| "mission.objective_changed"
+
+--- A condition is not a bare predicate — it carries metadata about what can
+--- change its answer (mission_authoring_dsl.md, "Conditions declare their
+--- inputs"). Inputs name events on the mission bus (MissionEventName).
+--- nil inputs = poll every cadence — the fallback stays.
+--- Pure: reads only the ctx it is handed; captures configuration (team ids,
+--- unit names), never progress. Progress lives in the engine's state tables;
+--- inputs are configuration, dirty flags are derived (the savegame rule).
+---@class MissionCondition
+---@field evaluate fun(ctx: MissionContext): boolean
+---@field inputs MissionEventName[]|nil events that can change this answer; nil = poll every cadence
+
+--- What the engine hands every condition and effect. The gadget builds it from
+--- Spring; specs build it from plain tables.
+---@class MissionContext
+---@field GetUnitDefCount fun(teamID: integer, unitDefName: string): integer count of finished units of that def
+---@field IsObjectiveComplete fun(name: string): boolean
+---@field frame integer current game frame
+
+--- A lazy effect built by a named verb (Objective("x").Complete(),
+--- MatchFlow.Victory(Team.Player)). The engine executes it when the trigger's
+--- condition fires. Like conditions, effects capture configuration only —
+--- never progress, and never author-written function bodies.
+---@class MissionEffect
+---@field execute fun(ctx: MissionContext)
+
+--- The injected Objective verb's handle: Complete() builds the effect side,
+--- IsComplete() the condition side — victory triggers watch objective state
+--- rather than living inside the objective's own trigger.
+---@class MissionObjective
+---@field Complete fun(): MissionEffect
+---@field IsComplete fun(): MissionCondition
+
+--- The injected MatchFlow verbs: lazy mirrors of the matchflow module api.
+--- They take the Team handle so mission lines read as English.
+---@class MissionMatchFlow
+---@field Victory fun(team: MissionTeam): MissionEffect
+---@field Defeat fun(team: MissionTeam): MissionEffect
+
+--- A registered trigger. Identity = source filename + declaration order,
+--- stamped at registration — the unregister-by-identity key for hot reload.
+---@class TriggerDescriptor
+---@field id string "<filename>:<order>"
+---@field filename string mission-relative trigger file path
+---@field order integer 1-based declaration order within the file
+---@field condition MissionCondition
+---@field effects MissionEffect[] executed in Do order when the condition fires
+---@field once boolean fire at most once (default true)
+
+--- The dot-only builder chain returned by When. Every step returns the
+--- chain. There is no terminator: the loader finalizes all chains when the
+--- file's include returns, and a chain without a Do fails the load.
+---@class TriggerChain
+---@field When fun(condition: MissionCondition): TriggerChain another condition; all must hold
+---@field Do fun(effect: MissionEffect): TriggerChain repeatable; effects run in Do order
+---@field Once fun(once: boolean?): TriggerChain default true; pass false for repeating triggers
+
+--- A unit-def reference produced by the injected UnitDef verb. Carries the
+--- name only; resolution to an id happens where Spring exists.
+---@class MissionUnitDefRef
+---@field name string
+
+--- The injected Team.Player handle. Demo rule: resolves to the first human
+--- team at mission load.
+---@class MissionTeam
+---@field teamID integer
+---@field allyTeam integer
+---@field Has fun(unitDef: MissionUnitDefRef, count: integer): MissionCondition
+
+--- Serializable trigger progress: the pile a checkpoint saves. Definitions
+--- reload from source; this table is reapplied on top.
+---@class TriggerEngineState
+---@field fired table<string, boolean> trigger id -> has fired

--- a/modules/module_handler.lua
+++ b/modules/module_handler.lua
@@ -1,0 +1,473 @@
+--- Encapsulated game modules: discovery, contracts, and auto-registration.
+---
+--- A module is a directory under modules/ with opinionated subdirectories:
+---   widgets/               unsynced widgets, auto-loaded (luaui/barwidgets.lua)
+---   rml_widgets/           RmlUi widgets, auto-loaded (luaui/barwidgets.lua)
+---   gadgets/               gadgets, auto-loaded (luarules/gadgets.lua)
+---   actions/               one file per action returning an ActionDescriptor
+---   policies/<category>/   one file per policy returning a PolicyDescriptor;
+---                          evaluated in filename order (use numeric prefixes)
+---   modes/                 declarative ModeConfig presets
+---   lib/                   shared pure code
+---   economy/, types/, spec/ ...
+---
+--- An optional module.lua manifest (ModuleManifest) declares version, requires
+--- and provides; a directory with any auto-loaded subdirectory is discovered as
+--- a module even without one. Plain shared-lib directories (modules/i18n,
+--- modules/graphics) have none of those subdirectories and are left alone.
+---
+--- Game-side loading is the shim for engine-native module loading (Recoil RFC);
+--- the layout is the contract, this file is the reference implementation.
+--- There is deliberately NO game-side include cache: VFS.Include is uncached in
+--- the engine, and a per-handler cache would only pretend otherwise (this file
+--- is itself re-included per consumer). Registries and contracts are memoized
+--- per handler; true load-once-per-state is the engine RFC's require().
+
+local LOG_TAG = "module_handler.lua"
+
+local PolicyBuilder = VFS.Include("modules/policy_builder.lua")
+
+local MODULES_DIR = "modules/"
+
+-- Subdirectories that mark a directory as a module even without a manifest.
+local MODULE_MARKERS = { "widgets", "rml_widgets", "gadgets", "actions", "policies" }
+
+local ModuleHandler = {}
+
+---Log an error via Spring when available; modoptions.lua pulls this file into
+---lobby/unitsync LuaParser contexts where the Spring global does not exist.
+---@param message string
+local function logError(message)
+	---@diagnostic disable-next-line: unnecessary-if -- Spring IS nil in lobby LuaParser; the analyzer can't know
+	if Spring and Spring.Log then
+		Spring.Log(LOG_TAG, LOG and LOG.ERROR or "error", message)
+	else
+		print("[" .. LOG_TAG .. "] ERROR: " .. message)
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Discovery
+--------------------------------------------------------------------------------
+
+---@param dir string directory with trailing slash
+---@return string name
+local function dirBasename(dir)
+	return dir:gsub("/+$", ""):match("([^/]+)$") --[[@as string]]
+end
+
+---Native VFS.SubDirs returns entries with a trailing slash; keep any source normalized.
+---@param dir string
+---@return string
+local function ensureSlash(dir)
+	if dir:sub(-1) ~= "/" then
+		return dir .. "/"
+	end
+	return dir
+end
+
+---@param moduleDir string
+---@param vfsMode string?
+---@return boolean
+local function hasModuleMarker(moduleDir, vfsMode)
+	for _, marker in ipairs(MODULE_MARKERS) do
+		local sub = moduleDir .. marker .. "/"
+		if #VFS.DirList(sub, "*", vfsMode) > 0 or #VFS.SubDirs(sub, "*", vfsMode) > 0 then
+			return true
+		end
+	end
+	return false
+end
+
+---@param moduleDir string
+---@param vfsMode string?
+---@return ModuleManifest|nil
+local function loadManifest(moduleDir, vfsMode)
+	local name = dirBasename(moduleDir)
+	local manifestPath = moduleDir .. "module.lua"
+	---@type ModuleManifestFile
+	local manifest
+	if VFS.FileExists(manifestPath, vfsMode) then
+		manifest = VFS.Include(manifestPath, nil, vfsMode)
+		if type(manifest) ~= "table" or type(manifest.name) ~= "string" then
+			logError("Invalid module manifest (missing name): " .. manifestPath)
+			return nil
+		end
+		if manifest.name ~= name then
+			logError(string.format("Module manifest name %q does not match directory %q", manifest.name, name))
+			return nil
+		end
+	elseif hasModuleMarker(moduleDir, vfsMode) then
+		-- Implicit manifest: a bare directory with auto-loaded subdirectories.
+		manifest = { name = name }
+	else
+		return nil
+	end
+	---@cast manifest ModuleManifest
+	manifest.dir = moduleDir
+	manifest.requires = manifest.requires or {}
+	return manifest
+end
+
+local manifestsCache = nil ---@type table<string, ModuleManifest>|nil
+
+---Discover all modules. Cached after the first call.
+---@param vfsMode string?
+---@return table<string, ModuleManifest> manifests keyed by module name
+function ModuleHandler.Discover(vfsMode)
+	if manifestsCache then
+		return manifestsCache
+	end
+	local manifests = {}
+	for _, moduleDir in ipairs(VFS.SubDirs(MODULES_DIR, "*", vfsMode)) do
+		local manifest = loadManifest(ensureSlash(moduleDir), vfsMode)
+		if manifest then
+			manifests[manifest.name] = manifest
+		end
+	end
+	for name, manifest in pairs(manifests) do
+		for _, required in ipairs(manifest.requires) do
+			if not manifests[required] then
+				logError(string.format("Module %q requires missing module %q", name, required))
+			end
+		end
+	end
+	manifestsCache = manifests
+	return manifests
+end
+
+---The current Lua state. Only the synced LuaRules/LuaGaia VM has SendToUnsynced;
+---LuaUI/LuaMenu and the unsynced gadget state resolve as "unsynced".
+---@return "synced"|"unsynced"
+local function currentState()
+	return (SendToUnsynced ~= nil) and "synced" or "unsynced"
+end
+
+local apiCache = {}
+
+---Resolve a module's public contract for the current Lua state.
+---
+---The manifest declares the partition explicitly — provides as a plain path
+---(state-agnostic) or { shared = path, synced = path, unsynced = path } —
+---and resolution merges implicitly: consumers hold one flat api holding
+---exactly the surface that exists where they stand (state keys win over
+---shared on collision). A widget never sees synced-only keys, and vice
+---versa; wrong-state access is nil at the first index, not a crash later.
+---@param name string
+---@param vfsMode string?
+---@return table|nil api
+function ModuleHandler.Get(name, vfsMode)
+	local state = currentState()
+	local cacheKey = name .. "|" .. state
+	if apiCache[cacheKey] then
+		return apiCache[cacheKey]
+	end
+
+	local manifest = ModuleHandler.Discover(vfsMode)[name]
+	if not manifest then
+		logError("Unknown module: " .. tostring(name))
+		return nil
+	end
+
+	local provides = manifest.provides
+	local parts = {}
+	if type(provides) == "table" then
+		parts[#parts + 1] = provides.shared
+		parts[#parts + 1] = provides[state]
+	else
+		parts[1] = provides or (manifest.dir .. "api.lua")
+	end
+
+	local api = {}
+	local resolved = 0
+	for _, path in ipairs(parts) do
+		if VFS.FileExists(path, vfsMode) then
+			local part = VFS.Include(path, nil, vfsMode)
+			if type(part) ~= "table" then
+				logError(string.format("Module %q contract must return a table: %s", name, path))
+			else
+				for key, value in pairs(part) do
+					api[key] = value
+				end
+				resolved = resolved + 1
+			end
+		else
+			logError(string.format("Module %q contract file not found: %s", name, path))
+		end
+	end
+	if resolved == 0 then
+		logError(string.format("Module %q provides nothing in %s state", name, state))
+		return nil
+	end
+
+	apiCache[cacheKey] = api
+	return api
+end
+
+--------------------------------------------------------------------------------
+-- Auto-loaded subdirectories (consumed by luarules/gadgets.lua, luaui/barwidgets.lua)
+--------------------------------------------------------------------------------
+
+---@param subdir string e.g. "widgets/"
+---@param vfsMode string?
+---@return string[] dirs
+local function moduleSubdirs(subdir, vfsMode)
+	local dirs = {}
+	for _, manifest in pairs(ModuleHandler.Discover(vfsMode)) do
+		local dir = manifest.dir .. subdir
+		if #VFS.DirList(dir, "*.lua", vfsMode) > 0 or #VFS.SubDirs(dir, "*", vfsMode) > 0 then
+			dirs[#dirs + 1] = dir
+		end
+	end
+	table.sort(dirs)
+	return dirs
+end
+
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.WidgetDirs(vfsMode)
+	return moduleSubdirs("widgets/", vfsMode)
+end
+
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.RmlWidgetDirs(vfsMode)
+	return moduleSubdirs("rml_widgets/", vfsMode)
+end
+
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.GadgetDirs(vfsMode)
+	return moduleSubdirs("gadgets/", vfsMode)
+end
+
+---Mode-preset directories contributed by modules ("surrogate modes": presets
+---travel with the module that owns the modoptions they lock; the root modes/
+---system aggregates them).
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.ModeDirs(vfsMode)
+	return moduleSubdirs("modes/", vfsMode)
+end
+
+--------------------------------------------------------------------------------
+-- Actions: registration-style, one file per action, identity = filename.
+-- The loader injects `Actions` into each file's environment (the widget-handler
+-- idiom: an explicit named Register call on an explicit local — NOT anonymous
+-- setfenv globals, which is the fragility dbg_test_runner migrated away from).
+-- Files register and return nothing; the runtime descriptor is assembled here,
+-- never hand-authored. Runtime parameter schemas return, derived from the
+-- LuaCATS annotations (single-sourced), if/when a data-driven dispatcher
+-- (mission_api, CampaignAPI) creates a boundary the type checker cannot see.
+--------------------------------------------------------------------------------
+
+---@param filePath string
+---@return string
+local function nameFromFile(filePath)
+	return filePath:match("([^/]+)%.lua$") --[[@as string]]
+end
+
+-- Base environment for registration files: this chunk's own environment, so
+-- injected files see exactly what this file sees (VFS, Spring, ...). The
+-- synced state defines _G; unsynced widget sandboxes may not, so fall back
+-- to getfenv (kept in unsynced). Discovered via headless smoke: __index = _G
+-- alone left action files without VFS in the widget path.
+---@type table
+local CHUNK_ENV = _G
+if CHUNK_ENV == nil or CHUNK_ENV.VFS == nil then
+	local ok, env = pcall(getfenv, 1)
+	if ok and env ~= nil then
+		CHUNK_ENV = env
+	end
+end
+
+---Include a registration file with names injected into its environment.
+---Deliberately UNCACHED: registration must re-fire per include. The engine's
+---VFS.Include is uncached by nature; the busted shim only caches truthy
+---returns, and registration files return nothing.
+---@param filePath string
+---@param injected table
+---@param vfsMode string?
+---@return any returned whatever the file returned (must be nil)
+local function includeRegistrationFile(filePath, injected, vfsMode)
+	local env = setmetatable(injected, { __index = CHUNK_ENV })
+	return VFS.Include(filePath, env, vfsMode)
+end
+
+local actionsCache = {}
+
+---Load a module's actions/ directory: bracketed registration per file.
+---@param name string module name
+---@param vfsMode string?
+---@return {byName: table<string, ActionDescriptor>, list: ActionDescriptor[]}
+function ModuleHandler.LoadActions(name, vfsMode)
+	if actionsCache[name] then
+		return actionsCache[name]
+	end
+	local manifest = ModuleHandler.Discover(vfsMode)[name]
+	local registry = { byName = {}, list = {} }
+	if not manifest then
+		logError("LoadActions: unknown module " .. tostring(name))
+		return registry
+	end
+	local files = VFS.DirList(manifest.dir .. "actions/", "*.lua", vfsMode)
+	table.sort(files)
+	for _, filePath in ipairs(files) do
+		local actionName = nameFromFile(filePath)
+		local entry = { name = actionName }
+		---@cast entry ActionDescriptor -- execute arrives via RegisterExecute; enforced below
+		local registrar = {
+			---@param fn function pure precondition; must precede RegisterExecute
+			RegisterValidate = function(fn)
+				if type(fn) ~= "function" then
+					error(filePath .. ": Actions.RegisterValidate expects a function")
+				end
+				if entry.execute ~= nil then
+					error(filePath .. ": RegisterValidate must precede RegisterExecute")
+				end
+				if entry.validate ~= nil then
+					error(filePath .. ": duplicate RegisterValidate")
+				end
+				entry.validate = fn
+			end,
+			---@param fn function the only effectful code; exactly one per file
+			RegisterExecute = function(fn)
+				if type(fn) ~= "function" then
+					error(filePath .. ": Actions.RegisterExecute expects a function")
+				end
+				if entry.execute ~= nil then
+					error(filePath .. ": duplicate RegisterExecute — exactly one per action file")
+				end
+				entry.execute = fn
+			end,
+		}
+		local returned = includeRegistrationFile(filePath, { Actions = registrar }, vfsMode)
+		if returned ~= nil then
+			error(filePath .. ": action files register, they do not return (old descriptor style?)")
+		end
+		if entry.execute == nil then
+			error(filePath .. ": no Actions.RegisterExecute — every action must register execute")
+		end
+		registry.byName[actionName] = entry
+		registry.list[#registry.list + 1] = entry
+	end
+	actionsCache[name] = registry
+	return registry
+end
+
+--------------------------------------------------------------------------------
+-- Policies: registration-style, one pipeline per category, identity = filename.
+-- The loader injects `Policies` (a Pipeline facade bound to this file's sink);
+-- files end with :Register() and return nothing. Stage order is declaration
+-- order; the first non-nil result wins; the Compute terminal always returns.
+--------------------------------------------------------------------------------
+
+local policiesCache = {}
+
+---Load a module's policies/ directory into per-category ordered stage lists.
+---@param name string module name
+---@param vfsMode string?
+---@return table<string, PolicyDescriptor[]> pipelines keyed by category (filename)
+function ModuleHandler.LoadPolicies(name, vfsMode)
+	if policiesCache[name] then
+		return policiesCache[name]
+	end
+	local manifest = ModuleHandler.Discover(vfsMode)[name]
+	local byCategory = {}
+	if not manifest then
+		logError("LoadPolicies: unknown module " .. tostring(name))
+		return byCategory
+	end
+	local files = VFS.DirList(manifest.dir .. "policies/", "*.lua", vfsMode)
+	table.sort(files)
+	for _, filePath in ipairs(files) do
+		local category = nameFromFile(filePath)
+		local registered = nil
+		local facade = {
+			Pipeline = function()
+				local builder = PolicyBuilder.Pipeline()
+				builder._sink = function(stages)
+					if registered ~= nil then
+						error(filePath .. ": duplicate pipeline registration")
+					end
+					for _, stage in ipairs(stages) do
+						stage.category = stage.category or category
+					end
+					registered = stages
+				end
+				return builder
+			end,
+		}
+		local returned = includeRegistrationFile(filePath, { Policies = facade }, vfsMode)
+		if returned ~= nil then
+			error(filePath .. ": policy files register, they do not return (end with :Register())")
+		end
+		if registered == nil then
+			error(filePath .. ": no pipeline registered — end with :Register()")
+		end
+		byCategory[category] = registered
+	end
+	policiesCache[name] = byCategory
+	return byCategory
+end
+
+---Evaluate an ordered policy list: the first non-nil result wins.
+---By convention the last policy (the 1xx_compute_* file) always returns.
+---@generic R
+---@param policies PolicyDescriptor[]
+---@param ... any arguments passed to each policy's evaluate
+---@return R|nil result nil only if no policy produced a result
+function ModuleHandler.Evaluate(policies, ...)
+	for _, policy in ipairs(policies) do
+		local result = policy.evaluate(...)
+		if result ~= nil then
+			return result
+		end
+	end
+	return nil
+end
+
+--------------------------------------------------------------------------------
+-- Mod options: modules ship their own modoptions.lua fragment, merged into the
+-- game's modoptions.lua (same entry format; append order = module-name order)
+--------------------------------------------------------------------------------
+
+---Collect module-contributed modoption entries.
+---@param vfsMode string?
+---@return table[] options
+function ModuleHandler.ModOptions(vfsMode)
+	local names = {}
+	for name in pairs(ModuleHandler.Discover(vfsMode)) do
+		names[#names + 1] = name
+	end
+	table.sort(names)
+
+	local options = {}
+	for _, name in ipairs(names) do
+		local manifest = ModuleHandler.Discover(vfsMode)[name]
+		local fragmentPath = manifest.dir .. "modoptions.lua"
+		if VFS.FileExists(fragmentPath, vfsMode) then
+			local fragment = VFS.Include(fragmentPath, nil, vfsMode)
+			if type(fragment) ~= "table" then
+				logError("Module modoptions fragment must return a list: " .. fragmentPath)
+			else
+				for _, option in ipairs(fragment) do
+					options[#options + 1] = option
+				end
+			end
+		end
+	end
+	return options
+end
+
+--------------------------------------------------------------------------------
+
+---Testing hook: reset discovery + include caches.
+function ModuleHandler.ResetCaches()
+	manifestsCache = nil
+	apiCache = {}
+	actionsCache = {}
+	policiesCache = {}
+end
+
+return ModuleHandler

--- a/modules/policy_builder.lua
+++ b/modules/policy_builder.lua
@@ -1,0 +1,82 @@
+--- Fluent builder that emits PolicyDescriptors — no runtime of its own.
+---
+--- The canonical policy format is the category file (see types/modules.lua):
+--- modules/<name>/policies/<category>.lua registers an ordered PolicyDescriptor[]
+--- and returns nothing. Pipeline() is how those files read — gates in declaration
+--- order, one terminal compute — and what it hands the loader is a plain
+--- descriptor list, byte-for-byte equivalent to writing the tables by hand:
+---
+---   Policies.Pipeline()
+---       :Gate("SharingEnabled", function(ctx, resourceType) ... end)
+---       :Compute("ComputeResourceTransfer", function(ctx, resourceType) ... end)
+---       :Register()
+---
+--- Register() is the terminal for category files. Build() returns the descriptor
+--- list instead, for programmatic pipelines and specs.
+
+local PolicyBuilder = {}
+
+---@class PolicyPipeline
+---@field stages PolicyDescriptor[]
+---@field computed boolean
+---@field _sink (fun(stages: PolicyDescriptor[]))|nil bound by the loader's Policies facade
+local PolicyPipeline = {}
+PolicyPipeline.__index = PolicyPipeline
+
+---One ordered pipeline per category file. Order is declaration order — the
+---framework evaluates stages top to bottom, first result wins.
+---@return PolicyPipeline
+---Category is NOT an argument: the pipeline's identity is its filename
+---(policies/<category>.lua) and ModuleHandler.LoadPolicies stamps it — one
+---source of truth, no magic strings to drift.
+function PolicyBuilder.Pipeline()
+	return setmetatable({
+		stages = {},
+		computed = false,
+	}, PolicyPipeline)
+end
+
+---A gate: return a result to end evaluation (usually a deny), nil to pass.
+---@param name string
+---@param evaluate fun(...): any
+---@return PolicyPipeline
+function PolicyPipeline:Gate(name, evaluate)
+	assert(not self.computed, "PolicyPipeline: Gate() after Compute() — the terminal must be last")
+	self.stages[#self.stages + 1] = {
+		name = name,
+		evaluate = evaluate,
+	}
+	return self
+end
+
+---The terminal: always returns a result. Exactly one, and last.
+---@param name string
+---@param evaluate fun(...): any
+---@return PolicyPipeline
+function PolicyPipeline:Compute(name, evaluate)
+	assert(not self.computed, "PolicyPipeline: only one Compute() per pipeline")
+	self.computed = true
+	self.stages[#self.stages + 1] = {
+		name = name,
+		evaluate = evaluate,
+	}
+	return self
+end
+
+---@return PolicyDescriptor[]
+function PolicyPipeline:Build()
+	assert(self.computed, "PolicyPipeline: a pipeline needs a terminal Compute()")
+	return self.stages
+end
+
+---Terminal for policies/<category>.lua files: hand the built stage list to
+---the loader's sink (injected by ModuleHandler.LoadPolicies). Registration
+---style, one idiom framework-wide: files register, they do not return.
+function PolicyPipeline:Register()
+	if self._sink == nil then
+		error("PolicyPipeline:Register() outside a policies/ loader bracket — use :Build() for programmatic pipelines")
+	end
+	self._sink(self:Build())
+end
+
+return PolicyBuilder

--- a/spec/modules/matchflow/ceremony_spec.lua
+++ b/spec/modules/matchflow/ceremony_spec.lua
@@ -1,0 +1,116 @@
+local Ceremony = VFS.Include("modules/matchflow/lib/ceremony.lua")
+
+local CMD_STOP = 99
+
+local function newStage(opts)
+	opts = opts or {}
+	local stage = {
+		losGrants = {},
+		gameOverCalls = {},
+		orders = {},
+		cobCalls = {},
+		units = opts.units or {},           -- unitID -> {defID, allyTeam, cobAnim}
+		maxDeathFrame = opts.maxDeathFrame, -- nil -> legacy 250 default
+	}
+
+	local function unitList()
+		local list = {}
+		for unitID in pairs(stage.units) do
+			list[#list + 1] = unitID
+		end
+		table.sort(list)
+		return list
+	end
+
+	stage.ceremony = Ceremony.New({
+		spring = {
+			SetGlobalLos = function(allyTeamID, value)
+				stage.losGrants[#stage.losGrants + 1] = allyTeamID
+			end,
+			GameOver = function(winners)
+				stage.gameOverCalls[#stage.gameOverCalls + 1] = winners
+			end,
+			GetAllUnits = unitList,
+			GetUnitDefID = function(unitID)
+				return stage.units[unitID].defID
+			end,
+			GetUnitAllyTeam = function(unitID)
+				return stage.units[unitID].allyTeam
+			end,
+			GiveOrderToUnit = function(unitID, cmd)
+				stage.orders[#stage.orders + 1] = { unitID = unitID, cmd = cmd }
+			end,
+			ValidUnitID = function()
+				return true
+			end,
+			GetCOBScriptID = function(unitID)
+				return stage.units[unitID].cobAnim and 1 or nil
+			end,
+			CallCOBScript = function(unitID)
+				stage.cobCalls[#stage.cobCalls + 1] = unitID
+			end,
+			UnitScriptGetScriptEnv = function()
+				return nil
+			end,
+			UnitScriptCallAsUnit = function() end,
+		},
+		isCommander = opts.isCommander or {},
+		cmdStop = CMD_STOP,
+		maxDeathFrame = function()
+			return stage.maxDeathFrame
+		end,
+	})
+
+	return stage
+end
+
+describe("matchflow ceremony", function()
+	it("is not started until Begin", function()
+		local stage = newStage()
+		assert.is_false(stage.ceremony.IsStarted())
+		stage.ceremony.Begin({ 0 }, 100)
+		assert.is_true(stage.ceremony.IsStarted())
+	end)
+
+	it("grants global LOS to every winner once", function()
+		local stage = newStage()
+		stage.ceremony.Begin({ 0, 2 }, 100)
+		stage.ceremony.GameFrame(101)
+		stage.ceremony.GameFrame(102)
+		assert.are.same({ 0, 2 }, stage.losGrants)
+	end)
+
+	it("calls GameOver after the legacy 250+70 frame delay", function()
+		local stage = newStage()
+		stage.ceremony.Begin({ 1 }, 100)
+		stage.ceremony.GameFrame(100 + 250 + 70 - 1)
+		assert.are.same({}, stage.gameOverCalls)
+		stage.ceremony.GameFrame(100 + 250 + 70)
+		assert.are.same({ { 1 } }, stage.gameOverCalls)
+	end)
+
+	it("uses GG.maxDeathFrame for the delay when set", function()
+		local stage = newStage({ maxDeathFrame = 10 })
+		stage.ceremony.Begin({ 1 }, 100)
+		stage.ceremony.GameFrame(100 + 10 + 70)
+		assert.are.same({ { 1 } }, stage.gameOverCalls)
+	end)
+
+	it("stops winner commanders at Begin and animates them at +55", function()
+		local stage = newStage({
+			isCommander = { [7] = true },
+			units = {
+				[201] = { defID = 7, allyTeam = 0, cobAnim = true },  -- winning commander
+				[202] = { defID = 7, allyTeam = 1, cobAnim = true },  -- losing commander
+				[203] = { defID = 1, allyTeam = 0 },                  -- winning non-commander
+			},
+		})
+		stage.ceremony.Begin({ 0 }, 100)
+		assert.are.same({ { unitID = 201, cmd = CMD_STOP } }, stage.orders)
+
+		stage.ceremony.GameFrame(154)
+		assert.are.same({}, stage.cobCalls)
+		stage.ceremony.GameFrame(155)
+		assert.are.same({ 201 }, stage.cobCalls)
+	end)
+end)

--- a/spec/modules/matchflow/game_over_policy_spec.lua
+++ b/spec/modules/matchflow/game_over_policy_spec.lua
@@ -1,0 +1,101 @@
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+
+-- Load the real pipeline through the real loader — the spec covers both the
+-- decision logic and the registration path.
+ModuleHandler.ResetCaches()
+local pipeline = ModuleHandler.LoadPolicies("matchflow").game_over
+
+---@param opts table
+local function makeCtx(opts)
+	return {
+		infos = opts.infos or {},
+		scriptedWinners = opts.scriptedWinners,
+		fixedallies = opts.fixedallies or false,
+		sharedDynamicAllianceVictory = opts.sharedDynamicAllianceVictory or false,
+		AreTeamsAllied = opts.AreTeamsAllied or function()
+			return false
+		end,
+	}
+end
+
+local function ally(dead, teams)
+	local info = { dead = dead, teams = {} }
+	for _, teamID in ipairs(teams or {}) do
+		info.teams[teamID] = {}
+	end
+	return info
+end
+
+describe("matchflow game_over pipeline", function()
+	it("registers a MissionOverride gate and a LastAllyStanding terminal", function()
+		assert.are.equal(2, #pipeline)
+		assert.are.equal("MissionOverride", pipeline[1].name)
+		assert.are.equal("LastAllyStanding", pipeline[2].name)
+		assert.are.equal("game_over", pipeline[1].category)
+	end)
+
+	describe("MissionOverride", function()
+		it("wins immediately with a scripted verdict, even with many alive", function()
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				scriptedWinners = { 1 },
+				infos = { [0] = ally(false), [1] = ally(false), [2] = ally(false) },
+			}))
+			assert.are.same({ winners = { 1 } }, verdict)
+		end)
+	end)
+
+	describe("LastAllyStanding, single-ally mode", function()
+		it("continues while more than one allyteam is alive", function()
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				infos = { [0] = ally(false), [1] = ally(false) },
+			}))
+			assert.are.same({ continue = true }, verdict)
+		end)
+
+		it("declares the last living allyteam the winner", function()
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				infos = { [0] = ally(false), [1] = ally(true) },
+			}))
+			assert.are.same({ winners = { 0 } }, verdict)
+		end)
+
+		it("declares a draw (empty winners) when everyone is dead", function()
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				infos = { [0] = ally(true), [1] = ally(true) },
+			}))
+			assert.are.same({ winners = {} }, verdict)
+		end)
+
+		it("is forced by fixedallies even when shared victory is on", function()
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				fixedallies = true,
+				sharedDynamicAllianceVictory = true,
+				infos = { [0] = ally(false), [1] = ally(false) },
+			}))
+			assert.are.same({ continue = true }, verdict)
+		end)
+	end)
+
+	describe("LastAllyStanding, shared-dynamic-alliance mode", function()
+		it("continues while living allyteams are not mutually allied", function()
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				sharedDynamicAllianceVictory = true,
+				infos = { [0] = ally(false, { 10 }), [1] = ally(false, { 11 }) },
+			}))
+			assert.are.same({ continue = true }, verdict)
+		end)
+
+		it("returns the legacy winner COUNT when all living allyteams are mutually allied", function()
+			-- Quirk preserved from game_end.lua: the shared path ships a count,
+			-- not a list (the list was built and commented out upstream).
+			local verdict = ModuleHandler.Evaluate(pipeline, makeCtx({
+				sharedDynamicAllianceVictory = true,
+				AreTeamsAllied = function()
+					return true
+				end,
+				infos = { [0] = ally(false, { 10 }), [1] = ally(false, { 11 }) },
+			}))
+			assert.are.same({ winners = 2 }, verdict)
+		end)
+	end)
+end)

--- a/spec/modules/matchflow/liveness_spec.lua
+++ b/spec/modules/matchflow/liveness_spec.lua
@@ -1,0 +1,348 @@
+local Liveness = VFS.Include("modules/matchflow/lib/liveness.lua")
+
+-- A controllable fake match: two allyteams, one human team each, by default.
+-- Every spec builds a world, drives the machine, and observes effects
+-- (KillTeam / DestroyUnit / wipeoutAllyTeam) plus the Infos() view.
+--
+-- These specs encode game_end.lua's CURRENT behavior, hacks included; if one
+-- fails after a refactor, the refactor changed behavior.
+
+local GAIA_TEAM = 99
+local GAIA_ALLY = 9
+
+local function newWorld(opts)
+	opts = opts or {}
+	local world = {
+		players = {},   -- playerID -> {active, spectator, teamID, allyTeamID}
+		teams = {},     -- teamID -> {leader, isAI, luaAI, allyTeamID, units}
+		allyTeams = {}, -- allyTeamID -> teamID[]
+		killed = {},
+		destroyed = {},
+		wipedOut = {},
+	}
+
+	local function addTeam(teamID, allyTeamID, teamOpts)
+		teamOpts = teamOpts or {}
+		world.teams[teamID] = {
+			leader = teamOpts.leader ~= nil and teamOpts.leader or 0,
+			isAI = teamOpts.isAI or false,
+			aiHost = teamOpts.aiHost,
+			luaAI = teamOpts.luaAI or "",
+			allyTeamID = allyTeamID,
+			units = teamOpts.units or {},
+		}
+		world.allyTeams[allyTeamID] = world.allyTeams[allyTeamID] or {}
+		table.insert(world.allyTeams[allyTeamID], teamID)
+	end
+
+	local function addPlayer(playerID, teamID)
+		world.players[playerID] = {
+			active = true,
+			spectator = false,
+			teamID = teamID,
+			allyTeamID = world.teams[teamID].allyTeamID,
+		}
+	end
+
+	world.addTeam = addTeam
+	world.addPlayer = addPlayer
+
+	world.spring = {
+		GetPlayerList = function(teamID)
+			local list = {}
+			for playerID, player in pairs(world.players) do
+				if teamID == nil or player.teamID == teamID then
+					list[#list + 1] = playerID
+				end
+			end
+			table.sort(list)
+			return list
+		end,
+		GetPlayerInfo = function(playerID)
+			local player = world.players[playerID]
+			return "player" .. playerID, player.active, player.spectator, player.teamID, player.allyTeamID
+		end,
+		GetTeamList = function(allyTeamID)
+			if allyTeamID == nil then
+				local all = {}
+				for teamID in pairs(world.teams) do
+					all[#all + 1] = teamID
+				end
+				table.sort(all)
+				return all
+			end
+			return world.allyTeams[allyTeamID] or {}
+		end,
+		GetTeamInfo = function(teamID)
+			local team = world.teams[teamID]
+			return teamID, team.leader, 0, team.isAI, "", team.allyTeamID
+		end,
+		GetTeamUnitCount = function(teamID)
+			return #world.teams[teamID].units
+		end,
+		GetTeamUnits = function(teamID)
+			return world.teams[teamID].units
+		end,
+		GetUnitDefID = function(unitID)
+			return world.unitDefOf and world.unitDefOf[unitID] or 1
+		end,
+		GetAIInfo = function(teamID)
+			return nil, nil, world.teams[teamID].aiHost
+		end,
+		GetTeamLuaAI = function(teamID)
+			return world.teams[teamID].luaAI
+		end,
+		KillTeam = function(teamID)
+			world.killed[#world.killed + 1] = teamID
+		end,
+		DestroyUnit = function(unitID)
+			world.destroyed[#world.destroyed + 1] = unitID
+		end,
+	}
+
+	world.config = {
+		gaiaTeamID = GAIA_TEAM,
+		gaiaAllyTeamID = GAIA_ALLY,
+		isFFA = opts.isFFA or false,
+		playerQuitIsDead = opts.playerQuitIsDead ~= false,
+		earlyDropGrace = 30 * 60,
+		killGraceFrames = 30 * (opts.isFFA and 20 or 12),
+		ignoredTeams = opts.ignoredTeams or { [GAIA_TEAM] = true },
+		unitDecoration = opts.unitDecoration or {},
+	}
+
+	world.start = function()
+		local liveness = Liveness.New({
+			spring = world.spring,
+			config = world.config,
+			wipeoutAllyTeam = function(allyTeamID)
+				world.wipedOut[#world.wipedOut + 1] = allyTeamID
+			end,
+		})
+		local allyList = {}
+		for allyTeamID in pairs(world.allyTeams) do
+			allyList[#allyList + 1] = allyTeamID
+		end
+		table.sort(allyList)
+		liveness.InitTeams(allyList)
+		world.liveness = liveness
+		return liveness
+	end
+
+	return world
+end
+
+local function standardWorld(opts)
+	local world = newWorld(opts)
+	world.addTeam(0, 0)
+	world.addTeam(1, 1)
+	world.addPlayer(10, 0)
+	world.addPlayer(11, 1)
+	return world
+end
+
+describe("matchflow liveness", function()
+	describe("initialization", function()
+		it("counts starting units per team and allyteam", function()
+			local world = newWorld()
+			world.addTeam(0, 0, { units = { 101, 102 } })
+			world.addTeam(1, 0, { units = { 103 } })
+			world.addTeam(2, 1, { units = {} })
+			world.addPlayer(10, 0)
+			world.addPlayer(11, 1)
+			world.addPlayer(12, 2)
+			local liveness = world.start()
+
+			local infos = liveness.Infos()
+			assert.are.equal(3, infos[0].unitCount)
+			assert.are.equal(2, infos[0].teams[0].unitCount)
+			assert.are.equal(1, infos[0].teams[1].unitCount)
+			assert.are.equal(0, infos[1].unitCount)
+		end)
+
+		it("counts starting decoration units", function()
+			local world = newWorld({ unitDecoration = { [7] = true } })
+			world.unitDefOf = { [101] = 7, [102] = 1 }
+			world.addTeam(0, 0, { units = { 101, 102 } })
+			world.addTeam(1, 1)
+			world.addPlayer(10, 0)
+			world.addPlayer(11, 1)
+			local liveness = world.start()
+			assert.are.equal(1, liveness.Infos()[0].unitDecorationCount)
+		end)
+
+		it("marks an empty allyteam dead from the start", function()
+			local world = standardWorld()
+			world.allyTeams[2] = {}
+			local liveness = world.start()
+			assert.is_true(liveness.Infos()[2].dead)
+		end)
+
+		it("marks a Lua-AI team controlled and AI", function()
+			local world = newWorld()
+			world.addTeam(0, 0)
+			world.addTeam(1, 1, { luaAI = "BARb" })
+			world.addPlayer(10, 0)
+			local liveness = world.start()
+			assert.is_true(liveness.Infos()[1].teams[1].isAI)
+			assert.is_true(liveness.Infos()[1].teams[1].isControlled)
+		end)
+	end)
+
+	describe("resignation (all players spectate)", function()
+		it("kills the team immediately on its next check", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.CheckAllPlayers(100)
+			assert.are.same({}, world.killed)
+
+			world.players[11].spectator = true
+			liveness.CheckAllPlayers(200)
+			assert.are.same({ 1 }, world.killed)
+		end)
+
+		it("never resigns an AI team", function()
+			local world = newWorld()
+			world.addTeam(0, 0)
+			world.addTeam(1, 1, { isAI = true, aiHost = 11 })
+			world.addPlayer(10, 0)
+			world.addPlayer(11, 1)
+			local liveness = world.start()
+			world.players[11].spectator = true
+			liveness.CheckAllPlayers(200)
+			assert.are.same({}, world.killed)
+		end)
+	end)
+
+	describe("leaderless grace period", function()
+		it("queues the kill for gameSpeed*12 frames (non-FFA), then kills", function()
+			local world = standardWorld()
+			local liveness = world.start()
+
+			-- player drops: still has a leader slot? no — leader gone too
+			world.players[11].active = false
+			world.teams[1].leader = -1
+			liveness.CheckAllPlayers(100)
+			assert.are.same({}, world.killed)
+
+			liveness.CheckAllPlayers(100 + 30 * 12 - 1)
+			assert.are.same({}, world.killed)
+			liveness.CheckAllPlayers(100 + 30 * 12)
+			assert.are.same({ 1 }, world.killed)
+		end)
+
+		it("cancels the queued kill when the leader returns", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			world.players[11].active = false
+			world.teams[1].leader = -1
+			liveness.CheckAllPlayers(100)
+
+			world.players[11].active = true
+			world.teams[1].leader = 11
+			liveness.CheckAllPlayers(150)
+
+			liveness.CheckAllPlayers(100 + 30 * 12)
+			assert.are.same({}, world.killed)
+		end)
+	end)
+
+	describe("the savegame active-flag hack", function()
+		it("keeps a team controlled for 60 frames after the player goes inactive", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.CheckAllPlayers(100) -- records isControlling = 100
+
+			world.players[11].active = false
+			liveness.CheckAllPlayers(159) -- 100 > 159-60: still controlled
+			assert.is_true(liveness.Infos()[1].teams[1].isControlled)
+
+			liveness.CheckAllPlayers(161) -- 100 <= 161-60: no longer controlled
+			assert.is_false(liveness.Infos()[1].teams[1].isControlled)
+		end)
+	end)
+
+	describe("allyteam death", function()
+		it("wipes out an allyteam when its only team dies", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.TeamDied(1, 500)
+			assert.are.same({ 1 }, world.wipedOut)
+			assert.is_true(liveness.Infos()[1].dead)
+		end)
+
+		it("does not evaluate death at frame 0", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.TeamDied(1, 0)
+			assert.are.same({}, world.wipedOut)
+			assert.is_false(liveness.Infos()[1].dead)
+		end)
+
+		it("declares an uncontrolled allyteam dead when playerQuitIsDead", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.CheckAllPlayers(100)
+			world.players[11].active = false
+			liveness.CheckAllPlayers(300) -- past the 60-frame window
+			assert.are.same({ 1 }, world.wipedOut)
+		end)
+
+		it("keeps an uncontrolled allyteam alive when playerQuitIsDead is off (1v1 rejoin)", function()
+			local world = standardWorld({ playerQuitIsDead = false })
+			local liveness = world.start()
+			liveness.CheckAllPlayers(100)
+			world.players[11].active = false
+			liveness.CheckAllPlayers(300)
+			assert.are.same({}, world.wipedOut)
+		end)
+
+		it("reclaims units instead of wiping out on FFA early drop", function()
+			local world = newWorld({ isFFA = true })
+			world.addTeam(0, 0)
+			world.addTeam(1, 1, { units = { 201, 202 } })
+			world.addTeam(2, 2)
+			world.addPlayer(10, 0)
+			world.addPlayer(11, 1)
+			world.addPlayer(12, 2)
+			local liveness = world.start()
+			liveness.TeamDied(1, 100) -- inside earlyDropGrace (30*60)
+			assert.are.same({ 201, 202 }, world.destroyed)
+			assert.are.same({}, world.wipedOut)
+			assert.is_true(liveness.Infos()[1].dead)
+		end)
+	end)
+
+	describe("unit counting", function()
+		it("tracks created and destroyed units", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.UnitCreated(1, 0)
+			liveness.UnitCreated(1, 0)
+			liveness.UnitDestroyed(1, 0)
+			assert.are.equal(1, liveness.Infos()[0].unitCount)
+		end)
+
+		it("ignores configured teams (gaia, Raptors/Scavengers)", function()
+			local world = standardWorld()
+			local liveness = world.start()
+			liveness.UnitCreated(1, GAIA_TEAM)
+			assert.are.equal(0, liveness.Infos()[0].unitCount)
+			assert.are.equal(0, liveness.Infos()[1].unitCount)
+		end)
+
+		it("kills every team in an allyteam left with only decorations", function()
+			local world = newWorld({ unitDecoration = { [7] = true } })
+			world.addTeam(0, 0)
+			world.addTeam(1, 1)
+			world.addPlayer(10, 0)
+			world.addPlayer(11, 1)
+			local liveness = world.start()
+
+			liveness.UnitCreated(1, 1) -- a real unit
+			liveness.UnitCreated(7, 1) -- a decoration
+			liveness.UnitDestroyed(1, 1) -- real unit dies -> only decoration left
+			assert.are.same({ 1 }, world.killed)
+		end)
+	end)
+end)

--- a/spec/modules/missions/chat_guard_spec.lua
+++ b/spec/modules/missions/chat_guard_spec.lua
@@ -1,0 +1,18 @@
+local ChatGuard = VFS.Include("modules/missions/lib/chat_guard.lua")
+
+describe("mission chat guard", function()
+	it("always allows singleplayer", function()
+		assert.is_true(ChatGuard.IsAllowed(true, false))
+		assert.is_true(ChatGuard.IsAllowed(true, true))
+	end)
+
+	it("allows multiplayer only with cheats enabled", function()
+		assert.is_true(ChatGuard.IsAllowed(false, true))
+		assert.is_false(ChatGuard.IsAllowed(false, false))
+	end)
+
+	it("treats missing facts as denial, not permission", function()
+		assert.is_false(ChatGuard.IsAllowed(nil, nil))
+		assert.is_false(ChatGuard.IsAllowed(nil, false))
+	end)
+end)

--- a/spec/modules/missions/dsl_spec.lua
+++ b/spec/modules/missions/dsl_spec.lua
@@ -1,0 +1,184 @@
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local alwaysTrue = { evaluate = function() return true end }
+local anEffect = { execute = function() end }
+
+describe("mission DSL", function()
+	local registered ---@type TriggerDescriptor[]
+	local When
+	local Finalize
+
+	before_each(function()
+		registered = {}
+		local file = DSL.ForFile("triggers/win.lua", function(descriptor)
+			registered[#registered + 1] = descriptor
+		end)
+		When = file.When
+		Finalize = file.Finalize
+	end)
+
+	it("builds a descriptor from a terminator-free chain at Finalize", function()
+		When(alwaysTrue).Do(anEffect)
+		assert.are.equal(0, #registered) -- nothing arms before the commit point
+		Finalize()
+
+		assert.are.equal(1, #registered)
+		local descriptor = registered[1]
+		assert.are.equal("triggers/win.lua:1", descriptor.id)
+		assert.are.equal("triggers/win.lua", descriptor.filename)
+		assert.are.equal(1, descriptor.order)
+		assert.are.equal(alwaysTrue, descriptor.condition)
+		assert.are.same({ anEffect }, descriptor.effects)
+		assert.is_true(descriptor.once)
+	end)
+
+	it("stamps declaration order by When-call order", function()
+		When(alwaysTrue).Do(anEffect)
+		When(alwaysTrue).Do(anEffect)
+		Finalize()
+		assert.are.equal("triggers/win.lua:1", registered[1].id)
+		assert.are.equal("triggers/win.lua:2", registered[2].id)
+	end)
+
+	it("accumulates multiple Do effects in order", function()
+		local first = { execute = function() end }
+		local second = { execute = function() end }
+		When(alwaysTrue).Do(first).Do(second)
+		Finalize()
+		assert.are.same({ first, second }, registered[1].effects)
+	end)
+
+	it("defaults Once to true and honors Once(false)", function()
+		When(alwaysTrue).Do(anEffect).Once(false)
+		Finalize()
+		assert.is_false(registered[1].once)
+	end)
+
+	it("a statement without a Do fails the load, naming the statement", function()
+		When(alwaysTrue).Do(anEffect)
+		When(alwaysTrue) -- half-finished
+		assert.has_error(function()
+			Finalize()
+		end)
+		assert.are.equal(0, #registered) -- the failed load arms nothing
+	end)
+
+	it("rejects a bare function in Do (closure-free surface)", function()
+		assert.has_error(function()
+			When(alwaysTrue).Do(function() end)
+		end)
+	end)
+
+	it("rejects a condition without evaluate", function()
+		assert.has_error(function()
+			When({})
+		end)
+	end)
+
+	it("rejects chain calls after Finalize", function()
+		local chain = When(alwaysTrue).Do(anEffect)
+		Finalize()
+		assert.has_error(function()
+			chain.Do(anEffect)
+		end)
+	end)
+
+	it("rejects Finalize twice", function()
+		Finalize()
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+end)
+
+describe("repeated When (AND composition)", function()
+	local registered
+	local When
+	local Finalize
+
+	before_each(function()
+		registered = {}
+		local file = DSL.ForFile("triggers/win.lua", function(descriptor)
+			registered[#registered + 1] = descriptor
+		end)
+		When = file.When
+		Finalize = file.Finalize
+	end)
+
+	local function cond(result, inputs)
+		return { inputs = inputs, evaluate = function() return result end }
+	end
+
+	it("fires only when every condition holds", function()
+		When(cond(true)).When(cond(false)).Do(anEffect)
+		When(cond(true)).When(cond(true)).Do(anEffect)
+		Finalize()
+		assert.is_false(registered[1].condition.evaluate({}))
+		assert.is_true(registered[2].condition.evaluate({}))
+	end)
+
+	it("composes inputs as the union of the parts'", function()
+		When(cond(true, { "A", "B" })).When(cond(true, { "B", "C" })).Do(anEffect)
+		Finalize()
+		local inputs = registered[1].condition.inputs
+		table.sort(inputs)
+		assert.are.same({ "A", "B", "C" }, inputs)
+	end)
+
+	it("a poll-only part makes the whole trigger poll", function()
+		When(cond(true, { "A" })).When(cond(true, nil)).Do(anEffect)
+		Finalize()
+		assert.is_nil(registered[1].condition.inputs)
+	end)
+
+	it("single-condition statements keep their original condition object", function()
+		local only = cond(true, { "A" })
+		When(only).Do(anEffect)
+		Finalize()
+		assert.are.equal(only, registered[1].condition)
+	end)
+
+	it("rejects a non-condition", function()
+		assert.has_error(function()
+			When(cond(true)).When(function() end)
+		end)
+	end)
+end)
+
+describe("mission verbs", function()
+	it("UnitDef carries the name", function()
+		assert.are.same({ name = "armpw" }, Verbs.UnitDef("armpw"))
+	end)
+
+	it("Team.Has evaluates against ctx counts", function()
+		local team = Verbs.MakeTeam(0, 0)
+		local condition = team.Has(Verbs.UnitDef("armpw"), 3)
+
+		local counts = { [0] = { armpw = 2 } }
+		local ctx = {
+			frame = 0,
+			GetUnitDefCount = function(teamID, defName)
+				return (counts[teamID] or {})[defName] or 0
+			end,
+			IsObjectiveComplete = function()
+				return false
+			end,
+		}
+		assert.is_false(condition.evaluate(ctx))
+		counts[0].armpw = 3
+		assert.is_true(condition.evaluate(ctx))
+	end)
+
+	it("Has declares its engine-callin inputs", function()
+		local team = Verbs.MakeTeam(0, 0)
+		local condition = team.Has(Verbs.UnitDef("armpw"), 3)
+		assert.are.same({ "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken" }, condition.inputs)
+	end)
+
+	it("Team carries teamID and allyTeam for MatchFlow calls", function()
+		local team = Verbs.MakeTeam(2, 1)
+		assert.are.equal(2, team.teamID)
+		assert.are.equal(1, team.allyTeam)
+	end)
+end)

--- a/spec/modules/missions/manifests_spec.lua
+++ b/spec/modules/missions/manifests_spec.lua
@@ -1,0 +1,28 @@
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+
+describe("mission module manifests", function()
+	local manifests
+
+	setup(function()
+		ModuleHandler.ResetCaches()
+		manifests = ModuleHandler.Discover()
+	end)
+
+	it("discovers missions and matchflow", function()
+		assert.is_table(manifests.missions)
+		assert.is_table(manifests.matchflow)
+	end)
+
+	it("missions declares its matchflow dependency", function()
+		assert.are.same({ "matchflow" }, manifests.missions.requires)
+	end)
+
+	it("every declared requirement resolves to a discovered module", function()
+		for name, manifest in pairs(manifests) do
+			for _, required in ipairs(manifest.requires or {}) do
+				assert.is_table(manifests[required],
+					name .. " requires missing module " .. required)
+			end
+		end
+	end)
+end)

--- a/spec/modules/missions/trigger_engine_spec.lua
+++ b/spec/modules/missions/trigger_engine_spec.lua
@@ -1,0 +1,206 @@
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+
+---@param counts table<integer, table<string, integer>> teamID -> defName -> count
+---@param frame integer?
+---@return MissionContext
+local function makeCtx(counts, frame)
+	return {
+		frame = frame or 0,
+		GetUnitDefCount = function(teamID, defName)
+			return (counts[teamID] or {})[defName] or 0
+		end,
+	}
+end
+
+---@param id string
+---@param result boolean|fun(ctx: MissionContext): boolean
+---@param log string[]
+---@return TriggerDescriptor
+local function makeTrigger(id, result, log)
+	return {
+		id = id,
+		filename = id:match("^(.*):") or id,
+		order = tonumber(id:match(":(%d+)$")) or 1,
+		condition = {
+			evaluate = function(ctx)
+				if type(result) == "function" then
+					return result(ctx)
+				end
+				return result
+			end,
+		},
+		effects = { {
+			execute = function()
+				log[#log + 1] = id
+			end,
+		} },
+		once = true,
+	}
+end
+
+describe("TriggerEngine", function()
+	it("runs an effect when its condition holds", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1" }, log)
+	end)
+
+	it("does not run an effect while its condition is false", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", false, log))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({}, log)
+	end)
+
+	it("fires a once trigger at most once", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1" }, log)
+	end)
+
+	it("fires a repeating trigger every evaluation", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		local trigger = makeTrigger("f.lua:1", true, log)
+		trigger.once = false
+		engine.Register(trigger)
+		engine.Evaluate(makeCtx({}))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1", "f.lua:1" }, log)
+	end)
+
+	it("rejects duplicate trigger ids", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		assert.has_error(function()
+			engine.Register(makeTrigger("f.lua:1", true, log))
+		end)
+	end)
+
+	it("keeps fired flags in the engine state table, not closures", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		assert.is_true(engine.GetState().fired["f.lua:1"])
+	end)
+
+	it("restores progress via SetState: a restored fired flag suppresses the effect", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.SetState({ fired = { ["f.lua:1"] = true } })
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({}, log)
+	end)
+
+	describe("condition inputs (event-driven evaluation)", function()
+		local function watcherTrigger(id, log, inputs, result)
+			return {
+				id = id,
+				filename = id:match("^(.*):") or id,
+				order = tonumber(id:match(":(%d+)$")) or 1,
+				condition = {
+					inputs = inputs,
+					evaluate = function()
+						log.evaluated[#log.evaluated + 1] = id
+						return result ~= false
+					end,
+				},
+				effects = { { execute = function()
+					log.fired[#log.fired + 1] = id
+				end } },
+				once = true,
+			}
+		end
+
+		local function newLog()
+			return { evaluated = {}, fired = {} }
+		end
+
+		it("indexes watched inputs at Register", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, { "UnitFinished", "UnitDestroyed" }))
+			assert.are.same({ UnitFinished = true, UnitDestroyed = true }, engine.WatchedInputs())
+		end)
+
+		it("evaluates a watcher once on arm, then only after its events", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, { "UnitFinished" }, false))
+			engine.Evaluate(makeCtx({})) -- armed: evaluates once
+			engine.Evaluate(makeCtx({})) -- no event since: skipped
+			assert.are.equal(1, #log.evaluated)
+			engine.OnEvent("UnitFinished")
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(2, #log.evaluated)
+		end)
+
+		it("ignores events nothing watches", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, { "UnitFinished" }, false))
+			engine.Evaluate(makeCtx({}))
+			engine.OnEvent("mission.objective_changed")
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(1, #log.evaluated)
+		end)
+
+		it("polls conditions with nil inputs every cadence", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, nil, false))
+			engine.Evaluate(makeCtx({}))
+			engine.Evaluate(makeCtx({}))
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(3, #log.evaluated)
+		end)
+
+		it("UnregisterFile cleans the watcher index", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("a.lua:1", log, { "UnitFinished" }))
+			engine.UnregisterFile("a.lua")
+			assert.are.same({}, engine.WatchedInputs())
+			engine.OnEvent("UnitFinished")
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(0, #log.evaluated)
+		end)
+	end)
+
+	describe("UnregisterFile", function()
+		it("removes exactly that file's triggers and their progress", function()
+			local engine = TriggerEngine.New()
+			local log = {}
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Register(makeTrigger("b.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+
+			local removed = engine.UnregisterFile("a.lua")
+			assert.are.equal(1, removed)
+			assert.is_nil(engine.GetState().fired["a.lua:1"])
+			assert.is_true(engine.GetState().fired["b.lua:1"])
+			assert.are.equal(1, #engine.Triggers())
+			assert.are.equal("b.lua:1", engine.Triggers()[1].id)
+		end)
+
+		it("lets a re-registered trigger fire again (hot reload)", function()
+			local engine = TriggerEngine.New()
+			local log = {}
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+			engine.UnregisterFile("a.lua")
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+			assert.are.same({ "a.lua:1", "a.lua:1" }, log)
+		end)
+	end)
+end)

--- a/types/modules.lua
+++ b/types/modules.lua
@@ -1,0 +1,45 @@
+--- What a module author writes in modules/<name>/module.lua.
+---@class ModuleManifestFile
+---@field name string Module name; must match its directory under modules/
+---@field version string|nil Semver-ish version string
+---@field description string|nil One-line description
+---@field requires string[]|nil Names of modules this module depends on
+---@field provides string|table|nil Public contract: a path (state-agnostic, default <dir>/api.lua) or an explicit partition { shared = path, synced = path, unsynced = path }; ModuleHandler.Get merges shared + current state into one flat api
+
+--- A discovered manifest, enriched by the loader.
+---@class ModuleManifest : ModuleManifestFile
+---@field dir string Module directory with trailing slash (loader-stamped)
+
+--- The runtime registry entry for an action — assembled by the LOADER, never
+--- hand-authored. Action files register via the injected `Actions` registrar
+--- (`local Actions = Actions`, the widget-handler idiom: explicit named calls
+--- on an explicit local, not anonymous setfenv globals): RegisterValidate
+--- (optional, first) then RegisterExecute (required, exactly one); files
+--- return nothing, and identity is the filename (actions/unit_transfer.lua →
+--- "unit_transfer"). Actions are the only effectful layer; validate stays pure.
+--- NOTE: no hand-written parameter schema — controllers are statically typed
+--- (LuaCATS + emmylua). A DERIVED schema (generated from the annotations, e.g.
+--- lua-doc-extractor) returns if/when a data-driven dispatcher (mission_api,
+--- CampaignAPI) creates a runtime boundary the type checker cannot see.
+---@class ActionDescriptor
+---@field name string From the filename; loader-stamped
+---@field validate function|nil Pure precondition check over the action's inputs (no mutation)
+---@field execute function Performs the action
+
+---@class ActionRegistrar
+---@field RegisterValidate fun(fn: function)
+---@field RegisterExecute fun(fn: function)
+
+---@class PoliciesRegistrar
+---@field Pipeline fun(): PolicyPipeline
+
+--- One pipeline per category: modules/<name>/policies/<category>.lua registers
+--- an ordered PolicyDescriptor[] via the injected `Policies` facade —
+--- Policies.Pipeline():Gate(...):Compute(...):Register(); files return nothing. Pure functions constrained by types: no engine mutation in
+--- evaluate. Stages run in declaration order; returning nil passes to the next
+--- stage, returning a result ends evaluation (first result wins). The terminal
+--- Compute stage always returns.
+---@class PolicyDescriptor
+---@field name string
+---@field category string|nil Defaults to the policies/<category>.lua filename
+---@field evaluate function fun(...): result|nil


### PR DESCRIPTION
One commit, one runtime: the mission/campaign API as encapsulated game modules, with a served editor over it. Playable today: start a skirmish and run `/luarules mission hello_pawns`.

This is 1/5 of the modules stack — mission api: this (the foundation) → #8464 matchflow → #8465 the served editor → #8460 combat → #8461 CM8 Ashfall; then multiplayer: #8462 the mode grammar → #8463 sharing v2. This PR's diff is the foundation; the editor and tooling sections below describe what the stack builds toward.

## The authoring surface

Mission files are Lua in a sandbox whose injected environment IS the API — dot-only, closure-free, terminator-free:

```lua
When(Team.Player.Has(UnitDef("armpw"), 3))
	.Do(Objective("build_pawns").Complete())

When(Objective("build_pawns").IsComplete())
	.Do(MatchFlow.Victory(Team.Player))
```

- Conditions declare their **inputs** (a closed, typed event vocabulary): the engine hooks only watched callins, evaluates on events plus a cadence for pollers.
- Trigger progress lives in the engine's serializable state table, never in closures (the savegame rule); identity is filename + declaration order, which is also the hot-reload key.

## The modules

- **module runtime** — discovery, per-state contracts, auto-loaded subdirectories, module-owned modoptions; the shim for engine-native module loading.
- **matchflow** — game_end's decision extracted behind a policy pipeline; scripted verdicts (`MatchFlow.Victory/Defeat`) enter through the same gate as elimination, so game-over has exactly one owner.
- **missions** — the trigger engine, DSL builder, and loader.

## The contract with tooling

Any types file declaring `---@meta dsl` publishes the DSL surface as ordinary LuaCATS annotations. The editor tooling (BAR-Devtools: bar-mission-kit) derives its entire grammar from these files — statement heads, chain verbs, slot semantics from parameter type aliases, editor enums from literal unions. Adding vocabulary is a game-side annotation edit; the language server does not change. Vocabulary lives with the module that injects it: a module named in the missions manifest's `requires` contributes its verbs and their types — the dependency list is the whitelist, for the sandbox and the tooling alike. What these files declare is the only Lua that works in a mission file, and the tooling marks that edge explicitly.

## Editing

The served editor renders missions as editable sentence cards in-game (RmlUi), in VS Code, and in a browser — all blind terminals of one server-rendered form. Every edit round-trips through the recognizer: a change that leaves the subset is rejected and the `.lua` file stays the source of truth.

## Testing

Pure-Lua specs under busted (`spec/modules/{missions,matchflow}`) cover the engine, DSL, verbs, and policies. The headless integration test plays `hello_pawns` end to end through the real verdict path.

