### PR TITLE
stylua: emit CRLF at 120 columns, matching .gitattributes

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,6 +1,6 @@
 syntax = "All"
-column_width = 2000
-line_endings = "Unix"
+column_width = 120
+line_endings = "Windows"
 indent_type = "Tabs"
 indent_width = 4
 quote_style = "AutoPreferDouble"

--- a/.styluaignore
+++ b/.styluaignore
@@ -2,3 +2,8 @@ common/luaUtilities/
 .lux/
 recoil-lua-library/
 mapgenerator/
+icons/icon_atlas.lua
+unittextures/decals_features/featureaoplates_atlas.lua
+luaui/images/decals_gl4/decalsgl4_atlas_diffuse.lua
+luaui/images/decals_gl4/decalsgl4_atlas_normal.lua
+unittextures/decals/unitaoplates_atlas.lua

--- a/common/lib_startpoint_guesser.lua
+++ b/common/lib_startpoint_guesser.lua
@@ -168,7 +168,7 @@ function GuessOne(teamID, allyID, xmin, zmin, xmax, zmax, startPointTable)
 	-- find nearest free spot closest to best
 	local bx,bz = freeMetalSpots[bestIndex][1],freeMetalSpots[bestIndex][2]
 	local nx,nz
-	local bestDistance = (xmax)*(xmax)+(zmax)*(zmax) -- meh, just need to be big
+	local bestDistance = xmax * xmax + zmax * zmax -- meh, just need to be big
 
 	for i=1,#freeMetalSpots do
 		if i ~= bestIndex then

--- a/luaui/Tests/select_api/compare_to_spring.lua
+++ b/luaui/Tests/select_api/compare_to_spring.lua
@@ -73,10 +73,8 @@ local function compareUnitSets(springUnitSet, apiUnitSet, filter)
 					name == "cormlv" or
 					name == "armmlv"
 				))
-				-- api command selects these, but spring select doesn't
-				-- I think they spawn? don't seem to exist during build script
-				or name == "armdrone" or name == "corvacct"
-				or name == "armtl"
+				or name == "armdrone" or name == "corvacct" -- api command selects these, but spring select doesn't
+				or name == "armtl" -- I think they spawn? don't seem to exist during build script
 
 			if not isWeirdOutlier then
 				table.insert(missingInSpring, uid)

--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -312,8 +312,8 @@ local function isValidLivingSeenUnit(unitID, unitDefID, verbose)
 		if unitDefID == nil or
 			spValidUnitID(unitID) ~= true or
 			spGetUnitIsDead(unitID) == true or
-			((not fullview) and (spGetUnitLosState(unitID, myAllyTeamID, true) % 2 == 0)) or -- outside of LOS
-			unitDefIgnore[unitDefID] then
+			((not fullview) and (spGetUnitLosState(unitID, myAllyTeamID, true) % 2 == 0)) -- outside of LOS
+			or unitDefIgnore[unitDefID] then
 			if debuglevel >= (verbose or 0) then
 				Spring.Debug.TraceEcho()
 				spEcho("not isValidLivingSeenUnit",
@@ -716,8 +716,8 @@ function widget:PlayerChanged(playerID)
 	end
 
 	-- testing for visible units changed
-	if (currentspec ~= spec) or -- we change from spec to non spec (I dont think its possible to go from player to non-fullview spec in one go)
-		(currentfullview ~= fullview) or
+	if (currentspec ~= spec) -- we change from spec to non spec (I dont think its possible to go from player to non-fullview spec in one go)
+		or (currentfullview ~= fullview) or
 		((currentAllyTeamID ~= myAllyTeamID) and not currentspec and not currentfullview) then -- our ALLYteam changes while playing, and we are not in fullview
 		reinit = true
 	end

--- a/luaui/Widgets/cmd_bomber_attack_building_ground.lua
+++ b/luaui/Widgets/cmd_bomber_attack_building_ground.lua
@@ -46,8 +46,8 @@ function widget:GameFrame(gf)
 	if gf % 7 == 1 then
 		for unitID, params in pairs(monitorTargets) do
 			if not spValidUnitID(unitID) then
-				if spIsPosInLos(params[1]-losGraceRadius,params[2],params[3]+losGraceRadius) and		-- check wider area because unit can be marked invalid while just becoming in los
-					spIsPosInLos(params[1]-losGraceRadius,params[2],params[3]-losGraceRadius) and
+				if spIsPosInLos(params[1]-losGraceRadius,params[2],params[3]+losGraceRadius) -- check wider area because unit can be marked invalid while just becoming in los
+					and spIsPosInLos(params[1]-losGraceRadius,params[2],params[3]-losGraceRadius) and
 					spIsPosInLos(params[1]+losGraceRadius,params[2],params[3]-losGraceRadius) and
 					spIsPosInLos(params[1]+losGraceRadius,params[2],params[3]+losGraceRadius)
 				then

--- a/luaui/Widgets/cmd_clone_tool.lua
+++ b/luaui/Widgets/cmd_clone_tool.lua
@@ -885,6 +885,7 @@ local function drawGroundRect(box, r, g, b, a, fillA)
 		glBlending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 		local gridStep = 64
 		for z = z1, z2 - gridStep, gridStep do
+			-- stylua: ignore start
 			glBeginEnd(GL_QUADS, function()
 				for x = x1, x2 - gridStep, gridStep do
 					local nx = min(x + gridStep, x2)
@@ -895,6 +896,7 @@ local function drawGroundRect(box, r, g, b, a, fillA)
 					glVertex(x,  spGetGroundHeight(x,  nz) + y_offset, nz)
 				end
 			end)
+			-- stylua: ignore end
 		end
 	end
 	glColor(1, 1, 1, 1)

--- a/luaui/Widgets/cmd_startpos_tool.lua
+++ b/luaui/Widgets/cmd_startpos_tool.lua
@@ -1975,6 +1975,7 @@ local function buildPolygonFillList(verts, lift, cellSize)
 				for ri = 0, N - 1 do
 					local rUBase = ri * (ri + 1) * 0.5
 					local rDBase = (ri + 1) * (ri + 2) * 0.5
+					-- stylua: ignore start
 					for j = 0, ri do
 						local uK  = (rUBase + j)     * 3
 						local d1K = (rDBase + j)     * 3
@@ -1991,6 +1992,7 @@ local function buildPolygonFillList(verts, lift, cellSize)
 						glVertex(rowBuf[dK  + 1], rowBuf[dK  + 2], rowBuf[dK  + 3])
 						glVertex(rowBuf[u2K + 1], rowBuf[u2K + 2], rowBuf[u2K + 3])
 					end
+					-- stylua: ignore end
 				end
 			end
 		end)
@@ -2708,6 +2710,7 @@ local function drawScreenBadge(cx, cy, color, allyTeamNum, teamName, playerIdx, 
 	local bx         = cx - w * 0.5
 	local by         = cy
 
+	-- stylua: ignore start
 	-- Card background (dark chamfered-corner rect — octagon fan)
 	local bgA = hovered and 0.85 or 0.68
 	glColor(0.04, 0.06, 0.09, bgA)
@@ -2755,6 +2758,7 @@ local function drawScreenBadge(cx, cy, color, allyTeamNum, teamName, playerIdx, 
 		glVertex(bx + w - padX,        by + h - padY)
 		glVertex(bx + padX + barW + 1, by + h - padY)
 	end)
+	-- stylua: ignore end
 
 	-- "Team N" label (shadow + color-bright)
 	local textX = bx + padX + barW + gap

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -5138,6 +5138,7 @@ function extraState.drawMeasureWorld()
 		local R = isHover and 11 or 8
 		glLineWidth(5)
 		glColor(0, 0, 0, 0.60)
+		-- stylua: ignore start
 		glBeginEnd(GL.LINE_LOOP, function()
 			glVertex(hx,     hy, hz - R) ; glVertex(hx + R, hy, hz    )
 			glVertex(hx,     hy, hz + R) ; glVertex(hx - R, hy, hz    )
@@ -5148,6 +5149,7 @@ function extraState.drawMeasureWorld()
 			glVertex(hx,     hy, hz - R) ; glVertex(hx + R, hy, hz    )
 			glVertex(hx,     hy, hz + R) ; glVertex(hx - R, hy, hz    )
 		end)
+		-- stylua: ignore end
 		if isHover then
 			local R2 = R + 7
 			glLineWidth(1.5)

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -1139,9 +1139,9 @@ function widget:PlayerChanged(playerID)
 	if debugmode then spEcho("HBGL4 widget:PlayerChanged",'spec', currentspec, 'fullview', currentfullview, 'teamID', currentTeamID, 'allyTeamID', currentAllyTeamID, "playerID", currentPlayerID) end
 
 	-- cases where we need to trigger:
-	if (currentspec ~= spec) or -- we transition from spec to player, yes this is needed
-		(currentfullview ~= fullview) or -- we turn on or off fullview
-		((currentAllyTeamID ~= myAllyTeamID) and not currentfullview)  -- our ALLYteam changes, and we are not in fullview
+	if (currentspec ~= spec) -- we transition from spec to player, yes this is needed
+		or (currentfullview ~= fullview) -- we turn on or off fullview
+		or ((currentAllyTeamID ~= myAllyTeamID) and not currentfullview)  -- our ALLYteam changes, and we are not in fullview
 
 		then
 		-- do the actual reinit stuff, but first change my own

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -388,13 +388,13 @@ local function refreshUnitInfo()
 					end
 
 				elseif
-					unitDef.customParams.evocomlvl  or -- use primary weapon for evolving commanders
-					unitDef.name == 'armcom'       or -- ignore underwater secondary
-					unitDef.name == 'corcom'       or
+					unitDef.customParams.evocomlvl -- use primary weapon for evolving commanders
+					or unitDef.name == 'armcom' -- ignore underwater secondary
+					or unitDef.name == 'corcom'       or
 					unitDef.name == 'legcom'       or
-					unitDef.name == 'corkarg'      or -- ignore secondary weapons, kick
-					unitDef.name == 'armguard'     or -- ignore high-trajectory modes
-					unitDef.name == 'corpun'       or
+					unitDef.name == 'corkarg' -- ignore secondary weapons, kick
+					or unitDef.name == 'armguard' -- ignore high-trajectory modes
+					or unitDef.name == 'corpun'       or
 					unitDef.name == 'legcluster'   or
 					unitDef.name == 'leglob'   or
 					unitDef.name == 'legnavyfrigate'   or

--- a/luaui/Widgets/gui_mapinfo.lua
+++ b/luaui/Widgets/gui_mapinfo.lua
@@ -87,6 +87,7 @@ local function createMapinfoList(opacityMultiplier)
 
 		local height = 90
 		local thickness = -(thickness*scale)
+		-- stylua: ignore start
 		glBeginEnd(GL.QUADS,function()
 			glColor(0.12,0.12,0.12,0.4*opacityMultiplier*opacityMultiplier)
 			glVertex( height, 0        , 0);         -- Top Right Of The Quad (Top)
@@ -121,6 +122,7 @@ local function createMapinfoList(opacityMultiplier)
 			glVertex( 0     ,-thickness, 0);         -- Bottom Left Of The Quad (Bottom)
 			glVertex( height,-thickness, 0);         -- Bottom Right Of The Quad (Bottom)
 		end)
+		-- stylua: ignore end
 
 		glRotate(180,1,0,0)
 		glRotate(90,0,1,0)

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -9109,8 +9109,8 @@ function widget:ViewResize()
 			                  oldVsx > 0 and oldVsy > 0 and
 			                  (render.dim.r - render.dim.l) >= minSize and
 			                  (render.dim.t - render.dim.b) >= minSize and
-			                  render.dim.r > minSize and  -- Not stuck at bottom-left
-			                  render.dim.t > minSize
+			                  render.dim.r > minSize -- Not stuck at bottom-left
+			                  and render.dim.t > minSize
 
 			if dimsValid then
 				render.dim.l, render.dim.r, render.dim.b, render.dim.t = render.dim.l/oldVsx, render.dim.r/oldVsx, render.dim.b/oldVsy, render.dim.t/oldVsy

--- a/luaui/Widgets/gui_unit_energy_icons.lua
+++ b/luaui/Widgets/gui_unit_energy_icons.lua
@@ -180,8 +180,8 @@ local function updateStalling()
 			--Previous implementation of such a mechanism led to the energy symbols then remaining when the condition was reached(worked for all but starfall)
 			for unitID, unitDefID in pairs(units) do
 				local unitEnergy = select(4, spGetUnitResources(unitID))
-				if teamEnergy[teamID] and unitConf[unitDefID][3] > teamEnergy[teamID] and -- more neededEnergy than we have
-					(not unitConf[unitDefID][4] or ((unitConf[unitDefID][4] and (unitEnergy or 999999)) < unitConf[unitDefID][3])) then
+				if teamEnergy[teamID] and unitConf[unitDefID][3] > teamEnergy[teamID] -- more neededEnergy than we have
+					and (not unitConf[unitDefID][4] or ((unitConf[unitDefID][4] and (unitEnergy or 999999)) < unitConf[unitDefID][3])) then
 
 					if not Spring.GetUnitIsBeingBuilt(unitID) and
 						energyIconVBO.instanceIDtoIndex[unitID] == nil then -- not already being drawn

--- a/luaui/Widgets/test_DPAT.lua
+++ b/luaui/Widgets/test_DPAT.lua
@@ -103,7 +103,7 @@ function widget:DrawWorldPreUnit()
 		glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE) -- Set The Stencil Buffer To 1 Where Draw Any Polygon		this to the shader
 		glClear(GL_STENCIL_BUFFER_BIT ) -- set stencil buffer to 0 
 
-		glStencilFunc(GL_NOTEQUAL, 1, 1); -- use NOTEQUAL instead of ALWAYS to ensure that overlapping transparent fragments dont get written multiple times
+		glStencilFunc(GL_NOTEQUAL, 1, 1) -- use NOTEQUAL instead of ALWAYS to ensure that overlapping transparent fragments dont get written multiple times
 		glStencilMask(1)
 	
 		selectShader:SetUniform("addRadius",0) -- pass this 

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -315,8 +315,9 @@ function widget:Update(dt)
 
 	for i = 1, #mouseSelection do
 		uid = mouseSelection[i]
-		if not spGetUnitNoSelect(uid) and -- filter unselectable units
-			 -- filter gaia units + ignored units (objects)
+		-- filter unselectable units
+		-- filter gaia units + ignored units (objects)
+		if not spGetUnitNoSelect(uid) and
 			(isGodMode or ((not spec or spGetUnitTeam(uid) ~= GaiaTeamID) and not ignoreUnits[spGetUnitDefID(uid)])) then
 			n = n + 1
 			included[n] = uid

--- a/luaui/configs/buildmenu_sorting.lua
+++ b/luaui/configs/buildmenu_sorting.lua
@@ -1,3 +1,4 @@
+-- stylua: ignore start
 ---@type table<string, number>
 local unitOrderTable = {
 -- UNITS
@@ -842,6 +843,7 @@ local unitOrderTable = {
    ['armatl']         = 260500,
    ['coratl']         = 260600,
 }
+-- stylua: ignore end
 
 ---@type table<string, number>
 local newUnitOrder = {}

--- a/modelmaterials/128_features_special.lua
+++ b/modelmaterials/128_features_special.lua
@@ -409,9 +409,9 @@ for id = 1, #FeatureDefs do
 
 				local wreckNormalTex = featureDef.model.textures.tex1  and
 					((lowercasetex1:find("arm_wreck") and "unittextures/Arm_wreck_color_normal.dds") or
-					(lowercasetex1:find("arm_color") and "unittextures/Arm_normal.dds") or -- for things like dead dragons claw armclaw
-					(lowercasetex1:find("cor_color.dds",1,true) and "unittextures/cor_normal.dds") or -- for things like dead dragons maw cormaw
-					(lowercasetex1:find("cor_color_wreck") and "unittextures/cor_color_wreck_normal.dds"))
+					(lowercasetex1:find("arm_color") and "unittextures/Arm_normal.dds") -- for things like dead dragons claw armclaw
+					or (lowercasetex1:find("cor_color.dds",1,true) and "unittextures/cor_normal.dds") -- for things like dead dragons maw cormaw
+					or (lowercasetex1:find("cor_color_wreck") and "unittextures/cor_color_wreck_normal.dds"))
 
 				if not wreckNormalTex then
 					table.insert(failedwrecknormaltex, 1, featureDef.name)

--- a/modelmaterials_gl4/128_features_special.lua
+++ b/modelmaterials_gl4/128_features_special.lua
@@ -409,9 +409,9 @@ for id = 1, #FeatureDefs do
 
 				local wreckNormalTex = featureDef.model.textures.tex1  and
 					((lowercasetex1:find("arm_wreck") and "unittextures/Arm_wreck_color_normal.dds") or
-					(lowercasetex1:find("arm_color") and "unittextures/Arm_normal.dds") or -- for things like dead dragons claw armclaw
-					(lowercasetex1:find("cor_color.dds",1,true) and "unittextures/cor_normal.dds") or -- for things like dead dragons maw cormaw
-					(lowercasetex1:find("cor_color_wreck") and "unittextures/cor_color_wreck_normal.dds"))
+					(lowercasetex1:find("arm_color") and "unittextures/Arm_normal.dds") -- for things like dead dragons claw armclaw
+					or (lowercasetex1:find("cor_color.dds",1,true) and "unittextures/cor_normal.dds") -- for things like dead dragons maw cormaw
+					or (lowercasetex1:find("cor_color_wreck") and "unittextures/cor_color_wreck_normal.dds"))
 
 				if not wreckNormalTex then
 					table.insert(failedwrecknormaltex, 1, featureDef.name)

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -253,9 +253,9 @@ local options = {
     {
         key    	= "norushtimer",
         name   	= "No Rush Time".."\255\128\128\128".." [minutes]",
+        -- tabs don't do much in chobby
         desc   	= "Set timer in which players cannot get out of their startbox, so you have time to prepare before fighting.\n"..
 			"PLEASE NOTE: For this to work, the game needs to have set startboxes.\n"..
-			-- tabs don't do much in chobby
 			"                          It won't work in FFA mode without boxes.\n"..
 			"                          Also, it does not affect Scavengers and Raptors.\n"..
 			"\255\75\0\100".."WARNING: No Rush Time over 30 minutes may cause performance or stability issues due to excessive unit buildup.",

--- a/modules/graphics/instancevbotable.lua
+++ b/modules/graphics/instancevbotable.lua
@@ -1231,51 +1231,52 @@ local function makeSphereVBO(sectorCount, stackCount, radius, name) -- http://ww
 
 	local VBOData = {}
 	radius = radius or 1
-	local x, y, z, xy; --  vertex position
+	-- stylua: ignore start
+	local x, y, z, xy  --  vertex position
 	local nx, ny, nz
-	local lengthInv = 1.0 / radius;    -- vertex normal
-	local s, t;                                     -- vertex texCoord
+	local lengthInv = 1.0 / radius     -- vertex normal
+	local s, t                                      -- vertex texCoord
 
-	local sectorStep = 2 * math.pi / sectorCount;
-	local stackStep = math.pi / stackCount;
-	local sectorAngle, stackAngle;
+	local sectorStep = 2 * math.pi / sectorCount
+	local stackStep = math.pi / stackCount
+	local sectorAngle, stackAngle
 
 	for i = 0, stackCount do
 
-		stackAngle = math.pi / 2 - i * stackStep;        -- starting from pi/2 to -pi/2
-		xy = radius * math.cos(stackAngle);             -- r * cos(u)
-		z = radius * math.sin(stackAngle);              -- r * sin(u)
+		stackAngle = math.pi / 2 - i * stackStep         -- starting from pi/2 to -pi/2
+		xy = radius * math.cos(stackAngle)              -- r * cos(u)
+		z = radius * math.sin(stackAngle)               -- r * sin(u)
 
 		-- add (sectorCount+1) vertices per stack
 		-- the first and last vertices have same position and normal, but different tex coords
 		for j = 0, sectorCount do -- for (int j = 0; j <= sectorCount; ++j)
 
-			sectorAngle = j * sectorStep;           -- starting from 0 to 2pi
+			sectorAngle = j * sectorStep            -- starting from 0 to 2pi
 
 			-- vertex position (x, y, z)
-			x = xy * math.cos(sectorAngle);             -- r * cos(u) * cos(v)
-			y = xy * math.sin(sectorAngle);             -- r * cos(u) * sin(v)
-			VBOData[#VBOData + 1] = x;
-			VBOData[#VBOData + 1] = y;
-			VBOData[#VBOData + 1] = z;
-			VBOData[#VBOData + 1] = sectorAngle;
+			x = xy * math.cos(sectorAngle)              -- r * cos(u) * cos(v)
+			y = xy * math.sin(sectorAngle)              -- r * cos(u) * sin(v)
+			VBOData[#VBOData + 1] = x
+			VBOData[#VBOData + 1] = y
+			VBOData[#VBOData + 1] = z
+			VBOData[#VBOData + 1] = sectorAngle
 			--Spring.Echo(x,y,z)
 			-- normalized vertex normal (nx, ny, nz)
-			nx = x * lengthInv;
-			ny = y * lengthInv;
-			nz = z * lengthInv;
+			nx = x * lengthInv
+			ny = y * lengthInv
+			nz = z * lengthInv
 
 
-			VBOData[#VBOData + 1] = nx;
-			VBOData[#VBOData + 1] = ny;
-			VBOData[#VBOData + 1] = nz;
+			VBOData[#VBOData + 1] = nx
+			VBOData[#VBOData + 1] = ny
+			VBOData[#VBOData + 1] = nz
 
 			-- vertex tex coord (s, t) range between [0, 1]
-			s = j / sectorCount;
-			t = i / stackCount;
+			s = j / sectorCount
+			t = i / stackCount
 
-			VBOData[#VBOData + 1] = s;
-			VBOData[#VBOData + 1] = t;
+			VBOData[#VBOData + 1] = s
+			VBOData[#VBOData + 1] = t
 		end
 	end
 	sphereVBO:Define(#VBOData/9, vertVBOLayout)
@@ -1325,6 +1326,7 @@ local function makeSphereVBO(sectorCount, stackCount, radius, name) -- http://ww
 			k2 = k2 + 1
 		end
 	end
+	-- stylua: ignore end
 
 
 	sphereIndexVBO:Define(#VBOData)


### PR DESCRIPTION
`.gitattributes` marks `*.lua` as `text eol=crlf`, so git writes CRLF into the working tree on checkout. `.stylua.toml` says `line_endings = "Unix"`, so the formatter writes LF back.

The result is that running `stylua` leaves every file it touched reported as modified with an **empty diff**, and every subsequent git command prints `warning: LF will be replaced by CRLF the next time Git touches it`. Committed content is LF either way — git normalises on add — so this changes nothing about repository content, only what the formatter writes to disk.

Measured on one file:

| | size | CRLF |
|---|---|---|
| after `git checkout` | 1371 | 60 |
| after `stylua` (`Unix`) | 1311 | 0 |
| after `stylua` (`Windows`) | 1371 | 60 |

Related: #4519 removed `end_of_line = lf` from `.editorconfig` so editors stopped contradicting the checkout. This is the same alignment for the third tool.

`column_width` also drops from the `2000` sentinel to `120` — the wrap width the formatting migration actually applies, stated in the config instead of implied by tooling defaults.

**Stylua bug making this difficult**: https://github.com/JohnnyMorganz/StyLua/pull/1140 — StyLua keeps a comment's source `\r` when it *relocates* the comment, so under CRLF output every comment sitting on a token it moves or deletes comes out as `\r\r\n`. Until that lands upstream, this PR reshapes the affected sites so the formatter passes them through instead of relocating them: trailing semicolons before comments dropped, trailing `and`/`or` moved below their comment, and comments pulled out of expressions StyLua rewrites on every pass. With these edits a full `stylua .` run under this config emits no `\r\r\n` anywhere in the tree.

**Hand-aligned blocks stay hand-aligned.** Some chunks genuinely read better as the author laid them out, and the 120-column wrap or space-collapsing would make them worse. Those sit inside `-- stylua: ignore start` / `end` ranges:

- `gui_mapinfo.lua` — the map-border quad fan (24 aligned `glVertex` rows)
- `cmd_startpos_tool.lua` — index-aligned triangle strips; the chamfered-card octagon fans and bars
- `cmd_terraform_brush.lua` — paired-diamond `glVertex(...) ; glVertex(...)` lines
- `cmd_clone_tool.lua` — the ground-grid quad block
- `modules/graphics/instancevbotable.lua` — the sphere VBO generator (C-port with comment columns; its trailing semicolons became spaces because StyLua strips `;` on locals/assignments even inside ignore ranges)
- `luaui/configs/buildmenu_sorting.lua` — the unit sort-code table (aligned positional codes)

Tool-generated atlas tables (`icons/icon_atlas.lua` and the three `texture_atlas_builder.ipynb` outputs, all marked "Do not edit") go in `.styluaignore` instead — markers inside generated files would be lost on regeneration.

Formatting policy still open for review: `effects/*.lua` (aligned key columns throughout), `modoptions.lua`, and `gui_options.lua` option tables use the same hand-aligned data-table idiom at whole-file scale; this PR leaves them formatted rather than deciding that unilaterally.
