### PR TITLE
Set Target: evict dead ghosts at same rate as target lost timer

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -242,6 +242,14 @@ if gadgetHandler:IsSyncedCode() then
 		return type(target) ~= "number" or not isAlliedUnit(teamID, target)
 	end
 
+	local function getTargetState(targetID, allyTeam)
+		local los = spGetUnitLosState(targetID, allyTeam, true)
+		if not los then
+			return false, false
+		end
+		return los % 4 ~= 0, true
+	end
+
 	local function inAttackCommand(unitID)
 		local inCommand = spGetUnitCurrentCommand(unitID)
 		return inCommand and isAttackCommand[inCommand]
@@ -323,20 +331,6 @@ if gadgetHandler:IsSyncedCode() then
 			spSetUnitTarget(unitID, nil)
 		end
 		SendToUnsynced("targetIndex", unitID, 1, false)
-	end
-
-	local function wasTargetLost(target, alwaysSeen, allyTeam)
-		if type(target) ~= "number" then
-			return false, false
-		elseif alwaysSeen then
-			local isDead = spGetUnitIsDead(target) ~= false
-			return isDead, isDead
-		end
-		local los = spGetUnitLosState(target, allyTeam, true)
-		if not los then
-			return true, true
-		end
-		return los % 4 == 0, false
 	end
 
 	--------------------------------------------------------------------------------
@@ -861,16 +855,30 @@ if gadgetHandler:IsSyncedCode() then
 
 	local function processSlowListUpdates()
 		for unitID, unitData in pairsNext, setTargetData do
+			local unitAllyTeam = unitData.allyTeam
 			local targets = unitData.targets
 			for index = #targets, 1, -1 do
 				local targetData = targets[index]
-				local isLost, isDead = wasTargetLost(targetData.target, targetData.alwaysSeen, unitData.allyTeam)
-				if not isLost then
-					targetData.unseen = unseenGracePasses
-				elseif not isDead and targetData.unseen > 0 then
-					targetData.unseen = targetData.unseen - 1
+				local target = targetData.target
+				if type(target) ~= "number" then
+					-- Keep all ground targets.
 				else
-					removeTarget(unitID, unitData, index)
+					local isTracked, isValid = getTargetState(target, unitAllyTeam)
+					if isTracked then
+						targetData.unseen = unseenGracePasses
+					elseif isValid then
+						if targetData.alwaysSeen then
+							-- This target cannot be lost.
+						elseif targetData.unseen >= 1 then
+							targetData.unseen = targetData.unseen - 1
+						else
+							removeTarget(unitID, unitData, index)
+						end
+					elseif targetData.alwaysSeen and targetData.unseen >= 1 then
+						targetData.unseen = targetData.unseen - 1
+					else
+						removeTarget(unitID, unitData, index)
+					end
 				end
 			end
 			if not targets[1] then


### PR DESCRIPTION
### Work done

The Set Target command matched other commands' 2.0s grace timer to handle units dipping in and out of line of sight. That change also began evicting dead targets from the target lists sooner, but still does so too slowly (due to e.g. crashing being its own thing).

ST already leaks out-of-vision information, though. First, we should try to shore up its intel model and make its behavior more consistent. This PR handles an easy step while I am too tired to think about the harder ones.

Units marked `alwaysSeen` need to be evicted from target lists in two ways. They can be visible when killed (and generally would be) or can be outside LOS and invalid. (They can die outside LOS, then be seen dying in LOS, and ...) Units feel a disturbance in the force in the latter case; to make the remote effect less spooky, these evictions use the target lost timer.

The remaining unhandled cases still point to centralized unit tracking imo rather than this idea that every gadget is somehow independent.

Hat tip, for reminding me to go back to this, though I wriggled my way out of doing fast-evict anyway: https://discord.com/channels/549281623154229250/549282166543089674/1542684688873693224