### PR TITLE
Allow give to take a unit's proper name

### DIFF
--- a/luarules/gadgets/cmd_give.lua
+++ b/luarules/gadgets/cmd_give.lua
@@ -13,6 +13,7 @@ function gadget:GetInfo()
 end
 
 -- usage: /luarules give 1 armcom 0
+--        /luarules give 1 Armada Commander 0
 
 local cmdname = "give"
 local PACKET_HEADER = "$g$"
@@ -140,6 +141,67 @@ else -- UNSYNCED
 		return perms and (perms[acID] or (myPlayerName and perms[myPlayerName]))
 	end
 
+	local isResourceName = { metal = true, energy = true }
+
+	-- unitdefs carry no humanName, so proper names live only in the i18n data.
+	-- They are per-language, which is why this resolves here and sends the unitdef
+	-- name onwards, instead of letting synced code do it and disagree per client.
+	local unitDefNameByProperName = {}
+	do
+		local unitNames = Json.decode(VFS.LoadFile("language/en/units.json")).units.names
+		for unitDefName, properName in pairs(unitNames) do
+			if UnitDefNames[unitDefName] then
+				local key = string.lower(properName)
+				local claimed = unitDefNameByProperName[key]
+				if claimed == nil then
+					unitDefNameByProperName[key] = unitDefName
+				elseif type(claimed) == "string" then
+					unitDefNameByProperName[key] = { claimed, unitDefName }
+				else
+					claimed[#claimed + 1] = unitDefName
+				end
+			end
+		end
+	end
+
+	-- returns the unitdef name, or nil plus every unitdef sharing that proper name
+	local function resolveUnitName(name)
+		if UnitDefNames[name] then
+			return name
+		end
+		local claimed = unitDefNameByProperName[string.lower(name)]
+		if type(claimed) == "string" then
+			return claimed
+		end
+		return nil, claimed
+	end
+
+	-- A proper name can hold spaces, and "Armada Commander Level 2" even ends in a
+	-- digit, so the name cannot be found by counting trailing numbers. It ends one
+	-- or two words from the end; only one of those splits resolves to a unit.
+	local function parseGive(words)
+		if tonumber(words[1]) == nil then
+			return nil
+		end
+		for last = #words - 1, math.max(#words - 2, 2), -1 do
+			local teamID = tonumber(words[last + 1])
+			local xp = words[last + 2] and tonumber(words[last + 2])
+			if teamID and (words[last + 2] == nil or xp) then
+				local name = table.concat(words, " ", 2, last)
+				if isResourceName[string.lower(name)] then
+					return string.lower(name), teamID, xp
+				end
+				local unitDefName, sharedBy = resolveUnitName(name)
+				if unitDefName then
+					return unitDefName, teamID, xp
+				elseif sharedBy then
+					return nil, nil, nil, name, sharedBy
+				end
+			end
+		end
+		return nil
+	end
+
 	local function RequestGive(cmd, line, words, playerID)
 		if isAuthorized() and playerID == myPlayerID then
 			local mx, my = Spring.GetMouseState()
@@ -149,29 +211,36 @@ else -- UNSYNCED
 			elseif targettype == "feature" then
 				pos = { Spring.GetFeaturePosition(pos) }
 			end
-			if
+			local unitDefName, teamID, xp, sharedName, sharedBy = parseGive(words)
+			if sharedName then
+				Spring.SendMessageToPlayer(
+					playerID,
+					"'" .. sharedName .. "' is the name of " .. #sharedBy .. " units, give one of: " .. table.concat(
+						sharedBy,
+						", "
+					)
+				)
+			elseif
 				type(pos) == "table"
 				and pos[1] ~= nil
 				and pos[3] ~= nil
 				and pos[1] > 0
 				and pos[3] > 0
-				and words[1] ~= nil
-				and words[2] ~= nil
-				and words[3] ~= nil
+				and unitDefName ~= nil
 			then
 				Spring.SendLuaRulesMsg(
 					PACKET_HEADER
 						.. ":"
 						.. words[1]
 						.. ":"
-						.. words[2]
+						.. unitDefName
 						.. ":"
-						.. words[3]
+						.. teamID
 						.. ":"
 						.. pos[1]
 						.. ":"
 						.. pos[3]
-						.. (words[4] ~= nil and ":" .. words[4] or "")
+						.. (xp ~= nil and ":" .. xp or "")
 				)
 			else
 				Spring.SendMessageToPlayer(playerID, "failed to give, check syntax or cursor position")

--- a/luarules/gadgets/cmd_give.lua
+++ b/luarules/gadgets/cmd_give.lua
@@ -13,7 +13,7 @@ function gadget:GetInfo()
 end
 
 -- usage: /luarules give 1 armcom 0
---        /luarules give 1 Armada Commander 0
+--        /luarules give 1 armada-commander 0
 
 local cmdname = "give"
 local PACKET_HEADER = "$g$"
@@ -141,17 +141,17 @@ else -- UNSYNCED
 		return perms and (perms[acID] or (myPlayerName and perms[myPlayerName]))
 	end
 
-	local isResourceName = { metal = true, energy = true }
-
-	-- unitdefs carry no humanName, so proper names live only in the i18n data.
-	-- They are per-language, which is why this resolves here and sends the unitdef
-	-- name onwards, instead of letting synced code do it and disagree per client.
+	-- BAR unitdefs carry no humanName, so a unit's proper name exists only in the
+	-- language files. Those are per-language, so resolve here and send the unitdef
+	-- name onwards rather than leaving synced code to disagree between clients.
 	local unitDefNameByProperName = {}
 	do
 		local unitNames = Json.decode(VFS.LoadFile("language/en/units.json")).units.names
 		for unitDefName, properName in pairs(unitNames) do
 			if UnitDefNames[unitDefName] then
-				local key = string.lower(properName)
+				-- spaces would break the one-word-per-argument syntax, so the name is
+				-- written with hyphens instead: "Armada Commander" -> armada-commander
+				local key = string.gsub(string.lower(properName), "[%s%-]+", "-")
 				local claimed = unitDefNameByProperName[key]
 				if claimed == nil then
 					unitDefNameByProperName[key] = unitDefName
@@ -166,7 +166,7 @@ else -- UNSYNCED
 
 	-- returns the unitdef name, or nil plus every unitdef sharing that proper name
 	local function resolveUnitName(name)
-		if UnitDefNames[name] then
+		if UnitDefNames[name] or name == "metal" or name == "energy" then
 			return name
 		end
 		local claimed = unitDefNameByProperName[string.lower(name)]
@@ -174,32 +174,6 @@ else -- UNSYNCED
 			return claimed
 		end
 		return nil, claimed
-	end
-
-	-- A proper name can hold spaces, and "Armada Commander Level 2" even ends in a
-	-- digit, so the name cannot be found by counting trailing numbers. It ends one
-	-- or two words from the end; only one of those splits resolves to a unit.
-	local function parseGive(words)
-		if tonumber(words[1]) == nil then
-			return nil
-		end
-		for last = #words - 1, math.max(#words - 2, 2), -1 do
-			local teamID = tonumber(words[last + 1])
-			local xp = words[last + 2] and tonumber(words[last + 2])
-			if teamID and (words[last + 2] == nil or xp) then
-				local name = table.concat(words, " ", 2, last)
-				if isResourceName[string.lower(name)] then
-					return string.lower(name), teamID, xp
-				end
-				local unitDefName, sharedBy = resolveUnitName(name)
-				if unitDefName then
-					return unitDefName, teamID, xp
-				elseif sharedBy then
-					return nil, nil, nil, name, sharedBy
-				end
-			end
-		end
-		return nil
 	end
 
 	local function RequestGive(cmd, line, words, playerID)
@@ -211,11 +185,11 @@ else -- UNSYNCED
 			elseif targettype == "feature" then
 				pos = { Spring.GetFeaturePosition(pos) }
 			end
-			local unitDefName, teamID, xp, sharedName, sharedBy = parseGive(words)
-			if sharedName then
+			local unitDefName, sharedBy = resolveUnitName(words[2] or "")
+			if sharedBy then
 				Spring.SendMessageToPlayer(
 					playerID,
-					"'" .. sharedName .. "' is the name of " .. #sharedBy .. " units, give one of: " .. table.concat(
+					"'" .. words[2] .. "' is the name of " .. #sharedBy .. " units, give one of: " .. table.concat(
 						sharedBy,
 						", "
 					)
@@ -226,7 +200,9 @@ else -- UNSYNCED
 				and pos[3] ~= nil
 				and pos[1] > 0
 				and pos[3] > 0
+				and words[1] ~= nil
 				and unitDefName ~= nil
+				and words[3] ~= nil
 			then
 				Spring.SendLuaRulesMsg(
 					PACKET_HEADER
@@ -235,12 +211,12 @@ else -- UNSYNCED
 						.. ":"
 						.. unitDefName
 						.. ":"
-						.. teamID
+						.. words[3]
 						.. ":"
 						.. pos[1]
 						.. ":"
 						.. pos[3]
-						.. (xp ~= nil and ":" .. xp or "")
+						.. (words[4] ~= nil and ":" .. words[4] or "")
 				)
 			else
 				Spring.SendMessageToPlayer(playerID, "failed to give, check syntax or cursor position")


### PR DESCRIPTION
`/give` only matched unitdefs by their internal name, so you had to know `armcom` rather than "Armada Commander". This accepts either, written with hyphens: `/give 1 armada-commander 0`.

Hyphens rather than spaces so the command keeps one word per argument. Spaces would mean finding the name boundary by counting trailing numbers, and that is ambiguous the moment a name ends in a digit, which "Armada Commander Level 2" does. Runs of space or hyphen collapse to one, so the names that already contain hyphens still work and no two units end up sharing a key that didn't already.

Resolution happens unsynced and sends the internal name onwards, because proper names come out of the language files and clients running different languages would otherwise disagree about what a name means. BAR's unitdefs carry no humanName at all, so `language/en/units.json` is the only place those names exist.

127 proper names belong to more than one unitdef, "Solar Collector" being all three factions, so those report the candidates instead of silently picking one.

Checked the resolution against the real language file and unitdef list: internal names, hyphenated proper names, mixed case, trailing digits, the metal/energy passthrough, three shared-name cases, and that a spaced name is refused.

AI disclosure: written with assistance from Claude Code.
