### PR TITLE
Fix misnamed getter function setUseTeamColorsWhenSpec

### DIFF
--- a/luaui/Widgets/gui_commands_fx.lua
+++ b/luaui/Widgets/gui_commands_fx.lua
@@ -559,7 +559,7 @@ function widget:Initialize()
 	WG['commandsfx'].setUseTeamColors = function(value)
 		useTeamColors = value
 	end
-	WG['commandsfx'].setUseTeamColorsWhenSpec = function()
+	WG['commandsfx'].getUseTeamColorsWhenSpec = function()
 		return useTeamColorsWhenSpec
 	end
 	WG['commandsfx'].setUseTeamColorsWhenSpec = function(value)


### PR DESCRIPTION
### Work done
Fix obvious typo, missing `WG['commandsfx'].getUseTeamColorsWhenSpec` was accidentally named `set...` and immediately overwritten by the real setter.

Nothing uses the getters here. I think these values are instead retrieved via GetConfigData. They could instead be removed if there is no intention to change that pattern.

### AI / LLM usage statement:
Claude Code Opus 5 identified this bug during a related type annotation effort. I made this change myself.