### PR TITLE
Fix Advanced Metal Fortifier ignoring Set Target and Attack commands

### DIFF
--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -21,8 +21,6 @@ local spGetUnitHealth = Spring.GetUnitHealth
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local SendToUnsynced = SendToUnsynced
 
-local reissueOrder = Game.Commands.ReissueOrder
-
 -- TODO: do not use hardcoded unit names
 local unitDefData = {
 	legmohocon = { mex = "legmohoconin", con = "legmohoconct" },
@@ -39,11 +37,6 @@ end
 local fakeBuildDefID = {} -- combined mex + con unit model used while constructing
 local mexActualDefID = {} -- the mex, which is non-interactive, but extracts metal
 local mexTurretDefID = {} -- the con, which is interactive and shows in GUI, etc.
-
--- the con turret is engine-"transported" by the mex and can never be targeted
--- (targetableTransportedUnits = false), so attack orders aimed at it are
--- redirected to the mex
-local turretToMex = {} -- con turret unitID -> its mex
 
 for unitName, unitPair in pairs(unitDefData) do
 	local buildDef = UnitDefNames[unitName]
@@ -94,7 +87,6 @@ local function doSwapMex(unitID, unitTeam, unitData)
 		return
 	end
 	Spring.SetUnitBlocking(mexID, true, true, false)
-	Spring.SetUnitNoSelect(mexID, true)
 	SendToUnsynced("setUnitNoGroup", mexID, true)
 	Spring.SetUnitStealth(mexID, true)
 
@@ -108,12 +100,17 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	Spring.SetUnitHealth(conID, unitHealth)
 
 	-- TODO: Get attachment piece by customparam.
-	Spring.UnitAttach(mexID, conID, 6, true)
+	-- the turret must be the transporter: transported units cannot be targeted
+	Spring.UnitAttach(conID, mexID, 1, true)
+	-- set after attaching, which resets these states
+	Spring.SetUnitNoSelect(mexID, true)
+	Spring.SetUnitNoMinimap(mexID, true)
+	Spring.SetUnitIconDraw(mexID, false)
+	Spring.SetUnitNoDraw(mexID, true)
 	Spring.SetUnitRulesParam(conID, "pairedUnitID", mexID)
 	Spring.SetUnitRulesParam(mexID, "pairedUnitID", conID)
 	pairedUnits[conID] = mexID
 	pairedUnits[mexID] = conID
-	turretToMex[conID] = mexID
 	setMexSpeed[conID] = mexID
 
 	if isUnitNeutral then
@@ -258,12 +255,10 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 	end
 
 	if mexActualDefID[unitDefID] or mexTurretDefID[unitDefID] then
-		turretToMex[unitID] = nil
 		local pairedUnitID = pairedUnits[unitID]
 		if pairedUnitID then
 			pairedUnits[unitID] = nil
 			pairedUnits[pairedUnitID] = nil
-			turretToMex[pairedUnitID] = nil
 			Spring.DestroyUnit(pairedUnitID, false, true)
 		end
 	end
@@ -282,18 +277,12 @@ function gadget:AllowCommand(
 	fromLua,
 	fromInsert
 )
-	-- accepts CMD.ONOFF, CMD.ATTACK:
-	if cmdID == CMD.ONOFF and mexTurretDefID[unitDefID] then
+	-- accepts CMD.ONOFF:
+	if mexTurretDefID[unitDefID] then
 		local mexID = pairedUnits[unitID]
 		if mexID then
 			spGiveOrderToUnit(mexID, cmdID, cmdParams, cmdOptions)
 			setMexSpeed[unitID] = mexID
-		end
-	elseif cmdID == CMD.ATTACK and #cmdParams == 1 then
-		local mexID = turretToMex[cmdParams[1]]
-		if mexID then
-			reissueOrder(unitID, cmdID, { mexID }, cmdOptions, cmdTag, fromInsert)
-			return false
 		end
 	end
 	return true
@@ -301,7 +290,6 @@ end
 
 function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD.ONOFF)
-	gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
 
 	for _, unitID in pairs(Spring.GetAllUnits()) do
 		if not Spring.GetUnitIsBeingBuilt(unitID) then
@@ -313,7 +301,6 @@ function gadget:Initialize()
 				if pairedUnitID then
 					pairedUnits[unitID] = pairedUnitID
 					pairedUnits[pairedUnitID] = unitID
-					turretToMex[pairedUnitID] = unitID
 					setMexSpeed[pairedUnitID] = unitID
 				end
 			end

--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -21,6 +21,8 @@ local spGetUnitHealth = Spring.GetUnitHealth
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local SendToUnsynced = SendToUnsynced
 
+local reissueOrder = Game.Commands.ReissueOrder
+
 -- TODO: do not use hardcoded unit names
 local unitDefData = {
 	legmohocon = { mex = "legmohoconin", con = "legmohoconct" },
@@ -37,6 +39,11 @@ end
 local fakeBuildDefID = {} -- combined mex + con unit model used while constructing
 local mexActualDefID = {} -- the mex, which is non-interactive, but extracts metal
 local mexTurretDefID = {} -- the con, which is interactive and shows in GUI, etc.
+
+-- the con turret is engine-"transported" by the mex and can never be targeted
+-- (targetableTransportedUnits = false), so attack orders aimed at it are
+-- redirected to the mex
+local turretToMex = {} -- con turret unitID -> its mex
 
 for unitName, unitPair in pairs(unitDefData) do
 	local buildDef = UnitDefNames[unitName]
@@ -106,6 +113,7 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	Spring.SetUnitRulesParam(mexID, "pairedUnitID", conID)
 	pairedUnits[conID] = mexID
 	pairedUnits[mexID] = conID
+	turretToMex[conID] = mexID
 	setMexSpeed[conID] = mexID
 
 	if isUnitNeutral then
@@ -250,10 +258,12 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
 	end
 
 	if mexActualDefID[unitDefID] or mexTurretDefID[unitDefID] then
+		turretToMex[unitID] = nil
 		local pairedUnitID = pairedUnits[unitID]
 		if pairedUnitID then
 			pairedUnits[unitID] = nil
 			pairedUnits[pairedUnitID] = nil
+			turretToMex[pairedUnitID] = nil
 			Spring.DestroyUnit(pairedUnitID, false, true)
 		end
 	end
@@ -272,12 +282,18 @@ function gadget:AllowCommand(
 	fromLua,
 	fromInsert
 )
-	-- accepts CMD.ONOFF:
-	if mexTurretDefID[unitDefID] then
+	-- accepts CMD.ONOFF, CMD.ATTACK:
+	if cmdID == CMD.ONOFF and mexTurretDefID[unitDefID] then
 		local mexID = pairedUnits[unitID]
 		if mexID then
 			spGiveOrderToUnit(mexID, cmdID, cmdParams, cmdOptions)
 			setMexSpeed[unitID] = mexID
+		end
+	elseif cmdID == CMD.ATTACK and #cmdParams == 1 then
+		local mexID = turretToMex[cmdParams[1]]
+		if mexID then
+			reissueOrder(unitID, cmdID, { mexID }, cmdOptions, cmdTag, fromInsert)
+			return false
 		end
 	end
 	return true
@@ -285,6 +301,7 @@ end
 
 function gadget:Initialize()
 	gadgetHandler:RegisterAllowCommand(CMD.ONOFF)
+	gadgetHandler:RegisterAllowCommand(CMD.ATTACK)
 
 	for _, unitID in pairs(Spring.GetAllUnits()) do
 		if not Spring.GetUnitIsBeingBuilt(unitID) then
@@ -296,6 +313,7 @@ function gadget:Initialize()
 				if pairedUnitID then
 					pairedUnits[unitID] = pairedUnitID
 					pairedUnits[pairedUnitID] = unitID
+					turretToMex[pairedUnitID] = unitID
 					setMexSpeed[pairedUnitID] = unitID
 				end
 			end

--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -91,17 +91,8 @@ local function doSwapMex(unitID, unitTeam, unitData)
 		return
 	end
 	Spring.SetUnitBlocking(mexID, true, true, false)
-	Spring.SetUnitNoSelect(mexID, true)
 	SendToUnsynced("setUnitNoGroup", mexID, true)
 	Spring.SetUnitStealth(mexID, true)
-
-	local piece = resolveAttachPiece(mexID)
-	if not piece then
-		Spring.DestroyUnit(mexID, false, true)
-		Spring.AddTeamResource(unitTeam, "m", unitData.metal)
-		Spring.AddTeamResource(unitTeam, "e", unitData.energy)
-		return
-	end
 
 	local conID = Spring.CreateUnit(unitData.swapDefs.con, ux, uy, uz, unitFacing, unitTeam)
 	if not conID then
@@ -112,7 +103,22 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	end
 	Spring.SetUnitHealth(conID, unitHealth)
 
-	Spring.UnitAttach(mexID, conID, piece, true)
+	local piece = resolveAttachPiece(conID)
+	if not piece then
+		Spring.DestroyUnit(conID, false, true)
+		Spring.DestroyUnit(mexID, false, true)
+		Spring.AddTeamResource(unitTeam, "m", unitData.metal)
+		Spring.AddTeamResource(unitTeam, "e", unitData.energy)
+		return
+	end
+
+	-- transported units can't be targeted, so the turret carries the mex
+	Spring.UnitAttach(conID, mexID, piece, true)
+	-- attaching resets these
+	Spring.SetUnitNoSelect(mexID, true)
+	Spring.SetUnitNoMinimap(mexID, true)
+	Spring.SetUnitIconDraw(mexID, false)
+	Spring.SetUnitNoDraw(mexID, true)
 	Spring.SetUnitRulesParam(conID, "pairedUnitID", mexID)
 	Spring.SetUnitRulesParam(mexID, "pairedUnitID", conID)
 	pairedUnits[conID] = mexID

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -27,7 +27,6 @@ if gadgetHandler:IsSyncedCode() then
 	local spValidUnitID = Spring.ValidUnitID
 	local spGetUnitDefID = Spring.GetUnitDefID
 	local spGetUnitLosState = Spring.GetUnitLosState
-	local spGetUnitRulesParam = Spring.GetUnitRulesParam
 	local spGetUnitTeam = Spring.GetUnitTeam
 	local spAreTeamsAllied = Spring.AreTeamsAllied
 	local spGetUnitsInRectangle = Spring.GetUnitsInRectangle
@@ -724,17 +723,7 @@ if gadgetHandler:IsSyncedCode() then
 			elseif nParams == 1 then
 				local target = cmdParams[1]
 				if spValidUnitID(target) and not spAreTeamsAllied(unitTeam, spGetUnitTeam(target)) then
-					local allowed = allowTargetUnit(unitID, weaponList, target)
-					if not allowed then
-						-- a paired unit half no weapon may target (eg. the Fortifier con
-						-- turret, engine-"transported" by its hidden mex): retry the pair
-						local pairedID = spGetUnitRulesParam(target, "pairedUnitID")
-						if pairedID and spValidUnitID(pairedID) and allowTargetUnit(unitID, weaponList, pairedID) then
-							target = pairedID
-							allowed = true
-						end
-					end
-					if allowed then
+					if allowTargetUnit(unitID, weaponList, target) then
 						addTargetList = {
 							{
 								alwaysSeen = unitAlwaysSeen[spGetUnitDefID(target)],

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -27,6 +27,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spValidUnitID = Spring.ValidUnitID
 	local spGetUnitDefID = Spring.GetUnitDefID
 	local spGetUnitLosState = Spring.GetUnitLosState
+	local spGetUnitRulesParam = Spring.GetUnitRulesParam
 	local spGetUnitTeam = Spring.GetUnitTeam
 	local spAreTeamsAllied = Spring.AreTeamsAllied
 	local spGetUnitsInRectangle = Spring.GetUnitsInRectangle
@@ -723,7 +724,17 @@ if gadgetHandler:IsSyncedCode() then
 			elseif nParams == 1 then
 				local target = cmdParams[1]
 				if spValidUnitID(target) and not spAreTeamsAllied(unitTeam, spGetUnitTeam(target)) then
-					if allowTargetUnit(unitID, weaponList, target) then
+					local allowed = allowTargetUnit(unitID, weaponList, target)
+					if not allowed then
+						-- a paired unit half no weapon may target (eg. the Fortifier con
+						-- turret, engine-"transported" by its hidden mex): retry the pair
+						local pairedID = spGetUnitRulesParam(target, "pairedUnitID")
+						if pairedID and spValidUnitID(pairedID) and allowTargetUnit(unitID, weaponList, pairedID) then
+							target = pairedID
+							allowed = true
+						end
+					end
+					if allowed then
 						addTargetList = {
 							{
 								alwaysSeen = unitAlwaysSeen[spGetUnitDefID(target)],

--- a/units/Legion/Economy/legmohoconin.lua
+++ b/units/Legion/Economy/legmohoconin.lua
@@ -33,6 +33,7 @@ return { --costs should be same as legmohocon and legmohoconct
 			unitgroup = "metal",
 			cvbuildable = true,
 			metal_extractor = 4,
+			nohealthbars = true,
 			model_author = "Tharsis and Protar",
 			normaltex = "unittextures/leg_normal.dds",
 			removestop = true,


### PR DESCRIPTION
Fixes #8845

## Work done

Another fix in the series of recent fixes of the Fortifier, a unique building that's secretly two units. Its visible con turret is "transported" by the hidden mex, and targetableTransportedUnits = false makes every weapon refuse the turret so Set Target and unit-targeted Attack commands aimed at it were silently dropped (only area attack worked).

Fix: flip the attach so the turret is the transporter, making it natively targetable. The carried mex is hidden and non-interactive (no selection/icon/draw/health bar) so the pair reads as one unit. Also fixes a pre-existing double health bar and the pair being invisible on radar.

This also fixes the range problem from the issue: attackers used to need to get well inside their max range before firing, because the only targetable half had a tiny hitbox. With the turret targetable, its full-size hitbox is used and units open fire at proper range.

Before:
<img width="788" height="586" alt="Image" src="https://github.com/user-attachments/assets/19871823-7cfa-44c2-81b7-9496426821fa" />

After:
<img width="953" height="673" alt="Image" src="https://github.com/user-attachments/assets/e4e85eb7-aeab-4c9e-9548-edbc06eba573" />

## Test steps
Skirmish with Legion, build an Advanced Metal Fortifier on a metal spot: extraction, blocking, single icon and single health bar all correct; enemy units can Set Target and Attack it directly. Verified in game.

Before:

https://github.com/user-attachments/assets/170622d9-2af4-42c4-aa8a-3b6812aa712d

Double health bar in current master (also fixed here):

https://github.com/user-attachments/assets/5873f8e5-d607-4e37-b45e-579a60662528

After:

https://github.com/user-attachments/assets/e8579f48-a41f-4f8d-b193-94736a9c3aef

## AI use
Used Claude for diagnosis and part of the code. Adjusted, tested and verified by me