### PR TITLE
Fix the scavenger dragon teeth decoy target

### DIFF
--- a/units/Scavengers/Buildings/DefenseOffense/corscavdtf.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corscavdtf.lua
@@ -9,7 +9,7 @@ return {
 		canrepeat = false,
 		corpse = "DEAD",
 		damagemodifier = 0.25,
-		decoyfor = "scavdrag",
+		decoyfor = "corscavdrag",
 		energystorage = 15,
 		explodeas = "flamethrower",
 		footprintx = 2,

--- a/units/Scavengers/Buildings/DefenseOffense/corscavdtl.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corscavdtl.lua
@@ -12,7 +12,7 @@ return {
 		collisionvolumetype = "Ell",
 		corpse = "DEAD",
 		damagemodifier = 0.25,
-		decoyfor = "scavdrag",
+		decoyfor = "corscavdrag",
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 2,
 		footprintz = 2,

--- a/units/Scavengers/Buildings/DefenseOffense/corscavdtm.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corscavdtm.lua
@@ -9,7 +9,7 @@ return {
 		canrepeat = false,
 		corpse = "DEAD",
 		damagemodifier = 0.25,
-		decoyfor = "scavdrag",
+		decoyfor = "corscavdrag",
 		explodeas = "flamethrower",
 		footprintx = 2,
 		footprintz = 2,

--- a/units/Scavengers/Buildings/DefenseOffense/legdtf.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legdtf.lua
@@ -9,7 +9,7 @@ return {
 		canrepeat = false,
 		corpse = "DEAD",
 		damagemodifier = 0.33,
-		decoyfor = "scavdrag",
+		decoyfor = "corscavdrag",
 		energystorage = 15,
 		explodeas = "flamethrower",
 		footprintx = 2,

--- a/units/Scavengers/Buildings/DefenseOffense/legdtl.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legdtl.lua
@@ -12,7 +12,7 @@ return {
 		collisionvolumetype = "Ell",
 		corpse = "DEAD",
 		damagemodifier = 0.33,
-		decoyfor = "scavdrag",
+		decoyfor = "corscavdrag",
 		explodeas = "smallBuildingexplosiongeneric",
 		footprintx = 2,
 		footprintz = 2,

--- a/units/Scavengers/Buildings/DefenseOffense/legdtm.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legdtm.lua
@@ -9,7 +9,7 @@ return {
 		canrepeat = false,
 		corpse = "DEAD",
 		damagemodifier = 0.33,
-		decoyfor = "scavdrag",
+		decoyfor = "corscavdrag",
 		explodeas = "flamethrower",
 		footprintx = 2,
 		footprintz = 2,


### PR DESCRIPTION
The six scavenger dragon teeth name scavdrag as what they disguise as, but scavdrag is a model file rather than a unit, so the decoy never resolves - in game corscavdtf comes back with decoyDef nil and shows as itself. The def they mean is corscavdrag, which their own customparams already name.

Found by the def invariant checks in #8630.
