### PR TITLE
Consolidate stockpile limit enforcement

### DIFF
--- a/luarules/gadgets/unit_stockpile_limit.lua
+++ b/luarules/gadgets/unit_stockpile_limit.lua
@@ -18,12 +18,48 @@ if gadgetHandler:IsSyncedCode() then
 
 	local CMD_STOCKPILE = CMD.STOCKPILE
 
-	local StockpileDesiredTarget = {}
+	---@type table<number, integer?>
+	local stockpileTarget = {}
+	---@type table<number, integer?>
 	local unitStockpileLimit = {}
 
+	local GetUnitDefID = Spring.GetUnitDefID
 	local GetUnitStockpile = Spring.GetUnitStockpile
 	local GiveOrderToUnit = Spring.GiveOrderToUnit
+	local SetUnitStockpile = Spring.SetUnitStockpile
 	local mathClamp = math.clamp
+	local mathFloor = math.floor
+
+	local stockpileStep = {
+		single = { amount = 1, add = 0, remove = { "right" } },
+		small = { amount = 5, add = { "shift" }, remove = { "shift", "right" } },
+		medium = { amount = 20, add = { "ctrl" }, remove = { "ctrl", "right" } },
+		large = { amount = 100, add = { "ctrl", "shift" }, remove = { "ctrl", "shift", "right" } },
+	}
+
+	local stockpileStepsDescending = {
+		stockpileStep.large,
+		stockpileStep.medium,
+		stockpileStep.small,
+		stockpileStep.single,
+	}
+
+	local function parsedStockpileLimit(weaponDef)
+		local configured = weaponDef.customParams.stockpilelimit
+		local limit = tonumber(configured)
+
+		if not limit or limit < 0 then
+			Spring.Log(
+				gadget:GetInfo().name,
+				LOG.WARNING,
+				weaponDef.name .. ": ignoring stockpilelimit of " .. tostring(configured)
+			)
+
+			return nil
+		end
+
+		return mathFloor(limit)
+	end
 
 	for udid, ud in pairs(UnitDefs) do
 		if ud.canStockpile then
@@ -32,55 +68,136 @@ if gadgetHandler:IsSyncedCode() then
 				for i = 1, #ud.weapons do
 					local weaponDef = WeaponDefs[ud.weapons[i].weaponDef]
 					if weaponDef.stockpile and weaponDef.customParams and weaponDef.customParams.stockpilelimit then
-						unitStockpileLimit[udid] = tonumber(weaponDef.customParams.stockpilelimit)
+						unitStockpileLimit[udid] = parsedStockpileLimit(weaponDef) or unitStockpileLimit[udid]
 					end
 				end
 			end
 		end
 	end
 
-	function UpdateStockpile(unitID, unitDefID)
-		if not unitID or not StockpileDesiredTarget[unitID] then
-			return
+	local function commandStockpileDelta(cmdOptions)
+		local step
+		if cmdOptions.shift then
+			step = cmdOptions.ctrl and stockpileStep.large or stockpileStep.small
+		elseif cmdOptions.ctrl then
+			step = stockpileStep.medium
+		else
+			step = stockpileStep.single
 		end
-		local MaxStockpile = mathClamp(unitStockpileLimit[unitDefID], 0, StockpileDesiredTarget[unitID])
 
-		local stock, queued = GetUnitStockpile(unitID)
-		if queued and stock then
-			local count = stock + queued - MaxStockpile
-			while count < 0 do
-				if count <= -100 then
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "ctrl", "shift" })
-					count = count + 100
-				elseif count <= -20 then
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "ctrl" })
-					count = count + 20
-				elseif count <= -5 then
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "shift" })
-					count = count + 5
-				else
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, 0)
-					count = count + 1
-				end
+		return cmdOptions.right and -step.amount or step.amount
+	end
+
+	local function giveStockpileOrders(unitID, delta)
+		for i = 1, #stockpileStepsDescending do
+			local step = stockpileStepsDescending[i]
+			while delta >= step.amount do
+				GiveOrderToUnit(unitID, CMD_STOCKPILE, {}, step.add)
+				delta = delta - step.amount
 			end
-			while count > 0 do
-				if count >= 100 then
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "ctrl", "shift", "right" })
-					count = count - 100
-				elseif count >= 20 then
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "ctrl", "right" })
-					count = count - 20
-				elseif count >= 5 then
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "shift", "right" })
-					count = count - 5
-				else
-					GiveOrderToUnit(unitID, CMD.STOCKPILE, {}, { "right" })
-					count = count - 1
-				end
+			while delta <= -step.amount do
+				GiveOrderToUnit(unitID, CMD_STOCKPILE, {}, step.remove)
+				delta = delta + step.amount
 			end
 		end
 	end
 
+	local function convergeStockpile(unitID)
+		local target = stockpileTarget[unitID]
+		if not target then
+			return
+		end
+
+		local stock, queued = GetUnitStockpile(unitID)
+		if not (stock and queued) then
+			return
+		end
+
+		giveStockpileOrders(unitID, target - stock - queued)
+	end
+
+	local function isRealNumber(value)
+		return type(value) == "number" and value == value
+	end
+
+	local function setStockpileTarget(unitID, unitDefID, target)
+		local limit = unitStockpileLimit[unitDefID]
+		if not limit or not isRealNumber(target) then
+			return false
+		end
+
+		stockpileTarget[unitID] = mathClamp(mathFloor(target), 0, limit)
+		convergeStockpile(unitID)
+
+		return true
+	end
+
+	local function addStockpileTarget(unitID, unitDefID, delta)
+		local target = stockpileTarget[unitID]
+		if not target then
+			return false
+		end
+
+		return setStockpileTarget(unitID, unitDefID, target + delta)
+	end
+
+	local function trimStockpileToTarget(unitID, unitDefID, target)
+		if not setStockpileTarget(unitID, unitDefID, target) then
+			return false
+		end
+
+		local clampedTarget = stockpileTarget[unitID]
+		local stock, _, buildPercent = GetUnitStockpile(unitID)
+		if stock and stock > clampedTarget then
+			SetUnitStockpile(unitID, clampedTarget, buildPercent)
+		end
+
+		return true
+	end
+
+	GG.StockpileLimit = {
+		---Stockpile limit of the unit's def.
+		---@param unitID integer
+		---@return integer? limit `nil` when the unit cannot stockpile.
+		GetLimit = function(unitID)
+			local unitDefID = GetUnitDefID(unitID)
+
+			return unitDefID and unitStockpileLimit[unitDefID]
+		end,
+		---@param unitDefID integer
+		---@return integer? limit `nil` when the def cannot stockpile.
+		GetDefLimit = function(unitDefID)
+			return unitStockpileLimit[unitDefID]
+		end,
+		---Stockpiled plus queued rounds the unit is working towards.
+		---@param unitID integer
+		---@return integer? target `nil` when the unit is not tracked.
+		GetTarget = function(unitID)
+			return stockpileTarget[unitID]
+		end,
+		---Sets the target, clamped to the unit's limit. Only the queue moves.
+		---@param unitID integer
+		---@param target number Floored, then clamped to `0`..limit.
+		---@return boolean applied `false` when the unit cannot stockpile.
+		SetTarget = function(unitID, target)
+			return setStockpileTarget(unitID, GetUnitDefID(unitID), target)
+		end,
+		---@param unitID integer
+		---@param delta number Added to the current target.
+		---@return boolean applied `false` when the unit is not tracked.
+		AddTarget = function(unitID, delta)
+			return addStockpileTarget(unitID, GetUnitDefID(unitID), delta)
+		end,
+		---Sets the target and discards built rounds above it.
+		---@param unitID integer
+		---@param target number Floored, then clamped to `0`..limit.
+		---@return boolean applied `false` when the unit cannot stockpile.
+		TrimToTarget = function(unitID, target)
+			return trimStockpileToTarget(unitID, GetUnitDefID(unitID), target)
+		end,
+	}
+
+	-- StockpileChanged doesn't fire on queue-only changes, so player commands have to be caught here
 	function gadget:AllowCommand(
 		unitID,
 		unitDefID,
@@ -92,62 +209,54 @@ if gadgetHandler:IsSyncedCode() then
 		playerID,
 		fromSynced,
 		fromLua
-	) -- Can't use StockPileChanged because that doesn't get called when the stockpile queue changes
-		-- accepts CMD_STOCKPILE
-		if unitID then
-			local stock, _ = GetUnitStockpile(unitID)
-			if stock == nil then
-				return true
-			end
-			local addQ = 1
-			if cmdOptions.shift then
-				if cmdOptions.ctrl then
-					addQ = 100
-				else
-					addQ = 5
-				end
-			elseif cmdOptions.ctrl then
-				addQ = 20
-			end
-			if cmdOptions.right then
-				addQ = -addQ
-			end
-			if fromLua == true and fromSynced == true then -- fromLua is *true* if command is sent from a gadget and *false* if it's sent by a player.
-				return true
-			else
-				if StockpileDesiredTarget[unitID] and unitStockpileLimit[unitDefID] then
-					StockpileDesiredTarget[unitID] =
-						mathClamp(StockpileDesiredTarget[unitID] + addQ, 0, unitStockpileLimit[unitDefID])
-					UpdateStockpile(unitID, unitDefID)
-				end
-				return false
-			end
+	)
+		if not unitID then
+			return true
 		end
-		return true
+
+		-- fromLua is true for gadget-issued commands, false for player ones
+		if fromLua == true and fromSynced == true then
+			return true
+		end
+
+		if GetUnitStockpile(unitID) == nil then
+			return true
+		end
+
+		addStockpileTarget(unitID, unitDefID, commandStockpileDelta(cmdOptions))
+
+		return false
 	end
 
 	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-		if unitStockpileLimit[unitDefID] then
-			StockpileDesiredTarget[unitID] = unitStockpileLimit[unitDefID]
-			UpdateStockpile(unitID, unitDefID)
+		if stockpileTarget[unitID] then
+			return
+		end
+
+		local limit = unitStockpileLimit[unitDefID]
+		if limit then
+			setStockpileTarget(unitID, unitDefID, limit)
 		end
 	end
 	gadget.UnitGiven = gadget.UnitCreated
 
 	function gadget:StockpileChanged(unitID, unitDefID, unitTeam, weaponNum, oldCount, newCount)
-		UpdateStockpile(unitID, unitDefID)
+		convergeStockpile(unitID)
 	end
 
 	function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-		StockpileDesiredTarget[unitID] = nil
+		stockpileTarget[unitID] = nil
 	end
 
 	function gadget:Initialize()
 		gadgetHandler:RegisterAllowCommand(CMD_STOCKPILE)
 		local units = Spring.GetAllUnits()
 		for i = 1, #units do
-			local unitDefID = Spring.GetUnitDefID(units[i])
-			gadget:UnitCreated(units[i], unitDefID)
+			gadget:UnitCreated(units[i], GetUnitDefID(units[i]))
 		end
+	end
+
+	function gadget:Shutdown()
+		GG.StockpileLimit = nil
 	end
 end


### PR DESCRIPTION
Consolidates the stockpile limit checks into one gate and exposes them to other gadgets as GG.StockpileLimit.

The stockpile command can only add and remove queued rounds, so setting a unit to an exact count means writing the built count directly and handing out rounds nobody paid for. TrimToTarget is named for what it can actually do: clamp a unit down to a target and leave growth to the build queue. Nothing calls the new API yet, and evolution and the carrier spawner still set stockpiles directly since both want the built count moved rather than a target.

AI disclosure: written with assistance from Claude Code.
