### PR TITLE
Fix the scavenger heavy laser tower emit height

### DIFF
--- a/units/Scavengers/Buildings/DefenseOffense/corhllllt.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/corhllllt.lua
@@ -9,7 +9,7 @@ return {
 		buildtime = 8800,
 		canrepeat = false,
 		cantbetransported = false,
-		collisionvolumeoffsets = "0-20 0",
+		collisionvolumeoffsets = "0 -20 0",
 		collisionvolumescales = "32 160 32",
 		collisionvolumetype = "CylY",
 		corpse = "DEAD",


### PR DESCRIPTION
corhllllt writes its volume offsets as "0-20 0" with no space. The engine copes and reads the Y offset as -20, but the sight and radar emit height pass in alldefs_post pulls the second whitespace separated token, which is "0" here, so the unit ships an emit height of 160 where the volume it is built from implies 140.

Found by the def invariant checks in #8630.
