### PR TITLE
modules: the mode grammar

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -42,6 +42,11 @@ local options = {
 		desc = "",
 		type = "section",
 		weight = 7,
+		-- The game axis governs these: the base rules of a match belong to
+		-- how the match is played, so a lobby folds them under the Game mode
+		-- (modules/modes/modoptions.lua) — a mode locks what it pins and
+		-- leaves the rest open.
+		mode_category = "game",
 	},
 
 	{

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -42,6 +42,7 @@ local options = {
 		desc = "",
 		type = "section",
 		weight = 7,
+		mode_category = "game",
 	},
 
 	{
@@ -2766,6 +2767,10 @@ for i = 1, 9 do
 		def = "",
 		hidden = true,
 	}
+end
+
+for _, option in ipairs(VFS.Include("modules/module_handler.lua").ModOptions()) do
+	options[#options + 1] = option
 end
 
 return options

--- a/modules/enums.lua
+++ b/modules/enums.lua
@@ -2,8 +2,10 @@
 ---the commit that adds the module, so a rename follows every reader.
 ---@class Modules
 ---@field Defs string
+---@field Modes string
 local Modules = {
 	Defs = "defs",
+	Modes = "modes",
 }
 
 return { Modules = Modules }

--- a/modules/mode_builder.lua
+++ b/modules/mode_builder.lua
@@ -1,0 +1,195 @@
+local PolicyBuilder = VFS.Include("modules/policy_builder.lua")
+
+---@class ModOptionConfig
+---@field value string|number|boolean
+---@field locked boolean
+---@field ui "hidden"|nil kept out of the lobby UI when hidden
+
+---@class ModePolicyRef
+---@field [1] string policy identity, e.g. "end.scripted"
+---@field locked boolean|"sealed"|nil nil/false = open, true = structure pinned, "sealed" = dials too
+---@field ui string|nil
+
+---@class ModeConfig
+---@field key string the name's snake_case
+---@field category string bound by the grammar, never by the preset
+---@field name string
+---@field desc string
+---@field allowRanked boolean
+---@field retainValues boolean|nil non-sticky preset: expose, keep current values
+---@field bots string[]|nil AI short names the lobby fields
+---@field uses string[]|nil modules this preset makes live besides its own
+---@field policies ModePolicyRef[]
+---@field modOptions table<string, ModOptionConfig>
+
+local ModeBuilder = {}
+
+local BuiltinSerializers = {
+	-- ranked prohibition is enforced, not advisory: the option is pinned off
+	["mode.ranked"] = function(_p, lock)
+		return { ranked_game = { value = false, locked = lock.structure } }
+	end,
+}
+
+---@param serializers table<string, fun(params: table, lock: { structure: boolean, dial: boolean }): table<string, ModOptionConfig>>
+---@param bundle ModePolicyRef[]
+---@return table<string, ModOptionConfig>
+function ModeBuilder.ToModOptions(serializers, bundle)
+	local options = {}
+	for _, entry in ipairs(bundle) do
+		local name, params
+		if type(entry) == "table" then
+			name, params = entry[1], entry
+		else
+			name, params = entry, {}
+		end
+		local serialize = serializers[name] or BuiltinSerializers[name]
+		if not serialize then
+			error("unknown mode policy: " .. tostring(name))
+		end
+		local locked = params.locked
+		local lock = { structure = locked == true or locked == "sealed", dial = locked == "sealed" }
+		for key, option in pairs(serialize(params, lock)) do
+			if options[key] ~= nil then
+				error("two policies own modoption " .. key)
+			end
+			options[key] = option
+		end
+	end
+	return options
+end
+
+---@param modeName string for error messages
+---@param verb string
+---@param noun table
+---@param domains table<string, boolean> domains the verb accepts
+---@param hint string noun spelling for the error message
+---@return string domain
+function ModeBuilder.DomainOf(modeName, verb, noun, domains, hint)
+	assert(
+		type(noun) == "table" and type(noun.domain) == "string",
+		modeName .. ": ." .. verb .. " expects a noun (" .. hint .. ")"
+	)
+	assert(domains[noun.domain], modeName .. ": ." .. verb .. " does not apply to " .. noun.domain)
+	return noun.domain
+end
+
+---@param grammar { category: string, serializers: table, verbs: table<string, fun(modeName: string, ...): table> }
+---@return fun(name: string): ModeConfig
+function ModeBuilder.Grammar(grammar)
+	---@param name string
+	---@return ModeConfig
+	return function(name)
+		local chain = {
+			key = name:lower():gsub("%s+", "_"),
+			category = grammar.category,
+			name = name,
+			desc = "",
+			allowRanked = false,
+			-- Unranked until a preset says Ranked(): the pin is a claim like any
+			-- other, so a mode that never mentions rating still carries it.
+			policies = { { "mode.ranked", implicit = true } }, ---@type ModePolicyRef[]
+			modOptions = {}, ---@type table<string, ModOptionConfig>
+		}
+
+		local function reserialize()
+			chain.modOptions = ModeBuilder.ToModOptions(grammar.serializers, chain.policies)
+			return chain
+		end
+
+		---@param modifier string
+		---@return table ref the most recent policy ref
+		local function lastPolicy(modifier)
+			local ref = chain.policies[#chain.policies]
+			-- the implicit ranked pin is not something a preset has said yet
+			assert(ref and not ref.implicit, name .. ": ." .. modifier .. " before any policy")
+			return ref
+		end
+
+		---@param desc string
+		chain.Desc = function(desc)
+			chain.desc = desc
+			return chain
+		end
+
+		---@param enabled boolean|nil nil means true
+		chain.Ranked = function(enabled)
+			enabled = enabled ~= false
+			chain.allowRanked = enabled
+			for i = #chain.policies, 1, -1 do
+				if chain.policies[i][1] == "mode.ranked" then
+					table.remove(chain.policies, i)
+				end
+			end
+			if not enabled then
+				chain.policies[#chain.policies + 1] = { "mode.ranked" }
+			end
+			return reserialize()
+		end
+
+		---@param aiName string
+		chain.Bot = function(aiName)
+			assert(type(aiName) == "string", "Mode(...).Bot expects an AI short name")
+			chain.bots = chain.bots or {}
+			chain.bots[#chain.bots + 1] = aiName
+			return chain
+		end
+
+		---A module whose providers this preset makes live, besides the one
+		---that ships it. The mode, not the module, decides who answers a fact.
+		---The module is named by its contract, never by a string.
+		---@param contract table the module's contract.lua
+		chain.Uses = function(contract)
+			local moduleName = PolicyBuilder.OwnerOf(contract)
+			assert(moduleName ~= nil, name .. ": .Uses expects a module's contract (VFS.Include its contract.lua)")
+			chain.uses = chain.uses or {}
+			chain.uses[#chain.uses + 1] = moduleName
+			return chain
+		end
+
+		chain.RetainValues = function()
+			chain.retainValues = true
+			return chain
+		end
+
+		chain.Hidden = function()
+			lastPolicy("Hidden").ui = "hidden"
+			return reserialize()
+		end
+
+		chain.Unlocked = function()
+			lastPolicy("Unlocked").locked = false
+			return reserialize()
+		end
+
+		chain.Locked = function()
+			lastPolicy("Locked").locked = true
+			return reserialize()
+		end
+
+		chain.Sealed = function()
+			lastPolicy("Sealed").locked = "sealed"
+			return reserialize()
+		end
+
+		for verbName, toRef in pairs(grammar.verbs) do
+			assert(chain[verbName] == nil, "ModeBuilder.Grammar: verb collides with a chain field: " .. verbName)
+			chain[verbName] = function(...)
+				chain.policies[#chain.policies + 1] = toRef(name, ...)
+				return reserialize()
+			end
+		end
+
+		for verbName, apply in pairs(grammar.chainVerbs or {}) do
+			assert(chain[verbName] == nil, "ModeBuilder.Grammar: chain verb collides with a chain field: " .. verbName)
+			chain[verbName] = function(...)
+				apply(chain, name, ...)
+				return chain
+			end
+		end
+
+		return reserialize()
+	end
+end
+
+return ModeBuilder

--- a/modules/mode_builder.lua
+++ b/modules/mode_builder.lua
@@ -1,0 +1,176 @@
+---@class ModOptionConfig
+---@field value string|number|boolean
+---@field locked boolean
+---@field ui "hidden"|nil kept out of the lobby UI when hidden
+
+---@class ModePolicyRef
+---@field [1] string policy identity, e.g. "end.scripted"
+---@field locked boolean|"sealed"|nil nil/false = open, true = structure pinned, "sealed" = dials too
+---@field ui string|nil
+
+---@class ModeConfig
+---@field key string the name's snake_case
+---@field category string bound by the grammar, never by the preset
+---@field name string
+---@field desc string
+---@field allowRanked boolean
+---@field retainValues boolean|nil non-sticky preset: expose, keep current values
+---@field bots string[]|nil AI short names the lobby fields
+---@field policies ModePolicyRef[]
+---@field modOptions table<string, ModOptionConfig>
+
+local ModeBuilder = {}
+
+-- Policies every grammar speaks without registering: the chain's own verbs
+-- serialize through these.
+local BuiltinSerializers = {
+	-- ranked prohibition is enforced, not advisory: the option is pinned off
+	["mode.ranked"] = function(_p, lock)
+		return { ranked_game = { value = false, locked = lock.structure } }
+	end,
+}
+
+---@param serializers table<string, fun(params: table, lock: { structure: boolean, dial: boolean }): table<string, ModOptionConfig>>
+---@param bundle ModePolicyRef[]
+---@return table<string, ModOptionConfig>
+function ModeBuilder.ToModOptions(serializers, bundle)
+	local options = {}
+	for _, entry in ipairs(bundle) do
+		local name, params
+		if type(entry) == "table" then
+			name, params = entry[1], entry
+		else
+			name, params = entry, {}
+		end
+		local serialize = serializers[name] or BuiltinSerializers[name]
+		if not serialize then
+			error("unknown mode policy: " .. tostring(name))
+		end
+		local locked = params.locked
+		local lock = { structure = locked == true or locked == "sealed", dial = locked == "sealed" }
+		for key, option in pairs(serialize(params, lock)) do
+			if options[key] ~= nil then
+				error("two policies own modoption " .. key)
+			end
+			options[key] = option
+		end
+	end
+	return options
+end
+
+---@param modeName string for error messages
+---@param verb string
+---@param noun table
+---@param domains table<string, boolean> domains the verb accepts
+---@param hint string noun spelling for the error message
+---@return string domain
+function ModeBuilder.DomainOf(modeName, verb, noun, domains, hint)
+	assert(
+		type(noun) == "table" and type(noun.domain) == "string",
+		modeName .. ": ." .. verb .. " expects a noun (" .. hint .. ")"
+	)
+	assert(domains[noun.domain], modeName .. ": ." .. verb .. " does not apply to " .. noun.domain)
+	return noun.domain
+end
+
+---@param grammar { category: string, serializers: table, verbs: table<string, fun(modeName: string, ...): table> }
+---@return fun(name: string): ModeConfig
+function ModeBuilder.Grammar(grammar)
+	---@param name string
+	---@return ModeConfig
+	return function(name)
+		local chain = {
+			key = name:lower():gsub("%s+", "_"),
+			category = grammar.category,
+			name = name,
+			desc = "",
+			allowRanked = false,
+			policies = {}, ---@type ModePolicyRef[]
+			modOptions = {}, ---@type table<string, ModOptionConfig>
+		}
+
+		local function reserialize()
+			chain.modOptions = ModeBuilder.ToModOptions(grammar.serializers, chain.policies)
+			return chain
+		end
+
+		---@param modifier string
+		---@return table ref the most recent policy ref
+		local function lastPolicy(modifier)
+			local ref = chain.policies[#chain.policies]
+			assert(ref, name .. ": ." .. modifier .. " before any policy")
+			return ref
+		end
+
+		---@param desc string
+		chain.Desc = function(desc)
+			chain.desc = desc
+			return chain
+		end
+
+		---Whether this preset may be played ranked. Permission is a flag the
+		---lobby reads; prohibition is a policy the options enforce —
+		---Ranked(false) writes ranked_game off; .Locked() makes it a rule.
+		---@param enabled boolean|nil nil means true
+		chain.Ranked = function(enabled)
+			enabled = enabled ~= false
+			chain.allowRanked = enabled
+			if not enabled then
+				chain.policies[#chain.policies + 1] = { "mode.ranked" }
+				return reserialize()
+			end
+			return chain
+		end
+
+		---A bot the lobby fields when this preset is picked. The one thing no
+		---modoption can express: some modes are activated (scavengers) or
+		---merely made launchable (a mission's seat-filler) by an AI being on
+		---the field. Rides the exported JSON beside the options; nothing in
+		---the game reads it.
+		---@param aiName string
+		chain.Bot = function(aiName)
+			assert(type(aiName) == "string", "Mode(...).Bot expects an AI short name")
+			chain.bots = chain.bots or {}
+			chain.bots[#chain.bots + 1] = aiName
+			return chain
+		end
+
+		chain.RetainValues = function()
+			chain.retainValues = true
+			return chain
+		end
+
+		chain.Hidden = function()
+			lastPolicy("Hidden").ui = "hidden"
+			return reserialize()
+		end
+
+		chain.Unlocked = function()
+			lastPolicy("Unlocked").locked = false
+			return reserialize()
+		end
+
+		chain.Locked = function()
+			lastPolicy("Locked").locked = true
+			return reserialize()
+		end
+
+		---Pins the dials as well as the structure.
+		chain.Sealed = function()
+			lastPolicy("Sealed").locked = "sealed"
+			return reserialize()
+		end
+
+		for verbName, toRef in pairs(grammar.verbs) do
+			assert(chain[verbName] == nil, "ModeBuilder.Grammar: verb collides with a chain field: " .. verbName)
+			chain[verbName] = function(...)
+				chain.policies[#chain.policies + 1] = toRef(name, ...)
+				return reserialize()
+			end
+		end
+
+		return chain
+	end
+end
+
+return ModeBuilder

--- a/modules/modes/enums.lua
+++ b/modules/modes/enums.lua
@@ -1,0 +1,64 @@
+local M = {}
+
+M.ModeCategories = {
+	Game = "game",
+}
+
+M.Modes = {
+	Standard = "standard",
+}
+
+---@alias DeathModeKey "neverend"|"com"|"territorial_domination"|"builders"|"killall"|"own_com"
+---@class DeathModeFields
+---@field NeverEnd "neverend" the game runs until everyone leaves
+---@field Commander "com" a team loses when its last commander dies
+---@field TerritorialDomination "territorial_domination" rounds of territory control decide it
+---@field Builders "builders" a team loses when it can no longer build
+---@field KillAll "killall" a team loses when every unit is dead
+---@field OwnCommander "own_com" a player loses when their own commander dies
+
+---@type DeathModeFields
+M.DeathMode = {
+	NeverEnd = "neverend",
+	Commander = "com",
+	TerritorialDomination = "territorial_domination",
+	Builders = "builders",
+	KillAll = "killall",
+	OwnCommander = "own_com",
+}
+
+---@alias DraftModeKey "disabled"|"random"|"captain"|"skill"|"fair"
+---@class DraftModeFields
+---@field Disabled "disabled"
+---@field Random "random"
+---@field Captain "captain"
+---@field Skill "skill"
+---@field Fair "fair"
+
+---@type DraftModeFields
+M.DraftMode = {
+	Disabled = "disabled",
+	Random = "random",
+	Captain = "captain",
+	Skill = "skill",
+	Fair = "fair",
+}
+
+---@alias AnonymousModeKey "disabled"|"global"|"local"|"disco"|"allred"
+---@class AnonymousModeFields
+---@field Disabled "disabled"
+---@field Global "global"
+---@field Local "local"
+---@field Disco "disco"
+---@field AllRed "allred"
+
+---@type AnonymousModeFields
+M.AnonymousMode = {
+	Disabled = "disabled",
+	Global = "global",
+	Local = "local",
+	Disco = "disco",
+	AllRed = "allred",
+}
+
+return M

--- a/modules/modes/lib/values.lua
+++ b/modules/modes/lib/values.lua
@@ -1,0 +1,25 @@
+---@class ModeValues
+local Values = {}
+
+---A modoption on the wire is a string. Booleans are the engine's "1"/"0".
+---Engine Lua numbers are float32, so a plain tostring leaks precision noise
+---("0.60000002"); round at float32's seven digits with %.7f, then strip the
+---trailing zeros the engine's %g would keep. Yields "0.6", "30", "-1".
+---
+---Every producer of a mode value string reads this one function: the CI
+---export that bakes modes.json, and the lobby, which includes it out of the
+---game archive. A client's "did the user deviate from the preset" compares
+---strings, so two formatters would be a bug waiting for a value.
+---@param v any
+---@return string
+function Values.ToModOption(v)
+	if type(v) == "boolean" then
+		return v and "1" or "0"
+	end
+	if type(v) == "number" then
+		return (string.format("%.7f", v):gsub("0+$", ""):gsub("%.$", ""))
+	end
+	return tostring(v)
+end
+
+return Values

--- a/modules/modes/mode_dsl.lua
+++ b/modules/modes/mode_dsl.lua
@@ -1,0 +1,184 @@
+
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+local ModeEnums = VFS.Include("modules/context/mode_enums.lua")
+
+---@class GameModeDSL
+---@field Mode fun(name: string): GameModeChain Start a preset. The category is not a parameter: the grammar binds every chain from this module to "game" — the name only names it.
+
+local M = {}
+---@cast M GameModeDSL
+
+local RESTRICTION_KEYS = {
+	"unit_restrictions_notech15",
+	"unit_restrictions_notech2",
+	"unit_restrictions_notech3",
+	"unit_restrictions_noair",
+	"unit_restrictions_nosea",
+	"unit_restrictions_noextractors",
+	"unit_restrictions_noconverters",
+	"unit_restrictions_nofusion",
+	"unit_restrictions_notacnukes",
+	"unit_restrictions_nonukes",
+	"unit_restrictions_noantinuke",
+	"unit_restrictions_nolrpc",
+	"unit_restrictions_noendgamelrpc",
+}
+
+local function option(key, value, locked)
+	return { [key] = { value = value, locked = locked } }
+end
+
+local Serializers = {
+	["game.end"] = function(p, lock)
+		local options = option("deathmode", p.deathmode, lock.structure)
+		if p.deathmode == "territorial_domination" then
+			options.territorial_domination_config = { value = "25_minutes", locked = false }
+			options.territorial_domination_elimination_threshold_multiplier = { value = 1.2, locked = false }
+		end
+		return options
+	end,
+	["game.wreckage"] = function(p, lock)
+		return option("ffa_wreckage", p.enabled, lock.structure)
+	end,
+	["game.shuffle"] = function(p, lock)
+		return option("teamffa_start_boxes_shuffle", p.enabled, lock.structure)
+	end,
+	["game.maxunits"] = function(p, lock)
+		return option("maxunits", p.count, lock.dial)
+	end,
+	["game.draft"] = function(p, lock)
+		return option("draft_mode", p.draft, lock.structure)
+	end,
+	["game.anonymous"] = function(p, lock)
+		return option("teamcolors_anonymous_mode", p.anonymous, lock.structure)
+	end,
+	["game.pausedcommands"] = function(p, lock)
+		return option("allowpausegameplay", p.enabled, lock.structure)
+	end,
+	["game.customwidgets"] = function(p, lock)
+		return option("allowuserwidgets", p.enabled, lock.structure)
+	end,
+	["game.unitcontrolwidgets"] = function(p, lock)
+		return option("allowunitcontrolwidgets", p.enabled, lock.structure)
+	end,
+	["game.fixedalliances"] = function(p, lock)
+		return option("fixedallies", p.enabled, lock.structure)
+	end,
+	-- stated in the player's terms; the wire keys are the Disable* inversions
+	["game.mapdeformation"] = function(p, lock)
+		return option("disablemapdamage", not p.enabled, lock.structure)
+	end,
+	["game.fogofwar"] = function(p, lock)
+		return option("disable_fogofwar", not p.enabled, lock.structure)
+	end,
+	["game.norush"] = function(p, lock)
+		return {
+			norushtimer = { value = p.minutes, locked = lock.dial },
+			norushmiddlefree = { value = p.middleFree == true, locked = lock.dial },
+		}
+	end,
+	["game.slowcomtransport"] = function(p, lock)
+		return option("comm_trans_slow", p.enabled, lock.structure)
+	end,
+	["game.restrictions"] = function(_p, lock)
+		local options = {}
+		for _, key in ipairs(RESTRICTION_KEYS) do
+			options[key] = { value = false, locked = lock.dial }
+		end
+		return options
+	end,
+}
+
+---@param modeName string
+---@param verb string
+---@param value any
+local function checkBoolean(modeName, verb, value)
+	assert(type(value) == "boolean", modeName .. ": ." .. verb .. " expects true or false")
+end
+
+M.Mode = ModeBuilder.Grammar({
+	category = ModeEnums.ModeCategories.Game,
+	serializers = Serializers,
+	verbs = {
+		End = function(modeName, deathmode)
+			assert(type(deathmode) == "string", modeName .. ": .End expects a deathmode key")
+			return { "game.end", deathmode = deathmode }
+		end,
+
+		Wreckage = function(modeName, enabled)
+			checkBoolean(modeName, "Wreckage", enabled)
+			return { "game.wreckage", enabled = enabled }
+		end,
+
+		ShuffleStartBoxes = function(modeName, enabled)
+			checkBoolean(modeName, "ShuffleStartBoxes", enabled)
+			return { "game.shuffle", enabled = enabled }
+		end,
+
+		MaxUnits = function(modeName, count)
+			assert(type(count) == "number", modeName .. ": .MaxUnits expects a number")
+			return { "game.maxunits", count = count }
+		end,
+
+		Draft = function(modeName, draft)
+			assert(type(draft) == "string", modeName .. ": .Draft expects a draft_mode key")
+			return { "game.draft", draft = draft }
+		end,
+
+		Anonymous = function(modeName, anonymous)
+			assert(type(anonymous) == "string", modeName .. ": .Anonymous expects a mode key")
+			return { "game.anonymous", anonymous = anonymous }
+		end,
+
+		PausedCommands = function(modeName, enabled)
+			checkBoolean(modeName, "PausedCommands", enabled)
+			return { "game.pausedcommands", enabled = enabled }
+		end,
+
+		CustomWidgets = function(modeName, enabled)
+			checkBoolean(modeName, "CustomWidgets", enabled)
+			return { "game.customwidgets", enabled = enabled }
+		end,
+
+		UnitControlWidgets = function(modeName, enabled)
+			checkBoolean(modeName, "UnitControlWidgets", enabled)
+			return { "game.unitcontrolwidgets", enabled = enabled }
+		end,
+
+		FixedAlliances = function(modeName, enabled)
+			checkBoolean(modeName, "FixedAlliances", enabled)
+			return { "game.fixedalliances", enabled = enabled }
+		end,
+
+		---The map deforms under fire. Stated in the player's terms; the wire
+		---key is the inversion (disablemapdamage).
+		MapDeformation = function(modeName, enabled)
+			checkBoolean(modeName, "MapDeformation", enabled)
+			return { "game.mapdeformation", enabled = enabled }
+		end,
+
+		---Fog of war. Stated in the player's terms; the wire key is the
+		---inversion (disable_fogofwar).
+		FogOfWar = function(modeName, enabled)
+			checkBoolean(modeName, "FogOfWar", enabled)
+			return { "game.fogofwar", enabled = enabled }
+		end,
+
+		---No attacking before the timer; minutes 0 means off.
+		NoRush = function(modeName, minutes, middleFree)
+			assert(type(minutes) == "number", modeName .. ": .NoRush expects minutes")
+			return { "game.norush", minutes = minutes, middleFree = middleFree }
+		end,
+
+		SlowComTransport = function(modeName, enabled)
+			checkBoolean(modeName, "SlowComTransport", enabled)
+			return { "game.slowcomtransport", enabled = enabled }
+		end,
+
+		Restrictions = function(_modeName)
+			return { "game.restrictions" }
+		end,
+	},
+}) --[[@as fun(name: string): GameModeChain]]
+
+return M

--- a/modules/modes/mode_dsl.lua
+++ b/modules/modes/mode_dsl.lua
@@ -1,0 +1,211 @@
+
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+local ModeEnums = VFS.Include("modules/modes/enums.lua")
+
+---@class GameModeDSL
+---@field DeathMode DeathModeFields the keys .End accepts
+---@field DraftMode DraftModeFields the keys .Draft accepts
+---@field AnonymousMode AnonymousModeFields the keys .Anonymous accepts
+---@field Mode fun(name: string): GameModeChain Start a preset. The category is not a parameter: the grammar binds every chain from this module to "game" — the name only names it.
+
+local M = {}
+---@cast M GameModeDSL
+M.DeathMode = ModeEnums.DeathMode
+M.DraftMode = ModeEnums.DraftMode
+M.AnonymousMode = ModeEnums.AnonymousMode
+
+---@param modeName string
+---@param verb string
+---@param enum table<string, string>
+---@param value any
+local function oneOf(modeName, verb, enum, value)
+	for _, allowed in pairs(enum) do
+		if value == allowed then
+			return
+		end
+	end
+	local keys = {}
+	for name in pairs(enum) do
+		keys[#keys + 1] = name
+	end
+	table.sort(keys)
+	error(
+		modeName
+			.. ": ."
+			.. verb
+			.. " expects one of "
+			.. verb
+			.. "Mode."
+			.. table.concat(keys, ", " .. verb .. "Mode.")
+	)
+end
+
+local RESTRICTION_KEYS = {
+	"unit_restrictions_notech15",
+	"unit_restrictions_notech2",
+	"unit_restrictions_notech3",
+	"unit_restrictions_noair",
+	"unit_restrictions_nosea",
+	"unit_restrictions_noextractors",
+	"unit_restrictions_noconverters",
+	"unit_restrictions_nofusion",
+	"unit_restrictions_notacnukes",
+	"unit_restrictions_nonukes",
+	"unit_restrictions_noantinuke",
+	"unit_restrictions_nolrpc",
+	"unit_restrictions_noendgamelrpc",
+}
+
+local function option(key, value, locked)
+	return { [key] = { value = value, locked = locked } }
+end
+
+local Serializers = {
+	["game.end"] = function(p, lock)
+		local options = option("deathmode", p.deathmode, lock.structure)
+		if p.deathmode == ModeEnums.DeathMode.TerritorialDomination then
+			options.territorial_domination_config = { value = "25_minutes", locked = false }
+			options.territorial_domination_elimination_threshold_multiplier = { value = 1.2, locked = false }
+		end
+		return options
+	end,
+	["game.wreckage"] = function(p, lock)
+		return option("ffa_wreckage", p.enabled, lock.structure)
+	end,
+	["game.shuffle"] = function(p, lock)
+		return option("teamffa_start_boxes_shuffle", p.enabled, lock.structure)
+	end,
+	["game.maxunits"] = function(p, lock)
+		return option("maxunits", p.count, lock.dial)
+	end,
+	["game.draft"] = function(p, lock)
+		return option("draft_mode", p.draft, lock.structure)
+	end,
+	["game.anonymous"] = function(p, lock)
+		return option("teamcolors_anonymous_mode", p.anonymous, lock.structure)
+	end,
+	["game.pausedcommands"] = function(p, lock)
+		return option("allowpausegameplay", p.enabled, lock.structure)
+	end,
+	["game.customwidgets"] = function(p, lock)
+		return option("allowuserwidgets", p.enabled, lock.structure)
+	end,
+	["game.unitcontrolwidgets"] = function(p, lock)
+		return option("allowunitcontrolwidgets", p.enabled, lock.structure)
+	end,
+	["game.fixedalliances"] = function(p, lock)
+		return option("fixedallies", p.enabled, lock.structure)
+	end,
+	-- stated in the player's terms; the wire keys are the Disable* inversions
+	["game.mapdeformation"] = function(p, lock)
+		return option("disablemapdamage", not p.enabled, lock.structure)
+	end,
+	["game.fogofwar"] = function(p, lock)
+		return option("disable_fogofwar", not p.enabled, lock.structure)
+	end,
+	["game.norush"] = function(p, lock)
+		return {
+			norushtimer = { value = p.minutes, locked = lock.dial },
+			norushmiddlefree = { value = p.middleFree == true, locked = lock.dial },
+		}
+	end,
+	["game.slowcomtransport"] = function(p, lock)
+		return option("comm_trans_slow", p.enabled, lock.structure)
+	end,
+	["game.unit_restrictions"] = function(_p, lock)
+		local options = {}
+		for _, key in ipairs(RESTRICTION_KEYS) do
+			options[key] = { value = false, locked = lock.dial }
+		end
+		return options
+	end,
+}
+
+---@param modeName string
+---@param verb string
+---@param value any
+local function checkBoolean(modeName, verb, value)
+	assert(type(value) == "boolean", modeName .. ": ." .. verb .. " expects true or false")
+end
+
+M.Mode = ModeBuilder.Grammar({
+	category = ModeEnums.ModeCategories.Game,
+	serializers = Serializers,
+	verbs = {
+		End = function(modeName, deathmode)
+			oneOf(modeName, "Death", ModeEnums.DeathMode, deathmode)
+			return { "game.end", deathmode = deathmode }
+		end,
+
+		Wreckage = function(modeName, enabled)
+			checkBoolean(modeName, "Wreckage", enabled)
+			return { "game.wreckage", enabled = enabled }
+		end,
+
+		ShuffleStartBoxes = function(modeName, enabled)
+			checkBoolean(modeName, "ShuffleStartBoxes", enabled)
+			return { "game.shuffle", enabled = enabled }
+		end,
+
+		MaxUnits = function(modeName, count)
+			assert(type(count) == "number", modeName .. ": .MaxUnits expects a number")
+			return { "game.maxunits", count = count }
+		end,
+
+		Draft = function(modeName, draft)
+			oneOf(modeName, "Draft", ModeEnums.DraftMode, draft)
+			return { "game.draft", draft = draft }
+		end,
+
+		Anonymous = function(modeName, anonymous)
+			oneOf(modeName, "Anonymous", ModeEnums.AnonymousMode, anonymous)
+			return { "game.anonymous", anonymous = anonymous }
+		end,
+
+		PausedCommands = function(modeName, enabled)
+			checkBoolean(modeName, "PausedCommands", enabled)
+			return { "game.pausedcommands", enabled = enabled }
+		end,
+
+		CustomWidgets = function(modeName, enabled)
+			checkBoolean(modeName, "CustomWidgets", enabled)
+			return { "game.customwidgets", enabled = enabled }
+		end,
+
+		UnitControlWidgets = function(modeName, enabled)
+			checkBoolean(modeName, "UnitControlWidgets", enabled)
+			return { "game.unitcontrolwidgets", enabled = enabled }
+		end,
+
+		FixedAlliances = function(modeName, enabled)
+			checkBoolean(modeName, "FixedAlliances", enabled)
+			return { "game.fixedalliances", enabled = enabled }
+		end,
+
+		MapDeformation = function(modeName, enabled)
+			checkBoolean(modeName, "MapDeformation", enabled)
+			return { "game.mapdeformation", enabled = enabled }
+		end,
+
+		FogOfWar = function(modeName, enabled)
+			checkBoolean(modeName, "FogOfWar", enabled)
+			return { "game.fogofwar", enabled = enabled }
+		end,
+
+		NoRush = function(modeName, minutes, middleFree)
+			assert(type(minutes) == "number", modeName .. ": .NoRush expects minutes")
+			return { "game.norush", minutes = minutes, middleFree = middleFree }
+		end,
+
+		SlowComTransport = function(modeName, enabled)
+			checkBoolean(modeName, "SlowComTransport", enabled)
+			return { "game.slowcomtransport", enabled = enabled }
+		end,
+
+		UnitRestrictions = function(_modeName)
+			return { "game.unit_restrictions" }
+		end,
+	},
+}) --[[@as fun(name: string): GameModeChain]]
+
+return M

--- a/modules/modes/modes/ffa.lua
+++ b/modules/modes/modes/ffa.lua
@@ -1,0 +1,24 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("FFA")
+	.Desc(
+		"Free for all: every player for themselves. Losing your commander resigns you, and the fallen leave wreckage behind."
+	)
+	.Ranked()
+	.End(DeathMode.OwnCommander)
+	.Wreckage(true).Locked()
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modes/ffa.lua
+++ b/modules/modes/modes/ffa.lua
@@ -1,0 +1,23 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+
+-- stylua: ignore
+return Mode("FFA")
+	.Desc(
+		"Free for all: every player for themselves. Losing your commander resigns you, and the fallen leave wreckage behind."
+	)
+	.Ranked()
+	.End("own_com")
+	.Wreckage(true).Locked()
+	.MaxUnits(2000)
+	.Draft("random")
+	.Anonymous("disabled")
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.Restrictions()

--- a/modules/modes/modes/standard.lua
+++ b/modules/modes/modes/standard.lua
@@ -1,0 +1,21 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("Standard")
+	.Desc("An ordinary game: no scripted mission, no PvE swarm.")
+	.Ranked()
+	.End(DeathMode.Commander)
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modes/standard.lua
+++ b/modules/modes/modes/standard.lua
@@ -1,0 +1,20 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+
+-- stylua: ignore
+return Mode("Standard")
+	.Desc("An ordinary game: no scripted mission, no PvE swarm.")
+	.Ranked()
+	.End("com")
+	.MaxUnits(2000)
+	.Draft("random")
+	.Anonymous("disabled")
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.Restrictions()

--- a/modules/modes/modes/team_ffa.lua
+++ b/modules/modes/modes/team_ffa.lua
@@ -1,0 +1,22 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+
+-- stylua: ignore
+return Mode("Team FFA")
+	.Desc("Several teams, every team for itself. Start boxes are dealt at random, and fallen teams leave wreckage behind.")
+	.Ranked()
+	.ShuffleStartBoxes(true).Locked()
+	.Wreckage(true).Locked()
+	.End("com")
+	.MaxUnits(2000)
+	.Draft("random")
+	.Anonymous("disabled")
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.Restrictions()

--- a/modules/modes/modes/team_ffa.lua
+++ b/modules/modes/modes/team_ffa.lua
@@ -1,0 +1,23 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("Team FFA")
+	.Desc("Several teams, every team for itself. Start boxes are dealt at random, and fallen teams leave wreckage behind.")
+	.Ranked()
+	.ShuffleStartBoxes(true).Locked()
+	.Wreckage(true).Locked()
+	.End(DeathMode.Commander)
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modes/territorial_domination.lua
+++ b/modules/modes/modes/territorial_domination.lua
@@ -1,0 +1,22 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+
+-- stylua: ignore
+return Mode("Territorial Domination")
+	.Desc(
+		"Teams earn points by capturing territory to stay in the game. At the end of the final round, the team with the most points wins."
+	)
+	.Ranked()
+	.End("territorial_domination").Locked()
+	.MaxUnits(2000)
+	.Draft("random")
+	.Anonymous("disabled")
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.Restrictions()

--- a/modules/modes/modes/territorial_domination.lua
+++ b/modules/modes/modes/territorial_domination.lua
@@ -1,0 +1,23 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("Territorial Domination")
+	.Desc(
+		"Teams earn points by capturing territory to stay in the game. At the end of the final round, the team with the most points wins."
+	)
+	.Ranked()
+	.End(DeathMode.TerritorialDomination).Locked()
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modoptions.lua
+++ b/modules/modes/modoptions.lua
@@ -1,0 +1,33 @@
+--- A match is exactly one way of playing, so the game-axis selector belongs to mode infrastructure, not a flavor.
+--- Flavors append their preset key to the items in their own commit: SPADS and unitsync accept only listed values.
+
+local ModeEnums = VFS.Include("modules/context/mode_enums.lua")
+
+return {
+	{
+		key = ModeEnums.ModeCategories.Game,
+		name = "Game",
+		desc = "Which game this is: one choice, everything else follows from it.",
+		type = "section",
+		weight = 8,
+	},
+
+	{
+		key = "game_mode",
+		name = "Game Mode",
+		desc = "How this match is played. Picking a mode sets everything the mode needs and locks what it depends on.",
+		type = "list",
+		section = ModeEnums.ModeCategories.Game,
+		def = "standard",
+		items = {
+			{ key = "standard", name = "Standard", desc = "An ordinary game: no scripted mission, no PvE swarm." },
+			{ key = "ffa", name = "FFA", desc = "Free for all: every player for themselves." },
+			{ key = "team_ffa", name = "Team FFA", desc = "Several teams, every team for itself." },
+			{
+				key = "territorial_domination",
+				name = "Territorial Domination",
+				desc = "Teams earn points by capturing territory to stay in the game.",
+			},
+		},
+	},
+}

--- a/modules/modes/modoptions.lua
+++ b/modules/modes/modoptions.lua
@@ -1,0 +1,36 @@
+--- Flavors append their preset key to the items in their own commit: SPADS and unitsync accept only listed values.
+
+local ModeEnums = VFS.Include("modules/modes/enums.lua")
+
+return {
+	{
+		key = ModeEnums.ModeCategories.Game,
+		name = "Game",
+		desc = "Which game this is: one choice, everything else follows from it.",
+		type = "section",
+		weight = 8,
+	},
+
+	{
+		key = "game_mode",
+		name = "Game Mode",
+		desc = "How this match is played. Picking a mode sets everything the mode needs and locks what it depends on.",
+		type = "list",
+		section = ModeEnums.ModeCategories.Game,
+		def = ModeEnums.Modes.Standard,
+		items = {
+			{
+				key = ModeEnums.Modes.Standard,
+				name = "Standard",
+				desc = "An ordinary game: no scripted mission, no PvE swarm.",
+			},
+			{ key = "ffa", name = "FFA", desc = "Free for all: every player for themselves." },
+			{ key = "team_ffa", name = "Team FFA", desc = "Several teams, every team for itself." },
+			{
+				key = "territorial_domination",
+				name = "Territorial Domination",
+				desc = "Teams earn points by capturing territory to stay in the game.",
+			},
+		},
+	},
+}

--- a/modules/modes/module.lua
+++ b/modules/modes/module.lua
@@ -1,0 +1,5 @@
+---@type ModuleManifestFile
+return {
+	name = "modes",
+	description = "Game mode infrastructure: the game axis, preset aggregation and export",
+}

--- a/modules/modes/spec/game_axis_spec.lua
+++ b/modules/modes/spec/game_axis_spec.lua
@@ -1,0 +1,108 @@
+
+local fragment = VFS.Include("modules/modes/modoptions.lua")
+
+---@param key string
+---@return table|nil
+local function option(key)
+	for _, entry in ipairs(fragment) do
+		if entry.key == key then
+			return entry
+		end
+	end
+	return nil
+end
+
+describe("the game axis", function()
+	it("ships the game section, weighted to lead", function()
+		local section = option("game")
+		assert.are.equal("section", section.type)
+		assert.are.equal("Game", section.name)
+		assert.are.equal(8, section.weight)
+	end)
+
+	it("ships the selector, defaulting to standard", function()
+		local selector = option("game_mode")
+		assert.are.equal("list", selector.type)
+		assert.are.equal("standard", selector.def)
+		assert.are.equal("game", selector.section)
+		assert.are.equal("standard", selector.items[1].key)
+	end)
+
+	it("governs the Main options — the base rules belong to how the match is played", function()
+		for _, entry in ipairs(VFS.Include("modoptions.lua")) do
+			if entry.key == "options_main" and entry.type == "section" then
+				assert.are.equal("game", entry.mode_category)
+				return
+			end
+		end
+		error("options_main section not found")
+	end)
+
+	describe("the Standard preset", function()
+		local standard = VFS.Include("modules/modes/modes/standard.lua")
+
+		it("exposes an ordinary game's dials, open, at their defaults", function()
+			assert.are.equal("standard", standard.key)
+			assert.are.equal("game", standard.category)
+			assert.are.same({ value = "com", locked = false }, standard.modOptions.deathmode)
+			assert.are.same({ value = 2000, locked = false }, standard.modOptions.maxunits)
+			assert.are.same({ value = "random", locked = false }, standard.modOptions.draft_mode)
+			assert.are.same({ value = false, locked = false }, standard.modOptions.unit_restrictions_noair)
+		end)
+
+		it("does not show what it does not speak: no TD config, no FFA manners", function()
+			assert.is_nil(standard.modOptions.territorial_domination_config)
+			assert.is_nil(standard.modOptions.ffa_wreckage)
+			assert.is_nil(standard.modOptions.teamffa_start_boxes_shuffle)
+		end)
+
+		it("stays ranked and fields no bot", function()
+			assert.is_true(standard.allowRanked)
+			assert.is_nil(standard.bots)
+		end)
+	end)
+
+	describe("the FFA preset", function()
+		local ffa = VFS.Include("modules/modes/modes/ffa.lua")
+
+		it("is Standard's dials with the FFA manners", function()
+			assert.are.equal("ffa", ffa.key)
+			assert.are.same({ value = "own_com", locked = false }, ffa.modOptions.deathmode)
+			assert.are.same({ value = true, locked = true }, ffa.modOptions.ffa_wreckage)
+			assert.are.same({ value = 2000, locked = false }, ffa.modOptions.maxunits)
+			assert.is_true(ffa.allowRanked)
+		end)
+	end)
+
+	describe("the Team FFA preset", function()
+		local teamFfa = VFS.Include("modules/modes/modes/team_ffa.lua")
+
+		it("shuffles the boxes, keeps the manners, opens the rest", function()
+			assert.are.equal("team_ffa", teamFfa.key)
+			assert.are.same({ value = true, locked = true }, teamFfa.modOptions.teamffa_start_boxes_shuffle)
+			assert.are.same({ value = true, locked = true }, teamFfa.modOptions.ffa_wreckage)
+			assert.are.same({ value = "com", locked = false }, teamFfa.modOptions.deathmode)
+			assert.is_true(teamFfa.allowRanked)
+		end)
+	end)
+
+	describe("the Territorial Domination preset", function()
+		local td = VFS.Include("modules/modes/modes/territorial_domination.lua")
+
+		it("locks the end rule, which brings its own dials along", function()
+			assert.are.equal("territorial_domination", td.key)
+			assert.are.same({ value = "territorial_domination", locked = true }, td.modOptions.deathmode)
+			assert.are.same({ value = "25_minutes", locked = false }, td.modOptions.territorial_domination_config)
+			assert.are.same(
+				{ value = 1.2, locked = false },
+				td.modOptions.territorial_domination_elimination_threshold_multiplier
+			)
+			assert.is_true(td.allowRanked)
+		end)
+
+		it("keeps the round dials to itself — Standard never shows them", function()
+			local standard = VFS.Include("modules/modes/modes/standard.lua")
+			assert.is_nil(standard.modOptions.territorial_domination_config)
+		end)
+	end)
+end)

--- a/modules/modes/spec/lib/values_spec.lua
+++ b/modules/modes/spec/lib/values_spec.lua
@@ -1,0 +1,21 @@
+local Values = VFS.Include("modules/modes/lib/values.lua") ---@type ModeValues
+
+describe("mode values on the wire", function()
+	it("writes booleans as the engine reads them", function()
+		assert.are.equal("1", Values.ToModOption(true))
+		assert.are.equal("0", Values.ToModOption(false))
+	end)
+
+	it("rounds numbers at float32 precision and trims what %g would keep", function()
+		assert.are.equal("0.6", Values.ToModOption(0.6))
+		assert.are.equal("0.6", Values.ToModOption(0.60000002))
+		assert.are.equal("30", Values.ToModOption(30))
+		assert.are.equal("-1", Values.ToModOption(-1))
+		assert.are.equal("0", Values.ToModOption(0))
+		assert.are.equal("1.5", Values.ToModOption(1.5))
+	end)
+
+	it("passes strings through", function()
+		assert.are.equal("notcoms", Values.ToModOption("notcoms"))
+	end)
+end)

--- a/modules/modes/spec/mode_builder_spec.lua
+++ b/modules/modes/spec/mode_builder_spec.lua
@@ -1,0 +1,135 @@
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+
+--- A throwaway vocabulary: one noun, one verb, two serializers, so the tests
+--- exercise the builder rather than any module's real grammar.
+local function grammar()
+	return ModeBuilder.Grammar({
+		category = "test",
+		serializers = {
+			["end.scripted"] = function(_params, lock)
+				return { deathmode = { value = "neverend", locked = lock.structure } }
+			end,
+			["dial.rate"] = function(params, lock)
+				return { rate = { value = params.rate or 1, locked = lock.dial } }
+			end,
+		},
+		verbs = {
+			Own = function(modeName, noun)
+				return { ModeBuilder.DomainOf(modeName, "Own", noun, { ["end"] = true }, "Match.End") .. ".scripted" }
+			end,
+			Rate = function(_modeName, rate)
+				return { "dial.rate", rate = rate }
+			end,
+		},
+	})
+end
+
+local MatchEnd = { domain = "end" }
+
+describe("mode builder", function()
+	describe("the chain", function()
+		it("keys a mode by the snake_case of its name", function()
+			assert.are.equal("easy_tax", grammar()("Easy Tax").key)
+			assert.are.equal("test", grammar()("Easy Tax").category)
+		end)
+
+		it("returns the chain from every verb, so authoring stays dot-only", function()
+			local Mode = grammar()
+			local chain = Mode("Scripted")
+			assert.are.equal(chain, chain.Desc("d"))
+			assert.are.equal(chain, chain.Ranked())
+			assert.are.equal(chain, chain.Own(MatchEnd))
+			assert.are.equal(chain, chain.Locked())
+		end)
+
+		it("re-derives modOptions after every step, so consumers read a plain table", function()
+			local chain = grammar()("Scripted").Own(MatchEnd)
+			assert.are.equal("neverend", chain.modOptions.deathmode.value)
+			chain.Rate(5)
+			assert.are.equal(5, chain.modOptions.rate.value)
+			-- the earlier policy's options survive the re-derivation
+			assert.are.equal("neverend", chain.modOptions.deathmode.value)
+		end)
+
+		it("refuses a modifier before any policy", function()
+			assert.has_error(function()
+				grammar()("Scripted").Locked()
+			end, "Scripted: .Locked before any policy")
+		end)
+
+		it("refuses a verb that collides with a chain field", function()
+			assert.has_error(function()
+				ModeBuilder.Grammar({
+					category = "test",
+					serializers = {},
+					verbs = { Desc = function() end },
+				})("Scripted")
+			end, "ModeBuilder.Grammar: verb collides with a chain field: Desc")
+		end)
+	end)
+
+	describe("lock defaults", function()
+		it("a bare policy is a suggestion: nothing locked", function()
+			local chain = grammar()("Scripted").Own(MatchEnd).Rate(2)
+			assert.is_false(chain.modOptions.deathmode.locked)
+			assert.is_false(chain.modOptions.rate.locked)
+		end)
+
+		it("Locked pins the structure, Sealed the dials too", function()
+			local chain = grammar()("Scripted").Own(MatchEnd).Locked().Rate(2).Locked()
+			assert.is_true(chain.modOptions.deathmode.locked)
+			assert.is_false(chain.modOptions.rate.locked)
+			assert.is_true(grammar()("Scripted").Rate(2).Sealed().modOptions.rate.locked)
+		end)
+	end)
+
+	describe("serialization", function()
+		it("rejects a policy no serializer owns", function()
+			assert.has_error(function()
+				ModeBuilder.ToModOptions({}, { "end.scripted" })
+			end, "unknown mode policy: end.scripted")
+		end)
+
+		it("rejects two policies owning one modoption", function()
+			local double = function()
+				return { deathmode = { value = "x", locked = true } }
+			end
+			assert.has_error(function()
+				ModeBuilder.ToModOptions({ a = double, b = double }, { "a", "b" })
+			end, "two policies own modoption deathmode")
+		end)
+	end)
+
+	describe("domain guard", function()
+		it("returns the noun's domain when the verb accepts it", function()
+			assert.are.equal("end", ModeBuilder.DomainOf("M", "Own", MatchEnd, { ["end"] = true }, "Match.End"))
+		end)
+
+		it("rejects a value that is not a noun", function()
+			assert.has_error(function()
+				ModeBuilder.DomainOf("M", "Own", "end", { ["end"] = true }, "Match.End")
+			end, "M: .Own expects a noun (Match.End)")
+		end)
+
+		it("rejects a noun the verb does not apply to", function()
+			assert.has_error(function()
+				ModeBuilder.DomainOf("M", "Own", { domain = "share" }, { ["end"] = true }, "Match.End")
+			end, "M: .Own does not apply to share")
+		end)
+	end)
+
+	describe("Ranked", function()
+		it("permission is a flag: nothing pinned", function()
+			local mode = grammar()("R").Ranked()
+			assert.is_true(mode.allowRanked)
+			assert.is_nil(mode.modOptions.ranked_game)
+		end)
+
+		it("prohibition is a policy: ranked_game off, pinned when Locked", function()
+			local mode = grammar()("R").Ranked(false).Locked()
+			assert.is_false(mode.allowRanked)
+			assert.are.same({ value = false, locked = true }, mode.modOptions.ranked_game)
+			assert.is_false(grammar()("R").Ranked(false).modOptions.ranked_game.locked)
+		end)
+	end)
+end)

--- a/modules/modes/spec/modoptions_spec.lua
+++ b/modules/modes/spec/modoptions_spec.lua
@@ -1,0 +1,108 @@
+
+local fragment = VFS.Include("modules/modes/modoptions.lua")
+
+---@param key string
+---@return table|nil
+local function option(key)
+	for _, entry in ipairs(fragment) do
+		if entry.key == key then
+			return entry
+		end
+	end
+	return nil
+end
+
+describe("the game axis", function()
+	it("ships the game section, weighted to lead", function()
+		local section = option("game")
+		assert.are.equal("section", section.type)
+		assert.are.equal("Game", section.name)
+		assert.are.equal(8, section.weight)
+	end)
+
+	it("ships the selector, defaulting to standard", function()
+		local selector = option("game_mode")
+		assert.are.equal("list", selector.type)
+		assert.are.equal("standard", selector.def)
+		assert.are.equal("game", selector.section)
+		assert.are.equal("standard", selector.items[1].key)
+	end)
+
+	it("governs the Main options — the base rules belong to how the match is played", function()
+		for _, entry in ipairs(VFS.Include("modoptions.lua")) do
+			if entry.key == "options_main" and entry.type == "section" then
+				assert.are.equal("game", entry.mode_category)
+				return
+			end
+		end
+		error("options_main section not found")
+	end)
+
+	describe("the Standard preset", function()
+		local standard = VFS.Include("modules/modes/modes/standard.lua")
+
+		it("exposes an ordinary game's dials, open, at their defaults", function()
+			assert.are.equal("standard", standard.key)
+			assert.are.equal("game", standard.category)
+			assert.are.same({ value = "com", locked = false }, standard.modOptions.deathmode)
+			assert.are.same({ value = 2000, locked = false }, standard.modOptions.maxunits)
+			assert.are.same({ value = "random", locked = false }, standard.modOptions.draft_mode)
+			assert.are.same({ value = false, locked = false }, standard.modOptions.unit_restrictions_noair)
+		end)
+
+		it("does not show what it does not speak: no TD config, no FFA manners", function()
+			assert.is_nil(standard.modOptions.territorial_domination_config)
+			assert.is_nil(standard.modOptions.ffa_wreckage)
+			assert.is_nil(standard.modOptions.teamffa_start_boxes_shuffle)
+		end)
+
+		it("stays ranked and fields no bot", function()
+			assert.is_true(standard.allowRanked)
+			assert.is_nil(standard.bots)
+		end)
+	end)
+
+	describe("the FFA preset", function()
+		local ffa = VFS.Include("modules/modes/modes/ffa.lua")
+
+		it("is Standard's dials with the FFA manners", function()
+			assert.are.equal("ffa", ffa.key)
+			assert.are.same({ value = "own_com", locked = false }, ffa.modOptions.deathmode)
+			assert.are.same({ value = true, locked = true }, ffa.modOptions.ffa_wreckage)
+			assert.are.same({ value = 2000, locked = false }, ffa.modOptions.maxunits)
+			assert.is_true(ffa.allowRanked)
+		end)
+	end)
+
+	describe("the Team FFA preset", function()
+		local teamFfa = VFS.Include("modules/modes/modes/team_ffa.lua")
+
+		it("shuffles the boxes, keeps the manners, opens the rest", function()
+			assert.are.equal("team_ffa", teamFfa.key)
+			assert.are.same({ value = true, locked = true }, teamFfa.modOptions.teamffa_start_boxes_shuffle)
+			assert.are.same({ value = true, locked = true }, teamFfa.modOptions.ffa_wreckage)
+			assert.are.same({ value = "com", locked = false }, teamFfa.modOptions.deathmode)
+			assert.is_true(teamFfa.allowRanked)
+		end)
+	end)
+
+	describe("the Territorial Domination preset", function()
+		local td = VFS.Include("modules/modes/modes/territorial_domination.lua")
+
+		it("locks the end rule, which brings its own dials along", function()
+			assert.are.equal("territorial_domination", td.key)
+			assert.are.same({ value = "territorial_domination", locked = true }, td.modOptions.deathmode)
+			assert.are.same({ value = "25_minutes", locked = false }, td.modOptions.territorial_domination_config)
+			assert.are.same(
+				{ value = 1.2, locked = false },
+				td.modOptions.territorial_domination_elimination_threshold_multiplier
+			)
+			assert.is_true(td.allowRanked)
+		end)
+
+		it("keeps the round dials to itself — Standard never shows them", function()
+			local standard = VFS.Include("modules/modes/modes/standard.lua")
+			assert.is_nil(standard.modOptions.territorial_domination_config)
+		end)
+	end)
+end)

--- a/modules/modes/types/mode_policy.lua
+++ b/modules/modes/types/mode_policy.lua
@@ -1,0 +1,41 @@
+---@meta policy mode
+
+---A game mode preset under construction. Every verb claims one policy and the
+---modoptions it writes; the panel is a whitelist, so a mode shows exactly what
+---it claims. A verb's claim is followed by at most one of Locked, Sealed,
+---Unlocked or Hidden, which applies to that claim only.
+---
+---Locked pins the claim's structure (the option a player would flip) and leaves
+---its dials open; Sealed pins the dials too. Dials are the numeric follow-ons:
+---MaxUnits, NoRush, UnitRestrictions, and the round settings End brings along.
+---@class GameModeChain
+---@field Desc fun(desc: string): GameModeChain The sentence the lobby shows under the mode's name.
+---@field Ranked fun(enabled: boolean?): GameModeChain Whether the mode may count for rating. Ranked() allows it; Ranked(false), or never saying Ranked, pins ranked_game off, lockable like any claim.
+---@field Bot fun(aiName: string): GameModeChain An AI the lobby fields for this mode, by short name; repeat for more.
+---@field Uses fun(contract: table): GameModeChain A module whose fact providers this preset makes live, besides the module that ships the preset; named by its contract.lua, never a string. The mode decides who answers a slot; two live providers for one slot is a load error.
+---@field RetainValues fun(): GameModeChain A non-sticky preset (Customize): picking it exposes and unlocks its claims but keeps the current values instead of resetting the category to defaults.
+---@field Hidden fun(): GameModeChain The last claim stays out of the lobby UI; its pin still applies.
+---@field Unlocked fun(): GameModeChain The last claim is fully editable, structure and dials.
+---@field Locked fun(): GameModeChain The last claim's structure is pinned; its dials stay editable.
+---@field Sealed fun(): GameModeChain The last claim is pinned outright, dials included.
+---@field End fun(deathmode: DeathModeKey): GameModeChain How the game ends: writes deathmode. territorial_domination brings its round length and elimination dials along, open.
+---@field Wreckage fun(enabled: boolean): GameModeChain Whether a resigned or eliminated player's units stay as wreckage: writes ffa_wreckage.
+---@field ShuffleStartBoxes fun(enabled: boolean): GameModeChain Randomise which start box each team gets: writes teamffa_start_boxes_shuffle.
+---@field MaxUnits fun(count: number): GameModeChain Unit cap per player: writes maxunits, a dial.
+---@field Draft fun(draft: DraftModeKey): GameModeChain Start position drafting: writes draft_mode with the given key.
+---@field Anonymous fun(anonymous: AnonymousModeKey): GameModeChain Team colour anonymity: writes teamcolors_anonymous_mode with the given key.
+---@field PausedCommands fun(enabled: boolean): GameModeChain Whether orders may be given while paused: writes allowpausegameplay.
+---@field CustomWidgets fun(enabled: boolean): GameModeChain Whether players may run their own widgets: writes allowuserwidgets.
+---@field UnitControlWidgets fun(enabled: boolean): GameModeChain Whether widgets may control units: writes allowunitcontrolwidgets.
+---@field FixedAlliances fun(enabled: boolean): GameModeChain Whether alliances are fixed for the game: writes fixedallies.
+---@field MapDeformation fun(enabled: boolean): GameModeChain Whether weapons reshape terrain. Stated in the player's terms; writes disablemapdamage inverted.
+---@field FogOfWar fun(enabled: boolean): GameModeChain Whether the map has fog of war. Stated in the player's terms; writes disable_fogofwar inverted.
+---@field NoRush fun(minutes: number, middleFree: boolean?): GameModeChain Minutes players must stay in their start boxes, 0 for none: writes norushtimer and norushmiddlefree, both dials.
+---@field SlowComTransport fun(enabled: boolean): GameModeChain Whether carrying your own commander slows a transport: writes comm_trans_slow.
+---@field UnitRestrictions fun(): GameModeChain Claims every unit_restrictions_* toggle at off, so the panel shows them as dials the host may flip. Sealed() pins them all off; Locked() does not, they are dials.
+
+---The category is not a parameter: the grammar binds every chain from this
+---module to "game".
+---@param name string
+---@return GameModeChain
+function Mode(name) end

--- a/modules/modes/types/mode_policy.lua
+++ b/modules/modes/types/mode_policy.lua
@@ -1,0 +1,32 @@
+---@meta policy mode
+
+---@class GameModeChain
+---@field Desc fun(desc: string): GameModeChain
+---@field Ranked fun(enabled: boolean?): GameModeChain permission is a flag; Ranked(false) pins ranked_game off, lockable like any policy
+---@field RetainValues fun(): GameModeChain
+---@field Hidden fun(): GameModeChain
+---@field Unlocked fun(): GameModeChain
+---@field Locked fun(): GameModeChain
+---@field Sealed fun(): GameModeChain pins the dials as well
+---@field End fun(deathmode: string): GameModeChain territorial_domination brings its round dials along
+---@field Wreckage fun(enabled: boolean): GameModeChain
+---@field ShuffleStartBoxes fun(enabled: boolean): GameModeChain
+---@field MaxUnits fun(count: number): GameModeChain
+---@field Draft fun(draft: string): GameModeChain
+---@field Anonymous fun(anonymous: string): GameModeChain
+---@field PausedCommands fun(enabled: boolean): GameModeChain
+---@field CustomWidgets fun(enabled: boolean): GameModeChain
+---@field UnitControlWidgets fun(enabled: boolean): GameModeChain
+---@field FixedAlliances fun(enabled: boolean): GameModeChain
+---@field MapDeformation fun(enabled: boolean): GameModeChain
+---@field FogOfWar fun(enabled: boolean): GameModeChain
+---@field NoRush fun(minutes: number, middleFree: boolean?): GameModeChain
+---@field SlowComTransport fun(enabled: boolean): GameModeChain
+---@field Restrictions fun(): GameModeChain
+
+---Start a mode chain; the key is the name's snake_case. The category is
+---not a parameter: the grammar binds every chain from this module to
+---"game".
+---@param name string
+---@return GameModeChain
+function Mode(name) end

--- a/modules/modes/widgets/export_modes.lua
+++ b/modules/modes/widgets/export_modes.lua
@@ -1,0 +1,121 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Modes JSON Export",
+		desc = "Exports every mode preset, all categories, to structured JSON.\nCommand: /exportmodes",
+		author = "Daniel Harvey",
+		date = "June 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = false,
+	}
+end
+
+local spEcho = Spring.Echo
+
+local SCHEMA_VERSION = 1
+local OUTPUT_PATH = "modes.json"
+
+-- One formatter for every mode value string, shared with the lobby.
+local Values = VFS.Include("modules/modes/lib/values.lua") ---@type ModeValues
+local toModOptionValue = Values.ToModOption
+
+local function collectDefaultsByCategory()
+	local defs = VFS.Include("modoptions.lua")
+	local sectionCategory = {}
+	for _, o in ipairs(defs) do
+		if o.key and o.type == "section" then
+			sectionCategory[o.key] = o.mode_category or o.key
+		end
+	end
+	local byCategory = {}
+	for _, o in ipairs(defs) do
+		if
+			o.key
+			and o.section
+			and o.def ~= nil
+			and o.type ~= "section"
+			and o.type ~= "subheader"
+			and o.type ~= "separator"
+		then
+			local category = sectionCategory[o.section] or o.section
+			byCategory[category] = byCategory[category] or {}
+			byCategory[category][o.key] = toModOptionValue(o.def)
+		end
+	end
+	return byCategory
+end
+
+local function collectModesByCategory()
+	local ModuleHandler = VFS.Include("modules/module_handler.lua")
+	local byCategory = {}
+	for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+		for _, modeFile in ipairs(VFS.DirList(dir, "*.lua") or {}) do
+			local ok, mode = pcall(VFS.Include, modeFile)
+			if ok and type(mode) == "table" and mode.key and mode.category then
+				byCategory[mode.category] = byCategory[mode.category] or {}
+				byCategory[mode.category][mode.key] = mode
+			end
+		end
+	end
+	return byCategory
+end
+
+-- Full effective option set (defaults then overrides), so applying a mode resets the previous one.
+local function buildEffectiveModOptions(defaults, mode, selector)
+	local effective = {}
+	for key, value in pairs(defaults) do
+		if key ~= selector then
+			effective[key] = { value = value, locked = false }
+		end
+	end
+	for key, rule in pairs(mode.modOptions or {}) do
+		if key ~= selector and rule.value ~= nil then
+			effective[key] = { value = toModOptionValue(rule.value), locked = rule.locked == true }
+		end
+	end
+	return effective
+end
+
+local function buildExport()
+	local defaultsByCategory = collectDefaultsByCategory()
+	local modesByCategory = collectModesByCategory()
+
+	local categories = {}
+	for category, modes in pairs(modesByCategory) do
+		local selector = category .. "_mode"
+		local defaults = defaultsByCategory[category] or {}
+		local presets = {}
+		for modeKey, mode in pairs(modes) do
+			presets[modeKey] = {
+				name = mode.name,
+				desc = mode.desc,
+				allowRanked = mode.allowRanked,
+				-- PvE modes are activated by an AI's presence, so the lobby has to be told to add one.
+				bots = mode.bots,
+				modOptions = buildEffectiveModOptions(defaults, mode, selector),
+			}
+		end
+		categories[category] = { selector = selector, presets = presets }
+	end
+
+	return { schemaVersion = SCHEMA_VERSION, categories = categories }
+end
+
+local function ExportModes()
+	local file, err = io.open(OUTPUT_PATH, "w")
+	if not file then
+		spEcho("Modes JSON Export: could not open " .. OUTPUT_PATH .. ": " .. tostring(err))
+		return
+	end
+	file:write(Json.encode(buildExport()))
+	file:close()
+	spEcho("Modes JSON Export: wrote " .. OUTPUT_PATH)
+end
+
+function widget:TextCommand(command)
+	if command == "exportmodes" then
+		ExportModes()
+	end
+end

--- a/modules/modes/widgets/export_modes.lua
+++ b/modules/modes/widgets/export_modes.lua
@@ -1,0 +1,133 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Modes JSON Export",
+		desc = "Exports every mode preset, all categories, to structured JSON.\nCommand: /exportmodes",
+		author = "Daniel Harvey",
+		date = "June 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = false,
+	}
+end
+
+-- Emit the Lua mode presets overlaid on modoptions.lua defaults as JSON so out-of-engine
+-- consumers (SPADS ModeCommand plugin) can expand a mode selection into its full option set.
+
+local spEcho = Spring.Echo
+
+local SCHEMA_VERSION = 1
+local OUTPUT_PATH = "modes.json"
+
+-- modoptions are strings; booleans -> "1"/"0", numbers rounded at float32 precision to avoid noise.
+local function toModOptionValue(v)
+	if type(v) == "boolean" then
+		return v and "1" or "0"
+	end
+	if type(v) == "number" then
+		local s = string.format("%.7f", v):gsub("0+$", ""):gsub("%.$", "")
+		return s
+	end
+	return tostring(v)
+end
+
+-- A category's default base is every option in the sections it governs. A
+-- section is governed by its `mode_category` when it declares one (a flavor's
+-- dials handing the choice to the game axis), else by its own key.
+local function collectDefaultsByCategory()
+	local defs = VFS.Include("modoptions.lua")
+	local sectionCategory = {}
+	for _, o in ipairs(defs) do
+		if o.key and o.type == "section" then
+			sectionCategory[o.key] = o.mode_category or o.key
+		end
+	end
+	local byCategory = {}
+	for _, o in ipairs(defs) do
+		if
+			o.key
+			and o.section
+			and o.def ~= nil
+			and o.type ~= "section"
+			and o.type ~= "subheader"
+			and o.type ~= "separator"
+		then
+			local category = sectionCategory[o.section] or o.section
+			byCategory[category] = byCategory[category] or {}
+			byCategory[category][o.key] = toModOptionValue(o.def)
+		end
+	end
+	return byCategory
+end
+
+local function collectModesByCategory()
+	local ModuleHandler = VFS.Include("modules/module_handler.lua")
+	local byCategory = {}
+	for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+		for _, modeFile in ipairs(VFS.DirList(dir, "*.lua") or {}) do
+			local ok, mode = pcall(VFS.Include, modeFile)
+			if ok and type(mode) == "table" and mode.key and mode.category then
+				byCategory[mode.category] = byCategory[mode.category] or {}
+				byCategory[mode.category][mode.key] = mode
+			end
+		end
+	end
+	return byCategory
+end
+
+-- Full effective option set (defaults then overrides), so applying a mode resets the previous one.
+local function buildEffectiveModOptions(defaults, mode, selector)
+	local effective = {}
+	for key, value in pairs(defaults) do
+		if key ~= selector then
+			effective[key] = { value = value, locked = false }
+		end
+	end
+	for key, rule in pairs(mode.modOptions or {}) do
+		if key ~= selector and rule.value ~= nil then
+			effective[key] = { value = toModOptionValue(rule.value), locked = rule.locked == true }
+		end
+	end
+	return effective
+end
+
+local function buildExport()
+	local defaultsByCategory = collectDefaultsByCategory()
+	local modesByCategory = collectModesByCategory()
+
+	local categories = {}
+	for category, modes in pairs(modesByCategory) do
+		local selector = category .. "_mode"
+		local defaults = defaultsByCategory[category] or {}
+		local presets = {}
+		for modeKey, mode in pairs(modes) do
+			presets[modeKey] = {
+				name = mode.name,
+				desc = mode.desc,
+				allowRanked = mode.allowRanked,
+				modOptions = buildEffectiveModOptions(defaults, mode, selector),
+			}
+		end
+		categories[category] = { selector = selector, presets = presets }
+	end
+
+	return { schemaVersion = SCHEMA_VERSION, categories = categories }
+end
+
+local function ExportModes()
+	local file, err = io.open(OUTPUT_PATH, "w")
+	if not file then
+		spEcho("Modes JSON Export: could not open " .. OUTPUT_PATH .. ": " .. tostring(err))
+		return
+	end
+	file:write(Json.encode(buildExport()))
+	file:close()
+	spEcho("Modes JSON Export: wrote " .. OUTPUT_PATH)
+end
+
+function widget:TextCommand(command)
+	if command == "exportmodes" then
+		ExportModes()
+	end
+end

--- a/modules/module_handler.lua
+++ b/modules/module_handler.lua
@@ -152,6 +152,14 @@ function ModuleHandler.GadgetDirs(vfsMode)
 	return moduleSubdirs(LAYOUT.gadgets, vfsMode)
 end
 
+---The presets a module ships, one file each under modes/; the modes module
+---aggregates them into the game's options.
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.ModeDirs(vfsMode)
+	return moduleSubdirs(LAYOUT.modes, vfsMode)
+end
+
 ---@param filePath string
 ---@return string
 local function nameFromFile(filePath)

--- a/spec/modules/mode_builder_spec.lua
+++ b/spec/modules/mode_builder_spec.lua
@@ -1,0 +1,155 @@
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+
+local function grammar()
+	return ModeBuilder.Grammar({
+		category = "test",
+		serializers = {
+			["end.scripted"] = function(_params, lock)
+				return { deathmode = { value = "neverend", locked = lock.structure } }
+			end,
+			["dial.rate"] = function(params, lock)
+				return { rate = { value = params.rate or 1, locked = lock.dial } }
+			end,
+		},
+		verbs = {
+			Own = function(modeName, noun)
+				return { ModeBuilder.DomainOf(modeName, "Own", noun, { ["end"] = true }, "Match.End") .. ".scripted" }
+			end,
+			Rate = function(_modeName, rate)
+				return { "dial.rate", rate = rate }
+			end,
+		},
+	})
+end
+
+local MatchEnd = { domain = "end" }
+
+describe("mode builder", function()
+	describe("the chain", function()
+		it("keys a mode by the snake_case of its name", function()
+			assert.are.equal("easy_tax", grammar()("Easy Tax").key)
+			assert.are.equal("test", grammar()("Easy Tax").category)
+		end)
+
+		it("returns the chain from every verb, so authoring stays dot-only", function()
+			local Mode = grammar()
+			local chain = Mode("Scripted")
+			assert.are.equal(chain, chain.Desc("d"))
+			assert.are.equal(chain, chain.Ranked())
+			assert.are.equal(chain, chain.Own(MatchEnd))
+			assert.are.equal(chain, chain.Locked())
+		end)
+
+		it("re-derives modOptions after every step, so consumers read a plain table", function()
+			local chain = grammar()("Scripted").Own(MatchEnd)
+			assert.are.equal("neverend", chain.modOptions.deathmode.value)
+			chain.Rate(5)
+			assert.are.equal(5, chain.modOptions.rate.value)
+			assert.are.equal("neverend", chain.modOptions.deathmode.value)
+		end)
+
+		it("refuses a modifier before any policy", function()
+			assert.has_error(function()
+				grammar()("Scripted").Locked()
+			end, "Scripted: .Locked before any policy")
+		end)
+
+		it("refuses a verb that collides with a chain field", function()
+			assert.has_error(function()
+				ModeBuilder.Grammar({
+					category = "test",
+					serializers = {},
+					verbs = { Desc = function() end },
+				})("Scripted")
+			end, "ModeBuilder.Grammar: verb collides with a chain field: Desc")
+		end)
+	end)
+
+	describe("lock defaults", function()
+		it("a bare policy is a suggestion: nothing locked", function()
+			local chain = grammar()("Scripted").Own(MatchEnd).Rate(2)
+			assert.is_false(chain.modOptions.deathmode.locked)
+			assert.is_false(chain.modOptions.rate.locked)
+		end)
+
+		it("Locked pins the structure, Sealed the dials too", function()
+			local chain = grammar()("Scripted").Own(MatchEnd).Locked().Rate(2).Locked()
+			assert.is_true(chain.modOptions.deathmode.locked)
+			assert.is_false(chain.modOptions.rate.locked)
+			assert.is_true(grammar()("Scripted").Rate(2).Sealed().modOptions.rate.locked)
+		end)
+	end)
+
+	describe("serialization", function()
+		it("rejects a policy no serializer owns", function()
+			assert.has_error(function()
+				ModeBuilder.ToModOptions({}, { "end.scripted" })
+			end, "unknown mode policy: end.scripted")
+		end)
+
+		it("rejects two policies owning one modoption", function()
+			local double = function()
+				return { deathmode = { value = "x", locked = true } }
+			end
+			assert.has_error(function()
+				ModeBuilder.ToModOptions({ a = double, b = double }, { "a", "b" })
+			end, "two policies own modoption deathmode")
+		end)
+	end)
+
+	describe("domain guard", function()
+		it("returns the noun's domain when the verb accepts it", function()
+			assert.are.equal("end", ModeBuilder.DomainOf("M", "Own", MatchEnd, { ["end"] = true }, "Match.End"))
+		end)
+
+		it("rejects a value that is not a noun", function()
+			assert.has_error(function()
+				ModeBuilder.DomainOf("M", "Own", "end", { ["end"] = true }, "Match.End")
+			end, "M: .Own expects a noun (Match.End)")
+		end)
+
+		it("rejects a noun the verb does not apply to", function()
+			assert.has_error(function()
+				ModeBuilder.DomainOf("M", "Own", { domain = "share" }, { ["end"] = true }, "Match.End")
+			end, "M: .Own does not apply to share")
+		end)
+	end)
+
+	describe("Uses", function()
+		it("names the modules a preset makes live besides its own, each by its contract", function()
+			local PolicyBuilder = VFS.Include("modules/policy_builder.lua")
+			local Tech = PolicyBuilder.Contract("tech", {})
+			local Other = PolicyBuilder.Contract("other", {})
+			local mode = grammar()("Customize").Uses(Tech).Uses(Other)
+			assert.are.same({ "tech", "other" }, mode.uses)
+			assert.is_nil(grammar()("Plain").uses)
+		end)
+
+		it("refuses a string: a module is its contract", function()
+			assert.has_error(function()
+				grammar()("Customize").Uses("tech")
+			end, "Customize: .Uses expects a module's contract (VFS.Include its contract.lua)")
+		end)
+	end)
+
+	describe("Ranked", function()
+		it("permission is a flag: nothing pinned", function()
+			local mode = grammar()("R").Ranked()
+			assert.is_true(mode.allowRanked)
+			assert.is_nil(mode.modOptions.ranked_game)
+		end)
+
+		it("a mode that never says Ranked is unranked, and carries the pin like any claim", function()
+			local mode = grammar()("R")
+			assert.is_false(mode.allowRanked)
+			assert.are.same({ value = false, locked = false }, mode.modOptions.ranked_game)
+		end)
+
+		it("prohibition is a policy: ranked_game off, pinned when Locked", function()
+			local mode = grammar()("R").Ranked(false).Locked()
+			assert.is_false(mode.allowRanked)
+			assert.are.same({ value = false, locked = true }, mode.modOptions.ranked_game)
+			assert.is_false(grammar()("R").Ranked(false).modOptions.ranked_game.locked)
+		end)
+	end)
+end)

--- a/tools/headless_testing/startscript_modes_export.txt
+++ b/tools/headless_testing/startscript_modes_export.txt
@@ -1,0 +1,28 @@
+[GAME]
+{
+	MapName=Quicksilver Remake 1.24;
+	GameType=Beyond All Reason $VERSION;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=ModesExport;
+	IsHost=1;
+	FixedRNGSeed = 1;
+  [MODOPTIONS]
+  {
+    debugcommands=1:luaui enablewidget Modes JSON Export|2:exportmodes|3:quitforce;
+    deathmode=neverend;
+  }
+  [ALLYTEAM0]
+  {
+  }
+  [TEAM0]
+  {
+    allyteam=0;
+    teamleader=0;
+  }
+  [PLAYER0]
+  {
+    team=0;
+  }
+}

--- a/types/Spring.lua
+++ b/types/Spring.lua
@@ -65,3 +65,10 @@
 ---@class ObjectRenderingTable
 ---@field ActivateMaterial fun(objectID: integer, lod: integer)
 ---@field DeactivateMaterial fun(objectID: integer, lod: integer)
+
+--- The submodule declares Spring as a GLOBAL, not a named type, so this alias is what makes
+--- `engine: Spring` annotations resolve; `table` keeps mock injection free of false mismatches.
+---@alias Spring table
+
+--- gadget:ResourceExcess payload comes from RecoilEngine PR #2642 (still open); overflow already deducted this frame.
+---@alias ResourceExcesses table<integer, { [1]: number, [2]: number }>


### PR DESCRIPTION
`mode_builder` turns a preset file into a ModeConfig. It has no runtime of its own; each module binds its own vocabulary over it, and preset files read as a dot-only chain. It is about 160 lines that every module's mode vocabulary passes through.

A preset is a whitelist: it claims the options it needs and says which are shown, hidden or locked, and the lobby shows exactly what it claims. Every verb on the chain is documented where the editor shows it, `modules/modes/types/mode_policy.lua`, with the option it writes.

```lua
return Mode("FFA")
	.Desc("Free for all: every player for themselves. ...")
	.Ranked()
	.End(DeathMode.OwnCommander)
	.Wreckage(true).Locked()
	.MaxUnits(2000)
	.Draft(DraftMode.Random)
	.Anonymous(AnonymousMode.Disabled)
	.EnemyTransporting("notcoms")
	.UnitRestrictions()
```

This PR also ships the game axis:

- A match is exactly one way of being played, so there is one selector, `game_mode`, owned by the mode infrastructure rather than any flavor. The presets are Standard, FFA, Team FFA and Territorial Domination (scavs and raptors would make sense here but putting them into this form met resistance so I left them alone for now).
- Section entries can declare `mode_category` (which axis governs their options) and `mode_key` (which preset reveals them).
- A bare preset verb is a suggestion and leaves its option open. `.Locked()` pins the structure, `.Sealed()` pins the dials as well. Verbs that are rules rather than suggestions come back already pinned.
- Verbs that pick from a list take an enum, not a string: `End`, `Draft` and `Anonymous` refuse anything outside `DeathMode`, `DraftMode` and `AnonymousMode`, which the DSL exports. `UnitRestrictions()` claims every `unit_restrictions_*` toggle at off, so the panel shows them as dials; only `.Sealed()` pins them, since they are dials.
- Rating is part of the preset. A mode that never says `Ranked()` is unranked and carries the `ranked_game` pin like any other claim, so the lobby never has to pin it itself.
- A preset says what it makes live. It makes the module that ships it live for the runtime's fact providers, and `.Uses(contract)` adds another, named by its contract.lua rather than a string. That is how transfer's Customize preset keeps Tech Core's tiered answers while Enabled does not. The runtime walks every combination of presets at load and refuses one that leaves two providers live for one slot (#8484).
- The root `modoptions.lua` appends every module's fragment through `ModuleHandler.ModOptions()`, so a module that ships options needs no change to the root file.
- `modules/modes/lib/values.lua` is the one formatter for a mode value on the wire (booleans as `1`/`0`, numbers at float32 precision). The export widget bakes `modes.json` with it and the lobby includes it out of the game archive (beyond-all-reason/BYAR-Chobby#1041), so neither side carries a copy. `tools/headless_testing/startscript_modes_export.txt` runs that export headless, which is what CI and `just spads::stage-modes` use.
