### PR TITLE
Fix Fortifier spawning its wreck while still alive

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -171,11 +171,10 @@ function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
     end
 end
 
--- The con turret has no corpse def; its remains are created manually on death.
--- Lethality cannot be judged inside UnitDamaged (it reports post-damage health),
--- so UnitDamaged only records the latest hit and UnitDestroyed creates the remains.
-local lastDamage = {} -- con turret unitID -> damage of its most recent hit
-local lastDamageFrame = {} -- con turret unitID -> frame of that hit
+-- Remains are derived from its base build def, created manually on death.
+local recentDamage = {} -- con turret unitID -> summed damage taken this frame
+local recentDamageFrame = {} -- con turret unitID -> frame of that damage
+local deathDamage = {} -- con turret unitID -> recent damage that proved lethal
 
 local function createRemains(unitID, unitDefID, unitTeam)
 	local buildAsUnitName = mexTurretDefID[unitDefID]
@@ -183,15 +182,9 @@ local function createRemains(unitID, unitDefID, unitTeam)
 		return
 	end
 
-	-- remains require a damage kill: dead at <= 0 health with a damage event on
-	-- this or the previous frame. Reclaim, self-destruct and pair-removal don't
-	-- fire UnitDamaged and leave no remains.
-	local health = spGetUnitHealth(unitID)
-	if not health or health > 0 then
-		return
-	end
-	local damageFrame = lastDamageFrame[unitID]
-	if not damageFrame or Spring.GetGameFrame() - damageFrame > 1 then
+	-- only damage kills leave remains; reclaim, self-destruct and pair-removal don't
+	local damage = deathDamage[unitID]
+	if not damage then
 		return
 	end
 
@@ -202,12 +195,11 @@ local function createRemains(unitID, unitDefID, unitTeam)
 
 	-- killing-blow severity picks between wreck, heap and nothing
 	local maxHealth = UnitDefs[unitDefID].health
-	local damage = lastDamage[unitID] or 0
 	local facing = Spring.GetUnitBuildFacing(unitID)
 
-	if damage >= maxHealth * 0.5 then
+	if damage > maxHealth * 0.5 then
 		return -- obliterated: nothing left to salvage
-	elseif damage < maxHealth * 0.25 then
+	elseif damage <= maxHealth * 0.25 then
 		local featureID = Spring.CreateFeature(buildAsUnitName .. "_dead" , xx, yy, zz, facing, unitTeam)
 		if featureID then
 			Spring.SetFeatureResurrect(featureID, buildAsUnitName, facing, 0)
@@ -219,8 +211,18 @@ end
 
 function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 	if mexTurretDefID[unitDefID] and not paralyzer then
-		lastDamage[unitID] = damage
-		lastDamageFrame[unitID] = Spring.GetGameFrame()
+		local frame = Spring.GetGameFrame()
+		if recentDamageFrame[unitID] == frame then
+			recentDamage[unitID] = recentDamage[unitID] + damage
+		else
+			recentDamage[unitID] = damage
+			recentDamageFrame[unitID] = frame
+		end
+
+		local health = spGetUnitHealth(unitID) -- post-damage; at or below zero this hit is lethal
+		if health and health <= 0 then
+			deathDamage[unitID] = recentDamage[unitID]
+		end
 	end
 end
 
@@ -229,8 +231,9 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 
 	if mexTurretDefID[unitDefID] then
 		createRemains(unitID, unitDefID, unitTeam)
-		lastDamage[unitID] = nil
-		lastDamageFrame[unitID] = nil
+		recentDamage[unitID] = nil
+		recentDamageFrame[unitID] = nil
+		deathDamage[unitID] = nil
 	end
 
 	if mexActualDefID[unitDefID] or mexTurretDefID[unitDefID] then

--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -171,13 +171,9 @@ function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
     end
 end
 
--- The con turret has no corpse of its own, so its remains are created here by
--- hand. They MUST be created when the unit actually dies, never predicted from
--- an incoming hit: UnitDamaged runs *after* the engine has already subtracted
--- the damage, so testing `health - damage` there subtracts it twice and fires a
--- hit early. That left a live, still-extracting Fortifier standing inside its
--- own blocking wreck, whose collision box is far larger than the unit's and so
--- absorbed the shots that should have finished it off.
+-- The con turret has no corpse def; its remains are created manually on death.
+-- Lethality cannot be judged inside UnitDamaged (it reports post-damage health),
+-- so UnitDamaged only records the latest hit and UnitDestroyed creates the remains.
 local lastDamage = {} -- con turret unitID -> damage of its most recent hit
 local lastDamageFrame = {} -- con turret unitID -> frame of that hit
 
@@ -187,10 +183,9 @@ local function createRemains(unitID, unitDefID, unitTeam)
 		return
 	end
 
-	-- Remains are only for units killed by damage: dead at <= 0 health, with a
-	-- damage event on this or the previous frame. This excludes reclaim,
-	-- self-destruct and being removed because the paired unit died — none of
-	-- which fire UnitDamaged, and none of which should leave remains.
+	-- remains require a damage kill: dead at <= 0 health with a damage event on
+	-- this or the previous frame. Reclaim, self-destruct and pair-removal don't
+	-- fire UnitDamaged and leave no remains.
 	local health = spGetUnitHealth(unitID)
 	if not health or health > 0 then
 		return
@@ -205,13 +200,13 @@ local function createRemains(unitID, unitDefID, unitTeam)
 		return
 	end
 
-	-- severity of the killing blow still picks the remains, as before
+	-- killing-blow severity picks between wreck, heap and nothing
 	local maxHealth = UnitDefs[unitDefID].health
 	local damage = lastDamage[unitID] or 0
 	local facing = Spring.GetUnitBuildFacing(unitID)
 
 	if damage >= maxHealth * 0.5 then
-		return -- obliterated outright: nothing left to salvage
+		return -- obliterated: nothing left to salvage
 	elseif damage < maxHealth * 0.25 then
 		local featureID = Spring.CreateFeature(buildAsUnitName .. "_dead" , xx, yy, zz, facing, unitTeam)
 		if featureID then

--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -171,33 +171,72 @@ function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
     end
 end
 
-local function doUnitDamaged(unitID, unitDefID, unitTeam, damage)
-	local health, maxHealth = spGetUnitHealth(unitID)
+-- The con turret has no corpse of its own, so its remains are created here by
+-- hand. They MUST be created when the unit actually dies, never predicted from
+-- an incoming hit: UnitDamaged runs *after* the engine has already subtracted
+-- the damage, so testing `health - damage` there subtracts it twice and fires a
+-- hit early. That left a live, still-extracting Fortifier standing inside its
+-- own blocking wreck, whose collision box is far larger than the unit's and so
+-- absorbed the shots that should have finished it off.
+local lastDamage = {} -- con turret unitID -> damage of its most recent hit
+local lastDamageFrame = {} -- con turret unitID -> frame of that hit
 
-	if health - damage < 0 and damage < maxHealth * 0.5 then
-		local buildAsUnitName = mexTurretDefID[unitDefID]
-		local xx, yy, zz = Spring.GetUnitPosition(unitID)
-		local facing = Spring.GetUnitBuildFacing(unitID)
+local function createRemains(unitID, unitDefID, unitTeam)
+	local buildAsUnitName = mexTurretDefID[unitDefID]
+	if not buildAsUnitName then
+		return
+	end
 
-		-- todo: "damage" is not "recent damage" is not "damage severity"
-		if damage < maxHealth * 0.25 then
-			local featureID = Spring.CreateFeature(buildAsUnitName .. "_dead" , xx, yy, zz, facing, unitTeam)
-			if featureID then
-				Spring.SetFeatureResurrect(featureID, buildAsUnitName, facing, 0)
-			end
-		else
-			Spring.CreateFeature(buildAsUnitName .. "_heap", xx, yy, zz, facing, unitTeam)
+	-- Remains are only for units killed by damage: dead at <= 0 health, with a
+	-- damage event on this or the previous frame. This excludes reclaim,
+	-- self-destruct and being removed because the paired unit died — none of
+	-- which fire UnitDamaged, and none of which should leave remains.
+	local health = spGetUnitHealth(unitID)
+	if not health or health > 0 then
+		return
+	end
+	local damageFrame = lastDamageFrame[unitID]
+	if not damageFrame or Spring.GetGameFrame() - damageFrame > 1 then
+		return
+	end
+
+	local xx, yy, zz = Spring.GetUnitPosition(unitID)
+	if not xx then
+		return
+	end
+
+	-- severity of the killing blow still picks the remains, as before
+	local maxHealth = UnitDefs[unitDefID].health
+	local damage = lastDamage[unitID] or 0
+	local facing = Spring.GetUnitBuildFacing(unitID)
+
+	if damage >= maxHealth * 0.5 then
+		return -- obliterated outright: nothing left to salvage
+	elseif damage < maxHealth * 0.25 then
+		local featureID = Spring.CreateFeature(buildAsUnitName .. "_dead" , xx, yy, zz, facing, unitTeam)
+		if featureID then
+			Spring.SetFeatureResurrect(featureID, buildAsUnitName, facing, 0)
 		end
+	else
+		Spring.CreateFeature(buildAsUnitName .. "_heap", xx, yy, zz, facing, unitTeam)
 	end
 end
+
 function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 	if mexTurretDefID[unitDefID] and not paralyzer then
-        doUnitDamaged(unitID, unitDefID, unitTeam, damage)
-    end
+		lastDamage[unitID] = damage
+		lastDamageFrame[unitID] = Spring.GetGameFrame()
+	end
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
 	mexesToSwap[unitID] = nil
+
+	if mexTurretDefID[unitDefID] then
+		createRemains(unitID, unitDefID, unitTeam)
+		lastDamage[unitID] = nil
+		lastDamageFrame[unitID] = nil
+	end
 
 	if mexActualDefID[unitDefID] or mexTurretDefID[unitDefID] then
 		local pairedUnitID = pairedUnits[unitID]


### PR DESCRIPTION
### Work done

The Advanced Metal Fortifier's con turret (`legmohoconct`) has no engine corpse; its wreck is created by hand in `unit_attached_con_turret_mex.lua`. That code ran in `UnitDamaged` and tried to *predict* the killing blow with `health - damage < 0` — but `UnitDamaged` fires after the engine has already subtracted the damage, so the damage was effectively counted twice and the wreck spawned roughly one hit early, while the unit was still alive.

Result: a Fortifier at a sliver of health standing inside its own blocking wreck. The wreck's collision box (85.8 x 30 x 74.3) is much larger than the live turret's (31 x 32 x 31), so it absorbed the follow-up shots — attackers had to chew through 2100 HP of corpse to finish a "dead" building that kept extracting metal the whole time.

Changes:
- `UnitDamaged` now only records the damage of the latest hit (and its frame).
- Remains are created in `UnitDestroyed`, where death is a fact rather than a guess: dead at <= 0 health, with a damage event on this or the previous frame.
- The frame check keeps reclaim, self-destruct and pair-removal wreck-free, as before (none of them fire `UnitDamaged`).
- Wreck-vs-heap selection by killing-blow severity is unchanged, as is "no remains" for hits >= 50% of max health.

Also fixes a latent double-spawn: the old prediction had no guard, so a unit that survived inside its wreck could spawn additional wrecks on subsequent hits.

#### Test steps
- [x] Build an Advanced Metal Fortifier (Legion T2), kill it with low-damage weapons. Expected: no wreck appears while it is alive; the wreck appears exactly when it dies. Before this PR, the wreck appears while the unit is still alive at near-0 HP and keeps working.
- [x] Reclaim a Fortifier fully. Expected: no wreck left behind.
- [x] Self-destruct a Fortifier. Expected: same behaviour as master (no phantom remains).
- [x] Kill one with a single huge hit (>= 50% of its HP). Expected: no wreck, same as master.

### Screenshots (Screen recording):
BEFORE FIX:
https://github.com/user-attachments/assets/df162177-97f6-4e22-9d90-10322530f027
https://github.com/user-attachments/assets/b699111c-0bdd-4e25-a441-425a26e0e369
AFTER FIX:
https://github.com/user-attachments/assets/ac9e7257-54bd-4e83-9937-e6ea23155693

### AI / LLM usage statement:
Diagnosed and drafted with the help of Cladude Code; reviewed and tested by me.
