### PR TITLE
Fix the self-destruct icon never showing on the Advanced Metal Fortifier

### DIFF
--- a/luaui/Widgets/gui_selfd_icons.lua
+++ b/luaui/Widgets/gui_selfd_icons.lua
@@ -19,12 +19,16 @@ local spGetSpectatingState = Spring.GetSpectatingState
 
 local ignoreUnitDefs = {}
 local unitConf = {}
+local isTransportDef = {}
 for udid, unitDef in pairs(UnitDefs) do
 	local xsize, zsize = unitDef.xsize, unitDef.zsize
 	local scale = 6 * (xsize * xsize + zsize * zsize) ^ 0.5
 	unitConf[udid] = 7 + (scale / 2.5)
 	if string.find(unitDef.name, "droppod") then
 		ignoreUnitDefs[udid] = true
+	end
+	if unitDef.isTransport then
+		isTransportDef[udid] = true
 	end
 end
 
@@ -178,7 +182,8 @@ function widget:DrawWorld()
 	-- draw icon + countodown if there is an active self-d countdown going
 	for unitID, unitDefID in pairs(activeSelfD) do
 		if (spIsUnitAllied(unitID) or spec) and spIsUnitInView(unitID) then
-			if spGetUnitTransporter(unitID) == nil then
+			local transporterID = spGetUnitTransporter(unitID)
+			if transporterID == nil or not isTransportDef[spGetUnitDefID(transporterID)] then
 				unitScale = unitConf[unitDefID]
 				countdown = math.ceil(spGetUnitSelfDTime(unitID) / 2)
 				if not drawLists[countdown] then
@@ -193,7 +198,8 @@ function widget:DrawWorld()
 	for unitID, unitDefID in pairs(queuedSelfD) do
 		-- don't draw this if it also has an active countdown
 		if activeSelfD[unitID] == nil and (spIsUnitAllied(unitID) or spec) and spIsUnitInView(unitID) then
-			if spGetUnitTransporter(unitID) == nil then
+			local transporterID = spGetUnitTransporter(unitID)
+			if transporterID == nil or not isTransportDef[spGetUnitDefID(transporterID)] then
 				unitScale = unitConf[unitDefID]
 				if not drawLists[0] then
 					drawLists[0] = gl.CreateList(DrawIcon, 0)


### PR DESCRIPTION
### Work done
The self-destruct countdown (skull icon) never shows on the Advanced Metal Fortifier. 
Its con turret (`legmohoconct`) is attached to the hidden extractor unit via `Spring.UnitAttach` and engine reports a transporter for it and `gui_selfd_icons.lua` hides the icon for any unit that has a transporter. 
The self-destruct itself works, only the countdown is missing.

BEFORE:

https://github.com/user-attachments/assets/d22774fe-366b-4dbc-a1fd-b059a1ab80b6


This PR changes the check to hide the icon only when the unit is riding an actual transport (`isTransport` def), instead of whenever any transporter exists. Behavior for units loaded into real transports is unchanged.

AFTER:

https://github.com/user-attachments/assets/80aa7eb9-294e-4e43-8ea8-76d9c27f4128


#### Test steps
- [x] Build an Advanced Metal Fortifier > self-destruct it. The skull + countdown now shows below it (it previously never did). A second self-d press cancels and removes the icon.
- [x] Self-destruct a regular mex/building: icon unchanged.


### AI / LLM usage statement:
Diagnosed and analyzed with the help of Claude Code, prepared and tested by me.
