### PR TITLE
Adding support for the Tab key to cycle through chat channels while text input is empty

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -3551,6 +3551,17 @@ function widget:TextInput(char) -- if it isnt working: chobby probably hijacked 
 	end
 end
 
+function widget:cycleInputMode()
+	if inputMode == 'a:' then
+		inputMode = ''
+	elseif inputMode == 's:' then
+		inputMode = mySpec and '' or 'a:'
+	else
+		inputMode = 's:'
+	end
+	updateTextInputDlist = true
+end
+
 function widget:KeyRelease(key, mods, label, unicode, scanCode)
 	-- Since we grab the keyboard, we need to specify a KeyRelease to make sure other release actions can be triggered
 	if
@@ -3913,15 +3924,19 @@ function widget:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
 			prevAutocompleteLetters = nil
 			autocomplete(inputText, true)
 		elseif key == 9 and inputMode ~= "label" then -- TAB
-			inputSelectionStart = nil
-			if autocompleteText and autocompleteWords[1] then
-				inputText = utf8.sub(inputText, 1, inputTextPosition)
+			if utf8.len(inputText) == 0 then
+				self:cycleInputMode()
+			else
+				inputSelectionStart = nil
+				if autocompleteText and autocompleteWords[1] then
+					inputText = utf8.sub(inputText, 1, inputTextPosition)
 					.. autocompleteText
 					.. utf8.sub(inputText, inputTextPosition + 1)
-				inputTextPosition = inputTextPosition + utf8.len(autocompleteText)
-				inputHistory[#inputHistory] = inputText
-				autocompleteText = nil
-				autocompleteWords = {}
+					inputTextPosition = inputTextPosition + utf8.len(autocompleteText)
+					inputHistory[#inputHistory] = inputText
+					autocompleteText = nil
+					autocompleteWords = {}
+				end
 			end
 		else
 			-- regular chars/keys handled in widget:TextInput
@@ -4035,13 +4050,7 @@ function widget:MousePress(x, y, button)
 			state.inputButtonRect[4]
 		)
 	then
-		if inputMode == "a:" then
-			inputMode = ""
-		elseif inputMode == "s:" then
-			inputMode = mySpec and "" or "a:"
-		else
-			inputMode = "s:"
-		end
+		self:cycleInputMode()
 		updateTextInputDlist = true
 		return true
 	end

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -3552,19 +3552,11 @@ function widget:TextInput(char) -- if it isnt working: chobby probably hijacked 
 end
 
 function widget:cycleInputMode(reverse)
-	local inputModeOrder = {'', 's:', 'a:'}
-	local zeroModeIndex = 0 -- use zero-based index for modulo, and add 1 before accessing inputModeOrder
-	for i, mode in ipairs(inputModeOrder) do
-		if mode == inputMode then
-			zeroModeIndex = i - 1
-			break
-		end
-	end
-
-	local modeCount = mySpec and #inputModeOrder - 1 or #inputModeOrder
+	local inputModeOrder = mySpec and {'', 's:'} or {'', 's:', 'a:'}
+	local modeIndex = table.getKeyOf(inputModeOrder, inputMode) or 1
 	local direction = reverse and -1 or 1
-	local newZeroIndex = (zeroModeIndex + direction) % modeCount
-	inputMode = inputModeOrder[newZeroIndex + 1] -- convert back to 1-based index
+
+	inputMode = inputModeOrder[(modeIndex - 1 + direction) % #inputModeOrder + 1]
 
 	updateTextInputDlist = true
 end
@@ -3931,19 +3923,17 @@ function widget:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
 			prevAutocompleteLetters = nil
 			autocomplete(inputText, true)
 		elseif key == 9 and inputMode ~= "label" then -- TAB
-			if inputText == '' then
+			inputSelectionStart = nil
+			if inputText == '' and not isRepeat then
 				self:cycleInputMode(shift)
-			else
-				inputSelectionStart = nil
-				if autocompleteText and autocompleteWords[1] then
-					inputText = utf8.sub(inputText, 1, inputTextPosition)
+			elseif autocompleteText and autocompleteWords[1] then
+				inputText = utf8.sub(inputText, 1, inputTextPosition)
 					.. autocompleteText
 					.. utf8.sub(inputText, inputTextPosition + 1)
-					inputTextPosition = inputTextPosition + utf8.len(autocompleteText)
-					inputHistory[#inputHistory] = inputText
-					autocompleteText = nil
-					autocompleteWords = {}
-				end
+				inputTextPosition = inputTextPosition + utf8.len(autocompleteText)
+				inputHistory[#inputHistory] = inputText
+				autocompleteText = nil
+				autocompleteWords = {}
 			end
 		else
 			-- regular chars/keys handled in widget:TextInput

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -3551,14 +3551,21 @@ function widget:TextInput(char) -- if it isnt working: chobby probably hijacked 
 	end
 end
 
-function widget:cycleInputMode()
-	if inputMode == 'a:' then
-		inputMode = ''
-	elseif inputMode == 's:' then
-		inputMode = mySpec and '' or 'a:'
-	else
-		inputMode = 's:'
+function widget:cycleInputMode(reverse)
+	local channelOrder = {'', 's:', 'a:'}
+	local zeroModeIndex -- use zero-based index for modulo, and add 1 before accessing channelOrder
+	for i, mode in ipairs(channelOrder) do
+		if mode == inputMode then
+			zeroModeIndex = i - 1
+			break
+		end
 	end
+
+	local channelCount = mySpec and #channelOrder - 1 or #channelOrder
+	local direction = reverse and -1 or 1
+	local newZeroIndex = (zeroModeIndex + direction) % channelCount
+	inputMode = channelOrder[newZeroIndex + 1] -- convert back to 1-based index
+
 	updateTextInputDlist = true
 end
 
@@ -3924,8 +3931,8 @@ function widget:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
 			prevAutocompleteLetters = nil
 			autocomplete(inputText, true)
 		elseif key == 9 and inputMode ~= "label" then -- TAB
-			if utf8.len(inputText) == 0 then
-				self:cycleInputMode()
+			if inputText == '' then
+				self:cycleInputMode(shift)
 			else
 				inputSelectionStart = nil
 				if autocompleteText and autocompleteWords[1] then

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -4048,7 +4048,6 @@ function widget:MousePress(x, y, button)
 		)
 	then
 		self:cycleInputMode()
-		updateTextInputDlist = true
 		return true
 	end
 

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -3552,19 +3552,19 @@ function widget:TextInput(char) -- if it isnt working: chobby probably hijacked 
 end
 
 function widget:cycleInputMode(reverse)
-	local channelOrder = {'', 's:', 'a:'}
-	local zeroModeIndex -- use zero-based index for modulo, and add 1 before accessing channelOrder
-	for i, mode in ipairs(channelOrder) do
+	local inputModeOrder = {'', 's:', 'a:'}
+	local zeroModeIndex = 0 -- use zero-based index for modulo, and add 1 before accessing inputModeOrder
+	for i, mode in ipairs(inputModeOrder) do
 		if mode == inputMode then
 			zeroModeIndex = i - 1
 			break
 		end
 	end
 
-	local channelCount = mySpec and #channelOrder - 1 or #channelOrder
+	local modeCount = mySpec and #inputModeOrder - 1 or #inputModeOrder
 	local direction = reverse and -1 or 1
-	local newZeroIndex = (zeroModeIndex + direction) % channelCount
-	inputMode = channelOrder[newZeroIndex + 1] -- convert back to 1-based index
+	local newZeroIndex = (zeroModeIndex + direction) % modeCount
+	inputMode = inputModeOrder[newZeroIndex + 1] -- convert back to 1-based index
 
 	updateTextInputDlist = true
 end


### PR DESCRIPTION
### Work done
Added support for the Tab key to cycle through chat channels similarly to clicking the channel button. This behavior only works while text input is empty to avoid colliding with autocomplete. I saw an issue filed for it and it felt like a good first PR, if acceptable to maintainers.

#### Addresses Issue(s)
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/8361

#### Test steps
- [ ] Start any game
- [ ] Hit Enter to open chat
- [ ] Hit the Tab key
- [ ] Observe the channels cycle in the same manner as clicking the channel name.

### AI / LLM usage statement:
VS autocomplete only