### PR TITLE
modules — 3/12: context

### DIFF
--- a/modules/context/context_factory.lua
+++ b/modules/context/context_factory.lua
@@ -1,0 +1,174 @@
+local TransferEnums = VFS.Include("modules/context/enums.lua")
+local TeamResourceData = VFS.Include("modules/context/team_resource_data.lua")
+
+---@alias PolicyContextEnricher fun(ctx: PolicyContext, springRepo: Spring, senderTeamID: integer, receiverTeamID: integer)
+
+---@class ContextFactory
+---@field create fun(springRepo: Spring): ContextFactory
+---@field registerPolicyContextEnricher fun(fn: PolicyContextEnricher)
+---@field policy fun(senderTeamID: integer, receiverTeamID: integer): PolicyContext
+---@field action fun(senderTeamId: integer, receiverTeamId: integer, policyType: string): PolicyActionContext
+---@field resourceTransfer fun(senderTeamId: integer, receiverTeamId: integer, resourceType: ResourceName, desiredAmount: number, policyResult: ResourcePolicyResult): ResourceTransferContext
+---@field unitTransfer fun(senderTeamId: integer, receiverTeamId: integer, unitIds: integer[], given: boolean, policyResult: UnitPolicyResult, unitValidationResult: UnitValidationResult): UnitTransferContext
+local ContextFactory = {}
+
+-- shared via GG because VFS.Include re-runs per call; a module-local list would split registrar and consumer into separate registries
+GG = GG or {}
+GG.policyContextEnrichers = GG.policyContextEnrichers or {}
+---@type PolicyContextEnricher[]
+local enrichers = GG.policyContextEnrichers
+
+---@param fn PolicyContextEnricher
+function ContextFactory.registerPolicyContextEnricher(fn)
+	enrichers[#enrichers + 1] = fn
+end
+
+function ContextFactory.getEnrichers()
+	local copy = {}
+	for i = 1, #enrichers do
+		copy[i] = enrichers[i]
+	end
+	return copy
+end
+
+-- mutate in place so the shared reference (and create()'s closures) stay valid
+function ContextFactory.setEnrichers(list)
+	for i = #enrichers, 1, -1 do
+		enrichers[i] = nil
+	end
+	if list then
+		for i = 1, #list do
+			enrichers[i] = list[i]
+		end
+	end
+end
+
+---@param springRepo Spring
+---@return table Context factory with closures
+function ContextFactory.create(springRepo)
+	-- per-snapshot resource memo so a refresh pass reads each team once, not once per pair; caller clears it at pass start
+	local resourceCache = {}
+
+	local function getResource(teamID, resourceType)
+		local perTeam = resourceCache[teamID]
+		if not perTeam then
+			perTeam = {}
+			resourceCache[teamID] = perTeam
+		end
+		local data = perTeam[resourceType]
+		if not data then
+			data = TeamResourceData.Get(springRepo, teamID, resourceType)
+			perTeam[resourceType] = data
+		end
+		return data
+	end
+
+	local function clearResourceCache()
+		resourceCache = {}
+	end
+
+	---@param senderTeamID integer
+	---@param receiverTeamID integer
+	---@param extensions? table
+	---@return PolicyContext
+	local function buildContext(senderTeamID, receiverTeamID, extensions)
+		---@type TeamResources
+		local senderResources = {
+			metal = getResource(senderTeamID, TransferEnums.ResourceType.METAL),
+			energy = getResource(senderTeamID, TransferEnums.ResourceType.ENERGY),
+		}
+
+		---@type TeamResources
+		local receiverResources = {
+			metal = getResource(receiverTeamID, TransferEnums.ResourceType.METAL),
+			energy = getResource(receiverTeamID, TransferEnums.ResourceType.ENERGY),
+		}
+
+		---@type PolicyContext
+		local ctx = {
+			senderTeamId = senderTeamID,
+			receiverTeamId = receiverTeamID,
+			sender = senderResources,
+			receiver = receiverResources,
+			springRepo = springRepo,
+			areAlliedTeams = springRepo.AreTeamsAllied(senderTeamID, receiverTeamID) == true,
+			isCheatingEnabled = springRepo.IsCheatingEnabled(),
+			ext = {},
+		}
+
+		for _, enricher in ipairs(enrichers) do
+			enricher(ctx, springRepo, senderTeamID, receiverTeamID)
+		end
+
+		if extensions then
+			for k, v in pairs(extensions) do
+				ctx[k] = v
+			end
+		end
+
+		return ctx
+	end
+
+	---@param senderTeamID integer
+	---@param receiverTeamID integer
+	---@param commandType? string
+	---@return PolicyContext
+	local function policy(senderTeamID, receiverTeamID, commandType)
+		return buildContext(senderTeamID, receiverTeamID, {
+			commandType = commandType,
+		})
+	end
+
+	---@param policyType string
+	---@param senderTeamId integer
+	---@param receiverTeamId integer
+	---@return PolicyActionContext
+	local function policyAction(senderTeamId, receiverTeamId, policyType)
+		return buildContext(senderTeamId, receiverTeamId, {
+			policyType = policyType,
+		}) --[[@as PolicyActionContext]]
+	end
+
+	---@param senderTeamId integer
+	---@param receiverTeamId integer
+	---@param resourceType ResourceName
+	---@param desiredAmount number
+	---@param policyResult ResourcePolicyResult
+	---@return ResourceTransferContext
+	local function resourceTransfer(senderTeamId, receiverTeamId, resourceType, desiredAmount, policyResult)
+		local policyType = resourceType == TransferEnums.ResourceType.METAL and TransferEnums.PolicyType.MetalTransfer or TransferEnums.PolicyType.EnergyTransfer
+		return buildContext(senderTeamId, receiverTeamId, {
+			policyType = policyType,
+			resourceType = resourceType,
+			desiredAmount = desiredAmount,
+			policyResult = policyResult,
+		}) --[[@as ResourceTransferContext]]
+	end
+
+	---@param senderTeamId integer
+	---@param receiverTeamId integer
+	---@param unitIds integer[]
+	---@param given boolean?
+	---@param policyResult UnitPolicyResult
+	---@param validationResult UnitValidationResult
+	---@return UnitTransferContext
+	local function unitTransfer(senderTeamId, receiverTeamId, unitIds, given, policyResult, validationResult)
+		return buildContext(senderTeamId, receiverTeamId, {
+			policyType = TransferEnums.PolicyType.UnitTransfer,
+			unitIds = unitIds,
+			given = given,
+			policyResult = policyResult,
+			validationResult = validationResult,
+		}) --[[@as UnitTransferContext]]
+	end
+
+	return {
+		policy = policy,
+		action = policyAction,
+		resourceTransfer = resourceTransfer,
+		unitTransfer = unitTransfer,
+		clearResourceCache = clearResourceCache,
+	}
+end
+
+return ContextFactory

--- a/modules/context/enums.lua
+++ b/modules/context/enums.lua
@@ -1,0 +1,44 @@
+local ResourceTypes = VFS.Include("gamedata/resource_types.lua")
+
+local M = {}
+
+M.PolicyType = {
+	MetalTransfer = "metal_transfer",
+	EnergyTransfer = "energy_transfer",
+	UnitTransfer = "unit_transfer",
+}
+
+M.ResourceType = ResourceTypes
+
+M.ResourceCommunicationCase = {
+	OnSelf = 1,
+	OnTaxFree = 2,
+	OnTaxed = 3,
+	OnDisabled = 4,
+}
+
+M.UnitCommunicationCase = {
+	OnSelf = 1,
+	OnFullyShareable = 2,
+	OnPartiallyShareable = 3,
+	OnPolicyDisabled = 4,
+	OnSelectionValidationFailed = 5,
+	OnTechBlocked = 6,
+}
+
+M.UnitValidationOutcome = {
+	Failure = "Failure",
+	PartialSuccess = "PartialSuccess",
+	Success = "Success",
+}
+
+M.UnitType = {
+	Combat = "combat",
+	Commander = "commander",
+	Constructor = "constructor",
+	Factory = "factory",
+	Resource = "resource",
+	Utility = "utility",
+}
+
+return M

--- a/modules/context/mode_enums.lua
+++ b/modules/context/mode_enums.lua
@@ -1,0 +1,115 @@
+local M = {}
+
+---@class EnabledField
+---@field Enabled "enabled"
+
+---@class DisabledField
+---@field Disabled "disabled"
+
+---@class AllField
+---@field All "all"
+
+---@class NoneField
+---@field None "none"
+
+---@class StunDelayField
+---@field StunDelay "stun_delay"
+
+---@class TakeDelayField
+---@field TakeDelay "take_delay"
+
+---@class UnitCategoryFields
+---@field Combat "combat"
+---@field Buildings "buildings"
+---@field Constructors "constructors"
+---@field Resource "resource"
+---@field NonCombat "non_combat"
+
+---@class AlliedAssistModeFields : EnabledField, DisabledField
+---@class AlliedUnitReclaimModeFields : EnabledField, DisabledField
+---@class AllowPartialResurrectionFields : EnabledField, DisabledField
+---@class UnitFilterCategoryFields : UnitCategoryFields, AllField, NoneField
+---@class TakeModeFields : EnabledField, DisabledField, StunDelayField, TakeDelayField
+
+M.ModOptions = {
+	AlliedAssistMode = "allied_assist_mode",
+	AlliedUnitReclaimMode = "allied_reclaim_mode",
+	ConstructorBuildDelay = "constructor_build_delay",
+	ResourceSharingEnabled = "resource_sharing_enabled",
+	AllowPartialResurrection = "allow_partial_resurrection",
+	SharingMode = "sharing_mode",
+	TakeMode = "take_mode",
+	TakeDelaySeconds = "take_delay_seconds",
+	TakeDelayCategory = "take_delay_category",
+	TaxResourceSharingAmount = "tax_resource_sharing_amount",
+	TaxResourceSharingAmountAtT2 = "tax_resource_sharing_amount_at_t2",
+	TaxResourceSharingAmountAtT3 = "tax_resource_sharing_amount_at_t3",
+	TechBlocking = "tech_blocking",
+	T2TechThreshold = "t2_tech_threshold",
+	T3TechThreshold = "t3_tech_threshold",
+	UnitSharingMode = "unit_sharing_mode",
+	UnitSharingModeAtT2 = "unit_sharing_mode_at_t2",
+	UnitSharingModeAtT3 = "unit_sharing_mode_at_t3",
+	UnitShareStunSeconds = "unit_share_stun_seconds",
+	UnitStunCategory = "unit_stun_category",
+}
+
+M.ModeCategories = {
+	Sharing = "sharing",
+}
+
+M.Modes = {
+	Disabled = "disabled",
+	Enabled = "enabled",
+	EasyTax = "easy_tax",
+	Customize = "customize",
+	TechCore = "tech_core",
+}
+
+---@type AlliedAssistModeFields
+M.AlliedAssistMode = {
+	Enabled = "enabled",
+	Disabled = "disabled",
+}
+
+---@type AlliedUnitReclaimModeFields
+M.AlliedUnitReclaimMode = {
+	Enabled = "enabled",
+	Disabled = "disabled",
+}
+
+---@type AllowPartialResurrectionFields
+M.AllowPartialResurrection = {
+	Enabled = "enabled",
+	Disabled = "disabled",
+}
+
+---@type UnitCategoryFields
+M.UnitCategory = {
+	Combat = "combat",
+	Buildings = "buildings",
+	Constructors = "constructors",
+	Resource = "resource",
+	NonCombat = "non_combat",
+}
+
+---@type UnitFilterCategoryFields
+M.UnitFilterCategory = {
+	All = "all",
+	None = "none",
+	Combat = "combat",
+	Buildings = "buildings",
+	Constructors = "constructors",
+	Resource = "resource",
+	NonCombat = "non_combat",
+}
+
+---@type TakeModeFields
+M.TakeMode = {
+	Enabled = "enabled",
+	Disabled = "disabled",
+	StunDelay = "stun_delay",
+	TakeDelay = "take_delay",
+}
+
+return M

--- a/modules/context/module.lua
+++ b/modules/context/module.lua
@@ -1,0 +1,8 @@
+--- Manifest for the context module: the facts a proposed action is judged on.
+--- Assembled once per decision and enriched by whichever module knows something
+--- relevant, so registrar and consumer never live in separate registries.
+---@type ModuleManifestFile
+return {
+	name = "context",
+	description = "Context factory and the shared policy vocabulary modules enrich",
+}

--- a/modules/context/policy_events.lua
+++ b/modules/context/policy_events.lua
@@ -1,0 +1,59 @@
+-- Synced-side surface for sharing-policy events forwarded to widgets (policy changes + build-delay debuff).
+local PolicyEvents = {}
+
+-- domain -> (teamId -> last signature seen). Lives for the synced state's lifetime.
+local lastSignature = {}
+
+---Emit SharePolicyChanged(teamId, domain) when the signature changes; first observation is silent.
+---@param teamId number
+---@param domain PolicyType the policy domain that changed (TransferEnums.PolicyType value)
+---@param signature string policy-relevant signature; identical strings count as no change
+---@param sendToUnsynced function? defaults to the synced SendToUnsynced global (injectable for tests)
+---@return boolean changed
+function PolicyEvents.NotifyIfChanged(teamId, domain, signature, sendToUnsynced)
+	local byTeam = lastSignature[domain]
+	if not byTeam then
+		byTeam = {}
+		lastSignature[domain] = byTeam
+	end
+
+	local previous = byTeam[teamId]
+	if previous == signature then
+		return false
+	end
+	byTeam[teamId] = signature
+
+	if previous == nil then
+		return false -- first observation: record baseline without emitting
+	end
+
+	local send = sendToUnsynced or SendToUnsynced ---@type function? absent outside the synced gadget context
+	if send then
+		send("SharePolicyChanged", teamId, domain)
+	end
+	return true
+end
+
+---A builder gained the constructor build-delay buildspeed debuff for [startFrame, expireFrame).
+---@param unitID number
+---@param startFrame number
+---@param expireFrame number
+---@param sendToUnsynced function? defaults to the synced SendToUnsynced global (injectable for tests)
+function PolicyEvents.NotifyBuildDelay(unitID, startFrame, expireFrame, sendToUnsynced)
+	local send = sendToUnsynced or SendToUnsynced ---@type function? absent outside the synced gadget context
+	if send then
+		send("UnitBuildDelayStarted", unitID, startFrame, expireFrame)
+	end
+end
+
+---The build-delay debuff on a unit ended (expired or unit gone).
+---@param unitID number
+---@param sendToUnsynced function? defaults to the synced SendToUnsynced global (injectable for tests)
+function PolicyEvents.NotifyBuildDelayEnd(unitID, sendToUnsynced)
+	local send = sendToUnsynced or SendToUnsynced ---@type function? absent outside the synced gadget context
+	if send then
+		send("UnitBuildDelayEnded", unitID)
+	end
+end
+
+return PolicyEvents

--- a/modules/context/serialization.lua
+++ b/modules/context/serialization.lua
@@ -1,0 +1,86 @@
+local TransferEnums = VFS.Include("modules/context/enums.lua")
+
+local M = {}
+
+M.FieldTypes = {
+	string = "string",
+	boolean = "boolean",
+	number = "number",
+}
+
+-- Pooled buffer for serialization (avoids table allocation per call)
+local serializeBuffer = {}
+
+---Generate base key for policy caching using PolicyType
+---@param receiverId number
+---@param policyType string TransferEnums.PolicyType enum value
+---@return string
+function M.MakeBaseKey(receiverId, policyType)
+	local baseKeyPrefix = policyType
+	return string.format("%s_policy_%d_", baseKeyPrefix, receiverId)
+end
+
+--- Serialize an object using a fields schema into a colon-delimited string
+--- @param fields table<string,string> fieldName -> FieldTypes
+--- @param obj table
+--- @return string
+function M.Serialize(fields, obj)
+	local n = 0
+	for fieldName, fieldType in pairs(fields) do
+		local v = obj[fieldName]
+		if v ~= nil then
+			if fieldType == M.FieldTypes.boolean then
+				v = v and "1" or "0"
+			else
+				v = tostring(v)
+			end
+			n = n + 1
+			serializeBuffer[n] = fieldName
+			n = n + 1
+			serializeBuffer[n] = v
+		end
+	end
+	-- Clear any leftover entries from previous calls
+	for i = n + 1, #serializeBuffer do
+		serializeBuffer[i] = nil
+	end
+	return table.concat(serializeBuffer, ":")
+end
+
+--- Deserialize a colon-delimited string into a table using a fields schema
+--- @param fields table<string,string> fieldName -> FieldTypes
+--- @param serialized string
+--- @param extras table? optional table of extra kv pairs to merge into result
+--- @return table
+function M.Deserialize(fields, serialized, extras)
+	local result = {}
+	if type(serialized) ~= "string" then
+		serialized = tostring(serialized or "")
+	end
+	local parts = {}
+	for part in string.gmatch(serialized, "([^:]+)") do
+		parts[#parts + 1] = part
+	end
+	for i = 1, #parts, 2 do
+		local key = parts[i] ---@type string?
+		local value = parts[i + 1] ---@type string? absent when the pair list is odd-length
+		if key and value then
+			local fieldType = fields[key]
+			if fieldType == M.FieldTypes.boolean then
+				result[key] = value == "1"
+			elseif fieldType == M.FieldTypes.number then
+				result[key] = tonumber(value) or 0
+			else
+				result[key] = value
+			end
+		end
+	end
+	if extras then
+		for k, v in pairs(extras) do
+			result[k] = v
+		end
+	end
+	return result
+end
+
+return M

--- a/modules/context/spec/policy_events_spec.lua
+++ b/modules/context/spec/policy_events_spec.lua
@@ -1,0 +1,71 @@
+local PolicyEvents = VFS.Include("modules/context/policy_events.lua")
+
+describe("PolicyEvents.NotifyIfChanged", function()
+	---@type { event: string, teamId: integer, domain: string }[]
+	local sent = {}
+
+	local function recorder()
+		return function(event, teamId, domain)
+			sent[#sent + 1] = { event = event, teamId = teamId, domain = domain }
+		end
+	end
+
+	before_each(function()
+		sent = {}
+	end)
+
+	it("records the first observation silently (no event on init)", function()
+		local changed = PolicyEvents.NotifyIfChanged(1, "unit", "modes=all", recorder())
+		assert.is_false(changed)
+		assert.are.equal(0, #sent)
+	end)
+
+	it("emits SharePolicyChanged when the signature changes", function()
+		PolicyEvents.NotifyIfChanged(2, "unit", "modes=none", recorder())
+		local changed = PolicyEvents.NotifyIfChanged(2, "unit", "modes=all", recorder())
+		assert.is_true(changed)
+		assert.are.equal(1, #sent)
+		assert.are.same({ event = "SharePolicyChanged", teamId = 2, domain = "unit" }, sent[1])
+	end)
+
+	it("does not emit when the signature is unchanged", function()
+		PolicyEvents.NotifyIfChanged(3, "metal", "tax=0.5", recorder())
+		local changed = PolicyEvents.NotifyIfChanged(3, "metal", "tax=0.5", recorder())
+		assert.is_false(changed)
+		assert.are.equal(0, #sent)
+	end)
+
+	it("tracks domains independently for the same team", function()
+		PolicyEvents.NotifyIfChanged(4, "unit", "a", recorder()) -- baseline unit
+		PolicyEvents.NotifyIfChanged(4, "metal", "x", recorder()) -- baseline metal
+		PolicyEvents.NotifyIfChanged(4, "unit", "b", recorder()) -- unit change -> emit
+		assert.are.equal(1, #sent)
+		assert.are.equal("unit", assert(sent[1]).domain)
+	end)
+
+	it("tracks teams independently within a domain", function()
+		PolicyEvents.NotifyIfChanged(5, "energy", "e0", recorder()) -- baseline team 5
+		PolicyEvents.NotifyIfChanged(6, "energy", "e0", recorder()) -- baseline team 6
+		PolicyEvents.NotifyIfChanged(5, "energy", "e1", recorder()) -- team 5 change
+		assert.are.equal(1, #sent)
+		assert.are.equal(5, assert(sent[1]).teamId)
+	end)
+end)
+
+describe("PolicyEvents build-delay debuff", function()
+	it("forwards NotifyBuildDelay with unit and frame window", function()
+		local args
+		PolicyEvents.NotifyBuildDelay(42, 100, 190, function(...)
+			args = { ... }
+		end)
+		assert.are.same({ "UnitBuildDelayStarted", 42, 100, 190 }, args)
+	end)
+
+	it("forwards NotifyBuildDelayEnd with the unit", function()
+		local args
+		PolicyEvents.NotifyBuildDelayEnd(42, function(...)
+			args = { ... }
+		end)
+		assert.are.same({ "UnitBuildDelayEnded", 42 }, args)
+	end)
+end)

--- a/modules/context/team_resource_data.lua
+++ b/modules/context/team_resource_data.lua
@@ -1,0 +1,24 @@
+local TeamResourceData = {}
+
+-- assemble a ResourceData snapshot from Spring.GetTeamResources (backs the GG.GetTeamResourceData synthetic call)
+---@param springRepo Spring
+---@param teamID integer
+---@param resourceType ResourceName
+---@return ResourceData
+function TeamResourceData.Get(springRepo, teamID, resourceType)
+	local current, storage, pull, income, expense, shareSlider, sent, received = springRepo.GetTeamResources(teamID, resourceType)
+	return {
+		resourceType = resourceType,
+		current = current or 0,
+		storage = storage or 0,
+		pull = pull or 0,
+		income = income or 0,
+		expense = expense or 0,
+		shareSlider = shareSlider or 0,
+		sent = sent or 0,
+		received = received or 0,
+		excess = 0, -- engine read has no excess notion; the solver snapshot supplies it
+	}
+end
+
+return TeamResourceData


### PR DESCRIPTION
The facts a proposed action is judged on: the policy enums, their wire form, the change bus, and the factory that assembles a context per decision.

It sits below every domain because it has to. Transfer reads the tax tier from tech and tech builds its contexts here, so filing the factory under either gives `transfer -> tech -> transfer`.