### PR TITLE
Fix the cycle-selected-previous keybind

### DIFF
--- a/luaui/configs/hotkeys/grid_keys.txt
+++ b/luaui/configs/hotkeys/grid_keys.txt
@@ -143,7 +143,7 @@ bind           Alt+sc_q  select PrevSelection+_Not_Building_Not_RelativeHealth_6
 
 // cycle camera through selected units
 bind               sc_.  cycleselected next
-bind               sc_,  cycleselected prev
+bind               sc_comma  cycleselected prev
 
   // numpad movement
 bind            numpad2  moveback

--- a/luaui/configs/hotkeys/grid_keys_60pct.txt
+++ b/luaui/configs/hotkeys/grid_keys_60pct.txt
@@ -145,7 +145,7 @@ bind      Ctrl+Alt+sc_q  select PrevSelection+_Not_Building_Not_RelativeHealth_6
 
 // cycle camera through selected units
 bind               sc_.  cycleselected next
-bind               sc_,  cycleselected prev
+bind               sc_comma  cycleselected prev
 
 // numpad movement
 bind            numpad2  moveback

--- a/luaui/configs/hotkeys/legacy_keys.txt
+++ b/luaui/configs/hotkeys/legacy_keys.txt
@@ -116,7 +116,7 @@ bind Ctrl+sc_z select AllMap+_InPrevSel+_ClearSelection_SelectAll+
 
 // cycle camera through selected units
 bind sc_. cycleselected next
-bind sc_, cycleselected prev
+bind sc_comma cycleselected prev
 
 // building hotkeys
 bind sc_z buildunit_armmex

--- a/luaui/configs/hotkeys/legacy_keys_60pct.txt
+++ b/luaui/configs/hotkeys/legacy_keys_60pct.txt
@@ -120,7 +120,7 @@ bind Ctrl+sc_z select AllMap+_InPrevSel+_ClearSelection_SelectAll+
 
 // cycle camera through selected units
 bind sc_. cycleselected next
-bind sc_, cycleselected prev
+bind sc_comma cycleselected prev
 
 // building hotkeys
 bind sc_z buildunit_armmex


### PR DESCRIPTION
Binds cycleselected prev to sc_comma in the four keybind presets, which had sc_, - a name the engine does not have, since comma separates the keys in a chain and the scancode table only registers the word form for it. The binding has never done anything.

AI disclosure: written with assistance from Claude Code.
