### PR TITLE
Keep the scavenger category off object defs

### DIFF
--- a/gamedata/scavengers/unitdef_post.lua
+++ b/gamedata/scavengers/unitdef_post.lua
@@ -1,7 +1,9 @@
 -- -- UnitDef postprocessing specific to Scavenger units only
 
 local function scavUnitDef_Post(name, uDef)
-	uDef.category = uDef.category .. ' SCAVENGER'
+	if not string.find(uDef.category, "OBJECT", 1, true) then
+		uDef.category = uDef.category .. ' SCAVENGER'
+	end
 	uDef.customparams.isscavenger = true
 	uDef.capturable = false
 	uDef.decloakonfire = true


### PR DESCRIPTION
alldefs_post skips the category pass for anything carrying OBJECT, since objects are not meant to be targetable, but the scav pass then appends SCAVENGER to every def it touches. That leaves 28 scav objects - the hats, xmas balls, dice, chips and similar - as OBJECT SCAVENGER instead of OBJECT on its own.

Nothing reads that today, no weapon filters on SCAVENGER and the scav code goes through customparams.isscavenger, so I would not expect any behaviour change. It matters the first time something does filter on it.

Raised by Boneless on #8680, and in the invariant list in #8630.
