### PR TITLE
Fix three ways the spec def harness misrepresents unit defs

### DIFF
--- a/spec/builder_specs/vfs_include_spec.lua
+++ b/spec/builder_specs/vfs_include_spec.lua
@@ -1,0 +1,28 @@
+describe("VFS.Include mock", function()
+	local path = "spec/builders/index.lua"
+
+	it("returns a fresh table on every call, as the engine does", function()
+		local first = VFS.Include(path)
+		local second = VFS.Include(path)
+
+		assert.is_table(first)
+		assert.is_table(second)
+		assert.is_false(rawequal(first, second))
+	end)
+
+	it("does not leak one caller's environment into the next", function()
+		local sandbox = setmetatable({}, { __index = _G })
+		VFS.Include(path, sandbox)
+
+		assert.is_table(VFS.Include(path))
+	end)
+
+	it("keeps a nested include of a path already being included isolated", function()
+		local outer = setmetatable({ marker = "outer" }, { __index = _G })
+
+		local reentrant = VFS.Include("spec/fixtures/reentrant_include.lua", outer)
+
+		assert.are.equal("outer", reentrant.before)
+		assert.are.equal("outer", reentrant.after)
+	end)
+end)

--- a/spec/builders/spring_synced_builder.lua
+++ b/spec/builders/spring_synced_builder.lua
@@ -124,9 +124,6 @@ local function buildUnitDefIndex(unitDefs, unitDefNames)
             if def.id then
                 index[def.id] = def
             end
-            if def.name then
-                index[def.name] = def
-            end
         end
     end
     for name, info in pairs(unitDefNames or {}) do

--- a/spec/builders/unit_defs_builder.lua
+++ b/spec/builders/unit_defs_builder.lua
@@ -100,9 +100,10 @@ function UDFB:WithRealUnitDefs(loadHarness)
             return
         end
         ---@diagnostic disable-next-line: global-in-non-module
+        -- gamedata/unitdefs.lua includes unitdefs_post, which includes
+        -- alldefs_post, so the defs arrive fully processed. Running either pass
+        -- again here appends the generated category tokens a second time.
         _G.UnitDefs = defs
-        pcall(require, "gamedata.alldefs_post")
-        pcall(require, "gamedata.unitdefs_post")
 
         local loaded = _G.UnitDefs
         local names  = _G.UnitDefNames

--- a/spec/fixtures/reentrant_include.lua
+++ b/spec/fixtures/reentrant_include.lua
@@ -1,0 +1,14 @@
+-- Includes itself once, under a different environment, and reads its own global
+-- again afterwards. A shared compiled chunk would have had its environment
+-- retargeted by the nested call, so the second read would come back "inner".
+local before = marker
+
+if not alreadyNested then
+	local nested = setmetatable({ marker = "inner", alreadyNested = true }, { __index = _G })
+	VFS.Include("spec/fixtures/reentrant_include.lua", nested)
+end
+
+return {
+	before = before,
+	after = marker,
+}

--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -48,7 +48,6 @@ end
 
 -- VFS.Include mock for testing
 _G.VFS = _G.VFS or {}
-_G.VFS._cache = _G.VFS._cache or {}
 
 _G.VFS.FileExists = function(path)
     -- First try the exact path provided
@@ -77,7 +76,7 @@ _G.VFS.FileExists = function(path)
     return _G.VFS._ci_file_cache[cleanPath:lower()] ~= nil
 end
 
-_G.VFS._chunks = _G.VFS._chunks or {}
+_G.VFS._sources = _G.VFS._sources or {}
 
 _G.VFS.Include = function(path, env, mode)
     -- Try direct path first
@@ -100,22 +99,34 @@ _G.VFS.Include = function(path, env, mode)
     end
 
     -- Use loadfile/dofile instead of require to better simulate VFS and handle case-insensitive paths
-    -- The engine re-executes an included file on every call, so only the compiled
-    -- chunk is reused: caching the result hands two defs the same table when one
+    -- The engine re-executes an included file on every call, so only the source
+    -- text is reused: caching the result hands two defs the same table when one
     -- unit file includes another, and whichever loads second mutates the first.
-    local chunk = _G.VFS._chunks[realPath]
-    if not chunk then
-        chunk = loadfile(realPath)
-        _G.VFS._chunks[realPath] = chunk
+    -- Each call compiles its own chunk, so a nested include of a path already on
+    -- the include stack cannot retarget the environment of the outer one.
+    local source = _G.VFS._sources[realPath]
+    if source == nil then
+        local sourceFile = io.open(realPath, "r")
+        source = sourceFile and sourceFile:read("*a") or false
+        if sourceFile then
+            sourceFile:close()
+        end
+        _G.VFS._sources[realPath] = source
     end
-    if chunk then
-        setfenv(chunk, env or _G)
 
-        local success, result = pcall(chunk)
-        if success then
-            return result
+    if source then
+        local chunk, compileError = loadstring(source, "@" .. realPath)
+        if chunk then
+            setfenv(chunk, env or _G)
+
+            local success, result = pcall(chunk)
+            if success then
+                return result
+            else
+                print("Error loading " .. path .. ": " .. tostring(result))
+            end
         else
-            print("Error loading " .. path .. ": " .. tostring(result))
+            print("Error compiling " .. path .. ": " .. tostring(compileError))
         end
     end
     
@@ -128,12 +139,10 @@ _G.VFS.Include = function(path, env, mode)
 
     local success, result = pcall(require, mod)
     if success then
-        _G.VFS._cache[path] = result
         return result
     else
         -- Instead of erroring, return an empty table for missing files
         -- This allows unitdefs.lua and other files to continue loading even if some dependencies are missing
-        _G.VFS._cache[path] = {}
         return {}
     end
 end

--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -77,12 +77,9 @@ _G.VFS.FileExists = function(path)
     return _G.VFS._ci_file_cache[cleanPath:lower()] ~= nil
 end
 
-_G.VFS.Include = function(path, env, mode)
-    -- Check cache first
-    if _G.VFS._cache[path] then
-        return _G.VFS._cache[path]
-    end
+_G.VFS._chunks = _G.VFS._chunks or {}
 
+_G.VFS.Include = function(path, env, mode)
     -- Try direct path first
     local realPath = path
     local file = io.open(path, "r")
@@ -103,16 +100,19 @@ _G.VFS.Include = function(path, env, mode)
     end
 
     -- Use loadfile/dofile instead of require to better simulate VFS and handle case-insensitive paths
-    local chunk, err = loadfile(realPath)
+    -- The engine re-executes an included file on every call, so only the compiled
+    -- chunk is reused: caching the result hands two defs the same table when one
+    -- unit file includes another, and whichever loads second mutates the first.
+    local chunk = _G.VFS._chunks[realPath]
+    if not chunk then
+        chunk = loadfile(realPath)
+        _G.VFS._chunks[realPath] = chunk
+    end
     if chunk then
-        -- Handle environment if provided
-        if env then
-            setfenv(chunk, env)
-        end
-        
+        setfenv(chunk, env or _G)
+
         local success, result = pcall(chunk)
         if success then
-            _G.VFS._cache[path] = result
             return result
         else
             print("Error loading " .. path .. ": " .. tostring(result))


### PR DESCRIPTION
Three fixes to the spec def harness, which was handing tests unit defs that don't match what the engine builds. Found while writing invariant tests over the real defs, where all three showed up as failures that weren't real.

The include mock remembered what each file returned and handed the same table back next time, so a unit file that starts from another unit file ended up sharing its stats - armcomlvl2 came back with its decoy's 3000 health rather than 6000. The engine's own def export has armcom with three weapons and dummycom with none, even though dummycom builds itself out of armcom.lua, which only works if the engine re-runs the file on each include. The other two are the same shape: gamedata/unitdefs.lua already runs the post pass, so the builder running it again doubled everything derived from it (1845 of 1907 defs carried their category list twice), and the engine's UnitDef.name is the internal name rather than the display name, so indexing on it invented nine units that don't exist.

Checked against the engine export under tools/headless_testing rather than against the harness, since the harness is the thing that changed. The mock has its own specs now because the existing ones pass either way - they check shapes rather than values.

AI disclosure: written with assistance from Claude Code.
