### PR TITLE
Name the perimeter camera rubble so the normaliser finds it

### DIFF
--- a/units/ArmBuildings/LandUtil/armeyes.lua
+++ b/units/ArmBuildings/LandUtil/armeyes.lua
@@ -9,7 +9,7 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "20 32 20",
 		collisionvolumetype = "CylY",
-		corpse = "DRAGONSEYES_DEAD",
+		corpse = "HEAP",
 		energycost = 850,
 		energyupkeep = 3,
 		footprintx = 1,
@@ -40,7 +40,7 @@ return {
 			unitgroup = "util",
 		},
 		featuredefs = {
-			dragonseyes_dead = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				collisionvolumeoffsets = "-0.0323944091797 0.0 0.00588226318359",

--- a/units/CorBuildings/LandUtil/coreyes.lua
+++ b/units/CorBuildings/LandUtil/coreyes.lua
@@ -9,7 +9,7 @@ return {
 		collisionvolumeoffsets = "0 0 0",
 		collisionvolumescales = "20 24 20",
 		collisionvolumetype = "CylY",
-		corpse = "CDRAGONSEYES_DEAD",
+		corpse = "HEAP",
 		energycost = 850,
 		energyupkeep = 5,
 		footprintx = 1,
@@ -40,7 +40,7 @@ return {
 			unitgroup = "util",
 		},
 		featuredefs = {
-			cdragonseyes_dead = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				collisionvolumeoffsets = "-0.0323944091797 0.0 0.00588226318359",

--- a/units/Legion/Other/legvision.lua
+++ b/units/Legion/Other/legvision.lua
@@ -14,7 +14,7 @@ return {
 		collisionvolumetype = "CylY",
 		cloakcost = 0.001,
 		cloakcostmoving = 0,
-		corpse = "CDRAGONSEYES_DEAD",
+		corpse = "HEAP",
 		energyupkeep = 0,
 		footprintx = 1,
 		footprintz = 1,
@@ -40,7 +40,7 @@ return {
 			subfolder = "CorBuildings/LandUtil",
 		},
 		featuredefs = {
-			cdragonseyes_dead = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				collisionvolumeoffsets = "-0.0323944091797 0.0 0.00588226318359",

--- a/units/Legion/Utilities/legeyes.lua
+++ b/units/Legion/Utilities/legeyes.lua
@@ -13,7 +13,7 @@ return {
 		collisionvolumescales = "20 24 20",
 		collisionvolumetype = "CylY",
 		cloakcost = 10,
-		corpse = "CDRAGONSEYES_DEAD",
+		corpse = "HEAP",
 		energyupkeep = 5,
 		footprintx = 1,
 		footprintz = 1,
@@ -40,7 +40,7 @@ return {
 			subfolder = "Legion/utilities",
 		},
 		featuredefs = {
-			cdragonseyes_dead = {
+			heap = {
 				blocking = false,
 				category = "heaps",
 				collisionvolumeoffsets = "-0.0323944091797 0.0 0.00588226318359",


### PR DESCRIPTION
The Beholder, Argus and Vision call their rubble dragonseyes_dead or cdragonseyes_dead, so the normaliser in alldefs_post skips it - it only rescales blocks named dead and heap. The blocks are already heaps in everything but name: category "heaps", blocking false, resurrectable 0. Same shape as #8659 and #8660, found by the checks in #8630.

I left the numbers in the files alone, so the effective values are now whatever the pass computes: the three cameras go from 12 metal and 120 hitpoints to 8 and 280, which is 25 percent of cost and unit health. The Vision is the odd one - it costs 1 metal and was dropping a 12 metal heap, and now drops nothing.

AI disclosure: written with assistance from Claude Code.
