### PR TITLE
Allow GL4 AirJets to be Teamcolored.

### DIFF
--- a/luaui/Widgets/gfx_airjets_gl4.lua
+++ b/luaui/Widgets/gfx_airjets_gl4.lua
@@ -562,9 +562,9 @@ local function Activate(unitID, unitDefID, who, when)
 				color[1], color[2], color[3] = spGetTeamColor(spGetUnitTeam(unitID))
 			end
 			if effectDef.teamcolorDesaturation then
-				color[1] = color[1] + ((1 - color[1])*effectDef.teamcolorDesaturation)
-				color[2] = color[2] + ((1 - color[2])*effectDef.teamcolorDesaturation)
-				color[3] = color[3] + ((1 - color[3])*effectDef.teamcolorDesaturation)
+				color[1] = color[1] + ((1 - color[1]) * effectDef.teamcolorDesaturation)
+				color[2] = color[2] + ((1 - color[2]) * effectDef.teamcolorDesaturation)
+				color[3] = color[3] + ((1 - color[3]) * effectDef.teamcolorDesaturation)
 			end
 		end
 		local effectdata = {

--- a/luaui/Widgets/gfx_airjets_gl4.lua
+++ b/luaui/Widgets/gfx_airjets_gl4.lua
@@ -561,10 +561,10 @@ local function Activate(unitID, unitDefID, who, when)
 			else
 				color[1], color[2], color[3] = spGetTeamColor(spGetUnitTeam(unitID))
 			end
-			if effectDef.desaturation then
-				color[1] = color[1] + ((1 - color[1])*effectDef.desaturation)
-				color[2] = color[2] + ((1 - color[2])*effectDef.desaturation)
-				color[3] = color[3] + ((1 - color[3])*effectDef.desaturation)
+			if effectDef.teamcolorDesaturation then
+				color[1] = color[1] + ((1 - color[1])*effectDef.teamcolorDesaturation)
+				color[2] = color[2] + ((1 - color[2])*effectDef.teamcolorDesaturation)
+				color[3] = color[3] + ((1 - color[3])*effectDef.teamcolorDesaturation)
 			end
 		end
 		local effectdata = {

--- a/luaui/Widgets/gfx_airjets_gl4.lua
+++ b/luaui/Widgets/gfx_airjets_gl4.lua
@@ -23,10 +23,12 @@ local mathFloor = math.floor
 -- Localized Spring API for performance
 local spGetUnitDefID = Spring.GetUnitDefID
 local spEcho = Spring.Echo
-local spGetAllUnits = Spring.GetAllUnits
 local spGetTeamUnitsByDefs = Spring.GetTeamUnitsByDefs
 local spGetTeamList = Spring.GetTeamList
 local spGetSpectatingState = Spring.GetSpectatingState
+local spGetUnitPaletteIndex = Spring.GetUnitPaletteIndex
+local spGetTeamColor = Spring.GetTeamColor
+local spGetCustomPaletteColor = Spring.GetCustomPaletteColor
 
 -- TODO:
 -- reflections
@@ -547,10 +549,24 @@ local function Activate(unitID, unitDefID, who, when)
 		return
 	end
 	local unitEffects = effectDefs[unitDefID]
+
 	for i = 1, #unitEffects do
 		local effectDef = unitEffects[i]
 		local color = effectDef.color
 		local emitVector = effectDef.emitVector
+		if effectDef.teamcolored then
+			local unitCustomPaletteIndex = spGetUnitPaletteIndex(unitID)
+			if unitCustomPaletteIndex then
+				color[1], color[2], color[3] = spGetCustomPaletteColor(unitCustomPaletteIndex)
+			else
+				color[1], color[2], color[3] = spGetTeamColor(spGetUnitTeam(unitID))
+			end
+			if effectDef.desaturation then
+				color[1] = color[1] + ((1 - color[1])*effectDef.desaturation)
+				color[2] = color[2] + ((1 - color[2])*effectDef.desaturation)
+				color[3] = color[3] + ((1 - color[3])*effectDef.desaturation)
+			end
+		end
 		local effectdata = {
 			effectDef.width * 0.4,
 			effectDef.length,


### PR DESCRIPTION
Allows AirJets to be Teamcolored. 
Doesn't affect any existing units yet.
<img width="1649" height="505" alt="obraz" src="https://github.com/user-attachments/assets/bc15c7ef-4b6e-4e71-9e54-711fbfa78846" />
