### PR TITLE
Drop damage entries for armour classes that do not exist

### DIFF
--- a/units/CorShips/T2/coronager.lua
+++ b/units/CorShips/T2/coronager.lua
@@ -150,7 +150,6 @@ return {
 				weaponvelocity = 700,
 				damage = {
 					default = 360,
-					ship = 200,
 					subs = 150,
 				},
 			},

--- a/units/Legion/T3/legeheatraymech.lua
+++ b/units/Legion/T3/legeheatraymech.lua
@@ -216,9 +216,7 @@ return {
 					exclude_preaim = true,
 				},
 				damage = {
-					bombers = 52,
 					default = 420,
-					fighters = 52,
 					subs = 160,
 					vtol = 52,
 				},

--- a/units/Legion/T3/legeheatraymech_old.lua
+++ b/units/Legion/T3/legeheatraymech_old.lua
@@ -213,9 +213,7 @@ return {
 				weapontype = "Cannon",
 				weaponvelocity = 750,
 				damage = {
-					bombers = 52,
 					default = 420,
-					fighters = 52,
 					subs = 160,
 					vtol = 52,
 				},

--- a/units/Legion/T3/legkeres.lua
+++ b/units/Legion/T3/legkeres.lua
@@ -131,9 +131,7 @@ return {
 				weapontype = "Cannon",
 				weaponvelocity = 650,
 				damage = {
-					bombers = 50,
 					default = 400,
-					fighters = 50,
 					subs = 150,
 					vtol = 50,
 				},

--- a/units/Scavengers/Air/corcrwt4.lua
+++ b/units/Scavengers/Air/corcrwt4.lua
@@ -153,8 +153,6 @@ return {
 				weapontype = "MissileLauncher",
 				weaponvelocity = 1250,
 				damage = {
-					bombers = 400,
-					fighters = 400,
 					vtol = 400,
 				},
 			},

--- a/units/other/meteor.lua
+++ b/units/other/meteor.lua
@@ -75,7 +75,6 @@ return {
 					raptor = 0.001,
 					commanders = 10,
 					default = 700,
-					tinyraptor = 0.001,
 				},
 			},
 		},


### PR DESCRIPTION
Ten damage entries name an armour class that armordefs.lua does not define, so they do nothing: bombers and fighters on the Epic Dragon, Sol Invictus, Archaic Sol Invictus and Keres, ship on the Onager, and tinyraptor on the meteor. The engine stores damages against armour class indices, so a name with no class behind it never gets an index and is dropped when the def is parsed.

Confirmed rather than assumed. Exporting the defs with and without this change gives identical output across 2627 weapondefs and 1870 unitdefs - not one damage value moves. Nothing in our Lua can read them either: damage is looked up as damages[Game.armorTypes.<class>], and the only classes anything asks for are default, vtol, shields, shield and indestructable.

What this does not do is give those weapons the damage someone meant them to have. bombers and fighters look like an attempt to split air damage finer than the vtol class allows, and ship on the Onager looks like it wanted lboats or hvyboats - a submarine's torpedo currently doing default damage to ships is worth someone's attention, but changing it is a balance decision rather than a cleanup, so it is deliberately not in here.

The matching check is in #8653: damage may only name a class armordefs defines, read from the file rather than hardcoded, since a unit can also mint a class through customparams.armordef.
