### PR TITLE
Add extreme difficulty option into the modoptions and adjust zombie spawn count for it.

### DIFF
--- a/luarules/gadgets/unit_zombies.lua
+++ b/luarules/gadgets/unit_zombies.lua
@@ -52,8 +52,8 @@ local zombieModeConfigs           = {
 		rezSpeed = 48,
 		rezMin = 30,
 		rezMax = 45,
-		countMin = 4,
-		countMax = 10
+		countMin = 3,
+		countMax = 6,
 	}
 }
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1523,6 +1523,8 @@ local options = {
             { key = "normal", name = "Normal", desc = "Slow revival rate, normal strength."},
             { key = "hard", name = "Hard", desc = "Fast revival rate, stronger Scavenger Zombies." },
             { key = "nightmare", name = "Nightmare", desc = "Extreme revival rate, stronger Scavenger Zombies, 2-5 spawn per corpse." },
+			{ key = "extreme", name = "Extreme", desc = "Extreme revival rate, stronger Scavenger Zombies, 3-6 spawn per corpse." },
+
         }
     },
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Enabled `extreme` difficulty in scav zombies mode.

<!--
Describe the changes or additions made in this PR, and why they
are necessary or important. If there is unusual complexity in the
code or functionality, please explain it so reviewers can understand.
-->

I just added it in modoptions so we can select `extreme` mode. The original code already has it but has not yet included in the UI to be selected.



#### Test steps
- [ ]  Create a new game. Select `Adv Options` -> `Extras` 
- [ ]  Under `Scavenger Zombies` click and select `Extreme`
- [ ] Start the game.

### AI / LLM usage statement:
No AI used here, just config changes.