### PR TITLE
Apply startbox overrides that define more boxes than teams

### DIFF
--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -81,8 +81,11 @@ local function getActiveAllyTeamCount()
 	return count
 end
 
+-- Spare boxes are harmless: transformArrangement maps box i to allyteam i-1, so any
+-- past numTeams describe allyteams that do not exist. Too few would leave a team
+-- without a box, so that case still defers to the set.
 local function matchOverride(override, numTeams)
-	if override and override.startboxes and #override.startboxes == numTeams then
+	if override and override.startboxes and #override.startboxes >= numTeams then
 		return override
 	end
 

--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -81,9 +81,7 @@ local function getActiveAllyTeamCount()
 	return count
 end
 
--- Spare boxes are harmless: transformArrangement maps box i to allyteam i-1, so any
--- past numTeams describe allyteams that do not exist. Too few would leave a team
--- without a box, so that case still defers to the set.
+-- Will match any spare boxes, but will not leave any teams without a box.
 local function matchOverride(override, numTeams)
 	if override and override.startboxes and #override.startboxes >= numTeams then
 		return override


### PR DESCRIPTION
A custom startbox override is currently thrown out unless it defines exactly as many boxes as there are teams, so a player who adds a box in a 2 team lobby loses every box edit they made, not just the extra one - the game falls back to the map's default set and silently ignores the positions they placed.

The set path already behaves the way you would expect here: matchSetLarger deliberately picks the nearest arrangement with more boxes than teams. This just brings the override path in line with it. Boxes are positional (box i is allyteam i-1), so anything past the team count describes allyteams that don't exist, which transformArrangement already handles - that is the same situation matchSetLarger produces today.

Fewer boxes than teams still defers to the set, since to do otherwise would leave a team with no box at all and the whole map to spawn in.

AI disclosure: written with assistance from Claude Code.
