### PR TITLE
Fix ruin geo spawn snap so they are upgradable

### DIFF
--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -254,6 +254,12 @@ function getNearestBlocker(x, z)
 	return math.sqrt(lowestDist)
 end
 
+-- CreateUnit does not snap; Pos2BuildPos uses even vs odd grid from footprint parity.
+local function createSnappedUnit(defID, x, y, z, facing, teamID)
+	x, y, z = Spring.Pos2BuildPos(defID, x, y, z, facing)
+	return Spring.CreateUnit(defID, x, y, z, facing, teamID)
+end
+
 local function spawnRuin(ruin, posx, posy, posz, blueprintTierLevel)
 	local swapXandY, flipX, flipZ, rotation = randomlyRotateBlueprint()
 	local mirrored, mirroredDirection, xOffset, zOffset
@@ -285,16 +291,11 @@ local function spawnRuin(ruin, posx, posy, posz, blueprintTierLevel)
 			local nonscavname = string.gsub(name, "_scav", "")
 			local r = math.random(1, 100)
 			if r < 40 and UnitDefNames[nonscavname] then
-				local posy =
-					Spring.GetGroundHeight(posx + (xOffset * flipX * mirrorX), posz + (zOffset * flipZ * mirrorZ))
-				local unit = Spring.CreateUnit(
-					UnitDefNames[nonscavname].id,
-					posx + (xOffset * flipX * mirrorX),
-					posy,
-					posz + (zOffset * flipZ * mirrorZ),
-					(building.direction + rotation + mirrorRotation) % 4,
-					GaiaTeamID
-				)
+				local facing = (building.direction + rotation + mirrorRotation) % 4
+				local bx = posx + (xOffset * flipX * mirrorX)
+				local bz = posz + (zOffset * flipZ * mirrorZ)
+				local posy = Spring.GetGroundHeight(bx, bz)
+				local unit = createSnappedUnit(UnitDefNames[nonscavname].id, bx, posy, bz, facing, GaiaTeamID)
 				if unit then
 					local radarRange = UnitDefs[building.unitDefID].radarDistance
 					local canMove = UnitDefs[building.unitDefID].canMove
@@ -371,7 +372,8 @@ local function SpawnMexes(mexSpots)
 
 			if canBuildHere then
 				local mex = mexesList[math.random(1, #mexesList)]
-				local unit = Spring.CreateUnit(UnitDefNames[mex].id, posx, posy, posz, math.random(0, 3), GaiaTeamID)
+				local facing = math.random(0, 3)
+				local unit = createSnappedUnit(UnitDefNames[mex].id, posx, posy, posz, facing, GaiaTeamID)
 				if unit then
 					Spring.SetUnitNeutral(unit, true)
 					Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)
@@ -401,7 +403,6 @@ local function SpawnGeos(geoSpots)
 			local geo = geosList[math.random(1, #geosList)]
 			local defID = UnitDefNames[geo].id
 			local facing = math.random(0, 3)
-			-- 5x5 geos must use the odd (8-mod-16) grid to be upgradable.
 			posx, posy, posz = Spring.Pos2BuildPos(defID, posx, posy, posz, facing)
 
 			local radius = 32
@@ -428,7 +429,7 @@ local function SpawnGeos(geoSpots)
 			end
 
 			if canBuildHere then
-				local unit = Spring.CreateUnit(defID, posx, posy, posz, facing, GaiaTeamID)
+				local unit = createSnappedUnit(defID, posx, posy, posz, facing, GaiaTeamID)
 				if unit then
 					Spring.SetUnitNeutral(unit, true)
 					Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)
@@ -487,14 +488,8 @@ local function SpawnMexGeoRandomStructures()
 
 					if canBuildHere then
 						local defence = defencesList[math.random(1, #defencesList)]
-						local unit = Spring.CreateUnit(
-							UnitDefNames[defence].id,
-							posx2,
-							posy2,
-							posz2,
-							math.random(0, 3),
-							GaiaTeamID
-						)
+						local facing = math.random(0, 3)
+						local unit = createSnappedUnit(UnitDefNames[defence].id, posx2, posy2, posz2, facing, GaiaTeamID)
 						if unit then
 							Spring.SetUnitNeutral(unit, true)
 							Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)
@@ -552,14 +547,8 @@ local function SpawnMexGeoRandomStructures()
 
 					if canBuildHere then
 						local defence = defencesList[math.random(1, #defencesList)]
-						local unit = Spring.CreateUnit(
-							UnitDefNames[defence].id,
-							posx2,
-							posy2,
-							posz2,
-							math.random(0, 3),
-							GaiaTeamID
-						)
+						local facing = math.random(0, 3)
+						local unit = createSnappedUnit(UnitDefNames[defence].id, posx2, posy2, posz2, facing, GaiaTeamID)
 						if unit then
 							Spring.SetUnitNeutral(unit, true)
 							Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)
@@ -614,8 +603,8 @@ local function SpawnRandomStructures()
 
 			if canBuildHere then
 				local defence = defencesList[math.random(1, #defencesList)]
-				local unit =
-					Spring.CreateUnit(UnitDefNames[defence].id, posx, posy, posz, math.random(0, 3), GaiaTeamID)
+				local facing = math.random(0, 3)
+				local unit = createSnappedUnit(UnitDefNames[defence].id, posx, posy, posz, facing, GaiaTeamID)
 				if unit then
 					Spring.SetUnitNeutral(unit, true)
 					Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)

--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -398,6 +398,12 @@ local function SpawnGeos(geoSpots)
 				geosList = seaGeosList
 			end
 
+			local geo = geosList[math.random(1, #geosList)]
+			local defID = UnitDefNames[geo].id
+			local facing = math.random(0, 3)
+			-- 5x5 geos must use the odd (8-mod-16) grid to be upgradable.
+			posx, posy, posz = Spring.Pos2BuildPos(defID, posx, posy, posz, facing)
+
 			local radius = 32
 			local canBuildHere = positionCheckLibrary.VisibilityCheckEnemy(
 				posx,
@@ -422,8 +428,7 @@ local function SpawnGeos(geoSpots)
 			end
 
 			if canBuildHere then
-				local geo = geosList[math.random(1, #geosList)]
-				local unit = Spring.CreateUnit(UnitDefNames[geo].id, posx, posy, posz, math.random(0, 3), GaiaTeamID)
+				local unit = Spring.CreateUnit(defID, posx, posy, posz, facing, GaiaTeamID)
 				if unit then
 					Spring.SetUnitNeutral(unit, true)
 					Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)

--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -489,7 +489,8 @@ local function SpawnMexGeoRandomStructures()
 					if canBuildHere then
 						local defence = defencesList[math.random(1, #defencesList)]
 						local facing = math.random(0, 3)
-						local unit = createSnappedUnit(UnitDefNames[defence].id, posx2, posy2, posz2, facing, GaiaTeamID)
+						local unit =
+							createSnappedUnit(UnitDefNames[defence].id, posx2, posy2, posz2, facing, GaiaTeamID)
 						if unit then
 							Spring.SetUnitNeutral(unit, true)
 							Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)
@@ -548,7 +549,8 @@ local function SpawnMexGeoRandomStructures()
 					if canBuildHere then
 						local defence = defencesList[math.random(1, #defencesList)]
 						local facing = math.random(0, 3)
-						local unit = createSnappedUnit(UnitDefNames[defence].id, posx2, posy2, posz2, facing, GaiaTeamID)
+						local unit =
+							createSnappedUnit(UnitDefNames[defence].id, posx2, posy2, posz2, facing, GaiaTeamID)
 						if unit then
 							Spring.SetUnitNeutral(unit, true)
 							Spring.GiveOrderToUnit(unit, CMD.FIRE_STATE, { 1 }, 0)


### PR DESCRIPTION
Buildings are snapped to a grid based on their size. Odd sized buildings (like 5x5 geos) use the odd grid (8-elmo offset) in snap. Even sided buildings (like mex) use the even grid (0 elmo offset). 

When spawning ruins, it universally uses the 0 elmo offset. 

For most buildings, this has no practical difference. For mex and geo, in order to be upgradable, they need to sit at the expected positions, otherwise, all the possible snapped positions from the existing widgets will always be off. Mex already are at the expected positions. Geo aren't. 

This one was a pain in the ass to figure out. 

Before:
if you capture geo, it was not upgradable nor side-upgradable

After:
<img width="1338" height="1155" alt="image" src="https://github.com/user-attachments/assets/cd66dc53-4c5c-4c8d-ace8-3561fa019099" />

A lot of AI use to figure this shit out. Handwrote it after.


cc @Damgam 