### PR TITLE
modules: placement — where a thing can legally stand, answered once

### DIFF
--- a/modules/placement/api.lua
+++ b/modules/placement/api.lua
@@ -1,0 +1,109 @@
+
+local Search = VFS.Include("modules/placement/lib/search.lua")
+local Ground = VFS.Include("modules/placement/spring/ground.lua")
+
+local ground
+local function checks()
+	if ground == nil then
+		ground = Ground.New({
+			positionChecks = VFS.Include("luarules/utilities/damgam_lib/position_checks.lua"),
+		})
+	end
+	return ground
+end
+
+--- Half a small structure: fine enough that "nearest" means something, coarse enough that a
+--- 512-elmo search is tens of samples rather than thousands.
+local DEFAULT_STEP = 64
+
+return {
+	---A fixed integer lattice and no random numbers, so every client and a replay agree.
+	---@param x number
+	---@param z number
+	---@param opts { radius: number|nil, step: number|nil, footprint: number|nil, surface: string|nil, flatness: number|nil, clearance: number|nil, limit: integer|nil }|nil
+	---@return number|nil x, number|nil y, number|nil z, string|nil why
+	NearestValid = function(x, z, opts)
+		opts = opts or {}
+		local want = {
+			footprint = opts.footprint or 64,
+			surface = opts.surface or "land",
+			flatness = opts.flatness,
+			clearance = opts.clearance,
+		}
+		local ground = checks()
+		local tally = ground.NewTally()
+		local found
+		local fx, fz = Search.Outward(x, z, {
+			radius = opts.radius or 0,
+			step = opts.step or DEFAULT_STEP,
+			limit = opts.limit,
+		}, function(cx, cz)
+			local ok, y = ground.Usable(cx, cz, want, tally)
+			if ok then
+				found = y
+			end
+			return ok
+		end)
+
+		if fx == nil then
+			return nil, nil, nil, ground.Explain(tally)
+		end
+		return fx, found, fz, nil
+	end,
+
+	---@param x number
+	---@param z number
+	---@param opts table|nil
+	---@return boolean ok, number|nil y
+	IsValid = function(x, z, opts)
+		opts = opts or {}
+		return checks().Usable(x, z, {
+			footprint = opts.footprint or 64,
+			surface = opts.surface or "land",
+			flatness = opts.flatness,
+			clearance = opts.clearance,
+		}, nil)
+	end,
+
+	---@param x number
+	---@param z number
+	---@param count integer
+	---@param opts table|nil
+	---@return { x: number, y: number, z: number }[] spots may be shorter than count
+	Cluster = function(x, z, count, opts)
+		opts = opts or {}
+		local footprint = opts.footprint or 64
+		local ground = checks()
+		local taken = {}
+		local out = {}
+		local want = {
+			footprint = footprint,
+			surface = opts.surface or "land",
+			flatness = opts.flatness,
+			clearance = opts.clearance,
+		}
+		for _ = 1, count do
+			local placed
+			local px, pz = Search.Outward(x, z, {
+				radius = opts.radius or 0,
+				step = opts.step or DEFAULT_STEP,
+				limit = opts.limit,
+			}, function(cx, cz)
+				if taken[cx .. "," .. cz] then
+					return false
+				end
+				local ok, y = ground.Usable(cx, cz, want, nil)
+				if ok then
+					placed = y
+				end
+				return ok
+			end)
+			if px == nil then
+				break
+			end
+			taken[px .. "," .. pz] = true
+			out[#out + 1] = { x = px, y = placed, z = pz }
+		end
+		return out
+	end,
+}

--- a/modules/placement/api.lua
+++ b/modules/placement/api.lua
@@ -1,0 +1,113 @@
+
+local Search = VFS.Include("modules/placement/lib/search.lua")
+local Ground = VFS.Include("modules/placement/spring/ground.lua")
+
+local ground
+local function checks()
+	if ground == nil then
+		ground = Ground.New({
+			positionChecks = VFS.Include("luarules/utilities/damgam_lib/position_checks.lua"),
+		})
+	end
+	return ground
+end
+
+--- Half a small structure: fine enough that "nearest" means something, coarse enough that a
+--- 512-elmo search is tens of samples rather than thousands.
+local DEFAULT_STEP = 64
+
+return {
+	---Deterministic: the walk is a fixed integer lattice, so the same request
+	---on the same map gives the same answer on every client, in a replay, and
+	---in a spec. Nothing here draws a random number.
+	---@param x number
+	---@param z number
+	---@param opts { radius: number|nil, step: number|nil, footprint: number|nil, surface: string|nil, flatness: number|nil, clearance: number|nil, limit: integer|nil }|nil
+	---@return number|nil x, number|nil y, number|nil z, string|nil why
+	NearestValid = function(x, z, opts)
+		opts = opts or {}
+		local want = {
+			footprint = opts.footprint or 64,
+			surface = opts.surface or "land",
+			flatness = opts.flatness,
+			clearance = opts.clearance,
+		}
+		local ground = checks()
+		local tally = ground.NewTally()
+		local found
+		local fx, fz = Search.Outward(x, z, {
+			radius = opts.radius or 0,
+			step = opts.step or DEFAULT_STEP,
+			limit = opts.limit,
+		}, function(cx, cz)
+			local ok, y = ground.Usable(cx, cz, want, tally)
+			if ok then
+				found = y
+			end
+			return ok
+		end)
+
+		if fx == nil then
+			return nil, nil, nil, ground.Explain(tally)
+		end
+		return fx, found, fz, nil
+	end,
+
+	---@param x number
+	---@param z number
+	---@param opts table|nil
+	---@return boolean ok, number|nil y
+	IsValid = function(x, z, opts)
+		opts = opts or {}
+		return checks().Usable(x, z, {
+			footprint = opts.footprint or 64,
+			surface = opts.surface or "land",
+			flatness = opts.flatness,
+			clearance = opts.clearance,
+		}, nil)
+	end,
+
+	---Each of `count` takes the nearest spot the ones before it have not taken: that is what makes
+	---a group land as a deliberate cluster rather than a scatter, and makes the result reproducible.
+	---@param x number
+	---@param z number
+	---@param count integer
+	---@param opts table|nil
+	---@return { x: number, y: number, z: number }[] spots may be shorter than count
+	Cluster = function(x, z, count, opts)
+		opts = opts or {}
+		local footprint = opts.footprint or 64
+		local ground = checks()
+		local taken = {}
+		local out = {}
+		local want = {
+			footprint = footprint,
+			surface = opts.surface or "land",
+			flatness = opts.flatness,
+			clearance = opts.clearance,
+		}
+		for _ = 1, count do
+			local placed
+			local px, pz = Search.Outward(x, z, {
+				radius = opts.radius or 0,
+				step = opts.step or DEFAULT_STEP,
+				limit = opts.limit,
+			}, function(cx, cz)
+				if taken[cx .. "," .. cz] then
+					return false
+				end
+				local ok, y = ground.Usable(cx, cz, want, nil)
+				if ok then
+					placed = y
+				end
+				return ok
+			end)
+			if px == nil then
+				break
+			end
+			taken[px .. "," .. pz] = true
+			out[#out + 1] = { x = px, y = placed, z = pz }
+		end
+		return out
+	end,
+}

--- a/modules/placement/lib/search.lua
+++ b/modules/placement/lib/search.lua
@@ -1,0 +1,80 @@
+
+local Search = {}
+
+---Ring k is exactly the Chebyshev shell, which is what makes the rings disjoint and the walk exhaustive.
+---@param ring integer 0-based ring index
+---@param step number lattice spacing in elmos
+---@return { dx: number, dz: number }[]
+function Search.Ring(ring, step)
+	assert(type(ring) == "number" and ring >= 0 and ring % 1 == 0, "Ring expects a non-negative integer ring")
+	assert(type(step) == "number" and step > 0, "Ring expects a positive step")
+
+	if ring == 0 then
+		return { { dx = 0, dz = 0 } }
+	end
+
+	local out = {}
+	for i = -ring, ring do
+		for j = -ring, ring do
+			if i == -ring or i == ring or j == -ring or j == ring then
+				out[#out + 1] = { dx = i * step, dz = j * step }
+			end
+		end
+	end
+
+	-- The dx/dz tiebreak is arbitrary but FIXED: equidistant candidates must always come in the same order.
+	table.sort(out, function(a, b)
+		local da = a.dx * a.dx + a.dz * a.dz
+		local db = b.dx * b.dx + b.dz * b.dz
+		if da ~= db then
+			return da < db
+		end
+		if a.dx ~= b.dx then
+			return a.dx < b.dx
+		end
+		return a.dz < b.dz
+	end)
+	return out
+end
+
+---@param radius number how far out the caller will accept a spot
+---@param step number lattice spacing
+---@return integer
+function Search.Rings(radius, step)
+	if radius <= 0 then
+		return 0
+	end
+	return math.ceil(radius / step)
+end
+
+---@param x number
+---@param z number
+---@param opts { radius: number, step: number|nil, limit: integer|nil }
+---@param accept fun(x: number, z: number, ring: integer): boolean
+---@return number|nil x, number|nil z, integer tried
+function Search.Outward(x, z, opts, accept)
+	assert(type(accept) == "function", "Outward expects an accept function")
+	local step = opts.step or 64
+	local radius = opts.radius or 0
+	local limit = opts.limit or 512
+
+	local tried = 0
+	for ring = 0, Search.Rings(radius, step) do
+		for _, offset in ipairs(Search.Ring(ring, step)) do
+			local dist2 = offset.dx * offset.dx + offset.dz * offset.dz
+			if dist2 <= radius * radius or ring == 0 then
+				tried = tried + 1
+				if tried > limit then
+					return nil, nil, tried - 1
+				end
+				local cx, cz = x + offset.dx, z + offset.dz
+				if accept(cx, cz, ring) then
+					return cx, cz, tried
+				end
+			end
+		end
+	end
+	return nil, nil, tried
+end
+
+return Search

--- a/modules/placement/lib/search.lua
+++ b/modules/placement/lib/search.lua
@@ -1,0 +1,88 @@
+
+local Search = {}
+
+---Ring k is exactly the Chebyshev shell, which is what makes the rings disjoint and the walk exhaustive.
+---@param ring integer 0-based ring index
+---@param step number lattice spacing in elmos
+---@return { dx: number, dz: number }[]
+function Search.Ring(ring, step)
+	assert(type(ring) == "number" and ring >= 0 and ring % 1 == 0, "Ring expects a non-negative integer ring")
+	assert(type(step) == "number" and step > 0, "Ring expects a positive step")
+
+	if ring == 0 then
+		return { { dx = 0, dz = 0 } }
+	end
+
+	local out = {}
+	for i = -ring, ring do
+		for j = -ring, ring do
+			-- The shell only: interior points belong to an earlier ring and
+			-- must not be offered twice.
+			if i == -ring or i == ring or j == -ring or j == ring then
+				out[#out + 1] = { dx = i * step, dz = j * step }
+			end
+		end
+	end
+
+	-- Nearest first inside the shell. The dx/dz tiebreak is arbitrary but
+	-- FIXED, which is the point: two candidates at the same distance must
+	-- always be offered in the same order.
+	table.sort(out, function(a, b)
+		local da = a.dx * a.dx + a.dz * a.dz
+		local db = b.dx * b.dx + b.dz * b.dz
+		if da ~= db then
+			return da < db
+		end
+		if a.dx ~= b.dx then
+			return a.dx < b.dx
+		end
+		return a.dz < b.dz
+	end)
+	return out
+end
+
+---@param radius number how far out the caller will accept a spot
+---@param step number lattice spacing
+---@return integer
+function Search.Rings(radius, step)
+	if radius <= 0 then
+		return 0
+	end
+	return math.ceil(radius / step)
+end
+
+---@param x number
+---@param z number
+---@param opts { radius: number, step: number|nil, limit: integer|nil }
+---@param accept fun(x: number, z: number, ring: integer): boolean
+---@return number|nil x, number|nil z, integer tried
+function Search.Outward(x, z, opts, accept)
+	assert(type(accept) == "function", "Outward expects an accept function")
+	local step = opts.step or 64
+	local radius = opts.radius or 0
+	-- A ceiling on work, not on distance: a caller that asks to search a whole
+	-- map should get a bounded answer rather than a frame-long stall.
+	local limit = opts.limit or 512
+
+	local tried = 0
+	for ring = 0, Search.Rings(radius, step) do
+		for _, offset in ipairs(Search.Ring(ring, step)) do
+			-- The shell overshoots the circle at its corners; skip what the
+			-- caller did not ask for so "radius" means radius.
+			local dist2 = offset.dx * offset.dx + offset.dz * offset.dz
+			if dist2 <= radius * radius or ring == 0 then
+				tried = tried + 1
+				if tried > limit then
+					return nil, nil, tried - 1
+				end
+				local cx, cz = x + offset.dx, z + offset.dz
+				if accept(cx, cz, ring) then
+					return cx, cz, tried
+				end
+			end
+		end
+	end
+	return nil, nil, tried
+end
+
+return Search

--- a/modules/placement/module.lua
+++ b/modules/placement/module.lua
@@ -1,0 +1,6 @@
+---@type ModuleManifestFile
+return {
+	name = "placement",
+	description = "Where a unit can legally stand: deterministic nearest-valid ground",
+	requires = {},
+}

--- a/modules/placement/spec/lib/search_spec.lua
+++ b/modules/placement/spec/lib/search_spec.lua
@@ -1,0 +1,101 @@
+
+local Search = VFS.Include("modules/placement/lib/search.lua")
+
+describe("placement search order", function()
+	it("starts at the point the caller actually asked for", function()
+		local ring = Search.Ring(0, 64)
+		assert.are.same({ { dx = 0, dz = 0 } }, ring)
+	end)
+
+	it("a ring is a shell, so no point is offered twice", function()
+		local seen = {}
+		for r = 0, 3 do
+			for _, o in ipairs(Search.Ring(r, 64)) do
+				local key = o.dx .. "," .. o.dz
+				assert.is_nil(seen[key], "offered twice: " .. key)
+				seen[key] = true
+			end
+		end
+		local count = 0
+		for _ in pairs(seen) do
+			count = count + 1
+		end
+		assert.are.equal(49, count)
+	end)
+
+	it("offers nearer candidates before further ones inside a ring", function()
+		local ring = Search.Ring(2, 100)
+		local previous = -1
+		for _, o in ipairs(ring) do
+			local d = o.dx * o.dx + o.dz * o.dz
+			assert.is_true(d >= previous, "ring is not sorted nearest-first")
+			previous = d
+		end
+		assert.are.equal(200 * 200, ring[1].dx * ring[1].dx + ring[1].dz * ring[1].dz)
+	end)
+
+	it("is deterministic: the same request gives byte-identical order", function()
+		local a = Search.Ring(3, 64)
+		local b = Search.Ring(3, 64)
+		assert.are.same(a, b)
+	end)
+
+	it("uses integer-exact offsets, so there is no float to disagree about", function()
+		for _, o in ipairs(Search.Ring(3, 64)) do
+			assert.are.equal(0, o.dx % 1)
+			assert.are.equal(0, o.dz % 1)
+		end
+	end)
+
+	it("takes the requested point when it is acceptable, and looks no further", function()
+		local tries = 0
+		local x, z, tried = Search.Outward(1000, 2000, { radius = 500, step = 64 }, function()
+			tries = tries + 1
+			return true
+		end)
+		assert.are.equal(1000, x)
+		assert.are.equal(2000, z)
+		assert.are.equal(1, tries)
+		assert.are.equal(1, tried)
+	end)
+
+	it("returns the NEAREST acceptable spot, not merely an acceptable one", function()
+		local wanted = { x = 1000 + 128, z = 2000 }
+		local x, z = Search.Outward(1000, 2000, { radius = 400, step = 64 }, function(cx, cz)
+			return cx == wanted.x and cz == wanted.z
+		end)
+		assert.are.equal(wanted.x, x)
+		assert.are.equal(wanted.z, z)
+	end)
+
+	it("never offers a candidate beyond the radius it was given", function()
+		local worst = 0
+		Search.Outward(0, 0, { radius = 300, step = 64 }, function(cx, cz)
+			worst = math.max(worst, cx * cx + cz * cz)
+			return false
+		end)
+		assert.is_true(worst <= 300 * 300, "offered a spot outside the requested radius: " .. math.sqrt(worst))
+	end)
+
+	it("gives up rather than stalling when nothing is acceptable", function()
+		local x, z, tried = Search.Outward(0, 0, { radius = 100000, step = 8, limit = 250 }, function()
+			return false
+		end)
+		assert.is_nil(x)
+		assert.is_nil(z)
+		assert.are.equal(250, tried, "the work ceiling is what stops a whole-map search costing a frame")
+	end)
+
+	it("reports how hard it looked, so a caller can say so", function()
+		local _, _, tried = Search.Outward(0, 0, { radius = 128, step = 64 }, function()
+			return false
+		end)
+		assert.is_true(tried > 1)
+	end)
+
+	it("Rings covers the radius asked for and no more", function()
+		assert.are.equal(0, Search.Rings(0, 64))
+		assert.are.equal(1, Search.Rings(64, 64))
+		assert.are.equal(2, Search.Rings(65, 64))
+	end)
+end)

--- a/modules/placement/spec/lib/search_spec.lua
+++ b/modules/placement/spec/lib/search_spec.lua
@@ -1,0 +1,108 @@
+
+local Search = VFS.Include("modules/placement/lib/search.lua")
+
+describe("placement search order", function()
+	it("starts at the point the caller actually asked for", function()
+		local ring = Search.Ring(0, 64)
+		assert.are.same({ { dx = 0, dz = 0 } }, ring)
+	end)
+
+	it("a ring is a shell, so no point is offered twice", function()
+		local seen = {}
+		for r = 0, 3 do
+			for _, o in ipairs(Search.Ring(r, 64)) do
+				local key = o.dx .. "," .. o.dz
+				assert.is_nil(seen[key], "offered twice: " .. key)
+				seen[key] = true
+			end
+		end
+		-- rings 0..3 on a 7x7 lattice
+		local count = 0
+		for _ in pairs(seen) do
+			count = count + 1
+		end
+		assert.are.equal(49, count)
+	end)
+
+	it("offers nearer candidates before further ones inside a ring", function()
+		local ring = Search.Ring(2, 100)
+		local previous = -1
+		for _, o in ipairs(ring) do
+			local d = o.dx * o.dx + o.dz * o.dz
+			assert.is_true(d >= previous, "ring is not sorted nearest-first")
+			previous = d
+		end
+		-- the four edge midpoints are the closest points on the shell
+		assert.are.equal(200 * 200, ring[1].dx * ring[1].dx + ring[1].dz * ring[1].dz)
+	end)
+
+	it("is deterministic: the same request gives byte-identical order", function()
+		-- The whole reason this is a lattice and not random sampling. If this
+		-- ever fails, replays and clients can disagree about where a unit went.
+		local a = Search.Ring(3, 64)
+		local b = Search.Ring(3, 64)
+		assert.are.same(a, b)
+	end)
+
+	it("uses integer-exact offsets, so there is no float to disagree about", function()
+		for _, o in ipairs(Search.Ring(3, 64)) do
+			assert.are.equal(0, o.dx % 1)
+			assert.are.equal(0, o.dz % 1)
+		end
+	end)
+
+	it("takes the requested point when it is acceptable, and looks no further", function()
+		local tries = 0
+		local x, z, tried = Search.Outward(1000, 2000, { radius = 500, step = 64 }, function()
+			tries = tries + 1
+			return true
+		end)
+		assert.are.equal(1000, x)
+		assert.are.equal(2000, z)
+		assert.are.equal(1, tries)
+		assert.are.equal(1, tried)
+	end)
+
+	it("returns the NEAREST acceptable spot, not merely an acceptable one", function()
+		-- Only one spot in the whole search is usable, and it is two rings out.
+		-- Anything that wanders past it and takes something further away has
+		-- broken the promise the caller relies on.
+		local wanted = { x = 1000 + 128, z = 2000 }
+		local x, z = Search.Outward(1000, 2000, { radius = 400, step = 64 }, function(cx, cz)
+			return cx == wanted.x and cz == wanted.z
+		end)
+		assert.are.equal(wanted.x, x)
+		assert.are.equal(wanted.z, z)
+	end)
+
+	it("never offers a candidate beyond the radius it was given", function()
+		local worst = 0
+		Search.Outward(0, 0, { radius = 300, step = 64 }, function(cx, cz)
+			worst = math.max(worst, cx * cx + cz * cz)
+			return false
+		end)
+		assert.is_true(worst <= 300 * 300, "offered a spot outside the requested radius: " .. math.sqrt(worst))
+	end)
+
+	it("gives up rather than stalling when nothing is acceptable", function()
+		local x, z, tried = Search.Outward(0, 0, { radius = 100000, step = 8, limit = 250 }, function()
+			return false
+		end)
+		assert.is_nil(x)
+		assert.is_nil(z)
+		assert.are.equal(250, tried, "the work ceiling is what stops a whole-map search costing a frame")
+	end)
+
+	it("reports how hard it looked, so a caller can say so", function()
+		local _, _, tried = Search.Outward(0, 0, { radius = 128, step = 64 }, function()
+			return false
+		end)
+		assert.is_true(tried > 1)
+	end)
+
+	it("Rings covers the radius asked for and no more", function()
+		assert.are.equal(0, Search.Rings(0, 64))
+		assert.are.equal(1, Search.Rings(64, 64))
+		assert.are.equal(2, Search.Rings(65, 64))
+	end)
+end)

--- a/modules/placement/spec/spring/ground_spec.lua
+++ b/modules/placement/spec/spring/ground_spec.lua
@@ -1,0 +1,155 @@
+
+local Ground = VFS.Include("modules/placement/spring/ground.lua")
+
+local function permissiveChecks()
+	return {
+		MapEdgeCheck = function()
+			return true
+		end,
+		LandOrSeaCheck = function()
+			return "land"
+		end,
+		FlatAreaCheck = function()
+			return true
+		end,
+		OccupancyCheck = function()
+			return true
+		end,
+	}
+end
+
+local savedHeight
+local function stubHeight(h)
+	savedHeight = Spring.GetGroundHeight
+	Spring.GetGroundHeight = function()
+		return h or 100
+	end
+end
+
+describe("what makes a spot usable", function()
+	before_each(function()
+		stubHeight(100)
+	end)
+	after_each(function()
+		Spring.GetGroundHeight = savedHeight
+	end)
+
+	it("answers with the ground height, so a caller never has to guess it", function()
+		stubHeight(237)
+		local ground = Ground.New({ positionChecks = permissiveChecks() })
+		local ok, y = ground.Usable(500, 500, { footprint = 64 })
+		assert.is_true(ok)
+		assert.are.equal(237, y)
+	end)
+
+	it("refuses ground that is the wrong surface, and says so", function()
+		local checks = permissiveChecks()
+		checks.LandOrSeaCheck = function()
+			return "sea"
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		local tally = ground.NewTally()
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, surface = "land" }, tally))
+		assert.are.equal(1, tally.wrongSurface)
+		assert.are.equal(0, tally.steep)
+	end)
+
+	it("refuses ground that is half in the water for land AND for sea", function()
+		local checks = permissiveChecks()
+		checks.LandOrSeaCheck = function()
+			return "mixed"
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, surface = "land" }))
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, surface = "sea" }))
+	end)
+
+	it('"solid" takes land or sea, but never the shoreline between them', function()
+		local checks = permissiveChecks()
+		local ground = Ground.New({ positionChecks = checks })
+		for _, surface in ipairs({ "land", "sea" }) do
+			checks.LandOrSeaCheck = function()
+				return surface
+			end
+			assert.is_true(
+				ground.Usable(0, 0, { footprint = 64, surface = "solid" }),
+				surface .. " should satisfy solid"
+			)
+		end
+		for _, surface in ipairs({ "mixed", "death" }) do
+			checks.LandOrSeaCheck = function()
+				return surface
+			end
+			assert.is_false(
+				ground.Usable(0, 0, { footprint = 64, surface = "solid" }),
+				surface .. " must not satisfy solid"
+			)
+		end
+	end)
+
+	it("takes any surface when the caller does not care", function()
+		local checks = permissiveChecks()
+		checks.LandOrSeaCheck = function()
+			return "mixed"
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_true(ground.Usable(0, 0, { footprint = 64, surface = "any" }))
+	end)
+
+	it("only measures flatness when the caller asked for it", function()
+		local asked = 0
+		local checks = permissiveChecks()
+		checks.FlatAreaCheck = function()
+			asked = asked + 1
+			return false
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_true(ground.Usable(0, 0, { footprint = 64 }))
+		assert.are.equal(0, asked)
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, flatness = 20 }))
+		assert.are.equal(1, asked)
+	end)
+
+	it("defaults clearance to the footprint, not to something roomier", function()
+		local seen
+		local checks = permissiveChecks()
+		checks.OccupancyCheck = function(_x, _y, _z, r)
+			seen = r
+			return true
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		ground.Usable(0, 0, { footprint = 96 })
+		assert.are.equal(96, seen)
+		ground.Usable(0, 0, { footprint = 96, clearance = 200 })
+		assert.are.equal(200, seen)
+	end)
+
+	it("stops at the first refusal, so a cheap test never runs an expensive one", function()
+		local occupancy = 0
+		local checks = permissiveChecks()
+		checks.MapEdgeCheck = function()
+			return false
+		end
+		checks.OccupancyCheck = function()
+			occupancy = occupancy + 1
+			return true
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_false(ground.Usable(0, 0, { footprint = 64 }))
+		assert.are.equal(0, occupancy)
+	end)
+
+	it("explains a failed area by what refused it, not by a guess", function()
+		local ground = Ground.New({ positionChecks = permissiveChecks() })
+		local tally = ground.NewTally()
+		tally.tried, tally.steep, tally.occupied = 40, 31, 9
+		local why = ground.Explain(tally)
+		assert.is_truthy(why:find("31 too steep", 1, true))
+		assert.is_truthy(why:find("9 too close", 1, true))
+	end)
+
+	it("says so plainly when nothing was even attempted", function()
+		local ground = Ground.New({ positionChecks = permissiveChecks() })
+		assert.are.equal("nowhere was tried", ground.Explain(ground.NewTally()))
+	end)
+end)

--- a/modules/placement/spec/spring/ground_spec.lua
+++ b/modules/placement/spec/spring/ground_spec.lua
@@ -1,0 +1,166 @@
+
+local Ground = VFS.Include("modules/placement/spring/ground.lua")
+
+--- A map that says yes to everything, so a test can say no to one thing.
+local function permissiveChecks()
+	return {
+		MapEdgeCheck = function()
+			return true
+		end,
+		LandOrSeaCheck = function()
+			return "land"
+		end,
+		FlatAreaCheck = function()
+			return true
+		end,
+		OccupancyCheck = function()
+			return true
+		end,
+	}
+end
+
+local savedHeight
+local function stubHeight(h)
+	savedHeight = Spring.GetGroundHeight
+	Spring.GetGroundHeight = function()
+		return h or 100
+	end
+end
+
+describe("what makes a spot usable", function()
+	before_each(function()
+		stubHeight(100)
+	end)
+	after_each(function()
+		Spring.GetGroundHeight = savedHeight
+	end)
+
+	it("answers with the ground height, so a caller never has to guess it", function()
+		-- The bug this exists to prevent: a mover that keeps the unit's OLD
+		-- height while changing x and z leaves it floating or buried on any
+		-- ground that is not perfectly level.
+		stubHeight(237)
+		local ground = Ground.New({ positionChecks = permissiveChecks() })
+		local ok, y = ground.Usable(500, 500, { footprint = 64 })
+		assert.is_true(ok)
+		assert.are.equal(237, y)
+	end)
+
+	it("refuses ground that is the wrong surface, and says so", function()
+		local checks = permissiveChecks()
+		checks.LandOrSeaCheck = function()
+			return "sea"
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		local tally = ground.NewTally()
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, surface = "land" }, tally))
+		assert.are.equal(1, tally.wrongSurface)
+		assert.are.equal(0, tally.steep)
+	end)
+
+	it("refuses ground that is half in the water for land AND for sea", function()
+		-- "mixed" is the shoreline. A thing placed across that line is half in
+		-- the sea whichever of the two you asked for.
+		local checks = permissiveChecks()
+		checks.LandOrSeaCheck = function()
+			return "mixed"
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, surface = "land" }))
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, surface = "sea" }))
+	end)
+
+	it('"solid" takes land or sea, but never the shoreline between them', function()
+		-- What a burrow wants: it can sit on land or under water, but not
+		-- straddling the line, because half its spawns would drown.
+		local checks = permissiveChecks()
+		local ground = Ground.New({ positionChecks = checks })
+		for _, surface in ipairs({ "land", "sea" }) do
+			checks.LandOrSeaCheck = function()
+				return surface
+			end
+			assert.is_true(
+				ground.Usable(0, 0, { footprint = 64, surface = "solid" }),
+				surface .. " should satisfy solid"
+			)
+		end
+		for _, surface in ipairs({ "mixed", "death" }) do
+			checks.LandOrSeaCheck = function()
+				return surface
+			end
+			assert.is_false(
+				ground.Usable(0, 0, { footprint = 64, surface = "solid" }),
+				surface .. " must not satisfy solid"
+			)
+		end
+	end)
+
+	it("takes any surface when the caller does not care", function()
+		local checks = permissiveChecks()
+		checks.LandOrSeaCheck = function()
+			return "mixed"
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_true(ground.Usable(0, 0, { footprint = 64, surface = "any" }))
+	end)
+
+	it("only measures flatness when the caller asked for it", function()
+		-- A unit that can stand on a slope should not be refused a slope.
+		local asked = 0
+		local checks = permissiveChecks()
+		checks.FlatAreaCheck = function()
+			asked = asked + 1
+			return false
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_true(ground.Usable(0, 0, { footprint = 64 }))
+		assert.are.equal(0, asked)
+		assert.is_false(ground.Usable(0, 0, { footprint = 64, flatness = 20 }))
+		assert.are.equal(1, asked)
+	end)
+
+	it("defaults clearance to the footprint, not to something roomier", function()
+		-- Demanding elbow room by default is how a search fails on a map that
+		-- had somewhere perfectly good to stand.
+		local seen
+		local checks = permissiveChecks()
+		checks.OccupancyCheck = function(_x, _y, _z, r)
+			seen = r
+			return true
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		ground.Usable(0, 0, { footprint = 96 })
+		assert.are.equal(96, seen)
+		ground.Usable(0, 0, { footprint = 96, clearance = 200 })
+		assert.are.equal(200, seen)
+	end)
+
+	it("stops at the first refusal, so a cheap test never runs an expensive one", function()
+		local occupancy = 0
+		local checks = permissiveChecks()
+		checks.MapEdgeCheck = function()
+			return false
+		end
+		checks.OccupancyCheck = function()
+			occupancy = occupancy + 1
+			return true
+		end
+		local ground = Ground.New({ positionChecks = checks })
+		assert.is_false(ground.Usable(0, 0, { footprint = 64 }))
+		assert.are.equal(0, occupancy)
+	end)
+
+	it("explains a failed area by what refused it, not by a guess", function()
+		local ground = Ground.New({ positionChecks = permissiveChecks() })
+		local tally = ground.NewTally()
+		tally.tried, tally.steep, tally.occupied = 40, 31, 9
+		local why = ground.Explain(tally)
+		assert.is_truthy(why:find("31 too steep", 1, true))
+		assert.is_truthy(why:find("9 too close", 1, true))
+	end)
+
+	it("says so plainly when nothing was even attempted", function()
+		local ground = Ground.New({ positionChecks = permissiveChecks() })
+		assert.are.equal("nowhere was tried", ground.Explain(ground.NewTally()))
+	end)
+end)

--- a/modules/placement/spring/ground.lua
+++ b/modules/placement/spring/ground.lua
@@ -1,0 +1,107 @@
+--- Spring lives here. Nothing above spring/ may include this file.
+--- Wraps damgam_lib/position_checks rather than reimplementing it, and records WHICH test refused: a caller that cannot place something needs to say why.
+
+local Ground = {}
+
+---@param deps { positionChecks: table }
+---@return table
+function Ground.New(deps)
+	local checks = deps.positionChecks
+	assert(type(checks) == "table", "placement ground needs positionChecks")
+
+	local ground = {}
+
+	--- Counting rather than returning the first reason: over a whole search the counts say what is
+	--- wrong with the AREA. "312 too steep, 4 occupied" is a cliff; "0 too steep, 316 occupied" is a crowded base.
+	---@return table
+	function ground.NewTally()
+		return { offMap = 0, steep = 0, occupied = 0, wrongSurface = 0, tried = 0 }
+	end
+
+	--- `want.surface` is "land", "sea" or "any". Mixed ground — half shore,
+	--- half water — is refused for land and sea alike: a unit placed across
+	--- that line is half in the sea whichever way you meant it.
+	---@param x number
+	---@param z number
+	---@param want { footprint: number, surface: string|nil, flatness: number|nil, clearance: number|nil }
+	---@param tally table|nil
+	---@return boolean ok, number|nil y
+	function ground.Usable(x, z, want, tally)
+		if tally then
+			tally.tried = tally.tried + 1
+		end
+		local footprint = want.footprint or 64
+		local y = Spring.GetGroundHeight(x, z)
+
+		if not checks.MapEdgeCheck(x, y, z, footprint) then
+			if tally then
+				tally.offMap = tally.offMap + 1
+			end
+			return false
+		end
+
+		-- "land" / "sea" ask for one of them. "solid" asks for either, but not
+		-- the shoreline between them: something spawning across that line has
+		-- half its output in the water whichever side you meant. "any" asks
+		-- nothing, for a caller that knows better than this module does.
+		local surface = want.surface or "land"
+		if surface ~= "any" then
+			local found = checks.LandOrSeaCheck(x, y, z, footprint)
+			local ok
+			if surface == "solid" then
+				ok = found == "land" or found == "sea"
+			else
+				ok = found == surface
+			end
+			if not ok then
+				if tally then
+					tally.wrongSurface = tally.wrongSurface + 1
+				end
+				return false
+			end
+		end
+
+		-- Flatness is measured over the footprint, not over some larger comfort
+		-- margin. Asking for a parade ground is how a search fails on maps that
+		-- had somewhere perfectly good to stand.
+		local flatness = want.flatness
+		if flatness ~= nil and not checks.FlatAreaCheck(x, y, z, footprint, flatness, true) then
+			if tally then
+				tally.steep = tally.steep + 1
+			end
+			return false
+		end
+
+		-- Clearance defaults to the footprint: enough not to overlap, and no
+		-- more. A caller that wants elbow room asks for it.
+		local clearance = want.clearance or footprint
+		if clearance > 0 and not checks.OccupancyCheck(x, y, z, clearance) then
+			if tally then
+				tally.occupied = tally.occupied + 1
+			end
+			return false
+		end
+
+		return true, y
+	end
+
+	---@param tally table
+	---@return string
+	function ground.Explain(tally)
+		if tally == nil or tally.tried == 0 then
+			return "nowhere was tried"
+		end
+		return string.format(
+			"%d tried: %d off the map, %d wrong surface, %d too steep, %d too close to something",
+			tally.tried,
+			tally.offMap,
+			tally.wrongSurface,
+			tally.steep,
+			tally.occupied
+		)
+	end
+
+	return ground
+end
+
+return Ground

--- a/modules/placement/spring/ground.lua
+++ b/modules/placement/spring/ground.lua
@@ -1,0 +1,95 @@
+local Ground = {}
+
+---@param deps { positionChecks: table }
+---@return table
+function Ground.New(deps)
+	local checks = deps.positionChecks
+	assert(type(checks) == "table", "placement ground needs positionChecks")
+
+	local ground = {}
+
+	--- Counts rather than the first reason: "312 too steep, 4 occupied" is a cliff; "0 too steep, 316 occupied" is a crowded base.
+	---@return table
+	function ground.NewTally()
+		return { offMap = 0, steep = 0, occupied = 0, wrongSurface = 0, tried = 0 }
+	end
+
+	---@param x number
+	---@param z number
+	---@param want { footprint: number, surface: string|nil, flatness: number|nil, clearance: number|nil }
+	---@param tally table|nil
+	---@return boolean ok, number|nil y
+	function ground.Usable(x, z, want, tally)
+		if tally then
+			tally.tried = tally.tried + 1
+		end
+		local footprint = want.footprint or 64
+		local y = Spring.GetGroundHeight(x, z)
+
+		if not checks.MapEdgeCheck(x, y, z, footprint) then
+			if tally then
+				tally.offMap = tally.offMap + 1
+			end
+			return false
+		end
+
+		-- "solid" is land or sea but not the shoreline between them: something
+		-- spawning across that line has half its output in the water
+		local surface = want.surface or "land"
+		if surface ~= "any" then
+			local found = checks.LandOrSeaCheck(x, y, z, footprint)
+			local ok
+			if surface == "solid" then
+				ok = found == "land" or found == "sea"
+			else
+				ok = found == surface
+			end
+			if not ok then
+				if tally then
+					tally.wrongSurface = tally.wrongSurface + 1
+				end
+				return false
+			end
+		end
+
+		-- flatness over the footprint, not a larger margin: asking for a parade
+		-- ground is how a search fails on maps with somewhere perfectly good to stand
+		local flatness = want.flatness
+		if flatness ~= nil and not checks.FlatAreaCheck(x, y, z, footprint, flatness, true) then
+			if tally then
+				tally.steep = tally.steep + 1
+			end
+			return false
+		end
+
+		local clearance = want.clearance or footprint
+		if clearance > 0 and not checks.OccupancyCheck(x, y, z, clearance) then
+			if tally then
+				tally.occupied = tally.occupied + 1
+			end
+			return false
+		end
+
+		return true, y
+	end
+
+	---@param tally table
+	---@return string
+	function ground.Explain(tally)
+		if tally == nil or tally.tried == 0 then
+			return "nowhere was tried"
+		end
+		return string.format(
+			"%d tried: %d off the map, %d wrong surface, %d too steep, %d too close to something",
+			tally.tried,
+			tally.offMap,
+			tally.wrongSurface,
+			tally.steep,
+			tally.occupied
+		)
+	end
+
+	return ground
+end
+
+return Ground


### PR DESCRIPTION
Three systems put units on the map and each decided "is this ground usable" separately. The wave director had a careful cascade, the mission roster had no check at all, and the mission move action teleported blind.

One place to ask now:

```lua
local x, y, z, why = Placement.NearestValid(wantX, wantZ, {
    radius = 400, footprint = 64, surface = "land",
})
```

The search walks an integer lattice outward in rings, no RNG and no trig, so the same request gives the same answer on every client and in a replay. It returns the nearest valid spot rather than an arbitrary legal one.

It wraps `damgam_lib/position_checks.lua` instead of reimplementing it, reports which check refused, and returns the ground height so callers don't have to look it up. One surface mode is new: `solid` means land or sea but not the shoreline between, which a burrow can't straddle.

`position_checks` reads the world when it loads, so it's pulled in on first use — loading it eagerly took every consumer's specs down.

No consumers in this commit. waves (#8576) and missions wire it in theirs, where the call is visible in context.

---
**Stack 3 of 3 — the PvE modules and the mission that uses them** (#8632 → #8494), based on #8522, the top of stack 2 (#8490 → #8522); stack 1 is the machinery (#8484 → #8689).
