### PR TITLE
modules — 4/12: the mode grammar

### DIFF
--- a/modules/mode_builder.lua
+++ b/modules/mode_builder.lua
@@ -1,0 +1,145 @@
+--- Fluent builder that emits ModeConfigs — no runtime of its own.
+---
+--- The canonical mode format is the preset file (see types/modules.lua):
+--- modules/<name>/modes/<key>.lua returns a ModeConfig — a surrogate mode;
+--- ModuleHandler.ModeDirs aggregates the preset dirs. Grammar() binds a
+--- module's vocabulary — nouns carrying domains, verbs mapping nouns to policy
+--- refs, serializers keyed by policy identity — and returns the Mode chain
+--- entry those files read as:
+---
+---   Mode("Scripted")
+---       .Desc("Triggers own the verdict.")
+---       .Own(Match.End)
+---
+--- The chain IS the ModeConfig: dot-only, closure-free authoring; every verb
+--- returns the chain; modifiers apply to the most recent policy; modOptions
+--- stay re-derived from the policy bundle after every step, so consumers read
+--- a plain preset table. Structural choices lock by default (.Unlocked()
+--- opens them); numeric dials stay host-tunable (.Locked() pins them).
+
+local ModeBuilder = {}
+
+---Serialize a policy bundle through a serializer registry. Each policy
+---serializes only the options it owns — a second owner is an error.
+---@param serializers table<string, fun(params: table, lock: { structure: boolean, dial: boolean }): table<string, ModOptionConfig>>
+---@param bundle ModePolicyRef[]
+---@return table<string, ModOptionConfig>
+function ModeBuilder.ToModOptions(serializers, bundle)
+	local options = {}
+	for _, entry in ipairs(bundle) do
+		local name, params
+		if type(entry) == "table" then
+			name, params = entry[1], entry
+		else
+			name, params = entry, {}
+		end
+		local serialize = serializers[name]
+		if not serialize then
+			error("unknown mode policy: " .. tostring(name))
+		end
+		local lock = { structure = params.locked ~= false, dial = params.locked == true }
+		for key, option in pairs(serialize(params, lock)) do
+			if options[key] ~= nil then
+				error("two policies own modoption " .. key)
+			end
+			options[key] = option
+		end
+	end
+	return options
+end
+
+---Domain guard for vocabulary verbs.
+---@param modeName string for error messages
+---@param verb string
+---@param noun table
+---@param domains table<string, boolean> domains the verb accepts
+---@param hint string noun spelling for the error message
+---@return string domain
+function ModeBuilder.DomainOf(modeName, verb, noun, domains, hint)
+	assert(type(noun) == "table" and type(noun.domain) == "string",
+		modeName .. ": ." .. verb .. " expects a noun (" .. hint .. ")")
+	assert(domains[noun.domain], modeName .. ": ." .. verb .. " does not apply to " .. noun.domain)
+	return noun.domain
+end
+
+---Bind a module's vocabulary; returns the Mode chain entry for its preset files.
+---Verbs receive (modeName, ...) and return a policy ref { "<identity>", ... }.
+---@param grammar { category: string, serializers: table, verbs: table<string, fun(modeName: string, ...): table> }
+---@return fun(name: string): ModeConfig
+function ModeBuilder.Grammar(grammar)
+	---Start a mode chain; the key is the name's snake_case.
+	---@param name string
+	---@return ModeConfig
+	return function(name)
+		local chain = {
+			key = name:lower():gsub("%s+", "_"),
+			category = grammar.category,
+			name = name,
+			desc = "",
+			allowRanked = false,
+			policies = {}, ---@type ModePolicyRef[]
+			modOptions = {}, ---@type table<string, ModOptionConfig>
+		}
+
+		local function reserialize()
+			chain.modOptions = ModeBuilder.ToModOptions(grammar.serializers, chain.policies)
+			return chain
+		end
+
+		---@param modifier string
+		---@return table ref the most recent policy ref
+		local function lastPolicy(modifier)
+			local ref = chain.policies[#chain.policies]
+			assert(ref, name .. ": ." .. modifier .. " before any policy")
+			return ref
+		end
+
+		---@param desc string
+		chain.Desc = function(desc)
+			chain.desc = desc
+			return chain
+		end
+
+		---Allowed in ranked games.
+		chain.Ranked = function()
+			chain.allowRanked = true
+			return chain
+		end
+
+		---Non-sticky preset: entries expose/unlock options, current values are kept.
+		chain.RetainValues = function()
+			chain.retainValues = true
+			return chain
+		end
+
+		---The most recent policy's option stays out of the lobby UI.
+		chain.Hidden = function()
+			lastPolicy("Hidden").ui = "hidden"
+			return reserialize()
+		end
+
+		---The most recent policy unlocks entirely (structure and dials).
+		chain.Unlocked = function()
+			lastPolicy("Unlocked").locked = false
+			return reserialize()
+		end
+
+		---The most recent policy locks entirely, dials included.
+		chain.Locked = function()
+			lastPolicy("Locked").locked = true
+			return reserialize()
+		end
+
+		for verbName, toRef in pairs(grammar.verbs) do
+			assert(chain[verbName] == nil, "ModeBuilder.Grammar: verb collides with a chain field: " .. verbName)
+			chain[verbName] = function(...)
+				chain.policies[#chain.policies + 1] = toRef(name, ...)
+				return reserialize()
+			end
+		end
+
+		return chain
+	end
+end
+
+return ModeBuilder

--- a/modules/modes/module.lua
+++ b/modules/modes/module.lua
@@ -1,0 +1,7 @@
+--- Manifest for the modes module: mode-infrastructure that belongs to no
+--- gameplay module — presets are aggregated across every module's modes/.
+---@type ModuleManifestFile
+return {
+	name = "modes",
+	description = "Game mode infrastructure: preset aggregation and export",
+}

--- a/modules/modes/spec/mode_builder_spec.lua
+++ b/modules/modes/spec/mode_builder_spec.lua
@@ -1,0 +1,118 @@
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+
+--- A throwaway vocabulary: one noun, one verb, two serializers, so the tests
+--- exercise the builder rather than any module's real grammar.
+local function grammar()
+	return ModeBuilder.Grammar({
+		category = "test",
+		serializers = {
+			["end.scripted"] = function(_params, lock)
+				return { deathmode = { value = "neverend", locked = lock.structure } }
+			end,
+			["dial.rate"] = function(params, lock)
+				return { rate = { value = params.rate or 1, locked = lock.dial } }
+			end,
+		},
+		verbs = {
+			Own = function(modeName, noun)
+				return { ModeBuilder.DomainOf(modeName, "Own", noun, { ["end"] = true }, "Match.End") .. ".scripted" }
+			end,
+			Rate = function(_modeName, rate)
+				return { "dial.rate", rate = rate }
+			end,
+		},
+	})
+end
+
+local MatchEnd = { domain = "end" }
+
+describe("mode builder", function()
+	describe("the chain", function()
+		it("keys a mode by the snake_case of its name", function()
+			assert.are.equal("easy_tax", grammar()("Easy Tax").key)
+			assert.are.equal("test", grammar()("Easy Tax").category)
+		end)
+
+		it("returns the chain from every verb, so authoring stays dot-only", function()
+			local Mode = grammar()
+			local chain = Mode("Scripted")
+			assert.are.equal(chain, chain.Desc("d"))
+			assert.are.equal(chain, chain.Ranked())
+			assert.are.equal(chain, chain.Own(MatchEnd))
+			assert.are.equal(chain, chain.Locked())
+		end)
+
+		it("re-derives modOptions after every step, so consumers read a plain table", function()
+			local chain = grammar()("Scripted").Own(MatchEnd)
+			assert.are.equal("neverend", chain.modOptions.deathmode.value)
+			chain.Rate(5)
+			assert.are.equal(5, chain.modOptions.rate.value)
+			-- the earlier policy's options survive the re-derivation
+			assert.are.equal("neverend", chain.modOptions.deathmode.value)
+		end)
+
+		it("refuses a modifier before any policy", function()
+			assert.has_error(function()
+				grammar()("Scripted").Locked()
+			end, "Scripted: .Locked before any policy")
+		end)
+
+		it("refuses a verb that collides with a chain field", function()
+			assert.has_error(function()
+				ModeBuilder.Grammar({
+					category = "test",
+					serializers = {},
+					verbs = { Desc = function() end },
+				})("Scripted")
+			end, "ModeBuilder.Grammar: verb collides with a chain field: Desc")
+		end)
+	end)
+
+	describe("lock defaults", function()
+		it("locks structure by default and leaves dials host-tunable", function()
+			local chain = grammar()("Scripted").Own(MatchEnd).Rate(2)
+			assert.is_true(chain.modOptions.deathmode.locked)
+			assert.is_false(chain.modOptions.rate.locked)
+		end)
+
+		it("Unlocked opens structure, Locked pins dials", function()
+			assert.is_false(grammar()("Scripted").Own(MatchEnd).Unlocked().modOptions.deathmode.locked)
+			assert.is_true(grammar()("Scripted").Rate(2).Locked().modOptions.rate.locked)
+		end)
+	end)
+
+	describe("serialization", function()
+		it("rejects a policy no serializer owns", function()
+			assert.has_error(function()
+				ModeBuilder.ToModOptions({}, { "end.scripted" })
+			end, "unknown mode policy: end.scripted")
+		end)
+
+		it("rejects two policies owning one modoption", function()
+			local double = function()
+				return { deathmode = { value = "x", locked = true } }
+			end
+			assert.has_error(function()
+				ModeBuilder.ToModOptions({ a = double, b = double }, { "a", "b" })
+			end, "two policies own modoption deathmode")
+		end)
+	end)
+
+	describe("domain guard", function()
+		it("returns the noun's domain when the verb accepts it", function()
+			assert.are.equal("end", ModeBuilder.DomainOf("M", "Own", MatchEnd, { ["end"] = true }, "Match.End"))
+		end)
+
+		it("rejects a value that is not a noun", function()
+			assert.has_error(function()
+				ModeBuilder.DomainOf("M", "Own", "end", { ["end"] = true }, "Match.End")
+			end, "M: .Own expects a noun (Match.End)")
+		end)
+
+		it("rejects a noun the verb does not apply to", function()
+			assert.has_error(function()
+				ModeBuilder.DomainOf("M", "Own", { domain = "share" }, { ["end"] = true }, "Match.End")
+			end, "M: .Own does not apply to share")
+		end)
+	end)
+end)

--- a/modules/modes/widgets/export_game_modes.lua
+++ b/modules/modes/widgets/export_game_modes.lua
@@ -1,0 +1,117 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Game Modes JSON Export",
+		desc = "Exports all game mode presets (modes/<category>/*.lua) to structured JSON.\nCommand: /exportgamemodes",
+		author = "Daniel Harvey",
+		date = "June 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = false,
+	}
+end
+
+-- Emit the Lua mode presets overlaid on modoptions.lua defaults as JSON so out-of-engine
+-- consumers (SPADS ModeCommand plugin) can expand a mode selection into its full option set.
+
+local spEcho = Spring.Echo
+
+local SCHEMA_VERSION = 1
+local OUTPUT_PATH = "game_modes.json"
+
+-- modoptions are strings; booleans -> "1"/"0", numbers rounded at float32 precision to avoid noise.
+local function toModOptionValue(v)
+	if type(v) == "boolean" then
+		return v and "1" or "0"
+	end
+	if type(v) == "number" then
+		local s = string.format("%.7f", v):gsub("0+$", ""):gsub("%.$", "")
+		return s
+	end
+	return tostring(v)
+end
+
+-- Each modoption section becomes a mode category's default base: section name == category.
+local function collectDefaultsBySection()
+	local bySection = {}
+	for _, o in ipairs(VFS.Include("modoptions.lua")) do
+		if o.key and o.section and o.def ~= nil and o.type ~= "section" and o.type ~= "subheader" and o.type ~= "separator" then
+			bySection[o.section] = bySection[o.section] or {}
+			bySection[o.section][o.key] = toModOptionValue(o.def)
+		end
+	end
+	return bySection
+end
+
+-- Discover every mode under modules/<name>/modes/*.lua; key/category-less returns are skipped.
+local function collectModesByCategory()
+	local ModuleHandler = VFS.Include("modules/module_handler.lua")
+	local byCategory = {}
+	for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+		for _, modeFile in ipairs(VFS.DirList(dir, "*.lua") or {}) do
+			local ok, mode = pcall(VFS.Include, modeFile)
+			if ok and type(mode) == "table" and mode.key and mode.category then
+				byCategory[mode.category] = byCategory[mode.category] or {}
+				byCategory[mode.category][mode.key] = mode
+			end
+		end
+	end
+	return byCategory
+end
+
+-- Full effective option set (defaults then overrides), so applying a mode resets the previous one.
+local function buildEffectiveModOptions(defaults, mode, selector)
+	local effective = {}
+	for key, value in pairs(defaults) do
+		if key ~= selector then
+			effective[key] = { value = value, locked = false }
+		end
+	end
+	for key, rule in pairs(mode.modOptions or {}) do
+		if key ~= selector and rule.value ~= nil then
+			effective[key] = { value = toModOptionValue(rule.value), locked = rule.locked == true }
+		end
+	end
+	return effective
+end
+
+local function buildExport()
+	local defaultsBySection = collectDefaultsBySection()
+	local modesByCategory = collectModesByCategory()
+
+	local categories = {}
+	for category, modes in pairs(modesByCategory) do
+		local selector = category .. "_mode"
+		local defaults = defaultsBySection[category] or {}
+		local presets = {}
+		for modeKey, mode in pairs(modes) do
+			presets[modeKey] = {
+				name = mode.name,
+				desc = mode.desc,
+				allowRanked = mode.allowRanked,
+				modOptions = buildEffectiveModOptions(defaults, mode, selector),
+			}
+		end
+		categories[category] = { selector = selector, presets = presets }
+	end
+
+	return { schemaVersion = SCHEMA_VERSION, categories = categories }
+end
+
+local function ExportGameModes()
+	local file, err = io.open(OUTPUT_PATH, "w")
+	if not file then
+		spEcho("Game Modes JSON Export: could not open " .. OUTPUT_PATH .. ": " .. tostring(err))
+		return
+	end
+	file:write(Json.encode(buildExport()))
+	file:close()
+	spEcho("Game Modes JSON Export: wrote " .. OUTPUT_PATH)
+end
+
+function widget:TextCommand(command)
+	if command == "exportgamemodes" then
+		ExportGameModes()
+	end
+end


### PR DESCRIPTION
`mode_builder` emits ModeConfigs and has no runtime of its own; a module binds its own vocabulary over it and its preset files read as a dot-only chain.

145 lines every module's mode vocabulary passes through, previously tested only via the presets built on it. Now spec'd directly: structural choices lock by default, dials stay host-tunable, a second owner of a modoption is an error.