### PR TITLE
Set target/fix captured targets in list

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -853,6 +853,7 @@ if gadgetHandler:IsSyncedCode() then
 			return
 		end
 		local targets, teamID, weapons = unitData.targets, unitData.teamID, unitData.weapons
+		local currentTargets = unitData.currentTargets
 		local targetCount = #targets
 		local activeIndex = 0
 		local updateIndex = 0 -- table.remove is slow, as is iterating forward then backward, so we do an erase-remove
@@ -874,7 +875,8 @@ if gadgetHandler:IsSyncedCode() then
 					targets[updateIndex] = targetData
 				end
 			else
-				SendToUnsynced("targetDrop", unitID, index)
+				currentTargets[targetData.target] = nil
+				SendToUnsynced("targetDrop", unitID, updateIndex + 1)
 			end
 		end
 		if updateIndex == 0 then


### PR DESCRIPTION
### Work done

Fixes Set Target not clearing captured units, and sending the wrong target index position to unsynced, making a mess of things. Really the graphical bug is the worse of the two, since being off by any index in any edge case makes synced/unsynced disagree from then on, so long shift+add queues get strange in tests.