### PR TITLE
Name the Experimental Gantry and Bot Lab wrecks so the normaliser finds them

### DIFF
--- a/unitbasedefs/techsplit_defs.lua
+++ b/unitbasedefs/techsplit_defs.lua
@@ -845,10 +845,10 @@ local function techsplitTweaks(name, uDef)
         uDef.yardmap = "ooooooooooooooo ooooooooooooooo ooooooooooooooo ooooooooooooooo ooooooooooooooo ooooooooooooooo ooooooooooooooo eeeeeeeeeeeeeee eeeeeeeeeeeeeee eeeeeeeeeeeeeee eeeeeeeeeeeeeee eeeeeeeeeeeeeee eeeeeeeeeeeeeee eeeeeeeeeeeeeee eeeeeeeeeeeeeee"
         uDef.objectname = "Units/ARMSHLTXBIG.s3o"
         uDef.script = "Units/techsplit/ARMSHLTXBIG.cob"
-        uDef.featuredefs.armshlt_dead.object = "Units/armshltxbig_dead.s3o"
-        uDef.featuredefs.armshlt_dead.footprintx = 11
-        uDef.featuredefs.armshlt_dead.footprintz = 11
-        uDef.featuredefs.armshlt_dead.collisionvolumescales = "155 95 180"
+        uDef.featuredefs.dead.object = "Units/armshltxbig_dead.s3o"
+        uDef.featuredefs.dead.footprintx = 11
+        uDef.featuredefs.dead.footprintz = 11
+        uDef.featuredefs.dead.collisionvolumescales = "155 95 180"
         uDef.customparams.buildinggrounddecalsizex = 18
         uDef.customparams.buildinggrounddecalsizez = 18
     end 

--- a/units/ArmBuildings/LandFactories/armhalab.lua
+++ b/units/ArmBuildings/LandFactories/armhalab.lua
@@ -8,7 +8,7 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",
-		corpse = "ARMSHLT_DEAD",
+		corpse = "DEAD",
 		energycost = 58000,
 		energystorage = 1400,
 		explodeas = "hugeBuildingexplosiongeneric",
@@ -54,14 +54,14 @@ return {
 			usebuildinggrounddecal = true,
 		},
 		featuredefs = {
-			armshlt_dead = {
+			dead = {
 				blocking = true,
 				category = "corpses",
 				collisionvolumeoffsets = "0 0 0",
 				collisionvolumescales = "125 75 145",
 				collisionvolumetype = "Box",
 				damage = 8640,
-				featuredead = "ARMSHLT_HEAP",
+				featuredead = "HEAP",
 				footprintx = 9,
 				footprintz = 9,
 				height = 20,
@@ -69,7 +69,7 @@ return {
 				object = "Units/armshltx_dead.s3o",
 				reclaimable = true,
 			},
-			armshlt_heap = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				damage = 4320,

--- a/units/ArmBuildings/LandFactories/armshltx.lua
+++ b/units/ArmBuildings/LandFactories/armshltx.lua
@@ -8,7 +8,7 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",
-		corpse = "ARMSHLT_DEAD",
+		corpse = "DEAD",
 		energycost = 58000,
 		energystorage = 1400,
 		explodeas = "hugeBuildingexplosiongeneric",
@@ -50,14 +50,14 @@ return {
 			usebuildinggrounddecal = true,
 		},
 		featuredefs = {
-			armshlt_dead = {
+			dead = {
 				blocking = true,
 				category = "corpses",
 				collisionvolumeoffsets = "0 0 0",
 				collisionvolumescales = "125 75 145",
 				collisionvolumetype = "Box",
 				damage = 8640,
-				featuredead = "ARMSHLT_HEAP",
+				featuredead = "HEAP",
 				footprintx = 9,
 				footprintz = 9,
 				height = 20,
@@ -65,7 +65,7 @@ return {
 				object = "Units/armshltx_dead.s3o",
 				reclaimable = true,
 			},
-			armshlt_heap = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				damage = 4320,

--- a/units/ArmBuildings/SeaFactories/armshltxuw.lua
+++ b/units/ArmBuildings/SeaFactories/armshltxuw.lua
@@ -8,7 +8,7 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "180 120 166",
 		collisionvolumetype = "Box",
-		corpse = "ARMSHLT_DEAD",
+		corpse = "DEAD",
 		energycost = 58000,
 		energystorage = 1400,
 		explodeas = "hugeBuildingexplosiongeneric-uw",
@@ -48,14 +48,14 @@ return {
 			usebuildinggrounddecal = true,
 		},
 		featuredefs = {
-			armshlt_dead = {
+			dead = {
 				blocking = true,
 				category = "corpses",
 				collisionvolumeoffsets = "0 0 0",
 				collisionvolumescales = "125 75 145",
 				collisionvolumetype = "Box",
 				damage = 8640,
-				featuredead = "ARMSHLT_HEAP",
+				featuredead = "HEAP",
 				footprintx = 9,
 				footprintz = 9,
 				height = 20,
@@ -63,7 +63,7 @@ return {
 				object = "Units/armshltx_dead.s3o",
 				reclaimable = true,
 			},
-			armshlt_heap = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				damage = 4320,


### PR DESCRIPTION
The two Experimental Gantries and the Experimental Bot Lab call their wreck and rubble armshlt_dead and armshlt_heap, so the normaliser in alldefs_post never touches them - it looks for blocks named dead and heap. Renaming them puts all three back under it. Found by the checks in #8630, and Damgam confirmed the naming is the rule.

The Bot Lab is the one that matters: its wreck was worth 4807 metal against a build cost of 4800, so killing your own building refunded essentially all of it, where 60 percent is intended. It now pays 2880. The two gantries land within 3 percent of where they already were, since 7900 happened to suit the copied numbers.

Wreck and rubble hitpoints go from 8640 and 4320 to 16000 on all three, which is unit health, and is what every other wreck in the game already does - these were outside the pass that sets it. That is the part worth a balance eye, though the blast radius is small: nothing builds these three in a normal game, the Bot Lab and its Butler build only each other, and the only way in is the hidden techsplit modoption.

I left the metal and damage numbers in the files alone rather than rewriting them to match. None of the 54 Armada building defs I checked carry values that match what the normaliser computes - armanni writes 1940 where the pass sets 2100 - so writing them here would be the odd one out. techsplit_defs.lua reaches into the old block by name, so it changes with them.

AI disclosure: written with assistance from Claude Code.
