### PR TITLE
Guard startbox modoption decoding against invalid values

### DIFF
--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -47,12 +47,13 @@ local function decodeModoption(raw)
 	end
 
 	local okDecode, decoded = pcall(base64.Decode, raw)
-	if not okDecode or not decoded then
+	if not okDecode or not decoded or decoded == "" then
 		return nil
 	end
 
-	local decompressed = VFS.ZlibDecompress(decoded)
-	if not decompressed then
+	-- VFS.ZlibDecompress raises on non-zlib or empty input rather than returning nil.
+	local okZlib, decompressed = pcall(VFS.ZlibDecompress, decoded)
+	if not okZlib or not decompressed then
 		return nil
 	end
 


### PR DESCRIPTION
Setting mapmetadata_startbox_override to any value that isn't valid zlib silently removes start box enforcement for the whole game - every player gets the entire map as their start area.

Empty decoded output is treated as unset too, since the engine raises on that as well rather than returning an empty string.

AI disclosure: written with assistance from Claude Code.
