### PR TITLE
Fix Stockpile count refresh in order menu

### DIFF
--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -527,6 +527,9 @@ local function refreshCommands()
 					commandsVisuallyChanged = true
 					break
 				end
+			elseif cmd.action == "stockpile" and cmd.cachedText ~= prevCmdStates[i] then
+				commandsVisuallyChanged = true
+				break
 			end
 		end
 	end
@@ -541,6 +544,9 @@ local function refreshCommands()
 					or (tonumber(commands[i].params[1]) + 1)
 			elseif commands[i].id == CMD.WAIT then
 				prevCmdStates[i] = cachedWaitState
+				prevCmdModes[i] = nil
+			elseif commands[i].action == "stockpile" then
+				prevCmdStates[i] = commands[i].cachedText
 				prevCmdModes[i] = nil
 			else
 				prevCmdStates[i] = nil


### PR DESCRIPTION
### Work done

Include Stockpile's dynamic display text in the order menu's visual-command
fingerprint.

The engine already marks the selected unit's command descriptions as changed
when its stockpile queue changes, and the order menu already recomputes the
translated Stockpile label. Retaining and comparing that label ensures the
render-to-texture cache is rebuilt when the displayed current/target count
changes.

#### Addresses Issue(s)

- Fixes https://github.com/beyond-all-reason/Beyond-All-Reason/issues/8803

#### Test steps

- [x] Select a Catalyst with an empty stockpile queue.
- [x] Click Stockpile repeatedly without changing the selection.
- [x] Verify the displayed target count updates immediately after each click.
- [x] Run `luac5.1 -p luaui/Widgets/gui_ordermenu.lua`.
- [x] Run `git diff --check`.

## Before

https://github.com/user-attachments/assets/dd5c97eb-eba0-4b3c-bbe1-0b374840b0aa

## After

https://github.com/user-attachments/assets/5c058fa0-6ec8-4b93-ad89-175a4f3a23a9





### AI / LLM usage statement

OpenAI Codex was used to investigate the issue and generate the production code
change. I reviewed the resulting code and diff, ran the Lua 5.1 syntax check,
and manually verified the behavior in game.
