### PR TITLE
fix: skip nil ringParams in Defense Range GL4

### DIFF
--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -647,33 +647,33 @@ local function UnitDetected(unitID, unitDefID, unitTeam, noUpload)
 			local weaponID = i
 			local ringParams = unitDefRings[unitDefID]['rings'][i]
 			if ringParams then
-			local x, y, z, mpx, mpy, mpz, apx, apy, apz = spGetUnitPosition(unitID, true, true)
-			local wpx, wpy, wpz, wdx, wdy, wdz = Spring.GetUnitWeaponVectors(unitID, weaponID)
-			--spEcho("Defranges: unitID", unitID,x,y,z,"weaponID", weaponID, "y", y, "mpy",  mpy,"wpy", wpy)
+				local x, y, z, mpx, mpy, mpz, apx, apy, apz = spGetUnitPosition(unitID, true, true)
+				local wpx, wpy, wpz, wdx, wdy, wdz = Spring.GetUnitWeaponVectors(unitID, weaponID)
+				--spEcho("Defranges: unitID", unitID,x,y,z,"weaponID", weaponID, "y", y, "mpy",  mpy,"wpy", wpy)
 
-			-- Now this is a truly terrible hack, we cache each unitDefID's max weapon turret height at position 18 in the table
-			-- so it only goes up with popups
-			local turretHeight = mathMax(ringParams[18] or 0, (wpy or mpy ) - y)
-			ringParams[18] = turretHeight
+				-- Now this is a truly terrible hack, we cache each unitDefID's max weapon turret height at position 18 in the table
+				-- so it only goes up with popups
+				local turretHeight = mathMax(ringParams[18] or 0, (wpy or mpy ) - y)
+				ringParams[18] = turretHeight
 
 
-			cacheTable[1] = mpx
-			cacheTable[2] = turretHeight
-			cacheTable[3] = mpz
-			local vaokey = allystring .. weaponType
+				cacheTable[1] = mpx
+				cacheTable[2] = turretHeight
+				cacheTable[3] = mpz
+				local vaokey = allystring .. weaponType
 
-			for j = 1,13 do
-				cacheTable[j+3] = ringParams[j]
-			end
+				for j = 1,13 do
+					cacheTable[j+3] = ringParams[j]
+				end
 
-			local instanceID = 1000000 * i + unitID
-			pushElementInstance(defenseRangeVAOs[vaokey], cacheTable, instanceID, true,  noUpload)
-			addedrings = addedrings + 1
-			if defenses[unitID] == nil then
-				--lazy creation
-				defenses[unitID] = { posx = mpx, posy = mpy, posz = mpz, vaokeys = {}, allied = alliedUnit, unitDefID = unitDefID}
-			end
-			defenses[unitID].vaokeys[instanceID] = vaokey
+				local instanceID = 1000000 * i + unitID
+				pushElementInstance(defenseRangeVAOs[vaokey], cacheTable, instanceID, true,  noUpload)
+				addedrings = addedrings + 1
+				if defenses[unitID] == nil then
+					--lazy creation
+					defenses[unitID] = { posx = mpx, posy = mpy, posz = mpz, vaokeys = {}, allied = alliedUnit, unitDefID = unitDefID}
+				end
+				defenses[unitID].vaokeys[instanceID] = vaokey
 			end
 		end
 	end

--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -646,6 +646,7 @@ local function UnitDetected(unitID, unitDefID, unitTeam, noUpload)
 
 			local weaponID = i
 			local ringParams = unitDefRings[unitDefID]['rings'][i]
+			if ringParams then
 			local x, y, z, mpx, mpy, mpz, apx, apy, apz = spGetUnitPosition(unitID, true, true)
 			local wpx, wpy, wpz, wdx, wdy, wdz = Spring.GetUnitWeaponVectors(unitID, weaponID)
 			--spEcho("Defranges: unitID", unitID,x,y,z,"weaponID", weaponID, "y", y, "mpy",  mpy,"wpy", wpy)
@@ -673,6 +674,7 @@ local function UnitDetected(unitID, unitDefID, unitTeam, noUpload)
 				defenses[unitID] = { posx = mpx, posy = mpy, posz = mpz, vaokeys = {}, allied = alliedUnit, unitDefID = unitDefID}
 			end
 			defenses[unitID].vaokeys[instanceID] = vaokey
+			end
 		end
 	end
 	if addedrings == 0 then


### PR DESCRIPTION
Prevents the widget from crashing when a configured weapon slot has no ring (e.g. antinuke ships under nonukes).

t=01:23:29.542476][f=0021303] Error in VisibleUnitAdded(): [string "LuaUI/Widgets/gui_defenserange_gl4.lua"]:655: attempt to index local 'ringParams' (a nil value)
[t=01:23:29.542493][f=0021303] Removed widget: Defense Range GL4

Repro: disable nukes in lobby. make AN ship. repros 100%

### AI / LLM usage statement:
Cursor to find relevant code, tested manually that fix works.  

Image shows that GLDefenseRange widget is working (see visible range on scorpion)
AN ships are active in the pond.
Nukes are disabled (greyed/cannot be built by builder) 

<img width="1920" height="1063" alt="image" src="https://github.com/user-attachments/assets/da693d33-18d8-4ce7-9c86-b9d7aff902d9" />

