### PR TITLE
ci: style fully ignores mission triggers, actions

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -7,3 +7,5 @@ unittextures/decals_features/featureaoplates_atlas.lua
 luaui/images/decals_gl4/decalsgl4_atlas_diffuse.lua
 luaui/images/decals_gl4/decalsgl4_atlas_normal.lua
 unittextures/decals/unitaoplates_atlas.lua
+luarules/mission_api/triggers/
+luarules/mission_api/actions/


### PR DESCRIPTION
### Work done

Stylua set to ignore mission_api/triggers, mission_api/actions.

We can produce a new .stylua.toml at any folder level in the project, but for ignored files we must use the root, so this change moves to master to prevent future conflicts.