### PR TITLE
Write the CEG test unit's health under the current tag

### DIFF
--- a/units/other/ceg_test_projectile.lua
+++ b/units/other/ceg_test_projectile.lua
@@ -40,7 +40,7 @@ return {
 		metalcost = 100,
 		energycost = 100,
 		buildtime = 1,
-		maxdamage = 1000000,
+		health = 100000,
 
 		--------------------------------------------------------------------------
 		-- Engine-valid but inert


### PR DESCRIPTION
The CEG browser's projectile carrier writes its health as maxdamage, the older spelling. The engine still reads it - the def export shows the unit at health 1000000 - but nothing else does, so the unit reads as having no health to any of our own Lua, and it was the one def that had to be carved out of the health check in #8653.

Same value under the current name, dropped a digit while I was there since a hundred thousand is already far more than a unit that is spawned and removed by a gadget without ever being shot at will use.

Raised by efrec on #8653, who would rather the unit were fixed than exempted.
