### PR TITLE
fix: allow same-tier geo sidegrades in extractor snap

### DIFF
--- a/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
+++ b/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
@@ -1,0 +1,72 @@
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+local function createExtractor(unitName, teamID)
+	return SyncedRun(function(locals)
+		local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+		local y = Spring.GetGroundHeight(x, z)
+		local unitID = Spring.CreateUnit(locals.unitName, x, y, z, 0, locals.teamID)
+		assert(unitID, "failed to create " .. tostring(locals.unitName))
+		return unitID
+	end)
+end
+
+local function assertUpgrade(currentName, newName, expected, label)
+	Test.clearMap()
+
+	local myTeamID = Spring.GetMyTeamID()
+	local currentUnitID = createExtractor(currentName, myTeamID)
+	local newDefID = UnitDefNames[newName].id
+
+	local canUpgrade = WG["resource_spot_builder"].ExtractorCanBeUpgraded(currentUnitID, newDefID)
+	assertEqual(
+		canUpgrade,
+		expected,
+		string.format(
+			"%s: expected ExtractorCanBeUpgraded(%s -> %s) == %s, got %s",
+			label,
+			currentName,
+			newName,
+			tostring(expected),
+			tostring(canUpgrade)
+		)
+	)
+end
+
+function test()
+	assert(WG["resource_spot_builder"], "resource_spot_builder API widget not loaded")
+	assert(WG["resource_spot_builder"].ExtractorCanBeUpgraded, "ExtractorCanBeUpgraded missing")
+
+	-- 1. arm mex upgradable to arm stealthy mex
+	assertUpgrade("armmex", "armamex", true, "1")
+
+	-- 2. arm stealthy mex not upgradable to arm t1 mex
+	assertUpgrade("armamex", "armmex", false, "2")
+
+	-- 3. prude upgradable to ageo
+	assertUpgrade("armgmm", "armageo", true, "3")
+
+	-- 4. ageo upgradable to prude
+	assertUpgrade("armageo", "armgmm", true, "4")
+
+	-- 5. cerberus upgradable into legion antinuke jammer geo (Rampart)
+	assertUpgrade("corbhmth", "legrampart", true, "5")
+
+	-- 6. t1 geo for one faction not upgradable to the same-tier t1 geo from another faction
+	assertUpgrade("armgeo", "corgeo", false, "6")
+
+	-- 7. ageo for one faction not upgradable to ageo from another faction
+	assertUpgrade("armageo", "corageo", false, "7")
+
+	-- 8. t2 mex not upgradable into t2 mex for another faction
+	assertUpgrade("armmoho", "cormoho", false, "8")
+end

--- a/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
+++ b/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
@@ -10,63 +10,57 @@ function cleanup()
 	Test.clearMap()
 end
 
-local function createExtractor(unitName, teamID)
-	return SyncedRun(function(locals)
-		local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
-		local y = Spring.GetGroundHeight(x, z)
-		local unitID = Spring.CreateUnit(locals.unitName, x, y, z, 0, locals.teamID)
-		assert(unitID, "failed to create " .. tostring(locals.unitName))
-		return unitID
-	end)
-end
-
-local function assertUpgrade(currentName, newName, expected, label)
-	Test.clearMap()
-
-	local myTeamID = Spring.GetMyTeamID()
-	local currentUnitID = createExtractor(currentName, myTeamID)
-	local newDefID = UnitDefNames[newName].id
-
-	local canUpgrade = WG["resource_spot_builder"].ExtractorCanBeUpgraded(currentUnitID, newDefID)
-	assertEqual(
-		canUpgrade,
-		expected,
-		string.format(
-			"%s: expected ExtractorCanBeUpgraded(%s -> %s) == %s, got %s",
-			label,
-			currentName,
-			newName,
-			tostring(expected),
-			tostring(canUpgrade)
-		)
-	)
-end
-
 function test()
 	assert(WG["resource_spot_builder"], "resource_spot_builder API widget not loaded")
 	assert(WG["resource_spot_builder"].ExtractorCanBeUpgraded, "ExtractorCanBeUpgraded missing")
 
-	-- 1. arm mex upgradable to arm stealthy mex
-	assertUpgrade("armmex", "armamex", true, "1")
+	local myTeamID = Spring.GetMyTeamID()
+	local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(x, z)
+	local facing = 0
 
-	-- 2. arm stealthy mex not upgradable to arm t1 mex
-	assertUpgrade("armamex", "armmex", false, "2")
+	local cases = {
+		-- label, current unit, new unit, expected
+		{ "1", "armmex", "armamex", true },       -- arm mex -> stealthy mex
+		{ "2", "armamex", "armmex", false },      -- stealthy mex -> t1 mex
+		{ "3", "armgmm", "armageo", true },       -- prude -> ageo
+		{ "4", "armageo", "armgmm", true },       -- ageo -> prude
+		{ "5", "corbhmth", "legrampart", true },  -- cerberus -> legion rampart
+		{ "6", "armgeo", "corgeo", false },       -- t1 geo cross-faction
+		{ "7", "armageo", "corageo", false },     -- ageo cross-faction
+		{ "8", "armmoho", "cormoho", false },     -- t2 mex cross-faction
+	}
 
-	-- 3. prude upgradable to ageo
-	assertUpgrade("armgmm", "armageo", true, "3")
+	for i = 1, #cases do
+		local label, currentName, newName, expected = cases[i][1], cases[i][2], cases[i][3], cases[i][4]
 
-	-- 4. ageo upgradable to prude
-	assertUpgrade("armageo", "armgmm", true, "4")
+		assert(UnitDefNames[currentName], "missing UnitDefNames." .. currentName)
+		assert(UnitDefNames[newName], "missing UnitDefNames." .. newName)
 
-	-- 5. cerberus upgradable into legion antinuke jammer geo (Rampart)
-	assertUpgrade("corbhmth", "legrampart", true, "5")
+		Test.clearMap()
 
-	-- 6. t1 geo for one faction not upgradable to the same-tier t1 geo from another faction
-	assertUpgrade("armgeo", "corgeo", false, "6")
+		local unitName = currentName
+		local teamID = myTeamID
+		local currentUnitID = SyncedRun(function(locals)
+			return Spring.CreateUnit(locals.unitName, locals.x, locals.y, locals.z, locals.facing, locals.teamID)
+		end)
+		assert(currentUnitID, "failed to create " .. currentName)
 
-	-- 7. ageo for one faction not upgradable to ageo from another faction
-	assertUpgrade("armageo", "corageo", false, "7")
-
-	-- 8. t2 mex not upgradable into t2 mex for another faction
-	assertUpgrade("armmoho", "cormoho", false, "8")
+		local canUpgrade = WG["resource_spot_builder"].ExtractorCanBeUpgraded(
+			currentUnitID,
+			UnitDefNames[newName].id
+		)
+		assertEqual(
+			canUpgrade,
+			expected,
+			string.format(
+				"%s: expected ExtractorCanBeUpgraded(%s -> %s) == %s, got %s",
+				label,
+				currentName,
+				newName,
+				tostring(expected),
+				tostring(canUpgrade)
+			)
+		)
+	end
 end

--- a/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
+++ b/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
@@ -29,6 +29,9 @@ function test()
 		{ "armageo", "corageo", false },     -- ageo cross-faction
 		{ "armmoho", "cormoho", false },     -- t2 mex cross-faction
 		{ "armmoho", "armmex", false },     -- t2 mex to t1 mex
+		{ "armmoho", "cormoho", false },     -- t2 mex to t2 mex cross-faction
+		{ "armamex", "armmex", false },     -- t1 mex to t1 mex
+		{"armgmm", "armgmm", false },     -- prude -> prude
 	}
 
 	for i = 1, #cases do

--- a/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
+++ b/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
@@ -20,19 +20,20 @@ function test()
 	local facing = 0
 
 	local cases = {
-		-- label, current unit, new unit, expected
-		{ "1", "armmex", "armamex", true },       -- arm mex -> stealthy mex
-		{ "2", "armamex", "armmex", false },      -- stealthy mex -> t1 mex
-		{ "3", "armgmm", "armageo", true },       -- prude -> ageo
-		{ "4", "armageo", "armgmm", true },       -- ageo -> prude
-		{ "5", "corbhmth", "legrampart", true },  -- cerberus -> legion rampart
-		{ "6", "armgeo", "corgeo", false },       -- t1 geo cross-faction
-		{ "7", "armageo", "corageo", false },     -- ageo cross-faction
-		{ "8", "armmoho", "cormoho", false },     -- t2 mex cross-faction
+		-- current unit, new unit, expected
+		{ "armmex", "armamex", true },       -- arm mex -> stealthy mex
+		{ "armamex", "armmex", false },      -- stealthy mex -> t1 mex
+		{ "armgmm", "armageo", true },       -- prude -> ageo
+		{ "armageo", "armgmm", true },       -- ageo -> prude
+		{ "corbhmth", "legrampart", true },  -- cerberus -> legion rampart
+		{ "armgeo", "corgeo", false },       -- t1 geo cross-faction
+		{ "armageo", "corageo", false },     -- ageo cross-faction
+		{ "armmoho", "cormoho", false },     -- t2 mex cross-faction
+		{ "armmoho", "armmex", false },     -- t2 mex to t1 mex
 	}
 
 	for i = 1, #cases do
-		local label, currentName, newName, expected = cases[i][1], cases[i][2], cases[i][3], cases[i][4]
+		local currentName, newName, expected = cases[i][1], cases[i][2], cases[i][3]
 
 		assert(UnitDefNames[currentName], "missing UnitDefNames." .. currentName)
 		assert(UnitDefNames[newName], "missing UnitDefNames." .. newName)
@@ -54,8 +55,7 @@ function test()
 			canUpgrade,
 			expected,
 			string.format(
-				"%s: expected ExtractorCanBeUpgraded(%s -> %s) == %s, got %s",
-				label,
+				"expected ExtractorCanBeUpgraded(%s -> %s) == %s, got %s",
 				currentName,
 				newName,
 				tostring(expected),

--- a/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
+++ b/luaui/Tests/mex-building/test_extractor_upgrade_rules.lua
@@ -25,7 +25,6 @@ function test()
 		{ "armamex", "armmex", false },      -- stealthy mex -> t1 mex
 		{ "armgmm", "armageo", true },       -- prude -> ageo
 		{ "armageo", "armgmm", true },       -- ageo -> prude
-		{ "corbhmth", "legrampart", true },  -- cerberus -> legion rampart
 		{ "armgeo", "corgeo", false },       -- t1 geo cross-faction
 		{ "armageo", "corageo", false },     -- ageo cross-faction
 		{ "armmoho", "cormoho", false },     -- t2 mex cross-faction

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -55,7 +55,7 @@ local geoConstructors = {}
 local geoConstructorsDef = {}
 local geoBuildings = {}
 
-local normalExtractors = {}
+local standardExtractors = {}
 ------------------------------------------------------------
 -- populate unit tables
 ------------------------------------------------------------
@@ -67,6 +67,10 @@ for uDefID, uDef in pairs(UnitDefs) do
 	local customParams = uDef.customParams or {}
 	if customParams.geothermal then
 		geoBuildings[uDefID] = uDef.energyMake
+	end
+	-- Standard extractors produce just metal / energy and are available to all factions.
+	if customParams.standardextractor then
+		standardExtractors[uDefID] = true
 	end
 end
 
@@ -94,28 +98,6 @@ for uDefID, uDef in pairs(UnitDefs) do
 				end
 			end
 		end
-	end
-end
-
-
--- Standard extractors produce just metal / energy and are available to all factions.
-local normalExtractorNames = {
-	-- T1 
-	"armmex", "cormex", "legmex",
-	-- T2 mexes
-	"armmoho", "cormoho", "legmoho", 
-	"armuwmme", "coruwmme", "leganavalmex",
-	-- T1 geos
-	"armgeo", "corgeo", "leggeo",
-	"armuwgeo", "coruwgeo", "leguwgeo",
-	-- T2 geos
-	"armageo", "corageo", "legageo",
-	"armuwageo", "coruwageo", "leganavaladvgeo",
-}
-for i = 1, #normalExtractorNames do
-	local unitDef = UnitDefNames[normalExtractorNames[i]]
-	if unitDef then
-		normalExtractors[unitDef.id] = true
 	end
 end
 
@@ -200,9 +182,10 @@ local function getBestExtractorFromBuilders(units, constructorIds, extractors)
 	return bestExtractor
 end
 
----extractorCanBeUpgraded
+---Whether an allied extractor can be replaced: higher techlevel or same-tier higher yield always upgrades; otherwise specialty extractors (does more than just produce metal/energy) may replace standard extractors/other specialty extractors.
 ---@param currentExtractorUuid number uuid of current extractor
 ---@param newExtractorId number unitDefID of new extractor
+---@return boolean
 local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 	local isAllied = Spring.AreTeamsAllied(spGetMyTeamID(), spGetUnitTeam(currentExtractorUuid))
 	if not isAllied then
@@ -222,20 +205,19 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 		return true
 	end
 
-	local newIsNormal = normalExtractors[newExtractorId]
-	local currentIsNormal = normalExtractors[currentExtractorId]
 
-	-- Special case for T2 Geo as AGeo is considered normal, but may be more desirable over other T2 Geos.
-	local isT2SpecialGeoToAgeo = geoBuildings[currentExtractorId]
-		and geoBuildings[newExtractorId]
-		and newTechLevel >= 2
-		and not currentIsNormal
-	if isT2SpecialGeoToAgeo then
+	local newExtractorStrength = mexBuildings[newExtractorId] or geoBuildings[newExtractorId]
+	local currentExtractorStrength = mexBuildings[currentExtractorId] or geoBuildings[currentExtractorId]
+	if not (newExtractorStrength and currentExtractorStrength) then
+		return false
+	end
+
+	if newExtractorStrength > currentExtractorStrength then
 		return true
 	end
 
-	-- In all other cases, specialty extractors are always considered to be better than normal extractors, but interchangable with each other.
-	return not newIsNormal
+	local newIsStandard = standardExtractors[newExtractorId]
+	return not newIsStandard
 end
 
 ---Returns true if the specified extractor be built on this spot - considers upgrades and sidegrades

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -189,6 +189,7 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 
 	local currentExtractorId = spGetUnitDefID(currentExtractorUuid)
 	local newExtractor = UnitDefs[newExtractorId]
+	local currentExtractor = UnitDefs[currentExtractorId]
 	local newExtractorStrength = mexBuildings[newExtractorId] or geoBuildings[newExtractorId]
 	local currentExtractorStrength = mexBuildings[currentExtractorId] or geoBuildings[currentExtractorId]
 
@@ -198,14 +199,23 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 
 	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0
 
-	if (newExtractorStrength > currentExtractorStrength) then
+	local newTechLevel = tonumber(newExtractor.customParams and newExtractor.customParams.techlevel) or 1
+	local currentTechLevel = tonumber(currentExtractor.customParams and currentExtractor.customParams.techlevel) or 1
+	
+	if newExtractorStrength > currentExtractorStrength then
 		return true
 	end
-	if (newExtractorStrength == currentExtractorStrength and newExtractorIsSpecial) then
+
+	-- Some extractors are special and may be desirable even if they produce less energy
+	if newExtractorStrength ~= currentExtractorStrength and newExtractorIsSpecial then
 		return true
 	end
-	if currentExtractorStrength == newExtractorStrength then
-		return false
+
+	-- Extractors on the same tier may always be upgraded to each other as long as they're different
+	if newExtractorStrength ~= currentExtractorStrength then
+		if newTechLevel == currentTechLevel then
+			return true
+		end
 	end
 
 	return false

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -193,6 +193,9 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 	end
 
 	local currentExtractorId = spGetUnitDefID(currentExtractorUuid)
+	if currentExtractorId == newExtractorId then
+		return false
+	end
 
 	local newExtractor = UnitDefs[newExtractorId]
 	local currentExtractor = UnitDefs[currentExtractorId]

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -55,6 +55,7 @@ local geoConstructors = {}
 local geoConstructorsDef = {}
 local geoBuildings = {}
 
+local normalExtractors = {}
 ------------------------------------------------------------
 -- populate unit tables
 ------------------------------------------------------------
@@ -96,6 +97,27 @@ for uDefID, uDef in pairs(UnitDefs) do
 	end
 end
 
+
+-- Standard extractors produce just metal / energy and are available to all factions.
+local normalExtractorNames = {
+	-- T1 
+	"armmex", "cormex", "legmex",
+	-- T2 mexes
+	"armmoho", "cormoho", "legmoho", 
+	"armuwmme", "coruwmme", "leganavalmex",
+	-- T1 geos
+	"armgeo", "corgeo", "leggeo",
+	"armuwgeo", "coruwgeo", "leguwgeo",
+	-- T2 geos
+	"armageo", "corageo", "legageo",
+	"armuwageo", "coruwageo", "leganavaladvgeo",
+}
+for i = 1, #normalExtractorNames do
+	local unitDef = UnitDefNames[normalExtractorNames[i]]
+	if unitDef then
+		normalExtractors[unitDef.id] = true
+	end
+end
 
 ------------------------------------------------------------
 -- Building logic
@@ -189,46 +211,31 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 
 	local currentExtractorId = spGetUnitDefID(currentExtractorUuid)
 
-	if currentExtractorId == newExtractorId then
-		return false
-	end
-
 	local newExtractor = UnitDefs[newExtractorId]
 	local currentExtractor = UnitDefs[currentExtractorId]
-	local newExtractorStrength = mexBuildings[newExtractorId] or geoBuildings[newExtractorId]
-	local currentExtractorStrength = mexBuildings[currentExtractorId] or geoBuildings[currentExtractorId]
 
-	if not (newExtractorStrength and currentExtractorStrength) then
-		return false
-	end
-
-	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0 or newExtractor.radarDistanceJam > 0
-
-	local newTechLevel = tonumber(newExtractor.customParams.techlevel) or 1
-	local currentTechLevel = tonumber(currentExtractor.customParams.techlevel) or 1
-
+	local newTechLevel = math.floor(tonumber(newExtractor.customParams.techlevel) or 1)
+	local currentTechLevel = math.floor(tonumber(currentExtractor.customParams.techlevel) or 1)
 	if newTechLevel < currentTechLevel then
 		return false
-	end
-
-	
-	if newExtractorStrength > currentExtractorStrength then
+	elseif newTechLevel > currentTechLevel then
 		return true
 	end
 
-	-- Some extractors are special and may be desirable regardless of yield
-	if newExtractorIsSpecial then
+	local newIsNormal = normalExtractors[newExtractorId]
+	local currentIsNormal = normalExtractors[currentExtractorId]
+
+	-- Special case for T2 Geo as AGeo is considered normal, but may be more desirable over other T2 Geos.
+	local isT2SpecialGeoToAgeo = geoBuildings[currentExtractorId]
+		and geoBuildings[newExtractorId]
+		and newTechLevel >= 2
+		and not currentIsNormal
+	if isT2SpecialGeoToAgeo then
 		return true
 	end
 
-	-- Extractors on the same tier may always be upgraded to each other as long as they're different
-	if newExtractorStrength ~= currentExtractorStrength then
-		if newTechLevel == currentTechLevel then
-			return true
-		end
-	end
-
-	return false
+	-- In all other cases, specialty extractors are always considered to be better than normal extractors, but interchangable with each other.
+	return not newIsNormal
 end
 
 ---Returns true if the specified extractor be built on this spot - considers upgrades and sidegrades

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -206,7 +206,7 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 		return true
 	end
 
-	-- Some extractors are special and may be desirable even if they produce less energy
+	-- Some extractors are special and may be desirable even if they produce less resources
 	if newExtractorStrength ~= currentExtractorStrength and newExtractorIsSpecial then
 		return true
 	end

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -189,7 +189,6 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 
 	local currentExtractorId = spGetUnitDefID(currentExtractorUuid)
 
-	-- Disallow building the same extractor over itself
 	if currentExtractorId == newExtractorId then
 		return false
 	end
@@ -203,10 +202,15 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 		return false
 	end
 
-	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0 or (newExtractor.radarDistanceJam or 0) > 0
+	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0 or newExtractor.radarDistanceJam > 0
 
-	local newTechLevel = tonumber(newExtractor.customParams and newExtractor.customParams.techlevel) or 1
-	local currentTechLevel = tonumber(currentExtractor.customParams and currentExtractor.customParams.techlevel) or 1
+	local newTechLevel = tonumber(newExtractor.customParams.techlevel) or 1
+	local currentTechLevel = tonumber(currentExtractor.customParams.techlevel) or 1
+
+	if newTechLevel < currentTechLevel then
+		return false
+	end
+
 	
 	if newExtractorStrength > currentExtractorStrength then
 		return true

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -188,6 +188,12 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 	end
 
 	local currentExtractorId = spGetUnitDefID(currentExtractorUuid)
+
+	-- Disallow building the same extractor over itself
+	if currentExtractorId == newExtractorId then
+		return false
+	end
+
 	local newExtractor = UnitDefs[newExtractorId]
 	local currentExtractor = UnitDefs[currentExtractorId]
 	local newExtractorStrength = mexBuildings[newExtractorId] or geoBuildings[newExtractorId]
@@ -197,7 +203,7 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 		return false
 	end
 
-	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0
+	local newExtractorIsSpecial = newExtractor.stealth or #newExtractor.weapons > 0 or (newExtractor.radarDistanceJam or 0) > 0
 
 	local newTechLevel = tonumber(newExtractor.customParams and newExtractor.customParams.techlevel) or 1
 	local currentTechLevel = tonumber(currentExtractor.customParams and currentExtractor.customParams.techlevel) or 1
@@ -206,8 +212,8 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 		return true
 	end
 
-	-- Some extractors are special and may be desirable even if they produce less resources
-	if newExtractorStrength ~= currentExtractorStrength and newExtractorIsSpecial then
+	-- Some extractors are special and may be desirable regardless of yield
+	if newExtractorIsSpecial then
 		return true
 	end
 

--- a/tools/headless_testing/startscript.txt
+++ b/tools/headless_testing/startscript.txt
@@ -10,6 +10,7 @@
 	FixedRNGSeed = 1;
   [MODOPTIONS]
   {
+    experimentallegionfaction=1;
     debugcommands=1:cheat|2:godmode|3:globallos|30:runtestsheadless;
 		deathmode=neverend;
   }

--- a/tools/headless_testing/startscript.txt
+++ b/tools/headless_testing/startscript.txt
@@ -10,7 +10,6 @@
 	FixedRNGSeed = 1;
   [MODOPTIONS]
   {
-    experimentallegionfaction=1;
     debugcommands=1:cheat|2:godmode|3:globallos|30:runtestsheadless;
 		deathmode=neverend;
   }

--- a/units/ArmBuildings/LandEconomy/armageo.lua
+++ b/units/ArmBuildings/LandEconomy/armageo.lua
@@ -33,6 +33,7 @@ return {
 			buildinggrounddecaltype = "decals/armageo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/ArmBuildings/LandEconomy/armgeo.lua
+++ b/units/ArmBuildings/LandEconomy/armgeo.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/armgeo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/ArmBuildings/LandEconomy/armmex.lua
+++ b/units/ArmBuildings/LandEconomy/armmex.lua
@@ -37,6 +37,7 @@ return {
 			buildinggrounddecaltype = "decals/armmex_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 1,
+			standardextractor = true,
 			model_author = "Cremuss",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/ArmBuildings/LandEconomy/armmoho.lua
+++ b/units/ArmBuildings/LandEconomy/armmoho.lua
@@ -36,6 +36,7 @@ return {
 			buildinggrounddecaltype = "decals/armmoho_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 4,
+			standardextractor = true,
 			model_author = "Cremuss",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/ArmBuildings/SeaEconomy/armuwageo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwageo.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/armageo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss, Hornet",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/ArmBuildings/SeaEconomy/armuwgeo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwgeo.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/armgeo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss, Hornet",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/ArmBuildings/SeaEconomy/armuwmme.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwmme.lua
@@ -33,6 +33,7 @@ return {
 			buildinggrounddecaltype = "decals/armuwmme_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 4,
+			standardextractor = true,
 			model_author = "FireStorm",
 			normaltex = "unittextures/Arm_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/LandEconomy/corageo.lua
+++ b/units/CorBuildings/LandEconomy/corageo.lua
@@ -33,6 +33,7 @@ return {
 			buildinggrounddecaltype = "decals/corageo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/LandEconomy/corgeo.lua
+++ b/units/CorBuildings/LandEconomy/corgeo.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/corgeo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/LandEconomy/cormex.lua
+++ b/units/CorBuildings/LandEconomy/cormex.lua
@@ -37,6 +37,7 @@ return {
 			buildinggrounddecaltype = "decals/cormex_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 1,
+			standardextractor = true,
 			model_author = "Mr Bob",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/LandEconomy/cormoho.lua
+++ b/units/CorBuildings/LandEconomy/cormoho.lua
@@ -36,6 +36,7 @@ return {
 			buildinggrounddecaltype = "decals/cormoho_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 4,
+			standardextractor = true,
 			model_author = "Mr Bob",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/SeaEconomy/coruwageo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwageo.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/corageo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss, Hornet",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/SeaEconomy/coruwgeo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwgeo.lua
@@ -35,6 +35,7 @@ return {
 			buildinggrounddecaltype = "decals/corgeo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Cremuss, Hornet",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/CorBuildings/SeaEconomy/coruwmme.lua
+++ b/units/CorBuildings/SeaEconomy/coruwmme.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/coruwmme_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 4,
+			standardextractor = true,
 			model_author = "Mr Bob",
 			normaltex = "unittextures/cor_normal.dds",
 			removestop = true,

--- a/units/Legion/Economy/legageo.lua
+++ b/units/Legion/Economy/legageo.lua
@@ -35,6 +35,7 @@ return {
 			unitgroup = 'energy',
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Tharsis",
 			normaltex = "unittextures/LEG_normal.dds",
 			removestop = true,

--- a/units/Legion/Economy/leggeo.lua
+++ b/units/Legion/Economy/leggeo.lua
@@ -36,6 +36,7 @@ return {
 			unitgroup = 'energy',
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Tharsis",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,

--- a/units/Legion/Economy/legmex.lua
+++ b/units/Legion/Economy/legmex.lua
@@ -40,6 +40,7 @@ return {
 			unitgroup = 'metal',
 			cvbuildable = true,
 			metal_extractor = 1,
+			standardextractor = true,
 			model_author = "Protar",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,

--- a/units/Legion/Economy/legmoho.lua
+++ b/units/Legion/Economy/legmoho.lua
@@ -38,6 +38,7 @@ return {
 			unitgroup = 'metal',
 			cvbuildable = true,
 			metal_extractor = 4,
+			standardextractor = true,
 			model_author = "Protar",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,

--- a/units/Legion/SeaEconomy/T2/leganavaladvgeo.lua
+++ b/units/Legion/SeaEconomy/T2/leganavaladvgeo.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/corageo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Tharsis, ZephyrSkies",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,

--- a/units/Legion/SeaEconomy/T2/leganavalmex.lua
+++ b/units/Legion/SeaEconomy/T2/leganavalmex.lua
@@ -34,6 +34,7 @@ return {
 			buildinggrounddecaltype = "decals/leganavalmex_aoplane.dds",
 			cvbuildable = true,
 			metal_extractor = 4,
+			standardextractor = true,
 			model_author = "Protar",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,

--- a/units/Legion/SeaEconomy/leguwgeo.lua
+++ b/units/Legion/SeaEconomy/leguwgeo.lua
@@ -35,6 +35,7 @@ return {
 			buildinggrounddecaltype = "decals/corgeo_aoplane.dds",
 			cvbuildable = true,
 			geothermal = 1,
+			standardextractor = true,
 			model_author = "Tharsis, ZephyrSkies",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,


### PR DESCRIPTION
## Summary
- Extractor snap could not place Prude, Cerberus, or Rampart on a vent that already held an advanced geothermal, because `extractorCanBeUpgraded` only accepted higher energy output.
- Allow same-tier extractor swaps when yield differs (including lower-yield specialty geos over an advanced geo).
- Keep allowing specialty (armed/stealth) extractors when yield differs from the plant already on the spot.

Concretely:
Allows Prude over A. Geo

Continues to:
Allow Cerb over Ageo
Allow Ageo over geo

Side Effect:
Allows t1 mex over legion overcharged mex (as they are both t1)

<img width="1283" height="825" alt="image" src="https://github.com/user-attachments/assets/5f38fd7f-a25a-48f6-9105-3d29931a48b5" />

Used cursor for coding, edited, tested by hand.