### PR TITLE
Fix the finished Metal Fortifier not listing its metal storage

### DIFF
--- a/units/Legion/Economy/legmohoconct.lua
+++ b/units/Legion/Economy/legmohoconct.lua
@@ -28,6 +28,7 @@ return { --costs should be same as legmohocon and legmohoconin
 		health = 3900,
 		maxslope = 10,
 		maxwaterdepth = 0,
+		metalstorage = 600,
 		movementclass = "NANO",
 		objectname = "Units/LEGMOHOCON.s3o",
 		onoffable = true,

--- a/units/Legion/Economy/legmohoconin.lua
+++ b/units/Legion/Economy/legmohoconin.lua
@@ -21,7 +21,6 @@ return { --costs should be same as legmohocon and legmohoconct
 		health = 3900,
 		maxslope = 30,
 		maxwaterdepth = 20,
-		metalstorage = 600,
 		objectname = "Units/legmohocon.s3o",
 		onoffable = true,
 		script = "Units/legmohoconin.cob",


### PR DESCRIPTION
### Work done
The finished Fortifier is two attached units (mex + nano) and its 600 metal storage sat on the mex, while the info panel reads the selected unit def (nano) so the storage was never listed. 
This fix moves `metalstorage` to the selectable con turret. 

Fixes #8672

#### Test steps
- [x] Select a finished Metal Fortifier. The info panel lists its 600 metal storage
- [x] Storage cap rises by 600 when it completes and drops when it dies.

### Screenshots:

#### BEFORE:
<img width="369" height="134" alt="currently doesnt show" src="https://github.com/user-attachments/assets/79a77118-de1f-4bc6-bf52-3e6267a54163" />

#### AFTER:
<img width="372" height="174" alt="now displays" src="https://github.com/user-attachments/assets/f3563b56-297a-4221-bdc6-2289d79e4301" />


#### Total storage behavior unchanged and working as expected:

1800 Metal storage before built
<img width="643" height="429" alt="before built" src="https://github.com/user-attachments/assets/bee73599-6ceb-4951-a710-a4694bc482ee" />
2400 Metal storage after built
<img width="641" height="554" alt="after built" src="https://github.com/user-attachments/assets/1d2e24a6-8f44-40d1-871b-c0b3e6616d9d" />

### AI Disclosure Statement:
Used Claude to check the change for any side effects. 