### PR TITLE
Fix loss of unit primitives after trying to draw >64 of them without geometry shaders

### DIFF
--- a/luaui/Include/DrawPrimitiveAtUnit.lua
+++ b/luaui/Include/DrawPrimitiveAtUnit.lua
@@ -192,22 +192,46 @@ local function InitDrawPrimitiveAtUnit(shaderConfig, DPATname)
 		DrawPrimitiveAtUnitVBO.nogsTemplateVBO = templateVBO
 		DrawPrimitiveAtUnitVBO.nogsIndexVBO = indexVBO
 
+		-- The instance table doubles its buffer as soon as it fills up, and rebuilds its VAO from
+		-- the vertex and index buffers it finds on itself. Without these it would rebuild the VAO
+		-- of the geometry shader path instead, which draws this template mesh as bare points.
+		DrawPrimitiveAtUnitVBO.vertexVBO = templateVBO
+		DrawPrimitiveAtUnitVBO.indexVBO = indexVBO
+
 		-- Wrap the real VAO so existing consumers can keep calling
 		-- VBO.VAO:DrawArrays(GL.POINTS, usedElements); under the hood we draw the
-		-- template mesh instanced once per element.
-		local indexCount = #indexData
-		DrawPrimitiveAtUnitVBO.VAO = {
+		-- template mesh instanced once per element. That rebuild on resize puts a plain VAO in the
+		-- field, so the wrapper is kept behind the field rather than in it, and takes over whatever
+		-- lands there.
+		local vaoWrapper = {
 			realVAO = realVAO,
-			indexCount = indexCount,
+			indexCount = #indexData,
 			DrawArrays = function(self, _primitiveType, instanceCount)
 				if instanceCount and instanceCount > 0 then
 					self.realVAO:DrawElements(GL.TRIANGLES, self.indexCount, 0, instanceCount)
 				end
 			end,
+			DrawElements = function(self, primitiveType, count, indexOffset, instanceCount, baseVertex)
+				self.realVAO:DrawElements(primitiveType, count, indexOffset, instanceCount, baseVertex)
+			end,
 			Delete = function(self)
 				self.realVAO:Delete()
 			end,
 		}
+		setmetatable(DrawPrimitiveAtUnitVBO, {
+			__index = function(_, key)
+				if key == "VAO" then
+					return vaoWrapper
+				end
+			end,
+			__newindex = function(instanceTable, key, value)
+				if key == "VAO" then
+					vaoWrapper.realVAO = value
+				else
+					rawset(instanceTable, key, value)
+				end
+			end,
+		})
 	end
 	return DrawPrimitiveAtUnitVBO, DrawPrimitiveAtUnitShader
 end


### PR DESCRIPTION
On machines without detected (more on this in my next PR following up on #8144) geometry shader support, every widget and gadget built on `DrawPrimitiveAtUnit` stops drawing entirely once it has more than 63 instances, and stays broken until the widget is reloaded. Widely used consumers are affected: rank icons, team platter, selected units, enemy spotter, unit trackers, etc.

## Why

The fallback path draws a template triangle-fan mesh instanced once per element, and wraps the VAO so consumers can keep calling `VBO.VAO:DrawArrays(GL.POINTS, usedElements)` as they do on the geometry shader path.

`makeInstanceVBOTable` starts at 64 elements. When the buffer fills, `resizeInstanceVBOTable` doubles it and rebuilds the VAO:

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/92e01286401d982f2808ab4b939b6b38efc45f74/modules/graphics/instancevbotable.lua#L466-L469
https://github.com/beyond-all-reason/Beyond-All-Reason/blob/92e01286401d982f2808ab4b939b6b38efc45f74/modules/graphics/instancevboidtable.lua#L183-L186

The fallback had set neither `iT.vertexVBO` nor `iT.indexVBO`, so `makeVAOandAttach` takes its ["vertices are instances" branch](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/92e01286401d982f2808ab4b939b6b38efc45f74/modules/graphics/instancevbotable.lua#L231-L232) and builds the geometry shader path's VAO incorrectly. Then the rebuilt VAO goes straight into the field the wrapper occupied, destroying the wrapper. From then on every draw is a handful of bare points fed to a shader that expects a triangle fan.

## The fix

Hand the instance table the template and index buffers it rebuilds from, and keep the wrapper behind the VAO field rather than in it, so the resize's assignment hands the wrapper its new VAO (through the metatable methods) instead of replacing it. No change to `instancevbotable.lua`, and the geometry shader path is untouched.

## Testing

Exercised by loading `DrawPrimitiveAtUnit.lua` against `modules/graphics/instancevbotable.lua` with `isGeometryShaderSupported` stubbed `false`, pushing past the doubling point and inspecting the resulting draw calls. Before the fix, the draw after growth degrades to `DrawArrays(GL.POINTS, …)` against the instance buffer; after it, it stays `DrawElements(GL.TRIANGLES, …)` against the same template mesh, with no VAO leaked.

Verified in game on Linux/Mesa (GL 4.6 compatibility profile, Mesa 26.1.7), where `LuaShader.isGeometryShaderSupported` is false even though the driver supports geometry shaders: the probe tests only for the two pre-core desktop extension strings (GL_ARB_geometry_shader4, GL_EXT_geometry_shader4) and an OpenGL ES one (GL_OES_geometry_shader), none of which a modern desktop GL context advertises, geometry shaders have been core since GL 3.2 and are reported by version instead. That probe will be fixed in my next PR.

## AI assistance

This code was authored ~95% by Claude Opus 5. This PR text was authored ~85% by Claude Opus 5. Diagnosis of the bug was mostly done by Claude Opus 5. I have reviewed all of the code and understand and approve of the changes. I have tested the fix in-game and found it to be effective and seen no side effects.