### PR TITLE
Re: Update mines enemy detection to use sphere search

### DIFF
--- a/scripts/mines_lus.lua
+++ b/scripts/mines_lus.lua
@@ -61,7 +61,7 @@ end
 function EnemyDetect()
 	SetSignalMask(stop_detect)
 	while true do
-		if spGetUnitNearestEnemy(unitID, triggerRange, true) ~= nil then
+		if spGetUnitNearestEnemy(unitID, triggerRange, false, true) ~= nil then -- useLOS = false, sphereSearch = true
 			StartThread(Detonate) -- Makes sure detonation is not cancellable
 			break
 		else


### PR DESCRIPTION
Fix GetUnitNearestEnemy()'s passed args: arg 3 is useLOS, arg 4 is sphereSearch.
Test results: does not trigger on flying by aircrafts unless their alt is low enough (3dDist vs 2dDist); properly restores detonation even when no los on the target.