### PR TITLE
missions: add waves

### DIFF
--- a/luaui/Tests/missions_smoke/test_pressure.lua
+++ b/luaui/Tests/missions_smoke/test_pressure.lua
@@ -1,0 +1,97 @@
+---@diagnostic disable: undefined-field
+
+-- Test.waitUntil counts FRAMES, not milliseconds: 3600 is two minutes of
+-- game time, generous because placement probes cost a cadence on a bad map
+-- corner.
+local SPAWN_TIMEOUT = 3600
+
+local function param(name)
+	return Spring.GetGameRulesParam(name)
+end
+
+local function skip()
+	if Spring.GetGameFrame() <= 0 then
+		return true
+	end
+	local gaia = Spring.GetGaiaTeamID()
+	local playerTeamID = Spring.GetLocalTeamID()
+	local _, _, _, _, _, myAllyTeamID = Spring.GetTeamInfo(playerTeamID, false)
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaia and teamID ~= playerTeamID then
+			local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+			if allyTeamID ~= myAllyTeamID then
+				return false
+			end
+		end
+	end
+	return true
+end
+
+local function setup()
+	Test.clearMap()
+end
+
+local function cleanup()
+	-- The director keeps running: stopping it needs the synced side, and this
+	-- test runs last in its scenario by name.
+	Test.clearMap()
+end
+
+local function test()
+	local playerTeamID = Spring.GetLocalTeamID()
+
+	Spring.SendCommands("luarules mission smoke_pressure")
+	Test.waitUntil(function()
+		return param("mission_active") == 1
+	end)
+
+	-- .After(30) holds the pressure back: nothing may exist before then, which is
+	-- what catches a delay that silently does nothing.
+	Test.waitFrames(20 * 30)
+	assert(param("scavGracePeriod") == nil, "the director must not start before the trigger's .After(30) elapses")
+
+	-- The director publishes its clocks at Start, so their existence IS
+	-- "the pack resolved and the roster built".
+	Test.waitUntil(function()
+		return param("scavGracePeriod") ~= nil and param("scavTechAnger") ~= nil
+	end, SPAWN_TIMEOUT)
+
+	Test.waitUntil(function()
+		return param("mission_trigger_fired_smoke_pressure/triggers/pressure.lua:1") == 1
+	end, SPAWN_TIMEOUT)
+
+	-- The mission's own dial, not the pack's default. Carried x1000, because
+	-- a rules param is a number and the trigger file asks for 0.3.
+	Test.waitUntil(function()
+		return param("scavIntensity") ~= nil
+	end, SPAWN_TIMEOUT)
+	assert(
+		param("scavIntensity") == 300,
+		"the trigger file asks for 0.3, got " .. tostring((param("scavIntensity") or 0) / 1000)
+	)
+
+	Test.waitUntil(function()
+		return (param("scav_hiveCount") or 0) > 0
+	end, SPAWN_TIMEOUT)
+	Test.waitUntil(function()
+		return (param("scavWaveNumber") or 0) > 0
+	end, SPAWN_TIMEOUT)
+
+	-- Skirmish has no boss because the mission keeps its own win condition.
+	assert(param("BossFightStarted") ~= 1, "the skirmish pack should never field a boss")
+
+	local scavengers = 0
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= playerTeamID then
+			for _, unitID in ipairs(Spring.GetTeamUnits(teamID)) do
+				local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
+				if unitDef and unitDef.customParams.isscavenger then
+					scavengers = scavengers + 1
+				end
+			end
+		end
+	end
+	assert(scavengers > 0, "expected scavenger units on the field, found none")
+end
+
+return { skip = skip, setup = setup, cleanup = cleanup, test = test }

--- a/luaui/Tests/missions_smoke/test_pressure.lua
+++ b/luaui/Tests/missions_smoke/test_pressure.lua
@@ -1,0 +1,102 @@
+---@diagnostic disable: undefined-field
+-- Runs only in the missions_smoke scenario (an enemy allyteam exists and
+-- forceallunits derives the scavenger defs); everywhere else it self-skips.
+-- A mission has no ScavengersAI bot, so this proves the director starts without one.
+
+-- Test.waitUntil counts FRAMES, not milliseconds: 3600 is two minutes of
+-- game time, generous because placement probes cost a cadence on a bad map
+-- corner.
+local SPAWN_TIMEOUT = 3600
+
+local function param(name)
+	return Spring.GetGameRulesParam(name)
+end
+
+local function skip()
+	if Spring.GetGameFrame() <= 0 then
+		return true
+	end
+	local gaia = Spring.GetGaiaTeamID()
+	local playerTeamID = Spring.GetLocalTeamID()
+	local _, _, _, _, _, myAllyTeamID = Spring.GetTeamInfo(playerTeamID, false)
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaia and teamID ~= playerTeamID then
+			local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+			if allyTeamID ~= myAllyTeamID then
+				return false
+			end
+		end
+	end
+	return true
+end
+
+local function setup()
+	Test.clearMap()
+end
+
+local function cleanup()
+	-- The director keeps running: stopping it needs the synced side, and this
+	-- test runs last in its scenario by name.
+	Test.clearMap()
+end
+
+local function test()
+	local playerTeamID = Spring.GetLocalTeamID()
+
+	Spring.SendCommands("luarules mission smoke_pressure")
+	Test.waitUntil(function()
+		return param("mission_active") == 1
+	end)
+
+	-- .After(30) holds the pressure back: nothing may exist before then, which is
+	-- what catches a delay that silently does nothing.
+	Test.waitFrames(20 * 30)
+	assert(param("scavGracePeriod") == nil, "the director must not start before the trigger's .After(30) elapses")
+
+	-- The director publishes its clocks at Start, so their existence IS
+	-- "the pack resolved and the roster built".
+	Test.waitUntil(function()
+		return param("scavGracePeriod") ~= nil and param("scavTechAnger") ~= nil
+	end, SPAWN_TIMEOUT)
+
+	-- Published under the runtime's own identity, mission prefix included: what
+	-- lets an editor shade the card.
+	Test.waitUntil(function()
+		return param("mission_trigger_fired_smoke_pressure/triggers/pressure.lua:1") == 1
+	end, SPAWN_TIMEOUT)
+
+	-- The mission's own dial, not the pack's default. Carried x1000, because
+	-- a rules param is a number and the trigger file asks for 0.3.
+	Test.waitUntil(function()
+		return param("scavIntensity") ~= nil
+	end, SPAWN_TIMEOUT)
+	assert(
+		param("scavIntensity") == 300,
+		"the trigger file asks for 0.3, got " .. tostring((param("scavIntensity") or 0) / 1000)
+	)
+
+	Test.waitUntil(function()
+		return (param("scav_hiveCount") or 0) > 0
+	end, SPAWN_TIMEOUT)
+	Test.waitUntil(function()
+		return (param("scavWaveNumber") or 0) > 0
+	end, SPAWN_TIMEOUT)
+
+	-- Skirmish has no boss because the mission keeps its own win condition.
+	assert(param("BossFightStarted") ~= 1, "the skirmish pack should never field a boss")
+
+	local scavengers = 0
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= playerTeamID then
+			for _, unitID in ipairs(Spring.GetTeamUnits(teamID)) do
+				local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
+				if unitDef and unitDef.customParams.isscavenger then
+					scavengers = scavengers + 1
+				end
+			end
+		end
+	end
+	assert(scavengers > 0, "expected scavenger units on the field, found none")
+end
+
+return { skip = skip, setup = setup, cleanup = cleanup, test = test }

--- a/modules/missions/README.md
+++ b/modules/missions/README.md
@@ -14,17 +14,28 @@ flowchart TB
         LOADER["mission_loader gadget<br/>injected env = the API surface;<br/>wires only watched callins"]
         DSL["DSL builder<br/>When/.When/Do/Once — no terminator;<br/>finalized at include → TriggerDescriptor"]
         ENGINE["trigger engine<br/>input→watchers index · dirty marks<br/>state tables (the save pile)"]
-        BUS["event bus (GG.Missions.OnEvent)<br/>engine callins + module events<br/>('UnitFinished', 'mission.objective_changed')"]
+        BUS["event bus (GG.Missions.OnEvent)<br/>engine callins + module events<br/>('UnitFinished', 'mission.objective_changed', 'waves.wave_cleared')"]
         MF["matchflow module<br/>Victory/Defeat → pending verdict"]
         VG["verdict gadget<br/>deferred, idempotent Spring.GameOver"]
+        WV["waves module<br/>named directors; scavengers builds the spec"]
     end
     LUA -->|"VFS.Include per file<br/>(hot reload by identity)"| LOADER
     LOADER --> DSL -->|"descriptors"| ENGINE
     LOADER -->|"forward watched callins"| BUS --> ENGINE
     ENGINE -->|"execute effects"| MF
+    ENGINE -->|"execute effects"| WV
     ENGINE -->|"Objective(...).Complete() emits<br/>'mission.objective_changed'"| BUS
+    WV -->|"wave_spawned / wave_cleared / boss_defeated"| BUS
     MF --> VG
 ```
+
+The manifest's `requires` list is the whitelist of what a trigger file may
+say: each required module ships a `mission_dsl.lua` whose env is merged into
+the sandbox. `waves` contributes the verbs (`Waves.Begin/Intensify/Surge/End`
+and the wave conditions); `scavengers` contributes the packs those verbs take
+(`Scavengers.Skirmish/Assault/Horde`). A mission's scavengers need no bot —
+but they do need the scavenger unit defs, which a game only derives when asked
+(`forceallunits`, `ruins`, or a scavengers AI on the field).
 
 Names have definition sites: `units.lua` declares every `Unit(...)` name the
 triggers may reference, and `objectives.lua` every `Objective(...)` id — in

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -27,6 +27,7 @@ local Roster = VFS.Include("modules/missions/lib/roster.lua")
 local Objectives = VFS.Include("modules/missions/lib/objectives.lua")
 local Variables = VFS.Include("modules/missions/lib/variables.lua")
 local Events = VFS.Include("modules/missions/lib/events.lua")
+local Placement = VFS.Include("modules/placement/api.lua")
 
 local MISSIONS_DIR = "modules/missions/"
 local EVALUATE_PERIOD = 15 -- frames
@@ -549,8 +550,34 @@ local function spawnRoster(entries, playerTeam)
 		local unitID = entry.claim and existingUnitOf(teamID, entry.def) or nil
 		local claimed = unitID ~= nil
 		if unitID == nil then
-			local x, z = entry.fx * Game.mapSizeX, entry.fz * Game.mapSizeZ
-			unitID = Spring.CreateUnit(entry.def, x, Spring.GetGroundHeight(x, z), z, 0, teamID)
+			local wantX, wantZ = entry.fx * Game.mapSizeX, entry.fz * Game.mapSizeZ
+			-- Positions are map fractions, so the author cannot know what is at that
+			-- point on THIS map; placement nudges a cliff/edge/overlap hit rather than
+			-- spawning a unit nobody can use. Surface is unconstrained: a roster may want a ship.
+			local def = UnitDefNames[entry.def]
+			local footprint = math.max(def.xsize or 8, def.zsize or 8) * 4
+			local x, y, z, why = Placement.NearestValid(wantX, wantZ, {
+				radius = footprint * 6,
+				footprint = footprint,
+				surface = "any",
+			})
+			if x == nil then
+				Spring.Log(
+					LOG_TAG,
+					LOG.ERROR,
+					"no room for roster unit "
+						.. entry.def
+						.. " near ("
+						.. math.floor(wantX)
+						.. ","
+						.. math.floor(wantZ)
+						.. "): "
+						.. tostring(why)
+				)
+				despawnRoster()
+				return false
+			end
+			unitID = Spring.CreateUnit(entry.def, x, y, z, 0, teamID)
 			if unitID == nil then
 				Spring.Log(LOG_TAG, LOG.ERROR, "could not spawn roster unit " .. entry.def .. " (unit limit)")
 				despawnRoster()

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -27,6 +27,7 @@ local Roster = VFS.Include("modules/missions/lib/roster.lua")
 local Objectives = VFS.Include("modules/missions/lib/objectives.lua")
 local Variables = VFS.Include("modules/missions/lib/variables.lua")
 local Events = VFS.Include("modules/missions/lib/events.lua")
+local Placement = VFS.Include("modules/placement/api.lua")
 
 local MISSIONS_DIR = "modules/missions/"
 local EVALUATE_PERIOD = 15 -- frames
@@ -515,8 +516,33 @@ local function spawnRoster(entries, playerTeam)
 		local unitID = entry.claim and existingUnitOf(teamID, entry.def) or nil
 		local claimed = unitID ~= nil
 		if unitID == nil then
-			local x, z = entry.fx * Game.mapSizeX, entry.fz * Game.mapSizeZ
-			unitID = Spring.CreateUnit(entry.def, x, Spring.GetGroundHeight(x, z), z, 0, teamID)
+			local wantX, wantZ = entry.fx * Game.mapSizeX, entry.fz * Game.mapSizeZ
+			-- positions are map fractions, so the author cannot know what is at that
+			-- point on THIS map; surface is unconstrained because a roster may want a ship
+			local def = UnitDefNames[entry.def]
+			local footprint = math.max(def.xsize or 8, def.zsize or 8) * 4
+			local x, y, z, why = Placement.NearestValid(wantX, wantZ, {
+				radius = footprint * 6,
+				footprint = footprint,
+				surface = "any",
+			})
+			if x == nil then
+				Spring.Log(
+					LOG_TAG,
+					LOG.ERROR,
+					"no room for roster unit "
+						.. entry.def
+						.. " near ("
+						.. math.floor(wantX)
+						.. ","
+						.. math.floor(wantZ)
+						.. "): "
+						.. tostring(why)
+				)
+				despawnRoster()
+				return false
+			end
+			unitID = Spring.CreateUnit(entry.def, x, y, z, 0, teamID)
 			if unitID == nil then
 				Spring.Log(LOG_TAG, LOG.ERROR, "could not spawn roster unit " .. entry.def .. " (unit limit)")
 				despawnRoster()

--- a/modules/missions/module.lua
+++ b/modules/missions/module.lua
@@ -2,5 +2,5 @@
 return {
 	name = "missions",
 	description = "Mission runtime: trigger engine, authoring DSL, mission loader",
-	requires = { "matchflow", "transport", "combat", "transfer" },
+	requires = { "matchflow", "transport", "combat", "transfer", "waves", "scavengers", "placement" },
 }

--- a/modules/missions/module.lua
+++ b/modules/missions/module.lua
@@ -2,5 +2,5 @@
 return {
 	name = "missions",
 	description = "Mission runtime: trigger engine, authoring DSL, mission loader",
-	requires = { "matchflow", "combat", "transfer" },
+	requires = { "matchflow", "combat", "transfer", "waves", "scavengers", "placement" },
 }

--- a/modules/missions/smoke_pressure/triggers/pressure.lua
+++ b/modules/missions/smoke_pressure/triggers/pressure.lua
@@ -1,0 +1,1 @@
+When(MatchFlow.Started()).After(30).Do(Scavengers.Skirmish.Begin().Against(Team.Player).From(0.85, 0.15).Intensity(0.3))

--- a/modules/missions/spec/builders/mission_builder_waves_spec.lua
+++ b/modules/missions/spec/builders/mission_builder_waves_spec.lua
@@ -1,0 +1,66 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+local PRESSURE = [[
+local pressure = Scavengers.Skirmish
+When(MatchFlow.Started())
+	.After(30)
+	.Do(pressure.Begin().Against(Team.Player).From(0.85, 0.15).Intensity(0.3))
+When(Objective("hold").IsComplete()).Do(pressure.Intensify(0.6)).Do(pressure.Surge())
+When(Objective("won").IsComplete()).Do(pressure.End())
+]]
+local OBJECTIVES = [[
+Objective("hold").CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+Objective("won").CompletedWhen(Team.Player.Has(UnitDef("armcom"), 2))
+]]
+
+local function mission()
+	return Builders.Mission
+		.new()
+		:WithSources("t", { ["objectives.lua"] = OBJECTIVES, ["triggers/p.lua"] = PRESSURE })
+		:Arm()
+end
+
+local function calls(m, moduleName, method)
+	local found = {}
+	for _, call in ipairs(m:Calls(moduleName)) do
+		if call.method == method then
+			found[#found + 1] = call
+		end
+	end
+	return found
+end
+
+describe("the mission builder's wave surface", function()
+	it("resolves the pack handle and its verbs, and the hold is in frames", function()
+		local m = mission()
+		local p = m:Triggers()
+		local opening
+		for _, trigger in ipairs(p) do
+			if trigger.filename == "t/triggers/p.lua" and trigger.order == 1 then
+				opening = trigger
+			end
+		end
+		assert.are.equal(30 * 30, opening.delayFrames)
+	end)
+
+	it("Begin reaches the flavor module with the shape it composed", function()
+		local m = mission():Frame(15)
+		assert.are.equal(0, #calls(m, "scavengers", "Start"))
+		m:Frame(15 + 30 * 30)
+		local request = calls(m, "scavengers", "Start")[1].args[1]
+		assert.are.equal("scavengers.skirmish", request.pack)
+		assert.are.equal("skirmish", request.builder)
+		assert.are.equal(0, request.against)
+		assert.are.same({ fx = 0.85, fz = 0.15 }, request.origin)
+		assert.are.equal(0.3, request.intensity)
+	end)
+
+	it("Intensify, Surge and End reach the director by pack", function()
+		local m = mission():WithUnits(0, "armpw", 3):Step():Step()
+		assert.are.same({ "scavengers.skirmish", 0.6 }, calls(m, "waves", "SetIntensity")[1].args)
+		assert.are.equal(1, #calls(m, "waves", "Surge"))
+		m:WithUnits(0, "armcom", 2):Step():Step()
+		assert.are.equal("scavengers.skirmish", calls(m, "waves", "Stop")[1].args[1])
+	end)
+end)

--- a/modules/missions/spec/manifest_spec.lua
+++ b/modules/missions/spec/manifest_spec.lua
@@ -14,6 +14,15 @@ describe("the missions manifest", function()
 	end)
 
 	it("missions declares the modules it draws vocabulary from", function()
-		assert.are.same({ "matchflow", "combat", "transfer" }, manifests.missions.requires)
+		assert.are.same(
+			{ "matchflow", "combat", "transfer", "waves", "scavengers", "placement" },
+			manifests.missions.requires
+		)
+	end)
+
+	it("every module it requires exists and contributes vocabulary or an api", function()
+		for _, name in ipairs(manifests.missions.requires) do
+			assert.is_table(manifests[name], "missions requires a module that was not discovered: " .. name)
+		end
 	end)
 end)

--- a/modules/missions/spec/manifest_spec.lua
+++ b/modules/missions/spec/manifest_spec.lua
@@ -14,6 +14,15 @@ describe("the missions manifest", function()
 	end)
 
 	it("missions declares the modules it draws vocabulary from", function()
-		assert.are.same({ "matchflow", "transport", "combat", "transfer" }, manifests.missions.requires)
+		assert.are.same(
+			{ "matchflow", "transport", "combat", "transfer", "waves", "scavengers", "placement" },
+			manifests.missions.requires
+		)
+	end)
+
+	it("every module it requires exists and contributes vocabulary or an api", function()
+		for _, name in ipairs(manifests.missions.requires) do
+			assert.is_table(manifests[name], "missions requires a module that was not discovered: " .. name)
+		end
 	end)
 end)

--- a/modules/missions/widgets/mission_bridge.lua
+++ b/modules/missions/widgets/mission_bridge.lua
@@ -89,6 +89,32 @@ local function countFinishedUnits(unitDefName)
 	return count
 end
 
+-- The director publishes counters under its OWN name: a mission names a pack
+-- and has no way to know a flavor's rulesparam prefix.
+local WAVE_COUNTERS = {
+	waves_spawned = "wave",
+	waves_cleared = "cleared",
+	waves_boss_defeated = "bosses",
+}
+
+---@param probe table
+---@return table
+local function waveProgress(probe)
+	local counter = WAVE_COUNTERS[probe.kind]
+	local have = Spring.GetGameRulesParam("waves_" .. probe.pack .. "_" .. counter)
+	if have == nil then
+		-- "–" rather than 0: "no director exists" is what a mission author is usually debugging.
+		return { text = "–", state = "pending", pct = 0 }
+	end
+	local need = math.max(1, math.floor(probe.need or 1))
+	local done = have >= need
+	return {
+		text = math.floor(have) .. "/" .. need,
+		state = done and "done" or "pending",
+		pct = math.min(1, have / need),
+	}
+end
+
 local function sampleLive()
 	if not probes or #probes == 0 then
 		return
@@ -130,6 +156,8 @@ local function sampleLive()
 					state = spotted and "done" or "pending",
 					pct = spotted and 1 or 0,
 				}
+			elseif WAVE_COUNTERS[probe.kind] and probe.pack then
+				values[probe.key] = waveProgress(probe)
 			elseif probe.kind == "trigger_fired" and probe.trigger then
 				local mission = Spring.GetGameRulesParam("mission_name")
 				local fired = mission ~= nil

--- a/modules/missions/widgets/mission_bridge.lua
+++ b/modules/missions/widgets/mission_bridge.lua
@@ -95,6 +95,34 @@ local function countFinishedUnits(unitDefName)
 	return count
 end
 
+-- The director publishes counters under its OWN name: a mission names a pack
+-- and has no way to know a flavor's rulesparam prefix.
+local WAVE_COUNTERS = {
+	waves_spawned = "wave",
+	waves_cleared = "cleared",
+	waves_boss_defeated = "bosses",
+}
+
+---@param probe table
+---@return table
+local function waveProgress(probe)
+	local counter = WAVE_COUNTERS[probe.kind]
+	local have = Spring.GetGameRulesParam("waves_" .. probe.pack .. "_" .. counter)
+	if have == nil then
+		-- The director has not started yet. "–" rather than 0/1, because
+		-- "no waves have spawned" and "no director exists" are different
+		-- things and a mission author is usually debugging the second one.
+		return { text = "–", state = "pending", pct = 0 }
+	end
+	local need = math.max(1, math.floor(probe.need or 1))
+	local done = have >= need
+	return {
+		text = math.floor(have) .. "/" .. need,
+		state = done and "done" or "pending",
+		pct = math.min(1, have / need),
+	}
+end
+
 local function sampleLive()
 	if not probes or #probes == 0 then
 		return
@@ -136,6 +164,8 @@ local function sampleLive()
 					state = spotted and "done" or "pending",
 					pct = spotted and 1 or 0,
 				}
+			elseif WAVE_COUNTERS[probe.kind] and probe.pack then
+				values[probe.key] = waveProgress(probe)
 			elseif probe.kind == "trigger_fired" and probe.trigger then
 				-- The kit knows a trigger as "<file>:<order>"; the runtime
 				-- stamps the mission in front of it. Composing here keeps the


### PR DESCRIPTION
Adds waves to missions, with a smoke integration test.

The order is deliberate: hello_pawns exists before missions grow to what CM8 Ashfall needs — the same way a new module would be onboarded in practice.

Requiring scavengers is all it takes. A pack handle carries the director's verbs:

```lua
local pressure = Scavengers.Skirmish
When(MatchFlow.Started()).After(60).Do(pressure.Begin().Against(Team.Player))
```

Nothing in the loader knows waves exist; the verbs, context and events arrive with the contribution. Spawns go through placement, so a map-fraction position lands on ground that exists.

### LLM Disclosure
Many and often. Description, design, and review are my own.