### PR TITLE
Everyone is Paratrooper modoption

### DIFF
--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -45,6 +45,12 @@ local minImpulseFactor = 0.15
 --any impulse to damage ratio below this is ignored to save performance
 local minImpulseToDamageRatio = 0.2
 
+--check for modoption everyoneisparatrooper
+local everyoneIsParatrooper = Spring.GetModOptions().everyoneisparatrooper
+
+--make fall damage survivable but damaging for modoption everyoneisparatrooper
+local paratrooperForAllFallDamageMultiple = 0.25
+
 local groundCollisionDefID = Game.envDamageTypes.GroundCollision
 local objectCollisionDefID = Game.envDamageTypes.ObjectCollision
 local spGetUnitHealth = Spring.GetUnitHealth
@@ -88,8 +94,9 @@ for unitDefID, unitDef in ipairs(UnitDefs) do
 	else
 		unitDefData[unitDefID].velocityCap = velocityCap
 	end
-
-	local fallDamageMultiplier = unitDef.customParams.fall_damage_multiplier or 1.0
+	
+	--use modoption everyoneIsParatrooper fall damage adjustment paratrooperForAllFallDamageMultiple
+	local fallDamageMultiplier = everyoneIsParatrooper and paratrooperForAllFallDamageMultiple or (unitDef.customParams.fall_damage_multiplier or 1.0)
 	fallDamageMultipliers[unitDefID] = fallDamageMultiplier * fallDamageMagnificationFactor
 	unitsMaxImpulse[unitDefID] = unitDef.mass * maxImpulseMultiplier
 	unitsMinImpulse[unitDefID] = unitDef.mass * minImpulseMultiplier

--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -49,7 +49,7 @@ local minImpulseToDamageRatio = 0.2
 local everyoneIsParatrooper = Spring.GetModOptions().everyoneisparatrooper
 
 --make fall damage survivable but damaging for modoption everyoneisparatrooper
-local paratrooperForAllFallDamageMultiple = 0.25
+local everyoneIsParatrooperFallDamageMultiple = 0.25
 
 local groundCollisionDefID = Game.envDamageTypes.GroundCollision
 local objectCollisionDefID = Game.envDamageTypes.ObjectCollision
@@ -95,8 +95,8 @@ for unitDefID, unitDef in ipairs(UnitDefs) do
 		unitDefData[unitDefID].velocityCap = velocityCap
 	end
 	
-	--use modoption everyoneIsParatrooper fall damage adjustment paratrooperForAllFallDamageMultiple
-	local fallDamageMultiplier = everyoneIsParatrooper and paratrooperForAllFallDamageMultiple or (unitDef.customParams.fall_damage_multiplier or 1.0)
+	--use modoption everyoneIsParatrooper fall damage adjustment everyoneIsParatrooperFallDamageMultiple
+	local fallDamageMultiplier = everyoneIsParatrooper and everyoneIsParatrooperFallDamageMultiple or (unitDef.customParams.fall_damage_multiplier or 1.0)
 	fallDamageMultipliers[unitDefID] = fallDamageMultiplier * fallDamageMagnificationFactor
 	unitsMaxImpulse[unitDefID] = unitDef.mass * maxImpulseMultiplier
 	unitsMinImpulse[unitDefID] = unitDef.mass * minImpulseMultiplier

--- a/luarules/gadgets/unit_transport_dies_load_dies.lua
+++ b/luarules/gadgets/unit_transport_dies_load_dies.lua
@@ -27,10 +27,12 @@ function gadget:GetInfo()
 	}
 end
 
+local everyoneIsParatrooper = Spring.GetModOptions().everyoneisparatrooper
+
 local isParatrooper = {}
 
 for udid, ud in pairs(UnitDefs) do
-	if ud.customParams.paratrooper or ud.customParams.subfolder == "other/hats" then
+	if ud.customParams.paratrooper or ud.customParams.subfolder == "other/hats" or everyoneIsParatrooper then
 		isParatrooper[udid] = true
 	end
 end

--- a/luarules/gadgets/unit_water_depth_damage.lua
+++ b/luarules/gadgets/unit_water_depth_damage.lua
@@ -41,9 +41,6 @@ local drownDepthSlack = 8
 --check for modoption everyoneisparatrooper
 local everyoneIsParatrooper = Spring.GetModOptions().everyoneisparatrooper
 
--- for units that would normally drown; hover/amphibious units take some damage since water is their normal environment
-local everyoneIsParatrooperWaterFallDamageMultiplier = 0.25
-
 local gameFrame = 0
 local gameFrameExpirationThreshold = 3
 local gaiaTeamID = Spring.GetGaiaTeamID()
@@ -99,9 +96,9 @@ for unitDefID, unitDef in ipairs(UnitDefs) do
 		defData.isDrownable = false
 	end
 
-	--check if everyoneIsParatrooper, use reduced damage, else, standard fall damage
+	--check if everyoneIsParatrooper, remove water fall damage if unit is amphib / hover, else, standard water fall damage
     if everyoneIsParatrooper then
-        defData.fallDamageMultiplier = (defData.isAmphibious or defData.isHover) and 0 or everyoneIsParatrooperWaterFallDamageMultiplier
+        defData.fallDamageMultiplier = (defData.isAmphibious or defData.isHover) and 0 or 1
     else
         defData.fallDamageMultiplier = unitDef.customParams.water_fall_damage_multiplier or 1
     end

--- a/luarules/gadgets/unit_water_depth_damage.lua
+++ b/luarules/gadgets/unit_water_depth_damage.lua
@@ -41,7 +41,7 @@ local drownDepthSlack = 8
 --check for modoption everyoneisparatrooper
 local everyoneIsParatrooper = Spring.GetModOptions().everyoneisparatrooper
 
--- for units that would normally drown; hover/amphibious units take none since water is their normal environment
+-- for units that would normally drown; hover/amphibious units take some damage since water is their normal environment
 local everyoneIsParatrooperWaterFallDamageMultiplier = 0.25
 
 local gameFrame = 0
@@ -99,14 +99,14 @@ for unitDefID, unitDef in ipairs(UnitDefs) do
 		defData.isDrownable = false
 	end
 
-	--check if everyoneIsParatrooper, reduce damage, else, standard fall damage
+	--check if everyoneIsParatrooper, use reduced damage, else, standard fall damage
     if everyoneIsParatrooper then
         defData.fallDamageMultiplier = (defData.isAmphibious or defData.isHover) and 0 or everyoneIsParatrooperWaterFallDamageMultiplier
     else
         defData.fallDamageMultiplier = unitDef.customParams.water_fall_damage_multiplier or 1
     end
 	
-	--damage moved to end to allow amphib / hover to survive water
+	--damage moved to end to allow amphib / hover checks to survive water
 	defData.drowningDamage = unitDef.health * drowningDamage
 	defData.fallDamage = unitDef.health * fallDamage * defData.fallDamageMultiplier
 

--- a/luarules/gadgets/unit_water_depth_damage.lua
+++ b/luarules/gadgets/unit_water_depth_damage.lua
@@ -38,6 +38,12 @@ local fallDamageCompoundingFactor = 1.05
 --TestMoveOrder check; covers pos-vs-square-center height differences on sloped seafloor
 local drownDepthSlack = 8
 
+--check for modoption everyoneisparatrooper
+local everyoneIsParatrooper = Spring.GetModOptions().everyoneisparatrooper
+
+-- for units that would normally drown; hover/amphibious units take none since water is their normal environment
+local everyoneIsParatrooperWaterFallDamageMultiplier = 0.25
+
 local gameFrame = 0
 local gameFrameExpirationThreshold = 3
 local gaiaTeamID = Spring.GetGaiaTeamID()
@@ -68,10 +74,8 @@ local livingTransports = {}
 
 for unitDefID, unitDef in ipairs(UnitDefs) do
 	local defData = {}
-	defData.fallDamageMultiplier = unitDef.customParams.water_fall_damage_multiplier or 1
-	defData.drowningDamage = unitDef.health * drowningDamage
-	defData.fallDamage = unitDef.health * fallDamage * defData.fallDamageMultiplier
 	defData.unitDefID = unitDefID
+
 	if
 		unitDef.moveDef.depth
 		and unitDef.moveDef.smClass ~= Game.speedModClasses.Boat
@@ -94,6 +98,18 @@ for unitDefID, unitDef in ipairs(UnitDefs) do
 		defData.isAmphibious = true
 		defData.isDrownable = false
 	end
+
+	--check if everyoneIsParatrooper, reduce damage, else, standard fall damage
+    if everyoneIsParatrooper then
+        defData.fallDamageMultiplier = (defData.isAmphibious or defData.isHover) and 0 or everyoneIsParatrooperWaterFallDamageMultiplier
+    else
+        defData.fallDamageMultiplier = unitDef.customParams.water_fall_damage_multiplier or 1
+    end
+	
+	--damage moved to end to allow amphib / hover to survive water
+	defData.drowningDamage = unitDef.health * drowningDamage
+	defData.fallDamage = unitDef.health * fallDamage * defData.fallDamageMultiplier
+
 	unitDefData[unitDefID] = defData
 end
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1808,7 +1808,7 @@ local options = {
 	
 	{
 		key = "everyoneisparatrooper",
-		name = "Paratroopers For All",
+		name = "Everyone is Paratrooper",
 		desc = "All units survive when their transport is destroyed mid-air, like the Commando does, instead of exploding. Somewhat damaging.",
 		type = "bool",
 		section = "options_extra",

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1799,6 +1799,21 @@ local options = {
 			},
 		},
 	},
+	
+	{
+		key = "sub_header",
+		section = "options_extra",
+		type = "separator",
+	},
+	
+	{
+		key = "everyoneisparatrooper",
+		name = "Paratroopers For All",
+		desc = "All units survive when their transport is destroyed mid-air, like the Commando does, instead of exploding. Somewhat damaging.",
+		type = "bool",
+		section = "options_extra",
+		def = false,
+	},
 
 	---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Extends the Commando's transport-death survival mechanic to all units via a new extras modoption. Units survive their transport being destroyed mid-air instead of instant death, but take reduced (non-zero) fall damage on landing via paratrooperForAllFallDamageMultiple constant (0.25). Fall damage depends on fall height but generally survivable in most cases.

### Work done

- modoptions.lua -- Added modoption under extras.
- luarules/gadgets/unit_transport_dies_load_dies.lua -- Adjusted UnitDefs to add isParatrooper parameter if modoption on
- luarules/gadgets/unit_collision_damage_behavior.lua -- added variable for paratrooperForAllFallDamageMultiple for easier adjustments. Flowed check for modoption is on, flow paratrooperForAllFallDamageMultiple into fallDamageMultiplier if modoption enabled. Units are able to survive most falls. Cortex Commando is unaffected.
- luarules/gadgets/unit_water_depth_damage.lua -- moved drowningDamage and fallDamage calcs after isHover and isAmphibious checks to set water_fall_damage_multiplier to 0. All non-amphib, non-hover units take full fall damage on landing on water. Drowning is unaffected.

#### Setup
Added modoption for "Everyone is Paratrooper" under Extras with separator.

#### Test steps
Can units survive falling from transports?
1. Build transports and load units
2. Get transports killed to enemy fire or self-destruct over land
3. Unit falls to the ground and takes damage depending on fall height -- approximately 15-25% of healthbar depending on height
4. Expected result: Unit survives the fall

Any changes to the Cortex Commando?
1. Build Cortex Commando and load to transport
2. Get transports killed to enemy fire or self-destruct
3. Commando falls to the ground and takes 0 damage
4. Expected result: Cortex Commando takes 0 damage from fall. Some damage may result from transport explosion.

Do non-amphib / non-hover units die when falling into water?
1. Build transports and load units
2. Get transports killed to enemy fire or self-destruct over water
3. Units fall into the water
4. Non-amphib / non-hover units take standard water fall damage on water impact.
5. Expected result: Unit takes more full fall damage from water entry if not allowed. Then 5% health damage per second from drowning is survived (highly unlikely).

Do Amphibious units die when falling into water?
1. Build transports and load units
2. Get transports killed to enemy fire or self-destruct over water
3. Units fall into the water. Amphibious units fall further as transport height is further above ground level (flight + water height)
4. Expected result: Unit takes fall damage but survives. Does not receive drowning damage.

Do Hover units die when falling into water?
1. Build transports and load units
2. Get transports killed to enemy fire or self-destruct over water
3. Hover units fall onto the water, splash down, enter hover state and take some damage.
4. Expected result: Unit takes fall damage but survives. Does not receive drowning damage.

### Screenshots:
See this video I recorded: https://www.youtube.com/watch?v=BlTBbRXOh3k for above tests

### AI / LLM usage statement:
Used Claude to help investigate whether paratrooper modoptions already exist within the game or historical modoptions. Then used to flag files related to Cortex Commando's isParatrooper param, transport-death and fall-damage and water-damage gadgets. I wrote conditional checks and updates and had Claude review the work. I ran the tests for various checks between combinations between units and terrain types.