### PR TITLE
Blank the hidden Metal Fortifier's dangling corpse reference

### DIFF
--- a/units/Legion/Economy/legmohoconin.lua
+++ b/units/Legion/Economy/legmohoconin.lua
@@ -12,7 +12,7 @@ return {						--costs should be same as legmohocon and legmohoconct
 		collisionvolumeoffsets = "0 -1 0",
 		collisionvolumescales = "7 4 7",
 		collisionvolumetype = "CylY",
-		corpse = "DEAD",
+		corpse = "",
 		energyupkeep = 20,
 		explodeas = "",
 		extractsmetal = 0.004,


### PR DESCRIPTION
legmohoconin sets corpse = "DEAD" while defining no featuredefs, so the name resolves to nothing and killing it leaves no wreck - it turned up in the checks in #8630. Blanking it matches the explodeas and selfdestructas two lines above and makes that intent explicit rather than accidental.

AI disclosure: written with assistance from Claude Code.
