### PR TITLE
Annotate the GG APIs

### DIFF
--- a/luarules/gadgets/api_build_blocking.lua
+++ b/luarules/gadgets/api_build_blocking.lua
@@ -296,6 +296,11 @@ if gadgetHandler:IsSyncedCode() then
 		gadgetHandler:RemoveChatAction("buildunblock")
 	end
 
+	---Marks a unit definition as unbuildable by a team for the given reason.
+	---Reasons stack: the unit stays blocked until every reason is removed.
+	---@param unitDefID UnitDefID
+	---@param teamID TeamID
+	---@param reasonKey string Identifier for why the unit is blocked, e.g. "terrain_water".
 	function GG.BuildBlocking.AddBlockedUnit(unitDefID, teamID, reasonKey)
 		local blockedUnitDefs = teamBlockedUnitDefs[teamID]
 		if not blockedUnitDefs then
@@ -308,6 +313,11 @@ if gadgetHandler:IsSyncedCode() then
 		notifyUnitBlocked(unitDefID, teamID, unitReasons)
 	end
 
+	---Removes one block reason from a unit definition for a team.
+	---@param unitDefID UnitDefID
+	---@param teamID TeamID
+	---@param reasonKey string Identifier previously passed to `AddBlockedUnit`.
+	---@return boolean removed `true` if that reason was set and has been cleared.
 	function GG.BuildBlocking.RemoveBlockedUnit(unitDefID, teamID, reasonKey)
 		local blockedUnitDefs = teamBlockedUnitDefs[teamID]
 		if not blockedUnitDefs then

--- a/luarules/gadgets/api_pbr_enabler.lua
+++ b/luarules/gadgets/api_pbr_enabler.lua
@@ -39,10 +39,14 @@ if not gadgetHandler:IsSyncedCode() then --unsynced gadget
 
 	local ENVLUT_SAMPLES -- number of cubemap samples
 
+	---Returns the name of the generated BRDF lookup texture.
+	---@return string? texName `nil` if the lookup table failed to generate.
 	local function GetBrdfTexture()
 		return brdfLut:GetTexture()
 	end
 
+	---Returns the name of the generated IBL environment lookup texture.
+	---@return string? texName `nil` if the lookup table failed to generate.
 	local function GetEnvTexture()
 		return envLut:GetTexture()
 	end

--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -244,6 +244,10 @@ local objectDefToUniformBin = {} -- maps unitDefID/featuredefID to a uniform bin
 -- objectDefs are negative for features
 -- objectIDs are negative for features too
 
+---Maps an object definition to the uniform bin its draw call belongs to.
+---@param objectDefID (UnitDefID|-FeatureDefID)? Positive for unitDefIDs, negative for featureDefIDs.
+---@param reason string? Label used in debug output when no bin is found.
+---@return string uniformBinID Falls back to `'otherunit'` for unmapped definitions.
 local function GetUniformBinID(objectDefID, reason)
 	if objectDefID and objectDefToUniformBin[objectDefID] then
 		return objectDefToUniformBin[objectDefID]
@@ -478,7 +482,9 @@ local unitDrawBins = nil -- this also controls whether cusgl4 is on at all!
 
 local objectIDtoDefID = {}
 
-local shaders = {} -- double nested table of {drawflag : {"units":shaderID}}
+---Compiled shaders, keyed by draw flag and then by material name.
+---@type table<integer, table<string, LuaShader>>
+local shaders = {}
 
 local modelsVertexVBO = nil
 local modelsIndexVBO = nil
@@ -550,6 +556,10 @@ end
 local featuresDefsWithAlpha = {}
 local unitDefsUseSkinning = {}
 
+---Returns the compiled shader used to draw an object in a given draw pass.
+---@param drawPass integer Draw flag of the current pass.
+---@param objectDefID (UnitDefID|-FeatureDefID)? Positive for unitDefIDs, negative for featureDefIDs.
+---@return LuaShader|false shader `false` when `objectDefID` is `nil`.
 local function GetShader(drawPass, objectDefID)
 	if objectDefID == nil then
 		return false
@@ -569,6 +579,10 @@ local function GetShader(drawPass, objectDefID)
 	end
 end
 
+---Returns the name of the shader used to draw an object in a given draw pass.
+---@param drawPass integer Draw flag of the current pass.
+---@param objectDefID (UnitDefID|-FeatureDefID)? Positive for unitDefIDs, negative for featureDefIDs.
+---@return "unit"|"unitskinning"|"tree"|"feature"|false shaderName `false` when `objectDefID` is `nil`.
 local function GetShaderName(drawPass, objectDefID)
 	-- this function does 2 table lookups, could get away with just one.
 	if objectDefID == nil then
@@ -603,6 +617,10 @@ local function SetFixedStatePost(drawPass, shaderID)
 	end
 end
 
+---Uploads the draw pass, clip plane, and uniform bin values to the active shader.
+---@param drawPass integer Draw flag of the current pass.
+---@param shaderID integer GL program id of the currently bound shader.
+---@param uniformBinID string Key into `uniformBins`, as returned by `GetUniformBinID`.
 local function SetShaderUniforms(drawPass, shaderID, uniformBinID)
 	-- Cache uniform locations per-shader to avoid repeated gl.GetUniformLocation calls every frame
 	local locCache = uniformLocCache[shaderID]

--- a/luarules/gadgets/game_apm_broadcast.lua
+++ b/luarules/gadgets/game_apm_broadcast.lua
@@ -31,6 +31,8 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	---Excludes the unit's next order from the team's APM count for one game frame.
+	---@param unitID UnitID
 	local function addSkipOrder(unitID)
 		ignoreUnits[unitID] = gameFrame + 1
 	end

--- a/luarules/gadgets/game_quick_start.lua
+++ b/luarules/gadgets/game_quick_start.lua
@@ -165,6 +165,9 @@ local buildsInProgress = {}
 
 GG.quick_start = {}
 
+---Moves tracked state from one commander unit to another.
+---@param oldUnitID UnitID?
+---@param newUnitID UnitID?
 function GG.quick_start.transferCommanderData(oldUnitID, newUnitID)
 	if oldUnitID and newUnitID and spValidUnitID(oldUnitID) and spValidUnitID(newUnitID) then
 		buildsInProgress[newUnitID] = buildsInProgress[oldUnitID]

--- a/luarules/gadgets/game_startbox_config.lua
+++ b/luarules/gadgets/game_startbox_config.lua
@@ -51,6 +51,12 @@ function gadget:Initialize()
 	GG.startBoxConfig = startBoxConfig
 	GG.startBoxConfigSource = configSource
 
+	---Tests a map position against an allyteam's polygonal start box.
+	---@param x number
+	---@param z number
+	---@param allyTeamID AllyTeamID
+	---@return boolean? inside `nil` when no polygon config exists; the caller should
+	---fall back to the engine's axis-aligned start box.
 	GG.IsInsideStartbox = function(x, z, allyTeamID)
 		if not isExplicitConfig then
 			return nil -- caller should fall back to engine AABB
@@ -64,6 +70,13 @@ function gadget:Initialize()
 		return PolygonLib.PointInStartbox(x, z, entry)
 	end
 
+	---Returns the axis-aligned bounding box of an allyteam's start box polygons.
+	---@param allyTeamID AllyTeamID
+	---@return number? xmin `nil` when no polygon config exists; the caller should
+	---fall back to the engine's axis-aligned start box.
+	---@return number? zmin
+	---@return number? xmax
+	---@return number? zmax
 	GG.GetStartboxBounds = function(allyTeamID)
 		if not isExplicitConfig then
 			return nil -- caller should fall back to engine AABB
@@ -77,6 +90,10 @@ function gadget:Initialize()
 		return PolygonLib.GetStartboxBounds(entry)
 	end
 
+	---Returns the raw start box polygons configured for an allyteam.
+	---@param allyTeamID AllyTeamID
+	---@return Position2D[][]? boxes Array of polygons, each an array of `{x, z}` vertex
+	---pairs. `nil` when no polygon config exists.
 	GG.GetStartboxPolygons = function(allyTeamID)
 		if not isExplicitConfig then
 			return nil

--- a/luarules/gadgets/game_team_death_effect.lua
+++ b/luarules/gadgets/game_team_death_effect.lua
@@ -44,6 +44,12 @@ local function getSqrDistance(x1, z1, x2, z2)
 	return (dx * dx) + (dz * dz)
 end
 
+---Neutralizes a team's units and queues them to explode
+---@param teamID TeamID
+---@param originX number? Wave epicentre; when omitted the death frames are randomized.
+---@param originZ number? Wave epicentre; when omitted the death frames are randomized.
+---@param attackerUnitID UnitID? Credited as the killer of the destroyed units.
+---@param periodMult number? Scales how long the wave takes. Defaults to `1`.
 local function wipeoutTeam(teamID, originX, originZ, attackerUnitID, periodMult) -- only teamID is required
 	wipedoutTeams[teamID] = Spring.GetGameFrame()
 	periodMult = periodMult or 1
@@ -101,6 +107,12 @@ local function wipeoutTeam(teamID, originX, originZ, attackerUnitID, periodMult)
 	GG.maxDeathFrame = GG.maxDeathFrame and math.max(GG.maxDeathFrame, maxDeathFrame) or maxDeathFrame -- storing frame of total unit wipeout
 end
 
+---Wipes out every team in an allyteam, shortening the wave when few units remain.
+---@param allyTeamID AllyTeamID
+---@param attackerUnitID UnitID? Credited as the killer of the destroyed units.
+---@param originX number? Wave epicentre; when omitted the death frames are randomized.
+---@param originZ number? Wave epicentre; when omitted the death frames are randomized.
+---@param periodMult number? Scales how long the wave takes. Defaults to `1`.
 local function wipeoutAllyTeam(allyTeamID, attackerUnitID, originX, originZ, periodMult) -- only allyTeamID is required
 	-- xmas gadget uses this (to prevent creating xmasballs)
 	if not _G.destroyingTeam then

--- a/luarules/gadgets/game_team_power_watcher.lua
+++ b/luarules/gadgets/game_team_power_watcher.lua
@@ -15,6 +15,11 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
+---A team paired with a power value, as returned by the highest/lowest lookups.
+---@class PowerLib.TeamPower
+---@field teamID TeamID? `nil` when no team qualified.
+---@field power number
+
 local teamIsOverPoweredRatio = 1.25
 local alliesAreWinningRatio = 1.25
 local mathHuge = math.huge
@@ -105,11 +110,14 @@ local function isPlayerTeam(teamID)
 end
 
 -- Returns the power of the input teamID as a number.
+---@param teamID TeamID
+---@return number power
 local function teamPower(teamID)
 	return teamPowers[teamID]
 end
 
 -- Returns the total power of all non scavenger/raptor teams as a number.
+---@return number power
 local function totalPlayerTeamsPower()
 	local totalPower = 0
 
@@ -123,6 +131,7 @@ local function totalPlayerTeamsPower()
 end
 
 -- Returns the highest non scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function highestPlayerTeamPower()
 	local highestPower = 0
 	local highestTeamID = nil
@@ -140,6 +149,7 @@ local function highestPlayerTeamPower()
 end
 
 -- Returns the average of all non scavenger/raptor teams as a number.
+---@return number power `0` when no team has any power.
 local function averagePlayerTeamPower()
 	local totalPower = 0
 	local teamCount = 0
@@ -156,6 +166,7 @@ local function averagePlayerTeamPower()
 end
 
 -- Returns the lowest non scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function lowestPlayerTeamPower()
 	local lowestPower = mathHuge
 	local lowestTeamID = nil
@@ -173,6 +184,7 @@ local function lowestPlayerTeamPower()
 end
 
 -- Returns the highest non AI/scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function highestHumanTeamPower()
 	local highestPower = 0
 	local highestTeamID = nil
@@ -190,6 +202,7 @@ local function highestHumanTeamPower()
 end
 
 -- Returns the average of all non AI/scavenger/raptor teams as a number.
+---@return number power `0` when no team has any power.
 local function averageHumanTeamPower()
 	local totalPower = 0
 	local teamCount = 0
@@ -206,6 +219,7 @@ local function averageHumanTeamPower()
 end
 
 -- Returns the lowest non AI/scavenger/raptor team power as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function lowestHumanTeamPower()
 	local lowestPower = mathHuge
 	local lowestTeamID = nil
@@ -223,6 +237,9 @@ local function lowestHumanTeamPower()
 end
 
 -- Returns the highest team power of the allies belonging to input team or allyID. Returns as a table {teamID, power}.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return PowerLib.TeamPower
 local function highestAlliedTeamPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local highestPower = 0
@@ -241,6 +258,9 @@ local function highestAlliedTeamPower(teamID, allyID)
 end
 
 -- Returns the average of all allies of the input teamID or allyID. Returns a number.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return number power `0` when no allied team has any power.
 local function averageAlliedTeamPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local totalPower = 0
@@ -258,6 +278,9 @@ local function averageAlliedTeamPower(teamID, allyID)
 end
 
 -- Returns the lowest of the teamID's allies or allyID's power as a table {teamID, power}.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return PowerLib.TeamPower
 local function lowestAlliedTeamPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local lowestPower = mathHuge
@@ -275,7 +298,11 @@ local function lowestAlliedTeamPower(teamID, allyID)
 	return { teamID = lowestTeamID, power = lowestPower }
 end
 
+---@alias PowerLib.TechLevel number Fractional tech level between `0.5` and `4.5`.
+
 -- Take an input of a power value and return an estimated tech level number.
+---@param power number
+---@return PowerLib.TechLevel
 local function techGuesstimate(power)
 	local techLevel = 0
 	for _, threshold in ipairs(powerThresholds) do
@@ -290,6 +317,8 @@ local function techGuesstimate(power)
 end
 
 -- Takes an input teamID return an estimated tech level number.
+---@param teamID TeamID
+---@return PowerLib.TechLevel
 local function teamTechGuesstimate(teamID)
 	local totalPower = teamPowers[teamID]
 	local techLevel = 0
@@ -305,6 +334,7 @@ local function teamTechGuesstimate(teamID)
 end
 
 -- Calculate all average powers of all non scavenger/raptor teams and return an estimated tech level number.
+---@return PowerLib.TechLevel
 local function averagePlayerTechGuesstimate()
 	local totalPower = 0
 	local teamCount = 0
@@ -331,6 +361,7 @@ local function averagePlayerTechGuesstimate()
 end
 
 -- Compares average powers of all non AI/scavenger/raptor teams return an estimated tech level number.
+---@return PowerLib.TechLevel
 local function averageHumanTechGuesstimate()
 	local totalPower = 0
 	local teamCount = 0
@@ -357,6 +388,9 @@ local function averageHumanTechGuesstimate()
 end
 
 -- Compare average powers of all allied teams of the input teamID or allyID  and return an estimated tech level number.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return PowerLib.TechLevel
 local function averageAlliedTechGuesstimate(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local totalPower = 0
@@ -384,6 +418,8 @@ local function averageAlliedTechGuesstimate(teamID, allyID)
 end
 
 -- Returns the highest power achieved by the the input teamID as a number.
+---@param teamID TeamID
+---@return number power `0` when the team has never held any power.
 local function teamPeakPower(teamID)
 	for id, power in pairs(peakTeamPowers) do
 		if id == teamID then
@@ -394,6 +430,7 @@ local function teamPeakPower(teamID)
 end
 
 -- Returns the total peak power achieved by all non scavenger/raptor teams as a number.
+---@return number power
 local function totalPlayerPeakPower()
 	local totalPeakPower = 0
 
@@ -407,6 +444,7 @@ local function totalPlayerPeakPower()
 end
 
 -- Returns the highest power achieved by any non scavenger/raptor team as a table {teamID, power}.
+---@return PowerLib.TeamPower
 local function highestPlayerPeakPower()
 	local highestPower = 0
 	local highestTeamID = nil
@@ -424,6 +462,9 @@ local function highestPlayerPeakPower()
 end
 
 -- Returns the highest power achieved by any non scavenger/raptor team on the same team as the input teamID or allyID  as a table {teamID, power}.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return PowerLib.TeamPower
 local function highestAlliedPeakPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local highestPower = 0
@@ -442,6 +483,7 @@ local function highestAlliedPeakPower(teamID, allyID)
 end
 
 -- Returns the average of all the peak powers achieved by non AI/scavenger/raptor teams as a number.
+---@return number power `0` when no team has any peak power.
 local function averageHumanPeakPower()
 	local totalPower = 0
 	local teamCount = 0
@@ -458,6 +500,9 @@ local function averageHumanPeakPower()
 end
 
 -- Returns the average of all the peak powers achieved by allied teams of the input teamID or allyID as a number.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return number power `0` when no allied team has any peak power.
 local function averageAlliedPeakPower(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local totalPower = 0
@@ -475,6 +520,8 @@ local function averageAlliedPeakPower(teamID, allyID)
 end
 
 -- Returns the ratio number of the input teamID compared to the average of all players.
+---@param teamID TeamID
+---@return number ratio The team's power divided by the player average; `0` if the average is `0`.
 local function teamComparedToAveragedPlayers(teamID)
 	local totalPower = 0
 	local teamCount = 0
@@ -494,6 +541,9 @@ local function teamComparedToAveragedPlayers(teamID)
 end
 
 -- Returns boolean true if the input teamID is considered significantly more powerful by the API. Second argument allows user-defined ratio.
+---@param teamID TeamID
+---@param marginRatio number? Ratio above the player average that counts as overpowered. Defaults to `1.25`.
+---@return boolean
 local function isTeamOverPowered(teamID, marginRatio)
 	marginRatio = marginRatio or teamIsOverPoweredRatio
 	local totalPower = 0
@@ -518,6 +568,9 @@ local function isTeamOverPowered(teamID, marginRatio)
 end
 
 -- Returns the ratio number of the input teamID's allies or allyID compared to the average of all player allies.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@return number ratio The allyteam's power divided by the allyteam average; `0` if the average is `0`.
 local function alliesComparedToAverage(teamID, allyID)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	local allyPowers = {}
@@ -545,7 +598,11 @@ local function alliesComparedToAverage(teamID, allyID)
 	return ratio
 end
 
--- Returns boolean true if the input teamID's allies or allyID is considered significantly more powerful by the API. Third argument allows user-defined ratio.
+-- Returns `true` if the input teamID's allies or allyID is considered significantly more powerful by the API. Third argument allows user-defined ratio.
+---@param teamID TeamID? Only used to look up `allyID`; ignored when `allyID` is given.
+---@param allyID AllyTeamID?
+---@param marginRatio number? Ratio above the allyteam average that counts as winning. Defaults to `1.25`.
+---@return boolean
 local function isAllyTeamWinning(teamID, allyID, marginRatio)
 	allyID = allyID or select(6, Spring.GetTeamInfo(teamID))
 	marginRatio = marginRatio or alliesAreWinningRatio

--- a/luarules/gadgets/gfx_environmental_lightning_gl4.lua
+++ b/luarules/gadgets/gfx_environmental_lightning_gl4.lua
@@ -40,7 +40,19 @@ if gadgetHandler:IsSyncedCode() then
 	local spGetTeamInfo = Spring.GetTeamInfo
 
 	function gadget:Initialize()
+		---Spawns a configured lightning effect at a world position.
+		---@param configName string Key of the lightning config to spawn.
+		---@param x number
+		---@param y number
+		---@param z number
+		---@param sizeScale number? Defaults to `1.0`.
+		---@param intensityScale number? Defaults to `1.0`.
+		---@param ownerTeamID TeamID? Team the strike belongs to, used to derive the
+		---owning allyteam for visibility. Defaults to no owner.
 		GG.SpawnEnvironmentalLightning = function(configName, x, y, z, sizeScale, intensityScale, ownerTeamID)
+			-- This guard is necessary as long as some call sites pass in nil coordinates,
+			-- e.g. unsanitized Spring.GetUnitPosition for a dead unit
+			---@diagnostic disable-next-line: unnecessary-if
 			if not configName or not x or not y or not z then
 				return
 			end

--- a/luarules/gadgets/gfx_fire_gl4.lua
+++ b/luarules/gadgets/gfx_fire_gl4.lua
@@ -1448,13 +1448,56 @@ end
 --------------------------------------------------------------------------------
 -- Public spawn helpers (also drive GG.Fire)
 --------------------------------------------------------------------------------
+
+---A live fire emitter. Returned by the spawn functions and accepted by `GG.Fire.StopFire`.
+---@class GG.Fire.Handle
+---@field unitID UnitID? Unit the emitter was spawned for, if any.
+---@field mappedUnit UnitID? Unit the emitter position follows, if any.
+---@field keepAfterUnitGone true? Keep burning after the followed unit disappears.
+---@field scavenger true? Set when the effect uses the scavenger palette.
+---@field x number
+---@field y number
+---@field z number
+---@field yOffset number
+---@field radius number
+---@field scale number
+---@field intensity number
+---@field lightIntensity number
+---@field lightRadiusMult number
+---@field fireRate number Particles per frame; `0` disables flames.
+---@field smokeRate number Particles per frame; `0` disables smoke.
+---@field emberRate number Particles per frame; `0` disables embers.
+---@field fireEnd integer Game frame at which flames stop spawning.
+---@field smokeEnd integer Game frame at which smoke stops spawning.
+---@field emberEnd integer Game frame at which embers stop spawning.
+
+---Options accepted by `GG.Fire.SpawnFire`.
+---@class GG.Fire.SpawnOpts
+---@field duration integer? Frames of flame. Defaults to the configured unit fire duration.
+---@field smokeDuration integer? Frames of smoke. Defaults to `duration` plus the configured extra.
+---@field emberDuration integer? Frames of embers. Defaults to `duration`.
+---@field unitID UnitID? Unit to associate the emitter with.
+---@field scavenger boolean? Use the scavenger palette.
+---@field yOffset number? Defaults to `0`.
+---@field radius number? Defaults to `14`.
+---@field scale number? Defaults to `1.0`.
+---@field intensity number? Defaults to `1.0`.
+---@field lightIntensity number? Defaults to `1.0`.
+---@field lightRadiusMult number? Defaults to `1.0`.
+---@field fire boolean? Set to `false` to suppress flames.
+---@field fireRate number? Particles per frame.
+---@field smoke boolean? Set to `false` to suppress smoke.
+---@field smokeRate number? Particles per frame.
+---@field embers boolean? Set to `false` to suppress embers.
+---@field emberRate number? Particles per frame.
+
 -- Spawn a free-standing fire effect. Returns an opaque handle usable with
--- StopFire. opts (all optional):
---   duration, smokeDuration, emberDuration (frames)
---   radius, scale, intensity
---   unitID  (attach to a unit; position follows it)
---   yOffset (vertical emit offset, default 0 / unit param)
---   fire, smoke, embers (booleans to enable each, default all true)
+-- StopFire.
+---@param x number?
+---@param y number?
+---@param z number?
+---@param opts GG.Fire.SpawnOpts?
+---@return GG.Fire.Handle
 local function spawnFire(x, y, z, opts)
 	opts = opts or {}
 	local now = cachedGameFrame
@@ -1960,12 +2003,18 @@ function gadget:Initialize()
 	gadgetHandler:AddSyncAction("treefire_fade", syncTreeFireFade)
 
 	GG.Fire = {
-		-- SpawnFire(x, y, z, opts) -> handle. See spawnFire above for opts.
+		---Spawns a fire emitter at a world position.
+		---@param x number?
+		---@param y number?
+		---@param z number?
+		---@param opts GG.Fire.SpawnOpts?
+		---@return GG.Fire.Handle
 		SpawnFire = function(x, y, z, opts)
 			return spawnFire(x, y, z, opts)
 		end,
 		-- StopFire(handle): immediately stop spawning new particles (existing
 		-- ones fade out naturally).
+		---@param handle GG.Fire.Handle
 		StopFire = function(handle)
 			if type(handle) == "table" then
 				handle.fireEnd = cachedGameFrame
@@ -1975,6 +2024,9 @@ function gadget:Initialize()
 		end,
 		-- AddUnitFire(unitID[, durationFrames]): attach a burning effect that
 		-- follows the unit. Refreshes the timer if already burning.
+		---@param unitID UnitID
+		---@param durationFrames integer? Frames of flame. Defaults to the configured unit fire duration.
+		---@return GG.Fire.Handle? handle `nil` if the unit no longer exists.
 		AddUnitFire = function(unitID, durationFrames)
 			local udid = Spring.GetUnitDefID(unitID)
 			if udid then
@@ -1982,15 +2034,23 @@ function gadget:Initialize()
 			end
 		end,
 		-- SpawnWreck(x, y, z[, scale]): short fire + long smoke at a position.
+		---@param x number
+		---@param y number
+		---@param z number
+		---@param scale number? Defaults to `1.0`.
+		---@return GG.Fire.Handle? handle `nil` when the position is not visible to the local player.
 		SpawnWreck = function(x, y, z, scale)
 			return spawnVisibleWreckageFire(x, y, z, scale)
 		end,
+		---@return integer count Particles currently alive.
 		GetParticleCount = function()
 			return particleVBO and particleVBO.usedElements or 0
 		end,
+		---@return integer count Particle budget for the whole system.
 		GetMaxParticles = function()
 			return MAX_PARTICLES
 		end,
+		---@return table<string, any> config The live tuning table, including nested colour tables; treat as read-only.
 		GetConfig = function()
 			return CONFIG
 		end,

--- a/luarules/gadgets/gfx_fire_smoke_gl4.lua
+++ b/luarules/gadgets/gfx_fire_smoke_gl4.lua
@@ -1669,6 +1669,11 @@ end
 -- Other gadgets can call these to spawn fire/smoke effects
 --------------------------------------------------------------------------------
 
+---Starts the trailing fire/smoke effect for an aircraft that has begun crashing.
+---Does nothing if the effect system is unavailable or the unit is already tracked.
+---@param unitID UnitID
+---@param unitDefID UnitDefID
+---@param teamID TeamID
 local function apiCrashingAircraft(unitID, unitDefID, teamID)
 	if not particleVBO then
 		return
@@ -1702,24 +1707,29 @@ local function apiCrashingAircraft(unitID, unitDefID, teamID)
 	crashingAircraftCount = crashingAircraftCount + 1
 end
 
--- Add a generic point emitter at a fixed position.
+---Parameters accepted by `GG.FireSmoke.AddPointEmitter`.
+---@class GG.FireSmoke.EmitterParams
+---@field x number World position X coordinate.
+---@field y number? World position Y coordinate. Defaults to the ground height at `x`, `z`.
+---@field z number? World position Z coordinate. Defaults to `0`.
+---@field duration integer? Frames the emitter lives for. `0` = permanent. Defaults to `300`.
+---@field sizeScale number? Particle size multiplier. Defaults to `1.0`.
+---@field fireIntensity number? `0` emits smoke only. `[0,1)` range of fire chance/brightness. Defaults to `0`.
+---@field spawnCount integer? Particles emitted per interval. Defaults to `POINT_SPAWN_COUNT``.
+---@field spawnInterval integer? Frames between spawns. Defaults to `POINT_SPAWN_INTERVAL``.
+---@field priority integer? One of the `PRIORITY_ESSENTIAL` `_NORMAL` `_COSMETIC` constants. Defaults to `PRIORITY_NORMAL`.
+---@field smokeSizeMult number? Multiplier on spoke particle size. Defaults to `1.0`.
+---@field smokeLifeMult number? Multiplier on smoke particle lifetime. Defaults to `1.0`.
+---@field smokeAlpha number? Base smoke alpha (opacity). Defaults to `1.0`.
+---@field fireSizeMult number? Multiplier on fire particle size. Defaults to `1.0`.
+---@field fireLifeMult number? Multiplier on fire particle lifetime. Defaults to `1.0`.
+---@field posSpread number? Random position jitter applied per particle in elmos. Defaults to `POINT_POS_SPREAD`
+---@field velocityScale number? Multiplier on particle velocity. Defaults to `1.0`.
+
+---Registers a long-lived point emitter that keeps spawning particles.
 -- Returns emitterID (use to remove later) or nil if VBO not ready.
---
--- params table fields (all optional except x,y,z):
---   x, y, z            - world position (required)
---   duration            - emit for this many frames, 0 = permanent (default: 300)
---   sizeScale           - particle size multiplier (default: 1.0)
---   fireIntensity       - 0 = smoke only, 0-1 = fire chance/brightness (default: 0)
---   spawnCount          - smoke particles per interval (default: POINT_SPAWN_COUNT)
---   spawnInterval       - frames between spawns (default: POINT_SPAWN_INTERVAL)
---   priority            - PRIORITY_ESSENTIAL/NORMAL/COSMETIC (default: NORMAL)
---   smokeSizeMult       - multiplier on smoke particle size (default: 1.0)
---   smokeLifeMult       - multiplier on smoke lifetime (default: 1.0)
---   smokeAlpha          - base smoke alpha (default: 1.0)
---   fireSizeMult        - multiplier on fire particle size (default: 1.0)
---   fireLifeMult        - multiplier on fire particle lifetime (default: 1.0)
---   posSpread           - random position offset radius in elmos (default: POINT_POS_SPREAD)
---   velocityScale       - multiplier on particle velocity (default: 1.0)
+---@param params GG.FireSmoke.EmitterParams
+---@return integer? emitterID `nil` when the effect system is unavailable or `params` or `params.x` is missing.
 local function apiAddPointEmitter(params)
 	if not particleVBO then
 		return nil
@@ -1756,7 +1766,9 @@ local function apiAddPointEmitter(params)
 	return id
 end
 
--- Remove a point emitter by ID (returned from AddPointEmitter)
+---Removes a point emitter.
+---@param emitterID integer? As returned by `AddPointEmitter`.
+---@return boolean removed `false` if no such emitter exists.
 local function apiRemoveEmitter(emitterID)
 	if emitterID and pointEmitters[emitterID] then
 		pointEmitters[emitterID] = nil
@@ -1767,6 +1779,11 @@ local function apiRemoveEmitter(emitterID)
 end
 
 -- Update emitter position (for moving sources)
+---@param emitterID integer As returned by `AddPointEmitter`.
+---@param x number
+---@param y number
+---@param z number
+---@return boolean updated `false` if no such emitter exists.
 local function apiUpdateEmitterPos(emitterID, x, y, z)
 	local emitter = pointEmitters[emitterID]
 	if not emitter then
@@ -1778,8 +1795,18 @@ local function apiUpdateEmitterPos(emitterID, x, y, z)
 	return true
 end
 
--- Spawn a single particle directly (one-shot, no emitter tracking)
--- priority: PRIORITY_ESSENTIAL/NORMAL/COSMETIC (default: NORMAL)
+---Spawns a single one-shot particle with no emitter tracking.
+---@param px number
+---@param py number
+---@param pz number
+---@param vx number? Defaults to `0`.
+---@param vy number? Defaults to `0`.
+---@param vz number? Defaults to `0`.
+---@param size number? Defaults to `2`.
+---@param isFireType boolean? Spawn a flame particle instead of smoke.
+---@param lifetime integer? Frames the particle lives for. Defaults to `60`.
+---@param alpha number? Defaults to `1.0`.
+---@param priority integer? One of the `PRIORITY_*` constants. Defaults to `PRIORITY_NORMAL`.
 local function apiSpawnParticle(px, py, pz, vx, vy, vz, size, isFireType, lifetime, alpha, priority)
 	if not particleVBO then
 		return
@@ -1789,14 +1816,20 @@ local function apiSpawnParticle(px, py, pz, vx, vy, vz, size, isFireType, lifeti
 end
 
 -- Query current state
+---@return integer count Particles currently alive.
 local function apiGetParticleCount()
 	return particleVBO and particleVBO.usedElements or 0
 end
 
+---@return number count Particle budget for the whole system.
 local function apiGetMaxParticles()
 	return MAX_PARTICLES
 end
 
+---Returns the wind vector the particle simulation is currently using.
+---@return number windX
+---@return number windZ
+---@return number windStrength
 local function apiGetWindState()
 	return windX, windZ, windStrength
 end

--- a/luarules/gadgets/gfx_flamethrower_gl4.lua
+++ b/luarules/gadgets/gfx_flamethrower_gl4.lua
@@ -2059,15 +2059,21 @@ function gadget:Initialize()
 	end
 
 	GG.Flamethrower = {
+		---@return integer count Particles currently alive.
 		GetParticleCount = function()
 			return particleVBO and particleVBO.usedElements or 0
 		end,
+		---@return integer count Particle budget for the whole system.
 		GetMaxParticles = function()
 			return CONFIG.maxParticles
 		end,
+		---@return table<string, any> config The live tuning table, including nested colour tables; treat as read-only.
 		GetConfig = function()
 			return CONFIG
 		end,
+		---Reports whether this gadget draws the flame effect for a weapon.
+		---@param weaponDefID WeaponDefID
+		---@return boolean
 		IsTracked = function(weaponDefID)
 			return weaponConfigs[weaponDefID] ~= nil
 		end,

--- a/luarules/gadgets/gfx_projectile_dispatch.lua
+++ b/luarules/gadgets/gfx_projectile_dispatch.lua
@@ -213,6 +213,13 @@ end
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
+
+---Registers a consumer of one of the shared projectile scans. The dispatcher runs
+---each scan at most once per tick and hands every subscriber its filtered matches.
+---@param name string Label used in debug output.
+---@param defIDSet table<WeaponDefID, true>? Set of weaponDefIDs to keep; `nil` matches every projectile.
+---@param scanID 1|2|3 One of `SCAN_VISIBLE`, `SCAN_MAP_WEAPONS` or `SCAN_MAP_PIECES`.
+---@return integer? handle `nil` when `scanID` is invalid.
 local function Subscribe(name, defIDSet, scanID)
 	local subs = subscribersByScan[scanID]
 	if not subs then
@@ -234,6 +241,10 @@ local function Subscribe(name, defIDSet, scanID)
 	return nextHandle
 end
 
+---Returns this subscriber's matching projectiles, refreshing the scan if stale.
+---@param handle integer As returned by `Subscribe`.
+---@return ProjectileID[]? projectileIDs `nil` when the handle is unknown.
+---@return integer count Number of valid entries in `projectileIDs`.
 local function GetMatches(handle)
 	local sub = subscribers[handle]
 	if not sub then
@@ -245,6 +256,11 @@ local function GetMatches(handle)
 	return sub.matches, sub.matchCount
 end
 
+---As `GetMatches`, but also returns the weaponDefID of each matched projectile.
+---@param handle integer As returned by `Subscribe`.
+---@return ProjectileID[]? projectileIDs `nil` when the handle is unknown.
+---@return WeaponDefID[]? weaponDefIDs Parallel to `projectileIDs`.
+---@return integer count Number of valid entries in both arrays.
 local function GetMatchesWithDefIDs(handle)
 	local sub = subscribers[handle]
 	if not sub then
@@ -256,6 +272,10 @@ local function GetMatchesWithDefIDs(handle)
 	return sub.matches, sub.matchDefIDs, sub.matchCount
 end
 
+---Returns the unfiltered result of a scan, refreshing it if stale.
+---@param scanID 1|2|3 One of `SCAN_VISIBLE`, `SCAN_MAP_WEAPONS` or `SCAN_MAP_PIECES`.
+---@return ProjectileID[]? projectileIDs `nil` when `scanID` is invalid.
+---@return integer count Number of valid entries in `projectileIDs`.
 local function GetScan(scanID)
 	local state = scanState[scanID]
 	if not state then

--- a/luarules/gadgets/gfx_raptor_scum_gl4.lua
+++ b/luarules/gadgets/gfx_raptor_scum_gl4.lua
@@ -138,7 +138,12 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	-- This checks whether the unit is under any scum
+	---Tests whether a map position is covered by raptor scum.
+	---Underwater scum is ignored for surface units, and positions outside the map never match.
+	---@param unitx number
+	---@param unity number? Height of the tested object. Defaults to `1`; values above `-1` skip underwater scum.
+	---@param unitz number
+	---@return integer? scumID `nil` when the position is not inside any scum.
 	local function IsPosInScum(unitx, unity, unitz)
 		-- out of bounds check, no scum outside of map bounds
 		if unitx < 0 or unitz < 0 or unitx > mapSizeX or unitz > mapSizeZ then
@@ -173,8 +178,11 @@ if gadgetHandler:IsSyncedCode() then
 		return nil
 	end
 
-	GG.IsPosInRaptorScum = IsPosInScum --(x,y,z)
+	GG.IsPosInRaptorScum = IsPosInScum
 
+	---Picks a scum patch at random.
+	---@param startID integer? Scum to start iterating from, so repeated calls can spread out.
+	---@return integer? scumID `nil` when no scum exists.
 	local function GetRandomScumID(startID)
 		if numscums < 1 then
 			return
@@ -190,8 +198,11 @@ if gadgetHandler:IsSyncedCode() then
 		return scumID
 	end
 
-	GG.GetRandomScumID = GetRandomScumID -- Returns nil or scumID
+	GG.GetRandomScumID = GetRandomScumID
 
+	---Picks a random map position inside a random scum patch, staying clear of the map edge.
+	---@return number? x `nil` when no scum exists or no valid position was found.
+	---@return number? z
 	local function GetRandomPositionInScum()
 		local scumID = GetRandomScumID()
 		if not scumID then
@@ -215,7 +226,7 @@ if gadgetHandler:IsSyncedCode() then
 		return px, pz
 	end
 
-	GG.GetRandomPositionInScum = GetRandomPositionInScum -- Returns nil or (X, Z)
+	GG.GetRandomPositionInScum = GetRandomPositionInScum
 
 	local function UpdateBins(scumID, removeScum)
 		local scumTable = scums[scumID]

--- a/luarules/gadgets/gfx_tree_feller.lua
+++ b/luarules/gadgets/gfx_tree_feller.lua
@@ -328,6 +328,11 @@ if gadgetHandler:IsSyncedCode() then
 		return fixedCount
 	end
 
+	---Fells every tree within 125 elmos of a position, as used by the commander spawn blast.
+	---@param spawnx number
+	---@param spawny number
+	---@param spawnz number
+	---@return integer? aborted Returns `0` and stops early if a geothermal feature is in range.
 	local function ComSpawnDefoliate(spawnx, spawny, spawnz)
 		local blasted_trees = Spring.GetFeaturesInCylinder(spawnx, spawnz, 125)
 

--- a/luarules/gadgets/gfx_unit_shield_effects.lua
+++ b/luarules/gadgets/gfx_unit_shield_effects.lua
@@ -433,6 +433,18 @@ end
 local DECAY_FACTOR = 0.2
 local MIN_DAMAGE = 3
 
+---A single recent impact on a unit's shield.
+---@class ShieldHit
+---@field hitFrame integer Game frame the damage was last accumulated.
+---@field dmg number Decaying damage value driving the effect's brightness.
+---@field aoe number Radius of the visual ripple.
+---@field x number
+---@field y number
+---@field z number
+
+---Returns the decaying list of recent impacts on a unit's shield.
+---@param unitID UnitID
+---@return ShieldHit[]? hits `nil` when the unit has no shield or has not been hit.
 local function GetShieldHitPositions(unitID)
 	local unitData = IterableMap.Get(shieldUnits, unitID)
 	return (((unitData and unitData.hitData) and unitData.hitData) or nil)

--- a/luarules/gadgets/gfx_water_type_overlay_state.lua
+++ b/luarules/gadgets/gfx_water_type_overlay_state.lua
@@ -226,22 +226,32 @@ function gadget:Initialize()
 	minGroundHeight = select(3, spGetGroundExtremes())
 
 	GG.WaterTypeOverlay = {
+		---@return boolean active Whether a hazardous water overlay is currently applied.
 		isActive = function()
 			return active
 		end,
+		---@return "lava"|"acid"|nil typeName `nil` while the overlay is inactive.
 		getActiveType = function()
 			return activeType
 		end,
+		---@return number level Current absolute world height of the overlay surface.
 		getLevel = function()
 			return currentLevel
 		end,
+		---@return number level Offset from the base water plane the overlay eases toward.
 		getTargetLevel = function()
 			return targetLevel
 		end,
+		---Sets the height the overlay surface eases toward, relative to the base water plane.
+		---@param level number
 		setLevel = function(level)
 			targetLevel = level
 		end,
+		---Turns the overlay on and starts damaging units in it.
+		---@param typeName "lava"|"acid"
+		---@return boolean started `false` when `typeName` is not a supported overlay type.
 		activate = function(typeName)
+			---@diagnostic disable-next-line: unnecessary-if
 			if typeName ~= "lava" and typeName ~= "acid" then
 				return false
 			end
@@ -252,6 +262,7 @@ function gadget:Initialize()
 			activeType = typeName
 			return true
 		end,
+		---Turns the overlay off and restores any unit state it changed.
 		deactivate = function()
 			if active then
 				restoreAllUnits()

--- a/luarules/gadgets/scav_spawn_effect.lua
+++ b/luarules/gadgets/scav_spawn_effect.lua
@@ -51,6 +51,8 @@ if gadgetHandler:IsSyncedCode() then -- Synced
 		end
 	end
 
+	---Plays the scavenger spawn explosion at a unit, sized from its unit definition.
+	---@param unitID UnitID
 	function ScavengersSpawnEffectUnitID(unitID)
 		local posx, posy, posz = Spring.GetUnitPosition(unitID)
 		local unitDefID = Spring.GetUnitDefID(unitID)
@@ -59,12 +61,19 @@ if gadgetHandler:IsSyncedCode() then -- Synced
 	end
 	GG.ScavengersSpawnEffectUnitID = ScavengersSpawnEffectUnitID
 
+	---Plays the scavenger spawn explosion at a position, sized from a unit definition.
+	---@param unitDefID UnitDefID
+	---@param posx number
+	---@param posy number
+	---@param posz number
 	function ScavengersSpawnEffectUnitDefID(unitDefID, posx, posy, posz)
 		local size = getUnitSize(unitDefID)
 		Spring.SpawnCEG("scav-spawnexplo-" .. size, posx, posy, posz, 0, 0, 0)
 	end
 	GG.ScavengersSpawnEffectUnitDefID = ScavengersSpawnEffectUnitDefID
 
+	---Plays the scavenger spawn explosion at a feature, sized from its feature definition.
+	---@param featureID FeatureID
 	function ScavengersSpawnEffectFeatureID(featureID)
 		local posx, posy, posz = Spring.GetFeaturePosition(featureID)
 		local featureDefID = Spring.GetFeatureDefID(featureID)
@@ -73,6 +82,11 @@ if gadgetHandler:IsSyncedCode() then -- Synced
 	end
 	GG.ScavengersSpawnEffectFeatureID = ScavengersSpawnEffectFeatureID
 
+	---Plays the scavenger spawn explosion at a position, sized from a feature definition.
+	---@param featureDefID FeatureDefID
+	---@param posx number
+	---@param posy number
+	---@param posz number
 	function ScavengersSpawnEffectFeatureDefID(featureDefID, posx, posy, posz)
 		local size = getFeatureSize(featureDefID)
 		Spring.SpawnCEG("scav-spawnexplo-" .. size, posx, posy, posz, 0, 0, 0)

--- a/luarules/gadgets/unit_attributes.lua
+++ b/luarules/gadgets/unit_attributes.lua
@@ -444,6 +444,11 @@ end
 
 --Spring.Echo("Hornet debug UpdateUnitAttributes defined")
 
+---Recomputes a unit's speed, turn rate, acceleration, reload, economy and build
+---multipliers from the `GG.att_*` tables and applies them to the engine.
+---Call after changing any `GG.att_*` entry for the unit.
+---@param unitID UnitID
+---@param frame integer? Game frame to attribute the change to. Defaults to the current frame.
 function UpdateUnitAttributes(unitID, frame)
 	if not spValidUnitID(unitID) then
 		removeUnit(unitID)
@@ -648,7 +653,11 @@ function UpdateUnitAttributes(unitID, frame)
 	end
 end
 
--- Whatever sets this should call UpdateUnitAttributes frames afterwards too
+---Controls whether the engine may coast this unit rather than braking it,
+---which the attribute system otherwise overrides.
+---Whatever sets this should call UpdateUnitAttributes frames afterwards too.
+---@param unitID UnitID
+---@param allowed boolean?
 local function SetAllowUnitCoast(unitID, allowed)
 	allowUnitCoast[unitID] = allowed
 end

--- a/luarules/gadgets/unit_capture_decay.lua
+++ b/luarules/gadgets/unit_capture_decay.lua
@@ -57,6 +57,9 @@ function gadget:AllowUnitCaptureStep(builderID, builderTeam, unitID, unitDefID, 
 	return true
 end
 
+---Starts tracking a unit so its partial capture progress decays over time.
+---Does nothing if the unit is already tracked.
+---@param unitID UnitID
 function addUnitToCaptureDecay(unitID)
 	if not unitsWithCaptureProgress[unitID] then
 		unitsWithCaptureProgress[unitID] = { previousCaptureProgress = 0, ticksFromLastCapture = 999 }

--- a/luarules/gadgets/unit_cloak.lua
+++ b/luarules/gadgets/unit_cloak.lua
@@ -65,6 +65,10 @@ for udid, ud in pairs(UnitDefs) do
 	end
 end
 
+---Forces a unit to decloak and blocks it from recloaking for a while.
+---Repeated calls extend the block rather than stacking.
+---@param unitID UnitID
+---@param duration integer? Frames to stay decloaked. Defaults to the gadget's decloak time.
 function PokeDecloakUnit(unitID, duration)
 	if recloakUnit[unitID] then
 		recloakUnit[unitID] = duration or DEFAULT_DECLOAK_TIME
@@ -176,6 +180,10 @@ function gadget:AllowUnitDecloak(unitID, objectID, weaponID)
 	recloakFrame[unitID] = currentFrame + DEFAULT_DECLOAK_TIME
 end
 
+---Sets the unit's desired cloak state, updating its command description to match.
+---Does nothing for dead or missing units.
+---@param unitID UnitID?
+---@param state 0|1 `1` to request cloaking, `0` to request decloaking.
 local function SetWantedCloaked(unitID, state)
 	if not unitID or spGetUnitIsDead(unitID) then
 		return

--- a/luarules/gadgets/unit_collision_damage_behavior.lua
+++ b/luarules/gadgets/unit_collision_damage_behavior.lua
@@ -293,6 +293,9 @@ function gadget:GameFrame(frame)
 	gameFrame = frame
 end
 
+---Enables or disables collision-damage velocity tracking for a unit.
+---@param unitID UnitID
+---@param enabled boolean? Pass `false` to stop tracking; any other value starts it.
 local function setVelocityControl(unitID, enabled)
 	if enabled == false then
 		launchedUnits[unitID] = nil

--- a/luarules/gadgets/unit_corpse_link.lua
+++ b/luarules/gadgets/unit_corpse_link.lua
@@ -40,6 +40,10 @@ local function GetFeatureResurrectDefID(featureID)
 	return unitDef.id
 end
 
+---Returns the unitID the corpse feature was created from, consuming the link so
+---each corpse resolves at most once.
+---@param featureID FeatureID
+---@return UnitID? unitID `nil` when no unit is linked to this corpse.
 local function GetCorpsePriorUnitID(featureID)
 	-- Technically features can rez into something else than they died as,
 	-- or even be rezzable without ever dying, but let's assume they don't

--- a/luarules/gadgets/unit_instant_self_destruct.lua
+++ b/luarules/gadgets/unit_instant_self_destruct.lua
@@ -43,6 +43,9 @@ end
 local toDestroy = {}
 local toDestroyCount = 0
 
+---Queues a unit to be destroyed on the next game frame.
+---@param unitID UnitID
+---@param skipChecks boolean? Destroy even while the unit is stunned.
 local function QueueUnitDestruction(unitID, skipChecks)
 	if skipChecks or not spGetUnitIsStunned(unitID) then
 		toDestroyCount = toDestroyCount + 1

--- a/luarules/gadgets/unit_reactive_armor.lua
+++ b/luarules/gadgets/unit_reactive_armor.lua
@@ -360,6 +360,10 @@ end
 -- Lifecycle
 
 ---Damages or repairs a unit's reactive armor without changing unit health.
+---@param unitID UnitID
+---@param damage number Positive damages the armor, negative repairs it.
+---@return boolean changed `false` when the unit has no reactive armor, its armor is
+---already broken, or a repair was requested while already at full armor.
 GG.AddReactiveArmorDamage = function(unitID, damage)
 	local unitDefData = armoredUnitDefs[spGetUnitDefID(unitID)]
 	if unitDefData and damage ~= 0 then
@@ -370,6 +374,8 @@ GG.AddReactiveArmorDamage = function(unitID, damage)
 end
 
 ---Get the current armor health remaining of a unit with reactive armor.
+---@param unitID UnitID
+---@return number? health `nil` when the unit has no reactive armor or it is broken.
 GG.GetReactiveArmorHealth = function(unitID)
 	return unitArmorHealth[unitID]
 end

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -55,8 +55,12 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 	end
 
 	---Pass a `weaponDefID` instead of a `damage` for shield damage to be determined for you.
+	---@param shieldUnitID UnitID
+	---@param damage number
+	---@param weaponDefID nil
 	---@return boolean exhausted The damage was mitigated, in full, by the shield.
 	---@return number damageDone The amount of damage done to the targeted shield.
+	---@overload fun(shieldUnitID: UnitID, damage: nil, weaponDefID: WeaponDefID): boolean, number
 	local function addEngineShieldDamage(shieldUnitID, damage, weaponDefID)
 		local state, power = spGetUnitShieldState(shieldUnitID)
 
@@ -132,6 +136,9 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 		registerScriptedShieldEntry(projectileTbl, callback)
 	end
 
+	---Stand-in for the sphere queries, which engine shields do not support.
+	---@return UnitID[] shieldUnits Always empty.
+	---@return integer count Always `0`.
 	local function getEmptyResultSet()
 		return {}, 0
 	end
@@ -143,10 +150,14 @@ if Spring.GetModOptions().experimentalshields:find("bounce") then
 		GG.Shields.RegisterShieldPreDamaged = registerShieldPreDamaged
 		GG.Shields.GetUnitShieldState = spGetUnitShieldState
 		-- FIXME: The shields api does not have full coverage for engine/bounce shields.
+		---Not supported for engine shields; always returns nothing.
+		---@type fun(shieldUnitID: UnitID): number?, number?, number?, number?
 		GG.Shields.GetUnitShieldPosition = function() end
 		GG.Shields.GetShieldUnitsInSphere = getEmptyResultSet
 		GG.Shields.GetBlockingShieldUnits = getEmptyResultSet
 		GG.Shields.GetCoveringShieldUnits = getEmptyResultSet
+		---Not supported for engine shields; always returns `false`.
+		---@type fun(x: number, y: number, z: number, shieldUnitID: UnitID): boolean
 		GG.Shields.IsInShield = function()
 			return false
 		end -- unfortunate
@@ -770,6 +781,7 @@ end
 
 -- Gadget interface methods ----------------------------------------------------
 
+---@param shieldUnitID UnitID
 ---@return integer state 0 := DISABLED, 1 := ENABLED
 ---@return number shieldHealthRemaining including the (hidden) damage done this frame so far
 local function getUnitShieldState(shieldUnitID)
@@ -790,8 +802,12 @@ local function getUnitShieldState(shieldUnitID)
 end
 
 ---Pass a `weaponDefID` instead of a `damage` for shield damage to be determined for you.
+---@param shieldUnitID UnitID
+---@param damage number
+---@param weaponDefID nil
 ---@return boolean exhausted The damage was mitigated, in full, by the shield.
 ---@return number damageDone The amount of damage done to the targeted shield.
+---@overload fun(shieldUnitID: UnitID, damage: nil, weaponDefID: WeaponDefID): boolean, number
 local function addCustomShieldDamage(shieldUnitID, damage, weaponDefID)
 	local state, power = getUnitShieldState(shieldUnitID) -- because the unit can be dead
 
@@ -816,6 +832,7 @@ local function addCustomShieldDamage(shieldUnitID, damage, weaponDefID)
 	return false, 0
 end
 
+---@param shieldUnitID UnitID
 ---@return number? x xyz, emitter point of the shield weapon
 ---@return number? y
 ---@return number? z
@@ -890,8 +907,8 @@ end
 ---@param x number
 ---@param y number
 ---@param z number
----@param allyTeam integer The ally team for the incoming damage source.
 ---@param radius number? Additive with the radius of the target shield (default := `0.01`)
+---@param allyTeam AllyTeamID? The ally team for the incoming damage source.
 ---@param onlyAlive boolean? Navigate the rework's one-frame delay on shield effects by excluding recently-dead units (default := `false`)
 ---@return integer[] shieldUnits
 ---@return integer count

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -518,16 +518,33 @@ if gadgetHandler:IsSyncedCode() then
 		refreshSendData(unitID, unitData, minIndex)
 	end
 
+	---A single entry in a unit's target queue, as tracked on the synced side.
+	---@class UnitTargetEntry
+	---@field target UnitID|Position3D Either a target unitID or a `{x, y, z}` ground position.
+	---@field alwaysSeen boolean? Target does not need to stay in sensor range to be kept.
+	---@field ignoreStop boolean? Target survives a Stop command.
+	---@field userTarget boolean? Target was set by the player rather than by Lua.
+	---@field sent boolean? Target has already been pushed to the unit's weapons.
+
+	---Returns the unit's currently active target.
+	---@param unitID UnitID
+	---@return UnitID|Position3D|nil target A unitID, a `{x, y, z}` ground position, or `nil` when untargeted.
 	function GG.GetUnitTarget(unitID)
 		local unitData = activeTargets[unitID]
 		local targetData = unitData and unitData.targets[unitData.currentIndex]
 		return targetData and targetData.target
 	end
 
+	---Returns the unit's whole target queue.
+	---@param unitID UnitID
+	---@return UnitTargetEntry[]? targets `nil` when the unit has no targets.
 	function GG.GetUnitTargetList(unitID)
 		return activeTargets[unitID] and activeTargets[unitID].targets
 	end
 
+	---Returns the position in the target queue that is currently active.
+	---@param unitID UnitID
+	---@return integer? index `nil` when the unit has no targets.
 	function GG.GetUnitTargetIndex(unitID)
 		return activeTargets[unitID] and activeTargets[unitID].currentIndex
 	end
@@ -1031,10 +1048,21 @@ else -- UNSYNCED
 		gadgetHandler:RemoveSyncAction("failCommand")
 	end
 
+	---An entry in the unsynced mirror of a unit's target queue, kept for drawing.
+	---@class UnitTargetEntryUnsynced
+	---@field target UnitID|Position3D Either a target unitID or a `{x, y, z}` ground position.
+	---@field userTarget boolean? Target was set by the player rather than by Lua.
+
+	---Returns the unsynced mirror of the unit's target queue.
+	---@param unitID UnitID
+	---@return table<integer, UnitTargetEntryUnsynced>? targets `nil` when the unit has no known targets.
 	function GG.getUnitTargetList(unitID)
 		return targetList[unitID] and targetList[unitID].targets
 	end
 
+	---Returns the position in the unsynced target queue that is currently active.
+	---@param unitID UnitID
+	---@return integer? index `nil` when the unit has no known targets.
 	function GG.getUnitTargetIndex(unitID)
 		return targetList[unitID] and targetList[unitID].currentIndex
 	end

--- a/luarules/gadgets/unit_wanted_speed.lua
+++ b/luarules/gadgets/unit_wanted_speed.lua
@@ -121,6 +121,11 @@ local function SetUnitWantedSpeed(unitID, unitDefID, wantedSpeed, forceUpdate)
 end
 
 ---this makes no sense, why does this chain exist
+---Reapplies the unit's wanted max speed to its move type,
+---e.g. after the engine has reset it.
+---@param unitID UnitID
+---@param unitDefID UnitDefID
+---@param clearWanted boolean? Drop the remembered wanted speed instead of restoring it.
 function GG.ForceUpdateWantedMaxSpeed(unitID, unitDefID, clearWanted)
 	SetUnitWantedSpeed(
 		unitID,

--- a/luarules/gadgets/unit_zombies.lua
+++ b/luarules/gadgets/unit_zombies.lua
@@ -61,6 +61,9 @@ local harderTechToRezPowerSpeeds = {
 	[4.5] = 130,
 }
 
+---One of the zombie difficulty presets, matching the keys of `zombieModeConfigs`.
+---@alias ZombieMode "normal"|"hard"|"nightmare"|"akumu"
+
 local zombieModeConfigs = {
 	normal = {
 		techToRezPowerSpeeds = standardTechToRezPowerSpeeds,
@@ -96,6 +99,7 @@ local zombieModeConfigs = {
 	},
 }
 
+---@type ZombieMode
 local currentZombieMode = "normal"
 local currentZombieConfig = zombieModeConfigs.normal
 
@@ -426,8 +430,12 @@ local function updateRezSpeed()
 	rebuildZombieCorpseSpawnDelays()
 end
 
+---Applies a preset's tuning to the live zombie config, falling back to `normal`
+---for an unknown mode.
+---@param mode ZombieMode
 local function applyZombieModeSettings(mode)
 	local config = zombieModeConfigs[mode]
+	---@diagnostic disable-next-line: unnecessary-if
 	if not config then
 		config = zombieModeConfigs.normal
 	end
@@ -812,6 +820,8 @@ local function spawnZombies(featureID, unitDefID, healthReductionRatio, x, y, z,
 	end
 end
 
+---Turns a unit into a zombie, swapping it for its `_scav` variant where one exists.
+---@param unitID UnitID
 local function setZombie(unitID)
 	local unitDefID = spGetUnitDefID(unitID)
 	if not unitDefID then
@@ -856,6 +866,7 @@ local function clearUnitOrders(unitID)
 	end
 end
 
+---Clears the queued orders of every tracked zombie.
 local function clearAllOrders()
 	for zombieID, _ in pairs(zombieWatch) do
 		clearUnitOrders(zombieID)
@@ -1230,6 +1241,9 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 	end
 end
 
+---Immediately raises zombies from a corpse feature. Only acts while in idle mode.
+---@param featureID FeatureID
+---@return boolean spawned `false` when not in idle mode, or the feature is not a zombie corpse.
 local function createZombieFromFeature(featureID)
 	if isIdleMode then
 		local featureDefID = spGetFeatureDefID(featureID)
@@ -1258,6 +1272,7 @@ local function createZombieFromFeature(featureID)
 	return false
 end
 
+---Queues every corpse currently on the map to raise zombies.
 local function queueAllCorpsesForSpawning()
 	local features = Spring.GetAllFeatures()
 	for _, featureID in ipairs(features) do
@@ -1265,6 +1280,8 @@ local function queueAllCorpsesForSpawning()
 	end
 end
 
+---Switches all zombies between return-fire with no auto-orders and normal aggression.
+---@param enabled boolean `true` to pacify, `false` to restore normal behavior.
 local function pacifyZombies(enabled)
 	local fireState
 	if enabled then
@@ -1282,6 +1299,8 @@ local function pacifyZombies(enabled)
 	end
 end
 
+---Stops or resumes the automatic orders given to zombies, without changing fire state.
+---@param enabled boolean `true` to suspend auto-orders, `false` to resume them.
 local function suspendAutoOrders(enabled)
 	if enabled then
 		ordersEnabled = false
@@ -1317,6 +1336,9 @@ local function fightNearTargets(targetUnits)
 	return true
 end
 
+---Sends every zombie to fight the units of one team.
+---@param teamID TeamID
+---@return boolean ordered `false` when the team is dead or has no units.
 local function aggroTeamID(teamID)
 	clearAllOrders()
 
@@ -1330,6 +1352,9 @@ local function aggroTeamID(teamID)
 	return fightNearTargets(targetUnits)
 end
 
+---Sends every zombie to fight the units of every team in an allyteam.
+---@param allyID AllyTeamID
+---@return boolean ordered `false` when the allyteam has no teams or no units.
 local function aggroAllyID(allyID)
 	clearAllOrders()
 
@@ -1350,6 +1375,7 @@ local function aggroAllyID(allyID)
 	return fightNearTargets(targetUnits)
 end
 
+---Kills every tracked zombie with environmental damage.
 local function killAllZombies()
 	for zombieID, zombieData in pairs(zombieWatch) do
 		if spValidUnitID(zombieID) and not Spring.GetUnitIsDead(zombieID) then
@@ -1361,6 +1387,9 @@ local function killAllZombies()
 	end
 end
 
+---Enables or disables raising zombies from corpses automatically.
+---Enabling also queues every corpse already on the map.
+---@param enabled boolean
 local function setAutoSpawning(enabled)
 	autoSpawningEnabled = enabled
 	if enabled then
@@ -1368,6 +1397,7 @@ local function setAutoSpawning(enabled)
 	end
 end
 
+---Drops every queued corpse spawn without affecting zombies already raised.
 local function clearAllZombieSpawns()
 	for featureID in pairs(corpsesData) do
 		clearCorpseRezRulesParam(featureID)
@@ -1399,6 +1429,9 @@ local function isAuthorized(playerID)
 	return false
 end
 
+---Turns each of the given units into a zombie.
+---@param unitIDs UnitID[]?
+---@return integer converted Number of units that were valid and converted.
 local function convertUnitsToZombies(unitIDs)
 	if not unitIDs or #unitIDs == 0 then
 		return 0
@@ -1415,6 +1448,8 @@ local function convertUnitsToZombies(unitIDs)
 	return convertedCount
 end
 
+---Turns every Gaia-owned unit that is not already a zombie into one.
+---@return integer converted
 local function setAllGaiaToZombies()
 	local allUnits = Spring.GetAllUnits()
 	local convertedCount = 0
@@ -1593,7 +1628,11 @@ local function commandClearZombieSpawns(_, line, words, playerID)
 	Spring.SendMessageToPlayer(playerID, "Cleared all queued zombie spawns")
 end
 
+---Switches the zombie difficulty preset.
+---@param mode ZombieMode
+---@return boolean applied `false` when `mode` is not a known preset.
 local function setZombieMode(mode)
+	---@diagnostic disable-next-line: unnecessary-if
 	if mode ~= "normal" and mode ~= "hard" and mode ~= "nightmare" and mode ~= "akumu" then
 		return false
 	end
@@ -1637,7 +1676,7 @@ function gadget:Initialize()
 		return
 	end
 
-	local initialMode = modOptions.zombies or "normal"
+	local initialMode = modOptions.zombies --[[@as ZombieMode?]] or "normal"
 	applyZombieModeSettings(initialMode)
 
 	autoSpawningEnabled = modOptionEnabled and not isIdleMode
@@ -1673,6 +1712,7 @@ function gadget:Initialize()
 	GG.Zombies.KillAllZombies = killAllZombies
 	GG.Zombies.ClearAllOrders = clearAllOrders
 	GG.Zombies.SetZombieMode = setZombieMode
+	---@return ZombieMode mode The active difficulty preset.
 	GG.Zombies.GetZombieMode = function()
 		return currentZombieMode
 	end

--- a/types/Position.lua
+++ b/types/Position.lua
@@ -1,0 +1,19 @@
+---@meta
+
+--- Coordinate shapes used across the BAR Lua code. Two forms are in circulation:
+--- fixed-length arrays, as the Spring API mostly returns, and named-field tables.
+--- Prefer these over `number[]` or `table`, so the language server checks the
+--- element count or the field names.
+---
+--- These stay aliases rather than numbered-field classes, unlike the heterogeneous
+--- tuples elsewhere: `api_object_spotlight` uses `integer|Position3D` as a table
+--- KEY type, and a class in key position makes every lookup an undefined-field.
+
+--- A world position as the array `{x, y, z}`, y being the height.
+---@alias Position3D [number, number, number]
+
+--- A map position as the array `{x, z}`, with the height implied by the terrain.
+---@alias Position2D [number, number]
+
+--- A map position as the named-field table `{x = ..., z = ...}`.
+---@alias PositionXZ {x: number, z: number}


### PR DESCRIPTION
### Work done

EmmyLua annotations for the gadget API surface (`GG.*`), including descriptions, function parameters they take, and the shapes they return. Covers 29 gadgets, plus one new type file for various ways to represent a position that will be used across future PRs. Annotation only — no runtime behavior changes.

This is the first PR split from #8743 which was too big to review.

This depends on https://github.com/beyond-all-reason/RecoilEngine/pull/3231 for type aliases. It can be merged sooner but will produce additional type warnings until then.

### Test steps

Use your IDE of choice and type, e.g., `GG.apm.addSkipOrder(` to see param autocomplete.

### AI / LLM usage statement:

Code is ~90% by Claude Opus 5. PR description is ~25% by Claude Opus 5. Testing via tools was done ~50% by Claude Opus 5.
I have reviewed this PR, experimented with these annotations in VSCode, and reviewed the results from `emmylua_check`. I understand and endorse this PR.