### PR TITLE
ignore death and self-damage reasons for DPS display

### DIFF
--- a/luarules/gadgets/gui_display_dps.lua
+++ b/luarules/gadgets/gui_display_dps.lua
@@ -96,8 +96,8 @@ local ignoreDamageTypes = {}
 
 -- Do not display death-reason damage types which typically use overkill damage.
 ignoreDamageTypes[Game.envDamageTypes.Killed] = true
+-- ignoreDamageTypes[Game.envDamageTypes.Crushed] = true -- Seems like an exception.
 ignoreDamageTypes[Game.envDamageTypes.Reclaimed] = true
-ignoreDamageTypes[Game.envDamageTypes.TurnedIntoFeature] = true
 ignoreDamageTypes[Game.envDamageTypes.TransportKilled] = true
 ignoreDamageTypes[Game.envDamageTypes.FactoryKilled] = true
 ignoreDamageTypes[Game.envDamageTypes.FactoryCancel] = true
@@ -105,6 +105,13 @@ ignoreDamageTypes[Game.envDamageTypes.SetNegativeHealth] = true
 ignoreDamageTypes[Game.envDamageTypes.OutOfBounds] = true
 ignoreDamageTypes[Game.envDamageTypes.KilledByCheat] = true
 ignoreDamageTypes[Game.envDamageTypes.KilledByLua] = true
+
+-- We likely want to ignore most self-damages used to control e.g. build progress.
+ignoreDamageTypes[Game.envDamageTypes.Kamikaze] = true
+ignoreDamageTypes[Game.envDamageTypes.SelfD] = true
+ignoreDamageTypes[Game.envDamageTypes.ConstructionDecay] = true
+ignoreDamageTypes[Game.envDamageTypes.TurnedIntoFeature] = true -- end of build with unitDef->isFeature
+ignoreDamageTypes[Game.envDamageTypes.UnitScript] = true -- likely to be self-damage?
 
 function gadget:ViewResize(n_vsx, n_vsy)
 	vsx, vsy = Spring.GetViewGeometry()

--- a/luarules/gadgets/gui_display_dps.lua
+++ b/luarules/gadgets/gui_display_dps.lua
@@ -104,7 +104,7 @@ ignoreDamageTypes[Game.envDamageTypes.TransportKilled] = true
 ignoreDamageTypes[Game.envDamageTypes.FactoryKilled] = true
 ignoreDamageTypes[Game.envDamageTypes.FactoryCancel] = true
 ignoreDamageTypes[Game.envDamageTypes.SetNegativeHealth] = true
-ignoreDamageTypes[Game.envDamageTypes.SetNegativeHealth] = true
+ignoreDamageTypes[Game.envDamageTypes.OutOfBounds] = true
 ignoreDamageTypes[Game.envDamageTypes.KilledByCheat] = true
 ignoreDamageTypes[Game.envDamageTypes.KilledByLua] = true
 

--- a/luarules/gadgets/gui_display_dps.lua
+++ b/luarules/gadgets/gui_display_dps.lua
@@ -95,9 +95,7 @@ local ignoreDamageTypes = {}
 --------------------------------------------------------------------------------
 
 -- Do not display death-reason damage types which typically use overkill damage.
-ignoreDamageTypes[Game.envDamageTypes.Kamikaze] = true
-ignoreDamageTypes[Game.envDamageTypes.SelfD] = true
-ignoreDamageTypes[Game.envDamageTypes.ConstructionDecay] = true
+ignoreDamageTypes[Game.envDamageTypes.Killed] = true
 ignoreDamageTypes[Game.envDamageTypes.Reclaimed] = true
 ignoreDamageTypes[Game.envDamageTypes.TurnedIntoFeature] = true
 ignoreDamageTypes[Game.envDamageTypes.TransportKilled] = true


### PR DESCRIPTION
### Work done

- Fix a duplicate envDamageType key masking another one.
- Organize damage types into death reasons and self-damage reasons.
- Add exceptions for Killed, OutOfBounds, UnitScript damages.

I kept Crushed off the exclude list but added a note. It can produce huge damage values but I think that helps crushing damage to stand out.