### PR TITLE
Build Queue: Use engine yardmap overlap for pregame build queues

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -16,6 +16,7 @@ local modrules = {
 		constructionDecay = true, -- Do uncompleted building frames begin to decay if no builder is working on them?
 		constructionDecayTime = 9, -- The time in seconds before abandoned building frames begin to decay.
 		constructionDecaySpeed = 0.03, -- How fast build progress decays for abandoned building frames. Note that the rate is inversely proportional to the buildtime i.e. a building with a larger buildtime will decay more slowly for a given value of this tag than a building with a shorter buildtime.
+		useYardmapsForQueuedBuildOverlap = true, -- Allow queued buildings to use the same yardmap-compatible overlap as sequential construction.
 	},
 
 	reclaim = {

--- a/luaui/Include/blueprint_substitution/logic.lua
+++ b/luaui/Include/blueprint_substitution/logic.lua
@@ -493,6 +493,44 @@ function BlueprintSubLogic.processBlueprintSubstitution(originalBlueprint, targe
 	return { stats = aggregatedStats, summaryMessage = summaryMsg, substitutionFailed = subFailed }
 end
 
+function BlueprintSubLogic.removeOverlappingBuildQueueItems(buildQueue, doBuildingsClash)
+	local keptItems = {}
+	local removedCount = 0
+
+	for _, buildQueueItem in ipairs(buildQueue) do
+		local overlaps = false
+
+		if type(buildQueueItem) == "table" and buildQueueItem[1] and buildQueueItem[1] > 0 then
+			for _, keptItem in ipairs(keptItems) do
+				if
+					type(keptItem) == "table"
+					and keptItem[1]
+					and keptItem[1] > 0
+					and doBuildingsClash(buildQueueItem, keptItem)
+				then
+					overlaps = true
+					break
+				end
+			end
+		end
+
+		if overlaps then
+			removedCount = removedCount + 1
+		else
+			keptItems[#keptItems + 1] = buildQueueItem
+		end
+	end
+
+	for i = #buildQueue, 1, -1 do
+		buildQueue[i] = nil
+	end
+	for i = 1, #keptItems do
+		buildQueue[i] = keptItems[i]
+	end
+
+	return removedCount
+end
+
 function BlueprintSubLogic.processBuildQueueSubstitution(originalBuildQueue, sourceSide, targetSide)
 	if not (originalBuildQueue and sourceSide and targetSide) then
 		Spring.Log(

--- a/luaui/Include/blueprint_substitution/logic.lua
+++ b/luaui/Include/blueprint_substitution/logic.lua
@@ -493,6 +493,39 @@ function BlueprintSubLogic.processBlueprintSubstitution(originalBlueprint, targe
 	return { stats = aggregatedStats, summaryMessage = summaryMsg, substitutionFailed = subFailed }
 end
 
+function BlueprintSubLogic.removeOverlappingBuildQueueItems(buildQueue, doBuildingsClash)
+    local keptItems = {}
+    local removedCount = 0
+
+    for _, buildQueueItem in ipairs(buildQueue) do
+        local overlaps = false
+
+        if type(buildQueueItem) == "table" and buildQueueItem[1] and buildQueueItem[1] > 0 then
+            for _, keptItem in ipairs(keptItems) do
+                if type(keptItem) == "table" and keptItem[1] and keptItem[1] > 0 and doBuildingsClash(buildQueueItem, keptItem) then
+                    overlaps = true
+                    break
+                end
+            end
+        end
+
+        if overlaps then
+            removedCount = removedCount + 1
+        else
+            keptItems[#keptItems + 1] = buildQueueItem
+        end
+    end
+
+    for i = #buildQueue, 1, -1 do
+        buildQueue[i] = nil
+    end
+    for i = 1, #keptItems do
+        buildQueue[i] = keptItems[i]
+    end
+
+    return removedCount
+end
+
 function BlueprintSubLogic.processBuildQueueSubstitution(originalBuildQueue, sourceSide, targetSide)
 	if not (originalBuildQueue and sourceSide and targetSide) then
 		Spring.Log(

--- a/luaui/Tests/pregame_build/behavior_matrix.md
+++ b/luaui/Tests/pregame_build/behavior_matrix.md
@@ -20,20 +20,20 @@ The case “inside the cancel region without yardmap overlap” cannot be tested
 | Placement scenario                            | Earlier queued build   | Non-BuildSquare GL4 preview  | BuildSquare GL4 preview                                   | Click result                                          |
 |-----------------------------------------------|------------------------|------------------------------|-----------------------------------------------------------|-------------------------------------------------------|
 | Free space                                    | —                      | Green square                 | All cells green                                           | New build is queued                                   |
-| Terrain obstruction, with yardmap overlap     | —                      | Red square                   | All cells red                                             | New build is not queued                               |
-| Terrain obstruction, without yardmap overlap  | —                      | Green square                 | Overlapping cells red and rest yellow                     | New build is queued                                   |
+| Terrain obstruction on occupied yardmap cells, or invalid slope/other constraints | — | Red square | All cells red | New build is not queued |
+| Terrain obstruction only on open yardmap cells | —                     | Green square                 | Overlapping cells red and rest yellow 🟢 → all cells green | New build is queued                                  |
 | Slight queue overlap, with yardmap overlap    | Keeps its green square | Red square                   | All cells red, regardless of which cells overlap          | Nothing happens                                       |
 | Slight queue overlap, without yardmap overlap | Keeps its green square | Red square 🟢 → green square | All cells red 🟢 → all cells green                        | Nothing happens 🟢 → new build is queued              |
 | Inside cancel region, with yardmap overlap    | Gets a red square      | Green square                 | Red outline; overlapping cells red; remaining cells green | Earlier build is dequeued                             |
-| Over commander/builder                        | —                      | Green square                 | All cells green                                           | A red square appears briefly; new build is not queued |
+| Over commander/builder                        | —                      | Green square                 | All cells green                                           | A red square appears briefly; new build is not queued 🟢 → new build is queued |
 
 ## In-game
 
 | Placement scenario                                   | Earlier queued build         | Non-BuildSquare GL4 preview                                                                             | BuildSquare GL4 preview                                                                                       | Click result                             |
 |------------------------------------------------------|------------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------|
 | Free space                                           | —                            | All cells green                                                                                         | All cells green                                                                                               | New build is queued                      |
-| Terrain obstruction, with yardmap overlap            | —                            | Overlapping cells red and rest yellow                                                                   | Cells intersecting the footprint rectangle are red; rest yellow                                               | New build is not queued                  |
-| Terrain obstruction, without yardmap overlap         | —                            | Overlapping cells red and rest yellow                                                                   | Cells intersecting the footprint rectangle are red; rest yellow                                               | New build is NOT queued                  |
+| Terrain obstruction on occupied yardmap cells, or invalid slope/other constraints | — | Overlapping cells red and rest yellow | Cells intersecting the footprint rectangle are red; rest yellow. For invalid slope, no individual cells are red | New build is not queued |
+| Terrain obstruction only on open yardmap cells       | —                            | All cells green                                                                                         | All cells green                                                                                               | New build is queued                      |
 | Completed building, with yardmap overlap             | —                            | Yardmap-conflicting cells red; rest yellow                                                              | Yardmap-conflicting cells red; rest yellow                                                                    | New build is not queued                  |
 | Completed building, without yardmap overlap          | —                            | Same as free space                                                                                      | Same as free space                                                                                            | New build is queued                      |
 | Slight queue overlap, with yardmap overlap           | Keeps its green square       | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → only yardmap-conflicting cells red | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → only yardmap-conflicting cells red       | Nothing happens                          |
@@ -51,18 +51,16 @@ Cases that were consistent both before and after the change are omitted.
 
 | Placement scenario | Before: pregame vs in-game | After: pregame vs in-game | Status |
 |---|---|---|---|
-| Terrain obstruction, with yardmap overlap | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes red and yellow cells | Unchanged | 🟡 **Remains:** previews differ |
-| Terrain obstruction, without yardmap overlap | Pregame queues the build with a green outline; in-game rejects it with a red/yellow preview | Unchanged | 🔴 **Remains:** click behavior differs |
+| Terrain obstruction on occupied yardmap cells | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes red and yellow cells | Unchanged | 🟡 **Remains:** previews differ |
+| Terrain obstruction only on open yardmap cells | Both queue the build, but the pregame GL4 preview falsely shows blocked cells while the in-game preview is green | Both previews are green and both queue the build | 🟢 **Resolved** |
 | Slight queue overlap, with yardmap overlap | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes yardmap-conflicting cells | Both still reject the build; pregame remains entirely red while in-game now marks only yardmap-conflicting cells red | 🟡 **Remains:** previews differ |
 | Slight queue overlap, without yardmap overlap | Both reject the build, with different blocked previews | Both show a green preview and queue the new build | 🟢 **Resolved** |
 | Inside cancel region, with yardmap overlap | Both dequeue the earlier build, but pregame and in-game highlight the cancellation differently | Both mark the earlier build and overlapping cells red and dequeue it, but outline and remaining-cell colors still differ | 🟡 **Remains:** previews differ |
-| Over commander/builder | Pregame rejects the build despite a green preview; in-game marks occupied cells yellow and queues it | Unchanged | 🔴 **Remains:** intentional pregame restriction |
+| Over commander/builder | Pregame rejects the build despite a green preview; in-game marks occupied cells yellow and queues it | Both queue the build; the commander moves out of the footprint before building | 🟢 **Resolved** |
 
 ## Design notes
 
-- Pregame placement over the commander/builder can be made configurable, but allowing it is probably undesirable.
-- Allowing construction when invalid terrain intersects only open yardmap cells might be desirable, but would require a
-  substantial change.
+- The former pregame commander restriction was introduced by BAR PR #1515 to address issue #803, where an already-spawned commander could start constructing over itself. That original behavior no longer reproduces: at game start the commander moves out of the footprint before building. The restriction remains configurable in `gui_pregame_build.lua`, and disabling placement also makes both pregame previews red.
 
 ## Automated coverage
 
@@ -73,10 +71,10 @@ Cases that were consistent both before and after the change are omitted.
 | Pregame slight queue overlap, with yardmap overlap | `test_yardmap_queue_behavior.lua` verifies the engine classification used by pregame, but not the pregame Lua queue mutation. | Engine result verified; click remains manual | Same |
 | Pregame slight queue overlap, without yardmap overlap | The same test verifies that the API changes from rectangle overlap to no overlap. The pregame widget consumes this API, but its click remains manual. | Engine result verified; click remains manual | Engine result verified; click remains manual |
 | Pregame cancel-region overlap | The same test verifies the engine cancellation classification. Actual pregame removal remains manual. | Engine result verified; click remains manual | Same |
-| Pregame commander/builder restriction | Not automated. | Manual result only | Manual result only |
+| Pregame commander/builder placement | Not automated. | Manual result only | Manual result only |
 | In-game free space | `test_yardmap_queue_behavior.lua`: the first real constructor build command remains queued. | Accepted | Accepted |
 | In-game terrain obstruction on an occupied yardmap cell | `test_world_obstruction_behavior.lua`: raises one occupied solar cell by 200 elmos and sends a real build command. | Rejected | Rejected |
-| In-game terrain obstruction on an open yardmap cell | The same test raises one open corner yardmap cell by 200 elmos. This explicitly tests terrain versus yardmap openness. | Rejected | Rejected |
+| In-game terrain deformation centered on an open yardmap cell | The same test raises terrain by 200 elmos at an open corner cell. The deformation can affect neighboring height/slope samples, so it does not isolate terrain validity to that single open cell. | Rejected | Rejected |
 | Completed building, with yardmap overlap | Creates a completed solar, then sends a conflicting real solar command. | Rejected | Rejected |
 | Completed building, without yardmap overlap | Creates a completed solar, then sends a diagonally interlocking real solar command. | Accepted | Accepted; placed-unit yardmaps predate this change |
 | Slight queued overlap, with yardmap overlap | Real constructor queue contains one command after the conflicting second command. | Rejected | Rejected |

--- a/luaui/Tests/pregame_build/behavior_matrix.md
+++ b/luaui/Tests/pregame_build/behavior_matrix.md
@@ -1,0 +1,110 @@
+# Build-placement behavior comparison
+
+This is the manual behavior table used while developing the yardmap-aware queue change. The automated coverage following
+the table explains which assertion checks each observation. “Yardmap-aware” and “rectangle compatibility” runs use the
+same engine binary and fixtures; the latter sets `construction.useYardmapsForQueuedBuildOverlap = false`.
+
+## Terminology
+
+- **Queue overlap:** overlap with an earlier queued build.
+- **Cancel region:** overlap large enough that clicking removes the earlier queued build.
+- **Yardmap overlap:** occupied yardmap cells intersect.
+- **Before 🟢 → after:** behavior before and after the yardmap-aware queue change. The green marker highlights changed
+  behavior.
+- **—:** no earlier queued build is involved.
+
+The case “inside the cancel region without yardmap overlap” cannot be tested independently.
+
+## Pregame
+
+| Placement scenario                            | Earlier queued build   | Non-BuildSquare GL4 preview  | BuildSquare GL4 preview                                   | Click result                                          |
+|-----------------------------------------------|------------------------|------------------------------|-----------------------------------------------------------|-------------------------------------------------------|
+| Free space                                    | —                      | Green square                 | All cells green                                           | New build is queued                                   |
+| Terrain obstruction, with yardmap overlap     | —                      | Red square                   | All cells red                                             | New build is not queued                               |
+| Terrain obstruction, without yardmap overlap  | —                      | Green square                 | Overlapping cells red and rest yellow                     | New build is queued                                   |
+| Slight queue overlap, with yardmap overlap    | Keeps its green square | Red square                   | All cells red, regardless of which cells overlap          | Nothing happens                                       |
+| Slight queue overlap, without yardmap overlap | Keeps its green square | Red square 🟢 → green square | All cells red 🟢 → all cells green                        | Nothing happens 🟢 → new build is queued              |
+| Inside cancel region, with yardmap overlap    | Gets a red square      | Green square                 | Red outline; overlapping cells red; remaining cells green | Earlier build is dequeued                             |
+| Over commander/builder                        | —                      | Green square                 | All cells green                                           | A red square appears briefly; new build is not queued |
+
+## In-game
+
+| Placement scenario                                   | Earlier queued build         | Non-BuildSquare GL4 preview                                                                             | BuildSquare GL4 preview                                                                                       | Click result                             |
+|------------------------------------------------------|------------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| Free space                                           | —                            | All cells green                                                                                         | All cells green                                                                                               | New build is queued                      |
+| Terrain obstruction, with yardmap overlap            | —                            | Overlapping cells red and rest yellow                                                                   | Cells intersecting the footprint rectangle are red; rest yellow                                               | New build is not queued                  |
+| Terrain obstruction, without yardmap overlap         | —                            | Overlapping cells red and rest yellow                                                                   | Cells intersecting the footprint rectangle are red; rest yellow                                               | New build is NOT queued                  |
+| Completed building, with yardmap overlap             | —                            | Yardmap-conflicting cells red; rest yellow                                                              | Yardmap-conflicting cells red; rest yellow                                                                    | New build is not queued                  |
+| Completed building, without yardmap overlap          | —                            | Same as free space                                                                                      | Same as free space                                                                                            | New build is queued                      |
+| Slight queue overlap, with yardmap overlap           | Keeps its green square       | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → only yardmap-conflicting cells red | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → only yardmap-conflicting cells red       | Nothing happens                          |
+| Slight queue overlap, without yardmap overlap        | Keeps its green square       | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → all cells green                    | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → all cells green                          | Nothing happens 🟢 → new build is queued |
+| Inside cancel region, with yardmap overlap           | Green square 🟢 → red square | All cells green 🟢 → overlapping cells red; remaining cells green                                       | All cells green 🟢 → overlapping cells red; rest yellow                                                       | Earlier build is dequeued                |
+| Building under construction, with yardmap overlap    | —                            | Cells intersecting the building outline red; rest yellow 🟢 → only yardmap-conflicting cells red        | Red outline; cells intersecting the building outline red; rest yellow 🟢 → only yardmap-conflicting cells red | Nothing happens                          |
+| Building under construction, without yardmap overlap | —                            | Cells intersecting the building outline red; rest yellow 🟢 → all cells green                           | Cells intersecting the building outline red; rest yellow 🟢 → all cells green                                 | Nothing happens 🟢 → new build is queued |
+| Over commander/builder/unit                          | —                            | Green square; unit-occupied cells yellow                                                                | Free cells green; unit-occupied cells yellow                                                                  | New build is queued                      |
+
+## Pregame vs in-game differences
+
+Cases that were consistent both before and after the change are omitted.
+
+🟢 resolved · 🟡 preview difference only · 🔴 click/behavior difference
+
+| Placement scenario | Before: pregame vs in-game | After: pregame vs in-game | Status |
+|---|---|---|---|
+| Terrain obstruction, with yardmap overlap | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes red and yellow cells | Unchanged | 🟡 **Remains:** previews differ |
+| Terrain obstruction, without yardmap overlap | Pregame queues the build with a green outline; in-game rejects it with a red/yellow preview | Unchanged | 🔴 **Remains:** click behavior differs |
+| Slight queue overlap, with yardmap overlap | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes yardmap-conflicting cells | Both still reject the build; pregame remains entirely red while in-game now marks only yardmap-conflicting cells red | 🟡 **Remains:** previews differ |
+| Slight queue overlap, without yardmap overlap | Both reject the build, with different blocked previews | Both show a green preview and queue the new build | 🟢 **Resolved** |
+| Inside cancel region, with yardmap overlap | Both dequeue the earlier build, but pregame and in-game highlight the cancellation differently | Both mark the earlier build and overlapping cells red and dequeue it, but outline and remaining-cell colors still differ | 🟡 **Remains:** previews differ |
+| Over commander/builder | Pregame rejects the build despite a green preview; in-game marks occupied cells yellow and queues it | Unchanged | 🔴 **Remains:** intentional pregame restriction |
+
+## Design notes
+
+- Pregame placement over the commander/builder can be made configurable, but allowing it is probably undesirable.
+- Allowing construction when invalid terrain intersects only open yardmap cells might be desirable, but would require a
+  substantial change.
+
+## Automated coverage
+
+| Manual scenario | Automated check | With yardmap-aware queue | Rectangle compatibility |
+|---|---|---|---|
+| Pregame free space | Not automated: the current headless runner starts after frame zero. | Manual result only | Manual result only |
+| Pregame terrain obstruction, either yardmap state | Not automated. The real in-game terrain fixtures below do not exercise the pregame widget. | Manual result only | Manual result only |
+| Pregame slight queue overlap, with yardmap overlap | `test_yardmap_queue_behavior.lua` verifies the engine classification used by pregame, but not the pregame Lua queue mutation. | Engine result verified; click remains manual | Same |
+| Pregame slight queue overlap, without yardmap overlap | The same test verifies that the API changes from rectangle overlap to no overlap. The pregame widget consumes this API, but its click remains manual. | Engine result verified; click remains manual | Engine result verified; click remains manual |
+| Pregame cancel-region overlap | The same test verifies the engine cancellation classification. Actual pregame removal remains manual. | Engine result verified; click remains manual | Same |
+| Pregame commander/builder restriction | Not automated. | Manual result only | Manual result only |
+| In-game free space | `test_yardmap_queue_behavior.lua`: the first real constructor build command remains queued. | Accepted | Accepted |
+| In-game terrain obstruction on an occupied yardmap cell | `test_world_obstruction_behavior.lua`: raises one occupied solar cell by 200 elmos and sends a real build command. | Rejected | Rejected |
+| In-game terrain obstruction on an open yardmap cell | The same test raises one open corner yardmap cell by 200 elmos. This explicitly tests terrain versus yardmap openness. | Rejected | Rejected |
+| Completed building, with yardmap overlap | Creates a completed solar, then sends a conflicting real solar command. | Rejected | Rejected |
+| Completed building, without yardmap overlap | Creates a completed solar, then sends a diagonally interlocking real solar command. | Accepted | Accepted; placed-unit yardmaps predate this change |
+| Slight queued overlap, with yardmap overlap | Real constructor queue contains one command after the conflicting second command. | Rejected | Rejected |
+| Slight queued overlap, without yardmap overlap | Real constructor queue length is checked after the interlocking second command. | Two commands | One command |
+| Cancel-region queued overlap | Real constructor queue becomes empty after the second command. | Earlier command removed | Earlier command removed |
+| Active construction, with yardmap overlap | A constructor starts a real nanoframe; after it appears with build progress below one, a conflicting second command is sent. The active command remains and the second is rejected. | One command | One command |
+| Active construction, without yardmap overlap | Same active-nanoframe fixture with the diagonal interlock. | Two commands | One command |
+| Mobile unit inside the proposed footprint | Creates a mobile `armck` on the solar site and sends a real build command from another constructor. | Command accepted so the unit can move away | Same |
+
+The behavioral assertions above do not compare rendered pixels. Cell colors are determined from the engine
+`DrawBuildSquare(..., statuses)` values and the Lua status-to-color mapping, while queued-outline red/green selection is
+native. Those two data boundaries need focused status/color tests before the preview columns can be considered fully
+automated. Until then, the preview wording in the manual table remains the visual oracle; the click-result columns are
+programmatically checked as described above.
+
+## Reproducing both runs
+
+Run the normal headless integration suite for the yardmap-aware result. For the compatibility result, add
+`useYardmapsForQueuedBuildOverlap = false` under `construction` in `gamedata/modrules.lua` and rerun the identical suite.
+Do not change the expected outcomes: the tests read `Game.useYardmapsForQueuedBuildOverlap` and assert the appropriate
+column above.
+
+The matrix was run successfully in all three configurations on 2026-08-12:
+
+- Local PR engine `2026.07.01-16-g9925d0a`, yardmap-aware mode: 10 passed, 8 skipped, 0 failed.
+- The identical local PR engine with rectangle compatibility enabled: 9 passed, 9 skipped, 0 failed. The faction
+  substitution test is intentionally skipped because it requires yardmap-aware classification.
+- Installed stock engine `2026.07.04`, which has no `Spring.TestBuildOrderOverlap` API: 9 passed, 9 skipped, 0 failed.
+
+The stock-engine and compatibility-mode behavioral results matched. The yardmap-aware run differed only in the intended
+cases: a queued compatible solar and a compatible solar after an active nanoframe were accepted instead of rejected.

--- a/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
+++ b/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
@@ -1,0 +1,49 @@
+local SubLogic = VFS.Include("luaui/Include/blueprint_substitution/logic.lua")
+
+function skip()
+	return Spring.GetGameFrame() <= 0 or not Spring.TestBuildOrderOverlap
+end
+
+function test()
+	local armSolarID = UnitDefNames.armsolar.id
+	local corSolarID = UnitDefNames.corsolar.id
+	local x = Game.mapSizeX * 0.5
+	local z = Game.mapSizeZ * 0.5
+	local y = Spring.GetGroundHeight(x, z)
+	local firstArmSolar = { armSolarID, x, y, z, 0 }
+	local firstCorSolar = { corSolarID, x, y, z, 0 }
+	local secondArmSolar
+
+	for xOffset = -40, 40, 8 do
+		for zOffset = -40, 40, 8 do
+			local armCandidate = { armSolarID, x + xOffset, y, z + zOffset, 0 }
+			local corCandidate = { corSolarID, x + xOffset, y, z + zOffset, 0 }
+			local armOverlaps = Spring.TestBuildOrderOverlap(firstArmSolar, armCandidate)
+			local corOverlaps = Spring.TestBuildOrderOverlap(firstCorSolar, corCandidate)
+
+			if not armOverlaps and corOverlaps then
+				secondArmSolar = armCandidate
+				break
+			end
+		end
+		if secondArmSolar then
+			break
+		end
+	end
+
+	assert(secondArmSolar, "expected to find a placement allowed by the Armada solar yardmap but not the Cortex solar yardmap")
+
+	local buildQueue = { firstArmSolar, secondArmSolar }
+	local result = SubLogic.processBuildQueueSubstitution(buildQueue, SubLogic.SIDES.ARMADA, SubLogic.SIDES.CORTEX)
+	assert(not result.substitutionFailed, result.summaryMessage)
+	assertEqual(buildQueue[1][1], corSolarID)
+	assertEqual(buildQueue[2][1], corSolarID)
+
+	local removedCount = SubLogic.removeOverlappingBuildQueueItems(buildQueue, function(proposedBuild, queuedBuild)
+		return Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild)
+	end)
+
+	assertEqual(removedCount, 1)
+	assertEqual(#buildQueue, 1)
+	assertEqual(buildQueue[1][1], corSolarID)
+end

--- a/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
+++ b/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
@@ -1,0 +1,54 @@
+local SubLogic = VFS.Include("luaui/Include/blueprint_substitution/logic.lua")
+
+function skip()
+	return Spring.GetGameFrame() <= 0 or not Spring.TestBuildOrderOverlap
+end
+
+function test()
+	local armSolarID = UnitDefNames.armsolar.id
+	local corSolarID = UnitDefNames.corsolar.id
+	local x = Game.mapSizeX * 0.5
+	local z = Game.mapSizeZ * 0.5
+	local y = Spring.GetGroundHeight(x, z)
+	local firstArmSolar = { armSolarID, x, y, z, 0 }
+	local firstCorSolar = { corSolarID, x, y, z, 0 }
+	local secondArmSolar
+
+	for xOffset = -40, 40, 8 do
+		for zOffset = -40, 40, 8 do
+			local armCandidate = { armSolarID, x + xOffset, y, z + zOffset, 0 }
+			local corCandidate = { corSolarID, x + xOffset, y, z + zOffset, 0 }
+			local armOverlaps = Spring.TestBuildOrderOverlap(firstArmSolar, armCandidate)
+			local corOverlaps = Spring.TestBuildOrderOverlap(firstCorSolar, corCandidate)
+
+			if not armOverlaps and corOverlaps then
+				secondArmSolar = armCandidate
+				break
+			end
+		end
+		if secondArmSolar then
+			break
+		end
+	end
+
+	assert(
+		secondArmSolar,
+		"expected to find a placement allowed by the Armada solar yardmap but not the Cortex solar yardmap"
+	)
+
+	local buildQueue = { firstArmSolar, secondArmSolar }
+	local result = SubLogic.processBuildQueueSubstitution(buildQueue, SubLogic.SIDES.ARMADA, SubLogic.SIDES.CORTEX)
+	assert(not result.substitutionFailed, result.summaryMessage)
+	assertEqual(buildQueue[1][1], corSolarID)
+	assertEqual(buildQueue[2][1], corSolarID)
+
+	local removedCount = SubLogic.removeOverlappingBuildQueueItems(buildQueue, function(proposedBuild, queuedBuild)
+		return Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild)
+	end)
+
+	assertEqual(removedCount, 1)
+	assertEqual(#buildQueue, 1)
+	assertEqual(buildQueue[1][1], corSolarID)
+end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }

--- a/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
+++ b/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
@@ -49,3 +49,5 @@ function test()
 	assertEqual(#buildQueue, 1)
 	assertEqual(buildQueue[1][1], corSolarID)
 end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }

--- a/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
+++ b/luaui/Tests/pregame_build/test_faction_queue_overlap.lua
@@ -1,7 +1,9 @@
 local SubLogic = VFS.Include("luaui/Include/blueprint_substitution/logic.lua")
 
 function skip()
-	return Spring.GetGameFrame() <= 0 or not Spring.TestBuildOrderOverlap
+	return Spring.GetGameFrame() <= 0
+		or not Spring.TestBuildOrderOverlap
+		or Game.useYardmapsForQueuedBuildOverlap == false
 end
 
 function test()

--- a/luaui/Tests/pregame_build/test_world_obstruction_behavior.lua
+++ b/luaui/Tests/pregame_build/test_world_obstruction_behavior.lua
@@ -127,3 +127,5 @@ function test()
 		assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 0, terrainCase.name)
 	end
 end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }

--- a/luaui/Tests/pregame_build/test_world_obstruction_behavior.lua
+++ b/luaui/Tests/pregame_build/test_world_obstruction_behavior.lua
@@ -1,0 +1,129 @@
+local WAIT_FRAMES = 5
+local SOLAR_OFFSET = 6 * Game.squareSize
+local TERRAIN_RAISE = 200
+
+local function getBuildCommandCount(unitID)
+	local count = 0
+	for _, command in ipairs(Spring.GetUnitCommands(unitID, -1) or {}) do
+		if command.id < 0 then
+			count = count + 1
+		end
+	end
+	return count
+end
+
+local function createUnit(unitName, x, y, z)
+	local unitID = SyncedProxy.Spring.CreateUnit(unitName, x, y, z, 0, Spring.GetMyTeamID())
+	return unitID
+end
+
+local function createBuilder(x, y, z)
+	return SyncedProxy.Spring.CreateUnit("armck", x, y, z, 0, Spring.GetMyTeamID())
+end
+
+local function queueBuild(builderID, build)
+	Spring.GiveOrderToUnit(builderID, -build[1], { build[2], build[3], build[4], build[5] }, { "shift" })
+	Test.waitFrames(WAIT_FRAMES)
+	return getBuildCommandCount(builderID)
+end
+
+local function raiseTerrain(x, z)
+	SyncedProxy.Spring.LevelHeightMap(x, z, x, z, TERRAIN_RAISE)
+	SyncedProxy.Spring.RebuildSmoothMesh(x - 32, z - 32, x + 32, z + 32)
+	Test.waitFrames(WAIT_FRAMES)
+end
+
+local function findUnit(unitDefID, x, z, radius, excludedUnitID)
+	for _, unitID in ipairs(Spring.GetUnitsInCylinder(x, z, radius) or {}) do
+		if unitID ~= excludedUnitID and Spring.GetUnitDefID(unitID) == unitDefID then
+			return unitID
+		end
+	end
+	return nil
+end
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+	Test.levelHeightMap()
+end
+
+function cleanup()
+	Test.clearMap()
+	Test.restoreHeightMap()
+end
+
+function test()
+	local yardmapAware = Spring.TestBuildOrderOverlap and Game.useYardmapsForQueuedBuildOverlap ~= false
+	local solarID = UnitDefNames.armsolar.id
+	local centerX = Game.mapSizeX * 0.5
+	local centerZ = Game.mapSizeZ * 0.5
+	local centerY = Spring.GetGroundHeight(centerX, centerZ)
+	local bx, by, bz = Spring.Pos2BuildPos(solarID, centerX, centerY, centerZ, 0)
+	local proposedConflict = { solarID, bx + SOLAR_OFFSET, by, bz, 0 }
+	local proposedCompatible = { solarID, bx + SOLAR_OFFSET, by, bz + SOLAR_OFFSET, 0 }
+
+	for _, placementCase in ipairs({
+		{ name = "with yardmap overlap", build = proposedConflict, expectedCommands = 0 },
+		{ name = "without yardmap overlap", build = proposedCompatible, expectedCommands = 1 },
+	}) do
+		Test.clearMap()
+		local obstructionID = createUnit("armsolar", bx, by, bz)
+		assert(obstructionID, "completed building: failed to create obstruction")
+		local builderID = createBuilder(bx - 1500, by, bz)
+		assert(builderID, "completed building: failed to create builder")
+		assertEqual(queueBuild(builderID, placementCase.build), placementCase.expectedCommands, "completed building, " .. placementCase.name)
+	end
+
+	for _, placementCase in ipairs({
+		{ name = "with yardmap overlap", build = proposedConflict, expectedCommands = 1 },
+		{
+			name = "without yardmap overlap",
+			build = proposedCompatible,
+			expectedCommands = yardmapAware and 2 or 1,
+		},
+	}) do
+		Test.clearMap()
+		local builderID = createBuilder(bx - 96, by, bz)
+		assert(builderID, "building under construction: failed to create builder")
+		assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 1, "initial active build command")
+		local nanoframeID
+		Test.waitUntil(function()
+			nanoframeID = findUnit(solarID, bx, bz, 32, builderID)
+			return nanoframeID ~= nil
+		end, 150)
+		local _, _, _, _, buildProgress = Spring.GetUnitHealth(nanoframeID)
+		assert(buildProgress and buildProgress < 1, "expected an active solar nanoframe")
+		assertEqual(queueBuild(builderID, placementCase.build), placementCase.expectedCommands, "building under construction, " .. placementCase.name)
+	end
+
+	Test.clearMap()
+	local mobileUnitID = createUnit("armck", bx, by, bz)
+	assert(mobileUnitID, "mobile unit: failed to create obstruction")
+	local builderID = createBuilder(bx - 1500, by, bz)
+	assert(builderID, "mobile unit: failed to create builder")
+	assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 1, "mobile unit inside proposed footprint")
+
+	for _, terrainCase in ipairs({
+		{
+			name = "terrain obstruction on an occupied yardmap cell",
+			x = bx,
+			z = bz,
+		},
+		{
+			name = "terrain obstruction on an open yardmap cell",
+			x = bx - 4 * Game.squareSize,
+			z = bz - 4 * Game.squareSize,
+		},
+	}) do
+		Test.clearMap()
+		Test.levelHeightMap()
+		raiseTerrain(terrainCase.x, terrainCase.z)
+		builderID = createBuilder(bx - 1500, by, bz)
+		assert(builderID, terrainCase.name .. ": failed to create builder")
+		assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 0, terrainCase.name)
+	end
+end

--- a/luaui/Tests/pregame_build/test_world_obstruction_behavior.lua
+++ b/luaui/Tests/pregame_build/test_world_obstruction_behavior.lua
@@ -1,0 +1,139 @@
+local WAIT_FRAMES = 5
+local SOLAR_OFFSET = 6 * Game.squareSize
+local TERRAIN_RAISE = 200
+
+local function getBuildCommandCount(unitID)
+	local count = 0
+	for _, command in ipairs(Spring.GetUnitCommands(unitID, -1) or {}) do
+		if command.id < 0 then
+			count = count + 1
+		end
+	end
+	return count
+end
+
+local function createUnit(unitName, x, y, z)
+	local unitID = SyncedProxy.Spring.CreateUnit(unitName, x, y, z, 0, Spring.GetMyTeamID())
+	return unitID
+end
+
+local function createBuilder(x, y, z)
+	return SyncedProxy.Spring.CreateUnit("armck", x, y, z, 0, Spring.GetMyTeamID())
+end
+
+local function queueBuild(builderID, build)
+	Spring.GiveOrderToUnit(builderID, -build[1], { build[2], build[3], build[4], build[5] }, { "shift" })
+	Test.waitFrames(WAIT_FRAMES)
+	return getBuildCommandCount(builderID)
+end
+
+local function raiseTerrain(x, z)
+	SyncedProxy.Spring.LevelHeightMap(x, z, x, z, TERRAIN_RAISE)
+	SyncedProxy.Spring.RebuildSmoothMesh(x - 32, z - 32, x + 32, z + 32)
+	Test.waitFrames(WAIT_FRAMES)
+end
+
+local function findUnit(unitDefID, x, z, radius, excludedUnitID)
+	for _, unitID in ipairs(Spring.GetUnitsInCylinder(x, z, radius) or {}) do
+		if unitID ~= excludedUnitID and Spring.GetUnitDefID(unitID) == unitDefID then
+			return unitID
+		end
+	end
+	return nil
+end
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+	Test.levelHeightMap()
+end
+
+function cleanup()
+	Test.clearMap()
+	Test.restoreHeightMap()
+end
+
+function test()
+	local yardmapAware = Spring.TestBuildOrderOverlap and Game.useYardmapsForQueuedBuildOverlap ~= false
+	local solarID = UnitDefNames.armsolar.id
+	local centerX = Game.mapSizeX * 0.5
+	local centerZ = Game.mapSizeZ * 0.5
+	local centerY = Spring.GetGroundHeight(centerX, centerZ)
+	local bx, by, bz = Spring.Pos2BuildPos(solarID, centerX, centerY, centerZ, 0)
+	local proposedConflict = { solarID, bx + SOLAR_OFFSET, by, bz, 0 }
+	local proposedCompatible = { solarID, bx + SOLAR_OFFSET, by, bz + SOLAR_OFFSET, 0 }
+
+	for _, placementCase in ipairs({
+		{ name = "with yardmap overlap", build = proposedConflict, expectedCommands = 0 },
+		{ name = "without yardmap overlap", build = proposedCompatible, expectedCommands = 1 },
+	}) do
+		Test.clearMap()
+		local obstructionID = createUnit("armsolar", bx, by, bz)
+		assert(obstructionID, "completed building: failed to create obstruction")
+		local builderID = createBuilder(bx - 1500, by, bz)
+		assert(builderID, "completed building: failed to create builder")
+		assertEqual(
+			queueBuild(builderID, placementCase.build),
+			placementCase.expectedCommands,
+			"completed building, " .. placementCase.name
+		)
+	end
+
+	for _, placementCase in ipairs({
+		{ name = "with yardmap overlap", build = proposedConflict, expectedCommands = 1 },
+		{
+			name = "without yardmap overlap",
+			build = proposedCompatible,
+			expectedCommands = yardmapAware and 2 or 1,
+		},
+	}) do
+		Test.clearMap()
+		local builderID = createBuilder(bx - 96, by, bz)
+		assert(builderID, "building under construction: failed to create builder")
+		assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 1, "initial active build command")
+		local nanoframeID
+		Test.waitUntil(function()
+			nanoframeID = findUnit(solarID, bx, bz, 32, builderID)
+			return nanoframeID ~= nil
+		end, 150)
+		local _, _, _, _, buildProgress = Spring.GetUnitHealth(nanoframeID)
+		assert(buildProgress and buildProgress < 1, "expected an active solar nanoframe")
+		assertEqual(
+			queueBuild(builderID, placementCase.build),
+			placementCase.expectedCommands,
+			"building under construction, " .. placementCase.name
+		)
+	end
+
+	Test.clearMap()
+	local mobileUnitID = createUnit("armck", bx, by, bz)
+	assert(mobileUnitID, "mobile unit: failed to create obstruction")
+	local builderID = createBuilder(bx - 1500, by, bz)
+	assert(builderID, "mobile unit: failed to create builder")
+	assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 1, "mobile unit inside proposed footprint")
+
+	for _, terrainCase in ipairs({
+		{
+			name = "terrain obstruction on an occupied yardmap cell",
+			x = bx,
+			z = bz,
+		},
+		{
+			name = "terrain obstruction on an open yardmap cell",
+			x = bx - 4 * Game.squareSize,
+			z = bz - 4 * Game.squareSize,
+		},
+	}) do
+		Test.clearMap()
+		Test.levelHeightMap()
+		raiseTerrain(terrainCase.x, terrainCase.z)
+		builderID = createBuilder(bx - 1500, by, bz)
+		assert(builderID, terrainCase.name .. ": failed to create builder")
+		assertEqual(queueBuild(builderID, { solarID, bx, by, bz, 0 }), 0, terrainCase.name)
+	end
+end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }

--- a/luaui/Tests/pregame_build/test_yardmap_queue_behavior.lua
+++ b/luaui/Tests/pregame_build/test_yardmap_queue_behavior.lua
@@ -93,3 +93,5 @@ function test()
 		assertEqual(#getBuildCommands(builderID), expectedBuildCommands, case.name .. ": in-game command queue")
 	end
 end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }

--- a/luaui/Tests/pregame_build/test_yardmap_queue_behavior.lua
+++ b/luaui/Tests/pregame_build/test_yardmap_queue_behavior.lua
@@ -1,0 +1,95 @@
+local WAIT_FRAMES = 5
+local SOLAR_OFFSET = 6 * Game.squareSize
+
+local function getBuildCommands(unitID)
+	local buildCommands = {}
+	for _, command in ipairs(Spring.GetUnitCommands(unitID, -1) or {}) do
+		if command.id < 0 then
+			buildCommands[#buildCommands + 1] = command
+		end
+	end
+	return buildCommands
+end
+
+local function giveBuildOrder(builderID, build)
+	Spring.GiveOrderToUnit(builderID, -build[1], { build[2], build[3], build[4], build[5] }, { "shift" })
+	Test.waitFrames(WAIT_FRAMES)
+end
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+	Test.levelHeightMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	local yardmapAware = Spring.TestBuildOrderOverlap and Game.useYardmapsForQueuedBuildOverlap ~= false
+	local solarID = UnitDefNames.armsolar.id
+	local teamID = Spring.GetMyTeamID()
+	local x = Game.mapSizeX * 0.5
+	local z = Game.mapSizeZ * 0.5
+	local y = Spring.GetGroundHeight(x, z)
+	local bx, by, bz = Spring.Pos2BuildPos(solarID, x, y, z, 0)
+	local queuedBuild = { solarID, bx, by, bz, 0 }
+	local cases = {
+		{
+			name = "slight footprint overlap without a yardmap conflict",
+			proposedBuild = { solarID, bx + SOLAR_OFFSET, by, bz + SOLAR_OFFSET, 0 },
+			overlaps = false,
+			cancels = false,
+			expectedBuildCommands = 2,
+			expectedLegacyBuildCommands = 1,
+		},
+		{
+			name = "slight footprint overlap with a yardmap conflict",
+			proposedBuild = { solarID, bx + SOLAR_OFFSET, by, bz, 0 },
+			overlaps = true,
+			cancels = false,
+			expectedBuildCommands = 1,
+			expectedLegacyBuildCommands = 1,
+		},
+		{
+			name = "yardmap conflict inside the cancel region",
+			proposedBuild = { solarID, bx, by, bz, 0 },
+			overlaps = true,
+			cancels = true,
+			expectedBuildCommands = 0,
+			expectedLegacyBuildCommands = 0,
+		},
+	}
+
+	for _, case in ipairs(cases) do
+		if Spring.TestBuildOrderOverlap then
+			local overlaps, cancels = Spring.TestBuildOrderOverlap(queuedBuild, case.proposedBuild)
+			local expectedOverlaps = case.overlaps
+			local expectedCancels = case.cancels
+			if not yardmapAware then
+				expectedOverlaps = case.expectedLegacyBuildCommands < 2
+				expectedCancels = case.expectedLegacyBuildCommands == 0
+			end
+			assertEqual(overlaps, expectedOverlaps, case.name .. ": engine overlap classification")
+			assertEqual(cancels, expectedCancels, case.name .. ": engine cancellation classification")
+		end
+
+		Test.clearMap()
+		local builderX = bx - 1500
+		local builderID = SyncedRun(function(locals)
+			return Spring.CreateUnit("armck", locals.builderX, locals.by, locals.bz, 0, locals.teamID)
+		end)
+		assert(builderID, case.name .. ": failed to create builder")
+
+		giveBuildOrder(builderID, queuedBuild)
+		assertEqual(#getBuildCommands(builderID), 1, case.name .. ": initial build command")
+
+		giveBuildOrder(builderID, case.proposedBuild)
+		local expectedBuildCommands = yardmapAware and case.expectedBuildCommands or case.expectedLegacyBuildCommands
+		assertEqual(#getBuildCommands(builderID), expectedBuildCommands, case.name .. ": in-game command queue")
+	end
+end

--- a/luaui/Tests/pregame_build/test_yardmap_queue_behavior.lua
+++ b/luaui/Tests/pregame_build/test_yardmap_queue_behavior.lua
@@ -1,0 +1,97 @@
+local WAIT_FRAMES = 5
+local SOLAR_OFFSET = 6 * Game.squareSize
+
+local function getBuildCommands(unitID)
+	local buildCommands = {}
+	for _, command in ipairs(Spring.GetUnitCommands(unitID, -1) or {}) do
+		if command.id < 0 then
+			buildCommands[#buildCommands + 1] = command
+		end
+	end
+	return buildCommands
+end
+
+local function giveBuildOrder(builderID, build)
+	Spring.GiveOrderToUnit(builderID, -build[1], { build[2], build[3], build[4], build[5] }, { "shift" })
+	Test.waitFrames(WAIT_FRAMES)
+end
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+	Test.levelHeightMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	local yardmapAware = Spring.TestBuildOrderOverlap and Game.useYardmapsForQueuedBuildOverlap ~= false
+	local solarID = UnitDefNames.armsolar.id
+	local teamID = Spring.GetMyTeamID()
+	local x = Game.mapSizeX * 0.5
+	local z = Game.mapSizeZ * 0.5
+	local y = Spring.GetGroundHeight(x, z)
+	local bx, by, bz = Spring.Pos2BuildPos(solarID, x, y, z, 0)
+	local queuedBuild = { solarID, bx, by, bz, 0 }
+	local cases = {
+		{
+			name = "slight footprint overlap without a yardmap conflict",
+			proposedBuild = { solarID, bx + SOLAR_OFFSET, by, bz + SOLAR_OFFSET, 0 },
+			overlaps = false,
+			cancels = false,
+			expectedBuildCommands = 2,
+			expectedLegacyBuildCommands = 1,
+		},
+		{
+			name = "slight footprint overlap with a yardmap conflict",
+			proposedBuild = { solarID, bx + SOLAR_OFFSET, by, bz, 0 },
+			overlaps = true,
+			cancels = false,
+			expectedBuildCommands = 1,
+			expectedLegacyBuildCommands = 1,
+		},
+		{
+			name = "yardmap conflict inside the cancel region",
+			proposedBuild = { solarID, bx, by, bz, 0 },
+			overlaps = true,
+			cancels = true,
+			expectedBuildCommands = 0,
+			expectedLegacyBuildCommands = 0,
+		},
+	}
+
+	for _, case in ipairs(cases) do
+		if Spring.TestBuildOrderOverlap then
+			local overlaps, cancels = Spring.TestBuildOrderOverlap(queuedBuild, case.proposedBuild)
+			local expectedOverlaps = case.overlaps
+			local expectedCancels = case.cancels
+			if not yardmapAware then
+				expectedOverlaps = case.expectedLegacyBuildCommands < 2
+				expectedCancels = case.expectedLegacyBuildCommands == 0
+			end
+			assertEqual(overlaps, expectedOverlaps, case.name .. ": engine overlap classification")
+			assertEqual(cancels, expectedCancels, case.name .. ": engine cancellation classification")
+		end
+
+		Test.clearMap()
+		local builderX = bx - 1500
+		local builderID = SyncedRun(function(locals)
+			return Spring.CreateUnit("armck", locals.builderX, locals.by, locals.bz, 0, locals.teamID)
+		end)
+		assert(builderID, case.name .. ": failed to create builder")
+
+		giveBuildOrder(builderID, queuedBuild)
+		assertEqual(#getBuildCommands(builderID), 1, case.name .. ": initial build command")
+
+		giveBuildOrder(builderID, case.proposedBuild)
+		local expectedBuildCommands = yardmapAware and case.expectedBuildCommands or case.expectedLegacyBuildCommands
+		assertEqual(#getBuildCommands(builderID), expectedBuildCommands, case.name .. ": in-game command queue")
+	end
+end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }

--- a/luaui/Widgets/gui_buildsquare_gl4.lua
+++ b/luaui/Widgets/gui_buildsquare_gl4.lua
@@ -1439,12 +1439,16 @@ local function collectPregameBuildSquare()
 			if placementValid then
 				local worldX = x + (xi - footprint.halfXsize) * SQUARE_SIZE
 				local worldZ = z + (zi - footprint.halfZsize) * SQUARE_SIZE
-				local status = getPredictedCellStatus(
+				local status, objectStatus = getPredictedCellStatus(
 					unitDef,
 					worldX,
 					worldZ,
 					buildHeight
 				)
+				-- Match the in-game preview: terrain does not block open yardmap cells.
+				if footprint.openYardmapCells and footprint.openYardmapCells[statusIndex] then
+					status = objectStatus
+				end
 				for i = 1, #pregameCancelledBuilds do
 					local cancelledBuild = pregameCancelledBuilds[i]
 					local cancelledFootprint = getFootprintData(cancelledBuild[1], cancelledBuild[5] or 0)

--- a/luaui/Widgets/gui_buildsquare_gl4.lua
+++ b/luaui/Widgets/gui_buildsquare_gl4.lua
@@ -1423,6 +1423,10 @@ local function collectPregameBuildSquare()
 	end
 
 	local placementValid = spTestBuildOrder(unitDefID, x, buildHeight, z, facing) ~= 0
+	local doesBuildClashWithCommander = pregameBuild.doesBuildClashWithCommander
+	if doesBuildClashWithCommander then
+		placementValid = placementValid and not doesBuildClashWithCommander(unitDefID, x, buildHeight, z, facing)
+	end
 	local getCancelledQueuedBuilds = pregameBuild.getCancelledQueuedBuilds
 	if getCancelledQueuedBuilds then
 		local overlapsQueuedBuild, cancelsQueuedBuild = getCancelledQueuedBuilds(unitDefID, x, buildHeight, z, facing, pregameCancelledBuilds)

--- a/luaui/Widgets/gui_buildsquare_gl4.lua
+++ b/luaui/Widgets/gui_buildsquare_gl4.lua
@@ -55,9 +55,7 @@ local spGetGroundNormal = Spring.GetGroundNormal
 local spGetGroundBlocked = Spring.GetGroundBlocked
 local spGetFeatureDefID = Spring.GetFeatureDefID
 local spGetUnitDefID = Spring.GetUnitDefID
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetUnitCommands = Spring.GetUnitCommands
-local spGetMyPlayerID = Spring.GetLocalPlayerID
+local spGetMyPlayerID = Spring.GetMyPlayerID
 local spGetMouseState = Spring.GetMouseState
 local spTraceScreenRay = Spring.TraceScreenRay
 local spWorldToScreenCoords = Spring.WorldToScreenCoords
@@ -92,7 +90,6 @@ local EXTENDED_CELLS = 0
 local COMBINE_FOUR_CELLS = true
 local EXTENDED_ALPHA_NEAR = 0.1
 local EXTENDED_ALPHA_FAR = 0.05
-local FOOTPRINT_BOUNDARY_ENABLED = true
 local FOOTPRINT_BOUNDARY_WIDTH = 0.22
 local SHOW_INVALID_FOOTPRINT_BOUNDARY = true
 local EXTENDED_STATUS_UPDATE_INTERVAL = 0.20
@@ -192,9 +189,7 @@ local statusCheckTargetPhase = 0
 local orderedPreviewCaches = {}
 local pregameStatuses = {}
 local pregameStatusCount = 0
-local queuedBuildFootprints = {}
-local queuedBuildFootprintCount = 0
-local queuedBuildFootprintsGameFrame = -1
+local pregameCancelledBuilds = {}
 
 local MAX_CELLS = 4096
 
@@ -301,79 +296,6 @@ local function getFootprintData(unitDefID, facing)
 	}
 	unitCaches[facing] = footprint
 	return footprint
-end
-
-local function addQueuedBuildFootprint(unitDefID, x, z, facing)
-	local queuedFootprint = getFootprintData(unitDefID, facing or 0)
-	if not queuedFootprint then
-		return
-	end
-	queuedBuildFootprintCount = queuedBuildFootprintCount + 1
-	local queuedBuildFootprint = queuedBuildFootprints[queuedBuildFootprintCount] or {}
-	queuedBuildFootprints[queuedBuildFootprintCount] = queuedBuildFootprint
-	queuedBuildFootprint.minX = x - queuedFootprint.halfXsize * SQUARE_SIZE
-	queuedBuildFootprint.maxX = queuedBuildFootprint.minX + queuedFootprint.xsize * SQUARE_SIZE
-	queuedBuildFootprint.minZ = z - queuedFootprint.halfZsize * SQUARE_SIZE
-	queuedBuildFootprint.maxZ = queuedBuildFootprint.minZ + queuedFootprint.zsize * SQUARE_SIZE
-end
-
-local function updateQueuedBuildFootprints(gameFrame)
-	if gameFrame > 0 and queuedBuildFootprintsGameFrame == gameFrame then
-		return
-	end
-	queuedBuildFootprintsGameFrame = gameFrame
-	queuedBuildFootprintCount = 0
-
-	if gameFrame <= 0 then
-		local pregameBuild = WG["pregame-build"]
-		local getBuildQueue = pregameBuild and pregameBuild.getBuildQueue
-		local buildQueue = getBuildQueue and getBuildQueue()
-		if buildQueue then
-			for queueIndex = 1, #buildQueue do
-				local buildData = buildQueue[queueIndex]
-				if buildData[1] and buildData[2] and buildData[4] then
-					addQueuedBuildFootprint(buildData[1], buildData[2], buildData[4], buildData[5])
-				end
-			end
-		end
-		return
-	end
-
-	local selectedUnits = spGetSelectedUnits()
-	for selectedIndex = 1, #selectedUnits do
-		local commands = spGetUnitCommands(selectedUnits[selectedIndex], -1)
-		if commands then
-			for commandIndex = 1, #commands do
-				local command = commands[commandIndex]
-				local commandID = command.id
-				local params = command.params
-				if commandID < 0 and params and params[1] and params[3] then
-					addQueuedBuildFootprint(-commandID, params[1], params[3], params[4])
-				end
-			end
-		end
-	end
-end
-
-local function hasQueuedBuildFootprintOverlap(unitDefID, x, z, facing, gameFrame)
-	updateQueuedBuildFootprints(gameFrame)
-	local footprint = getFootprintData(unitDefID, facing)
-	local minX = x - footprint.halfXsize * SQUARE_SIZE
-	local maxX = minX + footprint.xsize * SQUARE_SIZE
-	local minZ = z - footprint.halfZsize * SQUARE_SIZE
-	local maxZ = minZ + footprint.zsize * SQUARE_SIZE
-	for index = 1, queuedBuildFootprintCount do
-		local queuedFootprint = queuedBuildFootprints[index]
-		if
-			minX < queuedFootprint.maxX
-			and maxX > queuedFootprint.minX
-			and minZ < queuedFootprint.maxZ
-			and maxZ > queuedFootprint.minZ
-		then
-			return true
-		end
-	end
-	return false
 end
 
 local function appendCollectedPreview(renderCache)
@@ -720,7 +642,6 @@ out vec4 v_color;
 out vec4 v_outlineColor;
 flat out float v_footprintEdges;
 flat out float v_footprintValid;
-flat out float v_queuedFootprintConflict;
 flat out float v_simplified;
 out vec2 v_cellUV;
 
@@ -755,7 +676,6 @@ void main() {
 	float packedFootprintData = mix(a_cellData.w, 0.0, simplified);
 	v_footprintEdges = mod(packedFootprintData, 16.0);
 	v_footprintValid = step(15.5, mod(packedFootprintData, 32.0));
-	v_queuedFootprintConflict = step(31.5, packedFootprintData);
 	v_simplified = simplified;
 	v_cellUV = cellUV;
 	if (isMiniMap == 0) {
@@ -801,7 +721,6 @@ in vec4 v_color;
 in vec4 v_outlineColor;
 flat in float v_footprintEdges;
 flat in float v_footprintValid;
-flat in float v_queuedFootprintConflict;
 flat in float v_simplified;
 in vec2 v_cellUV;
 out vec4 fragColor;
@@ -809,7 +728,6 @@ out vec4 fragColor;
 uniform float simplifiedOutlineScale;
 uniform float simplifiedCornerRadiusScale;
 uniform float cornerRadius;
-uniform float footprintBoundaryEnabled;
 uniform float footprintBoundaryWidth;
 uniform float showInvalidFootprintBoundary;
 uniform vec4 invalidFootprintBoundaryColor;
@@ -825,9 +743,8 @@ void main() {
 	vec4 cellColor = mix(v_color, v_outlineColor, outline);
 	vec3 color = cellColor.rgb;
 	float alpha = cellColor.a;
-	bool showQueuedFootprintBoundary = footprintBoundaryEnabled > 0.5 && v_queuedFootprintConflict > 0.5;
 	bool showInvalidPlacementBoundary = showInvalidFootprintBoundary > 0.5 && v_footprintValid < 0.5;
-	if (showQueuedFootprintBoundary || showInvalidPlacementBoundary) {
+	if (showInvalidPlacementBoundary) {
 		float leftEdge = mod(floor(v_footprintEdges), 2.0);
 		float rightEdge = mod(floor(v_footprintEdges / 2.0), 2.0);
 		float topEdge = mod(floor(v_footprintEdges / 4.0), 2.0);
@@ -886,7 +803,6 @@ local function initGL4Resources()
 			cornerRadius = CORNER_RADIUS,
 			simplifiedOutlineScale = SIMPLIFIED_OUTLINE_SCALE,
 			simplifiedCornerRadiusScale = SIMPLIFIED_CORNER_RADIUS_SCALE,
-			footprintBoundaryEnabled = FOOTPRINT_BOUNDARY_ENABLED and 1.0 or 0.0,
 			footprintBoundaryWidth = FOOTPRINT_BOUNDARY_WIDTH,
 			showInvalidFootprintBoundary = SHOW_INVALID_FOOTPRINT_BOUNDARY and 1.0 or 0.0,
 			invalidFootprintBoundaryColor = INVALID_FOOTPRINT_BOUNDARY_COLOR,
@@ -1143,8 +1059,7 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 	local centerGridZ = math.floor(z / SQUARE_SIZE)
 	local placementX = centerGridX * SQUARE_SIZE
 	local placementZ = centerGridZ * SQUARE_SIZE
-	local queuedFootprintConflict = hasQueuedBuildFootprintOverlap(unitDefID, placementX, placementZ, facing, gameFrame)
-	if ONLY_WHEN_BLOCKED and footprintIsValid and not queuedFootprintConflict then
+	if ONLY_WHEN_BLOCKED and footprintIsValid then
 		extendedCells = 0
 	end
 	local xsize = footprint.xsize
@@ -1160,18 +1075,11 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 		or drawSquareCellCount + sourceCellCount > SIMPLIFIED_CELL_THRESHOLD
 		or needsDistanceSimplification(footprint, placementX, placementZ)
 	local renderCache = orderedPreviewCaches[sequenceIndex]
-	if
-		extendedCells == 0
-		and renderCache
-		and renderCache.unitDefID == unitDefID
-		and renderCache.facing == facing
-		and renderCache.inputX == x
-		and renderCache.inputZ == z
-		and renderCache.colorValid
-		and renderCache.extendedStatusCount == 0
-		and renderCache.simplifiedMode == simplified
-		and renderCache.queuedFootprintConflict == queuedFootprintConflict
-	then
+	if extendedCells == 0 and renderCache
+		and renderCache.unitDefID == unitDefID and renderCache.facing == facing
+		and renderCache.inputX == x and renderCache.inputZ == z
+		and renderCache.colorValid and renderCache.extendedStatusCount == 0
+		and renderCache.simplifiedMode == simplified then
 		local previewWasDrawnLastFrame = renderCache.lastDrawFrame == extendedCellsDrawFrame - 1
 		local statusCheckDue = not previewWasDrawnLastFrame
 			or renderCache.statusCheckGameFrame == nil
@@ -1247,10 +1155,8 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 		)
 	end
 	local extendedStatusCount = sourceCellCount - footprintCellCount
-	local needsColorUpload = not renderCache.colorValid
-		or renderCache.simplifiedMode ~= simplified
+	local needsColorUpload = not renderCache.colorValid or renderCache.simplifiedMode ~= simplified
 		or openYardmapStatusesChanged
-		or renderCache.queuedFootprintConflict ~= queuedFootprintConflict
 
 	if not needsColorUpload and statusCheckDue then
 		for cellIdx = 1, footprintCellCount do
@@ -1282,7 +1188,6 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 		renderCache.sourceCellCount = sourceCellCount
 		renderCache.statusCheckGameFrame = gameFrame
 		renderCache.extendedStatusCount = extendedStatusCount
-		renderCache.queuedFootprintConflict = queuedFootprintConflict
 		for cellIdx = 1, footprintCellCount do
 			local status = statuses[cellIdx] or STATUS_BLOCKED
 			renderCache.footprintStatuses[cellIdx] = status
@@ -1518,17 +1423,40 @@ local function collectPregameBuildSquare()
 	end
 
 	local placementValid = spTestBuildOrder(unitDefID, x, buildHeight, z, facing) ~= 0
+	local getCancelledQueuedBuilds = pregameBuild.getCancelledQueuedBuilds
+	if getCancelledQueuedBuilds then
+		local overlapsQueuedBuild, cancelsQueuedBuild = getCancelledQueuedBuilds(unitDefID, x, buildHeight, z, facing, pregameCancelledBuilds)
+		placementValid = placementValid and (not overlapsQueuedBuild or cancelsQueuedBuild)
+	else
+		for i = #pregameCancelledBuilds, 1, -1 do
+			pregameCancelledBuilds[i] = nil
+		end
+	end
 	local statusIndex = 0
 	for zi = 0, footprint.zsize - 1 do
 		for xi = 0, footprint.xsize - 1 do
 			statusIndex = statusIndex + 1
 			if placementValid then
-				pregameStatuses[statusIndex] = getPredictedCellStatus(
+				local worldX = x + (xi - footprint.halfXsize) * SQUARE_SIZE
+				local worldZ = z + (zi - footprint.halfZsize) * SQUARE_SIZE
+				local status = getPredictedCellStatus(
 					unitDef,
-					x + (xi - footprint.halfXsize) * SQUARE_SIZE,
-					z + (zi - footprint.halfZsize) * SQUARE_SIZE,
+					worldX,
+					worldZ,
 					buildHeight
 				)
+				for i = 1, #pregameCancelledBuilds do
+					local cancelledBuild = pregameCancelledBuilds[i]
+					local cancelledFootprint = getFootprintData(cancelledBuild[1], cancelledBuild[5] or 0)
+					local minX = cancelledBuild[2] - cancelledFootprint.halfXsize * SQUARE_SIZE
+					local minZ = cancelledBuild[4] - cancelledFootprint.halfZsize * SQUARE_SIZE
+					if worldX >= minX and worldX < minX + cancelledFootprint.xsize * SQUARE_SIZE
+						and worldZ >= minZ and worldZ < minZ + cancelledFootprint.zsize * SQUARE_SIZE then
+						status = STATUS_BLOCKED
+						break
+					end
+				end
+				pregameStatuses[statusIndex] = status
 			else
 				pregameStatuses[statusIndex] = STATUS_BLOCKED
 			end
@@ -1623,7 +1551,6 @@ local function rebuildBatchBuffer()
 					cellScale
 				)
 				local footprintValidityFlag = renderCache.footprintIsValid and 16 or 0
-				local queuedFootprintConflictFlag = renderCache.queuedFootprintConflict and 32 or 0
 				for cellIndex = 0, renderCache.batchNumCells - 1 do
 					local geometryIndex = cellIndex * 4
 					local colorIndex = cellIndex * 8
@@ -1636,7 +1563,6 @@ local function rebuildBatchBuffer()
 					dataIndex = dataIndex + 1
 					batchInstanceData[dataIndex] = geometryData[geometryIndex + 4]
 						+ footprintValidityFlag
-						+ queuedFootprintConflictFlag
 					dataIndex = dataIndex + 1
 					batchInstanceData[dataIndex] = colorData[colorIndex + 1]
 					dataIndex = dataIndex + 1

--- a/luaui/Widgets/gui_buildsquare_gl4.lua
+++ b/luaui/Widgets/gui_buildsquare_gl4.lua
@@ -1808,6 +1808,10 @@ local function collectPregameBuildSquare()
 	end
 
 	local placementValid = spTestBuildOrder(unitDefID, x, buildHeight, z, facing) ~= 0
+	local doesBuildClashWithCommander = pregameBuild.doesBuildClashWithCommander
+	if doesBuildClashWithCommander then
+		placementValid = placementValid and not doesBuildClashWithCommander(unitDefID, x, buildHeight, z, facing)
+	end
 	local getCancelledQueuedBuilds = pregameBuild.getCancelledQueuedBuilds
 	if getCancelledQueuedBuilds then
 		local overlapsQueuedBuild, cancelsQueuedBuild =

--- a/luaui/Widgets/gui_buildsquare_gl4.lua
+++ b/luaui/Widgets/gui_buildsquare_gl4.lua
@@ -56,9 +56,7 @@ local spGetGroundNormal = Spring.GetGroundNormal
 local spGetGroundBlocked = Spring.GetGroundBlocked
 local spGetFeatureDefID = Spring.GetFeatureDefID
 local spGetUnitDefID = Spring.GetUnitDefID
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetUnitCommands = Spring.GetUnitCommands
-local spGetMyPlayerID = Spring.GetLocalPlayerID
+local spGetMyPlayerID = Spring.GetMyPlayerID
 local spGetMouseState = Spring.GetMouseState
 local spTraceScreenRay = Spring.TraceScreenRay
 local spGetBuildFacing = Spring.GetBuildFacing
@@ -97,7 +95,6 @@ local COMBINE_VALID_FOOTPRINT_CELLS = true -- merge same-styled cells of a place
 local FOLLOW_EXTRACTOR_SNAP = true -- draw the preview at the spot the extractor snap widget targets instead of at the cursor
 local EXTENDED_ALPHA_NEAR = 0.1
 local EXTENDED_ALPHA_FAR = 0.05
-local FOOTPRINT_BOUNDARY_ENABLED = true
 local FOOTPRINT_BOUNDARY_WIDTH = 0.22
 local SHOW_INVALID_FOOTPRINT_BOUNDARY = false
 local EXTENDED_STATUS_UPDATE_INTERVAL = 0.20
@@ -212,9 +209,7 @@ local statusCheckTargetPhase = 0
 local orderedPreviewCaches = {}
 local pregameStatuses = {}
 local snapStatuses = {}
-local queuedBuildFootprints = {}
-local queuedBuildFootprintCount = 0
-local queuedBuildFootprintsGameFrame = -1
+local pregameCancelledBuilds = {}
 
 local MAX_CELLS = 4096
 
@@ -321,79 +316,6 @@ local function getFootprintData(unitDefID, facing)
 	}
 	unitCaches[facing] = footprint
 	return footprint
-end
-
-local function addQueuedBuildFootprint(unitDefID, x, z, facing)
-	local queuedFootprint = getFootprintData(unitDefID, facing or 0)
-	if not queuedFootprint then
-		return
-	end
-	queuedBuildFootprintCount = queuedBuildFootprintCount + 1
-	local queuedBuildFootprint = queuedBuildFootprints[queuedBuildFootprintCount] or {}
-	queuedBuildFootprints[queuedBuildFootprintCount] = queuedBuildFootprint
-	queuedBuildFootprint.minX = x - queuedFootprint.halfXsize * SQUARE_SIZE
-	queuedBuildFootprint.maxX = queuedBuildFootprint.minX + queuedFootprint.xsize * SQUARE_SIZE
-	queuedBuildFootprint.minZ = z - queuedFootprint.halfZsize * SQUARE_SIZE
-	queuedBuildFootprint.maxZ = queuedBuildFootprint.minZ + queuedFootprint.zsize * SQUARE_SIZE
-end
-
-local function updateQueuedBuildFootprints(gameFrame)
-	if gameFrame > 0 and queuedBuildFootprintsGameFrame == gameFrame then
-		return
-	end
-	queuedBuildFootprintsGameFrame = gameFrame
-	queuedBuildFootprintCount = 0
-
-	if gameFrame <= 0 then
-		local pregameBuild = WG["pregame-build"]
-		local getBuildQueue = pregameBuild and pregameBuild.getBuildQueue
-		local buildQueue = getBuildQueue and getBuildQueue()
-		if buildQueue then
-			for queueIndex = 1, #buildQueue do
-				local buildData = buildQueue[queueIndex]
-				if buildData[1] and buildData[2] and buildData[4] then
-					addQueuedBuildFootprint(buildData[1], buildData[2], buildData[4], buildData[5])
-				end
-			end
-		end
-		return
-	end
-
-	local selectedUnits = spGetSelectedUnits()
-	for selectedIndex = 1, #selectedUnits do
-		local commands = spGetUnitCommands(selectedUnits[selectedIndex], -1)
-		if commands then
-			for commandIndex = 1, #commands do
-				local command = commands[commandIndex]
-				local commandID = command.id
-				local params = command.params
-				if commandID < 0 and params and params[1] and params[3] then
-					addQueuedBuildFootprint(-commandID, params[1], params[3], params[4])
-				end
-			end
-		end
-	end
-end
-
-local function hasQueuedBuildFootprintOverlap(unitDefID, x, z, facing, gameFrame)
-	updateQueuedBuildFootprints(gameFrame)
-	local footprint = getFootprintData(unitDefID, facing)
-	local minX = x - footprint.halfXsize * SQUARE_SIZE
-	local maxX = minX + footprint.xsize * SQUARE_SIZE
-	local minZ = z - footprint.halfZsize * SQUARE_SIZE
-	local maxZ = minZ + footprint.zsize * SQUARE_SIZE
-	for index = 1, queuedBuildFootprintCount do
-		local queuedFootprint = queuedBuildFootprints[index]
-		if
-			minX < queuedFootprint.maxX
-			and maxX > queuedFootprint.minX
-			and minZ < queuedFootprint.maxZ
-			and maxZ > queuedFootprint.minZ
-		then
-			return true
-		end
-	end
-	return false
 end
 
 local function appendCollectedPreview(renderCache)
@@ -727,7 +649,6 @@ out vec4 v_color;
 out vec4 v_outlineColor;
 flat out float v_footprintEdges;
 flat out float v_footprintValid;
-flat out float v_queuedFootprintConflict;
 flat out float v_mode;
 flat out float v_externalEdges;
 flat out vec2 v_quadUnits;
@@ -780,7 +701,6 @@ void main() {
 	float packedFootprintData = a_cellExtra.w;
 	v_footprintEdges = mod(packedFootprintData, 16.0);
 	v_footprintValid = step(15.5, mod(packedFootprintData, 32.0));
-	v_queuedFootprintConflict = step(31.5, packedFootprintData);
 	v_mode = mode;
 	v_externalEdges = a_cellExtra.z;
 	// Merged blocks measure distances relative to the inset footprint, exactly like the simplified quad of the
@@ -846,7 +766,6 @@ in vec4 v_color;
 in vec4 v_outlineColor;
 flat in float v_footprintEdges;
 flat in float v_footprintValid;
-flat in float v_queuedFootprintConflict;
 flat in float v_mode;
 flat in float v_externalEdges;
 flat in vec2 v_quadUnits;
@@ -860,7 +779,6 @@ uniform float simplifiedCornerRadiusScale;
 uniform float cornerRadius;
 uniform float cellInset;
 uniform float cellSize;
-uniform float footprintBoundaryEnabled;
 uniform float footprintBoundaryWidth;
 uniform float showInvalidFootprintBoundary;
 uniform vec4 invalidFootprintBoundaryColor;
@@ -932,9 +850,8 @@ void main() {
 	vec4 cellColor = mix(v_color, v_outlineColor, outline);
 	vec3 color = cellColor.rgb;
 	float alpha = cellColor.a;
-	bool showQueuedFootprintBoundary = footprintBoundaryEnabled > 0.5 && v_queuedFootprintConflict > 0.5;
 	bool showInvalidPlacementBoundary = showInvalidFootprintBoundary > 0.5 && v_footprintValid < 0.5;
-	if (showQueuedFootprintBoundary || showInvalidPlacementBoundary) {
+	if (showInvalidPlacementBoundary) {
 		float leftEdge = mod(floor(v_footprintEdges), 2.0);
 		float rightEdge = mod(floor(v_footprintEdges / 2.0), 2.0);
 		float topEdge = mod(floor(v_footprintEdges / 4.0), 2.0);
@@ -997,7 +914,6 @@ local function initGL4Resources()
 			simplifiedCornerRadiusScale = SIMPLIFIED_CORNER_RADIUS_SCALE,
 			simplifiedReferenceCells = SIMPLIFIED_SIZE_REFERENCE_CELLS,
 			simplifiedSizeFalloff = SIMPLIFIED_SIZE_FALLOFF,
-			footprintBoundaryEnabled = FOOTPRINT_BOUNDARY_ENABLED and 1.0 or 0.0,
 			footprintBoundaryWidth = FOOTPRINT_BOUNDARY_WIDTH,
 			showInvalidFootprintBoundary = SHOW_INVALID_FOOTPRINT_BOUNDARY and 1.0 or 0.0,
 			invalidFootprintBoundaryColor = INVALID_FOOTPRINT_BOUNDARY_COLOR,
@@ -1281,7 +1197,7 @@ end
 -- fully exposed.
 -- Writes 14 numbers per rectangle into rectData: cell x, cell z, width, height (cells), external edge mask plus
 -- 16 * concave corner mask, packed footprint data, fill rgba, outline rgba. Returns the rectangle count.
-local function buildMergedFootprintRects(rectData, statuses, footprint, queuedFootprintConflict)
+local function buildMergedFootprintRects(rectData, statuses, footprint)
 	local xsize = footprint.xsize
 	local zsize = footprint.zsize
 	-- Hidden open yardmap cells get no rectangle, which keeps them as holes in the merged shape.
@@ -1377,7 +1293,7 @@ local function buildMergedFootprintRects(rectData, statuses, footprint, queuedFo
 		end
 	end
 
-	local packedFlags = 16 + (queuedFootprintConflict and 32 or 0)
+	local packedFlags = 16
 	local dataIndex = 0
 	for rectIndex = 0, rectCount - 1 do
 		local rectBase = rectIndex * 10
@@ -1433,12 +1349,17 @@ local function fillPredictedStatuses(statusList, unitDef, x, buildHeight, z, foo
 			statusIndex = statusIndex + 1
 			local status = STATUS_BLOCKED
 			if placementValid then
-				status = getPredictedCellStatus(
+				local objectStatus
+				status, objectStatus = getPredictedCellStatus(
 					unitDef,
 					x + (xi - footprint.halfXsize) * SQUARE_SIZE,
 					z + (zi - footprint.halfZsize) * SQUARE_SIZE,
 					buildHeight
 				)
+				-- Match the in-game preview: terrain does not block open yardmap cells.
+				if footprint.openYardmapCells and footprint.openYardmapCells[statusIndex] then
+					status = objectStatus
+				end
 				-- The engine accepted the order, so a cell the prediction calls blocked is really placeable
 				-- (e.g. an extractor upgrade over stackable / build-only yardmap squares).
 				if status == STATUS_BLOCKED then
@@ -1506,8 +1427,7 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 	local centerGridZ = math.floor(z / SQUARE_SIZE)
 	local placementX = centerGridX * SQUARE_SIZE
 	local placementZ = centerGridZ * SQUARE_SIZE
-	local queuedFootprintConflict = hasQueuedBuildFootprintOverlap(unitDefID, placementX, placementZ, facing, gameFrame)
-	if ONLY_WHEN_BLOCKED and footprintIsValid and not queuedFootprintConflict then
+	if ONLY_WHEN_BLOCKED and footprintIsValid then
 		extendedCells = 0
 	end
 	local xsize = footprint.xsize
@@ -1533,7 +1453,6 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 		and renderCache.extendedStatusCount == 0
 		and renderCache.simplifiedMode == simplified
 		and renderCache.mergedMode == merged
-		and renderCache.queuedFootprintConflict == queuedFootprintConflict
 	then
 		local previewWasDrawnLastFrame = renderCache.lastDrawFrame == extendedCellsDrawFrame - 1
 		local statusCheckDue = not previewWasDrawnLastFrame
@@ -1621,7 +1540,6 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 		or renderCache.simplifiedMode ~= simplified
 		or renderCache.mergedMode ~= merged
 		or openYardmapStatusesChanged
-		or renderCache.queuedFootprintConflict ~= queuedFootprintConflict
 
 	if not needsColorUpload and statusCheckDue then
 		for cellIdx = 1, footprintCellCount do
@@ -1654,7 +1572,6 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 		renderCache.sourceCellCount = sourceCellCount
 		renderCache.statusCheckGameFrame = gameFrame
 		renderCache.extendedStatusCount = extendedStatusCount
-		renderCache.queuedFootprintConflict = queuedFootprintConflict
 		for cellIdx = 1, footprintCellCount do
 			local status = statuses[cellIdx] or STATUS_BLOCKED
 			renderCache.footprintStatuses[cellIdx] = status
@@ -1693,7 +1610,7 @@ function widget:DrawBuildSquare(unitDefID, x, z, facing, statuses)
 			return
 		end
 		if merged then
-			local rectCount = buildMergedFootprintRects(colorData, statuses, footprint, queuedFootprintConflict)
+			local rectCount = buildMergedFootprintRects(colorData, statuses, footprint)
 			for index = rectCount * 14 + 1, renderCache.colorDataLength or 0 do
 				colorData[index] = nil
 			end
@@ -1891,7 +1808,44 @@ local function collectPregameBuildSquare()
 	end
 
 	local placementValid = spTestBuildOrder(unitDefID, x, buildHeight, z, facing) ~= 0
+	local getCancelledQueuedBuilds = pregameBuild.getCancelledQueuedBuilds
+	if getCancelledQueuedBuilds then
+		local overlapsQueuedBuild, cancelsQueuedBuild =
+			getCancelledQueuedBuilds(unitDefID, x, buildHeight, z, facing, pregameCancelledBuilds)
+		placementValid = placementValid and (not overlapsQueuedBuild or cancelsQueuedBuild)
+	else
+		for i = #pregameCancelledBuilds, 1, -1 do
+			pregameCancelledBuilds[i] = nil
+		end
+	end
 	fillPredictedStatuses(pregameStatuses, unitDef, x, buildHeight, z, footprint, placementValid)
+	-- Blank cells the engine would otherwise clear a queued build for: the cell prediction above only knows
+	-- about terrain/yardmap conflicts, not which earlier queued command this placement would cancel.
+	if #pregameCancelledBuilds > 0 then
+		local statusIndex = 0
+		for zi = 0, footprint.zsize - 1 do
+			for xi = 0, footprint.xsize - 1 do
+				statusIndex = statusIndex + 1
+				local worldX = x + (xi - footprint.halfXsize) * SQUARE_SIZE
+				local worldZ = z + (zi - footprint.halfZsize) * SQUARE_SIZE
+				for i = 1, #pregameCancelledBuilds do
+					local cancelledBuild = pregameCancelledBuilds[i]
+					local cancelledFootprint = getFootprintData(cancelledBuild[1], cancelledBuild[5] or 0)
+					local minX = cancelledBuild[2] - cancelledFootprint.halfXsize * SQUARE_SIZE
+					local minZ = cancelledBuild[4] - cancelledFootprint.halfZsize * SQUARE_SIZE
+					if
+						worldX >= minX
+						and worldX < minX + cancelledFootprint.xsize * SQUARE_SIZE
+						and worldZ >= minZ
+						and worldZ < minZ + cancelledFootprint.zsize * SQUARE_SIZE
+					then
+						pregameStatuses[statusIndex] = STATUS_BLOCKED
+						break
+					end
+				end
+			end
+		end
+	end
 
 	widget:DrawBuildSquare(unitDefID, x, z, facing, pregameStatuses)
 end
@@ -2030,8 +1984,7 @@ local function rebuildBatchBuffer()
 					renderCache.batchExtendedCells / cellScale,
 					cellScale
 				)
-				local packedFlags = (renderCache.footprintIsValid and 16 or 0)
-					+ (renderCache.queuedFootprintConflict and 32 or 0)
+				local packedFlags = renderCache.footprintIsValid and 16 or 0
 				for cellIndex = 0, renderCache.batchNumCells - 1 do
 					local geometryIndex = cellIndex * 3
 					local colorIndex = cellIndex * 8

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -32,6 +32,7 @@ local spGetGroundHeight = Spring.GetGroundHeight
 local spEcho = Spring.Echo
 
 local spTestBuildOrder = Spring.TestBuildOrder
+local spTestBuildOrderOverlap = Spring.TestBuildOrderOverlap
 
 local spawnWarpInFrame = Game.spawnWarpInFrame
 
@@ -79,6 +80,8 @@ local BUILDING_COUNT_FUDGE_FACTOR = 1.4
 local BUILDING_DETECTION_TOLERANCE = 10
 local HALF = 0.5
 local MAX_DRAG_BUILD_COUNT = 200
+-- Keep the production behavior by default: the future commander footprint blocks pregame builds.
+local ALLOW_BUILD_QUEUE_OVER_COMMANDER = false
 
 local function buildFacingHandler(command, line, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
@@ -133,6 +136,8 @@ local function handleBuildMenu(shift)
 end
 
 local FORCE_SHOW_REASON = "gui_pregame_build"
+local DoBuildingsClash
+
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
 
@@ -217,10 +222,14 @@ local function convertBuildQueueFaction(previousFactionSide, currentFactionSide)
 		)
 	)
 	local result = SubLogic.processBuildQueueSubstitution(buildQueue, previousFactionSide, currentFactionSide)
-
+	local removedCount = SubLogic.removeOverlappingBuildQueueItems(buildQueue, DoBuildingsClash)
 	if result.substitutionFailed then
 		spEcho(string.format("[gui_pregame_build] %s", result.summaryMessage))
 	end
+	if removedCount > 0 then
+		spEcho(string.format("[Pregame Build] Removed %d queued build order%s that overlap after changing faction.", removedCount, removedCount == 1 and "" or "s"))
+	end
+	forceRefreshCache = true
 end
 
 local function handleSelectedBuildingConversion(
@@ -329,6 +338,28 @@ function widget:Initialize()
 	end
 	WG["pregame-build"].getBuildQueue = function()
 		return buildQueue
+	end
+	WG["pregame-build"].getCancelledQueuedBuilds = function(unitDefID, x, y, z, facing, cancelledBuilds)
+		for i = #cancelledBuilds, 1, -1 do
+			cancelledBuilds[i] = nil
+		end
+		if not preGamestartPlayer then
+			return false, false
+		end
+		local proposedBuild = { unitDefID, x, y, z, facing }
+		local overlapsQueuedBuild = false
+		local cancelsQueuedBuild = false
+		for i = 1, #buildQueue do
+			if buildQueue[i][1] > 0 then
+				local overlaps, cancels = DoBuildingsClash(proposedBuild, buildQueue[i])
+				overlapsQueuedBuild = overlapsQueuedBuild or overlaps
+				cancelsQueuedBuild = cancelsQueuedBuild or cancels
+				if cancels then
+					cancelledBuilds[#cancelledBuilds + 1] = buildQueue[i]
+				end
+			end
+		end
+		return overlapsQueuedBuild, cancelsQueuedBuild
 	end
 	WG["pregame-build"].getBuildPositions = function()
 		return buildModeState.buildPositions
@@ -653,7 +684,7 @@ local function getGhostBuildingUnderCursor(mouseX, mouseY)
 	return nil
 end
 
-local function DoBuildingsClash(buildingData1, buildingData2)
+local function DoBuildingRectanglesClash(buildingData1, buildingData2)
 	local building1Width, building1Height = GetBuildingDimensions(buildingData1[1], buildingData1[5])
 	local building2Width, building2Height = GetBuildingDimensions(buildingData2[1], buildingData2[5])
 
@@ -663,7 +694,34 @@ local function DoBuildingsClash(buildingData1, buildingData2)
 	local xDistance = mathAbs(buildingData1[2] - buildingData2[2])
 	local zDistance = mathAbs(buildingData1[4] - buildingData2[4])
 
-	return xDistance < halfBuilding1Width + halfBuilding2Width and zDistance < halfBuilding1Height + halfBuilding2Height
+	local overlaps = xDistance < halfBuilding1Width + halfBuilding2Width and zDistance < halfBuilding1Height + halfBuilding2Height
+	local cancels = overlaps
+		and xDistance <= mathMax(building1Width, building2Width) * HALF
+		and zDistance <= mathMax(building1Height, building2Height) * HALF
+
+	return overlaps, cancels
+end
+
+DoBuildingsClash = function(buildingData1, buildingData2)
+	if spTestBuildOrderOverlap then
+		return spTestBuildOrderOverlap(
+			{ buildingData2[1], buildingData2[2], buildingData2[3], buildingData2[4], buildingData2[5] or 0 },
+			{ buildingData1[1], buildingData1[2], buildingData1[3], buildingData1[4], buildingData1[5] or 0 }
+		)
+	end
+
+	-- Compatibility with engines that predate Spring.TestBuildOrderOverlap.
+	-- buildingData1 is the proposed build and buildingData2 is earlier in the queue.
+	return DoBuildingRectanglesClash(buildingData1, buildingData2)
+end
+
+local function DoesBuildClashWithCommander(buildData, cx, cy, cz)
+	if ALLOW_BUILD_QUEUE_OVER_COMMANDER or cx == -100 then
+		return false
+	end
+
+	local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+	return DoBuildingRectanglesClash(buildData, { startDefID, cbx, cby, cbz, 1 })
 end
 
 local function removeUnitShape(id)
@@ -788,18 +846,18 @@ function widget:Update(dt)
 				local hasConflicts = false
 
 				local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
-				if cx ~= -100 then
-					local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-					if DoBuildingsClash(buildDataPos, { startDefID, cbx, cby, cbz, 1 }) then
-						hasConflicts = true
-					end
+				if DoesBuildClashWithCommander(buildDataPos, cx, cy, cz) then
+					hasConflicts = true
 				end
 
 				if not hasConflicts then
 					for i = #buildQueue, 1, -1 do
-						if buildQueue[i][1] > 0 and DoBuildingsClash(buildDataPos, buildQueue[i]) then
-							tableRemove(buildQueue, i)
-							hasConflicts = true
+						if buildQueue[i][1] > 0 then
+							local overlaps, cancels = DoBuildingsClash(buildDataPos, buildQueue[i])
+							if cancels then
+								tableRemove(buildQueue, i)
+							end
+							hasConflicts = hasConflicts or overlaps
 						end
 					end
 				end
@@ -976,11 +1034,8 @@ function widget:MousePress(mx, my, button)
 					local hasConflicts = false
 
 					local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
-					if cx ~= -100 then
-						local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-						if DoBuildingsClash(buildDataPos, { startDefID, cbx, cby, cbz, 1 }) then
-							hasConflicts = true
-						end
+					if DoesBuildClashWithCommander(buildDataPos, cx, cy, cz) then
+						hasConflicts = true
 					end
 
 					if
@@ -1047,31 +1102,26 @@ function widget:MousePress(mx, my, button)
 			buildModeState.buildPositions = {}
 			return true
 		end
-
-		if (meta or not shift) and cx ~= -100 then
-			local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-
-			if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then
-				return true
-			end
+		if (meta or not shift) and DoesBuildClashWithCommander(buildData, cx, cy, cz) then
+			return true
 		end
 
 		if Spring.TestBuildOrder(selBuildQueueDefID, bx, by, bz, buildFacing) ~= 0 then
 			local hasConflicts = false
 
 			local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
-			if cx ~= -100 then
-				local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-				if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then
-					hasConflicts = true
-				end
+			if DoesBuildClashWithCommander(buildData, cx, cy, cz) then
+				hasConflicts = true
 			end
 
 			if not hasConflicts then
 				for i = #buildQueue, 1, -1 do
-					if buildQueue[i][1] > 0 and DoBuildingsClash(buildData, buildQueue[i]) then
-						tableRemove(buildQueue, i)
-						hasConflicts = true
+					if buildQueue[i][1] > 0 then
+						local overlaps, cancels = DoBuildingsClash(buildData, buildQueue[i])
+						if cancels then
+							tableRemove(buildQueue, i)
+						end
+						hasConflicts = hasConflicts or overlaps
 					end
 				end
 			end
@@ -1119,7 +1169,7 @@ function widget:MousePress(mx, my, button)
 		end
 		local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, pos[1], pos[2], pos[3])
 
-		if DoBuildingsClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1]) then
+		if not ALLOW_BUILD_QUEUE_OVER_COMMANDER and DoBuildingRectanglesClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1]) then
 			return true
 		end
 	end
@@ -1313,7 +1363,12 @@ function widget:DrawWorld()
 			local isSpawned = alpha >= ALPHA_SPAWNED
 			local borderColor = isSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_NORMAL
 
-			if selBuildData and DoBuildingsClash(selBuildData, buildData) then
+			local cancels = false
+			if selBuildData then
+				local _, candidateCancels = DoBuildingsClash(selBuildData, buildData)
+				cancels = candidateCancels
+			end
+			if cancels then
 				DrawBuilding(buildData, BORDER_COLOR_CLASH, false, alpha)
 			else
 				DrawBuilding(buildData, borderColor, false, alpha)
@@ -1335,11 +1390,7 @@ function widget:DrawWorld()
 	end
 
 	local function checkCommanderClash(previewBuildData, cx, cy, cz)
-		if cx == -100 then
-			return false
-		end
-		local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-		return DoBuildingsClash(previewBuildData, { startDefID, cbx, cby, cbz, 1 })
+		return DoesBuildClashWithCommander(previewBuildData, cx, cy, cz)
 	end
 
 	local function checkMexValidity(posX, posZ, isMex)
@@ -1516,14 +1567,25 @@ function widget:DrawWorld()
 	if selBuildData and showSelectedBuilding then
 		local drawSelectedOutline = WG["buildsquare-gl4"] == nil
 		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+		local overlapsQueuedBuild = false
+		local cancelsQueuedBuild = false
+		for i = 1, #buildQueue do
+			if buildQueue[i][1] > 0 then
+				local overlaps, cancels = DoBuildingsClash(selBuildData, buildQueue[i])
+				overlapsQueuedBuild = overlapsQueuedBuild or overlaps
+				cancelsQueuedBuild = cancelsQueuedBuild or cancels
+			end
+		end
+		-- Cancellation takes precedence in CommandAI. Only an overlap with no
+		-- cancellation candidate rejects the proposed build.
+		local rejectedByQueuedBuild = overlapsQueuedBuild and not cancelsQueuedBuild
 		local testOrder = spTestBuildOrder(
 			selBuildQueueDefID,
 			selBuildData[2],
 			selBuildData[3],
 			selBuildData[4],
 			selBuildData[5]
-		) ~= 0
-
+		) ~= 0 and not rejectedByQueuedBuild
 		local isSelectedSpawned = false
 		local selectedAlpha = ALPHA_DEFAULT
 		local getBuildQueueSpawnStatus = WG.getBuildQueueSpawnStatus

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -80,8 +80,11 @@ local BUILDING_COUNT_FUDGE_FACTOR = 1.4
 local BUILDING_DETECTION_TOLERANCE = 10
 local HALF = 0.5
 local MAX_DRAG_BUILD_COUNT = 200
--- Keep the production behavior by default: the future commander footprint blocks pregame builds.
-local ALLOW_BUILD_QUEUE_OVER_COMMANDER = false
+-- BAR PR #1515 introduced the restriction for issue #803, where an already-spawned
+-- commander could build over itself. That case no longer reproduces: at game start
+-- the commander walks out of the footprint before executing the queued build.
+local ALLOW_BUILD_QUEUE_OVER_COMMANDER = true
+local DoesBuildClashWithCommander
 
 local function buildFacingHandler(command, line, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
@@ -338,6 +341,10 @@ function widget:Initialize()
 	end
 	WG["pregame-build"].getBuildQueue = function()
 		return buildQueue
+	end
+	WG["pregame-build"].doesBuildClashWithCommander = function(unitDefID, x, y, z, facing)
+		local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+		return DoesBuildClashWithCommander({ unitDefID, x, y, z, facing }, cx, cy, cz)
 	end
 	WG["pregame-build"].getCancelledQueuedBuilds = function(unitDefID, x, y, z, facing, cancelledBuilds)
 		for i = #cancelledBuilds, 1, -1 do
@@ -715,7 +722,7 @@ DoBuildingsClash = function(buildingData1, buildingData2)
 	return DoBuildingRectanglesClash(buildingData1, buildingData2)
 end
 
-local function DoesBuildClashWithCommander(buildData, cx, cy, cz)
+DoesBuildClashWithCommander = function(buildData, cx, cy, cz)
 	if ALLOW_BUILD_QUEUE_OVER_COMMANDER or cx == -100 then
 		return false
 	end

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -32,6 +32,7 @@ local spGetGroundHeight = Spring.GetGroundHeight
 local spEcho = Spring.Echo
 
 local spTestBuildOrder = Spring.TestBuildOrder
+local spTestBuildOrderOverlap = Spring.TestBuildOrderOverlap
 
 local spawnWarpInFrame = Game.spawnWarpInFrame
 
@@ -79,6 +80,8 @@ local BUILDING_COUNT_FUDGE_FACTOR = 1.4
 local BUILDING_DETECTION_TOLERANCE = 10
 local HALF = 0.5
 local MAX_DRAG_BUILD_COUNT = 200
+-- Keep the production behavior by default: the future commander footprint blocks pregame builds.
+local ALLOW_BUILD_QUEUE_OVER_COMMANDER = false
 
 local function buildFacingHandler(command, line, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
@@ -133,6 +136,8 @@ local function handleBuildMenu(shift)
 end
 
 local FORCE_SHOW_REASON = "gui_pregame_build"
+local DoBuildingsClash
+
 local function setPreGamestartDefID(uDefID)
 	selBuildQueueDefID = uDefID
 
@@ -217,10 +222,20 @@ local function convertBuildQueueFaction(previousFactionSide, currentFactionSide)
 		)
 	)
 	local result = SubLogic.processBuildQueueSubstitution(buildQueue, previousFactionSide, currentFactionSide)
-
+	local removedCount = SubLogic.removeOverlappingBuildQueueItems(buildQueue, DoBuildingsClash)
 	if result.substitutionFailed then
 		spEcho(string.format("[gui_pregame_build] %s", result.summaryMessage))
 	end
+	if removedCount > 0 then
+		spEcho(
+			string.format(
+				"[Pregame Build] Removed %d queued build order%s that overlap after changing faction.",
+				removedCount,
+				removedCount == 1 and "" or "s"
+			)
+		)
+	end
+	forceRefreshCache = true
 end
 
 local function handleSelectedBuildingConversion(
@@ -335,6 +350,28 @@ function widget:Initialize()
 	end
 	WG["pregame-build"].getBuildQueue = function()
 		return buildQueue
+	end
+	WG["pregame-build"].getCancelledQueuedBuilds = function(unitDefID, x, y, z, facing, cancelledBuilds)
+		for i = #cancelledBuilds, 1, -1 do
+			cancelledBuilds[i] = nil
+		end
+		if not preGamestartPlayer then
+			return false, false
+		end
+		local proposedBuild = { unitDefID, x, y, z, facing }
+		local overlapsQueuedBuild = false
+		local cancelsQueuedBuild = false
+		for i = 1, #buildQueue do
+			if buildQueue[i][1] > 0 then
+				local overlaps, cancels = DoBuildingsClash(proposedBuild, buildQueue[i])
+				overlapsQueuedBuild = overlapsQueuedBuild or overlaps
+				cancelsQueuedBuild = cancelsQueuedBuild or cancels
+				if cancels then
+					cancelledBuilds[#cancelledBuilds + 1] = buildQueue[i]
+				end
+			end
+		end
+		return overlapsQueuedBuild, cancelsQueuedBuild
 	end
 	WG["pregame-build"].getBuildPositions = function()
 		return buildModeState.buildPositions
@@ -659,7 +696,7 @@ local function getGhostBuildingUnderCursor(mouseX, mouseY)
 	return nil
 end
 
-local function DoBuildingsClash(buildingData1, buildingData2)
+local function DoBuildingRectanglesClash(buildingData1, buildingData2)
 	local building1Width, building1Height = GetBuildingDimensions(buildingData1[1], buildingData1[5])
 	local building2Width, building2Height = GetBuildingDimensions(buildingData2[1], buildingData2[5])
 
@@ -669,7 +706,35 @@ local function DoBuildingsClash(buildingData1, buildingData2)
 	local xDistance = mathAbs(buildingData1[2] - buildingData2[2])
 	local zDistance = mathAbs(buildingData1[4] - buildingData2[4])
 
-	return xDistance < halfBuilding1Width + halfBuilding2Width and zDistance < halfBuilding1Height + halfBuilding2Height
+	local overlaps = xDistance < halfBuilding1Width + halfBuilding2Width
+		and zDistance < halfBuilding1Height + halfBuilding2Height
+	local cancels = overlaps
+		and xDistance <= mathMax(building1Width, building2Width) * HALF
+		and zDistance <= mathMax(building1Height, building2Height) * HALF
+
+	return overlaps, cancels
+end
+
+DoBuildingsClash = function(buildingData1, buildingData2)
+	if spTestBuildOrderOverlap then
+		return spTestBuildOrderOverlap(
+			{ buildingData2[1], buildingData2[2], buildingData2[3], buildingData2[4], buildingData2[5] or 0 },
+			{ buildingData1[1], buildingData1[2], buildingData1[3], buildingData1[4], buildingData1[5] or 0 }
+		)
+	end
+
+	-- Compatibility with engines that predate Spring.TestBuildOrderOverlap.
+	-- buildingData1 is the proposed build and buildingData2 is earlier in the queue.
+	return DoBuildingRectanglesClash(buildingData1, buildingData2)
+end
+
+local function DoesBuildClashWithCommander(buildData, cx, cy, cz)
+	if ALLOW_BUILD_QUEUE_OVER_COMMANDER or cx == -100 then
+		return false
+	end
+
+	local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
+	return DoBuildingRectanglesClash(buildData, { startDefID, cbx, cby, cbz, 1 })
 end
 
 local function removeUnitShape(id)
@@ -794,18 +859,18 @@ function widget:Update(dt)
 				local hasConflicts = false
 
 				local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
-				if cx ~= -100 then
-					local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-					if DoBuildingsClash(buildDataPos, { startDefID, cbx, cby, cbz, 1 }) then
-						hasConflicts = true
-					end
+				if DoesBuildClashWithCommander(buildDataPos, cx, cy, cz) then
+					hasConflicts = true
 				end
 
 				if not hasConflicts then
 					for i = #buildQueue, 1, -1 do
-						if buildQueue[i][1] > 0 and DoBuildingsClash(buildDataPos, buildQueue[i]) then
-							tableRemove(buildQueue, i)
-							hasConflicts = true
+						if buildQueue[i][1] > 0 then
+							local overlaps, cancels = DoBuildingsClash(buildDataPos, buildQueue[i])
+							if cancels then
+								tableRemove(buildQueue, i)
+							end
+							hasConflicts = hasConflicts or overlaps
 						end
 					end
 				end
@@ -982,11 +1047,8 @@ function widget:MousePress(mx, my, button)
 					local hasConflicts = false
 
 					local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
-					if cx ~= -100 then
-						local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-						if DoBuildingsClash(buildDataPos, { startDefID, cbx, cby, cbz, 1 }) then
-							hasConflicts = true
-						end
+					if DoesBuildClashWithCommander(buildDataPos, cx, cy, cz) then
+						hasConflicts = true
 					end
 
 					if
@@ -1052,31 +1114,26 @@ function widget:MousePress(mx, my, button)
 			buildModeState.buildPositions = {}
 			return true
 		end
-
-		if (meta or not shift) and cx ~= -100 then
-			local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-
-			if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then
-				return true
-			end
+		if (meta or not shift) and DoesBuildClashWithCommander(buildData, cx, cy, cz) then
+			return true
 		end
 
 		if Spring.TestBuildOrder(selBuildQueueDefID, bx, by, bz, buildFacing) ~= 0 then
 			local hasConflicts = false
 
 			local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
-			if cx ~= -100 then
-				local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-				if DoBuildingsClash(buildData, { startDefID, cbx, cby, cbz, 1 }) then
-					hasConflicts = true
-				end
+			if DoesBuildClashWithCommander(buildData, cx, cy, cz) then
+				hasConflicts = true
 			end
 
 			if not hasConflicts then
 				for i = #buildQueue, 1, -1 do
-					if buildQueue[i][1] > 0 and DoBuildingsClash(buildData, buildQueue[i]) then
-						tableRemove(buildQueue, i)
-						hasConflicts = true
+					if buildQueue[i][1] > 0 then
+						local overlaps, cancels = DoBuildingsClash(buildData, buildQueue[i])
+						if cancels then
+							tableRemove(buildQueue, i)
+						end
+						hasConflicts = hasConflicts or overlaps
 					end
 				end
 			end
@@ -1124,7 +1181,10 @@ function widget:MousePress(mx, my, button)
 		end
 		local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, pos[1], pos[2], pos[3])
 
-		if DoBuildingsClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1]) then
+		if
+			not ALLOW_BUILD_QUEUE_OVER_COMMANDER
+			and DoBuildingRectanglesClash({ startDefID, cbx, cby, cbz, 1 }, buildQueue[1])
+		then
 			return true
 		end
 	end
@@ -1318,7 +1378,12 @@ function widget:DrawWorld()
 			local isSpawned = alpha >= ALPHA_SPAWNED
 			local borderColor = isSpawned and BORDER_COLOR_SPAWNED or BORDER_COLOR_NORMAL
 
-			if selBuildData and DoBuildingsClash(selBuildData, buildData) then
+			local cancels = false
+			if selBuildData then
+				local _, candidateCancels = DoBuildingsClash(selBuildData, buildData)
+				cancels = candidateCancels
+			end
+			if cancels then
 				DrawBuilding(buildData, BORDER_COLOR_CLASH, false, alpha)
 			else
 				DrawBuilding(buildData, borderColor, false, alpha)
@@ -1340,11 +1405,7 @@ function widget:DrawWorld()
 	end
 
 	local function checkCommanderClash(previewBuildData, cx, cy, cz)
-		if cx == -100 then
-			return false
-		end
-		local cbx, cby, cbz = Spring.Pos2BuildPos(startDefID, cx, cy, cz)
-		return DoBuildingsClash(previewBuildData, { startDefID, cbx, cby, cbz, 1 })
+		return DoesBuildClashWithCommander(previewBuildData, cx, cy, cz)
 	end
 
 	local function checkMexValidity(posX, posZ, isMex)
@@ -1521,14 +1582,25 @@ function widget:DrawWorld()
 	if selBuildData and showSelectedBuilding then
 		local drawSelectedOutline = WG["buildsquare-gl4"] == nil
 		local isMex = UnitDefs[selBuildQueueDefID] and UnitDefs[selBuildQueueDefID].extractsMetal > 0
+		local overlapsQueuedBuild = false
+		local cancelsQueuedBuild = false
+		for i = 1, #buildQueue do
+			if buildQueue[i][1] > 0 then
+				local overlaps, cancels = DoBuildingsClash(selBuildData, buildQueue[i])
+				overlapsQueuedBuild = overlapsQueuedBuild or overlaps
+				cancelsQueuedBuild = cancelsQueuedBuild or cancels
+			end
+		end
+		-- Cancellation takes precedence in CommandAI. Only an overlap with no
+		-- cancellation candidate rejects the proposed build.
+		local rejectedByQueuedBuild = overlapsQueuedBuild and not cancelsQueuedBuild
 		local testOrder = spTestBuildOrder(
 			selBuildQueueDefID,
 			selBuildData[2],
 			selBuildData[3],
 			selBuildData[4],
 			selBuildData[5]
-		) ~= 0
-
+		) ~= 0 and not rejectedByQueuedBuild
 		local isSelectedSpawned = false
 		local selectedAlpha = ALPHA_DEFAULT
 		local getBuildQueueSpawnStatus = WG.getBuildQueueSpawnStatus

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -80,8 +80,11 @@ local BUILDING_COUNT_FUDGE_FACTOR = 1.4
 local BUILDING_DETECTION_TOLERANCE = 10
 local HALF = 0.5
 local MAX_DRAG_BUILD_COUNT = 200
--- Keep the production behavior by default: the future commander footprint blocks pregame builds.
-local ALLOW_BUILD_QUEUE_OVER_COMMANDER = false
+-- BAR PR #1515 introduced the restriction for issue #803, where an already-spawned
+-- commander could build over itself. That case no longer reproduces: at game start
+-- the commander walks out of the footprint before executing the queued build.
+local ALLOW_BUILD_QUEUE_OVER_COMMANDER = true
+local DoesBuildClashWithCommander
 
 local function buildFacingHandler(command, line, args)
 	if not (preGamestartPlayer and selBuildQueueDefID) then
@@ -350,6 +353,10 @@ function widget:Initialize()
 	end
 	WG["pregame-build"].getBuildQueue = function()
 		return buildQueue
+	end
+	WG["pregame-build"].doesBuildClashWithCommander = function(unitDefID, x, y, z, facing)
+		local cx, cy, cz = Spring.GetTeamStartPosition(myTeamID)
+		return DoesBuildClashWithCommander({ unitDefID, x, y, z, facing }, cx, cy, cz)
 	end
 	WG["pregame-build"].getCancelledQueuedBuilds = function(unitDefID, x, y, z, facing, cancelledBuilds)
 		for i = #cancelledBuilds, 1, -1 do
@@ -728,7 +735,7 @@ DoBuildingsClash = function(buildingData1, buildingData2)
 	return DoBuildingRectanglesClash(buildingData1, buildingData2)
 end
 
-local function DoesBuildClashWithCommander(buildData, cx, cy, cz)
+DoesBuildClashWithCommander = function(buildData, cx, cy, cz)
 	if ALLOW_BUILD_QUEUE_OVER_COMMANDER or cx == -100 then
 		return false
 	end


### PR DESCRIPTION
## Summary

BAR now uses the engine's directional, facing-aware yardmap overlap decision for its Lua-only pregame build queue and removes the separate rectangular queue approximation from BuildSquare GL4.

This change:

- removes BuildSquare GL4's reconstruction and rectangular overlap scan of selected builders' command queues;
- uses the blocked-cell statuses already supplied by the existing `DrawBuildSquare` call-in for in-game placement feedback;
- makes the pregame queue use `Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild)`, while retaining the previous rectangular fallback for older engines;
- explicitly enables `construction.useYardmapsForQueuedBuildOverlap`, since the companion engine keeps rectangle-only behavior as its backward-compatible default;
- marks the prospective pregame build cells covered by commands that would be removed as blocked, matching the existing invalid-placement presentation;
- revalidates the pregame queue after faction substitution and removes later entries that conflict under the substituted faction's yardmaps;
- adds focused integration coverage for an Armada-to-Cortex faction change where a previously compatible solar placement becomes conflicting.

Queued-build outlines remain rendered by the engine. This PR does not add a queue-rendering widget or any new Lua call-ins.

As a result, pregame and in-game queues use the same authoritative overlap rule: yardmap-compatible queued buildings can interlock, while a true conflict removes the affected queued command.

Depends on beyond-all-reason/RecoilEngine#3192.

#### Addresses Issue(s)

- Fixes #8714

## Test steps

1. Use the companion RecoilEngine branch from beyond-all-reason/RecoilEngine#3192.
2. Start a game on All That Glitters v2.2.3 and remain in pregame.
3. Choose Armada and queue two solars whose rectangular footprints overlap but whose yardmaps permit sequential construction.
4. Confirm both solars remain in the pregame queue.
5. Preview a solar in a true yardmap conflict and confirm the existing queued entry is shown as conflicting and is removed when clicked.
6. Change faction after creating a queue whose substituted buildings are no longer yardmap-compatible; confirm the later conflicting entry is removed.
7. Start the game and repeat compatible and conflicting placements with a constructor.
8. Confirm the in-game result matches pregame behavior.
9. Repeat with BuildSquare GL4 disabled and confirm queue acceptance and cancellation behavior is unchanged.

## Validation

- Rebased onto current BAR master.
- The complete BAR headless integration suite passes against Recoil `2026.07.01-17-g2c4416e`.
- All three queued-build tests pass under BAR's explicit yardmap-overlap opt-in.
- `pregame_build/test_faction_queue_overlap.lua` passes.
- The changed Lua files pass `luac -p` and the changed-file lint checks.
- Manually verified pregame and in-game behavior on All That Glitters v2.2.3.

## Videos

### Before

https://github.com/user-attachments/assets/3ac1a36b-4e8a-40a0-83d8-9f5145fe214a

### After

https://github.com/user-attachments/assets/014715c5-54b9-425b-a250-9afd8c36b2fa

## AI / LLM usage statement

OpenAI Codex was used interactively to trace the engine/widget behavior, draft the implementation and focused integration test, and assist with testing. I reviewed the changes and manually verified them in-game.