### PR TITLE
Fix the Cortex floating missile turret's weapon reference

### DIFF
--- a/units/CorBuildings/SeaDefence/corfrt.lua
+++ b/units/CorBuildings/SeaDefence/corfrt.lua
@@ -120,7 +120,7 @@ return {
 		weapons = {
 			[1] = {
 				badtargetcategory = "LIGHTAIRSCOUT",
-				def = "ARMRL_MISSILE",
+				def = "CORRL_MISSILE",
 				fastautoretargeting = true,
 				onlytargetcategory = "VTOL",
 			},


### PR DESCRIPTION
The Cortex floating missile turret's weapon slot still points at ARMRL_MISSILE, but #8621 renamed its weapondef block to corrl_missile, so the name it asks for isn't defined by the unit any more.

Weapon defs are scoped per unit (they come out of the engine as corfrt_armrl_missile), so I'd expect the turret to end up with no usable weapon at all rather than falling back to the Armada one. Caught by the def invariant specs in #8653, not in game.
