### PR TITLE
Let widget enable and disable skip persisting the change

### DIFF
--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1219,12 +1219,6 @@ function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess)
 	return true
 end
 
----@param name string
----@param persist boolean? Write the change to the player's widget config. Defaults to true.
---- Pass false to take a widget off screen for this session alone: RemoveWidgetRaw is what
---- deactivates it, so the config keeps saying the widget is enabled and the next game loads
---- it as usual.
----@return boolean
 function widgetHandler:DisableWidgetRaw(name, persist)
 	local ki = self.knownWidgets[name]
 	if not ki then

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1197,7 +1197,7 @@ function widgetHandler:IsWidgetKnown(name)
 	return self.knownWidgets[name] and true or false
 end
 
-function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess)
+function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess, persist)
 	local ki = self.knownWidgets[name]
 	if not ki then
 		Spring.Echo("EnableWidget(), could not find widget: " .. tostring(name))
@@ -1205,16 +1205,20 @@ function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess)
 	end
 	if not ki.active then
 		Spring.Echo("Loading:  " .. ki.filename .. (enableLocalsAccess and " (with locals)" or ""))
-		local order = widgetHandler.orderList[name]
-		if not order or order <= 0 then
-			self.orderList[name] = 1
+		if persist ~= false then
+			local order = widgetHandler.orderList[name]
+			if not order or order <= 0 then
+				self.orderList[name] = 1
+			end
 		end
 		local w = self:LoadWidget(ki.filename, ki.fromZip, enableLocalsAccess)
 		if not w then
 			return false
 		end
 		self:InsertWidgetRaw(w)
-		self:SaveConfigData()
+		if persist ~= false then
+			self:SaveConfigData()
+		end
 	end
 	return true
 end

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1219,7 +1219,13 @@ function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess)
 	return true
 end
 
-function widgetHandler:DisableWidgetRaw(name)
+---@param name string
+---@param persist boolean? Write the change to the player's widget config. Defaults to true.
+--- Pass false to take a widget off screen for this session alone: RemoveWidgetRaw is what
+--- deactivates it, so the config keeps saying the widget is enabled and the next game loads
+--- it as usual.
+---@return boolean
+function widgetHandler:DisableWidgetRaw(name, persist)
 	local ki = self.knownWidgets[name]
 	if not ki then
 		Spring.Echo("DisableWidget(), could not find widget: " .. tostring(name))
@@ -1232,8 +1238,10 @@ function widgetHandler:DisableWidgetRaw(name)
 		end
 		Spring.Echo("Removed:  " .. ki.filename)
 		self:RemoveWidgetRaw(w) -- deactivate
-		self.orderList[name] = 0 -- disable
-		self:SaveConfigData()
+		if persist ~= false then
+			self.orderList[name] = 0 -- disable
+			self:SaveConfigData()
+		end
 	end
 	return true
 end


### PR DESCRIPTION
Enabling or disabling a widget always writes the widget config, so it cannot be changed for one game only. persist defaults to true, so existing callers are unaffected.

Needed for launching with a different widget set for that game alone.

AI disclosure: written with assistance from Claude Code.
