### PR TITLE
fix: nil check on quick upgrade mex/geo

### DIFF
--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -182,6 +182,10 @@ function widget:Update(dt)
 			local x, y, z = spGetUnitPosition(unitUuid)
 
 			extractor = unitIsMex and bestMex or bestGeo
+			if not extractor then
+				clearGhostBuild()
+				return
+			end
 			local canUpgrade = spotBuilder.ExtractorCanBeUpgraded(unitUuid, extractor)
 			if not canUpgrade then
 				clearGhostBuild()


### PR DESCRIPTION
Just a small fix to add a nil check on quick upgrade mex/geo.

The quick build extractor function can crash because ExtractorCanBeUpgraded expects non-nil inputs. 

`extractor = unitIsMex and bestMex or bestGeo` is nil if you take a butler and mouse-over a geo. bestMex is nil (can't build mex on a geo) and bestGeo is nil (because butlers can't build geos) 


