### PR TITLE
ci: report the type check only on modified files

### DIFF
--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -58,14 +58,27 @@ jobs:
           # Take the workspace root and analyze the entire tree in the report.
           # The report then has to be filtered to follow a CI rule on changes.
           set +e
-          emmylua_check -c .emmyrc.json -f json --output diagnostics.json .
+          emmylua_check -c .emmyrc.json -f json --output diagnostics.json . 2> emmylua.log
           emmylua_status=$?
           set -e
+          cat emmylua.log >&2
+
+          # Error and exit on missing config. This action is obsolete or broken.
+          if grep -Eq 'Failed to (read|parse) (lua )?config file' emmylua.log; then
+            echo "::error title=Type check ran without its config::emmylua_check could not load .emmyrc.json (missing or unparseable) and analyzed the tree unconfigured, so every finding is garbage. This is a CI defect, not a problem with this PR. Restore .emmyrc.json or fix type_check.yml."
+            exit 1
+          fi
 
           # Error for nonreporting, not for nonzero exit codes, as the failure case.
           # Emmylua exits nonzero for any type errors it finds, which is never none.
           if [ ! -s diagnostics.json ] || ! jq -e . diagnostics.json > /dev/null; then
             echo "emmylua_check produced no readable report (exit $emmylua_status)"
+            exit 1
+          fi
+
+          # The report filter works only on absolute paths under $PWD.
+          if ! jq -e --arg cwd "$PWD/" 'length == 0 or any(.[]; .file | startswith($cwd))' diagnostics.json > /dev/null; then
+            echo "::error title=Type check filter is broken::No path in diagnostics.json starts with $PWD, so the changed-file filter can never match and the check would pass while checking nothing. The emmylua report shape changed; update type_check.yml."
             exit 1
           fi
 

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -1,11 +1,11 @@
 name: Type Check
 
 on:
-  push:
-    branches: [master]
   pull_request:
-    branches: ['*']
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   emmylua_check:
@@ -36,5 +36,76 @@ jobs:
           sudo chmod +x /usr/local/bin/emmylua_check
           /usr/local/bin/emmylua_check --version
 
-      - name: Run emmylua_check
+      - name: Run emmylua_check on changed files
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Fetch the base revision to diff against it.
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+
+          # Lua paths may contain spaces, so the list uses NUL separators.
+          git diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.lua' > changed.txt
+          if [ ! -s changed.txt ]; then
+            echo "No Lua files changed."
+            exit 0
+          fi
+          echo "Reporting on:"
+          tr '\0' '\n' < changed.txt
+          jq -R -s 'split("\u0000") | map(select(. != ""))' changed.txt > changed.json
+
+          # Take the workspace root and analyze the entire tree in the report.
+          # The report then has to be filtered to follow a CI rule on changes.
+          set +e
+          emmylua_check -c .emmyrc.json -f json --output diagnostics.json .
+          emmylua_status=$?
+          set -e
+
+          # Error for nonreporting, not for nonzero exit codes, as the failure case.
+          # Emmylua exits nonzero for any type errors it finds, which is never none.
+          if [ ! -s diagnostics.json ] || ! jq -e . diagnostics.json > /dev/null; then
+            echo "emmylua_check produced no readable report (exit $emmylua_status)"
+            exit 1
+          fi
+
+          # Numeric severities (error 1, warning 2) and relative file paths.
+          jq --slurpfile changed changed.json --arg cwd "$PWD/" '
+            ($changed[0] | map({(.): true}) | add // {}) as $want
+            | [ .[]
+                | (.file | ltrimstr($cwd) | ltrimstr("./")) as $path
+                | select($want[$path])
+                | .diagnostics[]
+                | { path: $path,
+                    line: (.range.start.line + 1),
+                    col: (.range.start.character + 1),
+                    severity: (.severity // 1),
+                    code: ((.code // "unknown") | tostring),
+                    message: .message } ]
+          ' diagnostics.json > filtered.json
+
+          # Workflow commands are rendered as pull request annotations.
+          # We use these to display up to 10 rendered bubbles per type,
+          # then display the rest in the log (which keeps every line).
+          jq -r '
+            def esc: gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
+            def prop: esc | gsub(","; "%2C") | gsub(":"; "%3A");
+            .[]
+            | (if .severity == 1 then "error"
+               elif .severity == 2 then "warning"
+               else "notice" end) as $kind
+            | "::\($kind) file=\(.path | prop),line=\(.line),col=\(.col),title=\(.code | prop)::\(.message | esc)"
+          ' filtered.json
+
+          # Warnings notify, errors fail.
+          # Only the touched files are in scope.
+          errors=$(jq '[ .[] | select(.severity == 1) ] | length' filtered.json)
+          echo "$(jq length filtered.json) finding(s) in changed files, $errors error(s)."
+          if [ "$errors" -ne 0 ]; then
+            exit 1
+          fi
+
+      # The workflow runner does not have a scoped check. It runs on all files.
+      # This is going to be a massive, noisy report. Only use it for analytics.
+      - name: Run emmylua_check on the whole tree
+        if: github.event_name == 'workflow_dispatch'
         run: emmylua_check -c .emmyrc.json .

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -2,6 +2,7 @@ name: Type Check
 
 on:
   pull_request:
+    paths: ['**.lua']
   workflow_dispatch:
 
 permissions:

--- a/spec/ci/type_check_probe.lua
+++ b/spec/ci/type_check_probe.lua
@@ -1,7 +1,0 @@
--- Deliberate findings for the type check's red run. Removed before merge.
-
----@type string
-local probe = 12345
-
-ProbablyAnUndefinedGlobal(probe)
-IShouldSaySoGoodChap[probe]

--- a/spec/ci/type_check_probe.lua
+++ b/spec/ci/type_check_probe.lua
@@ -1,0 +1,7 @@
+-- Deliberate findings for the type check's red run. Removed before merge.
+
+---@type string
+local probe = 12345
+
+ProbablyAnUndefinedGlobal(probe)
+IShouldSaySoGoodChap[probe]


### PR DESCRIPTION
Changes the emmylua check to run on changed files, only.

Targets branches other than master. You will just be mad if you have to fix this later.