### PR TITLE
Fix: eradicator not able to CMD.stop

### DIFF
--- a/units/CorBuildings/LandDefenceOffence/corerad.lua
+++ b/units/CorBuildings/LandDefenceOffence/corerad.lua
@@ -29,7 +29,6 @@ return {
 			buildinggrounddecaltype = "decals/corerad_aoplane.dds",
 			model_author = "Mr Bob",
 			normaltex = "unittextures/cor_normal.dds",
-			removestop = true,
 			removewait = true,
 			subfolder = "CorBuildings/LandDefenceOffence",
 			unitgroup = "aa",


### PR DESCRIPTION
Fix eradicator not being able to CMD.stop due to incorrect custom param. 

### Work done
I went through all the other defensive buildings and all others are correct. 

#### Addresses Issue(s)
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/8781

Before:
<img width="1219" height="513" alt="image" src="https://github.com/user-attachments/assets/84cd14b3-6f48-4e98-8673-a78cb81fa280" />


After:

<img width="962" height="456" alt="image" src="https://github.com/user-attachments/assets/9a5bfdc8-00e7-4475-bf69-00c12e34f649" />
