### PR TITLE
Attack command: Fix ground Area Attack target cycling

### DIFF
--- a/luarules/gadgets/unit_areaattack.lua
+++ b/luarules/gadgets/unit_areaattack.lua
@@ -20,28 +20,30 @@ if gadgetHandler:IsSyncedCode() then
 	local attackList = {}
 	local closeList = {}
 	local activeAttacks = {}
-	local finishedAttacks = {}
 
 	local math_random = math.random
 	local math_pi = math.pi
 	local math_sqrt = math.sqrt
 	local math_cos = math.cos
 	local math_sin = math.sin
+	local math_max = math.max
+	local math_bit_and = math.bit_and
 
 	local CMD_ATTACK = CMD.ATTACK
+	local CMD_OPT_INTERNAL = CMD.OPT_INTERNAL
 	local reissueOrder = Game.Commands.ReissueOrder
 
 	local canAreaAttack = {}
-	local areaAttackWeapons = {}
-	local areaAttackWeaponByUnitDef = {}
+	local areaAttackWeaponDefs = {}
+	local areaAttackWeaponDefByUnitDef = {}
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		if #unitDef.weapons > 0 and unitDef.customParams.canareaattack then
 			local weaponDefID = unitDef.weapons[1].weaponDef
 			local weaponDef = WeaponDefs[weaponDefID]
 			if weaponDef then
 				canAreaAttack[unitDefID] = weaponDef.range
-				areaAttackWeapons[weaponDefID] = weaponDef.salvoSize
-				areaAttackWeaponByUnitDef[unitDefID] = weaponDefID
+				areaAttackWeaponDefs[weaponDefID] = true
+				areaAttackWeaponDefByUnitDef[unitDefID] = weaponDefID
 			end
 		end
 	end
@@ -57,22 +59,6 @@ if gadgetHandler:IsSyncedCode() then
 	}
 
 	function gadget:GameFrame(f)
-		-- Removing a command from ProjectileCreated can invalidate the engine's
-		-- active weapon-command state, so defer it until the next game frame.
-		for unitID, attack in pairs(finishedAttacks) do
-			finishedAttacks[unitID] = nil
-			local commandID, _, commandTag = Spring.GetUnitCurrentCommand(unitID)
-			if commandID == CMD_ATTACK and commandTag == attack.commandTag then
-				-- Preserve the engine's normal Repeat and UnitCmdDone handling. Generated
-				-- area-attack shots are internal, so the engine will not repeat them.
-				Spring.UnitFinishCommand(unitID)
-			else
-				-- A command can be inserted ahead of the attack before this deferred
-				-- callback runs. Remove only the completed attack in that case.
-				Spring.GiveOrderToUnit(unitID, CMD.REMOVE, { attack.commandTag }, 0)
-			end
-		end
-
 		for i, o in pairs(attackList) do
 			attackList[i] = nil
 			local phase = math_random(200 * math_pi) / 100.0
@@ -91,6 +77,31 @@ if gadgetHandler:IsSyncedCode() then
 		for i, o in pairs(closeList) do
 			closeList[i] = nil
 			Spring.SetUnitMoveGoal(o.unit, o.x, o.y, o.z, o.radius)
+		end
+	end
+
+	function gadget:GameFramePost(frame)
+		for unitID, attack in pairs(activeAttacks) do
+			if frame >= attack.checkFrame then
+				local salvoLeft = Spring.GetUnitWeaponState(unitID, 1, "salvoLeft")
+				if not salvoLeft then
+					activeAttacks[unitID] = nil
+				elseif salvoLeft > 0 then
+					local nextSalvo = Spring.GetUnitWeaponState(unitID, 1, "nextSalvo")
+					attack.checkFrame = math_max(nextSalvo or 0, frame + 1)
+				else
+					activeAttacks[unitID] = nil
+					local commandID, _, commandTag = Spring.GetUnitCurrentCommand(unitID)
+					if commandID == CMD_ATTACK and commandTag == attack.commandTag then
+						-- Internal commands are not requeued by normal command completion.
+						Spring.UnitFinishCommand(unitID)
+					else
+						-- A command can move ahead while the burst is active. Remove only
+						-- the generated attack in that case.
+						Spring.GiveOrderToUnit(unitID, CMD.REMOVE, { attack.commandTag }, 0)
+					end
+				end
+			end
 		end
 	end
 
@@ -143,51 +154,28 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
-		local salvoSize = areaAttackWeapons[weaponDefID]
+		if not areaAttackWeaponDefs[weaponDefID] or activeAttacks[ownerID] then
+			return
+		end
+
 		local unitDefID = Spring.GetUnitDefID(ownerID)
-		if not salvoSize or areaAttackWeaponByUnitDef[unitDefID] ~= weaponDefID then
+		if areaAttackWeaponDefByUnitDef[unitDefID] ~= weaponDefID then
 			return
 		end
 
-		local commands = Spring.GetUnitCommands(ownerID, 2)
-		local currentCommand = commands and commands[1]
-		if
-			not currentCommand
-			or currentCommand.id ~= CMD_ATTACK
-			or not currentCommand.params
-			or #currentCommand.params < 3
-			or not currentCommand.options
-			or not currentCommand.options.internal
-		then
+		local commandID, commandOptions, commandTag, _, _, targetZ = Spring.GetUnitCurrentCommand(ownerID)
+		if commandID ~= CMD_ATTACK or targetZ == nil or math_bit_and(commandOptions, CMD_OPT_INTERNAL) == 0 then
+			return
+		end
+		if not Spring.GetUnitCurrentCommand(ownerID, 2) then
 			return
 		end
 
-		local attack = activeAttacks[ownerID]
-		if not attack or attack.commandTag ~= currentCommand.tag then
-			if not commands[2] then
-				return
-			end
-			attack = {
-				commandTag = currentCommand.tag,
-				weaponDefID = weaponDefID,
-				projectilesLeft = salvoSize,
-			}
-			activeAttacks[ownerID] = attack
-		elseif attack.weaponDefID ~= weaponDefID then
-			return
-		end
-
-		attack.projectilesLeft = attack.projectilesLeft - 1
-		if attack.projectilesLeft > 0 then
-			return
-		end
-
-		activeAttacks[ownerID] = nil
-		-- Generated ground attacks are persistent, so finish this shot after one
-		-- complete salvo and let the area command choose another random position.
-		if commands[2] then
-			finishedAttacks[ownerID] = attack
-		end
+		-- Poll weapon state after simulation instead of counting every projectile.
+		activeAttacks[ownerID] = {
+			commandTag = commandTag,
+			checkFrame = Spring.GetGameFrame(),
+		}
 	end
 
 	function gadget:UnitCreated(u, ud, team)
@@ -198,13 +186,12 @@ if gadgetHandler:IsSyncedCode() then
 
 	function gadget:UnitDestroyed(unitID)
 		activeAttacks[unitID] = nil
-		finishedAttacks[unitID] = nil
 	end
 
 	function gadget:Initialize()
 		gadgetHandler:RegisterCMDID(CMD_AREA_ATTACK_GROUND)
 		gadgetHandler:RegisterAllowCommand(CMD_AREA_ATTACK_GROUND)
-		for weaponDefID in pairs(areaAttackWeapons) do
+		for weaponDefID in pairs(areaAttackWeaponDefs) do
 			Script.SetWatchProjectile(weaponDefID, true)
 		end
 	end

--- a/luarules/gadgets/unit_areaattack.lua
+++ b/luarules/gadgets/unit_areaattack.lua
@@ -19,6 +19,8 @@ local CMD_AREA_ATTACK_GROUND = GameCMD.AREA_ATTACK_GROUND
 if gadgetHandler:IsSyncedCode() then
 	local attackList = {}
 	local closeList = {}
+	local activeAttacks = {}
+	local finishedAttacks = {}
 
 	local math_random = math.random
 	local math_pi = math.pi
@@ -30,9 +32,17 @@ if gadgetHandler:IsSyncedCode() then
 	local reissueOrder = Game.Commands.ReissueOrder
 
 	local canAreaAttack = {}
+	local areaAttackWeapons = {}
+	local areaAttackWeaponByUnitDef = {}
 	for unitDefID, unitDef in pairs(UnitDefs) do
 		if #unitDef.weapons > 0 and unitDef.customParams.canareaattack then
-			canAreaAttack[unitDefID] = WeaponDefs[unitDef.weapons[1].weaponDef].range
+			local weaponDefID = unitDef.weapons[1].weaponDef
+			local weaponDef = WeaponDefs[weaponDefID]
+			if weaponDef then
+				canAreaAttack[unitDefID] = weaponDef.range
+				areaAttackWeapons[weaponDefID] = weaponDef.salvoSize
+				areaAttackWeaponByUnitDef[unitDefID] = weaponDefID
+			end
 		end
 	end
 	local range = canAreaAttack -- range per unitDefID, same data
@@ -47,17 +57,35 @@ if gadgetHandler:IsSyncedCode() then
 	}
 
 	function gadget:GameFrame(f)
+		-- Removing a command from ProjectileCreated can invalidate the engine's
+		-- active weapon-command state, so defer it until the next game frame.
+		for unitID, attack in pairs(finishedAttacks) do
+			finishedAttacks[unitID] = nil
+			local commandID, _, commandTag = Spring.GetUnitCurrentCommand(unitID)
+			if commandID == CMD_ATTACK and commandTag == attack.commandTag then
+				-- Preserve the engine's normal Repeat and UnitCmdDone handling. Generated
+				-- area-attack shots are internal, so the engine will not repeat them.
+				Spring.UnitFinishCommand(unitID)
+			else
+				-- A command can be inserted ahead of the attack before this deferred
+				-- callback runs. Remove only the completed attack in that case.
+				Spring.GiveOrderToUnit(unitID, CMD.REMOVE, { attack.commandTag }, 0)
+			end
+		end
+
 		for i, o in pairs(attackList) do
 			attackList[i] = nil
 			local phase = math_random(200 * math_pi) / 100.0
 			if o.radius > 0 then
 				local amp = math_random(o.radius)
-				Spring.GiveOrderToUnit(
-					o.unit,
-					CMD.INSERT,
-					{ 0, CMD.ATTACK, 0, o.x + math_cos(phase) * amp, o.y, o.z + math_sin(phase) * amp },
-					{ "alt" }
-				)
+				Spring.GiveOrderToUnit(o.unit, CMD.INSERT, {
+					0,
+					CMD.ATTACK,
+					CMD.OPT_INTERNAL,
+					o.x + math_cos(phase) * amp,
+					o.y,
+					o.z + math_sin(phase) * amp,
+				}, { "alt" })
 			end
 		end
 		for i, o in pairs(closeList) do
@@ -98,7 +126,13 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			local dist = math_sqrt((x - param[1]) * (x - param[1]) + (z - param[3]) * (z - param[3]))
 			if dist <= range[ud] - param[4] then
-				attackList[#attackList + 1] = { unit = u, x = param[1], y = param[2], z = param[3], radius = param[4] }
+				attackList[#attackList + 1] = {
+					unit = u,
+					x = param[1],
+					y = param[2],
+					z = param[3],
+					radius = param[4],
+				}
 			else
 				closeList[#closeList + 1] =
 					{ unit = u, x = param[1], y = param[2], z = param[3], radius = range[ud] - param[4] }
@@ -108,15 +142,71 @@ if gadgetHandler:IsSyncedCode() then
 		return false
 	end
 
+	function gadget:ProjectileCreated(projectileID, ownerID, weaponDefID)
+		local salvoSize = areaAttackWeapons[weaponDefID]
+		local unitDefID = Spring.GetUnitDefID(ownerID)
+		if not salvoSize or areaAttackWeaponByUnitDef[unitDefID] ~= weaponDefID then
+			return
+		end
+
+		local commands = Spring.GetUnitCommands(ownerID, 2)
+		local currentCommand = commands and commands[1]
+		if
+			not currentCommand
+			or currentCommand.id ~= CMD_ATTACK
+			or not currentCommand.params
+			or #currentCommand.params < 3
+			or not currentCommand.options
+			or not currentCommand.options.internal
+		then
+			return
+		end
+
+		local attack = activeAttacks[ownerID]
+		if not attack or attack.commandTag ~= currentCommand.tag then
+			if not commands[2] then
+				return
+			end
+			attack = {
+				commandTag = currentCommand.tag,
+				weaponDefID = weaponDefID,
+				projectilesLeft = salvoSize,
+			}
+			activeAttacks[ownerID] = attack
+		elseif attack.weaponDefID ~= weaponDefID then
+			return
+		end
+
+		attack.projectilesLeft = attack.projectilesLeft - 1
+		if attack.projectilesLeft > 0 then
+			return
+		end
+
+		activeAttacks[ownerID] = nil
+		-- Generated ground attacks are persistent, so finish this shot after one
+		-- complete salvo and let the area command choose another random position.
+		if commands[2] then
+			finishedAttacks[ownerID] = attack
+		end
+	end
+
 	function gadget:UnitCreated(u, ud, team)
 		if canAreaAttack[ud] then
 			Spring.InsertUnitCmdDesc(u, aadesc)
 		end
 	end
 
+	function gadget:UnitDestroyed(unitID)
+		activeAttacks[unitID] = nil
+		finishedAttacks[unitID] = nil
+	end
+
 	function gadget:Initialize()
 		gadgetHandler:RegisterCMDID(CMD_AREA_ATTACK_GROUND)
 		gadgetHandler:RegisterAllowCommand(CMD_AREA_ATTACK_GROUND)
+		for weaponDefID in pairs(areaAttackWeapons) do
+			Script.SetWatchProjectile(weaponDefID, true)
+		end
 	end
 else -- UNSYNCED
 	function gadget:Initialize()

--- a/luarules/gadgets/unit_areaattack.lua
+++ b/luarules/gadgets/unit_areaattack.lua
@@ -40,11 +40,9 @@ if gadgetHandler:IsSyncedCode() then
 		if #unitDef.weapons > 0 and unitDef.customParams.canareaattack then
 			local weaponDefID = unitDef.weapons[1].weaponDef
 			local weaponDef = WeaponDefs[weaponDefID]
-			if weaponDef then
-				canAreaAttack[unitDefID] = weaponDef.range
-				areaAttackWeaponDefs[weaponDefID] = true
-				areaAttackWeaponDefByUnitDef[unitDefID] = weaponDefID
-			end
+			canAreaAttack[unitDefID] = weaponDef.range
+			areaAttackWeaponDefs[weaponDefID] = true
+			areaAttackWeaponDefByUnitDef[unitDefID] = weaponDefID
 		end
 	end
 	local range = canAreaAttack -- range per unitDefID, same data
@@ -67,7 +65,7 @@ if gadgetHandler:IsSyncedCode() then
 				Spring.GiveOrderToUnit(o.unit, CMD.INSERT, {
 					0,
 					CMD.ATTACK,
-					CMD.OPT_INTERNAL,
+					CMD_OPT_INTERNAL,
 					o.x + math_cos(phase) * amp,
 					o.y,
 					o.z + math_sin(phase) * amp,
@@ -167,7 +165,7 @@ if gadgetHandler:IsSyncedCode() then
 		if commandID ~= CMD_ATTACK or targetZ == nil or math_bit_and(commandOptions, CMD_OPT_INTERNAL) == 0 then
 			return
 		end
-		if not Spring.GetUnitCurrentCommand(ownerID, 2) then
+		if Spring.GetUnitCurrentCommand(ownerID, 2) ~= CMD_AREA_ATTACK_GROUND then
 			return
 		end
 

--- a/spec/luarules/gadgets/unit_areaattack_spec.lua
+++ b/spec/luarules/gadgets/unit_areaattack_spec.lua
@@ -11,9 +11,11 @@ local WEAPON_DEF_ID = 5
 local UNIT_DEF_ID = 1
 local UNIT_ID = 7
 
-local function loadGadget(commands, salvoSize)
+local function loadGadget(commands, weaponState)
 	local orders = {}
 	local finishedUnits = {}
+	local currentFrame = 1
+	local unitDefLookups = 0
 	local env = {
 		gadget = {},
 		gadgetHandler = {
@@ -38,22 +40,29 @@ local function loadGadget(commands, salvoSize)
 				customParams = { canareaattack = true },
 			},
 		},
-		WeaponDefs = {
-			[WEAPON_DEF_ID] = { range = 1000, salvoSize = salvoSize or 1 },
-		},
+		WeaponDefs = { [WEAPON_DEF_ID] = { range = 1000 } },
+		math = setmetatable({
+			bit_and = function(a, b)
+				return a % (b * 2) >= b and b or 0
+			end,
+		}, { __index = math }),
 		Script = { SetWatchProjectile = function() end },
 		Spring = {
-			GetUnitCommands = function()
-				return commands
+			GetGameFrame = function()
+				return currentFrame
 			end,
-			GetUnitCurrentCommand = function()
-				local command = commands[1]
+			GetUnitCurrentCommand = function(_, index)
+				local command = commands[index or 1]
 				if command then
-					return command.id, command.options.coded, command.tag
+					return command.id, command.options.coded, command.tag, unpack(command.params)
 				end
 			end,
 			GetUnitDefID = function()
+				unitDefLookups = unitDefLookups + 1
 				return UNIT_DEF_ID
+			end,
+			GetUnitWeaponState = function(_, _, stateName)
+				return weaponState[stateName]
 			end,
 			GetUnitPosition = function()
 				return 0, 0, 0
@@ -74,7 +83,15 @@ local function loadGadget(commands, salvoSize)
 	setfenv(chunk, env)
 	chunk()
 
-	return env.gadget, orders, finishedUnits
+	return env.gadget,
+		orders,
+		finishedUnits,
+		function(frame)
+			currentFrame = frame
+		end,
+		function()
+			return unitDefLookups
+		end
 end
 
 local function generatedAreaCommands()
@@ -92,23 +109,92 @@ end
 describe("unit_areaattack", function()
 	it("changes area target after one complete salvo", function()
 		local commands = generatedAreaCommands()
-		local gadget, _, finishedUnits = loadGadget(commands, 2)
+		local weaponState = { salvoLeft = 1, nextSalvo = 2 }
+		local gadget, _, finishedUnits, setFrame = loadGadget(commands, weaponState)
 
 		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
-		gadget:GameFrame(1)
+		gadget:GameFramePost(1)
 		assert.equals(0, #finishedUnits)
 
+		weaponState.salvoLeft = 0
+		setFrame(2)
+		gadget:GameFramePost(2)
+		assert.same({ UNIT_ID }, finishedUnits)
+	end)
+
+	it("does not process every projectile in a burst", function()
+		local commands = generatedAreaCommands()
+		local weaponState = { salvoLeft = 2, nextSalvo = 2 }
+		local gadget, _, _, _, getUnitDefLookups = loadGadget(commands, weaponState)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
 		gadget:ProjectileCreated(2, UNIT_ID, WEAPON_DEF_ID)
-		gadget:GameFrame(2)
+		gadget:ProjectileCreated(3, UNIT_ID, WEAPON_DEF_ID)
+
+		assert.equals(1, getUnitDefLookups())
+	end)
+
+	it("finishes after a canceled final shot without another projectile", function()
+		local commands = generatedAreaCommands()
+		local weaponState = { salvoLeft = 1, nextSalvo = 2 }
+		local gadget, _, finishedUnits = loadGadget(commands, weaponState)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+		gadget:GameFramePost(1)
+		weaponState.salvoLeft = 0
+		gadget:GameFramePost(2)
+
+		assert.same({ UNIT_ID }, finishedUnits)
+	end)
+
+	it("follows a delayed next-salvo frame", function()
+		local commands = generatedAreaCommands()
+		local weaponState = { salvoLeft = 1, nextSalvo = 2 }
+		local gadget, _, finishedUnits = loadGadget(commands, weaponState)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+		gadget:GameFramePost(1)
+		weaponState.nextSalvo = 4
+		gadget:GameFramePost(2)
+		weaponState.salvoLeft = 0
+		gadget:GameFramePost(3)
+		assert.equals(0, #finishedUnits)
+		gadget:GameFramePost(4)
+
 		assert.same({ UNIT_ID }, finishedUnits)
 	end)
 
 	it("ignores unrelated weapon projectiles", function()
 		local commands = generatedAreaCommands()
-		local gadget, orders, finishedUnits = loadGadget(commands)
+		local gadget, orders, finishedUnits = loadGadget(commands, {})
 
 		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID + 1)
-		gadget:GameFrame(1)
+		gadget:GameFramePost(1)
+
+		assert.equals(0, #finishedUnits)
+		assert.equals(0, #orders)
+	end)
+
+	it("ignores player-issued ground attacks", function()
+		local commands = generatedAreaCommands()
+		commands[1].options = { coded = 0, internal = false }
+		local weaponState = { salvoLeft = 0, nextSalvo = 1 }
+		local gadget, orders, finishedUnits = loadGadget(commands, weaponState)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+		gadget:GameFramePost(1)
+
+		assert.equals(0, #finishedUnits)
+		assert.equals(0, #orders)
+	end)
+
+	it("keeps a generated attack persistent without its area command", function()
+		local commands = { generatedAreaCommands()[1] }
+		local weaponState = { salvoLeft = 0, nextSalvo = 1 }
+		local gadget, orders, finishedUnits = loadGadget(commands, weaponState)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+		gadget:GameFramePost(1)
 
 		assert.equals(0, #finishedUnits)
 		assert.equals(0, #orders)
@@ -116,7 +202,7 @@ describe("unit_areaattack", function()
 
 	it("marks generated area shots internal so repeat does not retain them", function()
 		local commands = {}
-		local gadget, orders = loadGadget(commands)
+		local gadget, orders = loadGadget(commands, {})
 
 		gadget:CommandFallback(UNIT_ID, UNIT_DEF_ID, 0, CMD_AREA_ATTACK_GROUND, { 0, 0, 0, 10 }, {})
 		gadget:GameFrame(1)
@@ -128,11 +214,12 @@ describe("unit_areaattack", function()
 	it("removes only the generated shot if another command moves ahead of it", function()
 		local commands = generatedAreaCommands()
 		local generatedAttack = commands[1]
-		local gadget, orders, finishedUnits = loadGadget(commands)
+		local weaponState = { salvoLeft = 0, nextSalvo = 1 }
+		local gadget, orders, finishedUnits = loadGadget(commands, weaponState)
 
 		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
 		commands[1] = { id = 10, tag = 99, params = { 0, 0, 0 }, options = { coded = 0 } }
-		gadget:GameFrame(1)
+		gadget:GameFramePost(1)
 
 		assert.equals(0, #finishedUnits)
 		assert.same({ UNIT_ID, CMD_REMOVE, { generatedAttack.tag }, 0 }, orders[1])

--- a/spec/luarules/gadgets/unit_areaattack_spec.lua
+++ b/spec/luarules/gadgets/unit_areaattack_spec.lua
@@ -1,0 +1,140 @@
+---@diagnostic disable: undefined-field
+
+local GADGET_PATH = "luarules/gadgets/unit_areaattack.lua"
+
+local CMD_ATTACK = 20
+local CMD_INSERT = 1
+local CMD_REMOVE = 2
+local CMD_OPT_INTERNAL = 8
+local CMD_AREA_ATTACK_GROUND = 39999
+local WEAPON_DEF_ID = 5
+local UNIT_DEF_ID = 1
+local UNIT_ID = 7
+
+local function loadGadget(commands, salvoSize)
+	local orders = {}
+	local finishedUnits = {}
+	local env = {
+		gadget = {},
+		gadgetHandler = {
+			IsSyncedCode = function()
+				return true
+			end,
+			RegisterCMDID = function() end,
+			RegisterAllowCommand = function() end,
+		},
+		GameCMD = { AREA_ATTACK_GROUND = CMD_AREA_ATTACK_GROUND },
+		CMD = {
+			ATTACK = CMD_ATTACK,
+			INSERT = CMD_INSERT,
+			REMOVE = CMD_REMOVE,
+			OPT_INTERNAL = CMD_OPT_INTERNAL,
+		},
+		CMDTYPE = { ICON_AREA = 5 },
+		Game = { Commands = { ReissueOrder = function() end } },
+		UnitDefs = {
+			[UNIT_DEF_ID] = {
+				weapons = { { weaponDef = WEAPON_DEF_ID } },
+				customParams = { canareaattack = true },
+			},
+		},
+		WeaponDefs = {
+			[WEAPON_DEF_ID] = { range = 1000, salvoSize = salvoSize or 1 },
+		},
+		Script = { SetWatchProjectile = function() end },
+		Spring = {
+			GetUnitCommands = function()
+				return commands
+			end,
+			GetUnitCurrentCommand = function()
+				local command = commands[1]
+				if command then
+					return command.id, command.options.coded, command.tag
+				end
+			end,
+			GetUnitDefID = function()
+				return UNIT_DEF_ID
+			end,
+			GetUnitPosition = function()
+				return 0, 0, 0
+			end,
+			GiveOrderToUnit = function(...)
+				orders[#orders + 1] = { ... }
+			end,
+			UnitFinishCommand = function(unitID)
+				finishedUnits[#finishedUnits + 1] = unitID
+			end,
+			InsertUnitCmdDesc = function() end,
+			SetUnitMoveGoal = function() end,
+		},
+	}
+	setmetatable(env, { __index = _G })
+
+	local chunk = assert(loadfile(GADGET_PATH))
+	setfenv(chunk, env)
+	chunk()
+
+	return env.gadget, orders, finishedUnits
+end
+
+local function generatedAreaCommands()
+	return {
+		{
+			id = CMD_ATTACK,
+			tag = 43,
+			params = { 5, 0, 5 },
+			options = { coded = CMD_OPT_INTERNAL, internal = true },
+		},
+		{ id = CMD_AREA_ATTACK_GROUND, tag = 44, params = { 0, 0, 0, 10 }, options = { coded = 0 } },
+	}
+end
+
+describe("unit_areaattack", function()
+	it("changes area target after one complete salvo", function()
+		local commands = generatedAreaCommands()
+		local gadget, _, finishedUnits = loadGadget(commands, 2)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+		gadget:GameFrame(1)
+		assert.equals(0, #finishedUnits)
+
+		gadget:ProjectileCreated(2, UNIT_ID, WEAPON_DEF_ID)
+		gadget:GameFrame(2)
+		assert.same({ UNIT_ID }, finishedUnits)
+	end)
+
+	it("ignores unrelated weapon projectiles", function()
+		local commands = generatedAreaCommands()
+		local gadget, orders, finishedUnits = loadGadget(commands)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID + 1)
+		gadget:GameFrame(1)
+
+		assert.equals(0, #finishedUnits)
+		assert.equals(0, #orders)
+	end)
+
+	it("marks generated area shots internal so repeat does not retain them", function()
+		local commands = {}
+		local gadget, orders = loadGadget(commands)
+
+		gadget:CommandFallback(UNIT_ID, UNIT_DEF_ID, 0, CMD_AREA_ATTACK_GROUND, { 0, 0, 0, 10 }, {})
+		gadget:GameFrame(1)
+
+		assert.equals(CMD_INSERT, orders[1][2])
+		assert.equals(CMD_OPT_INTERNAL, orders[1][3][3])
+	end)
+
+	it("removes only the generated shot if another command moves ahead of it", function()
+		local commands = generatedAreaCommands()
+		local generatedAttack = commands[1]
+		local gadget, orders, finishedUnits = loadGadget(commands)
+
+		gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+		commands[1] = { id = 10, tag = 99, params = { 0, 0, 0 }, options = { coded = 0 } }
+		gadget:GameFrame(1)
+
+		assert.equals(0, #finishedUnits)
+		assert.same({ UNIT_ID, CMD_REMOVE, { generatedAttack.tag }, 0 }, orders[1])
+	end)
+end)

--- a/spec/luarules/gadgets/unit_areaattack_spec.lua
+++ b/spec/luarules/gadgets/unit_areaattack_spec.lua
@@ -200,6 +200,25 @@ describe("unit_areaattack", function()
 		assert.equals(0, #orders)
 	end)
 
+	for _, nextCommandID in ipairs({ CMD_ATTACK, 10 }) do
+		it("ignores an internal ground attack followed by command " .. nextCommandID, function()
+			local commands = generatedAreaCommands()
+			table.insert(commands, 2, {
+				id = nextCommandID,
+				tag = 45,
+				params = { 100, 0, 200 },
+				options = { coded = 0 },
+			})
+			local gadget, orders, finishedUnits = loadGadget(commands, { salvoLeft = 0, nextSalvo = 1 })
+
+			gadget:ProjectileCreated(1, UNIT_ID, WEAPON_DEF_ID)
+			gadget:GameFramePost(1)
+
+			assert.equals(0, #finishedUnits)
+			assert.equals(0, #orders)
+		end)
+	end
+
 	it("marks generated area shots internal so repeat does not retain them", function()
 		local commands = {}
 		local gadget, orders = loadGadget(commands, {})


### PR DESCRIPTION
## Why

Ground Area Attack is currently stuck on its first randomly selected position. The Lua implementation inserts an ordinary ground `CMD_ATTACK` ahead of the persistent area command, but ordinary artillery ground attacks do not finish on their own. The area command therefore never gets another turn to choose a new position.

This PR fixes only the generated Area Attack command lifecycle. It does not change the behavior of player-issued or queued ground-attack commands.

Closes #8772.

Queued ground-attack behavior remains a separate design question in #8774, with the current prototype preserved in draft PR #8978.

## What

- Mark the point attacks generated by Area Attack as internal commands.
- Watch the designated Area Attack weapon and count all projectiles in one complete salvo.
- Finish only the generated point attack after that salvo so the persistent area command can choose another random position.
- Defer completion until the next game frame to avoid invalidating active engine weapon-command state.
- If another command moves ahead during that deferred frame, remove the generated attack by its exact command tag.
- Leave player-issued ground attacks, unit definitions, Repeat configuration, and ordinary command queues unchanged.

## Testing

- `stylua --check` on the gadget and focused spec.
- `luac5.1 -p` on the gadget and focused spec.
- Focused lifecycle spec: 4 successes, 0 failures, 0 errors.
- Full Lua unit suite: 76 successes, 0 failures, 0 errors.

The focused coverage verifies:

- advancement only after a complete multi-projectile salvo;
- unrelated weapon projectiles are ignored;
- generated point attacks are marked internal;
- deferred cleanup removes only the generated command by tag if another command moves ahead.

## Videos

### Before

https://github.com/user-attachments/assets/4a19f803-831e-4e8b-a6c6-ccfc0bc2ee50

### After

https://github.com/user-attachments/assets/d90fdcac-b56c-4421-a05f-175c32ca43f1

## AI / LLM usage statement

OpenAI Codex was used to assist with implementation, test development, review, and splitting the original gameplay behavior change into a separate draft PR. I reviewed the resulting code and verified it with the checks listed above.
