### PR TITLE
ci: rename lint.yml to lint_check.yml to match the other checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,7 +109,7 @@ Match the validator to the file type. If unsure of a tool's scope, inspect the p
 - lux 0.28.x appends duplicate `dependencies` and `entrypoints` entries to `lux.lock` on every cold sync (a run with
   no `.lux/` tree), growing the file by ~13 lines each time without ever converging. Tests still pass. Do not commit
   that churn: `git checkout -- lux.lock` afterwards, and only commit a lockfile change you made deliberately.
-- Lint: `luacheck` 1.2.0 with `.luacheckrc`; CI reports only lines changed in the PR (`.github/workflows/lint.yml`).
+- Lint: `luacheck` 1.2.0 with `.luacheckrc`; CI reports only lines changed in the PR (`.github/workflows/lint_check.yml`).
 - Format: StyLua with `.stylua.toml` (tabs, indent width 4, 120 columns, CRLF, sorted requires) and `.styluaignore`;
   `.editorconfig` mirrors the indent and whitespace rules.
 - Types: EmmyLua analyzer via `.emmyrc.json`, stubs in `types/`, engine definitions from the `recoil-lua-library`

--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint Check
 
 on:
   pull_request:


### PR DESCRIPTION
### Work done

The three Lua checks were named two different ways: `Format Check` and `Type Check` in `format_check.yml` and `type_check.yml`, then plain `Lint` in `lint.yml`. This renames the file and the workflow so all three match.

Nothing else changes — same triggers, same luacheck 1.2.0, same reviewdog reporting on changed lines only. Git sees it as a rename with 99% similarity; the only edited line is `name:`.

Note: the check context moves from `Lint / luacheck` to `Lint Check / luacheck`, so any branch protection rule naming the old context needs updating alongside this.

#### Test steps

Verified on a scratch PR against a clean base (keithharvey/bar#35).

- [x] PR touching a `.lua` file with a luacheck finding on a changed line — `Lint Check / luacheck` runs and fails as `Lint` did. [Run](https://github.com/keithharvey/bar/actions/runs/32776719031): `ci_scratch_delete_me.lua:4:5: (W581) 'not (x ~= y)' can be replaced by 'x == y'`, reported through reviewdog and exiting 1.
- [x] Same PR with the finding removed — passes under the new name. [Run](https://github.com/keithharvey/bar/actions/runs/32777083272).
- [ ] Confirm no branch protection rule still requires the old `Lint` context — needs repo admin, cannot be checked from a fork.

Unrelated to the rename, but visible in both runs and worth a follow-up: this job takes 2m47s–5m5s on a one-file diff, against 7s for `stylua` and 24s for `emmylua_check`. It is all setup — a full checkout, then building Lua, luarocks, luacheck and reviewdog on every run, including on pull requests that touch no Lua at all, since this workflow has no `paths` filter. Its actions also still target Node 20.

### AI / LLM usage statement
Written with Claude Code (Claude Fable 5).
