### PR TITLE
Mission API: Unit detection fixes

### DIFF
--- a/luarules/gadgets/api_missions.lua
+++ b/luarules/gadgets/api_missions.lua
@@ -61,11 +61,12 @@ function gadget:Initialize()
 	--local scriptPath = 'mission-api-tests/unit_triggers_test.lua'
 	--local scriptPath = 'mission-api-tests/feature_triggers_test.lua'
 	--local scriptPath = 'mission-api-tests/statistics_triggers_test.lua'
-	local scriptPath = 'mission-api-tests/resource_test.lua'
+	--local scriptPath = 'mission-api-tests/resource_test.lua'
 	--local scriptPath = 'mission-api-tests/loadout_test.lua'
 	--local scriptPath = 'mission-api-tests/stages_and_objectives_test.lua'
-	local scriptPath = 'mission-api-tests/unit_mover_test.lua'
-  
+	--local scriptPath = 'mission-api-tests/unit_mover_test.lua'
+	local scriptPath = 'mission-api-tests/unit_detection_test.lua'
+
 	if not scriptPath then
 		gadgetHandler:RemoveGadget()
 		return

--- a/luarules/gadgets/api_missions_triggers.lua
+++ b/luarules/gadgets/api_missions_triggers.lua
@@ -304,6 +304,9 @@ function gadget:GameFrame(frameNumber)
 	end
 end
 
+-- Both the detection sweep and the build-assist sweep run at the end of the frame.
+-- They have to share one callin: a second `function gadget:GameFramePost` would
+-- silently replace the first, which is how detection stopped being dispatched.
 function gadget:GameFramePost(frameNumber)
 	if detectionCount > 0 then
 		detectionLevels.BeginUpdate()
@@ -313,9 +316,7 @@ function gadget:GameFramePost(frameNumber)
 		end
 		detectionCount = 0
 	end
-end
 
-function gadget:GameFramePost(frameNumber)
 	if not next(buildPlacements) then
 		return
 	end

--- a/luarules/gadgets/api_missions_triggers.lua
+++ b/luarules/gadgets/api_missions_triggers.lua
@@ -304,9 +304,6 @@ function gadget:GameFrame(frameNumber)
 	end
 end
 
--- Both the detection sweep and the build-assist sweep run at the end of the frame.
--- They have to share one callin: a second `function gadget:GameFramePost` would
--- silently replace the first, which is how detection stopped being dispatched.
 function gadget:GameFramePost(frameNumber)
 	if detectionCount > 0 then
 		detectionLevels.BeginUpdate()

--- a/luarules/mission_api/detection_levels.lua
+++ b/luarules/mission_api/detection_levels.lua
@@ -107,21 +107,28 @@ local function beginUpdate()
 end
 
 ---The level bit a unit currently sits at. Without a sensorAllyTeam, the highest level held
----by any single allyTeam wins, so a unit seen by one and unheard by another reads as seen.
+---by any allyTeam other than the unit's own wins, so a unit seen by one and unheard by
+---another reads as seen. The owner is skipped because an allyTeam always has vision of
+---its own units, which would otherwise report every unit as seen by every sensor.
 ---@return integer levelBit
 local function levelBitOf(unitID, sensorAllyTeam)
 	if sensorAllyTeam then
 		return levelForAllyTeam(unitID, sensorAllyTeam)
 	end
 
+	local ownerAllyTeam = Spring.GetUnitAllyTeam(unitID)
+
 	local level = LEVEL_UNSEEN
 	for index = 1, sensorAllyTeamCount do
-		local allyTeamLevel = levelForAllyTeam(unitID, sensorAllyTeams[index])
-		if allyTeamLevel > level then
-			if allyTeamLevel == LEVEL_VISION then
-				return LEVEL_VISION -- nothing outranks vision, so stop looking
+		local allyTeamID = sensorAllyTeams[index]
+		if allyTeamID ~= ownerAllyTeam then
+			local allyTeamLevel = levelForAllyTeam(unitID, allyTeamID)
+			if allyTeamLevel > level then
+				if allyTeamLevel == LEVEL_VISION then
+					return LEVEL_VISION -- nothing outranks vision, so stop looking
+				end
+				level = allyTeamLevel
 			end
-			level = allyTeamLevel
 		end
 	end
 	return level

--- a/singleplayer/mission-api-tests/unit_detection_test.lua
+++ b/singleplayer/mission-api-tests/unit_detection_test.lua
@@ -1,0 +1,582 @@
+local triggerTypes = GG['MissionAPI'].TriggerDefinitions.Types
+local actionTypes = GG['MissionAPI'].ActionDefinitions.Types
+
+--- Covers UnitDetected and UnitUndetected across every sensor level and filter.
+---
+--- Detection levels escalate: unseen -> seismic -> radar -> vision, and a unit sits at
+--- exactly one of them per allyTeam. A trigger without sensorTypes watches all of them,
+--- so it reports first contact and total loss. A trigger with sensorTypes watches a
+--- subset, so a unit that *improves* from radar to vision leaves a radar-only trigger
+--- and reads as undetected there. Both behaviours are exercised below.
+---
+--- Player sensors (allyTeam 0), placed ~2900 apart so no target sits in two at once:
+---   armsd  at (1800, 1800)  seismic 2000, sight 240, no radar
+---   armrad at (4700, 2000)  radar 2100, sight  680
+--- A fusion plant backs each side: armsd draws upkeep, and the spy needs energy to
+--- stay cloaked while it moves.
+---
+--- Targets (team 1):
+---   spy          armspy, cloaked. stealth = true keeps it off radar and cloak keeps it
+---                out of vision, so seismic is the only level that can ever see it. This
+---                is what armsd exists for. cornecro is also stealth = true, but its
+---                seismicsignature is 0, so armsd would never hear it.
+---   radarTarget  corfast, parked inside radar range but outside armrad's sight.
+---   visionTarget corfast, driven all the way into armrad's sight.
+---   deathTarget  corak, spawned inside radar and destroyed there without ever moving.
+---
+--- Triggers whose message starts with "BUG:" are canaries and must never fire.
+
+local triggers = {
+
+	----------------------------------------------------------------
+	--- Setup ------------------------------------------------------
+
+	placeSensors = {
+		type = triggerTypes.TimeElapsed,
+		parameters = { seconds = 1 },
+		actions = { 'spawnSensors', 'spawnEnergy' },
+	},
+
+	-- Targets start outside every sensor, so each one produces a real unseen -> detected edge.
+	placeTargets = {
+		type = triggerTypes.TimeElapsed,
+		parameters = { seconds = 3 },
+		actions = { 'spawnTargets' },
+	},
+
+	-- Each target drives in and straight back out on one queued pair of moves, so the
+	-- detect and undetect edges come from travel rather than from a second timer.
+	sendTargets = {
+		type = triggerTypes.TimeElapsed,
+		parameters = { seconds = 6 },
+		actions = { 'moveSpy', 'moveRadarTarget', 'moveVisionTarget' },
+	},
+
+	-- Late enough that deathTarget has certainly been detected, early enough that it dies
+	-- while still held on radar rather than after drifting off sensors.
+	killDeathTarget = {
+		type = triggerTypes.TimeElapsed,
+		parameters = { seconds = 25 },
+		actions = { 'destroyDeathTarget' },
+	},
+
+	----------------------------------------------------------------
+	--- Any sensor: sensorTypes omitted ----------------------------
+
+	-- Watches every level but unseen, so this is first contact and total loss.
+	anyDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageAnyDetected' },
+	},
+
+	anyUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'radarTarget',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageAnyUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- Radar ------------------------------------------------------
+
+	radarDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'radar' },
+		},
+		actions = { 'messageRadarDetected' },
+	},
+
+	-- The target never enters armrad's sight, so this is a genuine loss of contact and
+	-- should land in the same frame as anyUndetected.
+	radarUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'radarTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'radar' },
+		},
+		actions = { 'messageRadarUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- Vision -----------------------------------------------------
+
+	visionDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'vision' },
+		},
+		actions = { 'messageVisionDetected' },
+	},
+
+	-- Fires as the target leaves armrad's sight, while it is still on radar. "Undetected by
+	-- vision" means "no longer at the vision level", not "gone".
+	visionUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'vision' },
+		},
+		actions = { 'messageVisionUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- Seismic ----------------------------------------------------
+
+	-- Seismic pings need a *moving* ground unit, which the drive in and out provides.
+	-- Falloff is scored over half-second intervals, so the undetect lands a few seconds
+	-- after the spy leaves the ring.
+	seismicDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'spy',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'seismic' },
+		},
+		actions = { 'messageSeismicDetected' },
+	},
+
+	seismicUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'spy',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'seismic' },
+		},
+		actions = { 'messageSeismicUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- A mask of several sensors ----------------------------------
+
+	-- The target enters radar and then improves to vision. Both levels are inside this
+	-- mask, so the improvement is not a boundary: this fires once going in and once going
+	-- out, unlike the vision-only pair above.
+	radarOrVisionDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'radar', 'vision' },
+		},
+		actions = { 'messageRadarOrVisionDetected' },
+	},
+
+	radarOrVisionUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'radar', 'vision' },
+		},
+		actions = { 'messageRadarOrVisionUndetected' },
+	},
+
+	-- A mask with a hole in it. The target passes through radar on its way to vision and
+	-- again on its way out, and radar sits between the two watched levels. If the mask were
+	-- ever treated as a range rather than a set, these would behave like the omitted pair
+	-- below; instead they must match the vision-only pair, ignoring both radar crossings.
+	seismicOrVisionDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'seismic', 'vision' },
+		},
+		actions = { 'messageSeismicOrVisionDetected' },
+	},
+
+	seismicOrVisionUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'seismic', 'vision' },
+		},
+		actions = { 'messageSeismicOrVisionUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- Climbing and dropping inside one mask ----------------------
+
+	-- The same target as the pairs above, but watching every level. Omitting sensorTypes
+	-- watches seismic, radar and vision at once, so the climb from radar to vision and the
+	-- drop back to radar are both movement *within* the mask and neither is an edge. This
+	-- pair must fire exactly twice for the whole run: once on first contact and once when
+	-- the target leaves every sensor. A drop to a lower level is not an undetection.
+	anyLevelDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageAnyLevelDetected' },
+	},
+
+	anyLevelUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'visionTarget',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageAnyLevelUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- Death is not a loss of detection ---------------------------
+
+	-- Spawned already inside radar and never moved, so it is detected on the first sweep.
+	deathDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'deathTarget',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageDeathDetected' },
+	},
+
+	-- Canary: the unit is destroyed while still detected. The engine treats death as death,
+	-- not as a sensor edge, so the latch is dropped without reporting and this must not fire.
+	-- messageDeathDetected proves the unit really was detected, so this silence means
+	-- something.
+	deathUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'deathTarget',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageDeathUndetected' },
+	},
+
+	----------------------------------------------------------------
+	--- Filters ----------------------------------------------------
+
+	-- No sensorAllyTeam: any allyTeam other than the unit's own may detect it. The owner is
+	-- skipped, because an allyTeam always has vision of its own units. For an enemy target
+	-- that leaves the player's sensors, so these should agree with the anyDetected pair.
+	unscopedDetected = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+		},
+		actions = { 'messageUnscopedDetected' },
+	},
+
+	unscopedUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'radarTarget',
+		},
+		actions = { 'messageUnscopedUndetected' },
+	},
+
+	owningTeamMatches = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+			owningTeamID = 1,
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageOwningTeamMatches' },
+	},
+
+	-- The filters apply to UnitUndetected exactly as they do to UnitDetected.
+	owningTeamUndetected = {
+		type = triggerTypes.UnitUndetected,
+		parameters = {
+			unitName = 'radarTarget',
+			owningTeamID = 1,
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageOwningTeamUndetected' },
+	},
+
+	-- Canary: the target belongs to team 1, so filtering on team 0 must never fire.
+	owningTeamExcludes = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+			owningTeamID = 0,
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageOwningTeamExcludes' },
+	},
+
+	-- Both name filters at once: they must agree on the same unit.
+	bothNameFilters = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+			unitDefName = 'corfast',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageBothNameFilters' },
+	},
+
+	-- requiresOneOf is satisfied by unitDefName alone. Both corfast targets match, so this
+	-- reports whichever of them is detected first.
+	unitDefNameOnly = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitDefName = 'corfast',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageUnitDefNameOnly' },
+	},
+
+	-- Canary: no armpw is ever spawned, so a unitDefName filter on one must never match.
+	unitDefNameExcludes = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitDefName = 'armpw',
+			sensorAllyTeam = 0,
+		},
+		actions = { 'messageUnitDefNameExcludes' },
+	},
+
+	-- Canary: the radar target never comes within 3300 of armsd, whose ring is 2000, and it
+	-- holds radar the whole time it is on any sensor at all. A sensorTypes set must reject
+	-- the levels it does not name, so watching seismic alone must never see this unit.
+	wrongSensorExcludes = {
+		type = triggerTypes.UnitDetected,
+		parameters = {
+			unitName = 'radarTarget',
+			sensorAllyTeam = 0,
+			sensorTypes = { 'seismic' },
+		},
+		actions = { 'messageWrongSensorExcludes' },
+	},
+}
+
+local actions = {
+
+	----------------------------------------------------------------
+	--- Setup ------------------------------------------------------
+
+	spawnSensors = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armsd', x = 1800, z = 1800, team = 0 },
+				{ unitDefName = 'armrad', x = 4700, z = 2000, team = 0 },
+			},
+		},
+	},
+
+	spawnEnergy = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armfus', x = 1800, z = 1600, team = 0 },
+				{ unitDefName = 'armfus', x = 3900, z = 6000, team = 1 },
+			},
+		},
+	},
+
+	spawnTargets = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armspy', x = 1800, z = 4600, team = 1, unitName = 'spy' },
+				{ unitDefName = 'corfast', x = 4500, z = 4900, team = 1, unitName = 'radarTarget' },
+				{ unitDefName = 'corfast', x = 4900, z = 4900, team = 1, unitName = 'visionTarget' },
+				-- 1600 from armrad: inside radar 2100, outside sight 680, and 3400 from
+				-- armsd so it is out of seismic. Detected where it stands, then destroyed.
+				{ unitDefName = 'corak', x = 4700, z = 3600, team = 1, unitName = 'deathTarget' },
+			},
+		},
+	},
+
+	destroyDeathTarget = {
+		type = actionTypes.DestroyUnits,
+		parameters = { unitName = 'deathTarget' },
+	},
+
+	----------------------------------------------------------------
+	--- Movement ---------------------------------------------------
+
+	-- Spawned 2800 from armsd, turns at 1500: inside seismic 2000, far outside its
+	-- sight of 240. Cloak is a state command, so it does not take a queue slot.
+	moveSpy = {
+		type = actionTypes.IssueOrders,
+		parameters = {
+			unitName = 'spy',
+			orders = {
+				{ CMD.CLOAK, 1 },
+				{ CMD.MOVE, { 1800, 0, 3300 } },
+				{ CMD.MOVE, { 1800, 0, 4600 }, { 'shift' } },
+			},
+		},
+	},
+
+	-- Spawned 2900 from armrad, turns at 1400: inside radar 2100 but outside sight 680,
+	-- so it never reaches the vision level.
+	moveRadarTarget = {
+		type = actionTypes.IssueOrders,
+		parameters = {
+			unitName = 'radarTarget',
+			orders = {
+				{ CMD.MOVE, { 4700, 0, 3400 } },
+				{ CMD.MOVE, { 4500, 0, 4900 }, { 'shift' } },
+			},
+		},
+	},
+
+	-- Spawned 2900 from armrad, turns at 500: crosses radar on the way in and ends up
+	-- inside sight 680, so it reaches the vision level and drops back through radar.
+	moveVisionTarget = {
+		type = actionTypes.IssueOrders,
+		parameters = {
+			unitName = 'visionTarget',
+			orders = {
+				{ CMD.MOVE, { 4700, 0, 2500 } },
+				{ CMD.MOVE, { 4900, 0, 4900 }, { 'shift' } },
+			},
+		},
+	},
+
+	----------------------------------------------------------------
+	--- Messages ---------------------------------------------------
+
+	messageAnyDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by any sensor: radar target made first contact." },
+	},
+
+	messageAnyUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected by any sensor: radar target contact lost entirely." },
+	},
+
+	messageRadarDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by radar." },
+	},
+
+	messageRadarUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected by radar: left radar range." },
+	},
+
+	messageVisionDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by vision." },
+	},
+
+	messageVisionUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected by vision: dropped to radar, still on sensors." },
+	},
+
+	messageSeismicDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by seismic: cloaked spy heard while moving." },
+	},
+
+	messageSeismicUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected by seismic: spy left the ring and fell off." },
+	},
+
+	messageRadarOrVisionDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by radar or vision: entered the mask at radar." },
+	},
+
+	messageRadarOrVisionUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected by radar or vision: left both, not merely one." },
+	},
+
+	messageSeismicOrVisionDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by seismic or vision: a mask with radar missing from the middle." },
+	},
+
+	messageSeismicOrVisionUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected by seismic or vision: dropped into the unwatched radar level." },
+	},
+
+	messageAnyLevelDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected watching every level: first contact at radar." },
+	},
+
+	messageAnyLevelUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected watching every level: only after leaving all of them." },
+	},
+
+	messageDeathDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected the target that will be destroyed while detected." },
+	},
+
+	messageDeathUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "BUG: destroying a detected unit reported a loss of detection." },
+	},
+
+	messageUnscopedDetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected without a sensorAllyTeam: seen by a non-owning allyTeam." },
+	},
+
+	messageUnscopedUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected without a sensorAllyTeam." },
+	},
+
+	messageOwningTeamMatches = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "owningTeamID matched the target's team." },
+	},
+
+	messageOwningTeamUndetected = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Undetected with an owningTeamID filter." },
+	},
+
+	messageOwningTeamExcludes = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "BUG: owningTeamID filter let through a unit of another team." },
+	},
+
+	messageBothNameFilters = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected with unitName and unitDefName both filtering." },
+	},
+
+	messageUnitDefNameOnly = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "Detected by unitDefName alone, without a unitName." },
+	},
+
+	messageUnitDefNameExcludes = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "BUG: unitDefName filter matched a unit def that was never spawned." },
+	},
+
+	messageWrongSensorExcludes = {
+		type = actionTypes.SendMessage,
+		parameters = { message = "BUG: a seismic-only trigger reported a unit held on radar." },
+	},
+}
+
+return {
+	Triggers = triggers,
+	Actions = actions,
+}

--- a/singleplayer/mission-api-tests/unit_triggers_test.lua
+++ b/singleplayer/mission-api-tests/unit_triggers_test.lua
@@ -18,7 +18,7 @@ local triggers = {
 			maxRepeats = 77,
 		},
 		parameters = {
-			nameRequired = 'bots',
+			unitName = 'bots',
 			teamID = 0,
 			unitDefName = 'armpw',
 			duration = 60,
@@ -35,7 +35,7 @@ local triggers = {
 			prerequisites = { 'unitRessed' },
 		},
 		parameters = {
-			nameRequired = 'bots',
+			unitName = 'bots',
 			teamID = 0,
 			unitDefName = 'armpw',
 			duration = 60,
@@ -71,7 +71,7 @@ local triggers = {
 	botEnteredLocation = {
 		type = triggerTypes.UnitEnteredLocation,
 		parameters = {
-			nameRequired = 'bots',
+			unitName = 'bots',
 			teamID = 0,
 			unitDefName = 'armpw',
 			area = { x1 = 1700, z1 = 2300, x2 = 1900, z2 = 2600 },
@@ -82,13 +82,13 @@ local triggers = {
 	botLeftLocation = {
 		type = triggerTypes.UnitLeftLocation,
 		parameters = {
-			nameRequired = 'bots',
+			unitName = 'bots',
 			teamID = 0,
 			unitDefName = 'armpw',
 			area = { x1 = 1700, z1 = 2300, x2 = 1900, z2 = 2600 },
 		},
 		-- for some reason, CMD.CAPTURE doesn't work in the same frame as either acting unit or its target is spawned
-		actions = { 'messageBotLeftLocation', 'orderDecoysCaptureAndBuild', 'spawnEngineer', 'orderEngineerMove' },
+		actions = { 'messageBotLeftLocation', 'orderDecoysCaptureAndBuild' },
 	},
 
 	unitCaptured = {
@@ -207,74 +207,6 @@ local triggers = {
 		actions = { 'messageRessed' },
 	},
 
-	engineerSpotted = {
-		type = triggerTypes.UnitSpotted,
-		parameters = {
-			unitName = 'engineers',
-			unitDefName = 'corfast',
-			owningTeamID = 1,
-		},
-		actions = { 'messageEngineerSpotted' },
-	},
-
-	engineerUnspotted = {
-		type = triggerTypes.UnitUnspotted,
-		parameters = {
-			unitName = 'engineers',
-			unitDefName = 'corfast',
-			owningTeamID = 1,
-			spottingAllyTeamID = 0,
-		},
-		actions = { 'messageEngineerUnspotted' },
-	},
-
-	engineerDetectedByRadar = {
-		type = triggerTypes.UnitDetected,
-		parameters = {
-			unitName = 'engineers',
-			unitDefName = 'corfast',
-			owningTeamID = 1,
-			sensorTypes = { 'radar' },
-		},
-		actions = { 'messageEngineerDetectedByRadar' },
-	},
-
-	engineerUndetectedByRadar = {
-		type = triggerTypes.UnitUndetected,
-		parameters = {
-			unitName = 'engineers',
-			unitDefName = 'corfast',
-			owningTeamID = 1,
-			sensorAllyTeam = 0,
-			sensorTypes = { 'radar' },
-		},
-		actions = { 'messageEngineerUndetectedByRadar' },
-	},
-
-	engineerDetectedBySeismic = {
-		type = triggerTypes.UnitDetected,
-		settings = {
-			repeating = true,
-		},
-		parameters = {
-			unitName = 'engineers',
-			unitDefName = 'corfast',
-			owningTeamID = 1,
-			sensorTypes = { 'seismic' },
-		},
-		actions = { 'messageEngineerDetectedBySeismic' },
-	},
-
-	engineerUndetectedBySeismic = {
-		type = triggerTypes.UnitUndetected,
-		parameters = {
-			unitName = 'engineers',
-			unitDefName = 'corfast',
-			owningTeamID = 1,
-			sensorTypes = { 'seismic' },
-		},
-		actions = { 'messageEngineerUndetectedBySeismic' },
-	},
 }
 
 local actions = {
@@ -544,67 +476,6 @@ local actions = {
 		},
 	},
 
-	spawnEngineer = {
-		type = actionTypes.SpawnUnits,
-		parameters = {
-			unitLoadout = {
-				{ unitDefName = 'corfast', x = 1500, z = 3400, team = 1, unitName = 'engineers' },
-			},
-		},
-	},
-
-	orderEngineerMove = {
-		type = actionTypes.IssueOrders,
-		parameters = {
-			unitName = 'engineers',
-			orders = {
-				{ CMD.MOVE, { 1600, 0, 2900 }, { 'shift' } },
-				{ CMD.MOVE, { 2000, 0, 3400 }, { 'shift' } },
-			},
-		},
-	},
-
-	messageEngineerSpotted = {
-		type = actionTypes.SendMessage,
-		parameters = {
-			message = "Engineer spotted!",
-		},
-	},
-
-	messageEngineerUnspotted = {
-		type = actionTypes.SendMessage,
-		parameters = {
-			message = "Engineer unspotted!",
-		},
-	},
-
-	messageEngineerDetectedByRadar = {
-		type = actionTypes.SendMessage,
-		parameters = {
-			message = "Engineer detected by radar!",
-		},
-	},
-
-	messageEngineerUndetectedByRadar = {
-		type = actionTypes.SendMessage,
-		parameters = {
-			message = "Engineer undetected by radar!",
-		},
-	},
-
-	messageEngineerDetectedBySeismic = {
-		type = actionTypes.SendMessage,
-		parameters = {
-			message = "Engineer detected by seismic!",
-		},
-	},
-
-	messageEngineerUndetectedBySeismic = {
-		type = actionTypes.SendMessage,
-		parameters = {
-			message = "Engineer undetected by seismic!",
-		},
-	},
 }
 
 return {

--- a/spec/mission_api/detection_levels_spec.lua
+++ b/spec/mission_api/detection_levels_spec.lua
@@ -33,6 +33,9 @@ describe("mission_api.detection_levels", function()
 		Spring.GetAllyTeamList = function() return { 0, 1, 2 } end
 		Spring.GetGaiaTeamID = function() return 2 end
 		Spring.GetTeamAllyTeamID = function(teamID) return teamID end
+		-- Tests drive LOS per allyTeam directly, so units are owned by Gaia, which never
+		-- senses. Tests about the owner's own vision override this.
+		Spring.GetUnitAllyTeam = function(_unitID) return 2 end
 		-- The module resolves the allyTeam layout at load, so each test reloads it after
 		-- the stubs above are in place. The reload also leaves the latch table empty.
 		DetectionLevels = VFS.Include('luarules/mission_api/detection_levels.lua')

--- a/spec/mission_api/triggers/construction_progress_spec.lua
+++ b/spec/mission_api/triggers/construction_progress_spec.lua
@@ -235,24 +235,6 @@ describe("mission_api.triggers.construction_progress", function()
 		assert.are.equal(0, fired())
 	end)
 
-	-- These describe the removed UnitBuildStepPost callin, which was handed the frame's net
-	-- build step. UnitBuildStepPost receives only a unitID, so the trigger cannot currently
-	-- tell building from reclaiming: a nanoframe reclaimed down past the threshold still
-	-- fires. Pending until the gadget passes the step delta again.
-	pending("ignores a frame whose steps net a loss", function()
-		local context, fired = newContext()
-		building(100, 0.6)
-		step(trigger({ teamID = 0, progress = 0.5, unitDefName = "armsolar" }), context, 100, -0.1)
-		assert.are.equal(0, fired())
-	end)
-
-	pending("ignores a frame whose steps net zero", function()
-		local context, fired = newContext()
-		building(100, 0.6)
-		step(trigger({ teamID = 0, progress = 0.5, unitDefName = "armsolar" }), context, 100, 0)
-		assert.are.equal(0, fired())
-	end)
-
 	it("forgets a unit when it is removed, so a reused unit ID arms again", function()
 		local context, fired = newContext()
 		local t = trigger({ teamID = 0, progress = 0.5, unitDefName = "armsolar" })

--- a/spec/mission_api/triggers/construction_progress_spec.lua
+++ b/spec/mission_api/triggers/construction_progress_spec.lua
@@ -9,7 +9,7 @@ GG["MissionAPI"].Modules.ParameterTypes = VFS.Include("luarules/mission_api/para
 _G.UnitDefs = { { name = "armsolar" }, { name = "armwar" } }
 
 local constructionProgress = VFS.Include("luarules/mission_api/triggers/construction_progress.lua")
-local onUnitBuildStep = constructionProgress.callins.UnitBuildStepTotal
+local onUnitBuildStep = constructionProgress.callins.UnitBuildStepPost
 local onMetaUnitRemoved = constructionProgress.callins.MetaUnitRemoved
 
 describe("mission_api.triggers.construction_progress", function()
@@ -235,14 +235,18 @@ describe("mission_api.triggers.construction_progress", function()
 		assert.are.equal(0, fired())
 	end)
 
-	it("ignores a frame whose steps net a loss", function()
+	-- These describe the removed UnitBuildStepTotal callin, which was handed the frame's net
+	-- build step. UnitBuildStepPost receives only a unitID, so the trigger cannot currently
+	-- tell building from reclaiming: a nanoframe reclaimed down past the threshold still
+	-- fires. Pending until the gadget passes the step delta again.
+	pending("ignores a frame whose steps net a loss", function()
 		local context, fired = newContext()
 		building(100, 0.6)
 		step(trigger({ teamID = 0, progress = 0.5, unitDefName = "armsolar" }), context, 100, -0.1)
 		assert.are.equal(0, fired())
 	end)
 
-	it("ignores a frame whose steps net zero", function()
+	pending("ignores a frame whose steps net zero", function()
 		local context, fired = newContext()
 		building(100, 0.6)
 		step(trigger({ teamID = 0, progress = 0.5, unitDefName = "armsolar" }), context, 100, 0)

--- a/spec/mission_api/triggers/construction_progress_spec.lua
+++ b/spec/mission_api/triggers/construction_progress_spec.lua
@@ -235,7 +235,7 @@ describe("mission_api.triggers.construction_progress", function()
 		assert.are.equal(0, fired())
 	end)
 
-	-- These describe the removed UnitBuildStepTotal callin, which was handed the frame's net
+	-- These describe the removed UnitBuildStepPost callin, which was handed the frame's net
 	-- build step. UnitBuildStepPost receives only a unitID, so the trigger cannot currently
 	-- tell building from reclaiming: a nanoframe reclaimed down past the threshold still
 	-- fires. Pending until the gadget passes the step delta again.

--- a/spec/mission_api/triggers/unit_detected_spec.lua
+++ b/spec/mission_api/triggers/unit_detected_spec.lua
@@ -42,6 +42,10 @@ describe("mission_api.triggers.unit_detected", function()
 		Spring.GetUnitIsDead = function(_unitID) return false end
 		Spring.GetUnitDefID = function(_unitID) return 1 end -- 'armpw', read back on an edge
 		Spring.GetUnitTeam = function(_unitID) return 3 end
+		-- These tests set LOS explicitly per allyTeam. The default owner is an allyTeam that
+		-- never senses, so ownership does not mask those setups; tests about the owner's own
+		-- vision override this.
+		Spring.GetUnitAllyTeam = function(_unitID) return GAIA_ALLY end
 	end)
 
 	local function freshTriggerID()
@@ -174,6 +178,26 @@ describe("mission_api.triggers.unit_detected", function()
 			local unitID = freshUnitID()
 			seeUnit(unitID, OTHER_ALLY)
 			update(trigger({ unitDefName = 'armpw' }), freshTriggerID(), context, { unitID })
+			assert.are.equal(1, fired())
+		end)
+
+		-- An allyTeam always has vision of its own units. Counting that would report every unit
+		-- as seen by every sensor, which silently disables sensorTypes and UnitUndetected.
+		it("ignores the owning allyTeam's own vision, absent a sensorAllyTeam", function()
+			local context, fired = newContext()
+			local unitID = freshUnitID()
+			Spring.GetUnitAllyTeam = function(_unitID) return OTHER_ALLY end
+			seeUnit(unitID, OTHER_ALLY)
+			update(trigger({ unitDefName = 'armpw' }), freshTriggerID(), context, { unitID })
+			assert.are.equal(0, fired())
+		end)
+
+		it("still reports a radar contact the owner cannot mask, absent a sensorAllyTeam", function()
+			local context, fired = newContext()
+			local unitID = freshUnitID()
+			Spring.GetUnitAllyTeam = function(_unitID) return OTHER_ALLY end
+			losStatus[unitID] = { [OTHER_ALLY] = INLOS, [SENSOR_ALLY] = INRADAR }
+			update(trigger({ unitDefName = 'armpw', sensorTypes = { radar = true } }), freshTriggerID(), context, { unitID })
 			assert.are.equal(1, fired())
 		end)
 	end)

--- a/spec/mission_api/triggers/unit_undetected_spec.lua
+++ b/spec/mission_api/triggers/unit_undetected_spec.lua
@@ -42,6 +42,10 @@ describe("mission_api.triggers.unit_undetected", function()
 		Spring.GetUnitIsDead = function(_unitID) return false end
 		Spring.GetUnitDefID = function(_unitID) return 1 end -- 'armpw', read back on an edge
 		Spring.GetUnitTeam = function(_unitID) return 3 end
+		-- These tests set LOS explicitly per allyTeam. The default owner is an allyTeam that
+		-- never senses, so ownership does not mask those setups; tests about the owner's own
+		-- vision override this.
+		Spring.GetUnitAllyTeam = function(_unitID) return GAIA_ALLY end
 	end)
 
 	local function freshTriggerID()


### PR DESCRIPTION

### Work done

- Combine double `gadget:GameFramePost` in `api_missions_triggers.lua`.
- detection_levels no longer count the unit's own allyTeam when no sensorAllyTeam is named.
- `construction_progress_spec.lua` no longer calls non-existant `callins.UnitBuildStepTotal`
- Detection specs stub Spring.GetUnitAllyTeam themselves, so no longer rely on global state from other specs

#### Test steps
- [ ] Run `unit_detection_test.lua` and watch.

### AI / LLM usage statement:

Bug analysis and test case generation.