### PR TITLE
chat: don't handle clicks on chat lines while a command is active

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2835,6 +2835,13 @@ drawUi = function()
 	end
 end
 
+-- Commands (area reclaim, build placement, ...) use the mouse and CTRL themselves,
+-- so the chat box must not grab the cursor or clicks while one is active.
+function state.hasActiveCommand()
+	local _, activeCmdID = spGetActiveCommand()
+	return activeCmdID ~= nil
+end
+
 drawTextInput = function()
 	if handleTextInput then
 		if showTextInput and updateTextInputDlist then
@@ -2845,6 +2852,9 @@ drawTextInput = function()
 			drawChatInputCursor()
 			-- button hover
 			local x, y, b = spGetMouseState()
+			if state.hasActiveCommand() then
+				return
+			end
 			local hoveredEmojiIndex, hoverLeft, hoverBottom, hoverRight, hoverTop = state.getEmojiPickerHoverRect(x, y)
 			if hoveredEmojiIndex then
 				Spring.SetMouseCursor("cursornormal")
@@ -3053,8 +3063,10 @@ function widget:DrawScreen()
 		updateDrawUi = true
 	end
 
+	local _, activeCmdID = spGetActiveCommand()
 	local ctrlHover = enableShortcutClick
 		and ctrl
+		and not activeCmdID
 		and math_isInRect(
 			x,
 			y,
@@ -3096,7 +3108,7 @@ function widget:DrawScreen()
 							),
 							translatedY + (lineHeight * checkedLines) + lineHeight,
 						}
-						if math_isInRect(x, y, lineArea[1], lineArea[2], lineArea[3], lineArea[4]) then
+						if not activeCmdID and math_isInRect(x, y, lineArea[1], lineArea[2], lineArea[3], lineArea[4]) then
 							UiSelectHighlight(
 								lineArea[1] - translatedX,
 								lineArea[2] - translatedY - (lineHeight * checkedLines),
@@ -3960,6 +3972,9 @@ function widget:MousePress(x, y, button)
 	end
 
 	if button ~= 1 or not handleTextInput or not showTextInput or Spring.IsGUIHidden() then
+		return false
+	end
+	if state.hasActiveCommand() then
 		return false
 	end
 	state.emojiPickerPressFromButton = false


### PR DESCRIPTION
Clicking a map marker or unit share chat line moved the camera or replaced the selection even when an area command was waiting for its click, so the command and the chat box both acted on it.

Skip the clickable line highlight and its click handler while a command is active, and stop the open chat box from grabbing the cursor and clicks on its emoji and mode buttons. Pressing enter sets history mode, which reaches the line handler without going through the ctrl hover path, so both entry points needed the guard.

Closes #6996

I manually tested this in game before and after the fix to confirm it worked with both versions of the chat window.

I used Claude Opus with medium and high effort.