### PR TITLE
Fix: Prevent double removal of pregame queue commands

### DIFF
--- a/luaui/Widgets/cmd_commandq_manager.lua
+++ b/luaui/Widgets/cmd_commandq_manager.lua
@@ -14,8 +14,8 @@ end
 
 -- Handlers
 function widget:Initialize()
-	widgetHandler:AddAction("command_skip_current", SkipCurrentCommand, nil, "pt")
-	widgetHandler:AddAction("command_cancel_last", CancelLastCommand, nil, "pt")
+	widgetHandler:AddAction("command_skip_current", SkipCurrentCommand, nil, "p")
+	widgetHandler:AddAction("command_cancel_last", CancelLastCommand, nil, "p")
 end
 
 -- Locals


### PR DESCRIPTION
Revert change causing double removal of pregame queue with `command_skip_current` and `command_cancel_last` actions until proper fix is applied. 

https://discord.com/channels/549281623154229250/549281623577722899/1535114770628354058