### PR TITLE
Stop the Stiletto's bomb claiming to be command fired

### DIFF
--- a/units/ArmAircraft/T2/armstil.lua
+++ b/units/ArmAircraft/T2/armstil.lua
@@ -73,7 +73,6 @@ return {
 				burst = 3,
 				burstrate = 0.2333,
 				collidefriendly = false,
-				commandfire = true,
 				craterboost = 0,
 				cratermult = 0,
 				edgeeffectiveness = 0.25,


### PR DESCRIPTION
The Stiletto's bomb is written with commandfire = true, but the unit never sets canmanualfire, so there is no command to fire it with - the engine reports the weapon as manualFire true and the unit as canManualFire false. Every other bomber in the game leaves commandfire off. Raised by efrec on #8653.

Worth a careful look rather than a rubber stamp, because it is not a pure data cleanup. commandfire sets two things in the engine, and a def export before and after this change shows both flipping:

    manualFire    true -> false
    noAutoTarget  true -> false

So today the bomb is marked as never acquiring a target on its own and only firing on a command the unit cannot receive. After this it behaves like every other aircraft bomb. If the Stiletto currently bombs normally in game, something other than the weapon flags is driving it and this is close to a no-op; if it has been quietly unable to bomb, this is a fix rather than a cleanup. I have not been able to settle which from the def data alone, and would rather someone who flies it says so.

Nothing else in the export moves - one weapondef, two fields.

The matching check is in #8653: a weapon that only fires on command has to sit on a unit that can command it, with stockpiled weapons exempt since the silos and junos go through the launch flow instead.
