### PR TITLE
Annotate the terraform brush tool and map manifest format

### DIFF
--- a/common/brush_shapes.lua
+++ b/common/brush_shapes.lua
@@ -21,6 +21,11 @@
 -- Supported shapes: "circle", "square", "hexagon", "octagon", "triangle".
 -- Unknown shapes return (false, 1).
 
+---A brush footprint. `isInside` recognizes exactly these; anything else is
+---treated as outside. Tools that offer extra footprints of their own (the
+---terraform brush's `"ring"` and `"fill"`) do not route them through here.
+---@alias BrushShape "circle"|"square"|"hexagon"|"octagon"|"triangle"
+
 local cos = math.cos
 local sin = math.sin
 local abs = math.abs

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1379,7 +1379,8 @@ local NEWMAP_MIN_UNITS = 4
 local NEWMAP_MAX_UNITS = 32
 local NEWMAP_DEFAULT_UNIT = 12
 local NEWMAP_BASE_HEIGHT = 100 -- starting ground height (elmos)
-local NEWMAP_COLOR = { 110, 130, 90 } -- base diffuse colour (0..255), muted grass
+---@type ColorRGBi
+local NEWMAP_COLOR = { 110, 130, 90 } -- base diffuse colour, muted grass
 
 -- ---- DNTS splat-set catalog (harvested from BAR maps) ----
 -- Each entry: { name, textures = {4 files}, scales = {4}, mults = {4}, diffuseAlpha }.
@@ -1959,6 +1960,9 @@ end
 -- Apply a full environment config table (schema = env_presets.lua / onEnvSave) to
 -- the live engine. Mirrors onEnvLoad's apply body so the env editor and the New
 -- Map preset path drive the engine identically. Every field is optional.
+---@param d table<string, any>? An environment snapshot as produced by
+---`buildEnvConfigContent`: sun, fog and atmosphere values keyed by name.
+---@return nil
 widgetState.applyEnvConfig = function(d)
 	if type(d) ~= "table" then
 		return
@@ -2067,11 +2071,15 @@ widgetState.applyEnvConfig = function(d)
 	end
 end
 
+---@class EnvConfigOpts
+---@field nodate boolean? Suppress the "generated on" date comment so that
+---repeated saves of unchanged state will serialize/hash identically
+
 -- Serialize the live environment state into the env-config Lua format (the same
 -- format onEnvSave writes and applyEnvConfig consumes). Shared by the env editor's
 -- SAVE button and the map-project orchestrator (cmd_map_project.lua).
--- opts.nodate suppresses the date comment: repeated project saves of unchanged
--- state must serialize identically (project files live in git).
+---@param opts EnvConfigOpts?
+---@return string content
 widgetState.buildEnvConfigContent = function(opts)
 	local sX, sY, sZ = gl.GetSun("pos")
 	local grA = { gl.GetSun("ambient") }
@@ -2286,17 +2294,35 @@ local function _nmSetAxis(axis, units)
 	_nmRefreshLabels()
 end
 
+---@class DntsSet
+---@field set string?
+---@field textures table<1|2|3|4,string>?
+---@field scales table<1|2|3|4,number>?
+---@field mults table<1|2|3|4,number>?
+---@field detail string?
+---@field diffuseAlpha number? created from `diffuse_alpha` on load
+---@field diffuse_alpha number? loaded as `diffuseAlpha`
+---@field rawPaths boolean? texture entries are full VFS paths already (project-local
+---assets/) instead of names under the library DNTS_DIR.
+
+-- Blank map start script options
+-- Defaults preserve the New Map behavior
+---@class BaseMapOpts
+---@field baseHeight number? blank_map_height (project manifests record theirs)
+---@field baseColor ColorRGBi? blank_map_color
+---@field customName string? user map name from the wizard; sanitized, still gets
+---the " s<time>" uniquifier. Default: "Editor Flat WxH"
+
 -- Build a start script for a blank/flat map of the given size by cloning the
 -- current session's _script.txt (preserving players/teams/modoptions) and
--- injecting the engine blank-map-generator keys. Returns (scriptText) or
--- (nil, errorMessage).
--- opts (all optional; defaults preserve the New Map behavior):
---   baseHeight   number  blank_map_height (project manifests record theirs)
---   baseColor    {r,g,b} 0..255 blank_map_color
---   customName   string  user map name from the wizard; sanitized, still gets
---                        the " s<time>" uniquifier. Blank/absent = "Editor Flat WxH"
--- dntsSet.rawPaths: texture entries are full VFS paths already (project-local
--- assets/) instead of names under the library DNTS_DIR.
+-- injecting the engine blank-map-generator keys.
+---@param widthUnits integer
+---@param heightUnits integer
+---@param dntsSet DntsSet
+---@param skyboxPath string?
+---@param opts BaseMapOpts?
+---@return string scriptText?
+---@return string errorMessage? with `nil` scriptText
 local function buildBlankMapStartScript(widthUnits, heightUnits, dntsSet, skyboxPath, opts)
 	local base = VFS.LoadFile("_script.txt")
 	if not base or base == "" then
@@ -2478,6 +2504,12 @@ end
 -- DNTS keys pointing at the project's own assets/dnts/ copies (self-contained —
 -- the library may have mutated since the save), skybox resolved from the
 -- library by basename. Returns (scriptText) or (nil, errorMessage).
+-- Start script for opening a map project (blank map at the manifest's
+-- size with project-local DNTS assets); called by WG.MapProject.open.
+---@param manifest MapProjectManifest
+---@param slug string Project folder name under `MapProjects/`.
+---@return string? scriptText `nil` on failure.
+---@return string? errorMessage Set when `scriptText` is `nil`.
 widgetState.buildProjectStartScript = function(manifest, slug)
 	if type(manifest) ~= "table" or type(manifest.map) ~= "table" then
 		return nil, "invalid manifest"
@@ -13788,30 +13820,63 @@ function widget:Initialize()
 	WG.TerraformBrushUI = {
 		-- Environment snapshot/apply, for the map-project orchestrator
 		-- (cmd_map_project.lua). Indirect so it tracks widgetState assignments.
+
+		---Pixel bounds of a brush panel, in Spring screen coordinates (Y=0 at the bottom).
+		---@class TerraformBrushPanelBounds
+		---@field left number
+		---@field right number
+		---@field topY number
+		---@field bottomY number
+
+		---Serializes the current sun, fog and water settings as a loadable Lua config.
+		---@param opts EnvConfigOpts?
+		---@return string content
 		buildEnvConfigContent = function(opts)
 			return widgetState.buildEnvConfigContent(opts)
 		end,
+		-- Apply a full environment config table (schema = env_presets.lua / onEnvSave) to
+		-- the live engine. Mirrors onEnvLoad's apply body so the env editor and the New
+		-- Map preset path drive the engine identically. Every field is optional.
+		---@param d table<string, any>? An environment snapshot as produced by
+		---`buildEnvConfigContent`: sun, fog and atmosphere values keyed by name.
+		---@return nil
 		applyEnvConfig = function(d)
 			return widgetState.applyEnvConfig(d)
 		end,
 		-- Start script for opening a map project (blank map at the manifest's
 		-- size with project-local DNTS assets); called by WG.MapProject.open.
+		---@param manifest MapProjectManifest
+		---@param slug string Project folder name under `MapProjects/`.
+		---@return string? scriptText `nil` on failure.
+		---@return string? errorMessage Set when `scriptText` is `nil`.
 		buildProjectStartScript = function(manifest, slug)
 			return widgetState.buildProjectStartScript(manifest, slug)
 		end,
+		---@return boolean capturing Whether the settings panel is waiting for a keypress to bind.
 		isCapturingKey = function()
 			return widgetState.settingsCapturing ~= nil
 		end,
+		---Feeds a keypress to the settings panel's key-capture flow.
+		---@param keyCode integer
+		---@return boolean consumed `false` when no capture is in progress.
 		captureKey = function(keyCode)
 			return handleSettingsKeyCapture(keyCode)
 		end,
+		---Redraws every keybind badge in the settings panel.
 		refreshBadges = function()
 			updateAllKeybindBadges()
 		end,
+		---Activates the brush tool bound to a key, if any.
+		---@param keyCode integer
+		---@return boolean consumed `false` when no tool is bound to that key.
 		handleToolKey = function(keyCode)
 			return handleToolKey(keyCode)
 		end,
 		-- Called by cmd_terraform_brush when the user clicks a height in sampling mode
+		---Records a height picked by the user in sampling mode, so the state sync loop
+		---reflects it.
+		---@param target "max"|"min" Which height cap was sampled.
+		---@param value number? Defaults to `0`.
 		onHeightSampled = function(target, value)
 			-- Update the local cap variables so the state sync loop reflects them
 			if target == "max" then
@@ -13835,6 +13900,7 @@ function widget:Initialize()
 		end,
 		-- Returns the panel pixel bounds in Spring screen coords (Y=0 at bottom).
 		-- Returns nil when the panel is hidden or not yet available.
+		---@return TerraformBrushPanelBounds? bounds
 		getPanelBounds = function()
 			local vsx, vsy = Spring.GetViewGeometry()
 			if vsx <= 0 then
@@ -13863,6 +13929,7 @@ function widget:Initialize()
 			}
 		end,
 		-- Returns bounds of the light library floating window, or nil if not visible.
+		---@return TerraformBrushPanelBounds? bounds
 		getLightLibraryBounds = function()
 			if not widgetState.lightLibraryOpen then
 				return nil

--- a/luaui/RmlWidgets/gui_terraformer_shared.lua
+++ b/luaui/RmlWidgets/gui_terraformer_shared.lua
@@ -34,8 +34,7 @@ local currentDpRatio = calculateDpRatio()
 WG.TerraformerShared = WG.TerraformerShared or {}
 
 -- Shared accessor so widgets don't reimplement calculateDpRatio().
--- Returns the current scale factor (resolution_factor * ui_scale), matching
--- whatever the shared RmlUi context is currently using.
+---@return number dpRatio Current scale factor `resolution_factor * ui_scale`, matching the shared RmlUi context.
 WG.TerraformerShared.getDpRatio = function()
 	return currentDpRatio
 end
@@ -141,6 +140,10 @@ WG.TerraformerShared.setWheelHeld = function(held)
 	end
 end
 
+---Registers a document so sibling widgets can read its live layout.
+---Call after `LoadDocument()`; pair with `unregisterDocument` on Shutdown.
+---@param name string?
+---@param document RmlUi.Document?
 WG.TerraformerShared.registerDocument = function(name, document)
 	if name and document then
 		registeredDocuments[name] = document
@@ -149,6 +152,8 @@ WG.TerraformerShared.registerDocument = function(name, document)
 	end
 end
 
+---Removes a document from the cross-widget registry.
+---@param name string?
 WG.TerraformerShared.unregisterDocument = function(name)
 	if name then
 		registeredDocuments[name] = nil
@@ -156,10 +161,24 @@ WG.TerraformerShared.unregisterDocument = function(name)
 	end
 end
 
+---@param name string
+---@return RmlUi.Document? document `nil` when no document is registered under `name`.
 WG.TerraformerShared.getDocument = function(name)
 	return registeredDocuments[name]
 end
 
+---A registered element's live layout, in pixel space.
+---@class TerraformerElementRect
+---@field left number
+---@field top number
+---@field width number
+---@field height number
+
+---Reads live pixel-space layout off an element of a registered document.
+---@param docName string
+---@param elementId string?
+---@return TerraformerElementRect? rect `nil` when the document or element is missing,
+---or the element has no width yet.
 WG.TerraformerShared.getElementRect = function(docName, elementId)
 	local doc = registeredDocuments[docName]
 	if not doc then
@@ -182,15 +201,26 @@ WG.TerraformerShared.getElementRect = function(docName, elementId)
 	}
 end
 
+---Options accepted by `attachDraggable`.
+---@class TerraformerDraggableOpts
+---@field snapThreshold number? Pixel snap distance for edges and panel snap. Defaults to `30`.
+---@field onDragStart fun()? Called on mousedown, e.g. to record that the user moved the panel.
+---@field snapDocName string? Registered document to snap against. Defaults to `"terraform_brush"`.
+---@field snapElementId string? Element within that document. Defaults to `"tf-root"`.
+
+---The value returned by `attachDraggable`.
+---@class TerraformerDraggable
+---@field tick fun() Call every frame from `widget:Update()` while the widget is alive.
+
 -- Shared drag-and-drop helper for floating panels.
 -- Sets up mousedown on handleId + mouseup on doc, returns a handle with tick().
 -- Call handle.tick() every frame from widget:Update() while the widget is alive.
---
--- opts fields (all optional):
---   snapThreshold (number, default 30) — pixel snap distance for edges + panel snap
---   onDragStart   (function)           — called on mousedown (e.g. set userDragged)
---   snapDocName   (string, default "terraform_brush") — registered document to snap to
---   snapElementId (string, default "tf-root")         — element within that document
+---Makes a floating panel draggable by a handle element, with edge and panel snapping.
+---@param doc RmlUi.Document?
+---@param handleId string Id of the element used as the drag handle.
+---@param rootEl RmlUi.Element? The panel being moved.
+---@param opts TerraformerDraggableOpts?
+---@return TerraformerDraggable handle A no-op handle when `doc`, `rootEl` or the handle element is missing.
 WG.TerraformerShared.attachDraggable = function(doc, handleId, rootEl, opts)
 	if not doc or not rootEl then
 		return { tick = function() end }

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -1333,6 +1333,45 @@ local function stepCleanupStale()
 	return true
 end
 
+---@class MapProjectManifest
+---@field kind "bar-map-project"
+---@field format_version integer
+---@field name string
+---@field created string date time
+---@field modified string date time
+---@field game_version string|"unknown"
+---@field map MapProjectManifestMap
+---@field sections MapProjectManifestSections
+---@field assets {decals: {name: string, file: string, installed: boolean}[]}
+---@field mission {zones: table, markers: table, placeholders: table, notes: string}
+
+---@class MapProjectManifestMap
+---@field size_x integer Map units (even, 2-64)
+---@field size_z integer Map units (even, 2-64)
+---@field base_height number?
+---@field base_color ColorRGBi?
+---@field height_range {min: integer, max: integer}?
+---@field skybox string?
+---@field source_map string|"unknown"
+---@field dnts DntsSet
+
+---@class MapProjectManifestSections
+---@field heightmap {file: string, version: 1, bytes: integer}
+---@field splat {file: string, version: 1, bytes: integer}
+---@field surface {file: string, version: 1, bytes: integer, meta:"surface.lua"}
+---@field diffuse {dir: "diffuse/", version: 1, bytes: integer, square_size: integer, squares: integer, full: string, channels: string[] }
+---@field metal {file: string, version: 1, bytes: integer}
+---@field features {file: string, version: 1, bytes: integer}
+---@field units {file: string, version: 1, bytes: integer, count: integer?}
+---@field decals {file: string, version: 1, bytes: integer}
+---@field startpos {file: string, version: 1, bytes: integer}
+---@field startboxes {file: string, version: 1, bytes: integer}
+---@field lights {file: string, version: 1, bytes: integer}
+---@field labels {file: string, version: 1, bytes: integer}
+---@field environment {file: string, version: 1, bytes: integer}
+---@field weather {file: string, version: 1, bytes: integer}
+---@field grass {file: string, version: 1, bytes: integer, patch_resolution: integer?, config: "grass_config.lua"}
+
 local function stepManifest()
 	local mo = job.mapOptions
 	local prev = job.prev

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -239,6 +239,7 @@ local function loadKeybindsFromDisk()
 	end
 end
 
+---Writes the current brush keybinds to the keybinds directory.
 local function saveKeybindsToDisk()
 	Spring.CreateDir(KEYBINDS_DIR)
 	local lines = { "return {" }
@@ -275,6 +276,8 @@ local function getKeybindKey(action)
 	return kb and kb.key or 0
 end
 
+---@param action string
+---@return string|"?" label Display label for the bound key, or `"?"` when unbound.
 local function getKeybindLabel(action)
 	local kb = activeKeybinds[action]
 	return kb and kb.label or "?"
@@ -451,6 +454,7 @@ end
 
 local activeDirection = nil
 local activeRadius = DEFAULT_RADIUS
+---@type BrushShape|"ring"|"fill"
 local activeShape = "circle"
 local activeRotation = 0
 local activeCurve = DEFAULT_CURVE
@@ -1021,6 +1025,8 @@ local function constrainToAxis(originX, originZ, rawX, rawZ)
 end
 
 -- Stamp mode: intensity maxed + at least one height cap → instant apply
+---@return boolean stamp Whether the brush stamps to a fixed height in one stroke,
+---which it does at full intensity with a height cap set.
 local function isStampMode()
 	return activeIntensity >= MAX_INTENSITY and (heightCapMin ~= nil or heightCapMax ~= nil)
 end
@@ -1232,6 +1238,7 @@ end
 -- Forward declaration
 local invalidateDrawCache
 
+---Disables the terrain brush and restores the default cursor.
 local function deactivateTerraform()
 	if activeMode then
 		Echo("[Terraform Brush] Deactivated")
@@ -1287,6 +1294,10 @@ extraState.swapModeParams = function(mode)
 	end
 end
 
+---@alias TerraformMode "raise"|"lower"|"level"|"smooth"|"ramp"|"noise"|"erode"|"restore"
+
+---Switches the terraform operation, swapping in that mode's saved brush settings.
+---@param mode TerraformMode
 local function setMode(mode)
 	extraState.ensureCheat()
 	extraState.swapModeParams(mode)
@@ -1320,6 +1331,10 @@ local function setMode(mode)
 	end
 end
 
+---Sets the brush footprint. Unknown shapes are ignored, as are shapes the active
+---mode does not support: ramp allows only circle and square, and level and smooth
+---do not allow ring.
+---@param shape BrushShape|"ring"|"fill"
 local function setShape(shape)
 	if
 		shape == "circle"
@@ -1340,6 +1355,8 @@ local function setShape(shape)
 	end
 end
 
+---Rotates the brush, honoring angle snap.
+---@param degrees number Degrees to add to the current rotation.
 local function rotateBy(degrees)
 	activeRotation = (activeRotation + degrees) % 360
 	if extraState.angleSnap and extraState.angleSnapStep > 0 then
@@ -1435,6 +1452,8 @@ local function snapDragToSpoke(wx, wz)
 	return dragOriginX + spokeX * projDist, dragOriginZ + spokeZ * projDist
 end
 
+---Sets the brush rotation, honoring angle snap.
+---@param degrees number Degrees, wrapped to `[0,360)`.
 local function setRotation(degrees)
 	activeRotation = degrees % 360
 	if extraState.angleSnap and extraState.angleSnapStep > 0 then
@@ -1443,42 +1462,59 @@ local function setRotation(degrees)
 	end
 end
 
+---@param value number Falloff curve exponent, clamped to the allowed range.
 local function setCurve(value)
 	activeCurve = max(MIN_CURVE, min(MAX_CURVE, value))
 end
 
+---@param value number Terraform strength per stroke, clamped to the allowed range.
 local function setIntensity(value)
 	activeIntensity = max(MIN_INTENSITY, min(MAX_INTENSITY, value))
 end
 
+---@param value number Stretches the brush along its rotation axis, clamped to the allowed range.
 local function setLengthScale(value)
 	activeLengthScale = max(MIN_LENGTH_SCALE, min(MAX_LENGTH_SCALE, value))
 end
 
+---@param value number Brush radius in elmos, clamped to the allowed range.
 local function setRadius(value)
 	activeRadius = max(MIN_RADIUS, min(MAX_RADIUS, floor(value)))
 end
 
+---Stops the brush lowering terrain past a height.
+---@param value number? Pass `nil` to remove the cap.
 local function setHeightCapMin(value)
 	heightCapMin = value
 end
 
+---Stops the brush raising terrain past a height.
+---@param value number? Pass `nil` to remove the cap.
 local function setHeightCapMax(value)
 	heightCapMax = value
 end
 
+---Treats the height caps as absolute world heights rather than relative to the
+---terrain under the brush.
+---@param value boolean
 local function setHeightCapAbsolute(value)
 	heightCapAbsolute = value
 end
 
+---Enables clay mode, which preserves volume by pushing displaced terrain outward.
+---@param value boolean?
 local function setClayMode(value)
 	clayMode = value and true or false
 end
 
+---@param value number? Opacity of the brush cursor ring, clamped to `0.01`-`1`.
+---Defaults to `1`.
 local function setBrushOpacity(value)
 	brushOpacity = math.max(0.01, math.min(1.0, tonumber(value) or 1.0))
 end
 
+---Shows or hides the build-grid overlay.
+---@param value boolean?
 local function setGridOverlay(value)
 	gridOverlay = value and true or false
 	if gridOverlay then
@@ -1486,26 +1522,38 @@ local function setGridOverlay(value)
 	end
 end
 
+---Enables the dust particles kicked up while terraforming.
+---@param value boolean?
 local function setDustEffects(value)
 	dustEffects = value and true or false
 end
 
+---Enables the camera shake applied while terraforming.
+---@param value boolean?
 local function setSeismicEffects(value)
 	seismicEffects = value and true or false
 end
 
+---Enables the beat-synced terraform mode.
+---@param value boolean?
 local function setDjMode(value)
 	djMode = value and true or false
 end
 
+---Tints the terrain by height, as an editing aid.
+---@param value boolean?
 local function setHeightColormap(value)
 	extraState.heightColormap = value and true or false
 end
 
+---Draws the falloff curve on the brush ring.
+---@param value boolean?
 local function setCurveOverlay(value)
 	extraState.curveOverlay = value and true or false
 end
 
+---@param value number? Inner radius of the ring shape as a fraction of the outer
+---radius, clamped to `0.05`-`0.95`. Defaults to `0.6`.
 local function setRingInnerRatio(value)
 	ringInnerRatio = math.max(0.05, math.min(0.95, value or 0.6))
 end
@@ -1610,10 +1658,13 @@ local function loadPresetsFromDisk()
 	end
 end
 
+---@param name string
+---@return boolean builtin Built-in presets cannot be deleted.
 local function isBuiltinPreset(name)
 	return builtinPresetNames[name] == true
 end
 
+---@return string[] names Every brush preset, built-in and user-saved.
 local function getPresetNames()
 	loadPresetsFromDisk()
 	local names = {}
@@ -1624,6 +1675,9 @@ local function getPresetNames()
 	return names
 end
 
+---Saves the current brush settings as a named preset. Empty names are ignored,
+---and the name is sanitized before use.
+---@param name string
 local function savePreset(name)
 	if not name or name == "" then
 		return
@@ -1713,6 +1767,8 @@ local function savePreset(name)
 	Echo("[Terraform Brush] Preset saved: " .. name)
 end
 
+---Applies a saved preset's brush settings. Unknown names are ignored.
+---@param name string
 local function loadPreset(name)
 	loadPresetsFromDisk()
 	local data = presets[name]
@@ -1800,6 +1856,8 @@ local function loadPreset(name)
 	Echo("[Terraform Brush] Preset loaded: " .. name)
 end
 
+---Deletes a user-saved preset. Unknown names and built-in presets are ignored.
+---@param name string
 local function deletePreset(name)
 	loadPresetsFromDisk()
 	if not presets[name] then
@@ -1815,6 +1873,31 @@ local function deletePreset(name)
 	Echo("[Terraform Brush] Preset deleted: " .. name)
 end
 
+---Fields shared between both brush presets and brushes
+---@class TerraformBrushBase
+---@field mode TerraformMode
+---@field shape BrushShape|"ring"|"fill"
+---@field radius number
+---@field rotationDeg number
+---@field curve number
+---@field intensity number
+---@field lengthScale number
+---@field heightCapMin number? `nil` when unset.
+---@field heightCapMax number? `nil` when unset.
+---@field heightCapAbsolute boolean
+---@field clayMode boolean
+---@field noiseType string
+---@field noiseScale number
+---@field noiseOctaves integer
+---@field noisePersistence number
+---@field noiseLacunarity number
+---@field noiseSeed number
+
+---@class TerraformPreset : TerraformBrushBase
+---@field name string
+
+---@param n string
+---@return TerraformPreset? preset `nil` when no preset has that name.
 local function getPreset(n)
 	loadPresetsFromDisk()
 	return presets[n]
@@ -2103,6 +2186,77 @@ extraState._newmapDrive = function()
 	end
 end
 
+---A snapshot of the terrain brush, for the UI to render.
+---@class TerraformBrushState : TerraformBrushBase
+---@field active boolean
+---@field direction integer `1` raises, `-1` lowers.
+---@field dustEffects boolean
+---@field seismicEffects boolean
+---@field djMode boolean
+---@field wiggleEnabled boolean
+---@field wiggleAmpIdx integer
+---@field wiggleSpdIdx integer
+---@field heightColormap boolean
+---@field heightSamplingMode boolean
+---@field gridOverlay boolean
+---@field gridSnap boolean
+---@field gridSnapSize number
+---@field angleSnap boolean
+---@field angleSnapStep number
+---@field angleSnapAuto boolean
+---@field angleSnapManualSpoke number
+---@field measureActive boolean
+---@field measureDrawing boolean
+---@field measureRulerMode boolean
+---@field measureStickyMode boolean
+---@field measureDistortMode boolean
+---@field measureShowLength boolean
+---@field linkedStrokeCount integer
+---@field measureChainCount integer
+---@field rampAutoAttach boolean
+---@field curveOverlay boolean
+---@field velocityIntensity boolean
+---@field dragVelocityFactor number
+---@field restoreStrength number
+---@field undoCount integer
+---@field redoCount integer
+---@field erodeReposeDeg number
+---@field ringInnerRatio number
+---@field importProgress integer? Rows imported so far; `nil` when no import is running.
+---@field importTotal integer? Rows in the running import; `nil` when none is running.
+---@field exportRangeMode "auto"|"initial"|"custom"
+---@field exportInitMin number? Map height extremes at load.
+---@field exportInitMax number?
+---@field exportCurrMin number? Map height extremes right now.
+---@field exportCurrMax number?
+---@field exportCustomMin number
+---@field exportCustomMax number
+---@field symmetryActive boolean
+---@field symmetryOriginX number
+---@field symmetryOriginZ number
+---@field symmetryMirrorX boolean
+---@field symmetryMirrorY boolean
+---@field symmetryRadial boolean
+---@field symmetryRadialCount integer
+---@field symmetryPlacingOrigin boolean
+---@field symmetryMirrorAngle number
+---@field symmetryFlipped boolean
+---@field symmetryHoveringOrigin boolean
+---@field symmetryDraggingOrigin boolean
+---@field penPressureEnabled boolean
+---@field penPressure number
+---@field penPressureMapped number
+---@field penTiltX number
+---@field penTiltY number
+---@field penInContact boolean
+---@field penPressureModulateIntensity boolean
+---@field penPressureModulateSize boolean
+---@field penPressureModulateRadius boolean
+---@field penPressureRadiusScale number
+---@field penPressureSensitivity number
+---@field penPressureCurve number
+
+---@return TerraformBrushState
 local function getState()
 	local initMinH, initMaxH, currMinH, currMaxH = Spring.GetGroundExtremes()
 	local customMin = extraState.heightmapExportCustomMin
@@ -2862,6 +3016,11 @@ function widget:Initialize()
 
 	WG.TerraformBrush = {
 		getImportStatus = extraState._importStatus,
+		---Queues a heightmap image to be imported on a later draw frame.
+		---@param filename string Path to the heightmap image.
+		---@param fallbackMin number|string? Range floor used when the file carries no height range.
+		---@param fallbackMax number|string? Range ceiling used when the file carries no height range.
+		---@return boolean queued `false` when no filename was given.
 		importHeightmap = function(filename, fallbackMin, fallbackMax)
 			if not filename or filename == "" then
 				return false
@@ -2887,9 +3046,14 @@ function widget:Initialize()
 
 		setBrushOpacity = setBrushOpacity,
 		setGridOverlay = setGridOverlay,
+		---Snaps brush strokes to the build grid.
+		---@param value boolean?
 		setGridSnap = function(value)
 			extraState.gridSnap = value and true or false
 		end,
+		---Chooses which height range a heightmap export normalizes against.
+		---Anything other than `"initial"` or `"custom"` selects `"auto"`.
+		---@param value "auto"|"initial"|"custom"
 		setHeightmapExportRangeMode = function(value)
 			if value == "initial" or value == "custom" then
 				extraState.heightmapExportRangeMode = value
@@ -2900,6 +3064,7 @@ function widget:Initialize()
 				extraState.heightmapExportRangeMode = "auto"
 			end
 		end,
+		---Advances the heightmap export range through auto, initial and custom.
 		cycleHeightmapExportRangeMode = function()
 			local mode = extraState.heightmapExportRangeMode
 			if mode == "auto" then
@@ -2911,26 +3076,33 @@ function widget:Initialize()
 				extraState.heightmapExportRangeMode = "auto"
 			end
 		end,
+		---@param value number|string Lowest height a custom-range export maps to black.
+		---Non-numeric input is ignored.
 		setHeightmapExportCustomMin = function(value)
 			local num = tonumber(value)
 			if num then
 				extraState.heightmapExportCustomMin = num
 			end
 		end,
+		---@param value number|string Highest height a custom-range export maps to white.
+		---Non-numeric input is ignored.
 		setHeightmapExportCustomMax = function(value)
 			local num = tonumber(value)
 			if num then
 				extraState.heightmapExportCustomMax = num
 			end
 		end,
-		-- Arm a deferred re-seed of the custom export range (exact scan a few
-		-- draw frames from now). Used by cmd_map_project after the heightmap
-		-- phase lands. No-op if the user hand-typed a range.
+		---Arms a deferred re-seed of the custom export range, scanning exactly a few draw
+		---frames from now. Used by `cmd_map_project` once the heightmap phase lands, and a
+		---no-op if the user hand-typed a range.
+		---@param delayFrames number|string? Draw frames to wait. Clamped to at least `1`.
 		reseedExportRange = function(delayFrames)
 			extraState._exportReseedFrames = max(1, tonumber(delayFrames) or 1)
 		end,
-		-- FIT button: force the custom range to the terrain's exact extremes,
-		-- regardless of what was typed before. Returns min, max (or nil).
+		---Forces the custom export range to the terrain's exact extremes, regardless of what
+		---was typed before. Backs the FIT button.
+		---@return number? min `nil` when the terrain could not be scanned.
+		---@return number? max
 		fitExportRangeToTerrain = function()
 			local mn, mx = extraState._scanTerrainExtremes()
 			if not mn then
@@ -2944,16 +3116,24 @@ function widget:Initialize()
 			extraState._exportRangeAutoSeed = { mn, mx }
 			return mn, mx
 		end,
+		---@param value number|string? Grid cell size in elmos, clamped to `16`-`128`.
+		---Defaults to `48`.
 		setGridSnapSize = function(value)
 			extraState.gridSnapSize = max(16, min(128, tonumber(value) or 48))
 			extraState.gridDirty = true
 		end,
+		---Snaps brush rotation to fixed angles.
+		---@param value boolean?
 		setAngleSnap = function(value)
 			extraState.angleSnap = value and true or false
 		end,
+		---Derives the angle snap step from the map's symmetry instead of the manual spoke count.
+		---@param value boolean?
 		setAngleSnapAuto = function(value)
 			extraState.angleSnapAuto = value and true or false
 		end,
+		---Rotates the brush to a numbered snap spoke, wrapping around.
+		---@param idx integer
 		setAngleSnapManualSpoke = function(idx)
 			local step = extraState.angleSnapStep
 			local numSpokes = (step > 0) and floor(360 / step) or 1
@@ -2961,6 +3141,8 @@ function widget:Initialize()
 			activeRotation = (extraState.angleSnapManualSpoke * step) % 360
 			extraState.angleSnapScrollAccum = 0
 		end,
+		---Sets the angle snap increment and re-snaps the current rotation.
+		---@param value number|string? Degrees, clamped to `0.5`-`90`. Defaults to `15`.
 		setAngleSnapStep = function(value)
 			extraState.angleSnapStep = max(0.5, min(90, tonumber(value) or 15))
 			-- re-snap current rotation immediately
@@ -2969,9 +3151,14 @@ function widget:Initialize()
 				activeRotation = (floor(activeRotation / s + 0.5) * s) % 360
 			end
 		end,
+		---Shows the length of each measure line.
+		---@param value boolean?
 		setMeasureShowLength = function(value)
 			extraState.measureShowLength = value and true or false
 		end,
+		---Enters or leaves the measuring tool. Entering also starts drawing and takes
+		---text ownership so Enter is intercepted before the chat binding.
+		---@param value boolean?
 		setMeasureActive = function(value)
 			extraState.measureActive = value and true or false
 			if extraState.measureActive then
@@ -2987,13 +3174,14 @@ function widget:Initialize()
 				widgetHandler:DisownText()
 			end
 		end,
+		---Removes every measure line.
 		clearMeasureLines = function()
 			extraState.measureLines = {}
 			extraState.measureActivePt = nil
 			extraState.measureActiveChain = nil
 			extraState.measureDragLine = nil
 		end,
-		-- G4: clear only ramp-linked chains from the measure layer
+		---Clears only the ramp-linked chains from the measure layer, leaving the rest.
 		clearRampChains = function()
 			local kept = {}
 			for _, c in ipairs(extraState.measureLines) do
@@ -3004,12 +3192,17 @@ function widget:Initialize()
 			extraState.measureLines = kept
 		end,
 		-- G4: toggle automatic ramp-chain attachment
+		---@param value boolean?
 		setRampAutoAttach = function(value)
 			extraState.rampAutoAttach = value and true or false
 		end,
+		---Measures in a straight line rather than following the terrain.
+		---@param value boolean?
 		setMeasureRulerMode = function(value)
 			extraState.measureRulerMode = value and true or false
 		end,
+		---Keeps measure lines attached to the point they were started from.
+		---@param value boolean?
 		setMeasureStickyMode = function(value)
 			extraState.measureStickyMode = value and true or false
 			if not extraState.measureStickyMode then
@@ -3018,9 +3211,12 @@ function widget:Initialize()
 				extraState.stickyUndoBaseline = nil
 			end
 		end,
+		---Lets measure chains be reshaped after they are drawn.
+		---@param value boolean?
 		setMeasureDistortMode = function(value)
 			extraState.measureDistortMode = value and true or false
 		end,
+		---Forgets the strokes currently linked together for repeated application.
 		clearLinkedStrokes = function()
 			extraState.linkedStrokes = {}
 			extraState.linkedStrokeGroupCount = 0
@@ -3029,6 +3225,10 @@ function widget:Initialize()
 		setDustEffects = setDustEffects,
 		setSeismicEffects = setSeismicEffects,
 		setDjMode = setDjMode,
+		---Configures the brush wiggle that breaks up straight strokes.
+		---@param enabled boolean?
+		---@param ampIdx integer? Amplitude preset index.
+		---@param spdIdx integer? Speed preset index.
 		setWiggle = function(enabled, ampIdx, spdIdx)
 			extraState.wiggleEnabled = enabled and true or false
 			extraState.wiggleAmpIdx = math.max(1, math.min(4, tonumber(ampIdx) or 1))
@@ -3038,6 +3238,9 @@ function widget:Initialize()
 			end
 		end,
 		setHeightColormap = setHeightColormap,
+		---Puts the brush into a height-sampling mode, auto-enabling the height colormap
+		---so contours are visible. Unknown targets clear the mode.
+		---@param target "max"|"min"|"fpAltMax"|"fpAltMin"|"gbAltMax"|"gbAltMin"|"spAltMax"|"spAltMin"|nil
 		setHeightSamplingMode = function(target)
 			local valid = {
 				max = true,
@@ -3054,10 +3257,13 @@ function widget:Initialize()
 				setHeightColormap(true) -- auto-enable the colormap so contours are visible
 			end
 		end,
+		---@return string? mode `nil` when not sampling.
 		getHeightSamplingMode = function()
 			return extraState.heightSamplingMode
 		end,
 		setCurveOverlay = setCurveOverlay,
+		---Scales stroke intensity by how fast the cursor is moving.
+		---@param value boolean?
 		setVelocityIntensity = function(value)
 			extraState.velocityIntensity = value and true or false
 			if not extraState.velocityIntensity then
@@ -3066,14 +3272,19 @@ function widget:Initialize()
 				extraState.lastDragScreenY = nil
 			end
 		end,
+		---@param value number|string? How strongly restore mode pulls terrain back toward
+		---its original height, clamped to `0`-`1`. Defaults to `1`.
 		setRestoreStrength = function(value)
 			extraState.restoreStrength = max(0.0, min(1.0, tonumber(value) or 1.0))
 		end,
+		---@param value number|string? Angle of repose for erode mode, in degrees.
 		setErodeReposeDeg = function(value)
 			extraState.erodeReposeDeg = max(10, min(60, tonumber(value) or 33))
 		end,
 		setRingInnerRatio = setRingInnerRatio,
 		-- Pen pressure API
+		---Enables graphics-tablet pen pressure input.
+		---@param value boolean?
 		setPenPressure = function(value)
 			extraState.penPressureEnabled = value and true or false
 			if not extraState.penPressureEnabled then
@@ -3082,29 +3293,45 @@ function widget:Initialize()
 				extraState.penInContact = false
 			end
 		end,
+		---Lets pen pressure drive stroke intensity.
+		---@param value boolean?
 		setPenPressureModulateIntensity = function(value)
 			extraState.penPressureModulateIntensity = value and true or false
 		end,
+		---Lets pen pressure drive brush size.
+		---@param value boolean?
 		setPenPressureModulateSize = function(value)
 			extraState.penPressureModulateSize = value and true or false
 		end,
+		---Lets pen pressure drive brush radius.
+		---@param value boolean?
 		setPenPressureModulateRadius = function(value)
 			extraState.penPressureModulateRadius = value and true or false
 		end,
+		---@param value number How much pen pressure scales the radius.
 		setPenPressureRadiusScale = function(value)
 			extraState.penPressureRadiusScale = max(0.0, min(1.0, tonumber(value) or 0.5))
 		end,
+		---@param value number Maps raw pen pressure onto the usable range.
 		setPenPressureSensitivity = function(value)
 			extraState.penPressureSensitivity = max(0.1, min(3.0, tonumber(value) or 1.0))
 		end,
+		---@param value number Response curve applied to pen pressure.
 		setPenPressureCurve = function(value)
 			extraState.penPressureCurve = max(1, min(5, math.floor(tonumber(value) or 2)))
 		end,
+		---Tells the brush the pen is currently over the UI rather than the map.
+		---@param value boolean?
 		setPenOverUI = function(value)
 			extraState.penOverUI = value and true or false
 		end,
 		-- Returns world X, Z to park a sub-tool brush when cursor is over the terraform UI panel.
 		-- Returns nil, nil when cursor is not over the panel (caller should use real mouse position).
+		---Where the brush should park while the cursor is over the terraform panel.
+		---@param radius number
+		---@param lengthScale number
+		---@return number? worldX `nil` when the cursor is not over the panel.
+		---@return number? worldZ
 		getUnmouseTarget = function(radius, lengthScale)
 			local tfUI = WG.TerraformBrushUI
 			if not tfUI or not tfUI.getPanelBounds then
@@ -3126,7 +3353,13 @@ function widget:Initialize()
 		-- when the cursor enters the terraform panel, and back toward the real
 		-- cursor position when it leaves. Sub-tools call this every DrawWorld
 		-- frame with a unique toolKey and their real world position (or nil).
-		-- Returns animated (worldX, worldZ) — may be nil if nothing to show.
+		---@param toolKey string Unique per sub-tool.
+		---@param realX number? The real cursor world position.
+		---@param realZ number?
+		---@param radius number
+		---@param lengthScale number
+		---@return number? worldX Animated position; `nil` when there is nothing to show.
+		---@return number? worldZ
 		animateUnmouse = function(toolKey, realX, realZ, radius, lengthScale)
 			return extraState.tickSubToolUnmouse(toolKey, realX, realZ, radius, lengthScale)
 		end,
@@ -3137,7 +3370,11 @@ function widget:Initialize()
 		setNoisePersistence = extraState._noiseSetters.setNoisePersistence,
 		setNoiseLacunarity = extraState._noiseSetters.setNoiseLacunarity,
 		setNoiseSeed = extraState._noiseSetters.setNoiseSeed,
+
 		-- Symmetry API
+
+		---Mirrors every stroke across the symmetry axes.
+		---@param value boolean?
 		setSymmetryActive = function(value)
 			extraState.symmetryActive = value and true or false
 			if not extraState.symmetryActive then
@@ -3145,22 +3382,31 @@ function widget:Initialize()
 				extraState.symmetryDraggingOrigin = false
 			end
 		end,
+		---Moves the symmetry origin.
+		---@param x number|string
+		---@param z number|string
 		setSymmetryOrigin = function(x, z)
 			extraState.symmetryOriginX = tonumber(x)
 			extraState.symmetryOriginZ = tonumber(z)
 		end,
+		---Mirrors along X. Enabling this disables radial symmetry.
+		---@param value boolean?
 		setSymmetryMirrorX = function(value)
 			extraState.symmetryMirrorX = value and true or false
 			if extraState.symmetryMirrorX then
 				extraState.symmetryRadial = false
 			end
 		end,
+		---Mirrors along Y. Enabling this disables radial symmetry.
+		---@param value boolean?
 		setSymmetryMirrorY = function(value)
 			extraState.symmetryMirrorY = value and true or false
 			if extraState.symmetryMirrorY then
 				extraState.symmetryRadial = false
 			end
 		end,
+		---Repeats strokes around the origin. Enabling this disables mirroring.
+		---@param value boolean?
 		setSymmetryRadial = function(value)
 			extraState.symmetryRadial = value and true or false
 			if extraState.symmetryRadial then
@@ -3168,18 +3414,26 @@ function widget:Initialize()
 				extraState.symmetryMirrorY = false
 			end
 		end,
+		---@param value number Copies placed around the origin in radial mode.
 		setSymmetryRadialCount = function(value)
 			extraState.symmetryRadialCount = max(2, min(16, floor(tonumber(value) or 2)))
 		end,
+		---Puts the tool into the mode where the next click places the symmetry origin.
+		---@param value boolean?
 		setSymmetryPlacingOrigin = function(value)
 			extraState.symmetryPlacingOrigin = value and true or false
 		end,
+		---@param value number|string? Mirror axis angle in degrees, wrapped to `[0,360)`.
+		---Defaults to `0`.
 		setSymmetryMirrorAngle = function(value)
 			extraState.symmetryMirrorAngle = (tonumber(value) or 0) % 360
 		end,
+		---Swaps which side of the mirror axis is the source.
+		---@param value boolean?
 		setSymmetryFlipped = function(value)
 			extraState.symmetryFlipped = value and true or false
 		end,
+		---Turns symmetry off and resets its origin, axes and radial count.
 		clearSymmetry = function()
 			extraState.symmetryActive = false
 			extraState.symmetryPlacingOrigin = false
@@ -3195,6 +3449,13 @@ function widget:Initialize()
 		end,
 		getSymmetricPositions = extraState.getSymmetricPositions,
 		getSymmetryOrigin = extraState.getSymmetryOrigin,
+		---Snaps a world position to the build grid, or returns it unchanged when grid
+		---snap is off.
+		---@param x number
+		---@param z number
+		---@param angleDeg number? Defaults to `0`.
+		---@return number x
+		---@return number z
 		snapWorld = function(x, z, angleDeg)
 			if not extraState.gridSnap then
 				return x, z
@@ -3209,6 +3470,14 @@ function widget:Initialize()
 		getPresetNames = getPresetNames,
 		isBuiltinPreset = isBuiltinPreset,
 		getPreset = getPreset,
+		---A heightmap export saved for this map.
+		---@class TerraformHeightmapEntry
+		---@field path string
+		---@field label string Display label; `"(legacy)"` for un-stamped saves.
+		---@field sortKey string
+
+		---Lists heightmap exports belonging to this map, newest first.
+		---@return TerraformHeightmapEntry[]
 		listHeightmaps = function()
 			local HEIGHTMAPS_DIR = "Terraform Brush/Heightmaps/"
 			local files = VFS.DirList(HEIGHTMAPS_DIR, "*.png", VFS.RAW)
@@ -3263,32 +3532,45 @@ function widget:Initialize()
 			return out
 		end,
 		deactivate = deactivateTerraform,
+		---Undoes the last terraform stroke, if there is one.
 		undo = function()
 			if historyUndoCount > 0 then
 				SendLuaRulesMsg(MSG.UNDO)
 			end
 		end,
+		---Reapplies the most recently undone terraform stroke, if there is one.
 		redo = function()
 			if historyRedoCount > 0 then
 				SendLuaRulesMsg(MSG.REDO)
 			end
 		end,
+		---Restores the whole map to its original heightmap.
 		fullRestore = function()
 			SendLuaRulesMsg(MSG.FULL_RESTORE)
 		end,
+
 		-- Keybind configuration API
+
+		---@return table<string, {key: integer, label: string, key2: integer?, label2: string?}> binds A copy.
 		getKeybinds = function()
 			return deepCopyKeybinds(activeKeybinds)
 		end,
+		---@return table<string, {key: integer, label: string, key2: integer?, label2: string?}> binds A copy.
 		getDefaultKeybinds = function()
 			return deepCopyKeybinds(DEFAULT_KEYBINDS)
 		end,
+		---Rebinds one brush action. Unknown actions are ignored.
+		---@param action string
+		---@param keyCode number|string? Left unchanged when not numeric.
+		---@param label string? Left unchanged when omitted.
 		setKeybind = function(action, keyCode, label)
 			if activeKeybinds[action] then
 				activeKeybinds[action].key = tonumber(keyCode) or activeKeybinds[action].key
 				activeKeybinds[action].label = tostring(label or activeKeybinds[action].label)
 			end
 		end,
+		---Applies a whole set of keybinds, ignoring unknown actions and malformed entries.
+		---@param binds table<string, {key: integer, label: string?, key2: integer?, label2: string?}>?
 		applyKeybinds = function(binds)
 			if type(binds) ~= "table" then
 				return
@@ -3307,6 +3589,7 @@ function widget:Initialize()
 			end
 		end,
 		saveKeybinds = saveKeybindsToDisk,
+		---Restores every brush keybind to its default.
 		resetKeybinds = function()
 			activeKeybinds = deepCopyKeybinds(DEFAULT_KEYBINDS)
 		end,
@@ -5790,6 +6073,9 @@ extraState.drawEx = {
 	falloffRing = extraState.drawFalloffCurveRing,
 	centerPost = extraState.drawCenterPost,
 	rampPreview = extraState.drawRampPreview,
+	---Draws the preview line for a spline ramp, with its width and direction markers.
+	---@param points [number, number][] Map positions as `{x, z}`. Fewer than two draws nothing.
+	---@param width number Ramp width in elmos.
 	splineRampPreview = function(points, width)
 		if #points < 2 then
 			return

--- a/luaui/Widgets/cmd_terraform_brush_capture.lua
+++ b/luaui/Widgets/cmd_terraform_brush_capture.lua
@@ -401,6 +401,23 @@ end
 -- Estimation (drives the live readout in the Capture window)
 --------------------------------------------------------------------------------
 
+---What a capture at a given detail level would produce.
+---@class TerraformCaptureEstimate
+---@field detail number Pixels per elmo the estimate was made for.
+---@field effectiveDetail number What the capture will actually use, lowered when `capped`.
+---@field capped boolean The requested detail exceeds the GPU texture limit.
+---@field maxTex integer The GPU's maximum texture dimension in pixels.
+---@field strips boolean Too large for one image, so the output lands as horizontal strips.
+---@field outW integer Output width in pixels.
+---@field outH integer Output height in pixels.
+---@field tilesX integer
+---@field tilesZ integer
+---@field tiles integer Total camera moves the walk needs.
+---@field seconds number Rough wall-clock cost of the walk.
+
+---Works out the output size and cost of a capture without starting one.
+---@param detail number? Pixels per elmo. Defaults to the current setting.
+---@return TerraformCaptureEstimate
 local function estimate(detail)
 	detail = tonumber(detail) or settings.detail
 	local mapX, mapZ = Game.mapSizeX, Game.mapSizeZ
@@ -1652,6 +1669,9 @@ end
 -- Driver
 --------------------------------------------------------------------------------
 
+---Starts the map capture walk, which runs across later frames.
+---@return boolean started
+---@return string? reason Why the capture could not start.
 local function startCapture()
 	if job then
 		return false, "a capture is already running"
@@ -1787,6 +1807,8 @@ end
 function widget:Initialize()
 	widgetHandler:AddAction("tfcapture", captureAction, nil, "t")
 	WG.TerraformCapture = {
+		---@return table<string, string|number|boolean> settings A shallow copy, so mutating it
+		---does not affect the live settings.
 		getSettings = function()
 			local copy = {}
 			for k, v in pairs(settings) do
@@ -1794,6 +1816,11 @@ function widget:Initialize()
 			end
 			return copy
 		end,
+		---Changes one capture setting.
+		---@param key string
+		---@param value string|number|boolean Must match the kind the setting already holds;
+		---no conversion or validation is done beyond checking that `key` exists.
+		---@return boolean set `false` when `key` is not a known setting.
 		setSetting = function(key, value)
 			if settings[key] == nil then
 				return false
@@ -1803,14 +1830,28 @@ function widget:Initialize()
 		end,
 		estimate = estimate,
 		start = startCapture,
+		---Aborts a running capture and restores the scene. Safe to call when idle.
 		cancel = function()
 			if job then
 				finish("cancelled")
 			end
 		end,
+		---@return boolean busy Whether a capture is running.
 		isBusy = function()
 			return job ~= nil
 		end,
+		---Progress of the current or last capture.
+		---@class TerraformCaptureStatus
+		---@field active boolean Whether a capture is running.
+		---@field phase string Which stage the capture is in.
+		---@field step integer Tiles completed.
+		---@field total integer Tiles to do in total.
+		---@field message string Human-readable progress line.
+		---@field lastPath string Where the last capture was written.
+		---@field lastSummary string One-line summary of the last capture.
+		---@field error string Empty unless the last capture failed.
+
+		---@return TerraformCaptureStatus status The live table; do not mutate.
 		getStatus = function()
 			return status
 		end,

--- a/types/Color.lua
+++ b/types/Color.lua
@@ -1,0 +1,11 @@
+---@meta
+
+--- Color tuples
+
+--- A color with integer `0`-`255` components, as the engine's blank map generator
+--- takes it and the map project manifest records it. Not interchangeable with the
+--- fractional forms: the same tuple means a different color in each.
+---@class ColorRGBi
+---@field [1] integer Red
+---@field [2] integer Green
+---@field [3] integer Blue


### PR DESCRIPTION
### Work done

Annotate `WG.TerraformBrush` and some other locals and functions in its files.

Annotate the map manifest format.

Add types for BrushShape and integer RGB colors (another color type PR is coming soon that will better justify that file).

### AI / LLM usage statement:

Claude Opus 5 authored 50% of the code, 100% of the commit messages, 25% of this PR description. I have reviewed and understand the code and endorse this PR.