### PR TITLE
Fix and Refactor Firestate handling

### DIFF
--- a/luarules/gadgets/unit_defend_firestate.lua
+++ b/luarules/gadgets/unit_defend_firestate.lua
@@ -48,11 +48,11 @@ local metaData = {}
 local gameFrame = 0
 
 local spGetUnitDefID = Spring.GetUnitDefID
-local spGetUnitRulesParam = Spring.GetUnitRulesParam
 local spGetUnitIsCloaked = Spring.GetUnitIsCloaked
 local spGetAllUnits = Spring.GetAllUnits
 local spGetUnitHealth = Spring.GetUnitHealth
 local spGetUnitSeparation = Spring.GetUnitSeparation
+local getUnitUserFirestate
 
 local function addWeaponWatches(weaponDefIDs)
 	for index = 1, #weaponDefIDs do
@@ -133,8 +133,8 @@ local function checkDefendUnitHealth(attackerID, meta)
 	meta[HP_CHECK_FRAME] = gameFrame + HP_CHECK_INTERVAL_FRAMES
 end
 
-local function updateDefendWatchFromRulesParam(unitID)
-	local state = spGetUnitRulesParam(unitID, CustomFirestateDefs.RULES_PARAM)
+local function updateDefendWatchFromFirestate(unitID)
+	local state = getUnitUserFirestate and getUnitUserFirestate(unitID)
 	setDefendWatch(unitID, state == CustomFirestateDefs.DEFEND)
 end
 
@@ -148,7 +148,7 @@ end
 
 function gadget:UnitCommand(unitID, unitDefID, unitTeamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua)
 	if cmdID == CMD_FIRE_STATE then
-		updateDefendWatchFromRulesParam(unitID)
+		updateDefendWatchFromFirestate(unitID)
 	end
 end
 
@@ -157,7 +157,7 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam)
 end
 
 function gadget:UnitFinished(unitID, unitDefID, unitTeam)
-	updateDefendWatchFromRulesParam(unitID)
+	updateDefendWatchFromFirestate(unitID)
 end
 
 function gadget:UnitCloaked(unitID, unitDefID, unitTeam)
@@ -236,12 +236,12 @@ end
 
 function gadget:Initialize()
 	defThreatRanges, watchedWeaponsByUnitDef, neverHesitateAttackers, alwaysHarmlessUnitDefs = WeaponThreat.buildDefendData()
-
+	getUnitUserFirestate = GG.getUnitUserFirestate
 	for _, unitID in ipairs(spGetAllUnits()) do
 		local unitDefID = spGetUnitDefID(unitID)
 		local meta = createUnitMeta(unitDefID)
 		metaData[unitID] = meta
-		updateDefendWatchFromRulesParam(unitID)
+		updateDefendWatchFromFirestate(unitID)
 		if spGetUnitIsCloaked(unitID) then
 			meta[CLOAKED] = true
 		end

--- a/luarules/gadgets/unit_firestate_handler.lua
+++ b/luarules/gadgets/unit_firestate_handler.lua
@@ -1,7 +1,5 @@
---DEFEND FIRESTATE REWORK: Remove guard; handler is always required
-if not Spring.GetModOptions().experimental_defend_firestate then
-	return
-end
+-- Firestate visibility/control bridge is always required (ally/godmode filtering).
+-- Defend combat stance behavior stays behind experimental_defend_firestate.
 
 local gadget = gadget ---@type Gadget
 
@@ -12,43 +10,59 @@ function gadget:GetInfo()
 		author = "SethDGamre",
 		date = "2026.06.28",
 		license = "GNU GPL, v2 or later",
-		layer = 0,
+		layer = -1,
 		enabled = true
 	}
 end
 
-if not gadgetHandler:IsSyncedCode() then
-	return false
-end
+local CustomFirestateDefs = VFS.Include("modules/custom_firestate_defs.lua")
+local UNKNOWN = CustomFirestateDefs.UNKNOWN
+
+if gadgetHandler:IsSyncedCode() then
 
 local CMD_FIRE_STATE = CMD.FIRE_STATE
 local CMD_USER_FIRESTATE = GameCMD.USER_FIRESTATE
-local CustomFirestateDefs = VFS.Include("modules/custom_firestate_defs.lua")
-local INLOS = { inlos = true }
 
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitStates = Spring.GetUnitStates
-local spGetUnitRulesParam = Spring.GetUnitRulesParam
-local spSetUnitRulesParam = Spring.SetUnitRulesParam
+local spGetAllUnits = Spring.GetAllUnits
+local spGetUnitTeam = Spring.GetUnitTeam
+local SendToUnsynced = SendToUnsynced
 local settingEngineFirestate = false
+local userFirestateByUnitID = {}
+local needsDump = true
 
-local function setUserFirestate(unitID, state)
+local function sendFirestateUpdate(unitID, state, unitTeam)
+	SendToUnsynced("firestateUpdate", unitID, state, unitTeam)
+end
+
+local function getUnitUserFirestate(unitID)
+	return userFirestateByUnitID[unitID]
+end
+
+local function storeUserFirestate(unitID, state, unitTeam)
+	userFirestateByUnitID[unitID] = state
+	sendFirestateUpdate(unitID, state, unitTeam or spGetUnitTeam(unitID))
+end
+
+local function setUnitUserFirestate(unitID, state)
 	local engineFirestate = CustomFirestateDefs.toEngineFirestate(state)
-	if not engineFirestate then
-		return
+	if engineFirestate == nil then
+		return false
 	end
-	spSetUnitRulesParam(unitID, CustomFirestateDefs.RULES_PARAM, state, INLOS)
+	storeUserFirestate(unitID, state, spGetUnitTeam(unitID))
 	settingEngineFirestate = true
 	spGiveOrderToUnit(unitID, CMD_FIRE_STATE, engineFirestate, 0)
 	settingEngineFirestate = false
+	return true
 end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, playerID, fromSynced, fromLua, fromInsert)
 	if cmdID == CMD_USER_FIRESTATE then
 		local state = cmdParams[1]
 		if CustomFirestateDefs.toEngineFirestate(state) ~= nil then
-			setUserFirestate(unitID, state)
+			setUnitUserFirestate(unitID, state)
 		end
 		return false
 	end
@@ -59,7 +73,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 
 	if cmdID == CMD_FIRE_STATE then
 		local state = CustomFirestateDefs.fromEngineFirestate(cmdParams[1])
-		spSetUnitRulesParam(unitID, CustomFirestateDefs.RULES_PARAM, state, INLOS)
+		storeUserFirestate(unitID, state, teamID)
 	end
 	return true
 end
@@ -68,17 +82,175 @@ function gadget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
 	local state
 	local builderDefID = builderID and spGetUnitDefID(builderID)
 	if builderDefID and UnitDefs[builderDefID].isFactory then
-		state = spGetUnitRulesParam(builderID, CustomFirestateDefs.RULES_PARAM)
+		state = getUnitUserFirestate(builderID)
 			or CustomFirestateDefs.fromEngineFirestate(spGetUnitStates(builderID, false))
 	end
 	if state == nil then
 		state = CustomFirestateDefs.fromEngineFirestate(spGetUnitStates(unitID, false))
 	end
-	spSetUnitRulesParam(unitID, CustomFirestateDefs.RULES_PARAM, state, INLOS)
+	storeUserFirestate(unitID, state, unitTeam)
+end
+
+function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
+	local state = getUnitUserFirestate(unitID)
+	if state == nil then
+		state = CustomFirestateDefs.fromEngineFirestate(spGetUnitStates(unitID, false))
+		userFirestateByUnitID[unitID] = state
+	end
+	sendFirestateUpdate(unitID, state, newTeam)
+end
+
+function gadget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
+	local state = getUnitUserFirestate(unitID)
+	if state == nil then
+		state = CustomFirestateDefs.fromEngineFirestate(spGetUnitStates(unitID, false))
+		userFirestateByUnitID[unitID] = state
+	end
+	sendFirestateUpdate(unitID, state, newTeam)
+end
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
+	userFirestateByUnitID[unitID] = nil
+	sendFirestateUpdate(unitID, UNKNOWN, unitTeam)
+end
+
+local function dumpAllFirestates()
+	local allUnits = spGetAllUnits()
+	for index = 1, #allUnits do
+		local unitID = allUnits[index]
+		local state = getUnitUserFirestate(unitID)
+		if state == nil then
+			state = CustomFirestateDefs.fromEngineFirestate(spGetUnitStates(unitID, false))
+			userFirestateByUnitID[unitID] = state
+		end
+		sendFirestateUpdate(unitID, state, spGetUnitTeam(unitID))
+	end
+end
+
+function gadget:GameFrame(frame)
+	if needsDump then
+		needsDump = false
+		dumpAllFirestates()
+	end
 end
 
 function gadget:Initialize()
+	GG.getUnitUserFirestate = getUnitUserFirestate
+	GG.setUnitUserFirestate = setUnitUserFirestate
 	gadgetHandler:RegisterCMDID(CMD_USER_FIRESTATE)
 	gadgetHandler:RegisterAllowCommand(CMD_FIRE_STATE)
 	gadgetHandler:RegisterAllowCommand(CMD_USER_FIRESTATE)
+	dumpAllFirestates()
+end
+
+function gadget:GameStart()
+	dumpAllFirestates()
+end
+
+function gadget:Shutdown()
+	GG.getUnitUserFirestate = nil
+	GG.setUnitUserFirestate = nil
+end
+
+else
+
+local spGetMyTeamID = Spring.GetMyTeamID
+local spGetSpectatingState = Spring.GetSpectatingState
+local spIsGodModeEnabled = Spring.IsGodModeEnabled
+local spAreTeamsAllied = Spring.AreTeamsAllied
+
+local allFirestates = {}
+local lastSentToUi = {}
+local myTeamID = spGetMyTeamID()
+local isSpectating = select(1, spGetSpectatingState())
+local isGodMode = spIsGodModeEnabled()
+local luaUiReady = false
+
+local function refreshAccessState()
+	myTeamID = spGetMyTeamID()
+	isSpectating = select(1, spGetSpectatingState())
+	isGodMode = spIsGodModeEnabled()
+end
+
+local function canKnow(unitTeam)
+	if isSpectating or isGodMode then
+		return true
+	end
+	if myTeamID == nil or unitTeam == nil then
+		return false
+	end
+	return spAreTeamsAllied(unitTeam, myTeamID)
+end
+
+local function publish(unitID)
+	local entry = allFirestates[unitID]
+	if not entry then
+		return
+	end
+	local desired = entry.state
+	if not canKnow(entry.teamID) then
+		desired = UNKNOWN
+	end
+	if desired == lastSentToUi[unitID] then
+		return
+	end
+	if not Script.LuaUI('FirestateUpdate') then
+		return
+	end
+	lastSentToUi[unitID] = desired
+	Script.LuaUI.FirestateUpdate(unitID, desired)
+end
+
+local function publishAll()
+	for unitID in pairs(allFirestates) do
+		publish(unitID)
+	end
+end
+
+local function firestateUpdate(_, unitID, state, unitTeam)
+	if state == UNKNOWN then
+		allFirestates[unitID] = nil
+		if lastSentToUi[unitID] ~= UNKNOWN and Script.LuaUI('FirestateUpdate') then
+			lastSentToUi[unitID] = UNKNOWN
+			Script.LuaUI.FirestateUpdate(unitID, UNKNOWN)
+		end
+		return
+	end
+	allFirestates[unitID] = {
+		state = state,
+		teamID = unitTeam,
+	}
+	publish(unitID)
+end
+
+function gadget:PlayerChanged(playerID)
+	refreshAccessState()
+	publishAll()
+end
+
+function gadget:Update()
+	local previousGodMode = isGodMode
+	local previousSpectating = isSpectating
+	refreshAccessState()
+	if isGodMode ~= previousGodMode or isSpectating ~= previousSpectating then
+		publishAll()
+	end
+	local isReady = Script.LuaUI('FirestateUpdate') and true or false
+	if isReady and not luaUiReady then
+		luaUiReady = true
+		publishAll()
+	elseif not isReady then
+		luaUiReady = false
+	end
+end
+
+function gadget:Initialize()
+	refreshAccessState()
+	gadgetHandler:AddSyncAction("firestateUpdate", firestateUpdate)
+end
+
+function gadget:Shutdown()
+	gadgetHandler:RemoveSyncAction("firestateUpdate")
+end
+
 end

--- a/luarules/gadgets/unit_firestate_handler.lua
+++ b/luarules/gadgets/unit_firestate_handler.lua
@@ -1,6 +1,3 @@
--- Firestate visibility/control bridge is always required (ally/godmode filtering).
--- Defend combat stance behavior stays behind experimental_defend_firestate.
-
 local gadget = gadget ---@type Gadget
 
 function gadget:GetInfo()
@@ -158,6 +155,7 @@ local spGetMyTeamID = Spring.GetMyTeamID
 local spGetSpectatingState = Spring.GetSpectatingState
 local spIsGodModeEnabled = Spring.IsGodModeEnabled
 local spAreTeamsAllied = Spring.AreTeamsAllied
+local osClock = os.clock
 
 local allFirestates = {}
 local lastSentToUi = {}
@@ -165,6 +163,8 @@ local myTeamID = spGetMyTeamID()
 local isSpectating = select(1, spGetSpectatingState())
 local isGodMode = spIsGodModeEnabled()
 local luaUiReady = false
+local ACCESS_CHECK_INTERVAL = 1
+local nextAccessCheckTime = 0
 
 local function refreshAccessState()
 	myTeamID = spGetMyTeamID()
@@ -229,11 +229,16 @@ function gadget:PlayerChanged(playerID)
 end
 
 function gadget:Update()
-	local previousGodMode = isGodMode
-	local previousSpectating = isSpectating
-	refreshAccessState()
-	if isGodMode ~= previousGodMode or isSpectating ~= previousSpectating then
-		publishAll()
+	local now = osClock()
+	if now >= nextAccessCheckTime then
+		nextAccessCheckTime = now + ACCESS_CHECK_INTERVAL
+		local previousGodMode = isGodMode
+		local previousSpectating = isSpectating
+		local previousMyTeamID = myTeamID
+		refreshAccessState()
+		if isGodMode ~= previousGodMode or isSpectating ~= previousSpectating or myTeamID ~= previousMyTeamID then
+			publishAll()
+		end
 	end
 	local isReady = Script.LuaUI('FirestateUpdate') and true or false
 	if isReady and not luaUiReady then

--- a/luaui/Include/ordermenu_firestate.lua
+++ b/luaui/Include/ordermenu_firestate.lua
@@ -73,7 +73,7 @@ local labelByVirtualIndexEnabled = {
 
 local function resolveVirtualIndex(unitID)
 	local userFirestate = CustomFirestateDefs.getUnitUserFirestate(unitID)
-	if userFirestate == nil then
+	if userFirestate == nil or userFirestate == CustomFirestateDefs.UNKNOWN then
 		return nil
 	end
 	local virtualIndexByState = Spring.GetModOptions().experimental_defend_firestate and virtualIndexByStateEnabled or virtualIndexByStateDisabled

--- a/luaui/Include/user_firestate_commands.lua
+++ b/luaui/Include/user_firestate_commands.lua
@@ -8,6 +8,7 @@ How to issue a firestate change from your widget:
   2. Pick a state from CustomFirestateDefs:
        HOLD_FIRE, DEFEND, RETURN_FIRE, FIRE_AT_WILL, FIRE_AT_ALL
        DEFEND is the new mode (hold fire unless a nearby enemy threatens you).
+       Do not issue UNKNOWN (-1); that is only returned when firestate is unknown.
 
   3. Call one of these:
        WG['firestate'].setSelectionFirestate(state, Spring.GetSelectedUnits(), opts)
@@ -21,8 +22,9 @@ How to issue a firestate change from your widget:
 
 How to read a unit's current firestate:
 
-  local state = CustomFirestateDefs.getUnitUserFirestate(unitID)
-  -- returns a CustomFirestateDefs value (e.g. DEFEND), or nil if invalid
+  local state = WG['firestate'].getUnitFirestate(unitID)
+  -- or: CustomFirestateDefs.getUnitUserFirestate(unitID)
+  -- returns a CustomFirestateDefs value (e.g. DEFEND), or CustomFirestateDefs.UNKNOWN (-1)
 ]]
 
 local CustomFirestateDefs = VFS.Include("modules/custom_firestate_defs.lua")
@@ -30,7 +32,6 @@ local CustomFirestateDefs = VFS.Include("modules/custom_firestate_defs.lua")
 local CMD_FIRE_STATE = CMD.FIRE_STATE
 local CMD_USER_FIRESTATE = GameCMD.USER_FIRESTATE
 
-local spGiveOrder = Spring.GiveOrder
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
 WG['firestate'] = WG['firestate'] or {}
@@ -56,11 +57,7 @@ local function issueToUnit(unitID, userState, userInitiated)
 	if engineFirestate == nil then
 		return false
 	end
-	if Spring.GetModOptions().experimental_defend_firestate then
-		spGiveOrderToUnit(unitID, CMD_USER_FIRESTATE, CustomFirestateDefs.buildUserFirestateParams(userState, userInitiated), 0)
-	else
-		spGiveOrderToUnit(unitID, CMD_FIRE_STATE, { engineFirestate }, 0)
-	end
+	spGiveOrderToUnit(unitID, CMD_USER_FIRESTATE, CustomFirestateDefs.buildUserFirestateParams(userState, userInitiated), 0)
 	return true
 end
 
@@ -85,14 +82,8 @@ local function setSelectionFirestate(userState, unitIDs, opts)
 	local userInitiated = opts.userInitiated and true or false
 	stageFirestate(unitIDs, userState, userInitiated)
 	notifyUserInitiatedFirestate(unitIDs, userState, userInitiated)
-	if Spring.GetModOptions().experimental_defend_firestate then
-		spGiveOrder(CMD_USER_FIRESTATE, CustomFirestateDefs.buildUserFirestateParams(userState, userInitiated), 0)
-	else
-		local engineFirestate = CustomFirestateDefs.toEngineFirestate(userState)
-		if engineFirestate == nil then
-			return false
-		end
-		spGiveOrder(CMD_FIRE_STATE, { engineFirestate }, 0)
+	for index = 1, #unitIDs do
+		issueToUnit(unitIDs[index], userState, userInitiated)
 	end
 	return true
 end

--- a/luaui/Widgets/api_firestate.lua
+++ b/luaui/Widgets/api_firestate.lua
@@ -1,0 +1,87 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Firestate API",
+		desc = "Central ally-filtered firestate cache for widgets",
+		author = "SethDGamre",
+		date = "2026",
+		license = "GNU GPL, v2 or later",
+		layer = -1000, -- has to be lower than consumer widgets, arbitrary value
+		enabled = true,
+		handler = true,
+	}
+end
+
+local CustomFirestateDefs = VFS.Include("modules/custom_firestate_defs.lua")
+local UNKNOWN = CustomFirestateDefs.UNKNOWN
+
+local firestateByUnitId = {}
+local firestateChangedListeners = {}
+
+local function notifyFirestateChanged(unitID, state)
+	for index = 1, #firestateChangedListeners do
+		firestateChangedListeners[index](unitID, state)
+	end
+	local onFirestateChanged = WG['firestate'] and WG['firestate'].onFirestateChanged
+	if onFirestateChanged then
+		onFirestateChanged(unitID, state)
+	end
+end
+
+local function getUnitFirestate(unitID)
+	local state = firestateByUnitId[unitID]
+	if state == nil then
+		return UNKNOWN
+	end
+	return state
+end
+
+local function setCachedFirestate(unitID, state)
+	if firestateByUnitId[unitID] == state then
+		return
+	end
+	firestateByUnitId[unitID] = state
+	notifyFirestateChanged(unitID, state)
+end
+
+local function addFirestateChangedListener(listener)
+	if type(listener) ~= "function" then
+		return
+	end
+	firestateChangedListeners[#firestateChangedListeners + 1] = listener
+end
+
+local function removeFirestateChangedListener(listener)
+	for index = #firestateChangedListeners, 1, -1 do
+		if firestateChangedListeners[index] == listener then
+			table.remove(firestateChangedListeners, index)
+		end
+	end
+end
+
+function widget:FirestateUpdate(unitID, state)
+	setCachedFirestate(unitID, state)
+end
+
+function widget:Initialize()
+	WG['firestate'] = WG['firestate'] or {}
+	WG['firestate'].byUnitID = firestateByUnitId
+	WG['firestate'].getUnitFirestate = getUnitFirestate
+	WG['firestate'].addFirestateChangedListener = addFirestateChangedListener
+	WG['firestate'].removeFirestateChangedListener = removeFirestateChangedListener
+	VFS.Include("luaui/Include/user_firestate_commands.lua")
+end
+
+function widget:Shutdown()
+	if WG['firestate'] then
+		WG['firestate'].byUnitID = nil
+		WG['firestate'].getUnitFirestate = nil
+		WG['firestate'].addFirestateChangedListener = nil
+		WG['firestate'].removeFirestateChangedListener = nil
+	end
+end
+
+function widget:UnitDestroyed(unitID)
+	setCachedFirestate(unitID, UNKNOWN)
+end

--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -168,6 +168,13 @@ local commandTextCache = {}
 local cachedWaitState = nil
 local hasWaitCommand = false
 local cachedFirstUnit = nil  -- first selected unit, avoids spGetSelectedUnits() table alloc
+local firestateChangedListener
+
+local function onSelectedUnitFirestateChanged(unitID, state)
+	if unitID == cachedFirstUnit then
+		doUpdate = true
+	end
+end
 
 -- Cancel target button visibility tracking
 local cancelTargetPollSec = 0
@@ -636,6 +643,10 @@ function widget:Initialize()
 		end,
 	})
 	installFirestateNotifyHooks()
+	if WG['firestate'] and WG['firestate'].addFirestateChangedListener then
+		firestateChangedListener = onSelectedUnitFirestateChanged
+		WG['firestate'].addFirestateChangedListener(firestateChangedListener)
+	end
 	reloadBindings()
 	activeCommand = select(4, spGetActiveCommand())
 	widget:ViewResize()
@@ -727,6 +738,10 @@ function widget:Initialize()
 end
 
 function widget:Shutdown()
+	if WG['firestate'] and WG['firestate'].removeFirestateChangedListener and firestateChangedListener then
+		WG['firestate'].removeFirestateChangedListener(firestateChangedListener)
+		firestateChangedListener = nil
+	end
 	clearStateLightDisplayLists()
 	if WG['guishader'] and displayListGuiShader then
 		WG['guishader'].DeleteDlist('ordermenu')

--- a/luaui/Widgets/gui_unit_firestate_icons.lua
+++ b/luaui/Widgets/gui_unit_firestate_icons.lua
@@ -252,11 +252,14 @@ local function userStateToIconState(userState)
 end
 
 local function resolveActualUserFirestate(unitID)
-	if not spValidUnitID(unitID) then return nil end
-	if Spring.GetModOptions().experimental_defend_firestate then
-		return CustomFirestateDefs.getUnitUserFirestate(unitID)
+	if not spValidUnitID(unitID) then
+		return nil
 	end
-	return CustomFirestateDefs.fromEngineFirestate(select(1, Spring.GetUnitStates(unitID, false)))
+	local userFirestate = CustomFirestateDefs.getUnitUserFirestate(unitID)
+	if userFirestate == CustomFirestateDefs.UNKNOWN then
+		return nil
+	end
+	return userFirestate
 end
 
 local function migrateUserSelectedFirestateStore()
@@ -358,7 +361,26 @@ local function refreshUnitFirestateIcon(unitID, unitDefID, teamID, commandActual
 	if returnFireVBO.dirty then uploadAllElements(returnFireVBO) end
 end
 
+local function onCachedFirestateChanged(unitID, state)
+	local unitDefID = visibleUnits[unitID]
+	if not unitDefID then
+		return
+	end
+	local teamID = unitToTeam[unitID]
+	if teamID == nil or teamID == gaiaTeamID then
+		return
+	end
+	local commandActualState = state
+	if state == CustomFirestateDefs.UNKNOWN then
+		commandActualState = nil
+	end
+	refreshUnitFirestateIcon(unitID, unitDefID, teamID, commandActualState)
+end
+
 local function applyFireStateOrder(unitID, unitDefID, teamID, userState, userInitiated, wasStagedByApi)
+	if userState == nil or userState == CustomFirestateDefs.UNKNOWN then
+		return
+	end
 	if userInitiated then
 		setUserSelectedFirestate(unitID, userState)
 	elseif userSelectedFirestate[unitID] == nil then
@@ -371,7 +393,11 @@ local function applyFireStateOrder(unitID, unitDefID, teamID, userState, userIni
 		visibleUnits[unitID] = unitDefID
 		unitToTeam[unitID] = teamID
 	end
-	refreshUnitFirestateIcon(unitID, unitDefID, teamID, userState)
+	local actualState = userState
+	if Spring.GetModOptions().experimental_defend_firestate then
+		actualState = resolveActualUserFirestate(unitID) or userState
+	end
+	refreshUnitFirestateIcon(unitID, unitDefID, teamID, actualState)
 end
 
 --------------------------------------------------------------------------------
@@ -386,7 +412,6 @@ function widget:Initialize()
 
 	migrateUserSelectedFirestateStore()
 
-	-- Build team → allyteam mapping
 	for _, allyTeamID in ipairs(Spring.GetAllyTeamList()) do
 		local teams = Spring.GetTeamList(allyTeamID)
 		allyTeamTeamCount[allyTeamID] = #teams
@@ -396,8 +421,18 @@ function widget:Initialize()
 		end
 	end
 
+	if WG['firestate'] and WG['firestate'].addFirestateChangedListener then
+		WG['firestate'].addFirestateChangedListener(onCachedFirestateChanged)
+	end
+
 	if WG['unittrackerapi'] and WG['unittrackerapi'].visibleUnits then
 		widget:VisibleUnitsChanged(WG['unittrackerapi'].visibleUnits, nil)
+	end
+end
+
+function widget:Shutdown()
+	if WG['firestate'] and WG['firestate'].removeFirestateChangedListener then
+		WG['firestate'].removeFirestateChangedListener(onCachedFirestateChanged)
 	end
 end
 

--- a/luaui/Widgets/unit_cloak_firestate.lua
+++ b/luaui/Widgets/unit_cloak_firestate.lua
@@ -61,18 +61,23 @@ function widget:UnitCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpts
 	if cmdID == CMD_WANT_CLOAK and cmdParams[1] ~= nil then -- is cloak command
 		if not cloakFireState[unitDefID] then return end
 
-		if cmdParams[1] == 1 then -- store current fire state and cloak
+		if cmdParams[1] == 1 then
+			local currentFirestate = CustomFirestateDefs.getUnitUserFirestate(unitID)
+			if currentFirestate == CustomFirestateDefs.UNKNOWN then
+				return
+			end
 			cloakActive[unitID] = true
-			decloakFireState[unitID] = CustomFirestateDefs.getUnitUserFirestate(unitID) --store last state
+			decloakFireState[unitID] = currentFirestate
 			local cloaktargetstate = cloakFireState[unitDefID]
 			local cloakTargetUserState = CustomFirestateDefs.fromEngineFirestate(cloaktargetstate)
-			if CustomFirestateDefs.getUnitUserFirestate(unitID) ~= cloakTargetUserState then
+			if currentFirestate ~= cloakTargetUserState then
 				WG['firestate'].setFirestateForUnits(cloakTargetUserState, { unitID }, { userInitiated = false })
 			end
-		else -- decloak and restore previous fire state
+		else
 			local decloaktargetState = decloakFireState[unitID] or CustomFirestateDefs.HOLD_FIRE
-			if CustomFirestateDefs.getUnitUserFirestate(unitID) ~= decloaktargetState then
-				WG['firestate'].setFirestateForUnits(decloaktargetState, { unitID }, { userInitiated = false }) --revert to last state
+			local currentFirestate = CustomFirestateDefs.getUnitUserFirestate(unitID)
+			if currentFirestate ~= CustomFirestateDefs.UNKNOWN and currentFirestate ~= decloaktargetState then
+				WG['firestate'].setFirestateForUnits(decloaktargetState, { unitID }, { userInitiated = false })
 			end
 			cloakActive[unitID] = nil
 			decloakFireState[unitID] = nil
@@ -82,7 +87,10 @@ end
 
 function widget:UnitCreated(unitID, unitDefID, unitTeam)
 	if unitTeam == myTeam then
-		decloakFireState[unitID] = CustomFirestateDefs.getUnitUserFirestate(unitID)	-- 1=firestate
+		local currentFirestate = CustomFirestateDefs.getUnitUserFirestate(unitID)
+		if currentFirestate ~= CustomFirestateDefs.UNKNOWN then
+			decloakFireState[unitID] = currentFirestate
+		end
 	else
 		decloakFireState[unitID] = nil
 		cloakActive[unitID] = nil

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -244,6 +244,7 @@ local callInLists = {
 	'RankingEvent',
 	'MouseCursorEvent',
 	'CameraBroadcastEvent',
+	'FirestateUpdate',
 	'FeatureReclaimStartedETA',
 	'UnitBuildspeedDebuffHealthbars',
 	'UnitBuildspeedDebuffEndHealthbars',
@@ -2989,6 +2990,15 @@ function widgetHandler:CameraBroadcastEvent(playerID, cameraState)
 	tracy.ZoneBeginN("W:CameraBroadcastEvent")
 	for _, w in ipairs(self.CameraBroadcastEventList) do
 		w:CameraBroadcastEvent(playerID, cameraState)
+	end
+	tracy.ZoneEnd()
+	return
+end
+
+function widgetHandler:FirestateUpdate(unitID, state)
+	tracy.ZoneBeginN("W:FirestateUpdate")
+	for _, w in ipairs(self.FirestateUpdateList) do
+		w:FirestateUpdate(unitID, state)
 	end
 	tracy.ZoneEnd()
 	return

--- a/modules/custom_firestate_defs.lua
+++ b/modules/custom_firestate_defs.lua
@@ -1,7 +1,7 @@
 local customFirestateDefs = {
-	RULES_PARAM = "user_firestate",
 	PARAM_USER_INITIATED = 2,
 
+	UNKNOWN = -1,
 	HOLD_FIRE = 0,
 	DEFEND = 1,
 	RETURN_FIRE = 2,
@@ -83,15 +83,17 @@ end
 
 function customFirestateDefs.getUnitUserFirestate(unitID)
 	if not Spring.ValidUnitID(unitID) then
-		return nil
+		return customFirestateDefs.UNKNOWN
 	end
-	if Spring.GetModOptions().experimental_defend_firestate then
-		local rulesState = Spring.GetUnitRulesParam(unitID, customFirestateDefs.RULES_PARAM)
-		if rulesState ~= nil then
-			return rulesState
-		end
+	local firestateApi = WG and WG['firestate']
+	if firestateApi and firestateApi.getUnitFirestate then
+		return firestateApi.getUnitFirestate(unitID)
 	end
-	return customFirestateDefs.fromEngineFirestate(select(1, Spring.GetUnitStates(unitID, false)))
+	local engineFirestate = select(1, Spring.GetUnitStates(unitID, false))
+	if engineFirestate == nil then
+		return customFirestateDefs.UNKNOWN
+	end
+	return customFirestateDefs.fromEngineFirestate(engineFirestate)
 end
 
 function customFirestateDefs.stateLabel(cmd)


### PR DESCRIPTION
## Bug
- play game as a player
- enable godmode
- select enemy unit
- change firestate
- firestate order change is accepted, but display is bugged

While trying to fix the bug, I came to realize it would introduce more noodles to the spaghetti buffet. Instead of more spaget, I refactored to hopefully have less pasta. I also learned that players could use widgets to get enemy firestate data so long as they were inLOS

## How
- unitRulesParams were not flexible enough to account for Godmode
- switch to synced -> unsynced communication approach where unit states are retained in a WG table instead of via unitRulesParams
- when unitRulesParams were removed from widgetspace, gadgetSpace barely used them also. It made more sense to store the data in GG table instead
- add another firestate - UNKNOWN to the firestate defs that maps user firestates to the actual resultant engine firestates. We send UNKNOWN as a response to widgets that inquire about the firestate of a unit that player shouldn't have access to.
- add a WG callin for firestate updates from the central authority api

AI disclosure
Used GPT 4.6, Grok 4.5 and Composer 2.5 for research and making changes. The overall approach and testing is mine.
