### PR TITLE
Tf brush improvements 9hotfix

### DIFF
--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -5459,6 +5459,11 @@
 							<input type="text" id="ts-slider-splatInfluence-numbox" class="tf-slider-numbox" readonly value="1" />
 						</div>
 						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="text-base text-light" style="flex: 0 0 96dp;">Protect cliffs</div>
+							<input type="range" id="ts-slider-cliffProtect" class="tf-slider" min="0" max="1" step="1" value="1" data-event-change="onTilesetKnob('cliffProtect')" />
+							<input type="text" id="ts-slider-cliffProtect-numbox" class="tf-slider-numbox" readonly value="1" />
+						</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
 							<div class="text-base text-light" style="flex: 0 0 96dp;">Punch talus</div>
 							<input type="range" id="ts-slider-splatPunchTalus" class="tf-slider" min="0" max="1.5" step="0.0075" value="0.55" data-event-change="onTilesetKnob('splatPunchTalus')" />
 							<input type="text" id="ts-slider-splatPunchTalus-numbox" class="tf-slider-numbox" readonly value="0.55" />

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -5420,6 +5420,16 @@
 								<input type="text" id="ts-slider-talusPatch-numbox" class="tf-slider-numbox" readonly value="0.9" />
 							</div>
 							<div class="flex flex-row gap-1 items-center mb-1">
+								<div class="text-base text-light" style="flex: 0 0 96dp;">Talus start</div>
+								<input type="range" id="ts-slider-talusStartDeg" class="tf-slider" min="5" max="45" step="0.1" value="23.1" data-event-change="onTilesetKnob('talusStartDeg')" />
+								<input type="text" id="ts-slider-talusStartDeg-numbox" class="tf-slider-numbox" readonly value="23.1" />
+							</div>
+							<div class="flex flex-row gap-1 items-center mb-1">
+								<div class="text-base text-light" style="flex: 0 0 96dp;">Talus full</div>
+								<input type="range" id="ts-slider-talusFullDeg" class="tf-slider" min="10" max="60" step="0.1" value="45.6" data-event-change="onTilesetKnob('talusFullDeg')" />
+								<input type="text" id="ts-slider-talusFullDeg-numbox" class="tf-slider-numbox" readonly value="45.6" />
+							</div>
+							<div class="flex flex-row gap-1 items-center mb-1">
 								<div class="text-base text-light" style="flex: 0 0 96dp;">Plateau height</div>
 								<input type="range" id="ts-slider-platHeight" class="tf-slider" min="0" max="1" step="0.005" value="0.60" data-event-change="onTilesetKnob('platHeight')" />
 								<input type="text" id="ts-slider-platHeight-numbox" class="tf-slider-numbox" readonly value="0.60" />

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -15,7 +15,7 @@
 					<span class="tf-title-accent">BRUSH</span>
 					<!-- Version tracks the tf-brush-improvements-N branch this shipped from:
 					     branch N is version 1.N. -->
-					<span class="tf-title-version">1.8</span>
+					<span class="tf-title-version">1.9</span>
 				</div>
 				<div class="tf-header-top-btns">
 					<div id="btn-passthrough" class="tf-header-btn tf-passthrough-btn" data-class-active="passthroughActive" data-event-mousedown="onGuideTogglePassthrough()">

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
@@ -22,6 +22,7 @@ local KNOBS = {
 	{ "cliffStartDeg", "%.1f" }, { "chunkyCliff", "%d" }, { "foothillsSpanDeg", "%.1f" }, { "footFloor", "%.2f" },
 	{ "platHeight", "%.2f" }, { "platBlend", "%.2f" }, { "cliffBlend", "%.2f" },
 	{ "gravelHeight", "%.2f" }, { "gravelBlend", "%.2f" }, { "talusPatch", "%.2f" },
+	{ "talusStartDeg", "%.1f" }, { "talusFullDeg", "%.1f" },
 	{ "splatInfluence", "%.2f" },
 	{ "splatPunchTalus", "%.2f" }, { "splatPunchCliff", "%.2f" }, { "splatPunchPlat", "%.2f" },
 	{ "antiTileWarp", "%.0f" }, { "parallaxAmp", "%.2f" },

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
@@ -23,7 +23,7 @@ local KNOBS = {
 	{ "platHeight", "%.2f" }, { "platBlend", "%.2f" }, { "cliffBlend", "%.2f" },
 	{ "gravelHeight", "%.2f" }, { "gravelBlend", "%.2f" }, { "talusPatch", "%.2f" },
 	{ "talusStartDeg", "%.1f" }, { "talusFullDeg", "%.1f" },
-	{ "splatInfluence", "%.2f" },
+	{ "splatInfluence", "%.2f" }, { "cliffProtect", "%d" },
 	{ "splatPunchTalus", "%.2f" }, { "splatPunchCliff", "%.2f" }, { "splatPunchPlat", "%.2f" },
 	{ "antiTileWarp", "%.0f" }, { "parallaxAmp", "%.2f" },
 	{ "macroVar", "%.2f" }, { "macroLod", "%.1f" }, { "albedoSortMode", "%d" },


### PR DESCRIPTION
# Terraform Brush 1.9 hotfix: version badge + two tileset knobs

Small follow-up to #8642. That PR shipped the 1.9 feature set but was published just before the version-badge commit, so the header still says 1.8; this carries the badge plus two tileset knobs added since.

- **Header version badge 1.9** (the badge tracks the branch stream: `tf-brush-improvements-N` ships as 1.N).
- **Talus slope-angle band sliders**: where the talus band sits on the slope, by start and full angle, instead of a fixed range in the shader.
- **Cliff splat protection switch**: exempts cliff walls from hand-painted splat influence, next to the splat sliders it guards against.

As with the rest of the TILESET panel, both knobs only drive `WG.TilesetTerrain` when the dev shader widget is present, and no-op without it.

## AI/LLM usage statement

Written and implemented with Claude Code under my direction; I reviewed the diff.
