### PR TITLE
Detect Apple Silicon as capable GPU

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -75,6 +75,8 @@ elseif Platform.glHaveAMD then
 		isPotatoGpu = true
 		gpuMem = 0 -- AMD integrated can report incorrect gpuMemorySize, so set to 0 to avoid false positives for low VRAM
 	end
+elseif string.find(glRendererLower, "apple m") then
+	-- Apple Silicon via zink reports vendor Mesa: "zink Vulkan 1.3(Apple M3 Max (MESA_KOSMICKRISP))"
 else
 	-- Unknown/Mesa vendor without specific detection — assume low-end
 	isPotatoGpu = true


### PR DESCRIPTION
### Work done
Apple Silicon Macs running BAR through the unofficial macOS port report GL vendor "Mesa" via zink, so the GPU check lands in the unknown vendor and every M chip gets branded low end. On first launch that writes the potato defaults. This adds a vendor branch that recognizes the renderer string "zink Vulkan 1.3(Apple M3 Max (MESA_KOSMICKRISP))" and leaves the defaults alone.

#### Test steps
- [ ] On non Mac platforms nothing changes, the new branch is unreachable for NVidia/Intel/AMD/unknown vendors.
- [ ] On an Apple Silicon Mac with the port: remove springsettings.cfg, launch, check graphics settings. Expected: standard defaults instead of water 0 and shadows 0.
