### PR TITLE
Mission AI: Fix stale unit triggers test

### DIFF
--- a/singleplayer/mission-api-tests/unit_triggers_test.lua
+++ b/singleplayer/mission-api-tests/unit_triggers_test.lua
@@ -208,22 +208,24 @@ local triggers = {
 	},
 
 	engineerSpotted = {
-		type = triggerTypes.UnitSpotted,
+		type = triggerTypes.UnitDetected,
 		parameters = {
 			unitName = 'engineers',
 			unitDefName = 'corfast',
 			owningTeamID = 1,
+			sensorTypes = { 'vision' },
 		},
 		actions = { 'messageEngineerSpotted' },
 	},
 
 	engineerUnspotted = {
-		type = triggerTypes.UnitUnspotted,
+		type = triggerTypes.UnitUndetected,
 		parameters = {
 			unitName = 'engineers',
 			unitDefName = 'corfast',
 			owningTeamID = 1,
-			spottingAllyTeamID = 0,
+			sensorAllyTeamID = 0,
+			sensorTypes = { 'vision' },
 		},
 		actions = { 'messageEngineerUnspotted' },
 	},


### PR DESCRIPTION
### Work done

Remove an old UnitSpotted test, superceded by UnitDetected with sensorTypes = { 'vision' }.