### PR TITLE
Added Unified factions settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 # August
+• [Allow Use All Units] New experimental modoption. Every factory and constructor can build the matching units of all factions
+	- Shared structures stay as your own faction's version, so there are no duplicate lab, mex or solar buttons
 • [Floating AA turrets] Stats made to match their land counterparts
 
 # July

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -348,6 +348,9 @@ preProcessUnitDefs()
 if scavengersEnabled then
 	createScavengerUnitDefs()
 end
+if modOptions.experimentalunifiedfactions then
+	VFS.Include("unitbasedefs/unified_factions.lua").Apply(UnitDefs)
+end
 postProcessAllUnitDefs()
 postProcessRegularUnitDefs()
 postProcessScavengerUnitDefs()

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -3568,6 +3568,10 @@
 			"name": "Legion Faction",
 			"desc": "3rd experimental faction"
 		},
+		"experimentalunifiedfactions": {
+			"name": "Allow Use All Units",
+			"desc": "Every factory and constructor can build the matching units of all factions.\nShared structures stay as your own faction's version, faction-unique ones are added.\nCommanders are excluded. Legion units are only included when the Legion Faction option is also enabled."
+		},
 		"legionsimplifiedmexes": {
 			"name": "Legion Simplified Mexes",
 			"desc": "Changes the legion T1 mex to act the same as the other T1 mexes.\nAlso buffs the solar/wind generators on par with other factions.\nGoblin cost 25m/500e -> 30m/420e, Satyr 400 -> 600e"

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1987,6 +1987,15 @@ local options = {
 		def = false,
 	},
 
+	{
+		key = "experimentalunifiedfactions",
+		name = "Allow Use All Units",
+		desc = "Every factory and constructor can build the matching units of all factions.\nShared structures stay as your own faction's version, faction-unique ones are added.\nCommanders are excluded. Legion units are only included when the Legion Faction option is also enabled.",
+		type = "bool",
+		section = "options_experimental",
+		def = false,
+	},
+
 	-- NOTE: update language/en/interface.json when you change name or desc
 	{
 		key = "legionsimplifiedmexes",

--- a/unitbasedefs/unified_factions.lua
+++ b/unitbasedefs/unified_factions.lua
@@ -44,7 +44,80 @@ local function GetOrderedOptions(BuildOptions)
 	return Ordered
 end
 
-local function ResolveOption(AllUnitDefs, OptionName, OwnPrefix)
+local function NormalizeDisplayName(Display)
+	if string.sub(Display, 1, 7) == "Legion " then
+		return string.sub(Display, 8)
+	end
+	return Display
+end
+
+local function LoadDisplayNames()
+	local Loaded, Raw = pcall(VFS.LoadFile, "language/en/units.json")
+	if not Loaded or type(Raw) ~= "string" then
+		return {}
+	end
+
+	local Decoded, Parsed = pcall(function()
+		return VFS.Include("common/luaUtilities/json.lua").decode(Raw)
+	end)
+	if not Decoded or type(Parsed) ~= "table" then
+		return {}
+	end
+
+	local Units = Parsed.units
+	if type(Units) ~= "table" or type(Units.names) ~= "table" then
+		return {}
+	end
+	return Units.names
+end
+
+local function BuildDisplayIndex(AllUnitDefs, DisplayNames)
+	local Index = { Mobile = {}, Static = {} }
+
+	for UnitName, UnitDef in pairs(AllUnitDefs) do
+		local Prefix = GetFactionPrefix(UnitName)
+		local Display = DisplayNames[UnitName]
+
+		if Prefix ~= nil and Display ~= nil and not IsScavengerName(UnitName) and not IsCommanderDef(UnitDef) then
+			local Kind = IsMobileDef(UnitDef) and Index.Mobile or Index.Static
+			local Key = NormalizeDisplayName(Display)
+
+			if Kind[Prefix] == nil then
+				Kind[Prefix] = {}
+			end
+
+			if Kind[Prefix][Key] == nil then
+				Kind[Prefix][Key] = UnitName
+			else
+				Kind[Prefix][Key] = false
+			end
+		end
+	end
+
+	return Index
+end
+
+local function FindOwnByDisplay(Context, OptionName, OptionDef, OwnPrefix)
+	local Display = Context.DisplayNames[OptionName]
+	if Display == nil then
+		return nil
+	end
+
+	local Kind = IsMobileDef(OptionDef) and Context.DisplayIndex.Mobile or Context.DisplayIndex.Static
+	local OwnBucket = Kind[OwnPrefix]
+	if OwnBucket == nil then
+		return nil
+	end
+
+	local Match = OwnBucket[NormalizeDisplayName(Display)]
+	if Match then
+		return Match
+	end
+	return nil
+end
+
+local function ResolveOption(Context, OptionName, OwnPrefix)
+	local AllUnitDefs = Context.UnitDefs
 	local OptionDef = AllUnitDefs[OptionName]
 	if OptionDef == nil then
 		return nil
@@ -60,7 +133,7 @@ local function ResolveOption(AllUnitDefs, OptionName, OwnPrefix)
 	end
 
 	if IsMobileDef(OptionDef) then
-		return OptionName
+		return FindOwnByDisplay(Context, OptionName, OptionDef, OwnPrefix) or OptionName
 	end
 
 	local OwnVariant = OwnPrefix .. GetBaseName(OptionName)
@@ -68,7 +141,7 @@ local function ResolveOption(AllUnitDefs, OptionName, OwnPrefix)
 		return OwnVariant
 	end
 
-	return OptionName
+	return FindOwnByDisplay(Context, OptionName, OptionDef, OwnPrefix) or OptionName
 end
 
 local function CollectBuilderGroups(AllUnitDefs)
@@ -92,18 +165,18 @@ local function CollectBuilderGroups(AllUnitDefs)
 	return BuilderGroups
 end
 
-local function BuildMergedOptions(AllUnitDefs, GroupMembers, OwnPrefix)
+local function BuildMergedOptions(Context, GroupMembers, OwnPrefix)
 	local MergedOptions = {}
 	local SeenOptions = {}
 
 	local function AppendFrom(SourceName)
-		local SourceDef = AllUnitDefs[SourceName]
+		local SourceDef = Context.UnitDefs[SourceName]
 		if SourceDef == nil then
 			return
 		end
 
 		for _, OptionName in ipairs(GetOrderedOptions(SourceDef.buildoptions)) do
-			local Resolved = ResolveOption(AllUnitDefs, OptionName, OwnPrefix)
+			local Resolved = ResolveOption(Context, OptionName, OwnPrefix)
 			if Resolved ~= nil and not SeenOptions[Resolved] then
 				SeenOptions[Resolved] = true
 				MergedOptions[#MergedOptions + 1] = Resolved
@@ -124,12 +197,19 @@ local function BuildMergedOptions(AllUnitDefs, GroupMembers, OwnPrefix)
 end
 
 local function ApplyUnifiedFactions(AllUnitDefs)
+	local DisplayNames = LoadDisplayNames()
+	local Context = {
+		UnitDefs = AllUnitDefs,
+		DisplayNames = DisplayNames,
+		DisplayIndex = BuildDisplayIndex(AllUnitDefs, DisplayNames),
+	}
+
 	local BuilderGroups = CollectBuilderGroups(AllUnitDefs)
 	local MergedResults = {}
 
 	for _, GroupMembers in pairs(BuilderGroups) do
 		for OwnPrefix, BuilderName in pairs(GroupMembers) do
-			MergedResults[BuilderName] = BuildMergedOptions(AllUnitDefs, GroupMembers, OwnPrefix)
+			MergedResults[BuilderName] = BuildMergedOptions(Context, GroupMembers, OwnPrefix)
 		end
 	end
 

--- a/unitbasedefs/unified_factions.lua
+++ b/unitbasedefs/unified_factions.lua
@@ -1,0 +1,143 @@
+local FactionPrefixes = { "arm", "cor", "leg" }
+
+local FactionLookup = {}
+for Index = 1, #FactionPrefixes do
+	FactionLookup[FactionPrefixes[Index]] = true
+end
+
+local function GetFactionPrefix(UnitName)
+	local Prefix = string.sub(UnitName, 1, 3)
+	if FactionLookup[Prefix] then
+		return Prefix
+	end
+	return nil
+end
+
+local function GetBaseName(UnitName)
+	return string.sub(UnitName, 4)
+end
+
+local function IsScavengerName(UnitName)
+	return string.sub(UnitName, -5) == "_scav"
+end
+
+local function IsMobileDef(UnitDef)
+	return UnitDef.speed ~= nil and UnitDef.speed > 0
+end
+
+local function IsCommanderDef(UnitDef)
+	local CustomParams = UnitDef.customparams
+	return CustomParams ~= nil and CustomParams.iscommander == true
+end
+
+local function GetOrderedOptions(BuildOptions)
+	local Keys = {}
+	for Key in pairs(BuildOptions) do
+		Keys[#Keys + 1] = Key
+	end
+	table.sort(Keys)
+
+	local Ordered = {}
+	for Index = 1, #Keys do
+		Ordered[Index] = BuildOptions[Keys[Index]]
+	end
+	return Ordered
+end
+
+local function ResolveOption(AllUnitDefs, OptionName, OwnPrefix)
+	local OptionDef = AllUnitDefs[OptionName]
+	if OptionDef == nil then
+		return nil
+	end
+
+	if IsCommanderDef(OptionDef) then
+		return nil
+	end
+
+	local OptionPrefix = GetFactionPrefix(OptionName)
+	if OptionPrefix == nil or OptionPrefix == OwnPrefix then
+		return OptionName
+	end
+
+	if IsMobileDef(OptionDef) then
+		return OptionName
+	end
+
+	local OwnVariant = OwnPrefix .. GetBaseName(OptionName)
+	if AllUnitDefs[OwnVariant] ~= nil then
+		return OwnVariant
+	end
+
+	return OptionName
+end
+
+local function CollectBuilderGroups(AllUnitDefs)
+	local BuilderGroups = {}
+
+	for UnitName, UnitDef in pairs(AllUnitDefs) do
+		if not IsScavengerName(UnitName) then
+			local Prefix = GetFactionPrefix(UnitName)
+			local BuildOptions = UnitDef.buildoptions
+
+			if Prefix ~= nil and BuildOptions ~= nil and next(BuildOptions) ~= nil then
+				local BaseName = GetBaseName(UnitName)
+				if BuilderGroups[BaseName] == nil then
+					BuilderGroups[BaseName] = {}
+				end
+				BuilderGroups[BaseName][Prefix] = UnitName
+			end
+		end
+	end
+
+	return BuilderGroups
+end
+
+local function BuildMergedOptions(AllUnitDefs, GroupMembers, OwnPrefix)
+	local MergedOptions = {}
+	local SeenOptions = {}
+
+	local function AppendFrom(SourceName)
+		local SourceDef = AllUnitDefs[SourceName]
+		if SourceDef == nil then
+			return
+		end
+
+		for _, OptionName in ipairs(GetOrderedOptions(SourceDef.buildoptions)) do
+			local Resolved = ResolveOption(AllUnitDefs, OptionName, OwnPrefix)
+			if Resolved ~= nil and not SeenOptions[Resolved] then
+				SeenOptions[Resolved] = true
+				MergedOptions[#MergedOptions + 1] = Resolved
+			end
+		end
+	end
+
+	AppendFrom(GroupMembers[OwnPrefix])
+
+	for Index = 1, #FactionPrefixes do
+		local OtherPrefix = FactionPrefixes[Index]
+		if OtherPrefix ~= OwnPrefix and GroupMembers[OtherPrefix] ~= nil then
+			AppendFrom(GroupMembers[OtherPrefix])
+		end
+	end
+
+	return MergedOptions
+end
+
+local function ApplyUnifiedFactions(AllUnitDefs)
+	local BuilderGroups = CollectBuilderGroups(AllUnitDefs)
+	local MergedResults = {}
+
+	for _, GroupMembers in pairs(BuilderGroups) do
+		for OwnPrefix, BuilderName in pairs(GroupMembers) do
+			MergedResults[BuilderName] = BuildMergedOptions(AllUnitDefs, GroupMembers, OwnPrefix)
+		end
+	end
+
+	for BuilderName, MergedOptions in pairs(MergedResults) do
+		AllUnitDefs[BuilderName].buildoptions = MergedOptions
+	end
+end
+
+return {
+	Apply = ApplyUnifiedFactions,
+}


### PR DESCRIPTION
### Work done
Adds an experimental modoption, `experimentalunifiedfactions` ("Allow Use All Units"), default off. When enabled, every factory and constructor can build the matching units of all factions from its existing build menu.

The merge lives in a new module, `unitbasedefs/unified_factions.lua`, called from `gamedata/unitdefs_post.lua` after scavenger defs are created and before `postProcessAllUnitDefs()`. It runs at def load time rather than from a gadget because the engine bakes build menus from `buildoptions` before any gadget runs, running it just before `postProcessAllUnitDefs()` also lets the existing validation and dedup pass clean up the merged lists.

How it works:
1. Group builders by faction stripped name, so `armlab` / `corlab` / `leglab` all map to `lab`.
2. Union each group's `buildoptions`, own faction first, preserving existing menu order.

Every merged entry already existed in some builder's `buildoptions`, so the option can't expose spawner only or otherwise unbuildable defs.

Two details worth flagging for review:
- **Shared table references.** Multiple defs can share one `buildoptions` table, so the module builds all merged lists first, then assigns fresh tables. Editing in place would cascade merges each other.

Legion is deliberately not force enabled, Legion units merge in only when `experimentallegionfaction` is also on, so Legion is either fully present or fully absent and gadgets reading that modoption never disagree with what's loaded.

#### Setup
Enable **Allow Use All Units** under Settings > Experimental. Optionally enable **Legion Faction** to include Legion units.

#### Test steps
- [ ] Option off - nothing changes: Armada Bot Lab builds 8, Vehicle Plant 10, Commander 26.
- [ ] Option on, Legion off — Bot Lab 14, Vehicle Plant 20, constructor 36. No Legion content.
- [ ] Both on - Bot Lab 22, Vehicle Plant 30, constructor 47, Commander 33.

### AI / LLM usage statement:
Claude helped me write my addition to `changelog.txt` because I could not for the life of me make a text thing for it. and this message to, heavily modified by me however to make it accurate.