### PR TITLE
Allow engine-native area attack above limiter

### DIFF
--- a/luarules/gadgets/unit_areaattack_limiter.lua
+++ b/luarules/gadgets/unit_areaattack_limiter.lua
@@ -3,7 +3,7 @@ local gadget = gadget ---@type Gadget
 function gadget:GetInfo()
 	return {
 		name = "Area Attack Limiter",
-		desc = "Converts excess area attack commands to fight commands to reduce lag from large (air) engagements",
+		desc = "Converts excess area-form attack commands to fight commands to reduce lag from large (air) engagements",
 		author = "Floris",
 		date = "2026",
 		license = "GNU GPL, v2 or later",
@@ -17,7 +17,6 @@ if gadgetHandler:IsSyncedCode() then
 end
 
 local CMD_ATTACK = CMD.ATTACK
-local CMD_AREA_ATTACK = CMD.AREA_ATTACK
 local CMD_FIGHT = CMD.FIGHT
 local CMD_STOP = CMD.STOP
 
@@ -44,10 +43,10 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 
--- Max units allowed to use the expensive engine-side area attack.
+-- Max non-bomber units allowed to use an area-form CMD_ATTACK.
 -- Excess units receive a FIGHT command to the area center instead,
--- which makes them converge and auto-engage without the costly
--- per-unit target resolution the engine performs for area attacks.
+-- which makes them converge and auto-engage without expanding the
+-- command into too many target-specific attack orders.
 local BATCH_LIMIT = 30
 
 local isReissuing = false
@@ -58,8 +57,9 @@ function gadget:CommandNotify(cmdID, cmdParams, cmdOpts)
 		return
 	end
 
-	-- Only intercept area-format commands (4 params: x, y, z, radius)
-	if (cmdID ~= CMD_ATTACK and cmdID ~= CMD_AREA_ATTACK) or #cmdParams ~= 4 or cmdParams[4] <= 0 then
+	-- Only intercept area-form CMD_ATTACK commands (4 params: x, y, z, radius).
+	-- Engine-native CMD_AREA_ATTACK remains compact and is intentionally not limited.
+	if cmdID ~= CMD_ATTACK or #cmdParams ~= 4 or cmdParams[4] <= 0 then
 		return
 	end
 


### PR DESCRIPTION
### Work done

- Restrict `unit_areaattack_limiter.lua` to four-parameter, area-form `CMD_ATTACK` commands.
- Let engine-native `CMD_AREA_ATTACK` pass through without replacing commands above 30 selected non-bomber units with `CMD_FIGHT`.
- Update the gadget description and comments to distinguish expanded attack orders from engine-native area attack.

Area-form `CMD_ATTACK` can be expanded immediately into target-specific orders for combinations of selected units and targets. `CMD_AREA_ATTACK` instead keeps one area command per aircraft and resolves targets during execution. Historical replay measurements documented in the issue found no command-aligned simulation-frame-time spike in 56 commands issued with 102–357 selected units.

#### Addresses Issue(s)

- Fixes #8770

#### Test steps

- [x] `luac -p luarules/gadgets/unit_areaattack_limiter.lua`
- [x] Loaded the gadget in a Lua mock with 31 selected non-bomber units and verified that `CMD_AREA_ATTACK` passes through without selection or order rewrites.
- [x] In the same mock, verified that a four-parameter `CMD_ATTACK` is still handled, split 30/1, and replaced with the existing attack/fight orders.
- [X] In game, select more than 30 fighters and issue `Ctrl+A` + drag. All selected fighters retained the engine-native area-attack command.
- [X] Issue an area-form `CMD_ATTACK` with more than 30 non-bomber units. The existing limiter behavior remained unchanged.

### AI / LLM usage statement

OpenAI Codex was used to inspect the command paths and history, make the focused Lua edit, and draft the validation harness and PR text. The resulting diff was reviewed and validated with the checks above.
