### PR TITLE
Mission API: add EnumSets

### DIFF
--- a/luarules/mission_api/parameter_processing.lua
+++ b/luarules/mission_api/parameter_processing.lua
@@ -5,6 +5,7 @@
 VFS.Include('common/wav.lua')
 
 local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+local enumSets = GG['MissionAPI'].Modules.ParameterTypes.EnumSets
 local actionDefinitions = GG['MissionAPI'].ActionDefinitions
 local actionsSchemaParameters = actionDefinitions.Parameters
 local triggersSchemaParameters = GG['MissionAPI'].TriggerDefinitions.Parameters
@@ -42,21 +43,23 @@ local function processSoundFile(soundfile)
 	end
 end
 
-local function processResourceIncomeSources(sources)
-	local sourcesAsSet = {}
-	for _, source in ipairs(sources) do
-		sourcesAsSet[source] = true
+local function processEnumSet(values)
+	local valueSet = {}
+	for _, value in ipairs(values) do
+		valueSet[value] = true
 	end
-	return sourcesAsSet
+	return valueSet
 end
 
 local processors = {
-	[ParameterTypes.Position]              = processPosition,
-	[ParameterTypes.Positions]             = processPositions,
-	[ParameterTypes.Orders]                = processOrders,
-	[ParameterTypes.SoundFile]             = processSoundFile,
-	[ParameterTypes.ResourceIncomeSources] = processResourceIncomeSources,
+	[ParameterTypes.Position]  = processPosition,
+	[ParameterTypes.Positions] = processPositions,
+	[ParameterTypes.Orders]    = processOrders,
+	[ParameterTypes.SoundFile] = processSoundFile,
 }
+for enumSetType in pairs(enumSets) do
+	processors[enumSetType]    = processEnumSet
+end
 
 ----------------------------------------------------------------
 --- Public processing functions:

--- a/luarules/mission_api/parameter_types.lua
+++ b/luarules/mission_api/parameter_types.lua
@@ -39,14 +39,30 @@ local types = {
 
 	-- Function Validators:
 	Function = 'Function',
+
 }
 
 local enums = {
 	[types.Facing] = { [0] = true, [1] = true, [2] = true, [3] = true, n = true, s = true, e = true, w = true, north = true, south = true, east = true, west = true },
-	[types.ResourceIncomeSources] = { extractor = true, production = true, reclaim = true, transfer = true },
 }
+
+local enumSets = {
+	[types.ResourceIncomeSources] = {
+		noun = 'resource income source',
+		values = { 'extractor', 'production', 'reclaim', 'transfer' },
+	},
+}
+
+for enumType, enumSpec in pairs(enumSets) do
+	local memberSet = {}
+	for _, value in ipairs(enumSpec.values) do
+		memberSet[value] = true
+	end
+	enums[enumType] = memberSet
+end
 
 return {
 	Types = types,
 	Enums = enums,
+	EnumSets = enumSets,
 }

--- a/luarules/mission_api/parameter_types.lua
+++ b/luarules/mission_api/parameter_types.lua
@@ -54,11 +54,11 @@ local enumSets = {
 }
 
 for enumType, enumSpec in pairs(enumSets) do
-	local memberSet = {}
+	local valueSet = {}
 	for _, value in ipairs(enumSpec.values) do
-		memberSet[value] = true
+		valueSet[value] = true
 	end
-	enums[enumType] = memberSet
+	enums[enumType] = valueSet
 end
 
 return {

--- a/luarules/mission_api/parameter_types.lua
+++ b/luarules/mission_api/parameter_types.lua
@@ -47,18 +47,15 @@ local enums = {
 }
 
 local enumSets = {
-	[types.ResourceIncomeSources] = {
-		noun = 'resource income source',
-		values = { 'extractor', 'production', 'reclaim', 'transfer' },
-	},
+	[types.ResourceIncomeSources] = { 'extractor', 'production', 'reclaim', 'transfer' },
 }
 
-for enumType, enumSpec in pairs(enumSets) do
+for enumSetName, enumSetValues in pairs(enumSets) do
 	local valueSet = {}
-	for _, value in ipairs(enumSpec.values) do
+	for _, value in ipairs(enumSetValues) do
 		valueSet[value] = true
 	end
-	enums[enumType] = valueSet
+	enums[enumSetName] = valueSet
 end
 
 return {

--- a/luarules/mission_api/validation.lua
+++ b/luarules/mission_api/validation.lua
@@ -321,13 +321,10 @@ validators[Types.Area] = function(area)
 	end
 
 
-local function getValidatorFromEnumSetSpec(emumSetSpec, enumSetName)
-	local noun = emumSetSpec.noun
-	local generalPlural = string.upper(string.sub(noun, 1, 1)) .. string.sub(noun, 2) .. 's'
-	local emptyMessage = generalPlural .. " table must not be empty"
-	local allowedList = "'" .. table.concat(emumSetSpec.values, "', '") .. "'"
-
-	local members = parameterTypes.Enums[enumSetName]
+local function getValidatorFromEnumSetSpec(enumSetName, enumSetList)
+	local valueSet = parameterTypes.Enums[enumSetName]
+	local emptyMessage = enumSetName .. " table must not be empty"
+	local allowedList = "'" .. table.concat(enumSetList, "', '") .. "'"
 
 	return function(values)
 		local luaTypeResult = validators[Types.Table](values)
@@ -338,16 +335,16 @@ local function getValidatorFromEnumSetSpec(emumSetSpec, enumSetName)
 
 		local result = {}
 		for i, value in ipairs(values) do
-			if not members[value] then
-				result[#result + 1] = { message = "Invalid " .. noun .. " [" .. i .. "]: '" .. tostring(value) .. "'. Must be one of: " .. allowedList }
+			if not valueSet[value] then
+				result[#result + 1] = { message = "Invalid " .. enumSetName .. " [" .. i .. "]: '" .. tostring(value) .. "'. Must be one of: " .. allowedList }
 			end
 		end
 		if #result > 0 then return result end
 	end
 end
 
-for enumSetName, spec in pairs(parameterTypes.EnumSets) do
-	validators[enumSetName] = getValidatorFromEnumSetSpec(spec, enumSetName)
+for enumSetName, valuesList in pairs(parameterTypes.EnumSets) do
+	validators[enumSetName] = getValidatorFromEnumSetSpec(enumSetName, valuesList)
 end
 
 --- String Validators:

--- a/luarules/mission_api/validation.lua
+++ b/luarules/mission_api/validation.lua
@@ -320,20 +320,37 @@ validators[Types.Area] = function(area)
 		end
 	end
 
-validators[Types.ResourceIncomeSources] = function(sources)
-	local luaTypeResult = validators[Types.Table](sources)
-	if luaTypeResult then return luaTypeResult end
-	if #sources == 0 then
-		return { { message = "Resource income sources table must not be empty" } }
+
+local function getValidatorFromEnumSetSpec(emumSetSpec)
+	local noun = emumSetSpec.noun
+	local generalPlural = string.upper(string.sub(noun, 1, 1)) .. string.sub(noun, 2) .. 's'
+	local emptyMessage = generalPlural .. " table must not be empty"
+	local allowedList = "'" .. table.concat(emumSetSpec.values, "', '") .. "'"
+
+	local members = {}
+	for _, value in ipairs(emumSetSpec.values) do
+		members[value] = true
 	end
 
-	local result = {}
-	for i, source in ipairs(sources) do
-		if not parameterTypeEnums[Types.ResourceIncomeSources][source] then
-			result[#result + 1] = { message = "Invalid resource income source [" .. i .. "]: '" .. tostring(source) .. "'. Must be one of: 'extractor', 'production', 'reclaim', 'transfer'" }
+	return function(values)
+		local luaTypeResult = validators[Types.Table](values)
+		if luaTypeResult then return luaTypeResult end
+		if #values == 0 then
+			return { { message = emptyMessage } }
 		end
+
+		local result = {}
+		for i, value in ipairs(values) do
+			if not members[value] then
+				result[#result + 1] = { message = "Invalid " .. noun .. " [" .. i .. "]: '" .. tostring(value) .. "'. Must be one of: " .. allowedList }
+			end
+		end
+		if #result > 0 then return result end
 	end
-	if #result > 0 then return result end
+end
+
+for enumSetType, spec in pairs(parameterTypes.EnumSets) do
+	validators[enumSetType] = getValidatorFromEnumSetSpec(spec)
 end
 
 --- String Validators:

--- a/luarules/mission_api/validation.lua
+++ b/luarules/mission_api/validation.lua
@@ -321,16 +321,13 @@ validators[Types.Area] = function(area)
 	end
 
 
-local function getValidatorFromEnumSetSpec(emumSetSpec)
+local function getValidatorFromEnumSetSpec(emumSetSpec, enumSetName)
 	local noun = emumSetSpec.noun
 	local generalPlural = string.upper(string.sub(noun, 1, 1)) .. string.sub(noun, 2) .. 's'
 	local emptyMessage = generalPlural .. " table must not be empty"
 	local allowedList = "'" .. table.concat(emumSetSpec.values, "', '") .. "'"
 
-	local members = {}
-	for _, value in ipairs(emumSetSpec.values) do
-		members[value] = true
-	end
+	local members = parameterTypes.Enums[enumSetName]
 
 	return function(values)
 		local luaTypeResult = validators[Types.Table](values)
@@ -349,8 +346,8 @@ local function getValidatorFromEnumSetSpec(emumSetSpec)
 	end
 end
 
-for enumSetType, spec in pairs(parameterTypes.EnumSets) do
-	validators[enumSetType] = getValidatorFromEnumSetSpec(spec)
+for enumSetName, spec in pairs(parameterTypes.EnumSets) do
+	validators[enumSetName] = getValidatorFromEnumSetSpec(spec, enumSetName)
 end
 
 --- String Validators:


### PR DESCRIPTION
### Work done

Constructs EnumSet entries from base specs for shared validation and type handling.

Right now, adding a second enum set requires a new validator with no functional differences. Only names change (var names + in the error message). Also, the API should keep identical expectations around set-like behavior (nil is permissive, no empty tables allowed, specifying any value in the set excludes unspecified values). Right now, that would require an error message per-use of the type.

Producing the sets constructively, then, cuts down on new code and is very DRY.

`EnumSets` otherwise still works like `Enums`, and each enumSet is included in `Enums`.

Has an example use case in https://github.com/beyond-all-reason/Beyond-All-Reason/compare/mission-api/dev...efrec:Beyond-All-Reason:mission-api/unit-detected-by-sensors, in parameter_types.lua, adding a Sensors enum.