### PR TITLE
missions: CM8 Ashfall under pressure

### DIFF
--- a/luaui/Tests/cm8_ashfall/test_outpost.lua
+++ b/luaui/Tests/cm8_ashfall/test_outpost.lua
@@ -1,0 +1,89 @@
+---@diagnostic disable: lowercase-global, undefined-field
+
+-- CM8 Ashfall, Beat 2: the outpost changes hands.
+--
+-- The roster spawns the outpost on Gaia — pilotless, story-critical — and
+-- Transfer.Give hands it to the player at match start. That is fiat, not a
+-- share: Gaia is nobody's ally, so no sharing mode can permit the move and
+-- the mission is not asking permission.
+--
+-- Which is precisely what made this worth a test. Give ran, reported success,
+-- and the units did not move, because Spring.TransferUnit fires
+-- AllowUnitTransfer and the sharing policy answered the question the fiat was
+-- supposed to have skipped. A mission whose opening beat is "you inherit this
+-- base" instead left the base in hostile hands.
+--
+-- Needs the same game as the waves scenario, for the same reason — the
+-- mission cannot arm without an enemy team for the enclave:
+--
+--   spring-headless --isolation \
+--     tools/headless_testing/startscript_cm8_waves.txt
+--
+-- Everywhere else it self-skips.
+
+-- The outpost is six structures. Match by def so this does not depend on the
+-- runtime's group bookkeeping — the question is where the units ARE, not
+-- where the mission believes it put them.
+local OUTPOST_DEFS = {
+	corlab = true,
+	corllt = true,
+	corrad = true,
+	corsolar = true,
+}
+
+local ARM_TIMEOUT = 900
+
+local function countOutpost(teamID)
+	local found = 0
+	for _, unitID in ipairs(Spring.GetTeamUnits(teamID) or {}) do
+		local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
+		if unitDef and OUTPOST_DEFS[unitDef.name] then
+			found = found + 1
+		end
+	end
+	return found
+end
+
+function skip()
+	if Spring.GetGameFrame() <= 0 then
+		return true
+	end
+	local gaia = Spring.GetGaiaTeamID()
+	local playerTeamID = Spring.GetLocalTeamID()
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaia and teamID ~= playerTeamID then
+			return false
+		end
+	end
+	return true
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	local playerTeamID = Spring.GetLocalTeamID()
+	local gaiaTeamID = Spring.GetGaiaTeamID()
+
+	assert(countOutpost(playerTeamID) == 0, "the outpost must not be the player's before the mission arms")
+
+	Spring.SendCommands("luarules mission cm8_ashfall")
+	Test.waitUntil(function()
+		return Spring.GetGameRulesParam("mission_active") == 1
+	end, ARM_TIMEOUT)
+
+	-- The give is on MatchFlow.Started with no delay, so it lands on the first
+	-- cadence after arming. Waiting on the units rather than on the trigger:
+	-- the trigger firing was never the part that broke.
+	Test.waitUntil(function()
+		return countOutpost(playerTeamID) >= 6
+	end, ARM_TIMEOUT)
+
+	assert(countOutpost(gaiaTeamID) == 0,
+		"every unit in the group moves, or the player inherits half a base")
+end

--- a/luaui/Tests/cm8_ashfall/test_waves.lua
+++ b/luaui/Tests/cm8_ashfall/test_waves.lua
@@ -1,0 +1,136 @@
+---@diagnostic disable: lowercase-global, undefined-field
+
+-- CM8 Ashfall's pressure, end to end, with no bot on the field.
+--
+-- That last part is the point. Scavengers in a multiplayer game are activated
+-- by a ScavengersAI being present; a mission is not a lobby and has no bot to
+-- add. This proves the mission path is bot-free: the trigger file names a
+-- pack, the missions module resolves it through the scavengers module, and
+-- the same wave director a multiplayer game runs starts spawning.
+--
+-- Fails if the DSL loses the Waves verbs or the Scavengers nouns, if the ctx
+-- facet is disconnected, if the pack cannot build a spec, or if the director
+-- starts but never puts anything on the map.
+--
+-- Needs a game with an enemy team for the mission's enclave to spawn on:
+-- tools/headless_testing/startscript_cm8_waves.txt is that game.
+--
+--   spring-headless --isolation \
+--     tools/headless_testing/startscript_cm8_waves.txt
+--
+-- Everywhere else it self-skips, so the standard suite pays nothing for it.
+-- Wiring extra scenarios into the integration runner is a BAR-Devtools
+-- change; the same follow-up covers the scavengers smoke.
+
+-- Grace on the skirmish pack is a tenth of the easy rung's 240s, so beacons
+-- are due around 24s and the first wave ten seconds after that. Test.waitUntil
+-- counts FRAMES, not milliseconds: 3600 is two minutes of game time, generous
+-- because placement probes are random and a bad map corner costs a cadence.
+local SPAWN_TIMEOUT = 3600
+
+---Everything below reads GameRulesParams. They are readable unsynced, they
+---are what a UI panel would use, and they keep this test out of the synced
+---state entirely.
+local function param(name)
+	return Spring.GetGameRulesParam(name)
+end
+
+function skip()
+	if Spring.GetGameFrame() <= 0 then
+		return true
+	end
+	-- CM8's enclave spawns for an enemy team. Without one the mission cannot
+	-- arm at all, and this is not the game to run it in.
+	local gaia = Spring.GetGaiaTeamID()
+	local playerTeamID = Spring.GetLocalTeamID()
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaia and teamID ~= playerTeamID then
+			return false
+		end
+	end
+	return true
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	-- The director keeps running: stopping it needs the synced side, and this
+	-- scenario is single-test by design — its startscript names one test, and
+	-- in the standard suite the skip above means none of this ever started.
+	Test.clearMap()
+end
+
+function test()
+	local playerTeamID = Spring.GetLocalTeamID()
+
+	Spring.SendCommands("luarules mission cm8_ashfall")
+	Test.waitUntil(function()
+		return param("mission_active") == 1
+	end)
+
+	-- The opening beat waits. .After(30) holds the pressure back half a
+	-- minute, so nothing may exist before then — this is the assertion that
+	-- would catch a delay that silently does nothing.
+	Test.waitFrames(20 * 30)
+	assert(param("scavGracePeriod") == nil,
+		"the director must not start before the trigger's .After(30) elapses")
+
+	-- MatchFlow.Started fires on the first cadence after arming, and its Do
+	-- is what asks for the pressure. The director publishes its clocks at
+	-- Start, so their existence IS "the pack resolved and the roster built".
+	Test.waitUntil(function()
+		return param("scavGracePeriod") ~= nil and param("scavTechAnger") ~= nil
+	end, SPAWN_TIMEOUT)
+
+	-- That trigger is published as FIRED, which is what lets the editor shade
+	-- a card once the engine has actually run it. The key is the runtime's own
+	-- trigger identity, mission prefix included.
+	Test.waitUntil(function()
+		return param("mission_trigger_fired_cm8_ashfall/triggers/waves.lua:1") == 1
+	end, SPAWN_TIMEOUT)
+	-- A trigger that has not fired publishes nothing rather than zero: the
+	-- Armada commander is alive, so the pressure has not been called off.
+	assert(param("mission_trigger_fired_cm8_ashfall/triggers/waves.lua:4") == nil,
+		"an unfired trigger should publish nothing")
+
+	-- The mission's own dial, not the pack's default. Carried x1000, because
+	-- a rules param is a number and the trigger file asks for 0.3.
+	Test.waitUntil(function()
+		return param("scavIntensity") ~= nil
+	end, SPAWN_TIMEOUT)
+	assert(param("scavIntensity") == 300,
+		"the trigger file asks for 0.3, got " .. tostring((param("scavIntensity") or 0) / 1000))
+
+	-- Beacons, then units, then the director's own account of it.
+	Test.waitUntil(function()
+		return (param("scav_hiveCount") or 0) > 0
+	end, SPAWN_TIMEOUT)
+
+	Test.waitUntil(function()
+		return (param("scavWaveNumber") or 0) > 0
+	end, SPAWN_TIMEOUT)
+
+	-- Skirmish is pressure with no ending of its own. The boss count is zero,
+	-- so this flag can never be raised — and the mission keeps its own win
+	-- condition, which is the whole reason the pack exists.
+	assert(param("BossFightStarted") ~= 1, "the skirmish pack should never field a boss")
+
+	-- And what is on the map is hostile to the player and is a scavenger,
+	-- neither of which needed a bot.
+	local scavengers = 0
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= playerTeamID then
+			for _, unitID in ipairs(Spring.GetTeamUnits(teamID)) do
+				local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
+				-- The mission's own roster sits on these teams too; count only
+				-- what the director put there.
+				if unitDef and unitDef.customParams.isscavenger then
+					scavengers = scavengers + 1
+				end
+			end
+		end
+	end
+	assert(scavengers > 0, "expected scavenger units on the field, found none")
+end

--- a/modules/combat/gadgets/combat_rules.lua
+++ b/modules/combat/gadgets/combat_rules.lua
@@ -51,6 +51,9 @@ local function onUnitPreDamaged(_, unitID)
 end
 
 local function onGameFrame(_, frame)
+	if not guard.HasStunned() then
+		return
+	end
 	if frame % STUN_TOPUP_PERIOD == 0 then
 		for unitID in pairs(guard.stunned) do
 			if Spring.ValidUnitID(unitID) then
@@ -64,21 +67,25 @@ local function onGameFrame(_, frame)
 			Spring.SetUnitHealth(unitID, { paralyze = 0 })
 		end
 	end
-	if not guard.HasStunned() then
-		gadget.GameFrame = nil
-		gadgetHandler:UpdateCallIn("GameFrame")
-	end
 end
 
+---Install both hot callins, once, and leave them installed.
+---
+---They used to come and go with the ledger. That is not safe from inside a
+---callin: the handler DEFERS its list update while it is iterating
+---(callinDepth > 0), but the method field goes nil immediately, so the gadget
+---sits in the handler's list with a nil method and the next gadget reached in
+---that same loop dies on it. UnitDestroyed fires inside GameFrame whenever
+---anything destroys a unit there — a wave director ageing out a squad, for
+---one — so the toggle was a crash waiting for a protected unit to die.
+---
+---Both callins now guard on the ledger instead, which costs one comparison.
 local function syncHooks()
-	local wantHot = guard.HasProtected()
-	if wantHot ~= (gadget.UnitPreDamaged ~= nil) then
-		gadget.UnitPreDamaged = wantHot and onUnitPreDamaged or nil
-		gadgetHandler:UpdateCallIn("UnitPreDamaged")
-	end
-	if guard.HasStunned() and gadget.GameFrame == nil then
-		gadget.GameFrame = onGameFrame
-		gadgetHandler:UpdateCallIn("GameFrame")
+	for _, name in ipairs({ "UnitPreDamaged", "GameFrame" }) do
+		if gadget[name] == nil then
+			gadget[name] = name == "GameFrame" and onGameFrame or onUnitPreDamaged
+			gadgetHandler:UpdateCallIn(name)
+		end
 	end
 end
 
@@ -123,6 +130,9 @@ function gadget:Initialize()
 			syncHooks()
 		end,
 	}
+	-- Installed up front rather than on the first exception: the ledger is
+	-- what gates the behaviour now, not the hook.
+	syncHooks()
 end
 
 function gadget:Shutdown()

--- a/modules/combat/spec/combat_rules_spec.lua
+++ b/modules/combat/spec/combat_rules_spec.lua
@@ -127,15 +127,21 @@ describe("combat_rules", function()
 	end)
 
 	describe("the damage floor", function()
-		it("is hooked only while something is protected", function()
+		it("applies only while something is protected", function()
+			-- The callin stays installed and answers nothing when the ledger is
+			-- empty. It used to be added and removed with the ledger, which is
+			-- not safe from inside a callin: the handler defers its list update
+			-- while iterating, so a gadget that unhooks itself mid-loop is left
+			-- in the list with a nil method for the rest of that loop.
 			local h = newGadget()
 			h.spawn(7)
-			assert.is_nil(h.gadget.UnitPreDamaged)
+			assert.is_function(h.gadget.UnitPreDamaged)
+			assert.is_nil(h.preDamaged(7))
 			h.Combat.Protect(7)
 			assert.are.same({ 0, 0 }, { h.preDamaged(7) })
 			assert.is_nil(h.preDamaged(8))
 			h.Combat.Unprotect(7)
-			assert.is_nil(h.gadget.UnitPreDamaged)
+			assert.is_nil(h.preDamaged(7))
 		end)
 
 		it("survives one release of two overlapping lifetimes", function()
@@ -152,7 +158,7 @@ describe("combat_rules", function()
 			h.spawn(7)
 			h.Combat.Protect(7)
 			h.gadget:UnitDestroyed(7)
-			assert.is_nil(h.gadget.UnitPreDamaged)
+			assert.is_nil(h.preDamaged(7))
 			assert.is_false(h.Combat.IsProtected(7))
 		end)
 
@@ -184,7 +190,19 @@ describe("combat_rules", function()
 			assert.are.equal(150, h.paralyze[7])
 			h.gadget:GameFrame(60)
 			assert.are.equal(0, h.paralyze[7])
-			assert.is_nil(h.gadget.GameFrame)
+		end)
+
+		it("keeps its callin installed once the last stun ends", function()
+			-- Same reason as the damage floor: it guards instead of unhooking,
+			-- and a frame with nothing stunned is a comparison and a return.
+			local h = newGadget()
+			h.spawn(7)
+			h.Combat.Stun(7, 2)
+			h.gadget:GameFrame(60)
+			assert.is_function(h.gadget.GameFrame)
+			assert.has_no.errors(function()
+				h.gadget:GameFrame(90)
+			end)
 		end)
 	end)
 end)

--- a/modules/missions/README.md
+++ b/modules/missions/README.md
@@ -14,14 +14,25 @@ flowchart TB
         LOADER["mission_loader gadget<br/>injected env = the API surface;<br/>wires only watched callins"]
         DSL["DSL builder<br/>When/.When/Do/Once — no terminator;<br/>finalized at include → TriggerDescriptor"]
         ENGINE["trigger engine<br/>input→watchers index · dirty marks<br/>state tables (the save pile)"]
-        BUS["event bus (engine.OnEvent)<br/>engine callins + module events<br/>('UnitFinished', 'mission.objective_changed')"]
+        BUS["event bus (GG.Missions.OnEvent)<br/>engine callins + module events<br/>('UnitFinished', 'mission.objective_changed', 'waves.wave_cleared')"]
         MF["matchflow module<br/>Victory/Defeat → pending verdict"]
         VG["verdict gadget<br/>deferred, idempotent Spring.GameOver"]
+        WV["waves module<br/>named directors; scavengers builds the spec"]
     end
     LUA -->|"VFS.Include per file<br/>(hot reload by identity)"| LOADER
     LOADER --> DSL -->|"descriptors"| ENGINE
     LOADER -->|"forward watched callins"| BUS --> ENGINE
     ENGINE -->|"execute effects"| MF
+    ENGINE -->|"execute effects"| WV
     ENGINE -->|"Objective(...).Complete() emits<br/>'mission.objective_changed'"| BUS
+    WV -->|"wave_spawned / wave_cleared / boss_defeated"| BUS
     MF --> VG
 ```
+
+The manifest's `requires` list is the whitelist of what a trigger file may
+say: each required module ships a `mission_dsl.lua` whose env is merged into
+the sandbox. `waves` contributes the verbs (`Waves.Begin/Intensify/Surge/End`
+and the wave conditions); `scavengers` contributes the packs those verbs take
+(`Scavengers.Skirmish/Assault/Horde`). A mission's scavengers need no bot —
+but they do need the scavenger unit defs, which a game only derives when asked
+(`forceallunits`, `ruins`, or a scavengers AI on the field).

--- a/modules/missions/cm8_ashfall/triggers/outpost.lua
+++ b/modules/missions/cm8_ashfall/triggers/outpost.lua
@@ -1,0 +1,8 @@
+-- CM8 "Ashfall", Beat 2 — the automated outpost: no pilots, story-critical hub.
+-- The player inherits the failing base; the command hub cannot die before the
+-- enclave reveal or the mission breaks.
+
+When(MatchFlow.Started())
+	.Do(Transfer.Give("outpost_auto", Team.Player))
+	.Do(Combat.Protect(Unit("outpost_command_hub"))
+		.Until(Objective("find_the_enclave").IsComplete()))

--- a/modules/missions/cm8_ashfall/triggers/victory.lua
+++ b/modules/missions/cm8_ashfall/triggers/victory.lua
@@ -1,0 +1,16 @@
+-- CM8 "Ashfall", Beat 6 — staged objectives; the verdict flows through matchflow.
+-- Trimmed to the modules in tree (combat, matchflow): the lava tiers, the
+-- scripted reveal, and the raptor waves wait on their modules.
+
+When(Team.Player.Has(UnitDef("corllt"), 4))
+	.Do(Objective("relieve_the_outpost").Complete())
+
+When(Objective("relieve_the_outpost").IsComplete())
+	.When(Unit("tenebrium_device").IsSpotted(Team.Player))
+	.Do(Objective("find_the_enclave").Complete())
+
+When(Unit("armada_commander").IsDestroyed())
+	.Do(Objective("kill_the_commander").Complete())
+
+When(Objective("kill_the_commander").IsComplete())
+	.Do(MatchFlow.Victory(Team.Player))

--- a/modules/missions/cm8_ashfall/triggers/victory.lua
+++ b/modules/missions/cm8_ashfall/triggers/victory.lua
@@ -1,6 +1,6 @@
 -- CM8 "Ashfall", Beat 6 — staged objectives; the verdict flows through matchflow.
--- Trimmed to the modules in tree (combat, matchflow): the lava tiers, the
--- scripted reveal, and the raptor waves wait on their modules.
+-- Trimmed to the modules in tree: the lava tiers and the scripted reveal still
+-- wait on theirs. The wave pressure these objectives drive lives in waves.lua.
 
 When(Team.Player.Has(UnitDef("corllt"), 4))
 	.Do(Objective("relieve_the_outpost").Complete())

--- a/modules/missions/cm8_ashfall/triggers/waves.lua
+++ b/modules/missions/cm8_ashfall/triggers/waves.lua
@@ -1,0 +1,29 @@
+-- CM8 "Ashfall", the pressure. Scavengers push in from the northeast for the
+-- whole mission, and every objective the player closes makes them worse.
+--
+-- The pack is Skirmish: pressure with no ending of its own. It has no boss
+-- and no win condition, because the mission already has one — the last
+-- statement here is what turns it off, and the commander's death is what
+-- reaches it.
+
+-- Half a minute of quiet first. The player inherits a failing base and needs
+-- long enough to read it before anything comes over the ridge; the director's
+-- own grace period is about spawner placement, not about the opening beat.
+When(MatchFlow.Started())
+	.After(30)
+	.Do(Waves.Begin(Scavengers.Skirmish).Against(Team.Player).From(0.85, 0.15).Intensity(0.3))
+
+-- Beat 3: the outpost holds. Something notices.
+When(Objective("relieve_the_outpost").IsComplete())
+	.Do(Waves.Intensify(Scavengers.Skirmish, 0.6))
+
+-- Beat 4: the enclave is found. One wave arrives immediately — the reveal
+-- costs the player their footing — and the pressure stays up afterwards.
+When(Objective("find_the_enclave").IsComplete())
+	.Do(Waves.Surge(Scavengers.Skirmish))
+	.Do(Waves.Intensify(Scavengers.Skirmish, 1.0))
+
+-- Beat 6: with the Armada commander dead there is nothing left to fight over.
+-- Units already on the field stay; only the spawner stops.
+When(Objective("kill_the_commander").IsComplete())
+	.Do(Waves.End(Scavengers.Skirmish))

--- a/modules/missions/cm8_ashfall/units.lua
+++ b/modules/missions/cm8_ashfall/units.lua
@@ -1,0 +1,53 @@
+-- CM8 "Ashfall" roster — stand-in defs until Teizer V and its assets exist;
+-- the trigger files are the acceptance shape, this makes them arm. Positions
+-- are map fractions so the mission plays on any test map. Named/Grouped are
+-- the definition sites the trigger files' Unit/Units references are
+-- validated against.
+
+-- Beat 2, the automated outpost: spawns pilotless (gaia) and is handed to
+-- the player at mission start by Transfer.Give("outpost_auto", Team.Player).
+-- Give, not Units: gaia is nobody's ally, so no sharing mode can permit it —
+-- this is the game handing the base over, not a team choosing to share.
+-- The command hub is the story-critical protected structure.
+
+Spawn(UnitDef("corlab"), "gaia")
+	.At(0.42, 0.42)
+	.Named("outpost_command_hub")
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corllt"), "gaia")
+	.At(0.39, 0.40)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corllt"), "gaia")
+	.At(0.45, 0.40)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corrad"), "gaia")
+	.At(0.42, 0.39)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corsolar"), "gaia")
+	.At(0.39, 0.44)
+	.Grouped("outpost_auto")
+
+Spawn(UnitDef("corsolar"), "gaia")
+	.At(0.45, 0.44)
+	.Grouped("outpost_auto")
+
+-- Beats 4 and 6, the Armada enclave: spotting the device closes
+-- find_the_enclave; killing the commander wins through matchflow.
+
+Spawn(UnitDef("armfus"), "enemy")
+	.At(0.75, 0.75)
+	.Named("tenebrium_device")
+
+Spawn(UnitDef("armcom"), "enemy")
+	.At(0.77, 0.77)
+	.Named("armada_commander")
+
+Spawn(UnitDef("armllt"), "enemy")
+	.At(0.73, 0.75)
+
+Spawn(UnitDef("armllt"), "enemy")
+	.At(0.75, 0.73)

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -123,6 +123,31 @@ local ctx = {
 			ModuleHandler.Get("combat").Unprotect(unitID)
 		end
 	end,
+	---Wave pressure, through the module that owns it. The mission names a
+	---PACK; the flavor module turns that into a spec and the waves module
+	---runs it — the same director a multiplayer game gets, at a different
+	---intensity and with no bot on the field.
+	---@param request table what Waves.Begin composed
+	StartWaves = function(request)
+		local flavor = ModuleHandler.Get(request.module)
+		if flavor == nil or flavor.Start == nil then
+			Spring.Log(LOG_TAG, LOG.ERROR, "Waves.Begin: module " .. tostring(request.module) .. " cannot start waves")
+			return
+		end
+		flavor.Start(request)
+	end,
+	StopWaves = function(pack)
+		ModuleHandler.Get("waves").Stop(pack)
+	end,
+	SetWaveIntensity = function(pack, intensity)
+		ModuleHandler.Get("waves").SetIntensity(pack, intensity)
+	end,
+	SurgeWaves = function(pack)
+		ModuleHandler.Get("waves").Surge(pack)
+	end,
+	WaveStatus = function(pack)
+		return ModuleHandler.Get("waves").Status(pack)
+	end,
 }
 
 ---Demo rule: Team.Player is the first human team (lowest non-Gaia teamID with no Lua AI, not AI-hosted).
@@ -250,6 +275,35 @@ local function despawnRoster()
 		end
 	end
 	namedUnits, unitNames, groupUnits, spawnedUnits = {}, {}, {}, {}
+end
+
+-- Which trigger ids have been published as fired. Derived, not progress: the
+-- engine's own state is the truth, this only avoids re-writing a param that
+-- has not changed.
+local publishedFired = {} ---@type table<string, boolean>
+
+---Publish what has FIRED, so an editor can shade a trigger it has watched
+---happen. Deliberately not "is the condition true": a once-trigger stays
+---fired after its condition goes false, and an editor shading off the live
+---condition would flicker back to unfired.
+local function publishFired()
+	for id in pairs(engine.GetState().fired) do
+		if not publishedFired[id] then
+			publishedFired[id] = true
+			Spring.SetGameRulesParam("mission_trigger_fired_" .. id, 1)
+		end
+	end
+end
+
+---Erase the fired pile. Progress clears with the triggers, so a reload is a
+---fresh run and the editor stops showing last run's progression.
+local function resetFired()
+	for name in pairs(Spring.GetGameRulesParams()) do
+		if name:find("^mission_trigger_fired_") then
+			Spring.SetGameRulesParam(name, nil)
+		end
+	end
+	publishedFired = {}
 end
 
 ---Erase the objective progress pile. The loader owns the objective_ prefix;
@@ -440,6 +494,7 @@ local function loadMission(missionName)
 	-- progress that belonged to it goes with it.
 	engine = staging
 	resetObjectives()
+	resetFired()
 	syncWatchedCallins()
 	-- CreateUnit raises; a bad roster is a load error, not a stack trace out
 	-- of the chat action.
@@ -522,6 +577,16 @@ function gadget:Initialize()
 		Active = function()
 			return activeMission
 		end,
+		---The mission bus, open to other modules.
+		---
+		---Engine callins reach the engine through syncWatchedCallins; a module
+		---event has no callin to hook, so the module that raises it says so
+		---here. Same convention mission.objective_changed already uses
+		---internally — this only makes it reachable from outside.
+		---@param name MissionEventName
+		OnEvent = function(name)
+			engine.OnEvent(name)
+		end,
 	}
 	gadgetHandler:AddChatAction("mission", missionChatAction, "missions: /mission load <name> | /mission reload")
 end
@@ -536,5 +601,6 @@ function gadget:GameFrame(frame)
 	if activeMission ~= nil and frame % EVALUATE_PERIOD == 0 then
 		ctx.frame = frame
 		engine.Evaluate(ctx)
+		publishFired()
 	end
 end

--- a/modules/missions/lib/dsl.lua
+++ b/modules/missions/lib/dsl.lua
@@ -20,6 +20,10 @@
 
 local DSL = {}
 
+-- Seconds are what a mission author writes; frames are what the engine
+-- counts. The fallback keeps this pure enough to spec without Spring.
+local GAME_SPEED = (Game and Game.gameSpeed) or 30
+
 ---Build one trigger file's authoring surface: the `When` chain entry the
 ---loader injects, and the Finalize the loader calls after the include.
 ---@param filename string mission-relative path, e.g. "triggers/win.lua"
@@ -40,6 +44,7 @@ function DSL.ForFile(filename, sink)
 			conditions = { condition }, ---@type MissionCondition[]
 			effects = {}, ---@type MissionEffect[]
 			once = true,
+			delayFrames = 0,
 		}
 		chains[#chains + 1] = build
 
@@ -63,6 +68,22 @@ function DSL.ForFile(filename, sink)
 			assert(type(effect) == "table" and type(effect.execute) == "function",
 				filename .. ": Do expects an effect (a table with an execute function) — build one with a named verb like Objective(...).Complete()")
 			build.effects[#build.effects + 1] = effect
+			return chain
+		end
+
+		---Hold the effects back until the conditions have held for `seconds`.
+		---
+		---Measured from when they FIRST held, and reset if they stop holding:
+		---"this has been true for thirty seconds", not "thirty seconds after
+		---the first time it flickered true". A repeating trigger re-arms after
+		---each fire, so .After doubles as a rate limit.
+		---@param seconds number
+		---@return TriggerChain
+		chain.After = function(seconds)
+			assert(not finalized, filename .. ": After after Finalize — the file already loaded")
+			assert(type(seconds) == "number" and seconds >= 0,
+				filename .. ": .After expects a non-negative number of seconds")
+			build.delayFrames = math.floor(seconds * GAME_SPEED)
 			return chain
 		end
 
@@ -132,6 +153,7 @@ function DSL.ForFile(filename, sink)
 				condition = combined,
 				effects = build.effects,
 				once = build.once,
+				delayFrames = build.delayFrames,
 			})
 		end
 		return #chains

--- a/modules/missions/lib/mode_dsl.lua
+++ b/modules/missions/lib/mode_dsl.lua
@@ -1,0 +1,30 @@
+--- Mission mode vocabulary over modules/mode_builder.lua: nouns for what the
+--- mission runtime owns, serializers for the options those policies pin.
+
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+
+local M = {}
+
+M.Match = {
+	End = { domain = "end" },
+}
+
+local Serializers = {
+	-- triggers own the verdict: engine elimination never ends the match
+	["end.scripted"] = function(_p, lock)
+		return { deathmode = { value = "neverend", locked = lock.structure } }
+	end,
+}
+
+M.Mode = ModeBuilder.Grammar({
+	category = "missions",
+	serializers = Serializers,
+	verbs = {
+		---The mission owns the noun's domain outright.
+		Own = function(modeName, noun)
+			return { ModeBuilder.DomainOf(modeName, "Own", noun, { ["end"] = true }, "Match.End") .. ".scripted" }
+		end,
+	},
+})
+
+return M

--- a/modules/missions/lib/trigger_engine.lua
+++ b/modules/missions/lib/trigger_engine.lua
@@ -27,7 +27,10 @@ local TriggerEngine = {}
 ---@return MissionTriggerEngine
 function TriggerEngine.New()
 	local triggers = {} ---@type TriggerDescriptor[]
-	local state = { fired = {} } ---@type TriggerEngineState
+	-- `fired` is the save pile; `heldSince` joins it — the frame each delayed
+	-- trigger's conditions first held, which a checkpoint must carry or a
+	-- reloaded mission would restart every countdown.
+	local state = { fired = {}, heldSince = {} } ---@type TriggerEngineState
 	-- Derived, never serialized: input name -> { [id] = true } watchers;
 	-- poller ids (nil-inputs conditions); ids awaiting evaluation.
 	local watchers = {} ---@type table<string, table<string, boolean>>
@@ -54,9 +57,13 @@ function TriggerEngine.New()
 		end
 		triggers[#triggers + 1] = descriptor
 		local inputs = descriptor.condition.inputs
-		if inputs == nil then
+		-- A delayed trigger polls whatever its inputs say. Events tell you the
+		-- answer CHANGED; a countdown needs to be asked again on a frame when
+		-- nothing changed at all, which is precisely when it comes due.
+		if inputs == nil or (descriptor.delayFrames or 0) > 0 then
 			pollers[descriptor.id] = true
-		else
+		end
+		if inputs ~= nil then
 			for _, input in ipairs(inputs) do
 				watchers[input] = watchers[input] or {}
 				watchers[input][descriptor.id] = true
@@ -77,6 +84,7 @@ function TriggerEngine.New()
 			if trigger.filename == filename then
 				removed = removed + 1
 				state.fired[trigger.id] = nil
+				state.heldSince[trigger.id] = nil
 				pollers[trigger.id] = nil
 				dirty[trigger.id] = nil
 				for _, ids in pairs(watchers) do
@@ -120,13 +128,39 @@ function TriggerEngine.New()
 			local id = trigger.id
 			if pollers[id] or dirty[id] then
 				dirty[id] = nil
-				if not (trigger.once and state.fired[id]) and trigger.condition.evaluate(ctx) then
-					state.fired[id] = true
-					for _, effect in ipairs(trigger.effects) do
-						effect.execute(ctx)
+				if not (trigger.once and state.fired[id]) then
+					local holds = trigger.condition.evaluate(ctx)
+					local delay = trigger.delayFrames or 0
+					if not holds then
+						-- The countdown measures a CONTINUOUS hold, so losing
+						-- the condition puts the clock back to zero.
+						state.heldSince[id] = nil
+					elseif delay == 0 then
+						engine.Fire(trigger, ctx)
+					else
+						if state.heldSince[id] == nil then
+							state.heldSince[id] = ctx.frame
+						end
+						if ctx.frame - state.heldSince[id] >= delay then
+							-- Re-arm from the FIRE, not from the next tick:
+							-- restarting at whenever the cadence next looks
+							-- would add the cadence to every interval, so a
+							-- repeating trigger would drift slower and slower.
+							state.heldSince[id] = ctx.frame
+							engine.Fire(trigger, ctx)
+						end
 					end
 				end
 			end
+		end
+	end
+
+	---@param trigger TriggerDescriptor
+	---@param ctx MissionContext
+	engine.Fire = function(trigger, ctx)
+		state.fired[trigger.id] = true
+		for _, effect in ipairs(trigger.effects) do
+			effect.execute(ctx)
 		end
 	end
 
@@ -143,6 +177,8 @@ function TriggerEngine.New()
 	---@param saved TriggerEngineState
 	engine.SetState = function(saved)
 		state = saved
+		-- An older checkpoint predates delays and carries no countdowns.
+		state.heldSince = state.heldSince or {}
 	end
 
 	return engine

--- a/modules/missions/modes/mission.lua
+++ b/modules/missions/modes/mission.lua
@@ -1,0 +1,6 @@
+local ModeDSL = VFS.Include("modules/missions/lib/mode_dsl.lua")
+local Mode, Match = ModeDSL.Mode, ModeDSL.Match
+
+return Mode("Mission")
+	.Desc("Triggers own the verdict; engine elimination never ends the match.")
+	.Own(Match.End)

--- a/modules/missions/module.lua
+++ b/modules/missions/module.lua
@@ -3,5 +3,8 @@
 return {
 	name = "missions",
 	description = "Mission runtime: trigger engine, authoring DSL, mission loader",
-	requires = { "matchflow", "combat", "transfer" },
+	-- The requires list IS the vocabulary whitelist: what a mission file may
+	-- say is exactly what these modules contribute. waves brings the verbs,
+	-- scavengers brings the packs those verbs take.
+	requires = { "matchflow", "combat", "transfer", "waves", "scavengers" },
 }

--- a/modules/missions/rml_widgets/mission_editor.lua
+++ b/modules/missions/rml_widgets/mission_editor.lua
@@ -58,6 +58,7 @@ local pendingEdits = {}
 -- and ordered even pre-game, where GetGameFrame() and a fresh counter are both 0.
 local editSequence = math.floor(os.clock() * 1000)
 local liveSpans = nil
+local liveShades = nil
 local collapsedSections = {}
 local pickerBypassed = false
 local applyViewLayout, renderCurrent
@@ -159,6 +160,7 @@ end
 
 local function collectLiveSpans()
 	liveSpans = {}
+	liveShades = {}
 	local content = document and document:GetElementById("me-content")
 	if not content then
 		return
@@ -168,6 +170,20 @@ local function collectLiveSpans()
 		local key = spans[i]:GetAttribute("data-live")
 		if key then
 			liveSpans[#liveSpans + 1] = { element = spans[i], key = key }
+		end
+	end
+	-- Whole-element state lives on the trigger card, which is a div, and
+	-- carries no text: writing into it would erase the card.
+	--
+	-- "data-fired" is a contract with bar-mission-kit, which emits it in
+	-- view.rs::trigger_card. The two live in different repos and nothing
+	-- checks them against each other, so renaming it on one side alone is a
+	-- silent no-op — as it was, briefly.
+	local divs = content:GetElementsByTagName("div")
+	for i = 1, #divs do
+		local key = divs[i]:GetAttribute("data-fired")
+		if key then
+			liveShades[#liveShades + 1] = { element = divs[i], key = key }
 		end
 	end
 end
@@ -191,6 +207,12 @@ local function applyLive()
 		local value = state.values[entry.key]
 		if value then
 			entry.element.inner_rml = drawable(escape(value.text))
+			entry.element:SetClass("done", value.state == "done")
+		end
+	end
+	for _, entry in ipairs(liveShades or {}) do
+		local value = state.values[entry.key]
+		if value then
 			entry.element:SetClass("done", value.state == "done")
 		end
 	end
@@ -454,7 +476,9 @@ local function refresh()
 	if content then
 		content.inner_rml = drawable((serveStatusLine() or "") .. (view and view.form or ('<div class="me-opaque">' .. (err or "?") .. "</div>")))
 		attachHandlers()
+		-- Both caches hold element handles into markup that just went away.
 		liveSpans = nil
+		liveShades = nil
 	end
 end
 

--- a/modules/missions/rml_widgets/mission_editor.rcss
+++ b/modules/missions/rml_widgets/mission_editor.rcss
@@ -66,11 +66,36 @@
 	font-size: 0.7em;
 }
 
+/* The file row is a path plus an "open" affordance. The browser separates
+   them with a flex gap; RCSS has neither flex gap nor a way to fake one
+   between inline siblings, so the affordance carries its own margin — without
+   it the two run together and the row reads "triggers/waves.luaopen". */
+.me-file-open {
+	margin-left: 8px;
+	color: #4c5d70;
+}
+
+.me-file:hover .me-file-open {
+	color: #8fbcff;
+}
+
 .me-group {
 	display: block;
 	margin: 12px 0 4px 0;
 	color: #e8c884;
 	font-size: 0.8em;
+}
+
+/* A fired trigger tints and lifts its rule, so progression reads straight
+   down the column without stopping at a single chip. Faint on purpose: this
+   is a backdrop, and the chips stay the thing you actually read. */
+.me-card.done {
+	border-left-color: #4a7f5e;
+	background-color: #16221b;
+}
+
+.me-card.done .me-card-title {
+	color: #9fb8a8;
 }
 
 /* One flat card: triggers are left-ruled groups, not nested boxes. */

--- a/modules/missions/spec/cm8_roster_spec.lua
+++ b/modules/missions/spec/cm8_roster_spec.lua
@@ -1,0 +1,43 @@
+--- The shipped roster stays loadable and keeps declaring the names
+--- triggers/*.lua reference, through the same sandbox the loader builds.
+
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+describe("cm8_ashfall roster", function()
+	local byName = {}
+	local groups = {}
+
+	setup(function()
+		local file = Roster.ForFile("cm8_ashfall/units.lua")
+		VFS.Include("modules/missions/cm8_ashfall/units.lua", {
+			Spawn = file.Spawn,
+			UnitDef = Verbs.UnitDef,
+		})
+		for _, entry in ipairs(file.Finalize()) do
+			if entry.name then
+				byName[entry.name] = entry
+			end
+			if entry.group then
+				groups[entry.group] = (groups[entry.group] or 0) + 1
+			end
+		end
+	end)
+
+	it("declares every name the trigger files reference", function()
+		assert.is_table(byName.outpost_command_hub)
+		assert.is_table(byName.tenebrium_device)
+		assert.is_table(byName.armada_commander)
+	end)
+
+	it("the protected hub travels with the transferred outpost group", function()
+		assert.are.equal("outpost_auto", byName.outpost_command_hub.group)
+		assert.is_true(groups.outpost_auto > 1)
+	end)
+
+	it("the outpost spawns pilotless and the enclave hostile", function()
+		assert.are.equal("gaia", byName.outpost_command_hub.team)
+		assert.are.equal("enemy", byName.tenebrium_device.team)
+		assert.are.equal("enemy", byName.armada_commander.team)
+	end)
+end)

--- a/modules/missions/spec/cm8_waves_spec.lua
+++ b/modules/missions/spec/cm8_waves_spec.lua
@@ -1,0 +1,181 @@
+--- CM8's pressure file, loaded through the same sandbox the loader builds.
+---
+--- A trigger file is only as good as the vocabulary it can reach, and the
+--- vocabulary is composed from the missions manifest's requires list at load
+--- time. That composition is exactly the thing a spec can check and the
+--- checker cannot: a pack name that does not resolve, or a verb the module
+--- declares but does not inject, is a nil global at arm time and nothing
+--- earlier.
+
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local TRIGGER_FILE = "modules/missions/cm8_ashfall/triggers/waves.lua"
+local PACK = "scavengers.skirmish"
+
+---Everything the ctx handed to a mission does, recorded rather than done.
+local function recordingContext()
+	local calls = {}
+	local status = { waveNumber = 0, wavesCleared = 0, bossesKilled = 0, intensity = 1 }
+	return {
+		calls = calls,
+		status = status,
+		frame = 30,
+		StartWaves = function(request)
+			calls[#calls + 1] = { "start", request }
+		end,
+		StopWaves = function(pack)
+			calls[#calls + 1] = { "stop", pack }
+		end,
+		SetWaveIntensity = function(pack, intensity)
+			calls[#calls + 1] = { "intensity", pack, intensity }
+		end,
+		SurgeWaves = function(pack)
+			calls[#calls + 1] = { "surge", pack }
+		end,
+		WaveStatus = function()
+			return status
+		end,
+		IsObjectiveComplete = function()
+			return true
+		end,
+	}
+end
+
+---Compose the trigger sandbox the loader composes, from the same manifest.
+---@param engine table
+---@return table env
+local function sandbox(engine)
+	local file = DSL.ForFile("cm8_ashfall/triggers/waves.lua", engine.Register)
+	local env = {
+		When = file.When,
+		Team = { Player = Verbs.MakeTeam(0, 0) },
+		UnitDef = Verbs.UnitDef,
+		Objective = function(name)
+			return {
+				Complete = function()
+					return { execute = function() end }
+				end,
+				IsComplete = function()
+					return {
+						inputs = { "mission.objective_changed" },
+						evaluate = function(ctx)
+							return ctx.IsObjectiveComplete(name)
+						end,
+					}
+				end,
+			}
+		end,
+	}
+	for _, name in ipairs(ModuleHandler.Discover().missions.requires) do
+		local path = "modules/" .. name .. "/mission_dsl.lua"
+		if VFS.FileExists(path) then
+			local contribution = VFS.Include(path).ForFile({
+				filename = "cm8_ashfall/triggers/waves.lua",
+				Register = engine.Register,
+				names = {},
+				groups = {},
+			})
+			for key, value in pairs(contribution.env) do
+				assert(env[key] == nil, "two modules contribute the global " .. key)
+				env[key] = value
+			end
+		end
+	end
+	return env, file
+end
+
+describe("cm8_ashfall wave pressure", function()
+	local engine, triggers
+
+	setup(function()
+		ModuleHandler.ResetCaches()
+		engine = TriggerEngine.New()
+		local env, file = sandbox(engine)
+		VFS.Include(TRIGGER_FILE, env)
+		file.Finalize()
+		triggers = engine.Triggers()
+	end)
+
+	it("loads through the composed sandbox — every verb and noun resolves", function()
+		assert.are.equal(4, #triggers, "expected the four beats of the pressure arc")
+	end)
+
+	it("holds the opening beat back half a minute", function()
+		-- The director's grace period is about spawner placement; this is the
+		-- mission's own beat, and only the trigger file can say how long the
+		-- player gets to read the base before anything arrives.
+		assert.are.equal(30 * 30, triggers[1].delayFrames)
+		for i = 2, 4 do
+			assert.are.equal(0, triggers[i].delayFrames or 0,
+				"only the opening waits; the rest answer their objective at once")
+		end
+	end)
+
+	it("opens the pressure when the match starts, aimed at the player", function()
+		local ctx = recordingContext()
+		for _, effect in ipairs(triggers[1].effects) do
+			effect.execute(ctx)
+		end
+		local request = ctx.calls[1][2]
+		assert.are.equal("start", ctx.calls[1][1])
+		assert.are.equal(PACK, request.pack)
+		assert.are.equal("scavengers", request.module)
+		assert.are.equal("skirmish", request.builder)
+		assert.are.equal(0, request.against)
+	end)
+
+	it("brings it in from the northeast, as map fractions", function()
+		local ctx = recordingContext()
+		triggers[1].effects[1].execute(ctx)
+		assert.are.same({ fx = 0.85, fz = 0.15 }, ctx.calls[1][2].origin)
+	end)
+
+	it("starts quiet: the first beat is background pressure, not a siege", function()
+		local ctx = recordingContext()
+		triggers[1].effects[1].execute(ctx)
+		assert.are.equal(0.3, ctx.calls[1][2].intensity)
+	end)
+
+	it("climbs once, spikes once, then climbs again", function()
+		local ctx = recordingContext()
+		for i = 2, 3 do
+			for _, effect in ipairs(triggers[i].effects) do
+				effect.execute(ctx)
+			end
+		end
+		assert.are.same({ "intensity", PACK, 0.6 }, ctx.calls[1])
+		assert.are.same({ "surge", PACK }, ctx.calls[2])
+		assert.are.same({ "intensity", PACK, 1.0 }, ctx.calls[3])
+	end)
+
+	it("ends the spawner when the commander dies, and says nothing about the field", function()
+		local ctx = recordingContext()
+		for _, effect in ipairs(triggers[4].effects) do
+			effect.execute(ctx)
+		end
+		assert.are.same({ "stop", PACK }, ctx.calls[1])
+		assert.are.equal(1, #ctx.calls, "ending the pressure must not also clear the map")
+	end)
+
+	it("watches the objectives it is paced by", function()
+		for i = 2, 4 do
+			assert.are.same({ "mission.objective_changed" }, triggers[i].condition.inputs)
+		end
+	end)
+
+	it("names one pack throughout, so every dial reaches the same director", function()
+		local ctx = recordingContext()
+		for _, trigger in ipairs(triggers) do
+			for _, effect in ipairs(trigger.effects) do
+				effect.execute(ctx)
+			end
+		end
+		for _, call in ipairs(ctx.calls) do
+			local named = call[1] == "start" and call[2].pack or call[2]
+			assert.are.equal(PACK, named)
+		end
+	end)
+end)

--- a/modules/missions/spec/manifest_spec.lua
+++ b/modules/missions/spec/manifest_spec.lua
@@ -14,6 +14,15 @@ describe("the missions manifest", function()
 	end)
 
 	it("missions declares the modules it draws vocabulary from", function()
-		assert.are.same({ "matchflow", "combat", "transfer" }, manifests.missions.requires)
+		-- The requires list IS the whitelist of what a mission file may say,
+		-- so adding to it is the entire authorization story for new
+		-- vocabulary: waves brings the verbs, scavengers brings the packs.
+		assert.are.same({ "matchflow", "combat", "transfer", "waves", "scavengers" }, manifests.missions.requires)
+	end)
+
+	it("every module it requires exists and contributes vocabulary or an api", function()
+		for _, name in ipairs(manifests.missions.requires) do
+			assert.is_table(manifests[name], "missions requires a module that was not discovered: " .. name)
+		end
 	end)
 end)

--- a/modules/missions/spec/mission_mode_spec.lua
+++ b/modules/missions/spec/mission_mode_spec.lua
@@ -1,0 +1,38 @@
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local ModeDSL = VFS.Include("modules/missions/lib/mode_dsl.lua")
+
+local mission = VFS.Include("modules/missions/modes/mission.lua")
+
+describe("missions mode preset", function()
+	it("is a missions-category preset with a snake_case key", function()
+		assert.equal("mission", mission.key)
+		assert.equal("missions", mission.category)
+		assert.equal(false, mission.allowRanked)
+	end)
+
+	it("serializes to exactly the options its policies own", function()
+		assert.same({
+			deathmode = { value = "neverend", locked = true },
+		}, mission.modOptions)
+	end)
+
+	it("rejects a second owner of the same modoption", function()
+		local Mode, Match = ModeDSL.Mode, ModeDSL.Match
+		local ok, err = pcall(function()
+			Mode("Twice").Own(Match.End).Own(Match.End)
+		end)
+		assert.is_false(ok)
+		assert.truthy(tostring(err):find("two policies own modoption deathmode", 1, true))
+	end)
+
+	it("ModeDirs aggregates the missions preset dir", function()
+		ModuleHandler.ResetCaches()
+		local found = false
+		for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+			if dir == "modules/missions/modes/" then
+				found = true
+			end
+		end
+		assert.is_true(found)
+	end)
+end)

--- a/modules/missions/spec/roster_spec.lua
+++ b/modules/missions/spec/roster_spec.lua
@@ -1,0 +1,78 @@
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+describe("mission roster DSL", function()
+	local Spawn
+	local Finalize
+
+	before_each(function()
+		local file = Roster.ForFile("cm8/units.lua")
+		Spawn = file.Spawn
+		Finalize = file.Finalize
+	end)
+
+	it("builds entries from Spawn chains at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia")
+			.At(0.42, 0.42)
+			.Named("hub")
+			.Grouped("outpost_auto")
+		Spawn(Verbs.UnitDef("armcom"), "enemy")
+			.At(0.77, 0.77)
+		local entries = Finalize()
+		assert.are.same({
+			{ def = "corlab", team = "gaia", fx = 0.42, fz = 0.42, name = "hub", group = "outpost_auto" },
+			{ def = "armcom", team = "enemy", fx = 0.77, fz = 0.77 },
+		}, entries)
+	end)
+
+	it("a spawn without an At fails the load, naming the statement", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").Named("hub")
+		local ok, err = pcall(Finalize)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("Spawn 1", 1, true))
+	end)
+
+	it("rejects duplicate unit names at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1).Named("hub")
+		Spawn(Verbs.UnitDef("corllt"), "gaia").At(0.2, 0.2).Named("hub")
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+
+	it("rejects a plain string where a UnitDef reference belongs", function()
+		assert.has_error(function()
+			Spawn("corlab", "gaia")
+		end)
+	end)
+
+	it("rejects an unknown team role", function()
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corlab"), "raptors")
+		end)
+	end)
+
+	it("rejects positions outside map fractions", function()
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corlab"), "gaia").At(512, 512)
+		end)
+	end)
+
+	it("rejects chain calls after Finalize", function()
+		local chain = Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1)
+		Finalize()
+		assert.has_error(function()
+			chain.Named("late")
+		end)
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corllt"), "gaia")
+		end)
+	end)
+
+	it("rejects Finalize twice", function()
+		Finalize()
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+end)

--- a/modules/missions/spec/trigger_engine_spec.lua
+++ b/modules/missions/spec/trigger_engine_spec.lua
@@ -204,3 +204,109 @@ describe("TriggerEngine", function()
 		end)
 	end)
 end)
+
+describe("delayed triggers", function()
+	local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+
+	---@param delayFrames integer
+	local function delayed(engine, delayFrames, holds, fired)
+		engine.Register({
+			id = "f.lua:1",
+			filename = "f.lua",
+			order = 1,
+			condition = { evaluate = function() return holds() end },
+			effects = { { execute = function() fired[#fired + 1] = true end } },
+			once = true,
+			delayFrames = delayFrames,
+		})
+	end
+
+	it("waits for the conditions to have held that long", function()
+		local engine, fired, holds = TriggerEngine.New(), {}, true
+		delayed(engine, 90, function() return holds end, fired)
+
+		engine.Evaluate({ frame = 100 })
+		assert.are.equal(0, #fired, "the clock starts, nothing fires")
+		engine.Evaluate({ frame = 180 })
+		assert.are.equal(0, #fired, "still short of the interval")
+		engine.Evaluate({ frame = 190 })
+		assert.are.equal(1, #fired)
+	end)
+
+	it("measures a CONTINUOUS hold — losing the condition resets the clock", function()
+		local engine, fired = TriggerEngine.New(), {}
+		local holds = true
+		delayed(engine, 90, function() return holds end, fired)
+
+		engine.Evaluate({ frame = 100 })
+		holds = false
+		engine.Evaluate({ frame = 150 })
+		holds = true
+		engine.Evaluate({ frame = 160 })
+		-- Were the clock still running from 100, this would fire.
+		engine.Evaluate({ frame = 200 })
+		assert.are.equal(0, #fired)
+		engine.Evaluate({ frame = 250 })
+		assert.are.equal(1, #fired)
+	end)
+
+	it("re-arms after each fire, so a repeating trigger is rate limited", function()
+		local engine, fired = TriggerEngine.New(), {}
+		engine.Register({
+			id = "f.lua:1",
+			filename = "f.lua",
+			order = 1,
+			condition = { evaluate = function() return true end },
+			effects = { { execute = function() fired[#fired + 1] = true end } },
+			once = false,
+			delayFrames = 30,
+		})
+		engine.Evaluate({ frame = 0 })
+		engine.Evaluate({ frame = 10 })
+		assert.are.equal(0, #fired)
+		engine.Evaluate({ frame = 30 })
+		assert.are.equal(1, #fired)
+		engine.Evaluate({ frame = 45 })
+		assert.are.equal(1, #fired, "the interval restarts at the fire")
+		-- Exactly one interval after the fire, with no cadence drift added.
+		engine.Evaluate({ frame = 60 })
+		assert.are.equal(2, #fired)
+		engine.Evaluate({ frame = 89 })
+		assert.are.equal(2, #fired)
+		engine.Evaluate({ frame = 90 })
+		assert.are.equal(3, #fired)
+	end)
+
+	it("polls even when its condition declares inputs — a countdown has no event", function()
+		local engine, fired = TriggerEngine.New(), {}
+		engine.Register({
+			id = "f.lua:1",
+			filename = "f.lua",
+			order = 1,
+			condition = { inputs = { "UnitFinished" }, evaluate = function() return true end },
+			effects = { { execute = function() fired[#fired + 1] = true end } },
+			once = true,
+			delayFrames = 30,
+		})
+		-- No OnEvent at all: an event-only trigger would never come due.
+		engine.Evaluate({ frame = 0 })
+		engine.Evaluate({ frame = 30 })
+		assert.are.equal(1, #fired)
+	end)
+
+	it("carries its countdowns in the save pile, and tolerates a checkpoint without them", function()
+		local engine = TriggerEngine.New()
+		assert.is_table(engine.GetState().heldSince)
+		engine.SetState({ fired = {} })
+		assert.is_table(engine.GetState().heldSince, "an older checkpoint predates delays")
+	end)
+
+	it("drops a countdown when its file unregisters", function()
+		local engine, fired = TriggerEngine.New(), {}
+		delayed(engine, 90, function() return true end, fired)
+		engine.Evaluate({ frame = 0 })
+		assert.is_not_nil(engine.GetState().heldSince["f.lua:1"])
+		engine.UnregisterFile("f.lua")
+		assert.is_nil(engine.GetState().heldSince["f.lua:1"])
+	end)
+end)

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -10,6 +10,12 @@
 ---@alias MissionUnitGroup string roster group name, declared by units.lua Grouped(...)
 ---@alias ObjectiveName string
 ---@alias MissionTeamRole "player"|"enemy"|"gaia" spawn-time team role, resolved at arm
+--- Wall-clock seconds, never frames. An alias and not a bare number for the
+--- usual reason — a `number` has nothing to call itself in a sentence, so an
+--- editor can only offer a nameless box, and the one thing an author needs to
+--- know here is which unit they are typing in. The DSL converts on the way in
+--- using the engine's own tick rate, so "30" is thirty seconds at any speed.
+---@alias MissionSeconds number
 
 --- Mission bus vocabulary, CLOSED BY TYPE: every event name crossing the bus
 --- is a member of this alias, so the checker flags typos across every inputs/OnEvent consumer as type errors.
@@ -20,6 +26,10 @@
 ---| "UnitTaken"
 ---| "UnitEnteredLos"
 ---| "mission.objective_changed"
+---| "waves.wave_spawned"
+---| "waves.wave_cleared"
+---| "waves.boss_spawned"
+---| "waves.boss_defeated"
 
 --- A condition carries metadata about what can change its answer: inputs
 --- name bus events (nil = poll every cadence). Pure — reads only ctx, captures configuration never progress (progress lives in engine state, the savegame rule).
@@ -37,6 +47,11 @@
 ---@field TransferGroup fun(groupName: string, teamID: integer)
 ---@field Protect fun(name: string) combat-module protection by roster name
 ---@field Unprotect fun(name: string)
+---@field StartWaves fun(request: table) waves-module pressure, by pack
+---@field StopWaves fun(pack: string)
+---@field SetWaveIntensity fun(pack: string, intensity: number)
+---@field SurgeWaves fun(pack: string)
+---@field WaveStatus fun(pack: string): WaveStatus|nil
 ---@field frame integer current game frame
 
 --- A lazy effect built by a named verb (e.g. Objective("x").Complete()); the
@@ -82,11 +97,13 @@
 ---@field condition MissionCondition
 ---@field effects MissionEffect[] executed in Do order when the condition fires
 ---@field once boolean fire at most once (default true)
+---@field delayFrames integer hold the effects until the conditions have held this long; 0 fires at once
 
 --- The dot-only builder chain returned by When. There is no terminator: the
 --- loader finalizes all chains when the file's include returns; a chain without a Do fails the load.
 ---@class TriggerChain
 ---@field When fun(condition: MissionCondition): TriggerChain another condition; all must hold
+---@field After fun(seconds: MissionSeconds): TriggerChain hold the effects until the conditions have held that long
 ---@field Do fun(effect: MissionEffect): TriggerChain repeatable; effects run in Do order
 ---@field Once fun(once: boolean?): TriggerChain default true; pass false for repeating triggers
 
@@ -106,6 +123,7 @@
 --- reload from source; this table is reapplied on top.
 ---@class TriggerEngineState
 ---@field fired table<string, boolean> trigger id -> has fired
+---@field heldSince table<string, integer> trigger id -> frame its conditions first held, for delays
 
 --- What a required module's mission_dsl.lua returns. The loader composes the
 --- sandbox env from the missions manifest's requires list — the dependency

--- a/modules/missions/types/mode_policy.lua
+++ b/modules/missions/types/mode_policy.lua
@@ -1,0 +1,27 @@
+---@meta policy mode
+
+--- The missions mode-preset surface: what modules/missions/modes/*.lua files
+--- author against (via lib/mode_dsl.lua over modules/mode_builder.lua).
+
+--- A mode noun: names the policy domain a verb acts on.
+---@class MissionModeNoun
+---@field domain string
+
+--- The Mode chain (missions vocabulary). Every verb returns the chain; the
+--- chain IS the ModeConfig the preset file returns.
+---@class MissionModeChain
+---@field Desc fun(desc: string): MissionModeChain
+---@field Ranked fun(): MissionModeChain
+---@field RetainValues fun(): MissionModeChain
+---@field Hidden fun(): MissionModeChain
+---@field Unlocked fun(): MissionModeChain
+---@field Locked fun(): MissionModeChain
+---@field Own fun(noun: MissionModeNoun): MissionModeChain
+
+---Start a mode chain; the key is the name's snake_case.
+---@param name string
+---@return MissionModeChain
+function Mode(name) end
+
+---@type { End: MissionModeNoun }
+Match = {}

--- a/modules/missions/widgets/mission_bridge.lua
+++ b/modules/missions/widgets/mission_bridge.lua
@@ -106,6 +106,36 @@ local function countFinishedUnits(unitDefName)
 	return count
 end
 
+-- Wave conditions are counters, so their probes are all the same shape: a
+-- director name, a counter, and how many the mission is waiting for. The
+-- director publishes these under its OWN name — a mission names a pack and
+-- has no way to know a flavor's rulesparam prefix.
+local WAVE_COUNTERS = {
+	waves_spawned = "wave",
+	waves_cleared = "cleared",
+	waves_boss_defeated = "bosses",
+}
+
+---@param probe table
+---@return table
+local function waveProgress(probe)
+	local counter = WAVE_COUNTERS[probe.kind]
+	local have = Spring.GetGameRulesParam("waves_" .. probe.pack .. "_" .. counter)
+	if have == nil then
+		-- The director has not started yet. "–" rather than 0/1, because
+		-- "no waves have spawned" and "no director exists" are different
+		-- things and a mission author is usually debugging the second one.
+		return { text = "–", state = "pending", pct = 0 }
+	end
+	local need = math.max(1, math.floor(probe.need or 1))
+	local done = have >= need
+	return {
+		text = math.floor(have) .. "/" .. need,
+		state = done and "done" or "pending",
+		pct = math.min(1, have / need),
+	}
+end
+
 local function sampleLive()
 	if not probes or #probes == 0 then
 		return
@@ -136,6 +166,16 @@ local function sampleLive()
 			elseif probe.kind == "unit_spotted" and probe.unit_name then
 				local spotted = Spring.GetGameRulesParam("mission_unit_spotted_" .. probe.unit_name .. "_" .. Spring.GetMyAllyTeamID()) == 1
 				values[probe.key] = { text = spotted and "✓" or "–", state = spotted and "done" or "pending", pct = spotted and 1 or 0 }
+			elseif WAVE_COUNTERS[probe.kind] and probe.pack then
+				values[probe.key] = waveProgress(probe)
+			elseif probe.kind == "trigger_fired" and probe.trigger then
+				-- The kit knows a trigger as "<file>:<order>"; the runtime
+				-- stamps the mission in front of it. Composing here keeps the
+				-- kit free of any idea which mission it is editing.
+				local mission = Spring.GetGameRulesParam("mission_name")
+				local fired = mission ~= nil
+					and Spring.GetGameRulesParam("mission_trigger_fired_" .. mission .. "/" .. probe.trigger) == 1
+				values[probe.key] = { state = fired and "done" or "pending" }
 			end
 		end
 	end

--- a/modules/missions/widgets/mission_bridge.lua
+++ b/modules/missions/widgets/mission_bridge.lua
@@ -128,6 +128,14 @@ local function sampleLive()
 			elseif probe.kind == "objective" and probe.objective then
 				local done = Spring.GetGameRulesParam("objective_" .. probe.objective) == 1
 				values[probe.key] = { text = done and "✓" or "–", state = done and "done" or "pending", pct = done and 1 or 0 }
+			elseif probe.kind == "unit_dead" and probe.unit_name then
+				-- Latched by the mission loader; readable here unlike unit
+				-- validity, which LOS would fog for enemy roster units.
+				local dead = Spring.GetGameRulesParam("mission_unit_dead_" .. probe.unit_name) == 1
+				values[probe.key] = { text = dead and "destroyed" or "alive", state = dead and "done" or "pending", pct = dead and 1 or 0 }
+			elseif probe.kind == "unit_spotted" and probe.unit_name then
+				local spotted = Spring.GetGameRulesParam("mission_unit_spotted_" .. probe.unit_name .. "_" .. Spring.GetMyAllyTeamID()) == 1
+				values[probe.key] = { text = spotted and "✓" or "–", state = spotted and "done" or "pending", pct = spotted and 1 or 0 }
 			end
 		end
 	end

--- a/modules/transfer/actions/give.lua
+++ b/modules/transfer/actions/give.lua
@@ -26,5 +26,12 @@ end)
 ---@param request TransferGiveRequest
 ---@return integer transferred
 Actions.RegisterExecute(function(request)
-	return request.move(request.unitIDs, request.to, true)
+	-- Announce the fiat for the duration of the move. Spring.TransferUnit
+	-- fires AllowUnitTransfer, which asks the sharing policy — and a policy
+	-- that has no idea this is fiat will refuse a hand-over from a team
+	-- nobody is allied with. Same shape as isTakeInProgress.
+	Spring.SetGameRulesParam("isGiveInProgress", 1)
+	local moved = request.move(request.unitIDs, request.to, true)
+	Spring.SetGameRulesParam("isGiveInProgress", 0)
+	return moved
 end)

--- a/modules/transfer/api.lua
+++ b/modules/transfer/api.lua
@@ -90,6 +90,17 @@ return {
 		if Spring.GetGameRulesParam("isTakeInProgress") == 1 then
 			return true
 		end
+		-- Nor to a fiat Give. Its whole contract is "no policy question
+		-- asked", but the engine asks this callin anyway on the way through
+		-- Spring.TransferUnit — so without this the bypass bypasses nothing,
+		-- and a mission handing a Gaia outpost to the player is refused for
+		-- the entirely correct reason that Gaia is nobody's ally.
+		--
+		-- A rulesparam rather than an upvalue because VFS.Include is uncached:
+		-- the controller and the caller hold DIFFERENT copies of this file.
+		if Spring.GetGameRulesParam("isGiveInProgress") == 1 then
+			return true
+		end
 		local policyResult = UnitShared.GetCachedPolicyResult(fromTeamID, toTeamID, Spring)
 		mayUnitScratch[1] = unitID
 		local validation = UnitShared.ValidateUnits(policyResult, mayUnitScratch, Spring, nil, mayValidationScratch)

--- a/modules/transfer/spec/give_fiat_spec.lua
+++ b/modules/transfer/spec/give_fiat_spec.lua
@@ -1,0 +1,87 @@
+--- Give's fiat, and the callin that used to quietly overrule it.
+---
+--- give.lua's whole contract is "no policy question asked": a mission handing
+--- an outpost to the player is not a team choosing to share, and no mode gets
+--- a say. But the move goes through Spring.TransferUnit, which fires
+--- AllowUnitTransfer, which asks the sharing policy — so the bypass bypassed
+--- nothing, and a hand-over from a team nobody is allied with (Gaia, or the
+--- enemy seat a mission parked an enclave on) was refused as an unallied
+--- share. The units stayed hostile and attacked the player they were meant
+--- to be given to.
+---
+--- The announcement is a rulesparam and not an upvalue because VFS.Include is
+--- uncached: the transfer controller and the caller hold different copies of
+--- api.lua and cannot share a Lua flag. isTakeInProgress solves the same
+--- problem the same way.
+
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+
+describe("transfer give — fiat", function()
+	local params, getParam, setParam
+
+	before_each(function()
+		params = {}
+		getParam, setParam = Spring.GetGameRulesParam, Spring.SetGameRulesParam
+		Spring.GetGameRulesParam = function(name)
+			return params[name]
+		end
+		Spring.SetGameRulesParam = function(name, value)
+			params[name] = value
+		end
+	end)
+
+	after_each(function()
+		Spring.GetGameRulesParam, Spring.SetGameRulesParam = getParam, setParam
+	end)
+
+	it("the policy stands aside while a give is in flight", function()
+		ModuleHandler.ResetCaches()
+		local TransferApi = VFS.Include("modules/transfer/api.lua")
+		params.isGiveInProgress = 1
+		-- Gaia to the player: no alliance, so every policy answer is no. The
+		-- only thing that can make this true is the announcement itself.
+		assert.is_true(TransferApi.MayTransfer(7, Spring.GetGaiaTeamID and Spring.GetGaiaTeamID() or 2, 0, false))
+	end)
+
+	it("and only while it is in flight — this is the refusal that was the bug", function()
+		ModuleHandler.ResetCaches()
+		local TransferApi = VFS.Include("modules/transfer/api.lua")
+		params.isGiveInProgress = 0
+
+		local saved = { Spring.GetModOptions, Spring.AreTeamsAllied, Spring.GetTeamRulesParam }
+		Spring.GetModOptions = function()
+			return {}
+		end
+		Spring.AreTeamsAllied = function()
+			return false
+		end
+		Spring.GetTeamRulesParam = function()
+			return nil
+		end
+
+		local answer = TransferApi.MayTransfer(7, 2, 0, false)
+
+		Spring.GetModOptions, Spring.AreTeamsAllied, Spring.GetTeamRulesParam =
+			saved[1], saved[2], saved[3]
+
+		assert.is_false(answer,
+			"an ordinary unallied share is refused — which is correct, and is exactly why a give has to announce itself")
+	end)
+
+	it("raises the announcement for the move and lowers it after", function()
+		ModuleHandler.ResetCaches()
+		local registry = ModuleHandler.LoadActions("transfer")
+		local duringMove
+		local moved = registry.byName.give.execute({
+			to = 0,
+			unitIDs = { 11, 12 },
+			move = function(unitIDs)
+				duringMove = params.isGiveInProgress
+				return #unitIDs
+			end,
+		})
+		assert.are.equal(2, moved)
+		assert.are.equal(1, duringMove, "the flag must be up while the engine is asking")
+		assert.are.equal(0, params.isGiveInProgress, "and down again once the move is done")
+	end)
+end)

--- a/tools/headless_testing/startscript_cm8_waves.txt
+++ b/tools/headless_testing/startscript_cm8_waves.txt
@@ -1,0 +1,37 @@
+[GAME]
+{
+	MapName=Supreme Isthmus v2.1;
+	GameType=Beyond All Reason $VERSION;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=TestRunner;
+	IsHost=1;
+	FixedRNGSeed = 1;
+  [MODOPTIONS]
+  {
+    debugcommands=1:cheat|2:godmode|3:globallos|30:runtestsheadless cm8_ashfall;
+		deathmode=neverend;
+		forceallunits=1;
+  }
+  [ALLYTEAM0]
+  {
+  }
+  [ALLYTEAM1]
+  {
+  }
+  [TEAM0]
+  {
+    allyteam=0;
+    teamleader=0;
+  }
+  [TEAM1]
+  {
+    allyteam=1;
+    teamleader=0;
+  }
+  [PLAYER0]
+  {
+    team=0;
+  }
+}


### PR DESCRIPTION
The mission gains scavenger waves, and everything the mission needed in order to ask for them.

### The pressure arc

Four beats in `cm8_ashfall/triggers/waves.lua`: open quiet half a minute in, climb when the outpost is relieved, spike when the enclave is found, stop when the commander dies. It names a pack — `scavengers.skirmish` — and the missions module resolves it through the scavengers module's mission vocabulary, so a mission gets **the same wave director a multiplayer game runs**, at a tenth of the intensity, with no bot on the field to activate it.

### `.After(seconds)`

New, and what makes the opening beat possible. A trigger holds its effects until its conditions have gone on being true for that long, re-arming each time it fires so a repeating trigger reads as a rate limit. Seconds, never frames: `MissionSeconds` is a declared alias, so every editor deriving slots from the types can name the unit instead of showing a bare number.

### `Transfer.Give` is repaired here, because CM8 is what proved it broken

Its contract is that no policy question is asked — the game moving a base, not a team choosing to share. But the move goes through `Spring.TransferUnit`, which fires `AllowUnitTransfer`, which the controller answers from the same sharing policy as any ordinary share. **So the bypass bypassed nothing**, and the policy gave the right answer to the wrong question: Gaia is nobody's ally, refuse.

The opening beat of this mission is "you inherit this failing base". What the player actually inherited was six structures that never moved and an enclave that shot at them. The give now announces itself for the duration of the move, the same way `/take` already did — a rules param rather than an upvalue, because `VFS.Include` is uncached and the controller and the caller hold different copies of `api.lua`.

### The editor learns to watch

A trigger publishes that it has FIRED — not that its condition is true, which would flicker back off on a once-trigger — and both editors shade a card that has fired. That is the difference between a list of rules and a visible run through them. Wave progress is published the same way, so a director's clocks are readable from a panel.

### One guard the combat module needed for the same reason waves did

The gadget handler defers its callin-list updates while iterating but nils the method field immediately, so unhooking from inside a callin takes the whole gadget down on the next frame.

### Tests

CM8 needs an enemy team to arm at all, which the shared headless startscript does not have, so the scenario brings its own. `test_waves.lua` drives the whole arc bot-free; `test_outpost.lua` is the one that fails for thirty seconds without the Give fix. Both self-skip everywhere else.

---

Stacked on #8577 (`scavengers`) → #8576 (`waves`) → #8494 (`cm8-ashfall`).

Note for review: this commit bundles more than its title suggests — the `Transfer.Give` fix, `.After`/`MissionSeconds`, the fired-trigger shading and the combat callin guard are all separable if you would rather they landed as their own units.