### PR TITLE
Fix CEG browser sound preview leaking globally, add minimize highlight

### DIFF
--- a/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.lua
+++ b/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.lua
@@ -691,6 +691,7 @@ local init_model = {
     pageDisplay  = "1 / 1",
     totalCount   = "",
     isCollapsed  = true,
+    showMinimizeHint = 1,
 
     -- UI scale
     scaleLabel   = "100%",
@@ -1011,6 +1012,7 @@ local init_model = {
 
     toggleCollapse = function(ev)
         dm_handle.isCollapsed = not dm_handle.isCollapsed
+        dm_handle.showMinimizeHint = 0
         if dm_handle.isCollapsed then
             preCollapseInfoOpen   = infoOpen
             preCollapseSoundsOpen = soundsOpen
@@ -1188,13 +1190,17 @@ local init_model = {
 
     playFireSound = function(ev)
         if selectedFireSound and selectedFireSound ~= "" then
-            spSendLuaRulesMsg("ceg_preview_sound:" .. selectedFireSound)
+            local p = "sounds/" .. selectedFireSound
+            if not p:find("%.[%a%d]+$") then p = p .. ".wav" end
+            Spring.PlaySoundFile(p, 0.7, "ui")
         end
     end,
 
     playImpactSound = function(ev)
         if selectedImpactSound and selectedImpactSound ~= "" then
-            spSendLuaRulesMsg("ceg_preview_sound:" .. selectedImpactSound)
+            local p = "sounds/" .. selectedImpactSound
+            if not p:find("%.[%a%d]+$") then p = p .. ".wav" end
+            Spring.PlaySoundFile(p, 0.7, "ui")
         end
     end,
 }

--- a/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.rcss
+++ b/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.rcss
@@ -169,6 +169,17 @@ body, div, p, span, input, button {
 .winbtn.danger   { background-color: #3d0808; border-color: #552222; color: #f87171; }
 .winbtn.danger:hover { background-color: #5a1010; }
 
+/* Draws attention to the minimize button on first load so new users notice
+   it - a static glow matching gui_modtools' .mt-minimize-btn.highlight,
+   driven by a one-time hint flag that clears on first click (not tied to
+   isCollapsed, so it won't reappear on every re-collapse). */
+.winbtn.minimize.highlight {
+    background-color: #243626;
+    border-color: #22c55e;
+    color: #a8c09a;
+    box-shadow: inset 0dp 0dp 0dp 1dp #22c55ea6, 0dp 0dp 6dp #22c55e47;
+}
+
 /* ── Content area ── */
 .content {
     margin-top: 6dp;

--- a/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.rml
+++ b/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.rml
@@ -28,7 +28,7 @@
             <button class="winbtn scale-btn" data-class-disabled="scaleAtMin == 1" data-event-click="scaleDown()">-</button>
             <span class="scale-label">{{scaleLabel}}</span>
             <button class="winbtn scale-btn" data-class-disabled="scaleAtMax == 1" data-event-click="scaleUp()">+</button>
-            <button class="winbtn minimize" data-event-click="toggleCollapse()">_</button>
+            <button class="winbtn minimize" data-class-highlight="showMinimizeHint == 1" data-event-click="toggleCollapse()">_</button>
             <button class="winbtn danger"   data-event-click="closeWidget()">X</button>
         </div>
     </div>


### PR DESCRIPTION
Preview buttons were playing globally instead of just the previewing player. Now call Spring.PlaySoundFile directly from the widget so it stays local;

Also adds a one-time green highlight on the minimize button on first load, clearing after the first click.

### AI / LLM usage statement:
VStudio / Claude Code
