### PR TITLE
Show build range when placing the Advanced Metal Fortifier

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -691,7 +691,11 @@ local function AddSelectedUnit(unitID, mouseover, newRange)
 		-- we need to check if the unit has on/off weapon states, and only add the one active
 		local weaponOnOff
 		-- on off can be set on a building, we need to check that
-		if unitOnOffable[unitDefID] and not unitOnOffName[unitDefID] then -- if it's a building with actual on/off, we display range if it's on
+		if weaponType == 2 then
+			-- nano/build range: never gated by on/off — a builder's build power is
+			-- not affected by its on/off state (e.g. the Legion Fortifier turret is
+			-- onoffable, but that only toggles its paired extractor)
+		elseif unitOnOffable[unitDefID] and not unitOnOffName[unitDefID] then -- if it's a building with actual on/off, we display range if it's on
 			weaponOnOff = unitsOnOff[unitID] or 1
 			drawIt = (weaponOnOff == 1)
 		elseif unitOnOffable[unitDefID] and unitOnOffName[unitDefID] then -- this is a unit or building with 2 weapons

--- a/units/Legion/Economy/legmohocon.lua
+++ b/units/Legion/Economy/legmohocon.lua
@@ -4,6 +4,13 @@ return {						--costs should be same as legmohoconct and legmohoconin
 		activatewhenbuilt = true,
 		maxdec = 0,
 		buildangle = 2048,
+		-- builder flags exist so the engine draws the build-range ring when this
+		-- is being placed (like any nano turret); the def is swapped for the
+		-- legmohoconin + legmohoconct pair right after completion, so it never
+		-- acts as a builder itself (matches legmohoconct: 400 range, 400 bp)
+		builder = true,
+		builddistance = 400,
+		workertime = 400,
 		energycost = 14500,
 		metalcost = 1060,
 		buildpic = "LEGMOHOCON.DDS",

--- a/units/Legion/Economy/legmohocon.lua
+++ b/units/Legion/Economy/legmohocon.lua
@@ -4,10 +4,6 @@ return {						--costs should be same as legmohoconct and legmohoconin
 		activatewhenbuilt = true,
 		maxdec = 0,
 		buildangle = 2048,
-		-- builder flags exist so the engine draws the build-range ring when this
-		-- is being placed (like any nano turret); the def is swapped for the
-		-- legmohoconin + legmohoconct pair right after completion, so it never
-		-- acts as a builder itself (matches legmohoconct: 400 range, 400 bp)
 		builder = true,
 		builddistance = 400,
 		workertime = 400,


### PR DESCRIPTION
### Work done

The Advanced Metal Fortifier was the only build turret that showed no build-range ring when being placed. Cause: the def you actually place (`legmohocon`) is the inert pre-swap def `unit_attached_con_turret_mex.lua` replaces it with the `legmohoconin` + `legmohoconct` pair right after completion and it had no builder flags at all, so the engine's placement ring (the green `rangeBuild` circle, drawn from the placed def's `buildDistance`) had nothing to draw.

Changes:
- `legmohocon`: added `builder = true, builddistance = 400, workertime = 400`, matching `legmohoconct`. The def never acts as a builder, nanoframes can't act, and the finished unit is swapped away one frame after completion. It has no canAssist/canReclaim, so builder-list widget filters (which require one of those) still exclude it.
- `gui_attackrange_gl4.lua`: the builder (nano) ring is no longer gated by on/off state. Build power is never affected by on/off; the Fortifier turret is onoffable purely to toggle its paired extractor, and toggling extraction off used to hide its build-range ring when selected.

#### Test steps
- [x] Select a Legion T2 constructor, pick the Advanced Metal Fortifier in the build menu. Expected: green build-range ring at the placement ghost, like any nano turret. (Before: no ring.)
- [x] Select a finished Fortifier, toggle its extraction off, reselect. Expected: build-range ring still shows.
- [x] Place/select a normal nano turret and an onoffable armed building. Expected: unchanged behaviour.

### AI / LLM usage statement:
Diagnosed and drafted with the help of Claude (Claude Code); reviewed and tested by me.
<img width="1098" height="594" alt="Screenshot_1" src="https://github.com/user-attachments/assets/019f2f91-e02b-4bd6-93a9-91abc9312da3" /> BEFORE FIX NO BUILD RANGE VISIBLE

<img width="855" height="796" alt="Screenshot_2" src="https://github.com/user-attachments/assets/5ad75f26-a5eb-42a7-8a9b-258bf4fd5d66" /> AFTER FIX BUILD RANGE VISIBLE


