### PR TITLE
Annotate the WG and GG APIs for language-server support

### DIFF
--- a/common/brush_shapes.lua
+++ b/common/brush_shapes.lua
@@ -21,6 +21,11 @@
 -- Supported shapes: "circle", "square", "hexagon", "octagon", "triangle".
 -- Unknown shapes return (false, 1).
 
+---A brush footprint. `isInside` recognizes exactly these; anything else is
+---treated as outside. Tools that offer extra footprints of their own (the
+---terraform brush's `"ring"` and `"fill"`) do not route them through here.
+---@alias BrushShape "circle"|"square"|"hexagon"|"octagon"|"triangle"
+
 local cos = math.cos
 local sin = math.sin
 local abs = math.abs

--- a/common/numberfunctions.lua
+++ b/common/numberfunctions.lua
@@ -267,8 +267,8 @@ if not math.getClosestPosition then
 	---Gets the closest position out of a list to given coordinates. 2d.
 	---@param x number
 	---@param z number
-	---@param positions {x:number, z:number}[] must have fields .x and .z
-	---@return {x:number, z:number}? position
+	---@param positions PositionXZ[]
+	---@return PositionXZ? position
 	function math.getClosestPosition(x, z, positions)
 		if not (x and z and positions and positions[1]) then
 			return

--- a/common/overlap_lines.lua
+++ b/common/overlap_lines.lua
@@ -6,8 +6,8 @@ local OverlapLines = {}
 ---@param centerX1 number
 ---@param centerZ1 number
 ---@param radius number
----@return table|nil intersection1 {x: number, z: number}
----@return table|nil intersection2 {x: number, z: number}
+---@return PositionXZ? intersection1
+---@return PositionXZ? intersection2
 local function getCircleIntersections(centerX0, centerZ0, centerX1, centerZ1, radius)
 	local distanceSquared = math.distance2dSquared(centerX0, centerZ0, centerX1, centerZ1)
 
@@ -106,11 +106,12 @@ function OverlapLines.isPointPastLines(pointX, pointZ, originX, originZ, lines)
 end
 
 ---Calculate intersection of two lines
----@param p1 table First point of first line {x: number, z: number}
----@param p2 table Second point of first line {x: number, z: number}
----@param p3 table First point of second line {x: number, z: number}
----@param p4 table Second point of second line {x: number, z: number}
----@return table|nil intersection Point of intersection {x: number, z: number, t: number} or nil if no intersection
+---@param p1 PositionXZ First point of first line.
+---@param p2 PositionXZ Second point of first line.
+---@param p3 PositionXZ First point of second line.
+---@param p4 PositionXZ Second point of second line.
+---@return {x: number, z: number, t: number}? intersection Point of intersection, with `t`
+---the parametric distance along the first line; `nil` when the lines do not cross.
 local function findLineIntersection(p1, p2, p3, p4)
 	local x1, z1 = p1.x, p1.z
 	local x2, z2 = p2.x, p2.z

--- a/luarules/gadgets/api_build_blocking.lua
+++ b/luarules/gadgets/api_build_blocking.lua
@@ -296,6 +296,11 @@ if gadgetHandler:IsSyncedCode() then
 		gadgetHandler:RemoveChatAction("buildunblock")
 	end
 
+	---Marks a unit definition as unbuildable by a team for the given reason.
+	---Reasons stack: the unit stays blocked until every reason is removed.
+	---@param unitDefID integer
+	---@param teamID integer
+	---@param reasonKey string Identifier for why the unit is blocked, e.g. "terrain_water".
 	function GG.BuildBlocking.AddBlockedUnit(unitDefID, teamID, reasonKey)
 		local blockedUnitDefs = teamBlockedUnitDefs[teamID]
 		if not blockedUnitDefs then
@@ -308,6 +313,11 @@ if gadgetHandler:IsSyncedCode() then
 		notifyUnitBlocked(unitDefID, teamID, unitReasons)
 	end
 
+	---Removes one block reason from a unit definition for a team.
+	---@param unitDefID integer
+	---@param teamID integer
+	---@param reasonKey string Identifier previously passed to `AddBlockedUnit`.
+	---@return boolean removed `true` if that reason was set and has been cleared.
 	function GG.BuildBlocking.RemoveBlockedUnit(unitDefID, teamID, reasonKey)
 		local blockedUnitDefs = teamBlockedUnitDefs[teamID]
 		if not blockedUnitDefs then

--- a/luarules/gadgets/api_pbr_enabler.lua
+++ b/luarules/gadgets/api_pbr_enabler.lua
@@ -39,10 +39,14 @@ if not gadgetHandler:IsSyncedCode() then --unsynced gadget
 
 	local ENVLUT_SAMPLES -- number of cubemap samples
 
+	---Returns the name of the generated BRDF lookup texture.
+	---@return string? texName `nil` if the lookup table failed to generate.
 	local function GetBrdfTexture()
 		return brdfLut:GetTexture()
 	end
 
+	---Returns the name of the generated IBL environment lookup texture.
+	---@return string? texName `nil` if the lookup table failed to generate.
 	local function GetEnvTexture()
 		return envLut:GetTexture()
 	end

--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -244,6 +244,10 @@ local objectDefToUniformBin = {} -- maps unitDefID/featuredefID to a uniform bin
 -- objectDefs are negative for features
 -- objectIDs are negative for features too
 
+---Maps an object definition to the uniform bin its draw call belongs to.
+---@param objectDefID integer? Positive for unitDefIDs, negative for featureDefIDs.
+---@param reason string? Label used in debug output when no bin is found.
+---@return string uniformBinID Falls back to `'otherunit'` for unmapped definitions.
 local function GetUniformBinID(objectDefID, reason)
 	if objectDefID and objectDefToUniformBin[objectDefID] then
 		return objectDefToUniformBin[objectDefID]
@@ -469,7 +473,9 @@ local unitDrawBins = nil -- this also controls wether cusgl4 is on at all!
 
 local objectIDtoDefID = {}
 
-local shaders = {} -- double nested table of {drawflag : {"units":shaderID}}
+---Compiled shaders, keyed by draw flag and then by material name.
+---@type table<integer, table<string, LuaShader>>
+local shaders = {}
 
 local modelsVertexVBO = nil
 local modelsIndexVBO = nil
@@ -505,6 +511,10 @@ end
 local featuresDefsWithAlpha = {}
 local unitDefsUseSkinning = {}
 
+---Returns the compiled shader used to draw an object in a given draw pass.
+---@param drawPass integer Draw flag of the current pass.
+---@param objectDefID integer? Positive for unitDefIDs, negative for featureDefIDs.
+---@return LuaShader|false shader `false` when `objectDefID` is `nil`.
 local function GetShader(drawPass, objectDefID)
 	if objectDefID == nil then
 		return false
@@ -524,6 +534,10 @@ local function GetShader(drawPass, objectDefID)
 	end
 end
 
+---Returns the name of the shader used to draw an object in a given draw pass.
+---@param drawPass integer Draw flag of the current pass.
+---@param objectDefID integer? Positive for unitDefIDs, negative for featureDefIDs.
+---@return "unit"|"unitskinning"|"tree"|"feature"|false shaderName `false` when `objectDefID` is `nil`.
 local function GetShaderName(drawPass, objectDefID)
 	-- this function does 2 table lookups, could get away with just one.
 	if objectDefID == nil then
@@ -560,6 +574,10 @@ local function SetFixedStatePost(drawPass, shaderID)
 	end
 end
 
+---Uploads the draw pass, clip plane and uniform bin values to the active shader.
+---@param drawPass integer Draw flag of the current pass.
+---@param shaderID integer GL program id of the currently bound shader.
+---@param uniformBinID string Key into `uniformBins`, as returned by `GetUniformBinID`.
 local function SetShaderUniforms(drawPass, shaderID, uniformBinID)
 	tracy.ZoneBeginN("G:CUS:SetShaderUniforms")
 	-- Cache uniform locations per-shader to avoid repeated gl.GetUniformLocation calls every frame

--- a/luarules/gadgets/game_apm_broadcast.lua
+++ b/luarules/gadgets/game_apm_broadcast.lua
@@ -31,6 +31,8 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	---Excludes the unit's next order from the team's APM count for one game frame.
+	---@param unitID integer
 	local function addSkipOrder(unitID)
 		ignoreUnits[unitID] = gameFrame + 1
 	end

--- a/luarules/gadgets/game_quick_start.lua
+++ b/luarules/gadgets/game_quick_start.lua
@@ -165,6 +165,9 @@ local buildsInProgress = {}
 
 GG.quick_start = {}
 
+---Moves tracked state from one commander unit to another,
+---@param oldUnitID integer?
+---@param newUnitID integer?
 function GG.quick_start.transferCommanderData(oldUnitID, newUnitID)
 	if oldUnitID and newUnitID and spValidUnitID(oldUnitID) and spValidUnitID(newUnitID) then
 		buildsInProgress[newUnitID] = buildsInProgress[oldUnitID]

--- a/luarules/gadgets/game_startbox_config.lua
+++ b/luarules/gadgets/game_startbox_config.lua
@@ -51,6 +51,12 @@ function gadget:Initialize()
 	GG.startBoxConfig = startBoxConfig
 	GG.startBoxConfigSource = configSource
 
+	---Tests a map position against an allyteam's polygonal start box.
+	---@param x number
+	---@param z number
+	---@param allyTeamID integer
+	---@return boolean? inside `nil` when no polygon config exists; the caller should
+	---fall back to the engine's axis-aligned start box.
 	GG.IsInsideStartbox = function(x, z, allyTeamID)
 		if not isExplicitConfig then
 			return nil -- caller should fall back to engine AABB
@@ -64,6 +70,13 @@ function gadget:Initialize()
 		return PolygonLib.PointInStartbox(x, z, entry)
 	end
 
+	---Returns the axis-aligned bounding box of an allyteam's start box polygons.
+	---@param allyTeamID integer
+	---@return number? xmin `nil` when no polygon config exists; the caller should
+	---fall back to the engine's axis-aligned start box.
+	---@return number? zmin
+	---@return number? xmax
+	---@return number? zmax
 	GG.GetStartboxBounds = function(allyTeamID)
 		if not isExplicitConfig then
 			return nil -- caller should fall back to engine AABB
@@ -77,6 +90,10 @@ function gadget:Initialize()
 		return PolygonLib.GetStartboxBounds(entry)
 	end
 
+	---Returns the raw start box polygons configured for an allyteam.
+	---@param allyTeamID integer
+	---@return Position2D[][]? boxes Array of polygons, each an array of `{x, z}` vertex
+	---pairs. `nil` when no polygon config exists.
 	GG.GetStartboxPolygons = function(allyTeamID)
 		if not isExplicitConfig then
 			return nil

--- a/luarules/gadgets/game_team_death_effect.lua
+++ b/luarules/gadgets/game_team_death_effect.lua
@@ -44,6 +44,12 @@ local function getSqrDistance(x1, z1, x2, z2)
 	return (dx * dx) + (dz * dz)
 end
 
+---Neutralizes a team's units and queues them to explode
+---@param teamID integer
+---@param originX number? Wave epicentre; when omitted the death frames are randomized.
+---@param originZ number? Wave epicentre; when omitted the death frames are randomized.
+---@param attackerUnitID integer? Credited as the killer of the destroyed units.
+---@param periodMult number? Scales how long the wave takes. Defaults to `1`.
 local function wipeoutTeam(teamID, originX, originZ, attackerUnitID, periodMult) -- only teamID is required
 	wipedoutTeams[teamID] = Spring.GetGameFrame()
 	periodMult = periodMult or 1
@@ -101,6 +107,12 @@ local function wipeoutTeam(teamID, originX, originZ, attackerUnitID, periodMult)
 	GG.maxDeathFrame = GG.maxDeathFrame and math.max(GG.maxDeathFrame, maxDeathFrame) or maxDeathFrame -- storing frame of total unit wipeout
 end
 
+---Wipes out every team in an allyteam, shortening the wave when few units remain.
+---@param allyTeamID integer
+---@param attackerUnitID integer? Credited as the killer of the destroyed units.
+---@param originX number? Wave epicentre; when omitted the death frames are randomized.
+---@param originZ number? Wave epicentre; when omitted the death frames are randomized.
+---@param periodMult number? Scales how long the wave takes. Defaults to `1`.
 local function wipeoutAllyTeam(allyTeamID, attackerUnitID, originX, originZ, periodMult) -- only allyTeamID is required
 	-- xmas gadget uses this (to prevent creating xmasballs)
 	if not _G.destroyingTeam then

--- a/luarules/gadgets/game_team_power_watcher.lua
+++ b/luarules/gadgets/game_team_power_watcher.lua
@@ -15,6 +15,11 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
+---A team paired with a power value, as returned by the highest/lowest lookups.
+---@class PowerLib.TeamPower
+---@field teamID integer? `nil` when no team qualified.
+---@field power number
+
 local teamIsOverPoweredRatio = 1.25
 local alliesAreWinningRatio = 1.25
 local mathHuge = math.huge
@@ -105,11 +110,14 @@ local function isPlayerTeam(teamID)
 end
 
 -- Returns the power of the input teamID as a number.
+---@param teamID integer
+---@return number power
 local function teamPower(teamID)
 	return teamPowers[teamID]
 end
 
 -- Returns the total power of all non scavenger/raptor teams as a number.
+---@return number power
 local function totalPlayerTeamsPower()
 	local totalPower = 0
 
@@ -123,6 +131,7 @@ local function totalPlayerTeamsPower()
 end
 
 -- Returns the highest non scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function highestPlayerTeamPower()
 	local highestPower = 0
 	local highestTeamID = nil
@@ -140,6 +149,7 @@ local function highestPlayerTeamPower()
 end
 
 -- Returns the average of all non scavenger/raptor teams as a number.
+---@return number power `0` when no team has any power.
 local function averagePlayerTeamPower()
 	local totalPower = 0
 	local teamCount = 0
@@ -156,6 +166,7 @@ local function averagePlayerTeamPower()
 end
 
 -- Returns the lowest non scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function lowestPlayerTeamPower()
 	local lowestPower = mathHuge
 	local lowestTeamID = nil
@@ -173,6 +184,7 @@ local function lowestPlayerTeamPower()
 end
 
 -- Returns the highest non AI/scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function highestHumanTeamPower()
 	local highestPower = 0
 	local highestTeamID = nil
@@ -190,6 +202,7 @@ local function highestHumanTeamPower()
 end
 
 -- Returns the average of all non AI/scavenger/raptor teams as a number.
+---@return number power `0` when no team has any power.
 local function averageHumanTeamPower()
 	local totalPower = 0
 	local teamCount = 0
@@ -206,6 +219,7 @@ local function averageHumanTeamPower()
 end
 
 -- Returns the lowest non AI/scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function lowestHumanTeamPower()
 	local lowestPower = mathHuge
 	local lowestTeamID = nil
@@ -223,6 +237,9 @@ local function lowestHumanTeamPower()
 end
 
 -- Returns the highest team power of the allies belonging to input team or allyID. Returns as a table {teamID, power}.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return PowerLib.TeamPower
 local function highestAlliedTeamPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local highestPower = 0
@@ -241,6 +258,9 @@ local function highestAlliedTeamPower(teamID, allyID)
 end
 
 -- Returns the average of all allies of the input teamID or allyID. Returns a number.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return number power `0` when no allied team has any power.
 local function averageAlliedTeamPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local totalPower = 0
@@ -258,6 +278,9 @@ local function averageAlliedTeamPower(teamID, allyID)
 end
 
 -- Returns the lowest of the teamID's allies or allyID's power as a table {teamID, power}.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return PowerLib.TeamPower
 local function lowestAlliedTeamPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local lowestPower = mathHuge
@@ -276,6 +299,8 @@ local function lowestAlliedTeamPower(teamID, allyID)
 end
 
 -- Take an input of a power value and return an estimated tech level number.
+---@param power number
+---@return number techLevel Fractional tech level between `0.5` and `4.5`.
 local function techGuesstimate(power)
 	local techLevel = 0
 	for _, threshold in ipairs(powerThresholds) do
@@ -290,6 +315,8 @@ local function techGuesstimate(power)
 end
 
 -- Takes an input teamID return an estimated tech level number.
+---@param teamID integer
+---@return number techLevel Fractional tech level between `0.5` and `4.5`.
 local function teamTechGuesstimate(teamID)
 	local totalPower = teamPowers[teamID]
 	local techLevel = 0
@@ -305,6 +332,7 @@ local function teamTechGuesstimate(teamID)
 end
 
 -- Calculate all average powers of all non scavenger/raptor teams and return an estimated tech level number.
+---@return number techLevel Fractional tech level between `0.5` and `4.5`.
 local function averagePlayerTechGuesstimate()
 	local totalPower = 0
 	local teamCount = 0
@@ -331,6 +359,7 @@ local function averagePlayerTechGuesstimate()
 end
 
 -- Compares average powers of all non AI/scavenger/raptor teams return an estimated tech level number.
+---@return number techLevel Fractional tech level between `0.5` and `4.5`.
 local function averageHumanTechGuesstimate()
 	local totalPower = 0
 	local teamCount = 0
@@ -357,6 +386,9 @@ local function averageHumanTechGuesstimate()
 end
 
 -- Compare average powers of all allied teams of the input teamID or allyID  and return an estimated tech level number.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return number techLevel Fractional tech level between `0.5` and `4.5`.
 local function averageAlliedTechGuesstimate(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local totalPower = 0
@@ -384,6 +416,8 @@ local function averageAlliedTechGuesstimate(teamID, allyID)
 end
 
 -- Returns the highest power achieved by the the input teamID as a number.
+---@param teamID integer
+---@return number power `0` when the team has never held any power.
 local function teamPeakPower(teamID)
 	for id, power in pairs(peakTeamPowers) do
 		if id == teamID then
@@ -394,6 +428,7 @@ local function teamPeakPower(teamID)
 end
 
 -- Returns the total peak power achieved by all non scavenger/raptor teams as a number.
+---@return number power
 local function totalPlayerPeakPower()
 	local totalPeakPower = 0
 
@@ -407,6 +442,7 @@ local function totalPlayerPeakPower()
 end
 
 -- Returns the highest power achieved by any non scavenger/raptor team as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function highestPlayerPeakPower()
 	local highestPower = 0
 	local highestTeamID = nil
@@ -424,6 +460,9 @@ local function highestPlayerPeakPower()
 end
 
 -- Returns the highest power achieved by any non scavenger/raptor team on the same team as the input teamID or allyID  as a table {teamID, power}.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return PowerLib.TeamPower
 local function highestAlliedPeakPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local highestPower = 0
@@ -442,6 +481,7 @@ local function highestAlliedPeakPower(teamID, allyID)
 end
 
 -- Returns the average of all the peak powers achieved by non AI/scavenger/raptor teams as a number.
+---@return number power `0` when no team has any peak power.
 local function averageHumanPeakPower()
 	local totalPower = 0
 	local teamCount = 0
@@ -458,6 +498,9 @@ local function averageHumanPeakPower()
 end
 
 -- Returns the average of all the peak powers achieved by allied teams of the input teamID or allyID as a number.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return number power `0` when no allied team has any peak power.
 local function averageAlliedPeakPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local totalPower = 0
@@ -475,6 +518,8 @@ local function averageAlliedPeakPower(teamID, allyID)
 end
 
 -- Returns the ratio number of the input teamID compared to the average of all players.
+---@param teamID integer
+---@return number ratio The team's power divided by the player average; `0` if the average is `0`.
 local function teamComparedToAveragedPlayers(teamID)
 	local totalPower = 0
 	local teamCount = 0
@@ -494,6 +539,9 @@ local function teamComparedToAveragedPlayers(teamID)
 end
 
 -- Returns boolean true if the input teamID is considered significantly more powerful by the API. Second argument allows user-defined ratio.
+---@param teamID integer
+---@param marginRatio number? Ratio above the player average that counts as overpowered. Defaults to `1.25`.
+---@return boolean
 local function isTeamOverPowered(teamID, marginRatio)
 	marginRatio = marginRatio or teamIsOverPoweredRatio
 	local totalPower = 0
@@ -518,6 +566,9 @@ local function isTeamOverPowered(teamID, marginRatio)
 end
 
 -- Returns the ratio number of the input teamID's allies or allyID compared to the average of all player allies.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@return number ratio The allyteam's power divided by the allyteam average; `0` if the average is `0`.
 local function alliesComparedToAverage(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local allyPowers = {}
@@ -546,6 +597,10 @@ local function alliesComparedToAverage(teamID, allyID)
 end
 
 -- Returns boolean true if the input teamID's allies or allyID is considered significantly more powerful by the API. Third argument allows user-defined ratio.
+---@param teamID integer? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID integer?
+---@param marginRatio number? Ratio above the allyteam average that counts as winning. Defaults to `1.25`.
+---@return boolean
 local function isAllyTeamWinning(teamID, allyID, marginRatio)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	marginRatio = marginRatio or alliesAreWinningRatio

--- a/luarules/gadgets/gfx_beam_laser_gl4.lua
+++ b/luarules/gadgets/gfx_beam_laser_gl4.lua
@@ -1019,6 +1019,8 @@ void main(void)
 --------------------------------------------------------------------------------
 -- GL4 state
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local beamVBO
 local beamShader
 local flareShader

--- a/luarules/gadgets/gfx_environmental_lightning_gl4.lua
+++ b/luarules/gadgets/gfx_environmental_lightning_gl4.lua
@@ -40,6 +40,16 @@ if gadgetHandler:IsSyncedCode() then
 	local spGetTeamInfo = Spring.GetTeamInfo
 
 	function gadget:Initialize()
+		---Spawns a configured lightning effect at a world position.
+		---Does nothing if `configName` or any coordinate is missing.
+		---@param configName string? Key of the lightning config to spawn.
+		---@param x number?
+		---@param y number?
+		---@param z number?
+		---@param sizeScale number? Defaults to `1.0`.
+		---@param intensityScale number? Defaults to `1.0`.
+		---@param ownerTeamID integer? Team the strike belongs to, used to derive the
+		---owning allyteam for visibility. Defaults to no owner.
 		GG.SpawnEnvironmentalLightning = function(configName, x, y, z, sizeScale, intensityScale, ownerTeamID)
 			if not configName or not x or not y or not z then
 				return
@@ -871,6 +881,8 @@ local glowShaderConfig = {
 --------------------------------------------------------------------------------
 -- GL4 state
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local boltVBO
 local boltShader
 local glowShader

--- a/luarules/gadgets/gfx_fire_gl4.lua
+++ b/luarules/gadgets/gfx_fire_gl4.lua
@@ -429,6 +429,7 @@ void main() {
 local fireTexture = "bitmaps/projectiletextures/BARFlame02.tga"
 local smokeTexture = "bitmaps/projectiletextures/smoke-beh-anim.tga"
 
+---@type InstanceVBOTable
 local particleVBO = nil
 local particleShader = nil
 local nextParticleID = 0
@@ -1443,13 +1444,56 @@ end
 --------------------------------------------------------------------------------
 -- Public spawn helpers (also drive GG.Fire)
 --------------------------------------------------------------------------------
+
+---A live fire emitter. Returned by the spawn functions and accepted by `GG.Fire.StopFire`.
+---@class GG.Fire.Handle
+---@field unitID integer? Unit the emitter was spawned for, if any.
+---@field mappedUnit integer? Unit the emitter position follows, if any.
+---@field keepAfterUnitGone true? Keep burning after the followed unit disappears.
+---@field scavenger true? Set when the effect uses the scavenger palette.
+---@field x number
+---@field y number
+---@field z number
+---@field yOffset number
+---@field radius number
+---@field scale number
+---@field intensity number
+---@field lightIntensity number
+---@field lightRadiusMult number
+---@field fireRate number Particles per frame; `0` disables flames.
+---@field smokeRate number Particles per frame; `0` disables smoke.
+---@field emberRate number Particles per frame; `0` disables embers.
+---@field fireEnd integer Game frame at which flames stop spawning.
+---@field smokeEnd integer Game frame at which smoke stops spawning.
+---@field emberEnd integer Game frame at which embers stop spawning.
+
+---Options accepted by `GG.Fire.SpawnFire`.
+---@class GG.Fire.SpawnOpts
+---@field duration integer? Frames of flame. Defaults to the configured unit fire duration.
+---@field smokeDuration integer? Frames of smoke. Defaults to `duration` plus the configured extra.
+---@field emberDuration integer? Frames of embers. Defaults to `duration`.
+---@field unitID integer? Unit to associate the emitter with.
+---@field scavenger boolean? Use the scavenger palette.
+---@field yOffset number? Defaults to `0`.
+---@field radius number? Defaults to `14`.
+---@field scale number? Defaults to `1.0`.
+---@field intensity number? Defaults to `1.0`.
+---@field lightIntensity number? Defaults to `1.0`.
+---@field lightRadiusMult number? Defaults to `1.0`.
+---@field fire boolean? Set to `false` to suppress flames.
+---@field fireRate number? Particles per frame.
+---@field smoke boolean? Set to `false` to suppress smoke.
+---@field smokeRate number? Particles per frame.
+---@field embers boolean? Set to `false` to suppress embers.
+---@field emberRate number? Particles per frame.
+
 -- Spawn a free-standing fire effect. Returns an opaque handle usable with
--- StopFire. opts (all optional):
---   duration, smokeDuration, emberDuration (frames)
---   radius, scale, intensity
---   unitID  (attach to a unit; position follows it)
---   yOffset (vertical emit offset, default 0 / unit param)
---   fire, smoke, embers (booleans to enable each, default all true)
+-- StopFire.
+---@param x number?
+---@param y number?
+---@param z number?
+---@param opts GG.Fire.SpawnOpts?
+---@return GG.Fire.Handle
 local function spawnFire(x, y, z, opts)
 	opts = opts or {}
 	local now = cachedGameFrame
@@ -1955,12 +1999,18 @@ function gadget:Initialize()
 	gadgetHandler:AddSyncAction("treefire_fade", syncTreeFireFade)
 
 	GG.Fire = {
-		-- SpawnFire(x, y, z, opts) -> handle. See spawnFire above for opts.
+		---Spawns a fire emitter at a world position.
+		---@param x number?
+		---@param y number?
+		---@param z number?
+		---@param opts GG.Fire.SpawnOpts?
+		---@return GG.Fire.Handle
 		SpawnFire = function(x, y, z, opts)
 			return spawnFire(x, y, z, opts)
 		end,
 		-- StopFire(handle): immediately stop spawning new particles (existing
 		-- ones fade out naturally).
+		---@param handle GG.Fire.Handle Ignored if not a table.
 		StopFire = function(handle)
 			if type(handle) == "table" then
 				handle.fireEnd = cachedGameFrame
@@ -1970,6 +2020,9 @@ function gadget:Initialize()
 		end,
 		-- AddUnitFire(unitID[, durationFrames]): attach a burning effect that
 		-- follows the unit. Refreshes the timer if already burning.
+		---@param unitID integer
+		---@param durationFrames integer? Frames of flame. Defaults to the configured unit fire duration.
+		---@return GG.Fire.Handle? handle `nil` if the unit no longer exists.
 		AddUnitFire = function(unitID, durationFrames)
 			local udid = Spring.GetUnitDefID(unitID)
 			if udid then
@@ -1977,15 +2030,23 @@ function gadget:Initialize()
 			end
 		end,
 		-- SpawnWreck(x, y, z[, scale]): short fire + long smoke at a position.
+		---@param x number
+		---@param y number
+		---@param z number
+		---@param scale number? Defaults to `1.0`.
+		---@return GG.Fire.Handle? handle `nil` when the position is not visible to the local player.
 		SpawnWreck = function(x, y, z, scale)
 			return spawnVisibleWreckageFire(x, y, z, scale)
 		end,
+		---@return integer count Particles currently alive.
 		GetParticleCount = function()
 			return particleVBO and particleVBO.usedElements or 0
 		end,
+		---@return integer count Particle budget for the whole system.
 		GetMaxParticles = function()
 			return MAX_PARTICLES
 		end,
+		---@return table<string, number|boolean> config The live tuning table; treat as read-only.
 		GetConfig = function()
 			return CONFIG
 		end,

--- a/luarules/gadgets/gfx_fire_smoke_gl4.lua
+++ b/luarules/gadgets/gfx_fire_smoke_gl4.lua
@@ -477,6 +477,8 @@ void main(void)
 --------------------------------------------------------------------------------
 -- State
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local particleVBO = nil
 local particleShader = nil
 local nextParticleID = 0
@@ -1669,6 +1671,11 @@ end
 -- Other gadgets can call these to spawn fire/smoke effects
 --------------------------------------------------------------------------------
 
+---Starts the trailing fire/smoke effect for an aircraft that has begun crashing.
+---Does nothing if the effect system is unavailable or the unit is already tracked.
+---@param unitID integer
+---@param unitDefID integer
+---@param teamID integer
 local function apiCrashingAircraft(unitID, unitDefID, teamID)
 	if not particleVBO then
 		return
@@ -1702,24 +1709,29 @@ local function apiCrashingAircraft(unitID, unitDefID, teamID)
 	crashingAircraftCount = crashingAircraftCount + 1
 end
 
--- Add a generic point emitter at a fixed position.
+---Parameters accepted by `GG.FireSmoke.AddPointEmitter`.
+---@class GG.FireSmoke.EmitterParams
+---@field x number World position X coordinate.
+---@field y number? World position Y coordinate. Defaults to the ground height at `x`, `z`.
+---@field z number? World position Z coordinate. Defaults to `0`.
+---@field duration integer? Frames the emitter lives for. `0` = permanent. Defaults to `300`.
+---@field sizeScale number? Particle size multiplier. Defaults to `1.0`.
+---@field fireIntensity number? `0` emits smoke only. `[0,1)` range of fire chance/brightness. Defaults to `0`.
+---@field spawnCount integer? Particles emitted per interval. Defaults to `POINT_SPAWN_COUNT``.
+---@field spawnInterval integer? Frames between spawns. Defaults to `POINT_SPAWN_INTERVAL``.
+---@field priority integer? One of the `PRIORITY_ESSENTIAL` `_NORMAL` `_COSMETIC` constants. Defaults to `PRIORITY_NORMAL`.
+---@field smokeSizeMult number? Multiplier on spoke particle size. Defaults to `1.0`.
+---@field smokeLifeMult number? Multiplier on smoke particle lifetime. Defaults to `1.0`.
+---@field smokeAlpha number? Base smoke alpha (opacity). Defaults to `1.0`.
+---@field fireSizeMult number? Multiplier on fire particle size. Defaults to `1.0`.
+---@field fireLifeMult number? Multiplier on fire particle lifetime. Defaults to `1.0`.
+---@field posSpread number? Random position jitter applied per particle in elmos. Defaults to `POINT_POS_SPREAD`
+---@field velocityScale number? Multiplier on particle velocity. Defaults to `1.0`.
+
+---Registers a long-lived point emitter that keeps spawning particles.
 -- Returns emitterID (use to remove later) or nil if VBO not ready.
---
--- params table fields (all optional except x,y,z):
---   x, y, z            - world position (required)
---   duration            - emit for this many frames, 0 = permanent (default: 300)
---   sizeScale           - particle size multiplier (default: 1.0)
---   fireIntensity       - 0 = smoke only, 0-1 = fire chance/brightness (default: 0)
---   spawnCount          - smoke particles per interval (default: POINT_SPAWN_COUNT)
---   spawnInterval       - frames between spawns (default: POINT_SPAWN_INTERVAL)
---   priority            - PRIORITY_ESSENTIAL/NORMAL/COSMETIC (default: NORMAL)
---   smokeSizeMult       - multiplier on smoke particle size (default: 1.0)
---   smokeLifeMult       - multiplier on smoke lifetime (default: 1.0)
---   smokeAlpha          - base smoke alpha (default: 1.0)
---   fireSizeMult        - multiplier on fire particle size (default: 1.0)
---   fireLifeMult        - multiplier on fire particle lifetime (default: 1.0)
---   posSpread           - random position offset radius in elmos (default: POINT_POS_SPREAD)
---   velocityScale       - multiplier on particle velocity (default: 1.0)
+---@param params GG.FireSmoke.EmitterParams
+---@return integer? emitterID `nil` when the effect system is unavailable or `params` or `params.x` is missing.
 local function apiAddPointEmitter(params)
 	if not particleVBO then
 		return nil
@@ -1756,7 +1768,9 @@ local function apiAddPointEmitter(params)
 	return id
 end
 
--- Remove a point emitter by ID (returned from AddPointEmitter)
+---Removes a point emitter.
+---@param emitterID integer? As returned by `AddPointEmitter`.
+---@return boolean removed `false` if no such emitter exists.
 local function apiRemoveEmitter(emitterID)
 	if emitterID and pointEmitters[emitterID] then
 		pointEmitters[emitterID] = nil
@@ -1767,6 +1781,11 @@ local function apiRemoveEmitter(emitterID)
 end
 
 -- Update emitter position (for moving sources)
+---@param emitterID integer As returned by `AddPointEmitter`.
+---@param x number
+---@param y number
+---@param z number
+---@return boolean updated `false` if no such emitter exists.
 local function apiUpdateEmitterPos(emitterID, x, y, z)
 	local emitter = pointEmitters[emitterID]
 	if not emitter then
@@ -1778,8 +1797,18 @@ local function apiUpdateEmitterPos(emitterID, x, y, z)
 	return true
 end
 
--- Spawn a single particle directly (one-shot, no emitter tracking)
--- priority: PRIORITY_ESSENTIAL/NORMAL/COSMETIC (default: NORMAL)
+---Spawns a single one-shot particle with no emitter tracking.
+---@param px number
+---@param py number
+---@param pz number
+---@param vx number? Defaults to `0`.
+---@param vy number? Defaults to `0`.
+---@param vz number? Defaults to `0`.
+---@param size number? Defaults to `2`.
+---@param isFireType boolean? Spawn a flame particle instead of smoke.
+---@param lifetime integer? Frames the particle lives for. Defaults to `60`.
+---@param alpha number? Defaults to `1.0`.
+---@param priority integer? One of the `PRIORITY_*` constants. Defaults to `PRIORITY_NORMAL`.
 local function apiSpawnParticle(px, py, pz, vx, vy, vz, size, isFireType, lifetime, alpha, priority)
 	if not particleVBO then
 		return
@@ -1789,14 +1818,20 @@ local function apiSpawnParticle(px, py, pz, vx, vy, vz, size, isFireType, lifeti
 end
 
 -- Query current state
+---@return integer count Particles currently alive.
 local function apiGetParticleCount()
 	return particleVBO and particleVBO.usedElements or 0
 end
 
+---@return number count Particle budget for the whole system.
 local function apiGetMaxParticles()
 	return MAX_PARTICLES
 end
 
+---Returns the wind vector the particle simulation is currently using.
+---@return number windX
+---@return number windZ
+---@return number windStrength
 local function apiGetWindState()
 	return windX, windZ, windStrength
 end

--- a/luarules/gadgets/gfx_flamethrower_gl4.lua
+++ b/luarules/gadgets/gfx_flamethrower_gl4.lua
@@ -592,6 +592,7 @@ void main() {
 local fireTexture = "bitmaps/projectiletextures/BARFlame02.tga"
 local smokeTexture = "bitmaps/projectiletextures/smoke-beh-anim.tga"
 
+---@type InstanceVBOTable
 local particleVBO = nil
 local particleShader = nil
 local nextParticleID = 0
@@ -2059,15 +2060,21 @@ function gadget:Initialize()
 	end
 
 	GG.Flamethrower = {
+		---@return integer count Particles currently alive.
 		GetParticleCount = function()
 			return particleVBO and particleVBO.usedElements or 0
 		end,
+		---@return integer count Particle budget for the whole system.
 		GetMaxParticles = function()
 			return CONFIG.maxParticles
 		end,
+		---@return table<string, number|boolean> config The live tuning table; treat as read-only.
 		GetConfig = function()
 			return CONFIG
 		end,
+		---Reports whether this gadget draws the flame effect for a weapon.
+		---@param weaponDefID integer
+		---@return boolean
 		IsTracked = function(weaponDefID)
 			return weaponConfigs[weaponDefID] ~= nil
 		end,

--- a/luarules/gadgets/gfx_lightning_cannon_gl4.lua
+++ b/luarules/gadgets/gfx_lightning_cannon_gl4.lua
@@ -897,6 +897,8 @@ local impactShaderConfig = {
 --------------------------------------------------------------------------------
 -- GL4 state
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local boltVBO
 local boltShader
 local glowShader

--- a/luarules/gadgets/gfx_missile_thruster_gl4.lua
+++ b/luarules/gadgets/gfx_missile_thruster_gl4.lua
@@ -817,6 +817,8 @@ void main(void)
 --------------------------------------------------------------------------------
 -- GL4 state
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local flameVBO
 local flameShader
 local crossFlameShader -- 90-degree rotated flame for volume from all angles

--- a/luarules/gadgets/gfx_plasma_cannon_gl4.lua
+++ b/luarules/gadgets/gfx_plasma_cannon_gl4.lua
@@ -692,6 +692,8 @@ void main(void)
 --------------------------------------------------------------------------------
 -- GL4 state
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local plasmaVBO
 local plasmaShader
 local crossShader -- 90-degree rotated copy for volume from all angles

--- a/luarules/gadgets/gfx_projectile_dispatch.lua
+++ b/luarules/gadgets/gfx_projectile_dispatch.lua
@@ -213,6 +213,13 @@ end
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
+
+---Registers a consumer of one of the shared projectile scans. The dispatcher runs
+---each scan at most once per tick and hands every subscriber its filtered matches.
+---@param name string Label used in debug output.
+---@param defIDSet table<integer, true>? Set of weaponDefIDs to keep; `nil` matches every projectile.
+---@param scanID 1|2|3 One of `SCAN_VISIBLE`, `SCAN_MAP_WEAPONS` or `SCAN_MAP_PIECES`.
+---@return integer? handle `nil` when `scanID` is invalid.
 local function Subscribe(name, defIDSet, scanID)
 	local subs = subscribersByScan[scanID]
 	if not subs then
@@ -234,6 +241,10 @@ local function Subscribe(name, defIDSet, scanID)
 	return nextHandle
 end
 
+---Returns this subscriber's matching projectiles, refreshing the scan if stale.
+---@param handle integer As returned by `Subscribe`.
+---@return integer[]? projectileIDs `nil` when the handle is unknown.
+---@return integer count Number of valid entries in `projectileIDs`.
 local function GetMatches(handle)
 	local sub = subscribers[handle]
 	if not sub then
@@ -245,6 +256,11 @@ local function GetMatches(handle)
 	return sub.matches, sub.matchCount
 end
 
+---As `GetMatches`, but also returns the weaponDefID of each matched projectile.
+---@param handle integer As returned by `Subscribe`.
+---@return integer[]? projectileIDs `nil` when the handle is unknown.
+---@return integer[]? weaponDefIDs Parallel to `projectileIDs`.
+---@return integer count Number of valid entries in both arrays.
 local function GetMatchesWithDefIDs(handle)
 	local sub = subscribers[handle]
 	if not sub then
@@ -256,6 +272,10 @@ local function GetMatchesWithDefIDs(handle)
 	return sub.matches, sub.matchDefIDs, sub.matchCount
 end
 
+---Returns the unfiltered result of a scan, refreshing it if stale.
+---@param scanID 1|2|3 One of `SCAN_VISIBLE`, `SCAN_MAP_WEAPONS` or `SCAN_MAP_PIECES`.
+---@return integer[]? projectileIDs `nil` when `scanID` is invalid.
+---@return integer count Number of valid entries in `projectileIDs`.
 local function GetScan(scanID)
 	local state = scanState[scanID]
 	if not state then

--- a/luarules/gadgets/gfx_raptor_scum_gl4.lua
+++ b/luarules/gadgets/gfx_raptor_scum_gl4.lua
@@ -175,6 +175,15 @@ if gadgetHandler:IsSyncedCode() then
 
 	GG.IsPosInRaptorScum = IsPosInScum --(x,y,z)
 
+	---Tests whether a map position is covered by raptor scum.
+	---Underwater scum is ignored for surface units, and positions outside the map never match.
+	---@param unitx number
+	---@param unity number? Height of the tested object. Defaults to `1`; values above `-1` skip underwater scum.
+	---@param unitz number
+	---@return integer? scumID `nil` when the position is not inside any scum.
+	---Picks a scum patch at random.
+	---@param startID integer? Scum to start iterating from, so repeated calls can spread out.
+	---@return integer? scumID `nil` when no scum exists.
 	local function GetRandomScumID(startID)
 		if numscums < 1 then
 			return
@@ -192,6 +201,9 @@ if gadgetHandler:IsSyncedCode() then
 
 	GG.GetRandomScumID = GetRandomScumID -- Returns nil or scumID
 
+	---Picks a random map position inside a random scum patch, staying clear of the map edge.
+	---@return number? x `nil` when no scum exists or no valid position was found.
+	---@return number? z
 	local function GetRandomPositionInScum()
 		local scumID = GetRandomScumID()
 		if not scumID then

--- a/luarules/gadgets/gfx_tree_feller.lua
+++ b/luarules/gadgets/gfx_tree_feller.lua
@@ -317,6 +317,11 @@ if gadgetHandler:IsSyncedCode() then
 		return maxMetal == 0 and maxEnergy > 0
 	end
 
+	---Fells every tree within 125 elmos of a position, as used by the commander spawn blast.
+	---@param spawnx number
+	---@param spawny number
+	---@param spawnz number
+	---@return integer? aborted Returns `0` and stops early if a geothermal feature is in range.
 	local function ComSpawnDefoliate(spawnx, spawny, spawnz)
 		local blasted_trees = Spring.GetFeaturesInCylinder(spawnx, spawnz, 125)
 

--- a/luarules/gadgets/gfx_unit_shield_effects.lua
+++ b/luarules/gadgets/gfx_unit_shield_effects.lua
@@ -433,6 +433,18 @@ end
 local DECAY_FACTOR = 0.2
 local MIN_DAMAGE = 3
 
+---A single recent impact on a unit's shield.
+---@class ShieldHit
+---@field hitFrame integer Game frame the damage was last accumulated.
+---@field dmg number Decaying damage value driving the effect's brightness.
+---@field aoe number Radius of the visual ripple.
+---@field x number
+---@field y number
+---@field z number
+
+---Returns the decaying list of recent impacts on a unit's shield.
+---@param unitID integer
+---@return ShieldHit[]? hits `nil` when the unit has no shield or has not been hit.
 local function GetShieldHitPositions(unitID)
 	local unitData = IterableMap.Get(shieldUnits, unitID)
 	return (((unitData and unitData.hitData) and unitData.hitData) or nil)

--- a/luarules/gadgets/gfx_water_type_overlay_state.lua
+++ b/luarules/gadgets/gfx_water_type_overlay_state.lua
@@ -226,21 +226,30 @@ function gadget:Initialize()
 	minGroundHeight = select(3, spGetGroundExtremes())
 
 	GG.WaterTypeOverlay = {
+		---@return boolean active Whether a hazardous water overlay is currently applied.
 		isActive = function()
 			return active
 		end,
+		---@return "lava"|"acid"|nil typeName `nil` while the overlay is inactive.
 		getActiveType = function()
 			return activeType
 		end,
+		---@return number level Current absolute world height of the overlay surface.
 		getLevel = function()
 			return currentLevel
 		end,
+		---@return number level Offset from the base water plane the overlay eases toward.
 		getTargetLevel = function()
 			return targetLevel
 		end,
+		---Sets the height the overlay surface eases toward, relative to the base water plane.
+		---@param level number
 		setLevel = function(level)
 			targetLevel = level
 		end,
+		---Turns the overlay on and starts damaging units in it.
+		---@param typeName "lava"|"acid"
+		---@return boolean started `false` when `typeName` is not a supported overlay type.
 		activate = function(typeName)
 			if typeName ~= "lava" and typeName ~= "acid" then
 				return false
@@ -252,6 +261,7 @@ function gadget:Initialize()
 			activeType = typeName
 			return true
 		end,
+		---Turns the overlay off and restores any unit state it changed.
 		deactivate = function()
 			if active then
 				restoreAllUnits()

--- a/luarules/gadgets/gui_territorial_domination.lua
+++ b/luarules/gadgets/gui_territorial_domination.lua
@@ -46,6 +46,7 @@ local NOTIFY_DELAY = math.floor(Game.gameSpeed * 1)
 local squareVBO = nil
 local squareVAO = nil
 local squareShader = nil
+---@type InstanceVBOTable
 local instanceVBO = nil
 local cachedMinimapFlipped = nil
 

--- a/luarules/gadgets/scav_spawn_effect.lua
+++ b/luarules/gadgets/scav_spawn_effect.lua
@@ -51,6 +51,8 @@ if gadgetHandler:IsSyncedCode() then -- Synced
 		end
 	end
 
+	---Plays the scavenger spawn explosion at a unit, sized from its unit definition.
+	---@param unitID integer
 	function ScavengersSpawnEffectUnitID(unitID)
 		local posx, posy, posz = Spring.GetUnitPosition(unitID)
 		local unitDefID = Spring.GetUnitDefID(unitID)
@@ -59,12 +61,19 @@ if gadgetHandler:IsSyncedCode() then -- Synced
 	end
 	GG.ScavengersSpawnEffectUnitID = ScavengersSpawnEffectUnitID
 
+	---Plays the scavenger spawn explosion at a position, sized from a unit definition.
+	---@param unitDefID integer
+	---@param posx number
+	---@param posy number
+	---@param posz number
 	function ScavengersSpawnEffectUnitDefID(unitDefID, posx, posy, posz)
 		local size = getUnitSize(unitDefID)
 		Spring.SpawnCEG("scav-spawnexplo-" .. size, posx, posy, posz, 0, 0, 0)
 	end
 	GG.ScavengersSpawnEffectUnitDefID = ScavengersSpawnEffectUnitDefID
 
+	---Plays the scavenger spawn explosion at a feature, sized from its feature definition.
+	---@param featureID integer
 	function ScavengersSpawnEffectFeatureID(featureID)
 		local posx, posy, posz = Spring.GetFeaturePosition(featureID)
 		local featureDefID = Spring.GetFeatureDefID(featureID)
@@ -73,6 +82,11 @@ if gadgetHandler:IsSyncedCode() then -- Synced
 	end
 	GG.ScavengersSpawnEffectFeatureID = ScavengersSpawnEffectFeatureID
 
+	---Plays the scavenger spawn explosion at a position, sized from a feature definition.
+	---@param featureDefID integer
+	---@param posx number
+	---@param posy number
+	---@param posz number
 	function ScavengersSpawnEffectFeatureDefID(featureDefID, posx, posy, posz)
 		local size = getFeatureSize(featureDefID)
 		Spring.SpawnCEG("scav-spawnexplo-" .. size, posx, posy, posz, 0, 0, 0)

--- a/luarules/gadgets/unit_attributes.lua
+++ b/luarules/gadgets/unit_attributes.lua
@@ -444,6 +444,11 @@ end
 
 --Spring.Echo("Hornet debug UpdateUnitAttributes defined")
 
+---Recomputes a unit's speed, turn rate, acceleration, reload, economy and build
+---multipliers from the `GG.att_*` tables and applies them to the engine.
+---Call after changing any `GG.att_*` entry for the unit.
+---@param unitID integer
+---@param frame integer? Game frame to attribute the change to. Defaults to the current frame.
 function UpdateUnitAttributes(unitID, frame)
 	if not spValidUnitID(unitID) then
 		removeUnit(unitID)
@@ -648,7 +653,11 @@ function UpdateUnitAttributes(unitID, frame)
 	end
 end
 
--- Whatever sets this should call UpdateUnitAttributes frames afterwards too
+---Controls whether the engine may coast this unit rather than braking it,
+---which the attribute system otherwise overrides.
+---Whatever sets this should call UpdateUnitAttributes frames afterwards too.
+---@param unitID integer
+---@param allowed boolean?
 local function SetAllowUnitCoast(unitID, allowed)
 	allowUnitCoast[unitID] = allowed
 end

--- a/luarules/gadgets/unit_capture_decay.lua
+++ b/luarules/gadgets/unit_capture_decay.lua
@@ -57,6 +57,9 @@ function gadget:AllowUnitCaptureStep(builderID, builderTeam, unitID, unitDefID, 
 	return true
 end
 
+---Starts tracking a unit so its partial capture progress decays over time.
+---Does nothing if the unit is already tracked.
+---@param unitID integer
 function addUnitToCaptureDecay(unitID)
 	if not unitsWithCaptureProgress[unitID] then
 		unitsWithCaptureProgress[unitID] = { previousCaptureProgress = 0, ticksFromLastCapture = 999 }

--- a/luarules/gadgets/unit_cloak.lua
+++ b/luarules/gadgets/unit_cloak.lua
@@ -65,6 +65,10 @@ for udid, ud in pairs(UnitDefs) do
 	end
 end
 
+---Forces a unit to decloak and blocks it from recloaking for a while.
+---Repeated calls extend the block rather than stacking.
+---@param unitID integer
+---@param duration integer? Frames to stay decloaked. Defaults to the gadget's decloak time.
 function PokeDecloakUnit(unitID, duration)
 	if recloakUnit[unitID] then
 		recloakUnit[unitID] = duration or DEFAULT_DECLOAK_TIME
@@ -176,6 +180,10 @@ function gadget:AllowUnitDecloak(unitID, objectID, weaponID)
 	recloakFrame[unitID] = currentFrame + DEFAULT_DECLOAK_TIME
 end
 
+---Sets the unit's desired cloak state, updating its command description to match.
+---Does nothing for dead or missing units.
+---@param unitID integer?
+---@param state 0|1 `1` to request cloaking, `0` to request decloaking.
 local function SetWantedCloaked(unitID, state)
 	if not unitID or spGetUnitIsDead(unitID) then
 		return

--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -293,6 +293,9 @@ function gadget:GameFrame(frame)
 	gameFrame = frame
 end
 
+---Enables or disables collision-damage velocity tracking for a unit.
+---@param unitID integer
+---@param enabled boolean? Pass `false` to stop tracking; any other value starts it.
 local function setVelocityControl(unitID, enabled)
 	if enabled == false then
 		launchedUnits[unitID] = nil

--- a/luarules/gadgets/unit_corpse_link.lua
+++ b/luarules/gadgets/unit_corpse_link.lua
@@ -40,6 +40,10 @@ local function GetFeatureResurrectDefID(featureID)
 	return unitDef.id
 end
 
+---Returns the unitID the corpse feature was created from, consuming the link so
+---each corpse resolves at most once.
+---@param featureID integer
+---@return integer? unitID `nil` when no unit is linked to this corpse.
 local function GetCorpsePriorUnitID(featureID)
 	-- Technically features can rez into something else than they died as,
 	-- or even be rezzable without ever dying, but let's assume they don't

--- a/luarules/gadgets/unit_instant_self_destruct.lua
+++ b/luarules/gadgets/unit_instant_self_destruct.lua
@@ -43,6 +43,9 @@ end
 local toDestroy = {}
 local toDestroyCount = 0
 
+---Queues a unit to be destroyed on the next game frame.
+---@param unitID integer
+---@param skipChecks boolean? Destroy even while the unit is stunned.
 local function QueueUnitDestruction(unitID, skipChecks)
 	if skipChecks or not spGetUnitIsStunned(unitID) then
 		toDestroyCount = toDestroyCount + 1

--- a/luarules/gadgets/unit_reactive_armor.lua
+++ b/luarules/gadgets/unit_reactive_armor.lua
@@ -360,6 +360,10 @@ end
 -- Lifecycle
 
 ---Damages or repairs a unit's reactive armor without changing unit health.
+---@param unitID integer
+---@param damage number Positive damages the armor, negative repairs it.
+---@return boolean changed `false` when the unit has no reactive armor, its armor is
+---already broken, or a repair was requested while already at full armor.
 GG.AddReactiveArmorDamage = function(unitID, damage)
 	local unitDefData = armoredUnitDefs[spGetUnitDefID(unitID)]
 	if unitDefData and damage ~= 0 then
@@ -370,6 +374,8 @@ GG.AddReactiveArmorDamage = function(unitID, damage)
 end
 
 ---Get the current armor health remaining of a unit with reactive armor.
+---@param unitID integer
+---@return number? health `nil` when the unit has no reactive armor or it is broken.
 GG.GetReactiveArmorHealth = function(unitID)
 	return unitArmorHealth[unitID]
 end

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -55,6 +55,9 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 	end
 
 	---Pass a `weaponDefID` instead of a `damage` for shield damage to be determined for you.
+	---@param shieldUnitID integer
+	---@param damage number? Omit to derive the damage from `weaponDefID`.
+	---@param weaponDefID integer? Used to look up the shield damage when `damage` is omitted.
 	---@return boolean exhausted The damage was mitigated, in full, by the shield.
 	---@return number damageDone The amount of damage done to the targeted shield.
 	local function addEngineShieldDamage(shieldUnitID, damage, weaponDefID)
@@ -132,6 +135,12 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 		registerScriptedShieldEntry(projectileTbl, callback)
 	end
 
+	---Add a scripted weapon type to be handled by the shield behavior gadget.
+	---@param projectileTbl table [projectileID] := true
+	---@param callback ShieldPreDamagedCallback? accepting the ShieldPreDamaged args (excluding self-ref), returning `true` when consuming the event
+	---Stand-in for the sphere queries, which engine shields do not support.
+	---@return integer[] shieldUnits Always empty.
+	---@return integer count Always `0`.
 	local function getEmptyResultSet()
 		return {}, 0
 	end
@@ -143,10 +152,14 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 		GG.Shields.RegisterShieldPreDamaged = registerShieldPreDamaged
 		GG.Shields.GetUnitShieldState = spGetUnitShieldState
 		-- FIXME: The shields api does not have full coverage for engine/bounce shields.
+		---Not supported for engine shields; always returns nothing.
+		---@type fun(shieldUnitID: integer): number?, number?, number?, number?
 		GG.Shields.GetUnitShieldPosition = function() end
 		GG.Shields.GetShieldUnitsInSphere = getEmptyResultSet
 		GG.Shields.GetBlockingShieldUnits = getEmptyResultSet
 		GG.Shields.GetCoveringShieldUnits = getEmptyResultSet
+		---Not supported for engine shields; always returns `false`.
+		---@type fun(x: number, y: number, z: number, shieldUnitID: integer): boolean
 		GG.Shields.IsInShield = function()
 			return false
 		end -- unfortunate
@@ -770,6 +783,7 @@ end
 
 -- Gadget interface methods ----------------------------------------------------
 
+---@param shieldUnitID integer
 ---@return integer state 0 := DISABLED, 1 := ENABLED
 ---@return number shieldHealthRemaining including the (hidden) damage done this frame so far
 local function getUnitShieldState(shieldUnitID)
@@ -790,6 +804,9 @@ local function getUnitShieldState(shieldUnitID)
 end
 
 ---Pass a `weaponDefID` instead of a `damage` for shield damage to be determined for you.
+---@param shieldUnitID integer
+---@param damage number? Omit to derive the damage from `weaponDefID`.
+---@param weaponDefID integer? Used to look up the shield damage when `damage` is omitted.
 ---@return boolean exhausted The damage was mitigated, in full, by the shield.
 ---@return number damageDone The amount of damage done to the targeted shield.
 local function addCustomShieldDamage(shieldUnitID, damage, weaponDefID)
@@ -816,6 +833,7 @@ local function addCustomShieldDamage(shieldUnitID, damage, weaponDefID)
 	return false, 0
 end
 
+---@param shieldUnitID integer
 ---@return number? x xyz, emitter point of the shield weapon
 ---@return number? y
 ---@return number? z
@@ -890,8 +908,8 @@ end
 ---@param x number
 ---@param y number
 ---@param z number
----@param allyTeam integer The ally team for the incoming damage source.
 ---@param radius number? Additive with the radius of the target shield (default := `0.01`)
+---@param allyTeam integer? The ally team for the incoming damage source.
 ---@param onlyAlive boolean? Navigate the rework's one-frame delay on shield effects by excluding recently-dead units (default := `false`)
 ---@return integer[] shieldUnits
 ---@return integer count

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -513,16 +513,33 @@ if gadgetHandler:IsSyncedCode() then
 		refreshSendData(unitID, unitData, minIndex)
 	end
 
+	---A single entry in a unit's target queue, as tracked on the synced side.
+	---@class UnitTargetEntry
+	---@field target integer|Position3D Either a target unitID or a `{x, y, z}` ground position.
+	---@field alwaysSeen boolean? Target does not need to stay in sensor range to be kept.
+	---@field ignoreStop boolean? Target survives a Stop command.
+	---@field userTarget boolean? Target was set by the player rather than by Lua.
+	---@field sent boolean? Target has already been pushed to the unit's weapons.
+
+	---Returns the unit's currently active target.
+	---@param unitID integer
+	---@return integer|Position3D|nil target A unitID, a `{x, y, z}` ground position, or `nil` when untargeted.
 	function GG.GetUnitTarget(unitID)
 		local unitData = activeTargets[unitID]
 		local targetData = unitData and unitData.targets[unitData.currentIndex]
 		return targetData and targetData.target
 	end
 
+	---Returns the unit's whole target queue.
+	---@param unitID integer
+	---@return UnitTargetEntry[]? targets `nil` when the unit has no targets.
 	function GG.GetUnitTargetList(unitID)
 		return activeTargets[unitID] and activeTargets[unitID].targets
 	end
 
+	---Returns the position in the target queue that is currently active.
+	---@param unitID integer
+	---@return integer? index `nil` when the unit has no targets.
 	function GG.GetUnitTargetIndex(unitID)
 		return activeTargets[unitID] and activeTargets[unitID].currentIndex
 	end
@@ -1024,10 +1041,21 @@ else -- UNSYNCED
 		gadgetHandler:RemoveSyncAction("failCommand")
 	end
 
+	---An entry in the unsynced mirror of a unit's target queue, kept for drawing.
+	---@class UnitTargetEntryUnsynced
+	---@field target integer|Position3D Either a target unitID or a `{x, y, z}` ground position.
+	---@field userTarget boolean? Target was set by the player rather than by Lua.
+
+	---Returns the unsynced mirror of the unit's target queue.
+	---@param unitID integer
+	---@return table<integer, UnitTargetEntryUnsynced>? targets `nil` when the unit has no known targets.
 	function GG.getUnitTargetList(unitID)
 		return targetList[unitID] and targetList[unitID].targets
 	end
 
+	---Returns the position in the unsynced target queue that is currently active.
+	---@param unitID integer
+	---@return integer? index `nil` when the unit has no known targets.
 	function GG.getUnitTargetIndex(unitID)
 		return targetList[unitID] and targetList[unitID].currentIndex
 	end

--- a/luarules/gadgets/unit_wanted_speed.lua
+++ b/luarules/gadgets/unit_wanted_speed.lua
@@ -121,6 +121,11 @@ local function SetUnitWantedSpeed(unitID, unitDefID, wantedSpeed, forceUpdate)
 end
 
 ---this makes no sense, why does this chain exist
+---Reapplies the unit's wanted max speed to its move type,
+---e.g. after the engine has reset it.
+---@param unitID integer
+---@param unitDefID integer
+---@param clearWanted boolean? Drop the remembered wanted speed instead of restoring it.
 function GG.ForceUpdateWantedMaxSpeed(unitID, unitDefID, clearWanted)
 	SetUnitWantedSpeed(
 		unitID,

--- a/luarules/gadgets/unit_zombies.lua
+++ b/luarules/gadgets/unit_zombies.lua
@@ -61,6 +61,9 @@ local harderTechToRezPowerSpeeds = {
 	[4.5] = 130,
 }
 
+---One of the zombie difficulty presets, matching the keys of `zombieModeConfigs`.
+---@alias ZombieMode "normal"|"hard"|"nightmare"|"extreme"
+
 local zombieModeConfigs = {
 	normal = {
 		techToRezPowerSpeeds = standardTechToRezPowerSpeeds,
@@ -96,6 +99,7 @@ local zombieModeConfigs = {
 	},
 }
 
+---@type ZombieMode
 local currentZombieMode = "normal"
 local currentZombieConfig = zombieModeConfigs.normal
 
@@ -426,6 +430,9 @@ local function updateRezSpeed()
 	rebuildZombieCorpseSpawnDelays()
 end
 
+---Applies a preset's tuning to the live zombie config, falling back to `normal`
+---for an unknown mode.
+---@param mode ZombieMode
 local function applyZombieModeSettings(mode)
 	local config = zombieModeConfigs[mode]
 	if not config then
@@ -812,6 +819,8 @@ local function spawnZombies(featureID, unitDefID, healthReductionRatio, x, y, z,
 	end
 end
 
+---Turns a unit into a zombie, swapping it for its `_scav` variant where one exists.
+---@param unitID integer
 local function setZombie(unitID)
 	local unitDefID = spGetUnitDefID(unitID)
 	if not unitDefID then
@@ -856,6 +865,7 @@ local function clearUnitOrders(unitID)
 	end
 end
 
+---Clears the queued orders of every tracked zombie.
 local function clearAllOrders()
 	for zombieID, _ in pairs(zombieWatch) do
 		clearUnitOrders(zombieID)
@@ -1231,6 +1241,9 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 	end
 end
 
+---Immediately raises zombies from a corpse feature. Only acts while in idle mode.
+---@param featureID integer
+---@return boolean spawned `false` when not in idle mode, or the feature is not a zombie corpse.
 local function createZombieFromFeature(featureID)
 	if isIdleMode then
 		local featureDefID = spGetFeatureDefID(featureID)
@@ -1259,6 +1272,7 @@ local function createZombieFromFeature(featureID)
 	return false
 end
 
+---Queues every corpse currently on the map to raise zombies.
 local function queueAllCorpsesForSpawning()
 	local features = Spring.GetAllFeatures()
 	for _, featureID in ipairs(features) do
@@ -1266,6 +1280,8 @@ local function queueAllCorpsesForSpawning()
 	end
 end
 
+---Switches all zombies between return-fire with no auto-orders and normal aggression.
+---@param enabled boolean `true` to pacify, `false` to restore normal behavior.
 local function pacifyZombies(enabled)
 	local fireState
 	if enabled then
@@ -1283,6 +1299,8 @@ local function pacifyZombies(enabled)
 	end
 end
 
+---Stops or resumes the automatic orders given to zombies, without changing fire state.
+---@param enabled boolean `true` to suspend auto-orders, `false` to resume them.
 local function suspendAutoOrders(enabled)
 	if enabled then
 		ordersEnabled = false
@@ -1318,6 +1336,9 @@ local function fightNearTargets(targetUnits)
 	return true
 end
 
+---Sends every zombie to fight the units of one team.
+---@param teamID integer
+---@return boolean ordered `false` when the team is dead or has no units.
 local function aggroTeamID(teamID)
 	clearAllOrders()
 
@@ -1331,6 +1352,9 @@ local function aggroTeamID(teamID)
 	return fightNearTargets(targetUnits)
 end
 
+---Sends every zombie to fight the units of every team in an allyteam.
+---@param allyID integer
+---@return boolean ordered `false` when the allyteam has no teams or no units.
 local function aggroAllyID(allyID)
 	clearAllOrders()
 
@@ -1351,6 +1375,7 @@ local function aggroAllyID(allyID)
 	return fightNearTargets(targetUnits)
 end
 
+---Kills every tracked zombie with environmental damage.
 local function killAllZombies()
 	for zombieID, zombieData in pairs(zombieWatch) do
 		if spValidUnitID(zombieID) and not Spring.GetUnitIsDead(zombieID) then
@@ -1362,6 +1387,9 @@ local function killAllZombies()
 	end
 end
 
+---Enables or disables raising zombies from corpses automatically.
+---Enabling also queues every corpse already on the map.
+---@param enabled boolean
 local function setAutoSpawning(enabled)
 	autoSpawningEnabled = enabled
 	if enabled then
@@ -1369,6 +1397,7 @@ local function setAutoSpawning(enabled)
 	end
 end
 
+---Drops every queued corpse spawn without affecting zombies already raised.
 local function clearAllZombieSpawns()
 	for featureID in pairs(corpsesData) do
 		clearCorpseRezRulesParam(featureID)
@@ -1400,6 +1429,9 @@ local function isAuthorized(playerID)
 	return false
 end
 
+---Turns each of the given units into a zombie.
+---@param unitIDs integer[]?
+---@return integer converted Number of units that were valid and converted.
 local function convertUnitsToZombies(unitIDs)
 	if not unitIDs or #unitIDs == 0 then
 		return 0
@@ -1416,6 +1448,8 @@ local function convertUnitsToZombies(unitIDs)
 	return convertedCount
 end
 
+---Turns every Gaia-owned unit that is not already a zombie into one.
+---@return integer converted
 local function setAllGaiaToZombies()
 	local allUnits = Spring.GetAllUnits()
 	local convertedCount = 0
@@ -1594,6 +1628,9 @@ local function commandClearZombieSpawns(_, line, words, playerID)
 	Spring.SendMessageToPlayer(playerID, "Cleared all queued zombie spawns")
 end
 
+---Switches the zombie difficulty preset.
+---@param mode ZombieMode
+---@return boolean applied `false` when `mode` is not a known preset.
 local function setZombieMode(mode)
 	if mode ~= "normal" and mode ~= "hard" and mode ~= "nightmare" and mode ~= "akumu" then
 		return false
@@ -1674,6 +1711,7 @@ function gadget:Initialize()
 	GG.Zombies.KillAllZombies = killAllZombies
 	GG.Zombies.ClearAllOrders = clearAllOrders
 	GG.Zombies.SetZombieMode = setZombieMode
+	---@return ZombieMode mode The active difficulty preset.
 	GG.Zombies.GetZombieMode = function()
 		return currentZombieMode
 	end

--- a/luaui/Include/user_firestate_commands.lua
+++ b/luaui/Include/user_firestate_commands.lua
@@ -82,6 +82,18 @@ local function notifyUserInitiatedFirestate(unitIDs, userState, userInitiated)
 	end
 end
 
+---Options accepted by the firestate setters.
+---@class FirestateOpts
+---@field userInitiated boolean? `true` when the player clicked something, `false` (the
+---default) for automatic or scripted changes.
+
+---Changes the firestate of the player's current selection.
+---Issues a selection-wide order, so `unitIDs` must be the current selection.
+---@param userState integer? A `CustomFirestateDefs` value, e.g. `DEFEND`.
+---@param unitIDs integer[]? The currently selected units.
+---@param opts FirestateOpts?
+---@return boolean issued `false` when `userState` is missing, `unitIDs` is empty, or
+---the state has no engine equivalent.
 local function setSelectionFirestate(userState, unitIDs, opts)
 	if userState == nil or not unitIDs or #unitIDs == 0 then
 		return false
@@ -102,6 +114,11 @@ local function setSelectionFirestate(userState, unitIDs, opts)
 	return true
 end
 
+---Changes the firestate of specific units, one order per unit.
+---@param userState integer? A `CustomFirestateDefs` value, e.g. `DEFEND`.
+---@param unitIDs integer[]?
+---@param opts FirestateOpts?
+---@return boolean issued `false` when `userState` or `unitIDs` is missing.
 local function setFirestateForUnits(userState, unitIDs, opts)
 	if userState == nil or not unitIDs then
 		return false
@@ -116,6 +133,14 @@ local function setFirestateForUnits(userState, unitIDs, opts)
 	return true
 end
 
+---Resolves a firestate command back into the user-facing state it represents,
+---consuming any state staged for that unit by this API.
+---@param cmdID integer Either `CMD.FIRE_STATE` or `GameCMD.USER_FIRESTATE`.
+---@param cmdParams number[]?
+---@param unitID integer
+---@return integer? userState A `CustomFirestateDefs` value, or `nil` for unrelated commands.
+---@return boolean userInitiated Whether the change came from a player action.
+---@return boolean fromApi Whether this API issued the command.
 local function decodeFirestateUnitCommand(cmdID, cmdParams, unitID)
 	if cmdID == CMD_USER_FIRESTATE then
 		local userState, userInitiated = CustomFirestateDefs.parseUserFirestateParams(cmdParams)

--- a/luaui/RmlWidgets/gui_map_labels/gui_map_labels.lua
+++ b/luaui/RmlWidgets/gui_map_labels/gui_map_labels.lua
@@ -101,6 +101,7 @@ end
 -- Persistence (one file per map in the Spring write dir)
 -- ===========================================================================
 
+
 local function labelsFilePath()
 	local slug = (Game.mapName or "unknown"):gsub("[^%w%-_%. ]", "_")
 	-- "labels_" prefix also sidesteps Windows reserved device names (CON, AUX...)
@@ -211,6 +212,7 @@ end
 -- Helpers
 -- ===========================================================================
 
+
 local function findLabel(id)
 	for _, L in ipairs(state.labels) do
 		if L.id == id then
@@ -267,6 +269,7 @@ end
 -- ===========================================================================
 -- Popup (open comment attached to a dot)
 -- ===========================================================================
+
 
 local function setEditing(on)
 	state.popupEditing = on
@@ -1017,19 +1020,35 @@ function widget:Initialize()
 	rebuildUi()
 
 	WG.MapLabels = {
+		---A map comment as exposed by `getLabels`.
+		---@class MapLabel
+		---@field id integer
+		---@field x number
+		---@field z number
+		---@field color string
+		---@field author string
+		---@field created string Local timestamp, formatted `"%Y-%m-%d %H:%M"`.
+		---@field text string
+
+		---Toggles the labels browser window.
+		---@return boolean open The window's new state.
 		toggle = function()
 			setWindowOpen(not state.windowOpen)
 			return state.windowOpen
 		end,
+		---Opens the labels browser window.
 		open = function()
 			setWindowOpen(true)
 		end,
+		---Closes the labels browser window.
 		close = function()
 			setWindowOpen(false)
 		end,
+		---@return boolean open
 		isOpen = function()
 			return state.windowOpen
 		end,
+		---@return boolean placing Whether the widget is waiting for a click to place a label.
 		isPlacing = function()
 			return state.placing
 		end,
@@ -1037,6 +1056,7 @@ function widget:Initialize()
 		-- widget hides its cursor ring whenever this is true. Covers label
 		-- placement, dot hover/drag, hovering our windows, and an open comment
 		-- (whose dismissing click is consumed instead of painting).
+		---@return boolean suppress Whether the terrain brush should hide its cursor ring.
 		shouldSuppressBrush = function()
 			if state.placing or state.openLabelId then
 				return true
@@ -1045,6 +1065,7 @@ function widget:Initialize()
 		end,
 		-- True when the cursor is over the labels browser window or an open
 		-- comment popup; cmd_terraform_brush hides the brush ring there.
+		---@return boolean over Whether the cursor is over the browser window or an open comment.
 		isCursorOver = function()
 			-- Hovering or dragging a dot is a label interaction, not painting
 			if state.hoverDotId or state.draggingId then
@@ -1067,12 +1088,14 @@ function widget:Initialize()
 			end
 			return false
 		end,
+		---@return integer count
 		getLabelCount = function()
 			return #state.labels
 		end,
 
 		-- Read-only snapshot for exporters (Terraform Brush Capture writes these
 		-- as an SVG pin layer). Copied so a caller cannot mutate live state.
+		---@return MapLabel[] labels A copy, so mutating it does not affect live state.
 		getLabels = function()
 			local out = {}
 			for i, L in ipairs(state.labels) do
@@ -1095,6 +1118,9 @@ function widget:Initialize()
 
 		-- Returns the number of comments written (0 = none, caller deletes the
 		-- file), or nil if the file could not be written.
+		---Writes the live comments into a map project folder.
+		---@param path string?
+		---@return integer? count
 		saveProject = function(path)
 			if not path then
 				return nil
@@ -1122,6 +1148,9 @@ function widget:Initialize()
 		-- Replaces every live comment with the project's. Also refreshes the
 		-- per-map autosave so the two copies do not disagree afterwards.
 		-- Returns ok, count.
+		---@param path string?
+		---@return boolean ok
+		---@return integer? count Number of comments loaded, when `ok` is `true`.
 		loadProject = function(path)
 			if not path then
 				return false

--- a/luaui/RmlWidgets/gui_quick_start/gui_quick_start.lua
+++ b/luaui/RmlWidgets/gui_quick_start/gui_quick_start.lua
@@ -95,6 +95,9 @@ local function linesHaveChanged(newLines, oldLines)
 	return false
 end
 
+---Replaces the externally-supplied start positions used to preview the quick-start
+---build queue, rebuilding the UI only when they actually changed.
+---@param spawnPositions table<integer, PositionXZ>? Keyed by teamID.
 local function updateSpawnPositions(spawnPositions)
 	if not spawnPositions then
 		return
@@ -729,6 +732,16 @@ local function updateDataModel(forceUpdate)
 	end
 end
 
+---Which parts of a pregame build queue the start budget can actually pay for.
+---@class QuickStartSpawnStatus
+---@field queueSpawned table<integer, boolean> Keyed by position in `buildQueue`.
+---@field selectedSpawned boolean Whether the currently held build order would spawn.
+
+---Works out which queued buildings would be instantly spawned at game start,
+---spending the start budget in queue order.
+---@param buildQueue BuildOrder[]?
+---@param selectedBuildData BuildOrder? The build order currently held by the cursor.
+---@return QuickStartSpawnStatus
 local function getBuildQueueSpawnStatus(buildQueue, selectedBuildData)
 	local myTeamID = spGetMyTeamID()
 	local gameRules = getCachedGameRules()

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -13055,30 +13055,59 @@ function widget:Initialize()
 	WG.TerraformBrushUI = {
 		-- Environment snapshot/apply, for the map-project orchestrator
 		-- (cmd_map_project.lua). Indirect so it tracks widgetState assignments.
+		---Pixel bounds of a brush panel, in Spring screen coordinates (Y=0 at the bottom).
+		---@class TerraformBrushPanelBounds
+		---@field left number
+		---@field right number
+		---@field topY number
+		---@field bottomY number
+
+		---Serializes the current sun, fog and water settings as a loadable Lua config.
+		---@param opts {nodate: boolean?}? Set `nodate` to omit the generated-on timestamp.
+		---@return string content
 		buildEnvConfigContent = function(opts)
 			return widgetState.buildEnvConfigContent(opts)
 		end,
+		---Applies a previously captured environment snapshot. Ignores non-table input.
+		---@param d table<string, any>? An environment snapshot as produced by
+		---`buildEnvConfigContent`: sun, fog and atmosphere values keyed by name.
 		applyEnvConfig = function(d)
 			return widgetState.applyEnvConfig(d)
 		end,
 		-- Start script for opening a map project (blank map at the manifest's
 		-- size with project-local DNTS assets); called by WG.MapProject.open.
+		---@param manifest MapProjectManifest
+		---@param slug string Project folder name under `MapProjects/`.
+		---@return string? scriptText `nil` on failure.
+		---@return string? errorMessage Set when `scriptText` is `nil`.
 		buildProjectStartScript = function(manifest, slug)
 			return widgetState.buildProjectStartScript(manifest, slug)
 		end,
+		---@return boolean capturing Whether the settings panel is waiting for a keypress to bind.
 		isCapturingKey = function()
 			return widgetState.settingsCapturing ~= nil
 		end,
+		---Feeds a keypress to the settings panel's key-capture flow.
+		---@param keyCode integer
+		---@return boolean consumed `false` when no capture is in progress.
 		captureKey = function(keyCode)
 			return handleSettingsKeyCapture(keyCode)
 		end,
+		---Redraws every keybind badge in the settings panel.
 		refreshBadges = function()
 			updateAllKeybindBadges()
 		end,
+		---Activates the brush tool bound to a key, if any.
+		---@param keyCode integer
+		---@return boolean consumed `false` when no tool is bound to that key.
 		handleToolKey = function(keyCode)
 			return handleToolKey(keyCode)
 		end,
 		-- Called by cmd_terraform_brush when the user clicks a height in sampling mode
+		---Records a height picked by the user in sampling mode, so the state sync loop
+		---reflects it.
+		---@param target "max"|"min" Which height cap was sampled.
+		---@param value number? Defaults to `0`.
 		onHeightSampled = function(target, value)
 			-- Update the local cap variables so the state sync loop reflects them
 			if target == "max" then
@@ -13096,6 +13125,7 @@ function widget:Initialize()
 		end,
 		-- Returns the panel pixel bounds in Spring screen coords (Y=0 at bottom).
 		-- Returns nil when the panel is hidden or not yet available.
+		---@return TerraformBrushPanelBounds? bounds
 		getPanelBounds = function()
 			local vsx, vsy = Spring.GetViewGeometry()
 			if vsx <= 0 then
@@ -13124,6 +13154,7 @@ function widget:Initialize()
 			}
 		end,
 		-- Returns bounds of the light library floating window, or nil if not visible.
+		---@return TerraformBrushPanelBounds? bounds
 		getLightLibraryBounds = function()
 			if not widgetState.lightLibraryOpen then
 				return nil

--- a/luaui/RmlWidgets/gui_terraformer_shared.lua
+++ b/luaui/RmlWidgets/gui_terraformer_shared.lua
@@ -36,6 +36,7 @@ WG.TerraformerShared = WG.TerraformerShared or {}
 -- Shared accessor so widgets don't reimplement calculateDpRatio().
 -- Returns the current scale factor (resolution_factor * ui_scale), matching
 -- whatever the shared RmlUi context is currently using.
+---@return number dpRatio Current scale factor `resolution_factor * ui_scale`, matching the shared RmlUi context.
 WG.TerraformerShared.getDpRatio = function()
 	return currentDpRatio
 end
@@ -141,6 +142,10 @@ WG.TerraformerShared.setWheelHeld = function(held)
 	end
 end
 
+---Registers a document so sibling widgets can read its live layout.
+---Call after `LoadDocument()`; pair with `unregisterDocument` on Shutdown.
+---@param name string?
+---@param document RmlUi.Document?
 WG.TerraformerShared.registerDocument = function(name, document)
 	if name and document then
 		registeredDocuments[name] = document
@@ -149,6 +154,8 @@ WG.TerraformerShared.registerDocument = function(name, document)
 	end
 end
 
+---Removes a document from the cross-widget registry.
+---@param name string?
 WG.TerraformerShared.unregisterDocument = function(name)
 	if name then
 		registeredDocuments[name] = nil
@@ -156,10 +163,24 @@ WG.TerraformerShared.unregisterDocument = function(name)
 	end
 end
 
+---@param name string
+---@return RmlUi.Document? document `nil` when no document is registered under `name`.
 WG.TerraformerShared.getDocument = function(name)
 	return registeredDocuments[name]
 end
 
+---A registered element's live layout, in pixel space.
+---@class TerraformerElementRect
+---@field left number
+---@field top number
+---@field width number
+---@field height number
+
+---Reads live pixel-space layout off an element of a registered document.
+---@param docName string
+---@param elementId string?
+---@return TerraformerElementRect? rect `nil` when the document or element is missing,
+---or the element has no width yet.
 WG.TerraformerShared.getElementRect = function(docName, elementId)
 	local doc = registeredDocuments[docName]
 	if not doc then
@@ -182,15 +203,26 @@ WG.TerraformerShared.getElementRect = function(docName, elementId)
 	}
 end
 
+---Options accepted by `attachDraggable`.
+---@class TerraformerDraggableOpts
+---@field snapThreshold number? Pixel snap distance for edges and panel snap. Defaults to `30`.
+---@field onDragStart fun()? Called on mousedown, e.g. to record that the user moved the panel.
+---@field snapDocName string? Registered document to snap against. Defaults to `"terraform_brush"`.
+---@field snapElementId string? Element within that document. Defaults to `"tf-root"`.
+
+---The value returned by `attachDraggable`.
+---@class TerraformerDraggable
+---@field tick fun() Call every frame from `widget:Update()` while the widget is alive.
+
 -- Shared drag-and-drop helper for floating panels.
 -- Sets up mousedown on handleId + mouseup on doc, returns a handle with tick().
 -- Call handle.tick() every frame from widget:Update() while the widget is alive.
---
--- opts fields (all optional):
---   snapThreshold (number, default 30) — pixel snap distance for edges + panel snap
---   onDragStart   (function)           — called on mousedown (e.g. set userDragged)
---   snapDocName   (string, default "terraform_brush") — registered document to snap to
---   snapElementId (string, default "tf-root")         — element within that document
+---Makes a floating panel draggable by a handle element, with edge and panel snapping.
+---@param doc RmlUi.Document?
+---@param handleId string Id of the element used as the drag handle.
+---@param rootEl RmlUi.Element? The panel being moved.
+---@param opts TerraformerDraggableOpts?
+---@return TerraformerDraggable handle A no-op handle when `doc`, `rootEl` or the handle element is missing.
 WG.TerraformerShared.attachDraggable = function(doc, handleId, rootEl, opts)
 	if not doc or not rootEl then
 		return { tick = function() end }

--- a/luaui/Widgets/api_analytics.lua
+++ b/luaui/Widgets/api_analytics.lua
@@ -59,6 +59,16 @@ local function analyticsCoroutine(eventType, eventData)
 	spSendLuaUIMsg(complexMatchEvent)
 end
 
+---Queues an analytics event for the telemetry system.
+---
+---WARNING: Do NOT include any personal information in `eventType` or `eventData`.
+---Data sent via this function may be intercepted by other players, including
+---opponents. Only send anonymized, non-personal game-related data. This is
+---intended for gameplay analytics and debugging, not for user tracking.
+---@param eventType string Event type; must not contain personal info.
+---@param eventData table<string, any> Additional event data, merged into the JSON
+---payload key by key; keys colliding with `eventtype`/`username`/`frame` are dropped.
+---Must not contain personal info.
 local function sendAnalyticsEvent(eventType, eventData)
 	local co = coroutine.create(function()
 		analyticsCoroutine(eventType, eventData)

--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -80,9 +80,9 @@ local function enum(...)
 	return result
 end
 
----@param a Point
----@param b Point
----@return Point
+---@param a Position3D
+---@param b Position3D
+---@return Position3D
 local function subtractPoints(a, b)
 	local result = {}
 	for i = 1, mathMax(#a, #b) do
@@ -91,10 +91,10 @@ local function subtractPoints(a, b)
 	return result
 end
 
----@param point Point
----@param center Point
+---@param point Position3D
+---@param center Position3D
 ---@param angle number
----@return Point
+---@return Position3D
 local function rotatePointXZ(point, center, angle)
 	local rotatedPoint = {}
 
@@ -200,6 +200,7 @@ local outlineVertexVBOLayout = {
 	{ id = 0, name = "position", size = 2 },
 }
 
+---@type InstanceVBOTable
 local outlineInstanceVBO = nil
 local outlineInstanceVBOLayout = {
 	{ id = 1, name = "position", size = 3 },
@@ -272,6 +273,11 @@ local UNIT_ALPHA = 0.6
 
 local BUILD_MODES = enum("SINGLE", "LINE", "SNAPLINE", "GRID", "BOX", "AROUND")
 
+---World-space footprint of a building, accounting for its facing.
+---@param unitDefID integer?
+---@param facing integer Build facing, `0`-`3`.
+---@return number width `0` when `unitDefID` is missing.
+---@return number depth
 local function getBuildingDimensions(unitDefID, facing)
 	if not unitDefID then
 		return 0, 0
@@ -284,6 +290,12 @@ local function getBuildingDimensions(unitDefID, facing)
 	end
 end
 
+---Axis-aligned bounds covering every unit's footprint, in blueprint-local space.
+---@param units BlueprintUnit[]
+---@return number? xMin `nil` when `units` is empty.
+---@return number? xMax
+---@return number? zMin
+---@return number? zMax
 local function getUnitsBounds(units)
 	if #units == 0 then
 		return nil, nil, nil, nil
@@ -310,6 +322,11 @@ local function getUnitsBounds(units)
 	return r.xMin, r.xMax, r.zMin, r.zMax
 end
 
+---Overall footprint of a blueprint, accounting for its facing.
+---@param blueprint Blueprint
+---@param facing integer? Build facing, `0`-`3`. Treated as unrotated when omitted.
+---@return number width `0` when the blueprint has no units.
+---@return number depth
 local function getBlueprintDimensions(blueprint, facing)
 	local xMin, xMax, zMin, zMax = getUnitsBounds(blueprint.units)
 
@@ -339,7 +356,7 @@ end
 ---
 ---Analogous to Pos2BuildPos (which positions individual units), but for whole blueprints.
 ---@param blueprint Blueprint
----@param pos Point
+---@param pos Position3D
 ---@param facing number
 local function snapBlueprint(blueprint, pos, facing)
 	local xSize, zSize = getBlueprintDimensions(blueprint, facing or 0)
@@ -532,8 +549,15 @@ local BUILD_MODES_HANDLERS = {
 	AROUND = getBuildPositionsAround,
 }
 
----@param blueprint Blueprint
----@param buildPositions table
+---A blueprint stamp location.
+---@class BuildPlacement
+---@field [1] number World X.
+---@field [2] number World Y. Always `0`: `fillRow` does not sample the ground.
+---@field [3] number World Z.
+---@field [4] integer? Build facing. Only the AROUND mode sets one; every other build
+---mode leaves this absent.
+
+---@param buildPositions BuildPlacement[]
 ---@return table
 local function createBuildings(blueprint, buildPositions)
 	local allBuildings = {}
@@ -561,7 +585,7 @@ end
 
 --- Gives build orders for a blueprint to a set of builders.
 ---@param blueprint Blueprint The blueprint to build.
----@param buildPositions table The locations to build the blueprint at.
+---@param buildPositions BuildPlacement[] The locations to build the blueprint at.
 ---@param builders number[] A list of builder unit IDs.
 ---@param isBuildSplit boolean If true, split the work among builders. If false, builders of the same faction work together.
 ---@param cmdOpts table Command options.
@@ -675,7 +699,7 @@ end
 
 ---Synchronize the building and outline instances with the given list of build positions.
 ---@param blueprint Blueprint
----@param buildPositions StartPoints
+---@param buildPositions BuildPlacement[]
 ---@param teamID number
 local function updateInstances(blueprint, buildPositions, teamID)
 	if isHeadless then
@@ -750,6 +774,9 @@ end
 -- api
 -- ===
 
+---Sets the blueprint currently being placed, substituting units from other factions
+---where needed. Pass `nil` to clear it and hide the ghost.
+---@param bp Blueprint?
 local function setActiveBlueprint(bp)
 	if not bp then
 		activeBlueprint = nil
@@ -796,16 +823,26 @@ local function setActiveBlueprint(bp)
 	updateInstances(activeBlueprint, activeBuildPositions, SpringGetMyTeamID())
 end
 
+---Sets the positions the active blueprint's ghost is drawn at.
+---@param buildPositions BuildPlacement[]
 local function setBlueprintPositions(buildPositions)
 	activeBuildPositions = buildPositions
 
 	updateInstances(activeBlueprint, activeBuildPositions, SpringGetMyTeamID())
 end
 
+---Works out where a blueprint should be stamped for the given placement mode.
+---@param blueprint Blueprint
+---@param mode "SINGLE"|"LINE"|"SNAPLINE"|"GRID"|"BOX"|"AROUND" A `BUILD_MODES` value.
+---@param ... any Mode-specific arguments, e.g. the drag start and end points.
+---@return BuildPlacement[] buildPositions
 local function calculateBuildPositions(blueprint, mode, ...)
 	return BUILD_MODES_HANDLERS[mode](blueprint, ...)
 end
 
+---Records which builders are selected, so the API knows what can be built and
+---which faction to substitute units to.
+---@param unitIDs integer[]
 local function setActiveBuilders(unitIDs)
 	activeBuilderBuildOptions = table.reduce(unitIDs, function(acc, cur)
 		local unitDefID = SpringGetUnitDefID(cur)
@@ -852,6 +889,10 @@ local function setActiveBuilders(unitIDs)
 	end
 end
 
+---Rebuilds a blueprint from its saved form, substituting units that are not in the
+---base game (e.g. Legion or unit-pack units) to a default faction so it stays usable.
+---@param serializedBlueprint SerializedBlueprint?
+---@return Blueprint? blueprint `nil` when the input is missing or has no `units`.
 local function createBlueprintFromSerialized(serializedBlueprint)
 	-- This function contains logic to handle blueprints with units that are not
 	-- in the base game (e.g., Legion, expiremental unit pack). It attempts to substitute

--- a/luaui/Widgets/api_build_orders.lua
+++ b/luaui/Widgets/api_build_orders.lua
@@ -28,7 +28,7 @@ end
 ---@field facing? number
 
 ---@param builderID number
----@return BuilderInfo
+---@return BuilderInfo? builderInfo `nil` when the unit no longer exists.
 local function getBuilderInfo(builderID)
 	local unitDefID = Spring.GetUnitDefID(builderID)
 	if not unitDefID then
@@ -96,8 +96,8 @@ end
 
 ---Groups builders so that each builder forms its own group, keyed by unitID.
 ---Used by split mode, where every builder works its own fork.
----@param builders table A list of builder info objects.
----@return table<number, table> One group per builder.
+---@param builders BuilderInfo[] A list of builder info objects.
+---@return table<number, BuilderInfo[]> One group per builder, keyed by unitID.
 local function forkBuilders(builders)
 	local forkGroups = {}
 	for _, builderInfo in ipairs(builders) do

--- a/luaui/Widgets/api_builder_queue.lua
+++ b/luaui/Widgets/api_builder_queue.lua
@@ -169,8 +169,9 @@ local function notifyEvent(eventName, ...)
 	end
 end
 
----@param eventName string
----@param callback function()
+---@param eventName string One of the `Event` values.
+---@param callback function
+---@return BuilderQueueEventCallback? handle Pass to `UnregisterCallback`; `nil` when `eventName` is unknown.
 local function registerCallback(eventName, callback)
 	local callbacks = eventCallbacks[eventName]
 	if callbacks then
@@ -183,6 +184,9 @@ local function registerCallback(eventName, callback)
 	end
 end
 
+---Removes a previously registered listener.
+---@param eventName string One of the `Event` values.
+---@param callback function The same function that was registered.
 local function unregisterCallback(eventName, callback)
 	local callbacks = eventCallbacks[eventName]
 	if callbacks then
@@ -490,18 +494,33 @@ function BuilderQueueApi.ForEachActiveBuildCommand(callback)
 	end
 end
 
+---Fires when a new build command starts being tracked.
+---@param callback fun(commandId: string, commandEntry: BuildCommandEntry)
+---@return BuilderQueueEventCallback? handle
 BuilderQueueApi.OnBuildCommandAdded = function(callback)
 	return registerCallback(Event.onBuildCommandAdded, callback)
 end
+---Fires when a tracked build command is canceled or completed.
+---@param callback fun(commandId: string, commandEntry: BuildCommandEntry)
+---@return BuilderQueueEventCallback? handle
 BuilderQueueApi.OnBuildCommandRemoved = function(callback)
 	return registerCallback(Event.onBuildCommandRemoved, callback)
 end
+---Fires when a tracked build command produces a unit (the nanoframe appears).
+---@param callback fun(unitId: integer, unitDefId: integer, commandId: string, commandEntry: BuildCommandEntry)
+---@return BuilderQueueEventCallback? handle
 BuilderQueueApi.OnUnitCreated = function(callback)
 	return registerCallback(Event.onUnitCreated, callback)
 end
+---Fires when a unit from a tracked build command finishes building.
+---@param callback fun(unitId: integer, commandId: string, commandEntry: BuildCommandEntry)
+---@return BuilderQueueEventCallback? handle
 BuilderQueueApi.OnUnitFinished = function(callback)
 	return registerCallback(Event.onUnitFinished, callback)
 end
+---Fires when a tracked builder is destroyed.
+---@param callback fun(unitId: integer, unitDefId: integer)
+---@return BuilderQueueEventCallback? handle
 BuilderQueueApi.OnBuilderDestroyed = function(callback)
 	return registerCallback(Event.onBuilderDestroyed, callback)
 end

--- a/luaui/Widgets/api_los_combiner_gl4.lua
+++ b/luaui/Widgets/api_los_combiner_gl4.lua
@@ -112,6 +112,9 @@ local shaderSourceCache = {
 	shaderConfig = shaderConfig,
 }
 
+---Returns the combined info/LOS texture for an allyteam.
+---@param allyTeam integer? Defaults to the local player's allyteam.
+---@return string? texName `nil` when no texture has been built for that allyteam.
 local function GetInfoLOSTexture(allyTeam)
 	return infoTextures[allyTeam or currentAllyTeam]
 end

--- a/luaui/Widgets/api_object_spotlight.lua
+++ b/luaui/Widgets/api_object_spotlight.lua
@@ -311,20 +311,22 @@ for k in pairs(spotlightTypes) do
 	objectOwners[k] = {}
 end
 
+---Extra options accepted by `addSpotlight`.
+---@class ObjectSpotlightOptions
+---@field duration number? If given, the spotlight fades out over this many seconds.
+---@field radius number? Override the radius. Defaults to the object's radius, or `100`.
+---@field radiusCoefficient number? Multiplicative factor for the radius. Defaults to `1`.
+---@field height number? Override the height. Defaults to `300`.
+---@field heightCoefficient number? Multiplicative factor for the height. Defaults to `1`.
+
 ---Adds a new spotlight for a given object. Only one call is needed to create the spotlight (the position is handled in
 ---the shader), but this can be called again to update extra options. Unless a duration is provided, calling
 ---removeSpotlight later is necessary to remove the spotlight.
----@param objectType string "unit", "feature", or "ground"
----@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@param objectID number|number[] unitID, featureID, or {x,y,z} table for a location
----@param color table RGBA color used for the spotlight
----@param options table extra optional parameters
----@param options.duration number if specified, the spotlight will fade out over this period of seconds
----@param options.radius number override the radius (default: the radius of the object, or 100 if that's not present)
----@param options.radiusCoefficient number multiplicative factor for the radius (default: 1)
----@param options.height number override the height (default: 300)
----@param options.heightCoefficient number multiplicative factor for the height (default: 1)
----@return nil
+---@param objectType WorldObjectType
+---@param owner string Identifier preventing collisions; one spotlight per objectID per owner.
+---@param objectID integer|Position3D A unitID, featureID, or `{x, y, z}` for a location.
+---@param color ColorRGBA RGBA color used for the spotlight.
+---@param options ObjectSpotlightOptions?
 local function addSpotlight(objectType, owner, objectID, color, options)
 	if not spotlightTypes[objectType] then
 		error("invalid spotlight target type: " .. (objectType or "<nil>"))
@@ -398,10 +400,10 @@ local function addSpotlight(objectType, owner, objectID, color, options)
 end
 
 ---Removes the spotlight for a given object. This can be called even if a spotlight might not be present.
----@param objectType string "unit" or "feature", or "ground"
----@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@param objectID number|number[] unitID, featureID, or {x,y,z} table for a location
----@return nil
+---Removes an object's spotlight. Safe to call when no spotlight is present.
+---@param objectType WorldObjectType
+---@param owner string Identifier preventing collisions; one spotlight per objectID per owner.
+---@param objectID integer|Position3D A unitID, featureID, or `{x, y, z}` for a location.
 local function removeSpotlight(objectType, owner, objectID)
 	if not spotlightTypes[objectType] then
 		error("invalid spotlight target type: " .. (objectType or "<nil>"))
@@ -436,9 +438,10 @@ local function removeSpotlight(objectType, owner, objectID)
 end
 
 ---Returns the objectID for all spotlights with the specified type and owner.
----@param objectType string "unit" or "feature", or "ground"
----@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@return (number|number[])[]
+---Returns the objectID of every spotlight with the given type and owner.
+---@param objectType WorldObjectType
+---@param owner string Identifier preventing collisions; one spotlight per objectID per owner.
+---@return (integer|Position3D)[] objectIDs
 local function getSpotlights(objectType, owner)
 	return table.reduce(objectOwners[objectType], function(acc, v, k)
 		if v[owner] then
@@ -449,8 +452,8 @@ local function getSpotlights(objectType, owner)
 end
 
 ---Removes all spotlights with the specified owner.
----@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@return nil
+---Removes every spotlight belonging to an owner, across all object types.
+---@param owner string Identifier preventing collisions; one spotlight per objectID per owner.
 local function removeAllSpotlights(owner)
 	for objectType in pairs(spotlightTypes) do
 		for _, id in ipairs(getSpotlights(objectType, owner)) do

--- a/luaui/Widgets/api_playernames.lua
+++ b/luaui/Widgets/api_playernames.lua
@@ -175,6 +175,11 @@ local function unpackHistory(packed)
 	return historyTable
 end
 
+---Resolves a player's display name, applying their alias or first-encountered name.
+---@param playerID integer?
+---@param accountID integer? Used iff `playerID` is `nil`
+---@param skipAlias boolean? Return the real name even when an alias is set.
+---@return string? name `nil` when the player is not known yet.
 local function getPlayername(playerID, accountID, skipAlias)
 	if playerID then
 		accountID = nil
@@ -237,6 +242,18 @@ local function getPlayername(playerID, accountID, skipAlias)
 	end
 end
 
+---Every name an account has been seen using.
+---@class PlayerNameHistory
+---@field i integer Number of games the account has been seen in.
+---@field d integer Date last seen, as `yymmdd`.
+---@field alias string? Player-set alias, which overrides the recorded names.
+---@field [integer] string Names in the order they were first encountered.
+
+---Returns the recorded name history for an account.
+---@param accountID integer
+---@param full boolean? Return the live table rather than a shallow copy. The live
+---table must not be mutated by the caller.
+---@return PlayerNameHistory? history `nil` when the account has no recorded history.
 local function getAccountHistory(accountID, full)
 	if history[accountID] then
 		if full then
@@ -368,15 +385,28 @@ function widget:Initialize()
 	end
 
 	WG.playernames = {}
+	---Resolves a player's display name, applying their alias or first-encountered name.
+	---@param playerID integer?
+	---@param accountID integer? Used iff `playerID` is `nil`
+	---@param skipAlias boolean? Return the real name even when an alias is set.
+	---@return string? name `nil` when the player is not known yet.
 	WG.playernames.getPlayername = function(playerID, accountID, skipAlias)
 		return getPlayername(playerID, accountID, skipAlias)
 	end
+	---Returns the recorded name history for an account.
+	---@param accountID integer
+	---@param full boolean? Return the live table rather than a shallow copy.
+	---@return PlayerNameHistory? history `nil` when the account has no recorded history.
 	WG.playernames.getAccountHistory = function(accountID, full)
 		return getAccountHistory(accountID, full)
 	end
+	---Shows each account under the first name it was seen using, rather than its
+	---current one.
+	---@param value boolean
 	WG.playernames.setUseFirstEncounter = function(value)
 		applyFirstEncounteredName = value
 	end
+	---@return boolean useFirstEncounter
 	WG.playernames.getUseFirstEncounter = function()
 		return applyFirstEncounteredName
 	end

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -104,7 +104,8 @@ end
 ------------------------------------------------------------
 
 ---Checks if there is an existing extractor (mex or geo) in the given spot
----@param spot table
+---@param spot ResourceSpot
+---@return integer|false unitID `false` when the spot is empty.
 local function spotHasExtractor(spot)
 	local units = Spring.GetUnitsInCylinder(spot.x, spot.z, Game_extractorRadius)
 	local type = spot.isMex and mexBuildings or geoBuildings
@@ -116,9 +117,19 @@ local function spotHasExtractor(spot)
 	return false
 end
 
+---A metal or geothermal spot on the map.
+---@class ResourceSpot
+---@field x number
+---@field z number
+---@field isMex boolean? `true` for metal spots. Consumers branch on this alone.
+---@field isGeo boolean? `true` for geothermal spots. Set by the spot finder but never
+---read. The absence of `isMex` selects the geothermal code paths.
+
 ---Checks if there is an existing command among the current builders to make an extractor on the given spot
----@param spot table
----@param builders table which units will have their queues checked - doing a global check is too expensive
+---@param spot ResourceSpot
+---@param builders integer[]? which units will have their queues checked - doing a global
+---check is too expensive. Defaults to the current selection.
+---@return boolean
 local function spotHasExtractorQueued(spot, builders)
 	builders = builders or selectedUnits
 
@@ -157,10 +168,12 @@ local function spotHasExtractorQueued(spot, builders)
 	return false
 end
 
----Gets the naive best extractor, ignores special mexes (exploiter etc), just finds highest extraction amount
----@param units table selected units
----@param constructorIds table builder types to check
----@param extractors table valid extractors, useful to specify specific types or check only geos etc
+---Gets the naive best extractor, ignores special mexes (exploiter etc), just finds highest extraction amount.
+---Only the first extractor option of each builder is considered.
+---@param units integer[] Selected builder unitIDs.
+---@param constructorIds table<integer, {buildings: integer, building: integer[]}> Builder types to check, keyed by unitID.
+---@param extractors table<integer, number> Yield per extractor unitDefID. Useful to specify specific types, or check only geos.
+---@return integer? unitDefID `nil` when none of the units can build an extractor.
 local function getBestExtractorFromBuilders(units, constructorIds, extractors)
 	local bestExtraction = 0
 	local bestExtractor
@@ -222,8 +235,10 @@ local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 end
 
 ---Returns true if the specified extractor be built on this spot - considers upgrades and sidegrades
----@param spot table
----@param extractorId table
+---Returns true if the specified extractor can be built on this spot - considers upgrades and sidegrades.
+---Upgradable allied extractors count as buildable; in-progress ones block.
+---@param spot ResourceSpot
+---@param extractorId integer unitDefID of the extractor to place.
 ---@return boolean
 local function extractorCanBeBuiltOnSpot(spot, extractorId)
 	local units = Spring.GetUnitsInCylinder(spot.x, spot.z, Game_extractorRadius)
@@ -247,11 +262,10 @@ local function extractorCanBeBuiltOnSpot(spot, extractorId)
 end
 
 ---Finds the nearest unoccupied resource spot from the provided list
----@param x number
----@param z number
----@param spotsIn table
----@param extractor table unitDefID
----@param shouldIgnoreAlreadyQueuedUpSpots boolean
+---@param spotsIn ResourceSpot[]
+---@param extractor integer unitDefID of the extractor to place.
+---@param shouldIgnoreAlreadyQueuedUpSpots boolean Skip spots that already have an extractor queued.
+---@return ResourceSpot? spot `nil` when no spot in the list can take the extractor.
 local function findNearestValidSpotForExtractor(x, z, spotsIn, extractor, shouldIgnoreAlreadyQueuedUpSpots)
 	-- sort spots by distance
 	local spots = table.copy(spotsIn)
@@ -373,11 +387,27 @@ end
 
 ---Puts together build orders for ghost previews (e.g. mex snap). These orders can be fed directly to
 ---ApplyPreviewCmds to actually give the orders to units
----@param params table
----@param extractor table
----@param spot table must be a full spot, not just position. isMex or isGeo field required for things to work.
----@param metalMap boolean if this is for a metal map. If so it's used for upgrade visualizing only and takes a different code path.
----@return table format is { buildingId, x, y, z, facing, owner }
+---A previewed extractor build order, in the argument order `Spring.GiveOrderToUnit`
+---wants for a build command, with the crediting team appended.
+---@class ExtractorCommand
+---@field [1] number Building id as a positive number; the callers negate it themselves.
+---@field [2] number World X, snapped to the spot.
+---@field [3] number World Y.
+---@field [4] number World Z.
+---@field [5] number Build facing, `0`-`3`.
+---@field [6] number Team credited with the build. This is the OCCUPYING team when
+---upgrading an ally's extractor, not necessarily the local one.
+
+---Puts together build orders for ghost previews (e.g. mex snap). These orders can be fed directly to
+---ApplyPreviewCmds to actually give the orders to units
+---Snaps the order to a valid position and credits an allied owner when upgrading.
+---@param params Position3D The cursor position as `{x, y, z}`.
+---@param extractor integer Negative unitDefID, as it appears in a build command.
+---@param spot ResourceSpot? Must be a full spot, not just a position. Omit together
+---with `metalMap` for spread metal maps.
+---@param metalMap boolean? If this is for a metal map. Used for upgrade visualizing only,
+---and takes a different code path.
+---@return ExtractorCommand? command `nil` when the spot cannot take the extractor.
 local function PreviewExtractorCommand(params, extractor, spot, metalMap)
 	if metalMap and not spot then
 		return previewMetalMapExtractorCommand(params, extractor)
@@ -412,6 +442,10 @@ local function PreviewExtractorCommand(params, extractor, spot, metalMap)
 	return finalCommand
 end
 
+---Issues previewed extractor build orders to the best-suited selected builders.
+---@param cmds ExtractorCommand[] All must share a building id.
+---@param constructorIds table<integer, {buildings: integer, building: integer[]}> Keyed by unitID.
+---@param shift boolean? Queue the orders instead of replacing the build queue.
 local function ApplyPreviewCmds(cmds, constructorIds, shift)
 	if not cmds or #cmds <= 0 then
 		return
@@ -519,18 +553,22 @@ function widget:Initialize()
 	-- builders and buildings - MEX
 	----------------------------------------------
 
+	---@return table<integer, {buildings: integer, building: integer[]}> constructors Metal extractor builders, keyed by unitID.
 	WG.resource_spot_builder.GetMexConstructors = function()
 		return mexConstructors
 	end
 
+	---@return table<integer, number> buildings Metal extraction per extractor unitDefID.
 	WG.resource_spot_builder.GetMexBuildings = function()
 		return mexBuildings
 	end
 
+	---@return table<integer, {buildings: integer, building: integer[]}> constructors Geothermal builders, keyed by unitID.
 	WG.resource_spot_builder.GetGeoConstructors = function()
 		return geoConstructors
 	end
 
+	---@return table<integer, number> buildings Energy production per geothermal unitDefID.
 	WG.resource_spot_builder.GetGeoBuildings = function()
 		return geoBuildings
 	end

--- a/luaui/Widgets/api_screencopy_manager.lua
+++ b/luaui/Widgets/api_screencopy_manager.lua
@@ -86,6 +86,9 @@ function widget:ViewResize()
 	end
 end
 
+---Returns a texture holding a copy of the current screen, refreshing it at most
+---once per draw frame.
+---@return string? texName `nil` on the very first call, before a copy exists.
 local function GetScreenCopy()
 	local df = Spring.GetDrawFrame()
 	--spEcho("GetScreenCopy", df)
@@ -100,6 +103,9 @@ local function GetScreenCopy()
 	return ScreenCopy
 end
 
+---Returns a texture holding a copy of the current depth buffer, refreshing it at
+---most once per draw frame.
+---@return string? texName `nil` on the very first call, before a copy exists.
 local function GetDepthCopy()
 	local df = Spring.GetDrawFrame()
 	--spEcho("GetScreenCopy", df)

--- a/luaui/Widgets/api_unit_tracker_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_gl4.lua
@@ -91,6 +91,7 @@ local InstanceVBOTable = gl.InstanceVBOTable
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 local popElementInstance = InstanceVBOTable.popElementInstance
 
+---@type InstanceVBOTable
 local unitTrackerVBO = nil
 local unitTrackerShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/api_unit_tracker_tester_gl4.lua
+++ b/luaui/Widgets/api_unit_tracker_tester_gl4.lua
@@ -18,6 +18,7 @@ local spGetUnitTeam = Spring.GetUnitTeam
 
 local myvisibleUnits = {} -- table of unitID : unitDefID
 
+---@type InstanceVBOTable
 local unitTrackerVBO = nil
 local unitTrackerShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/api_unitbufferuniform_copy.lua
+++ b/luaui/Widgets/api_unitbufferuniform_copy.lua
@@ -77,6 +77,7 @@ local structSizeInVec4s
 
 local copyRequested = false
 
+---@type VBO?
 local UniformsBufferCopy
 
 function widget:Initialize()
@@ -125,6 +126,9 @@ function widget:Initialize()
 
 	spEcho("Hello")
 	WG.api_unitbufferuniform_copy = {}
+	---Returns the shader storage buffer holding a copy of the engine's per-unit
+	---uniform data, and requests a refresh of it for the next frame.
+	---@return VBO? buffer `nil` before the first frame has built the copy.
 	WG.api_unitbufferuniform_copy.GetUnitUniformBufferCopy = function()
 		copyRequested = true
 		return UniformsBufferCopy

--- a/luaui/Widgets/camera_lockcamera.lua
+++ b/luaui/Widgets/camera_lockcamera.lua
@@ -263,15 +263,22 @@ end
 
 function widget:Initialize()
 	WG.lockcamera = {}
+	---@return integer? playerID The player the camera is locked to, or `nil` when unlocked.
 	WG.lockcamera.GetPlayerID = function()
 		return lockPlayerID
 	end
+	---Locks the camera to a player, or unlocks it.
+	---@param playerID integer? Pass `nil` to unlock.
 	WG.lockcamera.SetPlayerID = function(playerID)
 		LockCamera(playerID)
 	end
+	---@return boolean hideEnemies Whether the view is restricted to the locked player's vision.
 	WG.lockcamera.GetHideEnemies = function()
 		return lockcameraHideEnemies
 	end
+	---Restricts the view to the locked player's vision, toggling spectator full view
+	---and LOS mode to match.
+	---@param value boolean
 	WG.lockcamera.SetHideEnemies = function(value)
 		lockcameraHideEnemies = value
 		RefreshLocalPlayerStateIfDirty()
@@ -296,15 +303,20 @@ function widget:Initialize()
 			end
 		end
 	end
+	---@return number seconds How long the camera takes to ease to a new position.
 	WG.lockcamera.GetTransitionTime = function()
 		return transitionTime
 	end
+	---@param value number Seconds the camera takes to ease to a new position.
 	WG.lockcamera.SetTransitionTime = function(value)
 		transitionTime = value
 	end
+	---@return boolean los Whether LOS view follows the locked player.
 	WG.lockcamera.GetLos = function()
 		return lockcameraLos
 	end
+	---Makes the LOS view follow the locked player, toggling LOS mode to match.
+	---@param value boolean
 	WG.lockcamera.SetLos = function(value)
 		lockcameraLos = value
 		RefreshLocalPlayerStateIfDirty()
@@ -320,10 +332,16 @@ function widget:Initialize()
 			end
 		end
 	end
+	---Requests a map draw mode, applied on the next update.
+	---@param value "normal"|"los"
 	WG.lockcamera.SetLosMode = function(value)
 		desiredLosmode = value
 		desiredLosmodeChanged = os_clock()
 	end
+	---Returns the most recent camera state broadcast by a player.
+	---@param playerID integer
+	---@return CameraState? cameraState As `Spring.GetCameraState` returns it; `nil` when
+	---that player has not broadcast one.
 	WG.lockcamera.GetPlayerCameraState = function(playerID)
 		if lastBroadcasts[playerID] then
 			return lastBroadcasts[playerID][2]

--- a/luaui/Widgets/camera_player_tv.lua
+++ b/luaui/Widgets/camera_player_tv.lua
@@ -1145,22 +1145,30 @@ function widget:Initialize()
 
 	updatePosition()
 	WG.playertv = {}
+	---Screen rectangle of the PlayerTV panel.
+	---@return DockedPanelPosition position
 	WG.playertv.GetPosition = function()
 		return { top, left, bottom, right, widgetScale }
 	end
+	---@return boolean active `true` only while PlayerTV is toggled on and spectating.
 	WG.playertv.isActive = function()
 		return (toggled and isSpec)
 	end
+	---@return number seconds How long PlayerTV stays on each player.
 	WG.playertv.GetPlayerChangeDelay = function()
 		return playerChangeDelay
 	end
+	---Sets how long PlayerTV stays on each player, rebuilding the countdown display.
+	---@param value number Seconds.
 	WG.playertv.SetPlayerChangeDelay = function(value)
 		playerChangeDelay = value
 		createCountdownLists()
 	end
+	---@return boolean alwaysDisplay Whether the player name stays on screen between switches.
 	WG.playertv.GetAlwaysDisplayName = function()
 		return alwaysDisplayName
 	end
+	---@param value boolean Keep the player name on screen between switches.
 	WG.playertv.SetAlwaysDisplayName = function(value)
 		alwaysDisplayName = value
 	end

--- a/luaui/Widgets/camera_shake.lua
+++ b/luaui/Widgets/camera_shake.lua
@@ -52,9 +52,12 @@ function widget:Initialize()
 	spSetShockFrontFactors(minArea, minPower, distAdj)
 
 	WG.camerashake = {}
+	---@return integer strength Camera shake power scale; `0` disables shake.
 	WG.camerashake.getStrength = function()
 		return powerScale
 	end
+	---Sets the camera shake power scale, updating the engine's shock front thresholds.
+	---@param value number Rounded down; `0` or less disables shake.
 	WG.camerashake.setStrength = function(value)
 		powerScale = mathFloor(value)
 		if powerScale <= 0 then

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -31,6 +31,8 @@ local metalSpots
 
 local metalMap = false
 
+---Chooses which extractor the area-mex command places.
+---@param uDefID integer unitDefID of the extractor.
 local function setAreaMexType(uDefID)
 	selectedMex = -uDefID
 end
@@ -42,6 +44,8 @@ function widget:Initialize()
 	mexConstructors = WG.resource_spot_builder.GetMexConstructors()
 
 	WG.areamex = {}
+	---Chooses which extractor the area-mex command places.
+	---@param uDefID integer unitDefID of the extractor.
 	WG.areamex.setAreaMexType = function(uDefID)
 		setAreaMexType(uDefID)
 	end
@@ -123,7 +127,7 @@ end
 
 ---Make build commands for all passed in spots, but do not apply them
 ---@param spots table
----@return table An array of commands, in the same format as PreviewExtractorCommand
+---@return ExtractorCommand[] cmds As returned by `PreviewExtractorCommand`.
 local function getCmdsForValidSpots(spots, shift)
 	local cmds = {}
 	for i = 1, #spots do

--- a/luaui/Widgets/cmd_bar_hotkeys.lua
+++ b/luaui/Widgets/cmd_bar_hotkeys.lua
@@ -37,6 +37,8 @@ local function fallbackToDefault(currentKeys)
 	return default
 end
 
+---Reloads the keybinding file for the configured keyboard layout, falling back to
+---the default file when the configured one is missing.
 local function reloadBindings()
 	-- Second parameter here is just a fallback if this config is undefined
 	currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -31,7 +31,7 @@ local spGetViewGeometry = Spring.GetViewGeometry
 
 ---@class SerializedBlueprintUnit
 ---@field unitName string unit def name
----@field position Point
+---@field position Position3D
 ---@field facing number
 
 ---@class SerializedBlueprint
@@ -102,9 +102,9 @@ local function tablesEqual(tbl1, tbl2)
 	return true
 end
 
----@param a Point
----@param b Point
----@return Point
+---@param a Position3D
+---@param b Position3D
+---@return Position3D
 local function subtractPoints(a, b)
 	local result = {}
 	for i = 1, mathMax(#a, #b) do
@@ -114,7 +114,8 @@ local function subtractPoints(a, b)
 end
 
 local currentBlueprintUnitID = 0
----@return number
+---Hands out globally unique ids for units inside blueprints.
+---@return integer blueprintUnitID
 local function nextBlueprintUnitID()
 	currentBlueprintUnitID = currentBlueprintUnitID + 1
 	return currentBlueprintUnitID
@@ -176,11 +177,11 @@ local blueprintPlacementActive = false
 local lastExplicitlySelectedBlueprintIndex = nil
 
 local state = {
-	---@type Point|nil
+	---@type Position3D?
 	---non-nil implies that we are dragging
 	startPosition = nil,
 
-	---@type Point|nil
+	---@type Position3D?
 	---end of drag motion (basically current mouse position)
 	endPosition = nil,
 
@@ -197,8 +198,7 @@ local state = {
 	---@type number|nil
 	targetID = nil,
 
-	---@type number[]
-	---{ x, y, z, facing }
+	---@type BuildPlacement[]
 	buildPositions = nil,
 }
 
@@ -721,6 +721,7 @@ local drawCursorText = setmetatable({}, {
 	},
 })
 
+---Re-reads the keyboard layout and hotkey config, and invalidates the cursor text cache.
 local function reloadBindings()
 	currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")
 	actionHotkeys = VFS.Include("luaui/Include/action_hotkeys.lua")
@@ -1129,7 +1130,9 @@ local function serializeBlueprint(blueprint)
 end
 
 ---@param serializedBlueprint SerializedBlueprint
----@return Blueprint|nil
+---@param index integer Position in the saved list, used to name the blueprint in
+---the filtered-out message when it has no name of its own.
+---@return Blueprint? blueprint `nil` when the blueprint has no valid or substitutable units.
 local function deserializeBlueprint(serializedBlueprint, index)
 	local blueprint = WG.api_blueprint.createBlueprintFromSerialized(serializedBlueprint)
 

--- a/luaui/Widgets/cmd_buildsplit.lua
+++ b/luaui/Widgets/cmd_buildsplit.lua
@@ -68,9 +68,11 @@ local function getBuilderInfos(unitIDs)
 	return builders
 end
 
----@param builderIDs number[]
----@param buildings BuildingInfo[]
----@param cmdOpts table
+---Splits a set of buildings across builders so each works its own fork first.
+---@param builderIDs integer[]
+---@param buildings BuildingInfo[] Buildings to place, with positions.
+---@param cmdOpts CommandOptionName[]|table<CommandOptionName, boolean>|nil Held modifiers.
+---Defaults to `{ "shift" }`.
 local function splitBuildings(builderIDs, buildings, cmdOpts)
 	local builders = getBuilderInfos(builderIDs)
 	WG.api_build_orders.splitBuildOrders(builders, buildings, cmdOpts or { "shift" })

--- a/luaui/Widgets/cmd_clone_tool.lua
+++ b/luaui/Widgets/cmd_clone_tool.lua
@@ -203,6 +203,8 @@ end
 -- ---------------------------------------------------------------------------
 -- Activate / Deactivate API
 -- ---------------------------------------------------------------------------
+
+---Enables the clone tool and clears any copied region.
 local function activate()
 	active = true
 	state = "idle"
@@ -213,6 +215,7 @@ local function activate()
 	pasteMirrorZ = false
 end
 
+---Disables the clone tool, abandoning any in-progress copy or paste.
 local function deactivate()
 	active = false
 	state = "idle"
@@ -221,6 +224,27 @@ local function deactivate()
 	boxDrag.active = false
 end
 
+---A snapshot of the clone tool, for the UI to render.
+---@class CloneToolState
+---@field active boolean
+---@field state "idle"|"selecting"|"box_drawn"|"copied"|"paste_preview"
+---@field layers table<"terrain"|"metal"|"features"|"splats"|"grass"|"decals"|"weather"|"lights", boolean>
+---Whether each map layer is copied. Every key is always present; `false` means the
+---layer is skipped, not that it is unknown.
+---@field pasteRotation number Degrees, `0`-`359`.
+---@field pasteHeightOffset number
+---@field pasteMirrorX boolean
+---@field pasteMirrorZ boolean
+---@field progress number `0`-`1` while a copy or paste is running.
+---@field progressLabel string?
+---@field hasBuffer boolean Whether a region has been copied.
+---@field selBox {x1: number, z1: number, x2: number, z2: number}? Normalized so `x1 <= x2`
+---and `z1 <= z2`; absent while idle.
+---@field undoCount integer
+---@field redoCount integer
+---@field terrainQuality "full"|"balanced"|"fast"
+
+---@return CloneToolState
 local function getState()
 	return {
 		active = active,
@@ -240,30 +264,40 @@ local function getState()
 	}
 end
 
+---Enables or disables one map layer for copying. Unknown names are ignored.
+---@param name "terrain"|"metal"|"features"|"splats"|"grass"|"decals"|"weather"|"lights"
+---@param enabled boolean
 local function setLayer(name, enabled)
 	if layers[name] ~= nil then
 		layers[name] = enabled
 	end
 end
 
+---Sets the terrain resampling quality. Unknown values are ignored.
+---@param q "full"|"balanced"|"fast"
 local function setTerrainQuality(q)
 	if q == "full" or q == "balanced" or q == "fast" then
 		terrainQuality = q
 	end
 end
 
+---Sets the paste rotation, wrapped to `[0,360)`.
+---@param deg number Degrees.
 local function setRotation(deg)
 	pasteRotation = deg % 360
 end
 
+---@param val number Height added to the pasted terrain.
 local function setHeightOffset(val)
 	pasteHeightOffset = val
 end
 
+---@param val boolean Mirror the pasted region along X.
 local function setMirrorX(val)
 	pasteMirrorX = val
 end
 
+---@param val boolean Mirror the pasted region along Z.
 local function setMirrorZ(val)
 	pasteMirrorZ = val
 end
@@ -271,6 +305,9 @@ end
 -- ---------------------------------------------------------------------------
 -- COPY: capture data from selection box
 -- ---------------------------------------------------------------------------
+
+---Captures the enabled layers from the current selection box into the clone buffer.
+---Does nothing when the selection is smaller than one map square.
 local function doCopy()
 	local box = normalizeBox(selBox)
 	local sizeX = box.x2 - box.x1
@@ -497,12 +534,14 @@ local function doCopy()
 	spEcho("[Clone Tool] Region copied")
 end
 
+---Undoes the last applied paste, if there is one.
 local function doUndo()
 	if historyUndoCount > 0 then
 		sendMsg(MSG_UNDO)
 	end
 end
 
+---Reapplies the last undone paste, if there is one.
 local function doRedo()
 	if historyRedoCount > 0 then
 		sendMsg(MSG_REDO)
@@ -512,6 +551,8 @@ end
 -- ---------------------------------------------------------------------------
 -- PASTE: apply clone buffer at target position
 -- ---------------------------------------------------------------------------
+
+---Enters paste preview mode. Does nothing when nothing has been copied.
 local function startPaste()
 	if not cloneBuffer then
 		spEcho("[Clone Tool] Nothing copied")
@@ -930,6 +971,9 @@ end
 -- ---------------------------------------------------------------------------
 -- Cancel current operation
 -- ---------------------------------------------------------------------------
+
+---Steps back one stage: paste preview returns to copied, and a copied or drawn
+---selection returns to idle and drops the buffer.
 local function cancelOperation()
 	if state == "paste_preview" then
 		state = "copied"

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -131,6 +131,7 @@ local pathPositions = {} -- All positions added to the path, used to prevent ove
 local overriddenCmd = nil -- The command we ignored in favor of move
 local overriddenTarget = nil -- The target (for params) we ignored
 
+---@type integer?
 local usingCmd = nil -- The command to execute across the line
 local usingRMB = false -- All commands use right mouse + drag to do a formation command
 local inMinimap = false -- Is the line being drawn in the minimap
@@ -1379,9 +1380,11 @@ end
 
 function widget:Initialize()
 	WG.customformations = {}
+	---@return boolean repeatForSingle Whether a single selected unit repeats a drawn path.
 	WG.customformations.getRepeatForSingleUnit = function()
 		return repeatForSingleUnit
 	end
+	---@param value boolean Make a single selected unit repeat a drawn path.
 	WG.customformations.setRepeatForSingleUnit = function(value)
 		repeatForSingleUnit = value
 	end
@@ -1389,6 +1392,12 @@ function widget:Initialize()
 	-- External formation dragging API (for PIP window, etc.)
 	local isFirstPathCommand = true -- Track whether next path command should clear queue
 
+	---Begins a formation drag, discarding any formation already in progress.
+	---Part of the external dragging API used by the PIP window and similar widgets.
+	---@param worldPos Position3D The first node, as `{x, y, z}`.
+	---@param cmdID integer? Command to issue along the formation. Defaults to `CMD.MOVE`.
+	---@param fromMinimap boolean? The drag originated on the minimap.
+	---@return boolean started `false` when `worldPos` is off the map.
 	WG.customformations.StartFormation = function(worldPos, cmdID, fromMinimap)
 		-- Reset state
 		fNodes = {}
@@ -1417,6 +1426,9 @@ function widget:Initialize()
 		return false
 	end
 
+	---Extends the in-progress formation by one node.
+	---@param worldPos Position3D As `{x, y, z}`.
+	---@return boolean added `false` when no formation is in progress, or the position is off the map.
 	WG.customformations.AddFormationNode = function(worldPos)
 		if #fNodes == 0 then
 			return false
@@ -1476,6 +1488,10 @@ function widget:Initialize()
 		return added
 	end
 
+	---Finishes the formation and issues the resulting orders to the selection.
+	---@param worldPos Position3D? Final node to append before issuing orders.
+	---@param cmdID integer? Overrides the command chosen at `StartFormation`.
+	---@return boolean issued `false` when no formation is in progress, or no orders resulted.
 	WG.customformations.EndFormation = function(worldPos, cmdID)
 		if #fNodes == 0 then
 			return false
@@ -1581,6 +1597,8 @@ function widget:Initialize()
 		return result
 	end
 
+	---Discards the in-progress formation without issuing orders.
+	---@return boolean `true` always.
 	WG.customformations.CancelFormation = function()
 		fNodes = {}
 		fDists = {}
@@ -1590,26 +1608,35 @@ function widget:Initialize()
 		return true
 	end
 
+	---@return boolean active Whether a formation is currently being drawn.
 	WG.customformations.IsFormationActive = function()
 		return #fNodes > 0
 	end
 
+	---@return Position3D[] nodes The live node list, each `{x, y, z}`. Do not mutate.
 	WG.customformations.GetFormationNodes = function()
 		return fNodes
 	end
 
+	---@return integer cmdID The command the formation will issue.
 	WG.customformations.GetFormationCommand = function()
 		return usingCmd
 	end
 
+	---@return number length Total length of the drawn line, in elmos.
 	WG.customformations.GetFormationLineLength = function()
 		return lineLength
 	end
 
+	---@return integer count Units that would receive the formation orders.
 	WG.customformations.GetSelectedUnitsCount = function()
 		return selectedUnitsCount
 	end
 
+	---Resolves which unit goes where, assigning units to nodes and caching the result
+	---until the formation or shift state changes.
+	---@return table<integer, Position3D>? orders Target position per unitID; `nil` when the
+	---formation has fewer than two nodes or no unit can execute the command.
 	WG.customformations.GetFormationOrders = function()
 		if #fNodes < 2 then
 			return nil

--- a/luaui/Widgets/cmd_decal_placer.lua
+++ b/luaui/Widgets/cmd_decal_placer.lua
@@ -79,6 +79,7 @@ local dp = {
 	cadence = 50, -- per second
 	distribution = "random",
 	smartEnabled = false,
+	---@type table<string, boolean|number>
 	smartFilters = {
 		avoidWater = false,
 		avoidCliffs = false,
@@ -214,6 +215,17 @@ end
 -- Exposed so UI / exporter can look up the norm partner.
 local normPartnerByMain = {} -- { [mainName] = normName }
 
+---An entry in the decal library.
+---@class DecalLibraryEntry
+---@field name string
+---@field category string
+---@field filename string
+---@field normalName string? Paired normal map, when the library has one.
+---@field normalFilename string?
+
+---Returns the normal-map decal paired with a diffuse decal.
+---@param mainName string
+---@return string? normalName `nil` when the decal has no paired normal map.
 local function getNormalPartner(mainName)
 	return normPartnerByMain[mainName]
 end
@@ -529,6 +541,7 @@ local function placeSymmetric(fn, cx, cz)
 	fn(cx, cz)
 end
 
+---Removes the decals placed by the most recent stroke.
 local function decalUndo()
 	local entry = dp.undoStack[#dp.undoStack]
 	if not entry then
@@ -543,6 +556,7 @@ local function decalUndo()
 	-- redoStack would need re-creation info; skip redo for destructive ops
 end
 
+---Destroys every ground decal on the map, including ones this widget did not place.
 local function decalClearAll()
 	if not GetAllGroundDecals then
 		return
@@ -586,6 +600,8 @@ local function activate(mode)
 	return true
 end
 
+---Disables the decal tool.
+---@return boolean `true` always.
 local function deactivate()
 	if dp.active then
 		Echo("[Decal Placer] Deactivated")
@@ -598,6 +614,9 @@ local function deactivate()
 	return true
 end
 
+---Switches the decal tool's mode, deactivating the other map brushes first.
+---Unknown values are ignored.
+---@param mode BrushPlacementMode
 local function setMode(mode)
 	if mode == "scatter" or mode == "point" or mode == "remove" then
 		if not dp.active and WG.TerraformBrush then
@@ -624,72 +643,102 @@ end
 ----------------------------------------------------------------
 -- Setters
 ----------------------------------------------------------------
+
+---Sets the brush footprint. Unknown values are ignored.
+---@param s BrushShape
 local function setShape(s)
 	if s == "circle" or s == "square" or s == "hexagon" or s == "octagon" or s == "triangle" then
 		dp.shape = s
 	end
 end
+---@param r number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(r)
 	dp.radius = max(MIN_RADIUS, min(MAX_RADIUS, floor(r)))
 end
+---@param d number Decal rotation in degrees, wrapped to `[0,360)`.
 local function setRotation(d)
 	dp.rotation = d % 360
 end
+---@param step number Degrees to add to the current rotation.
 local function rotate(step)
 	dp.rotation = (dp.rotation + step) % 360
 end
+---@param v number Percent of random rotation jitter, clamped to `0`-`100`.
 local function setRotRandom(v)
 	dp.rotRandom = max(0, min(100, floor(v)))
 end
+---@param n number Decals placed per scatter stroke, clamped to `1`-`500`.
 local function setDecalCount(n)
 	dp.decalCount = max(1, min(500, floor(n)))
 end
+---@param v number Frames between placements while dragging, clamped to `1`-`1000`.
 local function setCadence(v)
 	dp.cadence = max(1, min(1000, floor(v)))
 end
+---Sets how scattered decals are spread. Unknown values are ignored.
+---@param m "random"|"regular"|"clustered"
 local function setDistribution(m)
 	if m == "random" or m == "regular" or m == "clustered" then
 		dp.distribution = m
 	end
 end
+---Enables the slope and altitude filters that restrict where decals are placed.
+---@param v boolean?
 local function setSmartEnabled(v)
 	dp.smartEnabled = v and true or false
 end
+---Sets one smart filter value. Unknown keys are ignored.
+---@param k string
+---@param v boolean|number
 local function setSmartFilter(k, v)
 	if dp.smartFilters[k] ~= nil then
 		dp.smartFilters[k] = v
 	end
 end
+---@param v number Smallest decal size, clamped to `4`-`1024`. Pushes the maximum up if needed.
 local function setSizeMin(v)
 	dp.sizeMin = max(4, min(1024, floor(v)))
 	if dp.sizeMin > dp.sizeMax then
 		dp.sizeMax = dp.sizeMin
 	end
 end
+---@param v number Largest decal size, clamped to `4`-`1024`. Pulls the minimum down if needed.
 local function setSizeMax(v)
 	dp.sizeMax = max(4, min(1024, floor(v)))
 	if dp.sizeMax < dp.sizeMin then
 		dp.sizeMin = dp.sizeMax
 	end
 end
+---@param v number Decal opacity, clamped to `0`-`1`.
 local function setAlpha(v)
 	dp.alpha = max(0, min(1, v))
 end
+---Sets the decal tint. Omitted components keep their current value.
+---@param r number? Clamped to `0`-`1`.
+---@param g number? Clamped to `0`-`1`.
+---@param b number? Clamped to `0`-`1`.
+---@param a number? Clamped to `0`-`1`.
 local function setTint(r, g, b, a)
 	dp.tintR = max(0, min(1, r or dp.tintR))
 	dp.tintG = max(0, min(1, g or dp.tintG))
 	dp.tintB = max(0, min(1, b or dp.tintB))
 	dp.tintA = max(0, min(1, a or dp.tintA))
 end
+---Aligns placed decals to the terrain normal instead of lying flat.
+---@param v boolean?
 local function setAlignToNormal(v)
 	dp.alignToNormal = v and true or false
 end
 
+---Selects a single decal, replacing the current selection.
+---@param name string
 local function selectDecal(name)
 	dp.selectedDecals = { name }
 	dp.selectedSet = { [name] = true }
 end
 
+---Adds or removes one decal from the multi-selection.
+---@param name string
 local function toggleDecal(name)
 	if dp.selectedSet[name] then
 		dp.selectedSet[name] = nil
@@ -705,11 +754,39 @@ local function toggleDecal(name)
 	end
 end
 
+---Clears the decal selection.
 local function clearSelectedDecals()
 	dp.selectedDecals = {}
 	dp.selectedSet = {}
 end
 
+---A snapshot of the decal placer, for the UI to render.
+---@class DecalPlacerState
+---@field active boolean
+---@field mode BrushPlacementMode? `nil` while the tool is inactive.
+---@field shape BrushShape
+---@field radius number
+---@field rotation number
+---@field rotRandom number
+---@field decalCount number
+---@field cadence number
+---@field distribution "random"|"regular"|"clustered"
+---@field smartEnabled boolean
+---@field smartFilters table<string, boolean|number> The live filter table. Do not mutate.
+---@field sizeMin number
+---@field sizeMax number
+---@field alpha number
+---@field tintR number
+---@field tintG number
+---@field tintB number
+---@field tintA number
+---@field alignToNormal boolean
+---@field selectedDecals string[]
+---@field selectedSet table<string, true>
+---@field undoCount integer
+---@field redoCount integer
+
+---@return DecalPlacerState
 local function getState()
 	return {
 		active = dp.active,
@@ -738,17 +815,21 @@ local function getState()
 	}
 end
 
+---@return DecalLibraryEntry[] decals Every decal in the library, built on first use.
 local function getDecalList()
 	buildDecalList()
 	return decalList
 end
+---@return table<string, DecalLibraryEntry[]> byCategory Decals grouped by category.
 local function getDecalCategories()
 	buildDecalList()
 	return decalCategories
 end
+---@return string[] order Category keys in the order the UI should show them.
 local function getCategoryOrder()
 	return CATEGORY_ORDER
 end
+---@return table<string, string> labels Display label per category key.
 local function getCategoryLabels()
 	return CATEGORY_LABELS
 end
@@ -756,6 +837,8 @@ end
 ----------------------------------------------------------------
 -- Save / Load decal map
 ----------------------------------------------------------------
+
+---Writes every ground decal on the map to a timestamped file in the save directory.
 local function decalSave()
 	if not GetAllGroundDecals then
 		return
@@ -801,6 +884,9 @@ end
 -- Project-mode save: only decals placed by this tool (dp.projectIDs), stable order,
 -- no timestamp comment — repeated saves of the same scene must serialize identically
 -- (project files live in git). Returns the decal count written, or nil on error.
+---Writes every ground decal to a project file, byte-identically across platforms.
+---@param explicitPath string
+---@return integer? count Decals written; `nil` when the file could not be opened.
 local function decalSaveProject(explicitPath)
 	if not GetAllGroundDecals then
 		return nil
@@ -844,6 +930,8 @@ local function decalSaveProject(explicitPath)
 	return #lines
 end
 
+---Loads decals from a saved file.
+---@param filename string? Defaults to the most recent save in the save directory.
 local function decalLoad(filename)
 	if not filename or filename == "" then
 		local saves = VFS.DirList(SAVE_DIR, "*.lua", VFS.RAW) or {}
@@ -890,6 +978,7 @@ local function decalLoad(filename)
 	Echo("[Decal Placer] Loaded " .. #placed .. " decals from " .. filename)
 end
 
+---@return string[] filenames Saved decal files, newest last.
 local function listSavedDecalMaps()
 	local files = VFS.DirList(SAVE_DIR, "*.lua", VFS.RAW)
 	return files or {}

--- a/luaui/Widgets/cmd_diffuse_painter.lua
+++ b/luaui/Widgets/cmd_diffuse_painter.lua
@@ -683,6 +683,9 @@ local function unbindChannel(ch)
 	ch.bound = false
 end
 
+---Enables or disables painting into one PBR channel. Unknown keys are ignored.
+---@param key "normals"|"specular"|"emission"
+---@param on boolean?
 local function setChannelEnabled(key, on)
 	if channelsEnabled[key] == nil then
 		return
@@ -2012,6 +2015,46 @@ end
 -- ============================================================================
 -- Layer management
 -- ============================================================================
+
+---One paint layer of the diffuse painter.
+---@class DiffuseLayer
+---@field id integer
+---@field name string
+---@field enabled boolean
+---@field opacity number
+---@field color ColorRGB RGB, each `0`-`1`.
+---@field blend string Blend mode, e.g. `"normal"`.
+---@field altEnabled boolean Restrict the layer by altitude.
+---@field altMin number
+---@field altMax number
+---@field altFalloffLo number
+---@field altFalloffHi number
+---@field slopeEnabled boolean Restrict the layer by slope.
+---@field slopeMin number
+---@field slopeMax number
+---@field slopeFalloffLo number
+---@field slopeFalloffHi number
+---@field handPaintEnabled boolean Allow brush strokes on this layer.
+---@field texturePath string?
+---@field tileScale number
+---@field normalPath string? PBR sibling resolved from the material library.
+---@field hydroEnabled boolean Paint preferentially in concave valleys and flow channels.
+---@field hydroStrength number
+---@field hydroFalloffLo number
+---@field hydroFalloffHi number
+---@field thermoEnabled boolean Paint at slope transitions near the repose angle.
+---@field thermoAngle number
+---@field thermoFalloff number
+---@field glowStrength number Emission written as `color * glowStrength`.
+---@field grassDensity number Grass planted by strokes; `0` is off.
+---@field grassDensityCustom boolean User override that material defaults must not clobber.
+
+---Builds a layer with default settings.
+---@param name string? Defaults to `"Layer"`.
+---@param r number? Defaults to `1`.
+---@param g number? Defaults to `1`.
+---@param b number? Defaults to `1`.
+---@return DiffuseLayer
 local function defaultLayer(name, r, g, b)
 	return {
 		id = 0,
@@ -2053,6 +2096,10 @@ local function defaultLayer(name, r, g, b)
 	}
 end
 
+---Adds a paint layer, becoming the active layer when it is the first one.
+---@param layerDef table<string, any>? Fields to override on the default layer; a partial
+---`DiffuseLayer`, copied over the defaults key by key.
+---@return integer? id `nil` when the layer cap has been reached.
 local function addLayer(layerDef)
 	if #layers >= MAX_LAYERS then
 		Echo("[Diffuse Painter] layer cap reached (" .. MAX_LAYERS .. ")")
@@ -2074,6 +2121,8 @@ local function addLayer(layerDef)
 	return layer.id
 end
 
+---Removes a paint layer and frees its masks. Unknown ids are ignored.
+---@param id integer
 local function removeLayer(id)
 	local _, idx = findLayer(id)
 	if not idx then
@@ -2094,6 +2143,11 @@ local function removeLayer(id)
 	pendingFullBake = true
 end
 
+---Sets one field on a layer and schedules a rebake. Unknown ids are ignored.
+---@param id integer
+---@param key string A `DiffuseLayer` field name.
+---@param val string|number|boolean|ColorRGB Whatever that field holds; written straight
+---through without checking that it matches.
 local function setLayerParam(id, key, val)
 	local layer = findLayer(id)
 	if not layer then
@@ -2125,6 +2179,8 @@ local function findSibling(diffPath, channel)
 	return nil
 end
 
+---Rebuilds the material library by walking the write-dir texture tree, preferring
+---the highest-resolution diffuse per material.
 local function scanMaterialLibrary()
 	materialLibrary = {}
 	-- Write-dir asset library (not committed to the game repo). VFS.RAW_FIRST
@@ -2193,6 +2249,12 @@ local function findMaterialByPath(p)
 	return nil
 end
 
+---Points a layer at a texture, resolving its PBR siblings from the material
+---library. Unknown ids are ignored.
+---@param id integer
+---@param path string? Empty string clears the texture.
+---@param tileScale number? Left unchanged when omitted.
+---@param name string? Display name for the layer.
 local function setLayerTexture(id, path, tileScale, name)
 	local layer = findLayer(id)
 	if not layer then
@@ -2231,6 +2293,10 @@ local function setLayerTexture(id, path, tileScale, name)
 	end
 end
 
+---Adds a hand-paintable layer already pointed at a material.
+---@param path string Diffuse texture path.
+---@param name string? Defaults to `"Layer"`.
+---@return integer? id `nil` when the layer cap has been reached.
 local function addLayerFromMaterial(path, name)
 	local id = addLayer({
 		name = name or "Layer",
@@ -2252,6 +2318,9 @@ end
 -- ============================================================================
 -- Activation
 -- ============================================================================
+
+---Enables the diffuse painter, compiling its shaders and scanning the material
+---library on first use.
 local function activate()
 	if active then
 		return
@@ -2273,6 +2342,7 @@ local function activate()
 	Echo("[Diffuse Painter] active. LMB paint, RMB erase. /diffusepaint to toggle.")
 end
 
+---Disables the diffuse painter, sealing any in-flight stroke into the undo stack.
 local function deactivate()
 	if not active then
 		return
@@ -2351,10 +2421,31 @@ function widget:Initialize()
 	end, nil, "t")
 
 	WG.DiffusePainter = {
+		---@return boolean active
 		isActive = function()
 			return active
 		end,
 		-- Snapshot of everything the UI needs, mirroring WG.TerraformBrush.getState.
+		---A snapshot of the diffuse painter, for the UI to render.
+		---@class DiffusePainterState
+		---@field active boolean
+		---@field radius number
+		---@field strength number
+		---@field curve number
+		---@field erase boolean
+		---@field fractalAmount number
+		---@field fractalFreq number
+		---@field layers DiffuseLayer[] The live layer list. Do not mutate.
+		---@field activeLayerId integer?
+		---@field historyIndex integer Strokes currently applied.
+		---@field historyMax integer Strokes applied plus undone.
+		---@field channelNormals boolean
+		---@field channelSpecular boolean
+		---@field channelEmission boolean
+		---@field specIntensity number
+		---@field grassAttach boolean
+
+		---@return DiffusePainterState
 		getState = function()
 			return {
 				active = active,
@@ -2375,28 +2466,42 @@ function widget:Initialize()
 				grassAttach = grassAttachEnabled,
 			}
 		end,
+		---Queues an undo, applied on the next draw pass.
 		undo = function()
 			pendingHistoryOps[#pendingHistoryOps + 1] = "undo"
 		end,
+		---Queues a redo, applied on the next draw pass.
 		redo = function()
 			pendingHistoryOps[#pendingHistoryOps + 1] = "redo"
 		end,
+		---Queues undos or redos until the history sits at the given position.
+		---@param idx number? Strokes that should remain applied. Defaults to `0`.
 		undoToIndex = function(idx)
 			pendingHistoryOps[#pendingHistoryOps + 1] = tonumber(idx) or 0
 		end,
 		setChannelEnabled = setChannelEnabled,
+		---@param v number? Specular intensity, clamped to `0`-`1`. Defaults to `0.25`.
 		setSpecIntensity = function(v)
 			specIntensity = max(0.0, min(1.0, v or 0.25))
 		end,
+		---Sets a layer's emission strength. Unknown ids are ignored.
+		---@param id integer
+		---@param v number? Clamped to `0`-`1`. Defaults to `0`.
 		setLayerGlow = function(id, v)
 			local layer = findLayer(id)
 			if layer then
 				layer.glowStrength = max(0.0, min(1.0, v or 0))
 			end
 		end,
+		---Makes brush strokes also plant grass.
+		---@param on boolean?
 		setGrassAttach = function(on)
 			grassAttachEnabled = on and true or false
 		end,
+		---Sets how much grass a layer's strokes plant, marking it as a user override.
+		---Unknown ids are ignored.
+		---@param id integer
+		---@param v number? Clamped to `0`-`1`. Defaults to `0`.
 		setLayerGrassDensity = function(id, v)
 			local layer = findLayer(id)
 			if not layer then
@@ -2407,12 +2512,16 @@ function widget:Initialize()
 		end,
 		activate = activate,
 		deactivate = deactivate,
+		---@return DiffuseLayer[] layers The live layer list. Do not mutate.
 		getLayers = function()
 			return layers
 		end,
+		---@return integer? id `nil` when no layer exists.
 		getActiveLayerId = function()
 			return activeLayerId
 		end,
+		---Selects the layer that strokes paint into. Unknown ids are ignored.
+		---@param id integer
 		setActiveLayer = function(id)
 			if findLayer(id) then
 				activeLayerId = id
@@ -2423,18 +2532,38 @@ function widget:Initialize()
 		setLayerParam = setLayerParam,
 		setLayerTexture = setLayerTexture,
 		addLayerFromMaterial = addLayerFromMaterial,
+		---One scanned PBR material. Only the highest-resolution diffuse per material
+		---key is kept; the sibling maps are whatever was found next to it.
+		---@class DiffuseMaterial
+		---@field key string Material key, parsed from `<key>_diff_<N>k.jpg`.
+		---@field name string Display name: `key` with underscores replaced by spaces.
+		---@field path string Diffuse texture path.
+		---@field resK integer Diffuse resolution in K, as parsed from the filename.
+		---@field normalPath string?
+		---@field roughPath string?
+		---@field dispPath string?
+
+		---@return DiffuseMaterial[] materials The scanned material library, sorted by `key`.
+		---Do not mutate.
 		getMaterialLibrary = function()
 			return materialLibrary
 		end,
 		rescanMaterialLibrary = scanMaterialLibrary,
+		---Queues a full rebake of every map square.
 		bakeAll = function()
 			pendingFullCover = true
 		end,
+		---Queues an export of the baked square textures to disk.
 		exportSquares = function()
 			pendingExport = true
 		end,
 		-- Map project (cmd_map_project.lua): chunked DrawWorld jobs saving/loading
 		-- baked square diffuse + channel textures; poll the pending flags.
+		---Starts a chunked save of the baked diffuse and channel textures into a project.
+		---Poll `isProjectSavePending` and then `getProjectSaveResult`.
+		---@param dir string Project directory to write into.
+		---@param allSquares boolean? Save every square rather than only painted ones.
+		---@return boolean started `false` when a project save or load is already running.
 		saveProject = function(dir, allSquares)
 			if pendingProjectSave or pendingProjectLoad then
 				return false
@@ -2443,12 +2572,29 @@ function widget:Initialize()
 			projectSaveResult = nil
 			return true
 		end,
+		---@return boolean pending
 		isProjectSavePending = function()
 			return pendingProjectSave ~= nil
 		end,
+		---@class DiffuseProjectSaveResult
+		---@field squares string[] Filenames written, as `sq_<sx>_<sy>.png`.
+		---@field channels string[] Channel keys written, sorted.
+		---@field full boolean Whether every square on the map was written.
+		---@field failed integer Squares or channels that could not be written.
+		---@field squareSize integer Pixel size of one square.
+		---@field error string? Set instead of the other fields when the save could not start.
+
+		---@return DiffuseProjectSaveResult? result `nil` until a save finishes.
 		getProjectSaveResult = function()
 			return projectSaveResult
 		end,
+		---Starts a chunked load of baked textures from a project.
+		---Poll `isProjectLoadPending` and then `getProjectLoadResult`.
+		---@param squareList {sx: integer, sy: integer, path: string}[]? Squares to restore.
+		---Defaults to none.
+		---@param channelMap table<string, string>? Channel texture paths by channel key.
+		---Defaults to none.
+		---@return boolean started `false` when a project save or load is already running.
 		loadProject = function(squareList, channelMap)
 			if pendingProjectSave or pendingProjectLoad then
 				return false
@@ -2457,12 +2603,22 @@ function widget:Initialize()
 			projectLoadResult = nil
 			return true
 		end,
+		---@return boolean pending
 		isProjectLoadPending = function()
 			return pendingProjectLoad ~= nil
 		end,
+		---@class DiffuseProjectLoadResult
+		---@field loaded integer Squares restored.
+		---@field failed integer Squares or channels that could not be restored.
+		---@field channels integer Channel textures restored.
+		---@field error string? Set instead of the other fields when the load could not start.
+
+		---@return DiffuseProjectLoadResult? result `nil` until a load finishes.
 		getProjectLoadResult = function()
 			return projectLoadResult
 		end,
+		---@return boolean hasState Whether anything has been painted that a project save
+		---would capture.
 		hasProjectState = function()
 			for _, s in pairs(squares) do
 				if s.compositeTex then
@@ -2476,21 +2632,32 @@ function widget:Initialize()
 			end
 			return false
 		end,
+		---@return number radius
+		---@return number strength
+		---@return number curve
+		---@return boolean erase
 		getBrush = function()
 			return brushRadius, brushStrength, brushCurve, eraseMode
 		end,
+		---@param r number Brush radius in elmos, clamped to the allowed range.
 		setRadius = function(r)
 			brushRadius = max(MIN_RADIUS, min(MAX_RADIUS, floor(r)))
 		end,
+		---@param v number Paint strength per stroke, clamped to the allowed range.
 		setStrength = function(v)
 			brushStrength = max(MIN_STRENGTH, min(MAX_STRENGTH, v))
 		end,
+		---@param v number Falloff curve exponent, clamped to the allowed range.
 		setCurve = function(v)
 			brushCurve = max(MIN_CURVE, min(MAX_CURVE, v))
 		end,
+		---@param b boolean? Erase paint instead of adding it.
 		setErase = function(b)
 			eraseMode = b and true or false
 		end,
+		---Sets the fractal break-up applied to strokes. Omitted values are left unchanged.
+		---@param amount number? Clamped to the allowed range.
+		---@param freq number? Clamped to the allowed range.
 		setFractal = function(amount, freq)
 			if amount ~= nil then
 				brushFractalAmount = max(MIN_FRACTAL, min(MAX_FRACTAL, amount))
@@ -2499,9 +2666,14 @@ function widget:Initialize()
 				brushFractalFreq = max(MIN_FRACTAL_FREQ, min(MAX_FRACTAL_FREQ, freq))
 			end
 		end,
+		---@return number amount
+		---@return number freq
 		getFractal = function()
 			return brushFractalAmount, brushFractalFreq
 		end,
+		---Sets a layer's blend mode and schedules a rebake. Unknown ids are ignored.
+		---@param id integer
+		---@param mode string? Defaults to `"normal"`.
 		setLayerBlend = function(id, mode)
 			local layer = findLayer(id)
 			if layer then
@@ -2509,6 +2681,13 @@ function widget:Initialize()
 				pendingFullBake = true
 			end
 		end,
+		---Configures a layer's hydro erosion masking. Omitted values are left unchanged,
+		---and unknown ids are ignored.
+		---@param id integer
+		---@param enabled boolean?
+		---@param strength number? Minimum `0.001`.
+		---@param fallLo number? Minimum `0`.
+		---@param fallHi number? Minimum `0`.
 		setLayerHydro = function(id, enabled, strength, fallLo, fallHi)
 			local layer = findLayer(id)
 			if not layer then
@@ -2528,6 +2707,12 @@ function widget:Initialize()
 			end
 			pendingFullBake = true
 		end,
+		---Configures a layer's thermo erosion masking. Omitted values are left unchanged,
+		---and unknown ids are ignored.
+		---@param id integer
+		---@param enabled boolean?
+		---@param angle number? Degrees, clamped to `0`-`85`.
+		---@param falloff number? Clamped to `0.5`-`45`.
 		setLayerThermo = function(id, enabled, angle, falloff)
 			local layer = findLayer(id)
 			if not layer then
@@ -2544,6 +2729,10 @@ function widget:Initialize()
 			end
 			pendingFullBake = true
 		end,
+		---Clears every layer's paint from the map square containing a world position,
+		---and drops the undo history since its snapshots are now stale.
+		---@param wx number
+		---@param wz number
 		resetSquare = function(wx, wz)
 			local sx, sy = floor(wx / SQUARE_SIZE_ELMOS), floor(wz / SQUARE_SIZE_ELMOS)
 			local k = squareKey(sx, sy)
@@ -2558,6 +2747,7 @@ function widget:Initialize()
 			clearHistory()
 			dirtySquares[k] = true
 		end,
+		---Clears every layer's paint across the whole map and drops the undo history.
 		resetAll = function()
 			for layerId, layerMasks in pairs(masks) do
 				for k, maskTex in pairs(layerMasks) do

--- a/luaui/Widgets/cmd_feature_placer.lua
+++ b/luaui/Widgets/cmd_feature_placer.lua
@@ -114,6 +114,7 @@ local fp = {
 	cadence = 10, -- 1-1000 logarithmic (higher = faster)
 	distribution = "random", -- "random", "regular", or "clustered"
 	smartEnabled = false, -- terrain-aware filtering applied on top of distribution
+	---@type table<string, boolean|number>
 	smartFilters = {
 		avoidWater = false, -- reject underwater positions (height < 0)
 		avoidCliffs = false, -- reject terrain steeper than slopeMax degrees
@@ -410,6 +411,8 @@ local function ensureBuildGridLoaded()
 	Spring.SendCommands("luaui enablewidget Building Grid GL4")
 end
 
+---Shows or hides the build-grid overlay.
+---@param value boolean?
 local function setGridOverlay(value)
 	gridOverlay = value and true or false
 	if gridOverlay then
@@ -418,6 +421,8 @@ local function setGridOverlay(value)
 	end
 end
 
+---Snaps placed features to the build grid.
+---@param value boolean?
 local function setGridSnap(value)
 	gridSnap = value and true or false
 	if gridSnap then
@@ -425,6 +430,7 @@ local function setGridSnap(value)
 	end
 end
 
+---@param value number? Grid cell size in elmos, clamped to `16`-`128`.
 local function setGridSnapSize(value)
 	gridSnapSize = max(16, min(128, floor(tonumber(value) or gridSnapSize)))
 	gridDirty = true
@@ -484,6 +490,7 @@ local preview = {
 local SEED_MAX = 16777216
 local SEED_STRIDE = 8191
 
+---Advances the scatter seed so the next preview lays features out differently.
 local function rerollPreview()
 	-- Advance a counter rather than re-reading the clock: os.clock is coarse
 	-- enough that two stamps in the same tick would land on the same seed and
@@ -914,6 +921,7 @@ local function showHiddenFeatures()
 	gz.hidden = {}
 end
 
+---Clears the picked-feature selection and hides the transform gizmo.
 local function clearSelection()
 	gz.selection = {}
 	gz.selectedSet = {}
@@ -1282,6 +1290,7 @@ local function tickSettle()
 	syncGizmoGhosts(remaining)
 end
 
+---Deletes every picked feature. Does nothing when the selection is empty.
 local function deleteSelection()
 	if #gz.selection == 0 then
 		return
@@ -1320,6 +1329,8 @@ local function activate(mode)
 	return true
 end
 
+---Disables the feature placer, clearing ghosts, selection and grid overlay.
+---@return boolean `true` always.
 local function deactivate()
 	if fp.active then
 		Echo("[Feature Placer] Deactivated")
@@ -1335,6 +1346,9 @@ local function deactivate()
 	return true
 end
 
+---Switches the tool's mode, deactivating the other map brushes first.
+---Unknown values are ignored.
+---@param mode BrushPlacementMode
 local function setMode(mode)
 	if mode == "scatter" or mode == "point" or mode == "remove" then
 		-- Deactivate terraform brush when feature placer activates
@@ -1353,57 +1367,76 @@ local function setMode(mode)
 	end
 end
 
+---Sets the brush footprint. Unknown values are ignored.
+---@param shape BrushShape
 local function setShape(shape)
 	if shape == "circle" or shape == "square" or shape == "hexagon" or shape == "octagon" or shape == "triangle" then
 		fp.shape = shape
 	end
 end
 
+---@param r number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(r)
 	fp.radius = max(MIN_RADIUS, min(MAX_RADIUS, floor(r)))
 end
 
+---@param deg number Feature rotation in degrees, wrapped to `[0,360)`.
 local function setRotation(deg)
 	fp.rotation = deg % 360
 end
 
+---@param step number Degrees to add to the current rotation.
 local function rotate(step)
 	fp.rotation = (fp.rotation + step) % 360
 end
 
+---@param v number Percent of random rotation jitter, clamped to `0`-`100`.
 local function setRotRandom(v)
 	fp.rotRandom = max(0, min(100, floor(v)))
 end
 
+---@param n number Features placed per scatter stroke, clamped to `1`-`500`.
 local function setFeatureCount(n)
 	fp.featureCount = max(1, min(500, floor(n)))
 end
 
+---@param v number Frames between placements while dragging, clamped to `1`-`1000`.
 local function setCadence(v)
 	fp.cadence = max(1, min(1000, floor(v)))
 end
 
+---Sets how scattered features are spread. Unknown values are ignored.
+---@param mode "random"|"regular"|"clustered"
 local function setDistribution(mode)
 	if mode == "random" or mode == "regular" or mode == "clustered" then
 		fp.distribution = mode
 	end
 end
 
+---Enables the slope and altitude filters that restrict where features are placed.
+---@param val boolean?
 local function setSmartEnabled(val)
 	fp.smartEnabled = val and true or false
 end
 
+---Sets one smart filter value. Unknown keys are ignored.
+---@param key string
+---@param val boolean|number
 local function setSmartFilter(key, val)
 	if fp.smartFilters[key] ~= nil then
 		fp.smartFilters[key] = val
 	end
 end
 
+---Selects a single feature type, replacing the current selection.
+---@param defName string
 local function selectFeature(defName)
 	fp.selectedDefs = { defName }
 	fp.selectedSet = { [defName] = true }
 end
 
+---Adds or removes one feature type from the multi-selection.
+---@param defName string
 local function toggleFeature(defName)
 	if fp.selectedSet[defName] then
 		fp.selectedSet[defName] = nil
@@ -1419,19 +1452,23 @@ local function toggleFeature(defName)
 	end
 end
 
+---Clears the feature type selection.
 local function clearSelectedFeatures()
 	fp.selectedDefs = {}
 	fp.selectedSet = {}
 end
 
+---Asks the gadget to undo the most recent feature placement.
 local function featureUndo()
 	SendLuaRulesMsg(UNDO_HEADER)
 end
 
+---Asks the gadget to reapply the most recently undone feature placement.
 local function featureRedo()
 	SendLuaRulesMsg(REDO_HEADER)
 end
 
+---Asks the gadget to remove every placed feature from the map.
 local function featureClearAll()
 	SendLuaRulesMsg(CLEARALL_HEADER)
 end
@@ -1479,8 +1516,23 @@ local function parseSavedEntries()
 	return entries
 end
 
----@param callback function receives (entries) or (nil, errorMessage)
----@return boolean started
+---One placed feature reported by the gadget, parsed out of its packed message.
+---`pitch`, `roll` and `y` are present only for features the gizmo tilted or lifted.
+---@class PlacedFeatureExport
+---@field name string FeatureDef name.
+---@field x number
+---@field z number
+---@field rot number Heading; `0` when unparsable.
+---@field pitch number?
+---@field roll number?
+---@field y number?
+
+---Asks the gadget for the current feature list, answering asynchronously.
+---Only one request may be pending at a time, and cheats must be enabled.
+---@param callback fun(entries: PlacedFeatureExport[]?, errorMessage: string?) Receives the entries
+---on success, or `nil` plus an error message on failure.
+---@return boolean started `false` when `callback` is not a function, a request is
+---already pending, or cheats are disabled.
 local function requestFeatureData(callback)
 	if type(callback) ~= "function" then
 		return false
@@ -1588,10 +1640,13 @@ local function handleSaveEnd(count)
 	Echo("[Feature Placer] Saved " .. tostring(count or 0) .. " features to " .. filename)
 end
 
+---Asks the gadget to export the current features, written asynchronously.
 local function featureSave()
 	SendLuaRulesMsg(SAVE_HEADER)
 end
 
+---Loads features from a saved file.
+---@param filename string Path to a saved feature map.
 local function featureLoad(filename)
 	if not filename or filename == "" then
 		Echo("[Feature Placer] No filename specified")
@@ -1664,11 +1719,37 @@ local function featureLoad(filename)
 	Echo("[Feature Placer] Loading " .. count .. " features from " .. filename)
 end
 
+---@return string[] filenames Saved feature map files.
 local function listSavedFeatureMaps()
 	local files = VFS.DirList(SAVE_DIR, "*.lua", VFS.RAW)
 	return files or {}
 end
 
+---A snapshot of the feature placer, for the UI to render.
+---@class FeaturePlacerState
+---@field active boolean
+---@field mode BrushPlacementMode? `nil` while the tool is inactive.
+---@field shape BrushShape
+---@field radius number
+---@field rotation number
+---@field rotRandom number
+---@field featureCount number
+---@field cadence number
+---@field distribution "random"|"regular"|"clustered"
+---@field smartEnabled boolean
+---@field smartFilters table<string, boolean|number> The live filter table. Do not mutate.
+---@field selectedDefs string[]
+---@field selectedSet table<string, true>
+---@field undoCount integer
+---@field redoCount integer
+---@field gridOverlay boolean
+---@field gridSnap boolean
+---@field gridSnapSize number
+---@field selectMode boolean Whether clicking the map picks features instead of placing them.
+---@field selectionCount integer Features currently picked.
+---@field gizmoDragging boolean
+
+---@return FeaturePlacerState
 local function getState()
 	return {
 		active = fp.active,
@@ -1697,20 +1778,30 @@ local function getState()
 	}
 end
 
+---One placeable feature, as classified from `FeatureDefs` on first use.
+---@class PlaceableFeatureDef
+---@field name string FeatureDef name.
+---@field id integer featureDefID.
+---@field category string One of `CATEGORY_ORDER`.
+
+---@return PlaceableFeatureDef[] features Every placeable feature, built on first use.
 local function getFeatureDefList()
 	buildFeatureDefList()
 	return featureDefList
 end
 
+---@return table<string, PlaceableFeatureDef[]> byCategory Grouped by category key.
 local function getFeatureCategories()
 	buildFeatureDefList()
 	return featureCategories
 end
 
+---@return string[] order Category keys in the order the UI should show them.
 local function getCategoryOrder()
 	return CATEGORY_ORDER
 end
 
+---@return table<string, string> labels Display label per category key.
 local function getCategoryLabels()
 	return CATEGORY_LABELS
 end

--- a/luaui/Widgets/cmd_grass_brush.lua
+++ b/luaui/Widgets/cmd_grass_brush.lua
@@ -96,6 +96,7 @@ local brushRadius = DEFAULT_RADIUS
 local brushCurve = DEFAULT_CURVE
 local brushRotation = 0
 local brushLengthScale = DEFAULT_LENGTH_SCALE
+---@type BrushShape
 local brushShape = "circle"
 local painting = false
 local paintButton = 0 -- 1 = LMB (add), 3 = RMB (remove)
@@ -157,6 +158,7 @@ local function strokeEnd()
 	end
 end
 
+---Reverts the most recent grass painting stroke.
 local function grassUndo()
 	if #undoStack == 0 then
 		return
@@ -176,6 +178,7 @@ local function grassUndo()
 	end
 end
 
+---Reapplies the most recently undone grass painting stroke.
 local function grassRedo()
 	if #redoStack == 0 then
 		return
@@ -192,6 +195,8 @@ local function grassRedo()
 	undoStack[#undoStack + 1] = patches
 end
 
+---Undoes or redoes strokes until the history sits at the given position.
+---@param targetIdx integer Number of strokes that should remain applied.
 local function grassUndoToIndex(targetIdx)
 	local cur = #undoStack
 	if targetIdx < cur then
@@ -207,6 +212,7 @@ end
 
 -- Smart filter state
 local smartEnabled = false
+---@type table<string, boolean|number>
 local smartFilters = {
 	avoidWater = false,
 	avoidCliffs = false,
@@ -1040,6 +1046,8 @@ end
 -- State Management & WG Interface
 -- ============================================================
 
+---Enables the grass brush.
+---@param mode "paint"|"fill"|"erase"? Defaults to `"paint"`.
 local function activate(mode)
 	active = true
 	subMode = mode or "paint"
@@ -1056,6 +1064,7 @@ local function activate(mode)
 	Echo("[Grass Brush] Activated: " .. subMode:upper())
 end
 
+---Disables the grass brush and leaves the grass edit mode.
 local function deactivate()
 	if active then
 		Echo("[Grass Brush] Deactivated")
@@ -1109,76 +1118,106 @@ local function checkConflictAndDeactivate()
 	return false
 end
 
+---Sets what a stroke does. Unknown values are ignored.
+---@param mode "paint"|"fill"|"erase"
 local function setSubMode(mode)
 	if mode == "paint" or mode == "fill" or mode == "erase" then
 		subMode = mode
 	end
 end
 
+---@param v number Target grass density, clamped to the allowed range.
 local function setDensity(v)
 	targetDensity = max(MIN_DENSITY, min(MAX_DENSITY, v))
 end
 
+---@param v number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(v)
 	brushRadius = max(MIN_RADIUS, min(MAX_RADIUS, v))
 end
 
+---@param v number Falloff curve exponent, clamped to the allowed range.
 local function setCurve(v)
 	brushCurve = max(MIN_CURVE, min(MAX_CURVE, v))
 end
 
+---@param v number Brush rotation in degrees, wrapped to `[0,360)`.
 local function setRotation(v)
 	brushRotation = v % 360
 end
 
+---@param v number Grass blade length multiplier, clamped to the allowed range.
 local function setLengthScale(v)
 	brushLengthScale = max(MIN_LENGTH_SCALE, min(MAX_LENGTH_SCALE, v))
 end
 
+---Sets the brush footprint. Unknown values are ignored.
+---@param shape BrushShape
 local function setShape(shape)
 	if shape == "circle" or shape == "square" or shape == "hexagon" or shape == "octagon" or shape == "triangle" then
 		brushShape = shape
 	end
 end
 
+---Enables the slope and altitude filters that restrict where grass is painted.
+---@param val boolean?
 local function setSmartEnabled(val)
 	smartEnabled = val and true or false
 end
 
+---Sets one smart filter value. Unknown keys are ignored.
+---@param key "avoidWater"|"avoidCliffs"|"slopeMax"|"preferSlopes"|"slopeMin"|"altMinEnable"|"altMin"|"altMaxEnable"|"altMax"
+---@param val boolean|number
 local function setSmartFilter(key, val)
 	if smartFilters[key] ~= nil then
 		smartFilters[key] = val
 	end
 end
 
+---Enables restricting painting to ground matching a target texture color.
+---@param val boolean?
 local function setTexFilterEnabled(val)
 	texFilterEnabled = val and true or false
 end
 
+---@param val number How close the ground color must be to match, clamped to `0`-`1.5`.
 local function setTexFilterThreshold(val)
 	texFilterThreshold = max(0, min(1.5, val))
 end
 
+---@param val number Elmos of tolerance around matching ground, clamped to `0`-`500`.
 local function setTexFilterPadding(val)
 	texFilterPadding = max(0, min(500, val))
 end
 
+---Sets the ground color to paint on.
+---@param r number Clamped to `0`-`1`.
+---@param g number Clamped to `0`-`1`.
+---@param b number Clamped to `0`-`1`.
 local function setTexFilterColor(r, g, b)
 	texFilterColor[1] = max(0, min(1, r))
 	texFilterColor[2] = max(0, min(1, g))
 	texFilterColor[3] = max(0, min(1, b))
 end
 
+---Enables excluding ground that matches the exclude color.
+---@param val boolean?
 local function setTexExcludeEnabled(val)
 	texFilterColor[4] = val and true or nil
 end
 
+---Sets the ground color to avoid painting on.
+---@param r number Clamped to `0`-`1`.
+---@param g number Clamped to `0`-`1`.
+---@param b number Clamped to `0`-`1`.
 local function setTexExcludeColor(r, g, b)
 	texFilterColor[5] = max(0, min(1, r))
 	texFilterColor[6] = max(0, min(1, g))
 	texFilterColor[7] = max(0, min(1, b))
 end
 
+---Puts the tool into the mode where the next click samples the filter color.
+---@param val boolean?
 local function setPipetteMode(val)
 	pipetteMode = val and true or false
 	if not val then
@@ -1186,6 +1225,8 @@ local function setPipetteMode(val)
 	end
 end
 
+---Puts the tool into the mode where the next click samples the exclude color.
+---@param val boolean?
 local function setPipetteExcludeMode(val)
 	pipetteExcludeMode = val and true or false
 	if not val then
@@ -1193,6 +1234,29 @@ local function setPipetteExcludeMode(val)
 	end
 end
 
+---A snapshot of the grass brush, for the UI to render.
+---@class GrassBrushState
+---@field active boolean
+---@field subMode "paint"|"fill"|"erase"
+---@field density number
+---@field radius number
+---@field curve number
+---@field rotationDeg number
+---@field lengthScale number
+---@field shape BrushShape
+---@field smartEnabled boolean
+---@field smartFilters table<string, boolean|number> The live filter table. Do not mutate.
+---@field texFilterEnabled boolean
+---@field texFilterColor number[] Match color in `1`-`3`, exclude color in `5`-`7`.
+---@field texFilterThreshold number
+---@field texFilterPadding number
+---@field texExcludeEnabled boolean
+---@field pipetteMode boolean
+---@field pipetteExcludeMode boolean
+---@field historyIndex integer Strokes currently applied.
+---@field historyMax integer Strokes applied plus undone.
+
+---@return GrassBrushState
 local function getState()
 	return {
 		active = active,

--- a/luaui/Widgets/cmd_guard_transport_factory.lua
+++ b/luaui/Widgets/cmd_guard_transport_factory.lua
@@ -174,9 +174,12 @@ function widget:Initialize()
 		return
 	end
 	WG.transportFactoryGuard = {}
+	---@return boolean blacklist Whether transports given explicit orders are excluded
+	---from automatically guarding a factory.
 	WG.transportFactoryGuard.getBlacklistOrderedUnits = function()
 		return blacklistOrderedUnits
 	end
+	---@param value boolean Exclude transports given explicit orders from auto-guarding.
 	WG.transportFactoryGuard.setBlacklistOrderedUnits = function(value)
 		blacklistOrderedUnits = value
 	end

--- a/luaui/Widgets/cmd_light_placer.lua
+++ b/luaui/Widgets/cmd_light_placer.lua
@@ -143,6 +143,7 @@ local lp = {
 
 	-- Smart filter
 	smartEnabled = false,
+	---@type table<string, boolean|number>
 	smartFilters = {
 		avoidWater = true,
 		avoidCliffs = true,
@@ -670,6 +671,7 @@ local function pushUndo(action, lights)
 	redoStack = {}
 end
 
+---Reverts the most recent light placement or removal.
 local function doUndo()
 	if #undoStack == 0 then
 		return
@@ -698,6 +700,7 @@ local function doUndo()
 	end
 end
 
+---Reapplies the most recently undone light placement or removal.
 local function doRedo()
 	if #redoStack == 0 then
 		return
@@ -815,6 +818,9 @@ local function getMapName()
 	return mapName:gsub("[^%w_%-]", "_")
 end
 
+---Writes every placed light to a Lua file.
+---@param explicitPath string? Defaults to a timestamped file in the save directory.
+---@return string filename The path written to, even if the write failed.
 local function save(explicitPath)
 	local lightList = {}
 	for _, rec in pairs(placedLights) do
@@ -904,6 +910,7 @@ local function save(explicitPath)
 	return filename
 end
 
+---Removes every placed light, as a single undoable step.
 local function clearAllLights()
 	local removed = {}
 	for instanceID, rec in pairs(placedLights) do
@@ -917,6 +924,7 @@ local function clearAllLights()
 	end
 end
 
+---@return string[] filenames Saved light files.
 local function listSaves()
 	local files = {}
 	local found = VFS.DirList(SAVE_DIR, "*.lua", VFS.RAW) or {}
@@ -926,6 +934,9 @@ local function listSaves()
 	return files
 end
 
+---Loads lights from a saved file, replacing the placed set.
+---@param filename string? Defaults to the most recent save.
+---@return boolean loaded `false` when no save exists or the file could not be read.
 local function load(filename)
 	-- If no filename given, load most recent save
 	if not filename then
@@ -974,6 +985,10 @@ end
 ----------------------------------------------------------------
 local PRESET_DIR = "lightmaps/presets/"
 
+---Saves the placed lights as a reusable preset, positions stored relative to their
+---center. The name is sanitized to word characters, `_` and `-`.
+---@param presetName string
+---@return string? filename `nil` when the name is empty or the file could not be written.
 local function saveUserPreset(presetName)
 	if not presetName or presetName == "" then
 		return nil
@@ -1076,6 +1091,7 @@ local function saveUserPreset(presetName)
 	end
 end
 
+---@return {name: string, path: string}[] presets User-saved light presets.
 local function listUserPresets()
 	local presets = {}
 	local found = VFS.DirList(PRESET_DIR, "*.lua", VFS.RAW) or {}
@@ -1088,6 +1104,10 @@ local function listUserPresets()
 	return presets
 end
 
+---Stamps a preset's lights around a map position, honoring the smart filters.
+---@param presetData LightPreset? Ignored when it has no `lights`.
+---@param worldX number
+---@param worldZ number
 local function placePreset(presetData, worldX, worldZ)
 	if not presetData or not presetData.lights then
 		return
@@ -1108,6 +1128,10 @@ local function placePreset(presetData, worldX, worldZ)
 	end
 end
 
+---Reads a preset file from disk.
+---@param filename string
+---@return LightPreset? presetData `nil` when the file could not be loaded or did not
+---return a table.
 local function loadPresetFile(filename)
 	local chunk, err = loadfile(filename)
 	if not chunk then
@@ -1120,6 +1144,10 @@ end
 ----------------------------------------------------------------
 -- Apply defaults when switching light type
 ----------------------------------------------------------------
+
+---Switches the light type and resets its tunables to that type's defaults.
+---Unknown types are ignored.
+---@param lightType "point"|"cone"|"beam"
 local function applyLightTypeDefaults(lightType)
 	local defaults = LIGHT_DEFAULTS[lightType]
 	if not defaults then
@@ -1450,12 +1478,34 @@ local function updatePresetPreviewLights(worldX, worldZ)
 	presetPreviewLast.count = #pendingPreset.lights
 end
 
+---One light inside a preset, positioned relative to the click point.
+---@class LightPresetLight
+---@field type "point"|"cone"|"beam"
+---@field offsetX number? Defaults to `0`.
+---@field offsetZ number? Defaults to `0`.
+---@field radius number?
+---@field color ColorRGB?
+---@field brightness number?
+---@field modelfactor number?
+---@field specular number?
+---@field scattering number?
+---@field lensflare number?
+
+---A named group of lights stamped together by one click.
+---@class LightPreset
+---@field name string
+---@field desc string?
+---@field lights LightPresetLight[]
+
+---Arms a preset so the next map click stamps it, clearing any live preview.
+---@param preset LightPreset?
 local function setPendingPreset(preset)
 	pendingPreset = preset
 	removePresetPreviewLights()
 	removePreviewLight()
 end
 
+---Disarms the pending preset and removes its preview lights.
 local function clearPendingPreset()
 	pendingPreset = nil
 	removePresetPreviewLights()
@@ -1648,6 +1698,39 @@ function widget:Initialize()
 	-- Save dirs are created at save time, not at load for every player.
 
 	WG.LightPlacer = {
+		---A snapshot of the light placer, for the UI to render.
+		---@class LightPlacerState
+		---@field active boolean
+		---@field mode BrushPlacementMode? `nil` while the tool is inactive.
+		---@field lightType "point"|"cone"|"beam"
+		---@field shape BrushShape
+		---@field radius number Brush radius.
+		---@field rotation number
+		---@field lightCount number Lights placed per scatter stroke.
+		---@field cadence number
+		---@field distribution string
+		---@field lightRadius number Radius of each placed light.
+		---@field color ColorRGB RGB, each `0`-`1`.
+		---@field brightness number
+		---@field modelfactor number
+		---@field specular number
+		---@field scattering number
+		---@field lensflare number
+		---@field pitch number
+		---@field yaw number
+		---@field roll number
+		---@field theta number Cone half-angle.
+		---@field beamLength number
+		---@field elevation number
+		---@field smartEnabled boolean
+		---@field smartFilters table<string, boolean|number> The live filter table. Do not mutate.
+		---@field undoCount integer
+		---@field redoCount integer
+		---@field lightCount_placed integer
+		---@field selectedLight nil Always `nil`: the backing field is initialized and
+		---reported but never assigned anywhere.
+
+		---@return LightPlacerState
 		getState = function()
 			return {
 				active = lp.active,
@@ -1681,9 +1764,11 @@ function widget:Initialize()
 			}
 		end,
 
+		---Enables the light placer.
 		activate = function()
 			lp.active = true
 		end,
+		---Disables the light placer and clears any preview or pending preset.
 		deactivate = function()
 			lp.active = false
 			lp.mode = nil
@@ -1692,79 +1777,109 @@ function widget:Initialize()
 			clearPendingPreset()
 		end,
 
+		---Sets the placement mode, activating the tool unless `m` is `nil`.
+		---@param m BrushPlacementMode? `nil` deactivates the tool.
 		setMode = function(m)
 			lp.mode = m
 			lp.active = (m ~= nil)
 		end,
+		---Switches the light type and resets its tunables to that type's defaults.
+		---@param t "point"|"cone"|"beam"
 		setLightType = function(t)
 			applyLightTypeDefaults(t)
 		end,
+		---@param s BrushShape Brush footprint.
 		setShape = function(s)
 			lp.shape = s
 		end,
+		---@param r number Brush radius in elmos, clamped to the allowed range.
 		setRadius = function(r)
 			lp.radius = max(MIN_RADIUS, min(MAX_RADIUS, r))
 		end,
+		---@param d number Degrees, wrapped to `[0,360)`.
 		setRotation = function(d)
 			lp.rotation = d % 360
 		end,
+		---@param step number Degrees to add to the current rotation.
 		rotate = function(step)
 			lp.rotation = (lp.rotation + step) % 360
 		end,
+		---@param n number Lights placed per scatter stroke, clamped to `1`-`500`.
 		setLightCount = function(n)
 			lp.lightCount = max(1, min(500, n))
 		end,
+		---@param v number Frames between placements while dragging, clamped to `1`-`1000`.
 		setCadence = function(v)
 			lp.cadence = max(1, min(1000, v))
 		end,
+		---@param d string How scattered lights are spread.
 		setDistribution = function(d)
 			lp.distribution = d
 		end,
 
+		---@param r number Radius of each placed light, clamped to `10`-`5000`.
 		setLightRadius = function(r)
 			lp.lightRadius = max(10, min(5000, r))
 		end,
+		---@param r number
+		---@param g number
+		---@param b number
 		setColor = function(r, g, b)
 			lp.color = { r, g, b }
 		end,
+		---@param v number Clamped to `0.01`-`50`.
 		setBrightness = function(v)
 			lp.brightness = max(0.01, min(50, v))
 		end,
+		---@param v number How strongly the light affects unit models, clamped to `0`-`5`.
 		setModelfactor = function(v)
 			lp.modelfactor = max(0, min(5, v))
 		end,
+		---@param v number Clamped to `0`-`5`.
 		setSpecular = function(v)
 			lp.specular = max(0, min(5, v))
 		end,
+		---@param v number Clamped to `0`-`5`.
 		setScattering = function(v)
 			lp.scattering = max(0, min(5, v))
 		end,
+		---@param v number Clamped to `0`-`5`.
 		setLensflare = function(v)
 			lp.lensflare = max(0, min(5, v))
 		end,
 
+		---@param v number Degrees, clamped to `-90`-`90`.
 		setPitch = function(v)
 			lp.pitch = max(-90, min(90, v))
 		end,
+		---@param v number Degrees, wrapped to `[0,360)`.
 		setYaw = function(v)
 			lp.yaw = v % 360
 		end,
+		---@param v number Degrees, wrapped to `[0,360)`.
 		setRoll = function(v)
 			lp.roll = v % 360
 		end,
+		---@param v number Cone half-angle in radians, clamped to `0.05`-`1.5`.
 		setTheta = function(v)
 			lp.theta = max(0.05, min(1.5, v))
 		end,
+		---@param v number Clamped to `10`-`5000`.
 		setBeamLength = function(v)
 			lp.beamLength = max(10, min(5000, v))
 		end,
+		---@param v number Height above the ground, clamped to `0`-`2000`.
 		setElevation = function(v)
 			lp.elevation = max(0, min(2000, v))
 		end,
 
+		---Enables the slope and altitude filters that restrict where lights are placed.
+		---@param b boolean
 		setSmartEnabled = function(b)
 			lp.smartEnabled = b
 		end,
+		---@param k string
+		---@param v boolean|number
 		setSmartFilter = function(k, v)
 			lp.smartFilters[k] = v
 		end,
@@ -1780,16 +1895,19 @@ function widget:Initialize()
 		listUserPresets = listUserPresets,
 		loadPresetFile = loadPresetFile,
 		placePreset = placePreset,
+		---@return LightPreset[] presets The built-in light presets. Do not mutate.
 		getBuiltinPresets = function()
 			return BUILTIN_PRESETS
 		end,
 
 		setPendingPreset = setPendingPreset,
 		clearPendingPreset = clearPendingPreset,
+		---@return LightPreset? preset The preset armed for the next click, if any.
 		getPendingPreset = function()
 			return pendingPreset
 		end,
 
+		---@return integer count Lights currently placed on the map.
 		getPlacedCount = function()
 			local n = 0
 			for _ in pairs(placedLights) do

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -33,6 +33,58 @@ end
 -- matches the recorded map (blank-map name, exact size, map damage enabled,
 -- local singleplayer); on mismatch it deletes the pointer and explains itself.
 
+---A saved project's `project.lua` manifest. Written last during a save, so its
+---presence is the commit marker for the folder, and checked by `validateManifest`
+---before any load.
+---@class MapProjectManifest
+---@field kind "bar-map-project"
+---@field format_version integer Opening is refused when this is newer than `FORMAT_VERSION`.
+---@field name string
+---@field created string ISO-8601; carried forward across re-saves.
+---@field modified string ISO-8601.
+---@field game_version string
+---@field map MapProjectMap
+---@field sections table<string, MapProjectSection> Keyed by section name; only sections actually written are present.
+---@field assets { decals: { name: string, file: string, installed: boolean }[] }
+---@field mission { zones: unknown[], markers: unknown[], placeholders: unknown[], notes: string }
+---Reserved for mission tooling; the three lists are always written empty, so their
+---element shape is not defined yet.
+
+---@class MapProjectMap
+---@field size_x integer Map units, not elmos: even, 2-64.
+---@field size_z integer
+---@field source_map string The map the project was captured from.
+---@field base_height number?
+---@field base_color ColorRGB?
+---@field height_range { min: integer, max: integer }? Canonical range, auto-widened across re-saves.
+---@field skybox string? Basename only, resolved against the skybox library when opening.
+---@field dnts MapProjectDnts?
+
+---Detail-normal-texture-set keys, recorded as the project's own `assets/dnts/`
+---copies so that opening stays self-contained if the library has since changed.
+---@class MapProjectDnts
+---@field textures table<integer, string> Sparse over channels 1-4, relative to the project folder.
+---@field scales [number, number, number, number]
+---@field mults [number, number, number, number]
+---@field diffuse_alpha number
+---@field set string?
+---@field detail string? Legacy SSMF splat detail texture.
+
+---One saved section. `file` and `dir` are alternatives: `diffuse` is a directory
+---of per-square PNGs, every other section is a single file.
+---@class MapProjectSection
+---@field version integer
+---@field bytes integer
+---@field file string?
+---@field dir string?
+---@field count integer? `units`: how many units were saved.
+---@field square_size integer? `diffuse`: pixel size of one square.
+---@field squares integer? `diffuse`: how many squares were written.
+---@field full boolean? `diffuse`: whether the whole map was captured.
+---@field channels string[]? `diffuse`: which texture keys were captured.
+---@field patch_resolution integer? `grass`.
+---@field config string? `grass`: config filename.
+
 local Echo = Spring.Echo
 
 local PROJECTS_DIR = "MapProjects/"
@@ -156,6 +208,9 @@ end
 -- Read a previously saved manifest (created timestamp + canonical height range
 -- must survive re-saves). Raw io.open, never VFS: fresh files can be invisible
 -- or stale in the VFS view within a session. Also the load-side manifest reader.
+---@param dir string Project folder, with a trailing slash.
+---@return MapProjectManifest? manifest Unvalidated: the file is hand-editable, so
+---pass it through `validateManifest` before trusting anything but `map.size_x`.
 local function readPrevManifest(dir)
 	local f = io.open(dir .. "project.lua", "r")
 	if not f then
@@ -754,6 +809,21 @@ end
 local unitsWaiter = nil
 local unitsWaiterTicks = 0
 
+---One unit reported by the loadout gadget, parsed out of its packed message.
+---@class MapProjectUnitExport
+---@field name string UnitDef name.
+---@field x number
+---@field z number
+---@field rot number Heading; `0` when unparsable.
+---@field team integer Team ID; `0` when unparsable.
+---@field neutral boolean
+
+---Asks the gadget side for the current unit loadout, answering asynchronously.
+---Only one request may be pending at a time.
+---@param callback fun(entries: MapProjectUnitExport[]?, reason: string?) Receives the entries on
+---success, or `nil` plus a reason on failure.
+---@return boolean started `false` when `callback` is not a function, another request
+---is pending, or a save or load is running.
 local function requestUnits(callback)
 	if type(callback) ~= "function" then
 		return false
@@ -1472,8 +1542,11 @@ local function finishSave()
 	job = nil
 end
 
--- opts.saveUnits: record the unit loadout (position/team of every unit) into
--- units.lua so a loaded project restores the drafted mission state.
+---Begins saving the current map as a project. The save runs incrementally across
+---later frames.
+---@param slug string Project folder name; must not contain a path separator.
+---@param opts {saveUnits: boolean?}? Set `saveUnits` to include the unit loadout (position/team of every unit) in units.lua.
+---@return boolean started `false` when a save or load is already running, or `slug` is invalid.
 local function startSave(slug, opts)
 	if job then
 		echoP("a save is already running")
@@ -1505,8 +1578,10 @@ local function startSave(slug, opts)
 	return true
 end
 
--- Does a saved project include a units section? (UI confirm guard: warns
--- before a toggle-off re-save silently drops a previously saved loadout.)
+---Whether a saved project includes a units section. Used to warn before a re-save
+---silently drops a previously saved loadout.
+---@param slug string
+---@return boolean
 local function projectHasUnits(slug)
 	local ok = validateSlug(slug)
 	if not ok then
@@ -1516,11 +1591,21 @@ local function projectHasUnits(slug)
 	return (manifest and manifest.sections and manifest.sections.units) and true or false
 end
 
--- Enumerate projects with manifest details for the Open Project dialog.
+---A saved map project, as listed for the Open Project dialog.
+---@class MapProjectEntry
+---@field slug string Folder name under the projects directory.
+---@field name string Display name; falls back to `slug`.
+---@field size_x number?
+---@field size_z number?
+---@field modified string?
+---@field format_version number?
+
+---Enumerates saved projects with their manifest details, newest first.
 -- VFS.SubDirs sees the folders; manifests are read via raw io (same-session
 -- folders may be invisible/stale in the VFS view — SubDirs RAW semantics for
 -- folders created THIS session are unpinned, so a just-saved project may need
 -- an engine restart to appear; the dialog says so when the list is empty).
+---@return MapProjectEntry[]
 local function listProjectsDetailed()
 	local out = {}
 	local dirs = VFS.SubDirs(PROJECTS_DIR, "*", VFS.RAW) or {}
@@ -1550,6 +1635,8 @@ local function listProjectsDetailed()
 	return out
 end
 
+---Prints the saved projects to the infolog.
+---@return integer count Projects found.
 local function listProjects()
 	local found = listProjectsDetailed()
 	for _, p in ipairs(found) do
@@ -1575,6 +1662,9 @@ end
 -- not write. The manifest goes first on purpose: if a file is locked and the
 -- sweep leaves junk behind, the project has already stopped listing (both list
 -- paths need project.lua) instead of showing up half-deleted.
+---@param slug string Project folder name; must not contain a path separator.
+---@return boolean deleted `false` when a save or load is running, `slug` is invalid,
+---or the folder has no readable manifest.
 local function deleteProject(slug)
 	if job then
 		echoP("cannot delete a project while a save is running")
@@ -1682,6 +1772,11 @@ end
 -- Load: manifest validation
 ----------------------------------------------------------------
 
+---Checks a manifest against the rules this tool can actually load, normalizing
+---each section's `bytes` to a number on the way through.
+---@param manifest MapProjectManifest?
+---@return true? ok `nil` when the manifest is unusable.
+---@return string? errorMessage Set when `ok` is `nil`.
 local function validateManifest(manifest)
 	if type(manifest) ~= "table" then
 		return nil, "manifest is not a table"
@@ -2566,6 +2661,10 @@ end
 -- Load: open (validate + restart), callable from UI and console
 ----------------------------------------------------------------
 
+---Opens a saved project, restarting into a blank map at the recorded size and
+---restoring the project's assets.
+---@param slug string Project folder name; must not contain a path separator.
+---@return boolean started `false` when a save or load is running, or `slug` is invalid.
 local function openProject(slug)
 	if job then
 		echoP("cannot open a project while a save is running")
@@ -2718,9 +2817,11 @@ function widget:Initialize()
 		hasUnitsSection = projectHasUnits,
 		-- callback(entries) on success, callback(nil, reason) on failure
 		requestUnits = requestUnits,
+		---@return boolean busy Whether a project save or load is running.
 		isBusy = function()
 			return job ~= nil or loadJob ~= nil
 		end,
+		---@return boolean loading Whether a project load is running.
 		isLoading = function()
 			return loadJob ~= nil
 		end,

--- a/luaui/Widgets/cmd_metal_brush.lua
+++ b/luaui/Widgets/cmd_metal_brush.lua
@@ -331,6 +331,8 @@ end
 -- Metal Map Save
 -- ============================================================
 
+---Writes the current metal map to a Lua file named after the map, under the
+---metal brush save directory.
 local function saveMetalMap()
 	Spring.CreateDir(SAVE_DIR)
 	local mmX, mmZ = GetMetalMapSize()
@@ -384,6 +386,8 @@ local function saveMetalMap()
 	end
 end
 
+---Loads the metal map previously saved for this map. Does nothing when no
+---save file exists.
 local function loadMetalMap()
 	local mapName = Game.mapName or "unknown"
 	local filename = SAVE_DIR .. mapName .. "_metalmap.lua"
@@ -432,6 +436,7 @@ local function loadMetalMap()
 	Echo("[Metal Brush] Loaded " .. #spots .. " metal spots from: " .. filename)
 end
 
+---Removes all metal from the map.
 local function clearMetalMap()
 	SendLuaRulesMsg(MSG_CLEAR, "")
 	Echo("[Metal Brush] Cleared all metal from map")
@@ -930,6 +935,8 @@ local function drawLassoInfo()
 	end
 end
 
+---Shows or hides the whole-map metal overlay, dimming the map while it is on.
+---@param v boolean?
 local function setMapOverlay(v)
 	mapOverlay = v and true or false
 	if mapOverlay then
@@ -948,6 +955,8 @@ local function setMapOverlay(v)
 	end
 end
 
+---Shows or hides the per-cluster metal totals.
+---@param v boolean?
 local function setClusterCounter(v)
 	clusterCounter = v and true or false
 	if clusterCounter then
@@ -955,6 +964,8 @@ local function setClusterCounter(v)
 	end
 end
 
+---Sets the radius used to group metal patches into clusters.
+---@param r number? Clamped to `32`-`4096`. Defaults to the configured radius.
 local function setClusterRadius(r)
 	r = tonumber(r) or DEFAULT_CLUSTER_RADIUS
 	if r < 32 then
@@ -967,6 +978,7 @@ local function setClusterRadius(r)
 	clusterCacheDirty = true
 end
 
+---Enters lasso mode, discarding any existing loops.
 local function startLasso()
 	lassoActive = true
 	lassoPoints = {}
@@ -975,11 +987,13 @@ local function startLasso()
 	lassoDragDetected = false
 end
 
+---Commits the in-progress lasso polygon without leaving lasso mode.
 local function finishLasso()
 	-- Commit current in-progress polygon (if any) without leaving lasso mode.
 	commitCurrentLasso()
 end
 
+---Leaves lasso mode and discards every committed loop.
 local function clearLasso()
 	lassoActive = false
 	lassoPoints = {}
@@ -998,6 +1012,7 @@ local function popLastLasso()
 	return true
 end
 
+---Enters lasso mode, or leaves it and discards the loops if already active.
 local function toggleLasso()
 	if lassoActive then
 		clearLasso()
@@ -1070,6 +1085,8 @@ invalidateMetalCaches = function()
 	balanceAxisSumsDirty = true
 end
 
+---Shows or hides the symmetry axis used to compare metal on either side of the map.
+---@param v boolean?
 local function setBalanceAxisActive(v)
 	balanceAxisActive = v and true or false
 	if balanceAxisActive then
@@ -1080,10 +1097,12 @@ local function setBalanceAxisActive(v)
 	end
 end
 
+---Toggles the metal balance axis.
 local function toggleBalanceAxis()
 	setBalanceAxisActive(not balanceAxisActive)
 end
 
+---@param deg number? Axis angle, wrapped to `[0,360)`. Defaults to `0`.
 local function setBalanceAxisAngle(deg)
 	deg = tonumber(deg) or 0
 	deg = ((deg % 360) + 360) % 360
@@ -1091,12 +1110,17 @@ local function setBalanceAxisAngle(deg)
 	balanceAxisSumsDirty = true
 end
 
+---Moves the balance axis to pass through a map position.
+---@param x number
+---@param z number
 local function setBalanceAxisOrigin(x, z)
 	balanceAxisOriginX = x
 	balanceAxisOriginZ = z
 	balanceAxisSumsDirty = true
 end
 
+---Puts the tool into the mode where the next click places the balance axis origin.
+---@param v boolean?
 local function setBalanceAxisPlacingOrigin(v)
 	balanceAxisPlacingOrigin = v and true or false
 end
@@ -1235,6 +1259,9 @@ end
 -- State Management & WG Interface
 -- ============================================================
 
+---Enables the metal brush, snapshotting the shared terrain brush settings so they
+---can be restored on `deactivate`.
+---@param mode "stamp"|"paint"? Defaults to `"stamp"`.
 local function activate(mode)
 	-- Snapshot the shared brush settings on ENTRY (not on paint/stamp submode
 	-- re-activations) so leaving the metal tool can restore them — the forced
@@ -1268,6 +1295,7 @@ local function activate(mode)
 	Echo("[Metal Brush] Activated: " .. subMode:upper() .. " | Metal Value: " .. metalValue)
 end
 
+---Disables the metal brush and restores the shared brush settings and map brightness.
 local function deactivate()
 	if active then
 		Echo("[Metal Brush] Deactivated")
@@ -1298,14 +1326,38 @@ local function deactivate()
 	end
 end
 
+---@param mode "stamp"|"paint"? Defaults to `"paint"`.
 local function setSubMode(mode)
 	subMode = mode or "paint"
 end
 
+---@param v number Metal amount painted per spot, clamped to the allowed range.
 local function setMetalValue(v)
 	metalValue = max(MIN_METAL_VALUE, min(MAX_METAL_VALUE, v))
 end
 
+---A snapshot of the metal brush, for the UI to render.
+---@class MetalBrushState
+---@field active boolean
+---@field subMode "stamp"|"paint"
+---@field metalValue number
+---@field mapOverlay boolean
+---@field clusterCounter boolean
+---@field clusterRadius number
+---@field lassoActive boolean
+---@field lassoClosed boolean `true` when at least one loop has been committed.
+---@field lassoPointCount integer Points in the in-progress loop.
+---@field lassoTotal number Metal summed across every committed loop.
+---@field lassoCount integer Committed loops.
+---@field balanceAxisActive boolean
+---@field balanceAxisAngleDeg number
+---@field balanceAxisOriginX number
+---@field balanceAxisOriginZ number
+---@field balanceAxisPlacingOrigin boolean
+---@field balanceAxisSumA number Metal on one side of the balance axis.
+---@field balanceAxisSumB number Metal on the other side.
+
+---@return MetalBrushState
 local function getState()
 	return {
 		active = active,

--- a/luaui/Widgets/cmd_no_self_selection.lua
+++ b/luaui/Widgets/cmd_no_self_selection.lua
@@ -227,8 +227,8 @@ widget.UnitEnteredRadar = unitAccessGained
 ---@param includeSky boolean? (default: `false`)
 ---@param ignoreWater boolean? (default: `false`)
 ---@param heightOffset number? (default: `0`)
----@return ("unit"|"feature"|"ground"|"sky")? description of traced object or position
----@return (integer|xyz|string|number|nil)? result unitID or featureID (integer), or position triple (xyz)
+---@return (WorldObjectType|"sky")? description of traced object or position
+---@return (integer|xyz)? result unitID or featureID (integer), or position triple (xyz)
 local function traceScreenRay(screenX, screenY, onlyCoords, useMinimap, includeSky, ignoreWater, heightOffset)
 	-- Explicitly check onlyCoords because `TraceScreenRay` accepts arguments (screenX, screenY, heightOffset).
 	local hiddenID = (onlyCoords ~= true) and not useMinimap and isVolumeHidden and selectedUnitID

--- a/luaui/Widgets/cmd_resolution_switcher.lua
+++ b/luaui/Widgets/cmd_resolution_switcher.lua
@@ -311,14 +311,39 @@ function widget:Initialize()
 
 	WG.screenMode = {}
 
+	---One selectable window mode. `SetScreenMode` indexes the list this order produces.
+	---@class ScreenMode
+	---@field display integer Display number, or a synthetic index for multi-monitor spans.
+	---@field actualDisplay integer? The real display a multi-monitor span starts on.
+	---@field name string Translated label.
+	---@field displayName string Monitor name, empty for spans.
+	---@field type integer One of the `windowType` constants.
+	---@field width integer
+	---@field height integer
+	---@field x integer? Span origin; absent for single-display modes.
+	---@field y integer?
+
+	---A monitor the game can be shown on.
+	---@class ScreenDisplay
+	---@field name string
+	---@field width integer
+	---@field height integer
+	---@field hz integer
+	---@field x integer
+	---@field y integer
+
+	---@return ScreenDisplay[] displays
 	WG.screenMode.GetDisplays = function()
 		return displays
 	end
 
+	---@return ScreenMode[] screenModes Selectable window modes.
 	WG.screenMode.GetScreenModes = function()
 		return screenModes
 	end
 
+	---Switches to a screen mode, doing nothing if it is already active.
+	---@param index integer Index into `GetScreenModes`.
 	WG.screenMode.SetScreenMode = function(index)
 		local prevScreenmode = screenModeIndex
 		screenModeIndex = index

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -97,6 +97,7 @@ local activeChannel = 1 -- 1=R, 2=G, 3=B, 4=A
 local activeStrength = DEFAULT_STRENGTH
 local activeIntensity = DEFAULT_INTENSITY
 local activeRadius = DEFAULT_RADIUS
+---@type BrushShape
 local activeShape = "circle"
 local activeRotation = 0
 local activeCurve = DEFAULT_CURVE
@@ -817,6 +818,9 @@ local function executeSaveSplats(explicitPath)
 end
 
 -- Public API: always defers to DrawWorld
+---Queues an export of the splat texture, written on the next draw pass.
+---Poll `isSavePending`.
+---@param explicitPath string? Defaults to a path derived from the map name.
 local function requestSaveSplats(explicitPath)
 	if not fboTex and not active then
 		Echo("[Splat Painter] No splat texture to save")
@@ -896,6 +900,10 @@ local function executeLoadSplats(path)
 end
 
 -- Public API: defers to DrawWorld (GL work). Poll isLoadPending / getLoadResult.
+---Queues loading a splat texture from disk, applied on the next draw pass.
+---Poll `isLoadPending` and then `getLoadResult`.
+---@param path string
+---@return boolean started `false` when `path` is empty.
 local function requestLoadSplats(path)
 	if not path or path == "" then
 		Echo("[Splat Painter] loadSplats: no path given")
@@ -908,6 +916,9 @@ end
 
 -- ============ GEO DECAL PLACEMENT ============
 
+---Stamps a geo decal at a map position, at the current rotation and size.
+---@param worldX number
+---@param worldZ number
 local function placeGeoDecal(worldX, worldZ)
 	local halfSize = GEO_DECAL_SIZE * 0.5
 	placedGeoDecals[#placedGeoDecals + 1] = {
@@ -927,6 +938,7 @@ local function placeGeoDecal(worldX, worldZ)
 	)
 end
 
+---Removes the most recently placed geo decal.
 local function undoGeoDecal()
 	if #placedGeoDecals == 0 then
 		Echo("[Splat Painter] No geo decals to undo")
@@ -976,14 +988,17 @@ local function takeSnapshot()
 	redoStack = {}
 end
 
+---Queues an undo, applied on the next draw pass.
 local function splatUndo()
 	pendingUndoCount = pendingUndoCount + 1
 end
 
+---Queues a redo, applied on the next draw pass.
 local function splatRedo()
 	pendingRedoCount = pendingRedoCount + 1
 end
 
+---Removes every placed geo decal.
 local function clearGeoDecals()
 	for i = #placedGeoDecals, 1, -1 do
 		placedGeoDecals[i] = nil
@@ -991,11 +1006,14 @@ local function clearGeoDecals()
 	Echo("[Splat Painter] Cleared all geo decals")
 end
 
+---Switches between painting splats and placing geo decals.
+---@param enabled boolean
 local function setGeoDecalMode(enabled)
 	geoDecalMode = enabled
 	invalidateDrawCache()
 end
 
+---@param size number Geo decal size in elmos, clamped to `16`-`512`.
 local function setGeoDecalSize(size)
 	GEO_DECAL_SIZE = max(16, min(512, size))
 	invalidateDrawCache()
@@ -1003,6 +1021,32 @@ end
 
 -- ============ STATE / API ============
 
+---A snapshot of the splat painter, for the UI to render.
+---@class SplatPainterState
+---@field active boolean
+---@field channel integer Splat channel being painted, `1`-`4`.
+---@field strength number
+---@field intensity number
+---@field radius number
+---@field shape BrushShape
+---@field rotationDeg number
+---@field curve number
+---@field fractalAmount number
+---@field fractalFreq number
+---@field eraseMode boolean
+---@field exportFormat "png"|"tga"|"bmp"
+---@field smartEnabled boolean
+---@field smartFilters table<string, boolean|number> The live filter table. Do not mutate.
+---@field splatTexWidth integer
+---@field splatTexHeight integer
+---@field geoDecalMode boolean
+---@field geoDecalSize number
+---@field geoDecalCount integer
+---@field undoCount integer
+---@field redoCount integer
+---@field showSplatOverlay boolean
+
+---@return SplatPainterState
 local function getState()
 	return {
 		active = active,
@@ -1030,10 +1074,13 @@ local function getState()
 	}
 end
 
+---Shows the splat channels as a map overlay.
+---@param enabled boolean?
 local function setSplatOverlay(enabled)
 	showSplatOverlay = enabled and true or false
 end
 
+---Enables the splat painter, compiling its shaders on first use.
 local function activateSplat()
 	if active then
 		return
@@ -1059,6 +1106,7 @@ local function activateSplat()
 	)
 end
 
+---Disables the splat painter.
 local function deactivateSplat()
 	if not active then
 		return
@@ -1070,25 +1118,31 @@ local function deactivateSplat()
 	invalidateDrawCache()
 end
 
+---@param ch integer Splat channel to paint, clamped to `1`-`4`.
 local function setChannel(ch)
 	ch = max(1, min(4, ch))
 	activeChannel = ch
 	invalidateDrawCache()
 end
 
+---@param s number Paint strength per stroke, clamped to the allowed range.
 local function setStrength(s)
 	activeStrength = max(MIN_STRENGTH, min(MAX_STRENGTH, s))
 end
 
+---@param i number Target channel value, clamped to the allowed range.
 local function setIntensity(i)
 	activeIntensity = max(MIN_INTENSITY, min(MAX_INTENSITY, i))
 end
 
+---@param r number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(r)
 	activeRadius = max(MIN_RADIUS, min(MAX_RADIUS, floor(r)))
 	invalidateDrawCache()
 end
 
+---Sets the brush footprint. Unknown values are ignored.
+---@param s BrushShape
 local function setShape(s)
 	for _, v in ipairs(SHAPES) do
 		if v == s then
@@ -1099,20 +1153,26 @@ local function setShape(s)
 	end
 end
 
+---@param deg number Brush rotation in degrees, wrapped to `[0,360)`.
 local function setRotation(deg)
 	activeRotation = deg % 360
 	invalidateDrawCache()
 end
 
+---@param delta number Degrees to add to the current rotation.
 local function rotateBy(delta)
 	setRotation(activeRotation + delta)
 end
 
+---@param c number Falloff curve exponent, clamped to the allowed range.
 local function setCurve(c)
 	activeCurve = max(MIN_CURVE, min(MAX_CURVE, c))
 	invalidateDrawCache()
 end
 
+---Sets the fractal break-up applied to strokes. Omitted values are left unchanged.
+---@param amount number? Clamped to the allowed range.
+---@param freq number? Clamped to the allowed range.
 local function setFractal(amount, freq)
 	if amount ~= nil then
 		activeFractalAmount = max(MIN_FRACTAL, min(MAX_FRACTAL, amount))
@@ -1123,14 +1183,18 @@ local function setFractal(amount, freq)
 	invalidateDrawCache()
 end
 
+---@param enabled boolean Remove splat coverage instead of adding it.
 local function setEraseMode(enabled)
 	eraseMode = enabled
 end
 
+---Advances the export format to the next of `png`, `tga`, `bmp`.
 local function cycleExportFormat()
 	exportFormatIndex = (exportFormatIndex % #EXPORT_FORMATS) + 1
 end
 
+---Sets the export image format. Unknown values are ignored.
+---@param fmt "png"|"tga"|"bmp"
 local function setExportFormat(fmt)
 	for i, v in ipairs(EXPORT_FORMATS) do
 		if v == fmt then
@@ -1140,10 +1204,15 @@ local function setExportFormat(fmt)
 	end
 end
 
+---Enables the slope and altitude filters that restrict where splats are painted.
+---@param enabled boolean
 local function setSmartEnabled(enabled)
 	smartFilterEnabled = enabled
 end
 
+---Sets one smart filter value. Unknown keys are ignored.
+---@param key string
+---@param val boolean|number
 local function setSmartFilter(key, val)
 	if smartFilter[key] ~= nil then
 		smartFilter[key] = val
@@ -1176,6 +1245,8 @@ function widget:Initialize()
 		rotate = rotateBy,
 		setCurve = setCurve,
 		setFractal = setFractal,
+		---@return number amount
+		---@return number freq
 		getFractal = function()
 			return activeFractalAmount, activeFractalFreq
 		end,
@@ -1183,16 +1254,20 @@ function widget:Initialize()
 		setSmartEnabled = setSmartEnabled,
 		setSmartFilter = setSmartFilter,
 		saveSplats = requestSaveSplats,
+		---@return boolean pending
 		isSavePending = function()
 			return pendingSave
 		end,
+		---@return boolean hasState Whether anything has been painted that a save would capture.
 		hasSplatState = function()
 			return fboTex ~= nil
 		end,
 		loadSplats = requestLoadSplats,
+		---@return boolean pending
 		isLoadPending = function()
 			return pendingLoadPath ~= nil
 		end,
+		---@return string? result `"ok"` or `"failed: <reason>"`; `nil` until a load finishes.
 		getLoadResult = function()
 			return lastLoadResult
 		end,

--- a/luaui/Widgets/cmd_startpos_tool.lua
+++ b/luaui/Widgets/cmd_startpos_tool.lua
@@ -141,7 +141,8 @@ local numTeamsPerAlly = 1 -- configurable count (players per ally)
 local placementMode = "roundrobin" -- "roundrobin" = A,B,C,A,B,C... | "sequential" = A,A,B,B,C,C...
 
 -- Shape placement state
-local shapeType = "circle" -- "circle"|"square"|"hexagon"|"octagon"|"triangle"
+---@type BrushShape
+local shapeType = "circle"
 local shapeRadius = 2000
 local shapeRotation = 0 -- degrees
 local shapeCount = 4 -- number of positions to place with shape
@@ -438,6 +439,22 @@ local function isPlaceableForCommander(x, z)
 	return getGroundSlopeAt(x, z) <= maxS
 end
 
+---A placed start position.
+---@class StartPosition
+---@field x number
+---@field y number Ground height at `x`, `z`.
+---@field z number
+---@field allyTeam integer
+---@field teamSlot integer
+---@field playerIdx integer
+
+---Places a start position, clamped to the map and rejected on ground the commander
+---cannot spawn on.
+---@param x number
+---@param z number
+---@param allyTeam integer? Defaults to the next allyteam in the placement order.
+---@param teamSlot integer? Defaults to the next slot in the placement order.
+---@return boolean placed `false` when the position cap is reached or the ground is too steep.
 local function addPosition(x, z, allyTeam, teamSlot)
 	if #positions >= MAX_POSITIONS then
 		return false
@@ -533,6 +550,7 @@ local function findNearestPosition(wx, wz)
 	return bestIdx
 end
 
+---Removes every placed start position and resets the placement order.
 local function clearAllPositions()
 	positions = {}
 	nextAllyTeam = 1
@@ -571,6 +589,9 @@ local function placeShapePositionsForTeam(cx, cz, allyTeam)
 	end
 end
 
+---Places a full set of start positions at random around a map point.
+---@param cx number
+---@param cz number
 local function placeRandomPositions(cx, cz)
 	local pts = generateRandomPositions(cx, cz)
 	local numAlly = math_max(1, numAllyTeams)
@@ -606,6 +627,7 @@ local function addStartboxVertex(x, z)
 	currentBoxVerts[#currentBoxVerts + 1] = { x = x, z = z }
 end
 
+---Commits the start box being drawn. Boxes with fewer than three vertices are dropped.
 local function finishStartbox()
 	if #currentBoxVerts >= 3 then
 		startboxes[#startboxes + 1] = {
@@ -760,6 +782,7 @@ local function removeLastStartbox()
 	end
 end
 
+---Removes every start box and resets the box drawing state.
 local function clearAllStartboxes()
 	for i = 1, #startboxes do
 		freeBoxFillList(startboxes[i])
@@ -941,6 +964,10 @@ local function getMapName()
 	return Game.mapName or "unknown"
 end
 
+---Writes the placed start positions to a Lua file.
+---@param name string? Save name. Defaults to the map name.
+---@param explicitPath string? Full path, overriding `name` and the save directory.
+---@return boolean saved `false` when the file could not be written.
 local function saveStartPositions(name, explicitPath)
 	local filename = explicitPath
 	if not filename then
@@ -980,6 +1007,10 @@ local function saveStartPositions(name, explicitPath)
 	end
 end
 
+---Loads start positions from a saved file, replacing the placed set.
+---@param name string? Save name. Defaults to the map name.
+---@param explicitPath string? Full path, overriding `name` and the save directory.
+---@return boolean loaded `false` when the file is missing or unreadable.
 local function loadStartPositions(name, explicitPath)
 	local filename = explicitPath or (SAVE_DIR .. (name or getMapName()) .. ".lua")
 	local ok, data = pcall(function()
@@ -999,6 +1030,7 @@ local function loadStartPositions(name, explicitPath)
 	end
 end
 
+---@return string[] names Saved start position configs, without their extension.
 local function listSavedConfigs()
 	local files = VFS.DirList(SAVE_DIR, "*.lua", VFS.RAW_FIRST)
 	local names = {}
@@ -1011,6 +1043,10 @@ local function listSavedConfigs()
 	return names
 end
 
+---Writes the drawn start boxes to a Lua file.
+---@param name string? Save name. Defaults to the map name.
+---@param explicitPath string? Full path, overriding `name` and the save directory.
+---@return boolean saved `false` when the file could not be written.
 local function saveStartboxes(name, explicitPath)
 	local filename = explicitPath
 	if not filename then
@@ -1050,6 +1086,10 @@ local function saveStartboxes(name, explicitPath)
 	end
 end
 
+---Loads start boxes from a saved file, replacing the drawn set.
+---@param name string? Save name. Defaults to the map name.
+---@param explicitPath string? Full path, overriding `name` and the save directory.
+---@return boolean loaded `false` when the file is missing or unreadable.
 local function loadStartboxes(name, explicitPath)
 	local filename = explicitPath or (STARTBOX_SAVE_DIR .. (name or getMapName()) .. ".lua")
 	local ok, data = pcall(function()
@@ -1071,6 +1111,7 @@ local function loadStartboxes(name, explicitPath)
 	end
 end
 
+---@return string[] names Saved start box configs, without their extension.
 local function listSavedStartboxConfigs()
 	local files = VFS.DirList(STARTBOX_SAVE_DIR, "*.lua", VFS.RAW_FIRST)
 	local names = {}
@@ -1089,17 +1130,21 @@ end
 
 local STARTSCRIPT_SAVE_DIR = "Terraform Brush/StartScripts/"
 
+---Optional overrides for `generateStartScript`.
+---@class StartScriptOpts
+---@field mapname string? Defaults to the current map.
+---@field playerName string? Defaults to `"Player"`.
+---@field aiShortName string? AI type for non-player teams. Defaults to `"NullAI"`.
+---@field aiVersion string? Defaults to `"0.1"`.
+---@field startpostype number? `0` fixed, `1` random, `2` choose. Defaults to `2`.
+---@field modoptions table<string, string|number|boolean>? Key-value pairs written verbatim
+---into the `[modoptions]` section.
+
 --- Generate a Spring engine start script (script.txt) from the current
 --- polygon startboxes. Each polygon is converted to an axis-aligned
 --- bounding rectangle normalised to 0-1 map coordinates.
----@param opts table|nil  Optional overrides:
----   mapname        (string)   default: current map
----   playerName     (string)   default: "Player"
----   aiShortName    (string)   AI type for non-player teams, default "NullAI"
----   aiVersion      (string)   default "0.1"
----   startpostype   (number)   0=fixed,1=random,2=choose  default 2
----   modoptions     (table)    key-value pairs for [modoptions] section
----@return string  The full script text
+---@param opts StartScriptOpts?
+---@return string script The full script text.
 local function generateStartScript(opts)
 	opts = opts or {}
 	local mapName = opts.mapname or getMapName()
@@ -1253,6 +1298,10 @@ local function generateStartScript(opts)
 	return table.concat(lines, "\n")
 end
 
+---Writes a generated start script to a text file.
+---@param name string? Save name. Defaults to the map name.
+---@param opts StartScriptOpts?
+---@return boolean saved `false` when no start boxes exist or the file could not be written.
 local function saveStartScript(name, opts)
 	local script = generateStartScript(opts)
 	if not script then
@@ -1278,12 +1327,15 @@ end
 -- Activate / Deactivate / State
 -- ============================================================
 
+---Enables the start position tool.
+---@param mode "express"|"shape"|"startbox"? Defaults to `"express"`.
 local function activate(mode)
 	active = true
 	subMode = mode or "express"
 	Echo("[StartPos Tool] Activated: " .. subMode:upper())
 end
 
+---Disables the start position tool.
 local function deactivate()
 	if active then
 		Echo("[StartPos Tool] Deactivated")
@@ -1294,30 +1346,38 @@ local function deactivate()
 	drawingBox = false
 end
 
+---Switches what clicking the map does. Unknown values are ignored.
+---@param mode "express"|"shape"|"startbox"
 local function setSubMode(mode)
 	if mode == "express" or mode == "shape" or mode == "startbox" then
 		subMode = mode
 	end
 end
 
+---Sets the layout used by shape mode. Unknown values are ignored.
+---@param shape BrushShape
 local function setShape(shape)
 	if shape == "circle" or shape == "square" or shape == "hexagon" or shape == "octagon" or shape == "triangle" then
 		shapeType = shape
 	end
 end
 
+---@param v number Shape radius in elmos, clamped to the allowed range.
 local function setRadius(v)
 	shapeRadius = math_max(MIN_RADIUS, math_min(MAX_RADIUS, v))
 end
 
+---@param deg number Shape rotation in degrees, wrapped to `[0,360)`.
 local function setRotation(deg)
 	shapeRotation = deg % 360
 end
 
+---@param c number Positions placed by shape mode, clamped to `2`-`MAX_POSITIONS`.
 local function setShapeCount(c)
 	shapeCount = math_max(2, math_min(MAX_POSITIONS, c))
 end
 
+---@param n number Allyteams to spread positions across, clamped to `2`-`MAX_ALLYTEAMS`.
 local function setNumAllyTeams(n)
 	numAllyTeams = math_max(2, math_min(MAX_ALLYTEAMS, n))
 	if nextAllyTeam > numAllyTeams then
@@ -1325,6 +1385,7 @@ local function setNumAllyTeams(n)
 	end
 end
 
+---@param n number Teams per allyteam, clamped to `1`-`MAX_TEAMS_PER_ALLY`.
 local function setNumTeamsPerAlly(n)
 	numTeamsPerAlly = math_max(1, math_min(MAX_TEAMS_PER_ALLY, n))
 	if nextTeamSlot > numTeamsPerAlly then
@@ -1332,17 +1393,24 @@ local function setNumTeamsPerAlly(n)
 	end
 end
 
+---Sets how placements cycle through allyteams. Unknown values are ignored.
+---@param m "roundrobin"|"sequential"
 local function setPlacementMode(m)
 	if m == "roundrobin" or m == "sequential" then
 		placementMode = m
 	end
 end
 
+---Switches between round-robin and sequential placement.
+---@return "roundrobin"|"sequential" mode The new mode.
 local function togglePlacementMode()
 	placementMode = (placementMode == "roundrobin") and "sequential" or "roundrobin"
 	return placementMode
 end
 
+---Sets how start boxes are drawn, discarding any in-progress box.
+---Unknown values are ignored.
+---@param m "polygon"|"box"|"freedraw"
 local function setStartboxMode(m)
 	if m == "polygon" or m == "box" or m == "freedraw" then
 		startboxMode = m
@@ -1394,6 +1462,33 @@ local function decimatePoints(pts, minDistSq)
 	return out
 end
 
+---A snapshot of the start position tool, for the UI to render.
+---@class StartPosToolState
+---@field active boolean
+---@field subMode "express"|"shape"|"startbox"
+---@field positions StartPosition[] The live list. Do not mutate.
+---@field numAllyTeams integer
+---@field numTeamsPerAlly integer
+---@field nextAllyTeam integer
+---@field nextTeamSlot integer
+---@field placementMode "roundrobin"|"sequential"
+---@field totalPlayers integer
+---@field maxAllyTeams integer
+---@field maxTeamsPerAlly integer
+---@field maxPositions integer
+---@field shapeType BrushShape
+---@field shapeRadius number
+---@field shapeRotation number
+---@field shapeCount integer
+---@field startboxes {vertices: PositionXZ[], allyTeam: integer}[] The live list.
+---Do not mutate.
+---@field startboxMode "polygon"|"box"|"freedraw"
+---@field drawingBox boolean
+---@field currentBoxVerts PositionXZ[]
+---@field boxRectActive boolean
+---@field freeDrawActive boolean
+
+---@return StartPosToolState
 local function getState()
 	return {
 		active = active,

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -239,6 +239,7 @@ local function loadKeybindsFromDisk()
 	end
 end
 
+---Writes the current brush keybinds to the keybinds directory.
 local function saveKeybindsToDisk()
 	Spring.CreateDir(KEYBINDS_DIR)
 	local lines = { "return {" }
@@ -275,6 +276,8 @@ local function getKeybindKey(action)
 	return kb and kb.key or 0
 end
 
+---@param action string
+---@return string label Display label for the bound key, or `"?"` when unbound.
 local function getKeybindLabel(action)
 	local kb = activeKeybinds[action]
 	return kb and kb.label or "?"
@@ -451,6 +454,7 @@ end
 
 local activeDirection = nil
 local activeRadius = DEFAULT_RADIUS
+---@type BrushShape|"ring"|"fill"
 local activeShape = "circle"
 local activeRotation = 0
 local activeCurve = DEFAULT_CURVE
@@ -1021,6 +1025,8 @@ local function constrainToAxis(originX, originZ, rawX, rawZ)
 end
 
 -- Stamp mode: intensity maxed + at least one height cap → instant apply
+---@return boolean stamp Whether the brush stamps to a fixed height in one stroke,
+---which it does at full intensity with a height cap set.
 local function isStampMode()
 	return activeIntensity >= MAX_INTENSITY and (heightCapMin ~= nil or heightCapMax ~= nil)
 end
@@ -1232,6 +1238,7 @@ end
 -- Forward declaration
 local invalidateDrawCache
 
+---Disables the terrain brush and restores the default cursor.
 local function deactivateTerraform()
 	if activeMode then
 		Echo("[Terraform Brush] Deactivated")
@@ -1287,6 +1294,8 @@ extraState.swapModeParams = function(mode)
 	end
 end
 
+---Switches the terraform operation, swapping in that mode's saved brush settings.
+---@param mode "raise"|"lower"|"level"|"smooth"|"ramp"|"noise"|"erode"|"restore"
 local function setMode(mode)
 	extraState.ensureCheat()
 	extraState.swapModeParams(mode)
@@ -1320,6 +1329,10 @@ local function setMode(mode)
 	end
 end
 
+---Sets the brush footprint. Unknown shapes are ignored, as are shapes the active
+---mode does not support: ramp allows only circle and square, and level and smooth
+---do not allow ring.
+---@param shape BrushShape|"ring"|"fill"
 local function setShape(shape)
 	if
 		shape == "circle"
@@ -1340,6 +1353,8 @@ local function setShape(shape)
 	end
 end
 
+---Rotates the brush, honoring angle snap.
+---@param degrees number Degrees to add to the current rotation.
 local function rotateBy(degrees)
 	activeRotation = (activeRotation + degrees) % 360
 	if extraState.angleSnap and extraState.angleSnapStep > 0 then
@@ -1435,6 +1450,8 @@ local function snapDragToSpoke(wx, wz)
 	return dragOriginX + spokeX * projDist, dragOriginZ + spokeZ * projDist
 end
 
+---Sets the brush rotation, honoring angle snap.
+---@param degrees number Degrees, wrapped to `[0,360)`.
 local function setRotation(degrees)
 	activeRotation = degrees % 360
 	if extraState.angleSnap and extraState.angleSnapStep > 0 then
@@ -1443,42 +1460,59 @@ local function setRotation(degrees)
 	end
 end
 
+---@param value number Falloff curve exponent, clamped to the allowed range.
 local function setCurve(value)
 	activeCurve = max(MIN_CURVE, min(MAX_CURVE, value))
 end
 
+---@param value number Terraform strength per stroke, clamped to the allowed range.
 local function setIntensity(value)
 	activeIntensity = max(MIN_INTENSITY, min(MAX_INTENSITY, value))
 end
 
+---@param value number Stretches the brush along its rotation axis, clamped to the allowed range.
 local function setLengthScale(value)
 	activeLengthScale = max(MIN_LENGTH_SCALE, min(MAX_LENGTH_SCALE, value))
 end
 
+---@param value number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(value)
 	activeRadius = max(MIN_RADIUS, min(MAX_RADIUS, floor(value)))
 end
 
+---Stops the brush lowering terrain past a height.
+---@param value number? Pass `nil` to remove the cap.
 local function setHeightCapMin(value)
 	heightCapMin = value
 end
 
+---Stops the brush raising terrain past a height.
+---@param value number? Pass `nil` to remove the cap.
 local function setHeightCapMax(value)
 	heightCapMax = value
 end
 
+---Treats the height caps as absolute world heights rather than relative to the
+---terrain under the brush.
+---@param value boolean
 local function setHeightCapAbsolute(value)
 	heightCapAbsolute = value
 end
 
+---Enables clay mode, which preserves volume by pushing displaced terrain outward.
+---@param value boolean?
 local function setClayMode(value)
 	clayMode = value and true or false
 end
 
+---@param value number? Opacity of the brush cursor ring, clamped to `0.01`-`1`.
+---Defaults to `1`.
 local function setBrushOpacity(value)
 	brushOpacity = math.max(0.01, math.min(1.0, tonumber(value) or 1.0))
 end
 
+---Shows or hides the build-grid overlay.
+---@param value boolean?
 local function setGridOverlay(value)
 	gridOverlay = value and true or false
 	if gridOverlay then
@@ -1486,26 +1520,38 @@ local function setGridOverlay(value)
 	end
 end
 
+---Enables the dust particles kicked up while terraforming.
+---@param value boolean?
 local function setDustEffects(value)
 	dustEffects = value and true or false
 end
 
+---Enables the camera shake applied while terraforming.
+---@param value boolean?
 local function setSeismicEffects(value)
 	seismicEffects = value and true or false
 end
 
+---Enables the beat-synced terraform mode.
+---@param value boolean?
 local function setDjMode(value)
 	djMode = value and true or false
 end
 
+---Tints the terrain by height, as an editing aid.
+---@param value boolean?
 local function setHeightColormap(value)
 	extraState.heightColormap = value and true or false
 end
 
+---Draws the falloff curve on the brush ring.
+---@param value boolean?
 local function setCurveOverlay(value)
 	extraState.curveOverlay = value and true or false
 end
 
+---@param value number? Inner radius of the ring shape as a fraction of the outer
+---radius, clamped to `0.05`-`0.95`. Defaults to `0.6`.
 local function setRingInnerRatio(value)
 	ringInnerRatio = math.max(0.05, math.min(0.95, value or 0.6))
 end
@@ -1610,10 +1656,13 @@ local function loadPresetsFromDisk()
 	end
 end
 
+---@param name string
+---@return boolean builtin Built-in presets cannot be deleted.
 local function isBuiltinPreset(name)
 	return builtinPresetNames[name] == true
 end
 
+---@return string[] names Every brush preset, built-in and user-saved.
 local function getPresetNames()
 	loadPresetsFromDisk()
 	local names = {}
@@ -1624,6 +1673,9 @@ local function getPresetNames()
 	return names
 end
 
+---Saves the current brush settings as a named preset. Empty names are ignored,
+---and the name is sanitized before use.
+---@param name string
 local function savePreset(name)
 	if not name or name == "" then
 		return
@@ -1713,6 +1765,8 @@ local function savePreset(name)
 	Echo("[Terraform Brush] Preset saved: " .. name)
 end
 
+---Applies a saved preset's brush settings. Unknown names are ignored.
+---@param name string
 local function loadPreset(name)
 	loadPresetsFromDisk()
 	local data = presets[name]
@@ -1800,6 +1854,8 @@ local function loadPreset(name)
 	Echo("[Terraform Brush] Preset loaded: " .. name)
 end
 
+---Deletes a user-saved preset. Unknown names and built-in presets are ignored.
+---@param name string
 local function deletePreset(name)
 	loadPresetsFromDisk()
 	if not presets[name] then
@@ -1815,6 +1871,31 @@ local function deletePreset(name)
 	Echo("[Terraform Brush] Preset deleted: " .. name)
 end
 
+---Fields shared between both brush presets and brushes
+---@class TerraformBrushBase
+---@field mode "raise"|"lower"|"level"|"smooth"|"ramp"|"noise"|"erode"|"restore"
+---@field shape BrushShape|"ring"|"fill"
+---@field radius number
+---@field rotationDeg number
+---@field curve number
+---@field intensity number
+---@field lengthScale number
+---@field heightCapMin number? `nil` when unset.
+---@field heightCapMax number? `nil` when unset.
+---@field heightCapAbsolute boolean
+---@field clayMode boolean
+---@field noiseType string
+---@field noiseScale number
+---@field noiseOctaves integer
+---@field noisePersistence number
+---@field noiseLacunarity number
+---@field noiseSeed number
+
+---@class TerraformPreset : TerraformBrushBase
+---@field name string
+
+---@param n string
+---@return TerraformPreset? preset `nil` when no preset has that name.
 local function getPreset(n)
 	loadPresetsFromDisk()
 	return presets[n]
@@ -2103,6 +2184,77 @@ extraState._newmapDrive = function()
 	end
 end
 
+---A snapshot of the terrain brush, for the UI to render.
+---@class TerraformBrushState : TerraformBrushBase
+---@field active boolean
+---@field direction integer `1` raises, `-1` lowers.
+---@field dustEffects boolean
+---@field seismicEffects boolean
+---@field djMode boolean
+---@field wiggleEnabled boolean
+---@field wiggleAmpIdx integer
+---@field wiggleSpdIdx integer
+---@field heightColormap boolean
+---@field heightSamplingMode boolean
+---@field gridOverlay boolean
+---@field gridSnap boolean
+---@field gridSnapSize number
+---@field angleSnap boolean
+---@field angleSnapStep number
+---@field angleSnapAuto boolean
+---@field angleSnapManualSpoke number
+---@field measureActive boolean
+---@field measureDrawing boolean
+---@field measureRulerMode boolean
+---@field measureStickyMode boolean
+---@field measureDistortMode boolean
+---@field measureShowLength boolean
+---@field linkedStrokeCount integer
+---@field measureChainCount integer
+---@field rampAutoAttach boolean
+---@field curveOverlay boolean
+---@field velocityIntensity boolean
+---@field dragVelocityFactor number
+---@field restoreStrength number
+---@field undoCount integer
+---@field redoCount integer
+---@field erodeReposeDeg number
+---@field ringInnerRatio number
+---@field importProgress integer? Rows imported so far; `nil` when no import is running.
+---@field importTotal integer? Rows in the running import; `nil` when none is running.
+---@field exportRangeMode "auto"|"initial"|"custom"
+---@field exportInitMin number? Map height extremes at load.
+---@field exportInitMax number?
+---@field exportCurrMin number? Map height extremes right now.
+---@field exportCurrMax number?
+---@field exportCustomMin number
+---@field exportCustomMax number
+---@field symmetryActive boolean
+---@field symmetryOriginX number
+---@field symmetryOriginZ number
+---@field symmetryMirrorX boolean
+---@field symmetryMirrorY boolean
+---@field symmetryRadial boolean
+---@field symmetryRadialCount integer
+---@field symmetryPlacingOrigin boolean
+---@field symmetryMirrorAngle number
+---@field symmetryFlipped boolean
+---@field symmetryHoveringOrigin boolean
+---@field symmetryDraggingOrigin boolean
+---@field penPressureEnabled boolean
+---@field penPressure number
+---@field penPressureMapped number
+---@field penTiltX number
+---@field penTiltY number
+---@field penInContact boolean
+---@field penPressureModulateIntensity boolean
+---@field penPressureModulateSize boolean
+---@field penPressureModulateRadius boolean
+---@field penPressureRadiusScale number
+---@field penPressureSensitivity number
+---@field penPressureCurve number
+
+---@return TerraformBrushState
 local function getState()
 	local initMinH, initMaxH, currMinH, currMaxH = Spring.GetGroundExtremes()
 	local customMin = extraState.heightmapExportCustomMin
@@ -2818,9 +2970,14 @@ function widget:Initialize()
 
 		setBrushOpacity = setBrushOpacity,
 		setGridOverlay = setGridOverlay,
+		---Snaps brush strokes to the build grid.
+		---@param value boolean?
 		setGridSnap = function(value)
 			extraState.gridSnap = value and true or false
 		end,
+		---Chooses which height range a heightmap export normalizes against.
+		---Anything other than `"initial"` or `"custom"` selects `"auto"`.
+		---@param value "auto"|"initial"|"custom"
 		setHeightmapExportRangeMode = function(value)
 			if value == "initial" or value == "custom" then
 				extraState.heightmapExportRangeMode = value
@@ -2831,6 +2988,7 @@ function widget:Initialize()
 				extraState.heightmapExportRangeMode = "auto"
 			end
 		end,
+		---Advances the heightmap export range through auto, initial and custom.
 		cycleHeightmapExportRangeMode = function()
 			local mode = extraState.heightmapExportRangeMode
 			if mode == "auto" then
@@ -2842,28 +3000,40 @@ function widget:Initialize()
 				extraState.heightmapExportRangeMode = "auto"
 			end
 		end,
+		---@param value number|string Lowest height a custom-range export maps to black.
+		---Non-numeric input is ignored.
 		setHeightmapExportCustomMin = function(value)
 			local num = tonumber(value)
 			if num then
 				extraState.heightmapExportCustomMin = num
 			end
 		end,
+		---@param value number|string Highest height a custom-range export maps to white.
+		---Non-numeric input is ignored.
 		setHeightmapExportCustomMax = function(value)
 			local num = tonumber(value)
 			if num then
 				extraState.heightmapExportCustomMax = num
 			end
 		end,
+		---@param value number|string? Grid cell size in elmos, clamped to `16`-`128`.
+		---Defaults to `48`.
 		setGridSnapSize = function(value)
 			extraState.gridSnapSize = max(16, min(128, tonumber(value) or 48))
 			extraState.gridDirty = true
 		end,
+		---Snaps brush rotation to fixed angles.
+		---@param value boolean?
 		setAngleSnap = function(value)
 			extraState.angleSnap = value and true or false
 		end,
+		---Derives the angle snap step from the map's symmetry instead of the manual spoke count.
+		---@param value boolean?
 		setAngleSnapAuto = function(value)
 			extraState.angleSnapAuto = value and true or false
 		end,
+		---Rotates the brush to a numbered snap spoke, wrapping around.
+		---@param idx integer
 		setAngleSnapManualSpoke = function(idx)
 			local step = extraState.angleSnapStep
 			local numSpokes = (step > 0) and floor(360 / step) or 1
@@ -2871,6 +3041,8 @@ function widget:Initialize()
 			activeRotation = (extraState.angleSnapManualSpoke * step) % 360
 			extraState.angleSnapScrollAccum = 0
 		end,
+		---Sets the angle snap increment and re-snaps the current rotation.
+		---@param value number|string? Degrees, clamped to `0.5`-`90`. Defaults to `15`.
 		setAngleSnapStep = function(value)
 			extraState.angleSnapStep = max(0.5, min(90, tonumber(value) or 15))
 			-- re-snap current rotation immediately
@@ -2879,9 +3051,14 @@ function widget:Initialize()
 				activeRotation = (floor(activeRotation / s + 0.5) * s) % 360
 			end
 		end,
+		---Shows the length of each measure line.
+		---@param value boolean?
 		setMeasureShowLength = function(value)
 			extraState.measureShowLength = value and true or false
 		end,
+		---Enters or leaves the measuring tool. Entering also starts drawing and takes
+		---text ownership so Enter is intercepted before the chat binding.
+		---@param value boolean?
 		setMeasureActive = function(value)
 			extraState.measureActive = value and true or false
 			if extraState.measureActive then
@@ -2897,6 +3074,7 @@ function widget:Initialize()
 				widgetHandler:DisownText()
 			end
 		end,
+		---Removes every measure line.
 		clearMeasureLines = function()
 			extraState.measureLines = {}
 			extraState.measureActivePt = nil
@@ -2914,12 +3092,17 @@ function widget:Initialize()
 			extraState.measureLines = kept
 		end,
 		-- G4: toggle automatic ramp-chain attachment
+		---@param value boolean?
 		setRampAutoAttach = function(value)
 			extraState.rampAutoAttach = value and true or false
 		end,
+		---Measures in a straight line rather than following the terrain.
+		---@param value boolean?
 		setMeasureRulerMode = function(value)
 			extraState.measureRulerMode = value and true or false
 		end,
+		---Keeps measure lines attached to the point they were started from.
+		---@param value boolean?
 		setMeasureStickyMode = function(value)
 			extraState.measureStickyMode = value and true or false
 			if not extraState.measureStickyMode then
@@ -2928,9 +3111,12 @@ function widget:Initialize()
 				extraState.stickyUndoBaseline = nil
 			end
 		end,
+		---Lets measure chains be reshaped after they are drawn.
+		---@param value boolean?
 		setMeasureDistortMode = function(value)
 			extraState.measureDistortMode = value and true or false
 		end,
+		---Forgets the strokes currently linked together for repeated application.
 		clearLinkedStrokes = function()
 			extraState.linkedStrokes = {}
 			extraState.linkedStrokeGroupCount = 0
@@ -2939,6 +3125,10 @@ function widget:Initialize()
 		setDustEffects = setDustEffects,
 		setSeismicEffects = setSeismicEffects,
 		setDjMode = setDjMode,
+		---Configures the brush wiggle that breaks up straight strokes.
+		---@param enabled boolean?
+		---@param ampIdx integer? Amplitude preset index.
+		---@param spdIdx integer? Speed preset index.
 		setWiggle = function(enabled, ampIdx, spdIdx)
 			extraState.wiggleEnabled = enabled and true or false
 			extraState.wiggleAmpIdx = math.max(1, math.min(4, tonumber(ampIdx) or 1))
@@ -2948,6 +3138,9 @@ function widget:Initialize()
 			end
 		end,
 		setHeightColormap = setHeightColormap,
+		---Puts the brush into a height-sampling mode, auto-enabling the height colormap
+		---so contours are visible. Unknown targets clear the mode.
+		---@param target "max"|"min"|"fpAltMax"|"fpAltMin"|"gbAltMax"|"gbAltMin"|"spAltMax"|"spAltMin"|nil
 		setHeightSamplingMode = function(target)
 			local valid = {
 				max = true,
@@ -2964,10 +3157,13 @@ function widget:Initialize()
 				setHeightColormap(true) -- auto-enable the colormap so contours are visible
 			end
 		end,
+		---@return string? mode `nil` when not sampling.
 		getHeightSamplingMode = function()
 			return extraState.heightSamplingMode
 		end,
 		setCurveOverlay = setCurveOverlay,
+		---Scales stroke intensity by how fast the cursor is moving.
+		---@param value boolean?
 		setVelocityIntensity = function(value)
 			extraState.velocityIntensity = value and true or false
 			if not extraState.velocityIntensity then
@@ -2976,14 +3172,19 @@ function widget:Initialize()
 				extraState.lastDragScreenY = nil
 			end
 		end,
+		---@param value number|string? How strongly restore mode pulls terrain back toward
+		---its original height, clamped to `0`-`1`. Defaults to `1`.
 		setRestoreStrength = function(value)
 			extraState.restoreStrength = max(0.0, min(1.0, tonumber(value) or 1.0))
 		end,
+		---@param value number|string? Angle of repose for erode mode, in degrees.
 		setErodeReposeDeg = function(value)
 			extraState.erodeReposeDeg = max(10, min(60, tonumber(value) or 33))
 		end,
 		setRingInnerRatio = setRingInnerRatio,
 		-- Pen pressure API
+		---Enables graphics-tablet pen pressure input.
+		---@param value boolean?
 		setPenPressure = function(value)
 			extraState.penPressureEnabled = value and true or false
 			if not extraState.penPressureEnabled then
@@ -2992,29 +3193,45 @@ function widget:Initialize()
 				extraState.penInContact = false
 			end
 		end,
+		---Lets pen pressure drive stroke intensity.
+		---@param value boolean?
 		setPenPressureModulateIntensity = function(value)
 			extraState.penPressureModulateIntensity = value and true or false
 		end,
+		---Lets pen pressure drive brush size.
+		---@param value boolean?
 		setPenPressureModulateSize = function(value)
 			extraState.penPressureModulateSize = value and true or false
 		end,
+		---Lets pen pressure drive brush radius.
+		---@param value boolean?
 		setPenPressureModulateRadius = function(value)
 			extraState.penPressureModulateRadius = value and true or false
 		end,
+		---@param value number How much pen pressure scales the radius.
 		setPenPressureRadiusScale = function(value)
 			extraState.penPressureRadiusScale = max(0.0, min(1.0, tonumber(value) or 0.5))
 		end,
+		---@param value number Maps raw pen pressure onto the usable range.
 		setPenPressureSensitivity = function(value)
 			extraState.penPressureSensitivity = max(0.1, min(3.0, tonumber(value) or 1.0))
 		end,
+		---@param value number Response curve applied to pen pressure.
 		setPenPressureCurve = function(value)
 			extraState.penPressureCurve = max(1, min(5, math.floor(tonumber(value) or 2)))
 		end,
+		---Tells the brush the pen is currently over the UI rather than the map.
+		---@param value boolean?
 		setPenOverUI = function(value)
 			extraState.penOverUI = value and true or false
 		end,
 		-- Returns world X, Z to park a sub-tool brush when cursor is over the terraform UI panel.
 		-- Returns nil, nil when cursor is not over the panel (caller should use real mouse position).
+		---Where the brush should park while the cursor is over the terraform panel.
+		---@param radius number
+		---@param lengthScale number
+		---@return number? worldX `nil` when the cursor is not over the panel.
+		---@return number? worldZ
 		getUnmouseTarget = function(radius, lengthScale)
 			local tfUI = WG.TerraformBrushUI
 			if not tfUI or not tfUI.getPanelBounds then
@@ -3036,7 +3253,13 @@ function widget:Initialize()
 		-- when the cursor enters the terraform panel, and back toward the real
 		-- cursor position when it leaves. Sub-tools call this every DrawWorld
 		-- frame with a unique toolKey and their real world position (or nil).
-		-- Returns animated (worldX, worldZ) — may be nil if nothing to show.
+		---@param toolKey string Unique per sub-tool.
+		---@param realX number? The real cursor world position.
+		---@param realZ number?
+		---@param radius number
+		---@param lengthScale number
+		---@return number? worldX Animated position; `nil` when there is nothing to show.
+		---@return number? worldZ
 		animateUnmouse = function(toolKey, realX, realZ, radius, lengthScale)
 			return extraState.tickSubToolUnmouse(toolKey, realX, realZ, radius, lengthScale)
 		end,
@@ -3048,6 +3271,8 @@ function widget:Initialize()
 		setNoiseLacunarity = extraState._noiseSetters.setNoiseLacunarity,
 		setNoiseSeed = extraState._noiseSetters.setNoiseSeed,
 		-- Symmetry API
+		---Mirrors every stroke across the symmetry axes.
+		---@param value boolean?
 		setSymmetryActive = function(value)
 			extraState.symmetryActive = value and true or false
 			if not extraState.symmetryActive then
@@ -3055,22 +3280,31 @@ function widget:Initialize()
 				extraState.symmetryDraggingOrigin = false
 			end
 		end,
+		---Moves the symmetry origin.
+		---@param x number|string
+		---@param z number|string
 		setSymmetryOrigin = function(x, z)
 			extraState.symmetryOriginX = tonumber(x)
 			extraState.symmetryOriginZ = tonumber(z)
 		end,
+		---Mirrors along X. Enabling this disables radial symmetry.
+		---@param value boolean?
 		setSymmetryMirrorX = function(value)
 			extraState.symmetryMirrorX = value and true or false
 			if extraState.symmetryMirrorX then
 				extraState.symmetryRadial = false
 			end
 		end,
+		---Mirrors along Y. Enabling this disables radial symmetry.
+		---@param value boolean?
 		setSymmetryMirrorY = function(value)
 			extraState.symmetryMirrorY = value and true or false
 			if extraState.symmetryMirrorY then
 				extraState.symmetryRadial = false
 			end
 		end,
+		---Repeats strokes around the origin. Enabling this disables mirroring.
+		---@param value boolean?
 		setSymmetryRadial = function(value)
 			extraState.symmetryRadial = value and true or false
 			if extraState.symmetryRadial then
@@ -3078,18 +3312,26 @@ function widget:Initialize()
 				extraState.symmetryMirrorY = false
 			end
 		end,
+		---@param value number Copies placed around the origin in radial mode.
 		setSymmetryRadialCount = function(value)
 			extraState.symmetryRadialCount = max(2, min(16, floor(tonumber(value) or 2)))
 		end,
+		---Puts the tool into the mode where the next click places the symmetry origin.
+		---@param value boolean?
 		setSymmetryPlacingOrigin = function(value)
 			extraState.symmetryPlacingOrigin = value and true or false
 		end,
+		---@param value number|string? Mirror axis angle in degrees, wrapped to `[0,360)`.
+		---Defaults to `0`.
 		setSymmetryMirrorAngle = function(value)
 			extraState.symmetryMirrorAngle = (tonumber(value) or 0) % 360
 		end,
+		---Swaps which side of the mirror axis is the source.
+		---@param value boolean?
 		setSymmetryFlipped = function(value)
 			extraState.symmetryFlipped = value and true or false
 		end,
+		---Turns symmetry off and resets its origin, axes and radial count.
 		clearSymmetry = function()
 			extraState.symmetryActive = false
 			extraState.symmetryPlacingOrigin = false
@@ -3105,6 +3347,13 @@ function widget:Initialize()
 		end,
 		getSymmetricPositions = extraState.getSymmetricPositions,
 		getSymmetryOrigin = extraState.getSymmetryOrigin,
+		---Snaps a world position to the build grid, or returns it unchanged when grid
+		---snap is off.
+		---@param x number
+		---@param z number
+		---@param angleDeg number? Defaults to `0`.
+		---@return number x
+		---@return number z
 		snapWorld = function(x, z, angleDeg)
 			if not extraState.gridSnap then
 				return x, z
@@ -3119,6 +3368,14 @@ function widget:Initialize()
 		getPresetNames = getPresetNames,
 		isBuiltinPreset = isBuiltinPreset,
 		getPreset = getPreset,
+		---A heightmap export saved for this map.
+		---@class TerraformHeightmapEntry
+		---@field path string
+		---@field label string Display label; `"(legacy)"` for un-stamped saves.
+		---@field sortKey string
+
+		---Lists heightmap exports belonging to this map, newest first.
+		---@return TerraformHeightmapEntry[]
 		listHeightmaps = function()
 			local HEIGHTMAPS_DIR = "Terraform Brush/Heightmaps/"
 			local files = VFS.DirList(HEIGHTMAPS_DIR, "*.png", VFS.RAW)
@@ -3173,32 +3430,45 @@ function widget:Initialize()
 			return out
 		end,
 		deactivate = deactivateTerraform,
+		---Undoes the last terraform stroke, if there is one.
 		undo = function()
 			if historyUndoCount > 0 then
 				SendLuaRulesMsg(MSG.UNDO)
 			end
 		end,
+		---Reapplies the most recently undone terraform stroke, if there is one.
 		redo = function()
 			if historyRedoCount > 0 then
 				SendLuaRulesMsg(MSG.REDO)
 			end
 		end,
+		---Restores the whole map to its original heightmap.
 		fullRestore = function()
 			SendLuaRulesMsg(MSG.FULL_RESTORE)
 		end,
+
 		-- Keybind configuration API
+
+		---@return table<string, {key: integer, label: string, key2: integer?, label2: string?}> binds A copy.
 		getKeybinds = function()
 			return deepCopyKeybinds(activeKeybinds)
 		end,
+		---@return table<string, {key: integer, label: string, key2: integer?, label2: string?}> binds A copy.
 		getDefaultKeybinds = function()
 			return deepCopyKeybinds(DEFAULT_KEYBINDS)
 		end,
+		---Rebinds one brush action. Unknown actions are ignored.
+		---@param action string
+		---@param keyCode number|string? Left unchanged when not numeric.
+		---@param label string? Left unchanged when omitted.
 		setKeybind = function(action, keyCode, label)
 			if activeKeybinds[action] then
 				activeKeybinds[action].key = tonumber(keyCode) or activeKeybinds[action].key
 				activeKeybinds[action].label = tostring(label or activeKeybinds[action].label)
 			end
 		end,
+		---Applies a whole set of keybinds, ignoring unknown actions and malformed entries.
+		---@param binds table<string, {key: integer, label: string?, key2: integer?, label2: string?}>?
 		applyKeybinds = function(binds)
 			if type(binds) ~= "table" then
 				return
@@ -3217,6 +3487,7 @@ function widget:Initialize()
 			end
 		end,
 		saveKeybinds = saveKeybindsToDisk,
+		---Restores every brush keybind to its default.
 		resetKeybinds = function()
 			activeKeybinds = deepCopyKeybinds(DEFAULT_KEYBINDS)
 		end,

--- a/luaui/Widgets/cmd_terraform_brush_capture.lua
+++ b/luaui/Widgets/cmd_terraform_brush_capture.lua
@@ -401,6 +401,18 @@ end
 -- Estimation (drives the live readout in the Capture window)
 --------------------------------------------------------------------------------
 
+---What a capture at a given detail level would produce.
+---@class TerraformCaptureEstimate
+---@field outW integer Output width in pixels.
+---@field outH integer Output height in pixels.
+---@field tilesX integer
+---@field tilesZ integer
+---@field tiles integer Total camera moves the walk needs.
+---@field seconds number Rough wall-clock cost of the walk.
+
+---Works out the output size and cost of a capture without starting one.
+---@param detail number? Pixels per elmo. Defaults to the current setting.
+---@return TerraformCaptureEstimate
 local function estimate(detail)
 	detail = tonumber(detail) or settings.detail
 	local mapX, mapZ = Game.mapSizeX, Game.mapSizeZ
@@ -1652,6 +1664,9 @@ end
 -- Driver
 --------------------------------------------------------------------------------
 
+---Starts the map capture walk, which runs across later frames.
+---@return boolean started
+---@return string? reason Why the capture could not start.
 local function startCapture()
 	if job then
 		return false, "a capture is already running"
@@ -1787,6 +1802,8 @@ end
 function widget:Initialize()
 	widgetHandler:AddAction("tfcapture", captureAction, nil, "t")
 	WG.TerraformCapture = {
+		---@return table<string, string|number|boolean> settings A shallow copy, so mutating it
+		---does not affect the live settings.
 		getSettings = function()
 			local copy = {}
 			for k, v in pairs(settings) do
@@ -1794,6 +1811,11 @@ function widget:Initialize()
 			end
 			return copy
 		end,
+		---Changes one capture setting.
+		---@param key string
+		---@param value string|number|boolean Must match the kind the setting already holds;
+		---no conversion or validation is done beyond checking that `key` exists.
+		---@return boolean set `false` when `key` is not a known setting.
 		setSetting = function(key, value)
 			if settings[key] == nil then
 				return false
@@ -1803,14 +1825,28 @@ function widget:Initialize()
 		end,
 		estimate = estimate,
 		start = startCapture,
+		---Aborts a running capture and restores the scene. Safe to call when idle.
 		cancel = function()
 			if job then
 				finish("cancelled")
 			end
 		end,
+		---@return boolean busy Whether a capture is running.
 		isBusy = function()
 			return job ~= nil
 		end,
+		---Progress of the current or last capture.
+		---@class TerraformCaptureStatus
+		---@field active boolean Whether a capture is running.
+		---@field phase string Which stage the capture is in.
+		---@field step integer Tiles completed.
+		---@field total integer Tiles to do in total.
+		---@field message string Human-readable progress line.
+		---@field lastPath string Where the last capture was written.
+		---@field lastSummary string One-line summary of the last capture.
+		---@field error string Empty unless the last capture failed.
+
+		---@return TerraformCaptureStatus status The live table; do not mutate.
 		getStatus = function()
 			return status
 		end,

--- a/luaui/Widgets/cmd_weather_brush.lua
+++ b/luaui/Widgets/cmd_weather_brush.lua
@@ -865,6 +865,9 @@ end
 -- ===========================================================================
 -- Mode Management
 -- ===========================================================================
+
+---Enables the weather brush, deactivating the terrain brush and feature placer.
+---@param mode BrushPlacementMode? Defaults to `"scatter"`.
 local function activate(mode)
 	wb.active = true
 	wb.mode = mode or "scatter"
@@ -877,12 +880,15 @@ local function activate(mode)
 	end
 end
 
+---Disables the weather brush.
 local function deactivate()
 	wb.active = false
 	wb.dragging = false
 	wb.dragAction = nil
 end
 
+---Switches the tool's mode. Unknown values are ignored.
+---@param mode BrushPlacementMode
 local function setMode(mode)
 	if mode == "scatter" or mode == "point" or mode == "remove" then
 		wb.mode = mode
@@ -892,55 +898,75 @@ end
 -- ===========================================================================
 -- Parameter Setters
 -- ===========================================================================
+
+---The subset of `BrushShape` this brush offers. `"triangle"` is deliberately
+---absent: `setShape` rejects it and the outline renderer has no case for it.
+---@alias WeatherBrushShape "circle"|"square"|"hexagon"|"octagon"
+
+---Sets the brush footprint. Unknown values are ignored.
+---@param shape WeatherBrushShape
 local function setShape(shape)
 	if shape == "circle" or shape == "square" or shape == "hexagon" or shape == "octagon" then
 		wb.shape = shape
 	end
 end
 
+---@param val number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(val)
 	wb.radius = max(MIN_RADIUS, min(MAX_RADIUS, floor(val)))
 end
 
+---@param val number Stretches the brush along its rotation axis, rounded to one decimal.
 local function setLengthScale(val)
 	wb.lengthScale = max(MIN_LENGTH_SCALE, min(MAX_LENGTH_SCALE, math.floor(val * 10 + 0.5) / 10))
 end
 
+---@param val number Brush rotation in degrees, wrapped to `[0,360)`.
 local function setRotation(val)
 	wb.rotation = val % 360
 end
 
+---@param delta number Degrees to add to the current rotation.
 local function rotate(delta)
 	setRotation(wb.rotation + delta)
 end
 
+---@param val number Percent of random rotation applied per placement, clamped to `0`-`100`.
 local function setRotRandom(val)
 	-- rotRandom is a 0-100% random-rotation amount applied per placement
 	wb.rotRandom = math.clamp(floor(val), 0, 100)
 end
 
+---@param val number Effects spawned per stroke, clamped to `1`-`500`.
 local function setSpawnCount(val)
 	wb.spawnCount = max(1, min(500, floor(val)))
 end
 
+---@param val number Frames between placements while dragging, clamped to `1`-`1000`.
 local function setCadence(val)
 	wb.cadence = max(1, min(1000, floor(val)))
 end
 
+---@param val number Height above the ground to spawn at, clamped to `0`-`2000`.
 local function setAltitude(val)
 	wb.altitude = max(0, min(2000, floor(val)))
 end
 
+---@param val number Spawns per second for persistent effects, clamped to `0.1`-`60`.
 local function setFrequency(val)
 	wb.frequency = max(0.1, min(60.0, val))
 end
 
+---Sets how scattered effects are spread. Unknown values are ignored.
+---@param dist "random"|"regular"
 local function setDistribution(dist)
 	if dist == "random" or dist == "regular" then
 		wb.distribution = dist
 	end
 end
 
+---Sets how long a placed persistent effect lasts.
+---@param val number Seconds, clamped to the allowed range. Negative means forever.
 local function setPersistenceSeconds(val)
 	val = floor(val)
 	if val < 0 then
@@ -978,6 +1004,8 @@ local function applyCegFlashbangOverride(name)
 	setPersistenceSeconds(ov.persistence)
 end
 
+---Selects a single effect, replacing the current selection. Unknown names are ignored.
+---@param name string A CEG name from `getCegNames`.
 local function selectCeg(name)
 	loadCEGNames()
 	if not cegNameSet[name] then
@@ -988,6 +1016,8 @@ local function selectCeg(name)
 	applyCegFlashbangOverride(name)
 end
 
+---Adds or removes one effect from the multi-selection. Unknown names are ignored.
+---@param name string A CEG name from `getCegNames`.
 local function toggleCeg(name)
 	loadCEGNames()
 	if not cegNameSet[name] then
@@ -1009,11 +1039,15 @@ local function toggleCeg(name)
 	end
 end
 
+---Clears the effect selection.
 local function clearSelectedCegs()
 	wb.selectedCegs = {}
 	wb.selectedCegSet = {}
 end
 
+---Replaces the selection and brush settings with a library preset.
+---Unknown indices are ignored.
+---@param index integer Index into `getWeatherLibrary`.
 local function applyWeatherPreset(index)
 	local preset = weatherLibrary[index]
 	if not preset then
@@ -1037,6 +1071,7 @@ local function applyWeatherPreset(index)
 	setPersistenceSeconds(preset.persistence or 0)
 end
 
+---Removes every persistent weather spawner from the map.
 local function clearAllPersistent()
 	local count = table.count(wb.persistentSpawners)
 	wb.persistentSpawners = {}
@@ -1046,9 +1081,29 @@ local function clearAllPersistent()
 	end
 end
 
+---A persistent weather spawner placed on the map.
+---@class WeatherSpawner
+---@field cegs string[]
+---@field x number
+---@field z number
+---@field radius number
+---@field count integer Effects spawned per cycle.
+---@field shape WeatherBrushShape
+---@field angleDeg number
+---@field lengthScale number
+---@field altitude number
+---@field interval integer Frames between spawn cycles.
+---@field refreshInterval integer Frames between full refreshes.
+---@field startFrame integer
+---@field expireFrame integer? `nil` means permanent.
+---@field nextFrame integer
+---@field spawnCycles integer
+---@field saturationCycles integer
+
 -- Raw copies of all persistent spawners, for project serialization.
 -- Frame fields (startFrame/expireFrame/nextFrame) are absolute game frames and
 -- NOT portable across sessions; callers must convert to relative durations.
+---@return WeatherSpawner[] spawners A copy, so mutating it does not affect live state.
 local function getPersistentSpawners()
 	local out = {}
 	for _, s in pairs(wb.persistentSpawners) do
@@ -1078,11 +1133,35 @@ local function getPersistentSpawners()
 	return out
 end
 
+---A serialized spawner, as a map project's `weather.lua` stores it. The same
+---fields as `WeatherSpawner` minus the session-local frame fields, with
+---`persistence` standing in for them. Only `cegs` is required; every other
+---field falls back to a default, and the numeric ones are coerced with
+---`tonumber`, so a value read from a hand-edited file need not be a number yet.
+---@class WeatherSpawnerEntry
+---@field cegs string[] Must be non-empty, or the entry is skipped.
+---@field x number? Defaults to `0`.
+---@field z number? Defaults to `0`.
+---@field radius number? Defaults to `100`.
+---@field count number? Effects spawned per cycle, floored, at least `1`. Defaults to `1`.
+---@field shape WeatherBrushShape? Defaults to `"circle"`.
+---@field angleDeg number? Defaults to `0`.
+---@field lengthScale number? Defaults to `1`.
+---@field altitude number? Defaults to `0`.
+---@field interval number? Frames between spawn cycles, floored, at least `1`.
+---Defaults to one second at the current game speed.
+---@field refreshInterval number? Frames between full refreshes, floored, never below
+---`interval`. Defaults to `interval`.
+---@field persistence number? Remaining lifetime in seconds; `-1` is permanent, which
+---is also the default.
+
 -- Reconstruct a persistent spawner from a serialized project entry, honoring
 -- the saved interval/refreshInterval instead of deriving them from the live UI
 -- cadence (which addPersistentSpawner does). Synthesizes every runtime field
 -- the Update loop dereferences — a missing one crashes the widget on the next
 -- tick. entry.persistence: -1 = permanent, else remaining seconds.
+---@param entry WeatherSpawnerEntry
+---@return integer? id `nil` when `entry` has no cegs.
 local function addSpawnerRaw(entry)
 	if type(entry) ~= "table" or type(entry.cegs) ~= "table" or #entry.cegs == 0 then
 		Echo("[Weather Brush] addSpawnerRaw: entry has no cegs, skipped")
@@ -1127,6 +1206,27 @@ end
 -- ===========================================================================
 -- State Export (for UI)
 -- ===========================================================================
+
+---A snapshot of the weather brush, for the UI to render.
+---@class WeatherBrushState
+---@field active boolean
+---@field mode BrushPlacementMode
+---@field shape WeatherBrushShape
+---@field radius number
+---@field lengthScale number
+---@field rotation number
+---@field rotRandom number
+---@field spawnCount number
+---@field cadence number
+---@field frequency number
+---@field distribution "random"|"regular"
+---@field altitude number
+---@field selectedCegs string[]
+---@field persistenceSeconds number
+---@field persistentMode boolean
+---@field persistentCount integer Only filled in by `getStateWithCount`.
+
+---@return WeatherBrushState
 local function getState()
 	return {
 		active = wb.active,
@@ -1148,17 +1248,34 @@ local function getState()
 	}
 end
 
+---@return WeatherBrushState
 local function getStateWithCount()
 	local state = getState()
 	state.persistentCount = table.count(wb.persistentSpawners)
 	return state
 end
 
+---@return string[] names Every CEG the brush can place, loaded on first use.
 local function getCegNames()
 	loadCEGNames()
 	return cegNames
 end
 
+---One entry in the built-in weather library, as `applyWeatherPreset` consumes it.
+---@class WeatherPreset
+---@field name string
+---@field description string
+---@field icon string
+---@field cegs string[] CEG names spawned together.
+---@field spawnCount integer Effects per cycle.
+---@field radius number
+---@field cadence integer Frames between cycles.
+---@field altitude number Spawn height above the ground.
+---@field persistence number Seconds the spawner lives; `-1` is permanent.
+---@field cegLifetimeS number How long one CEG lasts, for the refresh interval.
+
+---@return WeatherPreset[] presets Built-in weather presets, indexed as
+---`applyWeatherPreset` expects.
 local function getWeatherLibrary()
 	return weatherLibrary
 end

--- a/luaui/Widgets/dbg_decal_exporter.lua
+++ b/luaui/Widgets/dbg_decal_exporter.lua
@@ -51,6 +51,7 @@ local heatGrid = {}
 local heatMax = 0
 local totalExplosions = 0
 
+---Clears the explosion heatmap and its running totals.
 local function initHeatGrid()
 	for i = 1, heatGridW * heatGridH do
 		heatGrid[i] = 0
@@ -95,7 +96,24 @@ function widget:Explosion(weaponDefID, px, py, pz, ownerID, projectileID)
 end
 
 -- ========== SNAPSHOT: GL4 WIDGET DECALS ==========
+
+---One GL4 decal as the exporter records it, with the atlas UV bounds grouped
+---and the ground height sampled at the decal's position. `source` discriminates
+---these from the engine decals the exporter also collects.
+---@class Gl4DecalSnapshot
+---@field source "gl4"
+---@field posx number
+---@field posz number
+---@field posy number Ground height at `posx, posz`; `0` where that is unknown.
+---@field width number
+---@field length number
+---@field rotation number
+---@field alpha number The decay-adjusted alpha at capture time, capped at `1`.
+---@field isFootprint boolean
+---@field uv {p: number, q: number, s: number, t: number} Atlas UV bounds.
+
 -- Captures all active decals from the Decals GL4 widget
+---@return Gl4DecalSnapshot[]? snapshot `nil` when that widget is not loaded.
 local function snapshotGL4Decals()
 	local decalsApi = WG.decalsgl4
 	if not decalsApi then
@@ -144,7 +162,33 @@ local function snapshotGL4Decals()
 end
 
 -- ========== SNAPSHOT: ENGINE GROUND DECALS ==========
+
+---One engine ground decal as the exporter records it. Field names are
+---deliberately capitalized (`posX`) where the GL4 snapshot uses lowercase
+---(`posx`); the two shapes are otherwise unrelated and share only `source`,
+---`rotation` and `alpha`.
+---@class EngineDecalSnapshot
+---@field source "engine"
+---@field decalType "explosion"|"plate"|"lua"|"track"|"unknown" `"unknown"` when the
+---engine does not report one.
+---@field decalID integer
+---@field posX number
+---@field posZ number
+---@field posY number Ground height at `posX, posZ`; `0` where that is unknown.
+---@field sizeX number? Absent together with `sizeZ` and `projHeight`.
+---@field sizeZ number
+---@field projHeight number Height of the projection cube.
+---@field rotation number Radians; `0` where the engine does not report one.
+---@field texture string?
+---@field normalTexture string?
+---@field alpha number Defaults to `1`.
+---@field alphaFalloff number Per second; defaults to `0`.
+---@field tint ColorRGBA? `nil` when the engine build has no tint API.
+---@field glow number? `nil` when the engine build has no glow API.
+---@field glowFalloff number? Per second.
+
 -- Captures all engine-side ground decals (building plates, explosion scars, tracks, lua decals)
+---@return EngineDecalSnapshot[]? snapshot `nil` when the engine decal API is unavailable.
 local function snapshotEngineDecals()
 	if not Spring.GetAllGroundDecals then
 		spEcho("[Decal Exporter] Engine decal API not available (need engine 105+)")
@@ -206,8 +250,15 @@ local function snapshotEngineDecals()
 end
 
 -- ========== EXPORT: LUA TABLE (for map widgets / mapinfo) ==========
+
+---A decal from either source. `source` discriminates the two shapes, which
+---share almost no field names.
+---@alias DecalSnapshot Gl4DecalSnapshot|EngineDecalSnapshot
+
 -- Writes a self-contained Lua file that a map can dofile() to get decal placements.
 -- Mapper drops this into their map folder and loads it from a widget/gadget.
+---@param snapshot DecalSnapshot[]?
+---@param filename string? Defaults to a timestamped path under the decals directory.
 local function exportLuaTable(snapshot, filename)
 	if not snapshot or #snapshot == 0 then
 		spEcho("[Decal Exporter] Nothing to export")
@@ -272,6 +323,10 @@ local function exportLuaTable(snapshot, filename)
 end
 
 -- ========== EXPORT: CSV (for GIS tools, spreadsheets, Python scripts) ==========
+
+---Writes a decal snapshot as CSV. Does nothing when empty.
+---@param snapshot DecalSnapshot[]?
+---@param filename string? Defaults to a timestamped path under the decals directory.
 local function exportCSV(snapshot, filename)
 	if not snapshot or #snapshot == 0 then
 		spEcho("[Decal Exporter] Nothing to export")
@@ -323,7 +378,10 @@ local function exportCSV(snapshot, filename)
 end
 
 -- ========== EXPORT: STAMP FILE (re-importable via engine API) ==========
+
 -- Produces a Lua script that can be run as a widget to recreate all decals on any map.
+---@param snapshot DecalSnapshot[]?
+---@param filename string? Defaults to a timestamped path under the decals directory.
 local function exportStampFile(snapshot, filename)
 	if not snapshot or #snapshot == 0 then
 		spEcho("[Decal Exporter] Nothing to export")
@@ -413,8 +471,11 @@ local function exportStampFile(snapshot, filename)
 end
 
 -- ========== EXPORT: HEATMAP AS CSV GRID ==========
+
 -- Exports the accumulated combat heatmap as a CSV grid that can be
 -- opened in any image editor or imported into Python/numpy for visualization.
+---Does nothing until explosions are recorded.
+---@param filename string? Defaults to a timestamped path under the decals directory.
 local function exportHeatmapCSV(filename)
 	if totalExplosions == 0 then
 		spEcho("[Decal Exporter] No explosions recorded yet — play some game first")
@@ -465,7 +526,11 @@ local function exportHeatmapCSV(filename)
 end
 
 -- ========== EXPORT: HEATMAP AS PGM IMAGE (Portable Gray Map) ==========
+
 -- Mappers can open this directly in GIMP/Photoshop as an overlay reference.
+---Writes the explosion heatmap as a grayscale PGM image.
+---Does nothing until explosions are recorded.
+---@param filename string? Defaults to a timestamped path under the decals directory.
 local function exportHeatmapPGM(filename)
 	if totalExplosions == 0 then
 		spEcho("[Decal Exporter] No explosions recorded yet")
@@ -509,8 +574,13 @@ local function exportHeatmapPGM(filename)
 end
 
 -- ========== EXPORT: FEATURES.LUA (convert decal scars to map features) ==========
+
 -- Translates explosion decal positions into feature definitions that can be
 -- pasted into a map's features.lua to permanently scatter debris/craters.
+---Writes a decal snapshot as feature placements, mapping decal sizes to feature
+---types. Does nothing when empty.
+---@param snapshot DecalSnapshot[]?
+---@param filename string? Defaults to a timestamped path under the decals directory.
 local function exportFeaturesLua(snapshot, filename)
 	if not snapshot or #snapshot == 0 then
 		spEcho("[Decal Exporter] Nothing to export")
@@ -566,6 +636,8 @@ local function exportFeaturesLua(snapshot, filename)
 end
 
 -- ========== SUMMARY STATS ==========
+
+---Prints decal and heatmap counts to the infolog.
 local function printStats()
 	local gl4Count = 0
 	local decalsApi = WG.decalsgl4
@@ -686,9 +758,14 @@ function widget:Initialize()
 		exportFeatures = exportFeaturesLua,
 		exportHeatmapCSV = exportHeatmapCSV,
 		exportHeatmapPGM = exportHeatmapPGM,
+		---@return number[] heatGrid Row-major explosion counts.
+		---@return integer width
+		---@return integer height
+		---@return number max Highest count in the grid, for normalizing.
 		getHeatGrid = function()
 			return heatGrid, heatGridW, heatGridH, heatMax
 		end,
+		---@return integer count Explosions recorded since the last reset.
 		getTotalExplosions = function()
 			return totalExplosions
 		end,

--- a/luaui/Widgets/dbg_frame_grapher.lua
+++ b/luaui/Widgets/dbg_frame_grapher.lua
@@ -57,6 +57,7 @@ local uiScale = 1
 local graphHeightScale = 16
 local pixelsPerMs = 8
 
+---@type InstanceVBOTable
 local rectInstanceTable = nil
 local rectInstancePtr = 0
 

--- a/luaui/Widgets/gfx_DrawFeatureShape_GL4.lua
+++ b/luaui/Widgets/gfx_DrawFeatureShape_GL4.lua
@@ -178,6 +178,7 @@ local buckets = {} -- array of the above, for iteration
 local featureDefIDToBucket = {} -- featureDefID -> instance table
 local unsupportedDefIDs = {} -- featureDefIDs with no usable model, warned about once
 local uniqueIDToBucket = {}
+---@type table<integer, string>
 local owners = {} -- uniqueID -> ownerID
 
 local uniqueID = 0
@@ -255,21 +256,24 @@ end
 ---Callers own the lifetime of everything they submit: pair every call that
 ---creates a ghost with StopDrawFeatureShapeGL4, or batch-remove with
 ---StopDrawFeatureShapesGL4(ownerID).
----@param featureDefID number which featureDef to draw
----@param px number world position
----@param py number world position
----@param pz number world position
----@param yaw number optional rotation around Y in radians, matching Spring.SetFeatureRotation's yaw
----@param pitch number optional rotation around X in radians
----@param roll number optional rotation around Z in radians
----@param alpha number optional opacity, default 0.55
----@param tintR number optional tint target colour
----@param tintG number optional tint target colour
----@param tintB number optional tint target colour
----@param tintAmount number optional how much to blend the tint in [0-1], default 0
----@param updateID number optional a uniqueID returned earlier, to move that ghost instead of adding one
----@param ownerID any optional tag so a widget can batch-remove everything it submitted
----@return number|nil uniqueID pass to StopDrawFeatureShapeGL4 to stop drawing it
+---@param featureDefID integer Which featureDef to draw.
+---@param px number World position.
+---@param py number World position.
+---@param pz number World position.
+---@param yaw number? Rotation around Y in radians, matching `Spring.SetFeatureRotation`'s yaw.
+---@param pitch number? Rotation around X in radians.
+---@param roll number? Rotation around Z in radians.
+---@param alpha number? Opacity. Defaults to `0.55`.
+---@param tintR number? Tint target color.
+---@param tintG number? Tint target color.
+---@param tintB number? Tint target color.
+---@param tintAmount number? How much to blend the tint in, `0`-`1`. Defaults to `0`.
+---@param updateID integer? A uniqueID returned earlier, to move that ghost instead of adding one.
+---@param ownerID string? Tag so a widget can batch-remove everything it submitted.
+---Matched by equality, so any stable name works; the in-tree callers use their own
+---widget name.
+---@return integer? uniqueID Pass to `StopDrawFeatureShapeGL4` to stop drawing it;
+---`nil` when the featureDef has no drawable bucket.
 local function DrawFeatureShapeGL4(
 	featureDefID,
 	px,
@@ -333,8 +337,8 @@ local function DrawFeatureShapeGL4(
 	return updateID
 end
 
----@param handleID number a uniqueID returned by DrawFeatureShapeGL4
----@return any ownerID the owner the handle was registered under, if any
+---@param handleID integer? A uniqueID returned by `DrawFeatureShapeGL4`.
+---@return string? ownerID The owner the handle was registered under, if any.
 local function StopDrawFeatureShapeGL4(handleID)
 	if handleID == nil then
 		return nil
@@ -355,8 +359,8 @@ local function StopDrawFeatureShapeGL4(handleID)
 end
 
 ---Remove every ghost registered under an ownerID. Pass nil to remove all of them.
----@param ownerID any
----@return number count how many ghosts were removed
+---@param ownerID string?
+---@return integer count How many ghosts were removed.
 local function StopDrawFeatureShapesGL4(ownerID)
 	local removed = 0
 	for handleID, owner in pairs(owners) do

--- a/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
+++ b/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
@@ -239,6 +239,7 @@ local tex1ToVBO =
 local unitDeftoUnitShapeVBOTable = {} --  The important one, which keys the unitDefID to the actual vbo table to be used
 local uniqueIDtoUnitShapeVBOTable = {}
 
+---@type table<integer, string>
 local owners = {} -- maps uniqueIDs to their optional owners
 
 local uniqueID = 0
@@ -251,19 +252,21 @@ end
 ---DrawUnitGL4(unitID, unitDefID, px, py, pz, rotationY, alpha, teamID, teamcoloroverride, highlight, updateID, ownerID)
 ---Draw a copy of an actual unit, with all of its animations too. That unit must be in view. For things like highlighting under construction stuff.
 ---note that widgets are responsible for stopping the drawing of every unit that they submit! They may use RemoveMyDraws(ownerID). Note that prompt removal when widget:VisibleUnitRemoved(unitID) is essential here!
----@param unitID number the actual unitID that you want to draw
----@param unitDefID number which unitDef do you want to draw
----@param px number optional where in the world to do you want to draw it
----@param py number optional where in the world to do you want to draw it
----@param pz number optional where in the world to do you want to draw it
----@param rotationY number optional Angle in radians on how much to rotate the unit around Y, 0 means it faces south, (+Z), pi/2 points west (-X) -pi/2 points east
----@param alpha number optional the transparency level of the unit
----@param teamID number optional which teams teamcolor should this unit get, leave nil if you want to keep the original teamID
----@param teamcoloroverride number optional much we should mix the teamcolor into the model color [0-1]
----@param highlight number optional how much we should add a highlighting animation to the unit (blends white with [0-1])
----@param updateID number optional specify the previous uniqueID if you want to update it
----@param ownerID any optional unique identifier so that widgets can batch remove all of their own stuff
----@return uniqueID number a unique handler ID number that you should store and call StopDrawUnitGL4(uniqueID) with to stop drawing it
+---@param unitDefID integer? Which unitDef to draw. Defaults to the unit's own def.
+---@param px number? Where in the world to draw it. Defaults to `0`.
+---@param py number? Where in the world to draw it. Defaults to `0`.
+---@param pz number? Where in the world to draw it. Defaults to `0`.
+---@param rotationY number? Angle in radians to rotate the unit around Y. `0` faces south (+Z),
+---`pi/2` points west (-X), `-pi/2` points east.
+---@param alpha number? Transparency level of the unit.
+---@param teamID integer? Which team's teamcolor this unit gets. Omit to keep the unit's own team.
+---@param teamcoloroverride number? How much to mix the teamcolor into the model color, `0`-`1`.
+---@param highlight number? How much highlighting animation to add, blending white, `0`-`1`.
+---@param updateID integer? Pass a previous uniqueID to update that draw instead of adding one.
+---@param ownerID string? Identifier so a widget can batch-remove everything it registered.
+---Matched by equality; the in-tree callers pass `widget:GetInfo().name`.
+---@return integer? uniqueID Store this and pass it to `StopDrawUnitGL4` to stop drawing;
+---`nil` when the unitDef's model belongs to neither supported faction.
 local function DrawUnitGL4(
 	unitID,
 	unitDefID,
@@ -327,18 +330,21 @@ end
 ---DrawUnitShapeGL4(unitDefID, px, py, pz, rotationY, alpha, teamID, teamcoloroverride, highlight, updateID, ownerID)
 ---Draw a static unit shape model anywhere. Like for ghosted buildings
 ---note that widgets are responsible for stopping the drawing of every unit that they submit! They may use RemoveMyDraws(ownerID)
----@param unitDefID number which unitDef do you want to draw
----@param px number where in the world to do you want to draw it
----@param py number where in the world to do you want to draw it
----@param pz number where in the world to do you want to draw it
----@param rotationY number Angle in radians on how much to rotate the unit around Y, 0 means it faces south, (+Z), pi/2 points west (-X) -pi/2 points east
----@param alpha number optional the transparency level of the unit
----@param teamID number optional which teams teamcolor should this unit get, leave nil if you want to keep the original teamID
----@param teamcoloroverride number optional much we should mix the teamcolor into the model color [0-1]
----@param highlight number optional how much we should add a highlighting animation to the unit (blends white with [0-1])
----@param updateID number optional specify the previous uniqueID if you want to update it
----@param ownerID any optional unique identifier so that widgets can batch remove all of their own stuff
----@return uniqueID number a unique handler ID number that you should store and call StopDrawUnitGL4(uniqueID) with to stop drawing it
+---@param unitDefID integer Which unitDef to draw.
+---@param px number Where in the world to draw it.
+---@param py number Where in the world to draw it.
+---@param pz number Where in the world to draw it.
+---@param rotationY number Angle in radians to rotate the unit around Y. `0` faces south (+Z),
+---`pi/2` points west (-X), `-pi/2` points east.
+---@param alpha number? Transparency level of the unit. Defaults to `0.5`.
+---@param teamID integer? Which team's teamcolor this unit gets. Defaults to `256`.
+---@param teamcoloroverride number? How much to mix the teamcolor into the model color, `0`-`1`. Defaults to `0`.
+---@param highlight number? How much highlighting animation to add, blending white, `0`-`1`. Defaults to `0`.
+---@param updateID integer? Pass a previous uniqueID to update that draw instead of adding one.
+---@param ownerID string? Identifier so a widget can batch-remove everything it registered.
+---Matched by equality; the in-tree callers pass `widget:GetInfo().name`.
+---@return integer? uniqueID Store this and pass it to `StopDrawUnitShapeGL4` to stop drawing;
+---`nil` when the unitDef has no prepared shape buffer.
 local function DrawUnitShapeGL4(
 	unitDefID,
 	px,
@@ -391,8 +397,9 @@ local function DrawUnitShapeGL4(
 end
 
 ---StopDrawUnitGL4(uniqueID)
----@param uniqueID number the unique id of whatever you want to stop drawing
----@return the ownerID the uniqueID was associated to
+---Stops drawing whatever `StopDrawUnitGL4` was registered for.
+---@param uniqueID integer The unique id of whatever you want to stop drawing.
+---@return string? ownerID The owner the uniqueID was registered under, if any.
 local function StopDrawUnitGL4(uniqueID)
 	if corDrawUnitVBOTable.instanceIDtoIndex[uniqueID] then
 		popElementInstance(corDrawUnitVBOTable, uniqueID)
@@ -408,8 +415,9 @@ local function StopDrawUnitGL4(uniqueID)
 end
 
 ---StopDrawUnitGL4(uniqueID)
----@param uniqueID number the unique id of whatever you want to stop drawing
----@return the ownerID the uniqueID was associated to
+---Stops drawing whatever `StopDrawUnitShapeGL4` was registered for.
+---@param uniqueID integer The unique id of whatever you want to stop drawing.
+---@return string? ownerID The owner the uniqueID was registered under, if any.
 local function StopDrawUnitShapeGL4(uniqueID)
 	if uniqueIDtoUnitShapeVBOTable[uniqueID] then
 		local DrawUnitShapeVBOTable = uniqueIDtoUnitShapeVBOTable[uniqueID]
@@ -441,8 +449,9 @@ local function StopDrawUnitShapeGL4(uniqueID)
 end
 
 ---StopDrawAll(ownerID) removes all units and unitshapes registered for this owner ID
----@param ownerID any identifier for which to remove all things being drawn. All get removed if ownerID is nil
----@return ownedCount number how many items were removed
+---@param ownerID string? Identifier whose draws should be removed. Everything is removed
+---when `nil`.
+---@return integer ownedCount How many items were removed.
 local function StopDrawAll(ownerID)
 	local ownedCount = 0
 	for uniqueID, owner in pairs(owners) do

--- a/luaui/Widgets/gfx_HighlightUnit_GL4.lua
+++ b/luaui/Widgets/gfx_HighlightUnit_GL4.lua
@@ -194,6 +194,28 @@ local unitDefIgnore = {} -- We explicitly disallow the highlighting of any unitD
 --	end --ignore debug units
 --end
 
+---Highlights a unit or feature. Widgets are responsible for stopping every
+---highlight they submit.
+---@param objectID integer The unitID, unitDefID, featureID or featureDefID to highlight.
+---@param objecttype "unitID"|"unitDefID"|"featureID"|"featureDefID"
+---@param r number Highlight color.
+---@param g number
+---@param b number
+---@param alpha number? Global transparency of the highlight.
+---@param edgealpha number? How strongly edges are highlighted.
+---@param edgeexponent number? Exponent applied to the edge falloff.
+---@param animamount number? How much top-down animation to add.
+---@param px number? Position offset, usually `0`.
+---@param py number? Position offset, usually `0`.
+---@param pz number? Position offset, usually `0`.
+---@param rotationY number? Rotation offset around Y in radians, usually `0`.
+---@param consumerID string? Tag for which widget added this, so leaks can be traced.
+---Supplying one also changes the key: it becomes `tostring(objectID) .. consumerID`
+---instead of an auto-incremented number, so re-highlighting the same object from the
+---same widget reuses the slot rather than adding a second highlight.
+---@return string|number|nil uniqueID Store this and pass it to `StopHighlightUnitGL4`.
+---A string when `consumerID` was given, otherwise a number; `nil` when the unitDef is
+---on the ignore list.
 local function HighlightUnitGL4(
 	objectID,
 	objecttype,
@@ -210,22 +232,6 @@ local function HighlightUnitGL4(
 	rotationY,
 	consumerID
 )
-	-- Documentation for HighlightUnitGL4:
-	-- objectID: the unitID, unitDefID, featureID or featureDefID you want
-	-- objecttype: "unitID" or "unitDefID" or "featureID" or "featureDefID"
-	-- r,g,b : the color to use for highlighting
-	-- a, the global amount of alpha
-	-- rotationY: Angle in radians on how much to rotate the unit around Y, usually 0
-	-- alpha: the transparency level of the unit
-	-- edgealpha: the amount of edge highlighting
-	-- edgeexponent, the exponent of the edges
-	-- animamount, the amount of top-down anim to add
-	-- px, py, py: Apply an offset to the position of the unit, usually all 0
-	-- rotationY: apply a rot offset, usually all 0
-	-- consumerID: just a an optional tag for which widget added this garbage to this table so we can later find out who forgot to pop shit from here.
-	-- returns: a unique handler ID number that you should store and call StopHighlightUnitGL4(uniqueID) with to stop drawing it
-	-- note that widgets are responsible for stopping the drawing of every unit that they submit!
-
 	if objecttype == "unitID" then
 		local unitDefID = spGetUnitDefID(objectID)
 		if unitDefID == nil or unitDefIgnore[unitDefID] then
@@ -283,6 +289,10 @@ local function HighlightUnitGL4(
 	return key
 end
 
+---Stops a highlight added by `HighlightUnitGL4`.
+---@param uniqueID string|number The key `HighlightUnitGL4` returned.
+---@param noUpload boolean? True if the change shouldn't be uploaded to the GPU yet.
+---@return string|number|nil uniqueID The same key on success, `nil` when it was not found.
 local function StopHighlightUnitGL4(uniqueID, noUpload)
 	if debugmode > 0 then
 		local unitdefname = "bad unitdefid"
@@ -315,6 +325,7 @@ local function StopHighlightUnitGL4(uniqueID, noUpload)
 	--Spring.("Popped element", uniqueID)
 end
 
+---Re-uploads every highlight to the GPU, e.g. after a bulk change made with `noUpload`.
 local function RefreshHighlightUnitGL4()
 	InstanceVBOTable.uploadAllElements(highlightUnitVBOTable)
 end

--- a/luaui/Widgets/gfx_airjets_gl4.lua
+++ b/luaui/Widgets/gfx_airjets_gl4.lua
@@ -164,6 +164,7 @@ local lighteffectsEnabled = false -- TODO (enableLights and WG['lighteffects'] ~
 -- draw in refract/reflect too?
 -- GL4 Variables:
 
+---@type InstanceVBOTable
 local jetInstanceVBO = nil
 local jetShader = nil
 
@@ -797,6 +798,15 @@ function widget:Initialize()
 
 	WG.airjets = {}
 
+	---Attaches an engine exhaust jet to a unit piece, replacing any jet already on
+	---that piece.
+	---@param unitID integer
+	---@param piecenum integer Model piece the jet emits from.
+	---@param width number
+	---@param length number
+	---@param color3 ColorRGB RGB for the jet. Currently the widget's shared color is used.
+	---@param emitVector [number, number, number]? Direction the jet points, as `{x, y, z}`. Defaults to `{0, 0, -1}`.
+	---@return string airjetkey Pass to `removeAirJet` to remove this jet.
 	WG.airjets.addAirJet = function(unitID, piecenum, width, length, color3, emitVector) -- for WG external calls
 		local airjetkey = tostring(unitID) .. "_" .. tostring(piecenum)
 		if emitVector == nil then
@@ -828,6 +838,9 @@ function widget:Initialize()
 		return airjetkey
 	end
 
+	---Removes a jet previously added by `addAirJet`.
+	---@param airjetkey string
+	---@return integer? index The removed instance's former index, or `nil` if it was not found.
 	WG.airjets.removeAirJet = function(airjetkey) ---- for WG external calls
 		return popElementInstance(jetInstanceVBO, airjetkey)
 	end

--- a/luaui/Widgets/gfx_bloom_shader_deferred.lua
+++ b/luaui/Widgets/gfx_bloom_shader_deferred.lua
@@ -540,16 +540,22 @@ function widget:Initialize()
 	end
 
 	WG.bloomdeferred = {}
+	---@return number brightness Glow amplifier applied to the bloom pass.
 	WG.bloomdeferred.getBrightness = function()
 		return glowAmplifier
 	end
+	---Sets the glow amplifier and recompiles the bloom shaders.
+	---@param value number
 	WG.bloomdeferred.setBrightness = function(value)
 		glowAmplifier = value
 		MakeBloomShaders()
 	end
+	---@return integer preset Base downscale and mip count; more mips give a wider, softer halo.
 	WG.bloomdeferred.getPreset = function()
 		return preset
 	end
+	---Sets the bloom quality preset and recompiles the bloom shaders.
+	---@param value integer Index into the built-in preset list.
 	WG.bloomdeferred.setPreset = function(value)
 		preset = value
 		MakeBloomShaders()

--- a/luaui/Widgets/gfx_cas.lua
+++ b/luaui/Widgets/gfx_cas.lua
@@ -221,10 +221,13 @@ function widget:Initialize()
 	end
 
 	WG.cas = {}
+	---Sets the contrast-adaptive sharpening strength and recompiles the shader.
+	---@param value number
 	WG.cas.setSharpness = function(value)
 		SHARPNESS = value
 		UpdateShader()
 	end
+	---@return number sharpness
 	WG.cas.getSharpness = function()
 		return SHARPNESS
 	end

--- a/luaui/Widgets/gfx_darken_map.lua
+++ b/luaui/Widgets/gfx_darken_map.lua
@@ -29,10 +29,6 @@ local features
 local camX, camY, camZ = spGetCameraPosition()
 local camDirX, camDirY, camDirZ = Spring.GetCameraDirection()
 
-function widget:Shutdown()
-	WG.darkenmap = nil
-end
-
 local function mapDarkness(_, _, params)
 	if #params == 1 then
 		if type(tonumber(params[1])) == "number" then
@@ -46,13 +42,19 @@ end
 
 function widget:Initialize()
 	WG.darkenmap = {}
+	---@return number darkness `0` leaves the map at full brightness.
 	WG.darkenmap.getMapDarkness = function()
 		return darknessvalue
 	end
+	---@param value number|string How much to dim the map; `0` disables dimming.
 	WG.darkenmap.setMapDarkness = function(value)
 		darknessvalue = tonumber(value)
 	end
 	widgetHandler:AddAction("mapdarkness", mapDarkness, nil, "t")
+end
+
+function widget:Shutdown()
+	WG.darkenmap = nil
 end
 
 local prevCam = {}

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -127,8 +127,11 @@ end
 
 atlas.flip(atlas)
 
+---@type InstanceVBOTable?
 local decalVBO = nil
+---@type InstanceVBOTable?
 local decalLargeVBO = nil
+---@type InstanceVBOTable?
 local decalExtraLargeVBO = nil
 
 local decalShader = nil
@@ -497,6 +500,30 @@ end
 
 local dCT = {} -- decalCacheTable
 
+---Spawns a ground decal.
+---@param decaltexturename string Full path to the decal texture, which must already be
+---in the atlases, e.g. `'bitmaps/scars/scar1.bmp'`.
+---@param posx number World position of the decal center.
+---@param posz number World position of the decal center.
+---@param rotation number Rotation around Y in radians.
+---@param width number Elmos.
+---@param length number Elmos.
+---@param heatstart number? TODO: initial temperature in kelvins of the emissive parts
+---(alpha channel of the normal texture). Defaults to `0`.
+---@param heatdecay number? TODO: exponential rate at which the hot parts cool each frame. Defaults to `1`.
+---@param alphastart number? Initial transparency; may exceed `1`. Defaults to `1`.
+---@param alphadecay number? Alpha removed each frame. The decal is removed automatically
+---once `alphastart`/`alphadecay` drops below `0`. Defaults to `0`.
+---@param maxalpha number? Highest transparency this decal may reach.
+---@param bwfactor number? Mix toward black and white; `0` is original color, `1` is grayscale.
+---Defaults to `1`.
+---@param glowsustain number? Frames before the glow starts to recede. Defaults to `1`.
+---@param glowadd number? Additional glow not controlled by transparency. Defaults to `0`.
+---@param fadeintime number? Frames to reach max alpha after spawning.
+---@param spawnframe integer? Leave `nil` unless modifying an existing decal, in which case
+---pass the frame that decal was spawned on.
+---@return integer? decalIndex `nil` when the map area is oversaturated with decals.
+---@return integer? lifetime Frames the decal will live for.
 local function AddDecal(
 	decaltexturename,
 	posx,
@@ -515,21 +542,6 @@ local function AddDecal(
 	fadeintime,
 	spawnframe
 )
-	-- Documentation
-	-- decaltexturename, full path to the decal texture name, it must have been added to the atlasses, e.g. 'bitmaps/scars/scar1.bmp'
-	-- posx, posz, world pos to place center of decal
-	-- rotation: rotation around y in radians
-	-- width, length in elmos
-	-- TODO: heatstart: the initial temperature, in kelvins of the emissive parts (alpha channel of normal texture)
-	-- TODO: heatdecay: the exponential rate at which the hot parts are cooled down each frame
-	-- alphastart: The initial transparency amount, can be > 1 too
-	-- alphadecay: How much alpha is reduced each frame, when alphastart/alphadecay goes below 0, the decal will get automatically removed.
-	-- maxalpha: The highest amount of transparency this decal can have
-	-- bwfactor: the mix factor of the diffuse texture to black and whiteness, 0 is original cololr, 1 is black and white
-	-- glowsustain: how many frames to elapse before glow starts to recede
-	-- glowadd: how much additional, non-transparency controlled heat glow should the decal get
-	-- fadeintime: how many frames it takes for a decal to reach its max alpha after spawning
-	-- spawnframe: really shouldnt be touched (pass nil) unless you want to modify the params of an existing decal, then specify the frame that decal was spawned on.
 	heatstart = heatstart or 0
 	heatdecay = heatdecay or 1
 	alphastart = alphastart or 1
@@ -720,6 +732,8 @@ else
 	end
 end
 
+---Removes a decal spawned by `AddDecal`. Unknown ids are ignored.
+---@param instanceID integer As returned by `AddDecal`.
 local function RemoveDecal(instanceID)
 	RemoveDecalFromArea(instanceID)
 	footprintDecalSet[instanceID] = nil
@@ -2137,20 +2151,47 @@ function widget:Initialize()
 	WG.decalsgl4 = {}
 	WG.decalsgl4.AddDecalGL4 = AddDecal
 	WG.decalsgl4.RemoveDecalGL4 = RemoveDecal
+	---Scales how long newly spawned decals live.
+	---@param value number
 	WG.decalsgl4.SetLifeTimeMult = function(value)
 		lifeTimeMult = value
 	end
+	---Lightweight decal record kept for external consumers such as minimap overlays.
+	---Positional, not a record: every consumer indexes it numerically.
+	---@class ActiveDecal
+	---@field [1] number World X.
+	---@field [2] number World Z.
+	---@field [3] number Size: the larger of `[8]` and `[9]`.
+	---@field [4] number Alpha at spawn.
+	---@field [5] number Alpha lost per frame.
+	---@field [6] integer Game frame the decal spawned in.
+	---@field [7] boolean Whether this is a building footprint decal.
+	---@field [8] number Width.
+	---@field [9] number Length.
+	---@field [10] number Rotation in radians.
+	---@field [11] number Atlas UV bound `p`.
+	---@field [12] number Atlas UV bound `q`.
+	---@field [13] number Atlas UV bound `s`.
+	---@field [14] number Atlas UV bound `t`.
+
+	---@return table<integer, ActiveDecal> decals Keyed by decalIndex. Do not mutate.
 	WG.decalsgl4.GetActiveDecals = function()
 		return activeDecalData
 	end
+	---@return number multiplier Scales how long newly spawned decals live.
 	WG.decalsgl4.GetLifeTimeMult = function()
 		return lifeTimeMult
 	end
 	WG.decalsgl4.RebuildActiveDecalData = RebuildActiveDecalData
 	local vboTableCache = { decalVBO, decalLargeVBO, decalExtraLargeVBO }
+	---Exposes the raw decal VBOs, for widgets that draw decals themselves.
+	---@return [InstanceVBOTable, InstanceVBOTable, InstanceVBOTable] vboTables The small,
+	---large and extra-large decal buffers.
+	---@return table<integer, boolean> footprintDecalSet Which decalIndex values are footprints.
 	WG.decalsgl4.GetVBOData = function()
 		return vboTableCache, footprintDecalSet
 	end
+	---@return integer version Increments whenever cached decal data needs refreshing.
 	WG.decalsgl4.GetVersion = function()
 		return decalVersion
 	end

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -342,28 +342,45 @@ local skipdraw = false
 ------------------------------ Data structures and management variables ------------
 
 -- These will contain 'global' type lights, ones that dont get updated every frame
-local pointLightVBO = {} -- an instanceVBOTable
-local coneLightVBO = {} -- an instanceVBOTable
-local beamLightVBO = {} -- an instanceVBOTable
-local lightVBOMap -- a table of the above 3, keyed by light type, {point = pointLightVBO, ...}
+---@type InstanceVBOTable
+local pointLightVBO = {}
+---@type InstanceVBOTable
+local coneLightVBO = {}
+---@type InstanceVBOTable
+local beamLightVBO = {}
+---Table of the above 3, keyed by light type, {point = pointLightVBO, ...}
+---@type table<"point"|"beam"|"cone", InstanceVBOTable>
+local lightVBOMap
 
 -- These contain the unitdef defined, cob-instanced and unit event based lights
-local unitPointLightVBO = {} -- an instanceVBOTable, with unit-attachment
-local unitConeLightVBO = {} -- an instanceVBOTable
-local unitBeamLightVBO = {} -- an instanceVBOTable
-local unitLightVBOMap -- a table of the above 3, keyed by light type,  {point = unitPointLightVBO, ...}
+---@type InstanceVBOTable
+local unitPointLightVBO = {}
+---@type InstanceVBOTable
+local unitConeLightVBO = {}
+---@type InstanceVBOTable
+local unitBeamLightVBO = {}
+---Table of the above 3, keyed by light type, {point = unitPointLightVBO, ...}
+---@type table<"point"|"beam"|"cone", InstanceVBOTable>
+local unitLightVBOMap
 
 local unitAttachedLights = {} -- this is a table mapping unitID's to all their attached instanceIDs and vbos
 --{unitID = { instanceID = targetVBO, ... }}
 local visibleUnits = {} -- this is a proxy for the widget callins, used to ensure we dont add unitscriptlights to units that are not visible
 
 -- these will be separate, as they need per-frame updates!
+---@type InstanceVBOTable
 local projectilePointLightVBO = {} -- for plasma balls
+---@type InstanceVBOTable
 local projectileBeamLightVBO = {} -- for lasers
+---@type InstanceVBOTable
 local projectileConeLightVBO = {} -- for rockets
-local projectileLightVBOMap -- a table of the above 3, keyed by light type
+---Table of the above three, keyed by light shape.
+---@type table<"point"|"beam"|"cone", InstanceVBOTable>
+local projectileLightVBOMap
 
+---@type InstanceVBOTable
 local cursorPointLightVBO = {} -- this will contain ally and player cursor lights
+---@type InstanceVBOTable
 local predictivePointLightVBO = {} -- dedicated VBO for gadget-fed predictive nano lights
 local engineNano = {
 	vbo = nil,
@@ -682,13 +699,22 @@ end
 ---AddLight(instanceID, unitID, pieceIndex, targetVBO, lightparams, noUpload)
 ---Note that instanceID can be nil if an auto-generated one is OK.
 ---If the light is not attached to a unit, and its lifetime is > 0, then it will be automatically added to the removal queue
----@param instanceID any usually nil, supply an existing instance ID if you want to update an existing light,
----@param unitID nil if worldpos, supply valid unitID if you want to attach it to something
----@param pieceIndex number if worldpos, supply valid piece index  if you want to attach it to something, 0 attaches to world offset
----@param targetVBO table specify which one you want it to
----@param lightparams table a valid table of light parameters
----@param noUpload bool true if it shouldnt be uploaded to gpu yet
----@return instanceID for future reuse
+---@param instanceID string|number|nil Key for this light. Pass `nil` for an
+---auto-generated number, or an existing key to update that light in place.
+---Both forms are in use: numbers such as a projectileID, and strings such as
+---`"<unitID><lightName>"`.
+---@param unitID integer? Attaches the light to a unit, making its position an offset
+---from that unit instead of an absolute world position. `nil` leaves it fixed in
+---the world.
+---@param pieceIndex integer? Piece to attach to when `unitID` is given; `0`, and the
+---default, attach to the model origin. Ignored when `unitID` is `nil`.
+---@param targetVBO InstanceVBOTable Which light buffer to add to; this also picks the shape
+---(point/beam/cone) and whether it is drawn in the world or unit-attached pass.
+---@param lightparams number[] A flat array of exactly `instanceStep` values, laid out
+---by `lightParamKeyOrder`.
+---@param noUpload boolean? `true` to skip uploading to the GPU for now.
+---@return string|number|nil instanceID The key this light is filed under, for future
+---reuse; `nil` when the push failed.
 local function AddLight(instanceID, unitID, pieceIndex, targetVBO, lightparams, noUpload)
 	if instanceID == nil then
 		autoLightInstanceID = autoLightInstanceID + 1
@@ -891,31 +917,40 @@ end
 ---AddPointLight
 ---DEPRECATED Note that instanceID can be nil if an auto-generated one is OK.
 ---If the light is not attached to a unit, and its lifetime is > 0, then it will be automatically added to the removal queue
----@param instanceID any usually nil, supply an existing instance ID if you want to update an existing light,
----@param unitID nil if worldpos, supply valid unitID if you want to attach it to something
----@param pieceIndex nil if worldpos, supply valid piece index  if you want to attach it to something, 0 attaches to world offset
----@param targetVBO nil if you want to automatically add it to pointlightvbo/unitPointLightVBO, specify other if you do not
----@param px_or_table float position X or a valid table of parameters
----@param py float Y position of the light
----@param pz float Z position of the light
----@param radius float radius position of the light
----@param r float red color of the light (0-1), but can go higher
----@param g float green color of the light (0-1), but can go higher
----@param b float blue color of the light (0-1), but can go higher
----@param a float global brightness modifier of the light (0-1), but can go higher
----@param r2 float red secondary color of the light (0-1), but can go higher
----@param g2 float green secondary color of the light (0-1), but can go higher
----@param b2 float blue secondary color of the light (0-1), but can go higher
----@param colortime float time in seconds for the light to transition to secondary color. For unitlights, specify in frames the period you want
----@param modelfactor float how much more light gets applied to models vs terrain (default 1)
----@param specular float how strong specular highlights of this light are (default 1)
----@param scattering float how strong the atmospheric scattering effect is (default 1)
----@param lensflare float intensity of the lens flare effect( default 1)
----@param spawnframe float the gameframe the light was spawned in (for anims, in frames, default current game frame)
----@param lifetime float how many frames the light will live, with decreasing brightness
----@param sustain float how much sustain time the light will have at its original brightness (in game frames)
----@param selfshadowing int what further type of animation will be used (0 is default 1 is for screen space shadow)
----@return instanceID for future reuse
+---@param instanceID string|number|nil Key for this light. Pass `nil` for an
+---auto-generated number, or an existing key to update that light in place.
+---Both forms are in use: numbers such as a projectileID, and strings such as
+---`"<unitID><lightName>"`.
+---@param unitID integer? Attaches the light to a unit, making its position an offset
+---from that unit instead of an absolute world position. `nil` leaves it fixed in
+---the world.
+---@param pieceIndex integer? Piece to attach to when `unitID` is given; `0`, and the
+---default, attach to the model origin. Ignored when `unitID` is `nil`.
+---@param targetVBO InstanceVBOTable? Which light buffer to add to. Defaults to the buffer matching
+---this light's shape; pass another to override that.
+---@param px_or_table number|number[] Either the X position, or a complete flat
+---parameter array, in which case the remaining arguments are ignored.
+---@param py number Y position of the light
+---@param pz number Z position of the light
+---@param radius number radius position of the light
+---@param r number red color of the light (0-1), but can go higher
+---@param g number green color of the light (0-1), but can go higher
+---@param b number blue color of the light (0-1), but can go higher
+---@param a number global brightness modifier of the light (0-1), but can go higher
+---@param r2 number red secondary color of the light (0-1), but can go higher
+---@param g2 number green secondary color of the light (0-1), but can go higher
+---@param b2 number blue secondary color of the light (0-1), but can go higher
+---@param colortime number time in seconds for the light to transition to secondary color. For unitlights, specify in frames the period you want
+---@param modelfactor number? how much more light gets applied to models vs terrain (default 1)
+---@param specular number? how strong specular highlights of this light are (default 1)
+---@param scattering number? how strong the atmospheric scattering effect is (default 1)
+---@param lensflare number? intensity of the lens flare effect( default 1)
+---@param spawnframe number? the gameframe the light was spawned in (for anims, in frames, default current game frame)
+---@param lifetime number how many frames the light will live, with decreasing brightness
+---@param sustain number how much sustain time the light will have at its original brightness (in game frames)
+---@param selfshadowing integer? what further type of animation will be used (0 is default 1 is for screen space shadow)
+---@return string|number|nil instanceID The key this light is filed under, for future
+---reuse; `nil` when the push failed.
 local function AddPointLight(
 	instanceID,
 	unitID,
@@ -1084,31 +1119,40 @@ end
 ---AddBeamLight
 ---DEPRECATED Note that instanceID can be nil if an auto-generated one is OK.
 ---If the light is not attached to a unit, and its lifetime is > 0, then it will be automatically added to the removal queue
----@param instanceID any usually nil, supply an existing instance ID if you want to update an existing light,
----@param unitID nil if worldpos, supply valid unitID if you want to attach it to something
----@param pieceIndex nil if worldpos, supply valid piece index  if you want to attach it to something, 0 attaches to world offset
----@param targetVBO nil if you want to automatically add it to pointlightvbo/unitPointLightVBO, specify other if you do not
----@param px_or_table float position X or a valid table of parameters
----@param py float Y position of the light
----@param pz float Z position of the light
----@param radius float radius position of the light
----@param r float red color of the light (0-1), but can go higher
----@param g float green color of the light (0-1), but can go higher
----@param b float blue color of the light (0-1), but can go higher
----@param a float global brightness modifier of the light (0-1), but can go higher
----@param sx float pos of the endpoint of the beam
----@param sy float pos of the endpoint of the beam
----@param sz float pos of the endpoint of the beam
----@param r2 float radius2 is unused at the moment
----@param modelfactor float how much more light gets applied to models vs terrain (default 1)
----@param specular float how strong specular highlights of this light are (default 1)
----@param scattering float how strong the atmospheric scattering effect is (default 1)
----@param lensflare float intensity of the lens flare effect( default 1)
----@param spawnframe float the gameframe the light was spawned in (for anims, in frames, default current game frame)
----@param lifetime float how many frames the light will live, with decreasing brightness
----@param sustain float how much sustain time the light will have at its original brightness (in game frames)
----@param selfshadowing int what further type of animation will be used
----@return instanceID for future reuse
+---@param instanceID string|number|nil Key for this light. Pass `nil` for an
+---auto-generated number, or an existing key to update that light in place.
+---Both forms are in use: numbers such as a projectileID, and strings such as
+---`"<unitID><lightName>"`.
+---@param unitID integer? Attaches the light to a unit, making its position an offset
+---from that unit instead of an absolute world position. `nil` leaves it fixed in
+---the world.
+---@param pieceIndex integer? Piece to attach to when `unitID` is given; `0`, and the
+---default, attach to the model origin. Ignored when `unitID` is `nil`.
+---@param targetVBO InstanceVBOTable? Which light buffer to add to. Defaults to the buffer matching
+---this light's shape; pass another to override that.
+---@param px_or_table number|number[] Either the X position, or a complete flat
+---parameter array, in which case the remaining arguments are ignored.
+---@param py number Y position of the light
+---@param pz number Z position of the light
+---@param radius number radius position of the light
+---@param r number red color of the light (0-1), but can go higher
+---@param g number green color of the light (0-1), but can go higher
+---@param b number blue color of the light (0-1), but can go higher
+---@param a number global brightness modifier of the light (0-1), but can go higher
+---@param sx number pos of the endpoint of the beam
+---@param sy number pos of the endpoint of the beam
+---@param sz number pos of the endpoint of the beam
+---@param r2 number radius2 is unused at the moment
+---@param modelfactor number? how much more light gets applied to models vs terrain (default 1)
+---@param specular number? how strong specular highlights of this light are (default 1)
+---@param scattering number? how strong the atmospheric scattering effect is (default 1)
+---@param lensflare number? intensity of the lens flare effect( default 1)
+---@param spawnframe number? the gameframe the light was spawned in (for anims, in frames, default current game frame)
+---@param lifetime number how many frames the light will live, with decreasing brightness
+---@param sustain number how much sustain time the light will have at its original brightness (in game frames)
+---@param selfshadowing integer what further type of animation will be used
+---@return string|number|nil instanceID The key this light is filed under, for future
+---reuse; `nil` when the push failed.
 local function AddBeamLight(
 	instanceID,
 	unitID,
@@ -1193,31 +1237,40 @@ end
 ---AddConeLight
 ---DEPRECATED! Note that instanceID can be nil if an auto-generated one is OK.
 ---If the light is not attached to a unit, and its lifetime is > 0, then it will be automatically added to the removal queue
----@param instanceID any usually nil, supply an existing instance ID if you want to update an existing light,
----@param unitID nil if worldpos, supply valid unitID if you want to attach it to something
----@param pieceIndex nil if worldpos, supply valid piece index  if you want to attach it to something, 0 attaches to world offset
----@param targetVBO nil if you want to automatically add it to pointlightvbo/unitPointLightVBO, specify other if you do not
----@param px_or_table float position X or a valid table of parameters
----@param py float Y position of the light
----@param pz float Z position of the light
----@param radius float height of the cone
----@param r float red color of the light (0-1), but can go higher
----@param g float green color of the light (0-1), but can go higher
----@param b float blue color of the light (0-1), but can go higher
----@param a float global brightness modifier of the light (0-1), but can go higher
----@param dx float dirx of the cone
----@param dy float diry of the cone
----@param dz float dirz of the cone
----@param theta float half-angle of the cone in radians
----@param modelfactor float how much more light gets applied to models vs terrain (default 1)
----@param specular float how strong specular highlights of this light are (default 1)
----@param scattering float how strong the atmospheric scattering effect is (default 1)
----@param lensflare float intensity of the lens flare effect( default 1)
----@param spawnframe float the gameframe the light was spawned in (for anims, in frames, default current game frame)
----@param lifetime float how many frames the light will live, with decreasing brightness
----@param sustain float how much sustain time the light will have at its original brightness (in game frames)
----@param selfshadowing int what further type of animation will be used
----@return instanceID for future reuse
+---@param instanceID string|number|nil Key for this light. Pass `nil` for an
+---auto-generated number, or an existing key to update that light in place.
+---Both forms are in use: numbers such as a projectileID, and strings such as
+---`"<unitID><lightName>"`.
+---@param unitID integer? Attaches the light to a unit, making its position an offset
+---from that unit instead of an absolute world position. `nil` leaves it fixed in
+---the world.
+---@param pieceIndex integer? Piece to attach to when `unitID` is given; `0`, and the
+---default, attach to the model origin. Ignored when `unitID` is `nil`.
+---@param targetVBO InstanceVBOTable? Which light buffer to add to. Defaults to the buffer matching
+---this light's shape; pass another to override that.
+---@param px_or_table number|number[] Either the X position, or a complete flat
+---parameter array, in which case the remaining arguments are ignored.
+---@param py number Y position of the light
+---@param pz number Z position of the light
+---@param radius number height of the cone
+---@param r number red color of the light (0-1), but can go higher
+---@param g number green color of the light (0-1), but can go higher
+---@param b number blue color of the light (0-1), but can go higher
+---@param a number global brightness modifier of the light (0-1), but can go higher
+---@param dx number dirx of the cone
+---@param dy number diry of the cone
+---@param dz number dirz of the cone
+---@param theta number half-angle of the cone in radians
+---@param modelfactor number? how much more light gets applied to models vs terrain (default 1)
+---@param specular number? how strong specular highlights of this light are (default 1)
+---@param scattering number? how strong the atmospheric scattering effect is (default 1)
+---@param lensflare number? intensity of the lens flare effect( default 1)
+---@param spawnframe number? the gameframe the light was spawned in (for anims, in frames, default current game frame)
+---@param lifetime number how many frames the light will live, with decreasing brightness
+---@param sustain number how much sustain time the light will have at its original brightness (in game frames)
+---@param selfshadowing integer what further type of animation will be used
+---@return string|number|nil instanceID The key this light is filed under, for future
+---reuse; `nil` when the push failed.
 local function AddConeLight(
 	instanceID,
 	unitID,
@@ -1367,9 +1420,10 @@ end
 
 ---RemoveUnitAttachedLights(unitID, instanceID)
 ---Removes all or 1 light attached to a unit
----@param unitID the unit to remove lights from
----@param instanceID which light to remove, if nil, then all lights will be removed
----@returns the number of lights that got removed
+---@param unitID integer The unit to remove lights from.
+---@param instanceID string|number|nil Which light to remove. Removes all of the unit's
+---lights when `nil`.
+---@return integer count The number of lights that got removed.
 local function RemoveUnitAttachedLights(unitID, instanceID)
 	local numremoved = 0
 	if unitAttachedLights[unitID] then
@@ -1397,10 +1451,11 @@ end
 
 ---RemoveLight(lightshape, instanceID, unitID)
 ---Remove a light
----@param lightshape string 'point'|'beam'|'cone'
----@param instanceID any the ID of the light to remove
----@param unitID number make this non-nil to remove it from a unit
----@returns the same instanceID on success, nil if the light was not found
+---@param lightshape "point"|"beam"|"cone"? Ignored when `unitID` is given.
+---@param instanceID string|number The key the light was filed under.
+---@param unitID integer? Make this non-nil to remove it from a unit.
+---@param noUpload boolean? True if the change shouldn't be uploaded to the GPU yet.
+---@return integer? index Buffer index the light occupied; `nil` when it was not found.
 local function RemoveLight(lightshape, instanceID, unitID, noUpload)
 	if unitID then
 		if unitAttachedLights[unitID] and unitAttachedLights[unitID][instanceID] then
@@ -1604,6 +1659,10 @@ local function UnitScriptLight(unitID, unitDefID, lightIndex, param)
 	end
 end
 
+---Exposes one of the light VBOs by name, for widgets that upload light instances
+---themselves.
+---@param vboName string Currently only `'cursorPointLightVBO'` is exposed.
+---@return InstanceVBOTable? vbo `nil` for any other name.
 local function GetLightVBO(vboName)
 	if vboName == "cursorPointLightVBO" then
 		return cursorPointLightVBO
@@ -1651,61 +1710,6 @@ function widget:VisibleUnitRemoved(unitID) -- remove all the lights for this uni
 	--if debugmode then Spring.Debug.TraceEcho("remove",unitID,reason) end
 	RemoveUnitAttachedLights(unitID)
 	visibleUnits[unitID] = nil
-end
-
-function widget:Shutdown()
-	widgetHandler:RemoveAction("dlgl4stats", "t")
-	widgetHandler:RemoveAction("dlgl4skipdraw", "t")
-	WG.lightsgl4 = nil
-	widgetHandler:DeregisterGlobal("AddPointLight")
-	widgetHandler:DeregisterGlobal("AddBeamLight")
-	widgetHandler:DeregisterGlobal("AddConeLight")
-	widgetHandler:DeregisterGlobal("AddLight")
-	widgetHandler:DeregisterGlobal("RemoveLight")
-	widgetHandler:DeregisterGlobal("GetLightVBO")
-
-	widgetHandler:DeregisterGlobal("EnvLightningPointLight")
-	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightSpawn")
-	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightCorrect")
-	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightFade")
-	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightRemove")
-
-	deferredLightShader:Delete()
-	local ram = 0
-	for lighttype, vbo in pairs(unitLightVBOMap) do
-		ram = ram + vbo:Delete()
-	end
-	for lighttype, vbo in pairs(projectileLightVBOMap) do
-		ram = ram + vbo:Delete()
-	end
-	for lighttype, vbo in pairs(lightVBOMap) do
-		ram = ram + vbo:Delete()
-	end
-	ram = ram + cursorPointLightVBO:Delete()
-	ram = ram + predictivePointLightVBO:Delete()
-	if engineNano.vbo then
-		ram = ram + engineNano.vbo:Delete()
-	end
-
-	--spEcho("DLGL4 ram usage MB = ", ram / 1000000)
-	--spEcho("featureDefLights", table.countMem(featureDefLights))
-	--spEcho("unitEventLights", table.countMem(unitEventLights))
-	--spEcho("unitDefLights", table.countMem(unitDefLights))
-	--spEcho("projectileDefLights", table.countMem(projectileDefLights))
-	--spEcho("explosionLights", table.countMem(explosionLights))
-
-	-- Note, these must be nil'ed manually, because
-	-- tables included from VFS.Include dont get GC'd unless specifically nil'ed
-	unitDefLights = nil
-	featureDefLights = nil
-	unitEventLights = nil
-	muzzleFlashLights = nil
-	projectileDefLights = nil
-	explosionLights = nil
-	gibLight = nil
-
-	--collectgarbage("collect")
-	--collectgarbage("collect")
 end
 
 local windX = 0
@@ -2510,16 +2514,24 @@ function widget:Initialize()
 	WG.lightsgl4.RemoveLight = RemoveLight
 	WG.lightsgl4.GetLightVBO = GetLightVBO
 
+	---Globally scales the brightness of every deferred light.
+	---@param value number
 	WG.lightsgl4.IntensityMultiplier = function(value)
 		intensityMultiplier = value
 	end
+	---Globally scales the radius of every deferred light.
+	---@param value number
 	WG.lightsgl4.RadiusMultiplier = function(value)
 		radiusMultiplier = value
 	end
+	---Enables screen-space shadows cast by deferred lights.
+	---@param value boolean
 	WG.lightsgl4.ScreenSpaceShadows = function(value)
 		screenSpaceShadows = value
 	end
 
+	---Shows a light that follows the player's cursor, removing it when disabled.
+	---@param value boolean
 	WG.lightsgl4.ShowPlayerCursorLight = function(value)
 		showPlayerCursorLight = value
 		-- Remove the player's cursor light on disabling this feature
@@ -2527,9 +2539,11 @@ function widget:Initialize()
 			popElementInstance(cursorPointLightVBO, "PLAYERCURSOR")
 		end
 	end
+	---@param value number Radius of the cursor light.
 	WG.lightsgl4.PlayerCursorLightRadius = function(value)
 		playerCursorLightRadius = value
 	end
+	---@param value number Brightness of the cursor light.
 	WG.lightsgl4.PlayerCursorLightBrightness = function(value)
 		playerCursorLightBrightness = value
 	end
@@ -2546,8 +2560,21 @@ function widget:Initialize()
 	-- The gadget owns all tuning (see its lightning configs); this just forwards the
 	-- already-resolved values to AddPointLight. r2/g2/b2 = same color so the light
 	-- does not animate toward black; sustain holds full brightness before the fade.
-	-- Args: x,y,z, radius, r,g,b,a, lifetime, sustain, modelfactor, specular,
-	--       scattering, lensflare, spawnframe.
+	---@param x number
+	---@param y number
+	---@param z number
+	---@param radius number
+	---@param r number
+	---@param g number
+	---@param b number
+	---@param a number Global brightness modifier.
+	---@param lifetime number Frames the light lives for, fading out.
+	---@param sustain number Frames at full brightness before the fade.
+	---@param modelfactor number? How much more light is applied to models than terrain.
+	---@param specular number?
+	---@param scattering number?
+	---@param lensflare number?
+	---@param spawnframe number? Game frame the light was spawned in.
 	WG.lightsgl4.EnvLightningPointLight = function(
 		x,
 		y,
@@ -2596,6 +2623,30 @@ function widget:Initialize()
 	-- Gadget bridge: predictive nano point lights. Gadget sends one spawn event
 	-- per selected particle, plus sparse correction events when trajectory
 	-- changes (homing / terrain correction). Widget integrates in-between.
+	---Spawns a predictive nano point light that integrates its own trajectory between
+	---sparse correction events. Called by the nano gadget through `Script.LuaUI`.
+	---@param instanceID string Caller-chosen id, also used by the correct/fade/remove
+	---calls. The nano gadget passes `"NANOP_" .. projectileID`.
+	---@param x number
+	---@param y number
+	---@param z number
+	---@param vx number Velocity per frame.
+	---@param vy number
+	---@param vz number
+	---@param radius number
+	---@param r number
+	---@param g number
+	---@param b number
+	---@param a number Global brightness modifier.
+	---@param lifetime number Frames the light lives for; must be at least `1`.
+	---@param sustain number Frames at full brightness before the fade.
+	---@param modelfactor number?
+	---@param specular number?
+	---@param scattering number?
+	---@param lensflare number?
+	---@param spawnframe number?
+	---@param updateEvery number? Frames between predicted position updates.
+	---@param correctionMinFrames number? Minimum frames between accepted corrections.
 	WG.lightsgl4.EnvNanoBallisticLightSpawn = function(
 		instanceID,
 		x,
@@ -2657,6 +2708,17 @@ function widget:Initialize()
 		AddLight(instanceID, nil, nil, predictivePointLightVBO, lightparams)
 		return true
 	end
+	---Corrects a predictive nano light's position and velocity, e.g. after homing or
+	---terrain correction changed its trajectory.
+	---@param instanceID string As passed to `EnvNanoBallisticLightSpawn`.
+	---@param x number
+	---@param y number
+	---@param z number
+	---@param vx number
+	---@param vy number
+	---@param vz number
+	---@param frame integer? Defaults to the current game frame.
+	---@return boolean corrected `false` when no such light exists.
 	WG.lightsgl4.EnvNanoBallisticLightCorrect = function(instanceID, x, y, z, vx, vy, vz, frame)
 		local f = frame or gameFrame
 		local instanceIndex = predictivePointLightVBO.instanceIDtoIndex[instanceID]
@@ -2678,6 +2740,11 @@ function widget:Initialize()
 		end
 		return true
 	end
+	---Starts fading a predictive nano light out, queueing its removal.
+	---@param instanceID string As passed to `EnvNanoBallisticLightSpawn`.
+	---@param frame integer? Defaults to the current game frame.
+	---@param fadeFrames number? Frames to fade over; at least `1`. Defaults to `1`.
+	---@return boolean fading `false` when no such light exists.
 	WG.lightsgl4.EnvNanoBallisticLightFade = function(instanceID, frame, fadeFrames)
 		local f = frame or gameFrame
 		local instanceIndex = predictivePointLightVBO.instanceIDtoIndex[instanceID]
@@ -2701,6 +2768,9 @@ function widget:Initialize()
 		predictivePointLightVBO.dirty = true
 		return true
 	end
+	---Removes a predictive nano light immediately. Unknown ids are ignored.
+	---@param instanceID string As passed to `EnvNanoBallisticLightSpawn`.
+	---@return boolean `true` always.
 	WG.lightsgl4.EnvNanoBallisticLightRemove = function(instanceID)
 		if predictivePointLightVBO.instanceIDtoIndex[instanceID] then
 			popElementInstance(predictivePointLightVBO, instanceID)
@@ -2711,6 +2781,61 @@ function widget:Initialize()
 	widgetHandler:RegisterGlobal("EnvNanoBallisticLightCorrect", WG.lightsgl4.EnvNanoBallisticLightCorrect)
 	widgetHandler:RegisterGlobal("EnvNanoBallisticLightFade", WG.lightsgl4.EnvNanoBallisticLightFade)
 	widgetHandler:RegisterGlobal("EnvNanoBallisticLightRemove", WG.lightsgl4.EnvNanoBallisticLightRemove)
+end
+
+function widget:Shutdown()
+	widgetHandler:RemoveAction("dlgl4stats", "t")
+	widgetHandler:RemoveAction("dlgl4skipdraw", "t")
+	WG.lightsgl4 = nil
+	widgetHandler:DeregisterGlobal("AddPointLight")
+	widgetHandler:DeregisterGlobal("AddBeamLight")
+	widgetHandler:DeregisterGlobal("AddConeLight")
+	widgetHandler:DeregisterGlobal("AddLight")
+	widgetHandler:DeregisterGlobal("RemoveLight")
+	widgetHandler:DeregisterGlobal("GetLightVBO")
+
+	widgetHandler:DeregisterGlobal("EnvLightningPointLight")
+	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightSpawn")
+	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightCorrect")
+	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightFade")
+	widgetHandler:DeregisterGlobal("EnvNanoBallisticLightRemove")
+
+	deferredLightShader:Delete()
+	local ram = 0
+	for lighttype, vbo in pairs(unitLightVBOMap) do
+		ram = ram + vbo:Delete()
+	end
+	for lighttype, vbo in pairs(projectileLightVBOMap) do
+		ram = ram + vbo:Delete()
+	end
+	for lighttype, vbo in pairs(lightVBOMap) do
+		ram = ram + vbo:Delete()
+	end
+	ram = ram + cursorPointLightVBO:Delete()
+	ram = ram + predictivePointLightVBO:Delete()
+	if engineNano.vbo then
+		ram = ram + engineNano.vbo:Delete()
+	end
+
+	--spEcho("DLGL4 ram usage MB = ", ram / 1000000)
+	--spEcho("featureDefLights", table.countMem(featureDefLights))
+	--spEcho("unitEventLights", table.countMem(unitEventLights))
+	--spEcho("unitDefLights", table.countMem(unitDefLights))
+	--spEcho("projectileDefLights", table.countMem(projectileDefLights))
+	--spEcho("explosionLights", table.countMem(explosionLights))
+
+	-- Note, these must be nil'ed manually, because
+	-- tables included from VFS.Include dont get GC'd unless specifically nil'ed
+	unitDefLights = nil
+	featureDefLights = nil
+	unitEventLights = nil
+	muzzleFlashLights = nil
+	projectileDefLights = nil
+	explosionLights = nil
+	gibLight = nil
+
+	--collectgarbage("collect")
+	--collectgarbage("collect")
 end
 
 if autoupdate then

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -140,25 +140,40 @@ local noisetex3dcube = "LuaUI/images/noisetextures/noise64_cube_3.dds"
 ------------------------------ Data structures and management variables ------------
 
 -- These will contain 'global' type distortions, ones that dont get updated every frame
-local pointDistortionVBO = {} -- an instanceVBOTable
-local coneDistortionVBO = {} -- an instanceVBOTable
-local beamDistortionVBO = {} -- an instanceVBOTable
-local distortionVBOMap -- a table of the above 3, keyed by distortion type, {point = pointDistortionVBO, ...}
+---@type InstanceVBOTable
+local pointDistortionVBO = {}
+---@type InstanceVBOTable
+local coneDistortionVBO = {}
+---@type InstanceVBOTable
+local beamDistortionVBO = {}
+---Table of the above 3, keyed by distortion type., {point = pointDistortionVBO, ...}
+---@type table<"point"|"beam"|"cone", InstanceVBOTable>
+local distortionVBOMap
 
 -- These contain the unitdef defined, cob-instanced and unit event based distortions
-local unitPointDistortionVBO = {} -- an instanceVBOTable, with unit-attachment
-local unitConeDistortionVBO = {} -- an instanceVBOTable
-local unitBeamDistortionVBO = {} -- an instanceVBOTable
-local unitDistortionVBOMap -- a table of the above 3, keyed by distortion type,  {point = unitPointDistortionVBO, ...}
+---@type InstanceVBOTable
+local unitPointDistortionVBO = {}
+---@type InstanceVBOTable
+local unitConeDistortionVBO = {}
+---@type InstanceVBOTable
+local unitBeamDistortionVBO = {}
+---Table of the above 3, keyed by distortion shape,  {point = unitPointDistortionVBO, ...}
+---@type table<"point"|"beam"|"cone", InstanceVBOTable>
+local unitDistortionVBOMap
 
 local unitAttachedDistortions = {} -- this is a table mapping unitID's to all their attached instanceIDs and vbos
 --{unitID = { instanceID = targetVBO, ... }}
 local visibleUnits = {} -- this is a proxy for the widget callins, used to ensure we dont add unitscriptdistortions to units that are not visible
 
 -- these will be separate, as they need per-frame updates!
+---@type InstanceVBOTable
 local projectilePointDistortionVBO = {} -- for plasma balls
+---@type InstanceVBOTable
 local projectileBeamDistortionVBO = {} -- for lasers
+---@type InstanceVBOTable
 local projectileConeDistortionVBO = {} -- for rockets
+---Keyed by distortion shape: `point`, `beam`, `cone`.
+---@type table<"point"|"beam"|"cone", InstanceVBOTable>
 local projectileDistortionVBOMap -- a table of the above 3, keyed by distortion type
 
 local distortionRemoveQueue = {} -- stores distortions that have expired life {gameframe = {distortionIDs ... }}
@@ -550,13 +565,21 @@ end
 ---Note that instanceID can be nil if an auto-generated one is OK.
 ---If the distortion is not attached to a unit, and its lifeTime is > 0, then it will be automatically added to the removal queue
 ---TODO: is spawnframe even a good idea here, as it might fuck with updates, and is the only thing that doesnt have to be changed
----@param instanceID any usually nil, supply an existing instance ID if you want to update an existing distortion,
----@param unitID nil if worldpos, supply valid unitID if you want to attach it to something
----@param pieceIndex number if worldpos, supply valid piece index  if you want to attach it to something, 0 attaches to world offset
----@param targetVBO table specify which one you want it to
----@param distortionparams table a valid table of distortion parameters
----@param noUpload bool true if it shouldnt be uploaded to gpu yet
----@return instanceID for future reuse
+---@param instanceID string|number|nil Key for this distortion. Pass `nil` for an
+---auto-generated number, or an existing key to update that distortion in place.
+---Callers here use both forms: `nil`, and strings like `"<unitID><distortionName>"`.
+---@param unitID integer? Attaches the distortion to a unit, making the position in
+---`distortionparams` an offset from it instead of an absolute world position.
+---`nil` leaves it fixed in the world.
+---@param pieceIndex integer? Piece to attach to when `unitID` is given; `0`, and the
+---default, attach to the model origin. Ignored when `unitID` is `nil`.
+---@param targetVBO InstanceVBOTable Which distortion buffer to add to; this also picks the shape
+---(point/beam/cone) and whether it is drawn in the world or unit-attached pass.
+---@param distortionparams number[] A flat array of exactly `instanceStep` values, laid
+---out by `distortionParamKeyOrder`.
+---@param noUpload boolean? `true` to skip uploading to the GPU for now.
+---@return string|number|nil instanceID The key this distortion is filed under, for
+---future reuse; `nil` when the push failed.
 local function AddDistortion(instanceID, unitID, pieceIndex, targetVBO, distortionparams, noUpload)
 	if instanceID == nil then
 		autoDistortionInstanceID = autoDistortionInstanceID + 1
@@ -668,9 +691,10 @@ end
 
 ---RemoveUnitAttachedDistortions(unitID, instanceID)
 ---Removes all or 1 distortion attached to a unit
----@param unitID the unit to remove distortions from
----@param instanceID which distortion to remove, if nil, then all distortions will be removed
----@returns the number of distortions that got removed
+---@param unitID integer The unit to remove distortions from.
+---@param instanceID string|number|nil Which distortion to remove. Removes all of the
+---unit's distortions when `nil`.
+---@return integer count The number of distortions that got removed.
 local function RemoveUnitAttachedDistortions(unitID, instanceID)
 	local numremoved = 0
 	if unitAttachedDistortions[unitID] then
@@ -698,10 +722,11 @@ end
 
 ---RemoveDistortion(distortionshape, instanceID, unitID)
 ---Remove a distortion
----@param distortionshape string 'point'|'beam'|'cone'
----@param instanceID any the ID of the distortion to remove
----@param unitID number make this non-nil to remove it from a unit
----@returns the same instanceID on success, nil if the distortion was not found
+---@param distortionshape "point"|"beam"|"cone" Ignored when `unitID` is given.
+---@param instanceID string|number The key the distortion was filed under.
+---@param unitID integer? Make this non-nil to remove it from a unit.
+---@param noUpload boolean? True if the change shouldn't be uploaded to the GPU yet.
+---@return integer? index Buffer index the distortion occupied; `nil` when it was not found.
 local function RemoveDistortion(distortionshape, instanceID, unitID, noUpload)
 	if unitID then
 		if unitAttachedDistortions[unitID] and unitAttachedDistortions[unitID][instanceID] then
@@ -881,6 +906,9 @@ local function UnitScriptDistortion(unitID, unitDefID, distortionIndex, param)
 	end
 end
 
+---Not implemented; always returns `nil`.
+---@param vboName string
+---@return nil
 local function GetDistortionVBO(vboName)
 	return nil
 end
@@ -909,51 +937,6 @@ function widget:VisibleUnitRemoved(unitID) -- remove all the distortions for thi
 	--if debugmode then Spring.Debug.TraceEcho("remove",unitID,reason) end
 	RemoveUnitAttachedDistortions(unitID)
 	visibleUnits[unitID] = nil
-end
-
-function widget:Shutdown()
-	widgetHandler:RemoveAction("distortionGL4stats", "t")
-	widgetHandler:RemoveAction("distortionGL4skipdraw", "t")
-	-- TODO: delete the VBOs and shaders like a good boy
-	WG.distortionsgl4 = nil
-	widgetHandler:DeregisterGlobal("AddDistortion")
-	widgetHandler:DeregisterGlobal("RemoveDistortion")
-
-	deferredDistortionShader:Delete()
-	local ram = 0
-	for distortiontype, vbo in pairs(unitDistortionVBOMap) do
-		ram = ram + vbo:Delete()
-	end
-	for distortiontype, vbo in pairs(projectileDistortionVBOMap) do
-		ram = ram + vbo:Delete()
-	end
-	for distortiontype, vbo in pairs(distortionVBOMap) do
-		ram = ram + vbo:Delete()
-	end
-
-	--spEcho("distortionGL4 ram usage MB = ", ram / 1000000)
-	--spEcho("featureDefDistortions", table.countMem(featureDefDistortions))
-	--spEcho("unitEventDistortions", table.countMem(unitEventDistortions))
-	--spEcho("unitDefDistortions", table.countMem(unitDefDistortions))
-	--spEcho("projectileDefDistortions", table.countMem(projectileDefDistortions))
-	--spEcho("explosionDistortions", table.countMem(explosionDistortions))
-
-	-- Note, these must be nil'ed manually, because
-	-- tables included from VFS.Include dont get GC'd unless specifically nil'ed
-	unitDefDistortions = nil
-	featureDefDistortions = nil
-	unitEventDistortions = nil
-	muzzleFlashDistortions = nil
-	projectileDefDistortions = nil
-	explosionDistortions = nil
-	gibDistortion = nil
-
-	glDeleteTexture(ScreenCopy)
-	glDeleteTexture(DistortionTexture)
-	ScreenCopy, DistortionTexture = nil, nil
-
-	--collectgarbage("collect")
-	--collectgarbage("collect")
 end
 
 local windX = 0
@@ -1707,9 +1690,13 @@ function widget:Initialize()
 	WG.distortionsgl4.RemoveDistortion = RemoveDistortion
 	WG.distortionsgl4.GetDistortionVBO = GetDistortionVBO
 
+	---Globally scales the strength of every distortion.
+	---@param value number
 	WG.distortionsgl4.IntensityMultiplier = function(value)
 		intensityMultiplier = value
 	end
+	---Globally scales the radius of every distortion.
+	---@param value number
 	WG.distortionsgl4.RadiusMultiplier = function(value)
 		radiusMultiplier = value
 	end
@@ -1717,6 +1704,51 @@ function widget:Initialize()
 	widgetHandler:RegisterGlobal("AddDistortion", WG.distortionsgl4.AddDistortion)
 	widgetHandler:RegisterGlobal("RemoveDistortion", WG.distortionsgl4.RemoveDistortion)
 	widgetHandler:RegisterGlobal("GetDistortionVBO", WG.distortionsgl4.GetDistortionVBO)
+end
+
+function widget:Shutdown()
+	widgetHandler:RemoveAction("distortionGL4stats", "t")
+	widgetHandler:RemoveAction("distortionGL4skipdraw", "t")
+	-- TODO: delete the VBOs and shaders like a good boy
+	WG.distortionsgl4 = nil
+	widgetHandler:DeregisterGlobal("AddDistortion")
+	widgetHandler:DeregisterGlobal("RemoveDistortion")
+
+	deferredDistortionShader:Delete()
+	local ram = 0
+	for distortiontype, vbo in pairs(unitDistortionVBOMap) do
+		ram = ram + vbo:Delete()
+	end
+	for distortiontype, vbo in pairs(projectileDistortionVBOMap) do
+		ram = ram + vbo:Delete()
+	end
+	for distortiontype, vbo in pairs(distortionVBOMap) do
+		ram = ram + vbo:Delete()
+	end
+
+	--spEcho("distortionGL4 ram usage MB = ", ram / 1000000)
+	--spEcho("featureDefDistortions", table.countMem(featureDefDistortions))
+	--spEcho("unitEventDistortions", table.countMem(unitEventDistortions))
+	--spEcho("unitDefDistortions", table.countMem(unitDefDistortions))
+	--spEcho("projectileDefDistortions", table.countMem(projectileDefDistortions))
+	--spEcho("explosionDistortions", table.countMem(explosionDistortions))
+
+	-- Note, these must be nil'ed manually, because
+	-- tables included from VFS.Include dont get GC'd unless specifically nil'ed
+	unitDefDistortions = nil
+	featureDefDistortions = nil
+	unitEventDistortions = nil
+	muzzleFlashDistortions = nil
+	projectileDefDistortions = nil
+	explosionDistortions = nil
+	gibDistortion = nil
+
+	glDeleteTexture(ScreenCopy)
+	glDeleteTexture(DistortionTexture)
+	ScreenCopy, DistortionTexture = nil, nil
+
+	--collectgarbage("collect")
+	--collectgarbage("collect")
 end
 
 function widget:UnitScriptDistortion(unitID, unitDefID, distortionIndex, param)

--- a/luaui/Widgets/gfx_dof.lua
+++ b/luaui/Widgets/gfx_dof.lua
@@ -346,29 +346,41 @@ end
 function widget:Initialize()
 	init()
 	WG.dof = {}
+	---@return number depth Distance the lens is focused at.
 	WG.dof.getFocusDepth = function()
 		return focusDepth
 	end
+	---@param value number Distance the lens is focused at. Only used while autofocus is off.
 	WG.dof.setFocusDepth = function(value)
 		focusDepth = value
 	end
+	---@return number fStop Larger values give a deeper depth of field.
 	WG.dof.getFstop = function()
 		return fStop
 	end
+	---Sets the aperture. Larger values give a deeper depth of field.
+	---@param value number
 	WG.dof.setFstop = function(value)
 		fStop = value
 		autofocusInFocusMultiplier = fStop / 2
 	end
+	---@return boolean highQuality
 	WG.dof.getHighQuality = function()
 		return highQuality
 	end
+	---Switches the blur quality, reallocating the effect's textures.
+	---@param value boolean
 	WG.dof.setHighQuality = function(value)
 		highQuality = value
 		InitTextures()
 	end
+	---@return boolean autofocus
 	WG.dof.getAutofocus = function()
 		return autofocus
 	end
+	---Focuses on whatever is under the screen center. Turning it off focuses on the
+	---cursor instead.
+	---@param value boolean
 	WG.dof.setAutofocus = function(value)
 		autofocus = value
 		mousefocus = not autofocus

--- a/luaui/Widgets/gfx_fog_diaglines_gl4.lua
+++ b/luaui/Widgets/gfx_fog_diaglines_gl4.lua
@@ -159,14 +159,17 @@ function widget:Initialize()
 	needsClear = true
 
 	WG.fogdiaglines = {
+		---@return number strength Fog diagonal line opacity, `0`-`1`.
 		getStrength = function()
 			return strength
 		end,
+		---@param value number? Fog diagonal line opacity, clamped to `0`-`1`. Defaults to `0`.
 		setStrength = function(value)
 			strength = math.max(0, math.min(1, value or 0))
 		end,
 		-- Blurriness slider: 0 = sharp edges, 1 = strongly blurred. Maps linearly
 		-- onto lineSharpness (the smoothstep half-width at each line edge).
+		---@return number blurriness `0` is sharp edges, `1` is strongly blurred.
 		getBlurriness = function()
 			local range = sharpnessMax - sharpnessMin
 			if range <= 0 then
@@ -174,6 +177,8 @@ function widget:Initialize()
 			end -- guard against a degenerate (min == max) range
 			return (lineSharpness - sharpnessMin) / range
 		end,
+		---@param value number? `0` is sharp edges, `1` is strongly blurred. Clamped to `0`-`1`,
+		---and defaults to `0`.
 		setBlurriness = function(value)
 			local t = math.max(0, math.min(1, value or 0))
 			lineSharpness = sharpnessMin + t * (sharpnessMax - sharpnessMin)

--- a/luaui/Widgets/gfx_guishader.lua
+++ b/luaui/Widgets/gfx_guishader.lua
@@ -363,13 +363,6 @@ local function DeleteShaders()
 	blurShader = nil
 end
 
-function widget:Shutdown()
-	DeleteShaders()
-	WG.guishader = nil
-	widgetHandler:DeregisterGlobal("GuishaderInsertRect")
-	widgetHandler:DeregisterGlobal("GuishaderRemoveRect")
-end
-
 function widget:DrawScreenEffects() -- This blurs the world underneath UI elements
 	if spIsGUIHidden() or uiOpacity > 0.99 then
 		return
@@ -431,6 +424,10 @@ function widget:DrawScreenEffects() -- This blurs the world underneath UI elemen
 	end
 end
 
+---Blurs the UI elements obscured by other UI elements.
+---(only unit stats so far!) Exposed as `WG.guishader.DrawScreen`
+---because the widget handler skips `DrawScreen` while the Chobby
+---interface is shown, and this pass still needs to run.
 local function DrawScreen() -- This blurs the UI elements obscured by other UI elements (only unit stats so far!)
 	if spIsGUIHidden() then
 		return
@@ -510,12 +507,19 @@ function widget:Initialize()
 	self:UpdateCallIns()
 
 	WG.guishader = {}
+	---Registers a display list whose area is blurred behind the world.
+	---@param dlist integer GL display list id.
+	---@param name string Key the list is registered under; re-registering replaces it.
+	---@param force boolean? Re-register even when the same list is already stored.
 	WG.guishader.InsertDlist = function(dlist, name, force)
 		if force or guishaderDlists[name] ~= dlist then
 			guishaderDlists[name] = dlist
 			updateStencilTexture = true
 		end
 	end
+	---Unregisters a world-space blur display list without deleting it.
+	---@param name string
+	---@return boolean found `false` when nothing was registered under `name`.
 	WG.guishader.RemoveDlist = function(name)
 		local found = guishaderDlists[name] ~= nil
 		if found then
@@ -524,6 +528,9 @@ function widget:Initialize()
 		end
 		return found
 	end
+	---Unregisters a world-space blur display list and queues the list for deletion.
+	---@param name string
+	---@return boolean found `false` when nothing was registered under `name`.
 	WG.guishader.DeleteDlist = function(name)
 		local found = guishaderDlists[name] ~= nil
 		if found then
@@ -533,10 +540,19 @@ function widget:Initialize()
 		end
 		return found
 	end
+	---Registers a rectangle whose area is blurred behind the world.
+	---@param left number
+	---@param top number
+	---@param right number
+	---@param bottom number
+	---@param name string Key the rectangle is registered under; re-registering replaces it.
 	WG.guishader.InsertRect = function(left, top, right, bottom, name)
 		guishaderRects[name] = { left, top, right, bottom }
 		updateStencilTexture = true
 	end
+	---Unregisters a world-space blur rectangle.
+	---@param name string
+	---@return boolean found `false` when nothing was registered under `name`.
 	WG.guishader.RemoveRect = function(name)
 		local found = guishaderRects[name] ~= nil
 		if found then
@@ -545,10 +561,16 @@ function widget:Initialize()
 		end
 		return found
 	end
+	---Registers a display list whose area is blurred in screen space.
+	---@param dlist integer GL display list id.
+	---@param name string Key the list is registered under; re-registering replaces it.
 	WG.guishader.InsertScreenDlist = function(dlist, name)
 		guishaderScreenDlists[name] = dlist
 		updateStencilTextureScreen = true
 	end
+	---Unregisters a screen-space blur display list without deleting it.
+	---@param name string
+	---@return boolean found `false` when nothing was registered under `name`.
 	WG.guishader.RemoveScreenDlist = function(name)
 		local found = guishaderScreenDlists[name] ~= nil
 		if found then
@@ -557,6 +579,9 @@ function widget:Initialize()
 		end
 		return found
 	end
+	---Unregisters a screen-space blur display list and queues the list for deletion.
+	---@param name string
+	---@return boolean found `false` when nothing was registered under `name`.
 	WG.guishader.DeleteScreenDlist = function(name)
 		local found = guishaderScreenDlists[name] ~= nil
 		if found then
@@ -565,10 +590,19 @@ function widget:Initialize()
 		end
 		return found
 	end
+	---Registers a rectangle whose area is blurred in screen space.
+	---@param left number
+	---@param top number
+	---@param right number
+	---@param bottom number
+	---@param name string Key the rectangle is registered under; re-registering replaces it.
 	WG.guishader.InsertScreenRect = function(left, top, right, bottom, name)
 		guishaderScreenRects[name] = { left, top, right, bottom }
 		updateStencilTextureScreen = true
 	end
+	---Unregisters a screen-space blur rectangle.
+	---@param name string
+	---@return boolean found `false` when nothing was registered under `name`.
 	WG.guishader.RemoveScreenRect = function(name)
 		local found = guishaderScreenRects[name] ~= nil
 		if found then
@@ -578,18 +612,24 @@ function widget:Initialize()
 		return found
 	end
 
+	---Blurs the whole screen, e.g. behind a fullscreen menu.
+	---@param value boolean
 	WG.guishader.setScreenBlur = function(value)
 		updateStencilTextureScreen = true
 		screenBlur = value
 	end
+	---@return boolean screenBlur
 	WG.guishader.getScreenBlur = function(value)
 		return screenBlur
 	end
 
-	-- will let it draw a given dlist to be rendered on top of screenblur
+	---Registers a display list to be drawn on top of the screen blur.
+	---@param value integer GL display list id.
 	WG.guishader.insertRenderDlist = function(value)
 		renderDlists[value] = true
 	end
+	---Stops drawing a display list on top of the screen blur.
+	---@param value integer GL display list id.
 	WG.guishader.removeRenderDlist = function(value)
 		if renderDlists[value] then
 			renderDlists[value] = nil
@@ -600,6 +640,13 @@ function widget:Initialize()
 
 	widgetHandler:RegisterGlobal("GuishaderInsertRect", WG.guishader.InsertRect)
 	widgetHandler:RegisterGlobal("GuishaderRemoveRect", WG.guishader.RemoveRect)
+end
+
+function widget:Shutdown()
+	DeleteShaders()
+	WG.guishader = nil
+	widgetHandler:DeregisterGlobal("GuishaderInsertRect")
+	widgetHandler:DeregisterGlobal("GuishaderRemoveRect")
 end
 
 function widget:RecvLuaMsg(msg, playerID)

--- a/luaui/Widgets/gfx_highlight_commander_wrecks.lua
+++ b/luaui/Widgets/gfx_highlight_commander_wrecks.lua
@@ -117,6 +117,7 @@ local shader
 local highlightVBOLayout = {
 	{ id = 0, name = "position", size = 3 },
 }
+---@type InstanceVBOTable
 local instanceVBO = nil
 local instanceVBOLayout = {
 	{ id = 1, name = "position", size = 3 },
@@ -293,6 +294,9 @@ function widget:Initialize()
 	end
 
 	WG.highlightcomwrecks = {}
+	---Highlights commander wrecks in their owner's team color rather than the default,
+	---re-evaluating every feature on the map.
+	---@param value boolean
 	WG.highlightcomwrecks.setUseTeamColor = function(value)
 		useTeamColor = value
 		checkAllFeatures()

--- a/luaui/Widgets/gfx_limit_idle_fps.lua
+++ b/luaui/Widgets/gfx_limit_idle_fps.lua
@@ -30,11 +30,6 @@ local prevCamX, prevCamY, prevCamZ = spGetCameraPosition()
 local lastMouseOffScreen = false
 local chobbyInterface = false
 
-function widget:Shutdown()
-	Spring.SetConfigInt("VSync", vsyncValueActive)
-	WG.limitidlefps = nil
-end
-
 function widget:RecvLuaMsg(msg, playerID)
 	if msg:sub(1, 18) == "LobbyOverlayActive" then
 		chobbyInterface = (msg:sub(1, 19) == "LobbyOverlayActive1")
@@ -48,12 +43,20 @@ end
 
 function widget:Initialize()
 	WG.limitidlefps = {}
+	---@return boolean restrict Whether the framerate is currently being throttled
+	---because the game is idle.
 	WG.limitidlefps.restrictFps = function()
 		return restrictFps
 	end
+	---Reports user activity, so the idle framerate limit backs off.
 	WG.limitidlefps.update = function()
 		lastUserInputTime = os.clock()
 	end
+end
+
+function widget:Shutdown()
+	Spring.SetConfigInt("VSync", vsyncValueActive)
+	WG.limitidlefps = nil
 end
 
 local sec = 0

--- a/luaui/Widgets/gfx_los_colors.lua
+++ b/luaui/Widgets/gfx_los_colors.lua
@@ -55,9 +55,12 @@ end
 
 function widget:Initialize()
 	WG.los = {}
+	---@return number opacity Opacity of the LOS overlay colors.
 	WG.los.getOpacity = function()
 		return opacity
 	end
+	---Sets the LOS overlay opacity and reapplies the view colors.
+	---@param value number
 	WG.los.setOpacity = function(value)
 		opacity = value
 		updateLOS()

--- a/luaui/Widgets/gfx_orb_effects_gl4.lua
+++ b/luaui/Widgets/gfx_orb_effects_gl4.lua
@@ -525,6 +525,7 @@ UnitEffects = nil
 -- Variables
 --------------------------------------------------------------------------------
 
+---@type InstanceVBOTable
 local orbVBO = nil
 local orbShader = nil
 

--- a/luaui/Widgets/gfx_paralyze_effect.lua
+++ b/luaui/Widgets/gfx_paralyze_effect.lua
@@ -384,6 +384,19 @@ local function initGL4()
 	end
 end
 
+---Draws the paralysis effect on a unit. Widgets are responsible for stopping every
+---unit they submit.
+---@param unitID integer
+---@param unitDefID integer? Omit to look it up.
+---@param red_start number Effect color at the start of the animation.
+---@param green_start number
+---@param blue_start number
+---@param power_start number Effect strength at the start.
+---@param red_end number Effect color at the end of the animation.
+---@param green_end number
+---@param blue_end number
+---@param time_end number Game frame the animation ends on.
+---@return integer? unitID Pass to `StopDrawParalyzedUnitGL4`; `nil` if already drawn.
 local function DrawParalyzedUnitGL4(
 	unitID,
 	unitDefID,
@@ -396,12 +409,6 @@ local function DrawParalyzedUnitGL4(
 	blue_end,
 	time_end
 )
-	-- Documentation for DrawParalyzedUnitGL4:
-	--	unitID: the actual unitID that you want to draw
-	--	unitDefID: which unitDef is it (leave nil for autocomplete)
-	-- returns: a unique handler ID number that you should store and call StopDrawParalyzedUnitGL4(uniqueID) with to stop drawing it
-	-- note that widgets are responsible for stopping the drawing of every unit that they submit!
-
 	--spEcho("DrawParalyzedUnitGL4",unitID, unitDefID, UnitDefs[unitDefID].name)
 	if paralyzedDrawUnitVBOTable.instanceIDtoIndex[unitID] then
 		return
@@ -437,6 +444,8 @@ local function DrawParalyzedUnitGL4(
 	return unitID
 end
 
+---Stops drawing the paralysis effect on a unit. Unknown units are ignored.
+---@param unitID integer
 local function StopDrawParalyzedUnitGL4(unitID)
 	if paralyzedDrawUnitVBOTable.instanceIDtoIndex[unitID] then
 		popElementInstance(paralyzedDrawUnitVBOTable, unitID)

--- a/luaui/Widgets/gfx_sepia_tone.lua
+++ b/luaui/Widgets/gfx_sepia_tone.lua
@@ -184,38 +184,53 @@ function widget:Initialize()
 	end
 
 	WG.sepia = {}
+	---Sets the sepia filter gamma and recompiles the shader.
+	---@param value number
 	WG.sepia.setGamma = function(value)
 		params.gamma = value
 		UpdateShader()
 	end
+	---@return number gamma
 	WG.sepia.getGamma = function()
 		return params.gamma
 	end
+	---Sets the sepia filter saturation and recompiles the shader.
+	---@param value number
 	WG.sepia.setSaturation = function(value)
 		params.saturation = value
 		UpdateShader()
 	end
+	---@return number saturation
 	WG.sepia.getSaturation = function()
 		return params.saturation
 	end
+	---Sets the sepia filter contrast and recompiles the shader.
+	---@param value number
 	WG.sepia.setContrast = function(value)
 		params.contrast = value
 		UpdateShader()
 	end
+	---@return number contrast
 	WG.sepia.getContrast = function()
 		return params.contrast
 	end
+	---Sets how strongly the sepia tint is applied, and recompiles the shader.
+	---@param value number
 	WG.sepia.setSepia = function(value)
 		params.sepia = value
 		UpdateShader()
 	end
+	---@return number sepia
 	WG.sepia.getSepia = function()
 		return params.sepia
 	end
+	---Applies the sepia filter to the UI as well as the world.
+	---@param value boolean
 	WG.sepia.setShadeUI = function(value)
 		params.shadeUI = value
 		UpdateShader()
 	end
+	---@return boolean shadeUI
 	WG.sepia.getShadeUI = function()
 		return params.shadeUI
 	end

--- a/luaui/Widgets/gfx_showbuilderqueue.lua
+++ b/luaui/Widgets/gfx_showbuilderqueue.lua
@@ -91,6 +91,7 @@ local function removeUnitShape(shapeId)
 end
 
 -- Event handlers for API notifications
+
 --- @param id string
 --- @param buildCommand BuildCommandEntry
 local function onBuildCommandAdded(id, buildCommand)

--- a/luaui/Widgets/gfx_snow.lua
+++ b/luaui/Widgets/gfx_snow.lua
@@ -162,11 +162,6 @@ local function removeSnow()
 	end
 end
 
-function widget:Shutdown()
-	removeSnow()
-	WG.snow = nil
-end
-
 -- creating multiple lists per particleType so we can switch to less particles without causing lag
 local function CreateParticleLists()
 	removeParticleLists()
@@ -322,6 +317,8 @@ function widget:Initialize()
 	widget:ViewResize()
 
 	WG.snow = {}
+	---@return boolean snowing Whether snow is configured for this map, even if the
+	---widget has currently throttled it away.
 	WG.snow.getSnowMap = function()
 		if enabled or widgetDisabledSnow then
 			return true
@@ -329,15 +326,21 @@ function widget:Initialize()
 			return false
 		end
 	end
+	---Sets the particle count multiplier, rebuilding the particle lists when snow is on.
+	---@param value number
 	WG.snow.setMultiplier = function(value)
 		customParticleMultiplier = value
 		if enabled or widgetDisabledSnow then
 			CreateParticleLists()
 		end
 	end
+	---@return number multiplier Particle count multiplier.
 	WG.snow.getMultiplier = function()
 		return customParticleMultiplier
 	end
+	---Lets the widget thin out snow when the framerate drops. Turning it off restores
+	---the full particle count.
+	---@param value boolean
 	WG.snow.setAutoReduce = function(value)
 		autoReduce = value
 		if autoReduce == false then
@@ -348,9 +351,12 @@ function widget:Initialize()
 			averageFps = spGetFPS()
 		end
 	end
+	---@return boolean autoReduce
 	WG.snow.getAutoReduce = function()
 		return autoReduce
 	end
+	---Turns snow on or off for the current map, remembering the choice per map.
+	---@param value boolean
 	WG.snow.setSnowMap = function(value)
 		snowMaps[currentMapname] = value
 		enabled = value
@@ -360,35 +366,50 @@ function widget:Initialize()
 			removeSnow()
 		end
 	end
+	---Sets the snow color. Omitted components keep their current value.
+	---@param r number?
+	---@param g number?
+	---@param b number?
 	WG.snow.setColor = function(r, g, b)
 		snowColorR = r or snowColorR
 		snowColorG = g or snowColorG
 		snowColorB = b or snowColorB
 	end
+	---@return number r
+	---@return number g
+	---@return number b
 	WG.snow.getColor = function()
 		return snowColorR, snowColorG, snowColorB
 	end
+	---@param value number Snow particle opacity.
 	WG.snow.setOpacity = function(value)
 		snowOpacity = value
 	end
+	---@return number opacity
 	WG.snow.getOpacity = function()
 		return snowOpacity
 	end
+	---@param value number Multiplier on how fast snow falls.
 	WG.snow.setSpeedMultiplier = function(value)
 		speedMultiplier = value
 	end
+	---@return number multiplier
 	WG.snow.getSpeedMultiplier = function()
 		return speedMultiplier
 	end
+	---@param value number Multiplier on snowflake size.
 	WG.snow.setSizeMultiplier = function(value)
 		sizeMultiplier = value
 	end
+	---@return number multiplier
 	WG.snow.getSizeMultiplier = function()
 		return sizeMultiplier
 	end
+	---@param value number Multiplier on how far wind pushes the snow.
 	WG.snow.setWindMultiplier = function(value)
 		windMultiplier = value
 	end
+	---@return number multiplier
 	WG.snow.getWindMultiplier = function()
 		return windMultiplier
 	end
@@ -420,6 +441,11 @@ function widget:Initialize()
 	init()
 
 	widgetHandler:AddAction("snow", snowCmd, nil, "t")
+end
+
+function widget:Shutdown()
+	removeSnow()
+	WG.snow = nil
 end
 
 --------------------------------------------------------------------------------

--- a/luaui/Widgets/gfx_ssao.lua
+++ b/luaui/Widgets/gfx_ssao.lua
@@ -779,9 +779,12 @@ end
 
 function widget:Initialize()
 	WG.ssao = {}
+	---@return integer preset Quality preset index.
 	WG.ssao.getPreset = function()
 		return preset
 	end
+	---Switches the SSAO quality preset and rebuilds its shaders and textures.
+	---@param value integer
 	WG.ssao.setPreset = function(value)
 		preset = value
 		InitShaderDefines()
@@ -789,17 +792,23 @@ function widget:Initialize()
 		CleanGL()
 		InitGL()
 	end
+	---@return number strength Exponent applied to the occlusion term.
 	WG.ssao.getStrength = function()
 		return shaderConfig.SSAO_ALPHA_POW
 	end
+	---Sets the SSAO strength and rebuilds its GL resources.
+	---@param value number
 	WG.ssao.setStrength = function(value)
 		shaderConfig.SSAO_ALPHA_POW = value
 		CleanGL()
 		InitGL()
 	end
+	---@return number radius World-space sampling radius.
 	WG.ssao.getRadius = function()
 		return shaderConfig.SSAO_RADIUS
 	end
+	---Sets the SSAO sampling radius and rebuilds its GL resources.
+	---@param value number
 	WG.ssao.setRadius = function(value)
 		shaderConfig.SSAO_RADIUS = value
 		CleanGL()

--- a/luaui/Widgets/gfx_unit_stencil_gl4.lua
+++ b/luaui/Widgets/gfx_unit_stencil_gl4.lua
@@ -21,7 +21,9 @@ local spEcho = Spring.Echo
 -- Make this shared the same way screencopy texture is shared, via an api
 -- bind and sample this texture if needed for any other method :)
 
+---@type InstanceVBOTable
 local unitStencilVBO = nil
+---@type InstanceVBOTable
 local featureStencilVBO = nil -- TODO
 local unitStencilShader = nil
 
@@ -593,6 +595,9 @@ end
 ]]
 --
 
+---Returns the stencil texture covering units and features, and marks it as wanted
+---so the widget keeps rendering it.
+---@return string? texName
 local function GetUnitStencilTexture()
 	stencilRequested = true
 	return unitFeatureStencilTex

--- a/luaui/Widgets/gfx_volumetric_clouds.lua
+++ b/luaui/Widgets/gfx_volumetric_clouds.lua
@@ -574,9 +574,12 @@ end
 
 function widget:Initialize()
 	WG.clouds = {}
+	---@return number opacity Multiplier applied to the volumetric cloud opacity.
 	WG.clouds.getOpacity = function()
 		return opacityMult
 	end
+	---Sets the cloud opacity multiplier and reinitializes the effect.
+	---@param value number
 	WG.clouds.setOpacity = function(value)
 		opacityMult = value
 		init()

--- a/luaui/Widgets/gfx_water_type_overlay_gl4.lua
+++ b/luaui/Widgets/gfx_water_type_overlay_gl4.lua
@@ -212,6 +212,9 @@ local function ensurePlaneVAO()
 	return true
 end
 
+---Turns on the hazardous water overlay, compiling its shaders on first use.
+---Does nothing on maps that already have real lava, or for unknown types.
+---@param typeName "lava"|"acid"
 local function activateOverlay(typeName)
 	if isRealLavaMap then
 		return
@@ -252,6 +255,7 @@ local function activateOverlay(typeName)
 	sendOverlayMsg("wateroverlay:activate:" .. typeName)
 end
 
+---Turns off the overlay and restores the engine's own water rendering.
 local function deactivateOverlay()
 	if engineWaterHidden then
 		Spring.SetDrawWater(true)
@@ -272,12 +276,16 @@ function widget:Initialize()
 	WG.WaterTypeOverlay = {
 		activate = activateOverlay,
 		deactivate = deactivateOverlay,
+		---@return boolean active
 		isActive = function()
 			return active
 		end,
+		---@return "lava"|"acid"|nil typeName `nil` while the overlay is inactive.
 		getActiveType = function()
 			return activeType
 		end,
+		---Sets the height the overlay surface eases toward, relative to the base water plane.
+		---@param level number
 		setLevel = function(level)
 			Spring.Echo(
 				"[WaterOverlay] setLevel: "
@@ -290,18 +298,23 @@ function widget:Initialize()
 			targetLevel = level
 			sendOverlayMsg("wateroverlay:level:" .. string.format("%.1f", level))
 		end,
+		---@return number level Current absolute world height of the overlay surface.
 		getLevel = function()
 			return currentLevel
 		end,
+		---@return number level Offset from the base water plane the overlay eases toward.
 		getTargetLevel = function()
 			return targetLevel
 		end,
+		---@param v number How far the overlay surface rises and falls with the tide.
 		setTideAmplitude = function(v)
 			tideAmplitude = v
 		end,
+		---@param v number Seconds per tide cycle; at least `1`.
 		setTidePeriod = function(v)
 			tidePeriod = math.max(1, v)
 		end,
+		---@param v number How far the fog layer sits above the overlay surface.
 		setFogHeight = function(v)
 			fogheightabovelava = v
 		end,

--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -1049,9 +1049,12 @@ function widget:Initialize()
 	end
 
 	WG.advplayerlist_api = {}
+	---@return boolean hide Whether the spectator list is always collapsed.
 	WG.advplayerlist_api.GetAlwaysHideSpecs = function()
 		return alwaysHideSpecs
 	end
+	---Always collapses the spectator list, rebuilding the player list when it was open.
+	---@param value boolean
 	WG.advplayerlist_api.SetAlwaysHideSpecs = function(value)
 		alwaysHideSpecs = value
 		if alwaysHideSpecs and specListShow then
@@ -1061,25 +1064,38 @@ function widget:Initialize()
 			CreateLists()
 		end
 	end
+	---@return number scale UI scale of the player list.
 	WG.advplayerlist_api.GetScale = function()
 		return customScale
 	end
+	---Sets the player list UI scale and relays it out.
+	---@param value number
 	WG.advplayerlist_api.SetScale = function(value)
 		customScale = value
 		updateWidgetScale()
 	end
+	---Screen rectangle of the player list.
+	---@return [number, number, number, number, number, nil, boolean] position As
+	---`{top, left, bottom, right, widgetScale, ?, flipped}`. Slot 6 is always `nil`: the
+	---assignment reads an undefined global `right` (see the `apiAbsPosition` update).
 	WG.advplayerlist_api.GetPosition = function()
 		return apiAbsPosition
 	end
+	---@return boolean absolute Whether resource bars show absolute values rather than shares.
 	WG.advplayerlist_api.GetAbsoluteResbars = function()
 		return absoluteResbarValues
 	end
+	---@param value boolean Show absolute resource values rather than shares.
 	WG.advplayerlist_api.SetAbsoluteResbars = function(value)
 		absoluteResbarValues = value
 	end
+	---@param module integer Index into the player list's module table.
+	---@return boolean active
 	WG.advplayerlist_api.GetModuleActive = function(module)
 		return modules[module].active
 	end
+	---Shows or hides one player list column, relaying out the list.
+	---@param value {[1]: string, [2]: boolean} The module name and whether it is shown.
 	WG.advplayerlist_api.SetModuleActive = function(value)
 		for n, module in pairs(modules) do
 			if module.name == value[1] then

--- a/luaui/Widgets/gui_advplayerslist_gameinfo.lua
+++ b/luaui/Widgets/gui_advplayerslist_gameinfo.lua
@@ -181,6 +181,8 @@ function widget:Initialize()
 	widget:ViewResize()
 	updatePosition()
 	WG.displayinfo = {}
+	---Screen rectangle of the game info panel.
+	---@return DockedPanelPosition position
 	WG.displayinfo.GetPosition = function()
 		return { top, left, bottom, right, widgetScale }
 	end

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -959,6 +959,8 @@ function widget:Initialize()
 	--Spring.StopSoundStream() -- only for testing purposes
 
 	WG.music = {}
+	---Screen rectangle of the music player panel.
+	---@return DockedPanelPosition|false position `false` once the widget has shut down.
 	WG.music.GetPosition = function()
 		if shutdown then
 			return false
@@ -966,9 +968,13 @@ function widget:Initialize()
 		updatePosition()
 		return { showGUI and top or bottom, left, bottom, right, widgetScale }
 	end
+	---@return number volume Music volume, `0`-`100`.
 	WG.music.GetMusicVolume = function()
 		return maxMusicVolume
 	end
+	---Sets the music volume and persists it. The stored value is capped at `99`,
+	---because the engine does not save its own default of `100`.
+	---@param value number `0`-`100`.
 	WG.music.SetMusicVolume = function(value)
 		maxMusicVolume = value
 		spSetConfigInt("snd_volmusic", mathMin(99, mathCeil(maxMusicVolume))) -- It took us 2 and half year to realize that the engine is not saving value of a 100 because it's engine default, which is why we're maxing it at 99
@@ -977,12 +983,17 @@ function widget:Initialize()
 		end
 		updateDrawing = true
 	end
+	---@return boolean showGui Whether the music player panel is visible.
 	WG.music.GetShowGui = function()
 		return showGUI
 	end
+	---@param value boolean Show the music player panel.
 	WG.music.SetShowGui = function(value)
 		showGUI = value
 	end
+	---Lists every playable track, grouped by playlist and sorted by display name.
+	---@param value any? Unused.
+	---@return [string, string, string][] tracks Each entry is `{playlistLabel, displayName, path}`.
 	WG.music.getTracksConfig = function(value)
 		local tracksConfig = {}
 
@@ -1079,6 +1090,8 @@ function widget:Initialize()
 		end
 		return tracksConfig
 	end
+	---Stops whatever is playing and starts a specific track.
+	---@param track string Path to the audio file.
 	WG.music.playTrack = function(track)
 		currentTrack = track
 		updateCurrentTrackCache(currentTrack)
@@ -1095,10 +1108,12 @@ function widget:Initialize()
 		end
 		updateDrawing = true
 	end
+	---Re-reads the soundtrack interruption and fade settings from the engine config.
 	WG.music.RefreshSettings = function()
 		interruptionEnabled = Spring.GetConfigInt("UseSoundtrackInterruption", 1) == 1
 		useSoundtrackFades = Spring.GetConfigInt("UseSoundtrackFades", 1) == 1
 	end
+	---Reloads the playlists from disk and starts a new track.
 	WG.music.RefreshTrackList = function()
 		Spring.StopSoundStream()
 		ReloadMusicPlaylists()

--- a/luaui/Widgets/gui_advplayerslist_unittotals.lua
+++ b/luaui/Widgets/gui_advplayerslist_unittotals.lua
@@ -155,6 +155,8 @@ function widget:Initialize()
 	widget:ViewResize()
 	updatePosition()
 	WG.unittotals = {}
+	---Screen rectangle of the unit totals panel.
+	---@return DockedPanelPosition position
 	WG.unittotals.GetPosition = function()
 		return { top, left, bottom, right, widgetScale }
 	end

--- a/luaui/Widgets/gui_allySelectedUnits.lua
+++ b/luaui/Widgets/gui_allySelectedUnits.lua
@@ -685,12 +685,17 @@ function widget:Initialize()
 	widget:PlayerChanged(myPlayerID)
 
 	WG.allyselectedunits = {}
+	---@return boolean enabled Whether clicking an ally's cursor selects their units.
 	WG.allyselectedunits.getSelectPlayerUnits = function()
 		return selectPlayerUnits
 	end
+	---@param value boolean Let clicking an ally's cursor select their units.
 	WG.allyselectedunits.setSelectPlayerUnits = function(value)
 		selectPlayerUnits = value
 	end
+	---Returns the units an allied player currently has selected.
+	---@param playerID integer
+	---@return integer[]? unitIDs `nil` when that player's selection is not known.
 	WG.allyselectedunits.getPlayerSelectedUnits = function(playerID)
 		return playerSelectedUnits[playerID]
 	end

--- a/luaui/Widgets/gui_ally_cursors.lua
+++ b/luaui/Widgets/gui_ally_cursors.lua
@@ -295,56 +295,92 @@ function widget:Initialize()
 	updateSpecList(true)
 
 	WG.allycursors = {}
+	---Draws a light at each allied cursor.
+	---@param value boolean
 	WG.allycursors.setLights = function(value)
 		addLights = value
 		deleteDlists()
 	end
+	---@return boolean lights
 	WG.allycursors.getLights = function()
 		return addLights
 	end
+	---@param value number Brightness multiplier for allied cursor lights.
 	WG.allycursors.setLightStrength = function(value)
 		lightStrengthMult = value
 	end
+	---@return number multiplier
 	WG.allycursors.getLightStrength = function()
 		return lightStrengthMult
 	end
+	---@param value number Radius multiplier for allied cursor lights.
 	WG.allycursors.setLightRadius = function(value)
 		lightRadiusMult = value
 	end
+	---@param value boolean Let allied cursor lights cast screen-space shadows.
 	WG.allycursors.setLightSelfShadowing = function(value)
 		lightSelfShadowing = value
 	end
+	---@return number multiplier
 	WG.allycursors.getLightRadius = function()
 		return lightRadiusMult
 	end
 
+	---@return boolean selfShadowing
 	WG.allycursors.getLightSelfShadowing = function()
 		return lightSelfShadowing
 	end
+	---Draws a dot at each allied cursor position.
+	---@param value boolean
 	WG.allycursors.setCursorDot = function(value)
 		showCursorDot = value
 		deleteDlists()
 	end
+	---@return boolean cursorDot
 	WG.allycursors.getCursorDot = function()
 		return showCursorDot
 	end
+	---Labels allied cursors with the player's name.
+	---@param value boolean
 	WG.allycursors.setPlayerNames = function(value)
 		showPlayerName = value
 		deleteDlists()
 	end
+	---@return boolean playerNames
 	WG.allycursors.getPlayerNames = function()
 		return showPlayerName
 	end
+	---Labels spectator cursors with the spectator's name.
+	---@param value boolean
 	WG.allycursors.setSpectatorNames = function(value)
 		showSpectatorName = value
 		deleteDlists()
 	end
+	---@return boolean spectatorNames
 	WG.allycursors.getSpectatorNames = function()
 		return showSpectatorName
 	end
+	---One tracked ally cursor.
+	---@class AllyCursor
+	---@field [1] number World X of the cursor.
+	---@field [2] number World Y (ground height) under the cursor.
+	---@field [3] number World Z of the cursor.
+	---@field [4] number Camera X the cursor was sent from.
+	---@field [5] number Camera Y.
+	---@field [6] number Camera Z.
+	---@field [7] number Fade opacity; set to `0` to hide without removing.
+	---@field [8] boolean Whether the owner is a spectator.
+
+	---Returns every tracked cursor, without applying visibility rules.
+	---@return table<integer, AllyCursor> cursors Keyed by playerID. Do not mutate.
+	---@return table<integer, true> notIdle Players who have moved their cursor at least once.
 	WG.allycursors.getCursors = function()
 		return cursors, notIdle
 	end
+	---Returns one player's cursor, honoring what the local viewer is allowed to see.
+	---@param playerID integer?
+	---@return AllyCursor? cursor `nil` when the cursor is unknown or hidden from the viewer.
+	---@return true? notIdle Whether that player has moved their cursor at least once.
 	WG.allycursors.getCursor = function(playerID)
 		if not playerID then
 			return nil
@@ -355,6 +391,9 @@ function widget:Initialize()
 		end
 		return cursors[playerID], notIdle[playerID]
 	end
+	---Whether the local viewer is allowed to see a player's cursor.
+	---@param playerID integer?
+	---@return boolean
 	WG.allycursors.isCursorVisible = function(playerID)
 		if not playerID then
 			return false

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -1058,23 +1058,33 @@ function widget:Initialize()
 	InitializeBuilders()
 
 	WG.attackrange = {}
+	---@return boolean shiftOnly Whether attack ranges only show while shift is held.
 	WG.attackrange.getShiftOnly = function()
 		return shift_only
 	end
+	---Only shows attack ranges while shift is held, reinitializing the widget.
+	---@param value boolean
 	WG.attackrange.setShiftOnly = function(value)
 		shift_only = value
 		widget:Initialize()
 	end
+	---@return boolean enabled Whether the range of the unit under the cursor is shown.
 	WG.attackrange.getCursorUnitRange = function()
 		return cursor_unit_range
 	end
+	---Shows the range of the unit under the cursor, reinitializing the widget.
+	---@param value boolean
 	WG.attackrange.setCursorUnitRange = function(value)
 		cursor_unit_range = value
 		widget:Initialize()
 	end
+	---@return number multiplier Scales how many selected units may show ranges before
+	---the display switches off.
 	WG.attackrange.getNumRangesMult = function()
 		return selectionDisableThresholdMult
 	end
+	---@param value number Scales how many selected units may show ranges before the
+	---display switches off.
 	WG.attackrange.setNumRangesMult = function(value)
 		selectionDisableThresholdMult = value
 	end

--- a/luaui/Widgets/gui_buildbar.lua
+++ b/luaui/Widgets/gui_buildbar.lua
@@ -100,7 +100,12 @@ local msz = Game.mapY * 512
 local groups, unitGroup = {}, {} -- retrieves from buildmenu in initialize
 local unitOrder = {} -- retrieves from buildmenu in initialize
 
-local bgpadding, font, backgroundRect, backgroundOptionsRect, buildoptionsArea, dlistGuishader, dlistGuishader2, forceGuishader
+local bgpadding, font, dlistGuishader, dlistGuishader2, forceGuishader
+---@type ScreenRect?
+local backgroundRect
+---@type ScreenRect?
+local backgroundOptionsRect
+local buildoptionsArea
 local factoriesArea, cornerSize, setInfoDisplayUnitID, setInfoDisplayUnitDefID, factoriesAreaHovered
 
 -------------------------------------------------------------------------------

--- a/luaui/Widgets/gui_building_grid_gl4.lua
+++ b/luaui/Widgets/gui_building_grid_gl4.lua
@@ -155,13 +155,21 @@ end
 
 function widget:Initialize()
 	WG.buildinggrid = {}
+	---@return number opacity Opacity of the building grid overlay.
 	WG.buildinggrid.getOpacity = function()
 		return opacity
 	end
+	---Sets the building grid opacity. The widget must be reloaded for it to take effect.
+	---@param value number
 	WG.buildinggrid.setOpacity = function(value)
 		opacity = value
 		-- widget needs reloading wholly
 	end
+	---Forces the building grid on for a named reason, so several widgets can request
+	---it without fighting each other.
+	---@param reason string Caller-chosen key; pass the same one to turn it off again.
+	---@param enabled boolean
+	---@param unitDefID integer? Building whose footprint the grid should suit.
 	WG.buildinggrid.setForceShow = function(reason, enabled, unitDefID)
 		if enabled then
 			forceShow[reason] = unitDefID

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -138,6 +138,7 @@ local myTeamID = spGetMyTeamID()
 local startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 
 local disableInput = disableInputWhenSpec and isSpec
+---@type ScreenRect
 local backgroundRect = { 0, 0, 0, 0 }
 local colls = 5
 local rows = 5
@@ -2256,91 +2257,128 @@ function widget:Initialize()
 	widget:SelectionChanged(spGetSelectedUnits())
 
 	WG.buildmenu = {}
+	---@return table<string, string> groups Icon path per group name.
+	---@return table<integer, string> unitGroup Group name per unitDefID.
 	WG.buildmenu.getGroups = function()
 		return groups, units.unitGroup
 	end
+	---@return table<integer, integer> order Sort position per unitDefID.
 	WG.buildmenu.getOrder = function()
 		return units.unitOrder
 	end
+	---@return boolean showPrice Whether build options are labeled with their cost.
 	WG.buildmenu.getShowPrice = function()
 		return showPrice
 	end
+	---Labels build options with their cost, rebuilding the menu.
+	---@param value boolean
 	WG.buildmenu.setShowPrice = function(value)
 		showPrice = value
 		clear()
 	end
+	---@return boolean alwaysShow Whether the menu stays open with no builder selected.
 	WG.buildmenu.getAlwaysShow = function()
 		return alwaysShow
 	end
+	---Keeps the menu open with no builder selected, rebuilding the menu.
+	---@param value boolean
 	WG.buildmenu.setAlwaysShow = function(value)
 		alwaysShow = value
 		clear()
 	end
+	---@return boolean show Whether build options show their radar icon.
 	WG.buildmenu.getShowRadarIcon = function()
 		return showRadarIcon
 	end
+	---Shows the radar icon on build options, rebuilding the menu.
+	---@param value boolean
 	WG.buildmenu.setShowRadarIcon = function(value)
 		showRadarIcon = value
 		clear()
 	end
+	---@return boolean show Whether build options show their group icon.
 	WG.buildmenu.getShowGroupIcon = function()
 		return showGroupIcon
 	end
+	---Shows the group icon on build options, rebuilding the menu.
+	---@param value boolean
 	WG.buildmenu.setShowGroupIcon = function(value)
 		showGroupIcon = value
 		clear()
 	end
+	---@return boolean dynamic Whether icons resize to fill the available space.
 	WG.buildmenu.getDynamicIconsize = function()
 		return dynamicIconsize
 	end
+	---Resizes icons to fill the available space, rebuilding the menu.
+	---@param value boolean
 	WG.buildmenu.setDynamicIconsize = function(value)
 		dynamicIconsize = value
 		clear()
 	end
+	---@return integer minColumns
 	WG.buildmenu.getMinColls = function()
 		return minColls
 	end
+	---Sets the minimum column count and rebuilds the menu.
+	---@param value integer
 	WG.buildmenu.setMinColls = function(value)
 		minColls = value
 		clear()
 	end
+	---@return integer maxColumns
 	WG.buildmenu.getMaxColls = function()
 		return maxColls
 	end
+	---Sets the maximum column count and rebuilds the menu.
+	---@param value integer
 	WG.buildmenu.setMaxColls = function(value)
 		maxColls = value
 		clear()
 	end
+	---@return integer defaultColumns
 	WG.buildmenu.getDefaultColls = function()
 		return defaultColls
 	end
 
+	---Sets the preferred column count and rebuilds the menu.
+	---@param value integer
 	WG.buildmenu.setDefaultColls = function(value)
 		defaultColls = value
 		clear()
 	end
+	---@return boolean stickToBottom Whether the menu is docked to the bottom of the screen.
 	WG.buildmenu.getBottomPosition = function()
 		return stickToBottom
 	end
+	---Docks the menu to the bottom of the screen and relays it out.
+	---@param value boolean
 	WG.buildmenu.setBottomPosition = function(value)
 		stickToBottom = value
 		widget:Update(1000)
 		widget:ViewResize()
 		clear()
 	end
+	---@return number posY Screen Y of the menu's bottom edge.
+	---@return number posY2 Screen Y of the menu's top edge.
 	WG.buildmenu.getSize = function()
 		return posY, posY2
 	end
+	---@return number maxPosY Highest screen Y the menu may grow to.
 	WG.buildmenu.getMaxPosY = function()
 		return maxPosY
 	end
+	---Sets the highest screen Y the menu may grow to, and rebuilds it.
+	---@param value number
 	WG.buildmenu.setMaxPosY = function(value)
 		maxPosY = value
 		clear()
 	end
+	---Rebinds the build hotkeys, e.g. after the keybind config changed.
 	WG.buildmenu.reloadBindings = function()
 		bindBuildUnits(self)
 	end
+	---@return boolean showing Whether the build menu is currently drawn.
 	WG.buildmenu.getIsShowing = function()
 		return buildmenuShows
 	end

--- a/luaui/Widgets/gui_changelog_info.lua
+++ b/luaui/Widgets/gui_changelog_info.lua
@@ -71,7 +71,9 @@ local maxLines = 20
 
 local math_isInRect = math.isInRect
 
-local font, loadedFontSize, font2, changelogList, titleRect, backgroundGuishader, changelogList, dlistcreated, show, bgpadding
+local font, loadedFontSize, font2, changelogList, titleRect, backgroundGuishader, changelogList, dlistcreated, bgpadding
+---@type boolean
+local show
 
 function widget:ViewResize()
 	vsx, vsy = spGetViewGeometry()
@@ -461,6 +463,9 @@ function widget:Initialize()
 	widget:ViewResize()
 	if changelogFile then
 		WG.changelog = {}
+		---@type boolean
+		---Shows or hides the changelog window. Opening it marks the changelog as read.
+		---@param state boolean? Omit to toggle.
 		WG.changelog.toggle = function(state)
 			if state ~= nil then
 				show = state
@@ -474,9 +479,11 @@ function widget:Initialize()
 				end
 			end
 		end
+		---@return boolean visible
 		WG.changelog.isvisible = function()
 			return show
 		end
+		---@return boolean hasChanges Whether the changelog has entries the player has not read.
 		WG.changelog.haschanges = function()
 			return lastviewedHash ~= changelogFileHash and lastviewedChangelogLength < changelogFileLength
 		end

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -996,6 +996,9 @@ state.getMapmarkWorldPosition = function(mx, my)
 		mx, my = spGetMouseState()
 	end
 	for pipNumber = 0, 4 do
+		---The PIP API table. `WG['pip'..n]` is a computed key, so it has to be pinned
+		---here or it widens to the union of every typed `WG` member.
+		---@type table
 		local pipApi = WG["pip" .. pipNumber]
 		if pipApi and pipApi.ScreenToWorld then
 			local x, z = pipApi.ScreenToWorld(mx, my)
@@ -4461,36 +4464,56 @@ function widget:Initialize()
 	Spring.SendCommands("console 0")
 
 	WG.chat = {}
+	---@return boolean active Whether the chat input field is open.
 	WG.chat.isInputActive = function()
 		return showTextInput
 	end
+	---@return boolean active Whether the player is drawing on the map.
 	WG.chat.isMapDrawActive = function()
 		return state.mapDrawActive
 	end
+	---Opens the label input field for a map mark at a world position.
+	---@param x number
+	---@param y number
+	---@param z number
+	---@param triggerKey integer? Key that opened it, so releasing it can close it again.
+	---@param triggerScanCode integer? Scan code of that key.
+	---@return boolean started `false` when chat input is unavailable, e.g. the GUI is
+	---hidden or another widget owns text input.
 	WG.chat.startMapmarkInput = function(x, y, z, triggerKey, triggerScanCode)
 		return state.startMapmarkInput(x, y, z, triggerKey, triggerScanCode)
 	end
+	---@return boolean showing Whether the on-screen chat button is drawn.
 	WG.chat.getInputButton = function()
 		return inputButton
 	end
+	---@param value boolean Hide the chat display.
 	WG.chat.setHide = function(value)
 		hide = value
 	end
+	---@return boolean hidden
 	WG.chat.getHide = function()
 		return hide
 	end
+	---@param value boolean Show recent chat history while the input field is open.
 	WG.chat.setChatInputHistory = function(value)
 		showHistoryWhenChatInput = value
 	end
+	---@return boolean show
 	WG.chat.getChatInputHistory = function()
 		return showHistoryWhenChatInput
 	end
+	---@param value boolean Draw the on-screen chat button.
 	WG.chat.setInputButton = function(value)
 		inputButton = value
 	end
+	---@return boolean handle Whether this widget owns chat text input.
 	WG.chat.getHandleInput = function()
 		return handleTextInput
 	end
+	---Takes over or releases chat text input, cancelling any input in progress when
+	---releasing it.
+	---@param value boolean
 	WG.chat.setHandleInput = function(value)
 		handleTextInput = value
 		if not handleTextInput then
@@ -4500,39 +4523,62 @@ function widget:Initialize()
 			Spring.SDLStartTextInput() -- because: touch chobby's text edit field once and widget:TextInput is gone for the game, so we make sure its started!
 		end
 	end
+	---@return number volume Volume of the chat notification sound.
 	WG.chat.getChatVolume = function()
 		return sndChatFileVolume
 	end
+	---@param value number Volume of the chat notification sound.
 	WG.chat.setChatVolume = function(value)
 		sndChatFileVolume = value
 	end
+	---@return number opacity Opacity of the chat background.
 	WG.chat.getBackgroundOpacity = function()
 		return backgroundOpacity
 	end
+	---@param value number Opacity of the chat background.
 	WG.chat.setBackgroundOpacity = function(value)
 		backgroundOpacity = value
 	end
+	---@return integer lines Chat lines shown at once.
 	WG.chat.getMaxLines = function()
 		return maxLines
 	end
+	---Sets how many chat lines are shown at once and relays out.
+	---@param value integer
 	WG.chat.setMaxLines = function(value)
 		maxLines = value
 		widget:ViewResize()
 	end
+	---@return integer lines NOTE: returns the chat line count, not the console one.
 	WG.chat.getMaxConsoleLines = function()
 		return maxLines
 	end
+	---Sets how many console lines are shown at once and relays out.
+	---@param value integer
 	WG.chat.setMaxConsoleLines = function(value)
 		maxConsoleLines = value
 		widget:ViewResize()
 	end
+	---@return number multiplier Chat font size multiplier.
 	WG.chat.getFontsize = function()
 		return fontsizeMult
 	end
+	---Sets the chat font size multiplier and relays out.
+	---@param value number
 	WG.chat.setFontsize = function(value)
 		fontsizeMult = value
 		widget:ViewResize()
 	end
+	---Appends a line to the chat display, bypassing the registered chat processors.
+	---@param gameFrame integer
+	---@param lineType integer
+	---@param name string Speaker's plain name.
+	---@param nameText string Speaker's name as it should be drawn, including colors.
+	---@param text string
+	---@param orgLineID integer? Index of the original console line, if any.
+	---@param ignore boolean? The speaker is ignored, so the line is dimmed or hidden.
+	---@param chatLineID integer? Defaults to the next line index.
+	---@param channelScope string? Which chat channel the line belongs to.
 	WG.chat.addChatLine = function(
 		gameFrame,
 		lineType,
@@ -4546,11 +4592,18 @@ function widget:Initialize()
 	)
 		addChatLine(gameFrame, lineType, name, nameText, text, orgLineID, ignore, chatLineID, true, channelScope)
 	end
+	---Registers a filter that rewrites chat lines before they are displayed.
+	---Non-function values are ignored.
+	---@param id string Caller-chosen key; pass the same one to `removeChatProcessor`.
+	---@param func fun(gameFrame: integer, lineType: integer, name: string, nameText: string, text: string, orgLineID: integer?, ignore: boolean?, chatLineID: integer): string?
+	---Returns the rewritten text, or `nil` to drop the line.
 	WG.chat.addChatProcessor = function(id, func)
 		if type(func) == "function" then
 			chatProcessors[id] = func
 		end
 	end
+	---Unregisters a chat processor.
+	---@param id string
 	WG.chat.removeChatProcessor = function(id)
 		chatProcessors[id] = nil
 	end

--- a/luaui/Widgets/gui_com_nametags.lua
+++ b/luaui/Widgets/gui_com_nametags.lua
@@ -735,9 +735,12 @@ end
 
 function widget:Initialize()
 	WG.nametags = {}
+	---@return boolean show Whether commander nametags include the player's rank.
 	WG.nametags.GetShowPlayerRank = function()
 		return showPlayerRank
 	end
+	---Shows the player's rank on commander nametags, rebuilding the labels.
+	---@param value boolean
 	WG.nametags.SetShowPlayerRank = function(value)
 		showPlayerRank = value
 		RemoveLists()

--- a/luaui/Widgets/gui_commands_fx.lua
+++ b/luaui/Widgets/gui_commands_fx.lua
@@ -548,34 +548,45 @@ function widget:Initialize()
 	resetEnabledTeams()
 
 	WG.commandsfx = {}
+	---@return number opacity Opacity of the command effect lines.
 	WG.commandsfx.getOpacity = function()
 		return opacity
 	end
+	---@param value number Opacity of the command effect lines.
 	WG.commandsfx.setOpacity = function(value)
 		opacity = value
 	end
+	---@return number seconds How long a command effect stays on screen.
 	WG.commandsfx.getDuration = function()
 		return duration
 	end
+	---@param value number Seconds a command effect stays on screen.
 	WG.commandsfx.setDuration = function(value)
 		duration = value
 	end
+	---@return boolean filter Whether AI team commands are hidden.
 	WG.commandsfx.getFilterAI = function()
 		return filterAIteams
 	end
+	---Hides AI team commands, recomputing which teams are drawn.
+	---@param value boolean
 	WG.commandsfx.setFilterAI = function(value)
 		filterAIteams = value
 		resetEnabledTeams()
 	end
+	---@return boolean useTeamColors Whether effects are drawn in the issuing team's color.
 	WG.commandsfx.getUseTeamColors = function()
 		return useTeamColors
 	end
+	---@param value boolean Draw effects in the issuing team's color.
 	WG.commandsfx.setUseTeamColors = function(value)
 		useTeamColors = value
 	end
 	WG.commandsfx.getUseTeamColorsWhenSpec = function()
 		return useTeamColorsWhenSpec
 	end
+	---@return boolean useTeamColorsWhenSpec
+	---@param value boolean Draw effects in team colors while spectating.
 	WG.commandsfx.setUseTeamColorsWhenSpec = function(value)
 		useTeamColorsWhenSpec = value
 	end

--- a/luaui/Widgets/gui_converter_usage.lua
+++ b/luaui/Widgets/gui_converter_usage.lua
@@ -251,6 +251,28 @@ function widget:MousePress(x, y, button)
 	end
 end
 
+function widget:ViewResize()
+	vsx, vsy = glGetViewSizes()
+
+	RectRound = WG.FlowUI.Draw.RectRound
+	UiElement = WG.FlowUI.Draw.Element
+
+	font2 = WG.fonts.getFont(2)
+	layoutDirty = true
+end
+
+function widget:Initialize()
+	widget:ViewResize()
+	refreshTooltipText()
+
+	WG.converter_usage = {}
+	---Screen rectangle of the converter usage panel.
+	---@return ScreenRect area
+	WG.converter_usage.GetPosition = function()
+		return area
+	end
+end
+
 function widget:Shutdown()
 	if dlistGuishader ~= nil then
 		if WG.guishader then
@@ -268,26 +290,6 @@ function widget:Shutdown()
 		WG.tooltip.RemoveTooltip("converter_usage")
 	end
 	WG.converter_usage = nil
-end
-
-function widget:ViewResize()
-	vsx, vsy = glGetViewSizes()
-
-	RectRound = WG.FlowUI.Draw.RectRound
-	UiElement = WG.FlowUI.Draw.Element
-
-	font2 = WG.fonts.getFont(2)
-	layoutDirty = true
-end
-
-function widget:Initialize()
-	widget:ViewResize()
-	refreshTooltipText()
-
-	WG.converter_usage = {}
-	WG.converter_usage.GetPosition = function()
-		return area
-	end
 end
 
 function widget:LanguageChanged()

--- a/luaui/Widgets/gui_cursor.lua
+++ b/luaui/Widgets/gui_cursor.lua
@@ -58,9 +58,11 @@ function widget:Initialize()
 	widget:ViewResize()
 
 	WG.cursors = {}
+	---@return string cursorSet Name of the active cursor set.
 	WG.cursors.getcursor = function()
 		return Settings.cursorSet
 	end
+	---@return string[] sets Names of every available cursor set.
 	WG.cursors.getcursorsets = function()
 		local sets = {}
 		for i, y in pairs(cursorSets) do
@@ -68,13 +70,18 @@ function widget:Initialize()
 		end
 		return sets
 	end
+	---Switches to a cursor set, reloading the cursor images.
+	---@param value string A name from `getcursorsets`.
 	WG.cursors.setcursor = function(value)
 		force = true
 		SetCursor(value)
 	end
+	---@return number multiplier Cursor size multiplier.
 	WG.cursors.getsizemult = function()
 		return Spring.GetConfigFloat("cursorsize", 1)
 	end
+	---Sets the cursor size multiplier, persists it, and reloads the cursor images.
+	---@param value number
 	WG.cursors.setsizemult = function(value)
 		Spring.SetConfigFloat("cursorsize", value)
 		widget:ViewResize()

--- a/luaui/Widgets/gui_easyFacing.lua
+++ b/luaui/Widgets/gui_easyFacing.lua
@@ -302,6 +302,11 @@ function widget:Initialize()
 	end
 
 	WG.easyfacing = {}
+	---Forces the facing indicator on for a named reason, so several widgets can
+	---request it without fighting each other.
+	---@param reason string Caller-chosen key; pass the same one to turn it off again.
+	---@param enabled boolean
+	---@param unitDefID integer? Building the indicator should suit.
 	WG.easyfacing.setForceShow = function(reason, enabled, unitDefID)
 		if enabled then
 			forceShow[reason] = unitDefID

--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -662,21 +662,27 @@ function widget:Initialize()
 	end
 
 	WG.ecostats = {}
+	---@return boolean show Whether resource values are shown as text.
 	WG.ecostats.getShowText = function()
 		return cfgResText
 	end
+	---@param value boolean Show resource values as text.
 	WG.ecostats.setShowText = function(value)
 		cfgResText = value
 	end
+	---@return boolean track Whether reclaimed resources are tracked.
 	WG.ecostats.getReclaim = function()
 		return cfgTrackReclaim
 	end
+	---@param value boolean Track reclaimed resources.
 	WG.ecostats.setReclaim = function(value)
 		cfgTrackReclaim = value
 	end
+	---@return boolean visible Only shown to spectators with full view.
 	WG.ecostats.isvisible = function()
 		return myFullview and inSpecMode
 	end
+	---@return number y Screen Y of the panel's bottom edge.
 	WG.ecostats.getWidgetPosY = function()
 		return widgetPosY
 	end

--- a/luaui/Widgets/gui_enemy_spotter.lua
+++ b/luaui/Widgets/gui_enemy_spotter.lua
@@ -25,6 +25,7 @@ local InstanceVBOTable = gl.InstanceVBOTable
 local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 
+---@type InstanceVBOTable
 local enemyspotterVBO = nil
 local enemyspotterShader = nil
 local luaShaderDir = "LuaUI/Include/"
@@ -194,16 +195,22 @@ function widget:Initialize()
 		return
 	end
 	WG.enemyspotter = {}
+	---@return number opacity Opacity of the enemy spotter rings.
 	WG.enemyspotter.getOpacity = function()
 		return opacity
 	end
+	---Sets the spotter ring opacity and rebuilds the draw lists.
+	---@param value number
 	WG.enemyspotter.setOpacity = function(value)
 		opacity = value
 		init()
 	end
+	---@return boolean skip Whether the local team's own units are left unmarked.
 	WG.enemyspotter.getSkipOwnTeam = function()
 		return skipOwnTeam
 	end
+	---Leaves the local team's own units unmarked, rebuilding the draw lists.
+	---@param value boolean
 	WG.enemyspotter.setSkipOwnTeam = function(value)
 		skipOwnTeam = value
 		init()

--- a/luaui/Widgets/gui_flanking_icons.lua
+++ b/luaui/Widgets/gui_flanking_icons.lua
@@ -26,6 +26,7 @@ local InstanceVBOTable = gl.InstanceVBOTable
 local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 
+---@type InstanceVBOTable
 local flankingVBO = nil
 local flankingShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/gui_flowui.lua
+++ b/luaui/Widgets/gui_flowui.lua
@@ -40,6 +40,14 @@ WG.FlowUI.tileScale = Spring.GetConfigFloat("ui_tilescale", 7)
 WG.FlowUI.tileSize = WG.FlowUI.tileScale
 
 -- Guishader display list lifecycle helpers
+---Creates the guishader display list for a UI element if it does not exist yet,
+---and registers it for background blurring. Deletes it when the guishader widget
+---is not loaded.
+---@param currentDlist integer? The list this element already owns, if any.
+---@param name string Key the list is registered under.
+---@param drawFn fun() Draws the element's blur area.
+---@param force boolean? Rebuild the list even if one already exists.
+---@return integer? dlist The list to keep, or `nil` when blurring is unavailable.
 WG.FlowUI.guishaderCheckDlist = function(currentDlist, name, drawFn, force)
 	if WG.guishader then
 		if force and currentDlist then
@@ -56,6 +64,10 @@ WG.FlowUI.guishaderCheckDlist = function(currentDlist, name, drawFn, force)
 	return nil
 end
 
+---Unregisters a guishader display list and deletes it.
+---@param currentDlist integer?
+---@param name string
+---@return nil
 WG.FlowUI.guishaderRemoveDlist = function(currentDlist, name)
 	if WG.guishader then
 		WG.guishader.RemoveDlist(name)
@@ -66,6 +78,9 @@ WG.FlowUI.guishaderRemoveDlist = function(currentDlist, name)
 	return nil
 end
 
+---Unregisters a guishader display list by name and asks the guishader widget to
+---delete it.
+---@param name string
 WG.FlowUI.guishaderDeleteDlist = function(name)
 	if WG.guishader then
 		WG.guishader.DeleteDlist(name)
@@ -131,6 +146,9 @@ end
 
 WG.FlowUI.Callin = {}
 
+---Recomputes the shared FlowUI metrics for a new viewport size.
+---@param vsx integer
+---@param vsy integer
 WG.FlowUI.Callin.ViewResize1 = function(vsx, vsy)
 	ViewResize(vsx, vsy)
 end
@@ -141,16 +159,18 @@ end
 
 WG.FlowUI.Draw = {}
 
---[[
-	RectRound
-		draw rectangle with chopped off corners
-	params
-		px, py, sx, sy = left, bottom, right, top
-	optional
-		cs = corner size
-		tl, tr, br, bl = enable/disable corners for TopLeft, TopRight, BottomRight, BottomLeft (default: 1)
-		c1, c2 = top color, bottom color
-]]
+---Draws a rectangle with chopped off corners.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number? Corner size.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param c1 ColorRGBA? Top color as `{r, g, b, a}`.
+---@param c2 ColorRGBA? Bottom color as `{r, g, b, a}`.
 WG.FlowUI.Draw.RectRound = function(px, py, sx, sy, cs, tl, tr, br, bl, c1, c2)
 	if sx <= px or sy <= py or px ~= px or py ~= py or sx ~= sx or sy ~= sy or cs ~= cs then
 		return
@@ -285,20 +305,21 @@ WG.FlowUI.Draw.RectRound = function(px, py, sx, sy, cs, tl, tr, br, bl, c1, c2)
 	gl.BeginEnd(GL.QUADS, DrawRectRound, px, py, sx, sy, cs, tl, tr, br, bl, c1, c2)
 end
 
---[[
-	RectRoundQuad
-		draw a (possibly trapezoidal/skewed) quadrilateral with chamfered corners
-		generalization of RectRound supporting per-corner x/y offsets
-	params
-		px, py, sx, sy = left, bottom, right, top (base rectangle)
-		cs = corner chamfer size
-		tl, tr, br, bl = enable corner chamfer (1 = chamfered, 0 = square)
-		c1, c2 = bottom color, top color (gradient)
-		skew = table of per-corner pixel offsets from base rectangle corners:
-		       {tlx, tly, trx, try, brx, bry, blx, bly} (all default to 0)
-		       positive x = shift right, positive y = shift up
-		       example: skew = {tlx = -20}  makes top-left 20 px wider to the left
-]]
+---Draws a possibly trapezoidal quadrilateral with chamfered corners, generalizing
+---`RectRound` with per-corner offsets.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number? Corner chamfer size.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param c1 ColorRGBA? Bottom color as `{r, g, b, a}`.
+---@param c2 ColorRGBA? Top color as `{r, g, b, a}`.
+---@param skew {tlx: number?, tly: number?, trx: number?, try: number?, brx: number?, bry: number?, blx: number?, bly: number?}? Per-corner pixel offsets from the base rectangle; positive x shifts right, positive y shifts up. All default to `0`.
+---Example: `skew = {tlx = -20}` makes the top-left 20px wider to the left.
 WG.FlowUI.Draw.RectRoundQuad = function(px, py, sx, sy, cs, tl, tr, br, bl, c1, c2, skew)
 	local function DrawRectRoundQuad(px, py, sx, sy, cs, tl, tr, br, bl, c1, c2, skew)
 		cs = mathMax(cs, 1)
@@ -487,16 +508,14 @@ WG.FlowUI.Draw.RectRoundQuad = function(px, py, sx, sy, cs, tl, tr, br, bl, c1, 
 	gl.BeginEnd(GL.QUADS, DrawRectRoundQuad, px, py, sx, sy, cs, tl, tr, br, bl, c1, c2, skew)
 end
 
---[[
-	RectRoundProgress
-		draw rectangle pie (TODO: not with actual chopped off corners yet)
-	params
-		px, py, sx, sy = left, bottom, right, top
-	optional
-		cs = corner size
-		progress
-		color
-]]
+---Draws a rectangular progress pie. TODO: corners are not chopped off yet.
+---@param left number
+---@param bottom number
+---@param right number
+---@param top number
+---@param cs number? Corner size.
+---@param progress number `0`-`1`.
+---@param color ColorRGBA? As `{r, g, b, a}`.
 WG.FlowUI.Draw.RectRoundProgress = function(left, bottom, right, top, cs, progress, color)
 	gl.PushMatrix()
 	gl.Translate(left, bottom, 0)
@@ -562,17 +581,20 @@ WG.FlowUI.Draw.RectRoundProgress = function(left, bottom, right, top, cs, progre
 	gl.PopMatrix()
 end
 
---[[
-	TexturedRectRound
-		draw rectangle with chopped off corners and a textured background tile
-	params
-		px, py, sx, sy = left, bottom, right, top
-	optional
-		tl, tr, br, bl = enable/disable corners for TopLeft, TopRight, BottomRight, BottomLeft (default: 1)
-		size = texture tile size
-		offset, offsetY = texture offset coordinates (offsetY=offset when offsetY isnt defined)
-		texture = file location
-]]
+---Draws a rectangle with chopped off corners and a tiled texture background.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number? Corner size.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param size number? Texture tile size.
+---@param offset number? Texture offset.
+---@param offsetY number? Vertical texture offset. Defaults to `offset`.
+---@param texture string? Texture file location.
 WG.FlowUI.Draw.TexturedRectRound = function(px, py, sx, sy, cs, tl, tr, br, bl, size, offset, offsetY, texture)
 	if
 		sx <= px
@@ -681,17 +703,21 @@ WG.FlowUI.Draw.TexturedRectRound = function(px, py, sx, sy, cs, tl, tr, br, bl, 
 	end
 end
 
---[[
-	TexturedRectRoundQuad
-		same as TexturedRectRound but supports a skew table for trapezoidal shapes
-	params
-		px, py, sx, sy = left, bottom, right, top
-	optional
-		tl, tr, br, bl = enable/disable corners
-		size, offset, offsetY = texture tiling params
-		texture = file location
-		skew = table with optional tlx, tly, trx, try, brx, bry, blx, bly corner offsets
-]]
+---As `TexturedRectRound`, but supports a skew table for trapezoidal shapes.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number? Corner size.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param size number? Texture tile size.
+---@param offset number? Texture offset.
+---@param offsetY number? Vertical texture offset. Defaults to `offset`.
+---@param texture string? Texture file location.
+---@param skew {tlx: number?, tly: number?, trx: number?, try: number?, brx: number?, bry: number?, blx: number?, bly: number?}? Per-corner pixel offsets from the base rectangle; positive x shifts right, positive y shifts up.
 WG.FlowUI.Draw.TexturedRectRoundQuad = function(
 	px,
 	py,
@@ -864,14 +890,14 @@ WG.FlowUI.Draw.TexturedRectRoundQuad = function(
 	end
 end
 
---[[
-	RectRoundCircle
-		draw a square with border edge/fade
-	params
-		x,y,z, radius
-	optional
-
-]]
+---Draws a square with a rounded border edge that fades outward.
+---@param x number
+---@param y number
+---@param radius number
+---@param cs number? Corner size.
+---@param centerOffset number? Shifts the fade's center.
+---@param color1 ColorRGBA? Center color as `{r, g, b, a}`.
+---@param color2 ColorRGBA? Edge color as `{r, g, b, a}`.
 WG.FlowUI.Draw.RectRoundCircle = function(x, y, radius, cs, centerOffset, color1, color2)
 	local function DrawRectRoundCircle(x, y, radius, cs, centerOffset, color1, color2)
 		if not color2 then
@@ -922,16 +948,13 @@ WG.FlowUI.Draw.RectRoundCircle = function(x, y, radius, cs, centerOffset, color1
 	gl.BeginEnd(GL.QUADS, DrawRectRoundCircle, x, y, radius, cs, centerOffset, color1, color2)
 end
 
---[[
-	Circle
-		draw a circle
-	params
-		x,z, radius
-		sides = number outside vertexes
-		color1 = (center) color
-	optional
-		color2 = edge color
-]]
+---Draws a filled circle.
+---@param x number
+---@param z number
+---@param radius number
+---@param sides integer Number of outside vertices.
+---@param color1 ColorRGBA Center color as `{r, g, b, a}`.
+---@param color2 ColorRGBA? Edge color as `{r, g, b, a}`.
 WG.FlowUI.Draw.Circle = function(x, z, radius, sides, color1, color2)
 	local function DrawCircle(x, z, radius, sides, color1, color2)
 		if not color2 then
@@ -958,22 +981,29 @@ WG.FlowUI.Draw.Circle = function(x, z, radius, sides, color1, color2)
 	gl.BeginEnd(GL.TRIANGLE_FAN, DrawCircle, x, 0, z, radius, sides, color1, color2)
 end
 
---[[
-	Element
-		draw a complete standardized ui element having: border, tiled background, gloss on top and bottom
-	params
-		px, py, sx, sy = left, bottom, right, top
-	optional
-		tl, tr, br, bl = enable/disable corners for TopLeft, TopRight, BottomRight, BottomLeft (default: 1)
-		ptl, ptr, pbr, pbl = inner border padding/size multiplier (default: 1) (set to 0 when you want to attach this ui element to another element so there is only padding done by one of the 2 elements)
-		opacity = (default: ui_opacity springsetting)
-		color1, color2 = (color1[4 value overrides the opacity param defined above)
-		bgpadding = custom border size
-		skew = optional table of per-corner pixel offsets {tlx, tly, trx, try, brx, bry, blx, bly}
-		       shifts each corner of the element independently from the base rectangle
-		       example: skew = {tlx = -20, blx = -20}  slants the entire left side outward by 20px
-		                skew = {tlx = -20}  makes only the top-left corner 20px wider
-]]
+---Draws a complete standardized UI element: border, tiled background, and gloss on
+---the top and bottom.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param ptl number? Inner padding multiplier for the top-left corner. Defaults to `1`;
+---set to `0` when attaching this element to another so only one of the two pads.
+---@param ptr number? Inner padding multiplier for the top-right corner.
+---@param pbr number? Inner padding multiplier for the bottom-right corner.
+---@param pbl number? Inner padding multiplier for the bottom-left corner.
+---@param opacity number? Defaults to the `ui_opacity` setting.
+---@param color1 ColorRGBA? As `{r, g, b, a}`; its alpha overrides `opacity`.
+---@param color2 ColorRGBA? As `{r, g, b, a}`.
+---@param bgpadding number? Custom border size.
+---@param opaque boolean? Draw without transparency.
+---@param skew {tlx: number?, tly: number?, trx: number?, try: number?, brx: number?, bry: number?, blx: number?, bly: number?}? Per-corner pixel offsets from the base rectangle, shifting each corner independently; positive x shifts right, positive y shifts up.
+---Examples: `skew = {tlx = -20, blx = -20}` slants the whole left side outward by 20px;
+---`skew = {tlx = -20}` widens only the top-left corner.
 WG.FlowUI.Draw.Element = function(
 	px,
 	py,
@@ -1615,6 +1645,26 @@ DeleteButtonDisplayListCache = function()
 	cache.lists = {}
 end
 
+---Draws a standardized button: border, tiled background, and gloss on the top and
+---bottom. Repeated identical draws are served from a display list cache.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param ptl number? Inner padding multiplier for the top-left corner. Defaults to `1`;
+---set to `0` when attaching this button to another element so only one of the two pads.
+---@param ptr number? Inner padding multiplier for the top-right corner.
+---@param pbr number? Inner padding multiplier for the bottom-right corner.
+---@param pbl number? Inner padding multiplier for the bottom-left corner.
+---@param opacity number? Defaults to `1`.
+---@param color1 ColorRGBA? As `{r, g, b, a}`; its alpha overrides `opacity`.
+---@param color2 ColorRGBA? As `{r, g, b, a}`.
+---@param bgpadding number? Custom border size.
+---@param glossMult number? Scales the gloss brightness. Defaults to `1`.
 WG.FlowUI.Draw.Button = function(
 	px,
 	py,
@@ -1701,6 +1751,18 @@ WG.FlowUI.Draw.Button = function(
 end
 
 -- This was broken out from an internal "Unit" function, to allow drawing similar style icons in other places
+---Draws a textured rectangle with chopped off corners, using the currently bound
+---texture. Broken out of `Unit` so the same icon style can be drawn elsewhere.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number? Corner size.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param offset number? Texture inset, to zoom the image inside the rectangle.
 WG.FlowUI.Draw.TexRectRound = function(px, py, sx, sy, cs, tl, tr, br, bl, offset)
 	if sx <= px or sy <= py or px ~= px or py ~= py or sx ~= sx or sy ~= sy or cs ~= cs or offset ~= offset then
 		return
@@ -1779,17 +1841,19 @@ WG.FlowUI.Draw.TexRectRound = function(px, py, sx, sy, cs, tl, tr, br, bl, offse
 	drawTexCoordVertex(sx, sy - cs)
 end
 
---[[
-	RectRoundOutline
-		draw a rectangular outline with feathered edges and proper corner cutoffs
-	params
-		px, py, sx, sy = left, bottom, right, top
-		cs = corner size
-		outlineWidth = width of the outline/feather
-		tl, tr, br, bl = enable/disable corners for TopLeft, TopRight, BottomRight, BottomLeft (default: 1)
-		outerColor = color for the outside edge
-		innerColor = color for the inside edge (for feathering)
-]]
+---Draws a rectangular outline with feathered edges and chopped off corners.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number Corner size.
+---@param outlineWidth number Width of the outline and its feather.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param outerColor ColorRGBA Color at the outside edge, as `{r, g, b, a}`.
+---@param innerColor ColorRGBA Color at the inside edge, as `{r, g, b, a}`.
 WG.FlowUI.Draw.RectRoundOutline = function(px, py, sx, sy, cs, outlineWidth, tl, tr, br, bl, outerColor, innerColor)
 	local function DrawRectRoundOutline(px, py, sx, sy, cs, outlineWidth, tl, tr, br, bl, outerColor, innerColor)
 		local tl = tl or 1
@@ -1934,18 +1998,20 @@ WG.FlowUI.Draw.RectRoundOutline = function(px, py, sx, sy, cs, outlineWidth, tl,
 	)
 end
 
---[[
-	RectRoundOutlineQuad
-		same as RectRoundOutline but supports a skew table for trapezoidal (non-rectangular) shapes
-	params
-		px, py, sx, sy = left, bottom, right, top
-		cs = corner size
-		outlineWidth = width of the outline/feather
-		tl, tr, br, bl = enable/disable corners
-		outerColor = color for the outside edge
-		innerColor = color for the inside edge
-		skew = table with optional tlx, tly, trx, try, brx, bry, blx, bly corner offsets
-]]
+---As `RectRoundOutline`, but supports a skew table for trapezoidal shapes.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number Corner size.
+---@param outlineWidth number Width of the outline and its feather.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param outerColor ColorRGBA Color at the outside edge, as `{r, g, b, a}`.
+---@param innerColor ColorRGBA Color at the inside edge, as `{r, g, b, a}`.
+---@param skew {tlx: number?, tly: number?, trx: number?, try: number?, brx: number?, bry: number?, blx: number?, bly: number?}? Per-corner pixel offsets from the base rectangle; positive x shifts right, positive y shifts up.
 WG.FlowUI.Draw.RectRoundOutlineQuad = function(
 	px,
 	py,
@@ -2656,6 +2722,25 @@ DeleteUnitDisplayListCache = function()
 	cache.lists = {}
 end
 
+---Draws a unit icon tile, optionally overlaid with its radar icon, group icon,
+---price and queued count.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number? Corner size.
+---@param tl number? Enable the top-left chamfered corner. Defaults to `1`.
+---@param tr number? Enable the top-right chamfered corner. Defaults to `1`.
+---@param br number? Enable the bottom-right chamfered corner. Defaults to `1`.
+---@param bl number? Enable the bottom-left chamfered corner. Defaults to `1`.
+---@param zoom number? Zooms the unit picture inside the tile.
+---@param borderSize number? Defaults to a size derived from the tile width.
+---@param borderOpacity number?
+---@param texture string? Unit picture.
+---@param radarTexture string? Radar icon drawn in a corner.
+---@param groupTexture string? Group icon drawn in a corner.
+---@param price number|string|nil Cost label.
+---@param queueCount number|string|nil Queued count label.
 WG.FlowUI.Draw.Unit = function(
 	px,
 	py,
@@ -2738,15 +2823,13 @@ WG.FlowUI.Draw.Unit = function(
 	gl.PopMatrix()
 end
 
---[[
-	Scroller
-		draw a slider (vertical)
-	params
-		px, py, sx, sy = left, bottom, right, top
-		contentHeight = content height px
-	optional
-		position = (default: 0) current content height position
-]]
+---Draws a vertical scrollbar.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param contentHeight number Height of the scrolled content, in pixels.
+---@param position number? Current scroll position. Defaults to `0`.
 WG.FlowUI.Draw.Scroller = function(px, py, sx, sy, contentHeight, position)
 	local width = sx - px
 	local height = sy - py
@@ -2782,14 +2865,12 @@ WG.FlowUI.Draw.Scroller = function(px, py, sx, sy, contentHeight, position)
 	end
 end
 
---[[
-	Toggle
-		draw a toggle
-	params
-		px, py, sx, sy = left, bottom, right, top
-	optional
-		state = (default: 0) 0 / 0.5 / 1
-]]
+---Draws a toggle switch.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param state number? `0`, `0.5` or `1`. Defaults to `0`.
 WG.FlowUI.Draw.Toggle = function(px, py, sx, sy, state)
 	local height = sy - py
 	local width = sx - px
@@ -2878,14 +2959,11 @@ WG.FlowUI.Draw.Toggle = function(px, py, sx, sy, state)
 	end
 end
 
---[[
-	Slider
-		draw a slider knob
-	params
-		x, y, radius
-	optional
-		color
-]]
+---Draws a slider knob.
+---@param x number
+---@param y number
+---@param radius number
+---@param color ColorRGBA? As `{r, g, b, a}`.
 WG.FlowUI.Draw.SliderKnob = function(x, y, radius, color)
 	local color = color or { 0.95, 0.95, 0.95, 1 }
 	local color1 = { color[1] * 0.55, color[2] * 0.55, color[3] * 0.55, color[4] }
@@ -2943,14 +3021,14 @@ WG.FlowUI.Draw.SliderKnob = function(x, y, radius, color)
 	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
 end
 
---[[
-	Slider
-		draw a slider
-	params
-		px, py, sx, sy = left, bottom, right, top
-		steps = either a table of values or a number of smallest step size
-		min, max = when steps is number: min/max scope of steps
-]]
+---Draws a slider track, with tick marks when steps are given.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param steps number|number[]? Either the smallest step size, or a table of values.
+---@param min number? Lowest value, when `steps` is a number.
+---@param max number? Highest value, when `steps` is a number.
 WG.FlowUI.Draw.Slider = function(px, py, sx, sy, steps, min, max)
 	local height = sy - py
 	local width = sx - px
@@ -3028,12 +3106,11 @@ WG.FlowUI.Draw.Slider = function(px, py, sx, sy, steps, min, max)
 	WG.FlowUI.Draw.RectRound(px, py, sx, py + edgeWidth2, edgeWidth, 1, 1, 1, 1, { 1, 1, 1, 0 }, { 1, 1, 1, 0.045 })
 end
 
---[[
-	Selector
-		draw a selector (drop-down menu)
-	params
-		px, py, sx, sy = left, bottom, right, top
-]]
+---Draws a selector, as used for drop-down menus.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
 WG.FlowUI.Draw.Selector = function(px, py, sx, sy)
 	local height = sy - py
 	local cs = height * 0.1
@@ -3092,16 +3169,15 @@ WG.FlowUI.Draw.Selector = function(px, py, sx, sy)
 	--WG.FlowUI.Draw.Button(sx-(sy-py), py, sx, sy, 1, 1, 1, 1, 1,1,1,1, nil, { 1, 1, 1, 0.1 }, nil, cs)
 end
 
---[[
-	SelectHighlight
-		draw a highlighted area in a selector (drop-down menu)
-		(also usable to highlight some other generic area)
-	params
-		px, py, sx, sy = left, bottom, right, top
-		cs = corner size
-		opacity
-		color = {1,1,1}
-]]
+---Draws a highlighted area inside a selector. Also usable to highlight any other
+---generic area.
+---@param px number Left.
+---@param py number Bottom.
+---@param sx number Right.
+---@param sy number Top.
+---@param cs number Corner size.
+---@param opacity number?
+---@param color ColorRGB? As `{r, g, b}`.
 WG.FlowUI.Draw.SelectHighlight = function(px, py, sx, sy, cs, opacity, color)
 	local height = sy - py
 	cs = cs or (height * 0.08)

--- a/luaui/Widgets/gui_fonthandler.lua
+++ b/luaui/Widgets/gui_fonthandler.lua
@@ -85,6 +85,15 @@ function widget:Initialize()
 	widget:ViewResize(vsx, vsy, true)
 
 	WG.fonts = {}
+	---Returns a cached font, creating it on first use. Sizes are relative to the
+	---UI's base font size, so the same call scales with the player's UI settings.
+	---@param file string|1|2|3|nil A font path, or `1`-`3` for the built-in fonts.
+	---Defaults to the primary font.
+	---@param size number? Multiplier on the base font size. Defaults to `1`.
+	---@param outlineSize number? Multiplier on the base outline size.
+	---@param outlineStrength number? Defaults to the configured outline strength.
+	---@return LuaFont font
+	---@return number size The resolved pixel size, already scaled.
 	WG.fonts.getFont = function(file, size, outlineSize, outlineStrength)
 		if not file or file == 1 then
 			file = defaultFont

--- a/luaui/Widgets/gui_gameinfo.lua
+++ b/luaui/Widgets/gui_gameinfo.lua
@@ -26,7 +26,9 @@ local valuecolor = "\255\255\255\255"
 local valuegreycolor = "\255\180\180\180"
 local separator = "::"
 
-local font, font2, loadedFontSize, mainDList, titleRect, backgroundGuishader, show
+local font, font2, loadedFontSize, mainDList, titleRect, backgroundGuishader
+---@type boolean
+local show
 local maxLines = 22
 local math_isInRect = math.isInRect
 
@@ -636,6 +638,9 @@ function widget:Initialize()
 	widgetHandler:AddAction("customgameinfo_close", closeInfoHandler, nil, "p")
 
 	WG.gameinfo = {}
+	---@type boolean
+	---Shows or hides the game info window, closing the top bar windows when it opens.
+	---@param state boolean? Omit to toggle.
 	WG.gameinfo.toggle = function(state)
 		local newShow = state
 		if newShow == nil then
@@ -646,6 +651,7 @@ function widget:Initialize()
 		end
 		show = newShow
 	end
+	---@return boolean visible
 	WG.gameinfo.isvisible = function()
 		return show
 	end

--- a/luaui/Widgets/gui_geothermalspots.lua
+++ b/luaui/Widgets/gui_geothermalspots.lua
@@ -99,6 +99,7 @@ end
 --
 
 local spotVBO = nil
+---@type InstanceVBOTable
 local spotInstanceVBO = nil
 local spotShader = nil
 
@@ -414,21 +415,27 @@ function widget:Initialize()
 	initGL4()
 
 	WG.geothermalspots = {}
+	---@param value boolean Label geothermal spots with their energy output.
 	WG.geothermalspots.setShowValue = function(value)
 		showValue = value
 	end
+	---@return boolean showValue
 	WG.geothermalspots.getShowValue = function()
 		return showValue
 	end
+	---@param value number Opacity of the geothermal spot markers.
 	WG.geothermalspots.setOpacity = function(value)
 		opacity = value
 	end
+	---@return number opacity
 	WG.geothermalspots.getOpacity = function()
 		return opacity
 	end
+	---@param value boolean Only show geothermal spots while the metal map view is on.
 	WG.geothermalspots.setMetalViewOnly = function(value)
 		metalViewOnly = value
 	end
+	---@return boolean metalViewOnly
 	WG.geothermalspots.getMetalViewOnly = function()
 		return metalViewOnly
 	end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1424,96 +1424,133 @@ function widget:Initialize()
 		widget:SelectionChanged(Spring.GetSelectedUnits())
 	end
 
+	---@return integer? unitDefID The builder or factory the grid is currently showing.
 	WG.gridmenu.getActiveBuilder = function()
 		return activeBuilder
 	end
+	---@return boolean alwaysReturn Whether the grid returns to the root category after each build.
 	WG.gridmenu.getAlwaysReturn = function()
 		return alwaysReturn
 	end
+	---@param value boolean Return to the root category after each build.
 	WG.gridmenu.setAlwaysReturn = function(value)
 		alwaysReturn = value
 	end
+	---@return boolean autoSelect Whether entering a category preselects its first entry.
 	WG.gridmenu.getAutoSelectFirst = function()
 		return autoSelectFirst
 	end
+	---@param value boolean Preselect the first entry when entering a category.
 	WG.gridmenu.setAutoSelectFirst = function(value)
 		autoSelectFirst = value
 	end
+	---@return boolean labMode Whether factories use the dedicated lab build layout.
 	WG.gridmenu.getUseLabBuildMode = function()
 		return useLabBuildMode
 	end
+	---Uses the dedicated lab build layout for factories, rebuilding the grid.
+	---@param value boolean
 	WG.gridmenu.setUseLabBuildMode = function(value)
 		useLabBuildMode = value
 		updateGrid()
 	end
+	---Opens a build category.
+	---@param category string
 	WG.gridmenu.setCurrentCategory = function(category)
 		setCurrentCategory(category)
 	end
+	---Returns the grid to its root category.
 	WG.gridmenu.clearCategory = function()
 		clearCategory()
 	end
 
+	---@return number multiplier Build count multiplier applied while ctrl is held.
 	WG.gridmenu.getCtrlKeyModifier = function()
 		return modKeyMultiplier.keyPress.ctrl
 	end
+	---@param value number Build count multiplier applied while ctrl is held.
 	WG.gridmenu.setCtrlKeyModifier = function(value)
 		modKeyMultiplier.keyPress.ctrl = value
 	end
+	---@return number multiplier Build count multiplier applied while shift is held.
 	WG.gridmenu.getShiftKeyModifier = function()
 		return modKeyMultiplier.keyPress.shift
 	end
+	---@param value number Build count multiplier applied while shift is held.
 	WG.gridmenu.setShiftKeyModifier = function(value)
 		modKeyMultiplier.keyPress.shift = value
 	end
 
+	---@return table<string, string> groups Icon path per group name.
+	---@return table<integer, string> unitGroup Group name per unitDefID.
 	WG.buildmenu.getGroups = function()
 		return groups, units.unitGroup
 	end
+	---@return table<integer, integer> order Sort position per unitDefID.
 	WG.buildmenu.getOrder = function()
 		return units.unitOrder
 	end
+	---@return boolean showPrice Whether build options are labeled with their cost.
 	WG.buildmenu.getShowPrice = function()
 		return showPrice
 	end
+	---Labels build options with their cost, rebuilding the grid.
+	---@param value boolean
 	WG.buildmenu.setShowPrice = function(value)
 		showPrice = value
 		updateGrid()
 	end
+	---@return boolean alwaysShow Whether the grid stays open with no builder selected.
 	WG.buildmenu.getAlwaysShow = function()
 		return alwaysShow
 	end
+	---Keeps the grid open with no builder selected, rebuilding it.
+	---@param value boolean
 	WG.buildmenu.setAlwaysShow = function(value)
 		alwaysShow = value
 		refreshCommands()
 	end
+	---@return boolean show Whether build options show their radar icon.
 	WG.buildmenu.getShowRadarIcon = function()
 		return showRadarIcon
 	end
+	---Shows the radar icon on build options, rebuilding the grid.
+	---@param value boolean
 	WG.buildmenu.setShowRadarIcon = function(value)
 		showRadarIcon = value
 		updateGrid()
 	end
+	---@return boolean show Whether build options show their group icon.
 	WG.buildmenu.getShowGroupIcon = function()
 		return showGroupIcon
 	end
+	---Shows the group icon on build options, rebuilding the grid.
+	---@param value boolean
 	WG.buildmenu.setShowGroupIcon = function(value)
 		showGroupIcon = value
 		updateGrid()
 	end
+	---@return boolean stickToBottom Whether the grid is docked to the bottom of the screen.
 	WG.buildmenu.getBottomPosition = function()
 		return stickToBottom
 	end
+	---Docks the grid to the bottom of the screen and relays it out.
+	---@param value boolean
 	WG.buildmenu.setBottomPosition = function(value)
 		stickToBottom = value
 		widget:ViewResize()
 	end
+	---@return number y Screen Y of the grid's bottom edge.
+	---@return number yEnd Screen Y of the grid's top edge.
 	WG.buildmenu.getSize = function()
 		return backgroundRect.y, backgroundRect.yEnd
 	end
+	---Rebinds the build hotkeys and refreshes the shown commands.
 	WG.buildmenu.reloadBindings = function()
 		reloadBindings()
 		refreshCommands()
 	end
+	---@return boolean showing Whether the grid menu is currently drawn.
 	WG.buildmenu.getIsShowing = function()
 		return buildmenuShows
 	end
@@ -1571,6 +1608,8 @@ function widget:Initialize()
 		}
 	end
 
+	---Removes a highlight previously set via `setHighlight`.
+	---@param unitDefID integer?
 	local function removeHighlight(unitDefID)
 		local items = highlight.items
 		if unitDefID and items[unitDefID] then
@@ -1579,6 +1618,7 @@ function widget:Initialize()
 		end
 	end
 
+	---Clears all active highlights.
 	local function clearHighlights()
 		local items = highlight.items
 		for k in pairs(items) do
@@ -1587,6 +1627,8 @@ function widget:Initialize()
 		highlight.count = 0
 	end
 
+	---@param unitDefID integer?
+	---@return boolean highlighted
 	local function hasHighlight(unitDefID)
 		return unitDefID ~= nil and highlight.items[unitDefID] ~= nil
 	end

--- a/luaui/Widgets/gui_ground_ao_plates_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_gl4.lua
@@ -24,6 +24,7 @@ local getUVCoords = atlas.getUVCoords
 atlas.flip(atlas)
 local unitDefIDtoDecalInfo = {} -- key unitdef, table of {texfile = "", sizex = 4 , sizez = 4}
 
+---@type InstanceVBOTable
 local groundPlateVBO = nil
 local groundPlateShader = nil
 

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -387,8 +387,11 @@ local featureBars = {} -- we need this additional table of {[featureid] = {barhe
 --local empDecline = 1 / 40 --magic
 local minReloadTime = 4 -- weapons reloading slower than this willget bars
 
+---@type InstanceVBOTable
 local featureHealthVBO
+---@type InstanceVBOTable
 local featureResurrectVBO
+---@type InstanceVBOTable
 local featureReclaimVBO
 
 local barScale = 1 -- Option 'healthbarsscale'
@@ -401,6 +404,7 @@ local variableBarSizes = true -- Option 'healthbarsvariable'
 
 --------------------------------------------------------------------------------
 -- GL4 Backend stuff:
+---@type InstanceVBOTable
 local healthBarVBO = nil
 local healthBarShader = nil
 
@@ -1064,17 +1068,23 @@ function widget:Initialize()
 		return
 	end
 	WG.healthbars = {}
+	---@return number scale Width multiplier for health bars.
 	WG.healthbars.getScale = function()
 		return barScale
 	end
+	---Sets the health bar width multiplier and rebuilds the unit and feature bars.
+	---@param value number
 	WG.healthbars.setScale = function(value)
 		barScale = value
 		init()
 		initfeaturebars()
 	end
+	---@return number height Health bar height.
 	WG.healthbars.getHeight = function()
 		return barHeight
 	end
+	---Sets the health bar height, recomputing the corner rounding and rebuilding the bars.
+	---@param value number
 	WG.healthbars.setHeight = function(value)
 		barHeight = value
 		shaderSourceCache.shaderConfig.BARHEIGHT = barHeight
@@ -1083,17 +1093,22 @@ function widget:Initialize()
 		init()
 		initfeaturebars()
 	end
+	---@return boolean variable Whether bar size scales with unit size.
 	WG.healthbars.getVariableSizes = function()
 		return variableBarSizes
 	end
+	---Scales bar size with unit size, rebuilding the bars.
+	---@param value boolean
 	WG.healthbars.setVariableSizes = function(value)
 		variableBarSizes = value
 		init()
 		initfeaturebars()
 	end
+	---@return boolean draw Whether bars stay visible while the interface is hidden.
 	WG.healthbars.getDrawWhenGuiHidden = function()
 		return drawWhenGuiHidden
 	end
+	---@param value boolean Keep bars visible while the interface is hidden.
 	WG.healthbars.setDrawWhenGuiHidden = function(value)
 		drawWhenGuiHidden = value
 	end

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -89,7 +89,9 @@ local unitList = {}
 local idleList = {}
 local inIdleWorkerTask = table.ensureTable(WG, "InIdleWorkerTask")
 
-local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, backgroundRect, ordermenuPosY
+local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, ordermenuPosY
+---@type ScreenRect?
+local backgroundRect
 local guishaderWasActive = false
 
 local unitHumanName = {}
@@ -656,6 +658,11 @@ function widget:Initialize()
 	widget:ViewResize()
 	widget:PlayerChanged()
 	WG.idlebuilders = {}
+	---Screen rectangle of the idle builders panel.
+	---@return number left
+	---@return number bottom
+	---@return number right
+	---@return number top
 	WG.idlebuilders.getPosition = function()
 		return posX,
 			posY,

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -40,6 +40,7 @@ local sound_button2 = "LuaUI/Sounds/buildbar_rem.wav"
 
 local ui_scale = tonumber(Spring.GetConfigFloat("ui_scale", 1) or 1)
 
+---@type ScreenRect
 local backgroundRect = { 0, 0, 0, 0 }
 local currentTooltip = ""
 local lastUpdateClock = 0
@@ -880,47 +881,67 @@ function widget:Initialize()
 	widget:ViewResize()
 
 	WG.info = {}
+	---@return boolean show Whether a builder's build list is shown in the info panel.
 	WG.info.getShowBuilderBuildlist = function()
 		return showBuilderBuildlist
 	end
+	---@param value boolean Show a builder's build list in the info panel.
 	WG.info.setShowBuilderBuildlist = function(value)
 		showBuilderBuildlist = value
 	end
+	---@return boolean show Whether the cursor's map position is shown.
 	WG.info.getDisplayMapPosition = function()
 		return displayMapPosition
 	end
+	---@param value boolean Show the cursor's map position.
 	WG.info.setDisplayMapPosition = function(value)
 		displayMapPosition = value
 	end
+	---@return boolean alwaysShow Whether the panel stays open with nothing hovered.
 	WG.info.getAlwaysShow = function()
 		return alwaysShow
 	end
+	---@param value boolean Keep the panel open with nothing hovered.
 	WG.info.setAlwaysShow = function(value)
 		alwaysShow = value
 	end
+	---Pins the info panel to a specific unit, overriding what the cursor hovers.
+	---@param unitID integer
 	WG.info.displayUnitID = function(unitID)
 		cfgDisplayUnitID = unitID
 	end
+	---Unpins the info panel from a specific unit.
 	WG.info.clearDisplayUnitID = function()
 		cfgDisplayUnitID = nil
 	end
+	---Pins the info panel to a unit definition, overriding what the cursor hovers.
+	---@param unitDefID integer
 	WG.info.displayUnitDefID = function(unitDefID)
 		cfgDisplayUnitDefID = unitDefID
 	end
+	---Unpins the info panel from a unit definition.
 	WG.info.clearDisplayUnitDefID = function()
 		cfgDisplayUnitDefID = nil
 	end
+	---@return number width
+	---@return number height
 	WG.info.getPosition = function()
 		return width, height
 	end
+	---@return boolean showing Whether the info panel is currently drawn.
 	WG.info.getIsShowing = function()
 		return infoShows
 	end
+	---Supplies custom hover info from another widget, e.g. the PIP window.
+	---@param hType "unit"|"feature"|"ground"|nil What kind of thing is hovered.
+	---@param hData integer? The unitID or featureID to render. Both arguments must be
+	---given for the custom hover to take effect.
 	WG.info.setCustomHover = function(hType, hData)
 		-- Allow external widgets to supply custom hover info (e.g., PIP window)
 		customHoverType = hType
 		customHoverData = hData
 	end
+	---Clears custom hover info supplied by another widget.
 	WG.info.clearCustomHover = function()
 		customHoverType = nil
 		customHoverData = nil

--- a/luaui/Widgets/gui_infolos.lua
+++ b/luaui/Widgets/gui_infolos.lua
@@ -115,6 +115,9 @@ local shaderSourceCache = {
 	shaderConfig = shaderConfig,
 }
 
+---Returns the info/LOS texture for an allyteam.
+---@param allyTeam integer? Defaults to the local player's allyteam.
+---@return string? texName `nil` when no texture has been built for that allyteam.
 local function GetInfoLOSTexture(allyTeam)
 	return infoTextures[allyTeam or currentAllyTeam]
 end

--- a/luaui/Widgets/gui_keybind_info.lua
+++ b/luaui/Widgets/gui_keybind_info.lua
@@ -707,6 +707,8 @@ function widget:Initialize()
 	refreshText()
 
 	WG.keybinds = {}
+	---Shows or hides the keybind reference window.
+	---@param state boolean? Omit to toggle.
 	WG.keybinds.toggle = function(state)
 		if state ~= nil then
 			show = state
@@ -714,9 +716,11 @@ function widget:Initialize()
 			show = not show
 		end
 	end
+	---@return boolean visible
 	WG.keybinds.isvisible = function()
 		return show
 	end
+	---Re-reads the keybinds and redraws the reference window.
 	WG.keybinds.reloadBindings = function()
 		refreshText()
 		doUpdate = true

--- a/luaui/Widgets/gui_language.lua
+++ b/luaui/Widgets/gui_language.lua
@@ -37,6 +37,8 @@ function widget:Initialize()
 
 	WG.language = {}
 
+	---Switches the UI language, persists it, and notifies every widget.
+	---@param language string Language code, e.g. `"en"`.
 	WG.language.setLanguage = function(language)
 		Spring.SetConfigString("language", language)
 		BAR.I18N.setLanguage(language)
@@ -46,6 +48,8 @@ function widget:Initialize()
 		end
 	end
 
+	---Keeps unit names in English regardless of UI language, and notifies every widget.
+	---@param value boolean
 	WG.language.setEnglishUnitNames = function(value)
 		Spring.SetConfigInt("language_english_unit_names", value and 1 or 0)
 

--- a/luaui/Widgets/gui_messages.lua
+++ b/luaui/Widgets/gui_messages.lua
@@ -163,6 +163,8 @@ end
 function widget:Initialize()
 	widget:ViewResize()
 	WG.messages = {}
+	---Queues a message for the on-screen message feed.
+	---@param text string
 	WG.messages.addMessage = function(text)
 		addMessage(text)
 	end

--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -111,6 +111,7 @@ end
 local teamIncomeMultipliers = {} -- {key teamID value Multiplier number}
 
 local spotVBO = nil
+---@type InstanceVBOTable
 local spotInstanceVBO = nil
 local spotShader = nil
 
@@ -572,21 +573,27 @@ function widget:Initialize()
 	end
 
 	WG.metalspots = {}
+	---@param value boolean Label metal spots with their extraction rate.
 	WG.metalspots.setShowValue = function(value)
 		showValue = value
 	end
+	---@return boolean showValue
 	WG.metalspots.getShowValue = function()
 		return showValue
 	end
+	---@param value number Opacity of the metal spot markers.
 	WG.metalspots.setOpacity = function(value)
 		opacity = value
 	end
+	---@return number opacity
 	WG.metalspots.getOpacity = function()
 		return opacity
 	end
+	---@param value boolean Only show metal spots while the metal map view is on.
 	WG.metalspots.setMetalViewOnly = function(value)
 		metalViewOnly = value
 	end
+	---@return boolean metalViewOnly
 	WG.metalspots.getMetalViewOnly = function()
 		return metalViewOnly
 	end

--- a/luaui/Widgets/gui_minimap.lua
+++ b/luaui/Widgets/gui_minimap.lua
@@ -37,6 +37,7 @@ local ratio = Game.mapX / Game.mapY
 local maxWidth = mathMin(maxHeight * ratio, maxAllowedWidth * (vsx / vsy))
 local usedWidth = mathFloor(maxWidth * vsy)
 local usedHeight = mathFloor(maxHeight * vsy)
+---@type ScreenRect
 local backgroundRect = { 0, 0, 0, 0 }
 
 local delayedSetup = false
@@ -138,24 +139,33 @@ function widget:Initialize()
 	_, _, _, _, minimized, maximized = Spring.GetMiniMapGeometry()
 
 	WG.minimap = {}
+	---@return number height Current minimap height in pixels, including its padding.
 	WG.minimap.getHeight = function()
 		return usedHeight + elementPadding
 	end
+	---@return integer pixels Highest the minimap may grow to.
+	---@return number fraction The same limit as a fraction of screen height.
 	WG.minimap.getMaxHeight = function()
 		return mathFloor(maxAllowedHeight * vsy), maxAllowedHeight
 	end
+	---Sets how tall the minimap may grow, persists it, and relays out.
+	---@param value number Fraction of screen height.
 	WG.minimap.setMaxHeight = function(value)
 		Spring.SetConfigFloat("MinimapMaxHeight", value)
 		maxAllowedHeight = value
 		widget:ViewResize()
 	end
+	---@return boolean move Whether left-clicking the minimap moves the camera.
 	WG.minimap.getLeftClickMove = function()
 		return leftClickMove
 	end
+	---Makes left-clicking the minimap move the camera, and persists the choice.
+	---@param value boolean
 	WG.minimap.setLeftClickMove = function(value)
 		leftClickMove = value
 		Spring.SetConfigInt("MinimapLeftClickMove", value and 1 or 0)
 	end
+	---@param value number Base scale for unit icons drawn on the minimap.
 	WG.minimap.setBaseIconScale = function(value)
 		baseMinimapIconScale = value
 	end

--- a/luaui/Widgets/gui_mission_info.lua
+++ b/luaui/Widgets/gui_mission_info.lua
@@ -464,6 +464,8 @@ function widget:Initialize()
 	totalTextLines = #textLines
 
 	WG.missioninfo = {}
+	---Shows or hides the mission briefing, pausing the game while it is open.
+	---@param state boolean? Omit to toggle.
 	WG.missioninfo.toggle = function(state)
 		local wasVisible = show
 		if state ~= nil then
@@ -484,6 +486,8 @@ function widget:Initialize()
 			textList = gl.CreateList(DrawWindow)
 		end
 	end
+	---@return boolean visible Also reports `true` for one frame after a click-to-close,
+	---so a toggling caller does not immediately reopen the window.
 	WG.missioninfo.isvisible = function()
 		-- Report true while justClosedFromPress so toggleWindow treats us as
 		-- "was open" and doesn't immediately re-open after our mouseEvent close.

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -12734,6 +12734,8 @@ function widget:Initialize()
 	Spring.SendCommands("minimap unitsize " .. (Spring.GetConfigFloat("MinimapIconScale", 3.5))) -- spring wont remember what you set with '/minimap iconssize #'
 
 	WG.options = {}
+	---Shows or hides the options window, closing the top bar windows when it opens.
+	---@param state boolean? Omit to toggle.
 	WG.options.toggle = function(state)
 		local newShow = state
 		if newShow == nil then
@@ -12752,6 +12754,7 @@ function widget:Initialize()
 			end
 		end
 	end
+	---@return string[] ids Every registered option id.
 	WG.options.getOptionsList = function()
 		local optionList = {}
 		for i, option in pairs(options) do
@@ -12759,17 +12762,24 @@ function widget:Initialize()
 		end
 		return optionList
 	end
+	---@return boolean visible
 	WG.options.isvisible = function()
 		return show
 	end
+	---@param option string Option id.
+	---@return boolean|number|string|nil value A boolean for `bool` options, a number for
+	---`slider`, and the selected entry for `select`; `nil` when no option has that id.
 	WG.options.getOptionValue = function(option)
 		if getOptionByID(option) then
 			return options[getOptionByID(option)].value
 		end
 	end
+	---@return number seconds Camera transition time.
 	WG.options.getCameraSmoothness = function()
 		return cameraTransitionTime
 	end
+	---@return boolean disallow Whether Escape is being consumed by an open sub-menu
+	---and should not close the options window.
 	WG.options.disallowEsc = function()
 		if showSelectOptions then
 			--or draggingSlider then
@@ -12778,6 +12788,15 @@ function widget:Initialize()
 			return false
 		end
 	end
+	---An option row. The options widget only requires `id`; the rest of the fields
+	---are consumed by the renderer for whichever `type` the option declares.
+	---@class OptionDefinition
+	---@field id string Unique key; `removeOptions` matches on it.
+	---@field group string? Overwritten with `"custom"` when registered this way.
+	---@field [string] any Renderer-specific fields, e.g. `name`, `type`, `value`.
+
+	---Registers extra options under the custom group and rebuilds the options list.
+	---@param newOptions OptionDefinition[] `group` is overwritten with `"custom"`.
 	WG.options.addOptions = function(newOptions)
 		for _, option in ipairs(newOptions) do
 			option.group = "custom"
@@ -12786,6 +12805,8 @@ function widget:Initialize()
 
 		init()
 	end
+	---Removes custom options by id and rebuilds the options list.
+	---@param names string[]
 	WG.options.removeOptions = function(names)
 		for _, name in ipairs(names) do
 			for i, option in pairs(customOptions) do
@@ -12798,12 +12819,20 @@ function widget:Initialize()
 
 		init()
 	end
+	---Registers one extra option under the custom group.
+	---@param option OptionDefinition
 	WG.options.addOption = function(option)
 		return WG.options.addOptions({ option })
 	end
+	---Removes one custom option by id.
+	---@param name string
 	WG.options.removeOption = function(name)
 		return WG.options.removeOptions({ name })
 	end
+	---Sets an option's value and applies its side effects. Unknown ids are reported
+	---to the infolog and ignored.
+	---@param option string Option id.
+	---@param value number|string Coerced to a number.
 	WG.options.applyOptionValue = function(option, value)
 		local optionID = getOptionByID(option)
 		if not optionID then

--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -656,6 +656,7 @@ function widget:ViewResize()
 	tracy.ZoneEnd()
 end
 
+---Re-reads the keyboard layout and hotkey config used to label order buttons.
 local function reloadBindings()
 	currentLayout = Spring.GetConfigString("KeyboardLayout", "qwerty")
 	actionHotkeys = VFS.Include("luaui/Include/action_hotkeys.lua")
@@ -674,28 +675,42 @@ function widget:Initialize()
 	widget:SelectionChanged(spGetSelectedUnits())
 
 	WG.ordermenu = {}
+	---Screen rectangle of the order menu.
+	---@return number posX
+	---@return number posY
+	---@return number width
+	---@return number height
 	WG.ordermenu.getPosition = function()
 		return posX, posY, width, height
 	end
 	WG.ordermenu.reloadBindings = reloadBindings
+	---Docks the order menu to the bottom of the screen and relays it out.
+	---@param value boolean
 	WG.ordermenu.setBottomPosition = function(value)
 		stickToBottom = value
 		doUpdate = true
 		widget:ViewResize()
 	end
+	---@return boolean alwaysShow Whether the menu stays open with nothing selected.
 	WG.ordermenu.getAlwaysShow = function()
 		return alwaysShow
 	end
+	---@param value boolean Keep the menu open with nothing selected.
 	WG.ordermenu.setAlwaysShow = function(value)
 		alwaysShow = value
 		doUpdate = true
 	end
+	---@return boolean stickToBottom Whether the menu is docked to the bottom of the screen.
 	WG.ordermenu.getBottomPosition = function()
 		return stickToBottom
 	end
+	---@param cmd integer Command id.
+	---@return true? disabled `nil` when the command is not disabled.
 	WG.ordermenu.getDisabledCmd = function(cmd)
 		return disabledCommand[cmd]
 	end
+	---Hides or restores one command button.
+	---@param params {[1]: integer, [2]: boolean} The command id and whether to disable it.
 	WG.ordermenu.setDisabledCmd = function(params)
 		if params[2] then
 			disabledCommand[params[1]] = true
@@ -704,9 +719,11 @@ function widget:Initialize()
 		end
 		doUpdate = true
 	end
+	---@return number colorize How strongly command buttons are tinted, `0`-`1`.
 	WG.ordermenu.getColorize = function()
 		return colorize
 	end
+	---@param value number How strongly command buttons are tinted; clamped to at most `1`.
 	WG.ordermenu.setColorize = function(value)
 		doUpdate = true
 		colorize = value
@@ -714,6 +731,7 @@ function widget:Initialize()
 			colorize = 1
 		end
 	end
+	---@return boolean showing Whether the order menu is currently drawn.
 	WG.ordermenu.getIsShowing = function()
 		return ordermenuShows
 	end
@@ -737,6 +755,8 @@ function widget:Initialize()
 		}
 	end
 
+	---Removes a highlight previously set via `setHighlight`.
+	---@param cmdID integer?
 	WG.ordermenu.removeHighlight = function(cmdID)
 		local items = highlight.items
 		if cmdID and items[cmdID] then
@@ -745,6 +765,7 @@ function widget:Initialize()
 		end
 	end
 
+	---Clears all active command highlights.
 	WG.ordermenu.clearHighlights = function()
 		local items = highlight.items
 		for k in pairs(items) do
@@ -753,6 +774,8 @@ function widget:Initialize()
 		highlight.count = 0
 	end
 
+	---@param cmdID integer?
+	---@return boolean highlighted
 	WG.ordermenu.hasHighlight = function(cmdID)
 		return cmdID ~= nil and highlight.items[cmdID] ~= nil
 	end

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -8533,6 +8533,7 @@ local function RegisterMinimapWGAPI()
 		return
 	end
 	WG.minimap = {}
+	---@return number height Current minimap height in pixels, or `0` while minimized.
 	WG.minimap.getHeight = function()
 		if miscState.minimapMinimized then
 			return 0
@@ -8540,34 +8541,58 @@ local function RegisterMinimapWGAPI()
 		local padding = WG.FlowUI and WG.FlowUI.elementPadding or 5
 		return (render.dim.t - render.dim.b) + padding
 	end
+	---@return integer pixels Highest the minimap may grow to.
+	---@return number fraction The same limit as a fraction of screen height.
 	WG.minimap.getMaxHeight = function()
 		return math.floor(config.minimapModeMaxHeight * render.vsy), config.minimapModeMaxHeight
 	end
+	---Sets how tall the minimap may grow, persists it, and relays out.
+	---@param value number Fraction of screen height.
 	WG.minimap.setMaxHeight = function(value)
 		Spring.SetConfigFloat("MinimapMaxHeight", value)
 		config.minimapModeMaxHeight = value
 		widget:ViewResize()
 	end
+	---@return boolean move Whether left-clicking the minimap pans the camera.
 	WG.minimap.getLeftClickMove = function()
 		return config.leftButtonPansCamera
 	end
+	---Makes left-clicking the minimap pan the camera, and persists the choice.
+	---@param value boolean
 	WG.minimap.setLeftClickMove = function(value)
 		config.leftButtonPansCamera = value
 		Spring.SetConfigInt("MinimapLeftClickMove", value and 1 or 0)
 	end
+	---@return boolean active Always `true`; the standalone minimap widget returns nothing.
 	WG.minimap.isPipMinimapActive = function()
 		return true
 	end
 	WG.minimap.isDrawingInPip = false
+	---Screen rectangle the minimap occupies.
+	---@return number left
+	---@return number bottom
+	---@return number right
+	---@return number top
 	WG.minimap.getScreenBounds = function()
 		return render.dim.l, render.dim.b, render.dim.r, render.dim.t
 	end
+	---World area the minimap currently shows, in elmos.
+	---@return number left
+	---@return number right
+	---@return number bottom
+	---@return number top
 	WG.minimap.getVisibleWorldArea = function()
 		return render.world.l, render.world.r, render.world.b, render.world.t
 	end
+	---@return number radians Minimap rotation; `0` when unrotated.
 	WG.minimap.getRotation = function()
 		return render.minimapRotation or 0
 	end
+	---World area the minimap shows, as fractions of the map size.
+	---@return number left
+	---@return number right
+	---@return number bottom
+	---@return number top
 	WG.minimap.getNormalizedVisibleArea = function()
 		local normVisLeft = render.world.l / mapInfo.mapSizeX
 		local normVisRight = render.world.r / mapInfo.mapSizeX
@@ -8575,18 +8600,25 @@ local function RegisterMinimapWGAPI()
 		local normVisTop = render.world.t / mapInfo.mapSizeZ
 		return normVisLeft, normVisRight, normVisBottom, normVisTop
 	end
+	---@return number zoom Map width divided by the visible width; `1` shows the whole map.
 	WG.minimap.getZoomLevel = function()
 		return mapInfo.mapSizeX / (render.world.r - render.world.l)
 	end
+	---@return boolean show Whether spectator map pings are drawn.
 	WG.minimap.getShowSpectatorPings = function()
 		return config.showSpectatorPings
 	end
+	---@param value boolean Draw spectator map pings.
 	WG.minimap.setShowSpectatorPings = function(value)
 		config.showSpectatorPings = value
 	end
+	---@return boolean fallback Whether the engine minimap is used when PIP cannot render.
 	WG.minimap.getEngineMinimapFallback = function()
 		return config.engineMinimapFallback
 	end
+	---Allows falling back to the engine minimap. Turning it off while the engine
+	---minimap is showing restores the icon scale and re-minimizes it.
+	---@param value boolean
 	WG.minimap.setEngineMinimapFallback = function(value)
 		config.engineMinimapFallback = value
 		if not value and miscState.engineMinimapActive then
@@ -8602,18 +8634,25 @@ local function RegisterMinimapWGAPI()
 			pipR2T.unitsNeedsUpdate = true
 		end
 	end
+	---@return number threshold Frame cost above which the engine minimap takes over.
 	WG.minimap.getEngineMinimapFallbackThreshold = function()
 		return config.engineMinimapFallbackThreshold
 	end
+	---@param value number Frame cost above which the engine minimap takes over.
 	WG.minimap.setEngineMinimapFallbackThreshold = function(value)
 		config.engineMinimapFallbackThreshold = value
 	end
+	---@return boolean show Whether explosions are overlaid on the engine minimap.
 	WG.minimap.getEngineMinimapExplosionOverlay = function()
 		return config.engineMinimapExplosionOverlay
 	end
+	---@param value boolean Overlay explosions on the engine minimap.
 	WG.minimap.setEngineMinimapExplosionOverlay = function(value)
 		config.engineMinimapExplosionOverlay = value
 	end
+	---Remembers the icon scale to restore when the engine minimap fallback ends.
+	---Ignored unless the engine minimap is active.
+	---@param value number
 	WG.minimap.setBaseIconScale = function(value)
 		if miscState.engineMinimapActive then
 			miscState.baseMinimapIconScale = value
@@ -9495,62 +9534,124 @@ function widget:Initialize()
 
 	-- Create API for other widgets
 	WG["pip" .. pipNumber] = {}
+	---The PIP API table. `WG['pip'..n]` is a computed key, so it has to be pinned
+	---here or it widens to the union of every typed `WG` member.
+	---@type table
 	local pipApi = WG["pip" .. pipNumber]
+	---@param mx number
+	---@param my number
+	---@return boolean above Whether the position is over this PIP window.
 	pipApi.IsAbove = function(mx, my)
 		return widget:IsAbove(mx, my)
 	end
+	---Marks the PIP's rendered contents stale, so they redraw next frame.
 	pipApi.ForceUpdate = function()
 		pipR2T.contentNeedsUpdate = true
 	end
+	---@param fps number Redraws per second; `0` or less redraws every frame.
 	pipApi.SetUpdateRate = function(fps)
 		pipUpdateRate = fps
 		pipUpdateInterval = pipUpdateRate > 0 and (1 / pipUpdateRate) or 0
 	end
+	---@return number fps
 	pipApi.GetUpdateRate = function()
 		return pipUpdateRate
 	end
+	---@param enabled boolean Draw the distance ruler over the PIP.
 	pipApi.SetMapRuler = function(enabled)
 		config.showMapRuler = enabled
 	end
+	---@return boolean enabled
 	pipApi.GetMapRuler = function()
 		return config.showMapRuler
 	end
+	---@return number seconds Default easing time used when a call omits one.
 	pipApi.GetDefaultTransitionTime = function()
 		return config.switchTransitionTime
 	end
+	---Moves and zooms the PIP camera in one call, clearing any tracking.
+	---@param wcx number?
+	---@param wcz number?
+	---@param zoom number?
+	---@param transitionTime number? Seconds to ease over.
+	---@return boolean applied `false` when neither a position nor a zoom was given.
 	pipApi.SetCamera = function(wcx, wcz, zoom, transitionTime)
 		return ApplyApiCameraTarget(wcx, wcz, zoom, transitionTime, true)
 	end
+	---A snapshot of a PIP window's camera, as returned by `GetState`.
+	---@class PipState
+	---@field wcx number Current world center X.
+	---@field wcz number Current world center Z.
+	---@field targetWcx number World center X the camera is easing toward.
+	---@field targetWcz number World center Z the camera is easing toward.
+	---@field zoom number Current zoom.
+	---@field targetZoom number Zoom the camera is easing toward.
+	---@field trackingPlayerID integer? Player being followed, if any.
+	---@field trackedUnits integer[]? Units being followed, if any.
+
+	---Restores a camera snapshot, resuming any tracking it recorded.
+	---@param stateData PipState
+	---@param transitionTime number? Seconds to ease over. Defaults to the configured time.
+	---@return boolean applied `false` when `stateData` is not a table, or has nothing to apply.
 	pipApi.SetState = function(stateData, transitionTime)
 		return SetStateApi(stateData, transitionTime)
 	end
+	---Zooms out to show the whole map, clearing any tracking.
+	---@param transitionTime number? Seconds to ease over.
+	---@return boolean applied
 	pipApi.ZoomOutFull = function(transitionTime)
 		return ZoomOutFullApi(transitionTime)
 	end
+	---Stops the player from panning or zooming this PIP, leaving API control working.
+	---@param locked boolean
+	---@return boolean
 	pipApi.SetInteractionLocked = function(locked)
 		return SetInteractionLockedApi(locked)
 	end
+	---@return boolean locked
 	pipApi.GetInteractionLocked = function()
 		return miscState.apiInteractionLocked
 	end
+	---Runs a scripted camera sequence, for debugging the PIP camera.
 	pipApi.DebugCameraSequence = function()
 		return StartDebugCameraSequenceApi()
 	end
+	---Moves the PIP camera to a world position, clearing any tracking.
+	---@param wcx number
+	---@param wcz number
+	---@param transitionTime number? Seconds to ease over.
+	---@return boolean applied
 	pipApi.SetPosition = function(wcx, wcz, transitionTime)
 		return ApplyApiCameraTarget(wcx, wcz, nil, transitionTime, true)
 	end
+	---Sets the PIP zoom without moving the camera or clearing tracking.
+	---@param zoom number
+	---@param transitionTime number? Seconds to ease over.
+	---@return boolean applied
 	pipApi.SetZoom = function(zoom, transitionTime)
 		return ApplyApiCameraTarget(nil, nil, zoom, transitionTime, false)
 	end
+	---Follows one or more units, replacing any player tracking.
+	---@param unitsOrUnitID integer|integer[]
+	---@param transitionTime number? Seconds to ease over.
+	---@return boolean tracking `false` when no valid unit was given.
 	pipApi.TrackUnits = function(unitsOrUnitID, transitionTime)
 		return TrackUnitsApi(unitsOrUnitID, transitionTime)
 	end
+	---Follows a player's camera, replacing any unit tracking.
+	---@param playerID integer
+	---@param transitionTime number? Seconds to ease over.
+	---@return boolean tracking
 	pipApi.TrackPlayer = function(playerID, transitionTime)
 		return TrackPlayerApi(playerID, transitionTime)
 	end
+	---Stops following any player or units.
+	---@return boolean
 	pipApi.ClearTracking = function()
 		return ClearTrackingApi()
 	end
+	---Stops following a player, leaving unit tracking alone.
+	---@return boolean stopped `false` when no player was being followed.
 	pipApi.UntrackPlayer = function()
 		if interactionState.trackingPlayerID then
 			interactionState.trackingPlayerID = nil
@@ -9560,12 +9661,15 @@ function widget:Initialize()
 		end
 		return false
 	end
+	---@return integer? playerID `nil` when no player is being followed.
 	pipApi.GetTrackedPlayer = function()
 		return interactionState.trackingPlayerID
 	end
+	---@return integer[]? unitIDs `nil` when no units are being followed.
 	pipApi.GetTrackedUnits = function()
 		return interactionState.areTracking
 	end
+	---@return PipState
 	pipApi.GetState = function()
 		return {
 			wcx = cameraState.wcx,
@@ -9579,17 +9683,34 @@ function widget:Initialize()
 		}
 	end
 	-- API for minimap mode: get visible world area
+	---@return boolean minimapMode Whether this PIP is standing in for the minimap.
 	pipApi.IsMinimapMode = function()
 		return isMinimapMode
 	end
+	---World area the PIP currently shows, in elmos.
+	---@return number left
+	---@return number right
+	---@return number bottom
+	---@return number top
 	pipApi.GetVisibleWorldArea = function()
 		-- Returns the visible world coordinates: left, right, bottom, top
 		return render.world.l, render.world.r, render.world.b, render.world.t
 	end
+	---Screen rectangle the PIP occupies.
+	---@return number left
+	---@return number right
+	---@return number bottom
+	---@return number top
 	pipApi.GetScreenBounds = function()
 		-- Returns the screen coordinates of the PIP
 		return render.dim.l, render.dim.r, render.dim.b, render.dim.t
 	end
+	---Converts a screen position inside the PIP into world coordinates.
+	---@param mx number
+	---@param my number
+	---@return number? worldX `nil` when interaction is locked, the PIP is minimized,
+	---or the position is outside the PIP's map area.
+	---@return number? worldZ
 	pipApi.ScreenToWorld = function(mx, my)
 		if
 			miscState.apiInteractionLocked
@@ -9600,45 +9721,63 @@ function widget:Initialize()
 		end
 		return PipToWorldCoords(mx, my)
 	end
+	---@return boolean minimized
 	pipApi.IsMinimized = function()
 		return uiState.inMinMode or (isMinimapMode and miscState.minimapMinimized)
 	end
+	---@return number zoom
 	pipApi.GetZoom = function()
 		return cameraState.zoom
 	end
+	---@return number wcx
+	---@return number wcz
 	pipApi.GetCameraCenter = function()
 		return cameraState.wcx, cameraState.wcz
 	end
 	-- Expose ghost building cache so sibling PIPs can share data on reload
+	---Exposes the ghost building cache so sibling PIPs can share it across a reload.
+	---@return table<integer, {defID: integer, x: number, z: number, teamID: integer}> ghostBuildings
+	---Keyed by unitID. Do not mutate.
 	pipApi.GetGhostBuildings = function()
 		return ghostBuildings
 	end
+	---@return boolean draw Whether command lines are drawn inside the PIP.
 	pipApi.getDrawCommandFX = function()
 		return config.drawCommandFX
 	end
+	---@param value boolean Draw command lines inside the PIP.
 	pipApi.setDrawCommandFX = function(value)
 		config.drawCommandFX = value
 		pipR2T.unitsNeedsUpdate = true
 	end
+	---@return boolean draw Whether nano streams are drawn inside the PIP.
 	pipApi.getDrawNanoStreams = function()
 		return config.drawNanoStreams
 	end
+	---Draws nano streams inside the PIP, forcing a rescan.
+	---@param value boolean
 	pipApi.setDrawNanoStreams = function(value)
 		config.drawNanoStreams = value
 		gl4Prim.nanoStreams.lastScanFrame = -1000
 		pipR2T.unitsNeedsUpdate = true
 	end
+	---@return boolean reflect Whether nano stream colors follow the resource being used.
 	pipApi.getNanoStreamReflectUsage = function()
 		return config.nanoStreamReflectUsage
 	end
+	---Colors nano streams by the resource being used, forcing a rescan.
+	---@param value boolean
 	pipApi.setNanoStreamReflectUsage = function(value)
 		config.nanoStreamReflectUsage = value
 		gl4Prim.nanoStreams.lastScanFrame = -1000
 		pipR2T.unitsNeedsUpdate = true
 	end
+	---@return boolean show Whether player map drawings appear in the PIP.
 	pipApi.getShowMapDrawings = function()
 		return config.showMapDrawings
 	end
+	---Shows player map drawings in the PIP. Turning it off releases the cached lines.
+	---@param value boolean
 	pipApi.setShowMapDrawings = function(value)
 		config.showMapDrawings = value
 		if not value then
@@ -9653,17 +9792,21 @@ function widget:Initialize()
 		miscState.mapLinesDirty = true
 		miscState.mapLinesNextUpdateTime = 0
 	end
+	---@return number seconds How long map drawings stay visible.
 	pipApi.getMapDrawingDuration = function()
 		return config.mapDrawingDuration
 	end
+	---@param value number|string? Seconds, at least `0.1`. Defaults to `12`.
 	pipApi.setMapDrawingDuration = function(value)
 		config.mapDrawingDuration = math.max(0.1, tonumber(value) or 12)
 		miscState.mapLinesDirty = true
 		miscState.mapLinesNextUpdateTime = 0
 	end
+	---@return boolean required Whether alt must be held to zoom the PIP with the wheel.
 	pipApi.getAltKeyRequiredForZoom = function()
 		return config.altKeyRequiredForZoom
 	end
+	---@param value boolean Require alt to zoom the PIP with the wheel.
 	pipApi.setAltKeyRequiredForZoom = function(value)
 		config.altKeyRequiredForZoom = value
 	end
@@ -9674,6 +9817,7 @@ function widget:Initialize()
 	if isMinimapMode then
 		WG.pip_minimap = pipApi
 		-- Also expose getHeight like the original minimap widget for topbar compatibility
+		---@return number height Current minimap height in pixels, or `0` while minimized.
 		WG.pip_minimap.getHeight = function()
 			if miscState.minimapMinimized then
 				return 0

--- a/luaui/Widgets/gui_point_tracker.lua
+++ b/luaui/Widgets/gui_point_tracker.lua
@@ -61,6 +61,7 @@ end
 -- and clamp the size of it to always be screensized
 -- GL4 Stuff --
 
+---@type InstanceVBOTable
 local mapMarkInstanceVBO = nil
 local mapMarkShader = nil
 
@@ -71,6 +72,7 @@ local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 local drawInstanceVBO = InstanceVBOTable.drawInstanceVBO
 
+---Removes every tracked map point marker.
 local function ClearPoints()
 	mapPoints = {}
 	InstanceVBOTable.clearInstanceTable(mapMarkInstanceVBO)

--- a/luaui/Widgets/gui_pregame_build.lua
+++ b/luaui/Widgets/gui_pregame_build.lua
@@ -35,7 +35,10 @@ local spTestBuildOrder = Spring.TestBuildOrder
 
 local spawnWarpInFrame = Game.spawnWarpInFrame
 
+---@type BuildOrder[]
 local buildQueue = {}
+---The unitDefID of the building currently held by the cursor, if any.
+---@type integer?
 local selBuildQueueDefID
 local facingMap = { south = 0, east = 1, north = 2, west = 3 }
 
@@ -299,9 +302,13 @@ function widget:Initialize()
 	isMetalMap = WG.resource_spot_finder.isMetalMap
 
 	WG["pregame-build"] = {}
+	---@return integer? unitDefID The building currently held for pregame placement.
 	WG["pregame-build"].getPreGameDefID = function()
 		return selBuildQueueDefID
 	end
+	---Holds a building for pregame placement. Anything the starting unit cannot build
+	---clears the held building instead.
+	---@param value integer? unitDefID.
 	WG["pregame-build"].setPreGamestartDefID = function(value)
 		local inBuildOptions = {}
 		-- Ensure startDefID is valid before trying to access UnitDefs[startDefID]
@@ -324,15 +331,31 @@ function widget:Initialize()
 		end
 	end
 
+	---A single pregame build order.
+	---@class BuildOrder
+	---@field [1] integer unitDefID, or a negated command ID when negative -- the move
+	---order queued alongside a building uses `-CMD.MOVE`. Consumers test `> 0`.
+	---@field [2] number World X.
+	---@field [3] number World Y.
+	---@field [4] number World Z.
+	---@field [5] integer? Build facing, `0`-`3`. Absent for the move orders.
+
+	---Replaces the pregame build queue.
+	---@param value BuildOrder[]
 	WG["pregame-build"].setBuildQueue = function(value)
 		buildQueue = value
 	end
+	---@return BuildOrder[] queue Do not mutate.
 	WG["pregame-build"].getBuildQueue = function()
 		return buildQueue
 	end
+	---@return {x: number, y: number, z: number, facing: integer}[]? positions Snapped
+	---positions for the buildings currently being dragged out. Note the named fields:
+	---unlike `BuildOrder`, these are not arrays.
 	WG["pregame-build"].getBuildPositions = function()
 		return buildModeState.buildPositions
 	end
+	---Invalidates the cached pregame build preview, so it is rebuilt next frame.
 	WG["pregame-build"].forceRefresh = function()
 		forceRefreshCache = true
 	end

--- a/luaui/Widgets/gui_pregameui.lua
+++ b/luaui/Widgets/gui_pregameui.lua
@@ -368,6 +368,10 @@ function widget:Initialize()
 	checkStartPointChosen()
 
 	WG.pregameui = {}
+	---Blocks the ready button until the condition is removed, showing `description`
+	---in its tooltip. Several widgets can block independently.
+	---@param conditionKey string Caller-chosen key; pass the same one to clear it.
+	---@param description string Shown to the player as the reason they cannot ready up.
 	WG.pregameui.addReadyCondition = function(conditionKey, description)
 		if conditionKey and description then
 			readyBlockedConditions[conditionKey] = description
@@ -376,6 +380,8 @@ function widget:Initialize()
 			createButton()
 		end
 	end
+	---Clears one ready-blocking condition.
+	---@param conditionKey string
 	WG.pregameui.removeReadyCondition = function(conditionKey)
 		if conditionKey and readyBlockedConditions[conditionKey] then
 			readyBlockedConditions[conditionKey] = nil
@@ -383,6 +389,7 @@ function widget:Initialize()
 			createButton()
 		end
 	end
+	---Clears every ready-blocking condition, unblocking the ready button.
 	WG.pregameui.clearAllReadyConditions = function()
 		readyBlockedConditions = {}
 		isReadyBlocked = false

--- a/luaui/Widgets/gui_pregameui_draft.lua
+++ b/luaui/Widgets/gui_pregameui_draft.lua
@@ -1155,18 +1155,25 @@ function widget:Initialize()
 	end
 
 	WG.pregameui_draft = {}
+	---Blocks the draft ready button until the condition is removed, showing
+	---`description` in its tooltip.
+	---@param conditionKey string Caller-chosen key; pass the same one to clear it.
+	---@param description string Shown to the player as the reason they cannot ready up.
 	WG.pregameui_draft.addReadyCondition = function(conditionKey, description)
 		if conditionKey and description then
 			readyBlockedConditions[conditionKey] = description
 			updateTooltip()
 		end
 	end
+	---Clears one ready-blocking condition.
+	---@param conditionKey string
 	WG.pregameui_draft.removeReadyCondition = function(conditionKey)
 		if conditionKey and readyBlockedConditions[conditionKey] then
 			readyBlockedConditions[conditionKey] = nil
 			updateTooltip()
 		end
 	end
+	---Clears every ready-blocking condition.
 	WG.pregameui_draft.clearAllReadyConditions = function()
 		readyBlockedConditions = {}
 		updateTooltip()

--- a/luaui/Widgets/gui_rank_icons_gl4.lua
+++ b/luaui/Widgets/gui_rank_icons_gl4.lua
@@ -50,6 +50,7 @@ local atlasID = nil
 local atlasSize = 2048
 --local atlassedImages = {}
 
+---@type InstanceVBOTable
 local rankVBO = nil
 local rankShader = nil
 local luaShaderDir = "LuaUI/Include/"
@@ -285,24 +286,36 @@ function widget:Initialize()
 		return
 	end
 	WG.rankicons = {}
+	---@return number multiplier Scales how far away rank icons stay visible.
 	WG.rankicons.getDrawDistance = function()
 		return distanceMult
 	end
+	---@param value number Scales how far away rank icons stay visible.
 	WG.rankicons.setDrawDistance = function(value)
 		distanceMult = value
 		usedCutoffDistance = cutoffDistance * distanceMult
 	end
+	---@return number multiplier Rank icon size multiplier.
 	WG.rankicons.getScale = function()
 		return iconsizeMult
 	end
+	---Sets the rank icon size multiplier and refreshes the icons.
+	---@param value number
 	WG.rankicons.setScale = function(value)
 		iconsizeMult = value
 		usedIconsize = iconsize * iconsizeMult
 		doRefresh = true
 	end
+	---Works out which rank a unit has earned.
+	---@param unitDefID integer
+	---@param xp number Unit experience.
+	---@return integer rank
 	WG.rankicons.getRank = function(unitDefID, xp)
 		return getRank(unitDefID, xp)
 	end
+	---@param unitDefID integer? Unused.
+	---@param xp number? Unused.
+	---@return string[] textures Rank icon texture per rank.
 	WG.rankicons.getRankTextures = function(unitDefID, xp)
 		return rankTextures
 	end

--- a/luaui/Widgets/gui_reclaim_field_highlight.lua
+++ b/luaui/Widgets/gui_reclaim_field_highlight.lua
@@ -4395,35 +4395,49 @@ function widget:Initialize()
 	widgetHandler:AddAction("reclaim_highlight", disableHighlight, nil, "r")
 
 	WG.reclaimfieldhighlight = {}
+	---@return integer showOption When metal reclaim fields are highlighted.
 	WG.reclaimfieldhighlight.getShowOption = function()
 		return showOption
 	end
+	---@param value integer When metal reclaim fields are highlighted.
 	WG.reclaimfieldhighlight.setShowOption = function(value)
 		showOption = value
 	end
+	---@return integer segments Segments used to smooth each field's outline.
 	WG.reclaimfieldhighlight.getSmoothingSegments = function()
 		return smoothingSegments
 	end
+	---Sets the outline smoothing detail and forces a recluster.
+	---@param value number Clamped to `4`-`40`.
 	WG.reclaimfieldhighlight.setSmoothingSegments = function(value)
 		smoothingSegments = clamp(value, 4, 40) -- Clamp to reasonable range
 		dirty.needCluster = true -- Force recluster with new settings
 	end
+	---@return boolean show Whether energy reclaim fields are highlighted too.
 	WG.reclaimfieldhighlight.getShowEnergyFields = function()
 		return showEnergyFields
 	end
+	---Highlights energy reclaim fields as well, forcing a recluster.
+	---@param value boolean
 	WG.reclaimfieldhighlight.setShowEnergyFields = function(value)
 		showEnergyFields = value
 		dirty.needCluster = true -- Force recluster with new settings
 	end
+	---@return integer showOption When energy reclaim fields are highlighted.
 	WG.reclaimfieldhighlight.getShowEnergyOption = function()
 		return showEnergyOption
 	end
+	---@param value integer When energy reclaim fields are highlighted.
 	WG.reclaimfieldhighlight.setShowEnergyOption = function(value)
 		showEnergyOption = value
 	end
+	---@return number distance Camera distance at which fields start fading out.
 	WG.reclaimfieldhighlight.getFadeStartDistance = function()
 		return fadeStartDistance
 	end
+	---Sets where fields start fading. The end distance is pushed out if needed to
+	---stay above it.
+	---@param value number At least `100`.
 	WG.reclaimfieldhighlight.setFadeStartDistance = function(value)
 		fadeStartDistance = max(100, value)
 		-- Ensure start < end
@@ -4431,58 +4445,74 @@ function widget:Initialize()
 			fadeEndDistance = fadeStartDistance + 1000
 		end
 	end
+	---@return number distance Camera distance at which fields are fully faded.
 	WG.reclaimfieldhighlight.getFadeEndDistance = function()
 		return fadeEndDistance
 	end
+	---@param value number Kept at least `100` above the fade start distance.
 	WG.reclaimfieldhighlight.setFadeEndDistance = function(value)
 		fadeEndDistance = max(fadeStartDistance + 100, value)
 	end
 
+	---@return boolean alwaysShow Whether large fields stay highlighted regardless of distance.
 	WG.reclaimfieldhighlight.getAlwaysShowFields = function()
 		return alwaysShowFields
 	end
+	---@param value boolean Keep large fields highlighted regardless of distance.
 	WG.reclaimfieldhighlight.setAlwaysShowFields = function(value)
 		alwaysShowFields = value
 	end
 
+	---@return number threshold Metal value above which a field is always shown.
 	WG.reclaimfieldhighlight.getAlwaysShowFieldsThreshold = function()
 		return alwaysShowFieldsThreshold
 	end
+	---Deprecated no-op; the threshold is now derived from the map's total metal.
+	---@param value number? Ignored.
 	WG.reclaimfieldhighlight.setAlwaysShowFieldsThreshold = function(value)
-		-- Deprecated - threshold is now auto-calculated
-		-- This function kept for backwards compatibility
 	end
 
+	---@return number threshold Lower bound on the auto-calculated always-show threshold.
 	WG.reclaimfieldhighlight.getAlwaysShowFieldsMinThreshold = function()
 		return alwaysShowFieldsMinThreshold
 	end
+	---Sets the lower bound on the always-show threshold and recalculates it.
+	---@param value number At least `0`.
 	WG.reclaimfieldhighlight.setAlwaysShowFieldsMinThreshold = function(value)
 		alwaysShowFieldsMinThreshold = max(0, value)
 		alwaysShowFieldsThreshold = CalculateAlwaysShowThreshold()
 	end
 
+	---@return number threshold Upper bound on the auto-calculated always-show threshold.
 	WG.reclaimfieldhighlight.getAlwaysShowFieldsMaxThreshold = function()
 		return alwaysShowFieldsMaxThreshold
 	end
+	---Sets the upper bound on the always-show threshold and recalculates it.
+	---@param value number Kept at least at the minimum threshold.
 	WG.reclaimfieldhighlight.setAlwaysShowFieldsMaxThreshold = function(value)
 		alwaysShowFieldsMaxThreshold = max(alwaysShowFieldsMinThreshold, value)
 		alwaysShowFieldsThreshold = CalculateAlwaysShowThreshold()
 	end
 
+	---@return number metal Total reclaimable metal on the map.
 	WG.reclaimfieldhighlight.getTotalMapMetal = function()
 		return totalMapMetal
 	end
 
 	-- Deferred update settings
+	---@return boolean defer Whether off-screen fields skip their updates.
 	WG.reclaimfieldhighlight.getDeferOutOfViewUpdates = function()
 		return batch.deferOutOfView
 	end
+	---@param value boolean Skip updates for off-screen fields.
 	WG.reclaimfieldhighlight.setDeferOutOfViewUpdates = function(value)
 		batch.deferOutOfView = value
 	end
+	---@return number margin How far outside the view a field still counts as on-screen.
 	WG.reclaimfieldhighlight.getOutOfViewMargin = function()
 		return batch.outOfViewMargin
 	end
+	---@param value number At least `0`.
 	WG.reclaimfieldhighlight.setOutOfViewMargin = function(value)
 		batch.outOfViewMargin = max(0, value)
 	end
@@ -4490,27 +4520,38 @@ function widget:Initialize()
 	-- Diagnostics: toggle a periodic timing echo (per-call ms for the update
 	-- pass vs the draw/rebuild passes, plus display-list rebuilds per frame) so
 	-- it's easy to confirm whether updating or drawing is the per-frame cost.
+	---@return boolean enabled Whether periodic timing diagnostics are echoed.
 	WG.reclaimfieldhighlight.getDebugTiming = function()
 		return debugTiming
 	end
+	---Echoes periodic timing diagnostics, separating the update pass from the draw
+	---and rebuild passes.
+	---@param value boolean?
 	WG.reclaimfieldhighlight.setDebugTiming = function(value)
 		debugTiming = value and true or false
 	end
+	---@return integer frames Frames between timing echoes.
 	WG.reclaimfieldhighlight.getTimingInterval = function()
 		return timingInterval
 	end
+	---@param value number|string? Frames between timing echoes; at least `10`.
 	WG.reclaimfieldhighlight.setTimingInterval = function(value)
 		timingInterval = max(10, floor(tonumber(value) or timingInterval))
 	end
+	---@return number ms Frame time above which a spike is reported.
 	WG.reclaimfieldhighlight.getTimingSpikeMs = function()
 		return timingAccum.spikeMs
 	end
+	---@param value number|string? Milliseconds; at least `0.5`.
 	WG.reclaimfieldhighlight.setTimingSpikeMs = function(value)
 		timingAccum.spikeMs = max(0.5, tonumber(value) or timingAccum.spikeMs)
 	end
+	---@return integer ms Time budget per frame for incremental clustering.
 	WG.reclaimfieldhighlight.getClusterSliceBudgetMs = function()
 		return floor((batch.clusterJobBudget or 0) * 1000 + 0.5)
 	end
+	---Sets the per-frame clustering time budget. Non-numeric input is ignored.
+	---@param value number|string Milliseconds, clamped to the configured range.
 	WG.reclaimfieldhighlight.setClusterSliceBudgetMs = function(value)
 		local ms = tonumber(value)
 		if not ms then
@@ -4518,6 +4559,7 @@ function widget:Initialize()
 		end
 		batch.clusterJobBudget = clamp(ms * 0.001, batch.clusterJobBudgetMin, batch.clusterJobBudgetMax)
 	end
+	---Echoes the accumulated timing diagnostics immediately.
 	WG.reclaimfieldhighlight.printTimingNow = function()
 		local denom = timingCount > 0 and timingCount or 1
 		Spring.Echo(

--- a/luaui/Widgets/gui_rejoinprogress.lua
+++ b/luaui/Widgets/gui_rejoinprogress.lua
@@ -399,6 +399,7 @@ end
 function widget:Initialize()
 	widget:ViewResize()
 	WG.rejoin = {}
+	---@return boolean showing Whether the rejoin progress UI is on screen.
 	WG.rejoin.showingRejoining = function()
 		return showRejoinUI
 	end

--- a/luaui/Widgets/gui_resurrection_halos_gl4.lua
+++ b/luaui/Widgets/gui_resurrection_halos_gl4.lua
@@ -12,6 +12,7 @@ function widget:GetInfo()
 	}
 end
 
+---@type InstanceVBOTable
 local resurrectionHalosVBO = nil
 local resurrectionHalosShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/gui_scavenger_info.lua
+++ b/luaui/Widgets/gui_scavenger_info.lua
@@ -309,6 +309,8 @@ end
 function widget:Initialize()
 	if textFile then
 		WG.scavengerinfo = {}
+		---Shows or hides the scavenger info window.
+		---@param state boolean? Omit to toggle.
 		WG.scavengerinfo.toggle = function(state)
 			if state ~= nil then
 				show = state
@@ -316,6 +318,7 @@ function widget:Initialize()
 				show = not show
 			end
 		end
+		---@return boolean visible
 		WG.scavengerinfo.isvisible = function()
 			return show
 		end

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -717,33 +717,45 @@ function widget:Initialize()
 		return
 	end
 	WG.selectedunits = {}
+	---@return number opacity Opacity of the selection outlines.
 	WG.selectedunits.getOpacity = function()
 		return opacity
 	end
+	---Sets the selection outline opacity and rebuilds the effect.
+	---@param value number
 	WG.selectedunits.setOpacity = function(value)
 		opacity = value
 		init()
 	end
+	---@return number opacity How strongly the team color tints the selection outline.
 	WG.selectedunits.getTeamcolorOpacity = function()
 		return teamcolorOpacity
 	end
+	---Sets how strongly the team color tints the outline, and rebuilds the effect.
+	---@param value number
 	WG.selectedunits.setTeamcolorOpacity = function(value)
 		teamcolorOpacity = value
 		init()
 	end
 
+	---Highlights the models of selected units, rebuilding the effect.
+	---@param value boolean
 	WG.selectedunits.setSelectionHighlight = function(value)
 		selectionHighlight = value
 		init()
 	end
+	---@return boolean highlight
 	WG.selectedunits.getSelectionHighlight = function()
 		return selectionHighlight
 	end
 
+	---Highlights the model of the unit under the cursor, rebuilding the effect.
+	---@param value boolean
 	WG.selectedunits.setMouseoverHighlight = function(value)
 		mouseoverHighlight = value
 		init()
 	end
+	---@return boolean highlight
 	WG.selectedunits.getMouseoverHighlight = function()
 		return mouseoverHighlight
 	end

--- a/luaui/Widgets/gui_sensor_ranges_jammer.lua
+++ b/luaui/Widgets/gui_sensor_ranges_jammer.lua
@@ -43,6 +43,7 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 
 local jammerStencilShader = nil
 local jammerCircleShader = nil
+---@type InstanceVBOTable
 local circleInstanceVBO = nil
 
 local jammerStencilTexture
@@ -237,9 +238,11 @@ function widget:Initialize()
 	end
 
 	WG.jammerrange = {
+		---@return number opacity Opacity of the jammer range rings.
 		getOpacity = function()
 			return opacity
 		end,
+		---@param value number Opacity of the jammer range rings.
 		setOpacity = function(value)
 			opacity = value
 		end,

--- a/luaui/Widgets/gui_sensor_ranges_los.lua
+++ b/luaui/Widgets/gui_sensor_ranges_los.lua
@@ -64,6 +64,7 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 
 local losStencilShader = nil
 local losCircleShader = nil
+---@type InstanceVBOTable
 local circleInstanceVBO = nil
 
 local losStencilTexture
@@ -255,15 +256,19 @@ function widget:Initialize()
 	end
 
 	WG.losrange = {
+		---@return number opacity Opacity of the LOS range rings.
 		getOpacity = function()
 			return opacity
 		end,
+		---@param value number Opacity of the LOS range rings.
 		setOpacity = function(value)
 			opacity = value
 		end,
+		---@return boolean useTeamColors Whether rings are drawn in each unit's team color.
 		getUseTeamColors = function()
 			return useteamcolors
 		end,
+		---@param value boolean Draw rings in each unit's team color.
 		setUseTeamColors = function(value)
 			useteamcolors = value
 		end,

--- a/luaui/Widgets/gui_sensor_ranges_radar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_radar.lua
@@ -43,6 +43,7 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 
 local radarStencilShader = nil
 local radarCircleShader = nil
+---@type InstanceVBOTable
 local circleInstanceVBO = nil
 
 local radarStencilTexture
@@ -237,9 +238,11 @@ function widget:Initialize()
 	end
 
 	WG.radarrange = {
+		---@return number opacity Opacity of the radar range rings.
 		getOpacity = function()
 			return opacity
 		end,
+		---@param value number Opacity of the radar range rings.
 		setOpacity = function(value)
 			opacity = value
 		end,

--- a/luaui/Widgets/gui_sensor_ranges_sonar.lua
+++ b/luaui/Widgets/gui_sensor_ranges_sonar.lua
@@ -43,6 +43,7 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 
 local sonarStencilShader = nil
 local sonarCircleShader = nil
+---@type InstanceVBOTable
 local circleInstanceVBO = nil
 
 local sonarStencilTexture
@@ -247,9 +248,11 @@ function widget:Initialize()
 	end
 
 	WG.sonarrange = {
+		---@return number opacity Opacity of the sonar range rings.
 		getOpacity = function()
 			return opacity
 		end,
+		---@param value number Opacity of the sonar range rings.
 		setOpacity = function(value)
 			opacity = value
 		end,

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -1857,25 +1857,36 @@ function widget:Initialize()
 
 	WG.spectator_hud = {}
 
+	---@return number scale UI scale of the spectator HUD.
 	WG.spectator_hud.getWidgetSize = function()
 		return settings.widgetScale
 	end
+	---Sets the spectator HUD scale and rebuilds it.
+	---@param value number
 	WG.spectator_hud.setWidgetSize = function(value)
 		settings.widgetScale = value
 		reInit()
 	end
 
+	---@return integer config One of the `constants.configLevel` values, not a table:
+	---which preset tier of metrics the HUD shows.
 	WG.spectator_hud.getConfig = function()
 		return settings.widgetConfig
 	end
+	---Switches the HUD to a different preset tier and rebuilds it.
+	---@param value integer One of the `constants.configLevel` values.
 	WG.spectator_hud.setConfig = function(value)
 		settings.widgetConfig = value
 		reInit()
 	end
 
+	---@param metric string Metric name.
+	---@return boolean? enabled `nil` for unknown metrics.
 	WG.spectator_hud.getMetricEnabled = function(metric)
 		return settings.metricsEnabled[metric]
 	end
+	---Shows or hides one metric, rebuilding the HUD.
+	---@param args {[1]: string, [2]: boolean} The metric name and whether to show it.
 	WG.spectator_hud.setMetricEnabled = function(args)
 		settings.metricsEnabled[args[1]] = args[2]
 		reInit()

--- a/luaui/Widgets/gui_team_platter.lua
+++ b/luaui/Widgets/gui_team_platter.lua
@@ -23,6 +23,7 @@ local InstanceVBOTable = gl.InstanceVBOTable
 local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 
+---@type InstanceVBOTable
 local teamplatterVBO = nil
 local teamplatterShader = nil
 local luaShaderDir = "LuaUI/Include/"
@@ -219,16 +220,22 @@ function widget:Initialize()
 		return
 	end
 	WG.teamplatter = {}
+	---@return number opacity Opacity of the team platter rings.
 	WG.teamplatter.getOpacity = function()
 		return opacity
 	end
+	---Sets the platter opacity and rebuilds the draw lists.
+	---@param value number
 	WG.teamplatter.setOpacity = function(value)
 		opacity = value
 		init()
 	end
+	---@return boolean skip Whether the local team's own units are left unmarked.
 	WG.teamplatter.getSkipOwnTeam = function()
 		return skipOwnTeam
 	end
+	---Leaves the local team's own units unmarked, rebuilding the draw lists.
+	---@param value boolean
 	WG.teamplatter.setSkipOwnTeam = function(value)
 		skipOwnTeam = value
 		init()

--- a/luaui/Widgets/gui_teamstats.lua
+++ b/luaui/Widgets/gui_teamstats.lua
@@ -286,6 +286,8 @@ function widget:Initialize()
 	end
 
 	WG.teamstats = {}
+	---Shows or hides the team stats panel, refreshing it when it opens.
+	---@param state boolean? Omit to toggle.
 	WG.teamstats.toggle = function(state)
 		if state ~= nil then
 			guiData.mainPanel.visible = state
@@ -296,6 +298,7 @@ function widget:Initialize()
 			widget:GameFrame(GetGameFrame(), true)
 		end
 	end
+	---@return boolean visible
 	WG.teamstats.isvisible = function()
 		return guiData.mainPanel.visible
 	end

--- a/luaui/Widgets/gui_tooltip.lua
+++ b/luaui/Widgets/gui_tooltip.lua
@@ -135,9 +135,17 @@ function widget:Initialize()
 
 	if WG.tooltip == nil then
 		WG.tooltip = {}
+		---@return number size Font size tooltips are drawn at.
 		WG.tooltip.getFontsize = function()
 			return usedFontSize
 		end
+		---Registers a hover tooltip over a screen rectangle. Calling again with the same
+		---name updates it; pass only `name` and `area` to move an existing tooltip.
+		---@param name string Caller-chosen key; pass the same one to `RemoveTooltip`.
+		---@param area ScreenRect
+		---@param value string|number|nil Tooltip body.
+		---@param delay number? Seconds of hover before it appears. Defaults to the widget's delay.
+		---@param title string|number|nil Tooltip heading.
 		WG.tooltip.AddTooltip = function(name, area, value, delay, title)
 			if
 				(
@@ -165,6 +173,8 @@ function widget:Initialize()
 				end
 			end
 		end
+		---Removes a registered tooltip and frees its resources. Unknown names are ignored.
+		---@param name string
 		WG.tooltip.RemoveTooltip = function(name)
 			if tooltips[name] ~= nil then
 				if tooltips[name].dlist then
@@ -175,6 +185,12 @@ function widget:Initialize()
 				tooltips[name] = nil
 			end
 		end
+		---Shows a tooltip immediately, without waiting for a hover delay or a registered area.
+		---@param name string Caller-chosen key.
+		---@param value string|number|nil Tooltip body.
+		---@param x number? Screen position. Defaults to the cursor.
+		---@param y number? Screen position. Defaults to the cursor.
+		---@param title string|number|nil Tooltip heading.
 		WG.tooltip.ShowTooltip = function(name, value, x, y, title)
 			if value ~= nil or title ~= nil then
 				if not tooltips[name] then

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -234,7 +234,9 @@ end
 local draggingShareIndicatorValue = {}
 local draggingConversionIndicatorValue, draggingShareIndicator, draggingConversionIndicator
 local conversionIndicatorArea, quitscreenArea, quitscreenStayArea, quitscreenQuitArea, quitscreenResignArea, quitscreenTeamResignArea, hoveringTopbar, hideQuitWindow
-local font, font2, firstButton, fontSize, comcountChanged, showQuitscreen, resbarHover, teamResign
+local font, font2, firstButton, fontSize, comcountChanged, resbarHover, teamResign
+---@type boolean
+local showQuitscreen
 
 -- Audio
 local playSounds = true
@@ -1627,6 +1629,23 @@ function init()
 	updateButtons()
 
 	if WG.topbar then
+		---The top bar's screen rectangle plus the scale it was laid out at. Note the
+		---component order is left-bottom-right-top, unlike the top-left-bottom-right
+		---order the advplayerlist-adjacent panels use.
+		---@class TopBarArea
+		---@field [1] number Left edge, already offset for the skew and margin.
+		---@field [2] number Bottom edge.
+		---@field [3] number Right edge.
+		---@field [4] number Top edge.
+		---@field [5] number UI scale the bar was laid out at.
+
+		---A `TopBarArea` with the buttons' bottom edge appended, so a docked widget can
+		---align to the button row rather than to the bar itself.
+		---@class TopBarPosition : TopBarArea
+		---@field [6] number Bottom edge of the button row.
+
+		---Screen rectangle of the top bar.
+		---@return TopBarPosition position
 		WG.topbar.GetPosition = function()
 			local leftSkewOffset = cfg.useSkew and mathFloor((topbarArea[4] - topbarArea[2]) * skewTan) or 0
 			return {
@@ -1639,6 +1658,8 @@ function init()
 			}
 		end
 
+		---The unused span of the top bar, for widgets that want to dock into it.
+		---@return TopBarArea area
 		WG.topbar.GetFreeArea = function()
 			return {
 				topbarArea[1] + filledWidth,
@@ -1648,6 +1669,8 @@ function init()
 				widgetScale,
 			}
 		end
+		---How the top bar's edges are slanted, so docked widgets can match it.
+		---@return {useSkew: boolean, skewTan: number, smallElementHeightFraction: number}
 		WG.topbar.GetSkewConfig = function()
 			return {
 				useSkew = cfg.useSkew,
@@ -3457,14 +3480,18 @@ function widget:Initialize()
 
 	WG.topbar = {}
 
+	---@return boolean showing Whether the quit confirmation screen is up.
 	WG.topbar.showingQuit = function()
 		return showQuitscreen
 	end
 
+	---Closes every window the top bar owns.
 	WG.topbar.hideWindows = function()
 		hideWindows()
 	end
 
+	---Hides the top bar buttons until hovered, and relays the bar out.
+	---@param value boolean
 	WG.topbar.setAutoHideButtons = function(value)
 		refreshUi = true
 		autoHideButtons = value
@@ -3472,19 +3499,26 @@ function widget:Initialize()
 		updateButtons()
 	end
 
+	---@return boolean autoHide
 	WG.topbar.getAutoHideButtons = function()
 		return autoHideButtons
 	end
 
+	---@return boolean showing Whether the buttons are visible right now.
 	WG.topbar.getShowButtons = function()
 		return showButtons
 	end
 
+	---Previews an energy conversion slider position on the energy bar.
+	---@param value number? Pass `nil` to clear the preview.
 	WG.topbar.updateTopBarEnergy = function(value)
 		draggingConversionIndicatorValue = value
 		updateResbar("energy")
 	end
 
+	---Shows or hides the resource bars, as quick-start does pregame. Showing them
+	---again rebuilds the bar and slider geometry from the current top bar size.
+	---@param visible boolean
 	WG.topbar.setResourceBarsVisible = function(visible)
 		if showResourceBars == visible then
 			return
@@ -3507,6 +3541,7 @@ function widget:Initialize()
 		end
 	end
 
+	---@return boolean visible
 	WG.topbar.getResourceBarsVisible = function()
 		return showResourceBars
 	end

--- a/luaui/Widgets/gui_unit_energy_icons.lua
+++ b/luaui/Widgets/gui_unit_energy_icons.lua
@@ -94,6 +94,7 @@ end
 -- additional smartness for global stall/unstall
 
 -- GL4 Backend stuff:
+---@type InstanceVBOTable
 local energyIconVBO = nil
 local energyIconShader = nil
 

--- a/luaui/Widgets/gui_unit_firestate_icons.lua
+++ b/luaui/Widgets/gui_unit_firestate_icons.lua
@@ -19,6 +19,7 @@ local shouldShowToSpectators = false
 --------------------------------------------------------------------------------
 -- Localized Spring API
 --------------------------------------------------------------------------------
+
 local spGetGameFrame = Spring.GetGameFrame
 local spValidUnitID = Spring.ValidUnitID
 local spGetUnitIsDead = Spring.GetUnitIsDead
@@ -41,7 +42,10 @@ local returnFireTexture = "LuaUI/Images/returnfire.png"
 --------------------------------------------------------------------------------
 -- GL4 Backend
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local holdFireVBO = nil
+---@type InstanceVBOTable
 local returnFireVBO = nil
 local fireIconShader = nil
 
@@ -201,15 +205,20 @@ local function initGL4()
 end
 
 WG.unitfirestate = {}
+---@param value boolean Draw fire state icons over units.
 WG.unitfirestate.setEnabled = function(value)
 	showFireStateIcons = value
 end
+---Shows the hold-fire icon on every unit set to it, not just selected ones,
+---and refreshes the visible icons.
+---@param value boolean?
 WG.unitfirestate.setShowAllHoldFireIcons = function(value)
 	showAllHoldFireIcons = (value and true) or false
 	if widget and widget.VisibleUnitsChanged and visibleUnits then
 		widget:VisibleUnitsChanged(visibleUnits, nil)
 	end
 end
+---@return boolean showAll
 WG.unitfirestate.getShowAllHoldFireIcons = function()
 	return showAllHoldFireIcons
 end

--- a/luaui/Widgets/gui_unit_group_number.lua
+++ b/luaui/Widgets/gui_unit_group_number.lua
@@ -48,6 +48,7 @@ for i = minGroupID, maxNumGroups do
 	grouptounitID[i] = {}
 end
 
+---@type InstanceVBOTable
 local unitGroupVBO = nil
 local unitGroupShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/gui_unit_idlebuilder_icons.lua
+++ b/luaui/Widgets/gui_unit_idlebuilder_icons.lua
@@ -65,6 +65,7 @@ local uploadAllElements = InstanceVBOTable.uploadAllElements
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 local popElementInstance = InstanceVBOTable.popElementInstance
 
+---@type InstanceVBOTable
 local iconVBO = nil
 local energyIconShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/gui_unit_repeat_icon.lua
+++ b/luaui/Widgets/gui_unit_repeat_icon.lua
@@ -15,6 +15,7 @@ end
 --------------------------------------------------------------------------------
 -- Localized Spring API
 --------------------------------------------------------------------------------
+
 local spGetGameFrame = Spring.GetGameFrame
 local spGetUnitStates = Spring.GetUnitStates
 local spValidUnitID = Spring.ValidUnitID
@@ -25,6 +26,8 @@ local repeatTexture = "LuaUI/Images/repeat.png"
 --------------------------------------------------------------------------------
 -- GL4 Backend
 --------------------------------------------------------------------------------
+
+---@type InstanceVBOTable
 local repeatVBO = nil
 local repeatShader = nil
 
@@ -121,6 +124,7 @@ end
 --------------------------------------------------------------------------------
 -- Widget callbacks
 --------------------------------------------------------------------------------
+
 function widget:Initialize()
 	if not gl.CreateShader then
 		widgetHandler:RemoveWidget()

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -443,9 +443,12 @@ function widget:Initialize()
 	widget:ViewResize(vsx, vsy)
 
 	WG.unitstats = {}
+	---Pins the unit stats panel to a specific unit.
+	---@param unitID integer? Pass `nil` to follow the cursor again.
 	WG.unitstats.showUnit = function(unitID)
 		showUnitID = unitID
 	end
+	---@return boolean showing Whether the unit stats panel is drawn.
 	WG.unitstats.isShowing = function()
 		return showStats
 	end

--- a/luaui/Widgets/gui_unit_wait_icons.lua
+++ b/luaui/Widgets/gui_unit_wait_icons.lua
@@ -56,6 +56,7 @@ local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 local uploadAllElements = InstanceVBOTable.uploadAllElements
 
+---@type InstanceVBOTable
 local iconVBO = nil
 local energyIconShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/gui_unitgroups.lua
+++ b/luaui/Widgets/gui_unitgroups.lua
@@ -71,7 +71,9 @@ local doUpdate = true
 
 local groupButtons = {}
 
-local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, backgroundRect, ordermenuPosY
+local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, ordermenuPosY
+---@type ScreenRect?
+local backgroundRect
 local guishaderWasActive = false
 local buildmenuAlwaysShow = false
 local buildmenuShowingPosY = 0
@@ -149,6 +151,11 @@ function widget:Initialize()
 	widget:ViewResize()
 	widget:PlayerChanged()
 	WG.unitgroups = {}
+	---Screen rectangle of the unit groups panel.
+	---@return number left
+	---@return number bottom
+	---@return number right
+	---@return number top
 	WG.unitgroups.getPosition = function()
 		return posX,
 			backgroundRect and backgroundRect[2] or posY,

--- a/luaui/Widgets/logo_adjuster.lua
+++ b/luaui/Widgets/logo_adjuster.lua
@@ -57,6 +57,7 @@ function widget:Initialize()
 		widgetHandler.RemoveWidget()
 	end -- changing the taskbar icon causes a few secs of freezing there
 	WG.logo = {}
+	---Flashes the taskbar icon, but only while the game window is not focused.
 	WG.logo.mention = function()
 		if mouseOffscreen then
 			notif = true

--- a/luaui/Widgets/map_auto_mapmark_eraser.lua
+++ b/luaui/Widgets/map_auto_mapmark_eraser.lua
@@ -19,12 +19,19 @@ local recentlyErased = {}
 
 function widget:Initialize()
 	WG.autoeraser = {}
+	---@return number seconds How long a map mark lives before it is auto-erased.
 	WG.autoeraser.getEraseTime = function()
 		return eraseTime
 	end
+	---@param value number Seconds a map mark lives before it is auto-erased.
 	WG.autoeraser.setEraseTime = function(value)
 		eraseTime = value
 	end
+	---Lets the map mark effects widget tell auto-erasures apart from player erasures,
+	---so it does not play an effect for them.
+	---@param value any? Unused.
+	---@return [integer, number, number, number][] recentlyErased Marks this widget erased
+	---itself, each `{gameFrame, x, y, z}`.
 	WG.autoeraser.getRecentlyErased = function(value) -- so mapmarks fx widget can call this and wont activate on auto erasing
 		return recentlyErased
 	end

--- a/luaui/Widgets/map_edge_extension2.lua
+++ b/luaui/Widgets/map_edge_extension2.lua
@@ -665,16 +665,20 @@ function widget:Initialize()
 	end
 
 	WG.mapedgeextension = {}
+	---@return number brightness Brightness of the terrain drawn beyond the map edge.
 	WG.mapedgeextension.getBrightness = function()
 		return brightness
 	end
+	---@param value number Brightness of the terrain drawn beyond the map edge.
 	WG.mapedgeextension.setBrightness = function(value)
 		brightness = value
 		--UpdateShader()
 	end
+	---@return boolean curvature Whether the extended terrain curves away at all.
 	WG.mapedgeextension.getCurvature = function()
 		return curvature
 	end
+	---@param value boolean Whether the extended terrain curves away at all.
 	WG.mapedgeextension.setCurvature = function(value)
 		curvature = value
 		--UpdateShader()

--- a/luaui/Widgets/map_grass_gl4.lua
+++ b/luaui/Widgets/map_grass_gl4.lua
@@ -1375,15 +1375,22 @@ function widget:Initialize()
 		return
 	end
 	WG.grassgl4 = {}
+	---@return number multiplier Scales how far away grass stays drawn.
 	WG.grassgl4.getDistanceMult = function()
 		return distanceMult
 	end
+	---@param value number Scales how far away grass stays drawn.
 	WG.grassgl4.setDistanceMult = function(value)
 		distanceMult = value
 	end
+	---@return boolean enabled Whether units bend the grass they walk through.
 	WG.grassgl4.getUnitBendEnabled = function()
 		return unitBendSSBO ~= nil
 	end
+	---Removes grass in a circle, thinning it out toward the edge.
+	---@param wx number
+	---@param wz number
+	---@param radius number? Defaults to one grass patch.
 	WG.grassgl4.removeGrass = function(wx, wz, radius)
 		radius = radius or grassConfig.patchResolution
 		for x = wx - radius, wx + radius, grassConfig.patchResolution do
@@ -1396,6 +1403,10 @@ function widget:Initialize()
 			end
 		end
 	end
+	---Removes all grass below a world height, e.g. to clear flooded terrain.
+	---Only acts when the height is above any previous cut, so repeated calls are cheap.
+	---@param height number
+	---@return nil
 	WG.grassgl4.removeGrassBelowHeight = function(height)
 		if #grassInstanceData == 0 then
 			return nil
@@ -1447,6 +1458,8 @@ function widget:Initialize()
 		WG.grassgl4.removeGrassBelowHeight(initLavaLevel)
 	end
 	-- Brush-aware grass painting for integration with Grass Brush tool
+	---Grass layout constants, for tools that paint into the grass map.
+	---@return {patchResolution: number, grassMinSize: number, grassMaxSize: number, mapSizeX: number, mapSizeZ: number}
 	WG.grassgl4.getConfig = function()
 		return {
 			patchResolution = grassConfig.patchResolution,
@@ -1456,6 +1469,9 @@ function widget:Initialize()
 			mapSizeZ = mapSizeZ,
 		}
 	end
+	---@param wx number
+	---@param wz number
+	---@return number density `0`-`1`; `0` outside the map or where there is no grass.
 	WG.grassgl4.getDensityAt = function(wx, wz)
 		local vboOffset = world2grassmap(wx, wz) * grassInstanceVBOStep
 		if vboOffset < 0 or vboOffset >= #grassInstanceData then
@@ -1467,6 +1483,12 @@ function widget:Initialize()
 		end
 		return size / grassConfig.grassMaxSize
 	end
+	---Sets the grass density at a world position. Densities below the minimum size
+	---clear the patch entirely.
+	---@param wx number
+	---@param wz number
+	---@param density number `0`-`1`.
+	---@param skipAnim boolean? Apply instantly instead of animating the growth.
 	WG.grassgl4.setDensityAt = function(wx, wz, density, skipAnim)
 		local vboOffset = world2grassmap(wx, wz) * grassInstanceVBOStep
 		if vboOffset < 0 or vboOffset >= #grassInstanceData then
@@ -1510,6 +1532,7 @@ function widget:Initialize()
 			grassInstanceVBO:Upload(gCT, 7, elemIdx)
 		end
 	end
+	---Enters grass edit mode, allocating the grass map if the map has none yet.
 	WG.grassgl4.enableEditMode = function()
 		if not placementMode then
 			placementMode = true
@@ -1522,13 +1545,18 @@ function widget:Initialize()
 			end
 		end
 	end
+	---Leaves grass edit mode.
 	WG.grassgl4.disableEditMode = function()
 		placementMode = false
 		externalBrushActive = false
 	end
+	---@return boolean editing
 	WG.grassgl4.isEditMode = function()
 		return placementMode
 	end
+	---Tells the grass system an external brush is painting, so growth animates.
+	---Turning it off flushes every pending animation to its final value.
+	---@param active boolean?
 	WG.grassgl4.setExternalBrush = function(active)
 		externalBrushActive = active and true or false
 		if not active then
@@ -1546,9 +1574,13 @@ function widget:Initialize()
 			spawnAnimCount = 0
 		end
 	end
+	---@return boolean hasGrass Whether the map has any grass data.
 	WG.grassgl4.hasGrass = function()
 		return #grassInstanceData > 0
 	end
+	---Writes the grass density map as a TGA image.
+	---@param filename string? Defaults to `<mapname>_grassDist.tga`.
+	---@return boolean saved
 	WG.grassgl4.saveGrassTGA = function(filename)
 		if not filename or #filename < 2 then
 			filename = Game.mapName .. "_grassDist.tga"
@@ -1574,16 +1606,36 @@ function widget:Initialize()
 		spEcho("[Grass] Saved grass map: " .. filename)
 		return true
 	end
+	---Writes the grass visual settings as a loadable config.
+	---@param filename string
+	---@param opts {nodate: boolean?}? Set `nodate` to leave the timestamp header out,
+	---so re-exporting an unchanged map produces a byte-identical file.
+	---@return boolean saved
 	WG.grassgl4.saveGrassConfig = function(filename, opts)
 		local ok = exportGrassConfig(filename, opts)
 		return ok
 	end
+	---Grass appearance settings, as `getVisualConfig` reports and `setVisualConfig` accepts.
+	---@class GrassVisualConfig
+	---@field mapColorFactor number? How much map colour tints the blades. Defaults to `0.6`.
+	---@field mapColorBase number? Defaults to `1.0`.
+	---@field grassBrightness number? Defaults to `1.0`.
+	---@field grassBladeColorTex string?
+	---@field mapGrassColorModTex string?
+	---@field grassWindPerturbTex string?
+
+	---@return GrassVisualConfig config
 	WG.grassgl4.getVisualConfig = function()
 		return getGrassVisualConfig()
 	end
+	---Applies grass appearance settings.
+	---@param cfg GrassVisualConfig Partial: only the fields present are applied.
+	---@return boolean applied
 	WG.grassgl4.setVisualConfig = function(cfg)
 		return setGrassVisualConfig(cfg)
 	end
+	---Loads a grass density map from a TGA image and enters edit mode.
+	---@param filename string? Defaults to `<mapname>_grassDist.tga`.
 	WG.grassgl4.loadGrass = function(filename)
 		if not filename or #filename < 2 then
 			filename = Game.mapName .. "_grassDist.tga"
@@ -1596,6 +1648,7 @@ function widget:Initialize()
 		defineUploadGrassInstanceVBOData()
 		MakeAndAttachToVAO()
 	end
+	---Removes all grass from the map.
 	WG.grassgl4.clearGrass = function()
 		cleargrassCmd(nil, nil, {})
 	end

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -350,6 +350,12 @@ end
 
 local posCache = {}
 
+---Returns where a team's start position should be drawn, following the cursor
+---while that team's marker is being dragged and honoring coop start points.
+---@param teamID integer
+---@return number? x `nil` when the team has no start position.
+---@return number? y
+---@return number? z
 local function getEffectiveStartPosition(teamID)
 	if draggingTeamID == teamID then
 		local mouseX, mouseY = Spring.GetMouseState()
@@ -574,6 +580,7 @@ local coneShaderSourceCache = {
 	silent = not autoReload,
 }
 
+---@type InstanceVBOTable
 local startConeVBOTable = nil
 local startConeShader = nil
 

--- a/luaui/Widgets/minimap_rotation_manager.lua
+++ b/luaui/Widgets/minimap_rotation_manager.lua
@@ -56,6 +56,7 @@ local CameraRotationModes = {
 	autoLandscape = 4,
 }
 
+---@type 1|2|3|4
 local mode
 local prevSnap
 local trackingLock = false
@@ -230,6 +231,10 @@ end
 
 function widget:Initialize()
 	WG.minimaprotationmanager = {}
+	---Switches how the minimap follows the camera, applying the new mode immediately.
+	---Invalid modes are ignored.
+	---@param newMode 1|2|3|4 A `CameraRotationModes` value: `1` none, `2` autoFlip,
+	---`3` autoRotate, `4` autoLandscape.
 	WG.minimaprotationmanager.setMode = function(newMode)
 		if isValidOption(newMode) then
 			mode = newMode
@@ -253,6 +258,7 @@ function widget:Initialize()
 		end
 	end
 
+	---@return 1|2|3|4 mode A `CameraRotationModes` value.
 	WG.minimaprotationmanager.getMode = function()
 		return mode
 	end

--- a/luaui/Widgets/snd_mapmark_ping.lua
+++ b/luaui/Widgets/snd_mapmark_ping.lua
@@ -40,9 +40,11 @@ end
 
 function widget:Initialize()
 	WG.mapmarkping = {}
+	---@return number volume Volume of the map mark ping sound.
 	WG.mapmarkping.getMapmarkVolume = function()
 		return volume
 	end
+	---@param value number Volume of the map mark ping sound.
 	WG.mapmarkping.setMapmarkVolume = function(value)
 		volume = value
 	end

--- a/luaui/Widgets/snd_notifications.lua
+++ b/luaui/Widgets/snd_notifications.lua
@@ -524,13 +524,22 @@ function widget:Initialize()
 
 	WG.notifications = {}
 	for sound, params in pairs(notification) do
+		---Per-event getter, named `getNotification<eventName>`. Generated for every known
+		---notification, so these names are not statically visible.
+		---@return boolean enabled `false` when the event has never been configured.
 		WG.notifications["getNotification" .. sound] = function()
 			return notificationList[sound] or false
 		end
+		---Per-event setter, named `setNotification<eventName>`. Generated for every known
+		---notification, so these names are not statically visible.
+		---@param value boolean
 		WG.notifications["setNotification" .. sound] = function(value)
 			notificationList[sound] = value
 		end
 	end
+	---Lists every notification for the options UI, sorted by translated name.
+	---@return [string, boolean, string, integer][] soundInfo Each entry is
+	---`{eventName, enabled, textID, voiceFileCount}`.
 	WG.notifications.getNotificationList = function()
 		local soundInfo = {}
 
@@ -547,9 +556,12 @@ function widget:Initialize()
 
 		return soundInfo
 	end
+	---@return boolean tutorial Whether tutorial notifications play.
 	WG.notifications.getTutorial = function()
 		return tutorialMode
 	end
+	---Enables tutorial notifications, replaying ones already heard this session.
+	---@param value boolean
 	WG.notifications.setTutorial = function(value)
 		tutorialMode = value
 		if tutorialMode then
@@ -557,32 +569,47 @@ function widget:Initialize()
 		end
 		widget:PlayerChanged()
 	end
+	---@return number volume Volume notifications play at.
 	WG.notifications.getVolume = function()
 		return globalVolume
 	end
+	---@param value number Volume notifications play at.
 	WG.notifications.setVolume = function(value)
 		globalVolume = value
 	end
+	---@return boolean spoken Whether the spoken voice lines play.
 	WG.notifications.getSpoken = function()
 		return spoken
 	end
+	---@param value boolean Play the spoken voice lines.
 	WG.notifications.setSpoken = function(value)
 		spoken = value
 	end
+	---@return boolean messages Whether notifications also print to the message feed.
 	WG.notifications.getMessages = function()
 		return displayMessages
 	end
+	---@param value boolean Also print notifications to the message feed.
 	WG.notifications.setMessages = function(value)
 		displayMessages = value
 	end
+	---Queues a notification by event name. Unknown events are ignored.
+	---@param value string Event name.
+	---@param force boolean? Play even while the event is on cooldown.
 	WG.notifications.addEvent = function(value, force)
 		if notification[value] then
 			queueNotification(value, force)
 		end
 	end
+	---Queues a notification, honoring its configured delay.
+	---@param event string Event name.
+	---@param forceplay boolean? Play even while the event is on cooldown.
 	WG.notifications.queueNotification = function(event, forceplay)
 		queueNotification(event, forceplay)
 	end
+	---Plays a notification immediately, bypassing the queue and its delays.
+	---Unknown events are ignored.
+	---@param event string Event name.
 	WG.notifications.playNotification = function(event)
 		if notification[event] then
 			if notification[event].voiceFiles and #notification[event].voiceFiles > 0 then
@@ -615,15 +642,40 @@ function widget:Initialize()
 		end
 	end
 
+	---Restarts an event's cooldown, so it will not replay for its configured delay.
+	---@param event string Event name.
 	WG.notifications.resetEventDelay = function(event)
 		LastPlay[event] = spGetGameFrame()
 	end
 
+	---One notification definition, as `sounds/voice/config.lua` declares them.
+	---Every field is optional: a definition may carry nothing but its sound files,
+	---which are discovered by filename rather than listed here.
+	---@class NotificationDef
+	---@field delay number? Seconds before the same event may play again. Defaults to `2`.
+	---@field stackedDelay number? Delay applied even when a play attempt failed.
+	---@field notifText string? I18N key for the on-screen message.
+	---@field notext boolean? Play the sound without showing a message.
+	---@field tutorial boolean? Only play when tutorial notifications are enabled.
+	---@field soundEffect string? Extra sound played alongside the voice line.
+	---@field resetOtherEventDelay boolean? Also reset the delay of every other event.
+	---@field rulesEnable string? Only play while this game rules param is set.
+	---@field rulesDisable string? Never play while this game rules param is set.
+	---@field rulesPlayOnlyIfEnabled string?
+	---@field rulesPlayOnlyIfDisabled string?
+
+	---Merges extra notification definitions in and reprocesses them, so another
+	---widget can add its own events.
+	---@param tableOfNotifs table<string, NotificationDef> Keyed by event name.
 	WG.notifications.addNotificationDefs = function(tableOfNotifs)
 		notificationTable = table.merge(notificationTable, tableOfNotifs)
 		processNotificationDefs()
 	end
 
+	---Plays a notification the first time a given unit type is spotted, covering the
+	---scavenger variant too.
+	---@param unitName string Unit definition name.
+	---@param notifName string Event name to play.
 	WG.notifications.addUnitDetected = function(unitName, notifName)
 		if UnitDefNames[unitName] then
 			unitsOfInterest[UnitDefNames[unitName].id] = notifName
@@ -634,12 +686,16 @@ function widget:Initialize()
 	end
 
 	RegisteredCustomNotifWidgets = {}
+	---Records that a widget supplies its own notifications, so the options UI can
+	---list it.
+	---@param widgetName string
 	WG.notifications.registerCustomNotifWidget = function(widgetName)
 		if not RegisteredCustomNotifWidgets[widgetName] then
 			RegisteredCustomNotifWidgets[widgetName] = true
 		end
 	end
 
+	---@return table<string, true> widgets Widgets that supply their own notifications.
 	WG.notifications.registeredCustomNotifWidgets = function()
 		return RegisteredCustomNotifWidgets
 	end

--- a/luaui/Widgets/test_DPAT.lua
+++ b/luaui/Widgets/test_DPAT.lua
@@ -26,6 +26,7 @@ local InstanceVBOTable = gl.InstanceVBOTable
 local popElementInstance = InstanceVBOTable.popElementInstance
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 
+---@type InstanceVBOTable
 local selectionVBO = nil
 local selectShader = nil
 local luaShaderDir = "LuaUI/Include/"

--- a/luaui/Widgets/unit_auto_cloak.lua
+++ b/luaui/Widgets/unit_auto_cloak.lua
@@ -83,9 +83,12 @@ function widget:Initialize()
 	end
 
 	WG.autocloak = {}
+	---@return table<integer, boolean> config Which unit types auto-cloak, keyed by unitDefID.
 	WG.autocloak.getUnitdefConfig = function()
 		return unitdefConfig
 	end
+	---Sets whether one unit type auto-cloaks.
+	---@param data {[1]: integer, [2]: boolean} The unitDefID and whether it auto-cloaks.
 	WG.autocloak.setUnitdefConfig = function(data)
 		local type, value = data[1], data[2]
 		unitdefConfig[type] = value

--- a/luaui/Widgets/unit_auto_group.lua
+++ b/luaui/Widgets/unit_auto_group.lua
@@ -258,31 +258,43 @@ function widget:Initialize()
 	widgetHandler:AddAction("load_autogroup_preset", loadAutogroupPresetHandler, nil, "p") -- Changes the autogroup preset
 
 	WG.autogroup = {}
+	---@return boolean immediate Whether units join their autogroup as soon as they start
+	---building, rather than when finished.
 	WG.autogroup.getImmediate = function()
 		return immediate
 	end
+	---@param value boolean Add units to their autogroup as soon as they start building.
 	WG.autogroup.setImmediate = function(value)
 		immediate = value
 	end
 
+	---@return boolean persist Whether autogroup assignments survive between games.
 	WG.autogroup.getPersist = function()
 		return persist
 	end
+	---@param value boolean Keep autogroup assignments between games.
 	WG.autogroup.setPersist = function(value)
 		persist = value
 	end
+	---@return table<integer, integer> groups Group number per unitDefID. Do not mutate.
 	WG.autogroup.getGroups = function()
 		return unit2group
 	end
+	---Assigns every unit type in the current selection to an autogroup.
+	---@param groupNumber integer
 	WG.autogroup.addCurrentSelectionToAutogroup = function(groupNumber)
 		changeUnitTypeAutogroup(groupNumber)
 	end
+	---Clears the autogroup of every unit type in the current selection.
 	WG.autogroup.removeCurrentSelectionFromAutogroup = function()
 		changeUnitTypeAutogroup(nil, true)
 	end
+	---Removes a single unit from its autogroup, leaving the rest of its type alone.
 	WG.autogroup.removeOneUnitFromGroup = function()
 		removeOneUnitFromGroupHandler()
 	end
+	---Replaces every autogroup assignment with a saved preset.
+	---@param newPreset integer|string Preset identifier.
 	WG.autogroup.loadAutogroupPreset = function(newPreset)
 		loadAutogroupPreset(newPreset)
 	end

--- a/luaui/Widgets/unit_builder_priority.lua
+++ b/luaui/Widgets/unit_builder_priority.lua
@@ -127,23 +127,32 @@ function widget:Initialize()
 	end
 
 	WG.builderpriority = {}
+	---@return boolean lowPriority Whether nano turrets build at low priority.
 	WG.builderpriority.getLowPriorityNanos = function()
 		return lowpriorityNanos
 	end
+	---Sets nano turrets to low build priority and applies it to existing ones.
+	---@param value boolean
 	WG.builderpriority.setLowPriorityNanos = function(value)
 		lowpriorityNanos = value
 		toggleNanos()
 	end
+	---@return boolean lowPriority Whether factories build at low priority.
 	WG.builderpriority.getLowPriorityLabs = function()
 		return lowpriorityLabs
 	end
+	---Sets factories to low build priority and applies it to existing ones.
+	---@param value boolean
 	WG.builderpriority.setLowPriorityLabs = function(value)
 		lowpriorityLabs = value
 		toggleLabs()
 	end
+	---@return boolean lowPriority Whether construction units build at low priority.
 	WG.builderpriority.getLowPriorityCons = function()
 		return lowpriorityCons
 	end
+	---Sets construction units to low build priority and applies it to existing ones.
+	---@param value boolean
 	WG.builderpriority.setLowPriorityCons = function(value)
 		lowpriorityCons = value
 		toggleCons()

--- a/luaui/Widgets/unit_cloak_firestate.lua
+++ b/luaui/Widgets/unit_cloak_firestate.lua
@@ -117,6 +117,10 @@ function widget:Initialize()
 	myTeam = spGetMyTeamID()
 	maybeRemoveSelf()
 	local priorUserFirestateFunction = WG.firestate.userFirestateChanged
+	---Notified when a unit's firestate is changed by the player. This widget chains
+	---onto any handler already registered, so several widgets can observe the event.
+	---@param unitID integer
+	---@param userState integer A `CustomFirestateDefs` value.
 	WG.firestate.userFirestateChanged = function(unitID, userState)
 		userFirestateChangedWhileCloaked(unitID, userState)
 		if priorUserFirestateFunction then

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -55,7 +55,11 @@ local CMD_QUOTA_BUILD_TOGGLE = GameCMD.QUOTA_BUILD_TOGGLE
 -----
 
 --------- quota logic -------------
+---@param factoryID integer
+---@param unitDefID integer
+---@return integer count How many of that unit type the factory has built.
 local function getNumberOfUnits(factoryID, unitDefID)
+	---@type integer
 	local numberOfUnits
 	if builtUnits[factoryID] and builtUnits[factoryID][unitDefID] then
 		numberOfUnits = table.count(builtUnits[factoryID][unitDefID])
@@ -199,12 +203,21 @@ function widget:Initialize()
 	widget:PlayerChanged()
 
 	WG.Quotas = {}
+	---@return table<integer, table<integer, integer>> quotas Wanted unit counts, keyed by
+	---factory unitID then unitDefID.
+	---Do not mutate.
 	WG.Quotas.getQuotas = function()
 		return quotas
 	end
+	---Counts how many of a unit type a factory's quota currently accounts for.
+	---@param factoryID integer
+	---@param unitDefID integer
+	---@return integer count
 	WG.Quotas.getUnitAmount = function(factoryID, unitDefID)
 		return getNumberOfUnits(factoryID, unitDefID)
 	end
+	---@param unitID integer A factory.
+	---@return boolean onQuota Whether that factory is building to a quota.
 	WG.Quotas.isOnQuotaMode = function(unitID)
 		return isOnQuotaBuildMode(unitID)
 	end

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -227,6 +227,12 @@ end
 
 -- this widget gets called early due to its layer
 -- this function will get called after all widgets have had their chance with widget:MousePress
+---Starts a smart-select drag. Exposed as `WG.SmartSelect_MousePress2` so other
+---widgets can route their own mouse presses through it.
+---@param x number
+---@param y number
+---@param button integer Only button `1` starts a selection.
+---@param hasMouseOwner boolean? Another widget already owns the mouse, so the press is ignored.
 local function mousePress(x, y, button, hasMouseOwner) --function widget:MousePress(x, y, button)
 	if hasMouseOwner or button ~= 1 then
 		skipSel = true
@@ -517,19 +523,12 @@ end
 --	Spring.Echo('Update time:', Spring.DiffTimers(spGetTimer(), sTimer, nil, highres))
 --end
 --
-function widget:Shutdown()
-	WG.smartselect = nil
-
-	WG.SmartSelect_MousePress2 = nil
-	WG.SmartSelect_SelectUnits = nil
-	WG.SmartSelect_SetReference = nil
-	WG.SmartSelect_ClearReference = nil
-end
-
 function widget:Initialize()
 	WG.SmartSelect_MousePress2 = mousePress
 
 	-- Function to set the reference selection for external box selections
+	---Snapshots the current selection as the reference an external box selection
+	---should add to, so shift-dragging from another widget behaves like an in-game drag.
 	WG.SmartSelect_SetReference = function()
 		externalSelectionReference = {}
 		local current = spGetSelectedUnits()
@@ -544,6 +543,9 @@ function widget:Initialize()
 	end
 
 	-- Function to handle external unit selections (e.g., from PIP widget)
+	---Applies smart-select filtering to a set of units and selects the result.
+	---Used by widgets that box-select outside the main view, such as the PIP window.
+	---@param units integer[]
 	WG.SmartSelect_SelectUnits = function(units)
 		-- Apply smart select filtering to the provided units
 		local mouseSelection = units
@@ -719,44 +721,69 @@ function widget:Initialize()
 	widgetHandler:AddAction("selectbox", handleClearCustomFilter, nil, "r")
 
 	WG.smartselect = {}
+	---@return boolean include Whether dragging over mobiles also picks up buildings.
 	WG.smartselect.getIncludeBuildings = function()
 		return selectBuildingsWithMobile
 	end
+	---@param value boolean Also pick up buildings when dragging over mobiles.
 	WG.smartselect.setIncludeBuildings = function(value)
 		selectBuildingsWithMobile = value
 	end
+	---@return boolean include Whether builders are picked up alongside combat units.
 	WG.smartselect.getIncludeBuilders = function()
 		return includeBuilders
 	end
+	---@param value boolean Pick up builders alongside combat units.
 	WG.smartselect.setIncludeBuilders = function(value)
 		includeBuilders = value
 	end
+	---@return boolean include Whether resurrectors are picked up alongside combat units.
 	WG.smartselect.getIncludeResurrectors = function()
 		return includeResurrectors
 	end
+	---@param value boolean Pick up resurrectors alongside combat units.
 	WG.smartselect.setIncludeResurrectors = function(value)
 		includeResurrectors = value
 	end
+	---@return boolean include Whether antinukes are picked up alongside other buildings.
 	WG.smartselect.getIncludeAntinuke = function()
 		return includeAntinuke
 	end
+	---@param value boolean Pick up antinukes alongside other buildings.
 	WG.smartselect.setIncludeAntinuke = function(value)
 		includeAntinuke = value
 	end
+	---@return boolean include Whether radars are picked up alongside other buildings.
 	WG.smartselect.getIncludeRadar = function()
 		return includeRadar
 	end
+	---@param value boolean Pick up radars alongside other buildings.
 	WG.smartselect.setIncludeRadar = function(value)
 		includeRadar = value
 	end
+	---@return boolean include Whether jammers are picked up alongside other buildings.
 	WG.smartselect.getIncludeJammer = function()
 		return includeJammer
 	end
+	---@param value boolean Pick up jammers alongside other buildings.
 	WG.smartselect.setIncludeJammer = function(value)
 		includeJammer = value
 	end
 
 	widget:ViewResize()
+end
+
+function widget:Shutdown()
+	WG.smartselect = nil
+
+	---@type fun(x: number, y: number, button: integer, hasMouseOwner: boolean?)
+	WG.SmartSelect_MousePress2 = nil
+	---@type fun(units: integer[])
+	WG.SmartSelect_SelectUnits = nil
+	---@type fun()
+	WG.SmartSelect_SetReference = nil
+	---@type fun()
+	WG.SmartSelect_ClearReference = nil
 end
 
 function widget:GetConfigData()

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -124,6 +124,11 @@ local function GetCmdOpts(alt, ctrl, meta, shift, right)
 	return opts
 end
 
+---Notified when a unit's firestate is changed by the player. Chains onto any
+---handler already registered, then records the new state as this unit type's
+---preference while the record or clear hotkey is held.
+---@param unitID integer
+---@param userState integer A `CustomFirestateDefs` value.
 local function recordUserFirestateChanged(unitID, userState)
 	if priorUserFirestateFunction then
 		priorUserFirestateFunction(unitID, userState)

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -431,6 +431,9 @@ function widget:Initialize()
 	Spring.SendCommands("unbindkeyset f11")
 
 	WG.widgetselector = {}
+	---Shows or hides the widget selector, closing the top bar windows when it opens
+	---and taking text input ownership so its search field works.
+	---@param state boolean? Omit to toggle.
 	WG.widgetselector.toggle = function(state)
 		local newShow = state
 		if newShow == nil then
@@ -449,9 +452,11 @@ function widget:Initialize()
 			widgetHandler.textOwner = nil --widgetHandler:DisownText()
 		end
 	end
+	---@return boolean visible
 	WG.widgetselector.isvisible = function()
 		return show
 	end
+	---@return integer count Widgets loaded from the player's own widget folder.
 	WG.widgetselector.getLocalWidgetCount = function()
 		return localWidgetCount
 	end

--- a/types/BrushPlacementMode.lua
+++ b/types/BrushPlacementMode.lua
@@ -1,0 +1,15 @@
+---@meta
+
+--- What a placement tool does when the brush is applied. Shared by the decal,
+--- feature, light and weather placers, which all drive the same three-way mode
+--- switch from the terraform brush UI:
+---
+---  * `"scatter"` distributes randomly within the brush radius, and is the only
+---    mode that keeps acting while the cursor is dragged;
+---  * `"point"` places exactly one at the cursor;
+---  * `"remove"` erases what the brush touches instead of placing.
+---
+--- The tools treat `nil` as "not placing", so a nullable mode doubles as the
+--- inactive state. Not to be confused with the start position tool's unrelated
+--- `placementMode`, which is `"roundrobin"|"sequential"`.
+---@alias BrushPlacementMode "scatter"|"point"|"remove"

--- a/types/Color.lua
+++ b/types/Color.lua
@@ -1,0 +1,18 @@
+---@meta
+
+--- Color tuples, as passed to the gl.* API and the FlowUI drawing helpers.
+--- Components are normally `0`-`1`, though some call sites pass higher values
+--- deliberately to over-brighten.
+
+--- A color with an explicit alpha.
+---@class ColorRGBA
+---@field [1] number Red.
+---@field [2] number Green.
+---@field [3] number Blue.
+---@field [4] number Alpha.
+
+--- A color with alpha implied by the caller.
+---@class ColorRGB
+---@field [1] number Red.
+---@field [2] number Green.
+---@field [3] number Blue.

--- a/types/Color.lua
+++ b/types/Color.lua
@@ -6,13 +6,13 @@
 
 --- A color with an explicit alpha.
 ---@class ColorRGBA
----@field [1] number Red.
----@field [2] number Green.
----@field [3] number Blue.
----@field [4] number Alpha.
+---@field [1] number Red
+---@field [2] number Green
+---@field [3] number Blue
+---@field [4] number Alpha
 
 --- A color with alpha implied by the caller.
 ---@class ColorRGB
----@field [1] number Red.
----@field [2] number Green.
----@field [3] number Blue.
+---@field [1] number Red
+---@field [2] number Green
+---@field [3] number Blue

--- a/types/DockedPanelPosition.lua
+++ b/types/DockedPanelPosition.lua
@@ -1,0 +1,15 @@
+---@meta
+
+--- Where a docked UI panel sits on screen, as the `GetPosition` members of the
+--- advplayerlist-adjacent widgets return it, so a panel can stack itself against a
+--- neighbour.
+---
+--- The component order is top-left-bottom-right, NOT the left-bottom-right-top order
+--- `TopBarArea` and the screen-rect tuples use. Slot 5 is a UI scale, not a coordinate.
+--- The player list's own `GetPosition` is a different, longer shape again.
+---@class DockedPanelPosition
+---@field [1] number Top edge.
+---@field [2] number Left edge.
+---@field [3] number Bottom edge.
+---@field [4] number Right edge.
+---@field [5] number UI scale the panel was laid out at.

--- a/types/DockedPanelPosition.lua
+++ b/types/DockedPanelPosition.lua
@@ -8,8 +8,8 @@
 --- `TopBarArea` and the screen-rect tuples use. Slot 5 is a UI scale, not a coordinate.
 --- The player list's own `GetPosition` is a different, longer shape again.
 ---@class DockedPanelPosition
----@field [1] number Top edge.
----@field [2] number Left edge.
----@field [3] number Bottom edge.
----@field [4] number Right edge.
----@field [5] number UI scale the panel was laid out at.
+---@field [1] number Top edge
+---@field [2] number Left edge
+---@field [3] number Bottom edge
+---@field [4] number Right edge
+---@field [5] number UI scale the panel was laid out at

--- a/types/InstanceVBOTable.lua
+++ b/types/InstanceVBOTable.lua
@@ -29,3 +29,173 @@
 ---@field Delete fun(self: InstanceVBOTable)
 ---@field debug boolean?
 ---@field [string] any
+
+--- The shared instance-buffer helpers, reached as `gl.InstanceVBOTable`. The
+--- implementation lives in `modules/graphics/instancevbotable.lua`;
+--- `luaui/Include/instancevbotable.lua` is a deprecated shim that re-exports it.
+---
+--- Note the vocabulary: an `InstanceVBOTable` is a *wrapper* around a `VBO`, not a
+--- VBO itself. `pushElementInstance` and friends all take the wrapper.
+---@class InstanceVBOTableModule
+local InstanceVBOTableModule = {}
+
+--- Allocates an instance buffer. Returns `nil` when the VBO cannot be created.
+---@param layout table[] Attribute descriptors, e.g. `{{id = 1, name = 'pos', size = 4}}`.
+---@param maxElements integer? Grows dynamically anyway. Defaults to `64`.
+---@param myName string? Name used in log messages. Defaults to `"InstanceVBOTable"`.
+---@param unitIDattribID integer? Attribute id of the uvec4 holding unitID bindings.
+---@return InstanceVBOTable? instanceTable
+function InstanceVBOTableModule.makeInstanceVBOTable(layout, maxElements, myName, unitIDattribID) end
+
+--- Adds or updates one instance.
+---@param iT InstanceVBOTable
+---@param thisInstance number[] Exactly `iT.instanceStep` values.
+---@param instanceID string|number|nil Key for later reference; `nil` auto-generates one.
+---@param updateExisting boolean? Allow overwriting an element with the same key.
+---@param noUpload boolean? Skip the upload, to batch several operations.
+---@param unitID integer? Bind the instance to a unit, so the buffer tracks it.
+---@return string|number|nil instanceID The key it was filed under; `nil` on failure.
+function InstanceVBOTableModule.pushElementInstance(iT, thisInstance, instanceID, updateExisting, noUpload, unitID) end
+
+--- Removes one instance, swapping the last element into its place.
+---@param iT InstanceVBOTable
+---@param instanceID string|number
+---@param noUpload boolean?
+---@return integer? index The buffer index it occupied; `nil` when not found.
+function InstanceVBOTableModule.popElementInstance(iT, instanceID, noUpload) end
+
+--- Reads one instance back out of the buffer.
+---@param iT InstanceVBOTable
+---@param instanceID string|number
+---@param cacheTable number[]? Reused output table, to avoid an allocation.
+---@return number[]? instanceData
+function InstanceVBOTableModule.getElementInstanceData(iT, instanceID, cacheTable) end
+
+--- Empties the table without resizing its buffer.
+---@param iT InstanceVBOTable
+function InstanceVBOTableModule.clearInstanceTable(iT) end
+
+--- Uploads every used element.
+---@param iT InstanceVBOTable
+function InstanceVBOTableModule.uploadAllElements(iT) end
+
+---@param iT InstanceVBOTable
+---@param startElementIndex integer
+---@param endElementIndex integer
+function InstanceVBOTableModule.uploadElementRange(iT, startElementIndex, endElementIndex) end
+
+---@param iT InstanceVBOTable
+function InstanceVBOTableModule.drawInstanceVBO(iT) end
+
+--- Attaches a vertex buffer to an instance buffer, and an index buffer if given.
+---@param vertexVBO InstanceVBOTable|VBO|nil
+---@param instanceVBO InstanceVBOTable|VBO|nil
+---@param indexVBO InstanceVBOTable|VBO|nil
+---@return VAO|InstanceVBOTable|nil vao
+function InstanceVBOTableModule.makeVAOandAttach(vertexVBO, instanceVBO, indexVBO) end
+
+---@param iT InstanceVBOTable
+---@param removelist table<string|number, true>? Instance keys to drop.
+---@param keeplist table<string|number, true>? Instance keys to keep, dropping the rest.
+function InstanceVBOTableModule.compactInstanceVBO(iT, removelist, keeplist) end
+
+--- Reports instances bound to units that no longer exist.
+---@param iT InstanceVBOTable
+function InstanceVBOTableModule.locateInvalidUnits(iT) end
+
+--- The geometry helpers below each build a standalone vertex buffer, for use as the
+--- vertex side of `makeVAOandAttach`. `name` is only used in log messages.
+---@param circleSegments integer
+---@param radius number
+---@param startCenter boolean? Emit a centre vertex first, for a triangle fan.
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makeCircleVBO(circleSegments, radius, startCenter, name) end
+
+---@param xsize number Spans `-xsize` to `xsize`.
+---@param ysize number
+---@param xresolution integer? Subdivisions.
+---@param yresolution integer?
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makePlaneVBO(xsize, ysize, xresolution, yresolution, name) end
+
+---@param xresolution integer
+---@param yresolution integer
+---@param cutcircle boolean? Drop the triangles outside the inscribed circle.
+---@param name string?
+---@return InstanceVBOTable? indexVBO
+function InstanceVBOTableModule.makePlaneIndexVBO(xresolution, yresolution, cutcircle, name) end
+
+---@param numPoints integer
+---@param randomFactor number?
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makePointVBO(numPoints, randomFactor, name) end
+
+---@param minX number?
+---@param minY number?
+---@param maxX number?
+---@param maxY number?
+---@param minU number?
+---@param minV number?
+---@param maxU number?
+---@param maxV number?
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makeRectVBO(minX, minY, maxX, maxY, minU, minV, maxU, maxV, name) end
+
+---@param name string?
+---@return InstanceVBOTable? indexVBO
+function InstanceVBOTableModule.makeRectIndexVBO(name) end
+
+---@param numSegments integer
+---@param height number
+---@param radius number
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makeConeVBO(numSegments, height, radius, name) end
+
+---@param numSegments integer
+---@param height number
+---@param radius number
+---@param hastop boolean?
+---@param hasbottom boolean?
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makeCylinderVBO(numSegments, height, radius, hastop, hasbottom, name) end
+
+---@param minX number
+---@param minY number
+---@param minZ number
+---@param maxX number
+---@param maxY number
+---@param maxZ number
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makeBoxVBO(minX, minY, minZ, maxX, maxY, maxZ, name) end
+
+---@param sectorCount integer
+---@param stackCount integer
+---@param radius number
+---@param name string?
+---@return InstanceVBOTable? vertexVBO
+function InstanceVBOTableModule.makeSphereVBO(sectorCount, stackCount, radius, name) end
+
+--- A screen-space textured rectangle, already wrapped in a VAO.
+---@param minX number?
+---@param minY number?
+---@param maxX number?
+---@param maxY number?
+---@param minU number?
+---@param minV number?
+---@param maxU number?
+---@param maxV number?
+---@param name string?
+---@return InstanceVBOTable? rectVAO
+function InstanceVBOTableModule.MakeTexRectVAO(minX, minY, maxX, maxY, minU, minV, maxU, maxV, name) end
+
+--- `gl` is declared as a plain global by the engine library, so the helpers are
+--- attached to it here rather than through a class declaration.
+---@type InstanceVBOTableModule
+gl.InstanceVBOTable = InstanceVBOTableModule

--- a/types/Position.lua
+++ b/types/Position.lua
@@ -1,0 +1,19 @@
+---@meta
+
+--- Coordinate shapes used across the BAR Lua code. Two forms are in circulation:
+--- fixed-length arrays, as the Spring API mostly returns, and named-field tables.
+--- Prefer these over `number[]` or `table`, so the language server checks the
+--- element count or the field names.
+---
+--- These stay aliases rather than numbered-field classes, unlike the heterogeneous
+--- tuples elsewhere: `api_object_spotlight` uses `integer|Position3D` as a table
+--- KEY type, and a class in key position makes every lookup an undefined-field.
+
+--- A world position as the array `{x, y, z}`, y being the height.
+---@alias Position3D [number, number, number]
+
+--- A map position as the array `{x, z}`, with the height implied by the terrain.
+---@alias Position2D [number, number]
+
+--- A map position as the named-field table `{x = ..., z = ...}`.
+---@alias PositionXZ {x: number, z: number}

--- a/types/ScreenRect.lua
+++ b/types/ScreenRect.lua
@@ -9,7 +9,7 @@
 --- with `DockedPanelPosition`, which is top-left-bottom-right and carries a fifth
 --- element, or with the drag rects some widgets build as `{x1, y1, x2, y2}`.
 ---@class ScreenRect
----@field [1] number Left edge.
----@field [2] number Bottom edge.
----@field [3] number Right edge.
----@field [4] number Top edge.
+---@field [1] number Left edge
+---@field [2] number Bottom edge
+---@field [3] number Right edge
+---@field [4] number Top edge

--- a/types/ScreenRect.lua
+++ b/types/ScreenRect.lua
@@ -1,0 +1,15 @@
+---@meta
+
+--- A rectangle in Spring screen coordinates, in the order the FlowUI drawing
+--- helpers take it: `UiElement(left, bottom, right, top)` and
+--- `RectRound(left, bottom, right, top, ...)`. Y grows upward, so `[4] >= [2]`.
+---
+--- This is the codebase's most common rect convention -- the `backgroundRect` of
+--- most panels, and the area `WG['tooltip'].AddTooltip` takes. Do not confuse it
+--- with `DockedPanelPosition`, which is top-left-bottom-right and carries a fifth
+--- element, or with the drag rects some widgets build as `{x1, y1, x2, y2}`.
+---@class ScreenRect
+---@field [1] number Left edge.
+---@field [2] number Bottom edge.
+---@field [3] number Right edge.
+---@field [4] number Top edge.

--- a/types/WorldObject.lua
+++ b/types/WorldObject.lua
@@ -1,0 +1,8 @@
+---@meta
+
+--- What a reference into the world points at, as the engine names it: the string
+--- `Spring.TraceScreenRay` returns alongside a hit, and the discriminator that
+--- says whether an accompanying ID is a unitID, a featureID, or a position.
+--- A trace called with `includeSky` can also answer `"sky"`, so those call sites
+--- want `WorldObjectType|"sky"`.
+---@alias WorldObjectType "unit"|"feature"|"ground"


### PR DESCRIPTION
`WG` and `GG` (widget/gadget API function tables) have almost no type annotations. This PR adds `---@param` / `---@return` at every point where a `WG` or `GG` member is defined, plus the classes and aliases needed to support and deduplicate those annotations, and descriptive comments on most such members.

In addition to the IDE functionality improvements, a measurable result is 930 net fewer emmylua_check diagnostic messages, and that number will continue to increase as further type annotations are applied in later PRs.

There are no behavioral changes anywhere in the diff. This is 95% comments, a few rearranged functions (to put Shutdown after Initialize), and a few `local a,b,c` split up to allow annotating just one of the variables.

This adds a declaration for `gl.InstanceVBOTable` which is used and annotated in many places

Various existing annotations were incorrect and have been fixed.

## AI / LLM usage statement:
This patch was authored 91% by Claude Opus 5, 9% by myself. I reviewed every line of diff and made various corrections, prior to using the LLM again to rebase the changes against the latest master. I then reviewed again and made additional corrections and improvements, then finally un-drafted the PR. The text of this description was authored 30% by Claude Opus 5, 70% by myself.