### PR TITLE
Fix area attack limiter order permissions

### DIFF
--- a/luarules/gadgets/unit_areaattack_limiter.lua
+++ b/luarules/gadgets/unit_areaattack_limiter.lua
@@ -112,7 +112,7 @@ function gadget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	-- pipeline. GiveOrderArrayToUnitArray doesn't reliably deliver area attack
 	-- commands (4-param CMD_ATTACK) to the engine.
 	isReissuing = true
-	CallAsTeam(Spring.GetMyTeamID(), function()
+	CallAsTeam(Spring.GetLocalTeamID(), function()
 		Spring.SelectUnitArray(attackUnits)
 		if cmdOpts.shift then
 			Spring.GiveOrder(cmdID, cmdParams, opts + CMD.OPT_SHIFT)

--- a/luarules/gadgets/unit_areaattack_limiter.lua
+++ b/luarules/gadgets/unit_areaattack_limiter.lua
@@ -112,24 +112,25 @@ function gadget:CommandNotify(cmdID, cmdParams, cmdOpts)
 	-- pipeline. GiveOrderArrayToUnitArray doesn't reliably deliver area attack
 	-- commands (4-param CMD_ATTACK) to the engine.
 	isReissuing = true
+	CallAsTeam(Spring.GetMyTeamID(), function()
+		Spring.SelectUnitArray(attackUnits)
+		if cmdOpts.shift then
+			Spring.GiveOrder(cmdID, cmdParams, opts + CMD.OPT_SHIFT)
+		else
+			Spring.GiveOrder(CMD_STOP, {}, 0)
+			Spring.GiveOrder(cmdID, cmdParams, opts + CMD.OPT_SHIFT)
+		end
 
-	Spring.SelectUnitArray(attackUnits)
-	if cmdOpts.shift then
-		Spring.GiveOrder(cmdID, cmdParams, opts + CMD.OPT_SHIFT)
-	else
-		Spring.GiveOrder(CMD_STOP, {}, 0)
-		Spring.GiveOrder(cmdID, cmdParams, opts + CMD.OPT_SHIFT)
-	end
+		Spring.SelectUnitArray(fightUnits)
+		if cmdOpts.shift then
+			Spring.GiveOrder(CMD_FIGHT, { x, y, z }, opts + CMD.OPT_SHIFT)
+		else
+			Spring.GiveOrder(CMD_STOP, {}, 0)
+			Spring.GiveOrder(CMD_FIGHT, { x, y, z }, opts + CMD.OPT_SHIFT)
+		end
 
-	Spring.SelectUnitArray(fightUnits)
-	if cmdOpts.shift then
-		Spring.GiveOrder(CMD_FIGHT, { x, y, z }, opts + CMD.OPT_SHIFT)
-	else
-		Spring.GiveOrder(CMD_STOP, {}, 0)
-		Spring.GiveOrder(CMD_FIGHT, { x, y, z }, opts + CMD.OPT_SHIFT)
-	end
-
-	Spring.SelectUnitArray(selUnits)
+		Spring.SelectUnitArray(selUnits)
+	end)
 	isReissuing = false
 
 	return true


### PR DESCRIPTION
### Work done

- Run the area-attack limiter's complete select, reissue, and selection-restore transaction through one `CallAsTeam` using the local player's team.
- This gives unsynced LuaRules a non-negative control team while calling `Spring.GiveOrder`, preventing the split orders from being rejected and the original area attack from disappearing.
- Preserve the existing command split, Shift behavior, bomber exemption, and selection restoration.

#### Addresses Issue(s)

- Fixes #8641

#### Test steps

- [x] `luac -p luarules/gadgets/unit_areaattack_limiter.lua`
- [x] `stylua --check luarules/gadgets/unit_areaattack_limiter.lua`
- [x] Focused `luacheck`: 0 warnings / 0 errors.
- [x] Lua harness with 31 non-bomber units: verified one `CallAsTeam`, the 30/1 attack/fight split, order options, selection restoration, and both Shift and non-Shift paths.
- [x] Synthetic Git merge with #8771: no conflicts; the combined Lua file passes `luac` and contains both changes.

Manual reproduction without `/godmode`: select more than 30 non-bomber units and issue an area attack. The first 30 should receive the requested attack while the remaining units receive `CMD_FIGHT`; the command should no longer disappear.

### Videos

Both recordings use 60 non-bomber units with `/godmode` disabled.

#### Before — production (`test-30975-e8ec233`)

https://github.com/user-attachments/assets/b01b2ba9-4496-412a-b282-47e5ad681b99

#### After — PR #8776 (`f9b6c635a7`)

https://github.com/user-attachments/assets/1ea58ac4-0a0e-4bad-b27f-00bd7f19dd78

### AI / LLM usage statement

OpenAI Codex was used to trace the LuaRules control-team check, implement the focused wrapper, build the validation harness, verify compatibility with #8771, and draft this PR description. The final diff was reviewed and the checks above were run locally.
