### PR TITLE
gitignore: ignore .lux in symlink form too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 *.iml
 .project
 *.code-workspace
-.lux/
+.lux


### PR DESCRIPTION
## Problem

`.gitignore` line 10 is `.lux/`. The trailing slash restricts the pattern to **directories**, so a symlink named `.lux` is not ignored:

```
$ ln -s /somewhere .lux
$ git check-ignore -v .lux
(no match)
```

lux normally creates `.lux/` as a real directory, so this is invisible most of the time. But anything that leaves a symlink at that path — a stale link, a hand-rolled shared dependency tree pointed at another checkout — sails straight past the ignore rule and into `git add -A`.

A committed `.lux` symlink is nastier than a normal stray file:

- its target is an **absolute path**, so it is wrong on every machine except the one that created it;
- if it happens to point at its own directory, git faithfully restores a **self-referential** symlink on every checkout, reset, or branch switch;
- anything that walks the game files then fails on `ELOOP` rather than on something diagnosable:

```
filesystem error: status: Too many levels of symbolic links
  [~/.local/state/Beyond All Reason/games/Beyond-All-Reason.sdd/.lux]
```

`lx sync` also can't repair it, because the path it wants to create is already occupied by the broken link.

I hit exactly this: a `.lux` symlink got committed to a branch, and from then on every checkout of that branch re-created the loop and broke launching the game from a linked dev checkout. Nothing in the toolchain creates such a symlink — I checked, `lx sync` writes a real directory through both single- and double-level symlinked project dirs — but nothing in the ignore rules stops one from being committed either.

## Fix

Drop the trailing slash. `.lux` matches the path in every form:

```
$ git check-ignore -v .lux        # symlink
.gitignore:10:.lux	.lux
$ git check-ignore -v .lux/x      # directory contents
.gitignore:10:.lux	.lux/x
```

Directory coverage is unchanged, and the symlink and plain-file forms are now covered as well. One character, and the trap closes.

## LLM Disclosure

Diagnosed and drafted with Claude Code; reviewed and verified by me.