### PR TITLE
Added support for Action Files to contain group of actions

### DIFF
--- a/luarules/mission_api/actions/add_marker.lua
+++ b/luarules/mission_api/actions/add_marker.lua
@@ -8,11 +8,13 @@ local function addMarker(position, label, name)
 end
 
 return {
-	type = 'AddMarker',
-	parameters = {
-		{ name = 'position', required = true, type = ParameterTypes.Position },
-		{ name = 'label', required = false, type = ParameterTypes.String },
-		{ name = 'name', required = false, type = ParameterTypes.String },
-	},
-	actionFunction = addMarker,
+	{
+		type = 'AddMarker',
+		parameters = {
+			{ name = 'position', required = true, type = ParameterTypes.Position },
+			{ name = 'label', required = false, type = ParameterTypes.String },
+			{ name = 'name', required = false, type = ParameterTypes.String },
+		},
+		actionFunction = addMarker,
+	}
 }

--- a/luarules/mission_api/actions/add_resources.lua
+++ b/luarules/mission_api/actions/add_resources.lua
@@ -10,12 +10,14 @@ local function addResources(teamID, metal, energy)
 end
 
 return {
-	type = 'AddResources',
-	parameters = {
-		{ name = 'teamID', required = true, type = ParameterTypes.TeamID },
-		{ name = 'metal', required = false, type = ParameterTypes.Number },
-		{ name = 'energy', required = false, type = ParameterTypes.Number },
-		requiresOneOf = { 'metal', 'energy' },
-	},
-	actionFunction = addResources,
+	{
+		type = 'AddResources',
+		parameters = {
+			{ name = 'teamID', required = true, type = ParameterTypes.TeamID },
+			{ name = 'metal', required = false, type = ParameterTypes.Number },
+			{ name = 'energy', required = false, type = ParameterTypes.Number },
+			requiresOneOf = { 'metal', 'energy' },
+		},
+		actionFunction = addResources,
+	}
 }

--- a/luarules/mission_api/actions/change_stage.lua
+++ b/luarules/mission_api/actions/change_stage.lua
@@ -5,9 +5,11 @@ local function changeStage(stageID)
 end
 
 return {
-	type = 'ChangeStage',
-	parameters = {
-		{ name = 'stageID', required = true, type = ParameterTypes.StageID },
-	},
-	actionFunction = changeStage,
+	{
+		type = 'ChangeStage',
+		parameters = {
+			{ name = 'stageID', required = true, type = ParameterTypes.StageID },
+		},
+		actionFunction = changeStage,
+	}
 }

--- a/luarules/mission_api/actions/clear_all_markers.lua
+++ b/luarules/mission_api/actions/clear_all_markers.lua
@@ -4,7 +4,9 @@ local function clearAllMarkers()
 end
 
 return {
-	type = 'ClearAllMarkers',
-	parameters = {},
-	actionFunction = clearAllMarkers,
+	{
+		type = 'ClearAllMarkers',
+		parameters = {},
+		actionFunction = clearAllMarkers,
+	}
 }

--- a/luarules/mission_api/actions/create_features.lua
+++ b/luarules/mission_api/actions/create_features.lua
@@ -5,9 +5,11 @@ local function createFeatures(featureLoadout)
 end
 
 return {
-	type = 'CreateFeatures',
-	parameters = {
-		{ name = 'featureLoadout', required = true, type = ParameterTypes.FeatureLoadout },
-	},
-	actionFunction = createFeatures,
+	{
+		type = 'CreateFeatures',
+		parameters = {
+			{ name = 'featureLoadout', required = true, type = ParameterTypes.FeatureLoadout },
+		},
+		actionFunction = createFeatures,
+	}
 }

--- a/luarules/mission_api/actions/custom.lua
+++ b/luarules/mission_api/actions/custom.lua
@@ -5,9 +5,11 @@ local function custom(func)
 end
 
 return {
-	type = 'Custom',
-	parameters = {
-		{ name = 'function', required = true, type = ParameterTypes.Function },
-	},
-	actionFunction = custom,
+	{
+		type = 'Custom',
+		parameters = {
+			{ name = 'function', required = true, type = ParameterTypes.Function },
+		},
+		actionFunction = custom,
+	}
 }

--- a/luarules/mission_api/actions/defeat.lua
+++ b/luarules/mission_api/actions/defeat.lua
@@ -12,9 +12,11 @@ local function defeat(losingAllyTeamIDs)
 end
 
 return {
-	type = 'Defeat',
-	parameters = {
-		{ name = 'allyTeamIDs', required = true, type = ParameterTypes.AllyTeamIDs },
-	},
-	actionFunction = defeat,
+	{
+		type = 'Defeat',
+		parameters = {
+			{ name = 'allyTeamIDs', required = true, type = ParameterTypes.AllyTeamIDs },
+		},
+		actionFunction = defeat,
+	}
 }

--- a/luarules/mission_api/actions/despawn_units.lua
+++ b/luarules/mission_api/actions/despawn_units.lua
@@ -14,11 +14,13 @@ local function despawnUnits(unitName, selfDestruct, reclaimed)
 end
 
 return {
-	type = 'DespawnUnits',
-	parameters = {
-		{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
-		{ name = 'selfDestruct', required = false, type = ParameterTypes.Boolean },
-		{ name = 'reclaimed', required = false, type = ParameterTypes.Boolean },
-	},
-	actionFunction = despawnUnits,
+	{
+		type = 'DespawnUnits',
+		parameters = {
+			{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
+			{ name = 'selfDestruct', required = false, type = ParameterTypes.Boolean },
+			{ name = 'reclaimed', required = false, type = ParameterTypes.Boolean },
+		},
+		actionFunction = despawnUnits,
+	}
 }

--- a/luarules/mission_api/actions/destroy_features.lua
+++ b/luarules/mission_api/actions/destroy_features.lua
@@ -13,9 +13,11 @@ local function destroyFeatures(featureName)
 end
 
 return {
-	type = 'DestroyFeatures',
-	parameters = {
-		{ name = 'featureName', required = true, type = ParameterTypes.FeatureName },
-	},
-	actionFunction = destroyFeatures,
+	{
+		type = 'DestroyFeatures',
+		parameters = {
+			{ name = 'featureName', required = true, type = ParameterTypes.FeatureName },
+		},
+		actionFunction = destroyFeatures,
+	}
 }

--- a/luarules/mission_api/actions/disable_trigger.lua
+++ b/luarules/mission_api/actions/disable_trigger.lua
@@ -5,9 +5,11 @@ local function disableTrigger(triggerID)
 end
 
 return {
-	type = 'DisableTrigger',
-	parameters = {
-		{ name = 'triggerID', required = true, type = ParameterTypes.TriggerID },
-	},
-	actionFunction = disableTrigger,
+	{
+		type = 'DisableTrigger',
+		parameters = {
+			{ name = 'triggerID', required = true, type = ParameterTypes.TriggerID },
+		},
+		actionFunction = disableTrigger,
+	}
 }

--- a/luarules/mission_api/actions/draw_lines.lua
+++ b/luarules/mission_api/actions/draw_lines.lua
@@ -9,9 +9,11 @@ local function drawLines(positions)
 end
 
 return {
-	type = 'DrawLines',
-	parameters = {
-		{ name = 'positions', required = true, type = ParameterTypes.Positions },
-	},
-	actionFunction = drawLines,
+	{
+		type = 'DrawLines',
+		parameters = {
+			{ name = 'positions', required = true, type = ParameterTypes.Positions },
+		},
+		actionFunction = drawLines,
+	}
 }

--- a/luarules/mission_api/actions/enable_trigger.lua
+++ b/luarules/mission_api/actions/enable_trigger.lua
@@ -5,13 +5,15 @@ local function enableTrigger(triggerID)
 end
 
 return {
-	type = 'EnableTrigger',
-	parameters = {
-		{
-			name = 'triggerID',
-			required = true,
-			type = ParameterTypes.TriggerID
-		}
-	},
-	actionFunction = enableTrigger
+	{
+		type = 'EnableTrigger',
+		parameters = {
+			{
+				name = 'triggerID',
+				required = true,
+				type = ParameterTypes.TriggerID
+			}
+		},
+		actionFunction = enableTrigger
+	}
 }

--- a/luarules/mission_api/actions/erase_marker.lua
+++ b/luarules/mission_api/actions/erase_marker.lua
@@ -9,9 +9,11 @@ local function eraseMarker(name)
 end
 
 return {
-	type = 'EraseMarker',
-	parameters = {
-		{ name = 'name', required = true, type = ParameterTypes.String },
-	},
-	actionFunction = eraseMarker,
+	{
+		type = 'EraseMarker',
+		parameters = {
+			{ name = 'name', required = true, type = ParameterTypes.String },
+		},
+		actionFunction = eraseMarker,
+	}
 }

--- a/luarules/mission_api/actions/issue_orders.lua
+++ b/luarules/mission_api/actions/issue_orders.lua
@@ -9,10 +9,12 @@ local function issueOrders(unitName, orders)
 end
 
 return {
-	type = 'IssueOrders',
-	parameters = {
-		{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
-		{ name = 'orders', required = true, type = ParameterTypes.Orders },
-	},
-	actionFunction = issueOrders,
+	{
+		type = 'IssueOrders',
+		parameters = {
+			{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
+			{ name = 'orders', required = true, type = ParameterTypes.Orders },
+		},
+		actionFunction = issueOrders,
+	}
 }

--- a/luarules/mission_api/actions/name_units.lua
+++ b/luarules/mission_api/actions/name_units.lua
@@ -46,13 +46,15 @@ local function nameUnits(unitName, teamID, unitDefName, area)
 end
 
 return {
-	type = 'NameUnits',
-	parameters = {
-		{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
-		{ name = 'teamID', required = false, type = ParameterTypes.Number },
-		{ name = 'unitDefName', required = false, type = ParameterTypes.String },
-		{ name = 'area', required = false, type = ParameterTypes.Area },
-		requiresOneOf = { 'teamID', 'unitDefName', 'area' },
-	},
-	actionFunction = nameUnits,
+	{
+		type = 'NameUnits',
+		parameters = {
+			{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
+			{ name = 'teamID', required = false, type = ParameterTypes.Number },
+			{ name = 'unitDefName', required = false, type = ParameterTypes.String },
+			{ name = 'area', required = false, type = ParameterTypes.Area },
+			requiresOneOf = { 'teamID', 'unitDefName', 'area' },
+		},
+		actionFunction = nameUnits,
+	}
 }

--- a/luarules/mission_api/actions/play_sound.lua
+++ b/luarules/mission_api/actions/play_sound.lua
@@ -10,12 +10,14 @@ local function playSound(soundfile, volume, position, enqueue)
 end
 
 return {
-	type = 'PlaySound',
-	parameters = {
-		{ name = 'soundfile', required = true, type = ParameterTypes.SoundFile },
-		{ name = 'volume', required = false, type = ParameterTypes.Number },
-		{ name = 'position', required = false, type = ParameterTypes.Position },
-		{ name = 'enqueue', required = false, type = ParameterTypes.Boolean },
-	},
-	actionFunction = playSound,
+	{
+		type = 'PlaySound',
+		parameters = {
+			{ name = 'soundfile', required = true, type = ParameterTypes.SoundFile },
+			{ name = 'volume', required = false, type = ParameterTypes.Number },
+			{ name = 'position', required = false, type = ParameterTypes.Position },
+			{ name = 'enqueue', required = false, type = ParameterTypes.Boolean },
+		},
+		actionFunction = playSound,
+	}
 }

--- a/luarules/mission_api/actions/send_message.lua
+++ b/luarules/mission_api/actions/send_message.lua
@@ -1,9 +1,11 @@
 local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
 
 return {
-	type = 'SendMessage',
-	parameters = {
-		{ name = 'message', required = true, type = ParameterTypes.String },
-	},
-	actionFunction = Spring.Echo,
+	{
+		type = 'SendMessage',
+		parameters = {
+			{ name = 'message', required = true, type = ParameterTypes.String },
+		},
+		actionFunction = Spring.Echo,
+	}
 }

--- a/luarules/mission_api/actions/spawn_explosion.lua
+++ b/luarules/mission_api/actions/spawn_explosion.lua
@@ -21,11 +21,13 @@ local function spawnExplosion(weaponDefName, position, direction)
 end
 
 return {
-	type = 'SpawnExplosion',
-	parameters = {
-		{ name = 'weaponDefName', required = true, type = ParameterTypes.WeaponDefName },
-		{ name = 'position', required = true, type = ParameterTypes.Position },
-		{ name = 'direction', required = false, type = ParameterTypes.Position },
-	},
-	actionFunction = spawnExplosion,
+	{
+		type = 'SpawnExplosion',
+		parameters = {
+			{ name = 'weaponDefName', required = true, type = ParameterTypes.WeaponDefName },
+			{ name = 'position', required = true, type = ParameterTypes.Position },
+			{ name = 'direction', required = false, type = ParameterTypes.Position },
+		},
+		actionFunction = spawnExplosion,
+	}
 }

--- a/luarules/mission_api/actions/spawn_units.lua
+++ b/luarules/mission_api/actions/spawn_units.lua
@@ -5,9 +5,11 @@ local function spawnUnits(unitLoadout)
 end
 
 return {
-	type = 'SpawnUnits',
-	parameters = {
-		{ name = 'unitLoadout', required = true, type = ParameterTypes.UnitLoadout },
-	},
-	actionFunction = spawnUnits,
+	{
+		type = 'SpawnUnits',
+		parameters = {
+			{ name = 'unitLoadout', required = true, type = ParameterTypes.UnitLoadout },
+		},
+		actionFunction = spawnUnits,
+	}
 }

--- a/luarules/mission_api/actions/transfer_units.lua
+++ b/luarules/mission_api/actions/transfer_units.lua
@@ -13,10 +13,12 @@ local function transferUnits(unitName, newTeam)
 end
 
 return {
-	type = 'TransferUnits',
-	parameters = {
-		{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
-		{ name = 'newTeam', required = true, type = ParameterTypes.TeamID },
-	},
-	actionFunction = transferUnits,
+	{
+		type = 'TransferUnits',
+		parameters = {
+			{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
+			{ name = 'newTeam', required = true, type = ParameterTypes.TeamID },
+		},
+		actionFunction = transferUnits,
+	}
 }

--- a/luarules/mission_api/actions/unname_units.lua
+++ b/luarules/mission_api/actions/unname_units.lua
@@ -6,9 +6,11 @@ local function unnameUnits(unitName)
 end
 
 return {
-	type = 'UnnameUnits',
-	parameters = {
-		{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
-	},
-	actionFunction = unnameUnits,
+	{
+		type = 'UnnameUnits',
+		parameters = {
+			{ name = 'unitName', required = true, type = ParameterTypes.UnitName },
+		},
+		actionFunction = unnameUnits,
+	}
 }

--- a/luarules/mission_api/actions/update_objective.lua
+++ b/luarules/mission_api/actions/update_objective.lua
@@ -22,11 +22,13 @@ local function updateObjective(objectiveID, completed, textKey)
 end
 
 return {
-	type = 'UpdateObjective',
-	parameters = {
-		{ name = 'objectiveID', required = true, type = ParameterTypes.ObjectiveID },
-		{ name = 'completed', required = false, type = ParameterTypes.Boolean },
-		{ name = 'textKey', required = false, type = ParameterTypes.String },
-	},
-	actionFunction = updateObjective,
+	{
+		type = 'UpdateObjective',
+		parameters = {
+			{ name = 'objectiveID', required = true, type = ParameterTypes.ObjectiveID },
+			{ name = 'completed', required = false, type = ParameterTypes.Boolean },
+			{ name = 'textKey', required = false, type = ParameterTypes.String },
+		},
+		actionFunction = updateObjective,
+	}
 }

--- a/luarules/mission_api/actions/victory.lua
+++ b/luarules/mission_api/actions/victory.lua
@@ -5,9 +5,11 @@ local function victory(winningAllyTeamIDs)
 end
 
 return {
-	type = 'Victory',
-	parameters = {
-		{ name = 'allyTeamIDs', required = true, type = ParameterTypes.AllyTeamIDs },
-	},
-	actionFunction = victory,
+	{	
+		type = 'Victory',
+		parameters = {
+			{ name = 'allyTeamIDs', required = true, type = ParameterTypes.AllyTeamIDs },
+		},
+		actionFunction = victory,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_allow_commands.lua
+++ b/luarules/mission_api/actions/yet_to_implement_allow_commands.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'AllowCommands',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'AllowCommands',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_alter_buildlist.lua
+++ b/luarules/mission_api/actions/yet_to_implement_alter_buildlist.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'AlterBuildlist',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'AlterBuildlist',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_alter_map_zones.lua
+++ b/luarules/mission_api/actions/yet_to_implement_alter_map_zones.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'AlterMapZones',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'AlterMapZones',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_control_camera.lua
+++ b/luarules/mission_api/actions/yet_to_implement_control_camera.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'ControlCamera',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'ControlCamera',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_disable_build_option.lua
+++ b/luarules/mission_api/actions/yet_to_implement_disable_build_option.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'DisableBuildOption',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'DisableBuildOption',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_enable_build_option.lua
+++ b/luarules/mission_api/actions/yet_to_implement_enable_build_option.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'EnableBuildOption',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'EnableBuildOption',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_pause.lua
+++ b/luarules/mission_api/actions/yet_to_implement_pause.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'Pause',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'Pause',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_restrict_commands.lua
+++ b/luarules/mission_api/actions/yet_to_implement_restrict_commands.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'RestrictCommands',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'RestrictCommands',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_reveal_los.lua
+++ b/luarules/mission_api/actions/yet_to_implement_reveal_los.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'RevealLOS',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'RevealLOS',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_spawn_effect.lua
+++ b/luarules/mission_api/actions/yet_to_implement_spawn_effect.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'SpawnEffect',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'SpawnEffect',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_spawn_weapon.lua
+++ b/luarules/mission_api/actions/yet_to_implement_spawn_weapon.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'SpawnWeapon',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'SpawnWeapon',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_unpause.lua
+++ b/luarules/mission_api/actions/yet_to_implement_unpause.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'Unpause',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'Unpause',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions/yet_to_implement_unreveal_los.lua
+++ b/luarules/mission_api/actions/yet_to_implement_unreveal_los.lua
@@ -1,5 +1,7 @@
 return {
-	type = 'UnrevealLOS',
-	parameters = {},
-	actionFunction = function() end,
+	{
+		type = 'UnrevealLOS',
+		parameters = {},
+		actionFunction = function() end,
+	}
 }

--- a/luarules/mission_api/actions_loader.lua
+++ b/luarules/mission_api/actions_loader.lua
@@ -8,13 +8,16 @@ local function loadActionDefinitions()
 	local parameters = {}
 	local actionFunctions = {}
 
-	for typeID, filePath in ipairs(actionFiles) do
-		local actionDefinition = VFS.Include(filePath)
-		local actionType = actionDefinition.type
+	for _, filePath in ipairs(actionFiles) do
+		local actionDefinitions = VFS.Include(filePath)
+		for _, actionDefinition in ipairs(actionDefinitions) do
+			local typesCount = #types + 1
+			local actionType = actionDefinition.type
 
-		types[actionType] = typeID
-		parameters[typeID] = actionDefinition.parameters or {}
-		actionFunctions[typeID] = actionDefinition.actionFunction
+			types[actionType] = typesCount
+			parameters[typesCount] = actionDefinition.parameters or {}
+			actionFunctions[typesCount] = actionDefinition.actionFunction
+		end
 	end
 
 	return {


### PR DESCRIPTION
Required by https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8430

Allows to contain multiple actions per action file, to group similar actions together.
All actions, even if there's only one, are consistently nested as table within table, to reduce loader code complexity.