### PR TITLE
fix: beamburst typo, make a module for fiddlier weapon stats

### DIFF
--- a/common/weapons.lua
+++ b/common/weapons.lua
@@ -1,0 +1,64 @@
+---------------------------------------------------------------------------------------------------
+-- common/weapons.lua -----------------------------------------------------------------------------
+
+local math_floor = math.floor
+local math_max = math.max
+
+local gameSpeed = Game.gameSpeed
+local gameSpeedInv = 1 / gameSpeed
+
+local FRAME_EPS = 1e-3
+
+local function getBeamFiringCycle(weaponDef, reload)
+	if weaponDef.beamburst then
+		return weaponDef.salvoSize * weaponDef.projectiles,
+			math_max(reload, (weaponDef.salvoSize - 1) * weaponDef.salvoDelay)
+	end
+
+	-- Damage is spread across all beam frames (which may be just one frame).
+	local beamFrames = math_max(1, math_floor(weaponDef.beamtime * gameSpeed))
+
+	local fireTime = weaponDef.customParams.sweepfire_firetime
+	if fireTime then
+		-- Sweepfire unit scripts fire the beam for `sweepfire_firetime` out of `sweepfire_reloadtime`.
+		local fireFrames = math_floor(tonumber(fireTime) * gameSpeed + 0.5)
+		return weaponDef.projectiles * fireFrames / beamFrames,
+			tonumber(weaponDef.customParams.sweepfire_reloadtime) or reload
+	end
+
+	return weaponDef.projectiles, math_max(reload, beamFrames * gameSpeedInv)
+end
+
+---------------------------------------------------------------------------------------------------
+-- Module functions -------------------------------------------------------------------------------
+
+---@param weaponDef WeaponDef
+---@param reload number?
+---@return number shots
+---@return number period
+---@return number intensityMin
+local function getFiringCycle(weaponDef, reload)
+	-- The engine spends reload in whole frames but provides values to game code with no rounding.
+	reload = math_max(1, math_floor(((reload or weaponDef.reload) + FRAME_EPS) * gameSpeed)) * gameSpeedInv
+	if weaponDef.type == "BeamLaser" then
+		local shots, period = getBeamFiringCycle(weaponDef, reload)
+		return shots, period, math_max(weaponDef.minIntensity, 0.5)
+	end
+	return weaponDef.salvoSize * weaponDef.projectiles, reload, 1.0
+end
+
+---@param weaponDef WeaponDef
+---@param damage number
+---@param reload number?
+---@return number minDamagePerSecond At maximum range.
+---@return number maxDamagePerSecond At point blank.
+local function getDamagePerSecond(weaponDef, damage, reload)
+	local shots, period, intensityMin = getFiringCycle(weaponDef, reload)
+	local maxDamagePerSecond = damage * shots / period
+	return maxDamagePerSecond * intensityMin, maxDamagePerSecond
+end
+
+return {
+	GetFiringCycle = getFiringCycle,
+	GetDamagePerSecond = getDamagePerSecond,
+}

--- a/luaui/Widgets/dbg_unit_csv_export.lua
+++ b/luaui/Widgets/dbg_unit_csv_export.lua
@@ -14,6 +14,7 @@ end
 
 local filename = "unitlist.csv"
 local iconTypes = VFS.Include("gamedata/icontypes.lua")
+local weaponInfo = VFS.Include("common/weapons.lua")
 
 local function round(num, numDecimalPlaces)
 	local mult = 10 ^ (numDecimalPlaces or 0)
@@ -262,28 +263,12 @@ function widget:Initialize()
 									weapName = "EMP-StarburstLauncher"
 								end
 							else
-								if
-									weaponDef.damages[Game.armorTypes.vtol]
-									> weaponDef.damages[Game.armorTypes.default or 0]
-								then
-									dps = dps
-										+ (
-											(
-												(weaponDef.damages[Game.armorTypes.vtol] * (1 / weaponDef.reload))
-												* weaponDef.salvoSize
-											) * weaponDef.projectiles
-										)
-								else
-									dps = dps
-										+ (
-											(
-												(
-													weaponDef.damages[Game.armorTypes.default or 0]
-													* (1 / weaponDef.reload)
-												) * weaponDef.salvoSize
-											) * weaponDef.projectiles
-										)
-								end
+								local damage = math.max(
+									weaponDef.damages[Game.armorTypes.vtol],
+									weaponDef.damages[Game.armorTypes.default or 0]
+								)
+								local _, maxDps = weaponInfo.GetDamagePerSecond(weaponDef, damage)
+								dps = dps + maxDps
 							end
 							if weaponTable[weapName] then
 								weaponTable[weapName] = weaponTable[weapName] + 1

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -30,6 +30,7 @@ local emptyInfo = false
 local showEngineTooltip = false -- straight up display old engine delivered text
 
 local iconTypes = VFS.Include("gamedata/icontypes.lua")
+local weaponInfo = VFS.Include("common/weapons.lua")
 
 local vsx, vsy = Spring.GetViewGeometry()
 
@@ -362,24 +363,7 @@ local function refreshUnitInfo()
 		end
 
 		local function calculateLaserDPS(def, damage)
-			local minIntensity = math.max(def.minIntensity, 0.5)
-			local reload = def.reload
-			local burst = def.salvoSize * def.projectiles
-
-			local custom = def.customParams
-			if custom.sweepfire_firetime then
-				burst = tonumber(custom.sweepfire_firetime) * def.projectiles * Game.gameSpeed
-			end
-			if custom.sweepfire_reloadtime then
-				reload = tonumber(custom.sweepfire_reloadtime)
-			end
-
-			if not def.beamBurst then
-				burst = burst / (Game.gameSpeed * def.beamtime)
-			end
-
-			local maxdps = damage * burst / reload
-			return maxdps * minIntensity, maxdps
+			return weaponInfo.GetDamagePerSecond(def, damage)
 		end
 
 		local function calculateWeaponDPS(def, damage)
@@ -544,28 +528,11 @@ local function refreshUnitInfo()
 					setEnergyAndMetalCosts(weaponDef)
 
 					if weaponDef.paralyzer ~= true then
-						if weaponDef.customParams then
-							if weaponDef.customParams.sweepfire then
-								unitDefInfo[unitDefID].maxdps = (
-									weaponDef.damages[0] * weaponDef.customParams.sweepfire
-								) / math.max(weaponDef.minIntensity, 0.5)
-								unitDefInfo[unitDefID].mindps = weaponDef.damages[0] * weaponDef.customParams.sweepfire
-							else
-								addDPS(calculateLaserDPS(weaponDef, defDmg))
-							end
-						else
-							addDPS(calculateLaserDPS(weaponDef, defDmg))
-						end
+						addDPS(calculateLaserDPS(weaponDef, defDmg))
 					else
-						-- calculate laser emp dmg
-						local minIntensity = math.max(weaponDef.minIntensity, 0.5)
-						local prevMinDps = unitDefInfo[unitDefID].minemp or 0
-						local prevMaxDps = unitDefInfo[unitDefID].maxemp or 0
-						local mindps = minIntensity * (weaponDef.damages[0] * weaponDef.salvoSize / weaponDef.reload)
-						local maxdps = weaponDef.damages[0] * weaponDef.salvoSize / weaponDef.reload
-
-						unitDefInfo[unitDefID].minemp = mindps + prevMinDps
-						unitDefInfo[unitDefID].maxemp = maxdps + prevMaxDps
+						local minemp, maxemp = calculateLaserDPS(weaponDef, weaponDef.damages[0])
+						unitDefInfo[unitDefID].minemp = (unitDefInfo[unitDefID].minemp or 0) + minemp
+						unitDefInfo[unitDefID].maxemp = (unitDefInfo[unitDefID].maxemp or 0) + maxemp
 					end
 				elseif weaponDef.paralyzer == true and unitDef.name ~= "armthor" then -- exclude thor emp missile
 					local defDmg = weaponDef.damages[0] --Damage to default armor category

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -26,6 +26,7 @@ local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
 local spGetSpectatingState = Spring.GetSpectatingState
 
 local texts = {}
+local weaponInfo = VFS.Include("common/weapons.lua")
 local damageStats = (VFS.FileExists("LuaUI/Config/BAR_damageStats.lua"))
 	and VFS.Include("LuaUI/Config/BAR_damageStats.lua")
 local gameName = Game.gameName
@@ -827,11 +828,19 @@ local function computeContent(uDefID, uID, shiftBool)
 
 		-- Handle projectiles that spawn additional projectiles.
 		-- Many properties (might) have nothing to do with the spawned projectile:
-		local burst = uWep.salvoSize * uWep.projectiles
+		-- `reload` is a reported reload while `dpsCycle` is the engine's true time between shots.
+		-- Weapons with a firing time (so, beam weapons) can extend that time beyond their reload.
 		local range = uWep.range
 		local reload = uWep.reload
 		local accuracy = uWep.accuracy
 		local moveError = uWep.targetMoveError
+
+		if uID and weaponNumber > 0 then
+			reload = spGetUnitWeaponState(uID, weaponNumber, "reloadTimeXP") or reload
+		end
+		local reloadBonus = reload > 0 and (uWep.reload / reload - 1) or 0
+
+		local burst, dpsCycle = weaponInfo.GetFiringCycle(uWep, reload)
 
 		local damages = uWep.damages
 		local defaultArmorIndex = armorTypes.default
@@ -841,16 +850,8 @@ local function computeContent(uDefID, uID, shiftBool)
 
 		local custom = uWep.customParams
 
-		if uWep.type == "BeamLaser" then
-			if custom.sweepfire_firetime then
-				burst = tonumber(custom.sweepfire_firetime) * uWep.projectiles * simSpeed
-				if not uWep.beamBurst then
-					burst = burst / (simSpeed * uWep.beamtime)
-				end
-			end
-			if custom.sweepfire_reloadtime then
-				reload = tonumber(custom.sweepfire_reloadtime)
-			end
+		if uWep.type == "BeamLaser" and custom.sweepfire_reloadtime then
+			reload = tonumber(custom.sweepfire_reloadtime)
 		end
 
 		if custom.spark_forkdamage then
@@ -894,7 +895,6 @@ local function computeContent(uDefID, uID, shiftBool)
 
 			if uExp ~= 0 then
 				local rangeBonus = range ~= 0 and (range / uWep.range - 1) or 0
-				local reloadBonus = reload ~= 0 and (uWep.reload / reload - 1) or 0
 				local accuracyBonus = accuracy ~= 0 and (uWep.accuracy / accuracy - 1) or 0
 				local moveErrorBonus = moveError ~= 0 and (uWep.targetMoveError / moveError - 1) or 0
 				DrawText(
@@ -987,11 +987,11 @@ local function computeContent(uDefID, uID, shiftBool)
 				if wpnName == texts.deathexplosion or wpnName == texts.selfdestruct then
 					damageString = texts.burst .. " = " .. (format(yellow .. "%d", burstDamage)) .. white .. "."
 				else
-					local dps = burstDamage / (useExp and reload or uWep.reload)
+					local dps = burstDamage / dpsCycle
 					if custom.area_onhit_damage and custom.area_onhit_time then
 						local areaDps = custom.area_onhit_damage * burst
 						local duration = custom.area_onhit_time
-						dps = max(dps + areaDps, areaDps * duration / (useExp and reload or uWep.reload))
+						dps = max(dps + areaDps, areaDps * duration / dpsCycle)
 					end
 					damageString = texts.dps.." = "..(format(yellow .. "%d", dps))..white.."; "..texts.burst.." = "..(format(yellow .. "%d", burstDamage)) .. white .. (wepCount > 1 and (" ("..texts.each..").") or ("."))
 					-- Smart priority weapons should use the same weapon group number. But they should not add up their combined damages/DPS.


### PR DESCRIPTION
### Work done

Fixed a typo, `beamBurst` vs `beamburst`.

Fixed the DPS display of beam/beam-burst lasers in UI tooltips and the CSV export.

Then took it a bit far because I am tired of beam weapons. They have a bunch of quirks and rounding errors, and we need a weapons stats module anyway. This adds `weapons.lua` as a new module.