### PR TITLE
modules — mission api 5/5: CM8 Ashfall — the roster DSL, names declared once, the drafts arm

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -63,3 +63,8 @@ globals = {
 files["modules/missions/**/triggers/**"] = {
     read_globals = { "When", "Objective", "UnitDef", "Unit", "Team", "Units", "Combat", "MatchFlow" },
 }
+
+-- Mission rosters (units.lua) run in their own, smaller sandbox.
+files["modules/missions/**/units.lua"] = {
+    read_globals = { "Spawn", "UnitDef" },
+}

--- a/modules/combat/lib/mission_verbs.lua
+++ b/modules/combat/lib/mission_verbs.lua
@@ -1,0 +1,59 @@
+--- Combat's mission-sandbox verbs, pure half. Effects act through the ctx
+--- the engine is handed (ctx.Protect resolves the roster name where Spring
+--- exists), so this specs under busted.
+
+local CombatVerbs = {}
+
+---Build one trigger file's Combat verbs. Protect is a plain effect; its
+---.Until(condition) sugar bounds the protection's lifetime by recording a
+---companion into `untils` — registered after Finalize as the literal
+---desugared statement When(condition).Do(Combat.Unprotect(unit)).
+---@param untils { unit: MissionUnitRef, condition: MissionCondition }[] file-scoped, drained after Finalize
+---@return MissionCombat
+function CombatVerbs.MakeCombat(untils)
+	---@param unitRef MissionUnitRef
+	---@param verb string
+	local function checkUnitRef(unitRef, verb)
+		assert(type(unitRef) == "table" and type(unitRef.name) == "string",
+			verb .. " expects a Unit(...) reference")
+	end
+
+	local combat = {}
+
+	---@param unitRef MissionUnitRef
+	---@return MissionProtectEffect
+	combat.Protect = function(unitRef)
+		checkUnitRef(unitRef, "Combat.Protect")
+		---@param ctx MissionContext
+		local execute = function(ctx)
+			ctx.Protect(unitRef.name)
+		end
+		return {
+			execute = execute,
+			---@param condition MissionCondition
+			---@return MissionEffect
+			Until = function(condition)
+				assert(type(condition) == "table" and type(condition.evaluate) == "function",
+					"Combat.Protect(...).Until expects a condition")
+				untils[#untils + 1] = { unit = unitRef, condition = condition }
+				return { execute = execute }
+			end,
+		}
+	end
+
+	---@param unitRef MissionUnitRef
+	---@return MissionEffect
+	combat.Unprotect = function(unitRef)
+		checkUnitRef(unitRef, "Combat.Unprotect")
+		return {
+			---@param ctx MissionContext
+			execute = function(ctx)
+				ctx.Unprotect(unitRef.name)
+			end,
+		}
+	end
+
+	return combat
+end
+
+return CombatVerbs

--- a/modules/combat/mission_dsl.lua
+++ b/modules/combat/mission_dsl.lua
@@ -1,0 +1,30 @@
+--- Combat's contribution to the mission sandbox. The loader composes the
+--- authoring environment from the missions manifest's requires list; each
+--- contributing module ships a mission_dsl.lua returning a per-file factory.
+
+local CombatVerbs = VFS.Include("modules/combat/lib/mission_verbs.lua")
+
+return {
+	---@param file MissionDslFile
+	ForFile = function(file)
+		local untils = {} ---@type { unit: MissionUnitRef, condition: MissionCondition }[]
+		local combat = CombatVerbs.MakeCombat(untils)
+		return {
+			env = { Combat = combat },
+			-- The Until sugar, desugared: each recorded companion is the
+			-- literal statement When(condition).Do(Combat.Unprotect(unit)).
+			Finalize = function()
+				for order, entry in ipairs(untils) do
+					file.Register({
+						id = file.filename .. ":until:" .. order,
+						filename = file.filename,
+						order = order,
+						condition = entry.condition,
+						effects = { combat.Unprotect(entry.unit) },
+						once = true,
+					})
+				end
+			end,
+		}
+	end,
+}

--- a/modules/combat/types/dsl.lua
+++ b/modules/combat/types/dsl.lua
@@ -1,0 +1,16 @@
+---@meta dsl
+
+--- The Combat vocabulary combat contributes to the mission sandbox. Protect
+--- is an effect; its Until sugar bounds the protection with a companion
+--- trigger — the literal desugared When(condition).Do(Combat.Unprotect(unit)).
+---@class MissionCombat
+---@field Protect fun(unit: MissionUnitRef): MissionProtectEffect
+---@field Unprotect fun(unit: MissionUnitRef): MissionEffect
+
+--- Combat.Protect's return: a plain effect plus the Until lifetime sugar.
+---@class MissionProtectEffect
+---@field execute fun(ctx: MissionContext)
+---@field Until fun(condition: MissionCondition): MissionEffect
+
+---@type MissionCombat
+Combat = {}

--- a/modules/matchflow/lib/mission_verbs.lua
+++ b/modules/matchflow/lib/mission_verbs.lua
@@ -1,0 +1,48 @@
+--- MatchFlow's mission-sandbox verbs, pure half: lazy mirrors of the module
+--- api. Victory(team) builds an effect for a Do chain; the imperative api
+--- fires only when the trigger does. Takes the Team handle, not a raw
+--- allyTeam id, so the mission line reads as English.
+
+local MatchFlowVerbs = {}
+
+---@param matchflowApi table the matchflow module api (ModuleHandler.Get)
+---@return MissionMatchFlow
+function MatchFlowVerbs.Make(matchflowApi)
+	return {
+		---The mission-start condition. Empty inputs = evaluated once when the
+		---trigger arms — arming IS the mission starting, so it holds at the
+		---first cadence tick.
+		---@return MissionCondition
+		Started = function()
+			return {
+				inputs = {},
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return ctx.frame > 0
+				end,
+			}
+		end,
+		---@param team MissionTeam
+		---@return MissionEffect
+		Victory = function(team)
+			assert(type(team) == "table" and type(team.allyTeam) == "number", "MatchFlow.Victory expects a Team handle (e.g. Team.Player)")
+			return {
+				execute = function()
+					matchflowApi.Victory(team.allyTeam)
+				end,
+			}
+		end,
+		---@param team MissionTeam
+		---@return MissionEffect
+		Defeat = function(team)
+			assert(type(team) == "table" and type(team.allyTeam) == "number", "MatchFlow.Defeat expects a Team handle (e.g. Team.Player)")
+			return {
+				execute = function()
+					matchflowApi.Defeat({ team.allyTeam })
+				end,
+			}
+		end,
+	}
+end
+
+return MatchFlowVerbs

--- a/modules/matchflow/mission_dsl.lua
+++ b/modules/matchflow/mission_dsl.lua
@@ -1,0 +1,14 @@
+--- MatchFlow's contribution to the mission sandbox: the same verbs for every
+--- file, built once over the module api.
+
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local MatchFlowVerbs = VFS.Include("modules/matchflow/lib/mission_verbs.lua")
+
+local verbs = MatchFlowVerbs.Make(ModuleHandler.Get("matchflow"))
+
+return {
+	---@param file MissionDslFile
+	ForFile = function(file)
+		return { env = { MatchFlow = verbs } }
+	end,
+}

--- a/modules/matchflow/types/dsl.lua
+++ b/modules/matchflow/types/dsl.lua
@@ -1,0 +1,12 @@
+---@meta dsl
+
+--- The MatchFlow vocabulary matchflow contributes to the mission sandbox:
+--- lazy mirrors of the module api, plus the Started condition. They take the
+--- Team handle so mission lines read as English.
+---@class MissionMatchFlow
+---@field Started fun(): MissionCondition holds from the first cadence tick after arming
+---@field Victory fun(team: MissionTeam): MissionEffect
+---@field Defeat fun(team: MissionTeam): MissionEffect
+
+---@type MissionMatchFlow
+MatchFlow = {}

--- a/modules/missions/cm8_ashfall/triggers/outpost.lua
+++ b/modules/missions/cm8_ashfall/triggers/outpost.lua
@@ -1,0 +1,8 @@
+-- CM8 "Ashfall", Beat 2 — the automated outpost: no pilots, story-critical hub.
+-- The player inherits the failing base; the command hub cannot die before the
+-- enclave reveal or the mission breaks.
+
+When(MatchFlow.Started())
+	.Do(Units.Transfer("outpost_auto", Team.Player))
+	.Do(Combat.Protect(Unit("outpost_command_hub"))
+		.Until(Objective("find_the_enclave").IsComplete()))

--- a/modules/missions/cm8_ashfall/triggers/victory.lua
+++ b/modules/missions/cm8_ashfall/triggers/victory.lua
@@ -1,0 +1,16 @@
+-- CM8 "Ashfall", Beat 6 — staged objectives; the verdict flows through matchflow.
+-- Trimmed to the modules in tree (combat, matchflow): the lava tiers, the
+-- scripted reveal, and the raptor waves wait on their modules.
+
+When(Team.Player.Has(UnitDef("corllt"), 4))
+	.Do(Objective("relieve_the_outpost").Complete())
+
+When(Objective("relieve_the_outpost").IsComplete())
+	.When(Unit("tenebrium_device").IsSpotted(Team.Player))
+	.Do(Objective("find_the_enclave").Complete())
+
+When(Unit("armada_commander").IsDestroyed())
+	.Do(Objective("kill_the_commander").Complete())
+
+When(Objective("kill_the_commander").IsComplete())
+	.Do(MatchFlow.Victory(Team.Player))

--- a/modules/missions/cm8_ashfall/units.lua
+++ b/modules/missions/cm8_ashfall/units.lua
@@ -1,0 +1,51 @@
+-- CM8 "Ashfall" roster — stand-in defs until Teizer V and its assets exist;
+-- the trigger files are the acceptance shape, this makes them arm. Positions
+-- are map fractions so the mission plays on any test map. Named/Grouped are
+-- the definition sites the trigger files' Unit/Units references are
+-- validated against.
+
+-- Beat 2, the automated outpost: spawns pilotless (gaia) and is handed to
+-- the player at mission start by Units.Transfer("outpost_auto", Team.Player).
+-- The command hub is the story-critical protected structure.
+
+Spawn(UnitDef("corlab"), "gaia")
+	.At(0.42, 0.42)
+	.Named("outpost_command_hub")
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corllt"), "gaia")
+	.At(0.39, 0.40)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corllt"), "gaia")
+	.At(0.45, 0.40)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corrad"), "gaia")
+	.At(0.42, 0.39)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corsolar"), "gaia")
+	.At(0.39, 0.44)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corsolar"), "gaia")
+	.At(0.45, 0.44)
+	.Grouped("outpost_auto")
+
+-- Beats 4 and 6, the Armada enclave: spotting the device closes
+-- find_the_enclave; killing the commander wins through matchflow.
+
+Spawn(UnitDef("armfus"), "enemy")
+	.At(0.75, 0.75)
+	.Named("tenebrium_device")
+
+Spawn(UnitDef("armcom"), "enemy")
+	.At(0.77, 0.77)
+	.Named("armada_commander")
+
+Spawn(UnitDef("armllt"), "enemy")
+	.At(0.73, 0.75)
+
+Spawn(UnitDef("armllt"), "enemy")
+	.At(0.75, 0.73)

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -31,10 +31,8 @@ local EVALUATE_PERIOD = 15 -- frames
 local engine = TriggerEngine.New()
 local activeMission = nil ---@type string|nil
 
--- The roster registry: units spawned from the mission's units.lua.
--- Destroyed/spotted state is LATCHED into rulesparams (mission_unit_dead_*,
--- mission_unit_spotted_*) by the forwarders below — engine-serialized and
--- readable unsynced, same home as objective completion.
+-- The roster registry: units spawned from units.lua. Destroyed/spotted state
+-- is LATCHED into rulesparams by the forwarders below — engine-serialized, readable unsynced.
 local namedUnits = {} ---@type table<string, integer> name -> unitID
 local unitNames = {} ---@type table<integer, string> unitID -> name
 local groupUnits = {} ---@type table<string, integer[]>
@@ -96,8 +94,7 @@ local ctx = {
 	end,
 }
 
----Demo rule (documented in hello_pawns_plan.md): Team.Player is the first
----human team — lowest non-Gaia teamID with no Lua AI and not the AI-hosted kind.
+---Demo rule: Team.Player is the first human team (lowest non-Gaia teamID with no Lua AI, not AI-hosted).
 ---@return MissionTeam|nil
 local function resolvePlayerTeam()
 	local gaiaTeamID = Spring.GetGaiaTeamID()
@@ -112,19 +109,8 @@ local function resolvePlayerTeam()
 	return nil
 end
 
----Objective verb, demo-minimal. Closure-free surface: Complete() is LAZY —
----it builds an effect the engine executes when the trigger fires, so mission
----files chain it with Do instead of wrapping it in a function. IsComplete()
----is the condition side, so victory can be its own trigger driven by
----objective state (the "all objectives complete -> win" shape in miniature).
----Completion state lives in rulesparams (objective_<name>) —
----engine-serialized, so it survives a savegame like the rest of the trigger
----progress pile.
----
----Rulesparam changes have no callin, but this module is the thing that
----completes objectives — so Complete() emits "mission.objective_changed" on
----the mission bus, and IsComplete() declares it as its input (see
----mission_authoring_dsl.md, "Conditions declare their inputs").
+---Complete() is LAZY: builds an effect for Do, not run immediately. State
+---lives in rulesparams (savegame-safe); writes have no callin, so Complete() emits "mission.objective_changed" for IsComplete()'s declared input.
 ---@param name string
 ---@return MissionObjective
 local function Objective(name)
@@ -150,14 +136,12 @@ local function Objective(name)
 	}
 end
 
--- Engine callins the bus can forward. The gadget hooks ONLY the callins some
--- registered trigger actually watches (the don't-hook-what-you-don't-use
--- rule, applied automatically per mission); everything else stays unhooked.
+-- Engine callins the bus can forward; only callins some registered trigger
+-- watches get hooked (don't-hook-what-you-don't-use), automatically per mission.
 local FORWARDABLE_CALLINS = { "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken", "UnitEnteredLos" }
 
 -- Most callins forward as bare bus events; these also latch roster-unit
--- state into rulesparams first (conditions read the latch — "has been
--- destroyed/spotted", not "is right now").
+-- state first — conditions read "has been", not "is right now".
 local forwarders = {
 	UnitDestroyed = function(_, unitID)
 		local name = unitNames[unitID]
@@ -192,48 +176,20 @@ local function syncWatchedCallins()
 	end
 end
 
----The MatchFlow verbs injected into mission files: same names as the module
----api, but LAZY — Victory(team) builds an effect for a Do chain; the module's
----imperative api fires only when the trigger does. Takes the Team handle, not
----a raw allyTeam id, so the mission line reads as English.
----@param matchflowApi table the matchflow module api (ModuleHandler.Get)
----@return MissionMatchFlow
-local function makeMatchFlowVerbs(matchflowApi)
-	return {
-		---The mission-start condition. Empty inputs = evaluated once when the
-		---trigger arms (never event-driven after that) — arming IS the
-		---mission starting, so it holds at the first cadence tick.
-		---@return MissionCondition
-		Started = function()
-			return {
-				inputs = {},
-				---@param ctx MissionContext
-				evaluate = function(ctx)
-					return ctx.frame > 0
-				end,
-			}
-		end,
-		---@param team MissionTeam
-		---@return MissionEffect
-		Victory = function(team)
-			assert(type(team) == "table" and type(team.allyTeam) == "number", "MatchFlow.Victory expects a Team handle (e.g. Team.Player)")
-			return {
-				execute = function()
-					matchflowApi.Victory(team.allyTeam)
-				end,
-			}
-		end,
-		---@param team MissionTeam
-		---@return MissionEffect
-		Defeat = function(team)
-			assert(type(team) == "table" and type(team.allyTeam) == "number", "MatchFlow.Defeat expects a Team handle (e.g. Team.Player)")
-			return {
-				execute = function()
-					matchflowApi.Defeat({ team.allyTeam })
-				end,
-			}
-		end,
-	}
+---Load the sandbox contributions of every module the missions manifest
+---requires: modules/<name>/mission_dsl.lua returns a per-file factory. The
+---requires list IS the whitelist of what mission files may say.
+---@return MissionDslContribution[]
+local function loadContributions()
+	local contributions = {}
+	local manifest = ModuleHandler.Discover()["missions"]
+	for _, name in ipairs(manifest.requires) do
+		local path = "modules/" .. name .. "/mission_dsl.lua"
+		if VFS.FileExists(path) then
+			contributions[#contributions + 1] = VFS.Include(path)
+		end
+	end
+	return contributions
 end
 
 ---The "enemy" roster role: the first non-Gaia team that is not the player's.
@@ -259,27 +215,37 @@ local function despawnRoster()
 	namedUnits, unitNames, groupUnits, spawnedUnits = {}, {}, {}, {}
 end
 
----Spawn the mission's units.lua roster (optional — trigger-only missions
----stay legal). Runs AFTER syncWatchedCallins so spawn-time callins (a unit
----born inside LOS) reach the latches. Any failed spawn fails the load:
----roster names are story-critical.
+---Load units.lua through its sandbox (Spawn chains; the sandbox IS the API
+---surface). Parses before trigger files load, so Unit/Units references validate against declared names at load.
 ---@param missionName string
----@param playerTeam MissionTeam
----@return boolean ok
-local function spawnRoster(missionName, playerTeam)
-	despawnRoster()
+---@return MissionRosterEntry[]|nil entries nil on a load error; {} when the mission has no roster
+local function parseRoster(missionName)
 	local rosterPath = MISSIONS_DIR .. missionName .. "/units.lua"
 	if not VFS.FileExists(rosterPath) then
-		return true
+		return {}
 	end
 	local ok, entries = pcall(function()
-		return Roster.Parse(VFS.Include(rosterPath))
+		local file = Roster.ForFile(missionName .. "/units.lua")
+		VFS.Include(rosterPath, {
+			Spawn = file.Spawn,
+			UnitDef = Verbs.UnitDef,
+		})
+		return file.Finalize()
 	end)
 	if not ok then
 		Spring.Log(LOG_TAG, LOG.ERROR, tostring(entries))
-		return false
+		return nil
 	end
+	return entries
+end
 
+---Spawn parsed roster entries. Runs AFTER syncWatchedCallins so spawn-time
+---callins (a unit born inside LOS) reach the latches; any failed spawn fails the load.
+---@param entries MissionRosterEntry[]
+---@param playerTeam MissionTeam
+---@return boolean ok
+local function spawnRoster(entries, playerTeam)
+	despawnRoster()
 	local teamFor = {
 		player = playerTeam.teamID,
 		gaia = Spring.GetGaiaTeamID(),
@@ -293,8 +259,8 @@ local function spawnRoster(missionName, playerTeam)
 			despawnRoster()
 			return false
 		end
-		local y = Spring.GetGroundHeight(entry.x, entry.z)
-		local unitID = Spring.CreateUnit(entry.def, entry.x, y, entry.z, entry.facing, teamID)
+		local x, z = entry.fx * Game.mapSizeX, entry.fz * Game.mapSizeZ
+		local unitID = Spring.CreateUnit(entry.def, x, Spring.GetGroundHeight(x, z), z, 0, teamID)
 		if unitID == nil then
 			Spring.Log(LOG_TAG, LOG.ERROR, "could not spawn roster unit " .. entry.def .. " (unknown def or unit limit)")
 			despawnRoster()
@@ -321,12 +287,8 @@ local function spawnRoster(missionName, playerTeam)
 	return true
 end
 
----Load (or reload) a mission: run each triggers/*.lua through the injected
----environment. The sandbox IS the API surface — trigger files see the
----injected verbs and nothing else. Arming clears every armed trigger first
----(filenames are mission-qualified, so per-file unregistration alone would
----leak the previous mission's triggers across a switch); reloading the same
----mission is the same path.
+---Load (or reload) a mission: the sandbox IS the API surface. Clears every
+---armed trigger first — per-file unregistration alone would leak triggers across a mission switch since filenames are mission-qualified.
 ---@param missionName string
 ---@return boolean loaded
 local function loadMission(missionName)
@@ -344,6 +306,23 @@ local function loadMission(missionName)
 		return false
 	end
 
+	-- Roster parses before trigger files load, so Unit/Units references
+	-- validate against declared names — a typo is a load error, not a silent never-true condition.
+	local rosterEntries = parseRoster(missionName)
+	if rosterEntries == nil then
+		return false
+	end
+	local rosterNames = {} ---@type table<string, boolean>
+	local rosterGroups = {} ---@type table<string, boolean>
+	for _, entry in ipairs(rosterEntries) do
+		if entry.name ~= nil then
+			rosterNames[entry.name] = true
+		end
+		if entry.group ~= nil then
+			rosterGroups[entry.group] = true
+		end
+	end
+
 	local armedFiles = {}
 	for _, trigger in ipairs(engine.Triggers()) do
 		armedFiles[trigger.filename] = true
@@ -352,44 +331,48 @@ local function loadMission(missionName)
 		engine.UnregisterFile(filename)
 	end
 
-	local matchFlow = makeMatchFlowVerbs(ModuleHandler.Get("matchflow"))
+	local contributions = loadContributions()
+	local Unit = Verbs.MakeUnit(rosterNames)
+	local Units = Verbs.MakeUnits(rosterGroups)
 
 	for _, filePath in ipairs(files) do
 		-- Identity is mission-relative so ids survive install-path differences.
 		local filename = filePath:sub(#MISSIONS_DIR + 1)
 		local file = DSL.ForFile(filename, engine.Register)
-		local untils = {} ---@type { unit: MissionUnitRef, condition: MissionCondition }[]
-		local combat = Verbs.MakeCombat(untils)
 		local env = {
 			When = file.When,
 			Team = { Player = playerTeam },
 			UnitDef = Verbs.UnitDef,
-			Unit = Verbs.Unit,
-			Units = Verbs.Units,
+			Unit = Unit,
+			Units = Units,
 			Objective = Objective,
-			MatchFlow = matchFlow,
-			Combat = combat,
 		}
+		-- Each required module adds its vocabulary; a name collision between
+		-- modules is a load error, not a silent shadow.
+		local fileContributions = {}
+		for _, contribution in ipairs(contributions) do
+			local forFile = contribution.ForFile({ filename = filename, Register = engine.Register })
+			for key, value in pairs(forFile.env) do
+				if env[key] ~= nil then
+					error(filename .. ": two modules contribute the global " .. key)
+				end
+				env[key] = value
+			end
+			fileContributions[#fileContributions + 1] = forFile
+		end
 		VFS.Include(filePath, env)
 		-- The commit point: statements register here, and a half-finished
 		-- chain (no Do) is a load error naming the file and statement.
 		file.Finalize()
-		-- The Until sugar, desugared: each recorded companion is the literal
-		-- statement When(condition).Do(Combat.Unprotect(unit)).
-		for order, entry in ipairs(untils) do
-			engine.Register({
-				id = filename .. ":until:" .. order,
-				filename = filename,
-				order = order,
-				condition = entry.condition,
-				effects = { combat.Unprotect(entry.unit) },
-				once = true,
-			})
+		for _, forFile in ipairs(fileContributions) do
+			if forFile.Finalize then
+				forFile.Finalize()
+			end
 		end
 	end
 
 	syncWatchedCallins()
-	if not spawnRoster(missionName, playerTeam) then
+	if not spawnRoster(rosterEntries, playerTeam) then
 		activeMission = nil
 		Spring.SetGameRulesParam("mission_active", 0)
 		return false
@@ -405,8 +388,7 @@ end
 ---@param line string
 ---@param words string[]
 local function missionChatAction(cmd, line, words, playerID)
-	-- Synced chat actions arrive from ANY player in multiplayer; arming or
-	-- reloading a mission is not an open verb (review point on PR #8375).
+	-- Synced chat actions arrive from ANY player in multiplayer; arming or reloading a mission is not an open verb.
 	if not ChatGuard.IsAllowed(Spring.Utilities.Gametype.IsSinglePlayer(), Spring.IsCheatingEnabled()) then
 		Spring.Log(LOG_TAG, LOG.WARNING, "/mission refused: multiplayer without cheats (player " .. tostring(playerID) .. ")")
 		return true

--- a/modules/missions/lib/roster.lua
+++ b/modules/missions/lib/roster.lua
@@ -1,50 +1,95 @@
---- Mission unit roster: validate the spawn table a mission's units.lua
---- returns. Pure Lua — no Spring — so it specs under busted; the loader
---- resolves teams and spawns where Spring exists.
----
---- The smallest honest naming mechanism (no loadout system): one entry
---- spawns one unit; `name` makes it addressable as Unit("name"), `group`
---- collects it for the Units verbs. Teams are roles, not ids — "player",
---- "enemy", "gaia" — resolved at arm time.
+--- Mission roster DSL: units.lua's authoring surface. Pure Lua — no Spring —
+--- so it specs under busted; Named/Grouped are the only definition sites for names trigger files validate against.
 
 local Roster = {}
 
-local VALID_TEAMS = { player = true, enemy = true, gaia = true }
+local VALID_ROLES = { player = true, enemy = true, gaia = true }
 
----@param data any the table units.lua returned
----@return MissionRosterEntry[]
-function Roster.Parse(data)
-	assert(type(data) == "table", "units.lua must return a list of spawn entries")
-	local entries = {}
-	local seenNames = {}
-	for index, raw in ipairs(data) do
-		local where = "units.lua entry " .. index
-		assert(type(raw) == "table", where .. ": entries are tables")
-		assert(type(raw.def) == "string", where .. ": def (unit def name) is required")
-		assert(type(raw.team) == "string" and VALID_TEAMS[raw.team],
-			where .. ': team must be "player", "enemy" or "gaia"')
-		assert(type(raw.x) == "number" and type(raw.z) == "number",
-			where .. ": x and z are required numbers")
-		assert(raw.facing == nil or type(raw.facing) == "number", where .. ": facing must be a number")
-		if raw.name ~= nil then
-			assert(type(raw.name) == "string", where .. ": name must be a string")
-			assert(not seenNames[raw.name], where .. ": duplicate unit name " .. raw.name)
-			seenNames[raw.name] = true
-		end
-		if raw.group ~= nil then
-			assert(type(raw.group) == "string", where .. ": group must be a string")
-		end
-		entries[#entries + 1] = {
-			def = raw.def,
-			team = raw.team,
-			x = raw.x,
-			z = raw.z,
-			facing = raw.facing or 0,
-			name = raw.name,
-			group = raw.group,
-		}
+---Build one roster file's authoring surface: the Spawn chain entry the
+---loader injects, and the Finalize the loader calls after the include.
+---@param filename string mission-relative path, e.g. "cm8_ashfall/units.lua"
+---@return { Spawn: fun(unitDef: MissionUnitDefRef, team: MissionTeamRole): MissionSpawnChain, Finalize: fun(): MissionRosterEntry[] }
+function Roster.ForFile(filename)
+	local builds = {} ---@type MissionRosterEntry[]
+	local finalized = false
+
+	local function checkOpen(step)
+		assert(not finalized, filename .. ": " .. step .. " after Finalize — the file already loaded")
 	end
-	return entries
+
+	---@param unitDef MissionUnitDefRef
+	---@param team MissionTeamRole
+	---@return MissionSpawnChain
+	local Spawn = function(unitDef, team)
+		checkOpen("Spawn")
+		assert(type(unitDef) == "table" and type(unitDef.name) == "string",
+			filename .. ": Spawn expects a UnitDef(...) reference")
+		assert(type(team) == "string" and VALID_ROLES[team],
+			filename .. ': Spawn expects a team role: "player", "enemy" or "gaia"')
+
+		local build = { def = unitDef.name, team = team }
+		builds[#builds + 1] = build
+
+		local chain = {}
+
+		---Position as map fractions, so rosters play on any map until real
+		---maps pin real coordinates.
+		---@param fx number
+		---@param fz number
+		---@return MissionSpawnChain
+		chain.At = function(fx, fz)
+			checkOpen("At")
+			assert(type(fx) == "number" and type(fz) == "number"
+					and fx >= 0 and fx <= 1 and fz >= 0 and fz <= 1,
+				filename .. ": At expects map fractions in 0..1")
+			build.fx, build.fz = fx, fz
+			return chain
+		end
+
+		---@param name string
+		---@return MissionSpawnChain
+		chain.Named = function(name)
+			checkOpen("Named")
+			assert(type(name) == "string", filename .. ": Named expects a unit name string")
+			build.name = name
+			return chain
+		end
+
+		---@param group string
+		---@return MissionSpawnChain
+		chain.Grouped = function(group)
+			checkOpen("Grouped")
+			assert(type(group) == "string", filename .. ": Grouped expects a group name string")
+			build.group = group
+			return chain
+		end
+
+		return chain
+	end
+
+	---The commit point: validates every chain, in declaration order — a
+	---failed load spawns nothing.
+	---@return MissionRosterEntry[]
+	local Finalize = function()
+		assert(not finalized, filename .. ": Finalize called twice")
+		finalized = true
+		local seenNames = {}
+		for order, build in ipairs(builds) do
+			local where = filename .. ": Spawn " .. order
+			if build.fx == nil then
+				error(where .. " has no At — every spawn needs a position")
+			end
+			if build.name ~= nil then
+				if seenNames[build.name] then
+					error(where .. ": duplicate unit name " .. build.name)
+				end
+				seenNames[build.name] = true
+			end
+		end
+		return builds
+	end
+
+	return { Spawn = Spawn, Finalize = Finalize }
 end
 
 return Roster

--- a/modules/missions/lib/verbs.lua
+++ b/modules/missions/lib/verbs.lua
@@ -1,11 +1,5 @@
---- The mission verbs' pure halves: UnitDef refs, the Team handle with its Has
---- condition, the Unit noun over roster-named units, group verbs, and the
---- Combat sugar. No Spring here — conditions read from and effects act through
---- the ctx the engine is handed, so this specs under busted; the gadget
---- supplies a ctx backed by Spring.
----
---- Conditions and effects capture configuration only (team id, unit name,
---- threshold) — never progress. Dot-only surface, same rule as the chain DSL.
+--- Mission verbs' pure halves. No Spring here, so this specs under busted;
+--- conditions/effects capture configuration only, never progress.
 
 local Verbs = {}
 
@@ -46,111 +40,67 @@ function Verbs.MakeTeam(teamID, allyTeam)
 	return team
 end
 
----Named-unit reference: the condition side of one roster unit. The name is
----bound to a spawned unit by the mission's units.lua; resolution happens in
----ctx where Spring exists. Both conditions read latched state — "has been
----destroyed/spotted", not "is right now" — so they hold once true.
----@param name string
----@return MissionUnitRef
-function Verbs.Unit(name)
-	assert(type(name) == "string", "Unit expects a mission unit name string")
+---Build the Unit noun over the roster: unknown name is a LOAD error, not a
+---silently-never-true condition. IsDestroyed/IsSpotted read latched state.
+---@param names table<string, boolean> the roster's declared unit names
+---@return fun(name: MissionUnitName): MissionUnitRef
+function Verbs.MakeUnit(names)
+	return function(name)
+		assert(type(name) == "string", "Unit expects a mission unit name string")
+		assert(names[name],
+			'Unit("' .. name .. '"): no such unit — units.lua Named(...) declares the mission\'s unit names')
+		return {
+			name = name,
+			---@return MissionCondition
+			IsDestroyed = function()
+				return {
+					inputs = { "UnitDestroyed" },
+					---@param ctx MissionContext
+					evaluate = function(ctx)
+						return ctx.IsUnitDestroyed(name)
+					end,
+				}
+			end,
+			---@param team MissionTeam
+			---@return MissionCondition
+			IsSpotted = function(team)
+				assert(type(team) == "table" and type(team.allyTeam) == "number",
+					"Unit.IsSpotted expects a Team handle (e.g. Team.Player)")
+				return {
+					inputs = { "UnitEnteredLos" },
+					---@param ctx MissionContext
+					evaluate = function(ctx)
+						return ctx.IsUnitSpotted(name, team.allyTeam)
+					end,
+				}
+			end,
+		}
+	end
+end
+
+---Build the Units group verbs over one mission's roster; group references
+---are validated like unit names (declared in units.lua Grouped(...), only).
+---@param groups table<string, boolean> the roster's declared group names
+---@return MissionUnits
+function Verbs.MakeUnits(groups)
 	return {
-		name = name,
-		---@return MissionCondition
-		IsDestroyed = function()
-			return {
-				inputs = { "UnitDestroyed" },
-				---@param ctx MissionContext
-				evaluate = function(ctx)
-					return ctx.IsUnitDestroyed(name)
-				end,
-			}
-		end,
+		---@param group MissionUnitGroup
 		---@param team MissionTeam
-		---@return MissionCondition
-		IsSpotted = function(team)
-			assert(type(team) == "table" and type(team.allyTeam) == "number",
-				"Unit.IsSpotted expects a Team handle (e.g. Team.Player)")
+		---@return MissionEffect
+		Transfer = function(group, team)
+			assert(type(group) == "string", "Units.Transfer expects a group name string")
+			assert(groups[group],
+				'Units.Transfer("' .. group .. '"): no such group — units.lua Grouped(...) declares the mission\'s groups')
+			assert(type(team) == "table" and type(team.teamID) == "number",
+				"Units.Transfer expects a Team handle (e.g. Team.Player)")
 			return {
-				inputs = { "UnitEnteredLos" },
 				---@param ctx MissionContext
-				evaluate = function(ctx)
-					return ctx.IsUnitSpotted(name, team.allyTeam)
+				execute = function(ctx)
+					ctx.TransferGroup(group, team.teamID)
 				end,
 			}
 		end,
 	}
-end
-
----Group verbs over roster-named groups.
----@type MissionUnits
-Verbs.Units = {
-	---@param group string
-	---@param team MissionTeam
-	---@return MissionEffect
-	Transfer = function(group, team)
-		assert(type(group) == "string", "Units.Transfer expects a group name string")
-		assert(type(team) == "table" and type(team.teamID) == "number",
-			"Units.Transfer expects a Team handle (e.g. Team.Player)")
-		return {
-			---@param ctx MissionContext
-			execute = function(ctx)
-				ctx.TransferGroup(group, team.teamID)
-			end,
-		}
-	end,
-}
-
----Build one trigger file's Combat verbs. Protect is a plain effect; its
----.Until(condition) sugar bounds the protection's lifetime by recording a
----companion into `untils` — the loader registers it as the literal desugared
----statement When(condition).Do(Combat.Unprotect(unit)).
----@param untils { unit: MissionUnitRef, condition: MissionCondition }[] loader-owned, drained after Finalize
----@return MissionCombat
-function Verbs.MakeCombat(untils)
-	---@param unitRef MissionUnitRef
-	---@param verb string
-	local function checkUnitRef(unitRef, verb)
-		assert(type(unitRef) == "table" and type(unitRef.name) == "string",
-			verb .. " expects a Unit(...) reference")
-	end
-
-	local combat = {}
-
-	---@param unitRef MissionUnitRef
-	---@return MissionProtectEffect
-	combat.Protect = function(unitRef)
-		checkUnitRef(unitRef, "Combat.Protect")
-		---@param ctx MissionContext
-		local execute = function(ctx)
-			ctx.Protect(unitRef.name)
-		end
-		return {
-			execute = execute,
-			---@param condition MissionCondition
-			---@return MissionEffect
-			Until = function(condition)
-				assert(type(condition) == "table" and type(condition.evaluate) == "function",
-					"Combat.Protect(...).Until expects a condition")
-				untils[#untils + 1] = { unit = unitRef, condition = condition }
-				return { execute = execute }
-			end,
-		}
-	end
-
-	---@param unitRef MissionUnitRef
-	---@return MissionEffect
-	combat.Unprotect = function(unitRef)
-		checkUnitRef(unitRef, "Combat.Unprotect")
-		return {
-			---@param ctx MissionContext
-			execute = function(ctx)
-				ctx.Unprotect(unitRef.name)
-			end,
-		}
-	end
-
-	return combat
 end
 
 return Verbs

--- a/modules/missions/types/dsl.lua
+++ b/modules/missions/types/dsl.lua
@@ -23,19 +23,22 @@ function Objective(name) end
 function UnitDef(name) end
 
 ---Named-unit reference: the condition side of one unit the mission's
----units.lua roster spawned.
+---units.lua roster spawned. Validated against the roster at load — an
+---unknown name is a load error, not a silent never-true condition.
 ---@param name MissionUnitName
 ---@return MissionUnitRef
 function Unit(name) end
+
+---Declare one unit of the mission's opening world state. units.lua sandbox
+---only — not injected into trigger files. Chain .At(fx, fz) (required, map
+---fractions), .Named(name), .Grouped(group).
+---@param unitDef MissionUnitDefRef
+---@param team MissionTeamRole
+---@return MissionSpawnChain
+function Spawn(unitDef, team) end
 
 ---@type { Player: MissionTeam }
 Team = {}
 
 ---@type MissionUnits
 Units = {}
-
----@type MissionCombat
-Combat = {}
-
----@type MissionMatchFlow
-MatchFlow = {}

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -1,27 +1,18 @@
 ---@meta dsl
 
---- Mission-runtime types: the trigger engine's descriptors and the authoring
---- DSL's chain/condition/effect shapes. The DSL surface is dot-only AND
---- closure-free: every chain step is a plain call with parens, no colon
---- methods, no metatables, and no function bodies in mission files — effects
---- are lazy objects built by named verbs. Mission files must load identically
---- in the synced sandbox (which strips rawset) and in busted.
+--- Mission-runtime types: trigger engine descriptors and the authoring DSL's
+--- chain/condition/effect shapes, dot-only and closure-free. Mission files must load identically in the synced sandbox (which strips rawset) and in busted.
 
---- Domain aliases: the DSL's typed parameters. These names are LOAD-BEARING
---- beyond the checker — the mission kit derives its semantic model from them
---- (alias name -> slot semantic, literal unions -> editor enums), so a verb
---- annotated with these types is understood by the editor without kit code.
+--- Domain aliases: the DSL's typed parameters. Names are LOAD-BEARING beyond
+--- the checker — the mission kit derives its semantic model from them (alias -> slot semantic, literal unions -> editor enums).
 ---@alias UnitDefName string unit def name, e.g. "armpw"
----@alias MissionUnitName string roster unit name, declared by units.lua
----@alias MissionUnitGroup string roster group name, declared by units.lua
+---@alias MissionUnitName string roster unit name, declared by units.lua Named(...)
+---@alias MissionUnitGroup string roster group name, declared by units.lua Grouped(...)
 ---@alias ObjectiveName string
+---@alias MissionTeamRole "player"|"enemy"|"gaia" spawn-time team role, resolved at arm
 
---- The mission bus vocabulary, CLOSED BY TYPE: every event name that may
---- cross the bus is a member of this alias. Engine callins are one producer,
---- modules are another — same kind of string, one type. Adding an event
---- means extending this alias; the checker then walks you to every consumer
---- (inputs declarations, OnEvent emitters) and flags typos as type errors —
---- the state heritage is tied together by the compiler, not convention.
+--- Mission bus vocabulary, CLOSED BY TYPE: every event name crossing the bus
+--- is a member of this alias, so the checker flags typos across every inputs/OnEvent consumer as type errors.
 ---@alias MissionEventName
 ---| "UnitFinished"
 ---| "UnitDestroyed"
@@ -30,21 +21,14 @@
 ---| "UnitEnteredLos"
 ---| "mission.objective_changed"
 
---- A condition is not a bare predicate — it carries metadata about what can
---- change its answer (mission_authoring_dsl.md, "Conditions declare their
---- inputs"). Inputs name events on the mission bus (MissionEventName).
---- nil inputs = poll every cadence — the fallback stays.
---- Pure: reads only the ctx it is handed; captures configuration (team ids,
---- unit names), never progress. Progress lives in the engine's state tables;
---- inputs are configuration, dirty flags are derived (the savegame rule).
+--- A condition carries metadata about what can change its answer: inputs
+--- name bus events (nil = poll every cadence). Pure — reads only ctx, captures configuration never progress (progress lives in engine state, the savegame rule).
 ---@class MissionCondition
 ---@field evaluate fun(ctx: MissionContext): boolean
 ---@field inputs MissionEventName[]|nil events that can change this answer; nil = poll every cadence
 
---- What the engine hands every condition and effect. The gadget builds it from
---- Spring; specs build it from plain tables. The unit half reads/acts through
---- the roster registry: names come from the mission's units.lua, and the
---- destroyed/spotted answers are latched (once true, stay true).
+--- What the engine hands every condition and effect: the gadget builds it
+--- from Spring, specs from plain tables. Unit destroyed/spotted answers are latched — once true, stay true.
 ---@class MissionContext
 ---@field GetUnitDefCount fun(teamID: integer, unitDefName: string): integer count of finished units of that def
 ---@field IsObjectiveComplete fun(name: string): boolean
@@ -55,60 +39,44 @@
 ---@field Unprotect fun(name: string)
 ---@field frame integer current game frame
 
---- A lazy effect built by a named verb (Objective("x").Complete(),
---- MatchFlow.Victory(Team.Player)). The engine executes it when the trigger's
---- condition fires. Like conditions, effects capture configuration only —
---- never progress, and never author-written function bodies.
+--- A lazy effect built by a named verb (e.g. Objective("x").Complete()); the
+--- engine executes it when the trigger fires. Captures configuration only, never progress.
 ---@class MissionEffect
 ---@field execute fun(ctx: MissionContext)
 
 --- The injected Objective verb's handle: Complete() builds the effect side,
---- IsComplete() the condition side — victory triggers watch objective state
---- rather than living inside the objective's own trigger.
+--- IsComplete() the condition side.
 ---@class MissionObjective
 ---@field Complete fun(): MissionEffect
 ---@field IsComplete fun(): MissionCondition
 
---- The injected MatchFlow verbs: lazy mirrors of the matchflow module api,
---- plus the Started condition. They take the Team handle so mission lines
---- read as English.
----@class MissionMatchFlow
----@field Started fun(): MissionCondition holds from the first cadence tick after arming
----@field Victory fun(team: MissionTeam): MissionEffect
----@field Defeat fun(team: MissionTeam): MissionEffect
-
---- A named-unit reference produced by the injected Unit verb: the condition
---- side of one roster unit. Both conditions are latched.
+--- A named-unit reference produced by the injected Unit verb. Both
+--- conditions are latched; the name is validated against the roster at load — unknown names never arm.
 ---@class MissionUnitRef
 ---@field name MissionUnitName
 ---@field IsDestroyed fun(): MissionCondition
 ---@field IsSpotted fun(team: MissionTeam): MissionCondition
 
---- The injected Units verbs: effects over roster-named groups.
+--- The injected Units verbs: effects over roster-declared groups (validated
+--- at load, like unit names).
 ---@class MissionUnits
 ---@field Transfer fun(group: MissionUnitGroup, team: MissionTeam): MissionEffect
 
---- The injected Combat verbs. Protect is an effect; its Until sugar bounds
---- the protection with a companion trigger — the literal desugared statement
---- When(condition).Do(Combat.Unprotect(unit)).
----@class MissionCombat
----@field Protect fun(unit: MissionUnitRef): MissionProtectEffect
----@field Unprotect fun(unit: MissionUnitRef): MissionEffect
+--- The dot-only builder chain returned by Spawn. Positions are map fractions
+--- until real maps pin real coordinates; At is required — a chain without one fails the load.
+---@class MissionSpawnChain
+---@field At fun(fx: number, fz: number): MissionSpawnChain
+---@field Named fun(name: MissionUnitName): MissionSpawnChain
+---@field Grouped fun(group: MissionUnitGroup): MissionSpawnChain
 
---- Combat.Protect's return: a plain effect plus the Until lifetime sugar.
----@class MissionProtectEffect
----@field execute fun(ctx: MissionContext)
----@field Until fun(condition: MissionCondition): MissionEffect
-
---- One validated units.lua spawn entry. Teams are roles resolved at arm time.
+--- One validated spawn entry, as Roster.Finalize returns it.
 ---@class MissionRosterEntry
 ---@field def UnitDefName
----@field team "player"|"enemy"|"gaia"
----@field x number
----@field z number
----@field facing number
----@field name MissionUnitName|nil roster name (addressable as Unit("name"))
----@field group MissionUnitGroup|nil roster group (addressable via Units verbs)
+---@field team MissionTeamRole
+---@field fx number map-fraction position, resolved against map size at spawn
+---@field fz number
+---@field name MissionUnitName|nil declared by Named
+---@field group MissionUnitGroup|nil declared by Grouped
 
 --- A registered trigger. Identity = source filename + declaration order,
 --- stamped at registration — the unregister-by-identity key for hot reload.
@@ -120,9 +88,8 @@
 ---@field effects MissionEffect[] executed in Do order when the condition fires
 ---@field once boolean fire at most once (default true)
 
---- The dot-only builder chain returned by When. Every step returns the
---- chain. There is no terminator: the loader finalizes all chains when the
---- file's include returns, and a chain without a Do fails the load.
+--- The dot-only builder chain returned by When. There is no terminator: the
+--- loader finalizes all chains when the file's include returns; a chain without a Do fails the load.
 ---@class TriggerChain
 ---@field When fun(condition: MissionCondition): TriggerChain another condition; all must hold
 ---@field Do fun(effect: MissionEffect): TriggerChain repeatable; effects run in Do order
@@ -144,3 +111,13 @@
 --- reload from source; this table is reapplied on top.
 ---@class TriggerEngineState
 ---@field fired table<string, boolean> trigger id -> has fired
+
+--- What a required module's mission_dsl.lua returns. The loader composes the
+--- sandbox env from the missions manifest's requires list — the dependency
+--- list IS the vocabulary whitelist; a global collision is a load error.
+---@class MissionDslFile
+---@field filename string mission-relative trigger file path
+---@field Register fun(descriptor: TriggerDescriptor)
+
+---@class MissionDslContribution
+---@field ForFile fun(file: MissionDslFile): { env: table<string, any>, Finalize: fun()|nil }

--- a/spec/modules/missions/cm8_roster_spec.lua
+++ b/spec/modules/missions/cm8_roster_spec.lua
@@ -1,0 +1,43 @@
+--- The shipped roster stays loadable and keeps declaring the names
+--- triggers/*.lua reference, through the same sandbox the loader builds.
+
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+describe("cm8_ashfall roster", function()
+	local byName = {}
+	local groups = {}
+
+	setup(function()
+		local file = Roster.ForFile("cm8_ashfall/units.lua")
+		VFS.Include("modules/missions/cm8_ashfall/units.lua", {
+			Spawn = file.Spawn,
+			UnitDef = Verbs.UnitDef,
+		})
+		for _, entry in ipairs(file.Finalize()) do
+			if entry.name then
+				byName[entry.name] = entry
+			end
+			if entry.group then
+				groups[entry.group] = (groups[entry.group] or 0) + 1
+			end
+		end
+	end)
+
+	it("declares every name the trigger files reference", function()
+		assert.is_table(byName.outpost_command_hub)
+		assert.is_table(byName.tenebrium_device)
+		assert.is_table(byName.armada_commander)
+	end)
+
+	it("the protected hub travels with the transferred outpost group", function()
+		assert.are.equal("outpost_auto", byName.outpost_command_hub.group)
+		assert.is_true(groups.outpost_auto > 1)
+	end)
+
+	it("the outpost spawns pilotless and the enclave hostile", function()
+		assert.are.equal("gaia", byName.outpost_command_hub.team)
+		assert.are.equal("enemy", byName.tenebrium_device.team)
+		assert.are.equal("enemy", byName.armada_commander.team)
+	end)
+end)

--- a/spec/modules/missions/dsl_spec.lua
+++ b/spec/modules/missions/dsl_spec.lua
@@ -1,4 +1,5 @@
 local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local CombatVerbs = VFS.Include("modules/combat/lib/mission_verbs.lua")
 local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
 
 local alwaysTrue = { evaluate = function() return true end }
@@ -20,7 +21,7 @@ describe("mission DSL", function()
 
 	it("builds a descriptor from a terminator-free chain at Finalize", function()
 		When(alwaysTrue).Do(anEffect)
-		assert.are.equal(0, #registered) -- nothing arms before the commit point
+		assert.are.equal(0, #registered)
 		Finalize()
 
 		assert.are.equal(1, #registered)
@@ -57,11 +58,11 @@ describe("mission DSL", function()
 
 	it("a statement without a Do fails the load, naming the statement", function()
 		When(alwaysTrue).Do(anEffect)
-		When(alwaysTrue) -- half-finished
+		When(alwaysTrue)
 		assert.has_error(function()
 			Finalize()
 		end)
-		assert.are.equal(0, #registered) -- the failed load arms nothing
+		assert.are.equal(0, #registered)
 	end)
 
 	it("rejects a bare function in Do (closure-free surface)", function()
@@ -184,6 +185,8 @@ describe("mission verbs", function()
 end)
 
 describe("unit noun", function()
+	local Unit = Verbs.MakeUnit({ hub = true, device = true })
+
 	---@return MissionContext
 	local function makeCtx(dead, spotted)
 		return {
@@ -198,7 +201,7 @@ describe("unit noun", function()
 	end
 
 	it("IsDestroyed reads the latch through ctx and declares its input", function()
-		local condition = Verbs.Unit("hub").IsDestroyed()
+		local condition = Unit("hub").IsDestroyed()
 		assert.are.same({ "UnitDestroyed" }, condition.inputs)
 		assert.is_false(condition.evaluate(makeCtx({}, {})))
 		assert.is_true(condition.evaluate(makeCtx({ hub = true }, {})))
@@ -206,30 +209,38 @@ describe("unit noun", function()
 
 	it("IsSpotted is per-allyteam and declares its input", function()
 		local team = Verbs.MakeTeam(0, 1)
-		local condition = Verbs.Unit("device").IsSpotted(team)
+		local condition = Unit("device").IsSpotted(team)
 		assert.are.same({ "UnitEnteredLos" }, condition.inputs)
 		assert.is_false(condition.evaluate(makeCtx({}, {})))
 		assert.is_true(condition.evaluate(makeCtx({}, { device_1 = true })))
 		assert.is_false(condition.evaluate(makeCtx({}, { device_2 = true })))
 	end)
 
+	it("a name the roster never declared is a load error, not a dead condition", function()
+		local ok, err = pcall(Unit, "hubb")
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("hubb", 1, true))
+	end)
+
 	it("IsSpotted rejects a non-Team argument", function()
 		assert.has_error(function()
-			Verbs.Unit("device").IsSpotted("player")
+			Unit("device").IsSpotted("player")
 		end)
 	end)
 
 	it("Unit rejects a non-string name", function()
 		assert.has_error(function()
-			Verbs.Unit(7)
+			Unit(7)
 		end)
 	end)
 end)
 
 describe("units verbs", function()
+	local Units = Verbs.MakeUnits({ outpost_auto = true })
+
 	it("Transfer builds an effect that moves the group through ctx", function()
 		local team = Verbs.MakeTeam(3, 1)
-		local effect = Verbs.Units.Transfer("outpost_auto", team)
+		local effect = Units.Transfer("outpost_auto", team)
 		local transferred = {}
 		effect.execute({
 			TransferGroup = function(group, teamID)
@@ -239,23 +250,30 @@ describe("units verbs", function()
 		assert.are.same({ { group = "outpost_auto", teamID = 3 } }, transferred)
 	end)
 
+	it("a group the roster never declared is a load error", function()
+		local ok, err = pcall(Units.Transfer, "outpost", Verbs.MakeTeam(0, 0))
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("outpost", 1, true))
+	end)
+
 	it("Transfer rejects bad arguments", function()
 		assert.has_error(function()
-			Verbs.Units.Transfer(nil, Verbs.MakeTeam(0, 0))
+			Units.Transfer(nil, Verbs.MakeTeam(0, 0))
 		end)
 		assert.has_error(function()
-			Verbs.Units.Transfer("outpost_auto", 3)
+			Units.Transfer("outpost_auto", 3)
 		end)
 	end)
 end)
 
 describe("combat verbs", function()
+	local Unit = Verbs.MakeUnit({ hub = true })
 	local untils
 	local combat
 
 	before_each(function()
 		untils = {}
-		combat = Verbs.MakeCombat(untils)
+		combat = CombatVerbs.MakeCombat(untils)
 	end)
 
 	local function protectLog()
@@ -273,7 +291,7 @@ describe("combat verbs", function()
 
 	it("Protect builds an effect over the roster name", function()
 		local log, ctx = protectLog()
-		combat.Protect(Verbs.Unit("hub")).execute(ctx)
+		combat.Protect(Unit("hub")).execute(ctx)
 		assert.are.same({ "protect:hub" }, log)
 		assert.are.same({}, untils)
 	end)
@@ -281,7 +299,7 @@ describe("combat verbs", function()
 	it("Until records the companion and returns the same protect effect", function()
 		local condition = { evaluate = function() return true end }
 		local log, ctx = protectLog()
-		local effect = combat.Protect(Verbs.Unit("hub")).Until(condition)
+		local effect = combat.Protect(Unit("hub")).Until(condition)
 		effect.execute(ctx)
 		assert.are.same({ "protect:hub" }, log)
 		assert.are.equal(1, #untils)
@@ -291,7 +309,7 @@ describe("combat verbs", function()
 
 	it("Unprotect builds the primitive Until sugars over", function()
 		local log, ctx = protectLog()
-		combat.Unprotect(Verbs.Unit("hub")).execute(ctx)
+		combat.Unprotect(Unit("hub")).execute(ctx)
 		assert.are.same({ "unprotect:hub" }, log)
 	end)
 
@@ -303,7 +321,7 @@ describe("combat verbs", function()
 
 	it("Until rejects a non-condition", function()
 		assert.has_error(function()
-			combat.Protect(Verbs.Unit("hub")).Until(function() end)
+			combat.Protect(Unit("hub")).Until(function() end)
 		end)
 	end)
 end)

--- a/spec/modules/missions/roster_spec.lua
+++ b/spec/modules/missions/roster_spec.lua
@@ -1,58 +1,78 @@
 local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
 
-describe("mission roster", function()
-	it("parses entries with defaults applied", function()
-		local entries = Roster.Parse({
-			{ def = "corllt", team = "gaia", x = 100, z = 200 },
-			{ name = "hub", def = "corlab", team = "gaia", x = 300, z = 400, facing = 2, group = "outpost_auto" },
-		})
-		assert.are.equal(2, #entries)
-		assert.are.same(
-			{ def = "corllt", team = "gaia", x = 100, z = 200, facing = 0 },
-			entries[1]
-		)
-		assert.are.same(
-			{ name = "hub", def = "corlab", team = "gaia", x = 300, z = 400, facing = 2, group = "outpost_auto" },
-			entries[2]
-		)
+describe("mission roster DSL", function()
+	local Spawn
+	local Finalize
+
+	before_each(function()
+		local file = Roster.ForFile("cm8/units.lua")
+		Spawn = file.Spawn
+		Finalize = file.Finalize
 	end)
 
-	it("rejects a non-table roster", function()
-		assert.has_error(function()
-			Roster.Parse("nope")
-		end)
+	it("builds entries from Spawn chains at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia")
+			.At(0.42, 0.42)
+			.Named("hub")
+			.Grouped("outpost_auto")
+		Spawn(Verbs.UnitDef("armcom"), "enemy")
+			.At(0.77, 0.77)
+		local entries = Finalize()
+		assert.are.same({
+			{ def = "corlab", team = "gaia", fx = 0.42, fz = 0.42, name = "hub", group = "outpost_auto" },
+			{ def = "armcom", team = "enemy", fx = 0.77, fz = 0.77 },
+		}, entries)
 	end)
 
-	it("rejects an entry without a def, naming the entry", function()
-		local ok, err = pcall(Roster.Parse, { { team = "gaia", x = 1, z = 1 } })
+	it("a spawn without an At fails the load, naming the statement", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").Named("hub")
+		local ok, err = pcall(Finalize)
 		assert.is_false(ok)
-		assert.is_truthy(tostring(err):find("entry 1", 1, true))
+		assert.is_truthy(tostring(err):find("Spawn 1", 1, true))
 	end)
 
-	it("rejects unknown team roles", function()
+	it("rejects duplicate unit names at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1).Named("hub")
+		Spawn(Verbs.UnitDef("corllt"), "gaia").At(0.2, 0.2).Named("hub")
 		assert.has_error(function()
-			Roster.Parse({ { def = "corllt", team = "raptors", x = 1, z = 1 } })
+			Finalize()
 		end)
 	end)
 
-	it("rejects missing coordinates", function()
+	it("rejects a plain string where a UnitDef reference belongs", function()
 		assert.has_error(function()
-			Roster.Parse({ { def = "corllt", team = "gaia", x = 1 } })
+			Spawn("corlab", "gaia")
 		end)
 	end)
 
-	it("rejects duplicate unit names", function()
+	it("rejects an unknown team role", function()
 		assert.has_error(function()
-			Roster.Parse({
-				{ name = "hub", def = "corllt", team = "gaia", x = 1, z = 1 },
-				{ name = "hub", def = "corllt", team = "gaia", x = 2, z = 2 },
-			})
+			Spawn(Verbs.UnitDef("corlab"), "raptors")
 		end)
 	end)
 
-	it("rejects a non-numeric facing", function()
+	it("rejects positions outside map fractions", function()
 		assert.has_error(function()
-			Roster.Parse({ { def = "corllt", team = "gaia", x = 1, z = 1, facing = "south" } })
+			Spawn(Verbs.UnitDef("corlab"), "gaia").At(512, 512)
+		end)
+	end)
+
+	it("rejects chain calls after Finalize", function()
+		local chain = Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1)
+		Finalize()
+		assert.has_error(function()
+			chain.Named("late")
+		end)
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corllt"), "gaia")
+		end)
+	end)
+
+	it("rejects Finalize twice", function()
+		Finalize()
+		assert.has_error(function()
+			Finalize()
 		end)
 	end)
 end)


### PR DESCRIPTION
5/5 of the modules stack (base: `combat`, #8460 — review this diff only).

CM8 "Ashfall" as the acceptance mission: the campaign-spec beats that today's modules can express, written in the DSL and armed on stand-in unit defs (`/luarules mission cm8_ashfall` in a skirmish vs any AI).

- **The roster DSL** — `Spawn(UnitDef("corlab"), "gaia").At(0.42, 0.42).Named("outpost_command_hub").Grouped("outpost_auto")`: map-fraction positions, team roles resolved at arm. `Named`/`Grouped` are the single definition sites; a trigger referencing an undeclared name is a load error, not a condition that silently never fires.
- **The mission** — the automated outpost transfers at mission start with its command hub protected until the enclave reveal; spotting the tenebrium device and killing the Armada commander close the objectives; victory flows through matchflow.
- **Vocabulary travels with the module that injects it** — combat and matchflow ship `mission_dsl.lua` (their sandbox verbs) and `types/dsl.lua` (the annotations the editor derives from); the loader composes the sandbox from the missions manifest's `requires`, and a global collision between contributors is a load error.

