### PR TITLE
Fix NoGS instance tables losing template mesh on resize

### DIFF
--- a/luaui/Widgets/gfx_unit_stencil_gl4.lua
+++ b/luaui/Widgets/gfx_unit_stencil_gl4.lua
@@ -352,7 +352,10 @@ local function attachStencilVAO(stencilVBO, templateVBO, indexVBO, indexCount)
 		stencilVBO.VAO:AttachVertexBuffer(stencilVBO.instanceVBO)
 	else
 		local realVAO = InstanceVBOTable.makeVAOandAttach(templateVBO, stencilVBO.instanceVBO, indexVBO)
-		stencilVBO.VAO = {
+		-- so the resize can find the template mesh when it rebuilds the VAO
+		stencilVBO.vertexVBO = templateVBO
+		stencilVBO.indexVBO = indexVBO
+		local vaoWrapper = {
 			realVAO = realVAO,
 			indexCount = indexCount,
 			DrawArrays = function(self, _primitiveType, instanceCount)
@@ -364,6 +367,21 @@ local function attachStencilVAO(stencilVBO, templateVBO, indexVBO, indexCount)
 				self.realVAO:Delete()
 			end,
 		}
+		-- the resize will put a plain VAO into this field, keep our wrapper working like DrawPrimitiveAtUnit.lua does
+		setmetatable(stencilVBO, {
+			__index = function(_, key)
+				if key == "VAO" then
+					return vaoWrapper
+				end
+			end,
+			__newindex = function(instanceTable, key, value)
+				if key == "VAO" then
+					vaoWrapper.realVAO = value
+				else
+					rawset(instanceTable, key, value)
+				end
+			end,
+		})
 	end
 end
 

--- a/luaui/Widgets/gui_flanking_icons.lua
+++ b/luaui/Widgets/gui_flanking_icons.lua
@@ -158,7 +158,7 @@ function widget:Initialize()
 	shaderConfig.POST_SHADING = "fragColor.a = fragColor.a * g_color.a;" -- alpha blend
 	shaderConfig.ANIMATION = nil
 	shaderConfig.USE_CIRCLES = nil
-	shaderConfig.MAX_VERTICES = 4
+	shaderConfig.MAXVERTICES = 4
 	shaderConfig.USE_CORNERRECT = nil
 	flankingVBO, flankingShader = InitDrawPrimitiveAtUnit(shaderConfig, "FlankingIcons")
 	if flankingVBO == nil then

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -602,6 +602,8 @@ local function initializeInstanceVBOTable(myName, usesFeatures)
 		newVBOTable.VAO = newVAO
 	else
 		newVBOTable.VAO = InstanceVBOTable.makeVAOandAttach(unitQuadVBO, newVBOTable.instanceVBO)
+		-- so the resize can find the quad when it rebuilds the VAO
+		newVBOTable.vertexVBO = unitQuadVBO
 	end
 	if usesFeatures then
 		newVBOTable.featureIDs = true

--- a/luaui/Widgets/gui_unit_firestate_icons.lua
+++ b/luaui/Widgets/gui_unit_firestate_icons.lua
@@ -153,8 +153,11 @@ local function createFireIconVBO(shaderConfig, vboName, useGeometryShaderForThis
 
 		vboTable.nogsTemplateVBO = templateVBO
 		vboTable.nogsIndexVBO = indexVBO
+		-- so the resize can find the template mesh when it rebuilds the VAO
+		vboTable.vertexVBO = templateVBO
+		vboTable.indexVBO = indexVBO
 		local indexCount = #indexData
-		vboTable.VAO = {
+		local vaoWrapper = {
 			realVAO = realVAO,
 			indexCount = indexCount,
 			DrawArrays = function(self, _primitiveType, instanceCount)
@@ -166,6 +169,21 @@ local function createFireIconVBO(shaderConfig, vboName, useGeometryShaderForThis
 				self.realVAO:Delete()
 			end,
 		}
+		-- the resize will put a plain VAO into this field, keep our wrapper working like DrawPrimitiveAtUnit.lua does
+		setmetatable(vboTable, {
+			__index = function(_, key)
+				if key == "VAO" then
+					return vaoWrapper
+				end
+			end,
+			__newindex = function(instanceTable, key, value)
+				if key == "VAO" then
+					vaoWrapper.realVAO = value
+				else
+					rawset(instanceTable, key, value)
+				end
+			end,
+		})
 	end
 	return vboTable
 end


### PR DESCRIPTION
### Work done
Health bars, unit stencil and firestate icons stop drawing mid-game on machines without geometry shaders. Their instance tables rebuild the VAO when they grow, and these widgets never stored the template mesh the rebuild needs, so the first resize kills the widget until reload

Also fixed a typo in flanking icons, MAX_VERTICES instead of MAXVERTICES, which left the fallback mesh at 64 slots instead of 4.

#### Test steps
- [ ] On a mac or any setup without geometry shaders, play until there are more than 256 health bars. Bars should keep drawing. Without the fix they disappear for good.
- [ ] Same for unit stencil and firestate icons past 64 units.
- [ ] With geometry shaders nothing changes.

### Test artifacts
Same replay, same moment, bar table capacity forced to 8 so the resize happens right away. Before and after below.
<img width="1720" height="962" alt="IMG_0870" src="https://github.com/user-attachments/assets/d3c6e912-9c92-4e01-9eb0-24def0363f37" />

<img width="1720" height="962" alt="IMG_0869" src="https://github.com/user-attachments/assets/6783c70b-8390-40bf-8aae-c7e9285cce66" />
