### PR TITLE
decals: performance optimization

### DIFF
--- a/luaui/Shaders/decals_gl4.frag.glsl
+++ b/luaui/Shaders/decals_gl4.frag.glsl
@@ -108,41 +108,45 @@ void main(void)
 {
 	vec3 campos = cameraViewInv[3].xyz;
 	vec3 camtoworld = normalize(g_position.xyz - campos);
-	
-	vec3 tangentviewpos = (tbnmatrix * campos.xzy).xyz; // Y points to camera
-	vec3 tangentfragpos = (tbnmatrix * g_position.xzy).xyz; // Y points up
-	vec3 tangentviewdir =  normalize(tangentfragpos - tangentviewpos); // Y points up!
-	vec3 tspace = tangentfragpos - tangentviewpos;
-	
-	#if (PARALLAX == 1) 
+
+	#if (PARALLAX == 1)
+		vec3 tangentviewpos = (tbnmatrix * campos.xzy).xyz; // Y points to camera
+		vec3 tangentfragpos = (tbnmatrix * g_position.xzy).xyz; // Y points up
+		vec3 tangentviewdir =  normalize(tangentfragpos - tangentviewpos); // Y points up!
 		vec4 tex3color = texture(atlasHeights, g_uv.xy);
-		//float height = 
-		
+		//float height =
+
 		// do parallax here !
 		vec2 parallaxUV = (tangentviewdir.xz) * (1.0 - tex3color.b )* 0.00002;
 	#else
 		vec2 parallaxUV = vec2(0.0);
-		
+
 	#endif
 
-	
+	// Sample the decal color first, so invisible fragments bail before all the sampling and shading below.
+	// This matters a lot in fields of overlapping alpha-blended decals: most of every decal quad is
+	// transparent padding, and faded decals linger in the VBOs long before batched removal kicks in.
+	vec4 tex1color = texture(atlasColorAlpha, g_uv.xy - parallaxUV.xy);
+
+	// The blended alpha is tex1color.a^2 * fade, so below ~1/255 this fragment cannot change the framebuffer.
+	// The glow contribution is provably black too: Temperature() is black below 300 kelvin, and its argument
+	// hotness * glowChannel is bounded by g_parameters.w * tex1color.a.
+	if (tex1color.a * tex1color.a * g_position.w < 0.0039 && g_parameters.w * tex1color.a < 300.0){
+		discard;
+		return;
+	}
+
 	vec2 uvhm = heightmapUVatWorldPos(g_position.xz);
 	vec4 minimapcolor = textureLod(miniMapTex, uvhm, 0.0);
 	vec3 mapnormal = textureLod(mapNormalsTex, uvhm, 0.0).raa; // seems to be in the [-1, 1] range!, raaa is its true return
 	mapnormal.g = sqrt( 1.0 - dot( mapnormal.rb, mapnormal.rb)); // reconstruct Y	from it
 	float offaxis = 1.0 - clamp(dot(mapnormal,-camtoworld), 0.0, 1.0);
 	float bias = (offaxis*offaxis)*-2.0;
-	
-	vec4 tex1color = texture(atlasColorAlpha, g_uv.xy - parallaxUV.xy, bias);
-	tex1color.rgb = mix (tex1color.rgb, vec3(dot(tex1color.rgb, vec3(0.299, 0.587, 0.114))), g_parameters.x);
-	
-	// bail early if theres shit here, but this might not be useful in the long term, due to no emissive application?
-	
-	if (tex1color.a < 0.005){
-		fragColor.rgba = vec4(0.0); 
-		discard; 
-		return;
+
+	if (bias < -0.01){ // only pay for the sharper-mip resample at grazing view angles
+		tex1color = texture(atlasColorAlpha, g_uv.xy - parallaxUV.xy, bias);
 	}
+	tex1color.rgb = mix (tex1color.rgb, vec3(dot(tex1color.rgb, vec3(0.299, 0.587, 0.114))), g_parameters.x);
 	
 	vec4 tex2color = texture(atlasNormals, g_uv.xy  - parallaxUV.xy, bias);
 	vec3 fragNormal = tex2color.rgb * 2.0 - 1.0;
@@ -174,8 +178,8 @@ void main(void)
 	fragColor.rgb += vec3(diffuselight) * ( fragColor.rgb * sunDiffuseMap.rgb * 2.0);
 	
 	// Specular Color
-	vec3 reflvect = reflect(normalize(1.0 * sunDir.xyz), reorientedNormal);
-	float specular = clamp(pow(clamp(dot(normalize(camtoworld), normalize(reflvect)), 0.0, 1.0), SPECULAREXPONENT), 0.0, 1.0) * SPECULARSTRENGTH;// * shadow;
+	vec3 reflvect = reflect(normalize(sunDir.xyz), reorientedNormal); // stays unit length, reflect() preserves it
+	float specular = clamp(pow(clamp(dot(camtoworld, reflvect), 0.0, 1.0), SPECULAREXPONENT), 0.0, 1.0) * SPECULARSTRENGTH;// * shadow;
 	fragColor.rgb += fragColor.rgb * specular;
 	
 	// Apply darkening based on LOS texture
@@ -205,7 +209,10 @@ void main(void)
 	//fragColor.a = fract(g_position.w*10);
 	
 	// add emissive heat, if required
-	#if (USEGLOW == 1) 
+	#if (USEGLOW == 1)
+	// Temperature() is black below 300 kelvin and hotness * glowChannel <= g_parameters.w * tex1color.a,
+	// so cold decals (the vast majority) skip the log/pow heavy glow math entirely.
+	if (g_parameters.w * tex1color.a >= 300.0){
 		float glowChannel = tex2color.a * tex1color.a; // Could use a power operator here?
 
 		float hotness = max(0,g_parameters.w);
@@ -213,12 +220,13 @@ void main(void)
 		//fragColor.rgb += heatColor * pow(glowChannel.r, 2) * hotness ;
 		//fragColor.rgb = vec3(fract(g_uv.w*20));
 		fragColor.rgb += (heatColor.rgb * max(glowChannel,0.0)*12); //was *10 - icex increase to more brightness
-		
+
 		//experiment with glowadd:
-		// we kinda need to additively blend here... 
+		// we kinda need to additively blend here...
 		float heatalpha = dot (vec3(1.0),heatColor);
-		fragColor.rgba +=  g_parameters.z * heatalpha * vec4(heatColor.rgb ,g_position.w); 
-	#endif 
+		fragColor.rgba +=  g_parameters.z * heatalpha * vec4(heatColor.rgb ,g_position.w);
+	}
+	#endif
 	
 	//fragColor.a = 1.0;
 	// plenty of debug outputs for your viewing pleasure

--- a/luaui/Shaders/decals_large_gl4.vert.glsl
+++ b/luaui/Shaders/decals_large_gl4.vert.glsl
@@ -72,15 +72,23 @@ void offsetVertex4( float x, float y, float z, float u, float v){
 #line 11000
 void main()
 {
+	// Calc the fade alpha first: dead or off-screen decals collapse to a single clipped vertex, so their
+	// triangles never rasterize (mirrors the v_skipdraw culling done in the geometry shader path).
+	float currentFrame = timeInfo.x + timeInfo.w;
+	float lifetonow = currentFrame - worldPos.w;
+	float alphastart = alphastart_alphadecay_heatstart_heatdecay.x;
+	float alphadecay = alphastart_alphadecay_heatstart_heatdecay.y;
+	float currentAlpha = min(1.0, (lifetonow / parameters.w))  * alphastart - lifetonow* alphadecay;
+	currentAlpha = clamp(currentAlpha, 0.0, lengthwidthrotation.w);
+
+	// note: isSphereVisibleXY() is misnamed, it returns true when the sphere is OUTSIDE the view
+	float maxradius = lengthwidthrotation.x + lengthwidthrotation.y;
+	if ((currentAlpha < 0.01) || isSphereVisibleXY(vec4(worldPos.xyz, 1.0), maxradius)) {
+		gl_Position = vec4(-2.0, -2.0, -2.0, 1.0);
+		return;
+	}
+
 	// take the vertex, scale it to size, and rotate it around 0,0
-	
-	#if 0
-		//if (isSphereVisibleXY(vec4(worldPos.xyz,1.0), 1.0* max(lengthwidthrotation.x, lengthwidthrotation.y))) {
-		//	gl_Position= vec4(-100,-100,-100,1);
-		//	return; // yay for useless visiblity culling!
-		//}
-	#endif
-	
 	vec4 vertexPos = vec4(xyworld_xyfract.x, 0.0, xyworld_xyfract.y, 1.0);
 	vertexPos.xz *= lengthwidthrotation.xy * 0.5;
 	
@@ -113,13 +121,7 @@ void main()
 	g_position = vertexPos;
 	g_parameters = parameters;
 	
-	// Calc alphadecay
-	float currentFrame = timeInfo.x + timeInfo.w;
-	float lifetonow = (timeInfo.x + timeInfo.w) - worldPos.w;
-	float alphastart = alphastart_alphadecay_heatstart_heatdecay.x;
-	float alphadecay = alphastart_alphadecay_heatstart_heatdecay.y;
-	float currentAlpha = min(1.0, (lifetonow / parameters.w))  * alphastart - lifetonow* alphadecay;
-	currentAlpha = clamp(currentAlpha, 0.0, lengthwidthrotation.w);
+	// pass the fade alpha computed at the top
 	g_position.w = currentAlpha;
 	
 	// heatdecay is:

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -94,6 +94,12 @@ local autoupdate = false -- auto update shader, for debugging only!
 -- for automatic oversaturation prevention, not sure if it even works, but hey!
 local areaResolution = 256 -- elmos per square, for a 64x map this is uh, big? for 32x32 its 4k
 local saturationThreshold = 16 * areaResolution
+local cellArea = areaResolution * areaResolution
+-- Overdraw budget: the maximum accumulated decal area per map cell, expressed in full layers of coverage
+-- of that cell. When exceeded, the oldest decals in the cell get evicted. New decals draw on top of old
+-- ones anyway, so evicting the oldest (most faded) ones is visually near-free, but it bounds the worst-case
+-- GPU fill cost when zooming into fields of stacked decals.
+local maxDecalLayersPerCell = 16
 
 ------------------------ GL4 BACKEND -----------------------------------
 
@@ -396,16 +402,33 @@ local function initAreas()
 	end
 end
 
+local RemoveDecal -- forward declaration, defined below, needed for eviction in AddDecalToArea
+
 local function AddDecalToArea(instanceID, posx, posz, width, length)
 	local hash = hashPos(posx, posz)
 	local maparea = areaDecals[hash]
 	if maparea == nil then
 		return
 	end
-	local area = width * length
+	-- cap the accounted area at one full cell, so a single giant decal counts as one layer, not dozens
+	local area = mathMin(width * length, cellArea)
 	maparea.instanceIDs[instanceID] = area
 	maparea.totalarea = maparea.totalarea + area
 	decalToArea[instanceID] = hash
+
+	-- evict the oldest decals in this cell while the accumulated area exceeds the overdraw budget
+	while maparea.totalarea > maxDecalLayersPerCell * cellArea do
+		local oldest
+		for id in pairs(maparea.instanceIDs) do
+			if id ~= instanceID and (oldest == nil or id < oldest) then
+				oldest = id
+			end
+		end
+		if oldest == nil then
+			break
+		end
+		RemoveDecal(oldest) -- updates maparea.totalarea via RemoveDecalFromArea
+	end
 end
 
 local function RemoveDecalFromArea(instanceID)
@@ -720,7 +743,7 @@ else
 	end
 end
 
-local function RemoveDecal(instanceID)
+function RemoveDecal(instanceID) -- assigns the forward-declared local above
 	RemoveDecalFromArea(instanceID)
 	footprintDecalSet[instanceID] = nil
 	local removed = false


### PR DESCRIPTION
decals_gl4.frag.glsl — discard invisible fragments before the expensive work. The decal color is now sampled first, and the fragment bails immediately when its final blended alpha (texture alpha² × time-fade) would be below 1/255 — previously it only checked raw texture alpha > 0.005, after already sampling minimap and map normals. This kills the transparent padding that makes up most of every scar quad, plus everything from old faded decals, before the other five texture samples, lighting, shadow, and blend. It's mathematically safe: I gate it so glow can't be lost (the blackbody Temperature() function is pitch black below 300 K, and its input is bounded by heat × texture alpha). The glow math itself (log + pows per pixel) is now also skipped for cold decals — i.e. almost all of them — and the grazing-angle mip resample only happens when the bias is actually nonzero.

decals_large_gl4.vert.glsl — stop rasterizing dead and off-screen large decals. The geometry-shader path (small decals) already skipped fully-faded and off-screen decals, but the large-decal path (and the no-geometry-shader fallback) rasterized them at ~0 alpha with the full fragment shader running. They now collapse to a clipped vertex. (Fun find: the engine's isSphereVisibleXY() is misnamed — it returns true when the sphere is outside the view; existing usage confirms this.)

gfx_decals_gl4.lua — actually bound the overdraw. The widget already had a "saturation" system meant to prevent decal spam, but its threshold works out to ~256 stacked layers per 256-elmo cell, so it never fired. I added a real budget: past 16 full layers of accumulated decal area in a cell, the oldest decals there get evicted (maxDecalLayersPerCell in the config section). Since new decals draw on top anyway, removing the oldest, most-faded one under a pile is visually near-free — and unlike the old system, fresh explosions always still leave their mark. Giant decals count as at most one layer per cell so a single Juno scar can't blow the budget.