### PR TITLE
ci: no style on missionapi test data files

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -9,3 +9,4 @@ luaui/images/decals_gl4/decalsgl4_atlas_normal.lua
 unittextures/decals/unitaoplates_atlas.lua
 luarules/mission_api/triggers/
 luarules/mission_api/actions/
+singleplayer/mission-api-tests/


### PR DESCRIPTION
### Work done

Stylua still not appropriate for structured same-line data at 120 chars. Leave mission test data alone for now. It is hard enough for a human being to validate without crumpling it.