### PR TITLE
luarules: localize or remove accidental globals, annotate some types

### DIFF
--- a/luarules/gadgets/cmd_dev_helpers.lua
+++ b/luarules/gadgets/cmd_dev_helpers.lua
@@ -8,6 +8,15 @@ end
 
 local gadget = gadget ---@type Gadget
 
+---@type table<string, true>
+local startPlayers
+---@type number
+local uiScale
+---@type integer
+local vsx
+---@type integer
+local vsy
+
 function gadget:GetInfo()
 	return {
 		name = "Dev Helper Cmds",
@@ -1031,6 +1040,10 @@ if gadgetHandler:IsSyncedCode() then
 	function ExecuteRemoveUnitDefName(unitdefname)
 		local unitDefID = UnitDefNames[unitdefname].id
 		if unitDefID then
+			---@type FeatureDefID?
+			local wreckFeatureDefID
+			---@type FeatureDefID?
+			local heapFeatureDefID
 			if FeatureDefNames[unitdefname .. "_dead"] then
 				wreckFeatureDefID = FeatureDefNames[unitdefname .. "_dead"].id
 			end
@@ -1842,7 +1855,6 @@ else -- UNSYNCED
 			sd = alpha * sd + (1 - alpha) * drawTime
 
 			lastFrameType = "draw"
-			dt = drawTime
 		end
 	end
 
@@ -1874,7 +1886,6 @@ else -- UNSYNCED
 				if elapsed > MODBROADCAST_HOLD then
 					alpha = 1 - ((elapsed - MODBROADCAST_HOLD) / (MODBROADCAST_DURATION - MODBROADCAST_HOLD))
 				end
-				local vsx, vsy = Spring.GetViewGeometry()
 				local c = modbroadcastActive
 				gl.Color(c.r, c.g, c.b, alpha)
 				gl.Text(c.text, vsx / 2, vsy / 2, MODBROADCAST_FONT_SIZE, "cvo")
@@ -2070,7 +2081,7 @@ else -- UNSYNCED
 			return
 		end
 		if not words[1] then
-			units = Spring.GetSelectedUnits()
+			local units = Spring.GetSelectedUnits()
 			if #units > 0 then
 				words[1] = Spring.GetUnitTeam(units[1])
 			else

--- a/luarules/gadgets/cmd_get_player_data.lua
+++ b/luarules/gadgets/cmd_get_player_data.lua
@@ -1,5 +1,8 @@
 local gadget = gadget ---@type Gadget
 
+---@type LuaFont
+local font
+
 function gadget:GetInfo()
 	return {
 		name = "Get Player Data",

--- a/luarules/gadgets/dbg_benchmark.lua
+++ b/luarules/gadgets/dbg_benchmark.lua
@@ -1,5 +1,8 @@
 local gadget = gadget ---@type Gadget
 
+---@type table<string, true>
+local startPlayers
+
 function gadget:GetInfo()
 	return {
 		name = "Benchmark",
@@ -175,6 +178,10 @@ if gadgetHandler:IsSyncedCode() then
 	function ExecuteRemoveUnitDefName(unitdefname)
 		local unitDefID = UnitDefNames[unitdefname].id
 		if unitDefID then
+			---@type FeatureDefID?
+			local wreckFeatureDefID
+			---@type FeatureDefID?
+			local heapFeatureDefID
 			if FeatureDefNames[unitdefname .. "_dead"] then
 				wreckFeatureDefID = FeatureDefNames[unitdefname .. "_dead"].id
 			end
@@ -522,7 +529,6 @@ else -- UNSYNCED
 			sd = alpha * sd + (1 - alpha) * drawTime
 
 			lastFrameType = "draw"
-			dt = drawTime
 		end
 	end
 

--- a/luarules/gadgets/dbg_gadget_profiler.lua
+++ b/luarules/gadgets/dbg_gadget_profiler.lua
@@ -217,7 +217,13 @@ else
 end
 
 local gname2name = {}
-Hook = function(gadget, callinName)
+---@class HookedGadget : Gadget
+---@field [string] function
+
+---@param gadget HookedGadget
+---@param callinName string
+---@return function
+local function Hook(gadget, callinName)
 	local gadgetName = gadget.ghInfo.name
 	local realFunc = gadget[callinName]
 
@@ -288,6 +294,8 @@ local function ForAllGadgetCallins(action)
 end
 
 -- Helper for StartHook
+---@param gadget HookedGadget
+---@param callin string
 local function AddHook(gadget, callin)
 	gadget[callin] = Hook(gadget, callin)
 end
@@ -335,6 +343,8 @@ local function StartHook(optName, line, words, playerID) -- this one is synced?
 end
 
 -- Helper for Kill Hook
+---@param gadget HookedGadget
+---@param callin string
 local function RemoveHook(gadget, callin)
 	if gadget["_old" .. callin] then
 		gadget[callin] = gadget["_old" .. callin]

--- a/luarules/gadgets/dbg_synctest.lua
+++ b/luarules/gadgets/dbg_synctest.lua
@@ -1,5 +1,8 @@
 local gadget = gadget ---@type Gadget
 
+---@type table<string, true>
+local startPlayers
+
 function gadget:GetInfo()
 	return {
 		name = "Synctest",

--- a/luarules/gadgets/game_battle_royale.lua
+++ b/luarules/gadgets/game_battle_royale.lua
@@ -219,7 +219,7 @@ else
 				circleuniforms = { 1, 1, 1, 1 }, -- unused
 			},
 		}, "ground circles shader GL4")
-		shaderCompiled = circleShader:Initialize()
+		local shaderCompiled = circleShader:Initialize()
 		if not shaderCompiled then
 			goodbye("Failed to compile circleShader GL4 ")
 		end

--- a/luarules/gadgets/game_restrict_unit_sharing.lua
+++ b/luarules/gadgets/game_restrict_unit_sharing.lua
@@ -51,7 +51,7 @@ function gadget:AllowUnitTransfer(unitID, unitDefID, fromTeamID, toTeamID, captu
 	then
 		return true
 	end
-	beingBuilt, buildProgress = spGetUnitIsBeingBuilt(unitID)
+	local beingBuilt, buildProgress = spGetUnitIsBeingBuilt(unitID)
 	if beingBuilt and buildProgress > 0 and next(Spring.GetPlayerList(fromTeamID, true)) ~= nil then
 		return false -- Sharing partly built nanoframes is not allowed because letting it decay bypasses taxation and letting it build runs out the debuff early. Also if you can't assist ally build the unit could get stuck in factory.
 	end

--- a/luarules/gadgets/gfx_unit_glass.lua
+++ b/luarules/gadgets/gfx_unit_glass.lua
@@ -112,7 +112,7 @@ else -- Unsynced
 	-- Shader sources
 	-----------------------------------------------------------------
 
-	vertGlass = [[
+	local vertGlass = [[
 #version 150 compatibility
 #line 100054
 
@@ -151,7 +151,7 @@ void main() {
 }
 ]]
 
-	fragGlass = [[
+	local fragGlass = [[
 #version 150 compatibility
 #line 200094
 

--- a/luarules/gadgets/gui_display_dps.lua
+++ b/luarules/gadgets/gui_display_dps.lua
@@ -353,8 +353,6 @@ function checkEnabled()
 	enabled = (tonumber(Spring.GetConfigInt("DisplayDPS", 0) or 0) == 1)
 	if prevEnabled ~= enabled then
 		damageTable = {}
-		unitParalyze = {}
-		unitDamage = {}
 		deadList = {}
 		lastTime = 0
 		changed = false

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -1,5 +1,12 @@
 local gadget = gadget ---@type Gadget
 
+---@type table<UnitID, UnitDefID>
+local attached_builder_def
+---@type table<UnitID, UnitID>
+local attached_builders
+---@type UnitID?
+local nanoID
+
 function gadget:GetInfo()
 	return {
 		name = "Attached Construction Turret",
@@ -50,7 +57,7 @@ local max_unit_radius = 0
 function gadget:Initialize()
 	local radius = 0
 	for ix, udef in pairs(UnitDefs) do
-		dimensions = SpGetUnitDefDimensions(udef.id)
+		local dimensions = SpGetUnitDefDimensions(udef.id)
 		radius = dimensions.radius
 		max_unit_radius = math.max(radius, max_unit_radius)
 	end
@@ -130,8 +137,8 @@ local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 	if tx and distance <= radius then
 		--let auto con turret continue its thing
 		--update heading, by calling into unit script
-		heading1 = SpGetHeadingFromVector(ux - tx, uz - tz)
-		heading2 = SpGetUnitHeading(nanoID)
+		local heading1 = SpGetHeadingFromVector(ux - tx, uz - tz)
+		local heading2 = SpGetUnitHeading(nanoID)
 		SpCallCOBScript(nanoID, "UpdateHeading", 0, heading1 - heading2 + 32768)
 		return
 	end

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -1185,7 +1185,7 @@ local function updateStandaloneDrones(frame)
 				if not engaged and ((DEFAULT_UPDATE_ORDER_FREQUENCY + droneData.lastOrderUpdate) < frame) then
 					local idleRadius = droneData.idleRadius * 0.2
 					droneData.lastOrderUpdate = frame
-					rx, rz = randomPointInUnitCircle(5)
+					local rx, rz = randomPointInUnitCircle(5)
 					spGiveOrderToUnit(
 						unitID,
 						CMD.MOVE,

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -20,7 +20,7 @@ local DEBUG = false
 
 function gadget:GameID(gameID)
 	-- make sure gameID is a string because i'm not actually sure
-	cachedGameID = tostring(gameID)
+	local cachedGameID = tostring(gameID)
 	-- Initialise this madness
 	local FakeRandomSeed = ""
 	-- because yes

--- a/luarules/gadgets/unit_paralyze_damage_limit.lua
+++ b/luarules/gadgets/unit_paralyze_damage_limit.lua
@@ -192,7 +192,7 @@ function gadget:UnitPreDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, 
 				thismaxtime = weaponParalyzeDamageTime[weaponID] * ((ohm == 1 and 0.85) or ohm)
 
 				if ohm > 0 then
-					bufferdamage = hp / 200
+					local bufferdamage = hp / 200
 					--rootdamage = (damage / 50) * hp^0.5
 					--Spring.Echo('h damage rootdamage',hp,damage, rootdamage)
 					damage = damage + bufferdamage --overcome relative effects drain (eg stunned unit with 90000 hp loses 900 emp damage a tick, whereas unit with 900 hp loses 9 a tick. impossible to balance low damage emp weapons to overcome this without making them OP vs low HP units)
@@ -211,7 +211,7 @@ function gadget:UnitPreDamaged(uID, uDefID, uTeam, damage, paralyzer, weaponID, 
 			--thanks to sprung for this arcane spell
 			local maxEmpDamage = (1 + (thismaxtime / paralyzeDeclineRate)) * effectiveHP
 
-			newdamage = math_max(0, math_min(damage, maxEmpDamage - currentEmp))
+			local newdamage = math_max(0, math_min(damage, maxEmpDamage - currentEmp))
 			--Spring.Echo('h mh ph wpt old new',hp,maxHP, currentEmp, thismaxtime, damage, newdamage)
 
 			damage = newdamage

--- a/luarules/gadgets/unit_transported_building_ghost.lua
+++ b/luarules/gadgets/unit_transported_building_ghost.lua
@@ -12,7 +12,7 @@ function gadget:GetInfo()
 	}
 end
 
-spSetUnitLeavesGhost = Spring.SetUnitLeavesGhost
+local spSetUnitLeavesGhost = Spring.SetUnitLeavesGhost
 
 if not gadgetHandler:IsSyncedCode() then
 	return


### PR DESCRIPTION
**THIS PR CONTAINS UNTESTED CODE CHANGES**

### Work done

1. Declare block or file scoped locals where globals were (seeming accidentally) created in `luarules/`
2. Add type annotations to them where possible, and to some adjacent locals
3. Remove unused globals
4. Remove redundant shadows

### Test steps

I'm still figuring out how to do most of these and will un-draft this PR once I do.

- [ ] Start a game with `/luarules profile` — the gadget profiler overlay draws, sorts and toggles as before, and `/luarules profile` a second time removes the hooks cleanly.
- [ ] With `DisplayDPS` enabled, deal damage and EMP damage to units — DPS numbers still accumulate and expire.
- [ ] Share a partly built nanoframe to an allied team — the transfer is still refused (`game_restrict_unit_sharing`).
- [ ] Build a unit with an attached construction turret and let it auto-repair — the turret still tracks and updates heading.
- [ ] View units with glass pieces (`gfx_unit_glass`) — the glass shader still compiles and renders.
- [ ] In a dev build, run the `removeunitdefname` dev helper on a unit with a `_dead` feature — wrecks and heaps are removed, not left behind.

### AI / LLM usage statement:

Code 85% by Claude Opus 5. Commit messages 100% by Claude Opus 5. PR description 50% by Claude Opus 5. I have reviewed the code and understand it. I will un-draft this PR after I succeed at testing everything in-game.