### PR TITLE
ci: hunk-scoped changes and warning allowances

### DIFF
--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -365,7 +365,7 @@ def main():
     warnings = [f for f in new if f["severity"] == WARNING]
     others = [f for f in new if f["severity"] > WARNING]
 
-    allowance = max(
+    allowance = min(
         args.warn_floor, round(args.warn_per_kloc * args.added_lines / 1000.0)
     )
 

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -19,8 +19,10 @@ paths are moved through the pull request's renames for the same reason.
 
 New errors block.
 
-New warnings are allowed up to a budget that is the smaller of a flat floor and
-a rate per thousand changed lines. Small changes are judged at high scrictness.
+New warnings are allowed up to a budget that is the smaller of a flat cap and a
+rate per thousand changed lines. Small changes receive a very strict allowance.
+
+A line rewritten in place is one changed line, not one added and one removed.
 """
 
 import argparse
@@ -162,8 +164,8 @@ def write_summary(
                     "%d changed line%s, allowance %d new warning%s, %d run%s per side."
                     "%s The full report is on the check's own page.\n"
                     % (
-                        args.added_lines,
-                        plural(args.added_lines),
+                        args.changed_lines,
+                        plural(args.changed_lines),
                         allowance,
                         plural(allowance),
                         args.runs,
@@ -179,8 +181,8 @@ def write_summary(
                 % (
                     args.runs,
                     plural(args.runs),
-                    args.added_lines,
-                    plural(args.added_lines),
+                    args.changed_lines,
+                    plural(args.changed_lines),
                     allowance,
                     plural(allowance),
                 )
@@ -201,8 +203,9 @@ def write_summary(
                 )
             out.write(
                 "emmylua disagreed with itself about %d finding%s on this branch and %d "
-                "on the base. Those are excluded rather than counted, which is the whole "
-                "reason the check runs more than once per side.\n"
+                "on the base. The base is read at its highest count and this branch "
+                "at its lowest, so that disagreement is absorbed instead of charged to "
+                "the author, which is why the check runs more than once per side.\n"
                 % (unstable["head"], plural(unstable["head"]), unstable["base"])
             )
         else:
@@ -293,7 +296,7 @@ def main():
     parser.add_argument("--head-root", required=True)
     parser.add_argument("--renames")
     parser.add_argument("--changed-files")
-    parser.add_argument("--added-lines", type=int, default=0)
+    parser.add_argument("--changed-lines", type=int, default=0)
     parser.add_argument("--warn-max", type=int, required=True)
     parser.add_argument("--warn-per-kloc", type=float, required=True)
     # Errors are always judged over the whole tree: there are almost none left,
@@ -366,11 +369,13 @@ def main():
     others = [f for f in new if f["severity"] > WARNING]
 
     allowance = min(
-        args.warn_max, round(args.warn_per_kloc * args.added_lines / 1000.0)
+        args.warn_max, int(args.warn_per_kloc * args.changed_lines / 1000.0)
     )
 
+    # Scope is a pull request idea. A manual run has no changed set, so narrowing
+    # to it would report every finding as out of scope and then budget none of them.
     budgeted = warnings
-    if args.warn_scope == "changed":
+    if args.compared and args.warn_scope == "changed":
         budgeted = [f for f in warnings if f["changed"]]
     ripple = len(warnings) - len(budgeted)
 
@@ -395,12 +400,13 @@ def main():
             allowance,
             ripple,
             len(others),
-            args.added_lines,
+            args.changed_lines,
             args.runs,
         )
     )
 
-    for pool, kind in ((errors, "error"), (warnings, "warning")):
+    # Warnings outside the scope are not budgeted, so they are not annotated.
+    for pool, kind in ((errors, "error"), (budgeted, "warning")):
         for finding in pool[:ANNOTATION_CAP]:
             print(
                 "::%s file=%s,line=%d,col=%d,title=%s::%s"
@@ -450,7 +456,7 @@ def main():
             allowance,
             reasons,
             unstable,
-            any(not f["changed"] for f in new),
+            args.compared and any(not f["changed"] for f in new),
             len(budgeted),
             ripple,
             detail,

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -17,10 +17,14 @@ Findings are keyed on (severity, code, path, message) rather than on position,
 so that inserting a line above a finding does not present it as new, and base
 paths are moved through the pull request's renames for the same reason.
 
-New errors block.
+New errors block, anywhere in the repo.
 
 New warnings are allowed up to a budget that is the smaller of a flat cap and a
 rate per thousand changed lines. Small changes receive a very strict allowance.
+
+Warnings are ranked by how near they are to the change. The lines changed, then
+the rest of the files it touched, then everywhere else. The annotation budget
+spends itself down that order. In scope always sorts ahead of out of scope.
 
 A line rewritten in place is one changed line, not one added and one removed.
 """
@@ -35,6 +39,9 @@ ERROR, WARNING = 1, 2
 SEVERITY_NAME = {1: "error", 2: "warning", 3: "info", 4: "hint"}
 ANNOTATION_CAP = 10
 TABLE_CAP = 50
+
+# How near a finding sits to the change.
+HUNK, FILE, TREE = 0, 1, 2
 
 # The CI Results comment trims anything past its slice, cutting a table mid-row.
 # So the report renders twice, and the compact one carries only what blocked.
@@ -80,6 +87,30 @@ def read_renames(path):
                 if old and new:
                     pairs[old] = new
     return pairs
+
+
+def read_hunks(path):
+    """The head-side line ranges the pull request wrote, per file."""
+    ranges = collections.defaultdict(list)
+    if path and os.path.exists(path):
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                file, _, span = line.rstrip("\n").partition("\t")
+                start, _, end = span.partition("\t")
+                if file and start and end:
+                    ranges[file].append((int(start), int(end)))
+    return ranges
+
+
+def scope_of(path, line, changed, hunks):
+    """Which ring a finding sits in: the lines written, the file, or elsewhere."""
+    if path not in changed:
+        return TREE
+    # With no ranges supplied nothing resolves to HUNK and every finding in a
+    # changed file lands on FILE, which is the scope this check had before.
+    if any(start <= line <= end for start, end in hunks.get(path, ())):
+        return HUNK
+    return FILE
 
 
 def apply_renames(counts, renames):
@@ -142,8 +173,6 @@ def write_summary(
             new_total,
             plural(new_total),
         )
-    elif reasons and args.report_only:
-        headline = "Type check: would have failed on " + ", ".join(reasons)
     elif reasons:
         headline = "Type check: " + ", ".join(reasons)
     elif new_total:
@@ -161,8 +190,8 @@ def write_summary(
         if compact:
             if args.compared:
                 out.write(
-                    "%d changed line%s, allowance %d new warning%s, %d run%s per side."
-                    "%s The full report is on the check's own page.\n"
+                    "%d changed line%s, allowance %d new warning%s, %d run%s per "
+                    "side. The full report is on the check's own page.\n"
                     % (
                         args.changed_lines,
                         plural(args.changed_lines),
@@ -170,14 +199,13 @@ def write_summary(
                         plural(allowance),
                         args.runs,
                         plural(args.runs),
-                        " Reporting only, not gating." if args.report_only else "",
                     )
                 )
         elif args.compared:
             out.write(
                 "Compared against the base over %d run%s per side. %d changed line%s "
-                "have an allowance of %d new warning%s. Any new error blocks. Info and "
-                "hints never block.\n\n"
+                "have an allowance of %d new warning%s. Any new error blocks, "
+                "wherever in the tree it landed. Info and hints never block.\n\n"
                 % (
                     args.runs,
                     plural(args.runs),
@@ -187,18 +215,13 @@ def write_summary(
                     plural(allowance),
                 )
             )
-            if args.report_only:
-                out.write(
-                    "This check is reporting only and does not gate anything yet, so "
-                    "the thresholds can be read off real pull requests before they "
-                    "start turning anyone red.\n\n"
-                )
             if args.warn_scope == "changed" and ripple:
                 out.write(
                     "A further %d new warning%s landed in files this pull request did "
                     "not touch. Those are reported below but not budgeted: emmylua "
                     "re-infers its way through unrelated files when anything moves, "
-                    "and holding an author to that is not useful.\n\n"
+                    "and holding an author to that is not useful. Errors are not "
+                    "treated this way and never have been.\n\n"
                     % (ripple, plural(ripple))
                 )
             out.write(
@@ -262,12 +285,19 @@ def write_summary(
                 message = finding["message"].replace("|", "\\|")
                 if compact and len(message) > COMPACT_MESSAGE_CAP:
                     message = message[: COMPACT_MESSAGE_CAP - 1] + "…"
+                # Errors are in scope wherever they are, so they are never
+                # marked as though their address excused them.
+                marked = (
+                    finding["severity"] != ERROR
+                    and not finding["changed"]
+                    and not compact
+                )
                 out.write(
                     "| `%s:%d`%s | `%s` | %s |\n"
                     % (
                         finding["path"],
                         finding["line"],
-                        "" if finding["changed"] or compact else " *",
+                        " *" if marked else "",
                         finding["code"],
                         message,
                     )
@@ -296,26 +326,30 @@ def main():
     parser.add_argument("--head-root", required=True)
     parser.add_argument("--renames")
     parser.add_argument("--changed-files")
+    # path<TAB>start<TAB>end, one head-side hunk per line. Without it the near
+    # ring is empty and warnings are scoped to whole files, as they were before.
+    parser.add_argument("--changed-hunks")
     parser.add_argument("--changed-lines", type=int, default=0)
     parser.add_argument("--warn-max", type=int, required=True)
     parser.add_argument("--warn-per-kloc", type=float, required=True)
-    # Errors are always judged over the whole tree: there are almost none left,
-    # and they do not move between runs. Warnings are a different animal. A
-    # change to one widget can shift how emmylua infers its way through an
-    # unrelated one, and it does so reproducibly, so repeat runs do not catch
-    # it -- budgeting that against its author is not useful, so by default
-    # only warnings in the files they touched count against the allowance, and
-    # the rest are reported as ripple effects for the reviewer to decide.
+    # Errors are always judged over the whole tree, and blocked on there: there
+    # are almost none left, and they do not move between runs. Warnings are a
+    # different animal. A change to one widget can shift how emmylua infers its
+    # way through an unrelated one, and it does so reproducibly, so repeat runs
+    # do not catch it -- budgeting that against its author is not useful, so by
+    # default only warnings in the files they touched count against the
+    # allowance, and the rest are reported as ripple for the reviewer to decide.
+    # Ripple is a warning idea only. An error is never excused by its address.
     parser.add_argument("--warn-scope", choices=("changed", "tree"), default="changed")
-    parser.add_argument("--report-only", action="store_true")
     parser.add_argument("--summary")
     # The compact rendering the CI Results comment pulls in as an artifact.
     parser.add_argument("--ci-report")
     args = parser.parse_args()
     args.runs = len(args.head)
     args.compared = bool(args.base)
-    if not args.compared:
-        args.report_only = True
+    # A manual run has no base, so there is nothing it can have made worse and
+    # nothing for it to gate. A pull request is compared, and a comparison gates.
+    args.report_only = not args.compared
 
     renames = read_renames(args.renames)
     base_runs = [
@@ -339,6 +373,7 @@ def main():
     if args.changed_files and os.path.exists(args.changed_files):
         with open(args.changed_files, encoding="utf-8", errors="replace") as handle:
             changed = {p for p in handle.read().split("\0") if p}
+    hunks = read_hunks(args.changed_hunks)
 
     new = []
     for key, count in head_min.items():
@@ -347,6 +382,7 @@ def main():
             continue
         severity, code, path, message = key
         for line, col in sorted(head_places.get(key, []))[-extra:] or [(1, 1)]:
+            scope = scope_of(path, line, changed, hunks)
             new.append(
                 {
                     "severity": severity,
@@ -355,14 +391,16 @@ def main():
                     "message": message,
                     "line": line,
                     "col": col,
-                    "changed": path in changed,
+                    "scope": scope,
+                    "changed": scope <= FILE,
                 }
             )
 
-    # Findings in the files this pull request touched come first, everywhere they
-    # are listed: those are the ones its author can act on without going hunting.
+    # Nearest first, everywhere a finding is listed: the lines this pull request
+    # wrote, then the rest of the files it touched, then the ones it did not.
+    # Those are the ones its author can act on without going hunting.
     new.sort(
-        key=lambda f: (not f["changed"], f["severity"], f["path"], f["line"], f["col"])
+        key=lambda f: (f["scope"], f["severity"], f["path"], f["line"], f["col"])
     )
     errors = [f for f in new if f["severity"] == ERROR]
     warnings = [f for f in new if f["severity"] == WARNING]
@@ -388,25 +426,31 @@ def main():
             % (len(budgeted), plural(len(budgeted)), allowance)
         )
 
+    on_lines = sum(1 for f in warnings if f["scope"] == HUNK)
     print(
-        "%d new finding(s): %d error(s), %d warning(s) of which %d in changed files "
-        "against an allowance of %d, %d ripple, %d info/hint. "
-        "%d changed line(s), %d run(s) per side."
+        "%d new finding(s): %d error(s), %d warning(s) -- %d on changed lines, %d "
+        "elsewhere in changed files, %d ripple -- %d budgeted against an allowance "
+        "of %d, %d info/hint. %d changed line(s), %d run(s) per side."
         % (
             len(new),
             len(errors),
             len(warnings),
+            on_lines,
+            len(warnings) - on_lines - ripple,
+            ripple,
             len(budgeted),
             allowance,
-            ripple,
             len(others),
             args.changed_lines,
             args.runs,
         )
     )
 
-    # Warnings outside the scope are not budgeted, so they are not annotated.
-    for pool, kind in ((errors, "error"), (budgeted, "warning")):
+    # Both pools are already sorted nearest first, so the cap spends itself on
+    # the changed lines, then the changed files, then the ripple. Every error is
+    # a candidate wherever it sits; a warning out of scope is still worth a
+    # bubble once the ones in scope have taken what they need.
+    for pool, kind in ((errors, "error"), (warnings, "warning")):
         for finding in pool[:ANNOTATION_CAP]:
             print(
                 "::%s file=%s,line=%d,col=%d,title=%s::%s"
@@ -456,7 +500,8 @@ def main():
             allowance,
             reasons,
             unstable,
-            args.compared and any(not f["changed"] for f in new),
+            args.compared
+            and any(f["severity"] != ERROR and not f["changed"] for f in new),
             len(budgeted),
             ripple,
             detail,

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -62,55 +62,138 @@ COMPACT_CODE_CAP = 10
 COMPACT_MESSAGE_CAP = 100
 
 
+def broken(detail):
+    """A report we cannot read is a CI defect, not a finding. Say which."""
+    print(
+        "::error title=Type check is broken::%s This is a CI defect, not a problem "
+        "with this PR; fix emmylua_compare.py or its pinned emmylua_check." % detail
+    )
+    sys.exit(1)
+
+
 def load(path, root):
-    """Reduce one report to {finding: count} and {finding: [positions]}."""
-    with open(path, encoding="utf-8", errors="replace") as handle:
-        report = json.load(handle)
+    """Reduce one report to {finding: count} and {finding: [positions]}.
+
+    Nothing here trusts the report's shape. emmylua_check writing something
+    unexpected has to arrive as a defect annotation, the way every other
+    breakage in this workflow does, and not as a traceback that reads to the
+    author like their own pull request broke.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            report = json.load(handle)
+    except (OSError, ValueError) as err:
+        broken("%s could not be read as Json (%s)." % (path, err))
+
+    if not isinstance(report, list):
+        broken(
+            "%s holds a Json %s where the report should be a list of files."
+            % (path, type(report).__name__)
+        )
 
     root = root.replace("\\", "/").rstrip("/") + "/"
     counts = collections.Counter()
     places = collections.defaultdict(list)
 
     for entry in report:
-        rel = entry.get("file", "").replace("\\", "/")
+        if not isinstance(entry, dict):
+            broken(
+                "%s lists a %s where a file object belongs."
+                % (path, type(entry).__name__)
+            )
+        rel = entry.get("file")
+        if not isinstance(rel, str):
+            broken("A file in %s carries no string path (got %r)." % (path, rel))
+        rel = rel.replace("\\", "/")
         rel = rel[len(root) :] if rel.startswith(root) else rel.lstrip("./")
-        for finding in entry.get("diagnostics", []):
+
+        # A file with nothing wrong may carry null rather than an empty list.
+        found = entry.get("diagnostics") or []
+        if not isinstance(found, list):
+            broken(
+                "The diagnostics for %s in %s are a %s, not a list."
+                % (rel, path, type(found).__name__)
+            )
+
+        for finding in found:
+            if not isinstance(finding, dict):
+                broken(
+                    "A diagnostic for %s in %s is a %s, not an object."
+                    % (rel, path, type(finding).__name__)
+                )
+            try:
+                severity = int(finding.get("severity", ERROR))
+            except (TypeError, ValueError):
+                broken(
+                    "A diagnostic for %s in %s has a non-numeric severity (%r), so "
+                    "there is no telling what blocks."
+                    % (rel, path, finding.get("severity"))
+                )
             key = (
-                int(finding.get("severity", ERROR)),
+                severity,
                 str(finding.get("code", "unknown")),
                 rel,
                 " ".join(str(finding.get("message", "")).split()),
             )
-            start = finding.get("range", {}).get("start", {})
+            # A position we cannot read is not worth failing over: it costs the
+            # finding its line number and nothing else, so it lands at the top
+            # of the file rather than taking the whole check down with it.
+            where = finding.get("range")
+            start = where.get("start") if isinstance(where, dict) else None
+            start = start if isinstance(start, dict) else {}
+            line, col = start.get("line", 0), start.get("character", 0)
             counts[key] += 1
             places[key].append(
-                (start.get("line", 0) + 1, start.get("character", 0) + 1)
+                (
+                    line + 1 if isinstance(line, int) else 1,
+                    col + 1 if isinstance(col, int) else 1,
+                )
             )
 
     return counts, places
 
 
+def read_records(path, width):
+    """Fixed-width records of NUL-separated fields.
+
+    A contributor can add a Lua file whose path holds a tab or a newline, so
+    every sidecar this script reads is NUL-separated, the way changed.txt is.
+    NUL is the one byte a path cannot contain, which is what makes it the only
+    safe separator here. Anything else silently splits a path in two and hands
+    its hunks to whatever file shares the prefix.
+    """
+    if not path or not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        fields = handle.read().split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+    if len(fields) % width:
+        broken(
+            "%s holds %d NUL-separated field(s), which is not a whole number of "
+            "%d-field records." % (path, len(fields), width)
+        )
+    return [tuple(fields[i : i + width]) for i in range(0, len(fields), width)]
+
+
 def read_renames(path):
-    pairs = {}
-    if path and os.path.exists(path):
-        with open(path, encoding="utf-8", errors="replace") as handle:
-            for line in handle:
-                old, _, new = line.rstrip("\n").partition("\t")
-                if old and new:
-                    pairs[old] = new
-    return pairs
+    """git diff --name-status -z writes status, old path, new path."""
+    return {old: new for _, old, new in read_records(path, 3) if old and new}
 
 
 def read_hunks(path):
     """The head-side line ranges the pull request wrote, per file."""
     ranges = collections.defaultdict(list)
-    if path and os.path.exists(path):
-        with open(path, encoding="utf-8", errors="replace") as handle:
-            for line in handle:
-                file, _, span = line.rstrip("\n").partition("\t")
-                start, _, end = span.partition("\t")
-                if file and start and end:
-                    ranges[file].append((int(start), int(end)))
+    for file, start, end in read_records(path, 3):
+        if not file:
+            continue
+        try:
+            ranges[file].append((int(start), int(end)))
+        except ValueError:
+            broken(
+                "%s carries a hunk range for %s that is not a pair of numbers "
+                "(%r, %r)." % (path, file, start, end)
+            )
     return ranges
 
 
@@ -187,6 +270,14 @@ def write_summary(
         )
     elif reasons:
         headline = "Type check: " + ", ".join(reasons)
+    elif not budget["total_judged"]:
+        # No lines in the changed files, so the total rule has no denominator
+        # and did not run. Saying "within 0" would read as a ceiling it met.
+        headline = (
+            "Type check: %d net new on the changed lines within %d; the changed "
+            "files have no lines to measure a rate against"
+            % (budget["net"], budget["added_allowance"])
+        )
     else:
         headline = (
             "Type check: %d net new on the changed lines within %d, %d left in the "
@@ -233,10 +324,6 @@ def write_summary(
                 "- **Added.** %d new warning%s on the lines this pull request wrote, "
                 "less %d it resolved in the files it touched, is %d net against an "
                 "allowance of %d -- %g per thousand of its %d changed line%s.\n"
-                "- **Total.** %d warning%s remain in the files it touched, against a "
-                "ceiling of %d -- %g per thousand of their %d line%s. This one does "
-                "not read the base: it is the state left behind, so a file already "
-                "over the line has to come under it.\n\n"
                 % (
                     args.runs,
                     plural(args.runs),
@@ -248,14 +335,30 @@ def write_summary(
                     args.warn_added_per_kloc,
                     args.changed_lines,
                     plural(args.changed_lines),
-                    budget["total"],
-                    plural(budget["total"]),
-                    budget["total_allowance"],
-                    args.warn_total_per_kloc,
-                    args.changed_file_lines,
-                    plural(args.changed_file_lines),
                 )
             )
+            if budget["total_judged"]:
+                out.write(
+                    "- **Total.** %d warning%s remain in the files it touched, "
+                    "against a ceiling of %d -- %g per thousand of their %d line%s. "
+                    "This one does not read the base: it is the state left behind, "
+                    "so a file already over the line has to come under it.\n\n"
+                    % (
+                        budget["total"],
+                        plural(budget["total"]),
+                        budget["total_allowance"],
+                        args.warn_total_per_kloc,
+                        args.changed_file_lines,
+                        plural(args.changed_file_lines),
+                    )
+                )
+            else:
+                out.write(
+                    "- **Total.** Not measured. The changed files hold no lines to "
+                    "divide by, so there is no rate to compare against %g per "
+                    "thousand, and this rule did not run.\n\n"
+                    % args.warn_total_per_kloc
+                )
             if ripple:
                 out.write(
                     "A further %d new warning%s landed in files this pull request did "
@@ -310,7 +413,10 @@ def write_summary(
         # standing warnings are listed whenever it is the thing that failed --
         # otherwise its author is handed a number and nowhere to go. They are
         # not listed when it passes: they are not news, and there are thousands.
-        over_total = budget["total"] > budget["total_allowance"]
+        over_total = (
+            budget["total_judged"]
+            and budget["total"] > budget["total_allowance"]
+        )
         standing_section = (list(standing), "Warnings in the changed files")
 
         sections = [
@@ -496,6 +602,12 @@ def main():
         severity, code, path, message = key
         if severity != WARNING or path not in changed:
             continue
+        # A key present in some head runs and absent from the last one reads as
+        # zero here. Falling through to the no-position default would invent a
+        # warning at line 1 and charge the total rule for the wobble that the
+        # four readings above exist to keep out of the numbers.
+        if count <= 0:
+            continue
         for line, col in sorted(head_places.get(key, []))[:count] or [(1, 1)]:
             standing.append(
                 {
@@ -512,6 +624,9 @@ def main():
     standing.sort(key=lambda f: (f["scope"], f["path"], f["line"], f["col"]))
     total = len(standing)
 
+    # A rate needs a denominator. Changed files with no lines to measure -- an
+    # empty file added on its own -- would otherwise get a ceiling of zero and
+    # fail on a warning they cannot be carrying, so the rule sits that one out.
     budget = {
         "added": added,
         "resolved": resolved,
@@ -521,6 +636,7 @@ def main():
         "total_allowance": int(
             args.warn_total_per_kloc * args.changed_file_lines / 1000.0
         ),
+        "total_judged": args.compared and args.changed_file_lines > 0,
     }
 
     reasons = []
@@ -531,7 +647,7 @@ def main():
             "%d net new warning%s on the changed lines over an allowance of %d"
             % (budget["net"], plural(budget["net"]), budget["added_allowance"])
         )
-    if args.compared and budget["total"] > budget["total_allowance"]:
+    if budget["total_judged"] and budget["total"] > budget["total_allowance"]:
         reasons.append(
             "%d warning%s left in the changed files over a ceiling of %d"
             % (budget["total"], plural(budget["total"]), budget["total_allowance"])
@@ -608,7 +724,11 @@ def main():
 
     # The whole standing set, when it is the thing that failed. Uncapped here,
     # the way the new findings are: the summary tables are the ones with a cap.
-    if standing and budget["total"] > budget["total_allowance"]:
+    if (
+        standing
+        and budget["total_judged"]
+        and budget["total"] > budget["total_allowance"]
+    ):
         print(
             "::group::warnings in the changed files - %d finding%s"
             % (len(standing), plural(len(standing)))

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -7,20 +7,32 @@ off one shared analysis and the inference-dependent diagnostics come out
 order-dependent (EmmyLuaLs/emmylua-analyzer-rust#1091).
 
 So "worse" cannot be read off one run against one run. Each side is analysed
-several times and the two are compared as multisets of findings, taking the
-generous reading of the base and the conservative one of the head:
+several times and the two are compared as multisets of findings. Each direction
+is read at the smallest figure the runs will support:
 
-    base  ->  the most times a finding appeared in any one base run
-    head  ->  the fewest times it appeared across every head run
+    added     ->  fewest head appearances  minus  most base appearances
+    resolved  ->  fewest base appearances  minus  most head appearances
+
+Read any other way round, the wobble becomes harvestable -- as a charge against
+an author who wrote nothing, or as credit for the same. A pull request that
+changed nothing nets exactly zero.
 
 Findings are keyed on (severity, code, path, message) rather than on position,
 so that inserting a line above a finding does not present it as new, and base
 paths are moved through the pull request's renames for the same reason.
 
-New errors block, anywhere in the repo.
+Three rules decide a pull request, and any one of them fails it:
 
-New warnings are allowed up to a budget that is the smaller of a flat cap and a
-rate per thousand changed lines. Small changes receive a very strict allowance.
+    errors    any new error, anywhere in the repo
+    added     net new warnings on the lines it wrote, per thousand changed
+              lines. Net: warnings it resolved pay for warnings it introduced.
+    total     every warning left in the files it touched, per thousand lines of
+              those files. This one never looks at the base. It is the state the
+              pull request leaves behind, so touching a file that is already
+              over the line means bringing it under.
+
+Small changes receive a very strict allowance on the added rule, and under about
+seventy changed lines that allowance is zero.
 
 Warnings are ranked by how near they are to the change. The lines changed, then
 the rest of the files it touched, then everywhere else. The annotation budget
@@ -155,12 +167,12 @@ def write_summary(
     path,
     args,
     pools,
-    allowance,
+    budget,
     reasons,
     unstable,
     any_untouched,
-    budgeted=0,
     ripple=0,
+    standing=(),
     detail="full",
 ):
     errors, warnings, others = pools
@@ -175,14 +187,17 @@ def write_summary(
         )
     elif reasons:
         headline = "Type check: " + ", ".join(reasons)
-    elif new_total:
-        headline = "Type check: %d new warning%s within an allowance of %d" % (
-            budgeted,
-            plural(budgeted),
-            allowance,
-        )
     else:
-        headline = "Type check: nothing new"
+        headline = (
+            "Type check: %d net new on the changed lines within %d, %d left in the "
+            "changed files within %d"
+            % (
+                budget["net"],
+                budget["added_allowance"],
+                budget["total"],
+                budget["total_allowance"],
+            )
+        )
 
     # The summary page is appended to, the comment's report is a file of its own.
     with open(path, "w" if compact else "a", encoding="utf-8") as out:
@@ -190,32 +205,58 @@ def write_summary(
         if compact:
             if args.compared:
                 out.write(
-                    "%d changed line%s, allowance %d new warning%s, %d run%s per "
-                    "side. The full report is on the check's own page.\n"
+                    "Added: %d new minus %d resolved is %d net on %d changed line%s, "
+                    "against an allowance of %d. Total: %d warning%s left in the "
+                    "changed files across %d line%s, against a ceiling of %d. "
+                    "%d run%s per side. The full report is on the check's own page.\n"
                     % (
+                        budget["added"],
+                        budget["resolved"],
+                        budget["net"],
                         args.changed_lines,
                         plural(args.changed_lines),
-                        allowance,
-                        plural(allowance),
+                        budget["added_allowance"],
+                        budget["total"],
+                        plural(budget["total"]),
+                        args.changed_file_lines,
+                        plural(args.changed_file_lines),
+                        budget["total_allowance"],
                         args.runs,
                         plural(args.runs),
                     )
                 )
         elif args.compared:
             out.write(
-                "Compared against the base over %d run%s per side. %d changed line%s "
-                "have an allowance of %d new warning%s. Any new error blocks, "
-                "wherever in the tree it landed. Info and hints never block.\n\n"
+                "Compared against the base over %d run%s per side. Any new error "
+                "blocks, wherever in the tree it landed. Info and hints never "
+                "block. Warnings are judged twice:\n\n"
+                "- **Added.** %d new warning%s on the lines this pull request wrote, "
+                "less %d it resolved in the files it touched, is %d net against an "
+                "allowance of %d -- %g per thousand of its %d changed line%s.\n"
+                "- **Total.** %d warning%s remain in the files it touched, against a "
+                "ceiling of %d -- %g per thousand of their %d line%s. This one does "
+                "not read the base: it is the state left behind, so a file already "
+                "over the line has to come under it.\n\n"
                 % (
                     args.runs,
                     plural(args.runs),
+                    budget["added"],
+                    plural(budget["added"]),
+                    budget["resolved"],
+                    budget["net"],
+                    budget["added_allowance"],
+                    args.warn_added_per_kloc,
                     args.changed_lines,
                     plural(args.changed_lines),
-                    allowance,
-                    plural(allowance),
+                    budget["total"],
+                    plural(budget["total"]),
+                    budget["total_allowance"],
+                    args.warn_total_per_kloc,
+                    args.changed_file_lines,
+                    plural(args.changed_file_lines),
                 )
             )
-            if args.warn_scope == "changed" and ripple:
+            if ripple:
                 out.write(
                     "A further %d new warning%s landed in files this pull request did "
                     "not touch. Those are reported below but not budgeted: emmylua "
@@ -226,9 +267,9 @@ def write_summary(
                 )
             out.write(
                 "emmylua disagreed with itself about %d finding%s on this branch and %d "
-                "on the base. The base is read at its highest count and this branch "
-                "at its lowest, so that disagreement is absorbed instead of charged to "
-                "the author, which is why the check runs more than once per side.\n"
+                "on the base. Both directions are read at the smallest figure the runs "
+                "will support, so that disagreement can be turned into neither a charge "
+                "nor a credit, which is why the check runs more than once per side.\n"
                 % (unstable["head"], plural(unstable["head"]), unstable["base"])
             )
         else:
@@ -265,16 +306,25 @@ def write_summary(
         if not args.compared:
             return
 
+        # The total rule can fail a pull request that introduced nothing, so the
+        # standing warnings are listed whenever it is the thing that failed --
+        # otherwise its author is handed a number and nowhere to go. They are
+        # not listed when it passes: they are not news, and there are thousands.
+        over_total = budget["total"] > budget["total_allowance"]
+        standing_section = (list(standing), "Warnings in the changed files")
+
         sections = [
             (errors, "New errors"),
             (warnings, "New warnings"),
             (others, "New info and hints"),
         ]
         if compact:
-            # The warnings table earns its bytes only when the budget was spent.
+            # A table earns its bytes only when its own rule failed.
             sections = [(errors, "New errors")]
-            if budgeted > allowance:
+            if budget["net"] > budget["added_allowance"]:
                 sections.append((warnings, "New warnings"))
+        if over_total:
+            sections.append(standing_section)
 
         for pool, title in sections:
             if not pool:
@@ -308,6 +358,14 @@ def write_summary(
                     % (table_cap, len(pool))
                 )
 
+        if over_total and not compact:
+            out.write(
+                "\n_The warnings in the changed files are listed whether or not this "
+                "pull request wrote them. The rule is on the state it leaves behind, "
+                "so clearing enough of them -- or splitting the already-noisy file out "
+                "of this change -- is what brings it under the ceiling._\n"
+            )
+
         if any_untouched and not compact:
             out.write(
                 "\n_Rows marked `*` are in files this pull request did not touch. The "
@@ -329,18 +387,20 @@ def main():
     # path<TAB>start<TAB>end, one head-side hunk per line. Without it the near
     # ring is empty and warnings are scoped to whole files, as they were before.
     parser.add_argument("--changed-hunks")
+    # The denominator of each rule is the size of its own scope: the added rule
+    # divides by the lines the diff touched, the total rule by the size of the
+    # files it touched.
     parser.add_argument("--changed-lines", type=int, default=0)
-    parser.add_argument("--warn-max", type=int, required=True)
-    parser.add_argument("--warn-per-kloc", type=float, required=True)
-    # Errors are always judged over the whole tree, and blocked on there: there
-    # are almost none left, and they do not move between runs. Warnings are a
+    parser.add_argument("--changed-file-lines", type=int, default=0)
+    parser.add_argument("--warn-added-per-kloc", type=float, required=True)
+    parser.add_argument("--warn-total-per-kloc", type=float, required=True)
+    # Errors are judged over the whole tree and blocked on there: there are
+    # almost none left, and they do not move between runs. Warnings are a
     # different animal. A change to one widget can shift how emmylua infers its
     # way through an unrelated one, and it does so reproducibly, so repeat runs
-    # do not catch it -- budgeting that against its author is not useful, so by
-    # default only warnings in the files they touched count against the
-    # allowance, and the rest are reported as ripple for the reviewer to decide.
+    # do not catch it. Neither warning rule reaches outside the files the pull
+    # request touched, so those land as ripple: reported, never charged.
     # Ripple is a warning idea only. An error is never excused by its address.
-    parser.add_argument("--warn-scope", choices=("changed", "tree"), default="changed")
     parser.add_argument("--summary")
     # The compact rendering the CI Results comment pulls in as an artifact.
     parser.add_argument("--ci-report")
@@ -362,12 +422,15 @@ def main():
         head_runs.append(counts)
         head_places = places  # positions are quoted from whichever run came last
 
-    base_max = (
-        {k: max(r[k] for r in base_runs) for k in set().union(*base_runs)}
-        if base_runs
-        else {}
-    )
-    head_min = {k: min(r[k] for r in head_runs) for k in set().union(*head_runs)}
+    # Four readings, not two: added is charged at its lowest and resolved is
+    # credited at its lowest, so emmylua's disagreement with itself cannot be
+    # turned into either a charge or a credit. See the module docstring.
+    base_keys = set().union(*base_runs) if base_runs else set()
+    head_keys = set().union(*head_runs)
+    base_max = {k: max(r[k] for r in base_runs) for k in base_keys}
+    base_min = {k: min(r[k] for r in base_runs) for k in base_keys}
+    head_min = {k: min(r[k] for r in head_runs) for k in head_keys}
+    head_max = {k: max(r[k] for r in head_runs) for k in head_keys}
 
     changed = set()
     if args.changed_files and os.path.exists(args.changed_files):
@@ -406,42 +469,96 @@ def main():
     warnings = [f for f in new if f["severity"] == WARNING]
     others = [f for f in new if f["severity"] > WARNING]
 
-    allowance = min(
-        args.warn_max, int(args.warn_per_kloc * args.changed_lines / 1000.0)
-    )
+    # Scope is a pull request idea. A manual run has no changed set, so every
+    # finding reads as ripple and neither warning rule has anything to say.
+    added = sum(1 for f in warnings if f["scope"] == HUNK)
+    in_files = sum(1 for f in warnings if f["scope"] == FILE)
+    ripple = len(warnings) - added - in_files
 
-    # Scope is a pull request idea. A manual run has no changed set, so narrowing
-    # to it would report every finding as out of scope and then budget none of them.
-    budgeted = warnings
-    if args.compared and args.warn_scope == "changed":
-        budgeted = [f for f in warnings if f["changed"]]
-    ripple = len(warnings) - len(budgeted)
+    # A resolved warning has no head position to place in a hunk, so credit is
+    # scoped to the file. In practice a warning only leaves a file the pull
+    # request touched because one of its hunks removed it.
+    resolved = 0
+    for key, count in base_min.items():
+        severity, _, path, _ = key
+        if severity != WARNING or path not in changed:
+            continue
+        gone = count - head_max.get(key, 0)
+        if gone > 0:
+            resolved += gone
+
+    # Every warning the pull request leaves behind in the files it touched,
+    # whether or not it put them there. This rule does not read the base at all.
+    # They are listed as well as counted: this rule can fail a pull request that
+    # introduced nothing, and a number on its own gives its author nowhere to go.
+    standing = []
+    for key, count in head_min.items():
+        severity, code, path, message = key
+        if severity != WARNING or path not in changed:
+            continue
+        for line, col in sorted(head_places.get(key, []))[:count] or [(1, 1)]:
+            standing.append(
+                {
+                    "severity": severity,
+                    "code": code,
+                    "path": path,
+                    "message": message,
+                    "line": line,
+                    "col": col,
+                    "scope": scope_of(path, line, changed, hunks),
+                    "changed": True,
+                }
+            )
+    standing.sort(key=lambda f: (f["scope"], f["path"], f["line"], f["col"]))
+    total = len(standing)
+
+    budget = {
+        "added": added,
+        "resolved": resolved,
+        "net": added - resolved,
+        "added_allowance": int(args.warn_added_per_kloc * args.changed_lines / 1000.0),
+        "total": total,
+        "total_allowance": int(
+            args.warn_total_per_kloc * args.changed_file_lines / 1000.0
+        ),
+    }
 
     reasons = []
     if errors:
         reasons.append("%d new type error%s" % (len(errors), plural(len(errors))))
-    if len(budgeted) > allowance:
+    if args.compared and budget["net"] > budget["added_allowance"]:
         reasons.append(
-            "%d new warning%s over an allowance of %d"
-            % (len(budgeted), plural(len(budgeted)), allowance)
+            "%d net new warning%s on the changed lines over an allowance of %d"
+            % (budget["net"], plural(budget["net"]), budget["added_allowance"])
+        )
+    if args.compared and budget["total"] > budget["total_allowance"]:
+        reasons.append(
+            "%d warning%s left in the changed files over a ceiling of %d"
+            % (budget["total"], plural(budget["total"]), budget["total_allowance"])
         )
 
-    on_lines = sum(1 for f in warnings if f["scope"] == HUNK)
     print(
         "%d new finding(s): %d error(s), %d warning(s) -- %d on changed lines, %d "
-        "elsewhere in changed files, %d ripple -- %d budgeted against an allowance "
-        "of %d, %d info/hint. %d changed line(s), %d run(s) per side."
+        "elsewhere in changed files, %d ripple -- %d info/hint. "
+        "Added: %d - %d resolved = %d net, allowance %d over %d changed line(s). "
+        "Total: %d warning(s) left in the changed files, ceiling %d over %d line(s). "
+        "%d run(s) per side."
         % (
             len(new),
             len(errors),
             len(warnings),
-            on_lines,
-            len(warnings) - on_lines - ripple,
+            added,
+            in_files,
             ripple,
-            len(budgeted),
-            allowance,
             len(others),
+            budget["added"],
+            budget["resolved"],
+            budget["net"],
+            budget["added_allowance"],
             args.changed_lines,
+            budget["total"],
+            budget["total_allowance"],
+            args.changed_file_lines,
             args.runs,
         )
     )
@@ -489,6 +606,26 @@ def main():
             )
         print("::endgroup::")
 
+    # The whole standing set, when it is the thing that failed. Uncapped here,
+    # the way the new findings are: the summary tables are the ones with a cap.
+    if standing and budget["total"] > budget["total_allowance"]:
+        print(
+            "::group::warnings in the changed files - %d finding%s"
+            % (len(standing), plural(len(standing)))
+        )
+        for finding in standing:
+            print(
+                "%s:%d:%d: %s: %s"
+                % (
+                    finding["path"],
+                    finding["line"],
+                    finding["col"],
+                    finding["code"],
+                    finding["message"],
+                )
+            )
+        print("::endgroup::")
+
     # The same report, rendered for the job's own page and for the comment.
     for path, detail in ((args.summary, "full"), (args.ci_report, "compact")):
         if not path:
@@ -497,13 +634,13 @@ def main():
             path,
             args,
             (errors, warnings, others),
-            allowance,
+            budget,
             reasons,
             unstable,
             args.compared
             and any(f["severity"] != ERROR and not f["changed"] for f in new),
-            len(budgeted),
             ripple,
+            standing,
             detail,
         )
 

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -294,7 +294,7 @@ def main():
     parser.add_argument("--renames")
     parser.add_argument("--changed-files")
     parser.add_argument("--added-lines", type=int, default=0)
-    parser.add_argument("--warn-floor", type=int, required=True)
+    parser.add_argument("--warn-max", type=int, required=True)
     parser.add_argument("--warn-per-kloc", type=float, required=True)
     # Errors are always judged over the whole tree: there are almost none left,
     # and they do not move between runs. Warnings are a different animal. A
@@ -366,7 +366,7 @@ def main():
     others = [f for f in new if f["severity"] > WARNING]
 
     allowance = min(
-        args.warn_floor, round(args.warn_per_kloc * args.added_lines / 1000.0)
+        args.warn_max, round(args.warn_per_kloc * args.added_lines / 1000.0)
     )
 
     budgeted = warnings

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Decide whether a pull request made type checking worse, and report on it.
+
+emmylua_check is not deterministic. Run it twice over an unchanged tree and a
+couple of percent of its findings move, because it diagnoses files concurrently
+off one shared analysis and the inference-dependent diagnostics come out
+order-dependent (EmmyLuaLs/emmylua-analyzer-rust#1091).
+
+So "worse" cannot be read off one run against one run. Each side is analysed
+several times and the two are compared as multisets of findings, taking the
+generous reading of the base and the conservative one of the head:
+
+    base  ->  the most times a finding appeared in any one base run
+    head  ->  the fewest times it appeared across every head run
+
+Findings are keyed on (severity, code, path, message) rather than on position,
+so that inserting a line above a finding does not present it as new, and base
+paths are moved through the pull request's renames for the same reason.
+
+New errors block. New warnings are allowed up to a budget that is the larger of
+a flat floor and a rate per thousand changed lines: the floor keeps a one-line
+fix from being judged on a ratio, and the rate stops a large pull request from
+spending that floor over and over.
+"""
+
+import argparse
+import collections
+import json
+import os
+import sys
+
+ERROR, WARNING = 1, 2
+SEVERITY_NAME = {1: "error", 2: "warning", 3: "info", 4: "hint"}
+ANNOTATION_CAP = 10
+TABLE_CAP = 50
+
+# The CI Results comment trims anything past its slice, cutting a table mid-row.
+# So the report renders twice, and the compact one carries only what blocked.
+COMPACT_TABLE_CAP = 10
+COMPACT_CODE_CAP = 10
+COMPACT_MESSAGE_CAP = 100
+
+
+def load(path, root):
+    """Reduce one report to {finding: count} and {finding: [positions]}."""
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        report = json.load(handle)
+
+    root = root.replace("\\", "/").rstrip("/") + "/"
+    counts = collections.Counter()
+    places = collections.defaultdict(list)
+
+    for entry in report:
+        rel = entry.get("file", "").replace("\\", "/")
+        rel = rel[len(root) :] if rel.startswith(root) else rel.lstrip("./")
+        for finding in entry.get("diagnostics", []):
+            key = (
+                int(finding.get("severity", ERROR)),
+                str(finding.get("code", "unknown")),
+                rel,
+                " ".join(str(finding.get("message", "")).split()),
+            )
+            start = finding.get("range", {}).get("start", {})
+            counts[key] += 1
+            places[key].append(
+                (start.get("line", 0) + 1, start.get("character", 0) + 1)
+            )
+
+    return counts, places
+
+
+def read_renames(path):
+    pairs = {}
+    if path and os.path.exists(path):
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                old, _, new = line.rstrip("\n").partition("\t")
+                if old and new:
+                    pairs[old] = new
+    return pairs
+
+
+def apply_renames(counts, renames):
+    """Move base findings onto their head paths, so a rename reads as no change."""
+    if not renames:
+        return counts
+    moved = collections.Counter()
+    for (severity, code, path, message), n in counts.items():
+        moved[(severity, code, renames.get(path, path), message)] += n
+    return moved
+
+
+def escape(text):
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def escape_property(text):
+    return escape(text).replace(",", "%2C").replace(":", "%3A")
+
+
+def plural(n):
+    return "" if n == 1 else "s"
+
+
+def group_by_code(findings):
+    grouped = collections.defaultdict(list)
+    for finding in findings:
+        grouped[finding["code"]].append(finding)
+    return grouped
+
+
+def wobble(runs):
+    """How many findings the runs of one side disagreed with each other about."""
+    return sum(
+        1
+        for key in set().union(*runs)
+        if min(run[key] for run in runs) != max(run[key] for run in runs)
+    )
+
+
+def write_summary(
+    path,
+    args,
+    pools,
+    allowance,
+    reasons,
+    unstable,
+    any_untouched,
+    budgeted=0,
+    ripple=0,
+    detail="full",
+):
+    errors, warnings, others = pools
+    new_total = len(errors) + len(warnings) + len(others)
+    compact = detail == "compact"
+    table_cap = COMPACT_TABLE_CAP if compact else TABLE_CAP
+
+    if not args.compared:
+        headline = "Type check: %d finding%s in the whole tree" % (
+            new_total,
+            plural(new_total),
+        )
+    elif reasons and args.report_only:
+        headline = "Type check: would have failed on " + ", ".join(reasons)
+    elif reasons:
+        headline = "Type check: " + ", ".join(reasons)
+    elif new_total:
+        headline = "Type check: %d new warning%s within an allowance of %d" % (
+            budgeted,
+            plural(budgeted),
+            allowance,
+        )
+    else:
+        headline = "Type check: nothing new"
+
+    # The summary page is appended to, the comment's report is a file of its own.
+    with open(path, "w" if compact else "a", encoding="utf-8") as out:
+        out.write("### %s\n\n" % headline)
+        if compact:
+            if args.compared:
+                out.write(
+                    "%d changed line%s, allowance %d new warning%s, %d run%s per side."
+                    "%s The full report is on the check's own page.\n"
+                    % (
+                        args.added_lines,
+                        plural(args.added_lines),
+                        allowance,
+                        plural(allowance),
+                        args.runs,
+                        plural(args.runs),
+                        " Reporting only, not gating." if args.report_only else "",
+                    )
+                )
+        elif args.compared:
+            out.write(
+                "Compared against the base over %d run%s per side. %d changed line%s "
+                "have an allowance of %d new warning%s. Any new error blocks. Info and "
+                "hints never block.\n\n"
+                % (
+                    args.runs,
+                    plural(args.runs),
+                    args.added_lines,
+                    plural(args.added_lines),
+                    allowance,
+                    plural(allowance),
+                )
+            )
+            if args.report_only:
+                out.write(
+                    "This check is reporting only and does not gate anything yet, so "
+                    "the thresholds can be read off real pull requests before they "
+                    "start turning anyone red.\n\n"
+                )
+            if args.warn_scope == "changed" and ripple:
+                out.write(
+                    "A further %d new warning%s landed in files this pull request did "
+                    "not touch. Those are reported below but not budgeted: emmylua "
+                    "re-infers its way through unrelated files when anything moves, "
+                    "and holding an author to that is not useful.\n\n"
+                    % (ripple, plural(ripple))
+                )
+            out.write(
+                "emmylua disagreed with itself about %d finding%s on this branch and %d "
+                "on the base. Those are excluded rather than counted, which is the whole "
+                "reason the check runs more than once per side.\n"
+                % (unstable["head"], plural(unstable["head"]), unstable["base"])
+            )
+        else:
+            out.write(
+                "Manual whole-tree run, with nothing to compare against. Reporting "
+                "only -- this does not gate anything.\n"
+            )
+
+        # Grouped by code rather than lumped under a severity, because "1354
+        # unnecessary-if" and "1 undefined-global" are two different
+        # conversations and a flat list buries that.
+        if new_total:
+            counts = sorted(
+                group_by_code(errors + warnings + others).items(),
+                key=lambda kv: (kv[1][0]["severity"], -len(kv[1])),
+            )
+            shown = counts[:COMPACT_CODE_CAP] if compact else counts
+            out.write("\n| Code | Severity | Count |\n| --- | --- | --- |\n")
+            for code, findings in shown:
+                out.write(
+                    "| `%s` | %s | %d |\n"
+                    % (
+                        code,
+                        SEVERITY_NAME.get(findings[0]["severity"], "?"),
+                        len(findings),
+                    )
+                )
+            if len(shown) < len(counts):
+                out.write(
+                    "\n_%d more code%s not shown._\n"
+                    % (len(counts) - len(shown), plural(len(counts) - len(shown)))
+                )
+
+        if not args.compared:
+            return
+
+        sections = [
+            (errors, "New errors"),
+            (warnings, "New warnings"),
+            (others, "New info and hints"),
+        ]
+        if compact:
+            # The warnings table earns its bytes only when the budget was spent.
+            sections = [(errors, "New errors")]
+            if budgeted > allowance:
+                sections.append((warnings, "New warnings"))
+
+        for pool, title in sections:
+            if not pool:
+                continue
+            out.write("\n#### %s (%d)\n\n" % (title, len(pool)))
+            out.write("| Location | Code | Message |\n| --- | --- | --- |\n")
+            for finding in pool[:table_cap]:
+                message = finding["message"].replace("|", "\\|")
+                if compact and len(message) > COMPACT_MESSAGE_CAP:
+                    message = message[: COMPACT_MESSAGE_CAP - 1] + "…"
+                out.write(
+                    "| `%s:%d`%s | `%s` | %s |\n"
+                    % (
+                        finding["path"],
+                        finding["line"],
+                        "" if finding["changed"] or compact else " *",
+                        finding["code"],
+                        message,
+                    )
+                )
+            if len(pool) > table_cap:
+                out.write(
+                    "\n_Showing %d of %d; the workflow log lists every one._\n"
+                    % (table_cap, len(pool))
+                )
+
+        if any_untouched and not compact:
+            out.write(
+                "\n_Rows marked `*` are in files this pull request did not touch. The "
+                "change reached them through inference, which is exactly what a "
+                "whole-tree comparison is for._\n"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    # Without a base there is nothing to compare against, so every finding is
+    # reported as-is and nothing blocks. That is the manual whole-tree run.
+    parser.add_argument("--base", nargs="+")
+    parser.add_argument("--head", nargs="+", required=True)
+    parser.add_argument("--base-root", default="")
+    parser.add_argument("--head-root", required=True)
+    parser.add_argument("--renames")
+    parser.add_argument("--changed-files")
+    parser.add_argument("--added-lines", type=int, default=0)
+    parser.add_argument("--warn-floor", type=int, required=True)
+    parser.add_argument("--warn-per-kloc", type=float, required=True)
+    # Errors are always judged over the whole tree: there are almost none left,
+    # and they do not move between runs. Warnings are a different animal. A
+    # change to one widget can shift how emmylua infers its way through an
+    # unrelated one, and it does so reproducibly, so repeat runs do not catch
+    # it -- budgeting that against its author is not useful, so by default
+    # only warnings in the files they touched count against the allowance, and
+    # the rest are reported as ripple effects for the reviewer to decide.
+    parser.add_argument("--warn-scope", choices=("changed", "tree"), default="changed")
+    parser.add_argument("--report-only", action="store_true")
+    parser.add_argument("--summary")
+    # The compact rendering the CI Results comment pulls in as an artifact.
+    parser.add_argument("--ci-report")
+    args = parser.parse_args()
+    args.runs = len(args.head)
+    args.compared = bool(args.base)
+    if not args.compared:
+        args.report_only = True
+
+    renames = read_renames(args.renames)
+    base_runs = [
+        apply_renames(load(p, args.base_root)[0], renames) for p in (args.base or [])
+    ]
+
+    head_runs, head_places = [], {}
+    for path in args.head:
+        counts, places = load(path, args.head_root)
+        head_runs.append(counts)
+        head_places = places  # positions are quoted from whichever run came last
+
+    base_max = (
+        {k: max(r[k] for r in base_runs) for k in set().union(*base_runs)}
+        if base_runs
+        else {}
+    )
+    head_min = {k: min(r[k] for r in head_runs) for k in set().union(*head_runs)}
+
+    changed = set()
+    if args.changed_files and os.path.exists(args.changed_files):
+        with open(args.changed_files, encoding="utf-8", errors="replace") as handle:
+            changed = {p for p in handle.read().split("\0") if p}
+
+    new = []
+    for key, count in head_min.items():
+        extra = count - base_max.get(key, 0)
+        if extra <= 0:
+            continue
+        severity, code, path, message = key
+        for line, col in sorted(head_places.get(key, []))[-extra:] or [(1, 1)]:
+            new.append(
+                {
+                    "severity": severity,
+                    "code": code,
+                    "path": path,
+                    "message": message,
+                    "line": line,
+                    "col": col,
+                    "changed": path in changed,
+                }
+            )
+
+    # Findings in the files this pull request touched come first, everywhere they
+    # are listed: those are the ones its author can act on without going hunting.
+    new.sort(
+        key=lambda f: (not f["changed"], f["severity"], f["path"], f["line"], f["col"])
+    )
+    errors = [f for f in new if f["severity"] == ERROR]
+    warnings = [f for f in new if f["severity"] == WARNING]
+    others = [f for f in new if f["severity"] > WARNING]
+
+    allowance = max(
+        args.warn_floor, round(args.warn_per_kloc * args.added_lines / 1000.0)
+    )
+
+    budgeted = warnings
+    if args.warn_scope == "changed":
+        budgeted = [f for f in warnings if f["changed"]]
+    ripple = len(warnings) - len(budgeted)
+
+    reasons = []
+    if errors:
+        reasons.append("%d new type error%s" % (len(errors), plural(len(errors))))
+    if len(budgeted) > allowance:
+        reasons.append(
+            "%d new warning%s over an allowance of %d"
+            % (len(budgeted), plural(len(budgeted)), allowance)
+        )
+
+    print(
+        "%d new finding(s): %d error(s), %d warning(s) of which %d in changed files "
+        "against an allowance of %d, %d ripple, %d info/hint. "
+        "%d changed line(s), %d run(s) per side."
+        % (
+            len(new),
+            len(errors),
+            len(warnings),
+            len(budgeted),
+            allowance,
+            ripple,
+            len(others),
+            args.added_lines,
+            args.runs,
+        )
+    )
+
+    for pool, kind in ((errors, "error"), (warnings, "warning")):
+        for finding in pool[:ANNOTATION_CAP]:
+            print(
+                "::%s file=%s,line=%d,col=%d,title=%s::%s"
+                % (
+                    kind,
+                    escape_property(finding["path"]),
+                    finding["line"],
+                    finding["col"],
+                    escape_property(finding["code"]),
+                    escape(finding["message"]),
+                )
+            )
+        if len(pool) > ANNOTATION_CAP:
+            print(
+                "::notice title=Type check::Only the first %d new %ss are annotated; "
+                "the job summary lists every one." % (ANNOTATION_CAP, kind)
+            )
+
+    unstable = {
+        "base": wobble(base_runs) if base_runs else 0,
+        "head": wobble(head_runs),
+    }
+
+    # One collapsible fold per code. Uncapped: on a whole-tree run that is tens
+    # of thousands of lines, which is readable folded and unreadable flat.
+    for code, findings in sorted(
+        group_by_code(new).items(), key=lambda kv: (kv[1][0]["severity"], -len(kv[1]))
+    ):
+        print(
+            "::group::%s - %d finding%s" % (code, len(findings), plural(len(findings)))
+        )
+        for finding in findings:
+            print(
+                "%s:%d:%d: %s"
+                % (finding["path"], finding["line"], finding["col"], finding["message"])
+            )
+        print("::endgroup::")
+
+    # The same report, rendered for the job's own page and for the comment.
+    for path, detail in ((args.summary, "full"), (args.ci_report, "compact")):
+        if not path:
+            continue
+        write_summary(
+            path,
+            args,
+            (errors, warnings, others),
+            allowance,
+            reasons,
+            unstable,
+            any(not f["changed"] for f in new),
+            len(budgeted),
+            ripple,
+            detail,
+        )
+
+    return 1 if reasons and not args.report_only else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -17,10 +17,10 @@ Findings are keyed on (severity, code, path, message) rather than on position,
 so that inserting a line above a finding does not present it as new, and base
 paths are moved through the pull request's renames for the same reason.
 
-New errors block. New warnings are allowed up to a budget that is the larger of
-a flat floor and a rate per thousand changed lines: the floor keeps a one-line
-fix from being judged on a ratio, and the rate stops a large pull request from
-spending that floor over and over.
+New errors block.
+
+New warnings are allowed up to a budget that is the smaller of a flat floor and
+a rate per thousand changed lines. Small changes are judged at high scrictness.
 """
 
 import argparse

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -95,13 +95,13 @@ jobs:
             | map(
                 . as $file
                 | ($lines[$file.file] // []) as $ranges
-                | $file + { mismatches: [ $file.mismatches[] | select(overlaps($ranges)) ] }
+                | $file + { mismatches: [ ($file.mismatches // [])[] | select(overlaps($ranges)) ] }
               )
             | map(select(.mismatches | length > 0))
           ' mismatches.json > blocking.json
 
-          raw_hunks=$(jq -s '[ .[].mismatches[] ] | length' mismatches.json)
-          bad_hunks=$(jq '[ .[].mismatches[] ] | length' blocking.json)
+          raw_hunks=$(jq -s '[ .[] | .mismatches // [] | .[] ] | length' mismatches.json)
+          bad_hunks=$(jq '[ .[] | .mismatches // [] | .[] ] | length' blocking.json)
           preexisting_hunks=$((raw_hunks - bad_hunks))
           jq -r '.[].file' blocking.json | sort -u > misformatted.txt
 

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -71,6 +71,16 @@ jobs:
             | jq -s -c --arg file "$file" '{file: $file, ranges: .}' >> ranges.json
           done < changed.txt
 
+          # One record per changed file. Short of that, the overlap test below
+          # finds no ranges for the missing ones, reads their mismatches as
+          # lines this PR did not write, and passes them. Silence, not failure.
+          changed_files=$(tr -cd '\0' < changed.txt | wc -c)
+          range_records=$(wc -l < ranges.json)
+          if [ "$range_records" -ne "$changed_files" ]; then
+            echo "::error title=Formatting check is broken::ranges.json holds $range_records record(s) for $changed_files changed file(s), so the overlap test would wave through every file it failed to scope. This is a CI defect, not a problem with this PR; fix format_check.yml."
+            exit 1
+          fi
+
           # No human being fixes their formatting by reading a diff from a linter
           # so we prevent the logging of any diff. The JSON check output reports
           # formatting mismatches per file on stdout and parse errs on stderr, so
@@ -82,9 +92,29 @@ jobs:
           stylua_status=$?
           set -e
 
-          if ! jq -e -s 'type == "array"' mismatches.json > /dev/null 2>&1; then
+          # -s always yields an array, so testing for one tests only that the
+          # report parsed. What matters is that the records are file objects.
+          if ! jq -e -s '
+                type == "array"
+                and all(type == "object" and (.file | type == "string"))
+              ' mismatches.json > /dev/null 2>&1; then
             echo "::error title=Formatting check is broken::stylua wrote an unreadable Json report (exit $stylua_status). This is a CI defect, not a problem with this PR; fix format_check.yml or its pinned stylua."
             cat mismatches.json errors.json
+            exit 1
+          fi
+
+          raw_hunks=$(jq -s '[ .[] | .mismatches // [] | .[] ] | length' mismatches.json)
+
+          # jq reads a missing field as null and null + 1 as 1, so renaming the
+          # line fields would not fail the overlap test below: it would scope
+          # every mismatch to line 1 and then block or ignore by whether the PR
+          # happened to touch the top of the file. Assert rather than trust.
+          if [ "$raw_hunks" -gt 0 ] && ! jq -e -s '
+                [ .[] | .mismatches // [] | .[] ]
+                | all((.original_start_line | type == "number")
+                      and (.original_end_line | type == "number"))
+              ' mismatches.json > /dev/null 2>&1; then
+            echo "::error title=Formatting check is broken::stylua's mismatches no longer carry numeric original_start_line and original_end_line, so the overlap test would scope every one of them to line 1. This is a CI defect, not a problem with this PR; fix format_check.yml or its pinned stylua."
             exit 1
           fi
 
@@ -103,7 +133,6 @@ jobs:
             | map(select(.mismatches | length > 0))
           ' mismatches.json > blocking.json
 
-          raw_hunks=$(jq -s '[ .[] | .mismatches // [] | .[] ] | length' mismatches.json)
           bad_hunks=$(jq '[ .[] | .mismatches // [] | .[] ] | length' blocking.json)
           preexisting_hunks=$((raw_hunks - bad_hunks))
           jq -r '.[].file' blocking.json | sort -u > misformatted.txt

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -34,7 +34,7 @@ jobs:
           chmod +x stylua
           ./stylua --version
 
-      - name: Check formatting of changed files
+      - name: Check formatting of changed lines
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -52,6 +52,22 @@ jobs:
           echo "Checking:"
           tr '\0' '\n' < changed.txt
 
+          # The scope is lines not files, but we get hunks so ignore deletion,
+          # treating it as a write on the two lines that it "joins" together.
+          : > ranges.json
+          while IFS= read -r -d '' file; do
+            git diff --unified=0 "$BASE_SHA" HEAD -- "$file" \
+            | awk '
+                /^@@/ {
+                  split($3, hunk, ",")
+                  start = hunk[1] + 0; if (start < 0) start = -start
+                  count = (hunk[2] == "" ? 1 : hunk[2] + 0)
+                  if (count == 0) printf "[%d,%d]\n", start, start + 1
+                  else            printf "[%d,%d]\n", start, start + count - 1
+                }' \
+            | jq -s -c --arg file "$file" '{file: $file, ranges: .}' >> ranges.json
+          done < changed.txt
+
           # No human being fixes their formatting by reading a diff from a linter
           # so we prevent the logging of any diff. The JSON check output reports
           # formatting mismatches per file on stdout and parse errs on stderr, so
@@ -68,7 +84,26 @@ jobs:
             cat mismatches.json errors.json
             exit 1
           fi
-          jq -r '.file' mismatches.json | sort -u > misformatted.txt
+
+          # Stylua counts lines from zero and the diff counts them from one.
+          jq -s --slurpfile touched ranges.json '
+            def overlaps($ranges): . as $hunk
+              | any($ranges[];
+                  .[0] <= ($hunk.original_end_line + 1)
+                  and ($hunk.original_start_line + 1) <= .[1]);
+            ($touched | map({ key: .file, value: .ranges }) | from_entries) as $lines
+            | map(
+                . as $file
+                | ($lines[$file.file] // []) as $ranges
+                | $file + { mismatches: [ $file.mismatches[] | select(overlaps($ranges)) ] }
+              )
+            | map(select(.mismatches | length > 0))
+          ' mismatches.json > blocking.json
+
+          raw_hunks=$(jq -s '[ .[].mismatches[] ] | length' mismatches.json)
+          bad_hunks=$(jq '[ .[].mismatches[] ] | length' blocking.json)
+          preexisting_hunks=$((raw_hunks - bad_hunks))
+          jq -r '.[].file' blocking.json | sort -u > misformatted.txt
 
           # Swallow any parse errors from stylua and leave them to the emmylua ci.
           # Nonzero exit status from stylua still needs a backstop against crashes.
@@ -97,17 +132,20 @@ jobs:
           # Pass or fail is decided from reports, not status, to backstop a crash.
           bad_files=$(wc -l < misformatted.txt)
           if [ "$bad_files" -eq 0 ] && [ ! -s errlines.txt ]; then
-            if [ "$stylua_status" -ne 0 ] && [ "$parse_errors" -eq 0 ]; then
+            if [ "$stylua_status" -ne 0 ] && [ "$parse_errors" -eq 0 ] && [ "$raw_hunks" -eq 0 ]; then
               echo "::error title=Formatting check is broken::stylua exited $stylua_status without reporting anything. This is a CI defect, not a problem with this PR; fix format_check.yml or its pinned stylua."
               exit 1
             fi
-            echo "All changed files are formatted."
+            if [ "$preexisting_hunks" -gt 0 ]; then
+              echo "::notice title=Formatting::$preexisting_hunks hunk(s) in the changed files are not formatted, but this pull request did not write those lines, so they do not fail the check."
+            fi
+            echo "All changed lines are formatted."
             exit 0
           fi
 
           ver=$(./stylua --version)
           if [ "$bad_files" -gt 0 ]; then
-            echo "$bad_files file(s) are not formatted with $ver:"
+            echo "$bad_hunks hunk(s) written by this pull request are not formatted with $ver, in:"
             cat misformatted.txt
           fi
           if [ -s errlines.txt ]; then
@@ -129,7 +167,7 @@ jobs:
           # Stylua indexes from zero while github indexes from one, in this case.
           # GH keeps up to 10 annotation bubbles and discards the rest (kept in logs)
           # so these are sorted by the worst offenders, determined by total diff size.
-          jq -s -r --arg ver "$ver" '
+          jq -r --arg ver "$ver" '
             def esc($s): $s | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
             def prop($s): esc($s) | gsub(","; "%2C") | gsub(":"; "%3A");
             map(
@@ -145,7 +183,7 @@ jobs:
             | sort_by(-.lines)
             | .[0:10][]
             | "::error file=\(prop(.file)),line=\(.line),title=Not formatted::\(.lines) line(s) would change. Run \($ver) on this file and commit the result."
-          ' mismatches.json
+          ' blocking.json
 
           # GH annotation cap of 10 is per-category, so folder rollups use warnings.
           if [ "$bad_files" -gt 10 ] && [ "$bad_folders" -le 10 ]; then
@@ -167,7 +205,7 @@ jobs:
             echo "### Formatting check failed"
             echo
             if [ "$bad_files" -gt 0 ]; then
-              echo "$bad_files changed file(s) are not formatted. Run $ver on them and commit the result."
+              echo "$bad_hunks hunk(s) written by this pull request, across $bad_files file(s), are not formatted. Run $ver on them and commit the result."
               echo
               if [ "$bad_files" -le 10 ]; then
                 sed -e 's/^/- `/' -e 's/$/`/' misformatted.txt
@@ -178,6 +216,10 @@ jobs:
               else
                 echo "The files span $bad_folders folders; the workflow log lists every one."
               fi
+            fi
+            if [ "$preexisting_hunks" -gt 0 ]; then
+              echo
+              echo "_A further $preexisting_hunks hunk(s) in these files are not formatted either, but this pull request did not write those lines and is not being failed for them._"
             fi
             if [ -s errlines.txt ]; then
               echo

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -2,7 +2,10 @@ name: Format Check
 
 on:
   pull_request:
-    paths: ['**.lua']
+    paths:
+      - "**.lua"
+      # So that a change to the check runs the check.
+      - ".github/workflows/format_check.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -145,7 +145,7 @@ jobs:
 
           ver=$(./stylua --version)
           if [ "$bad_files" -gt 0 ]; then
-            echo "$bad_hunks hunk(s) written by this pull request are not formatted with $ver, in:"
+            echo "$bad_hunks hunk(s) overlapping lines this pull request wrote are not formatted with $ver, in:"
             cat misformatted.txt
           fi
           if [ -s errlines.txt ]; then
@@ -205,7 +205,7 @@ jobs:
             echo "### Formatting check failed"
             echo
             if [ "$bad_files" -gt 0 ]; then
-              echo "$bad_hunks hunk(s) written by this pull request, across $bad_files file(s), are not formatted. Run $ver on them and commit the result."
+              echo "$bad_hunks hunk(s) overlapping lines this pull request wrote, across $bad_files file(s), are not formatted. Run $ver on them and commit the result."
               echo
               if [ "$bad_files" -le 10 ]; then
                 sed -e 's/^/- `/' -e 's/$/`/' misformatted.txt
@@ -219,7 +219,7 @@ jobs:
             fi
             if [ "$preexisting_hunks" -gt 0 ]; then
               echo
-              echo "_A further $preexisting_hunks hunk(s) in these files are not formatted either, but this pull request did not write those lines and is not being failed for them._"
+              echo "_A further $preexisting_hunks hunk(s) in the changed files are not formatted either, but this pull request did not write those lines and is not being failed for them._"
             fi
             if [ -s errlines.txt ]; then
               echo

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -30,10 +30,6 @@ env:
   # "changed" | "tree"
   WARN_SCOPE: changed
 
-  # Leave this on until the summaries on PRs state the lines containing blockers.
-  # Right now, we are giving diagnostic summaries that state "better, or worse?".
-  REPORT_ONLY: "true"
-
   # The slice ci_results.yml allots one report. Keep the two in step.
   REPORT_LIMIT: 6000
 
@@ -129,6 +125,23 @@ jobs:
           echo "CHANGED_LINES=$changed" >> "$GITHUB_ENV"
           echo "$changed changed line(s) across $(tr -cd '\0' < changed.txt | wc -c) file(s)."
 
+          # Warnings are ranked by nearness to the change scope: hunk > file > tree.
+          # A deletion has no head-side line so is matched against adjoining lines.
+          # Paths are tab-separated, like renames.txt above; separators could use work.
+          : > hunks.txt
+          while IFS= read -r -d '' file; do
+            git -C head diff --unified=0 "$BASE_SHA" HEAD -- "$file" \
+            | awk -v file="$file" '
+                /^@@/ {
+                  split(substr($3, 2), new, ",")
+                  start = new[1] + 0
+                  count = (new[2] == "" ? 1 : new[2] + 0)
+                  if (count == 0) printf "%s\t%d\t%d\n", file, start, start + 1
+                  else            printf "%s\t%d\t%d\n", file, start, start + count - 1
+                }' >> hunks.txt
+          done < changed.txt
+          echo "$(wc -l < hunks.txt) hunk(s) written."
+
       - name: Run emmylua_check
         if: github.event_name != 'pull_request' || steps.describe.outputs.lua == 'true'
         run: |
@@ -178,19 +191,15 @@ jobs:
             exit 0
           fi
 
-          report_only=""
-          if [ "$REPORT_ONLY" = "true" ]; then
-            report_only="--report-only"
-          fi
-
           set +e
-          python3 head/.github/scripts/emmylua_compare.py $report_only \
+          python3 head/.github/scripts/emmylua_compare.py \
             --base base-*.json \
             --head head-*.json \
             --base-root "$GITHUB_WORKSPACE/base" \
             --head-root "$GITHUB_WORKSPACE/head" \
             --renames renames.txt \
             --changed-files changed.txt \
+            --changed-hunks hunks.txt \
             --changed-lines "${CHANGED_LINES:-0}" \
             --warn-max "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
             --warn-scope "$WARN_SCOPE" \

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -103,8 +103,11 @@ jobs:
 
           # The base findings get moved onto the head's previous paths, first.
           # A rename would otherwise present every finding in the file as new.
-          git -C head diff --name-status -M --diff-filter=R "$BASE_SHA" HEAD -- '*.lua' \
-          | cut -f2,3 > renames.txt
+          # -z keeps the paths raw and NUL-separated: without it git quotes any
+          # path holding a tab or a newline, and the quoted form would no longer
+          # match the raw one in changed.txt. Records are status, old, new.
+          git -C head diff --name-status -z -M --diff-filter=R "$BASE_SHA" HEAD -- '*.lua' \
+          > renames.txt
 
           # A hunk header carries both sides: @@ -old,removed +new,added @@, with
           # a count of 1 where it is omitted. Rewriting 3 lines in place is 3
@@ -124,20 +127,26 @@ jobs:
 
           # Warnings are ranked by nearness to the change scope: hunk > file > tree.
           # A deletion has no head-side line so is matched against adjoining lines.
-          # Paths are tab-separated, like renames.txt above; separators could use work.
-          : > hunks.txt
+          #
+          # Records are NUL-separated path, start, end. A contributor can add a
+          # file whose path holds a tab or a newline, so awk is given no path to
+          # print -- it emits the two numbers and the shell writes the path,
+          # which is the only part of this that can carry an arbitrary byte.
           while IFS= read -r -d '' file; do
             git -C head diff --unified=0 "$BASE_SHA" HEAD -- "$file" \
-            | awk -v file="$file" '
+            | awk '
                 /^@@/ {
                   split(substr($3, 2), new, ",")
                   start = new[1] + 0
                   count = (new[2] == "" ? 1 : new[2] + 0)
-                  if (count == 0) printf "%s\t%d\t%d\n", file, start, start + 1
-                  else            printf "%s\t%d\t%d\n", file, start, start + count - 1
-                }' >> hunks.txt
-          done < changed.txt
-          echo "$(wc -l < hunks.txt) hunk(s) written."
+                  if (count == 0) print start, start + 1
+                  else            print start, start + count - 1
+                }' \
+            | while read -r start end; do
+                printf '%s\0%s\0%s\0' "$file" "$start" "$end"
+              done
+          done < changed.txt > hunks.txt
+          echo "$(tr -cd '\0' < hunks.txt | wc -c) hunk field(s) written."
 
           # The total rule divides by the size of the file, not the diff.
           # This has to check for files deleted by the change.

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -20,15 +20,12 @@ env:
   RUNS: 3
 
   # Type errors are largely absorbed already so do not matter on the base pass.
-  # New warnings are budgeted at a rate per thousand changed lines, capped at an
-  # absolute maximum. The smaller applies, so either one on its own can fail a PR.
-  WARN_MAX: 100
-  WARN_PER_KLOC: 15
+  # Net new warnings on the lines the PR wrote, per thousand changed lines.
+  # Reduced by the warnings resolved in the same files as the changed hunk.
+  WARN_ADDED_PER_KLOC: 15
 
-  # Warnings also ripple out into other files rapidly after relatively small code
-  # changes. This should upgrade to "tree" once we have things under control.
-  # "changed" | "tree"
-  WARN_SCOPE: changed
+  # Every warning left in the files touched, per thousand lines of those files.
+  WARN_TOTAL_PER_KLOC: 30
 
   # The slice ci_results.yml allots one report. Keep the two in step.
   REPORT_LIMIT: 6000
@@ -142,6 +139,17 @@ jobs:
           done < changed.txt
           echo "$(wc -l < hunks.txt) hunk(s) written."
 
+          # The total rule divides by the size of the file, not the diff.
+          # This has to check for files deleted by the change.
+          file_lines=0
+          while IFS= read -r -d '' file; do
+            if [ -f "head/$file" ]; then
+              file_lines=$((file_lines + $(wc -l < "head/$file")))
+            fi
+          done < changed.txt
+          echo "CHANGED_FILE_LINES=$file_lines" >> "$GITHUB_ENV"
+          echo "$file_lines line(s) in the changed files."
+
       - name: Run emmylua_check
         if: github.event_name != 'pull_request' || steps.describe.outputs.lua == 'true'
         run: |
@@ -185,7 +193,8 @@ jobs:
             python3 head/.github/scripts/emmylua_compare.py \
               --head head-*.json \
               --head-root "$GITHUB_WORKSPACE/head" \
-              --warn-max "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
+              --warn-added-per-kloc "$WARN_ADDED_PER_KLOC" \
+              --warn-total-per-kloc "$WARN_TOTAL_PER_KLOC" \
               --summary "$GITHUB_STEP_SUMMARY" \
               --ci-report ci-report.md
             exit 0
@@ -201,8 +210,9 @@ jobs:
             --changed-files changed.txt \
             --changed-hunks hunks.txt \
             --changed-lines "${CHANGED_LINES:-0}" \
-            --warn-max "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
-            --warn-scope "$WARN_SCOPE" \
+            --changed-file-lines "${CHANGED_FILE_LINES:-0}" \
+            --warn-added-per-kloc "$WARN_ADDED_PER_KLOC" \
+            --warn-total-per-kloc "$WARN_TOTAL_PER_KLOC" \
             --summary "$GITHUB_STEP_SUMMARY" \
             --ci-report ci-report.md
           exit_code=$?

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -23,7 +23,7 @@ env:
   # New warnings are budgeted at a rate per thousand changed lines, capped at an
   # absolute maximum. The smaller applies, so either one on its own can fail a PR.
   WARN_MAX: 100
-  WARN_PER_KLOC: 10
+  WARN_PER_KLOC: 15
 
   # Warnings also ripple out into other files rapidly after relatively small code
   # changes. This should upgrade to "tree" once we have things under control.

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -163,8 +163,6 @@ jobs:
             report_only="--report-only"
           fi
 
-          # ! Adding a python dependency so need to evaluate the universe from scratch again.
-          # Hold the verdict so the report is sized up before we exit on it.
           set +e
           python3 head/.github/scripts/emmylua_compare.py $report_only \
             --base base-*.json \
@@ -178,7 +176,7 @@ jobs:
             --warn-scope "$WARN_SCOPE" \
             --summary "$GITHUB_STEP_SUMMARY" \
             --ci-report ci-report.md
-          verdict=$?
+          exit_code=$?
           set -e
 
           # The compact report is bounded by construction. Over its slice anyway
@@ -192,7 +190,7 @@ jobs:
             echo "Compact report: $report_bytes bytes (limit $REPORT_LIMIT)."
           fi
 
-          exit $verdict
+          exit $exit_code
 
       # Picked up by the CI Results comment. Named the same in every check, so
       # that job can fetch it by name from whichever run it is looking at.

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -18,7 +18,7 @@ env:
   # Type errors are largely absorbed already so do not matter on the base pass.
   # We check against a warning floor (absolute count) and a warning rate (KLOC).
   WARN_FLOOR: 15
-  WARN_PER_KLOC: 150
+  WARN_PER_KLOC: 15
 
   # Warnings also ripple out into other files rapidly after relatively small code
   # changes. This should upgrade to "tree" once we have things under control.

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -2,11 +2,35 @@ name: Type Check
 
 on:
   pull_request:
-    paths: ['**.lua']
+    paths: ["**.lua"]
   workflow_dispatch:
 
 permissions:
   contents: read
+
+env:
+  EMMYLUA_VERSION: 0.24.0
+
+  # emmylua has nondeterministic warnings: EmmyLuaLs/emmylua-analyzer-rust#1091
+  # so we check our findings against a number of initial diagnostic runs' state
+  RUNS: 3
+
+  # Type errors are largely absorbed already so do not matter on the base pass.
+  # We check against a warning floor (absolute count) and a warning rate (KLOC).
+  WARN_FLOOR: 15
+  WARN_PER_KLOC: 150
+
+  # Warnings also ripple out into other files rapidly after relatively small code
+  # changes. This should upgrade to "tree" once we have things under control.
+  # "changed" | "tree"
+  WARN_SCOPE: changed
+
+  # Leave this on until the summaries on PRs state the lines containing blockers.
+  # Right now, we are giving diagnostic summaries that state "better, or worse?".
+  REPORT_ONLY: "true"
+
+  # The slice ci_results.yml allots one report. Keep the two in step.
+  REPORT_LIMIT: 6000
 
 jobs:
   emmylua_check:
@@ -14,13 +38,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # compare below: "Checkout base"
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          path: head
           submodules: recursive
-          # Pull down only the PR's changed files and the checkers's own config files
+          # Pull down only the Lua tree and the checker's own config files
           filter: blob:none
           # Cone mode cannot filter correctly for our repo, picks up asset files, etc.
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.emmyrc.json
+            /.gitmodules
+            /.github/scripts
+            /recoil-lua-library
+            *.lua
+
+      - name: Checkout base
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          submodules: recursive
+          filter: blob:none
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /.emmyrc.json
@@ -29,10 +71,6 @@ jobs:
             *.lua
 
       - name: Install emmylua_check
-        env:
-          # This file owns the version. BAR-Devtools' dev image tracks it, so
-          # update it there too when you bump.
-          EMMYLUA_VERSION: 0.24.0
         run: |
           set -euo pipefail
           ARCH=$(uname -m)
@@ -46,232 +84,115 @@ jobs:
           sudo chmod +x /usr/local/bin/emmylua_check
           /usr/local/bin/emmylua_check --version
 
-      # emmylua_check has no scoped mode: it analyses the whole workspace
-      # whatever you ask it for. So it runs once here, for both events, and the
-      # pull request scope is applied to its report afterwards. A manual run
-      # reports the same data unfiltered rather than re-deriving it from a
-      # second pass.
-      - name: Run emmylua_check
+      # This runs is shared for both workspace and pull request scopes.
+      # We write the same basic report out since emmylua has no scoped mode.
+      - name: Describe the change
+        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          # The slice ci_results.yml allots one report. Keep the two in step.
-          REPORT_LIMIT: 6000
         run: |
+          git -C head fetch --no-tags --depth=1 origin "$BASE_SHA"
+
+          # Lua paths may contain spaces, so the list uses NUL separators.
+          git -C head diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.lua' > changed.txt
+
+          # The base findings get moved onto the head's previous paths, first.
+          # A rename would otherwise present every finding in the file as new.
+          git -C head diff --name-status -M --diff-filter=R "$BASE_SHA" HEAD -- '*.lua' \
+          | cut -f2,3 > renames.txt
+
+          added=$(git -C head diff --numstat "$BASE_SHA" HEAD -- '*.lua' \
+                  | awk '$1 ~ /^[0-9]+$/ { total += $1 } END { print total + 0 }')
+          echo "ADDED_LINES=$added" >> "$GITHUB_ENV"
+          echo "$added changed line(s) across $(tr -cd '\0' < changed.txt | wc -c) file(s)."
+
+      - name: Run emmylua_check
+        run: |
+          # A manual run has nothing to compare against (yet) so it runs once.
+          sides="head"
+          runs=1
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            MODE=pr
-            WHERE="changed files"
-
-            # Fetch the base revision to diff against it.
-            git fetch --no-tags --depth=1 origin "$BASE_SHA"
-
-            # Lua paths may contain spaces, so the list uses NUL separators.
-            git diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.lua' > changed.txt
-            if [ ! -s changed.txt ]; then
-              echo "No Lua files changed."
-              exit 0
-            fi
-            echo "Reporting on:"
-            tr '\0' '\n' < changed.txt
-            jq -R -s 'split("\u0000") | map(select(. != ""))' changed.txt > changed.json
-          else
-            MODE=tree
-            WHERE="the whole tree"
-            echo "[]" > changed.json
-            echo "Manual run: reporting on the whole tree."
+            sides="base head"
+            runs="$RUNS"
           fi
 
+          for side in $sides; do
+            for run in $(seq 1 "$runs"); do
+              # A nonzero exit only means findings exist, which is always true.
+              ( cd "$side" && emmylua_check -c .emmyrc.json -f json \
+                  --output "$GITHUB_WORKSPACE/$side-$run.json" . ) \
+                > "$side-$run.log" 2>&1 || true
+
+              # Without its config emmylua analyses the tree unconfigured and
+              # every finding is garbage, so that is a defect and not a result.
+              if grep -Eq 'Failed to (read|parse) (lua )?config file' "$side-$run.log"; then
+                echo "::error title=Type check ran without its config::emmylua_check could not load $side/.emmyrc.json (missing or unparseable) and analyzed the tree unconfigured, so every finding is garbage. This is a CI defect, not a problem with this PR. Restore .emmyrc.json or fix type_check.yml."
+                exit 1
+              fi
+              if [ ! -s "$side-$run.json" ] || ! jq -e . "$side-$run.json" > /dev/null 2>&1; then
+                echo "::error title=Type check is broken::emmylua_check produced no readable report for $side run $run. This is a CI defect, not a problem with this PR; fix type_check.yml or its pinned emmylua_check."
+                cat "$side-$run.log"
+                exit 1
+              fi
+            done
+          done
+
+      # Errors block outright.
+      # Warnings are compared against a budget.
+      # Info and hints are only ever reported.
+      # Manual runs always report green and are presumed informational/analytical.
+      - name: Compare against the base
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            python3 head/.github/scripts/emmylua_compare.py \
+              --head head-*.json \
+              --head-root "$GITHUB_WORKSPACE/head" \
+              --warn-floor "$WARN_FLOOR" --warn-per-kloc "$WARN_PER_KLOC" \
+              --summary "$GITHUB_STEP_SUMMARY" \
+              --ci-report ci-report.md
+            exit 0
+          fi
+
+          if [ ! -s changed.txt ]; then
+            echo "No Lua files changed."
+            exit 0
+          fi
+
+          report_only=""
+          if [ "$REPORT_ONLY" = "true" ]; then
+            report_only="--report-only"
+          fi
+
+          # ! Adding a python dependency so need to evaluate the universe from scratch again.
+          # Hold the verdict so the report is sized up before we exit on it.
           set +e
-          emmylua_check -c .emmyrc.json -f json --output diagnostics.json . 2> emmylua.log
-          emmylua_status=$?
+          python3 head/.github/scripts/emmylua_compare.py $report_only \
+            --base base-*.json \
+            --head head-*.json \
+            --base-root "$GITHUB_WORKSPACE/base" \
+            --head-root "$GITHUB_WORKSPACE/head" \
+            --renames renames.txt \
+            --changed-files changed.txt \
+            --added-lines "${ADDED_LINES:-0}" \
+            --warn-floor "$WARN_FLOOR" --warn-per-kloc "$WARN_PER_KLOC" \
+            --warn-scope "$WARN_SCOPE" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --ci-report ci-report.md
+          verdict=$?
           set -e
-          cat emmylua.log >&2
 
-          # Error and exit on missing config. This action is obsolete or broken.
-          if grep -Eq 'Failed to (read|parse) (lua )?config file' emmylua.log; then
-            echo "::error title=Type check ran without its config::emmylua_check could not load .emmyrc.json (missing or unparseable) and analyzed the tree unconfigured, so every finding is garbage. This is a CI defect, not a problem with this PR. Restore .emmyrc.json or fix type_check.yml."
-            exit 1
-          fi
-
-          # Error for nonreporting, not for nonzero exit codes, as the failure case.
-          # Emmylua exits nonzero for any type errors it finds, which is never none.
-          if [ ! -s diagnostics.json ] || ! jq -e . diagnostics.json > /dev/null; then
-            echo "emmylua_check produced no readable report (exit $emmylua_status)"
-            exit 1
-          fi
-
-          # The report filter works only on absolute paths under $PWD.
-          if ! jq -e --arg cwd "$PWD/" 'length == 0 or any(.[]; .file | startswith($cwd))' diagnostics.json > /dev/null; then
-            echo "::error title=Type check filter is broken::No path in diagnostics.json starts with $PWD, so the changed-file filter can never match and the check would pass while checking nothing. The emmylua report shape changed; update type_check.yml."
-            exit 1
-          fi
-
-          # Severity is the LSP numbering: 1 error, 2 warning, 3 information,
-          # 4 hint. Paths are made relative so they match the annotation API.
-          jq --slurpfile changed changed.json --arg cwd "$PWD/" --arg mode "$MODE" '
-            ($changed[0] | map({(.): true}) | add // {}) as $want
-            | [ .[]
-                | (.file | ltrimstr($cwd) | ltrimstr("./")) as $path
-                | select($mode == "tree" or $want[$path])
-                | .diagnostics[]
-                | { path: $path,
-                    line: (.range.start.line + 1),
-                    col: (.range.start.character + 1),
-                    severity: (.severity // 1),
-                    code: ((.code // "unknown") | tostring),
-                    message: .message } ]
-          ' diagnostics.json > filtered.json
-
-          errors=$(jq '[ .[] | select(.severity == 1) ] | length' filtered.json)
-          warnings=$(jq '[ .[] | select(.severity == 2) ] | length' filtered.json)
-          hints=$(jq '[ .[] | select(.severity >= 3) ] | length' filtered.json)
-          echo "$(jq length filtered.json) finding(s) in $WHERE: $errors error(s), $warnings warning(s), $hints hint(s)."
-
-          # Annotations only make sense against a diff. A manual run has no pull
-          # request to hang them on, and the whole tree would blow the cap many
-          # times over, so it gets the log and the summary instead.
-          #
-          # Errors and warnings are annotated; hints are not. Hints are style
-          # nudges (`unused` is the bulk of them) and every changed file carries
-          # a few, so annotating them buries the type errors that this check
-          # exists to surface. They stay in the counts and in the job summary.
-          #
-          # GitHub renders at most 10 annotations per severity and silently
-          # drops the rest, so each pool is sorted and sliced deliberately
-          # rather than letting the report order decide what a reviewer sees.
-          if [ "$MODE" = "pr" ]; then
-            jq -r '
-              def esc($s): $s | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
-              def prop($s): esc($s) | gsub(","; "%2C") | gsub(":"; "%3A");
-              def pool($sev; $kind):
-                [ .[] | select(.severity == $sev) ]
-                | sort_by(.path, .line, .col)
-                | .[0:10][]
-                | "::\($kind) file=\(prop(.path)),line=\(.line),col=\(.col),title=\(prop(.code))::\(esc(.message))";
-              pool(1; "error"), pool(2; "warning")
-            ' filtered.json
-
-            if [ "$errors" -gt 10 ] || [ "$warnings" -gt 10 ]; then
-              echo "::notice title=Type check::Only the first 10 findings per severity are annotated; the job summary and the log below list every one."
+          # The compact report is bounded by construction. Over its slice anyway
+          # means the rendering regressed, and the comment would cut mid-table.
+          if [ -s ci-report.md ]; then
+            report_bytes=$(wc -c < ci-report.md)
+            if [ "$report_bytes" -gt "$REPORT_LIMIT" ]; then
+              echo "::error title=Type check report is oversized::The compact report is $report_bytes bytes, past the $REPORT_LIMIT the CI Results comment allots it, so it would be truncated mid-table. This is a CI defect, not a problem with this PR; fix the compact rendering in emmylua_compare.py."
+              exit 1
             fi
+            echo "Compact report: $report_bytes bytes (limit $REPORT_LIMIT)."
           fi
 
-          # ::group:: is what makes the log collapsible, one fold per code. It
-          # is uncapped in here -- on a whole-tree run that is tens of thousands
-          # of lines, which is readable folded and unreadable flat.
-          jq -r '
-            def sevname($s): if $s == 1 then "error" elif $s == 2 then "warning"
-                             elif $s == 3 then "info" else "hint" end;
-            def plural($n): if $n == 1 then "" else "s" end;
-            group_by(.code)
-            | sort_by(.[0].severity, -length)
-            | .[]
-            | ("::group::\(.[0].code) - \(length) \(sevname(.[0].severity))\(plural(length))"),
-              (sort_by(.path, .line, .col)[] | "\(.path):\(.line):\(.col): \(.message)"),
-              "::endgroup::"
-          ' filtered.json
-
-          # The whole summary is one jq program. Findings are grouped by code
-          # rather than lumped under a severity, because "1354 unnecessary-if"
-          # and "1 undefined-global" are two different conversations and a flat
-          # list buries that. Errors stay open because they block; everything
-          # else is a collapsed section per code, ordered by severity then size.
-          #
-          # Annotations cannot be bucketed the same way -- GitHub has only the
-          # error, warning and notice pools -- but each bubble already carries
-          # its code as the title, so the two views agree.
-          # One program, rendered twice: in full for this job's own summary
-          # page, and compact for the CI Results comment, which is capped at
-          # 65536 characters and which a full report can exceed on its own.
-          SUMMARY_JQ='
-            def cell($s): $s | gsub("\\|"; "\\|") | gsub("[\r\n]+"; " ");
-            # emmylua messages can carry a whole union type. The comment has a
-            # byte budget the summary page does not, so they are clipped there.
-            def msg($s): cell($s) as $t
-              | if $detail == "full" or ($t | length) <= 120 then $t
-                else $t[0:119] + "…" end;
-            def sevname($s): if $s == 1 then "error" elif $s == 2 then "warning"
-                             elif $s == 3 then "info" else "hint" end;
-            def plural($n): if $n == 1 then "" else "s" end;
-
-            # Fifty rows per code is where a table stops being readable. The
-            # log above is uncapped, so nothing is actually lost.
-            def rows($f):
-              ( $f | sort_by(.path, .line, .col) | .[0:50][]
-                | "| `\(.path):\(.line)` | \(msg(.message)) |" ),
-              ( if ($f | length) > 50
-                then "", "_Showing 50 of \($f | length); the workflow log lists every one._"
-                else empty end );
-
-            . as $all
-            | ([ $all[] | select(.severity == 1) ]) as $errors
-            | ($all | group_by(.code)
-                    | map({ code: .[0].code, severity: (map(.severity) | min), n: length })
-                    | sort_by(.severity, -.n)) as $codes
-
-            | ( if ($errors | length) > 0
-                then "### Type check: \($errors | length) error\(plural($errors | length)) in \($where)"
-                else "### Type check: no errors in \($where)"
-                end ),
-              "",
-              ( if $mode == "tree"
-                then "Manual whole-tree run. Reporting only -- this does not gate anything."
-                else "Warnings and hints do not block."
-                end ),
-
-              ( if ($all | length) > 0
-                then "", "| Code | Severity | Count |", "| --- | --- | --- |",
-                     ( $codes[] | "| `\(.code)` | \(sevname(.severity)) | \(.n) |" )
-                else empty end ),
-
-              # Errors are not collapsed and keep a Code column, since one run
-              # can fail on several different ones at once.
-              ( (if $detail == "full" then 50 else 10 end) as $cap
-                | if ($errors | length) > 0
-                then "", "#### Errors", "",
-                     "| Location | Code | Message |", "| --- | --- | --- |",
-                     ( $errors | sort_by(.path, .line, .col) | .[0:$cap][]
-                       | "| `\(.path):\(.line)` | `\(.code)` | \(msg(.message)) |" ),
-                     ( if ($errors | length) > $cap
-                       then "", "_Showing \($cap) of \($errors | length); the workflow log lists every one._"
-                       else empty end )
-                else empty end ),
-
-              # The comment gets the headline, the counts and the errors.
-              # The per-code detail would swamp it many times over, so it stays
-              # on the summary page of the job that produced it.
-              ( if $detail != "full" then empty else
-                [ $codes[] | select(.severity != 1) ][]
-                | . as $c
-                | [ $all[] | select(.code == $c.code) ] as $f
-                | "",
-                  "<details><summary><code>\($c.code)</code> - \($c.n) \(sevname($c.severity))\(plural($c.n))</summary>",
-                  "", "| Location | Message |", "| --- | --- |",
-                  rows($f),
-                  "", "</details>" end )
-          '
-
-          jq -r --arg mode "$MODE" --arg where "$WHERE" --arg detail full \
-            "$SUMMARY_JQ" filtered.json >> "$GITHUB_STEP_SUMMARY"
-          jq -r --arg mode "$MODE" --arg where "$WHERE" --arg detail compact \
-            "$SUMMARY_JQ" filtered.json > ci-report.md
-
-          # The compact report is bounded by construction: at most one row per
-          # diagnostic code plus twenty errors. If it is over its slice of the
-          # CI Results comment anyway, the rendering has regressed and the
-          # comment would be cut mid-table, so say so rather than ship it.
-          report_bytes=$(wc -c < ci-report.md)
-          if [ "$report_bytes" -gt "$REPORT_LIMIT" ]; then
-            echo "::error title=Type check report is oversized::The compact report is $report_bytes bytes, past the $REPORT_LIMIT the CI Results comment allots it, so it would be truncated mid-table. This is a CI defect, not a problem with this PR; fix the compact rendering in type_check.yml."
-            exit 1
-          fi
-          echo "Compact report: $report_bytes bytes (limit $REPORT_LIMIT)."
-
-          # Errors fail a pull request. A manual run is an analytics view, so it
-          # reports and stays green -- a red X on a report nobody asked to gate
-          # only teaches people to ignore the colour.
-          if [ "$MODE" = "pr" ] && [ "$errors" -ne 0 ]; then
-            exit 1
-          fi
+          exit $verdict
 
       # Picked up by the CI Results comment. Named the same in every check, so
       # that job can fetch it by name from whichever run it is looking at.

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -16,7 +16,8 @@ env:
   RUNS: 3
 
   # Type errors are largely absorbed already so do not matter on the base pass.
-  # We check against a warning floor (absolute count) and a warning rate (KLOC).
+  # New warnings are budgeted at a rate per thousand changed lines, capped at an
+  # absolute maximum. The smaller applies, so either one on its own can fail a PR.
   WARN_MAX: 100
   WARN_PER_KLOC: 10
 
@@ -87,6 +88,7 @@ jobs:
       # This runs is shared for both workspace and pull request scopes.
       # We write the same basic report out since emmylua has no scoped mode.
       - name: Describe the change
+        id: describe
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -95,16 +97,33 @@ jobs:
 
           # Lua paths may contain spaces, so the list uses NUL separators.
           git -C head diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.lua' > changed.txt
+          if [ ! -s changed.txt ]; then
+            echo "No Lua files changed."
+            echo "lua=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "lua=true" >> "$GITHUB_OUTPUT"
 
           # The base findings get moved onto the head's previous paths, first.
           # A rename would otherwise present every finding in the file as new.
           git -C head diff --name-status -M --diff-filter=R "$BASE_SHA" HEAD -- '*.lua' \
           | cut -f2,3 > renames.txt
 
-          added=$(git -C head diff --numstat "$BASE_SHA" HEAD -- '*.lua' \
-                  | awk '$1 ~ /^[0-9]+$/ { total += $1 } END { print total + 0 }')
-          echo "ADDED_LINES=$added" >> "$GITHUB_ENV"
-          echo "$added changed line(s) across $(tr -cd '\0' < changed.txt | wc -c) file(s)."
+          # A hunk header carries both sides: @@ -old,removed +new,added @@, with
+          # a count of 1 where it is omitted. Rewriting 3 lines in place is 3
+          # changed lines and not 6, so a hunk counts for its wider side.
+          changed=$(git -C head diff --unified=0 "$BASE_SHA" HEAD -- '*.lua' \
+                    | awk '
+                        /^@@/ {
+                          split(substr($2, 2), old, ",")
+                          split(substr($3, 2), new, ",")
+                          removed = (old[2] == "" ? 1 : old[2] + 0)
+                          added   = (new[2] == "" ? 1 : new[2] + 0)
+                          total += (added > removed ? added : removed)
+                        }
+                        END { print total + 0 }')
+          echo "CHANGED_LINES=$changed" >> "$GITHUB_ENV"
+          echo "$changed changed line(s) across $(tr -cd '\0' < changed.txt | wc -c) file(s)."
 
       - name: Run emmylua_check
         run: |
@@ -153,11 +172,6 @@ jobs:
             exit 0
           fi
 
-          if [ ! -s changed.txt ]; then
-            echo "No Lua files changed."
-            exit 0
-          fi
-
           report_only=""
           if [ "$REPORT_ONLY" = "true" ]; then
             report_only="--report-only"
@@ -171,8 +185,8 @@ jobs:
             --head-root "$GITHUB_WORKSPACE/head" \
             --renames renames.txt \
             --changed-files changed.txt \
-            --added-lines "${ADDED_LINES:-0}" \
-            --warn-floor "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
+            --changed-lines "${CHANGED_LINES:-0}" \
+            --warn-max "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
             --warn-scope "$WARN_SCOPE" \
             --summary "$GITHUB_STEP_SUMMARY" \
             --ci-report ci-report.md

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -2,7 +2,11 @@ name: Type Check
 
 on:
   pull_request:
-    paths: ["**.lua"]
+    paths:
+      - "**.lua"
+      # So that a change to the check runs the check.
+      - ".github/workflows/type_check.yml"
+      - ".github/scripts/**"
   workflow_dispatch:
 
 permissions:
@@ -126,6 +130,7 @@ jobs:
           echo "$changed changed line(s) across $(tr -cd '\0' < changed.txt | wc -c) file(s)."
 
       - name: Run emmylua_check
+        if: github.event_name != 'pull_request' || steps.describe.outputs.lua == 'true'
         run: |
           # A manual run has nothing to compare against (yet) so it runs once.
           sides="head"
@@ -161,6 +166,7 @@ jobs:
       # Info and hints are only ever reported.
       # Manual runs always report green and are presumed informational/analytical.
       - name: Compare against the base
+        if: github.event_name != 'pull_request' || steps.describe.outputs.lua == 'true'
         run: |
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
             python3 head/.github/scripts/emmylua_compare.py \

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -17,8 +17,8 @@ env:
 
   # Type errors are largely absorbed already so do not matter on the base pass.
   # We check against a warning floor (absolute count) and a warning rate (KLOC).
-  WARN_FLOOR: 15
-  WARN_PER_KLOC: 15
+  WARN_MAX: 100
+  WARN_PER_KLOC: 10
 
   # Warnings also ripple out into other files rapidly after relatively small code
   # changes. This should upgrade to "tree" once we have things under control.
@@ -147,7 +147,7 @@ jobs:
             python3 head/.github/scripts/emmylua_compare.py \
               --head head-*.json \
               --head-root "$GITHUB_WORKSPACE/head" \
-              --warn-floor "$WARN_FLOOR" --warn-per-kloc "$WARN_PER_KLOC" \
+              --warn-max "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
               --summary "$GITHUB_STEP_SUMMARY" \
               --ci-report ci-report.md
             exit 0
@@ -172,7 +172,7 @@ jobs:
             --renames renames.txt \
             --changed-files changed.txt \
             --added-lines "${ADDED_LINES:-0}" \
-            --warn-floor "$WARN_FLOOR" --warn-per-kloc "$WARN_PER_KLOC" \
+            --warn-floor "$WARN_MAX" --warn-per-kloc "$WARN_PER_KLOC" \
             --warn-scope "$WARN_SCOPE" \
             --summary "$GITHUB_STEP_SUMMARY" \
             --ci-report ci-report.md


### PR DESCRIPTION
### Work done

CI was way over "be annoying" budget so we are scoping it down:

- File-level => hunk-level. Overlapping regions may include a few lines that were untouched.
  - Renames are now tracked, and hunks are accurate across renames.
  - If you do not use `git mv`, that is on you.
- Sufficient warning diagnostics now can fail CI based on a simple idea: "making things worse" is bad.
  - Fail on any error, repo scoped.
  - Fail above +15 warn/kloc added, hunk scoped. This will decrease.
  - Fail above 30 warn/kloc total, file scoped. This will decrease.
  - Fail on stylua errors, hunk scoped.
- Annotations prioritize hunk > file > repo.
- Type errors anywhere in the repo is a CI failure, again.
  - We have one of these, currently; resolving before merging this.

#### Considerations

We are running at around 13–27 warns/1k loc at the moment, with just a few files that inflate this value astronomically. We have no local code regions where emmylua resolves without making a mess, so there is nowhere I can exempt from checks. All I can do is switch the whole thing over to an acceptable defect rate and ratchet the rate down over time.

The nondeterminism in emmylua type checks is limited to its warnings. We have 39,000 current warnings, though, so that has made testing this hellish.

### AI disclosure

Opus 5 translated my sprawling jq into a py script.