### PR TITLE
Fix: nocost t2 air units no longer stay neutral after finishing

### DIFF
--- a/luarules/gadgets/unit_air_plants.lua
+++ b/luarules/gadgets/unit_air_plants.lua
@@ -54,7 +54,6 @@ end
 
 local plantList = {}
 local buildingUnits = {}
-local unitsToDeneutralize = {}
 
 local landCmd = {
 	id = CMD_LAND_AT,
@@ -80,23 +79,11 @@ end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
 	plantList[unitID] = nil
 	buildingUnits[unitID] = nil
-	unitsToDeneutralize[unitID] = nil
 end
 
 function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 	if buildingUnits[unitID] then
-		-- Delaying SetUnitNeutral to GameFrame to avoid /nocost race conditions
-		unitsToDeneutralize[unitID] = true
-		buildingUnits[unitID] = nil
-	end
-end
-
-function gadget:GameFrame(frame)
-	if next(unitsToDeneutralize) then
-		for unitID in pairs(unitsToDeneutralize) do
-			SetUnitNeutral(unitID, false)
-		end
-		unitsToDeneutralize = {}
+		SetUnitNeutral(unitID, false)
 	end
 end
 

--- a/luarules/gadgets/unit_prevent_nanoframe_blocking_hax.lua
+++ b/luarules/gadgets/unit_prevent_nanoframe_blocking_hax.lua
@@ -43,9 +43,10 @@ local function RemoveNanoFrame(i)
 		Spring.SetUnitBlocking(unitID, a,b, true, d,e,f,g) -- blocking for projectiles
 
 		local neutral = newNanoFrameNeutralState[unitID]
-		Spring.SetUnitNeutral(unitID, neutral)
-
-		--Spring.Echo("unset", unitID)
+		-- If a unit has already been set to neutral=false, don't overwrite that here
+		if Spring.GetUnitNeutral(unitID) then
+			Spring.SetUnitNeutral(unitID, neutral)
+		end
 	end
 	table.remove(newNanoFrames, i)
 	newNanoFrameNeutralState[unitID] = nil


### PR DESCRIPTION
### Work done
- Revert https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7137
    - Unless this resolved other `nocost` race conditions, the extra overhead should no longer be necessary
- In `unit_prevent_nanoframe_blocking_hax`, check if a unit has already been set to `neutral=false`. If so, skip restoring neutral state
    - Since the stated goal of `nanoframe_blocking` is to prevent nanoframes from blocking projectiles until the unit hits 5% build progress, it doesn't really make sense for it to force `neutral=true` if something else has decided to set `neutral=false`

#### Addresses Issue
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6704

#### Test steps
1. Start a skirmish (remove/set inactive the ai if you want)
2. Enable cheats, enable nocost
3. Build
    1. T1 air lab
    2. T1 air constructor
    3. T2 air lab
    4. At least one AA turret within range of both air labs
4. Select the AA turret and assign it to team 2 (`/luarules transferunits :1`)
5. Build any unit from the T1 air lab
    1. Observe enemy AA fires on new unit
6. Build any unit from the T2 air lab
    1. Observe enemy AA fires on new unit

### Videos:
#### BEFORE:
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/6704#issuecomment-4147845830

#### AFTER:
https://github.com/user-attachments/assets/36e94c20-a9ef-4faa-92e7-146681b87388

### AI / LLM usage statement:
Implemented and tested with help from OpenCode running Qwen 3.6 🤖