### PR TITLE
hide "api" widgets so they can be recovered during gameplay

### DIFF
--- a/common/upgets/api_resource_spot_finder.lua
+++ b/common/upgets/api_resource_spot_finder.lua
@@ -15,6 +15,7 @@ function upget:GetInfo()
 		license = "GNU GPL, v2 or later",
 		layer = layer,
 		enabled = true,
+		hidden = true, -- other upgets need this one, so it is not the player's to toggle
 	}
 end
 

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -10,6 +10,7 @@ function widget:GetInfo()
 		license = "GNU GPL, v2 or later",
 		layer = -1, -- load before all widgets that need these mex/geo building tools
 		enabled = true,
+		hidden = true, -- other widgets need this one, so it is not the player's to toggle
 	}
 end
 
@@ -534,4 +535,8 @@ function widget:Initialize()
 	WG.resource_spot_builder.GetGeoBuildings = function()
 		return geoBuildings
 	end
+end
+
+function widget:Shutdown()
+	WG.resource_spot_builder = nil
 end

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -36,6 +36,12 @@ local function setAreaMexType(uDefID)
 end
 
 function widget:Initialize()
+	if not WG.resource_spot_builder or not WG.resource_spot_finder then
+		Spring.Echo("Area Mex: the mex/geo resource spot API is missing, disabling")
+		widgetHandler:RemoveWidget()
+		return
+	end
+
 	metalSpots = WG.resource_spot_finder.metalSpotsList
 	metalMap = WG.resource_spot_finder.isMetalMap
 	mexBuildings = WG.resource_spot_builder.GetMexBuildings()

--- a/luaui/Widgets/cmd_extractor_snap.lua
+++ b/luaui/Widgets/cmd_extractor_snap.lua
@@ -52,6 +52,12 @@ function widget:Initialize()
 		return
 	end
 
+	if not WG.resource_spot_builder or not WG.resource_spot_finder then
+		Spring.Echo("Extractor Snap: the mex/geo resource spot API is missing, disabling")
+		widgetHandler:RemoveWidget()
+		return
+	end
+
 	WG.ExtractorSnap = {}
 	local builder = WG.resource_spot_builder
 

--- a/luaui/Widgets/cmd_quick_build_extractor.lua
+++ b/luaui/Widgets/cmd_quick_build_extractor.lua
@@ -79,6 +79,13 @@ local spotBuilder
 function widget:Initialize()
 	if not WG.DrawUnitShapeGL4 then
 		widgetHandler:RemoveWidget()
+		return
+	end
+
+	if not WG.resource_spot_builder or not WG.resource_spot_finder then
+		Spring.Echo("Quick Build Extractor: the mex/geo resource spot API is missing, disabling")
+		widgetHandler:RemoveWidget()
+		return
 	end
 
 	spotBuilder = WG.resource_spot_builder

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -607,7 +607,7 @@ function UpdateList(force)
 	end
 	local scoredList = lowerInput and {} or nil
 	for name, data in pairs(widgetHandler.knownWidgets) do
-		if name ~= myName and name ~= "Write customparam.__def to files" then
+		if name ~= myName and name ~= "Write customparam.__def to files" and not data.hidden then
 			if not lowerInput then
 				fullWidgetsList[#fullWidgetsList + 1] = { name, data }
 				local width = fontSize * font:GetTextWidth(name)

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -604,6 +604,8 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 	local name = widget.whInfo.name
 	if basename == SELECTOR_BASENAME then
 		self.orderList[name] = 1 -- always load the widget selector
+	elseif widget.whInfo.hidden then
+		self.orderList[name] = 1 -- hidden widgets back other widgets, so they always load
 	end
 
 	err = self:ValidateWidget(widget)
@@ -626,6 +628,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 		knownInfo.basename = widget.whInfo.basename
 		knownInfo.filename = widget.whInfo.filename
 		knownInfo.fromZip = fromZip
+		knownInfo.hidden = widget.whInfo.hidden
 		self.knownWidgets[name] = knownInfo
 		self.knownCount = self.knownCount + 1
 		self.knownChanged = true
@@ -801,6 +804,7 @@ function widgetHandler:FinalizeWidget(widget, filename, basename)
 		wi.author = info.author or ""
 		wi.license = info.license or ""
 		wi.enabled = info.enabled or false
+		wi.hidden = info.hidden or false
 	end
 
 	widget.whInfo = {} --  a proxy table
@@ -1224,6 +1228,9 @@ function widgetHandler:DisableWidgetRaw(name)
 	if not ki then
 		Spring.Echo("DisableWidget(), could not find widget: " .. tostring(name))
 		return false
+	end
+	if ki.hidden then
+		return false -- hidden widgets back other widgets; disabling one breaks them with no way back
 	end
 	if ki.active then
 		local w = self:FindWidget(name)


### PR DESCRIPTION
### Work done

Fix for widgets with required ordering becoming bricked once disabled and the bricked-state saving to the user's configs.

Previously, toggling any of these widgets, or hitting "disable all" ever, writes order 0 to the user's BYAR.lua config file and bricks every widget in the stack. They die all over in Initialize, then, for multiple reasons, but mainly because "0" is a magic order value meaning "disabled". The widget handler wraps these bricked widgets in function stubs to keep its always-registered pattern.

Now, these sensitive widgets are hidden. Hidden widgets always load, are not listed in the widget selector, and refuse to be disabled via selector. Configs that already disabled a widget then should repair on next load because the orderList is rewritten before the next enable.

Also adds some shutdown methods and user-facing, loud shutdown reasons so breakages are immediate and attributable to their errors. This is a temporary bridge, let's not handle errors this way.