### PR TITLE
modules: construction policy

### DIFF
--- a/modules/construction/gadgets/game_allied_assist_mode.lua
+++ b/modules/construction/gadgets/game_allied_assist_mode.lua
@@ -1,0 +1,198 @@
+local gadget = gadget ---@type Gadget
+
+local ModeEnums = VFS.Include("modules/context/mode_enums.lua")
+
+local assistEnabled = Spring.GetModOptions()[ModeEnums.ModOptions.AlliedAssistMode] == ModeEnums.AlliedAssistMode.Enabled
+
+function gadget:GetInfo()
+	return {
+		name = "Disable Assist Ally Construction",
+		desc = "Disable assisting allied units (e.g. labs and units/buildings under construction) when modoption is disabled",
+		author = "Rimilel",
+		date = "April 2024",
+		license = "GNU GPL, v2 or later",
+		layer = 1,
+		enabled = not assistEnabled,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+if assistEnabled then
+	return false
+end
+
+local spAreTeamsAllied = Spring.AreTeamsAllied
+local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
+
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
+local spGetUnitTeam = Spring.GetUnitTeam
+local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
+local mathRandom = math.random
+
+local CMD_GUARD = CMD.GUARD
+local CMD_REPAIR = CMD.REPAIR
+local CMD_MOVESTATE = CMD.MOVE_STATE
+local MOVESTATE_ROAM = CMD.MOVESTATE_ROAM
+
+local footprintSize = Game.squareSize * Game.footprintScale
+
+local builderMoveStateCmdDesc = {
+	params = {
+		1,
+		"Hold pos",
+		"Maneuver", --[["Roam"]]
+	},
+}
+
+local gaiaTeam = Spring.GetGaiaTeamID()
+
+local isFactory = {}
+local canBuildStep = {}
+for unitDefID, unitDef in ipairs(UnitDefs) do
+	isFactory[unitDefID] = unitDef.isFactory
+	canBuildStep[unitDefID] = unitDef.isFactory or (unitDef.isBuilder and (unitDef.canBuild or unitDef.canAssist))
+end
+
+local checkUnitCommandList = {} -- Delay validating given units so the order of calls to UnitGiven does not matter.
+
+local function removeRoamMoveState(unitID)
+	local index = Spring.FindUnitCmdDesc(unitID, CMD_MOVESTATE)
+	if index then
+		local moveState = select(2, Spring.GetUnitStates(unitID, false))
+		local params = builderMoveStateCmdDesc.params
+		params[1] = math.min(moveState or 1, MOVESTATE_ROAM - 1)
+		Spring.EditUnitCmdDesc(unitID, index, builderMoveStateCmdDesc)
+	end
+end
+
+local function isComplete(unitID)
+	local beingBuilt, buildProgress = spGetUnitIsBeingBuilt(unitID)
+	return not beingBuilt or buildProgress >= 1
+end
+
+local function isAlliedUnit(teamID, unitID)
+	local unitTeam = unitID and spGetUnitTeam(unitID)
+	return unitTeam and teamID ~= unitTeam and spAreTeamsAllied(teamID, unitTeam)
+end
+
+-- Awkward, because we get the params in a table format ~half the time.
+local function isBuilderAllowedCommand(cmdID, p1, p2, p5, p6, unitTeam)
+	if cmdID == CMD_GUARD then
+		return not isAlliedUnit(unitTeam, p1) or (isComplete(p1) and not canBuildStep[spGetUnitDefID(p1)])
+	elseif cmdID == CMD_REPAIR then
+		if p6 or (not p5 and p2) or not p1 then -- check for 1 or 5 arguments
+			return true -- Area Repair is okay.
+		end
+		return not isAlliedUnit(unitTeam, p1) or (isComplete(p1))
+	elseif cmdID == CMD_MOVESTATE then
+		return p1 ~= MOVESTATE_ROAM
+	else
+		return true
+	end
+end
+
+local function validateCommands(unitID, unitTeam)
+	local GetUnitCurrentCommand = spGetUnitCurrentCommand
+	local tags, count = {}, 0
+
+	for index = 1, Spring.GetUnitCommandCount(unitID) do
+		local command, _, tag, p1, p2, _, _, p5, p6 = GetUnitCurrentCommand(unitID, index)
+		if not isBuilderAllowedCommand(command, p1, p2, p5, p6, unitTeam) then
+			count = count + 1
+			tags[count] = tag
+		end
+	end
+
+	if count > 0 then
+		Spring.GiveOrderToUnit(unitID, CMD.REMOVE, tags)
+	end
+end
+
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_GUARD)
+	gadgetHandler:RegisterAllowCommand(CMD_REPAIR)
+	gadgetHandler:RegisterAllowCommand(CMD_MOVESTATE)
+end
+
+function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+	if canBuildStep[unitDefID] then
+		removeRoamMoveState(unitID)
+	end
+
+	-- upgrade-reclaimer gadgets transfer units instantly, so check immediately
+	if builderID and isAlliedUnit(unitTeam, builderID) then
+		checkUnitCommandList[unitID] = spGetUnitTeam(builderID)
+	end
+end
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
+	checkUnitCommandList[unitID] = nil
+end
+
+function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+	if not canBuildStep[unitDefID] then
+		return true
+	else
+		return isBuilderAllowedCommand(cmdID, cmdParams[1], cmdParams[2], cmdParams[5], cmdParams[6], unitTeam)
+	end
+end
+
+function gadget:AllowUnitCreation(unitDefID, builderID, builderTeam, x, y, z, facing)
+	if builderID and not isFactory[spGetUnitDefID(builderID)] then
+		local units = spGetUnitsInCylinder(x, z, footprintSize)
+		for _, unitID in pairs(units) do
+			if unitDefID == spGetUnitDefID(unitID) and not isComplete(unitID) and isAlliedUnit(builderTeam, unitID) then
+				return false, false
+			end
+		end
+	end
+
+	return true, true
+end
+
+function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
+	if newTeam ~= gaiaTeam and canBuildStep[unitDefID] then
+		checkUnitCommandList[unitID] = newTeam
+	end
+end
+
+local function _GameFramePost(unitList)
+	local GetUnitIsDead = Spring.GetUnitIsDead
+	for unitID, newTeam in pairs(unitList) do
+		unitList[unitID] = nil
+		if GetUnitIsDead(unitID) == false then
+			validateCommands(unitID, newTeam)
+		end
+	end
+end
+function gadget:GameFramePost()
+	if next(checkUnitCommandList) then
+		_GameFramePost(checkUnitCommandList)
+	end
+end
+
+-- Temp anti-cheat-esque guard. We check on random frames for units bypassing the rules.
+local function AllowUnitBuildStep(self, builderID, builderTeam, unitID, unitDefID, part)
+	if part > 0 and builderTeam ~= spGetUnitTeam(unitID) and spGetUnitIsBeingBuilt(unitID) then
+		checkUnitCommandList[builderID] = builderTeam
+		return false
+	end
+	return true
+end
+
+local seed = mathRandom(Game.spawnWarpInFrame + 1, Game.spawnWarpInFrame + Game.gameSpeed - 1)
+
+function gadget:GameFrame(frame)
+	if frame % seed == 0 then
+		gadget.AllowUnitBuildStep = AllowUnitBuildStep
+		gadgetHandler:UpdateCallIn("AllowUnitBuildStep")
+	elseif gadget.AllowUnitBuildStep then
+		gadget.AllowUnitBuildStep = nil
+		gadgetHandler:UpdateCallIn("AllowUnitBuildStep")
+		seed = mathRandom(1, 119)
+	end
+end

--- a/modules/construction/gadgets/game_allied_unit_reclaim_mode.lua
+++ b/modules/construction/gadgets/game_allied_unit_reclaim_mode.lua
@@ -1,0 +1,73 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Allied Reclaim Control",
+		desc = "Controls reclaiming allied units based on modoption",
+		author = "Rimilel",
+		date = "October 2025",
+		license = "GNU GPL, v2 or later",
+		layer = 1,
+		enabled = true,
+	}
+end
+
+local ModeEnums = VFS.Include("modules/context/mode_enums.lua")
+
+----------------------------------------------------------------
+-- Synced only
+----------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local reclaimEnabled = Spring.GetModOptions()[ModeEnums.ModOptions.AlliedUnitReclaimMode] == ModeEnums.AlliedUnitReclaimMode.Enabled
+if reclaimEnabled then
+	return
+end
+
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD.RECLAIM)
+	gadgetHandler:RegisterAllowCommand(CMD.GUARD)
+end
+
+function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions, cmdTag, synced)
+	if cmdID == CMD.RECLAIM and #cmdParams >= 1 then
+		local targetID = cmdParams[1]
+		local targetTeam
+
+		if targetID >= Game.maxUnits then
+			return true
+		end
+
+		targetTeam = Spring.GetUnitTeam(targetID)
+		if targetTeam == nil then
+			return true -- shouldn't happen; GetUnitTeam is nullable
+		end
+
+		if unitTeam ~= targetTeam and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+			return false
+		end
+	elseif cmdID == CMD.GUARD and #cmdParams >= 1 then
+		local targetID = cmdParams[1]
+
+		if targetID >= Game.maxUnits then
+			return true
+		end
+
+		local targetTeam = Spring.GetUnitTeam(targetID)
+		if targetTeam == nil then
+			return true -- shouldn't happen; GetUnitTeam is nullable
+		end
+
+		local targetUnitDef = UnitDefs[Spring.GetUnitDefID(targetID)]
+
+		if unitTeam ~= targetTeam and Spring.AreTeamsAllied(unitTeam, targetTeam) then
+			-- labs count as canReclaim, so guarding them is blocked too
+			if targetUnitDef and targetUnitDef.canReclaim then
+				return false
+			end
+		end
+	end
+	return true
+end

--- a/modules/construction/gadgets/game_allow_partial_resurrection.lua
+++ b/modules/construction/gadgets/game_allow_partial_resurrection.lua
@@ -1,0 +1,40 @@
+local gadget = gadget ---@type Gadget
+
+local ModeEnums = VFS.Include("modules/context/mode_enums.lua")
+
+local allowPartialResurrection = Spring.GetModOptions()[ModeEnums.ModOptions.AllowPartialResurrection] == ModeEnums.AllowPartialResurrection.Enabled
+
+function gadget:GetInfo()
+	return {
+		name = "Allow Partial Resurrection",
+		desc = "Controls whether partly reclaimed wrecks can be resurrected.",
+		author = "RebelNode",
+		date = "January 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = not allowPartialResurrection,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+if allowPartialResurrection then
+	return false
+end
+
+local spGetFeatureResources = Spring.GetFeatureResources
+local spSetFeatureResurrect = Spring.SetFeatureResurrect
+
+function gadget:AllowFeatureBuildStep(builderID, builderTeam, featureID, featureDefID, part)
+	if part >= 0 then
+		return true
+	end
+
+	local metal, defMetal = spGetFeatureResources(featureID)
+	if metal == defMetal then -- first reclaim touch on this wreck
+		spSetFeatureResurrect(featureID, false)
+	end
+	return true
+end

--- a/modules/construction/gadgets/game_disable_ally_geo_mex_upgrades.lua
+++ b/modules/construction/gadgets/game_disable_ally_geo_mex_upgrades.lua
@@ -1,0 +1,78 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Disable ally extractor upgrade",
+		desc = "Removes the ability for players to upgrade teammate mexes and geos in-place",
+		author = "Hobo Joe",
+		date = "August 2025",
+		license = "GNU GPL, v2 or later",
+		layer = 1,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local UnitTransfer = VFS.Include("modules/transfer/unit/synced.lua")
+local TransferEnums = VFS.Include("modules/context/enums.lua")
+
+local mode = Spring.GetModOptions().unit_sharing_mode
+local modeUnitTypes = UnitTransfer.GetModeUnitTypes(mode)
+local enableShare = table.contains(modeUnitTypes, TransferEnums.UnitType.Utility)
+
+if enableShare then
+	return false
+end
+
+local extractorRadius = Game.extractorRadius
+
+local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitTeam = Spring.GetUnitTeam
+
+local isMex = {}
+local isGeo = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.extractsMetal > 0 then
+		isMex[unitDefID] = true
+	end
+	if unitDef.customParams.geothermal then
+		isGeo[unitDefID] = true
+	end
+end
+
+local function mexBlocked(myTeam, x, y, z)
+	local units = spGetUnitsInCylinder(x, z, extractorRadius)
+	for _, unitID in ipairs(units) do
+		if isMex[spGetUnitDefID(unitID)] then
+			if spGetUnitTeam(unitID) ~= myTeam then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+local function geoBlocked(myTeam, x, y, z)
+	local units = spGetUnitsInCylinder(x, z, extractorRadius)
+	for _, unitID in ipairs(units) do
+		if isGeo[spGetUnitDefID(unitID)] then
+			if spGetUnitTeam(unitID) ~= myTeam then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+function gadget:AllowUnitCreation(unitDefID, builderID, builderTeam, x, y, z)
+	if isMex[unitDefID] then
+		return not mexBlocked(builderTeam, x, y, z)
+	elseif isGeo[unitDefID] then
+		return not geoBlocked(builderTeam, x, y, z)
+	end
+	return true
+end

--- a/modules/construction/module.lua
+++ b/modules/construction/module.lua
@@ -1,0 +1,9 @@
+--- Manifest for the construction module: what may be built, assisted,
+--- reclaimed or resurrected, and by whom. These are policies over building —
+--- allied is the scope they happen to be written for, not what they are about.
+---@type ModuleManifestFile
+return {
+	name = "construction",
+	description = "Construction policy: assist, reclaim, resurrect, and ally mex upgrades",
+	requires = { "context", "transfer" },
+}


### PR DESCRIPTION
Four gadgets filed under sharing because they are written for allies: assist, reclaim, resurrect, ally mex upgrades. None of them transfers anything — they are policies over building.

Three of the four need nothing but the policy vocabulary. `Spawn` belongs here too and is not moved yet: the roster still places units inside the mission loader.