### PR TITLE
ci: restore the type check that never made it to master

### DIFF
--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -1,0 +1,40 @@
+name: Type Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ['*']
+  workflow_dispatch:
+
+jobs:
+  emmylua_check:
+    name: emmylua_check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install emmylua_check
+        env:
+          # This file owns the version. BAR-Devtools' dev image tracks it, so
+          # update it there too when you bump.
+          EMMYLUA_VERSION: 0.24.0
+        run: |
+          set -euo pipefail
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  ASSET=emmylua_check-linux-x64.tar.gz ;;
+            aarch64) ASSET=emmylua_check-linux-aarch64-glibc.2.17.tar.gz ;;
+            *) echo "unsupported arch for emmylua_check: $ARCH" >&2; exit 1 ;;
+          esac
+          URL="https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases/download/${EMMYLUA_VERSION}/${ASSET}"
+          curl -fsSL "$URL" | sudo tar xz -C /usr/local/bin
+          sudo chmod +x /usr/local/bin/emmylua_check
+          /usr/local/bin/emmylua_check --version
+
+      - name: Run emmylua_check
+        run: emmylua_check -c .emmyrc.json .


### PR DESCRIPTION
`.emmyrc.json` and the type stubs are in the tree. Nothing reads them.

The type-check env layer that landed in #8398 brought the config, but `type_check.yml` was written alongside it and did not survive into master. We need to merge this before it drifts.