### PR TITLE
Set target/target draw list appends an empty target

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -1076,7 +1076,7 @@ else -- UNSYNCED
 	function handleTargetListEvent(_, unitID, index, userTarget, targetA, targetB, targetC)
 		--tracy.ZoneBeginN(string.format("handleTargetListEvent %d %d ", unitID, index))
 		local unitData = getUnitTargetList(unitID, not targetA and index)
-		if unitData then
+		if unitData and targetA then
 			unitData.targets[index] = {
 				userTarget = userTarget,
 				target = (not targetB and targetA) or { targetA, targetB, targetC },


### PR DESCRIPTION
Maybe the end of graphics mismatch between synced and unsynced, then?

Thanks to Harkenn for finding this. I just didn't have time to look into it for over a week.

### Work done

Skip the append to the target draw lists when they are sent with intentionally empty targets; an empty target means to trunc the list.