### PR TITLE
modules — multiplayer 1/2: the mode grammar — mode_builder, Scripted as the surrogate mode

### DIFF
--- a/modules/missions/lib/mode_dsl.lua
+++ b/modules/missions/lib/mode_dsl.lua
@@ -1,0 +1,30 @@
+--- Mission mode vocabulary over modules/mode_builder.lua: nouns for what the
+--- mission runtime owns, serializers for the options those policies pin.
+
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+
+local M = {}
+
+M.Match = {
+	End = { domain = "end" },
+}
+
+local Serializers = {
+	-- triggers own the verdict: engine elimination never ends the match
+	["end.scripted"] = function(_p, lock)
+		return { deathmode = { value = "neverend", locked = lock.structure } }
+	end,
+}
+
+M.Mode = ModeBuilder.Grammar({
+	category = "missions",
+	serializers = Serializers,
+	verbs = {
+		---The mission owns the noun's domain outright.
+		Own = function(modeName, noun)
+			return { ModeBuilder.DomainOf(modeName, "Own", noun, { ["end"] = true }, "Match.End") .. ".scripted" }
+		end,
+	},
+})
+
+return M

--- a/modules/missions/modes/scripted.lua
+++ b/modules/missions/modes/scripted.lua
@@ -1,0 +1,6 @@
+local ModeDSL = VFS.Include("modules/missions/lib/mode_dsl.lua")
+local Mode, Match = ModeDSL.Mode, ModeDSL.Match
+
+return Mode("Scripted")
+	.Desc("Triggers own the verdict; engine elimination never ends the match.")
+	.Own(Match.End)

--- a/modules/missions/types/mode_dsl.lua
+++ b/modules/missions/types/mode_dsl.lua
@@ -1,0 +1,27 @@
+---@meta dsl
+
+--- The missions mode-preset surface: what modules/missions/modes/*.lua files
+--- author against (via lib/mode_dsl.lua over modules/mode_builder.lua).
+
+--- A mode noun: names the policy domain a verb acts on.
+---@class MissionModeNoun
+---@field domain string
+
+--- The Mode chain (missions vocabulary). Every verb returns the chain; the
+--- chain IS the ModeConfig the preset file returns.
+---@class MissionModeChain
+---@field Desc fun(desc: string): MissionModeChain
+---@field Ranked fun(): MissionModeChain
+---@field RetainValues fun(): MissionModeChain
+---@field Hidden fun(): MissionModeChain
+---@field Unlocked fun(): MissionModeChain
+---@field Locked fun(): MissionModeChain
+---@field Own fun(noun: MissionModeNoun): MissionModeChain
+
+---Start a mode chain; the key is the name's snake_case.
+---@param name string
+---@return MissionModeChain
+function Mode(name) end
+
+---@type { End: MissionModeNoun }
+Match = {}

--- a/modules/mode_builder.lua
+++ b/modules/mode_builder.lua
@@ -1,0 +1,145 @@
+--- Fluent builder that emits ModeConfigs — no runtime of its own.
+---
+--- The canonical mode format is the preset file (see types/modules.lua):
+--- modules/<name>/modes/<key>.lua returns a ModeConfig — a surrogate mode;
+--- ModuleHandler.ModeDirs aggregates the preset dirs. Grammar() binds a
+--- module's vocabulary — nouns carrying domains, verbs mapping nouns to policy
+--- refs, serializers keyed by policy identity — and returns the Mode chain
+--- entry those files read as:
+---
+---   Mode("Scripted")
+---       .Desc("Triggers own the verdict.")
+---       .Own(Match.End)
+---
+--- The chain IS the ModeConfig: dot-only, closure-free authoring; every verb
+--- returns the chain; modifiers apply to the most recent policy; modOptions
+--- stay re-derived from the policy bundle after every step, so consumers read
+--- a plain preset table. Structural choices lock by default (.Unlocked()
+--- opens them); numeric dials stay host-tunable (.Locked() pins them).
+
+local ModeBuilder = {}
+
+---Serialize a policy bundle through a serializer registry. Each policy
+---serializes only the options it owns — a second owner is an error.
+---@param serializers table<string, fun(params: table, lock: { structure: boolean, dial: boolean }): table<string, ModOptionConfig>>
+---@param bundle ModePolicyRef[]
+---@return table<string, ModOptionConfig>
+function ModeBuilder.ToModOptions(serializers, bundle)
+	local options = {}
+	for _, entry in ipairs(bundle) do
+		local name, params
+		if type(entry) == "table" then
+			name, params = entry[1], entry
+		else
+			name, params = entry, {}
+		end
+		local serialize = serializers[name]
+		if not serialize then
+			error("unknown mode policy: " .. tostring(name))
+		end
+		local lock = { structure = params.locked ~= false, dial = params.locked == true }
+		for key, option in pairs(serialize(params, lock)) do
+			if options[key] ~= nil then
+				error("two policies own modoption " .. key)
+			end
+			options[key] = option
+		end
+	end
+	return options
+end
+
+---Domain guard for vocabulary verbs.
+---@param modeName string for error messages
+---@param verb string
+---@param noun table
+---@param domains table<string, boolean> domains the verb accepts
+---@param hint string noun spelling for the error message
+---@return string domain
+function ModeBuilder.DomainOf(modeName, verb, noun, domains, hint)
+	assert(type(noun) == "table" and type(noun.domain) == "string",
+		modeName .. ": ." .. verb .. " expects a noun (" .. hint .. ")")
+	assert(domains[noun.domain], modeName .. ": ." .. verb .. " does not apply to " .. noun.domain)
+	return noun.domain
+end
+
+---Bind a module's vocabulary; returns the Mode chain entry for its preset files.
+---Verbs receive (modeName, ...) and return a policy ref { "<identity>", ... }.
+---@param grammar { category: string, serializers: table, verbs: table<string, fun(modeName: string, ...): table> }
+---@return fun(name: string): ModeConfig
+function ModeBuilder.Grammar(grammar)
+	---Start a mode chain; the key is the name's snake_case.
+	---@param name string
+	---@return ModeConfig
+	return function(name)
+		local chain = {
+			key = name:lower():gsub("%s+", "_"),
+			category = grammar.category,
+			name = name,
+			desc = "",
+			allowRanked = false,
+			policies = {}, ---@type ModePolicyRef[]
+			modOptions = {}, ---@type table<string, ModOptionConfig>
+		}
+
+		local function reserialize()
+			chain.modOptions = ModeBuilder.ToModOptions(grammar.serializers, chain.policies)
+			return chain
+		end
+
+		---@param modifier string
+		---@return table ref the most recent policy ref
+		local function lastPolicy(modifier)
+			local ref = chain.policies[#chain.policies]
+			assert(ref, name .. ": ." .. modifier .. " before any policy")
+			return ref
+		end
+
+		---@param desc string
+		chain.Desc = function(desc)
+			chain.desc = desc
+			return chain
+		end
+
+		---Allowed in ranked games.
+		chain.Ranked = function()
+			chain.allowRanked = true
+			return chain
+		end
+
+		---Non-sticky preset: entries expose/unlock options, current values are kept.
+		chain.RetainValues = function()
+			chain.retainValues = true
+			return chain
+		end
+
+		---The most recent policy's option stays out of the lobby UI.
+		chain.Hidden = function()
+			lastPolicy("Hidden").ui = "hidden"
+			return reserialize()
+		end
+
+		---The most recent policy unlocks entirely (structure and dials).
+		chain.Unlocked = function()
+			lastPolicy("Unlocked").locked = false
+			return reserialize()
+		end
+
+		---The most recent policy locks entirely, dials included.
+		chain.Locked = function()
+			lastPolicy("Locked").locked = true
+			return reserialize()
+		end
+
+		for verbName, toRef in pairs(grammar.verbs) do
+			assert(chain[verbName] == nil, "ModeBuilder.Grammar: verb collides with a chain field: " .. verbName)
+			chain[verbName] = function(...)
+				chain.policies[#chain.policies + 1] = toRef(name, ...)
+				return reserialize()
+			end
+		end
+
+		return chain
+	end
+end
+
+return ModeBuilder

--- a/spec/modules/missions/scripted_mode_spec.lua
+++ b/spec/modules/missions/scripted_mode_spec.lua
@@ -1,0 +1,38 @@
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local ModeDSL = VFS.Include("modules/missions/lib/mode_dsl.lua")
+
+local scripted = VFS.Include("modules/missions/modes/scripted.lua")
+
+describe("missions scripted mode", function()
+	it("is a missions-category preset with a snake_case key", function()
+		assert.equal("scripted", scripted.key)
+		assert.equal("missions", scripted.category)
+		assert.equal(false, scripted.allowRanked)
+	end)
+
+	it("serializes to exactly the options its policies own", function()
+		assert.same({
+			deathmode = { value = "neverend", locked = true },
+		}, scripted.modOptions)
+	end)
+
+	it("rejects a second owner of the same modoption", function()
+		local Mode, Match = ModeDSL.Mode, ModeDSL.Match
+		local ok, err = pcall(function()
+			Mode("Twice").Own(Match.End).Own(Match.End)
+		end)
+		assert.is_false(ok)
+		assert.truthy(tostring(err):find("two policies own modoption deathmode", 1, true))
+	end)
+
+	it("ModeDirs aggregates the missions preset dir", function()
+		ModuleHandler.ResetCaches()
+		local found = false
+		for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+			if dir == "modules/missions/modes/" then
+				found = true
+			end
+		end
+		assert.is_true(found)
+	end)
+end)

--- a/types/modules.lua
+++ b/types/modules.lua
@@ -43,3 +43,25 @@
 ---@field name string
 ---@field category string|nil Defaults to the policies/<category>.lua filename
 ---@field evaluate function fun(...): result|nil
+
+--- Mode presets (surrogate modes): modules/<name>/modes/<key>.lua returns a
+--- ModeConfig built by modules/mode_builder.lua over the module's vocabulary;
+--- ModuleHandler.ModeDirs aggregates the preset dirs.
+---@class ModOptionConfig
+---@field value any
+---@field locked boolean
+---@field ui string|nil UI hints (e.g., "hidden")
+
+--- A policy reference in a mode's bundle: the policy identity, or a table
+--- with the identity at [1] plus its params (locked, ui, dials, ...).
+---@alias ModePolicyRef string|table
+
+---@class ModeConfig
+---@field key string Unique identifier for this mode
+---@field category string Mode category (e.g., "sharing")
+---@field name string Display name
+---@field desc string Description
+---@field allowRanked boolean Whether this mode is allowed in ranked games
+---@field retainValues boolean|nil Non-sticky: keep current modoption values instead of resetting to this preset
+---@field policies ModePolicyRef[]|nil Named policy bundle this mode activates; modOptions is its serialization
+---@field modOptions table<string, ModOptionConfig> Map of mod option keys to their configurations


### PR DESCRIPTION
The mode grammar as foundation (base: `cm8_ashfall`): modes are authored in the same dot-only, closure-free chain idiom as missions, over each module's own vocabulary.

```lua
return Mode("Scripted")
	.Desc("Triggers own the verdict; engine elimination never ends the match.")
	.Own(Match.End)
```

`mode_builder.lua` binds a module's nouns, verbs, and serializers; the chain IS the ModeConfig (policies as the source, modOptions re-derived after every step; structural choices lock by default, dials stay host-tunable). The missions module ships `Scripted` as its surrogate mode — the `deathmode=neverend` contract stated as a mode instead of a convention.
