### PR TITLE
Mission API: Add stubs for objective presentation

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -348,6 +348,13 @@
 			"summary": "Summary",
 			"briefing": "Briefing"
 		},
+		"mission": {
+			"objectives": "Objectives",
+			"completed": "Completed",
+			"failed": "Failed",
+			"optional": "Optional",
+			"noObjectives": "No objectives yet."
+		},
 		"keybinds": {
 			"title": "Keybinds",
 			"disclaimer": "These keybinds are set by default. If you remove/replace hotkey widgets, or use your own uikeys, they might stop working!",

--- a/luarules/gadgets/api_missions.lua
+++ b/luarules/gadgets/api_missions.lua
@@ -11,7 +11,19 @@ function gadget:GetInfo()
 end
 
 if not gadgetHandler:IsSyncedCode() then
-	return false
+	---The unsynced half exists only to relay moments to LuaUI. State must not come
+	---through here: It is published as rules params which survive a /luaui reload.
+	local function forwardMissionMessage(_, textKey)
+		if Script.LuaUI("MissionMessage") then
+			Script.LuaUI.MissionMessage(textKey)
+		end
+	end
+
+	function gadget:Initialize()
+		gadgetHandler:AddSyncAction("MissionMessage", forwardMissionMessage)
+	end
+
+	return
 end
 
 local objectivesController, stagesController, triggersController, actionsController
@@ -76,6 +88,7 @@ function gadget:Initialize()
 	GG["MissionAPI"].Modules.Loadout = VFS.Include("luarules/mission_api/loadout.lua")
 	GG["MissionAPI"].Modules.Sounds = VFS.Include("luarules/mission_api/sounds.lua")
 	GG["MissionAPI"].Modules.Objectives = VFS.Include("luarules/mission_api/objectives.lua")
+	GG["MissionAPI"].Modules.Presentation = VFS.Include("luarules/mission_api/presentation.lua")
 	GG["MissionAPI"].Modules.SeismicContacts = VFS.Include("luarules/mission_api/seismic_contacts.lua")
 	GG["MissionAPI"].Modules.DetectionLevels = VFS.Include("luarules/mission_api/detection_levels.lua")
 
@@ -103,6 +116,23 @@ end
 
 function gadget:GameFrame(frameNumber)
 	GG["MissionAPI"].Modules.Sounds.ProcessSoundQueue(frameNumber)
+end
+
+function gadget:RecvLuaMsg(msg, playerID)
+	local interactionID, choice = msg:match("^mission:choose:(%d+):(%d+)$")
+	if not interactionID then
+		interactionID = msg:match("^mission:ack:(%d+)$")
+	end
+	if not interactionID then
+		return
+	end
+
+	local missionAPI = GG["MissionAPI"]
+	if not missionAPI or not missionAPI.Modules.Presentation then
+		return
+	end
+
+	missionAPI.Modules.Presentation.EndInteraction(tonumber(interactionID), playerID, tonumber(choice))
 end
 
 function gadget:Shutdown()

--- a/luarules/gadgets/api_missions_triggers.lua
+++ b/luarules/gadgets/api_missions_triggers.lua
@@ -255,7 +255,11 @@ function gadget:Initialize()
 	}
 
 	-- The objectives module dispatches its own triggers on objectives:
-	GG['MissionAPI'].Modules.Objectives.Init({ processTriggersOfType = processTriggersOfType, activateTrigger = activateTrigger })
+	GG['MissionAPI'].Modules.Objectives.Init({
+		processTriggersOfType = processTriggersOfType,
+		activateTrigger = activateTrigger,
+		presentation = GG['MissionAPI'].Modules.Presentation,
+	})
 
 	-- AllowFeatureBuildStep / AllowUnitBuildStep fire on every builder's build or
 	-- reclaim step (among the hottest call-ins in the game), so only stay subscribed

--- a/luarules/mission_api/actions/misc/send_message.lua
+++ b/luarules/mission_api/actions/misc/send_message.lua
@@ -1,11 +1,18 @@
 local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+local Presentation = GG['MissionAPI'].Modules.Presentation
+
+---Messages resolve first as an i18n key unsynced-side, then fall back as literal text.
+local function sendMessage(message, audience)
+	Presentation.SendMessage(message, audience)
+end
 
 return {
 	{
 		type = 'SendMessage',
 		parameters = {
-			{ name = 'message', required = true, type = ParameterTypes.String },
+			{ name = 'message',  required = true,  type = ParameterTypes.String },
+			{ name = 'audience', required = false, type = ParameterTypes.Table }, -- todo: PlayerIDs as audience type
 		},
-		actionFunction = Spring.Echo,
+		actionFunction = sendMessage,
 	}
 }

--- a/luarules/mission_api/objectives.lua
+++ b/luarules/mission_api/objectives.lua
@@ -2,17 +2,22 @@
 --- Shared helpers for objective progress/completion and stage changes.
 ---
 
--- Activating and iterating triggers is handled through the triggers gadget.
-local processTriggersOfType, activateTrigger
+local processTriggersOfType, activateTrigger, presentation
 
 local function init(dependencies)
 	processTriggersOfType = dependencies.processTriggersOfType
 	activateTrigger = dependencies.activateTrigger
+	presentation = dependencies.presentation
 end
 
 local function changeStage(stageID)
 	GG["MissionAPI"].CurrentStageID = stageID
 	Spring.Echo("Stage set to: " .. stageID)
+
+	if presentation then
+		presentation.PublishStage(stageID)
+		presentation.PublishObjectives()
+	end
 end
 
 -- placeholder until UI widget exists
@@ -30,6 +35,10 @@ local function echoObjectiveUpdate(objectiveID, objective)
 			.. tostring(objective.completed)
 			.. (objective.failed and " (failed)" or "")
 	)
+
+	if presentation then
+		presentation.PublishObjectives()
+	end
 end
 
 ---@param amount integer? `nil` completes on any progress, `0` only on exactly zero

--- a/luarules/mission_api/presentation.lua
+++ b/luarules/mission_api/presentation.lua
@@ -1,0 +1,162 @@
+---
+--- Publishes mission state to unsynced, and settles interactions answered from there.
+---
+
+-- We have four channels available for sending data:
+--
+-- - RulesParams. State with an optional limited audience.
+-- - SendToUnsynced. Uses a broadcast so must not be audience-sensitive.
+-- - Unsynced callouts (Spring.PlaySoundFile). These are also broadcasts.
+-- - SendLuaRulesMsg. Audience replies, handled in api_missions.lua.
+--
+-- Where audience limiting generally does not apply to spectators, e.g. for replays.
+
+local PRIVATE = { private = true } ---@type losAccess
+
+local STAGE_PARAM = "missionStage"
+local OBJECTIVES_PARAM = "missionObjectives"
+local VERSION_PARAM = "missionObjectivesVersion"
+local INTERACTION_PARAM = "missionInteraction"
+
+local version = 0
+local interactions = {}
+local lastInteractionID = 0
+
+---STUB
+---@param audience table? `nil` for everyone
+---@return integer[]? playerIDs `nil` means everyone
+local function getPlayerList(audience)
+	return nil
+end
+
+local function publish(name, value, audience)
+	local playerIDs = getPlayerList(audience)
+	if not playerIDs then
+		Spring.SetGameRulesParam(name, value)
+		return
+	end
+	for i = 1, #playerIDs do
+		Spring.SetPlayerRulesParam(playerIDs[i], name, value, PRIVATE)
+	end
+end
+
+---@param playerID integer
+---@param audience table?
+local function isInAudience(playerID, audience)
+	local playerIDs = getPlayerList(audience)
+	if not playerIDs then
+		return true
+	end
+	for i = 1, #playerIDs do
+		if playerIDs[i] == playerID then
+			return true
+		end
+	end
+	return false
+end
+
+local function objectiveRow(objectiveID, objective)
+	return {
+		id = objectiveID,
+		textKey = objective.textKey,
+		completed = objective.completed or false,
+		failed = objective.failed or false,
+		progress = objective.progress,
+		amount = objective.amount,
+	}
+end
+
+local function orderedObjectiveIDs(missionAPI, objectives)
+	local stage = (missionAPI.Stages or {})[missionAPI.CurrentStageID]
+
+	local ordered, listed = {}, {}
+	for _, objectiveID in ipairs((stage or {}).objectives or {}) do
+		if objectives[objectiveID] and not listed[objectiveID] then
+			listed[objectiveID] = true
+			ordered[#ordered + 1] = objectiveID
+		end
+	end
+
+	local rest = {}
+	for objectiveID in pairs(objectives) do
+		if not listed[objectiveID] then
+			rest[#rest + 1] = objectiveID
+		end
+	end
+	table.sort(rest)
+
+	for i = 1, #rest do
+		ordered[#ordered + 1] = rest[i]
+	end
+	return ordered
+end
+
+local function publishObjectives(audience)
+	local missionAPI = GG["MissionAPI"]
+	local objectives = missionAPI.Objectives or {}
+	local rows = {}
+	for _, objectiveID in ipairs(orderedObjectiveIDs(missionAPI, objectives)) do
+		local objective = objectives[objectiveID]
+		if not objective.hidden then
+			rows[#rows + 1] = objectiveRow(objectiveID, objective)
+		end
+	end
+
+	version = version + 1
+	publish(OBJECTIVES_PARAM, Json.encode(rows), audience)
+	publish(VERSION_PARAM, version, audience)
+end
+
+local function publishStage(stageID, audience)
+	publish(STAGE_PARAM, stageID or "", audience)
+end
+
+---For light data that can be lost on `/luaui reload` and has no audience restriction.
+local function sendMessage(textKey, audience)
+	SendToUnsynced("MissionMessage", textKey)
+end
+
+---An open interaction is an ongoing _state_. Reloading UI mid-prompt has to maintain
+---or restore state. Its dismissal is the interaction, and arrives on the reply path.
+local function openInteraction(kind, textKey, options, audience, onEnd)
+	lastInteractionID = lastInteractionID + 1
+	local interactionID = lastInteractionID
+
+	interactions[interactionID] = { audience = audience, onEnd = onEnd }
+	publish(
+		INTERACTION_PARAM,
+		Json.encode({ id = interactionID, kind = kind, textKey = textKey, options = options }),
+		audience
+	)
+
+	return interactionID
+end
+
+local function closeInteraction(interactionID, playerID, choice)
+	local interaction = interactions[interactionID]
+	if not interaction then
+		return false
+	end
+	-- RecvLuaMsg is not authenticated, so verify the sender is in the audience.
+	if not isInAudience(playerID, interaction.audience) then
+		return false
+	end
+
+	interactions[interactionID] = nil
+	publish(INTERACTION_PARAM, "", interaction.audience)
+
+	if interaction.onEnd then
+		interaction.onEnd(playerID, choice)
+	end
+	return true
+end
+
+return {
+	IsInAudience = isInAudience,
+	Publish = publish,
+	PublishObjectives = publishObjectives,
+	PublishStage = publishStage,
+	SendMessage = sendMessage,
+	OpenInteraction = openInteraction,
+	CloseInteraction = closeInteraction,
+}

--- a/luaui/Widgets/gui_mission_objectives.lua
+++ b/luaui/Widgets/gui_mission_objectives.lua
@@ -1,0 +1,131 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Mission Objectives",
+		desc = "Shows the mission's live objective list.",
+		author = "Mission API",
+		date = "August 2026",
+		license = "GNU GPL, v2 or later",
+		layer = -99989,
+		enabled = true,
+	}
+end
+
+local spGetGameRulesParam = Spring.GetGameRulesParam
+local spGetViewGeometry = Spring.GetViewGeometry
+
+local OBJECTIVES_PARAM = "missionObjectives"
+local VERSION_PARAM = "missionObjectivesVersion"
+
+local objectives = {}
+local knownVersion = -1
+local vsx, vsy = spGetViewGeometry()
+
+local font
+
+local function resolveText(textKey)
+	if not textKey or textKey == "" then
+		return ""
+	end
+	local translated = BAR.I18N(textKey)
+	if translated and translated ~= "" then
+		return translated
+	end
+	return textKey
+end
+
+local function readObjectives()
+	local version = spGetGameRulesParam(VERSION_PARAM)
+	if not version or version == knownVersion then
+		return false
+	end
+
+	knownVersion = version
+
+	local encoded = spGetGameRulesParam(OBJECTIVES_PARAM)
+	if type(encoded) ~= "string" or encoded == "" then
+		objectives = {}
+		return true
+	end
+
+	local ok, decoded = pcall(Json.decode, encoded)
+	objectives = (ok and type(decoded) == "table") and decoded or {}
+	return true
+end
+
+local function objectiveLine(objective)
+	local text = resolveText(objective.textKey)
+
+	if objective.amount and objective.amount > 0 and not objective.completed then
+		text = text .. "  " .. tostring(objective.progress or 0) .. "/" .. tostring(objective.amount)
+	end
+
+	if objective.completed then
+		local outcome = objective.failed and BAR.I18N("ui.mission.failed") or BAR.I18N("ui.mission.completed")
+		text = text .. "  (" .. tostring(outcome) .. ")"
+	end
+
+	return text
+end
+
+---Relayed by the mission gadget's unsynced half through `Script.LuaUI.MissionMessage`.
+---Reached by a registered global, not a callin.
+---STUB: echoed to console until there is somewhere better to put transient text.
+local function MissionMessage(message)
+	Spring.Echo(resolveText(message))
+end
+
+function widget:Initialize()
+	if not WG.FlowUI then
+		widgetHandler:RemoveWidget()
+		return
+	end
+	font = WG.fonts and WG.fonts.getFont and WG.fonts.getFont() or gl.LoadFont("FreeSansBold.otf", 16, 2, 2)
+	widgetHandler:RegisterGlobal("MissionMessage", MissionMessage)
+	readObjectives()
+end
+
+function widget:Shutdown()
+	widgetHandler:DeregisterGlobal("MissionMessage")
+end
+
+function widget:GameFrame(frameNumber)
+	if frameNumber % 15 == 0 then
+		readObjectives()
+	end
+end
+
+function widget:ViewResize()
+	vsx, vsy = spGetViewGeometry()
+end
+
+function widget:DrawScreen()
+	if #objectives == 0 then
+		return
+	end
+
+	local lineHeight = 18
+	local padding = 10
+	local width = 320
+	local height = padding * 2 + lineHeight * (#objectives + 1)
+	local x = vsx - width - 20
+	local y = vsy - 140
+
+	WG.FlowUI.Draw.Element(x, y - height, x + width, y, 1, 1, 1, 1)
+
+	font:Begin()
+	font:SetTextColor(1, 1, 1, 1)
+	font:Print(BAR.I18N("ui.mission.objectives"), x + padding, y - padding - lineHeight, 16, "o")
+
+	for i = 1, #objectives do
+		local objective = objectives[i]
+		if objective.completed then
+			font:SetTextColor(0.6, 0.6, 0.6, 1)
+		else
+			font:SetTextColor(1, 1, 1, 1)
+		end
+		font:Print(objectiveLine(objective), x + padding, y - padding - lineHeight * (i + 1), 14, "o")
+	end
+	font:End()
+end

--- a/spec/mission_api/actions/misc/send_message_spec.lua
+++ b/spec/mission_api/actions/misc/send_message_spec.lua
@@ -4,6 +4,15 @@ GG["MissionAPI"] = GG["MissionAPI"] or {}
 GG["MissionAPI"].Modules = GG["MissionAPI"].Modules or {}
 GG["MissionAPI"].Modules.ParameterTypes = VFS.Include("luarules/mission_api/parameter_types.lua")
 
+-- The action captures the module at load, as every action does for ParameterTypes, so
+-- it has to exist before the include. Tests reset its record rather than replace it.
+local sent = {}
+GG["MissionAPI"].Modules.Presentation = {
+	SendMessage = function(message, audience)
+		sent[#sent + 1] = { message = message, audience = audience }
+	end,
+}
+
 local actions = VFS.Include("luarules/mission_api/actions/misc/send_message.lua")
 local action = actions[1]
 local summarizeSchema = require("mission_api.schema_spec_helper")
@@ -14,18 +23,26 @@ describe("mission_api.actions.send_message", function()
 		assert.are.same({
 			type = "SendMessage",
 			message = "String!",
+			audience = "Table",
 		}, summarizeSchema(action))
 	end)
 
 	describe("actionFunction", function()
-		it("is Spring.Echo", function()
-			assert.are.equal(Spring.Echo, action.actionFunction)
+		before_each(function()
+			for i = #sent, 1, -1 do
+				sent[i] = nil
+			end
 		end)
 
-		it("can be called without error", function()
-			assert.has_no.errors(function()
-				action.actionFunction("hello mission")
-			end)
+		it("delegates to the presentation module", function()
+			action.actionFunction("hello mission")
+			assert.are.equal(1, #sent)
+			assert.are.equal("hello mission", sent[1].message)
+		end)
+
+		it("passes the audience through", function()
+			action.actionFunction("hello mission", { playerIDs = { 3 } })
+			assert.are.same({ playerIDs = { 3 } }, sent[1].audience)
 		end)
 	end)
 

--- a/spec/mission_api/presentation_spec.lua
+++ b/spec/mission_api/presentation_spec.lua
@@ -1,0 +1,148 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+-- Json.encode is not ours to test; passing the table straight through keeps the
+-- assertions on the row building and ordering, which are.
+_G.Json = {
+	encode = function(value)
+		return value
+	end,
+}
+
+local paramWrites = {}
+local playerParamWrites = {}
+local unsyncedSends = {}
+
+_G.Spring.SetGameRulesParam = function(name, value)
+	paramWrites[#paramWrites + 1] = { name = name, value = value }
+end
+_G.Spring.SetPlayerRulesParam = function(playerID, name, value, access)
+	playerParamWrites[#playerParamWrites + 1] = { playerID = playerID, name = name, value = value, access = access }
+end
+_G.SendToUnsynced = function(...)
+	unsyncedSends[#unsyncedSends + 1] = { ... }
+end
+
+Builders.MissionApi.new():Install()
+
+local Presentation = VFS.Include("luarules/mission_api/presentation.lua")
+
+local function lastWrite(name)
+	for i = #paramWrites, 1, -1 do
+		if paramWrites[i].name == name then
+			return paramWrites[i].value
+		end
+	end
+end
+
+describe("mission_api.presentation", function()
+	before_each(function()
+		paramWrites = {}
+		playerParamWrites = {}
+		unsyncedSends = {}
+		Builders.MissionApi.new():Install()
+	end)
+
+	describe("PublishObjectives", function()
+		it("publishes a row per objective", function()
+			Builders.MissionApi.new():WithObjective("obj1", { textKey = "a", completed = false }):Install()
+			Presentation.PublishObjectives()
+
+			local rows = lastWrite("missionObjectives")
+			assert.are.equal(1, #rows)
+			assert.are.equal("obj1", rows[1].id)
+			assert.are.equal("a", rows[1].textKey)
+			assert.is_false(rows[1].completed)
+			assert.is_false(rows[1].failed)
+		end)
+
+		it("omits hidden objectives, because a widget cannot be trusted to", function()
+			Builders.MissionApi
+				.new()
+				:WithObjective("shown", { textKey = "a" })
+				:WithObjective("secret", { textKey = "b", hidden = true })
+				:Install()
+			Presentation.PublishObjectives()
+
+			local rows = lastWrite("missionObjectives")
+			assert.are.equal(1, #rows)
+			assert.are.equal("shown", rows[1].id)
+		end)
+
+		it("orders by the current stage's list, then the rest", function()
+			Builders.MissionApi
+				.new()
+				:WithObjective("third", { textKey = "c" })
+				:WithObjective("first", { textKey = "a" })
+				:WithObjective("second", { textKey = "b" })
+				:Install()
+			GG["MissionAPI"].Stages = { only = { objectives = { "first", "second" } } }
+			GG["MissionAPI"].CurrentStageID = "only"
+			Presentation.PublishObjectives()
+
+			local rows = lastWrite("missionObjectives")
+			assert.are.same({ "first", "second", "third" }, { rows[1].id, rows[2].id, rows[3].id })
+		end)
+
+		it("bumps the version so a poller can tell something changed", function()
+			Builders.MissionApi.new():WithObjective("obj1", { textKey = "a" }):Install()
+			Presentation.PublishObjectives()
+			local first = lastWrite("missionObjectivesVersion")
+			Presentation.PublishObjectives()
+			assert.are.equal(first + 1, lastWrite("missionObjectivesVersion"))
+		end)
+
+		it("writes a game param while the audience is everyone", function()
+			Builders.MissionApi.new():WithObjective("obj1", { textKey = "a" }):Install()
+			Presentation.PublishObjectives()
+			assert.is_true(#paramWrites > 0)
+			assert.are.equal(0, #playerParamWrites)
+		end)
+	end)
+
+	describe("SendMessage", function()
+		it("goes out on the broadcast channel", function()
+			Presentation.SendMessage("hello")
+			assert.are.equal(1, #unsyncedSends)
+			assert.are.equal("MissionMessage", unsyncedSends[1][1])
+			assert.are.equal("hello", unsyncedSends[1][2])
+		end)
+	end)
+
+	describe("interactions", function()
+		it("publishes the open interaction as state, not a message", function()
+			Presentation.RaiseInteraction("prompt", "ask", nil, nil, nil)
+			assert.is_table(lastWrite("missionInteraction"))
+			assert.are.equal(0, #unsyncedSends)
+		end)
+
+		it("settles on a reply, clearing the param and running the callback", function()
+			local answered
+			local id = Presentation.RaiseInteraction("prompt", "ask", nil, nil, function(playerID, choice)
+				answered = { playerID = playerID, choice = choice }
+			end)
+
+			assert.is_true(Presentation.EndInteraction(id, 7, 2))
+			assert.are.same({ playerID = 7, choice = 2 }, answered)
+			assert.are.equal("", lastWrite("missionInteraction"))
+		end)
+
+		it("rejects a reply to an interaction that is not open", function()
+			assert.is_false(Presentation.EndInteraction(999, 7, nil))
+		end)
+
+		it("rejects a second reply to the same interaction", function()
+			local id = Presentation.RaiseInteraction("prompt", "ask", nil, nil, nil)
+			assert.is_true(Presentation.EndInteraction(id, 7, nil))
+			assert.is_false(Presentation.EndInteraction(id, 7, nil))
+		end)
+	end)
+
+	describe("IsInAudience", function()
+		it("admits everyone while resolveAudience is stubbed", function()
+			assert.is_true(Presentation.IsInAudience(0, nil))
+			assert.is_true(Presentation.IsInAudience(42, { playerIDs = { 1 } }))
+		end)
+	end)
+end)


### PR DESCRIPTION
### Work done

Adds multiple paths for sending notifications and sharing game state from synced to unsynced for missions.

Unsynced can respond to close an open interaction without causing desyncs in multiplayer/coop.