### PR TITLE
Set target/fix paused targeting regression

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -486,7 +486,7 @@ if gadgetHandler:IsSyncedCode() then
 			if targetList[i].ignoreStop then
 				moveToIndex = moveToIndex + 1
 				if moveToIndex ~= i then
-					targetList[moveToIndex] = i
+					targetList[moveToIndex] = targetList[i]
 				end
 			else
 				currentTargets[targetList[i].target] = nil

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -354,15 +354,15 @@ if gadgetHandler:IsSyncedCode() then
 		if activeTargets[unitID] and not inAttackCommand(unitID) then
 			spSetUnitTarget(unitID, nil)
 		end
+		activeTargets[unitID] = nil
+		removeFromQueue(unitID)
 		if keeptrack then
 			setTargetPassive(unitID, setTargetData[unitID])
 		else
+			setTargetData[unitID] = nil
+			pausedTargets[unitID] = nil
 			SendToUnsynced("targetList", unitID, 0) -- clear command gfx
 		end
-		removeFromQueue(unitID)
-		setTargetData[unitID] = nil
-		activeTargets[unitID] = nil
-		pausedTargets[unitID] = nil
 		spSetUnitRulesParam(unitID, "unitTargetID", nil)
 	end
 

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -479,12 +479,16 @@ if gadgetHandler:IsSyncedCode() then
 		end
 		-- Otherwise there really are targets to keep:
 		local currentTargets = unitData.currentTargets
-		local currentIndex = unitData.currentIndex
+		local oldIndex = unitData.currentIndex
+		local currentIndex = oldIndex
 		local minIndex
 		local moveToIndex = 0
 		for i = 1, n do
 			if targetList[i].ignoreStop then
 				moveToIndex = moveToIndex + 1
+				if oldIndex == i then
+					currentIndex = moveToIndex
+				end
 				if moveToIndex ~= i then
 					targetList[moveToIndex] = targetList[i]
 				end
@@ -493,10 +497,8 @@ if gadgetHandler:IsSyncedCode() then
 				if not minIndex then
 					minIndex = i
 				end
-				if i == currentIndex then
+				if oldIndex == i then
 					currentIndex = 0 -- invalid, see below
-				elseif currentIndex > i then
-					currentIndex = currentIndex - 1
 				end
 			end
 		end
@@ -506,7 +508,7 @@ if gadgetHandler:IsSyncedCode() then
 		for i = moveToIndex + 1, n do
 			targetList[i] = nil
 		end
-		if currentIndex ~= unitData.currentIndex then
+		if currentIndex ~= oldIndex then
 			unitData.currentIndex = currentIndex == 0 and 1 or currentIndex
 			unitData.activeTarget = false
 		end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -508,9 +508,12 @@ if gadgetHandler:IsSyncedCode() then
 		for i = moveToIndex + 1, n do
 			targetList[i] = nil
 		end
-		if currentIndex ~= oldIndex then
-			unitData.currentIndex = currentIndex == 0 and 1 or currentIndex
+		if currentIndex == 0 then
+			unitData.currentIndex = 1
 			unitData.activeTarget = false
+		else
+			unitData.currentIndex = currentIndex
+			-- The active target remains the same.
 		end
 		refreshSendData(unitID, unitData, minIndex)
 	end


### PR DESCRIPTION
### Work done

Last change did one too many steps. I only needed it to remove paused lists from the queue, but I dropped their data. This fixes.

I'd been testing the bug with mixed target lists issued with & without Ctrl, which keeps targets when Stop is issued, and was able to find that bug also and retain the active target across removals. This should make sense because Set Target prioritizes by list order, and we don't change list order, here.