### PR TITLE
modules — 12/12: CM8 Ashfall

### DIFF
--- a/modules/missions/cm8_ashfall/triggers/outpost.lua
+++ b/modules/missions/cm8_ashfall/triggers/outpost.lua
@@ -1,0 +1,8 @@
+-- CM8 "Ashfall", Beat 2 — the automated outpost: no pilots, story-critical hub.
+-- The player inherits the failing base; the command hub cannot die before the
+-- enclave reveal or the mission breaks.
+
+When(MatchFlow.Started())
+	.Do(Units.Transfer("outpost_auto", Team.Player))
+	.Do(Combat.Protect(Unit("outpost_command_hub"))
+		.Until(Objective("find_the_enclave").IsComplete()))

--- a/modules/missions/cm8_ashfall/triggers/victory.lua
+++ b/modules/missions/cm8_ashfall/triggers/victory.lua
@@ -1,0 +1,16 @@
+-- CM8 "Ashfall", Beat 6 — staged objectives; the verdict flows through matchflow.
+-- Trimmed to the modules in tree (combat, matchflow): the lava tiers, the
+-- scripted reveal, and the raptor waves wait on their modules.
+
+When(Team.Player.Has(UnitDef("corllt"), 4))
+	.Do(Objective("relieve_the_outpost").Complete())
+
+When(Objective("relieve_the_outpost").IsComplete())
+	.When(Unit("tenebrium_device").IsSpotted(Team.Player))
+	.Do(Objective("find_the_enclave").Complete())
+
+When(Unit("armada_commander").IsDestroyed())
+	.Do(Objective("kill_the_commander").Complete())
+
+When(Objective("kill_the_commander").IsComplete())
+	.Do(MatchFlow.Victory(Team.Player))

--- a/modules/missions/cm8_ashfall/units.lua
+++ b/modules/missions/cm8_ashfall/units.lua
@@ -1,0 +1,51 @@
+-- CM8 "Ashfall" roster — stand-in defs until Teizer V and its assets exist;
+-- the trigger files are the acceptance shape, this makes them arm. Positions
+-- are map fractions so the mission plays on any test map. Named/Grouped are
+-- the definition sites the trigger files' Unit/Units references are
+-- validated against.
+
+-- Beat 2, the automated outpost: spawns pilotless (gaia) and is handed to
+-- the player at mission start by Units.Transfer("outpost_auto", Team.Player).
+-- The command hub is the story-critical protected structure.
+
+Spawn(UnitDef("corlab"), "gaia")
+	.At(0.42, 0.42)
+	.Named("outpost_command_hub")
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corllt"), "gaia")
+	.At(0.39, 0.40)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corllt"), "gaia")
+	.At(0.45, 0.40)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corrad"), "gaia")
+	.At(0.42, 0.39)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corsolar"), "gaia")
+	.At(0.39, 0.44)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corsolar"), "gaia")
+	.At(0.45, 0.44)
+	.Grouped("outpost_auto")
+
+-- Beats 4 and 6, the Armada enclave: spotting the device closes
+-- find_the_enclave; killing the commander wins through matchflow.
+
+Spawn(UnitDef("armfus"), "enemy")
+	.At(0.75, 0.75)
+	.Named("tenebrium_device")
+
+Spawn(UnitDef("armcom"), "enemy")
+	.At(0.77, 0.77)
+	.Named("armada_commander")
+
+Spawn(UnitDef("armllt"), "enemy")
+	.At(0.73, 0.75)
+
+Spawn(UnitDef("armllt"), "enemy")
+	.At(0.75, 0.73)

--- a/modules/missions/lib/mode_dsl.lua
+++ b/modules/missions/lib/mode_dsl.lua
@@ -1,0 +1,30 @@
+--- Mission mode vocabulary over modules/mode_builder.lua: nouns for what the
+--- mission runtime owns, serializers for the options those policies pin.
+
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+
+local M = {}
+
+M.Match = {
+	End = { domain = "end" },
+}
+
+local Serializers = {
+	-- triggers own the verdict: engine elimination never ends the match
+	["end.scripted"] = function(_p, lock)
+		return { deathmode = { value = "neverend", locked = lock.structure } }
+	end,
+}
+
+M.Mode = ModeBuilder.Grammar({
+	category = "missions",
+	serializers = Serializers,
+	verbs = {
+		---The mission owns the noun's domain outright.
+		Own = function(modeName, noun)
+			return { ModeBuilder.DomainOf(modeName, "Own", noun, { ["end"] = true }, "Match.End") .. ".scripted" }
+		end,
+	},
+})
+
+return M

--- a/modules/missions/modes/mission.lua
+++ b/modules/missions/modes/mission.lua
@@ -1,0 +1,6 @@
+local ModeDSL = VFS.Include("modules/missions/lib/mode_dsl.lua")
+local Mode, Match = ModeDSL.Mode, ModeDSL.Match
+
+return Mode("Mission")
+	.Desc("Triggers own the verdict; engine elimination never ends the match.")
+	.Own(Match.End)

--- a/modules/missions/spec/cm8_roster_spec.lua
+++ b/modules/missions/spec/cm8_roster_spec.lua
@@ -1,0 +1,43 @@
+--- The shipped roster stays loadable and keeps declaring the names
+--- triggers/*.lua reference, through the same sandbox the loader builds.
+
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+describe("cm8_ashfall roster", function()
+	local byName = {}
+	local groups = {}
+
+	setup(function()
+		local file = Roster.ForFile("cm8_ashfall/units.lua")
+		VFS.Include("modules/missions/cm8_ashfall/units.lua", {
+			Spawn = file.Spawn,
+			UnitDef = Verbs.UnitDef,
+		})
+		for _, entry in ipairs(file.Finalize()) do
+			if entry.name then
+				byName[entry.name] = entry
+			end
+			if entry.group then
+				groups[entry.group] = (groups[entry.group] or 0) + 1
+			end
+		end
+	end)
+
+	it("declares every name the trigger files reference", function()
+		assert.is_table(byName.outpost_command_hub)
+		assert.is_table(byName.tenebrium_device)
+		assert.is_table(byName.armada_commander)
+	end)
+
+	it("the protected hub travels with the transferred outpost group", function()
+		assert.are.equal("outpost_auto", byName.outpost_command_hub.group)
+		assert.is_true(groups.outpost_auto > 1)
+	end)
+
+	it("the outpost spawns pilotless and the enclave hostile", function()
+		assert.are.equal("gaia", byName.outpost_command_hub.team)
+		assert.are.equal("enemy", byName.tenebrium_device.team)
+		assert.are.equal("enemy", byName.armada_commander.team)
+	end)
+end)

--- a/modules/missions/spec/mission_mode_spec.lua
+++ b/modules/missions/spec/mission_mode_spec.lua
@@ -1,0 +1,38 @@
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local ModeDSL = VFS.Include("modules/missions/lib/mode_dsl.lua")
+
+local mission = VFS.Include("modules/missions/modes/mission.lua")
+
+describe("missions mode preset", function()
+	it("is a missions-category preset with a snake_case key", function()
+		assert.equal("mission", mission.key)
+		assert.equal("missions", mission.category)
+		assert.equal(false, mission.allowRanked)
+	end)
+
+	it("serializes to exactly the options its policies own", function()
+		assert.same({
+			deathmode = { value = "neverend", locked = true },
+		}, mission.modOptions)
+	end)
+
+	it("rejects a second owner of the same modoption", function()
+		local Mode, Match = ModeDSL.Mode, ModeDSL.Match
+		local ok, err = pcall(function()
+			Mode("Twice").Own(Match.End).Own(Match.End)
+		end)
+		assert.is_false(ok)
+		assert.truthy(tostring(err):find("two policies own modoption deathmode", 1, true))
+	end)
+
+	it("ModeDirs aggregates the missions preset dir", function()
+		ModuleHandler.ResetCaches()
+		local found = false
+		for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+			if dir == "modules/missions/modes/" then
+				found = true
+			end
+		end
+		assert.is_true(found)
+	end)
+end)

--- a/modules/missions/spec/roster_spec.lua
+++ b/modules/missions/spec/roster_spec.lua
@@ -1,0 +1,78 @@
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+describe("mission roster DSL", function()
+	local Spawn
+	local Finalize
+
+	before_each(function()
+		local file = Roster.ForFile("cm8/units.lua")
+		Spawn = file.Spawn
+		Finalize = file.Finalize
+	end)
+
+	it("builds entries from Spawn chains at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia")
+			.At(0.42, 0.42)
+			.Named("hub")
+			.Grouped("outpost_auto")
+		Spawn(Verbs.UnitDef("armcom"), "enemy")
+			.At(0.77, 0.77)
+		local entries = Finalize()
+		assert.are.same({
+			{ def = "corlab", team = "gaia", fx = 0.42, fz = 0.42, name = "hub", group = "outpost_auto" },
+			{ def = "armcom", team = "enemy", fx = 0.77, fz = 0.77 },
+		}, entries)
+	end)
+
+	it("a spawn without an At fails the load, naming the statement", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").Named("hub")
+		local ok, err = pcall(Finalize)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("Spawn 1", 1, true))
+	end)
+
+	it("rejects duplicate unit names at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1).Named("hub")
+		Spawn(Verbs.UnitDef("corllt"), "gaia").At(0.2, 0.2).Named("hub")
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+
+	it("rejects a plain string where a UnitDef reference belongs", function()
+		assert.has_error(function()
+			Spawn("corlab", "gaia")
+		end)
+	end)
+
+	it("rejects an unknown team role", function()
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corlab"), "raptors")
+		end)
+	end)
+
+	it("rejects positions outside map fractions", function()
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corlab"), "gaia").At(512, 512)
+		end)
+	end)
+
+	it("rejects chain calls after Finalize", function()
+		local chain = Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1)
+		Finalize()
+		assert.has_error(function()
+			chain.Named("late")
+		end)
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corllt"), "gaia")
+		end)
+	end)
+
+	it("rejects Finalize twice", function()
+		Finalize()
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+end)

--- a/modules/missions/types/mode_dsl.lua
+++ b/modules/missions/types/mode_dsl.lua
@@ -1,0 +1,27 @@
+---@meta dsl
+
+--- The missions mode-preset surface: what modules/missions/modes/*.lua files
+--- author against (via lib/mode_dsl.lua over modules/mode_builder.lua).
+
+--- A mode noun: names the policy domain a verb acts on.
+---@class MissionModeNoun
+---@field domain string
+
+--- The Mode chain (missions vocabulary). Every verb returns the chain; the
+--- chain IS the ModeConfig the preset file returns.
+---@class MissionModeChain
+---@field Desc fun(desc: string): MissionModeChain
+---@field Ranked fun(): MissionModeChain
+---@field RetainValues fun(): MissionModeChain
+---@field Hidden fun(): MissionModeChain
+---@field Unlocked fun(): MissionModeChain
+---@field Locked fun(): MissionModeChain
+---@field Own fun(noun: MissionModeNoun): MissionModeChain
+
+---Start a mode chain; the key is the name's snake_case.
+---@param name string
+---@return MissionModeChain
+function Mode(name) end
+
+---@type { End: MissionModeNoun }
+Match = {}

--- a/modules/missions/widgets/mission_bridge.lua
+++ b/modules/missions/widgets/mission_bridge.lua
@@ -128,6 +128,14 @@ local function sampleLive()
 			elseif probe.kind == "objective" and probe.objective then
 				local done = Spring.GetGameRulesParam("objective_" .. probe.objective) == 1
 				values[probe.key] = { text = done and "✓" or "–", state = done and "done" or "pending", pct = done and 1 or 0 }
+			elseif probe.kind == "unit_dead" and probe.unit_name then
+				-- Latched by the mission loader; readable here unlike unit
+				-- validity, which LOS would fog for enemy roster units.
+				local dead = Spring.GetGameRulesParam("mission_unit_dead_" .. probe.unit_name) == 1
+				values[probe.key] = { text = dead and "destroyed" or "alive", state = dead and "done" or "pending", pct = dead and 1 or 0 }
+			elseif probe.kind == "unit_spotted" and probe.unit_name then
+				local spotted = Spring.GetGameRulesParam("mission_unit_spotted_" .. probe.unit_name .. "_" .. Spring.GetMyAllyTeamID()) == 1
+				values[probe.key] = { text = spotted and "✓" or "–", state = spotted and "done" or "pending", pct = spotted and 1 or 0 }
 			end
 		end
 	end


### PR DESCRIPTION
The first mission on the framework: a unit is declared once with its team and the name triggers use, so a typo is a load error rather than a condition that silently never fires.

Three of eight beats — spawn the world, the automated outpost, objectives and victory. The lava tiers, scripted reveal and raptor waves wait on modules that do not exist yet (environment, intel, ai_director).