### PR TITLE
Fix scav and raptor spawners: expose BAR to the def-file sandbox

### DIFF
--- a/gamedata/featuredefs.lua
+++ b/gamedata/featuredefs.lua
@@ -46,6 +46,7 @@ for _, filename in ipairs(luaFiles) do
 	local featureDefsEnv = {}
 	featureDefsEnv._G = featureDefsEnv
 	featureDefsEnv.Shared = shared
+	featureDefsEnv.BAR = BAR
 	featureDefsEnv.GetFilename = function()
 		return filename
 	end

--- a/gamedata/unitdefs.lua
+++ b/gamedata/unitdefs.lua
@@ -82,6 +82,7 @@ for _, filename in ipairs(luaFiles) do
 		local unitDefsEnv = {}
 		unitDefsEnv._G = unitDefsEnv
 		unitDefsEnv.Shared = shared
+		unitDefsEnv.BAR = BAR
 		unitDefsEnv.GetFilename = function()
 			return filename
 		end

--- a/gamedata/weapondefs.lua
+++ b/gamedata/weapondefs.lua
@@ -47,6 +47,7 @@ for _, filename in ipairs(luaFiles) do
 	local weaponDefsEnv = {}
 	weaponDefsEnv._G = weaponDefsEnv
 	weaponDefsEnv.Shared = shared
+	weaponDefsEnv.BAR = BAR
 	weaponDefsEnv.GetFilename = function()
 		return filename
 	end


### PR DESCRIPTION
### Work done

Add `BAR` to the per-file environment in the three def loaders (`unitdefs.lua`, `featuredefs.lua`, `weapondefs.lua`).


### Background

All in all I think it can be viewed as a missing include that was hard to spot since Spring was global. Adding BAR specifically fixes that.

In the current release 2026.08-15-1 and merge of branch `detach-bar-modules` the defs loaders does not have access to BAR.

Essentially a nil reference error but at module level.

The result is that scav and raptor gadgets crash and games run with no spawner and no boss.

Error:
```
[unitdefs.lua] Error: Error parsing units/scavengers/boss/scavengerbossv4.lua: ... attempt to index global 'BAR' (a nil value)
Error: Failed to load: scav_spawner_defense.lua  (... scav_spawn_defs.lua:54: attempt to index field 'scavengerbossv4_veryeasy_scav' (a nil value))
```

Feature and weapon def files don't reference `BAR` yet, but they run in the same sandbox, so they get the same include.

#### Test steps

- [x] Manual test (headfull, regular client, branch mounted as `.sdd`): played one Scavengers defense skirmish and one Raptors game through to game over. Defs parsed clean, spawners loaded and ran normally, no related Lua errors in either infolog.

### AI / LLM usage statement:
Claude Code investigated the infolog, identified the regression, and wrote the change; I reviewed the diff, and played the two headfull games and wrote this text.