### PR TITLE
Fix: Dragons Jaw no height boost

### DIFF
--- a/units/Legion/Defenses/legdtr.lua
+++ b/units/Legion/Defenses/legdtr.lua
@@ -120,6 +120,7 @@ return {
 				explosiongenerator = "custom:genericshellexplosion-large",
 				flighttime = 0.610,
 				heightboostfactor = 0,
+				heightmod = 1,
 				impulsefactor = 2.0,
 				name = "Area Control Riot Cannon",
 				noselfdamage = true,

--- a/units/Legion/Defenses/legdtr.lua
+++ b/units/Legion/Defenses/legdtr.lua
@@ -118,6 +118,8 @@ return {
 				cylindertargeting = 1,
 				edgeeffectiveness = 0.9,
 				explosiongenerator = "custom:genericshellexplosion-large",
+				flighttime = 0.610,
+				heightboostfactor = 0,
 				impulsefactor = 2.0,
 				name = "Area Control Riot Cannon",
 				noselfdamage = true,


### PR DESCRIPTION
Patch notes were meant to give dragons jaw (legdtr) no height boost but only gave it cylindrical targeting.  

### Work done
I used the changes to corlevlr that were made with the same reason to the same riotcannon weapon. The flight time is probably not completely necessary but prevents the projectile path increase resulting from the cylindrical targeting. It does mean on very steep hills it wont reach the edge of the rendered range ring, same as pounder. 

#### Addresses Issue(s)
https://discord.com/channels/549281623154229250/1063217502898884701/1526599125557313546

### Screenshots:
#### BEFORE:
Pounder no range increase, also shots explode midair:
<img width="1254" height="785" alt="image" src="https://github.com/user-attachments/assets/0f3bbdd4-6473-4f5c-89ef-d46dcfef2c40" /> 

<img width="919" height="789" alt="image" src="https://github.com/user-attachments/assets/099d83c2-cbf9-4aca-bb04-8c5646208f14" />


Dragons Jaw showing massive range increase:
<img width="1524" height="843" alt="image" src="https://github.com/user-attachments/assets/6fb9b5b4-9f7f-49c0-b818-b88db31b5967" />

#### AFTER:
Dragons jaw no range increase:
<img width="1414" height="1043" alt="image" src="https://github.com/user-attachments/assets/38e457a2-6388-45fd-9f0d-39fff81a102d" />

Also jaw shots explode midair:
<img width="1011" height="792" alt="image" src="https://github.com/user-attachments/assets/72150403-0033-4fce-ad3b-5ed101f0fe0f" />


<img width="1205" height="933" alt="image" src="https://github.com/user-attachments/assets/2f17071c-9264-4d37-a702-d24c98ded7cd" />

No AI. 