### PR TITLE
Fix spectator player-view freeze on ally-team switch

### DIFF
--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -840,7 +840,7 @@ function widget:PlayerChanged(playerID)
 	if
 		(currentspec ~= spec) -- we change from spec to non spec (I dont think its possible to go from player to non-fullview spec in one go)
 		or (currentfullview ~= fullview)
-		or ((currentAllyTeamID ~= myAllyTeamID) and not currentspec and not currentfullview)
+		or ((currentAllyTeamID ~= myAllyTeamID) and not currentfullview)
 	then -- our ALLYteam changes while playing, and we are not in fullview
 		reinit = true
 	end


### PR DESCRIPTION
## Summary

- refresh the unit tracker when a spectator changes ally team while full view is disabled
- restore the behavior that existed before `7967edeff7`

Spectators in player view still have `currentspec == true`. Requiring `not currentspec` therefore prevented `initializeAllUnits()` from running when switching to a player on another ally team, leaving consumers with stale and unreadable unit IDs.

Fixes #8741.

## Testing

- `luac -p luaui/Widgets/api_unit_tracker_gl4.lua`
- `git diff --check`
- replay benchmark at 15:00 with 1,884 units:
  - before: 13,648 ms maximum update gap and an invalid-unit traceback flood
  - after: 53 ms maximum update gap, one fresh 893-unit `VisibleUnitsChanged` snapshot, and no invalid-unit errors
  - repeated switch: 52 ms maximum update gap
