### PR TITLE
Load Map Project with the terraform suite

### DIFF
--- a/luaui/Widgets/cmd_terraform_suite.lua
+++ b/luaui/Widgets/cmd_terraform_suite.lua
@@ -43,6 +43,7 @@ local SUITE_WIDGETS = {
 	"Feature Placer UI",
 	"Weather Brush UI",
 	"Map Labels UI",
+	"Map Project",
 }
 
 -- Entry commands that must work before the suite is loaded. Sub-tool actions


### PR DESCRIPTION
Map Project ships disabled like the rest of the suite but was not on the launcher's list, so nothing ever brought it up and an editor session could not open or save projects.

AI disclosure: written with assistance from Claude Code.