### PR TITLE
Spawn all ruins during game loading

### DIFF
--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -57,7 +57,14 @@ local positionCheckLibrary = VFS.Include("luarules/utilities/damgam_lib/position
 local blueprintController = VFS.Include("luarules/gadgets/ruins/Blueprints/BYAR/blueprint_controller.lua")
 local scavConfig = VFS.Include("LuaRules/Configs/scav_spawn_defs.lua")
 
-local spawnCutoffFrame = (math.ceil(math.ceil(mapsizeX * mapsizeZ) / 1000000)) * 3
+-- All ruins finish spawning within the first seconds of the game, before the earliest
+-- possible player-built radar (~7s) can block them: the schedule's frame numbers are
+-- divided by spawnSpeedMultiplier, and as many blueprint ruins spawn per tick.
+local spawnSpeedMultiplier = 5
+local spawnCutoffFrame = math.ceil((math.ceil(math.ceil(mapsizeX * mapsizeZ) / 1000000)) * 3 / spawnSpeedMultiplier)
+
+-- capped so at least one spawn tick fits even on the smallest maps at the rarest density
+local blueprintTickInterval = math.min(math.ceil(5 / ruinDensityMultiplier), spawnCutoffFrame)
 
 -- TODO: Add weights to this crap.
 local landMexesList = {
@@ -568,7 +575,7 @@ local function SpawnMexGeoRandomStructures()
 end
 
 local function SpawnRandomStructures()
-	for i = 1, math.ceil(spawnCutoffFrame / 10) do
+	for i = 1, math.ceil(spawnCutoffFrame * spawnSpeedMultiplier / 10) do
 		for j = 1, math.ceil(10 * ruinDensityMultiplier) do
 			local posx = math.ceil(math.random(196, Game.mapSizeX - 196) / 16) * 16
 			local posz = math.ceil(math.random(196, Game.mapSizeZ - 196) / 16) * 16
@@ -622,37 +629,7 @@ local function SpawnRandomStructures()
 	end
 end
 
-function gadget:GameFrame(n)
-	if n == math.ceil(spawnCutoffFrame * 0.5) then
-		local mexSpots = GG.resource_spot_finder and GG.resource_spot_finder.metalSpotsList or nil
-		if mexSpots and #mexSpots > 5 then
-			SpawnMexes(mexSpots)
-		end
-	end
-
-	if n == 30 then
-		local geoSpots = GG.resource_spot_finder and GG.resource_spot_finder.geoSpotsList or nil
-		if geoSpots and #geoSpots >= 1 then
-			SpawnGeos(geoSpots)
-		end
-	end
-
-	if n == spawnCutoffFrame + 30 then
-		SpawnMexGeoRandomStructures()
-	end
-
-	if n == spawnCutoffFrame + 60 then
-		SpawnRandomStructures()
-	end
-
-	if
-		n < (5 / ruinDensityMultiplier)
-		or n % math.ceil((5 / ruinDensityMultiplier)) ~= 0
-		or n > spawnCutoffFrame + 5
-	then
-		return
-	end
-
+local function SpawnBlueprintRuin()
 	local landRuin, seaRuin, posx, posy, posz, seaRuinChance, radius, canBuildHere, r, blueprintTierLevel
 	for i = 1, 100 do
 		local ruin
@@ -728,5 +705,37 @@ function gadget:GameFrame(n)
 				break
 			end
 		end
+	end
+end
+
+function gadget:GameFrame(n)
+	if n == math.ceil(spawnCutoffFrame * 0.5) then
+		local mexSpots = GG.resource_spot_finder and GG.resource_spot_finder.metalSpotsList or nil
+		if mexSpots and #mexSpots > 5 then
+			SpawnMexes(mexSpots)
+		end
+	end
+
+	if n == math.ceil(Game.gameSpeed / spawnSpeedMultiplier) then
+		local geoSpots = GG.resource_spot_finder and GG.resource_spot_finder.geoSpotsList or nil
+		if geoSpots and #geoSpots >= 1 then
+			SpawnGeos(geoSpots)
+		end
+	end
+
+	if n == spawnCutoffFrame + math.ceil(Game.gameSpeed / spawnSpeedMultiplier) then
+		SpawnMexGeoRandomStructures()
+	end
+
+	if n == spawnCutoffFrame + math.ceil(2 * Game.gameSpeed / spawnSpeedMultiplier) then
+		SpawnRandomStructures()
+	end
+
+	if n < blueprintTickInterval or n % blueprintTickInterval ~= 0 or n > spawnCutoffFrame + 5 then
+		return
+	end
+
+	for _ = 1, spawnSpeedMultiplier do
+		SpawnBlueprintRuin()
 	end
 end

--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -57,26 +57,21 @@ local positionCheckLibrary = VFS.Include("luarules/utilities/damgam_lib/position
 local blueprintController = VFS.Include("luarules/gadgets/ruins/Blueprints/BYAR/blueprint_controller.lua")
 local scavConfig = VFS.Include("LuaRules/Configs/scav_spawn_defs.lua")
 
--- All ruins spawn during loading (GamePreload), like scenario unit loadouts: the whole
--- cost is absorbed into the loading screen and ruins are never seen appearing.
 -- spawnAmountBudget scales ruin amounts with map area.
 local spawnAmountBudget = (math.ceil(math.ceil(mapsizeX * mapsizeZ) / 1000000)) * 3
 local blueprintTicksTotal = math.floor((spawnAmountBudget + 5) / math.ceil(5 / ruinDensityMultiplier))
 
--- Ruins overlapping a start position are erased right after commanders are placed: the
--- cleared area is just commander size plus a small margin, so ruins stand right outside.
-local startClearMargin = 8
-local maxCommanderRadius = 0
-local maxUnitRadius = 0
-for _, unitDef in pairs(UnitDefs) do
-	if unitDef.radius > maxUnitRadius then
-		maxUnitRadius = unitDef.radius
-	end
-	if unitDef.customParams.iscommander and unitDef.radius > maxCommanderRadius then
-		maxCommanderRadius = unitDef.radius
+local unitHalfFootprint = {}
+local maxUnitHalfFootprint = 0
+for unitDefID, unitDef in pairs(UnitDefs) do
+	-- xsize/zsize are footprint sizes in map squares
+	local halfFootprint = math.max(unitDef.xsize, unitDef.zsize) * Game.squareSize / 2
+	unitHalfFootprint[unitDefID] = halfFootprint
+
+	if halfFootprint > maxUnitHalfFootprint then
+		maxUnitHalfFootprint = halfFootprint
 	end
 end
-local startClearRadius = maxCommanderRadius + startClearMargin
 
 -- TODO: Add weights to this crap.
 local landMexesList = {
@@ -725,7 +720,6 @@ function gadget:GamePreload()
 		return -- savegames and mid-game reloads already have their ruins
 	end
 
-	-- geos first, mexes halfway through the blueprint ruins, defence batches last:
 	-- spawn order affects placement success rates near resource spots
 	local geoSpots = GG.resource_spot_finder and GG.resource_spot_finder.geoSpotsList or nil
 	if geoSpots and #geoSpots >= 1 then
@@ -750,20 +744,26 @@ function gadget:GamePreload()
 	SpawnRandomStructures()
 end
 
-function gadget:GameFrame(n)
-	if n == 1 then
-		-- commanders were placed in GameStart; erase the ruins they physically overlap,
-		-- counting each unit's own radius so large buildings poking into the area go too
+function gadget:GameFramePost(n)
+	if n == 0 then
+		-- commanders were placed in GameStart: clear each one's build range, the ring shown during start placement
 		for _, teamID in ipairs(Spring.GetTeamList()) do
 			if teamID ~= GaiaTeamID then
-				local x, _, z = Spring.GetTeamStartPosition(teamID)
-				if x > 0 then
-					local nearbyRuins = Spring.GetUnitsInCylinder(x, z, startClearRadius + maxUnitRadius, GaiaTeamID)
-					for i = 1, #nearbyRuins do
-						local unitID = nearbyRuins[i]
-						local ux, _, uz = Spring.GetUnitPosition(unitID)
-						if math.distance2d(ux, uz, x, z) - Spring.GetUnitRadius(unitID) < startClearRadius then
-							Spring.DestroyUnit(unitID, false, true)
+				local teamUnits = Spring.GetTeamUnits(teamID)
+				for i = 1, #teamUnits do
+					local commanderID = teamUnits[i]
+					local commanderDef = UnitDefs[Spring.GetUnitDefID(commanderID)]
+					if commanderDef.customParams.iscommander then
+						local clearRadius = commanderDef.buildDistance
+						local x, _, z = Spring.GetUnitPosition(commanderID)
+						local nearbyRuins =
+							Spring.GetUnitsInCylinder(x, z, clearRadius + maxUnitHalfFootprint, GaiaTeamID)
+						for j = 1, #nearbyRuins do
+							local unitID = nearbyRuins[j]
+							local ux, _, uz = Spring.GetUnitPosition(unitID)
+							if math.distance2d(ux, uz, x, z) < clearRadius + unitHalfFootprint[Spring.GetUnitDefID(unitID)] then
+								Spring.DestroyUnit(unitID, false, true)
+							end
 						end
 					end
 				end

--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -57,14 +57,26 @@ local positionCheckLibrary = VFS.Include("luarules/utilities/damgam_lib/position
 local blueprintController = VFS.Include("luarules/gadgets/ruins/Blueprints/BYAR/blueprint_controller.lua")
 local scavConfig = VFS.Include("LuaRules/Configs/scav_spawn_defs.lua")
 
--- All ruins finish spawning within the first seconds of the game, before the earliest
--- possible player-built radar (~7s) can block them: the schedule's frame numbers are
--- divided by spawnSpeedMultiplier, and as many blueprint ruins spawn per tick.
-local spawnSpeedMultiplier = 5
-local spawnCutoffFrame = math.ceil((math.ceil(math.ceil(mapsizeX * mapsizeZ) / 1000000)) * 3 / spawnSpeedMultiplier)
+-- All ruins spawn during loading (GamePreload), like scenario unit loadouts: the whole
+-- cost is absorbed into the loading screen and ruins are never seen appearing.
+-- spawnAmountBudget scales ruin amounts with map area.
+local spawnAmountBudget = (math.ceil(math.ceil(mapsizeX * mapsizeZ) / 1000000)) * 3
+local blueprintTicksTotal = math.floor((spawnAmountBudget + 5) / math.ceil(5 / ruinDensityMultiplier))
 
--- capped so at least one spawn tick fits even on the smallest maps at the rarest density
-local blueprintTickInterval = math.min(math.ceil(5 / ruinDensityMultiplier), spawnCutoffFrame)
+-- Ruins overlapping a start position are erased right after commanders are placed: the
+-- cleared area is just commander size plus a small margin, so ruins stand right outside.
+local startClearMargin = 8
+local maxCommanderRadius = 0
+local maxUnitRadius = 0
+for _, unitDef in pairs(UnitDefs) do
+	if unitDef.radius > maxUnitRadius then
+		maxUnitRadius = unitDef.radius
+	end
+	if unitDef.customParams.iscommander and unitDef.radius > maxCommanderRadius then
+		maxCommanderRadius = unitDef.radius
+	end
+end
+local startClearRadius = maxCommanderRadius + startClearMargin
 
 -- TODO: Add weights to this crap.
 local landMexesList = {
@@ -575,7 +587,7 @@ local function SpawnMexGeoRandomStructures()
 end
 
 local function SpawnRandomStructures()
-	for i = 1, math.ceil(spawnCutoffFrame * spawnSpeedMultiplier / 10) do
+	for i = 1, math.ceil(spawnAmountBudget / 10) do
 		for j = 1, math.ceil(10 * ruinDensityMultiplier) do
 			local posx = math.ceil(math.random(196, Game.mapSizeX - 196) / 16) * 16
 			local posz = math.ceil(math.random(196, Game.mapSizeZ - 196) / 16) * 16
@@ -708,34 +720,56 @@ local function SpawnBlueprintRuin()
 	end
 end
 
-function gadget:GameFrame(n)
-	if n == math.ceil(spawnCutoffFrame * 0.5) then
-		local mexSpots = GG.resource_spot_finder and GG.resource_spot_finder.metalSpotsList or nil
-		if mexSpots and #mexSpots > 5 then
-			SpawnMexes(mexSpots)
-		end
+function gadget:GamePreload()
+	if Spring.GetGameRulesParam("loadedGame") == 1 or Spring.GetGameFrame() >= 1 then
+		return -- savegames and mid-game reloads already have their ruins
 	end
 
-	if n == math.ceil(Game.gameSpeed / spawnSpeedMultiplier) then
-		local geoSpots = GG.resource_spot_finder and GG.resource_spot_finder.geoSpotsList or nil
-		if geoSpots and #geoSpots >= 1 then
-			SpawnGeos(geoSpots)
-		end
+	-- geos first, mexes halfway through the blueprint ruins, defence batches last:
+	-- spawn order affects placement success rates near resource spots
+	local geoSpots = GG.resource_spot_finder and GG.resource_spot_finder.geoSpotsList or nil
+	if geoSpots and #geoSpots >= 1 then
+		SpawnGeos(geoSpots)
 	end
 
-	if n == spawnCutoffFrame + math.ceil(Game.gameSpeed / spawnSpeedMultiplier) then
-		SpawnMexGeoRandomStructures()
-	end
-
-	if n == spawnCutoffFrame + math.ceil(2 * Game.gameSpeed / spawnSpeedMultiplier) then
-		SpawnRandomStructures()
-	end
-
-	if n < blueprintTickInterval or n % blueprintTickInterval ~= 0 or n > spawnCutoffFrame + 5 then
-		return
-	end
-
-	for _ = 1, spawnSpeedMultiplier do
+	local firstHalfTicks = math.floor(blueprintTicksTotal * 0.5)
+	for _ = 1, firstHalfTicks do
 		SpawnBlueprintRuin()
 	end
+
+	local mexSpots = GG.resource_spot_finder and GG.resource_spot_finder.metalSpotsList or nil
+	if mexSpots and #mexSpots > 5 then
+		SpawnMexes(mexSpots)
+	end
+
+	for _ = 1, blueprintTicksTotal - firstHalfTicks do
+		SpawnBlueprintRuin()
+	end
+
+	SpawnMexGeoRandomStructures()
+	SpawnRandomStructures()
+end
+
+function gadget:GameFrame(n)
+	if n == 1 then
+		-- commanders were placed in GameStart; erase the ruins they physically overlap,
+		-- counting each unit's own radius so large buildings poking into the area go too
+		for _, teamID in ipairs(Spring.GetTeamList()) do
+			if teamID ~= GaiaTeamID then
+				local x, _, z = Spring.GetTeamStartPosition(teamID)
+				if x > 0 then
+					local nearbyRuins = Spring.GetUnitsInCylinder(x, z, startClearRadius + maxUnitRadius, GaiaTeamID)
+					for i = 1, #nearbyRuins do
+						local unitID = nearbyRuins[i]
+						local ux, _, uz = Spring.GetUnitPosition(unitID)
+						if math.distance2d(ux, uz, x, z) - Spring.GetUnitRadius(unitID) < startClearRadius then
+							Spring.DestroyUnit(unitID, false, true)
+						end
+					end
+				end
+			end
+		end
+	end
+
+	gadgetHandler:RemoveGadget(self)
 end


### PR DESCRIPTION
### Work done

Ruins currently spawn across the first 5 to 25+ seconds of the game, depending on map size. Any radar finished during that window blocks ruins from spawning inside its range, so one uninformed player building an early radar cancels a significant number of ruins. Players are asked not to build early radar in Ruins lobbies but often miss or ignore it. The staged spawning also forces everyone to place their start position ~3.5 tiles away from mexes, since commander sight/radar blocks nearby ruins from spawning.

This PR moves all ruin spawning into GamePreload (the loading phase), the same way scenario unit loadouts spawn. Ruins are fully placed before the game starts, so nothing can block them and nothing is ever seen appearing. Right after commanders are placed, ruins within each commander's build range are erased, matching the ring players see during start placement (including lobbies with increased build range), so a commander can never spawn clipped into a building and always has room for its opening build.

### Player-facing results:

- Radar timing no longer matters at all.
- Players can spawn next to mexes, and ruins now appear everywhere including start areas, matching the original concept of ruins as ancient buildings that have always been there
- Zero cost in live frames: spawning adds ~1s to the loading screen (measured on the 32x32 map, Very dense) and the erase takes ~25ms in the first sim frame
- Approach discussed in the PR conversation and with Damgam and Ruins players on Discord https://discord.com/channels/549281623154229250/1540099822499926117
- Measurements (32x32 map, Very dense, same seed) 2010 ruins on master vs ~1910 with this PR, within ~5% while also newly covering start areas. 
Side note: with the "Disable Fog of War" modoption, ruins previously did not spawn at all (everything counted as visible); with this PR they work there too.

### Test steps

- [x]  Start a game with Ruins enabled (Very dense shows it best)
- [x]  All ruins are already present the moment the game starts, including near start positions
- [x]  Place your start next to a mex, the commander lands with ruins visible in its vicinity
- [x]  Build a radar immediately: ruin coverage is unaffected
- [x]  Ruin amounts are roughly the same as on master

### Screenshots:
BEFORE:

https://github.com/user-attachments/assets/8a8902dd-9325-4474-bf49-5395c1e07a3c

AFTER:

https://github.com/user-attachments/assets/c114ba67-0f46-4422-ad26-b3d742d47213


### AI / LLM usage statement:
Used Claude Fable to help with coding and tuning of the right approach.