### PR TITLE
Fix eight wreck chains that fall through to the global heap

### DIFF
--- a/units/ArmBuildings/SeaDefence/armanavaldefturret.lua
+++ b/units/ArmBuildings/SeaDefence/armanavaldefturret.lua
@@ -52,6 +52,18 @@ return {
 				object = "Units/armanavaldefturret_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 6200,
+				footprintx = 5,
+				footprintz = 5,
+				height = 4,
+				metal = 437,
+				object = "Units/arm5X5B.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/ArmBuildings/SeaDefence/armnavaldefturret.lua
+++ b/units/ArmBuildings/SeaDefence/armnavaldefturret.lua
@@ -49,6 +49,18 @@ return {
 				object = "Units/armnavaldefturret_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 5190,
+				footprintx = 5,
+				footprintz = 5,
+				height = 4,
+				metal = 187,
+				object = "Units/arm5X5B.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/ArmBuildings/SeaFactories/armhasy.lua
+++ b/units/ArmBuildings/SeaFactories/armhasy.lua
@@ -64,6 +64,18 @@ return {
 				object = "Units/armhasy_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 16000,
+				footprintx = 15,
+				footprintz = 15,
+				height = 4,
+				metal = 1250,
+				object = "Units/arm7X7A.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sounds = {
 			canceldestruct = "cancel2",

--- a/units/CorBuildings/SeaDefence/coranavaldefturret.lua
+++ b/units/CorBuildings/SeaDefence/coranavaldefturret.lua
@@ -52,6 +52,18 @@ return {
 				object = "Units/coranavaldefturret_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 8000,
+				footprintx = 5,
+				footprintz = 5,
+				height = 4,
+				metal = 500,
+				object = "Units/cor5X5C.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/CorBuildings/SeaDefence/cornavaldefturret.lua
+++ b/units/CorBuildings/SeaDefence/cornavaldefturret.lua
@@ -49,6 +49,18 @@ return {
 				object = "Units/cornavaldefturret_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 5800,
+				footprintx = 5,
+				footprintz = 5,
+				height = 4,
+				metal = 175,
+				object = "Units/cor5X5C.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/CorBuildings/SeaFactories/corhasy.lua
+++ b/units/CorBuildings/SeaFactories/corhasy.lua
@@ -64,6 +64,18 @@ return {
 				object = "Units/corhasy_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 17800,
+				footprintx = 9,
+				footprintz = 9,
+				height = 4,
+				metal = 1250,
+				object = "Units/cor7X7A.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/Legion/SeaDefenses/T2/leganavaldefturret.lua
+++ b/units/Legion/SeaDefenses/T2/leganavaldefturret.lua
@@ -51,6 +51,18 @@ return {
 				object = "Units/leganavaldefturret_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 6300,
+				footprintx = 5,
+				footprintz = 5,
+				height = 4,
+				metal = 312,
+				object = "Units/cor5X5C.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {

--- a/units/Legion/SeaDefenses/legnavaldefturret.lua
+++ b/units/Legion/SeaDefenses/legnavaldefturret.lua
@@ -49,6 +49,18 @@ return {
 				object = "Units/legnavaldefturret_dead.s3o",
 				reclaimable = true,
 			},
+			heap = {
+				blocking = false,
+				category = "heaps",
+				damage = 5190,
+				footprintx = 5,
+				footprintz = 5,
+				height = 4,
+				metal = 150,
+				object = "Units/cor5X5C.s3o",
+				reclaimable = true,
+				resurrectable = 0,
+			},
 		},
 		sfxtypes = {
 			explosiongenerators = {


### PR DESCRIPTION
Eight sea structures name a heap in their wreck that they never define, so the reference is left unqualified and lands on the one global feature called heap, in features/xmascomwreck.lua. That is a fixed 500 metal 2x2 pile which no scaling touches, so the second stage of these wreck chains has been paying the wrong amount and dropping the wrong debris. Follows on from #8654, which fixed the ninth, and the checks that found them are in #8630.

Nothing errors when this happens, which is why it has sat: featuredefs_post only rewrites "HEAP" into unitname_heap when the sibling exists, and silently leaves the bare string when it does not.

The cheap ones overpay and the expensive ones underpay. The naval def turrets were handing back 500 against 150 to 187 due, while both Experimental Shipyards paid 500 where 1250 was due - a 15x15 building leaving a 2x2 pile worth less than a third of what its own rubble should be. Giving each a heap of its own puts them back under the normaliser in alldefs_post, so the values now come from unit cost and keep following the wreck ratio modoption instead of being frozen.

The metal and damage in each block are placeholders that the normaliser overwrites; I checked the loaded defs afterwards and all eight come out at exactly 25 percent of cost with damage equal to unit health. Footprints match each unit's existing wreck. The debris models are the judgement call - I used the faction-matched model closest to the wreck footprint, and an artist should say if a different one suits a sea structure better.

AI disclosure: written with assistance from Claude Code.
