### PR TITLE
Type the rectangle shapes widgets pass between each other

### DIFF
--- a/luaui/Widgets/camera_player_tv.lua
+++ b/luaui/Widgets/camera_player_tv.lua
@@ -1145,6 +1145,8 @@ function widget:Initialize()
 
 	updatePosition()
 	WG.playertv = {}
+	---Where the PlayerTV panel sits, so a neighbour can stack against it.
+	---@return DockedPanelPosition position
 	WG.playertv.GetPosition = function()
 		return { top, left, bottom, right, widgetScale }
 	end

--- a/luaui/Widgets/gui_advplayerslist_gameinfo.lua
+++ b/luaui/Widgets/gui_advplayerslist_gameinfo.lua
@@ -181,6 +181,8 @@ function widget:Initialize()
 	widget:ViewResize()
 	updatePosition()
 	WG.displayinfo = {}
+	---Where the game info panel sits, so a neighbour can stack against it.
+	---@return DockedPanelPosition position
 	WG.displayinfo.GetPosition = function()
 		return { top, left, bottom, right, widgetScale }
 	end

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -959,6 +959,8 @@ function widget:Initialize()
 	--Spring.StopSoundStream() -- only for testing purposes
 
 	WG.music = {}
+	---Where the music player panel sits, so a neighbour can stack against it.
+	---@return DockedPanelPosition|false position `false` once the widget has shut down.
 	WG.music.GetPosition = function()
 		if shutdown then
 			return false

--- a/luaui/Widgets/gui_advplayerslist_unittotals.lua
+++ b/luaui/Widgets/gui_advplayerslist_unittotals.lua
@@ -155,6 +155,8 @@ function widget:Initialize()
 	widget:ViewResize()
 	updatePosition()
 	WG.unittotals = {}
+	---Where the unit totals panel sits, so a neighbour can stack against it.
+	---@return DockedPanelPosition position
 	WG.unittotals.GetPosition = function()
 		return { top, left, bottom, right, widgetScale }
 	end

--- a/luaui/Widgets/gui_buildbar.lua
+++ b/luaui/Widgets/gui_buildbar.lua
@@ -100,7 +100,12 @@ local msz = Game.mapY * 512
 local groups, unitGroup = {}, {} -- retrieves from buildmenu in initialize
 local unitOrder = {} -- retrieves from buildmenu in initialize
 
-local bgpadding, font, backgroundRect, backgroundOptionsRect, buildoptionsArea, dlistGuishader, dlistGuishader2, forceGuishader
+local bgpadding, font, dlistGuishader, dlistGuishader2, forceGuishader
+---@type ScreenRect?
+local backgroundRect
+---@type ScreenRect?
+local backgroundOptionsRect
+local buildoptionsArea
 local factoriesArea, cornerSize, setInfoDisplayUnitID, setInfoDisplayUnitDefID, factoriesAreaHovered
 
 -------------------------------------------------------------------------------

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -138,6 +138,7 @@ local myTeamID = spGetMyTeamID()
 local startDefID = Spring.GetTeamRulesParam(myTeamID, "startUnit")
 
 local disableInput = disableInputWhenSpec and isSpec
+---@type ScreenRect
 local backgroundRect = { 0, 0, 0, 0 }
 local colls = 5
 local rows = 5

--- a/luaui/Widgets/gui_converter_usage.lua
+++ b/luaui/Widgets/gui_converter_usage.lua
@@ -285,6 +285,8 @@ function widget:Initialize()
 	refreshTooltipText()
 
 	WG.converter_usage = {}
+	---Screen rectangle of the converter usage panel.
+	---@return ScreenRect area
 	WG.converter_usage.GetPosition = function()
 		return area
 	end

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -89,7 +89,9 @@ local unitList = {}
 local idleList = {}
 local inIdleWorkerTask = table.ensureTable(WG, "InIdleWorkerTask")
 
-local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, backgroundRect, ordermenuPosY
+local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, ordermenuPosY
+---@type ScreenRect?
+local backgroundRect
 local guishaderWasActive = false
 
 local unitHumanName = {}
@@ -656,6 +658,11 @@ function widget:Initialize()
 	widget:ViewResize()
 	widget:PlayerChanged()
 	WG.idlebuilders = {}
+	---Screen rectangle of the idle builders panel, as four values rather than a `ScreenRect`.
+	---@return number left
+	---@return number bottom
+	---@return number right
+	---@return number top
 	WG.idlebuilders.getPosition = function()
 		return posX,
 			posY,

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -41,6 +41,7 @@ local sound_button2 = "LuaUI/Sounds/buildbar_rem.wav"
 
 local ui_scale = tonumber(Spring.GetConfigFloat("ui_scale", 1) or 1)
 
+---@type ScreenRect
 local backgroundRect = { 0, 0, 0, 0 }
 local currentTooltip = ""
 local lastUpdateClock = 0

--- a/luaui/Widgets/gui_minimap.lua
+++ b/luaui/Widgets/gui_minimap.lua
@@ -37,6 +37,7 @@ local ratio = Game.mapX / Game.mapY
 local maxWidth = mathMin(maxHeight * ratio, maxAllowedWidth * (vsx / vsy))
 local usedWidth = mathFloor(maxWidth * vsy)
 local usedHeight = mathFloor(maxHeight * vsy)
+---@type ScreenRect
 local backgroundRect = { 0, 0, 0, 0 }
 
 local delayedSetup = false

--- a/luaui/Widgets/gui_tooltip.lua
+++ b/luaui/Widgets/gui_tooltip.lua
@@ -29,7 +29,7 @@ local glTranslate = gl.Translate
 --[[
 
 -- Available API functions:
-WG['tooltip'].AddTooltip(name, area, value, delay, x, y, title)  -- area: {x1,y1,x2,y2}   value(optional): 'text'   delay(optional): #seconds   x/y(optional): display coordinates   title(optional): 'text'
+WG['tooltip'].AddTooltip(name, area, value, delay, title)  -- area: ScreenRect {left,bottom,right,top}   value(optional): 'text'   delay(optional): #seconds   title(optional): 'text'
 WG['tooltip'].RemoveTooltip(name)
 
 WG['tooltip'].ShowTooltip(name, value, x, y, title)    -- value(optional): 'text'   x/y (optional): display coordinates   title(optional): 'text'
@@ -138,6 +138,13 @@ function widget:Initialize()
 		WG.tooltip.getFontsize = function()
 			return usedFontSize
 		end
+		---Registers a hover tooltip over a screen rectangle. Calling again with the same
+		---name updates it; pass only `name` and `area` to move an existing tooltip.
+		---@param name string Caller-chosen key; pass the same one to `RemoveTooltip`.
+		---@param area ScreenRect
+		---@param value string|number|nil Tooltip body.
+		---@param delay number? Seconds of hover before it appears. Defaults to the widget's delay.
+		---@param title string|number|nil Tooltip heading.
 		WG.tooltip.AddTooltip = function(name, area, value, delay, title)
 			if
 				(

--- a/luaui/Widgets/gui_unitgroups.lua
+++ b/luaui/Widgets/gui_unitgroups.lua
@@ -71,7 +71,9 @@ local doUpdate = true
 
 local groupButtons = {}
 
-local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, backgroundRect, ordermenuPosY
+local font, font2, buildmenuBottomPosition, dlist, dlistGuishader, ordermenuPosY
+---@type ScreenRect?
+local backgroundRect
 local guishaderWasActive = false
 local buildmenuAlwaysShow = false
 local buildmenuShowingPosY = 0
@@ -149,6 +151,11 @@ function widget:Initialize()
 	widget:ViewResize()
 	widget:PlayerChanged()
 	WG.unitgroups = {}
+	---Screen rectangle of the unit groups panel, as four values rather than a `ScreenRect`.
+	---@return number left
+	---@return number bottom
+	---@return number right
+	---@return number top
 	WG.unitgroups.getPosition = function()
 		return posX,
 			backgroundRect and backgroundRect[2] or posY,

--- a/luaui/Widgets/unit_smart_select.lua
+++ b/luaui/Widgets/unit_smart_select.lua
@@ -255,6 +255,7 @@ function widget:PlayerChanged()
 end
 
 local sec = 0
+---@type SelectionBoxRect
 local prevSelRect = {}
 function widget:Update(dt)
 	sec = sec + dt

--- a/types/Rect.lua
+++ b/types/Rect.lua
@@ -1,0 +1,33 @@
+---@meta
+
+--- Rectangle shapes used across the UI. Several mutually incompatible four-number
+--- conventions are in play, and nothing distinguishes them at a glance, so they are
+--- collected here to be named at the point of use rather than inferred from the
+--- surrounding arithmetic.
+
+--- A rectangle in Spring screen coordinates, in the order the FlowUI drawing
+--- helpers take it: `UiElement(left, bottom, right, top)` and
+--- `RectRound(left, bottom, right, top, ...)`. Y grows upward, so `[4] >= [2]`.
+---@class ScreenRect
+---@field [1] number Left edge
+---@field [2] number Bottom edge
+---@field [3] number Right edge
+---@field [4] number Top edge
+
+--- Where a docked UI panel sits on screen, as the `GetPosition` members of the
+--- advplayerlist-adjacent widgets return it, so a panel can stack itself against a
+--- neighbour.
+---@class DockedPanelPosition
+---@field [1] number Top edge
+---@field [2] number Left edge
+---@field [3] number Bottom edge
+---@field [4] number Right edge
+---@field [5] number UI scale the panel was laid out at
+
+--- A mouse selection box, in the order the engine uses: `Spring.GetSelectionBox`
+--- returns these four values and `Spring.GetUnitsInScreenRectangle` takes them.
+---@class SelectionBoxRect
+---@field [1] number? Left edge
+---@field [2] number? Top edge
+---@field [3] number? Right edge
+---@field [4] number? Bottom edge


### PR DESCRIPTION
### Work done

The UI passes rectangles between widgets in several mutually incompatible four-number conventions, and nothing distinguishes them at a glance. `gui_buildbar` already carries a hand-written comment on the conversion between two of them to stay readable, and `gui_tooltip`'s API header documented the wrong one.

1. Add `types/Rect.lua` which annotates classes for three different "rectangle" data structures used across various widgets.
2. Annotate all the sites using those structures, and a few related annotations and comments.
3. Update non-annotation comment docs where these types are used.

This PR should have no effect on game behavior.

### AI / LLM usage statement:

Claude Opus 5 authored 95% of the PR code, 10% of this PR text, and 100% of the commit message. I have reviewed the code changes, understand them, and endorse them.

### Followup

`WG.music.GetPosition` is typed `DockedPanelPosition|false` which surfaces three `assign-type-mismatch` warnings where consumers assign the result straight into a table and then index it. Guards should be added to those sites, probably in a future pass of eliminating warnings once we have more things typed.
