### PR TITLE
Fix JSON decoding of \uXXXX and escaped forward slashes

### DIFF
--- a/common/luaUtilities/json.lua
+++ b/common/luaUtilities/json.lua
@@ -18,6 +18,7 @@
 --   compat-5.1 if using Lua 5.0
 --
 -- CHANGELOG
+--   0.9.50.2 BAR change: fix issues decoding unicode and backslash in loadstring
 --   0.9.50.1 BAR changes by Beherith: fix issue when decoding empty arrays.
 --	 0.9.50 Radical performance improvement on decode from Eike Decker. Many thanks!
 --	 0.9.40 Changed licence to MIT License (MIT)
@@ -112,6 +113,71 @@ local function encode (v)
   base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
 end
 
+
+-- A code point as the Lua decimal escapes for its UTF-8 bytes, so the result survives
+-- being handed to loadstring below. Always three digits, or a digit following in the
+-- string would be swallowed into the escape.
+local function utf8Escapes(code)
+	local bytes
+	if code < 0x80 then
+		bytes = { code }
+	elseif code < 0x800 then
+		bytes = { 0xC0 + math.floor(code / 0x40), 0x80 + code % 0x40 }
+	elseif code < 0x10000 then
+		bytes = { 0xE0 + math.floor(code / 0x1000), 0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40 }
+	else
+		bytes = { 0xF0 + math.floor(code / 0x40000), 0x80 + math.floor(code / 0x1000) % 0x40,
+			0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40 }
+	end
+
+	for i = 1, #bytes do
+		bytes[i] = string.format("\\%03d", bytes[i])
+	end
+
+	return table.concat(bytes)
+end
+
+-- Strings are unescaped by handing the literal to loadstring, which accepts every JSON
+-- escape except \uXXXX and \/ - Lua 5.1 rejects both outright, taking the whole decode
+-- down with them. Rewrite only those two into forms it does accept.
+local function rewriteJsonOnlyEscapes(literal)
+	local out = {}
+	local pos = 1
+	local len = #literal
+
+	while pos <= len do
+		local char = literal:sub(pos, pos)
+		if char ~= "\\" then
+			out[#out + 1] = char
+			pos = pos + 1
+		else
+			local following = literal:sub(pos + 1, pos + 1)
+			if following == "/" then
+				out[#out + 1] = "/"
+				pos = pos + 2
+			elseif following == "u" then
+				local code = tonumber(literal:sub(pos + 2, pos + 5), 16)
+				pos = pos + 6
+				-- Anything above the BMP arrives as a surrogate pair.
+				if code and code >= 0xD800 and code <= 0xDBFF and literal:sub(pos, pos + 1) == "\\u" then
+					local low = tonumber(literal:sub(pos + 2, pos + 5), 16)
+					if low and low >= 0xDC00 and low <= 0xDFFF then
+						code = 0x10000 + (code - 0xD800) * 0x400 + (low - 0xDC00)
+						pos = pos + 6
+					end
+				end
+				out[#out + 1] = code and utf8Escapes(code) or ""
+			else
+				-- Kept as-is, which also steps past an escaped backslash so the character
+				-- after it is not mistaken for an escape of its own.
+				out[#out + 1] = char .. following
+				pos = pos + 2
+			end
+		end
+	end
+
+	return table.concat(out)
+end
 
 --- Decodes a JSON string and returns the decoded value as a Lua data structure / value.
 -- @param s The string to scan.
@@ -381,17 +447,30 @@ do
 		-- read a string, double and single quoted ones
 		local function read_string (tok)
 			local start = pos
+			local rewrite = false
 			--local returnString = {}
 			repeat
 				local t = next_token(tok)
 				if t == c_esc then 
+					-- pos sits on the escaped character. u and / are the two JSON escapes Lua
+					-- has no equivalent for, and the interpreters disagree on them: 5.1 quietly
+					-- drops the backslash while LuaJIT refuses to compile at all. Neither can be
+					-- left to loadstring, so flag them here rather than reacting to a failure.
+					local e = js_string:byte(pos)
+					if e == 117 or e == 47 then
+						rewrite = true
+					end
 					--table.insert(returnString, js_string:sub(start, pos-2))
 					--table.insert(returnString, escapechar[ js_string:byte(pos) ])
 					pos = pos + 1
 					--start = pos
 				end -- jump over escaped chars, no matter what
 			until t == true
-			return (base.loadstring("return " .. js_string:sub(start-1, pos-1) ) ())
+			local literal = js_string:sub(start-1, pos-1)
+			if rewrite then
+				literal = rewriteJsonOnlyEscapes(literal)
+			end
+			return (base.loadstring("return " .. literal) ())
 
 			-- We consider the situation where no escaped chars were encountered separately,
 			-- and use the fastest possible return in this case.

--- a/common/luaUtilities/json.lua
+++ b/common/luaUtilities/json.lua
@@ -156,7 +156,16 @@ local function rewriteJsonOnlyEscapes(literal)
 				out[#out + 1] = "/"
 				pos = pos + 2
 			elseif following == "u" then
-				local code = tonumber(literal:sub(pos + 2, pos + 5), 16)
+				-- Four hex digits are the only legal form. Without this check a short or
+				-- non-hex escape either loses characters silently or shifts the rest of the
+				-- literal out of step, and the failure then surfaces as a loadstring error
+				-- that says nothing about where it came from.
+				local hex = literal:sub(pos + 2, pos + 5)
+				if not hex:match("^%x%x%x%x$") then
+					error("Invalid \\u escape in JSON string: " .. literal:sub(pos, pos + 5))
+				end
+
+				local code = tonumber(hex, 16)
 				pos = pos + 6
 				-- Anything above the BMP arrives as a surrogate pair.
 				if code and code >= 0xD800 and code <= 0xDBFF and literal:sub(pos, pos + 1) == "\\u" then
@@ -166,7 +175,13 @@ local function rewriteJsonOnlyEscapes(literal)
 						pos = pos + 6
 					end
 				end
-				out[#out + 1] = code and utf8Escapes(code) or ""
+				-- A surrogate half that never found its partner is not a code point at all.
+				-- Encoding it anyway yields bytes no UTF-8 reader accepts, which spreads the
+				-- damage into whatever handles the string later, so drop it and leave the rest
+				-- of the string well formed.
+				if code < 0xD800 or code > 0xDFFF then
+					out[#out + 1] = utf8Escapes(code)
+				end
 			else
 				-- Kept as-is, which also steps past an escaped backslash so the character
 				-- after it is not mistaken for an escape of its own.

--- a/spec/common/json_spec.lua
+++ b/spec/common/json_spec.lua
@@ -55,6 +55,57 @@ describe("json string escapes", function()
 		end)
 	end)
 
+	describe("a code point that decodes to a character Lua source cares about", function()
+		-- These are the ones that could break the loadstring approach: a quote or backslash
+		-- arriving inside the literal would end or re-escape it. They survive because the
+		-- rewrite emits three-digit decimal escapes rather than the characters themselves.
+		it("keeps quotes, backslashes and control characters intact", function()
+			assert.are.equal(string.char(34), value([[{"a":"\u0022"}]]))
+			assert.are.equal(string.char(92), value([[{"a":"\u005C"}]]))
+			assert.are.equal(string.char(10), value([[{"a":"\u000A"}]]))
+			assert.are.equal(string.char(0), value([[{"a":"\u0000"}]]))
+			assert.are.equal("x" .. string.char(34) .. "y", value([[{"a":"x\u0022y"}]]))
+		end)
+
+		it("does not let a decoded backslash start an escape of its own", function()
+			assert.are.equal("x" .. string.char(92) .. "u0041", value([[{"a":"x\u005Cu0041"}]]))
+		end)
+	end)
+
+	describe("a surrogate with no partner", function()
+		-- Half a pair is not a code point. Encoding it produces bytes no UTF-8 reader accepts,
+		-- and that travels on into fonts and text layout, so it is dropped instead. The pair it
+		-- was meant to be half of still decodes normally.
+		it("is dropped rather than encoded", function()
+			assert.are.equal("", value([[{"a":"\ud83d"}]]))
+			assert.are.equal("", value([[{"a":"\udc00"}]]))
+			assert.are.equal("xy", value([[{"a":"x\ud83dy"}]]))
+			assert.are.equal("A", value([[{"a":"\ud83dA"}]]))
+		end)
+
+		it("still decodes a complete pair", function()
+			assert.are.equal("\240\159\152\128", value([[{"a":"\ud83d\ude00"}]]))
+		end)
+	end)
+
+	describe("a malformed code point escape", function()
+		-- Four hex digits is the only legal form. Anything shorter or non-hex either loses
+		-- characters or pushes the rest of the literal out of step, so it has to be caught
+		-- where it is parsed rather than surfacing as a loadstring failure later.
+		it("is rejected rather than silently dropped", function()
+			assert.has_error(function() Json.decode([[{"a":"\u47"}]]) end)
+			assert.has_error(function() Json.decode([[{"a":"\uZZZZ"}]]) end)
+			assert.has_error(function() Json.decode([[{"a":"\u"}]]) end)
+			assert.has_error(function() Json.decode([[{"a":"x\u47y"}]]) end)
+		end)
+
+		it("names the escape it choked on", function()
+			local ok, err = pcall(Json.decode, [[{"a":"\uZZZZ"}]])
+			assert.is_false(ok)
+			assert.is_truthy(tostring(err):find("\uZZZZ", 1, true))
+		end)
+	end)
+
 	describe("a shipped file that carries these escapes", function()
 		it("decodes interface.json with the escaped characters intact", function()
 			local path = "language/en/interface.json"

--- a/spec/common/json_spec.lua
+++ b/spec/common/json_spec.lua
@@ -1,0 +1,73 @@
+-- Escape handling in common/luaUtilities/json.lua.
+--
+-- Strings are unescaped by handing the literal to loadstring, so any escape Lua 5.1
+-- rejects used to fail the whole decode rather than the one string. Long strings below
+-- keep backslashes literal, so the JSON really does carry escapes.
+
+local Json = VFS.Include("common/luaUtilities/json.lua")
+
+local function value(text)
+	return Json.decode(text).a
+end
+
+describe("json string escapes", function()
+	describe("escapes Lua rejects", function()
+		it("decodes \\uXXXX below 0x80", function()
+			assert.are.equal("x&y", value([[{"a":"x\u0026y"}]]))
+			assert.are.equal("it's", value([[{"a":"it\u0027s"}]]))
+			assert.are.equal("<tag>", value([[{"a":"\u003ctag\u003e"}]]))
+		end)
+
+		it("decodes an escaped forward slash", function()
+			assert.are.equal("a/b", value([[{"a":"a\/b"}]]))
+		end)
+	end)
+
+	describe("multi-byte code points", function()
+		it("encodes two- and three-byte code points as UTF-8", function()
+			assert.are.equal("\195\169", value([[{"a":"\u00e9"}]]))
+			assert.are.equal("\226\130\172", value([[{"a":"\u20ac"}]]))
+		end)
+
+		it("combines a surrogate pair into one 4-byte code point", function()
+			assert.are.equal("\240\159\152\128", value([[{"a":"\ud83d\ude00"}]]))
+		end)
+
+		it("does not swallow a digit that follows the escape", function()
+			assert.are.equal("\195\1691", value([[{"a":"\u00e91"}]]))
+		end)
+	end)
+
+	describe("escapes that already worked", function()
+		it("keeps handling the ones Lua shares with JSON", function()
+			assert.are.equal("line\nbreak", value([[{"a":"line\nbreak"}]]))
+			assert.are.equal("tab\there", value([[{"a":"tab\there"}]]))
+			assert.are.equal('quote"inside', value([[{"a":"quote\"inside"}]]))
+			assert.are.equal("back\\slash", value([[{"a":"back\\slash"}]]))
+		end)
+	end)
+
+	describe("an escaped backslash", function()
+		it("does not let the next character start an escape", function()
+			-- the characters a \ u 0 0 4 1 b, not an escaped code point
+			assert.are.equal("a\\u0041b", value([[{"a":"a\\u0041b"}]]))
+			assert.are.equal("a\\/b", value([[{"a":"a\\/b"}]]))
+		end)
+	end)
+
+	describe("a shipped file that carries these escapes", function()
+		it("decodes interface.json with the escaped characters intact", function()
+			local path = "language/en/interface.json"
+			local f = assert(io.open(path, "r"), "cannot open " .. path)
+			local body = f:read("*a")
+			f:close()
+
+			local decoded = Json.decode(body)
+			assert.is_table(decoded, path .. " failed to decode")
+			-- Asserting the value, not just that it parsed: an interpreter that treats an
+			-- unknown escape as the bare character decodes happily but corrupts the string.
+			assert.are.equal(true,
+				decoded.cmd.set.AutoAddBuiltUnitsToFactoryGroup:find("factory's", 1, true) ~= nil)
+		end)
+	end)
+end)


### PR DESCRIPTION
`json.lua` mishandles the two JSON escapes Lua has no equivalent for, `\uXXXX` and `\/`, and how it goes wrong depends on which interpreter you are on.

It unescapes by handing the string literal to `loadstring`, which works because Lua accepts most JSON escapes as-is. For these two it does not: LuaJIT refuses to compile and the whole document fails with "attempt to call a nil value" from inside the parser, while PUC Lua 5.1 quietly drops the backslash and hands back a corrupted string. So in-game you get a hard failure and under busted you get silently wrong data. The first push of this branch relied on `loadstring` failing to detect the case, and CI caught that it does not - the spec here is the one that caught it.

~~Nothing in the game trips over this today: the configs read through this module are escape-free, and `interface.json` (which has 21 of them) is loaded by the engine's own I18N rather than here. It is waiting for the first translator to put a smart quote somewhere we parse.~~

This is subtly erroring today although PUCLua silently eats the error and continues onwards and its in a code path that almost no one has noticed since the unicode characters made their way into the descriptions a couple weeks ago now:
<img width="2204" height="207" alt="image" src="https://github.com/user-attachments/assets/7861afa1-cdc6-4b61-b039-8fbcceecb44d" />
As opposed to this PR's version:
<img width="2133" height="200" alt="image" src="https://github.com/user-attachments/assets/b7eb6cf2-a29d-4158-afd1-0d638d0ab953" />

It is not quite free, since the two escapes are now detected during the scan that was already running rather than after the fact. Measured against master, a decode of a 108K escape-free config costs about 0.3ms more, and a synthetic document where every string carries an escape about 0.7ms; small configs are unchanged. These are load-time decodes, not per-frame.

AI disclosure: written with assistance from Claude Code.
