### PR TITLE
Fix Factory Guard state light refresh

### DIFF
--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -177,6 +177,7 @@ local cancelTargetLastState = false
 local prevCmdCount = 0
 local prevCmdIDs = {}
 local prevCmdStates = {}
+local prevCmdModes = {}
 local prevActiveCmd = nil
 local commandsVisuallyChanged = true
 
@@ -497,8 +498,8 @@ local function refreshCommands()
 				break
 			end
 			if isStateCommand[cmd.id] then
-				local s = cmd.cachedText
-				if s ~= prevCmdStates[i] then
+				local mode = (cmd.id == CMD.FIRE_STATE) and (cmd.virtualIndex or 1) or (tonumber(cmd.params[1]) + 1)
+				if cmd.cachedText ~= prevCmdStates[i] or mode ~= prevCmdModes[i] then
 					commandsVisuallyChanged = true
 					break
 				end
@@ -517,16 +518,20 @@ local function refreshCommands()
 			prevCmdIDs[i] = commands[i].id
 			if isStateCommand[commands[i].id] then
 				prevCmdStates[i] = commands[i].cachedText
+				prevCmdModes[i] = (commands[i].id == CMD.FIRE_STATE) and (commands[i].virtualIndex or 1) or (tonumber(commands[i].params[1]) + 1)
 			elseif commands[i].id == CMD.WAIT then
 				prevCmdStates[i] = cachedWaitState
+				prevCmdModes[i] = nil
 			else
 				prevCmdStates[i] = nil
+				prevCmdModes[i] = nil
 			end
 		end
 		-- Clear excess fingerprint entries
 		for i = cmdCount + 1, #prevCmdIDs do
 			prevCmdIDs[i] = nil
 			prevCmdStates[i] = nil
+			prevCmdModes[i] = nil
 		end
 		-- Invalidate print text cache since display changed
 		for k in pairs(printTextCache) do


### PR DESCRIPTION
  ### Work done

  Include the active state-light mode in the order menu's visual command
  fingerprint.

  Factory Guard uses the same translated label for both modes, so comparing
  only the cached display text did not detect its state change. The fingerprint
  now also tracks the effective mode used to draw state lights, including the
  special virtual index used by fire state commands.

  #### Addresses Issue(s)

  - Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/8712

  #### Test steps

  - [x] Select a factory that has the Factory Guard command.
  - [x] Toggle Factory Guard without changing the selection.
  - [x] Verify that the red/green state light updates immediately.
  - [x] Toggle it again and verify that the light updates immediately in the
    opposite direction.
  - [x] Run `luac5.1 -p luaui/Widgets/gui_ordermenu.lua`.

  ### AI / LLM usage statement

  OpenAI Codex was used to investigate the issue and generate the production
  code change. I reviewed the resulting code and diff, ran the Lua 5.1 syntax
  check, and manually verified the behavior in game.

Behavior before change

https://github.com/user-attachments/assets/ed407f0d-7bd5-4f58-bca0-2a1f4cc30425

Behavior after change

https://github.com/user-attachments/assets/2b5f4441-a81d-4143-8872-f9425531f8e9