### PR TITLE
Move the remaining defs off the superseded acceleration keys

### DIFF
--- a/unitbasedefs/skyshiftunits_post.lua
+++ b/unitbasedefs/skyshiftunits_post.lua
@@ -10,7 +10,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "armpeep" then
-		uDef.acceleration = 0.8
 		uDef.blocking = false
 		uDef.maxdec = 0.8
 		uDef.energycost = 1550
@@ -53,7 +52,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "armfig" then
-		uDef.acceleration = 0.6
 		uDef.airsightdistance = 950
 		uDef.airstrafe = false
 		uDef.blocking = false
@@ -140,7 +138,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "armthund" then
-		uDef.acceleration = 0.3
 		uDef.maxdec = 0.3
 		uDef.energycost = 2400
 		uDef.metalcost = 220
@@ -222,7 +219,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "armkam" then
-		uDef.acceleration = 0.7
 		uDef.airstrafe = false
 		uDef.blocking = false
 		uDef.energycost = 2600
@@ -319,7 +315,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "armsfig" then
-		uDef.acceleration = 0.35
 		uDef.airsightdistance = 950
 		uDef.airstrafe = false
 		uDef.blocking = false
@@ -420,7 +415,6 @@ local function skyshiftUnitTweaks(name, uDef)
 
 
 	if name == "corfink" then
-		uDef.acceleration = 0.6
 		uDef.blocking = false
 		uDef.maxdec = 0.6
 		uDef.energycost = 1450
@@ -467,7 +461,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "corveng" then
-		uDef.acceleration = 0.45
 		uDef.airsightdistance = 950
 		uDef.airstrafe = false
 		uDef.blocking = false
@@ -558,7 +551,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "corshad" then
-		uDef.acceleration = 0.045
 		uDef.blocking = false
 		uDef.maxdec = 0.045
 		uDef.energycost = 2400
@@ -637,7 +629,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "corbw" then
-		uDef.acceleration = 0.5
 		uDef.blocking = false
 		uDef.maxdec = 0.4
 		uDef.energycost = 700
@@ -730,7 +721,6 @@ local function skyshiftUnitTweaks(name, uDef)
 	end
 
 	if name == "corcut" then
-		uDef.acceleration = 1
 		uDef.airstrafe = false
 		uDef.blocking = false
 		uDef.maxdec = 0.85

--- a/units/ArmBuildings/SeaEconomy/armuwageo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwageo.lua
@@ -1,5 +1,7 @@
 return {
 	armuwageo = {
+		maxacc = 0,
+		maxdec = 0,
 		activatewhenbuilt = true,
 		buildangle = 0,
 		energycost = 27000,

--- a/units/ArmBuildings/SeaEconomy/armuwageo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwageo.lua
@@ -1,8 +1,6 @@
 return {
 	armuwageo = {
-		acceleration = 0,
 		activatewhenbuilt = true,
-		brakerate = 0,
 		buildangle = 0,
 		energycost = 27000,
 		metalcost = 1600,

--- a/units/ArmBuildings/SeaEconomy/armuwgeo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwgeo.lua
@@ -1,8 +1,6 @@
 return {
 	armuwgeo = {
-		acceleration = 0,
 		activatewhenbuilt = true,
-		brakerate = 0,
 		buildangle = 2048,
 		energycost = 13000,
 		metalcost = 560,

--- a/units/ArmBuildings/SeaEconomy/armuwgeo.lua
+++ b/units/ArmBuildings/SeaEconomy/armuwgeo.lua
@@ -1,5 +1,7 @@
 return {
 	armuwgeo = {
+		maxacc = 0,
+		maxdec = 0,
 		activatewhenbuilt = true,
 		buildangle = 2048,
 		energycost = 13000,

--- a/units/CorBuildings/SeaEconomy/coruwageo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwageo.lua
@@ -1,5 +1,7 @@
 return {
 	coruwageo = {
+		maxacc = 0,
+		maxdec = 0,
 		activatewhenbuilt = true,
 		buildangle = 0,
 		energycost = 27000,

--- a/units/CorBuildings/SeaEconomy/coruwageo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwageo.lua
@@ -1,8 +1,6 @@
 return {
 	coruwageo = {
-		acceleration = 0,
 		activatewhenbuilt = true,
-		brakerate = 0,
 		buildangle = 0,
 		energycost = 27000,
 		metalcost = 1500,

--- a/units/CorBuildings/SeaEconomy/coruwgeo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwgeo.lua
@@ -1,5 +1,7 @@
 return {
 	coruwgeo = {
+		maxacc = 0,
+		maxdec = 0,
 		activatewhenbuilt = true,
 		buildangle = 4096,
 		energycost = 13000,

--- a/units/CorBuildings/SeaEconomy/coruwgeo.lua
+++ b/units/CorBuildings/SeaEconomy/coruwgeo.lua
@@ -1,8 +1,6 @@
 return {
 	coruwgeo = {
-		acceleration = 0,
 		activatewhenbuilt = true,
-		brakerate = 0,
 		buildangle = 4096,
 		energycost = 13000,
 		metalcost = 540,

--- a/units/Legion/Air/T2 Air/legmineb.lua
+++ b/units/Legion/Air/T2 Air/legmineb.lua
@@ -1,6 +1,5 @@
 return {
 	legmineb = {
-		acceleration = 0.055,
 		blocking = false,
 		maxdec = 0.045,
 		energycost = 21000,

--- a/units/Legion/Air/T2 Air/legnap.lua
+++ b/units/Legion/Air/T2 Air/legnap.lua
@@ -1,6 +1,5 @@
 return {
 	legnap = {
-		acceleration = 0.04,
 		airsightdistance = 800,
 		blocking = false,
 		maxdec = 0.045,

--- a/units/Legion/Air/legcib.lua
+++ b/units/Legion/Air/legcib.lua
@@ -1,6 +1,5 @@
 return {
 	legcib = {
-		acceleration = 0.2,
 		blocking = false,
 		maxdec = 0.055,
 		energycost = 3500,

--- a/units/Legion/Air/legfig.lua
+++ b/units/Legion/Air/legfig.lua
@@ -1,6 +1,5 @@
 return {
 	legfig = {
-		acceleration = 0.35,
 		airsightdistance = 950,
 		blocking = false,
 		maxdec = 0.075,

--- a/units/Legion/Air/legkam.lua
+++ b/units/Legion/Air/legkam.lua
@@ -1,6 +1,5 @@
 return {
 	legkam = {
-		acceleration = 0.3,
 		blocking = false,
 		maxdec = 0.1,
 		energycost = 2000,

--- a/units/Legion/Bots/T2 Bots/legamph.lua
+++ b/units/Legion/Bots/T2 Bots/legamph.lua
@@ -1,7 +1,6 @@
 return {
 	legamph = {
 		activatewhenbuilt = true,
-		brakerate = 0.5,
 		buildpic = "LEGAMPH.DDS",
 		buildtime = 16980,
 		canmove = true,

--- a/units/Legion/SeaEconomy/T2/leganavaladvgeo.lua
+++ b/units/Legion/SeaEconomy/T2/leganavaladvgeo.lua
@@ -1,5 +1,7 @@
 return {
 	leganavaladvgeo = {
+		maxacc = 0,
+		maxdec = 0,
 		activatewhenbuilt = true,
 		buildangle = 0,
 		energycost = 27000,

--- a/units/Legion/SeaEconomy/T2/leganavaladvgeo.lua
+++ b/units/Legion/SeaEconomy/T2/leganavaladvgeo.lua
@@ -1,8 +1,6 @@
 return {
 	leganavaladvgeo = {
-		acceleration = 0,
 		activatewhenbuilt = true,
-		brakerate = 0,
 		buildangle = 0,
 		energycost = 27000,
 		metalcost = 1500,

--- a/units/Legion/SeaEconomy/leguwgeo.lua
+++ b/units/Legion/SeaEconomy/leguwgeo.lua
@@ -1,8 +1,6 @@
 return {
 	leguwgeo = {
-		acceleration = 0,
 		activatewhenbuilt = true,
-		brakerate = 0,
 		buildangle = 4096,
 		energycost = 13000,
 		metalcost = 540,

--- a/units/Legion/SeaEconomy/leguwgeo.lua
+++ b/units/Legion/SeaEconomy/leguwgeo.lua
@@ -1,5 +1,7 @@
 return {
 	leguwgeo = {
+		maxacc = 0,
+		maxdec = 0,
 		activatewhenbuilt = true,
 		buildangle = 4096,
 		energycost = 13000,

--- a/units/Legion/T3/legerailtank.lua
+++ b/units/Legion/T3/legerailtank.lua
@@ -1,7 +1,7 @@
 return {
 	legerailtank = {
-		acceleration = 0.035,
-		brakerate = 0.055,
+		maxacc = 0.035,
+		maxdec = 0.055,
 		energycost = 165000,
 		metalcost = 6500,
 		buildpic = "LEGERAILTANK.DDS",

--- a/units/Legion/T3/legkeres.lua
+++ b/units/Legion/T3/legkeres.lua
@@ -1,7 +1,7 @@
 return {
 	legkeres = {
-		acceleration = 0.02,
-		brakerate = 0.04,
+		maxacc = 0.02,
+		maxdec = 0.04,
 		energycost = 57000,
 		metalcost = 2600,
 		buildpic = "LEGKERES.DDS",

--- a/units/Scavengers/Air/armlichet4.lua
+++ b/units/Scavengers/Air/armlichet4.lua
@@ -1,6 +1,5 @@
 return {
 	armlichet4 = {
-		acceleration = 0.15,
 		blocking = false,
 		maxdec = 0.05,
 		energycost = 240000,

--- a/units/Scavengers/Air/armthundt4.lua
+++ b/units/Scavengers/Air/armthundt4.lua
@@ -1,6 +1,5 @@
 return {
 	armthundt4 = {
-		acceleration = 0.020,
 		maxdec = 0.010,
 		energycost = 150000,
 		metalcost = 15000,

--- a/units/Scavengers/Air/cords.lua
+++ b/units/Scavengers/Air/cords.lua
@@ -1,6 +1,5 @@
 return {
 	cords = {
-		acceleration = 0.05,
 		blocking = false,
 		maxdec = 0.055,
 		energycost = 14600,

--- a/units/Scavengers/Buildings/DefenseOffense/legministarfall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legministarfall.lua
@@ -1,7 +1,5 @@
 return {
 	legministarfall = {
-		acceleration = 0,
-		brakerate = 0,
 		buildangle = 29096,
 		energycost = 60000,
 		metalcost = 2000,

--- a/units/Scavengers/Buildings/DefenseOffense/legministarfall.lua
+++ b/units/Scavengers/Buildings/DefenseOffense/legministarfall.lua
@@ -1,5 +1,7 @@
 return {
 	legministarfall = {
+		maxacc = 0,
+		maxdec = 0,
 		buildangle = 29096,
 		energycost = 60000,
 		metalcost = 2000,

--- a/units/Scavengers/Vehicles/legapollyon.lua
+++ b/units/Scavengers/Vehicles/legapollyon.lua
@@ -1,7 +1,7 @@
 return {
 	legapollyon = {
-		acceleration = 0.02,
-		brakerate = 0.04,
+		maxacc = 0.02,
+		maxdec = 0.04,
 		energycost = 300000,
 		metalcost = 15000,
 		buildpic = "LEGAPOLLYON.DDS",

--- a/units/other/armsat.lua
+++ b/units/other/armsat.lua
@@ -1,6 +1,5 @@
 return {
 	armsat = {
-		acceleration = 0.05,
 		airhoverfactor = 0.4,
 		blocking = false,
 		maxdec = 0.01,

--- a/units/other/corsat.lua
+++ b/units/other/corsat.lua
@@ -1,6 +1,5 @@
 return {
 	corsat = {
-		acceleration = 0.05,
 		airhoverfactor = 0.4,
 		blocking = false,
 		maxdec = 0.01,

--- a/units/other/raptors/Acid/raptor_air_bomber_acid_t2_v1.lua
+++ b/units/other/raptors/Acid/raptor_air_bomber_acid_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_acid_t2_v1 = {
-		acceleration = 1,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Bomber/raptor_air_bomber_basic_t1_v1.lua
+++ b/units/other/raptors/Bomber/raptor_air_bomber_basic_t1_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_basic_t1_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Bomber/raptor_air_bomber_basic_t2_v1.lua
+++ b/units/other/raptors/Bomber/raptor_air_bomber_basic_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_basic_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Bomber/raptor_air_bomber_basic_t2_v2.lua
+++ b/units/other/raptors/Bomber/raptor_air_bomber_basic_t2_v2.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_basic_t2_v2 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Bomber/raptor_air_bomber_basic_t4_v1.lua
+++ b/units/other/raptors/Bomber/raptor_air_bomber_basic_t4_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_basic_t4_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Bomber/raptor_air_bomber_basic_t4_v2.lua
+++ b/units/other/raptors/Bomber/raptor_air_bomber_basic_t4_v2.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_basic_t4_v2 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Brood/raptor_air_bomber_brood_t4_v2.lua
+++ b/units/other/raptors/Brood/raptor_air_bomber_brood_t4_v2.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_brood_t4_v2 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Brood/raptor_air_bomber_brood_t4_v3.lua
+++ b/units/other/raptors/Brood/raptor_air_bomber_brood_t4_v3.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_brood_t4_v3 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Brood/raptor_air_bomber_brood_t4_v4.lua
+++ b/units/other/raptors/Brood/raptor_air_bomber_brood_t4_v4.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_brood_t4_v4 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Electric/raptor_air_bomber_emp_t2_v1.lua
+++ b/units/other/raptors/Electric/raptor_air_bomber_emp_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_bomber_emp_t2_v1 = {
-		acceleration = 1,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Fighter/raptor_air_fighter_basic_t1_v1.lua
+++ b/units/other/raptors/Fighter/raptor_air_fighter_basic_t1_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_fighter_basic_t1_v1 = {
-		acceleration = 2,
 		airsightdistance = 600,
 		amphibious = true,
 		bankscale = "1",

--- a/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v1.lua
+++ b/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_fighter_basic_t2_v1 = {
-		acceleration = 2,
 		airsightdistance = 600,
 		amphibious = true,
 		bankscale = "1",

--- a/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v2.lua
+++ b/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v2.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_fighter_basic_t2_v2 = {
-		acceleration = 2,
 		airsightdistance = 600,
 		amphibious = true,
 		bankscale = "1",

--- a/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v3.lua
+++ b/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v3.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_fighter_basic_t2_v3 = {
-		acceleration = 2,
 		airsightdistance = 600,
 		amphibious = true,
 		bankscale = "1",

--- a/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v4.lua
+++ b/units/other/raptors/Fighter/raptor_air_fighter_basic_t2_v4.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_fighter_basic_t2_v4 = {
-		acceleration = 2,
 		airsightdistance = 600,
 		amphibious = true,
 		bankscale = "1",

--- a/units/other/raptors/Fighter/raptor_air_fighter_basic_t4_v1.lua
+++ b/units/other/raptors/Fighter/raptor_air_fighter_basic_t4_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_fighter_basic_t4_v1 = {
-		acceleration = 2,
 		airsightdistance = 1500,
 		amphibious = true,
 		autoheal = 10,

--- a/units/other/raptors/Kamikaze/raptor_air_kamikaze_basic_t2_v1.lua
+++ b/units/other/raptors/Kamikaze/raptor_air_kamikaze_basic_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_kamikaze_basic_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/Scout/raptor_air_scout_basic_t2_v1.lua
+++ b/units/other/raptors/Scout/raptor_air_scout_basic_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_scout_basic_t2_v1 = {
-		acceleration = 2,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.4,

--- a/units/other/raptors/Scout/raptor_air_scout_basic_t3_v1.lua
+++ b/units/other/raptors/Scout/raptor_air_scout_basic_t3_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_scout_basic_t3_v1 = {
-		acceleration = 2,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.4,

--- a/units/other/raptors/Scout/raptor_air_scout_basic_t4_v1.lua
+++ b/units/other/raptors/Scout/raptor_air_scout_basic_t4_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_scout_basic_t4_v1 = {
-		acceleration = 2,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.4,

--- a/units/other/raptors/raptor_air_gunship_acid_t2_v1.lua
+++ b/units/other/raptors/raptor_air_gunship_acid_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_gunship_acid_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/raptor_air_gunship_antiair_t2_v1.lua
+++ b/units/other/raptors/raptor_air_gunship_antiair_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_gunship_antiair_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/raptor_air_gunship_basic_t2_v1.lua
+++ b/units/other/raptors/raptor_air_gunship_basic_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_gunship_basic_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/raptor_air_gunship_emp_t2_v1.lua
+++ b/units/other/raptors/raptor_air_gunship_emp_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_gunship_emp_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,

--- a/units/other/raptors/raptor_air_gunship_fire_t2_v1.lua
+++ b/units/other/raptors/raptor_air_gunship_fire_t2_v1.lua
@@ -1,6 +1,5 @@
 return {
 	raptor_air_gunship_fire_t2_v1 = {
-		acceleration = 0.8,
 		airhoverfactor = 0,
 		attackrunlength = 32,
 		maxdec = 0.1,


### PR DESCRIPTION
Follows #8683, same family of keys. The reason to move is the engine changelog for 105-2314: acceleration and brakeRate are scheduled to change from elmo/frame to elmo/s at some point, while maxAcc and maxDec stay elmo/frame. Defs left on the old spelling get their numbers reinterpreted 30x when that lands, and nothing would fail loudly when it happens.

46 unit defs still write acceleration or brakerate. Three of them - legapollyon, legerailtank and legkeres - only have the old spelling, so they get renamed. That one is not cosmetic today either: unitdefs_post gives a unit with maxacc above zero the mobile selection scale of 1.22 and everything else 1.15, so their click boxes have been about 6 percent smaller than every comparable unit, and they miss the max speed modoption which scales maxacc and maxdec.

The rest already carry maxacc or maxdec, so the old line is dead - the engine takes the modern key, which I checked on units where the old value is higher (legfig 0.35 against 0.2) and lower (legkam 0.3 against 0.6). Reading the file gives you a number the game never uses, so those lines go. The seven immobile ones - the underwater geos and legministarfall - are written as maxacc = 0 and maxdec = 0 rather than dropped, since acceleration defaults to 0.5 and deleting the line would have handed them that default.

Also picks up the skyshift tweaks, per sprunk's note. That file sets both spellings on ten aircraft with values that have drifted apart - armkam writes acceleration 0.7 and maxacc 0.065, corcut writes 1 and 0.065 - so the old lines have been doing nothing there for about two years. Removing them keeps today's behaviour rather than reviving numbers nobody has followed up on.

Verified by exporting the defs with and without this branch, and separately with skyshift enabled since that file only runs under the modoption. The skyshift pair is identical across all 1900 defs. The main pair differs on 16 defs, all of them the renamed units and the five from #8683, only in their categories and selection volume.

26 of the deletions are raptor air units. Raptor defs only load with their modoption on, so the checks do not cover them and that part is by inspection - each has maxacc alongside the acceleration line being removed.

Found by the def invariant checks in #8630.
