### PR TITLE
Remove the duplicate Metal Fortifier button from scav Legion constructors

### DIFF
--- a/gamedata/scavengers/unitdef_post.lua
+++ b/gamedata/scavengers/unitdef_post.lua
@@ -370,11 +370,10 @@ local function scavUnitDef_Post(name, uDef)
 		-- Legion T2 Land Constructors
 		if name == "legaca_scav" or name == "legack_scav" or name == "legacv_scav" then
 			local numBuildoptions = #uDef.buildoptions
-			uDef.buildoptions[numBuildoptions + 1] = "legmohocon_scav" -- Advanced Metal Fortifier - Metal Extractor with Constructor Turret
-			uDef.buildoptions[numBuildoptions + 2] = "legwint2_scav" -- T2 Wind Generator
-			uDef.buildoptions[numBuildoptions + 3] = "legnanotct2_scav" -- T2 Constructor Turret
-			uDef.buildoptions[numBuildoptions + 4] = "legrwall_scav" -- Dragon's Constitution - T2 (not Pop-up) Wall Turret
-			uDef.buildoptions[numBuildoptions + 5] = "leggatet3_scav" -- Elysium - Advanced Shield Generator
+			uDef.buildoptions[numBuildoptions + 1] = "legwint2_scav" -- T2 Wind Generator
+			uDef.buildoptions[numBuildoptions + 2] = "legnanotct2_scav" -- T2 Constructor Turret
+			uDef.buildoptions[numBuildoptions + 3] = "legrwall_scav" -- Dragon's Constitution - T2 (not Pop-up) Wall Turret
+			uDef.buildoptions[numBuildoptions + 4] = "leggatet3_scav" -- Elysium - Advanced Shield Generator
 		end
 
 		-- Legion T2 Sea Constructors


### PR DESCRIPTION
legaca, legack and legacv already build legmohocon, and the scav pass renames that to legmohocon_scav on its own, so the extra append gives their scav versions two identical Advanced Metal Fortifier buttons - visible in game under Economy. The other four appends in that block are not in the parent, so they stay.

Found by the def invariant checks in #8630.
