### PR TITLE
ci: use the merge base, never an old SHA

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -41,6 +41,22 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # GitHub rebuilds refs/pull/N/merge against master as it stands now,
+          # while the event's base.sha is master as it stood then. Diffing one
+          # against the other hands this pull request every commit that landed
+          # in between and blames their lines on its author. Parent 1 of the
+          # merge commit is the base it was really built on.
+          #
+          # cat-file and not HEAD^1: the checkout is shallow, and the graft
+          # hides the parents from rev-parse, which fails outright.
+          parents=$(git cat-file commit HEAD | awk '/^parent /{print $2}')
+          if [ "$(printf '%s\n' "$parents" | grep -c .)" -eq 2 ]; then
+            BASE_SHA=$(printf '%s\n' "$parents" | head -1)
+            echo "Base is $BASE_SHA, parent 1 of the merge commit."
+          else
+            echo "HEAD is not a merge commit, so the event's base sha stands."
+          fi
+
           # The pull request checkout only holds the merge commit, so the base
           # revision has to be fetched before anything can be diffed against it.
           git fetch --no-tags --depth=1 origin "$BASE_SHA"

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -19,7 +19,6 @@ env:
   # so we check our findings against a number of initial diagnostic runs' state
   RUNS: 3
 
-  # Type errors are largely absorbed already so do not matter on the base pass.
   # Net new warnings on the lines the PR wrote, per thousand changed lines.
   # Reduced by the warnings resolved in the same files as the changed hunk.
   WARN_ADDED_PER_KLOC: 15

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -89,6 +89,22 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # GitHub rebuilds refs/pull/N/merge against master as it stands now,
+          # while the event's base.sha is master as it stood then. Diffing one
+          # against the other hands this pull request every commit that landed
+          # in between and blames their lines on its author. Parent 1 of the
+          # merge commit is the base it was really built on.
+          #
+          # cat-file and not HEAD^1: the checkout is shallow, and the graft
+          # hides the parents from rev-parse, which fails outright.
+          parents=$(git -C head cat-file commit HEAD | awk '/^parent /{print $2}')
+          if [ "$(printf '%s\n' "$parents" | grep -c .)" -eq 2 ]; then
+            BASE_SHA=$(printf '%s\n' "$parents" | head -1)
+            echo "Base is $BASE_SHA, parent 1 of the merge commit."
+          else
+            echo "HEAD is not a merge commit, so the event's base sha stands."
+          fi
+
           git -C head fetch --no-tags --depth=1 origin "$BASE_SHA"
 
           # Lua paths may contain spaces, so the list uses NUL separators.


### PR DESCRIPTION
### Work done

Misformatted code reaching master: It's more likely than you think.

This fixes someone else's breaks turning your PR's CI red.