### PR TITLE
modules — 6/12: the trigger runtime and the DSL

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -57,3 +57,9 @@ globals = {
 
     "CMDTYPE", "COBSCALE", "CallAsTeam", "SYNCED", "loadlib",
 }
+
+-- Mission trigger files run in the mission_loader sandbox; these are its
+-- injected environment (modules/missions/types/dsl.lua mirrors it).
+files["modules/missions/**/triggers/**"] = {
+    read_globals = { "When", "Objective", "UnitDef", "Team", "MatchFlow" },
+}

--- a/luaui/Tests/hello_pawns/test_win.lua
+++ b/luaui/Tests/hello_pawns/test_win.lua
@@ -1,0 +1,93 @@
+---@diagnostic disable: lowercase-global, undefined-field
+
+-- Plays the hello_pawns mission end to end: load it via the chat command,
+-- reach 3 Pawns, expect scripted victory through the matchflow verdict path.
+-- Fails if DSL registration breaks, the loader env is missing a verb, the
+-- condition never fires, or the verdict path is disconnected.
+--
+-- NOTE: this test really ends the game (Spring.GameOver). If it disturbs
+-- later tests in a full suite run, scope the run: `runtestsheadless hello_pawns`.
+
+local PAWN = "armpw"
+local PAWN_COUNT = 3
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	-- SyncedRun ships the caller's stack locals (not upvalues), so copy the
+	-- file-level config into locals for the spawn block below.
+	local pawnName = PAWN
+	local pawnCount = PAWN_COUNT
+	local teamID = Spring.GetLocalTeamID()
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+	local pawnDefID = UnitDefNames[PAWN].id
+
+	-- Arm the mission via the same chat command a player would use.
+	Spring.SendCommands("luarules mission hello_pawns")
+	Test.waitUntil(function()
+		return Spring.GetGameRulesParam("mission_active") == 1
+	end)
+
+	-- Buffer GameOver before anything can win.
+	Test.expectCallin("GameOver")
+
+	-- Cheat-spawn toward the objective instead of really building: two finished
+	-- Pawns plus one nanoframe. Has() means COMPLETED units — the nanoframe
+	-- must not win the mission (the factory-blueprint bug).
+	local x = Game.mapSizeX / 2
+	local z = Game.mapSizeZ / 2
+	local frameUnitID = SyncedRun(function(locals)
+		for i = 1, locals.pawnCount - 1 do
+			Spring.CreateUnit(locals.pawnName, locals.x + i * 32, Spring.GetGroundHeight(locals.x + i * 32, locals.z), locals.z, 0, locals.teamID)
+		end
+		-- The nanoframe needs a live builder: unit_prevent_lab_hax2 destroys
+		-- fresh under-construction units whose builder is dead/absent.
+		local builderID = Spring.CreateUnit("armck", locals.x - 64, Spring.GetGroundHeight(locals.x - 64, locals.z), locals.z, 0, locals.teamID)
+		local unitID = Spring.CreateUnit(locals.pawnName, locals.x, Spring.GetGroundHeight(locals.x, locals.z), locals.z, 0, locals.teamID, true, true, nil, builderID)
+		if unitID ~= nil then
+			-- Give it real progress so abandoned-nanoframe decay stays far away.
+			Spring.SetUnitHealth(unitID, { build = 0.8 })
+		end
+		return unitID
+	end)
+	assert(frameUnitID ~= nil, "failed to spawn the nanoframe Pawn")
+
+	Test.waitUntil(function()
+		return Spring.GetTeamUnitDefCount(teamID, pawnDefID) >= PAWN_COUNT
+	end)
+
+	-- Two evaluation cadences with the third Pawn still a nanoframe: no verdict.
+	Test.waitFrames(2 * 15 + 2)
+	assert(Spring.GetGameRulesParam("objective_build_pawns") ~= 1, "mission must not complete while the third Pawn is a nanoframe")
+
+	-- Finish the build; NOW the mission should be won.
+	SyncedRun(function(locals)
+		Spring.SetUnitHealth(locals.frameUnitID, { build = 1 })
+	end)
+
+	-- The mission's effect chain: objective completes, then scripted victory
+	-- for the player's ally team.
+	Test.waitUntilCallin("GameOver", function(winningAllyTeams)
+		if type(winningAllyTeams) ~= "table" then
+			return false
+		end
+		for _, winner in ipairs(winningAllyTeams) do
+			if winner == allyTeamID then
+				return true
+			end
+		end
+		return false
+	end, 10 * 30)
+
+	assert(Spring.GetGameRulesParam("objective_build_pawns") == 1, "objective build_pawns should be complete before victory")
+end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -1047,6 +1047,9 @@ local function initializeTestEnvironment()
 		type = type,
 		unpack = unpack,
 		select = select,
+		setmetatable = setmetatable,
+		getmetatable = getmetatable,
+		getfenv = getfenv,
 		Scenario = scenarioConfig,
 
 		Json = Json,

--- a/modules/missions/README.md
+++ b/modules/missions/README.md
@@ -1,0 +1,27 @@
+# The missions module
+
+Mission logic is authored as dot-only, closure-free, terminator-free trigger chains in
+missions/<name>/triggers/*.lua. The loader includes each file in an injected
+environment (the env IS the API surface), the DSL builds descriptors, and the
+trigger engine evaluates them — event-driven where conditions declare inputs,
+polling as the fallback. Effects are lazy objects executed when a condition
+fires; matchflow owns the game-over verdict.
+
+```mermaid
+flowchart TB
+    LUA["missions/&lt;name&gt;/triggers/*.lua<br/>dot-only, closure-free chains"]
+    subgraph SYNCED["synced runtime"]
+        LOADER["mission_loader gadget<br/>injected env = the API surface;<br/>wires only watched callins"]
+        DSL["DSL builder<br/>When/.When/Do/Once — no terminator;<br/>finalized at include → TriggerDescriptor"]
+        ENGINE["trigger engine<br/>input→watchers index · dirty marks<br/>state tables (the save pile)"]
+        BUS["event bus (engine.OnEvent)<br/>engine callins + module events<br/>('UnitFinished', 'mission.objective_changed')"]
+        MF["matchflow module<br/>Victory/Defeat → pending verdict"]
+        VG["verdict gadget<br/>deferred, idempotent Spring.GameOver"]
+    end
+    LUA -->|"VFS.Include per file<br/>(hot reload by identity)"| LOADER
+    LOADER --> DSL -->|"descriptors"| ENGINE
+    LOADER -->|"forward watched callins"| BUS --> ENGINE
+    ENGINE -->|"execute effects"| MF
+    ENGINE -->|"Objective(...).Complete() emits<br/>'mission.objective_changed'"| BUS
+    MF --> VG
+```

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -1,0 +1,279 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Mission Loader",
+		desc = "Loads mission trigger files (/luarules mission <name>) into the trigger engine and evaluates them on a cadence",
+		author = "Beyond All Reason",
+		date = "July 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local LOG_TAG = "mission_loader"
+
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local ChatGuard = VFS.Include("modules/missions/lib/chat_guard.lua")
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local MISSIONS_DIR = "modules/missions/"
+local EVALUATE_PERIOD = 15 -- frames
+
+local engine = TriggerEngine.New()
+local activeMission = nil ---@type string|nil
+
+--- The engine's view of the world. Built once; frame is updated per tick.
+---@type MissionContext
+local ctx = {
+	frame = 0,
+	GetUnitDefCount = function(teamID, unitDefName)
+		local unitDef = UnitDefNames[unitDefName]
+		if unitDef == nil then
+			return 0
+		end
+		-- GetTeamUnitDefCount includes nanoframes; Has() means finished units,
+		-- so filter out anything still being built.
+		local count = 0
+		for _, unitID in ipairs(Spring.GetTeamUnitsByDefs(teamID, unitDef.id)) do
+			if not Spring.GetUnitIsBeingBuilt(unitID) then
+				count = count + 1
+			end
+		end
+		return count
+	end,
+	IsObjectiveComplete = function(name)
+		return Spring.GetGameRulesParam("objective_" .. name) == 1
+	end,
+}
+
+---Demo rule (documented in hello_pawns_plan.md): Team.Player is the first
+---human team — lowest non-Gaia teamID with no Lua AI and not the AI-hosted kind.
+---@return MissionTeam|nil
+local function resolvePlayerTeam()
+	local gaiaTeamID = Spring.GetGaiaTeamID()
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaiaTeamID then
+			local _, _, _, isAiTeam, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+			if not isAiTeam and (Spring.GetTeamLuaAI(teamID) or "") == "" then
+				return Verbs.MakeTeam(teamID, allyTeamID)
+			end
+		end
+	end
+	return nil
+end
+
+---Objective verb, demo-minimal. Closure-free surface: Complete() is LAZY —
+---it builds an effect the engine executes when the trigger fires, so mission
+---files chain it with Do instead of wrapping it in a function. IsComplete()
+---is the condition side, so victory can be its own trigger driven by
+---objective state (the "all objectives complete -> win" shape in miniature).
+---Completion state lives in rulesparams (objective_<name>) —
+---engine-serialized, so it survives a savegame like the rest of the trigger
+---progress pile.
+---
+---Rulesparam changes have no callin, but this module is the thing that
+---completes objectives — so Complete() emits "mission.objective_changed" on
+---the mission bus, and IsComplete() declares it as its input (see
+---mission_authoring_dsl.md, "Conditions declare their inputs").
+---@param name string
+---@return MissionObjective
+local function Objective(name)
+	return {
+		Complete = function()
+			return {
+				execute = function()
+					Spring.SetGameRulesParam("objective_" .. name, 1)
+					Spring.Echo("[" .. LOG_TAG .. "] objective complete: " .. name)
+					engine.OnEvent("mission.objective_changed")
+				end,
+			}
+		end,
+		IsComplete = function()
+			return {
+				inputs = { "mission.objective_changed" },
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return ctx.IsObjectiveComplete(name)
+				end,
+			}
+		end,
+	}
+end
+
+-- Engine callins the bus can forward. The gadget hooks ONLY the callins some
+-- registered trigger actually watches (the don't-hook-what-you-don't-use
+-- rule, applied automatically per mission); everything else stays unhooked.
+local FORWARDABLE_CALLINS = { "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken" }
+
+---(Re)hook engine callins to match the engine's watched-input set. Called
+---after every mission (re)load, when the watch set may have changed.
+local function syncWatchedCallins()
+	local watched = engine.WatchedInputs()
+	for _, name in ipairs(FORWARDABLE_CALLINS) do
+		if watched[name] and gadget[name] == nil then
+			gadget[name] = function()
+				engine.OnEvent(name)
+			end
+			gadgetHandler:UpdateCallIn(name)
+		elseif not watched[name] and gadget[name] ~= nil then
+			gadget[name] = nil
+			gadgetHandler:UpdateCallIn(name)
+		end
+	end
+end
+
+---The MatchFlow verbs injected into mission files: same names as the module
+---api, but LAZY — Victory(team) builds an effect for a Do chain; the module's
+---imperative api fires only when the trigger does. Takes the Team handle, not
+---a raw allyTeam id, so the mission line reads as English.
+---@param matchflowApi table the matchflow module api (ModuleHandler.Get)
+---@return MissionMatchFlow
+local function makeMatchFlowVerbs(matchflowApi)
+	return {
+		---@param team MissionTeam
+		---@return MissionEffect
+		Victory = function(team)
+			assert(type(team) == "table" and type(team.allyTeam) == "number",
+				"MatchFlow.Victory expects a Team handle (e.g. Team.Player)")
+			return {
+				execute = function()
+					matchflowApi.Victory(team.allyTeam)
+				end,
+			}
+		end,
+		---@param team MissionTeam
+		---@return MissionEffect
+		Defeat = function(team)
+			assert(type(team) == "table" and type(team.allyTeam) == "number",
+				"MatchFlow.Defeat expects a Team handle (e.g. Team.Player)")
+			return {
+				execute = function()
+					matchflowApi.Defeat({ team.allyTeam })
+				end,
+			}
+		end,
+	}
+end
+
+---Load (or reload) a mission: run each triggers/*.lua through the injected
+---environment. The sandbox IS the API surface — trigger files see the five
+---verbs and nothing else. Unregister-by-identity first makes loading
+---idempotent and is the hot-reload path.
+---Erase the objective progress pile. The loader owns the objective_ prefix;
+---progress clears with the triggers, so a reload is a fresh run and a
+---completed objective cannot re-fire its trigger on the next cadence.
+local function resetObjectives()
+	for name in pairs(Spring.GetGameRulesParams()) do
+		if name:find("^objective_") then
+			Spring.SetGameRulesParam(name, nil)
+		end
+	end
+end
+
+---@param missionName string
+---@return boolean loaded
+local function loadMission(missionName)
+	local triggersDir = MISSIONS_DIR .. missionName .. "/triggers/"
+	local files = VFS.DirList(triggersDir, "*.lua")
+	if #files == 0 then
+		Spring.Log(LOG_TAG, LOG.ERROR, "no trigger files under " .. triggersDir)
+		return false
+	end
+	table.sort(files)
+
+	local playerTeam = resolvePlayerTeam()
+	if playerTeam == nil then
+		Spring.Log(LOG_TAG, LOG.ERROR, "no human team found for Team.Player")
+		return false
+	end
+
+	local matchFlow = makeMatchFlowVerbs(ModuleHandler.Get("matchflow"))
+
+	-- One transaction: the incoming mission arms into a staging engine that
+	-- is swapped in whole. Unregistering per incoming file would leave a
+	-- renamed or deleted trigger armed, and a file that fails to parse would
+	-- take the running mission with it.
+	local staging = TriggerEngine.New()
+	local parsed, err = pcall(function()
+		for _, filePath in ipairs(files) do
+			-- Identity is mission-relative so ids survive install-path differences.
+			local filename = filePath:sub(#MISSIONS_DIR + 1)
+			local file = DSL.ForFile(filename, staging.Register)
+			local env = {
+				When = file.When,
+				Team = { Player = playerTeam },
+				UnitDef = Verbs.UnitDef,
+				Objective = Objective,
+				MatchFlow = matchFlow,
+			}
+			VFS.Include(filePath, env)
+			-- Statements register here, and a half-finished chain (no Do) is a
+			-- load error naming the file and statement.
+			file.Finalize()
+		end
+	end)
+	if not parsed then
+		Spring.Log(LOG_TAG, LOG.ERROR, tostring(err))
+		return false
+	end
+
+	-- The commit point: the armed set is replaced, not amended, and the
+	-- progress that belonged to it goes with it.
+	engine = staging
+	resetObjectives()
+	syncWatchedCallins()
+	activeMission = missionName
+	Spring.SetGameRulesParam("mission_active", 1)
+	Spring.Echo("[" .. LOG_TAG .. "] mission armed: " .. missionName .. " (" .. #engine.Triggers() .. " trigger(s))")
+	return true
+end
+
+---@param cmd string
+---@param line string
+---@param words string[]
+local function missionChatAction(cmd, line, words, playerID)
+	-- Synced chat actions arrive from ANY player in multiplayer; arming or
+	-- reloading a mission is not an open verb (review point on PR #8375).
+	if not ChatGuard.IsAllowed(Spring.Utilities.Gametype.IsSinglePlayer(), Spring.IsCheatingEnabled()) then
+		Spring.Log(LOG_TAG, LOG.WARNING, "/mission refused: multiplayer without cheats (player " .. tostring(playerID) .. ")")
+		return true
+	end
+	local missionName = words[1]
+	if missionName == nil or missionName == "" then
+		Spring.Log(LOG_TAG, LOG.ERROR, "usage: /luarules mission <name> | reload")
+		return true
+	end
+	if missionName == "reload" then
+		if activeMission == nil then
+			Spring.Log(LOG_TAG, LOG.ERROR, "no active mission to reload")
+			return true
+		end
+		missionName = activeMission
+	end
+	loadMission(missionName)
+	return true
+end
+
+function gadget:Initialize()
+	gadgetHandler:AddChatAction("mission", missionChatAction, "load a mission: /luarules mission <name>")
+end
+
+function gadget:Shutdown()
+	gadgetHandler:RemoveChatAction("mission")
+end
+
+---@param frame integer
+function gadget:GameFrame(frame)
+	if activeMission ~= nil and frame % EVALUATE_PERIOD == 0 then
+		ctx.frame = frame
+		engine.Evaluate(ctx)
+	end
+end

--- a/modules/missions/hello_pawns/triggers/win.lua
+++ b/modules/missions/hello_pawns/triggers/win.lua
@@ -1,0 +1,5 @@
+When(Team.Player.Has(UnitDef("armpw"), 3))
+	.Do(Objective("build_pawns").Complete())
+
+When(Objective("build_pawns").IsComplete())
+	.Do(MatchFlow.Victory(Team.Player))

--- a/modules/missions/lib/chat_guard.lua
+++ b/modules/missions/lib/chat_guard.lua
@@ -1,0 +1,17 @@
+--- Who may drive mission chat commands. Pure — the gadget supplies the
+--- Spring facts — so the policy specs under busted.
+---
+--- Missions are a dev/campaign surface: in multiplayer, any player can send
+--- a synced chat action, so arming or reloading a mission must not be an
+--- open verb. Singleplayer is always allowed; elsewhere cheats must be on.
+
+local ChatGuard = {}
+
+---@param isSinglePlayer boolean
+---@param cheatsEnabled boolean
+---@return boolean
+function ChatGuard.IsAllowed(isSinglePlayer, cheatsEnabled)
+	return isSinglePlayer == true or cheatsEnabled == true
+end
+
+return ChatGuard

--- a/modules/missions/lib/dsl.lua
+++ b/modules/missions/lib/dsl.lua
@@ -1,0 +1,143 @@
+--- The mission authoring DSL builder: chain -> descriptor -> sink, the
+--- policy_builder idiom. Pure Lua, no Spring.
+---
+--- The surface is dot-only, closure-free, and terminator-free:
+---
+---     When(Team.Player.Has(UnitDef("armpw"), 3))
+---         .Do(Objective("build_pawns").Complete())
+---
+--- No colon methods, no metatables, no function bodies, no Register. A
+--- statement's identity is the chain object the When call creates — every
+--- .When/.Do returns it, so Lua's own parser attaches continuation lines and
+--- separates statements (they start with the name `When`; whitespace was
+--- never the delimiter). Repeated .When AND-composes. The loader calls
+--- Finalize after including the file: every chain registers in creation
+--- order, and a chain without a Do is a load error naming the file — the
+--- transaction check Register used to provide, without the ceremony.
+---
+--- Trigger identity = filename + declaration order (When-call order),
+--- stamped at Finalize — the key hot reload unregisters by.
+
+local DSL = {}
+
+---Build one trigger file's authoring surface: the `When` chain entry the
+---loader injects, and the Finalize the loader calls after the include.
+---@param filename string mission-relative path, e.g. "triggers/win.lua"
+---@param sink fun(descriptor: TriggerDescriptor)
+---@return { When: fun(condition: MissionCondition): TriggerChain, Finalize: fun(): integer }
+function DSL.ForFile(filename, sink)
+	local chains = {} ---@type table[] chain build-state, in When-call (declaration) order
+	local finalized = false
+
+	---@param condition MissionCondition
+	---@return TriggerChain
+	local When = function(condition)
+		assert(not finalized, filename .. ": When after Finalize — the file already loaded")
+		assert(type(condition) == "table" and type(condition.evaluate) == "function",
+			filename .. ": When expects a condition (a table with an evaluate function)")
+
+		local build = {
+			conditions = { condition }, ---@type MissionCondition[]
+			effects = {}, ---@type MissionEffect[]
+			once = true,
+		}
+		chains[#chains + 1] = build
+
+		local chain = {}
+
+		---Another condition on the same statement; all must hold (AND).
+		---@param another MissionCondition
+		---@return TriggerChain
+		chain.When = function(another)
+			assert(not finalized, filename .. ": When after Finalize — the file already loaded")
+			assert(type(another) == "table" and type(another.evaluate) == "function",
+				filename .. ": .When expects a condition (a table with an evaluate function)")
+			build.conditions[#build.conditions + 1] = another
+			return chain
+		end
+
+		---@param effect MissionEffect a lazy effect built by a named verb
+		---@return TriggerChain
+		chain.Do = function(effect)
+			assert(not finalized, filename .. ": Do after Finalize — the file already loaded")
+			assert(type(effect) == "table" and type(effect.execute) == "function",
+				filename .. ": Do expects an effect (a table with an execute function) — build one with a named verb like Objective(...).Complete()")
+			build.effects[#build.effects + 1] = effect
+			return chain
+		end
+
+		---@param flag boolean?
+		---@return TriggerChain
+		chain.Once = function(flag)
+			assert(not finalized, filename .. ": Once after Finalize — the file already loaded")
+			build.once = flag ~= false
+			return chain
+		end
+
+		return chain
+	end
+
+	---The commit point: called by the loader when the file's include
+	---returns. Registers every chain in declaration order; a chain without a
+	---Do is a load error here — half-finished statements cannot arm.
+	---@return integer registered count
+	local Finalize = function()
+		assert(not finalized, filename .. ": Finalize called twice")
+		finalized = true
+		-- Validate before committing anything: a failed load arms nothing.
+		for order, build in ipairs(chains) do
+			if #build.effects == 0 then
+				error(filename .. ": statement " .. order .. " has no Do — every trigger needs at least one effect")
+			end
+		end
+		for order, build in ipairs(chains) do
+			local combined = build.conditions[1]
+			if #build.conditions > 1 then
+				-- AND-composition. Inputs compose as the UNION of the parts';
+				-- any poll-only part (nil inputs) makes the whole trigger
+				-- poll. The closure captures the conditions list —
+				-- configuration, never progress (the savegame rule holds).
+				local conditions = build.conditions
+				local union = {}
+				local seen = {}
+				for _, part in ipairs(conditions) do
+					if part.inputs == nil then
+						union = nil
+						break
+					end
+					for _, input in ipairs(part.inputs) do
+						if not seen[input] then
+							seen[input] = true
+							union[#union + 1] = input
+						end
+					end
+				end
+				combined = {
+					inputs = union,
+					---@param ctx MissionContext
+					evaluate = function(ctx)
+						for _, part in ipairs(conditions) do
+							if not part.evaluate(ctx) then
+								return false
+							end
+						end
+						return true
+					end,
+				}
+			end
+			sink({
+				id = filename .. ":" .. order,
+				filename = filename,
+				order = order,
+				condition = combined,
+				effects = build.effects,
+				once = build.once,
+			})
+		end
+		return #chains
+	end
+
+	return { When = When, Finalize = Finalize }
+end
+
+return DSL

--- a/modules/missions/lib/trigger_engine.lua
+++ b/modules/missions/lib/trigger_engine.lua
@@ -1,0 +1,151 @@
+--- Mission trigger engine: holds registered triggers, evaluates their
+--- conditions on the caller's cadence, runs effects. Pure Lua — no Spring —
+--- so it specs under busted.
+---
+--- State discipline (the savegame rule, enforced from commit one): trigger
+--- progress — fired flags — lives in the engine's plain `state` table, never
+--- in closures. Definitions are the source pile; `state` is the save pile.
+---
+--- Conditions declare their inputs (mission_authoring_dsl.md): the engine
+--- indexes input -> watching triggers at Register; OnEvent marks watchers
+--- dirty; the evaluation cadence processes dirty triggers plus pollers
+--- (conditions with nil inputs). The watcher index and dirty flags are
+--- DERIVED — rebuilt from source at load, never serialized.
+
+local TriggerEngine = {}
+
+---@class MissionTriggerEngine
+---@field Register fun(descriptor: TriggerDescriptor)
+---@field UnregisterFile fun(filename: string): integer removed count
+---@field OnEvent fun(name: MissionEventName) mark the input's watchers dirty (the mission bus entry point)
+---@field WatchedInputs fun(): table<MissionEventName, boolean> input names some registered trigger watches
+---@field Evaluate fun(ctx: MissionContext)
+---@field Triggers fun(): TriggerDescriptor[] registration order, read-only by convention
+---@field GetState fun(): TriggerEngineState the serializable progress pile
+---@field SetState fun(state: TriggerEngineState) reapply saved progress over reloaded definitions
+
+---@return MissionTriggerEngine
+function TriggerEngine.New()
+	local triggers = {} ---@type TriggerDescriptor[]
+	local state = { fired = {} } ---@type TriggerEngineState
+	-- Derived, never serialized: input name -> { [id] = true } watchers;
+	-- poller ids (nil-inputs conditions); ids awaiting evaluation.
+	local watchers = {} ---@type table<string, table<string, boolean>>
+	local pollers = {} ---@type table<string, boolean>
+	local dirty = {} ---@type table<string, boolean>
+
+	local engine = {}
+
+	---@param descriptor TriggerDescriptor
+	engine.Register = function(descriptor)
+		assert(type(descriptor.id) == "string", "trigger descriptor needs an id")
+		assert(type(descriptor.condition) == "table" and type(descriptor.condition.evaluate) == "function",
+			descriptor.id .. ": condition must have an evaluate function")
+		assert(type(descriptor.effects) == "table" and #descriptor.effects > 0,
+			descriptor.id .. ": descriptor needs a non-empty effects list")
+		for _, effect in ipairs(descriptor.effects) do
+			assert(type(effect) == "table" and type(effect.execute) == "function",
+				descriptor.id .. ": every effect must have an execute function")
+		end
+		for _, existing in ipairs(triggers) do
+			if existing.id == descriptor.id then
+				error("duplicate trigger id: " .. descriptor.id)
+			end
+		end
+		triggers[#triggers + 1] = descriptor
+		local inputs = descriptor.condition.inputs
+		if inputs == nil then
+			pollers[descriptor.id] = true
+		else
+			for _, input in ipairs(inputs) do
+				watchers[input] = watchers[input] or {}
+				watchers[input][descriptor.id] = true
+			end
+		end
+		-- A trigger armed mid-game evaluates once immediately, whatever its
+		-- inputs — its condition may already hold.
+		dirty[descriptor.id] = true
+	end
+
+	---Remove every trigger registered from `filename`, and its progress —
+	---the hot-reload half of unregister-by-identity.
+	---@param filename string
+	---@return integer removed
+	engine.UnregisterFile = function(filename)
+		local kept, removed = {}, 0
+		for _, trigger in ipairs(triggers) do
+			if trigger.filename == filename then
+				removed = removed + 1
+				state.fired[trigger.id] = nil
+				pollers[trigger.id] = nil
+				dirty[trigger.id] = nil
+				for _, ids in pairs(watchers) do
+					ids[trigger.id] = nil
+				end
+			else
+				kept[#kept + 1] = trigger
+			end
+		end
+		for input, ids in pairs(watchers) do
+			if next(ids) == nil then
+				watchers[input] = nil
+			end
+		end
+		triggers = kept
+		return removed
+	end
+
+	---An event on the mission bus: engine callins and module events are the
+	---same kind of string here. Marks the input's watchers for evaluation on
+	---the next cadence.
+	---@param name MissionEventName
+	engine.OnEvent = function(name)
+		for id in pairs(watchers[name] or {}) do
+			dirty[id] = true
+		end
+	end
+
+	---@return table<string, boolean>
+	engine.WatchedInputs = function()
+		local out = {}
+		for input in pairs(watchers) do
+			out[input] = true
+		end
+		return out
+	end
+
+	---@param ctx MissionContext
+	engine.Evaluate = function(ctx)
+		for _, trigger in ipairs(triggers) do
+			local id = trigger.id
+			if pollers[id] or dirty[id] then
+				dirty[id] = nil
+				if not (trigger.once and state.fired[id]) and trigger.condition.evaluate(ctx) then
+					state.fired[id] = true
+					for _, effect in ipairs(trigger.effects) do
+						effect.execute(ctx)
+					end
+				end
+			end
+		end
+	end
+
+	---@return TriggerDescriptor[]
+	engine.Triggers = function()
+		return triggers
+	end
+
+	---@return TriggerEngineState
+	engine.GetState = function()
+		return state
+	end
+
+	---@param saved TriggerEngineState
+	engine.SetState = function(saved)
+		state = saved
+	end
+
+	return engine
+end
+
+return TriggerEngine

--- a/modules/missions/lib/verbs.lua
+++ b/modules/missions/lib/verbs.lua
@@ -1,0 +1,48 @@
+--- The three demo verbs' pure halves: UnitDef refs and the Team handle with
+--- its Has condition. No Spring here — conditions read counts from the ctx the
+--- engine is handed, so this specs under busted; the gadget supplies a ctx
+--- backed by Spring.GetTeamUnitDefCount.
+---
+--- Conditions capture configuration only (team id, unit name, threshold) —
+--- never progress. Dot-only surface, same rule as the chain DSL.
+
+local Verbs = {}
+
+---@param name string unit def name, e.g. "armpw"
+---@return MissionUnitDefRef
+function Verbs.UnitDef(name)
+	assert(type(name) == "string", "UnitDef expects a unit def name string")
+	return { name = name }
+end
+
+---Build a Team handle for one team.
+---@param teamID integer
+---@param allyTeam integer
+---@return MissionTeam
+function Verbs.MakeTeam(teamID, allyTeam)
+	local team = {
+		teamID = teamID,
+		allyTeam = allyTeam,
+	}
+
+	---@param unitDef MissionUnitDefRef
+	---@param count integer
+	---@return MissionCondition
+	team.Has = function(unitDef, count)
+		assert(type(unitDef) == "table" and type(unitDef.name) == "string",
+			"Team.Has expects a UnitDef(...) reference")
+		assert(type(count) == "number", "Team.Has expects a count")
+		return {
+			-- Transfers move counts too, hence Given/Taken.
+			inputs = { "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken" },
+			---@param ctx MissionContext
+			evaluate = function(ctx)
+				return ctx.GetUnitDefCount(teamID, unitDef.name) >= count
+			end,
+		}
+	end
+
+	return team
+end
+
+return Verbs

--- a/modules/missions/module.lua
+++ b/modules/missions/module.lua
@@ -1,0 +1,7 @@
+--- Manifest for the mission-runtime module (the CampaignAPI home).
+---@type ModuleManifestFile
+return {
+	name = "missions",
+	description = "Mission runtime: trigger engine, authoring DSL, mission loader",
+	requires = { "matchflow" },
+}

--- a/modules/missions/spec/chat_guard_spec.lua
+++ b/modules/missions/spec/chat_guard_spec.lua
@@ -1,0 +1,18 @@
+local ChatGuard = VFS.Include("modules/missions/lib/chat_guard.lua")
+
+describe("mission chat guard", function()
+	it("always allows singleplayer", function()
+		assert.is_true(ChatGuard.IsAllowed(true, false))
+		assert.is_true(ChatGuard.IsAllowed(true, true))
+	end)
+
+	it("allows multiplayer only with cheats enabled", function()
+		assert.is_true(ChatGuard.IsAllowed(false, true))
+		assert.is_false(ChatGuard.IsAllowed(false, false))
+	end)
+
+	it("treats missing facts as denial, not permission", function()
+		assert.is_false(ChatGuard.IsAllowed(nil, nil))
+		assert.is_false(ChatGuard.IsAllowed(nil, false))
+	end)
+end)

--- a/modules/missions/spec/dsl_spec.lua
+++ b/modules/missions/spec/dsl_spec.lua
@@ -1,0 +1,184 @@
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local alwaysTrue = { evaluate = function() return true end }
+local anEffect = { execute = function() end }
+
+describe("mission DSL", function()
+	local registered ---@type TriggerDescriptor[]
+	local When
+	local Finalize
+
+	before_each(function()
+		registered = {}
+		local file = DSL.ForFile("triggers/win.lua", function(descriptor)
+			registered[#registered + 1] = descriptor
+		end)
+		When = file.When
+		Finalize = file.Finalize
+	end)
+
+	it("builds a descriptor from a terminator-free chain at Finalize", function()
+		When(alwaysTrue).Do(anEffect)
+		assert.are.equal(0, #registered) -- nothing arms before the commit point
+		Finalize()
+
+		assert.are.equal(1, #registered)
+		local descriptor = registered[1]
+		assert.are.equal("triggers/win.lua:1", descriptor.id)
+		assert.are.equal("triggers/win.lua", descriptor.filename)
+		assert.are.equal(1, descriptor.order)
+		assert.are.equal(alwaysTrue, descriptor.condition)
+		assert.are.same({ anEffect }, descriptor.effects)
+		assert.is_true(descriptor.once)
+	end)
+
+	it("stamps declaration order by When-call order", function()
+		When(alwaysTrue).Do(anEffect)
+		When(alwaysTrue).Do(anEffect)
+		Finalize()
+		assert.are.equal("triggers/win.lua:1", registered[1].id)
+		assert.are.equal("triggers/win.lua:2", registered[2].id)
+	end)
+
+	it("accumulates multiple Do effects in order", function()
+		local first = { execute = function() end }
+		local second = { execute = function() end }
+		When(alwaysTrue).Do(first).Do(second)
+		Finalize()
+		assert.are.same({ first, second }, registered[1].effects)
+	end)
+
+	it("defaults Once to true and honors Once(false)", function()
+		When(alwaysTrue).Do(anEffect).Once(false)
+		Finalize()
+		assert.is_false(registered[1].once)
+	end)
+
+	it("a statement without a Do fails the load, naming the statement", function()
+		When(alwaysTrue).Do(anEffect)
+		When(alwaysTrue) -- half-finished
+		assert.has_error(function()
+			Finalize()
+		end)
+		assert.are.equal(0, #registered) -- the failed load arms nothing
+	end)
+
+	it("rejects a bare function in Do (closure-free surface)", function()
+		assert.has_error(function()
+			When(alwaysTrue).Do(function() end)
+		end)
+	end)
+
+	it("rejects a condition without evaluate", function()
+		assert.has_error(function()
+			When({})
+		end)
+	end)
+
+	it("rejects chain calls after Finalize", function()
+		local chain = When(alwaysTrue).Do(anEffect)
+		Finalize()
+		assert.has_error(function()
+			chain.Do(anEffect)
+		end)
+	end)
+
+	it("rejects Finalize twice", function()
+		Finalize()
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+end)
+
+describe("repeated When (AND composition)", function()
+	local registered
+	local When
+	local Finalize
+
+	before_each(function()
+		registered = {}
+		local file = DSL.ForFile("triggers/win.lua", function(descriptor)
+			registered[#registered + 1] = descriptor
+		end)
+		When = file.When
+		Finalize = file.Finalize
+	end)
+
+	local function cond(result, inputs)
+		return { inputs = inputs, evaluate = function() return result end }
+	end
+
+	it("fires only when every condition holds", function()
+		When(cond(true)).When(cond(false)).Do(anEffect)
+		When(cond(true)).When(cond(true)).Do(anEffect)
+		Finalize()
+		assert.is_false(registered[1].condition.evaluate({}))
+		assert.is_true(registered[2].condition.evaluate({}))
+	end)
+
+	it("composes inputs as the union of the parts'", function()
+		When(cond(true, { "A", "B" })).When(cond(true, { "B", "C" })).Do(anEffect)
+		Finalize()
+		local inputs = registered[1].condition.inputs
+		table.sort(inputs)
+		assert.are.same({ "A", "B", "C" }, inputs)
+	end)
+
+	it("a poll-only part makes the whole trigger poll", function()
+		When(cond(true, { "A" })).When(cond(true, nil)).Do(anEffect)
+		Finalize()
+		assert.is_nil(registered[1].condition.inputs)
+	end)
+
+	it("single-condition statements keep their original condition object", function()
+		local only = cond(true, { "A" })
+		When(only).Do(anEffect)
+		Finalize()
+		assert.are.equal(only, registered[1].condition)
+	end)
+
+	it("rejects a non-condition", function()
+		assert.has_error(function()
+			When(cond(true)).When(function() end)
+		end)
+	end)
+end)
+
+describe("mission verbs", function()
+	it("UnitDef carries the name", function()
+		assert.are.same({ name = "armpw" }, Verbs.UnitDef("armpw"))
+	end)
+
+	it("Team.Has evaluates against ctx counts", function()
+		local team = Verbs.MakeTeam(0, 0)
+		local condition = team.Has(Verbs.UnitDef("armpw"), 3)
+
+		local counts = { [0] = { armpw = 2 } }
+		local ctx = {
+			frame = 0,
+			GetUnitDefCount = function(teamID, defName)
+				return (counts[teamID] or {})[defName] or 0
+			end,
+			IsObjectiveComplete = function()
+				return false
+			end,
+		}
+		assert.is_false(condition.evaluate(ctx))
+		counts[0].armpw = 3
+		assert.is_true(condition.evaluate(ctx))
+	end)
+
+	it("Has declares its engine-callin inputs", function()
+		local team = Verbs.MakeTeam(0, 0)
+		local condition = team.Has(Verbs.UnitDef("armpw"), 3)
+		assert.are.same({ "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken" }, condition.inputs)
+	end)
+
+	it("Team carries teamID and allyTeam for MatchFlow calls", function()
+		local team = Verbs.MakeTeam(2, 1)
+		assert.are.equal(2, team.teamID)
+		assert.are.equal(1, team.allyTeam)
+	end)
+end)

--- a/modules/missions/spec/manifest_spec.lua
+++ b/modules/missions/spec/manifest_spec.lua
@@ -1,0 +1,19 @@
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+
+describe("the missions manifest", function()
+	local manifests
+
+	setup(function()
+		ModuleHandler.ResetCaches()
+		manifests = ModuleHandler.Discover()
+	end)
+
+	it("discovers missions and matchflow", function()
+		assert.is_table(manifests.missions)
+		assert.is_table(manifests.matchflow)
+	end)
+
+	it("missions declares its matchflow dependency", function()
+		assert.are.same({ "matchflow" }, manifests.missions.requires)
+	end)
+end)

--- a/modules/missions/spec/mission_loader_spec.lua
+++ b/modules/missions/spec/mission_loader_spec.lua
@@ -1,0 +1,357 @@
+--- The mission loader's reload transaction. Reload is the authoring
+--- workflow, and every step of it is a pure state transition: the gadget is
+--- loaded into a mocked environment and driven through its own chat action.
+---
+--- CreateUnit's contract is the engine's, not a convenience: a bad def name
+--- RAISES (LuaSyncedCtrl.cpp), nil means the unit limit.
+
+local realVFS = VFS
+
+local LOADER = "modules/missions/gadgets/mission_loader.lua"
+local MISSIONS = "modules/missions/"
+
+local UNIT_DEFS = { armpw = { id = 11 }, armcom = { id = 12 } }
+local DEF_NAMES = { [11] = "armpw", [12] = "armcom" }
+
+---@param name string
+---@param files table<string, string> mission-relative path -> chunk source
+---@return table<string, string>
+local function mission(name, files)
+	local sources = {}
+	for path, source in pairs(files) do
+		sources[MISSIONS .. name .. "/" .. path] = source
+	end
+	return sources
+end
+
+---Load the gadget over a mock VFS/Spring. `sources` is the mission tree;
+---anything else falls through to the real spec VFS.
+---@param sources table<string, string>
+---@param requires string[]? modules the missions manifest pulls DSL from
+local function newLoader(sources, requires)
+	local h = {
+		sources = sources,
+		params = {},
+		echo = {},
+		log = {},
+		counts = {}, -- teamID -> defName -> finished count
+		actions = {},
+	}
+	local env
+
+	local moduleHandler = {
+		Discover = function()
+			return { missions = { name = "missions", dir = MISSIONS, requires = requires or {} } }
+		end,
+		Get = function()
+			return { Protect = function() end, Unprotect = function() end }
+		end,
+	}
+
+	local vfs = {}
+	vfs.Include = function(path, fileEnv)
+		local source = h.sources[path]
+		if source ~= nil then
+			local chunk = assert(loadstring(source, "@" .. path))
+			-- No env means the handler's own globals, as in the engine.
+			setfenv(chunk, fileEnv or env)
+			return chunk()
+		end
+		if path == "modules/module_handler.lua" then
+			return moduleHandler
+		end
+		return realVFS.Include(path, fileEnv)
+	end
+	vfs.FileExists = function(path)
+		if h.sources[path] ~= nil then
+			return true
+		end
+		if path:sub(1, #MISSIONS) == MISSIONS or path:find("/mission_dsl%.lua$") then
+			return false
+		end
+		return realVFS.FileExists(path)
+	end
+	vfs.DirList = function(dir)
+		local found = {}
+		for path in pairs(h.sources) do
+			if path:sub(1, #dir) == dir and not path:sub(#dir + 1):find("/") then
+				found[#found + 1] = path
+			end
+		end
+		return found
+	end
+
+	local spring = {
+		Echo = function(message)
+			h.echo[#h.echo + 1] = tostring(message)
+		end,
+		Log = function(_, level, message)
+			h.log[#h.log + 1] = tostring(level) .. " " .. tostring(message)
+		end,
+		GetGameRulesParam = function(name)
+			return h.params[name]
+		end,
+		GetGameRulesParams = function()
+			local all = {}
+			for name, value in pairs(h.params) do
+				all[name] = value
+			end
+			return all
+		end,
+		-- A nil value ERASES the param (LuaSyncedCtrl.cpp SetRulesParam).
+		SetGameRulesParam = function(name, value)
+			h.params[name] = value
+		end,
+		GetGaiaTeamID = function()
+			return 2
+		end,
+		GetTeamList = function()
+			return { 0, 1, 2 }
+		end,
+		GetTeamInfo = function(teamID)
+			return teamID, 0, false, teamID == 1, "", teamID
+		end,
+		GetTeamLuaAI = function()
+			return ""
+		end,
+		GetAllyTeamList = function()
+			return { 0, 1 }
+		end,
+		GetTeamUnitsByDefs = function(teamID, defID)
+			local units = {}
+			for i = 1, ((h.counts[teamID] or {})[DEF_NAMES[defID]] or 0) do
+				units[i] = -i
+			end
+			return units
+		end,
+		GetUnitIsBeingBuilt = function()
+			return false
+		end,
+		IsCheatingEnabled = function()
+			return false
+		end,
+		Utilities = { Gametype = { IsSinglePlayer = function()
+			return true
+		end } },
+	}
+
+	env = setmetatable({
+		VFS = vfs,
+		Spring = spring,
+		UnitDefNames = UNIT_DEFS,
+		gadget = {},
+		gadgetHandler = {
+			IsSyncedCode = function()
+				return true
+			end,
+			AddChatAction = function(_, name, fn)
+				h.actions[name] = fn
+			end,
+			RemoveChatAction = function(_, name)
+				h.actions[name] = nil
+			end,
+			UpdateCallIn = function() end,
+		},
+	}, { __index = _G })
+
+	realVFS._cache[LOADER] = nil
+	realVFS.Include(LOADER, env)
+	assert(type(env.gadget.Initialize) == "function", "the mission loader did not load")
+	h.gadget = env.gadget
+	h.gadget:Initialize()
+
+	h.mission = function(name)
+		return h.actions.mission("mission", name, { name }, 0)
+	end
+	h.frame = function(frame)
+		h.gadget:GameFrame(frame)
+	end
+	h.clear = function()
+		h.echo, h.log = {}, {}
+	end
+	h.echoed = function(needle)
+		local seen = 0
+		for _, line in ipairs(h.echo) do
+			if line:find(needle, 1, true) then
+				seen = seen + 1
+			end
+		end
+		return seen
+	end
+	h.logged = function(needle)
+		for _, line in ipairs(h.log) do
+			if line:find(needle, 1, true) then
+				return true
+			end
+		end
+		return false
+	end
+	---@return integer|nil count from the last "mission armed" echo, nil if none
+	h.armed = function()
+		local count
+		for _, line in ipairs(h.echo) do
+			local n = line:match("mission armed: .* %((%d+) trigger")
+			if n ~= nil then
+				count = tonumber(n)
+			end
+		end
+		return count
+	end
+
+	return h
+end
+
+local BUILD = [[
+When(Team.Player.Has(UnitDef("armpw"), 3))
+	.Do(Objective("build_pawns").Complete())
+]]
+
+local VICTORY = [[
+When(Objective("build_pawns").IsComplete())
+	.Do(Objective("win").Complete())
+]]
+
+local ROSTER = [[
+Spawn(UnitDef("armcom"), "player").At(0.5, 0.5).Named("hero")
+]]
+
+-- A module DSL contribution: registers one trigger per Mark at Finalize.
+local CONTRIBUTION = [[
+return {
+	ForFile = function(file)
+		local marks = {}
+		return {
+			env = {
+				Mark = function(name)
+					marks[#marks + 1] = name
+				end,
+			},
+			Finalize = function()
+				for order, name in ipairs(marks) do
+					file.Register({
+						id = file.filename .. ":mark:" .. order,
+						filename = file.filename,
+						order = order,
+						condition = { inputs = { "UnitFinished" }, evaluate = function() return true end },
+						effects = { { execute = function() Spring.Echo("mark: " .. name) end } },
+						once = true,
+					})
+				end
+			end,
+		}
+	end,
+}
+]]
+
+describe("mission loader reload", function()
+	describe("stale triggers", function()
+		it("arms a renamed trigger file once, not twice", function()
+			local h = newLoader(mission("t", { ["triggers/win.lua"] = BUILD }))
+			h.counts[0] = { armpw = 3 }
+			h.mission("t")
+			h.frame(15)
+			assert.are.equal(1, h.armed())
+
+			h.sources[MISSIONS .. "t/triggers/victory.lua"] = h.sources[MISSIONS .. "t/triggers/win.lua"]
+			h.sources[MISSIONS .. "t/triggers/win.lua"] = nil
+			h.clear()
+			h.mission("t")
+			assert.are.equal(1, h.armed())
+			h.frame(30)
+			assert.are.equal(1, h.echoed("objective complete: build_pawns"))
+		end)
+
+		it("drops the previous mission's triggers on a switch", function()
+			local sources = mission("t", { ["triggers/win.lua"] = BUILD })
+			for path, source in pairs(mission("u", { ["triggers/other.lua"] = [[
+When(Team.Player.Has(UnitDef("armpw"), 3))
+	.Do(Objective("scout").Complete())
+]] })) do
+				sources[path] = source
+			end
+			local h = newLoader(sources)
+			h.mission("t")
+			h.clear()
+			h.mission("u")
+			assert.are.equal(1, h.armed())
+			h.counts[0] = { armpw = 3 }
+			h.frame(15)
+			assert.are.equal(1, h.params.objective_scout)
+			assert.is_nil(h.params.objective_build_pawns)
+		end)
+	end)
+
+	describe("objective progress", function()
+		it("clears completed objectives so a reload is a fresh run", function()
+			local h = newLoader(mission("t", {
+				["triggers/a_build.lua"] = BUILD,
+				["triggers/z_win.lua"] = VICTORY,
+			}))
+			h.counts[0] = { armpw = 3 }
+			h.mission("t")
+			h.frame(15)
+			assert.are.equal(1, h.params.objective_build_pawns)
+			assert.are.equal(1, h.params.objective_win)
+
+			-- The author reloads to test from the top; the pawns are gone.
+			h.counts[0] = { armpw = 0 }
+			h.clear()
+			h.mission("t")
+			assert.is_nil(h.params.objective_build_pawns)
+			assert.is_nil(h.params.objective_win)
+			h.frame(30)
+			assert.is_nil(h.params.objective_win)
+		end)
+
+		it("clears the objective prefix and nothing else", function()
+			local h = newLoader(mission("t", { ["triggers/a_build.lua"] = BUILD }))
+			h.mission("t")
+			h.params.some_other_gadget = 7
+			h.params.mission_unit_dead_ghost = 1
+			h.mission("t")
+			assert.are.equal(7, h.params.some_other_gadget)
+			assert.are.equal(1, h.params.mission_unit_dead_ghost)
+		end)
+	end)
+
+	describe("a failed load", function()
+		it("leaves the running mission armed when a trigger file fails", function()
+			local h = newLoader(mission("t", {
+				["triggers/a_build.lua"] = BUILD,
+				["triggers/z_win.lua"] = VICTORY,
+			}))
+			h.counts[0] = { armpw = 3 }
+			h.mission("t")
+			assert.are.equal(2, h.armed())
+			h.frame(15)
+			assert.are.equal(1, h.params.objective_build_pawns)
+
+			h.sources[MISSIONS .. "t/triggers/z_win.lua"] = "NoSuchVerb()"
+			h.clear()
+			local ok, err = pcall(h.mission, "t")
+			assert.is_true(ok, tostring(err))
+			assert.is_nil(h.armed())
+			assert.is_true(h.logged("z_win.lua"))
+			-- Progress belongs to the mission that is still running.
+			assert.are.equal(1, h.params.objective_build_pawns)
+
+			-- And that mission is still whole: the second trigger fires too.
+			h.frame(30)
+			assert.are.equal(1, h.params.objective_win)
+		end)
+
+		it("keeps a half-parsed mission's triggers out of the armed set", function()
+			local h = newLoader(mission("t", {
+				["triggers/a_build.lua"] = BUILD,
+				["triggers/z_win.lua"] = "NoSuchVerb()",
+			}))
+			local ok = pcall(h.mission, "t")
+			assert.is_true(ok)
+			assert.is_nil(h.armed())
+			h.counts[0] = { armpw = 3 }
+			h.frame(15)
+			assert.is_nil(h.params.objective_build_pawns)
+			assert.is_nil(h.params.mission_active)
+		end)
+	end)
+end)

--- a/modules/missions/spec/trigger_engine_spec.lua
+++ b/modules/missions/spec/trigger_engine_spec.lua
@@ -1,0 +1,206 @@
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+
+---@param counts table<integer, table<string, integer>> teamID -> defName -> count
+---@param frame integer?
+---@return MissionContext
+local function makeCtx(counts, frame)
+	return {
+		frame = frame or 0,
+		GetUnitDefCount = function(teamID, defName)
+			return (counts[teamID] or {})[defName] or 0
+		end,
+	}
+end
+
+---@param id string
+---@param result boolean|fun(ctx: MissionContext): boolean
+---@param log string[]
+---@return TriggerDescriptor
+local function makeTrigger(id, result, log)
+	return {
+		id = id,
+		filename = id:match("^(.*):") or id,
+		order = tonumber(id:match(":(%d+)$")) or 1,
+		condition = {
+			evaluate = function(ctx)
+				if type(result) == "function" then
+					return result(ctx)
+				end
+				return result
+			end,
+		},
+		effects = { {
+			execute = function()
+				log[#log + 1] = id
+			end,
+		} },
+		once = true,
+	}
+end
+
+describe("TriggerEngine", function()
+	it("runs an effect when its condition holds", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1" }, log)
+	end)
+
+	it("does not run an effect while its condition is false", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", false, log))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({}, log)
+	end)
+
+	it("fires a once trigger at most once", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1" }, log)
+	end)
+
+	it("fires a repeating trigger every evaluation", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		local trigger = makeTrigger("f.lua:1", true, log)
+		trigger.once = false
+		engine.Register(trigger)
+		engine.Evaluate(makeCtx({}))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1", "f.lua:1" }, log)
+	end)
+
+	it("rejects duplicate trigger ids", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		assert.has_error(function()
+			engine.Register(makeTrigger("f.lua:1", true, log))
+		end)
+	end)
+
+	it("keeps fired flags in the engine state table, not closures", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		assert.is_true(engine.GetState().fired["f.lua:1"])
+	end)
+
+	it("restores progress via SetState: a restored fired flag suppresses the effect", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.SetState({ fired = { ["f.lua:1"] = true } })
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({}, log)
+	end)
+
+	describe("condition inputs (event-driven evaluation)", function()
+		local function watcherTrigger(id, log, inputs, result)
+			return {
+				id = id,
+				filename = id:match("^(.*):") or id,
+				order = tonumber(id:match(":(%d+)$")) or 1,
+				condition = {
+					inputs = inputs,
+					evaluate = function()
+						log.evaluated[#log.evaluated + 1] = id
+						return result ~= false
+					end,
+				},
+				effects = { { execute = function()
+					log.fired[#log.fired + 1] = id
+				end } },
+				once = true,
+			}
+		end
+
+		local function newLog()
+			return { evaluated = {}, fired = {} }
+		end
+
+		it("indexes watched inputs at Register", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, { "UnitFinished", "UnitDestroyed" }))
+			assert.are.same({ UnitFinished = true, UnitDestroyed = true }, engine.WatchedInputs())
+		end)
+
+		it("evaluates a watcher once on arm, then only after its events", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, { "UnitFinished" }, false))
+			engine.Evaluate(makeCtx({})) -- armed: evaluates once
+			engine.Evaluate(makeCtx({})) -- no event since: skipped
+			assert.are.equal(1, #log.evaluated)
+			engine.OnEvent("UnitFinished")
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(2, #log.evaluated)
+		end)
+
+		it("ignores events nothing watches", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, { "UnitFinished" }, false))
+			engine.Evaluate(makeCtx({}))
+			engine.OnEvent("mission.objective_changed")
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(1, #log.evaluated)
+		end)
+
+		it("polls conditions with nil inputs every cadence", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("f.lua:1", log, nil, false))
+			engine.Evaluate(makeCtx({}))
+			engine.Evaluate(makeCtx({}))
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(3, #log.evaluated)
+		end)
+
+		it("UnregisterFile cleans the watcher index", function()
+			local engine = TriggerEngine.New()
+			local log = newLog()
+			engine.Register(watcherTrigger("a.lua:1", log, { "UnitFinished" }))
+			engine.UnregisterFile("a.lua")
+			assert.are.same({}, engine.WatchedInputs())
+			engine.OnEvent("UnitFinished")
+			engine.Evaluate(makeCtx({}))
+			assert.are.equal(0, #log.evaluated)
+		end)
+	end)
+
+	describe("UnregisterFile", function()
+		it("removes exactly that file's triggers and their progress", function()
+			local engine = TriggerEngine.New()
+			local log = {}
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Register(makeTrigger("b.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+
+			local removed = engine.UnregisterFile("a.lua")
+			assert.are.equal(1, removed)
+			assert.is_nil(engine.GetState().fired["a.lua:1"])
+			assert.is_true(engine.GetState().fired["b.lua:1"])
+			assert.are.equal(1, #engine.Triggers())
+			assert.are.equal("b.lua:1", engine.Triggers()[1].id)
+		end)
+
+		it("lets a re-registered trigger fire again (hot reload)", function()
+			local engine = TriggerEngine.New()
+			local log = {}
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+			engine.UnregisterFile("a.lua")
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+			assert.are.same({ "a.lua:1", "a.lua:1" }, log)
+		end)
+	end)
+end)

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -1,0 +1,92 @@
+--- Mission-runtime types: the trigger engine's descriptors and the authoring
+--- DSL's chain/condition/effect shapes. The DSL surface is dot-only AND
+--- closure-free: every chain step is a plain call with parens, no colon
+--- methods, no metatables, and no function bodies in mission files — effects
+--- are lazy objects built by named verbs. Mission files must load identically
+--- in the synced sandbox (which strips rawset) and in busted.
+
+--- The mission bus vocabulary, CLOSED BY TYPE: every event name that may
+--- cross the bus is a member of this alias. Engine callins are one producer,
+--- modules are another — same kind of string, one type. Adding an event
+--- means extending this alias; the checker then walks you to every consumer
+--- (inputs declarations, OnEvent emitters) and flags typos as type errors —
+--- the state heritage is tied together by the compiler, not convention.
+---@alias MissionEventName
+---| "UnitFinished"
+---| "UnitDestroyed"
+---| "UnitGiven"
+---| "UnitTaken"
+---| "mission.objective_changed"
+
+--- A condition is not a bare predicate — it carries metadata about what can
+--- change its answer (mission_authoring_dsl.md, "Conditions declare their
+--- inputs"). Inputs name events on the mission bus (MissionEventName).
+--- nil inputs = poll every cadence — the fallback stays.
+--- Pure: reads only the ctx it is handed; captures configuration (team ids,
+--- unit names), never progress. Progress lives in the engine's state tables;
+--- inputs are configuration, dirty flags are derived (the savegame rule).
+---@class MissionCondition
+---@field evaluate fun(ctx: MissionContext): boolean
+---@field inputs MissionEventName[]|nil events that can change this answer; nil = poll every cadence
+
+--- What the engine hands every condition and effect. The gadget builds it from
+--- Spring; specs build it from plain tables.
+---@class MissionContext
+---@field GetUnitDefCount fun(teamID: integer, unitDefName: string): integer count of finished units of that def
+---@field IsObjectiveComplete fun(name: string): boolean
+---@field frame integer current game frame
+
+--- A lazy effect built by a named verb (Objective("x").Complete(),
+--- MatchFlow.Victory(Team.Player)). The engine executes it when the trigger's
+--- condition fires. Like conditions, effects capture configuration only —
+--- never progress, and never author-written function bodies.
+---@class MissionEffect
+---@field execute fun(ctx: MissionContext)
+
+--- The injected Objective verb's handle: Complete() builds the effect side,
+--- IsComplete() the condition side — victory triggers watch objective state
+--- rather than living inside the objective's own trigger.
+---@class MissionObjective
+---@field Complete fun(): MissionEffect
+---@field IsComplete fun(): MissionCondition
+
+--- The injected MatchFlow verbs: lazy mirrors of the matchflow module api.
+--- They take the Team handle so mission lines read as English.
+---@class MissionMatchFlow
+---@field Victory fun(team: MissionTeam): MissionEffect
+---@field Defeat fun(team: MissionTeam): MissionEffect
+
+--- A registered trigger. Identity = source filename + declaration order,
+--- stamped at registration — the unregister-by-identity key for hot reload.
+---@class TriggerDescriptor
+---@field id string "<filename>:<order>"
+---@field filename string mission-relative trigger file path
+---@field order integer 1-based declaration order within the file
+---@field condition MissionCondition
+---@field effects MissionEffect[] executed in Do order when the condition fires
+---@field once boolean fire at most once (default true)
+
+--- The dot-only builder chain returned by When. Every step returns the
+--- chain. There is no terminator: the loader finalizes all chains when the
+--- file's include returns, and a chain without a Do fails the load.
+---@class TriggerChain
+---@field When fun(condition: MissionCondition): TriggerChain another condition; all must hold
+---@field Do fun(effect: MissionEffect): TriggerChain repeatable; effects run in Do order
+---@field Once fun(once: boolean?): TriggerChain default true; pass false for repeating triggers
+
+--- A unit-def reference produced by the injected UnitDef verb. Carries the
+--- name only; resolution to an id happens where Spring exists.
+---@class MissionUnitDefRef
+---@field name string
+
+--- The injected Team.Player handle. Demo rule: resolves to the first human
+--- team at mission load.
+---@class MissionTeam
+---@field teamID integer
+---@field allyTeam integer
+---@field Has fun(unitDef: MissionUnitDefRef, count: integer): MissionCondition
+
+--- Serializable trigger progress: the pile a checkpoint saves. Definitions
+--- reload from source; this table is reapplied on top.
+---@class TriggerEngineState
+---@field fired table<string, boolean> trigger id -> has fired


### PR DESCRIPTION
Triggers are declared, not scripted: a file states `When(condition).Do(effect)` and the loader arms what it finds. Identity is filename plus declaration order, and a half-written statement is a load error naming the file.

Loading is one transaction. The incoming mission arms into a staging engine swapped in whole, which fixes reload leaving renamed triggers armed (effects running twice) and one typo taking the running mission down with it.