### PR TITLE
ci: rework the type check report, drop the format check's CRLF pass

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -49,14 +49,6 @@ jobs:
             exit 0
           fi
 
-          # .stylua.toml asks for CRLF, so the input has to be CRLF or every line
-          # reports as a mismatch. .gitattributes already checks *.lua out that
-          # way; normalising anyway keeps the check from depending on the runner
-          # reproducing it.
-          while IFS= read -r -d '' file; do
-            perl -pi -e 's/\r?\n/\r\n/' "$file"
-          done < changed.txt
-
           echo "Checking:"
           tr '\0' '\n' < changed.txt
 

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -46,26 +46,38 @@ jobs:
           sudo chmod +x /usr/local/bin/emmylua_check
           /usr/local/bin/emmylua_check --version
 
-      - name: Run emmylua_check on changed files
-        if: github.event_name == 'pull_request'
+      # emmylua_check has no scoped mode: it analyses the whole workspace
+      # whatever you ask it for. So it runs once here, for both events, and the
+      # pull request scope is applied to its report afterwards. A manual run
+      # reports the same data unfiltered rather than re-deriving it from a
+      # second pass.
+      - name: Run emmylua_check
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # Fetch the base revision to diff against it.
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            MODE=pr
+            WHERE="changed files"
 
-          # Lua paths may contain spaces, so the list uses NUL separators.
-          git diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.lua' > changed.txt
-          if [ ! -s changed.txt ]; then
-            echo "No Lua files changed."
-            exit 0
+            # Fetch the base revision to diff against it.
+            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+
+            # Lua paths may contain spaces, so the list uses NUL separators.
+            git diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.lua' > changed.txt
+            if [ ! -s changed.txt ]; then
+              echo "No Lua files changed."
+              exit 0
+            fi
+            echo "Reporting on:"
+            tr '\0' '\n' < changed.txt
+            jq -R -s 'split("\u0000") | map(select(. != ""))' changed.txt > changed.json
+          else
+            MODE=tree
+            WHERE="the whole tree"
+            echo "[]" > changed.json
+            echo "Manual run: reporting on the whole tree."
           fi
-          echo "Reporting on:"
-          tr '\0' '\n' < changed.txt
-          jq -R -s 'split("\u0000") | map(select(. != ""))' changed.txt > changed.json
 
-          # Take the workspace root and analyze the entire tree in the report.
-          # The report then has to be filtered to follow a CI rule on changes.
           set +e
           emmylua_check -c .emmyrc.json -f json --output diagnostics.json . 2> emmylua.log
           emmylua_status=$?
@@ -91,12 +103,13 @@ jobs:
             exit 1
           fi
 
-          # Numeric severities (error 1, warning 2) and relative file paths.
-          jq --slurpfile changed changed.json --arg cwd "$PWD/" '
+          # Severity is the LSP numbering: 1 error, 2 warning, 3 information,
+          # 4 hint. Paths are made relative so they match the annotation API.
+          jq --slurpfile changed changed.json --arg cwd "$PWD/" --arg mode "$MODE" '
             ($changed[0] | map({(.): true}) | add // {}) as $want
             | [ .[]
                 | (.file | ltrimstr($cwd) | ltrimstr("./")) as $path
-                | select($want[$path])
+                | select($mode == "tree" or $want[$path])
                 | .diagnostics[]
                 | { path: $path,
                     line: (.range.start.line + 1),
@@ -106,29 +119,125 @@ jobs:
                     message: .message } ]
           ' diagnostics.json > filtered.json
 
-          # Workflow commands are rendered as pull request annotations.
-          # We use these to display up to 10 rendered bubbles per type,
-          # then display the rest in the log (which keeps every line).
-          jq -r '
-            def esc: gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
-            def prop: esc | gsub(","; "%2C") | gsub(":"; "%3A");
-            .[]
-            | (if .severity == 1 then "error"
-               elif .severity == 2 then "warning"
-               else "notice" end) as $kind
-            | "::\($kind) file=\(.path | prop),line=\(.line),col=\(.col),title=\(.code | prop)::\(.message | esc)"
-          ' filtered.json
-
-          # Warnings notify, errors fail.
-          # Only the touched files are in scope.
           errors=$(jq '[ .[] | select(.severity == 1) ] | length' filtered.json)
-          echo "$(jq length filtered.json) finding(s) in changed files, $errors error(s)."
-          if [ "$errors" -ne 0 ]; then
-            exit 1
+          warnings=$(jq '[ .[] | select(.severity == 2) ] | length' filtered.json)
+          hints=$(jq '[ .[] | select(.severity >= 3) ] | length' filtered.json)
+          echo "$(jq length filtered.json) finding(s) in $WHERE: $errors error(s), $warnings warning(s), $hints hint(s)."
+
+          # Annotations only make sense against a diff. A manual run has no pull
+          # request to hang them on, and the whole tree would blow the cap many
+          # times over, so it gets the log and the summary instead.
+          #
+          # Errors and warnings are annotated; hints are not. Hints are style
+          # nudges (`unused` is the bulk of them) and every changed file carries
+          # a few, so annotating them buries the type errors that this check
+          # exists to surface. They stay in the counts and in the job summary.
+          #
+          # GitHub renders at most 10 annotations per severity and silently
+          # drops the rest, so each pool is sorted and sliced deliberately
+          # rather than letting the report order decide what a reviewer sees.
+          if [ "$MODE" = "pr" ]; then
+            jq -r '
+              def esc: gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
+              def prop: esc | gsub(","; "%2C") | gsub(":"; "%3A");
+              def pool($sev; $kind):
+                [ .[] | select(.severity == $sev) ]
+                | sort_by(.path, .line, .col)
+                | .[0:10][]
+                | "::\($kind) file=\(.path | prop),line=\(.line),col=\(.col),title=\(.code | prop)::\(.message | esc)";
+              pool(1; "error"), pool(2; "warning")
+            ' filtered.json
+
+            if [ "$errors" -gt 10 ] || [ "$warnings" -gt 10 ]; then
+              echo "::notice title=Type check::Only the first 10 findings per severity are annotated; the job summary and the log below list every one."
+            fi
           fi
 
-      # The workflow runner does not have a scoped check. It runs on all files.
-      # This is going to be a massive, noisy report. Only use it for analytics.
-      - name: Run emmylua_check on the whole tree
-        if: github.event_name == 'workflow_dispatch'
-        run: emmylua_check -c .emmyrc.json .
+          # ::group:: is what makes the log collapsible, one fold per code. It
+          # is uncapped in here -- on a whole-tree run that is tens of thousands
+          # of lines, which is readable folded and unreadable flat.
+          jq -r '
+            def sevname: if . == 1 then "error" elif . == 2 then "warning"
+                         elif . == 3 then "info" else "hint" end;
+            def plural($n): if $n == 1 then "" else "s" end;
+            group_by(.code)
+            | sort_by(.[0].severity, -length)
+            | .[]
+            | ("::group::\(.[0].code) - \(length) \(.[0].severity | sevname)\(plural(length))"),
+              (sort_by(.path, .line, .col)[] | "\(.path):\(.line):\(.col): \(.message)"),
+              "::endgroup::"
+          ' filtered.json
+
+          # The whole summary is one jq program. Findings are grouped by code
+          # rather than lumped under a severity, because "1354 unnecessary-if"
+          # and "1 undefined-global" are two different conversations and a flat
+          # list buries that. Errors stay open because they block; everything
+          # else is a collapsed section per code, ordered by severity then size.
+          #
+          # Annotations cannot be bucketed the same way -- GitHub has only the
+          # error, warning and notice pools -- but each bubble already carries
+          # its code as the title, so the two views agree.
+          jq -r --arg mode "$MODE" --arg where "$WHERE" '
+            def cell: gsub("\\|"; "\\|") | gsub("[\r\n]+"; " ");
+            def sevname: if . == 1 then "error" elif . == 2 then "warning"
+                         elif . == 3 then "info" else "hint" end;
+            def plural($n): if $n == 1 then "" else "s" end;
+
+            # Fifty rows per code is where a table stops being readable. The
+            # log above is uncapped, so nothing is actually lost.
+            def rows($f):
+              ( $f | sort_by(.path, .line, .col) | .[0:50][]
+                | "| `\(.path):\(.line)` | \(.message | cell) |" ),
+              ( if ($f | length) > 50
+                then "", "_Showing 50 of \($f | length); the workflow log lists every one._"
+                else empty end );
+
+            . as $all
+            | ([ $all[] | select(.severity == 1) ]) as $errors
+            | ($all | group_by(.code)
+                    | map({ code: .[0].code, severity: (map(.severity) | min), n: length })
+                    | sort_by(.severity, -.n)) as $codes
+
+            | ( if ($errors | length) > 0
+                then "### Type check: \($errors | length) error\(plural($errors | length)) in \($where)"
+                else "### Type check: no errors in \($where)"
+                end ),
+              "",
+              ( if $mode == "tree"
+                then "Manual whole-tree run. Reporting only -- this does not gate anything."
+                else "Warnings and hints do not block."
+                end ),
+
+              ( if ($all | length) > 0
+                then "", "| Code | Severity | Count |", "| --- | --- | --- |",
+                     ( $codes[] | "| `\(.code)` | \(.severity | sevname) | \(.n) |" )
+                else empty end ),
+
+              # Errors are not collapsed and keep a Code column, since one run
+              # can fail on several different ones at once.
+              ( if ($errors | length) > 0
+                then "", "#### Errors", "",
+                     "| Location | Code | Message |", "| --- | --- | --- |",
+                     ( $errors | sort_by(.path, .line, .col) | .[0:50][]
+                       | "| `\(.path):\(.line)` | `\(.code)` | \(.message | cell) |" ),
+                     ( if ($errors | length) > 50
+                       then "", "_Showing 50 of \($errors | length); the workflow log lists every one._"
+                       else empty end )
+                else empty end ),
+
+              ( [ $codes[] | select(.severity != 1) ][]
+                | . as $c
+                | [ $all[] | select(.code == $c.code) ] as $f
+                | "",
+                  "<details><summary><code>\($c.code)</code> - \($c.n) \($c.severity | sevname)\(plural($c.n))</summary>",
+                  "", "| Location | Message |", "| --- | --- |",
+                  rows($f),
+                  "", "</details>" )
+          ' filtered.json >> "$GITHUB_STEP_SUMMARY"
+
+          # Errors fail a pull request. A manual run is an analytics view, so it
+          # reports and stays green -- a red X on a report nobody asked to gate
+          # only teaches people to ignore the colour.
+          if [ "$MODE" = "pr" ] && [ "$errors" -ne 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
### Work done

**Type check** — emmylua ran twice, scoped for PRs and unscoped for manual runs, but it has no scoped mode, so the second run only re-derived what the first already had; it runs once now. The report is grouped by diagnostic code rather than severity, since the tree holds 39095 findings and exactly one of them is an error.

Hints are no longer annotated — `unused` alone is 11691 tree-wide — but stay in the counts, log and summary. Manual runs report and stay green instead of always going red.

**Format check** — dropped the `perl` CRLF pass. `.gitattributes` already checks `*.lua` out as CRLF, and it was the only thing in the job writing to a file.

#### Test steps

Verified on a scratch PR against a clean base (keithharvey/bar#35), one `.lua` file carrying a deliberate error, warning, hint and misformatting.

- [x] `workflow_dispatch` Type Check — whole tree, no annotations, green. [Run](https://github.com/keithharvey/bar/actions/runs/32768278697): `39095 finding(s) in the whole tree: 1 error(s), 27403 warning(s), 11691 hint(s)`.
- [x] PR with a `.lua` type error — fails, error and warning annotated, hint not, all three folded per code. [Run](https://github.com/keithharvey/bar/actions/runs/32776719090): `3 finding(s) in changed files: 1 error(s), 1 warning(s), 1 hint(s)`.
- [x] PR with `.lua` warnings only — passes, findings still listed. [Run](https://github.com/keithharvey/bar/actions/runs/32777083223): `2 finding(s): 0 error(s), 1 warning(s), 1 hint(s)`, job green.
- [x] PR with a misformatted `.lua` — Format Check fails and names the file. [Run](https://github.com/keithharvey/bar/actions/runs/32776719068): `1 file(s) are not formatted with stylua 2.5.2`.
- [x] Format check still passes on correctly formatted CRLF sources with the `perl` pass removed. [Run](https://github.com/keithharvey/bar/actions/runs/32777083221).

This PR touches no `.lua`, so its own Type Check and Format Check are skipped by the `paths` filter.
<img width="1639" height="1442" alt="image" src="https://github.com/user-attachments/assets/053529ee-f374-4d5b-8c74-8ec6f33837b6" />

### AI / LLM usage statement
Written with Claude Code (Claude Fable 5), verified locally and on real Actions runs.
