### PR TITLE
Fix nil arithmetic in corcom ResumeBuilding

### DIFF
--- a/scripts/Units/corcom_lus.lua
+++ b/scripts/Units/corcom_lus.lua
@@ -657,8 +657,8 @@ end
 function ResumeBuilding()
 	Sleep(800)
 	if isBuilding and not isAiming then
-		Turn(aimy1, 2, buildheading - rad(20), rad(300.000000))
-		Turn(aimx1, 1, rad(-20.000000) - buildpitch, rad(90.000000))
+		Turn(aimy1, 2, buildHeading - rad(20), rad(300.000000))
+		Turn(aimx1, 1, rad(-20.000000) - buildPitch, rad(90.000000))
 	end
 	return 0
 end


### PR DESCRIPTION
### Work done
Fix two casing typos causing arithmetic on nil values.

### Test steps
I don't actually know how to produce the case to test this. I'm sorry, but I am confident this is clearly a mistake and bug, especially given the correct implementation in the equivalent arm and leg com files.

### AI / LLM usage statement:
The mistake was identified and patched by Claude Opus 5 while searching for accidental global variables. I have reviewed and endorse this fix. I understand the code implications, even though I can't figure out how to test it in-game.