### PR TITLE
Add a map editor session mode

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -3652,6 +3652,10 @@
 			"name": "Animation Cleanup",
 			"desc": "Use animations from the BOSCleanup branch"
 		},
+		"mapeditor": {
+			"name": "Map Editor Session",
+			"desc": "Launch as a map editor: the combat UI is left out and the terraformer opens on load."
+		},
 		"pushresistant": {
 			"name": "Pushresistance",
 			"desc": "Enable to do desync test by the use of pushresistance"

--- a/luaui/Widgets/cmd_map_editor_session.lua
+++ b/luaui/Widgets/cmd_map_editor_session.lua
@@ -1,0 +1,74 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Map Editor Session",
+		desc = "Opens the terraformer and strips the combat UI when the session was launched to edit a map",
+		author = "Robert Burnham",
+		date = "2026",
+		license = "GNU GPL, v2 or later",
+		layer = 1000001,
+		enabled = true,
+		handler = true,
+	}
+end
+
+-- The lobby marks a session with the mapeditor modoption; everything here is keyed off that, so
+-- opening the terraformer in an ordinary game is untouched.
+
+local HIDDEN_WIDGETS = {
+	"AdvPlayersList",
+	"Build menu",
+	"Grid menu",
+	"Order menu",
+	"Unit Groups",
+	"Idle Builders",
+}
+
+local sessionActive = false
+local step = 1
+
+-- RemoveWidgetRaw rather than DisableWidgetRaw: the latter zeroes the widget's order and saves,
+-- which would leave a player's next real game missing its UI.
+local function hideWidget(name)
+	local instance = widgetHandler:FindWidget(name)
+	if instance then
+		widgetHandler:RemoveWidgetRaw(instance)
+	end
+end
+
+function widget:Initialize()
+	sessionActive = Spring.GetModOptions().mapeditor and true or false
+end
+
+-- Both steps run from Update, not Initialize: Initialize is called while the handler is still
+-- walking its load list, and removing widgets there reenters it.
+function widget:Update()
+	if not sessionActive then
+		return
+	end
+
+	-- Cheat is deliberately not sent here: engaging a terrain mode already nudges it on, and
+	-- the command toggles, so a second sender racing the first turns cheats back off.
+	if step == 1 then
+		step = 2
+		for i = 1, #HIDDEN_WIDGETS do
+			hideWidget(HIDDEN_WIDGETS[i])
+		end
+
+		-- The top bar keeps its buttons: they carry the only way back to the lobby.
+		if WG.topbar then
+			WG.topbar.setResourceBarsVisible(false)
+			WG.topbar.setIndicatorsVisible(false)
+		end
+
+		return
+	end
+
+	-- terraformbrush is one of the suite launcher's entry commands: it loads the whole suite on
+	-- first use and re-dispatches, so the editor needs no widget wrangling from here.
+	if step == 2 then
+		step = 3
+		Spring.SendCommands("terraformbrush")
+	end
+end

--- a/luaui/Widgets/cmd_map_editor_session.lua
+++ b/luaui/Widgets/cmd_map_editor_session.lua
@@ -13,8 +13,16 @@ function widget:GetInfo()
 	}
 end
 
--- The lobby marks a session with the mapeditor modoption; everything here is keyed off that, so
--- opening the terraformer in an ordinary game is untouched.
+-- The lobby marks a session with the mapeditor modoption. Stopping the file here rather than
+-- checking the flag inside the callins means an ordinary game defines none of them and pays
+-- nothing, and opening the terraformer in a normal game is untouched.
+--
+-- Not gated through the enabled field: LoadWidget only consults that when the widget has no
+-- entry in the order list, and the first game without the modoption writes a zero, after which
+-- the field is never read again.
+if not Spring.GetModOptions().mapeditor then
+	return
+end
 
 local HIDDEN_WIDGETS = {
 	"AdvPlayersList",
@@ -25,7 +33,6 @@ local HIDDEN_WIDGETS = {
 	"Idle Builders",
 }
 
-local sessionActive = false
 local step = 1
 
 -- RemoveWidgetRaw rather than DisableWidgetRaw: the latter zeroes the widget's order and saves,
@@ -37,17 +44,9 @@ local function hideWidget(name)
 	end
 end
 
-function widget:Initialize()
-	sessionActive = Spring.GetModOptions().mapeditor and true or false
-end
-
 -- Both steps run from Update, not Initialize: Initialize is called while the handler is still
 -- walking its load list, and removing widgets there reenters it.
 function widget:Update()
-	if not sessionActive then
-		return
-	end
-
 	-- Cheat is deliberately not sent here: engaging a terrain mode already nudges it on, and
 	-- the command toggles, so a second sender racing the first turns cheats back off.
 	if step == 1 then

--- a/luaui/Widgets/cmd_map_project.lua
+++ b/luaui/Widgets/cmd_map_project.lua
@@ -1736,6 +1736,14 @@ local function writePointer(t)
 	return writeFile(POINTER_PATH, content) ~= nil
 end
 
+-- Counts clients rather than team-attached players: a map editor session runs with no teams
+-- at all, so its lone spectator counts as zero. api_permissions gates the same way.
+local function isLocalSession()
+	local count = BAR.Utilities and BAR.Utilities.GetPlayerCount and BAR.Utilities.GetPlayerCount()
+
+	return count == nil or count <= 1
+end
+
 local function readPointer()
 	local f = io.open(POINTER_PATH, "r")
 	if not f then
@@ -2665,8 +2673,7 @@ local function maybeStartLoad()
 	if Spring.IsReplay() then
 		reasons[#reasons + 1] = "this is a replay"
 	end
-	local gt = BAR.Utilities and BAR.Utilities.Gametype
-	if gt and gt.IsSinglePlayer and not gt.IsSinglePlayer() then
+	if not isLocalSession() then
 		reasons[#reasons + 1] = "not a local singleplayer session"
 	end
 	if #reasons > 0 then
@@ -2737,8 +2744,7 @@ local function openProject(slug)
 		echoP("cannot open: " .. err)
 		return false
 	end
-	local gt = BAR.Utilities and BAR.Utilities.Gametype
-	if gt and gt.IsSinglePlayer and not gt.IsSinglePlayer() then
+	if not isLocalSession() then
 		echoP("cannot open: project loading needs a local singleplayer session")
 		return false
 	end

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -381,9 +381,11 @@ local function updateButtons()
 	local function addButton(name, text, badge)
 		local textWidth = font2:GetTextWidth(text) * fontsize
 		-- the circle grows along with the amount of characters the number has
-		local badgeRadius = badge
-				and mathMax(badgeMinRadius, ((font2:GetTextWidth(badge) * badgeFontsize) / 2) + (fontsize * 0.25))
-			or 0
+		local badgeRadius = 0
+		if badge then
+			local badgeTextWidth = font2:GetTextWidth(badge) * badgeFontsize
+			badgeRadius = mathMax(badgeMinRadius, (badgeTextWidth / 2) + (fontsize * 0.25))
+		end
 		local badgeWidth = badgeRadius * 2
 		local width = mathFloor(textWidth + badgeWidth + textPadding)
 		local textCenter = buttonsArea[3] - offset - (width / 2) - (badgeWidth / 2)

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -2152,6 +2152,15 @@ local options = {
 	},
 	-- NOTE: update language/en/interface.json when you change name or desc
 	{
+		key = "mapeditor",
+		name = "Map Editor Session",
+		desc = "Launch as a map editor: the combat UI is left out and the terraformer opens on load.",
+		section = "dev",
+		type = "bool",
+		def = false,
+	},
+	-- NOTE: update language/en/interface.json when you change name or desc
+	{
 		key = "pushresistant",
 		name = "Pushresistance",
 		desc = "Enable to do desync test by the use of pushresistance",


### PR DESCRIPTION
Adds a `mapeditor` modoption and a widget that acts on it, so a session can come up with the terraformer already open and the combat UI out of the way. Everything is keyed off the modoption, so opening the terraformer in an ordinary game is untouched.

Project load and save were gated on `IsSinglePlayer()`, which is `playerCount == 1` counted over team-attached players. An editor session declares no teams so nothing spawns, which makes that count zero and the guard refuse. It now checks the player count is at most one, the way api_permissions already does, so the multiplayer case it exists for still fails.

Depends on #8880 for `setIndicatorsVisible`. Launched from the lobby on a real map and on a saved project: the suite loads, the brush engages, cheats stay on.

AI disclosure: written with assistance from Claude Code.
