### PR TITLE
Detect geometry shader support by GLSL and Mesa versions rather than by extension names or OS+GPU

### DIFF
--- a/luarules/gadgets/gfx_energy_explosion_particles_gl4.lua
+++ b/luarules/gadgets/gfx_energy_explosion_particles_gl4.lua
@@ -781,19 +781,9 @@ local function initGL4()
 		forceupdate = true,
 	}
 
-	-- AMD GPUs have no native geometry-shader stage. Mesa emulates this GS by translating it
-	-- onto the hardware's real shader stages, emitting every vertex through memory buffers.
-	-- This is slow both to compile (a multi-second GS compile that stalls on the first draw,
-	-- and isn't kept in the disk cache so it recurs) and to run (those memory round-trips
-	-- cost bandwidth every frame). The no-GS path draws the same particles with none of that.
-	-- AMD-on-Linux is always Mesa.
-	local preferNoGS = (Platform ~= nil and Platform.gpuVendor == "AMD" and Platform.osFamily == "Linux")
+	useGeometryShader = LuaShader.isGeometryShaderSupported
 
-	-- Try the geometry-shader path first (unless we already know to skip it); only
-	-- fall back if compile actually fails. LuaShader.isGeometryShaderSupported can
-	-- report false negatives on some drivers (e.g. AMD/Mesa), so we don't trust it
-	-- alone.
-	useGeometryShader = not preferNoGS
+	-- a driver can still fail to compile one, and the path that needs none is right here
 	particleShader = useGeometryShader and LuaShader.CheckShaderUpdates(shaderCacheGS) or nil
 	if not particleShader then
 		if useGeometryShader then

--- a/luarules/gadgets/gfx_nano_particles_gl4.lua
+++ b/luarules/gadgets/gfx_nano_particles_gl4.lua
@@ -1304,19 +1304,9 @@ local function initGL4()
 		forceupdate = true,
 	}
 
-	-- AMD GPUs have no native geometry-shader stage. Mesa emulates this GS by translating it
-	-- onto the hardware's real shader stages, emitting every vertex through memory buffers.
-	-- This is slow both to compile (a multi-second GS compile that stalls on the first draw,
-	-- and isn't kept in the disk cache so it recurs) and to run (those memory round-trips
-	-- cost bandwidth every frame). The no-GS path draws the same particles with none of that.
-	-- AMD-on-Linux is always Mesa.
-	local preferNoGS = (Platform ~= nil and Platform.gpuVendor == "AMD" and Platform.osFamily == "Linux")
+	useGeometryShader = LuaShader.isGeometryShaderSupported
 
-	-- Try the geometry-shader path first (unless we already know to skip it); only
-	-- fall back if compile actually fails. LuaShader.isGeometryShaderSupported can
-	-- report false negatives on some drivers (e.g. AMD/Mesa), so we don't trust it
-	-- alone.
-	useGeometryShader = not preferNoGS
+	-- a driver can still fail to compile one, and the path that needs none is right here
 	nanoShader = useGeometryShader and LuaShader.CheckShaderUpdates(shaderCacheGS) or nil
 	if not nanoShader then
 		if useGeometryShader then

--- a/modules/graphics/LuaShader.lua
+++ b/modules/graphics/LuaShader.lua
@@ -13,6 +13,14 @@ local glUniformArray = gl.UniformArray
 
 local gldebugannotations = (Spring.GetConfigInt("gldebugannotations") == 1)
 
+-- OpenGL 3.2 took the geometry shader stage into the standard, and came with this shading language
+-- version. Drivers newer than that mostly no longer name the extensions the stage arrived through.
+local GLSL_VERSION_WITH_GEOMETRY_SHADERS = 150
+
+-- [Some] Mesa versions prior to this stalled for several seconds the first time a geometry shader
+-- was drawn due to emulation involving memory buffers.
+local OLDEST_MESA_WITH_CHEAP_GEOMETRY_SHADERS = 2601 -- major * 100 + minor, so Mesa 26.1
+
 local function new(class, shaderParams, shaderName, logEntries)
 	local logEntriesSanitized
 	if type(logEntries) == "number" then
@@ -34,11 +42,41 @@ local function new(class, shaderParams, shaderName, logEntries)
 	}, class)
 end
 
-local function IsGeometryShaderSupported()
-	local hasGeometryShaderExtension = gl.HasExtension("GL_ARB_geometry_shader4")
+--- Whether this machine has the geometry shader stage at all. Asking for the extensions alone finds
+--- only drivers old enough to still name them: the stage has been part of OpenGL since 3.2, and a
+--- current driver says so with its version rather than with an extension string. The names are kept
+--- for drivers older than that, and for OpenGL ES, whose version string the engine cannot read.
+local function HasGeometryShaderStage()
+	local glslVersion = Platform and Platform.glslVersionNum or 0
+	local hasStage = glslVersion >= GLSL_VERSION_WITH_GEOMETRY_SHADERS
+		or gl.HasExtension("GL_ARB_geometry_shader4")
 		or gl.HasExtension("GL_EXT_geometry_shader4")
 		or gl.HasExtension("GL_OES_geometry_shader")
-	return hasGeometryShaderExtension and (gl.SetShaderParameter ~= nil or gl.SetGeometryShaderParameter ~= nil)
+
+	-- an engine that can build a shader with a geometry stage lets a widget set that stage up
+	return hasStage and (gl.SetShaderParameter ~= nil or gl.SetGeometryShaderParameter ~= nil)
+end
+
+--- Which Mesa this is, as major * 100 + minor, or nil on a driver that is not Mesa. Mesa names
+--- itself in the version string it answers with, as in "4.6 (Compatibility Profile) Mesa 26.1.7".
+local function MesaVersion()
+	local glVersion = Platform and Platform.glVersion
+	if not glVersion then
+		return nil
+	end
+
+	local major, minor = glVersion:match("Mesa (%d+)%.(%d+)")
+	---@diagnostic disable-next-line: need-check-nil
+	return major and (tonumber(major) * 100 + tonumber(minor)) or nil
+end
+
+--- Whether to take a geometry shader where there is a path with one and a path without, which is
+--- what every reader of this has always used it for. Older Mesa is left out although it has the
+--- stage, since it incurs long delays for shader compilation.
+local function IsGeometryShaderSupported()
+	local mesaVersion = MesaVersion()
+	local mesaExpensive = mesaVersion ~= nil and mesaVersion < OLDEST_MESA_WITH_CHEAP_GEOMETRY_SHADERS
+	return HasGeometryShaderStage() and not mesaExpensive
 end
 
 local function IsTesselationShaderSupported()

--- a/modules/graphics/LuaShader.lua
+++ b/modules/graphics/LuaShader.lua
@@ -42,10 +42,6 @@ local function new(class, shaderParams, shaderName, logEntries)
 	}, class)
 end
 
---- Whether this machine has the geometry shader stage at all. Asking for the extensions alone finds
---- only drivers old enough to still name them: the stage has been part of OpenGL since 3.2, and a
---- current driver says so with its version rather than with an extension string. The names are kept
---- for drivers older than that, and for OpenGL ES, whose version string the engine cannot read.
 local function HasGeometryShaderStage()
 	local glslVersion = Platform and Platform.glslVersionNum or 0
 	local hasStage = glslVersion >= GLSL_VERSION_WITH_GEOMETRY_SHADERS
@@ -70,9 +66,9 @@ local function MesaVersion()
 	return major and (tonumber(major) * 100 + tonumber(minor)) or nil
 end
 
---- Whether to take a geometry shader where there is a path with one and a path without, which is
---- what every reader of this has always used it for. Older Mesa is left out although it has the
---- stage, since it incurs long delays for shader compilation.
+--- Whether to take a geometry shader where there is a path with one and a path without.
+--- Older Mesa is left out although it has the stage, since it incurs long delays for
+--- shader compilation.
 local function IsGeometryShaderSupported()
 	local mesaVersion = MesaVersion()
 	local mesaExpensive = mesaVersion ~= nil and mesaVersion < OLDEST_MESA_WITH_CHEAP_GEOMETRY_SHADERS


### PR DESCRIPTION
### Work done

Improve `LuaShader.isGeometryShaderSupported` by splitting it into a helper that also checks GLSL version in addition to the deprecated/mobile driver extension tests.asked whether the driver names, and including a check for new Mesa versions that don't have the geometry shader compilation slowdown behind #8144. Use it to replace #8144's OS+GPU tests.

### Addresses Issue(s)

- Follow-up to #8144

### Test steps

1. Start a game
2. Build and self-destruct an advanced fusion plant
3. Build and use a nano turret
4. Confirm no lag at the first render of each effect
5. Confirm the log shows NanoParticlesGL4_Shape and UnitEnergyExplosionParticlesGL4 loaded without the _NoGS suffix

### AI / LLM usage statement:

Claude Opus 5 authored ~80% of the code, 100% of the commit messages, and ~20% of this PR description. I tested in-game and confirmed the GS-ful shaders were being used and saw no delays. I have reviewed the code and understand it.

### Followup needed

While this works for me (Radeon RX 6600, Mesa 26.1.7), I don't have enough computers to test with other GPUs, and I have conflicts preventing a driver downgrade. Additional testing is needed with other configurations to make sure this isn't a regression for anyone.