### PR TITLE
Fix the Ferret's stealth tag and the Gelasma's heap wreck

### DIFF
--- a/units/ArmBuildings/LandDefenceOffence/armferret.lua
+++ b/units/ArmBuildings/LandDefenceOffence/armferret.lua
@@ -28,7 +28,7 @@ return {
 		seismicsignature = 0,
 		selfdestructas = "mediumBuildingExplosionGenericSelfd",
 		sightdistance = 375,
-		stealthy = true,
+		stealth = true,
 		yardmap = "ooooooooo",
 		customparams = {
 			buildinggrounddecaldecayspeed = 30,

--- a/units/Legion/SeaDefenses/legfmg.lua
+++ b/units/Legion/SeaDefenses/legfmg.lua
@@ -51,6 +51,20 @@ return {
 				object = "Units/legfmg_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				collisionvolumescales = "35.0 4.0 6.0",
+				collisionvolumetype = "cylY",
+				damage = 3900,
+				footprintx = 2,
+				footprintz = 2,
+				height = 4,
+				metal = 112,
+				object = "Units/cor2X2A.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {


### PR DESCRIPTION
Two def bugs found while writing the invariant checks in #8630, both of which change behaviour, so they want a balance eye rather than a rubber stamp.

The Ferret has been writing stealthy where the engine tag is stealth. Nothing in the repo reads stealthy and 137 defs use stealth, so the July "Ferret: Stealth added" change note never took effect - in a live game the unit has no Stealthy line on its card and enemy radar picks it up normally. Renaming the tag is what makes that note true, which means the Ferret gains stealth for the first time here.

The Gelasma's wreck says featuredead = "HEAP" but the unit never defined a heap. featuredefs_post only rewrites that reference into legfmg_heap when the sibling exists, so the bare string escaped into the global namespace and matched the one top-level feature called heap, in features/xmascomwreck.lua - a fixed 500 metal, 2x2 debris pile that no scaling ever touches. Killing the wreck in game paid 500 against a wreck worth 270, inverting the reclaim gradient. With a heap of its own it comes out at 112, since alldefs_post scales wrecks to 60 percent of unit cost and heaps to 25.

The heap block is modelled on legctl, its nearest neighbour with a correct chain. The one judgement call is the debris model: I used cor2X2A, which is what Legion 2x2 heaps use elsewhere, but an artist should say if a different one suits a sea structure better.

Eight more defs have the same dangling heap reference - the naval defence turrets and both advanced shipyards - and they are listed in #8630 rather than fixed here, because each wants its own decision about whether to add a heap or drop the reference.

AI disclosure: written with assistance from Claude Code.
