### PR TITLE
Stop stub globals from shadowing engine definitions

### DIFF
--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -93,7 +93,9 @@
       ".lux"
     ],
     "ignoreGlobs": [
-      "**/.lux/**"
+      "**/.lux/**",
+      "spec/spec_helper.lua",
+      "spec/builders/**"
     ],
     "library": [
       ".lux/5.1/test_dependencies/5.1/01a3c364614bddff7370223a5a9c4580f8e62d144384148444c518ec5367a59b-mediator_lua@1.1.2-0/src",

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -32,25 +32,17 @@ if gadgetHandler:IsSyncedCode() then
 	-- Speed-ups
 	if tracy == nil then
 		--Spring.Echo("Gadgetside tracy: No support detected, replacing tracy.* with function stubs.")
-		tracy = {}
-		tracy.ZoneBeginN = function()
-			return
-		end
-		tracy.ZoneBegin = function()
-			return
-		end
-		tracy.ZoneEnd = function()
-			return
-		end --Spring.Echo("No Tracy") return end
-		tracy.Message = function()
-			return
-		end
-		tracy.ZoneName = function()
-			return
-		end
-		tracy.ZoneText = function()
-			return
-		end
+		-- Built in a local and rawset, so the language server does not read the
+		-- stubs as competing definitions of the engine's `tracy` global -- which
+		-- makes every tracy.* call site disagree about its parameters.
+		local tracyStub = {}
+		tracyStub.ZoneBeginN = function() end
+		tracyStub.ZoneBegin = function() end
+		tracyStub.ZoneEnd = function() end
+		tracyStub.Message = function() end
+		tracyStub.ZoneName = function() end
+		tracyStub.ZoneText = function() end
+		rawset(_G, "tracy", tracyStub)
 	end
 	--
 

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -13,25 +13,17 @@
 if System == nil then
 	if tracy == nil then
 		Spring.Echo("Gadgetside tracy: No support detected, replacing tracy.* with function stubs.")
-		tracy = {}
-		tracy.ZoneBeginN = function()
-			return
-		end
-		tracy.ZoneBegin = function()
-			return
-		end
-		tracy.ZoneEnd = function()
-			return
-		end --Spring.Echo("No Tracy") return end
-		tracy.Message = function()
-			return
-		end
-		tracy.ZoneName = function()
-			return
-		end
-		tracy.ZoneText = function()
-			return
-		end
+		-- Built in a local and rawset, so the language server does not read the
+		-- stubs as competing definitions of the engine's `tracy` global -- which
+		-- makes every tracy.* call site disagree about its parameters.
+		local tracyStub = {}
+		tracyStub.ZoneBeginN = function() end
+		tracyStub.ZoneBegin = function() end
+		tracyStub.ZoneEnd = function() end
+		tracyStub.Message = function() end
+		tracyStub.ZoneName = function() end
+		tracyStub.ZoneText = function() end
+		rawset(_G, "tracy", tracyStub)
 	end
 
 	System = {

--- a/luaui/Include/AtlasOnDemand.lua
+++ b/luaui/Include/AtlasOnDemand.lua
@@ -73,17 +73,19 @@ end
 local UNITTEST = false
 if not Spring then
 	UNITTEST = true
-	Spring = {
+	-- rawset so the language server does not read these test stubs as competing
+	-- definitions of the engine globals, which makes every other field unknown
+	rawset(_G, "Spring", {
 		Echo = function(s)
 			print(s)
 		end,
-	}
-	gl = {
+	})
+	rawset(_G, "gl", {
 		CreateTexture = function()
 			return 0
 		end,
-	}
-	GL = {}
+	})
+	rawset(_G, "GL", {})
 end
 
 --- Create a new texture atlas for any image/text type

--- a/luaui/system.lua
+++ b/luaui/system.lua
@@ -14,25 +14,17 @@
 if System == nil then
 	if tracy == nil then
 		Spring.Echo("Tracy: No support detected, replacing tracy.* with function stubs.")
-		tracy = {}
-		tracy.ZoneBeginN = function()
-			return
-		end
-		tracy.ZoneBegin = function()
-			return
-		end
-		tracy.ZoneEnd = function()
-			return
-		end --Spring.Echo("No Tracy") return end
-		tracy.Message = function()
-			return
-		end
-		tracy.ZoneName = function()
-			return
-		end
-		tracy.ZoneText = function()
-			return
-		end
+		-- Built in a local and rawset, so the language server does not read the
+		-- stubs as competing definitions of the engine's `tracy` global -- which
+		-- makes every tracy.* call site disagree about its parameters.
+		local tracyStub = {}
+		tracyStub.ZoneBeginN = function() end
+		tracyStub.ZoneBegin = function() end
+		tracyStub.ZoneEnd = function() end
+		tracyStub.Message = function() end
+		tracyStub.ZoneName = function() end
+		tracyStub.ZoneText = function() end
+		rawset(_G, "tracy", tracyStub)
 	end
 
 	System = {


### PR DESCRIPTION
### Work done

Some files make bare assignments into engine globals, which confuses emmylua which sees competing definitions of the same global. This causes thousands of flaky diagnostics.

- **`luaui/Include/AtlasOnDemand.lua`** stubs `Spring`, `gl` and `GL` under `if not Spring then`, so the file can be run standalone for the self-test at the bottom. When the stub won, `gl` had exactly one field, so every `local glTexture = gl.Texture` resolved to `nil` and was reported at each use. 3895 flaky diagnostics.
- **`luaui/system.lua`, `luarules/system.lua`, `luarules/gadgets/raptor_spawner_defense.lua`** stub `tracy` when the engine has no Tracy support. The `ZoneBeginN` stub takes no arguments where the real one takes a name. 439 flaky diagnostics.
- **`spec/spec_helper.lua` and `spec/builders/`** mock `Spring`, `VFS`, `Game`, `LOG` and `GG` for testing.

The runtime stubs are now built in a local and installed into the global table with `rawset`. That is equivalent at runtime but emmylua doesn't respect it for analysis purposes.

The spec mocks are deliberately partial and can never agree with the real definitions, so they are excluded from analysis in `.emmyrc.json` rather than rewritten. The `*_spec.lua` files themselves will continue to be analyzed automatically. The excluded files can still be explicitly targeted for analysis (e.g. `emmylua_check spec/spec_helper.lua`).

#### Test steps

Run `emmylua_check` multiple times. On master there will be ~36k stable diagnostics and ~9700 flaky/intermittent. With this PR there will be ~38k stable diagnostics and ~700 flaky/intermittent.

### AI / LLM usage statement:

PR code ~90% by Claude Opus 5. PR description ~40% by Claude Opus 5. I have reviewed all of the changes, understand what they are doing, and endorse this change.