### PR TITLE
Add missing defenses to the defense range widget

### DIFF
--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -262,6 +262,7 @@ local function initUnitList()
 		['armnavaldefturret'] = { weapons = { 'ground' } },  --cauterizer
 		['armanavaldefturret'] = { weapons = { 'ground' } },  --liquifier
 		['armfrt'] = { weapons = { 'air' } },  --floating rocket laucher
+		['armfrock'] = { weapons = { 'air' } },  --floating AA rockets
 		['armfflak'] = { weapons = { 'air' } },  --floating flak AA
 		['armatl'] = { weapons = { 'ground' } }, --adv torpedo launcher
 		['armkraken'] = { weapons = { 'cannon' } }, --adv torpedo launcher
@@ -272,6 +273,7 @@ local function initUnitList()
 		['armflak'] = { weapons = { 'air' } },
 		['armmercury'] = { weapons = { 'air' } },
 		['armemp'] = { weapons = { 'ground' } },
+		['armshockwave'] = { weapons = { 'ground' } },
 		['armamd'] = { weapons = { 'nuke' } }, --antinuke
 
 		['armbrtha'] = { weapons = { 'lrpc' } },
@@ -297,10 +299,12 @@ local function initUnitList()
 		['cortl'] = { weapons = { 'ground' } }, --torp launcher
 		['coratl'] = { weapons = { 'ground' } }, --T2 torp launcher
 		['corfrt'] = { weapons = { 'air' } }, --floating rocket laucher
+		['corfrock'] = { weapons = { 'air' } }, --floating AA rockets
 		['corenaa'] = { weapons = { 'air' } }, --floating flak AA
 		['corfdoom'] = { weapons = { [1] = 'cannon' } },
 
 		['cortoast'] = { weapons = { 'cannon' } },
+		['corbhmth'] = { weapons = { 'cannon' } }, --cerberus
 		['corvipe'] = { weapons = { 'ground' } },
 		['cordoom'] = { weapons = { 'ground', 'ground', 'ground'} },
 		['corflak'] = { weapons = { 'air' } },
@@ -334,6 +338,8 @@ local function initUnitList()
 		['legperdition'] = { weapons = { 'cannon' } }, --T2 LR-AA
 		['legapopupdef'] = { weapons = { 'ground' } }, --popup riot/minigun turret
 		['leganavaltorpturret'] = { weapons = { 'ground' } }, --torpedo launcher
+		['leganavalaaturret'] = { weapons = { 'air' } }, --Fulmen
+		['legfrl'] = { weapons = { 'air' } }, --Polybolos
 
 		['legstarfall'] = { weapons = { 'lrpc' } },
 		['leglrpc'] = { weapons = { 'lrpc' } },
@@ -353,6 +359,12 @@ local function initUnitList()
 		['scavbeacon_t2_scav'] = { weapons = { 'ground' } },
 		['scavbeacon_t3_scav'] = { weapons = { 'ground' } },
 		['scavbeacon_t4_scav'] = { weapons = { 'ground' } },
+
+		['armbotrail'] = { weapons = { 'lrpc' } }, --pawn launcher
+		['armlwall'] = { weapons = { 'ground' } }, --armed wall
+		['cormwall'] = { weapons = { 'ground' } }, --armed wall
+		['legrwall'] = { weapons = { 'ground' } }, --armed wall
+		['legministarfall'] = { weapons = { 'cannon' } },
 
 		['armannit3'] = { weapons = { 'ground' } },
 		['armminivulc'] = { weapons = { 'ground' } },

--- a/units/Legion/SeaDefenses/T2/leganavalaaturret.lua
+++ b/units/Legion/SeaDefenses/T2/leganavalaaturret.lua
@@ -111,9 +111,6 @@ return {
 				weapontimer = 1,
 				weapontype = "Cannon",
 				weaponvelocity = 2600,
-				customparams = {
-					norangering = 1,
-				},
 				damage = {
 					vtol = 58,
 				},


### PR DESCRIPTION
### Work done

The defense range widget only shows rings for units in its hardcoded list, so anything not listed gets no ring at all when placing it. Added the ones that were missing: Cerberus, Shockwave, Scumbag, Janitor, Polybolos, Fulmen, and the Pawn Launcher, Dragon's Fury/Rage/Constitution and Mini Starfall. The _scav variants are covered by the existing auto-clone.

Fulmen additionally had `norangering` set on its only weapon, so it showed no ring on hover/select either. That flag is for suppressing duplicate rings on multi-weapon units (Guardian, Ambusher), so removed it there.

#### Test steps
- [x] Place each added unit, the range ring now shows at the placement ghost (screenshots below show current behaviour: no ring)
- [x] Hover/select a built Fulmen AA ring shows on build, on default and on select.

### Screenshots:

#### BEFORE:
<img width="745" height="543" alt="Screenshot_7" src="https://github.com/user-attachments/assets/fd8d0c9b-719e-4af7-82d5-5913498f2302" />
<img width="1121" height="614" alt="Screenshot_8" src="https://github.com/user-attachments/assets/07c0d15f-1474-47de-9d72-e5e2280cce8c" />
<img width="1027" height="615" alt="Screenshot_9" src="https://github.com/user-attachments/assets/15803dba-03ef-401d-bbec-93e91eb9bf3b" />
<img width="1231" height="608" alt="Screenshot_1" src="https://github.com/user-attachments/assets/a77539bf-b881-4730-bd1d-e7ce45c8b423" />
<img width="1265" height="556" alt="Screenshot_2" src="https://github.com/user-attachments/assets/e8e58666-2576-405a-8958-eb3392c11eb7" />
<img width="1310" height="609" alt="Screenshot_3" src="https://github.com/user-attachments/assets/2e45ba98-8bb5-4edc-81d5-0909724f44d1" />
<img width="1222" height="607" alt="Screenshot_4" src="https://github.com/user-attachments/assets/a8b0137d-2e90-4c78-9e5c-4117fcd3bea0" />
<img width="1187" height="544" alt="Screenshot_5" src="https://github.com/user-attachments/assets/bff882a3-a3f3-4ea7-a9a6-9eed93dcbfab" />
<img width="1120" height="584" alt="Screenshot_6" src="https://github.com/user-attachments/assets/64f295ea-9c8d-472c-9724-0ceaa5c62e18" />

#### AFTER:
<img width="1194" height="596" alt="Screenshot_10" src="https://github.com/user-attachments/assets/3939afa4-3aa4-469d-a0aa-0a941add84ab" />


### AI / LLM usage statement:
Minor help with revision and investigation using Claude Code. All else done by me
