### PR TITLE
Fix Unit clean builder queue removing build commands despite unfinished repairs

### DIFF
--- a/luaui/Widgets/unit_clean_builder_queue.lua
+++ b/luaui/Widgets/unit_clean_builder_queue.lua
@@ -20,7 +20,10 @@ local GetTeamUnits = Spring.GetTeamUnits
 local GetMyTeamID = Spring.GetLocalTeamID
 local GetSpectatingState = Spring.GetSpectatingState
 local GetUnitsInCylinder = Spring.GetUnitsInCylinder
+local ValidUnitID = Spring.ValidUnitID
 local select = select
+local GetUnitHealth = Spring.GetUnitHealth
+local GetUnitDefID = Spring.GetUnitDefID
 
 local CMD_REMOVE = CMD.REMOVE
 local CMD_REPEAT = CMD.REPEAT
@@ -118,10 +121,10 @@ end
 function widget:GameFrame(f)
 	if f%5 == 0 then
 		for unitID, _ in pairs(finishedButNotRepaired) do
-			if not Spring.ValidUnitID(unitID) then
+			if not ValidUnitID(unitID) then
 				finishedButNotRepaired[unitID] = nil
 			else
-				local hp, maxHP = Spring.GetUnitHealth(unitID)
+				local hp, maxHP = GetUnitHealth(unitID)
 				if hp and maxHP and hp == maxHP then
 					widget:UnitFinished(unitID, Spring.GetUnitDefID(unitID), Spring.GetUnitTeam(unitID))
 					finishedButNotRepaired[unitID] = nil

--- a/luaui/Widgets/unit_clean_builder_queue.lua
+++ b/luaui/Widgets/unit_clean_builder_queue.lua
@@ -31,6 +31,7 @@ local trackedBuilders = {}
 local isBuilding = {}
 local builderDefs = {}
 local myTeamID = GetMyTeamID()
+local finishedButNotRepaired = {} -- unitID -> true, for buildings that are finished but not fully repaired yet
 
 -- Calculate maximum build distance from all builder units + margin
 local maxBuildDistance = 0
@@ -114,6 +115,22 @@ function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID)
 	end
 end
 
+function widget:GameFrame(f)
+	if f%5 == 0 then
+		for unitID, _ in pairs(finishedButNotRepaired) do
+			if not Spring.ValidUnitID(unitID) then
+				finishedButNotRepaired[unitID] = nil
+			else
+				local hp, maxHP = Spring.GetUnitHealth(unitID)
+				if hp and maxHP and hp == maxHP then
+					widget:UnitFinished(unitID, Spring.GetUnitDefID(unitID), Spring.GetUnitTeam(unitID))
+					finishedButNotRepaired[unitID] = nil
+				end
+			end
+		end
+	end
+end
+
 function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	if unitTeam ~= myTeamID or not isBuilding[unitDefID] then
 		return
@@ -127,6 +144,13 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	-- Use spatial query to only check nearby units (team-filtered to reduce table size)
 	local nearbyUnits = GetUnitsInCylinder(x, z, SEARCH_RADIUS, myTeamID)
 	if not nearbyUnits or #nearbyUnits == 0 then
+		return
+	end
+
+	local hp, maxHP = Spring.GetUnitHealth(unitID)
+	if hp and maxHP and hp < maxHP then
+		-- Building is not fully constructed; defer removal until it is finished
+		finishedButNotRepaired[unitID] = true
 		return
 	end
 

--- a/luaui/Widgets/unit_clean_builder_queue.lua
+++ b/luaui/Widgets/unit_clean_builder_queue.lua
@@ -119,7 +119,7 @@ function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID)
 end
 
 function widget:GameFrame(f)
-	if f%5 == 0 then
+	if f % 5 == 0 then
 		for unitID, _ in pairs(finishedButNotRepaired) do
 			if not ValidUnitID(unitID) then
 				finishedButNotRepaired[unitID] = nil


### PR DESCRIPTION
https://www.youtube.com/watch?v=swxe_fHSpxY

> Build commands are removed as soon as UnitFinished() is reached; which causes the builders immediately follow up with repairing the buildee (which is the default behaviour).

This restores the default behaviour by filtering out finished but not fully repaired units first.
A coroutine (f%5) is responsible for re-calling UnitFinished when hp == maxhp on every buildee that had its UnitFinished() call skipped due to hp < maxhp