### PR TITLE
Place AI and PvE spawns inside the real start box shape

### DIFF
--- a/luarules/gadgets/game_coop_II.lua
+++ b/luarules/gadgets/game_coop_II.lua
@@ -21,6 +21,8 @@ if gadgetHandler:IsSyncedCode() then
 	----------------------------------------------------------------
 	-- Synced Var
 	----------------------------------------------------------------
+	local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
+
 	local coopStartPoints = {} -- coopStartPoints[playerID] = {x,y,z}, also acts as is-player-a-coop-player
 	GG.coopStartPoints = coopStartPoints -- Share to other gadgets
 
@@ -81,9 +83,7 @@ if gadgetHandler:IsSyncedCode() then
 			local _, _, _, teamID, allyID = Spring.GetPlayerInfo(playerID, false)
 			local osx, _, osz = Spring.GetTeamStartPosition(teamID)
 			if x ~= osx or z ~= osz then
-				local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(allyID)
-				x = math.clamp(x, xmin, xmax)
-				z = math.clamp(z, zmin, zmax)
+				x, z = StartboxLib.ClosestPos(allyID, x, z)
 
 				SetCoopStartPoint(playerID, x, Spring.GetGroundHeight(x, z), z) -- record coop start point, display it
 				return false
@@ -140,22 +140,19 @@ if gadgetHandler:IsSyncedCode() then
 		end
 
 		if x <= 0 or z <= 0 then --TODO: improve this
-			local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(allyID)
 			local tx, tz
 			if GG.teamStartPoints then
 				tx = GG.teamStartPoints[teamID][1]
 				tz = GG.teamStartPoints[teamID][3]
 			else
-				tx = (xmin + xmax) / 2
-				tz = (zmin + zmax) / 2
+				tx, tz = StartboxLib.GetCenter(allyID)
 			end
 			local thetaStart = math.random(15) - 1
 			for theta = thetaStart, 15 + thetaStart do
 				local sx = tx + 45 * math.cos((math.pi / 8) * theta)
 				local sz = tz + 45 * math.sin((math.pi / 8) * theta)
 				if not IsSteep(sx, sz) then
-					x = math.clamp(sx, xmin, xmax)
-					x = math.clamp(sz, zmin, zmax)
+					x, z = StartboxLib.ClosestPos(allyID, sx, sz)
 					break
 				else -- fallback
 					x = tx

--- a/luarules/gadgets/game_startbox_config.lua
+++ b/luarules/gadgets/game_startbox_config.lua
@@ -23,7 +23,8 @@ local configSource
 local isExplicitConfig = false
 
 function gadget:Initialize()
-	local ParseBoxes = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
+	local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
+	local ParseBoxes = StartboxLib.ParseBoxes
 	local ok, config, source, isExplicit = pcall(ParseBoxes)
 	if ok then
 		startBoxConfig = config

--- a/luarules/gadgets/include/SpawnerEnemyLib.lua
+++ b/luarules/gadgets/include/SpawnerEnemyLib.lua
@@ -34,18 +34,4 @@ EnemyLib.GetAdjustedStartBox = function(enemyAllyTeamID, spread)
 	return startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax
 end
 
--- The bounds above are only a sampling window for a shape that may not fill them, so
--- spawners pick through here rather than randomising between the bounds themselves.
-EnemyLib.GetRandomPosInStartBox = function(enemyAllyTeamID, inset, tries)
-	return StartboxLib.GetRandomPos(enemyAllyTeamID, inset, tries)
-end
-
-EnemyLib.HasStartBox = function(enemyAllyTeamID)
-	return StartboxLib.HasStartbox(enemyAllyTeamID)
-end
-
-EnemyLib.IsInStartBox = function(enemyAllyTeamID, x, z)
-	return StartboxLib.IsInside(enemyAllyTeamID, x, z)
-end
-
 return EnemyLib

--- a/luarules/gadgets/include/SpawnerEnemyLib.lua
+++ b/luarules/gadgets/include/SpawnerEnemyLib.lua
@@ -20,13 +20,32 @@ local adjustStartBox = function(startBoxXMin, startBoxZMin, startBoxXMax, startB
 	return startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax
 end
 
+local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
+
+-- Not Spring.GetAllyTeamStartBox: callers ask for this while gadget files are still being
+-- loaded, and the config gadget does not apply the startbox modoption until its Initialize
+-- runs, so the engine still reports whatever the host put in the start script.
 EnemyLib.GetAdjustedStartBox = function(enemyAllyTeamID, spread)
-	local startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax = Spring.GetAllyTeamStartBox(enemyAllyTeamID)
+	local startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax = StartboxLib.GetBounds(enemyAllyTeamID)
 	if startBoxXMin and startBoxZMin and startBoxXMax and startBoxZMax then
 		startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax =
 			adjustStartBox(startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax, spread)
 	end
 	return startBoxXMin, startBoxZMin, startBoxXMax, startBoxZMax
+end
+
+-- The bounds above are only a sampling window for a shape that may not fill them, so
+-- spawners pick through here rather than randomising between the bounds themselves.
+EnemyLib.GetRandomPosInStartBox = function(enemyAllyTeamID, inset, tries)
+	return StartboxLib.GetRandomPos(enemyAllyTeamID, inset, tries)
+end
+
+EnemyLib.HasStartBox = function(enemyAllyTeamID)
+	return StartboxLib.HasStartbox(enemyAllyTeamID)
+end
+
+EnemyLib.IsInStartBox = function(enemyAllyTeamID, x, z)
+	return StartboxLib.IsInside(enemyAllyTeamID, x, z)
 end
 
 return EnemyLib

--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -337,4 +337,206 @@ local function ParseBoxes()
 	return startBoxConfig, configSource, isExplicitSource(configSource)
 end
 
-return ParseBoxes
+--------------------------------------------------------------------------------
+-- Shared accessors
+--
+-- Each of these answers a question about one allyteam's start box without the caller
+-- needing to know whether the boxes came from a modoption or from the engine. That
+-- distinction is what several callers got wrong: Spring.GetAllyTeamStartBox reports the
+-- bounding box of a polygon rather than its shape, and during the gadget load phase it
+-- still reports whatever the host put in the start script, because the config gadget
+-- does not apply the modoption until its Initialize runs. Reading through here is
+-- correct in both phases and on both sides of the sync boundary.
+--------------------------------------------------------------------------------
+
+local PolygonLib = VFS.Include("common/lib_polygon.lua")
+
+local cachedConfig, cachedSource, cachedExplicit
+local haveParsed = false
+
+-- Modoptions and the allyteam list are both fixed for the life of the game, so the parse
+-- happens once however many callers ask for it.
+local function GetConfig()
+	if not haveParsed then
+		haveParsed = true
+		local ok, config, source, explicit = pcall(ParseBoxes)
+		if ok then
+			cachedConfig, cachedSource, cachedExplicit = config, source, explicit
+		else
+			Spring.Log("startbox_utilities", LOG.WARNING, "Could not parse start boxes: " .. tostring(config))
+		end
+	end
+
+	return cachedConfig, cachedSource, cachedExplicit
+end
+
+-- nil unless this allyteam has a polygon worth consulting, so every accessor below
+-- shares one guard before falling back to the engine.
+local function GetEntry(allyTeamID)
+	local config, _, explicit = GetConfig()
+	if not (explicit and config) then
+		return nil
+	end
+
+	local entry = config[allyTeamID]
+	if entry and entry.boxes and #entry.boxes > 0 then
+		return entry
+	end
+
+	return nil
+end
+
+local function GetBounds(allyTeamID)
+	local entry = GetEntry(allyTeamID)
+	if entry then
+		return PolygonLib.GetStartboxBounds(entry)
+	end
+
+	return Spring.GetAllyTeamStartBox(allyTeamID)
+end
+
+local function IsInside(allyTeamID, x, z)
+	local entry = GetEntry(allyTeamID)
+	if entry then
+		return PolygonLib.PointInStartbox(x, z, entry)
+	end
+
+	local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(allyTeamID)
+	if not (xmin and zmin and xmax and zmax) or xmin >= xmax or zmin >= zmax then
+		return true -- no box means nowhere is out of bounds
+	end
+
+	return x >= xmin and x <= xmax and z >= zmin and z <= zmax
+end
+
+-- Callers hand-rolled this by comparing the box against the whole map, one of them
+-- against the wrong axis. A box covering everything restricts nothing, which is what
+-- those callers were really asking about.
+local function HasStartbox(allyTeamID)
+	if GetEntry(allyTeamID) then
+		return true
+	end
+
+	local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(allyTeamID)
+	if not (xmin and zmin and xmax and zmax) or xmin >= xmax or zmin >= zmax then
+		return false
+	end
+
+	return not (xmin <= 0 and zmin <= 0 and xmax >= Game.mapSizeX and zmax >= Game.mapSizeZ)
+end
+
+local function GetCenter(allyTeamID)
+	local entry = GetEntry(allyTeamID)
+	if entry and entry.startpoints and entry.startpoints[1] then
+		return entry.startpoints[1][1], entry.startpoints[1][2]
+	end
+
+	local xmin, zmin, xmax, zmax = GetBounds(allyTeamID)
+	if not (xmin and zmin and xmax and zmax) then
+		return Game.mapSizeX * 0.5, Game.mapSizeZ * 0.5
+	end
+
+	return (xmin + xmax) * 0.5, (zmin + zmax) * 0.5
+end
+
+local DEFAULT_TRIES = 100
+
+-- Rejection sampling inside the bounding box, so the result is uniform over the real
+-- shape rather than over the rectangle around it. inset keeps whatever is being placed
+-- clear of the edge; it is tested on the four cardinal offsets, which is cheaper than
+-- eroding the polygon and good enough for deciding whether something fits.
+--
+-- Returns nil when nothing suitable turned up. Treat that as "no room" rather than
+-- widening the search, or a deliberately small box stops meaning anything.
+local function GetRandomPos(allyTeamID, inset, tries)
+	local xmin, zmin, xmax, zmax = GetBounds(allyTeamID)
+	if not (xmin and zmin and xmax and zmax) then
+		return nil
+	end
+
+	inset = inset or 0
+	xmin, zmin = math.max(xmin + inset, 0), math.max(zmin + inset, 0)
+	xmax, zmax = math.min(xmax - inset, Game.mapSizeX), math.min(zmax - inset, Game.mapSizeZ)
+	if xmin > xmax or zmin > zmax then
+		return nil
+	end
+
+	for _ = 1, (tries or DEFAULT_TRIES) do
+		local x = math.random(xmin, xmax)
+		local z = math.random(zmin, zmax)
+		if
+			IsInside(allyTeamID, x, z)
+			and (
+				inset == 0
+				or (
+					IsInside(allyTeamID, x - inset, z)
+					and IsInside(allyTeamID, x + inset, z)
+					and IsInside(allyTeamID, x, z - inset)
+					and IsInside(allyTeamID, x, z + inset)
+				)
+			)
+		then
+			return x, z
+		end
+	end
+
+	return nil
+end
+
+-- For callers that used to clamp a point into the rectangle. A polygon has no clamp, so
+-- a point outside is pulled onto the nearest edge instead.
+local function ClosestPos(allyTeamID, x, z)
+	if IsInside(allyTeamID, x, z) then
+		return x, z
+	end
+
+	local entry = GetEntry(allyTeamID)
+	if not entry then
+		local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(allyTeamID)
+		if not (xmin and zmin and xmax and zmax) or xmin >= xmax or zmin >= zmax then
+			return x, z
+		end
+
+		return math.clamp(x, xmin, xmax), math.clamp(z, zmin, zmax)
+	end
+
+	local bestX, bestZ, bestDist = x, z, math.huge
+	for i = 1, #entry.boxes do
+		local poly = entry.boxes[i]
+		local n = #poly
+		for j = 1, n do
+			local ax, az = poly[j][1], poly[j][2]
+			local bx, bz = poly[(j % n) + 1][1], poly[(j % n) + 1][2]
+			local ex, ez = bx - ax, bz - az
+			local lenSq = (ex * ex) + (ez * ez)
+			local t = 0
+			if lenSq > 0 then
+				t = math.clamp((((x - ax) * ex) + ((z - az) * ez)) / lenSq, 0, 1)
+			end
+			local px, pz = ax + (ex * t), az + (ez * t)
+			local dx, dz = x - px, z - pz
+			local dist = (dx * dx) + (dz * dz)
+			if dist < bestDist then
+				bestX, bestZ, bestDist = px, pz, dist
+			end
+		end
+	end
+
+	return bestX, bestZ
+end
+
+-- Callable as well as indexable: some callers include this file and call the result as the parser.
+return setmetatable({
+	ParseBoxes = ParseBoxes,
+	GetConfig = GetConfig,
+	GetBounds = GetBounds,
+	GetCenter = GetCenter,
+	HasStartbox = HasStartbox,
+	IsInside = IsInside,
+	GetRandomPos = GetRandomPos,
+	ClosestPos = ClosestPos,
+}, {
+	__call = function(_, ...)
+		return ParseBoxes(...)
+	end,
+})

--- a/luarules/gadgets/pve_supply_drops.lua
+++ b/luarules/gadgets/pve_supply_drops.lua
@@ -6,18 +6,6 @@ local scavengerAllyTeamID = BAR.Utilities.GetScavAllyTeamID()
 
 if BAR.Utilities.Gametype.IsScavengers() then
 	scavengersAIEnabled = true
-	ScavengerStartboxXMin, ScavengerStartboxZMin, ScavengerStartboxXMax, ScavengerStartboxZMax =
-		Spring.GetAllyTeamStartBox(scavengerAllyTeamID)
-	if
-		ScavengerStartboxXMin == 0
-		and ScavengerStartboxZMin == 0
-		and ScavengerStartboxXMax == mapsizeX
-		and ScavengerStartboxZMax == mapsizeZ
-	then
-		ScavengerStartboxExists = false
-	else
-		ScavengerStartboxExists = true
-	end
 end
 
 if

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -21,6 +21,7 @@ end
 
 local config = VFS.Include("LuaRules/Configs/raptor_spawn_defs.lua")
 local EnemyLib = VFS.Include("LuaRules/Gadgets/Include/SpawnerEnemyLib.lua")
+local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -872,7 +873,7 @@ if gadgetHandler:IsSyncedCode() then
 					0.5 * math.min(RaptorStartboxXMax - RaptorStartboxXMin, RaptorStartboxZMax - RaptorStartboxZMin)
 				)
 				for _ = 1, 100 do
-					spawnPosX, spawnPosZ = EnemyLib.GetRandomPosInStartBox(raptorAllyTeamID, spreadStartBox, 1)
+					spawnPosX, spawnPosZ = StartboxLib.GetRandomPos(raptorAllyTeamID, spreadStartBox, 1)
 					if not spawnPosX then
 						break
 					end
@@ -1215,7 +1216,7 @@ if gadgetHandler:IsSyncedCode() then
 		local tries = 0
 		local canSpawnQueen = false
 		repeat
-			x, z = EnemyLib.GetRandomPosInStartBox(raptorAllyTeamID, 0, 1)
+			x, z = StartboxLib.GetRandomPos(raptorAllyTeamID, 0, 1)
 			if not x then
 				break
 			end
@@ -1263,7 +1264,7 @@ if gadgetHandler:IsSyncedCode() then
 			return CreateUnit(config.queenName, x, y, z, mRandom(0, 3), raptorTeamID)
 		else
 			for i = 1, 100 do
-				x, z = EnemyLib.GetRandomPosInStartBox(raptorAllyTeamID, 0, 1)
+				x, z = StartboxLib.GetRandomPos(raptorAllyTeamID, 0, 1)
 				if not x then
 					break
 				end
@@ -2127,7 +2128,7 @@ if gadgetHandler:IsSyncedCode() then
 						"No Raptor start box available, Burrow Placement set to 'Avoid Players'"
 					)
 					noRaptorStartbox = true
-				elseif not EnemyLib.HasStartBox(raptorAllyTeamID) then
+				elseif not StartboxLib.HasStartbox(raptorAllyTeamID) then
 					config.burrowSpawnType = "avoid"
 					Spring.Log(
 						gadget:GetInfo().name,

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -872,8 +872,10 @@ if gadgetHandler:IsSyncedCode() then
 					0.5 * math.min(RaptorStartboxXMax - RaptorStartboxXMin, RaptorStartboxZMax - RaptorStartboxZMin)
 				)
 				for _ = 1, 100 do
-					spawnPosX = mRandom(RaptorStartboxXMin + spreadStartBox, RaptorStartboxXMax - spreadStartBox)
-					spawnPosZ = mRandom(RaptorStartboxZMin + spreadStartBox, RaptorStartboxZMax - spreadStartBox)
+					spawnPosX, spawnPosZ = EnemyLib.GetRandomPosInStartBox(raptorAllyTeamID, spreadStartBox, 1)
+					if not spawnPosX then
+						break
+					end
 					spawnPosY = GetGroundHeight(spawnPosX, spawnPosZ)
 					canSpawnBurrow =
 						positionCheckLibrary.FlatAreaCheck(spawnPosX, spawnPosY, spawnPosZ, spreadStartBox, 30, true)
@@ -1213,8 +1215,10 @@ if gadgetHandler:IsSyncedCode() then
 		local tries = 0
 		local canSpawnQueen = false
 		repeat
-			x = mRandom(RaptorStartboxXMin, RaptorStartboxXMax)
-			z = mRandom(RaptorStartboxZMin, RaptorStartboxZMax)
+			x, z = EnemyLib.GetRandomPosInStartBox(raptorAllyTeamID, 0, 1)
+			if not x then
+				break
+			end
 			y = GetGroundHeight(x, z)
 			tries = tries + 1
 			canSpawnQueen = positionCheckLibrary.FlatAreaCheck(x, y, z, 128, 30, true)
@@ -1259,8 +1263,10 @@ if gadgetHandler:IsSyncedCode() then
 			return CreateUnit(config.queenName, x, y, z, mRandom(0, 3), raptorTeamID)
 		else
 			for i = 1, 100 do
-				x = mRandom(RaptorStartboxXMin, RaptorStartboxXMax)
-				z = mRandom(RaptorStartboxZMin, RaptorStartboxZMax)
+				x, z = EnemyLib.GetRandomPosInStartBox(raptorAllyTeamID, 0, 1)
+				if not x then
+					break
+				end
 				y = GetGroundHeight(x, z)
 
 				canSpawnQueen = positionCheckLibrary.StartboxCheck(x, y, z, raptorAllyTeamID)
@@ -2121,7 +2127,7 @@ if gadgetHandler:IsSyncedCode() then
 						"No Raptor start box available, Burrow Placement set to 'Avoid Players'"
 					)
 					noRaptorStartbox = true
-				elseif lsx1 == 0 and lsz1 == 0 and lsx2 == Game.mapSizeX and lsz2 == Game.mapSizeX then
+				elseif not EnemyLib.HasStartBox(raptorAllyTeamID) then
 					config.burrowSpawnType = "avoid"
 					Spring.Log(
 						gadget:GetInfo().name,

--- a/luarules/gadgets/scav_lootbox_collector.lua
+++ b/luarules/gadgets/scav_lootbox_collector.lua
@@ -75,9 +75,6 @@ local aliveSpawners = {}
 local aliveSpawnersCount = 0
 local lastTransportSentFrame = 0
 local handledLootboxesList = {}
-local RaptorStartboxXMin, RaptorStartboxZMin, RaptorStartboxXMax, RaptorStartboxZMax =
-	Spring.GetAllyTeamStartBox(scavAllyTeamID)
-
 local config = VFS.Include("LuaRules/Configs/scav_spawn_defs.lua")
 
 function gadget:UnitCreated(unitID, unitDefID, unitTeam)

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1149,8 +1149,10 @@ if gadgetHandler:IsSyncedCode() then
 						and ScavStartboxZMin + spread < ScavStartboxZMax - spread
 					then
 						for _ = 1, 100 do
-							spawnPosX = mRandom(ScavStartboxXMin + spread, ScavStartboxXMax - spread)
-							spawnPosZ = mRandom(ScavStartboxZMin + spread, ScavStartboxZMax - spread)
+							spawnPosX, spawnPosZ = EnemyLib.GetRandomPosInStartBox(scavAllyTeamID, spread, 1)
+							if not spawnPosX then
+								break
+							end
 							spawnPosY = Spring.GetGroundHeight(spawnPosX, spawnPosZ)
 							canSpawnBurrow =
 								positionCheckLibrary.FlatAreaCheck(spawnPosX, spawnPosY, spawnPosZ, spread, 30, true)
@@ -1479,8 +1481,10 @@ if gadgetHandler:IsSyncedCode() then
 		local tries = 0
 		local canSpawnBoss = false
 		repeat
-			x = mRandom(ScavStartboxXMin, ScavStartboxXMax)
-			z = mRandom(ScavStartboxZMin, ScavStartboxZMax)
+			x, z = EnemyLib.GetRandomPosInStartBox(scavAllyTeamID, 0, 1)
+			if not x then
+				break
+			end
 			y = GetGroundHeight(x, z)
 			tries = tries + 1
 			canSpawnBoss = positionCheckLibrary.FlatAreaCheck(x, y, z, 128, 30, true)
@@ -1525,8 +1529,10 @@ if gadgetHandler:IsSyncedCode() then
 			return CreateUnit(config.bossName, x, y, z, mRandom(0, 3), scavTeamID)
 		else
 			for i = 1, 100 do
-				x = mRandom(ScavStartboxXMin, ScavStartboxXMax)
-				z = mRandom(ScavStartboxZMin, ScavStartboxZMax)
+				x, z = EnemyLib.GetRandomPosInStartBox(scavAllyTeamID, 0, 1)
+				if not x then
+					break
+				end
 				y = GetGroundHeight(x, z)
 
 				canSpawnBoss = positionCheckLibrary.StartboxCheck(x, y, z, scavAllyTeamID)
@@ -2535,7 +2541,7 @@ if gadgetHandler:IsSyncedCode() then
 						"No Scav start box available, Burrow Placement set to 'Avoid Players'"
 					)
 					noScavStartbox = true
-				elseif lsx1 == 0 and lsz1 == 0 and lsx2 == Game.mapSizeX and lsz2 == Game.mapSizeX then
+				elseif not EnemyLib.HasStartBox(scavAllyTeamID) then
 					config.burrowSpawnType = "avoid"
 					Spring.Log(
 						gadget:GetInfo().name,

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -22,6 +22,7 @@ Spring.SetLogSectionFilterLevel("Dynamic Difficulty", LOG.INFO)
 
 local config = VFS.Include("LuaRules/Configs/scav_spawn_defs.lua")
 local EnemyLib = VFS.Include("LuaRules/Gadgets/Include/SpawnerEnemyLib.lua")
+local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -1149,7 +1150,7 @@ if gadgetHandler:IsSyncedCode() then
 						and ScavStartboxZMin + spread < ScavStartboxZMax - spread
 					then
 						for _ = 1, 100 do
-							spawnPosX, spawnPosZ = EnemyLib.GetRandomPosInStartBox(scavAllyTeamID, spread, 1)
+							spawnPosX, spawnPosZ = StartboxLib.GetRandomPos(scavAllyTeamID, spread, 1)
 							if not spawnPosX then
 								break
 							end
@@ -1481,7 +1482,7 @@ if gadgetHandler:IsSyncedCode() then
 		local tries = 0
 		local canSpawnBoss = false
 		repeat
-			x, z = EnemyLib.GetRandomPosInStartBox(scavAllyTeamID, 0, 1)
+			x, z = StartboxLib.GetRandomPos(scavAllyTeamID, 0, 1)
 			if not x then
 				break
 			end
@@ -1529,7 +1530,7 @@ if gadgetHandler:IsSyncedCode() then
 			return CreateUnit(config.bossName, x, y, z, mRandom(0, 3), scavTeamID)
 		else
 			for i = 1, 100 do
-				x, z = EnemyLib.GetRandomPosInStartBox(scavAllyTeamID, 0, 1)
+				x, z = StartboxLib.GetRandomPos(scavAllyTeamID, 0, 1)
 				if not x then
 					break
 				end
@@ -2541,7 +2542,7 @@ if gadgetHandler:IsSyncedCode() then
 						"No Scav start box available, Burrow Placement set to 'Avoid Players'"
 					)
 					noScavStartbox = true
-				elseif not EnemyLib.HasStartBox(scavAllyTeamID) then
+				elseif not StartboxLib.HasStartbox(scavAllyTeamID) then
 					config.burrowSpawnType = "avoid"
 					Spring.Log(
 						gadget:GetInfo().name,

--- a/luaui/Widgets/camera_startup.lua
+++ b/luaui/Widgets/camera_startup.lua
@@ -1,5 +1,7 @@
 local STARTUP_CAMERA_INITIAL_ZOOM_DISTANCE = 5000
 
+local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
+
 local widget = widget ---@type Widget
 
 function widget:GetInfo()
@@ -40,7 +42,7 @@ function widget:Initialize()
 		xMax = Game.mapSizeX
 		zMax = Game.mapSizeZ
 	else
-		xMin, zMin, xMax, zMax = Spring.GetAllyTeamStartBox(Spring.GetLocalAllyTeamID())
+		xMin, zMin, xMax, zMax = StartboxLib.GetBounds(Spring.GetLocalAllyTeamID())
 	end
 
 	if not xMin or not zMin or not xMax or not zMax then

--- a/luaui/Widgets/gui_pregameui_draft.lua
+++ b/luaui/Widgets/gui_pregameui_draft.lua
@@ -13,6 +13,8 @@ function widget:GetInfo()
 end
 
 -- Localized functions for performance
+local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
+
 local mathFloor = math.floor
 local mathMax = math.max
 local mathRandom = math.random
@@ -1141,11 +1143,7 @@ function widget:Initialize()
 		end
 	end
 
-	local xn, zn, xp, zp = Spring.GetAllyTeamStartBox(myAllyTeamID)
-	local msx, msz = Game.mapSizeX, Game.mapSizeZ
-	if xn and (xn ~= 0 or zn ~= 0 or xp ~= msx or zp ~= msz) then
-		hasStartbox = true
-	end
+	hasStartbox = StartboxLib.HasStartbox(myAllyTeamID)
 
 	widget:ViewResize(vsx, vsy)
 	checkStartPointChosen()

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -44,6 +44,7 @@ local UPDATE_RATE = 30
 
 local noRushTime = 0 -- was a bare read that always resolved nil; 0 matches runtime behavior
 
+local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
 local getCurrentMiniMapRotationOption = VFS.Include("luaui/Include/minimap_utils.lua").getCurrentMiniMapRotationOption
 local ROTATION = VFS.Include("luaui/Include/minimap_utils.lua").ROTATION
 
@@ -911,8 +912,8 @@ local function InitStartPolygons()
 	-- hardcoded fallback fires we defer to the engine startrect path below so
 	-- the lobby/host's rectangles remain authoritative.
 	local configLoaded = false
-	local ok, ParseBoxes = pcall(VFS.Include, "luarules/gadgets/include/startbox_utilities.lua")
-	if ok and ParseBoxes then
+	local ParseBoxes = StartboxLib and StartboxLib.ParseBoxes
+	if ParseBoxes then
 		local pok, startBoxConfig, _, isExplicit = pcall(ParseBoxes)
 		if pok and startBoxConfig and isExplicit then
 			local activeAllyTeams = {}
@@ -1595,9 +1596,8 @@ function widget:MousePress(x, y, button)
 		local aiTeamID = aiCurrentlyBeingPlaced
 		local _, _, _, _, _, aiAllyTeamID = spGetTeamInfo(aiTeamID, false)
 
-		local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(aiAllyTeamID)
-		if xmin < xmax and zmin < zmax then
-			if worldX >= xmin and worldX <= xmax and worldZ >= zmin and worldZ <= zmax then
+		if StartboxLib.HasStartbox(aiAllyTeamID) then
+			if StartboxLib.IsInside(aiAllyTeamID, worldX, worldZ) then
 				Spring.SendLuaRulesMsg("aiPlacedPosition:" .. aiTeamID .. ":" .. worldX .. ":" .. worldZ)
 				aiCurrentlyBeingPlaced = nil
 				return true
@@ -1654,10 +1654,8 @@ function widget:MouseRelease(x, y, button)
 			local finalZ = worldZ + dragOffsetZ
 
 			local _, _, _, _, _, aiAllyTeamID = spGetTeamInfo(draggingTeamID, false)
-			local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(aiAllyTeamID)
-
-			if xmin < xmax and zmin < zmax then
-				if finalX >= xmin and finalX <= xmax and finalZ >= zmin and finalZ <= zmax then
+			if StartboxLib.HasStartbox(aiAllyTeamID) then
+				if StartboxLib.IsInside(aiAllyTeamID, finalX, finalZ) then
 					aiPlacedPositions[draggingTeamID] = { x = finalX, z = finalZ }
 					posCache[draggingTeamID] = nil
 					Spring.SendLuaRulesMsg("aiPlacedPosition:" .. draggingTeamID .. ":" .. finalX .. ":" .. finalZ)


### PR DESCRIPTION
Places AI and PvE spawns inside the real start box shape instead of the engine rectangle.

All of these read the engine's start rectangles, and that source is wrong in two ways. A rectangle describes the box around the shape rather than the shape, so a start box built as a ring drops its spawns in the hole. And they read it as their file loads, before any gadget starts up, so the start box gadget has not applied the modoption yet and the rectangle still holds whatever the host put in the start script. The shared module covers both, and since it used to hand back one parse function and now hands back a table of accessors, callers moved even where their behaviour did not.

Tested with a raptor AI on Full Metal Plate 1.7 and an override putting the raptor box off centre.

AI disclosure: written with assistance from Claude Code.
