### PR TITLE
Balance test modoption

### DIFF
--- a/luarules/gadgets/game_team_resources.lua
+++ b/luarules/gadgets/game_team_resources.lua
@@ -38,6 +38,10 @@ local function setup(addResources)
 	local startEnergyStorage = Spring.GetModOptions().startenergystorage
 	local startMetal = Spring.GetModOptions().startmetal
 	local startEnergy = Spring.GetModOptions().startenergy
+	if Spring.GetModOptions().proposed_unit_reworks == true then
+	    startMetal = startMetal - 100
+    	startEnergy = startEnergy - 100
+	end
 	local bonusMultiplierEnabled = Spring.GetModOptions().bonusstartresourcemultiplier
 
 	local commanderMinMetal, commanderMinEnergy = 0, 0

--- a/luarules/gadgets/unit_reclaim_fix.lua
+++ b/luarules/gadgets/unit_reclaim_fix.lua
@@ -50,6 +50,9 @@ local function getStep(featureDefID, unitDefID)
 	if maxResource == nil or reclaimTime == nil or reclaimSpeed == nil then
 		return nil
 	end
+	if Spring.GetModOptions().proposed_unit_reworks == true then
+		return ((4.4 - 0.2 * reclaimSpeed ) / reclaimTime) --there's [reclaimSpeed / reclaimTime] amount of reclaim, added on top of this from engine
+	end
 	return ((0.05 * reclaimSpeed + 4.5) / reclaimTime) --there's [reclaimSpeed / reclaimTime] amount of reclaim, added on top of this from engine
 end
 

--- a/modoptions.lua
+++ b/modoptions.lua
@@ -1845,9 +1845,9 @@ local options = {
 		name = "Placeholder for BLT testing",
 		desc = "Placeholder for official balance testing mod option",
 		type = "bool",
-		hidden = true,
+		--hidden = true,
 		section = "options_experimental",
-		def = false,
+		def = true,
 	},
 
 	-- NOTE: update language/en/interface.json when you change name or desc

--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -1,4 +1,194 @@
 local function proposed_unit_reworksTweaks(name, uDef)
+
+	if name == "armrock" or name == "corstorm" then
+		uDef.speed = uDef.speed + 4.3
+		uDef.turnrate = 900
+		uDef.buildtime = math.ceil(uDef.buildtime * 1.15 / 100) * 100
+	end
+	
+	if name == "armwar" then
+		uDef.metalcost = 200
+		uDef.energycost = 2300
+		uDef.turnrate = 650
+		uDef.health = 1500
+		uDef.speed = 50
+		uDef.weapondefs.armwar_laser.range = 290
+		uDef.weapondefs.armwar_laser.damage.default = 40
+	end
+
+	if name == "armham" then
+		uDef.speed = 47
+		uDef.weapondefs.arm_ham.areaofeffect = 48
+		uDef.weapondefs.arm_ham.reloadtime = 1.8
+	end
+	if name == "corthud" then
+		uDef.health = 1200
+		uDef.buildtime = 2400
+		uDef.weapondefs.arm_ham.areaofeffect = 48
+		uDef.weapondefs.arm_ham.reloadtime = 1.8
+	end
+
+
+	if name == "armart" then
+		uDef.speed = 56 --was 54
+		uDef.weapondefs.tawf113_weapon.weaponvelocity = 400
+		uDef.weapondefs.tawf113_weapon.mygravity = nil
+		uDef.weapondefs.tawf113_weapon.areaofeffect = 100 --75
+		uDef.weapondefs.tawf113_weapon.range = 730 --710
+		uDef.weapondefs.tawf113_weapon.impulsefactor = 0.7
+		uDef.weapondefs.tawf113_weapon.damage.default = 210
+	end
+	if name == "corwolv" then
+		uDef.speed = 50 --was 48
+		uDef.weapondefs.corwolv_gun.weaponvelocity = 400
+		uDef.weapondefs.corwolv_gun.mygravity = nil
+		uDef.weapondefs.corwolv_gun.range = 730 --710
+		uDef.weapondefs.corwolv_gun.areaofeffect = 140 --113
+		uDef.weapondefs.corwolv_gun.impulsefactor = 0.7
+		uDef.weapondefs.corwolv_gun.damage.default = 320
+		uDef.health = 850
+	end
+
+	if name == "armmart" then
+		uDef.metalcost = 260 --320
+		uDef.speed = 48 --was 60
+		uDef.weapondefs.arm_artillery.edgeeffectiveness = 0.15
+		uDef.weapondefs.arm_artillery.accuracy = 0
+		uDef.weapondefs.arm_artillery.reloadtime = 3.4 --3.05
+		uDef.weapondefs.arm_artillery.damage.default = 300 --260. DPS 85 -> 91
+	end
+	if name == "cormart" then
+		uDef.metalcost = 320 --400
+		uDef.speed = 46 -- was 58
+		uDef.weapondefs.cor_artillery.edgeeffectiveness = 0.15
+		uDef.weapondefs.cor_artillery.accuracy = 0
+		uDef.weapondefs.cor_artillery.reloadtime = 6.4 --5
+		uDef.weapondefs.cor_artillery.damage.default = 580 --420. DPS 84 -> 90
+	end
+
+	if name == "armsam" then
+		uDef.weapondefs.armtruck_missile.flighttime = 1.6
+		uDef.weapondefs.armtruck_missile.tracks = true
+		uDef.weapondefs.armtruck_missile.turnrate = 10000
+		uDef.weapondefs.armtruck_missile.damage.default = 55
+		--uDef.weapondefs.armtruck_missile.range = 525
+		uDef.weapondefs.armtruck_missile.weaponvelocity = 550
+	end
+	if name == "cormist" then
+		uDef.weapondefs.cortruck_missile.tracks = true
+		--uDef.weapondefs.cortruck_missile.range = 550
+		uDef.weapondefs.cortruck_missile.turnrate = 10000
+		uDef.weapondefs.cortruck_missile.damage.default = 40
+		uDef.weapondefs.cortruck_missile.flighttime = 1.6
+		uDef.weapondefs.cortruck_missile.weaponvelocity = 550		
+	end
+
+	if name == "armjanus" then
+		uDef.weapondefs.janus_rocket.edgeeffectiveness = 0.55
+		uDef.weapondefs.janus_rocket.impulsefactor = 1
+		uDef.speed = 56
+		uDef.turnrate = 300
+	end
+
+	if name == "armllt" then
+		uDef.buildtime = uDef.buildtime - 900
+		uDef.health = uDef.health - 180
+		uDef.weapondefs.arm_lightlaser.range = uDef.weapondefs.arm_lightlaser.range - 10
+		uDef.weapondefs.arm_lightlaser.energypershot = 15		
+		uDef.weapondefs.arm_lightlaser.reloadtime = 0.5
+	end
+	if name == "corllt" then
+		uDef.buildtime = uDef.buildtime - 900
+		uDef.health = uDef.health - 180
+		uDef.weapondefs.cor_lightlaser.range = uDef.weapondefs.cor_lightlaser.range - 10
+		uDef.weapondefs.cor_lightlaser.energypershot = 15
+		uDef.weapondefs.cor_lightlaser.reloadtime = 0.5
+	end
+	if name == "corhllt" then
+		uDef.health = 1500
+		uDef.weapondefs.hllt_bottom.range = 425
+		uDef.weapondefs.hllt_bottom.reloadtime = 0.5
+		uDef.weapondefs.hllt_top.reloadtime = 0.5
+	end
+	if name == "armbeamer" then
+		uDef.health = 1100
+		uDef.weapondefs.armbeamer_weapon.damage.default = 28
+	end
+	if name == "armclaw" then
+		uDef.health = 1600
+	end
+	if name == "cormaw" then
+		uDef.health = 1900
+	end
+	if name == "corhlt" then
+		uDef.weapondefs.cor_laserh1.range = 660
+		uDef.health = 2600
+	end
+	if name == "armhlt" then
+		uDef.weapondefs.arm_laserh1.range = 660
+		uDef.health = 2400
+	end
+	if name == "armpb" then
+		uDef.weapondefs.armpb_weapon.range = 600
+		uDef.weapondefs.armpb_weapon.damage = 
+			{
+				default = 330,
+				vtol = 80,
+			}
+		uDef.weapondefs.armpb_weapon.reloadtime = 0.8
+		--uDef.weapondefs.armpb_weapon.areaofeffect = 36		
+		uDef.weapondefs.armpb_weapon.impulsefactor = 1.1
+		uDef.weapondefs.armpb_weapon.targetmoveerror = 0
+		uDef.metalcost = 470
+		uDef.energycost = 7000
+		uDef.buildtime = 12000
+		uDef.damagemodifier = 0.33
+		uDef.health = 2500
+	end
+	if name == "corvipe" then
+		uDef.weapondefs.vipersabot.range = 600
+		uDef.weapondefs.vipersabot.areaofeffect = 48
+		uDef.weapondefs.vipersabot.targetmoveerror = 0
+		uDef.metalcost = 500
+		uDef.energycost = 6000
+		uDef.buildtime = 12000
+		uDef.damagemodifier = 0.33
+		uDef.health = 2700
+	end
+
+	if name == "armaap" or name == "armalab" or name == "armasy" or name == "armavp"
+	or name == "coraap" or name == "coralab" or name == "corasy" or name == "coravp"
+	or name == "legaap" or name == "legalab" or name == "legadvshipyard" or name == "legavp"
+	then
+		uDef.metalcost = uDef.metalcost - 300
+		uDef.energycost = uDef.energycost + 7000
+	end
+
+	if name == "armap" or name == "armlab" or name == "armsy" or name == "armvp"
+	or name == "corap" or name == "corlab" or name == "corsy" or name == "corvp"
+	or name == "legap" or name == "leglab" or name == "legsy" or name == "legvp"
+	then
+		uDef.energycost = uDef.energycost + 150
+	end
+
+	if name == "armcom" or name == "corcom" or name == "legcom" then
+		uDef.energymake = 50
+		uDef.metalmake = 2.5
+		uDef.speed = 38
+	end
+
+	if name == "armmex" or name == "cormex" or name == "legmex" then
+		uDef.energycost = uDef.energycost + 100
+	end
+
+	if name == "armck" or name == "corck" or name == "legck" 
+	or name == "armcv" or name == "corcv" or name == "legcv" 
+	or name == "armca" or name == "corca" or name == "legca" 
+	then
+		uDef.energycost = uDef.energycost + 200
+	end
+
+
 	return uDef
 end
 

--- a/unitbasedefs/proposed_unit_reworks_defs.lua
+++ b/unitbasedefs/proposed_unit_reworks_defs.lua
@@ -23,7 +23,7 @@ local function proposed_unit_reworksTweaks(name, uDef)
 	end
 	if name == "corthud" then
 		uDef.health = 1200
-		uDef.buildtime = 2400
+		uDef.buildtime = 2300
 		uDef.weapondefs.arm_ham.areaofeffect = 48
 		uDef.weapondefs.arm_ham.reloadtime = 1.8
 	end


### PR DESCRIPTION
## **Goals:**

**Openings**: Make less (1v1) games decided in the opening, with one player getting a big lead due to starting builds. With the changes it's more punishable to spam a ton of cons very early.

**T1 turrets / slow T1 units**: Overall an increase in power level, so that
 - Stronger turrets make it easier to stabilize the game in 1v1 / open maps -> game more likely to progress to committed pushes with slower T1 units, and to T2.
 - Stronger T1 units make committed T1 pushes more viable in teamgames also. But not so good they're consistently game-ending
 - The buffed T1 units fare a little bit better against T2

Mex upgrades: T2 mexes cost more -> Make it more punishable if your opponent is focusing heavily on just building them.

Commander: Make Commander more economically valuable, to discourage self-Ding it for metal.


## **Unit changes:**

Rocket bots:
 - +4.3 speed, turnrate 1270 -> 950, +15% buildtime
 - Faster at reaching the frontline, but worse repair rate and dodging.

Plasma bots:
 - 46.2 -> 47 Speed (Mace)
 - 1100 -> 1200 health, 2100 -> 2300 buildtime (Thug)
 - 36 -> 48 AoE, 1.73 -> 1.7 reloadtime (Both)
 - Better at beating light units with the extra AoE, and just overall a bit better.

Centurion:
 - Metalcost 270 -> 200, Energycost 3100 -> 2300, turnrate 885 -> 700, Speed 45 -> 50, range 325 -> 290, damage 55 -> 40
 - Big redesign. Make it a more accessible earlygame unit on open maps, "mobile llt" to provide cover to cons and Pawns from kiting.
 - Less capable of zoning back commanders or generally fighting longer range units, more focused as antispam.

Janus:
 - 54 -> 56 speed, 271 -> 300 turnrate, 0.15 -> 0.5 edgeeffectiveness
 - Slightly easier to use, faster reach frontline. EE makes it better vs massed units, while not better vs Commanders (on direct hits)
 - Other AoE missile weapons, like Banisher, Shiva, etc have high EE -> more consistent

Missile trucks: 
 - -30% dps vs land units, homing vs land units
 - +10% dps vs air
 - Better vs scouts and lone mobile units, worse vs turrets. More unique niche than specialising at clearing LLTs (which have lower health now).
 - Not meant to be strong enough to be a viable massed unit

T1 artillery:
 - +2 speed, longer projectile flight time, 0.5 impulse, 710 -> 730 range (both)
 - +15% DPS, better accuracy (Shellshocker)
 - 113 -> 144 AoE, 750 -> 900 health (Wolverine)
 - More differentiation between the two, overall stronger. Extra range gives more area to target at HLT (which has 660 range).

Hovertanks:
 - +5% health, +15% turnrate, AoE 32 -> 48, +3% DPS
 - Small buffs all around

T1 Amphib tanks:
 - +5% health, 305 -> 320 range, 8 -> 24 AoE, +3% DPS


T2 artillery:
 - -20% metalcost, -12 speed, 0.65 -> 0.15 edgeeffectiveness, remove inaccuracy vs static target (both)
 - 420 -> 500 damage, 5s -> 6s reloadtime -> ~same DPS, but able to 1-shot LLT (Quaker)
 - Less effective vs massed units, but better at clearing turrets.

Commander:
 - 37.5 -> 38 speed
 - Rounding up, makes it slightly better overall.

## **Turrets:**
LLT:
 - 2500 -> 1600 bt, 620 -> 470 health, 435 -> 425 range, reloadtime 0.467 -> 0.5s, 20 -> 15 energypershot 
 - Easier to set up during expansion, while not being as cost-effective metal-wise.
Beamer / twinguard:
 - -20% health, +5% dps 
 - Better at fighting units that attack them head on, but more vulnerable to artillery
HLT:
 - 620 -> 660 range, -10% health
Claw / maw:
 - +20% health
 - More differentiated from Beamer/Twinguard, as a more anti-artillery turret

T2 popups:
 - 730 -> 600 range
 - 14000 -> 7000 energycost, 680 -> 500 metalcost, 15000 -> 12000 buildtime
 - -10% health, 50% -> 67% damage reduction when closed
 - Targetmoveerror removed
 - Damage reduction vs ships removed
 - 24 -> 48 AoE (Scorpion only)
 - Halved reloadtime and damage per hit. Ie higher firerate but same DPS. Added impulse (Pitbull only)
 - Stronger as defense, esp vs spam. Worse at turret creeping / outranging T1 turrets
 - Low E:M cost ratio, similar to T1 popups.


## **Economy:**
- Commander: 30e/s -> 50e/s energymake, 2m/s -> 2.5m/s metalmake
- T1 mexes: +100 ecost
- T1 factories: +150 ecost
- T1 bot/veh/ship cons: +300 ecost, +150 buildtime
- -100m/-100e starting resources
- T2 mexes: ~8000 -> ~12000 ecost, -20% hp
- Reduce reclaimspeed from X = (0.175 * buildpower + 22.5) to X = (0.135 * buildpower + 22) resources/second