### PR TITLE
Stop the heavy transports claiming the WEAPON category

### DIFF
--- a/units/ArmAircraft/armhvytrans.lua
+++ b/units/ArmAircraft/armhvytrans.lua
@@ -5,7 +5,7 @@ return {
 		buildtime = 8500,
 		canfly = true,
 		canmove = true,
-		category = "ALL MOBILE WEAPON NOTLAND NOTSUB VTOL NOTSHIP NOTHOVER",
+		category = "ALL MOBILE NOTLAND NOTSUB VTOL NOTSHIP NOTHOVER",
 		collide = false,
 		cruisealtitude = 100,
 		energycost = 4000,

--- a/units/CorAircraft/corhvytrans.lua
+++ b/units/CorAircraft/corhvytrans.lua
@@ -5,7 +5,7 @@ return {
 		buildtime = 8500,
 		canfly = true,
 		canmove = true,
-		category = "ALL MOBILE WEAPON NOTLAND VTOL NOTSUB NOTSHIP NOTHOVER",
+		category = "ALL MOBILE NOTLAND VTOL NOTSUB NOTSHIP NOTHOVER",
 		collide = false,
 		cruisealtitude = 100,
 		energycost = 4000,

--- a/units/Legion/Air/legatrans.lua
+++ b/units/Legion/Air/legatrans.lua
@@ -5,7 +5,7 @@ return {
 		buildtime = 8500,
 		canfly = true,
 		canmove = true,
-		category = "ALL MOBILE WEAPON NOTLAND VTOL NOTSUB NOTSHIP NOTHOVER",
+		category = "ALL MOBILE NOTLAND VTOL NOTSUB NOTSHIP NOTHOVER",
 		collide = false,
 		cruisealtitude = 100,
 		energycost = 4000,


### PR DESCRIPTION
armhvytrans, corhvytrans and legatrans write WEAPON into their category and define no weapons, so the category pass adds NOWEAPON on top and they end up carrying both. They have been like that since the day they were added. armatlas, which does not hand write the token, comes out as noweapon only, and that looks like the shape these should have.

This might change behaviour rather than just tidy the data, so it is worth a second opinion. cormandot4 splits its two weapons on this token - the stunner is onlytargetcategory WEAPON and the cannon is badtargetcategory WEAPON - and the raptor fighters use badtargetcategory WEAPON as well, so how those pick between a transport and everything else could shift. The AA turrets that use badtargetcategory NOWEAPON already match these units through the other token, so I would not expect anything there to move.

I could not find anything that looks like it was built around the current behaviour - nothing in luarules or luaui reads the weapon or noweapon categories, and there is no target priority system - but the AIs ship separately so I have not checked those.

Found by the def invariant checks in #8630.
