### PR TITLE
Let wind, tidal and the com counter hide with the resource bars

### DIFF
--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -382,7 +382,7 @@ local function updateButtons()
 		local textWidth = font2:GetTextWidth(text) * fontsize
 		-- the circle grows along with the amount of characters the number has
 		local badgeRadius = badge
-			and mathMax(badgeMinRadius, ((font2:GetTextWidth(badge) * badgeFontsize) / 2) + (fontsize * 0.25))
+				and mathMax(badgeMinRadius, ((font2:GetTextWidth(badge) * badgeFontsize) / 2) + (fontsize * 0.25))
 			or 0
 		local badgeWidth = badgeRadius * 2
 		local width = mathFloor(textWidth + badgeWidth + textPadding)

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -210,6 +210,7 @@ local cache = {
 	lastDrawnValue = { metal = "", energy = "" },
 	warningCleared = { metal = false, energy = false },
 	prevShowButtons = showButtons,
+	showIndicators = true,
 }
 
 -- Reused scratch tables for DrawScreen to avoid per-frame allocations.
@@ -2620,7 +2621,7 @@ local function drawUiBackground()
 			)
 		end
 	end
-	if comsArea[1] then
+	if cache.showIndicators and comsArea[1] then
 		local H = comsArea[4] - comsArea[2]
 		local smallSkew = cfg.useSkew and { blx = -(H * skewTan), brx = -(H * skewTan) } or nil
 		UiElement(
@@ -2644,7 +2645,7 @@ local function drawUiBackground()
 			smallSkew
 		)
 	end
-	if windArea[1] then
+	if cache.showIndicators and windArea[1] then
 		local H = windArea[4] - windArea[2]
 		local smallSkew = cfg.useSkew and { blx = -(H * skewTan), brx = -(H * skewTan) } or nil
 		UiElement(
@@ -2668,7 +2669,7 @@ local function drawUiBackground()
 			smallSkew
 		)
 	end
-	if displayTidalSpeed and tidalarea[1] then
+	if cache.showIndicators and displayTidalSpeed and tidalarea[1] then
 		local H = tidalarea[4] - tidalarea[2]
 		local smallSkew = cfg.useSkew and { blx = -(H * skewTan), brx = -(H * skewTan) } or nil
 		UiElement(
@@ -2727,7 +2728,7 @@ local function drawUi()
 	local windH = windArea[4] - windArea[2]
 	local fontsize = windH / 3.2
 	local windSkewCX = windArea[1] + ((windArea[3] - windArea[1]) / 2) - (cfg.useSkew and windH * skewTan * 0.5 or 0)
-	if noWind then
+	if cache.showIndicators and noWind then
 		font2:Begin(true)
 		--font2:Print("\255\200\200\200no wind", windSkewCX, windArea[2] + ((windArea[4] - windArea[2]) / 2.05) - (fontsize / 5), fontsize, 'oc') -- Wind speed text
 		font2:Print(
@@ -2748,7 +2749,7 @@ local function drawUi()
 	end
 
 	-- tidal speed
-	if displayTidalSpeed then
+	if cache.showIndicators and displayTidalSpeed then
 		local fontSize = (tidalarea[4] - tidalarea[2]) / 2.3
 		local skewCenterOffset = cfg.useSkew and (tidalarea[4] - tidalarea[2]) * skewTan * 0.5 or 0
 		font2:Begin(true)
@@ -2983,7 +2984,7 @@ function widget:DrawScreen()
 	end
 
 	-- current wind
-	if not noWind then
+	if cache.showIndicators and not noWind then
 		if currentWind ~= prevWind or refreshUi then
 			prevWind = currentWind
 			windTextScissor[1] = windArea[1] - topbarArea[1]
@@ -2998,7 +2999,7 @@ function widget:DrawScreen()
 	drawResBars()
 
 	glPushMatrix()
-	if displayComCounter and dlist.coms then
+	if cache.showIndicators and displayComCounter and dlist.coms then
 		-- commander counter
 		if
 			refreshUi
@@ -3639,6 +3640,19 @@ function widget:Initialize()
 
 	WG.topbar.getResourceBarsVisible = function()
 		return showResourceBars
+	end
+
+	WG.topbar.setIndicatorsVisible = function(visible)
+		if cache.showIndicators == visible then
+			return
+		end
+
+		cache.showIndicators = visible
+		refreshUi = true
+	end
+
+	WG.topbar.getIndicatorsVisible = function()
+		return cache.showIndicators
 	end
 
 	updateAvgWind()


### PR DESCRIPTION
Wind, tidal and the commander counter stay on screen when the resource bars are hidden, so `setResourceBarsVisible(false)` leaves you a half-populated bar. This adds `setIndicatorsVisible` alongside it to cover those three.

`showResourceBars` only ever gated metal and energy - the other three each sit outside that block on their own guard, in both `drawUiBackground` and `DrawScreen`. Quick start is the only caller of the existing setter today and hides the bars pregame, so the two flags stay separate rather than one covering everything; nothing about its behaviour changes here.

The new flag lives on the `cache` table instead of as its own local because `DrawScreen` is already at 60 upvalues, and one more stops the file compiling.

AI disclosure: written with assistance from Claude Code.
