### PR TITLE
fix: guard in area mex

### DIFF
--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -203,6 +203,10 @@ function widget:CommandNotify(id, params, options)
 	end
 
 	local cmdX, _, cmdZ, cmdRadius = params[1], params[2], params[3], params[4]
+	if not cmdRadius or cmdRadius <= 0 then
+		return true
+	end
+
 	local spots = getSpotsInArea(cmdX, cmdZ, cmdRadius)
 	if WG.skip_allied_upgrade then
 		spots = WG.skip_allied_upgrade.filterOutAlliedSpots(spots, mexBuildings)


### PR DESCRIPTION
### Work done

Our real culprint is probably click-drags landing in pip again: https://github.com/beyond-all-reason/Beyond-All-Reason/blob/f0dbadd7b951bf0ac40360cefdf66c1b6d66d640/luaui/Widgets/gui_pip.lua#L8481-L8577

And pip not filtering cmds by their parameter types, e.g. areas not being handled as area-types but instead per-command-ID. This is doomed to break forever, so I did not fix it in PIP, I fixed it at the point of command notify, which seems maybe fine.