### PR TITLE
add Game and Game.envDamageTypes (from engine) to specs

### DIFF
--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -38,6 +38,33 @@ _G.Spring.Echo = _G.Spring.Echo or function(...)
 	print(...)
 end
 
+_G.Game = _G.Game or {}
+
+_G.Game.envDamageTypes = _G.Game.envDamageTypes or {
+    Debris            =  -1,
+    GroundCollision   =  -2,
+    ObjectCollision   =  -3,
+    Fire              =  -4,
+    Water             =  -5,
+    Killed            =  -6,
+    Crushed           =  -7,
+    AircraftCrashed   =  -8,
+    SetNegativeHealth =  -9,
+    SelfD             = -10,
+    KilledByCheat     = -11,
+    Reclaimed         = -12,
+    OutOfBounds       = -13,
+    TransportKilled   = -14,
+    FactoryKilled     = -15,
+    FactoryCancel     = -16,
+    UnitScript        = -17,
+    Kamikaze          = -18,
+    ConstructionDecay = -19,
+    TurnedIntoFeature = -20,
+    KilledByLua       = -21,
+	-- More are added via code for our lua-scripted damages.
+}
+
 _G.GG = _G.GG or {}
 
 _G.unpack = _G.unpack


### PR DESCRIPTION
### Work done

Add `envDamageTypes` to the spec_helper. This is a shared ref table for special weaponDefIDs (<0) that are used to indicate environmental, scripted, and custom (game-defined) damage types.