### PR TITLE
Name the Tumbleweed's wreck so the normaliser finds it

### DIFF
--- a/units/ArmBots/T2/armvader.lua
+++ b/units/ArmBots/T2/armvader.lua
@@ -7,7 +7,7 @@ return {
 		collisionvolumeoffsets = "0 2 0",
 		collisionvolumescales = "17 13 17",
 		collisionvolumetype = "box",
-		corpse = "CORPSE",
+		corpse = "DEAD",
 		energycost = 5800,
 		explodeas = "crawl_blastsml",
 		firestate = 0,
@@ -42,7 +42,7 @@ return {
 			unitgroup = "explo",
 		},
 		featuredefs = {
-			corpse = {
+			dead = {
 				blocking = true,
 				category = "corpses",
 				damage = 300,


### PR DESCRIPTION
The Tumbleweed's wreck block is named corpse rather than dead, so the normaliser in alldefs_post skips it - it only rescales blocks named dead and heap. Its heap is named correctly and does get scaled, so the unit has been half normalised: wreck metal 49 against the 39 its cost calls for, and wreck hitpoints 300 where every other wreck in the game carries unit health, which here is 445.

Same shape as #8659, found by the checks in #8630. This one is a live T2 unit rather than techsplit-only content, so the hitpoint change is worth a glance even though the metal barely moves.

AI disclosure: written with assistance from Claude Code.
