### PR TITLE
git-blame-ignore-revs: point at the merged SHAs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,15 +1,15 @@
 # gen(stylua): initial formatting of entire codebase
-b955520aab3c0b71bdaa7198a5a480acaeb7f406
+fd46cb8511567bbb23f96daac2cdb6705c3d44a7
 
 # gen(stylua): initial formatting of entire codebase
-f44c947f7e94f5f96c757ea85d860814d4e29131
+94c1cd36a6c0e9db006b0fc4ced58c41c6e9f506
 
 # gen(bar_codemod): bracket-to-dot
-68acd60c4199212f22339edb1636a6a8a0da54c8
+45751e42bd21224f74dc7d2e8b8549078140eff4
 
 # gen(bar_codemod): rename-aliases
-ce9c4a0a1da5ee00143225694fa9a1411ee2263b
+80e857c4a65f5de930c5a29a879a847be59feaa1
 
 # gen(bar_codemod): detach-bar-modules
-422b41057ef05cfaa3332c5c29c64b92cb4a6719
+addf4addf97734cf04e0ea1254a57b0da90ebea4
 


### PR DESCRIPTION
Part of #7408

The #8395–#8398 stack was landed with **Rebase and merge**, which always rewrites commits and stamps new committer info — even when the branch is already a linear descendant and a plain fast-forward would have sufficed. So the five SHAs recorded in `.git-blame-ignore-revs` are not in `master`'s history.

This is a silent failure, not a loud one: `git blame --ignore-revs-file` tolerates unresolvable revs and exits 0. The file still parses, it just stops skipping anything, so every reformatted line blames the transform commit instead of its author.

Before / after on `common/constants.lua`, same line:

```
without a working ignore-revs:  fd46cb85115 (Daniel Harvey 2026-08-12)  <- the reformat
with this fix:                  9a8ce1bb102 (efrec         2026-01-26)  <- the actual author
```

Subjects and ordering are unchanged; only the hashes move. They were read directly off `master` rather than transcribed:

| commit | old | new |
|---|---|---|
| `gen(stylua): initial formatting of entire codebase` | `b955520a` | `fd46cb85` |
| `gen(stylua): initial formatting of entire codebase` | `f44c947f` | `94c1cd36` |
| `gen(bar_codemod): bracket-to-dot` | `68acd60c` | `45751e42` |
| `gen(bar_codemod): rename-aliases` | `ce9c4a0a` | `80e857c4` |
| `gen(bar_codemod): detach-bar-modules` | `422b4105` | `addf4add` |

Note for future migration stacks: **Rebase and merge** and **Squash and merge** both invalidate this file. Only *Create a merge commit* (or a CLI `git merge --ff-only`) preserves the SHAs it depends on.
