### PR TITLE
Fix area reclaim replacing the queue when inserting with space

### DIFF
--- a/luaui/Widgets/unit_smart_area_reclaim.lua
+++ b/luaui/Widgets/unit_smart_area_reclaim.lua
@@ -48,7 +48,9 @@ local sort = table.sort
 
 local RECLAIM = CMD.RECLAIM
 local MOVE = CMD.MOVE
+local INSERT = CMD.INSERT
 local OPT_SHIFT = CMD.OPT_SHIFT
+local OPT_ALT = CMD.OPT_ALT
 
 local abs = math.abs
 local sqrt = math.sqrt
@@ -167,20 +169,28 @@ local function stationary(rList)
 end
 
 
-local function issue(rList, shift)
+local function issue(rList, shift, meta)
 	local opts = {}
+	local insertPos = {}
 
 	for i=1, #rList do
 		local item = rList[i]
 		local uid, fid = item[3], item[4]
 
-		local opt = {}
-		if opts[uid] ~= nil or shift then
-			opt = OPT_SHIFT
-		end
+		if meta then
+			-- insert at the front of the queue, keeping the order computed above
+			local pos = insertPos[uid] or 0
+			GiveOrderToUnit(uid, INSERT, {pos, RECLAIM, 0, fid+maxUnits}, OPT_ALT)
+			insertPos[uid] = pos + 1
+		else
+			local opt = {}
+			if opts[uid] ~= nil or shift then
+				opt = OPT_SHIFT
+			end
 
-		GiveOrderToUnit(uid, RECLAIM, {fid+maxUnits}, opt)
-		opts[uid] = 1
+			GiveOrderToUnit(uid, RECLAIM, {fid+maxUnits}, opt)
+			opts[uid] = 1
+		end
 	end
 end
 
@@ -259,13 +269,17 @@ function widget:CommandNotify(id, params, options)
 			end
 
 			local ux, _, uz = GetUnitPosition(uid)
-			if options.shift then
+			if options.shift or options.meta then
 				local cmds = storeReclaimOrders(uid)
-				for ci=#cmds, 1, -1 do
-					local cmd = cmds[ci]
-					if cmd.id == MOVE then
-						ux, uz = cmd.params[1], cmd.params[3]
-						break
+				-- appended orders start where the queue ends; inserted ones run
+				-- first, so those keep the unit's current position
+				if options.shift and not options.meta then
+					for ci=#cmds, 1, -1 do
+						local cmd = cmds[ci]
+						if cmd.id == MOVE then
+							ux, uz = cmd.params[1], cmd.params[3]
+							break
+						end
 					end
 				end
 			end
@@ -325,12 +339,12 @@ function widget:CommandNotify(id, params, options)
 					local dx, dz = ux-fx, uz-fz
 					local item = {dx, dz, uid, fid}
 					if mobiles[uid] ~= nil then
-						if not options.shift or checkNoDuplicateOrder(uid, fid) then
+						if not (options.shift or options.meta) or checkNoDuplicateOrder(uid, fid) then
 							mListCount = mListCount + 1
 							mList[mListCount] = item
 						end
 					elseif stationaries[uid] ~= nil then
-						if sqrt((dx*dx)+(dz*dz)) <= stationaries[uid] and (not options.shift or checkNoDuplicateOrder(uid, fid)) then
+						if sqrt((dx*dx)+(dz*dz)) <= stationaries[uid] and (not (options.shift or options.meta) or checkNoDuplicateOrder(uid, fid)) then
 							sListCount = sListCount + 1
 							sList[sListCount] = item
 						end
@@ -346,13 +360,13 @@ function widget:CommandNotify(id, params, options)
 		local issued = false
 		if mobileb then
 			mList = tsp(mList)
-			issue(mList, options.shift)
+			issue(mList, options.shift, options.meta)
 			issued = true
 		end
 
 		if stationaryb then
 			sList = stationary(sList)
-			issue(sList, options.shift)
+			issue(sList, options.shift, options.meta)
 			issued = true
 		end
 


### PR DESCRIPTION
### Current problem:
Area-reclaim dragged from a feature with space held (queue insert) wipes the constructor's existing queue instead of inserting into it.
<img width="900" height="538" alt="this" src="https://github.com/user-attachments/assets/39eb0c21-3da2-4eba-94a2-40470ffe39cc" />

Recording:
https://github.com/user-attachments/assets/a8fe2c32-ed06-4d73-89a6-c1c658daed9e

The widget claims the command in CommandNotify (layer 0) and issues its own per-feature orders, so cmd_commandinsert.lua (layer 5) never sees it and it only read options.shift, so the first order per unit went out without OPT_SHIFT, which replaces the queue.

### Changes made:
- `issue()` uses `CMD.INSERT` when meta is held, with a per-unit running index so the travel order computed by `tsp()` is preserved.
- Travel distance is measured from the unit's current position when inserting, since inserted orders run first; appending still measures from the end of the queue.
- Duplicate-order suppression now also applies when inserting, because the existing queue survives.

Behaviour with no modifier, and with shift alone, is unchanged. 
This follows the convention already used by `cmd_area_commands_filter.lua` and `cmd_commandinsert.lua`.

Not covered here: Enemy units (including Ruins) aren't features. Their reclaiming is handled by `unit_area_reclaim_enemy.lua` instead and still replaces the queue. Untouched here.

### Test steps:
- [x] Give a constructor a queue of orders, hold space, drag an area reclaim starting on a tree or a metal wreck. Expected: the existing queue is kept and the reclaim orders are inserted at the front. Before this PR the queue is cleared.
- [x] Same with shift+space held. Expected: also inserted at the front.
- [x] Drag with no modifier held. Expected: unchanged, queue is replaced.
- [x] Drag with shift only. Expected: unchanged, orders appended to the end.
- [x] Space-drag twice over the same field. Expected: no duplicate reclaim orders.
- [x] Nano turret (stationary builder). Expected: only features within build range are queued/reclaimed.
- [x] Trees vs metal wrecks. Expected: metal/energy filtering unchanged.

### After fix:
Area-reclaim dragged from a feature with space held (queue insert) properly inserts the reclaim queue into the existing queue.
<img width="900" height="472" alt="this2" src="https://github.com/user-attachments/assets/fc7b534b-e01a-4c27-855a-29a832814ea7" />

Recording:
https://github.com/user-attachments/assets/c993c97a-4f34-44f7-9d9a-99d8b94c86ab

AI / LLM usage statement:
Used Claude Opus 5 for diagnosis and draft. Reviewed and thoroughly tested by me.
