### PR TITLE
modules: mission objectives

### DIFF
--- a/modules/missions/README.md
+++ b/modules/missions/README.md
@@ -25,3 +25,14 @@ flowchart TB
     ENGINE -->|"Objective(...).Complete() emits<br/>'mission.objective_changed'"| BUS
     MF --> VG
 ```
+
+`objectives.lua` declares every `Objective(...)` id the triggers may reference —
+a typo is a load error, not a silently-never-true condition. An objective
+declaration carries its wording (`.Title`), its completion (`.CompletedWhen`,
+`.When` to AND), and the tracker's cadence: declaration order is the display
+order, the first line is revealed at arm and each next when its predecessor
+completes (`.RevealedWhen` overrides, `.Foreshadow` draws a line greyed-out
+early). The declarations compile into ordinary triggers through the same DSL;
+the loader publishes the board to rulesparams (`objective_display_order`,
+`objective_title_*`, `objective_revealed_*`), and the `mission_objectives`
+widget just draws what the params say.

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -23,6 +23,7 @@ local ChatGuard = VFS.Include("modules/missions/lib/chat_guard.lua")
 local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
 local DSL = VFS.Include("modules/missions/lib/dsl.lua")
 local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+local Objectives = VFS.Include("modules/missions/lib/objectives.lua")
 local Events = VFS.Include("modules/missions/lib/events.lua")
 
 local MISSIONS_DIR = "modules/missions/"
@@ -222,6 +223,26 @@ local function resetObjectives()
 	end
 end
 
+---Everything under the objective_ prefix, so presentation sweeps with progress.
+---@param declarations MissionObjectiveDeclarationEntry[]|nil nil when the mission has no objectives.lua
+local function publishObjectives(declarations)
+	if declarations == nil then
+		return
+	end
+	local order = {}
+	for _, decl in ipairs(declarations) do
+		order[#order + 1] = decl.id
+		Spring.SetGameRulesParam("objective_title_" .. decl.id, decl.title)
+		Spring.SetGameRulesParam("objective_foreshadow_" .. decl.id, decl.foreshadow and 1 or nil)
+	end
+	Spring.SetGameRulesParam("objective_display_order", table.concat(order, ","))
+	for _, decl in ipairs(declarations) do
+		if decl.revealAtArm then
+			Spring.SetGameRulesParam("objective_revealed_" .. decl.id, 1)
+		end
+	end
+end
+
 ---VFS.Include wraps a Lua error in engine bookkeeping (include mode, pcall
 ---depth, environment flag) and buries the one line an author needs.
 ---@param err any
@@ -290,6 +311,28 @@ local function loadMission(missionName, preserve)
 		end
 	end
 
+	-- The mission's own module system: its files link with VFS.Include, and a
+	-- definition file's return table is what an include yields — once per load,
+	-- the same table to every importer, so objectives.lua never registers twice.
+	local missionDir = MISSIONS_DIR .. missionName .. "/"
+	local included = {} ---@type table<string, table|false>
+	local sandboxVFS = {}
+	sandboxVFS.Include = function(path)
+		assert(type(path) == "string", "VFS.Include expects a path")
+		local normalized = path:gsub("\\", "/"):gsub("^%./", "")
+		if normalized:sub(1, #missionDir) ~= missionDir then
+			error("a mission may only include its own files, not " .. tostring(path))
+		end
+		local exports = included[normalized]
+		if exports == nil then
+			error(normalized .. " is not a definition file loaded before this one — include objectives.lua")
+		end
+		if exports == false then
+			error(normalized .. " returned nothing to include — return the handles the other files need")
+		end
+		return exports
+	end
+
 	local contributions = loadContributions()
 
 	for key in pairs(contributedContext) do
@@ -346,6 +389,8 @@ local function loadMission(missionName, preserve)
 			end
 		end
 	end
+	local objectiveDecls = nil ---@type MissionObjectiveDeclarationEntry[]|nil
+	local declaredObjectives = nil ---@type table<string, boolean>|nil
 	local parsed, err = pcall(function()
 		local function checkInputs()
 			for _, trigger in ipairs(staging.Triggers()) do
@@ -363,15 +408,86 @@ local function loadMission(missionName, preserve)
 				end
 			end
 		end
+		-- The definition site parses first: objectives.lua declares the ids the
+		-- trigger files may speak.
+		local objectivesPath = MISSIONS_DIR .. missionName .. "/objectives.lua"
+		if VFS.FileExists(objectivesPath) then
+			local filename = missionName .. "/objectives.lua"
+			local file = Objectives.ForFile(filename, function(id, verb)
+				return Objective(id)[verb]()
+			end)
+			local env = {
+				Objective = file.Objective,
+				Team = { Player = playerTeam },
+				UnitDef = Verbs.UnitDef,
+				VFS = sandboxVFS,
+			}
+			local finalizeContributions = contribute(filename, env)
+			local exports = VFS.Include(objectivesPath, env)
+			objectiveDecls = file.Finalize(exports)
+			included[objectivesPath] = exports or false
+			finalizeContributions()
+			declaredObjectives = {}
+			for _, decl in ipairs(objectiveDecls) do
+				declaredObjectives[decl.id] = true
+			end
+
+			local derived = DSL.ForFile(filename, staging.Register)
+			-- standing objectives (no completion) are transparent to the cadence:
+			-- a line that never completes must not dam it
+			local prevCompletable = nil
+			for _, decl in ipairs(objectiveDecls) do
+				-- one trigger per disjunct; Complete is idempotent, so a second way firing later is a no-op
+				for _, group in ipairs(decl.completions) do
+					local chain = derived.When(group[1])
+					for i = 2, #group do
+						chain = chain.When(group[i])
+					end
+					for _, gate in ipairs(decl.gates or {}) do
+						chain = chain.When(gate)
+					end
+					chain.Do(Objective(decl.id).Complete())
+				end
+				local revealedWhen = decl.revealedWhen
+				if revealedWhen == nil and prevCompletable ~= nil then
+					revealedWhen = Objective(prevCompletable.id).IsComplete()
+				end
+				if revealedWhen ~= nil then
+					derived.When(revealedWhen).Do(Objective(decl.id).Reveal())
+				else
+					decl.revealAtArm = true
+				end
+				if #decl.completions > 0 then
+					prevCompletable = decl
+				end
+			end
+			derived.Finalize()
+		end
+
 		for _, filePath in ipairs(files) do
 			-- mission-relative so ids survive install-path differences
 			local filename = filePath:sub(#MISSIONS_DIR + 1)
 			local file = DSL.ForFile(filename, staging.Register)
+			local ObjectiveVerb = Objective
+			if declaredObjectives ~= nil then
+				ObjectiveVerb = function(name)
+					if not declaredObjectives[name] then
+						error(
+							filename
+								.. ': Objective("'
+								.. tostring(name)
+								.. '") — objectives.lua declares no such objective'
+						)
+					end
+					return Objective(name)
+				end
+			end
 			local env = {
 				When = file.When,
 				Team = { Player = playerTeam },
 				UnitDef = Verbs.UnitDef,
-				Objective = Objective,
+				Objective = ObjectiveVerb,
+				VFS = sandboxVFS,
 			}
 			local finalizeContributions = contribute(filename, env)
 			VFS.Include(filePath, env)
@@ -412,6 +528,7 @@ local function loadMission(missionName, preserve)
 	activeMission = missionName
 	Spring.SetGameRulesParam("mission_active", 1)
 	Spring.SetGameRulesParam("mission_name", missionName)
+	publishObjectives(objectiveDecls)
 	Spring.Echo(
 		"["
 			.. LOG_TAG

--- a/modules/missions/lib/objectives.lua
+++ b/modules/missions/lib/objectives.lua
@@ -1,0 +1,147 @@
+local Events = VFS.Include("modules/missions/lib/events.lua")
+
+local Objectives = {}
+
+local function prettify(id)
+	return (id:gsub("_", " "))
+end
+
+---@param filename string mission-relative path, e.g. "cm8_ashfall/objectives.lua"
+---@return { Objective: fun(id: string): MissionObjectiveDeclaration, Finalize: fun(exports: table?): MissionObjectiveDeclarationEntry[] }
+---@param effects fun(id: string, verb: "Complete"|"Reveal"): MissionEffect|nil the loader's effect side, so an exported handle can be Done
+function Objectives.ForFile(filename, effects)
+	local declarations = {} ---@type MissionObjectiveDeclarationEntry[]
+	local idByChain = {} ---@type table<table, string>
+	local declared = {} ---@type table<string, boolean>
+	local referenced = {} ---@type table<string, boolean>
+	local finalized = false
+
+	local function checkOpen(step)
+		assert(not finalized, filename .. ": " .. step .. " after Finalize — the file already loaded")
+	end
+
+	---@param id string
+	---@return MissionObjectiveDeclaration
+	local Objective = function(id)
+		checkOpen("Objective")
+		assert(type(id) == "string" and id ~= "", filename .. ": Objective expects an id string")
+
+		local build = nil ---@type MissionObjectiveDeclarationEntry|nil
+
+		-- Registration is lazy: Objective("x") inside a condition argument is a
+		-- reference, not a declaration; the first DECLARING verb stamps the entry.
+		local function declare(step)
+			checkOpen(step)
+			if build ~= nil then
+				return
+			end
+			assert(not declared[id], filename .. ': Objective("' .. id .. '") declared twice')
+			declared[id] = true
+			build = { id = id, title = prettify(id), completions = {}, gates = {}, foreshadow = false }
+			declarations[#declarations + 1] = build
+		end
+
+		local function checkCondition(step, condition)
+			assert(
+				type(condition) == "table" and type(condition.evaluate) == "function",
+				filename .. ": " .. step .. " expects a condition (a table with an evaluate function)"
+			)
+		end
+
+		local chain = { id = id }
+		idByChain[chain] = id
+
+		---@param title string
+		---@return MissionObjectiveDeclaration
+		chain.Title = function(title)
+			declare("Title")
+			assert(type(title) == "string", filename .. ": Title expects a string")
+			build.title = title
+			return chain
+		end
+
+		---@param condition MissionCondition
+		---@return MissionObjectiveDeclaration
+		chain.CompletedWhen = function(condition)
+			declare("CompletedWhen")
+			checkCondition("CompletedWhen", condition)
+			build.completions[#build.completions + 1] = { condition }
+			return chain
+		end
+
+		---@param condition MissionCondition
+		---@return MissionObjectiveDeclaration
+		chain.When = function(condition)
+			declare("When")
+			checkCondition("When", condition)
+			build.gates[#build.gates + 1] = condition
+			return chain
+		end
+
+		---@param condition MissionCondition
+		---@return MissionObjectiveDeclaration
+		chain.RevealedWhen = function(condition)
+			declare("RevealedWhen")
+			checkCondition("RevealedWhen", condition)
+			build.revealedWhen = condition
+			return chain
+		end
+
+		---@return MissionObjectiveDeclaration
+		chain.Foreshadow = function()
+			declare("Foreshadow")
+			build.foreshadow = true
+			return chain
+		end
+
+		---@return MissionCondition
+		---@return MissionEffect
+		chain.Complete = function()
+			assert(effects, filename .. ": Complete is the loader's to build")
+			return effects(id, "Complete")
+		end
+
+		---@return MissionEffect
+		chain.Reveal = function()
+			assert(effects, filename .. ": Reveal is the loader's to build")
+			return effects(id, "Reveal")
+		end
+
+		chain.IsComplete = function()
+			referenced[id] = true
+			return {
+				inputs = { Events.ObjectiveChanged },
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return ctx.IsObjectiveComplete(id)
+				end,
+			}
+		end
+
+		return chain
+	end
+
+	---@return MissionObjectiveDeclarationEntry[]
+	---@param exports table<string, table>|nil what objectives.lua returned: key -> handle
+	---@return MissionObjectiveDeclarationEntry[] declarations
+	local Finalize = function(exports)
+		assert(not finalized, filename .. ": Finalize called twice")
+		finalized = true
+		assert(
+			exports == nil or type(exports) == "table",
+			filename .. ": an objectives file returns a table of its values, or nothing"
+		)
+		for id in pairs(referenced) do
+			if not declared[id] then
+				error(
+					filename .. ': Objective("' .. id .. '").IsComplete() references an objective no declaration backs'
+				)
+			end
+		end
+		return declarations
+	end
+
+	return { Objective = Objective, Finalize = Finalize }
+end
+
+return Objectives

--- a/modules/missions/rml_widgets/mission_objectives.lua
+++ b/modules/missions/rml_widgets/mission_objectives.lua
@@ -1,0 +1,213 @@
+if not RmlUi then
+	return
+end
+
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Mission Objectives",
+		desc = "Quest-log corner for the active mission: draws revealed objectives from rulesparams, titles from the mission manifest",
+		author = "Beyond All Reason",
+		date = "August 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+local RML_PATH = "modules/missions/rml_widgets/mission_objectives.rml"
+local POLL_SECONDS = 0.5
+
+local document
+local listElement
+local shown = false
+local lobbyHidden = false
+local pollAccumulator = 0
+local lastStateKey = nil
+
+local function prettify(id)
+	return (id:gsub("_", " "))
+end
+
+---@return { title: string, state: "done"|"active"|"pending" }[]
+local function collectRows()
+	local rows = {}
+	local function add(id, title, foreshadow)
+		local revealed = Spring.GetGameRulesParam("objective_revealed_" .. id) == 1
+		if revealed then
+			rows[#rows + 1] = {
+				title = title,
+				state = Spring.GetGameRulesParam("objective_" .. id) == 1 and "done" or "active",
+			}
+		elseif foreshadow then
+			rows[#rows + 1] = { title = title, state = "pending" }
+		end
+	end
+	local order = Spring.GetGameRulesParam("objective_display_order")
+	if type(order) == "string" and order ~= "" then
+		for id in order:gmatch("[^,]+") do
+			local title = Spring.GetGameRulesParam("objective_title_" .. id)
+			add(
+				id,
+				type(title) == "string" and title or prettify(id),
+				Spring.GetGameRulesParam("objective_foreshadow_" .. id) == 1
+			)
+		end
+	else
+		local ids = {}
+		for name in pairs(Spring.GetGameRulesParams()) do
+			local id = name:match("^objective_revealed_(.+)$")
+			if id then
+				ids[#ids + 1] = id
+			end
+		end
+		table.sort(ids)
+		for _, id in ipairs(ids) do
+			add(id, prettify(id))
+		end
+	end
+	return rows
+end
+
+local function escape(text)
+	return (text:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;"))
+end
+
+local ROW_CLASS = { done = " mo-done", active = "", pending = " mo-pending" }
+
+local function render(rows)
+	local parts = {}
+	for _, row in ipairs(rows) do
+		-- The mark is an empty span the stylesheet draws (a dot, colored by
+		-- state) — no glyph, so no bet on the game font's coverage.
+		parts[#parts + 1] = string.format(
+			'<div class="mo-row%s"><span class="mo-mark"></span><span>%s</span></div>',
+			ROW_CLASS[row.state],
+			escape(row.title)
+		)
+	end
+	listElement.inner_rml = table.concat(parts)
+end
+
+---vw units resolve to 0 in this RmlUi build, and `right:` anchors to the
+---body box, not the viewport — so the corner is computed from real view
+---geometry, the same way the editor places itself.
+local function applyViewLayout()
+	local root = document and document:GetElementById("mo-root")
+	if not root then
+		return
+	end
+	local vsx, vsy = Spring.GetViewGeometry()
+	local scale = math.max(0.9, math.min(1.8, vsy / 1080))
+	local width = math.floor(320 * scale)
+	root.style.left = tostring(math.max(0, vsx - width - 32)) .. "px"
+	root.style.top = tostring(math.floor(140 * scale)) .. "px"
+	root.style.width = tostring(width) .. "px"
+	root.style["font-size"] = tostring(math.floor(15 * scale)) .. "px"
+end
+
+local function setShown(on)
+	if on == shown then
+		return
+	end
+	shown = on
+	if on then
+		applyViewLayout()
+		if not lobbyHidden then
+			-- Never take keyboard focus on show: a focused document eats TAB
+			-- (and friends) that belong to the game.
+			document:Show(RmlUi.RmlModalFlag.None, RmlUi.RmlFocusFlag.None)
+		end
+	else
+		document:Hide()
+	end
+end
+
+function widget:ViewResize()
+	if document and shown then
+		applyViewLayout()
+	end
+end
+
+local function refresh()
+	if Spring.GetGameRulesParam("mission_active") ~= 1 then
+		setShown(false)
+		lastStateKey = nil
+		return
+	end
+	local rows = collectRows()
+	if #rows == 0 then
+		setShown(false)
+		lastStateKey = nil
+		return
+	end
+	local key = {}
+	for _, row in ipairs(rows) do
+		key[#key + 1] = row.title .. row.state
+	end
+	key = table.concat(key, "\n")
+	if key ~= lastStateKey then
+		lastStateKey = key
+		render(rows)
+	end
+	setShown(true)
+end
+
+function widget:Update(dt)
+	if not document then
+		return
+	end
+	pollAccumulator = pollAccumulator + dt
+	if pollAccumulator < POLL_SECONDS then
+		return
+	end
+	pollAccumulator = 0
+	refresh()
+end
+
+-- Hide while the lobby/menu overlay is up so the panel never draws over
+-- Chobby (LobbyOverlayActive broadcast from barwidgets.lua).
+function widget:RecvLuaMsg(message)
+	if not document then
+		return
+	end
+	if message:sub(1, 19) == "LobbyOverlayActive0" then
+		lobbyHidden = false
+		if shown then
+			document:Show(RmlUi.RmlModalFlag.None, RmlUi.RmlFocusFlag.None)
+		end
+	elseif message:sub(1, 19) == "LobbyOverlayActive1" then
+		lobbyHidden = true
+		document:Hide()
+	end
+end
+
+function widget:Initialize()
+	local context = RmlUi.GetContext("shared")
+	if not context then
+		Spring.Echo("[mission_objectives] no shared RmlUi context — widget dead")
+		return false
+	end
+	document = context:LoadDocument(RML_PATH)
+	if not document then
+		Spring.Echo("[mission_objectives] LoadDocument failed: " .. RML_PATH)
+		return false
+	end
+	listElement = document:GetElementById("mo-list")
+	if not listElement then
+		Spring.Echo("[mission_objectives] document has no mo-list element")
+		document:Close()
+		document = nil
+		return false
+	end
+	applyViewLayout()
+	refresh()
+end
+
+function widget:Shutdown()
+	if document then
+		document:Close()
+		document = nil
+	end
+end

--- a/modules/missions/rml_widgets/mission_objectives.rcss
+++ b/modules/missions/rml_widgets/mission_objectives.rcss
@@ -1,0 +1,77 @@
+/* Mission objectives tracker. A quest log corner, not a window: no chrome,
+   no buttons, and the whole panel is transparent to the mouse — a HUD
+   readout must never cost a click that belonged to the game. */
+
+/* top/left/width are set from Lua (applyViewLayout): vw units resolve to 0
+   in this RmlUi build and `right:` anchors to the body box, not the
+   viewport. These are the pre-layout fallback only. */
+.mo-root {
+	position: absolute;
+	top: 140px;
+	left: 40px;
+	width: 320px;
+	z-index: 900;
+	pointer-events: none;
+	decorator: vertical-gradient( #111823d8 #0a0e14e0 );
+	border: 1px #223040;
+	border-radius: 8px;
+	padding: 10px 14px;
+	font-family: Exo 2;
+	font-size: 15px;
+	color: #d5dde7;
+}
+
+.mo-header {
+	font-size: 0.85em;
+	letter-spacing: 2px;
+	color: #7f93a8;
+	margin-bottom: 6px;
+	padding-bottom: 5px;
+	border-bottom: 1px #1d2938;
+}
+
+.mo-row {
+	display: flex;
+	align-items: center;
+	margin: 4px 0;
+	color: #e8eef5;
+}
+
+/* The mark is drawn, not typed: an 8px dot colored by state. A glyph here
+   is a bet on the game font's coverage; a box with border-radius is not. */
+.mo-mark {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 4px;
+	margin-right: 9px;
+	background-color: #e8b64c;
+}
+
+/* A foreshadowed line (Foreshadow() in objectives.lua) is on the board
+   before its reveal — the mission telling the player what is coming. Its
+   mark is a hollow ring. */
+.mo-pending {
+	color: #55667a;
+}
+
+.mo-pending .mo-mark {
+	background-color: #00000000;
+	border: 1px #55667a;
+}
+
+/* A completed line stays on the board — dimmed, its mark turned green — so
+   the list reads as a story so far, not a shrinking todo pile. */
+.mo-done {
+	color: #5c6b7a;
+}
+
+.mo-done .mo-mark {
+	background-color: #57a55a;
+}
+
+/* Risky property in its own block, same convention as the editor theme: if
+   the engine build lacks line-through, only this declaration dies. */
+.mo-done {
+	text-decoration: line-through;
+}

--- a/modules/missions/rml_widgets/mission_objectives.rml
+++ b/modules/missions/rml_widgets/mission_objectives.rml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<rml>
+<head>
+	<title>Mission Objectives</title>
+	<link type="text/rcss" href="mission_objectives.rcss" />
+</head>
+<body>
+	<div id="mo-root" class="mo-root">
+		<div class="mo-header">Objectives</div>
+		<div id="mo-list" class="mo-list"></div>
+	</div>
+</body>
+</rml>

--- a/modules/missions/spec/builders/mission_builder.lua
+++ b/modules/missions/spec/builders/mission_builder.lua
@@ -455,6 +455,21 @@ function MissionBuilder:Load()
 				end,
 			}, { __index = lib })
 		end,
+		["modules/missions/lib/objectives.lua"] = function(lib)
+			return setmetatable({
+				ForFile = function(...)
+					local file = lib.ForFile(...)
+					local finalize = file.Finalize
+					file.Finalize = function(exports, ...)
+						local decls = finalize(exports, ...)
+						self_.objectiveDecls[#self_.objectiveDecls + 1] = decls
+						self_.includes.objectives = exports
+						return decls
+					end
+					return file
+				end,
+			}, { __index = lib })
+		end,
 		["modules/placement/api.lua"] = function()
 			return {
 				NearestValid = function(x, z)

--- a/modules/missions/spec/builders/mission_builder_exports_spec.lua
+++ b/modules/missions/spec/builders/mission_builder_exports_spec.lua
@@ -1,0 +1,76 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+describe("objectives.lua exports its handles", function()
+	local OBJECTIVES = [[
+local first = Objective("first").CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+local second = Objective("second").CompletedWhen(Team.Player.Has(UnitDef("armcom"), 1)).When(first.IsComplete())
+return { first = first, second = second }
+]]
+
+	it("trigger files reference them as Objectives.<key>, no string in sight", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["objectives.lua"] = OBJECTIVES,
+				["triggers/win.lua"] = 'local Objectives = VFS.Include("modules/missions/t/objectives.lua")\nWhen(Objectives.second.IsComplete()).Do(MatchFlow.Victory(Team.Player))\n',
+			})
+			:WithUnits(0, "armcom", 1)
+			:Arm()
+		local fromFile = 0
+		for _, trigger in ipairs(m:Triggers()) do
+			if trigger.filename == "t/triggers/win.lua" then
+				fromFile = fromFile + 1
+			end
+		end
+		assert.are.equal(1, fromFile)
+		m:WithUnits(0, "armpw", 3):Step():Step()
+		assert.are.equal(1, m:Param("objective_second"))
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+
+	it("a key nothing exported is a load error naming the file", function()
+		local m = Builders.Mission.new():WithSources("t", {
+			["objectives.lua"] = OBJECTIVES,
+			["triggers/win.lua"] = 'local Objectives = VFS.Include("modules/missions/t/objectives.lua")\nWhen(Objectives.third.IsComplete()).Do(MatchFlow.Victory(Team.Player))\n',
+		})
+		assert.is_true(pcall(m.Arm, m))
+		assert.is_nil(m:Param("mission_active"))
+		assert.is_true(m:Logged("win.lua"))
+	end)
+
+	it("only the mission's own definition files can be included", function()
+		local m = Builders.Mission.new():WithSources("t", {
+			["objectives.lua"] = OBJECTIVES,
+			["triggers/a.lua"] = 'local X = VFS.Include("modules/missions/u/objectives.lua")\n',
+		})
+		assert.is_true(pcall(m.Arm, m))
+		assert.is_nil(m:Param("mission_active"))
+		assert.is_true(m:Logged("only include its own files"))
+	end)
+
+	it("a trigger file cannot be included — it returns nothing", function()
+		local m = Builders.Mission.new():WithSources("t", {
+			["triggers/a.lua"] = 'When(Team.Player.Has(UnitDef("armpw"), 1)).Do(MatchFlow.Victory(Team.Player))\n',
+			["triggers/b.lua"] = 'local A = VFS.Include("modules/missions/t/triggers/a.lua")\n',
+		})
+		assert.is_true(pcall(m.Arm, m))
+		assert.is_nil(m:Param("mission_active"))
+		assert.is_true(m:Logged("not a definition file"))
+	end)
+
+	it("anything exports — a value reads on the other side as what it is", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["objectives.lua"] = 'local armed = Objective("armed").CompletedWhen(Team.Player.Has(UnitDef("armpw"), 2))\nreturn { armed = armed, enough = 2 }\n',
+				["triggers/win.lua"] = 'local Objectives = VFS.Include("modules/missions/t/objectives.lua")\nWhen(Objectives.armed.IsComplete()).When(Team.Player.Has(UnitDef("armpw"), Objectives.enough)).Do(MatchFlow.Victory(Team.Player))\n',
+			})
+			:Arm()
+			:Step()
+		assert.is_nil(m:Param("objective_armed"))
+		m:WithUnits(0, "armpw", 2):Step():Step()
+		assert.are.equal(1, m:Param("objective_armed"))
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+end)

--- a/modules/missions/spec/builders/mission_builder_objectives_spec.lua
+++ b/modules/missions/spec/builders/mission_builder_objectives_spec.lua
@@ -1,0 +1,44 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+describe("the mission builder's objective board", function()
+	it("publishes the objective board a mission declares", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["objectives.lua"] = [[
+Objective("first").Title("The First Step").CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+Objective("second").CompletedWhen(Team.Player.Has(UnitDef("armcom"), 1)).When(Objective("first").IsComplete())
+]],
+				["triggers/quiet.lua"] = [[
+When(Team.Player.Has(UnitDef("armcom"), 5)).Do(Objective("first").Complete())
+]],
+			})
+			:Arm()
+		assert.are.same({ "first", "second" }, m:ObjectiveOrder())
+		assert.are.equal("The First Step", m:Param("objective_title_first"))
+		assert.are.equal(2, #m:Objectives())
+		assert.are.equal(1, m:Param("objective_revealed_first"))
+		assert.is_nil(m:Param("objective_revealed_second"))
+	end)
+
+	it("a spec reads the board by the mission's own handles", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["objectives.lua"] = 'local armed = Objective("armed").Title("Arm up").CompletedWhen(Team.Player.Has(UnitDef("armpw"), 2))\nlocal won = Objective("won").CompletedWhen(armed.IsComplete())\nreturn { armed = armed, won = won }\n',
+				["triggers/win.lua"] = 'local Objectives = VFS.Include("modules/missions/t/objectives.lua")\nWhen(Objectives.won.IsComplete()).Do(MatchFlow.Victory(Team.Player))\n',
+			})
+			:Arm()
+			:Step()
+		local _, Objectives = m:Includes()
+		assert.are.equal("armed", Objectives.armed.id)
+		assert.are.equal("Arm up", m:TitleOf(Objectives.armed))
+		assert.is_true(m:IsRevealed(Objectives.armed))
+		assert.is_false(m:IsRevealed(Objectives.won))
+		assert.is_false(m:IsComplete(Objectives.armed))
+		m:WithUnits(0, "armpw", 2):Step():Step()
+		assert.is_true(m:IsComplete(Objectives.armed))
+		assert.is_true(m:IsRevealed(Objectives.won))
+	end)
+end)

--- a/modules/missions/spec/gadgets/mission_objectives_spec.lua
+++ b/modules/missions/spec/gadgets/mission_objectives_spec.lua
@@ -1,0 +1,130 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+local BUILD = [[
+When(Team.Player.Has(UnitDef("armpw"), 3))
+	.Do(Objective("build_pawns").Complete())
+]]
+
+local function armed(m)
+	return m:Param("mission_active") == 1 and #m:Triggers() or nil
+end
+
+describe("mission objectives", function()
+	describe("objective declarations", function()
+		local DECLS = [[
+Objective("first")
+	.Title("The First Step")
+	.CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+
+Objective("second")
+	.Foreshadow()
+	.CompletedWhen(Team.Player.Has(UnitDef("armcom"), 1))
+	.When(Objective("first").IsComplete())
+]]
+		local QUIET = [[
+When(Team.Player.Has(UnitDef("armcom"), 5))
+	.Do(Objective("first").Complete())
+]]
+
+		it("publishes the board and reveals the opening line at arm", function()
+			local m = Builders.Mission
+				.new()
+				:WithSources("t", { ["objectives.lua"] = DECLS, ["triggers/quiet.lua"] = QUIET })
+				:Arm()
+			assert.are.same({ "first", "second" }, m:ObjectiveOrder())
+			assert.are.equal("The First Step", m:Param("objective_title_first"))
+			assert.are.equal("second", m:Param("objective_title_second"))
+			assert.are.equal(1, m:Param("objective_foreshadow_second"))
+			assert.is_nil(m:Param("objective_foreshadow_first"))
+			assert.are.equal(1, m:Param("objective_revealed_first"))
+			assert.is_nil(m:Param("objective_revealed_second"))
+		end)
+
+		it("declarations compile to triggers: completion, gate and cadence", function()
+			local m =
+				Builders.Mission.new():WithSources("t", { ["objectives.lua"] = DECLS, ["triggers/quiet.lua"] = QUIET })
+			m:WithUnits(0, "armcom", 1):Arm():Frame(15)
+			assert.is_nil(m:Param("objective_second"))
+			assert.is_nil(m:Param("objective_revealed_second"))
+
+			m:WithUnits(0, "armpw", 3):Frame(30)
+			assert.are.equal(1, m:Param("objective_first"))
+			assert.are.equal(1, m:Param("objective_revealed_second"))
+			assert.are.equal(1, m:Param("objective_second"))
+		end)
+
+		it("RevealedWhen replaces the cadence, for the opening line too", function()
+			local m = Builders.Mission
+				.new()
+				:WithSources("t", {
+					["objectives.lua"] = [[
+Objective("first")
+	.RevealedWhen(Team.Player.Has(UnitDef("armpw"), 1))
+	.CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+]],
+					["triggers/quiet.lua"] = QUIET,
+				})
+				:Arm()
+			assert.is_nil(m:Param("objective_revealed_first"))
+			m:WithUnits(0, "armpw", 1):Frame(15)
+			assert.are.equal(1, m:Param("objective_revealed_first"))
+			assert.is_nil(m:Param("objective_first"))
+		end)
+
+		it("a standing objective does not dam the reveal cadence", function()
+			local m = Builders.Mission
+				.new()
+				:WithSources("t", {
+					["objectives.lua"] = [[
+Objective("standing")
+	.RevealedWhen(Team.Player.Has(UnitDef("armcom"), 5))
+
+Objective("first")
+	.Title("The First Step")
+	.CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+]],
+					["triggers/quiet.lua"] = QUIET,
+				})
+				:Arm()
+			assert.are.equal(1, m:Param("objective_revealed_first"))
+			assert.is_nil(m:Param("objective_revealed_standing"))
+		end)
+
+		it("a second CompletedWhen is another way to complete", function()
+			local m = Builders.Mission.new():WithSources("t", {
+				["objectives.lua"] = [[
+Objective("found")
+	.CompletedWhen(Team.Player.Has(UnitDef("armpw"), 3))
+	.CompletedWhen(Team.Player.Has(UnitDef("armcom"), 1))
+]],
+				["triggers/quiet.lua"] = [[
+When(Team.Player.Has(UnitDef("armcom"), 5))
+	.Do(Objective("found").Complete())
+]],
+			})
+			m:WithUnits(0, "armcom", 1):Arm():Frame(15)
+			assert.are.equal(1, m:Param("objective_found"))
+		end)
+
+		it("a trigger speaking an undeclared id is a load error", function()
+			local m = Builders.Mission.new():WithSources("t", {
+				["objectives.lua"] = DECLS,
+				["triggers/typo.lua"] = [[
+When(Team.Player.Has(UnitDef("armpw"), 1))
+	.Do(Objective("ghost").Complete())
+]],
+			})
+			assert.is_true(pcall(m.Arm, m))
+			assert.is_nil(armed(m))
+			assert.is_true(m:Logged("ghost"))
+			assert.is_true(m:Logged("no such objective"))
+		end)
+
+		it("a mission without a definition site stays unvalidated", function()
+			local m = Builders.Mission.new():WithSources("t", { ["triggers/win.lua"] = BUILD }):Arm()
+			assert.is_nil(m:Param("objective_display_order"))
+			assert.are.equal(1, armed(m))
+		end)
+	end)
+end)

--- a/modules/missions/spec/lib/objectives_spec.lua
+++ b/modules/missions/spec/lib/objectives_spec.lua
@@ -1,0 +1,111 @@
+local Objectives = VFS.Include("modules/missions/lib/objectives.lua")
+
+local function condition()
+	return {
+		evaluate = function()
+			return false
+		end,
+	}
+end
+
+describe("objectives DSL", function()
+	it("declaration order is the board order; a title defaults to the id", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		file.Objective("first_step").Title("The First Step").CompletedWhen(condition())
+		file.Objective("second_step").CompletedWhen(condition())
+		local decls = file.Finalize()
+		assert.are.equal(2, #decls)
+		assert.are.equal("first_step", decls[1].id)
+		assert.are.equal("The First Step", decls[1].title)
+		assert.are.equal("second step", decls[2].title)
+	end)
+
+	it("a second declaration of the same id is a load error", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		file.Objective("twice").Title("Once")
+		local ok, err = pcall(function()
+			file.Objective("twice").Title("Again")
+		end)
+		assert.is_false(ok)
+		assert.matches("declared twice", tostring(err))
+	end)
+
+	it("When gates the whole objective, wherever it sits in the chain", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		local gate = condition()
+		file.Objective("gated").When(gate).CompletedWhen(condition()).CompletedWhen(condition())
+		local decls = file.Finalize()
+		assert.are.equal(2, #decls[1].completions)
+		assert.are.same({ gate }, decls[1].gates)
+	end)
+
+	it("a reference no declaration backs fails Finalize", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		file.Objective("real").CompletedWhen(file.Objective("ghost").IsComplete())
+		local ok, err = pcall(file.Finalize)
+		assert.is_false(ok)
+		assert.matches("ghost", tostring(err))
+		assert.matches("no declaration backs", tostring(err))
+	end)
+
+	it("forward references are fine — order is display, not scoping", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		file.Objective("early").CompletedWhen(file.Objective("late").IsComplete())
+		file.Objective("late").CompletedWhen(condition())
+		assert.are.equal(2, #file.Finalize())
+	end)
+
+	it("a bare reference never declares", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		file.Objective("declared").CompletedWhen(file.Objective("declared").IsComplete())
+		local decls = file.Finalize()
+		assert.are.equal(1, #decls)
+		assert.are.equal("declared", decls[1].id)
+	end)
+
+	it("gates, overrides and foreshadow ride the entry", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		local moment = condition()
+		file.Objective("rich")
+			.Title("Rich")
+			.CompletedWhen(condition())
+			.When(condition())
+			.RevealedWhen(moment)
+			.Foreshadow()
+		local decls = file.Finalize()
+		assert.are.equal(1, #decls[1].completions)
+		assert.are.equal(1, #decls[1].gates)
+		assert.are.equal(moment, decls[1].revealedWhen)
+		assert.is_true(decls[1].foreshadow)
+	end)
+
+	it("a second CompletedWhen is another way, not another requirement", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		file.Objective("found").CompletedWhen(condition()).When(condition()).CompletedWhen(condition())
+		local decls = file.Finalize()
+		assert.are.equal(2, #decls[1].completions)
+		assert.are.equal(1, #decls[1].completions[1])
+		assert.are.equal(1, #decls[1].completions[2])
+		assert.are.equal(1, #decls[1].gates)
+	end)
+
+	it("IsComplete builds the same condition shape triggers speak", function()
+		local file = Objectives.ForFile("t/objectives.lua")
+		local built = file.Objective("step").IsComplete()
+		file.Objective("step").CompletedWhen(condition())
+		file.Finalize()
+		assert.are.same({ "mission.objective_changed" }, built.inputs)
+		local completed = {}
+		assert.is_false(built.evaluate({
+			IsObjectiveComplete = function(id)
+				return completed[id] == true
+			end,
+		}))
+		completed.step = true
+		assert.is_true(built.evaluate({
+			IsObjectiveComplete = function(id)
+				return completed[id] == true
+			end,
+		}))
+	end)
+end)

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -28,12 +28,37 @@
 ---@class MissionEffect
 ---@field execute fun(ctx: MissionContext)
 
---- Complete implies Reveal.
 ---@class MissionObjective
 ---@field Complete fun(): MissionEffect
 ---@field Reveal fun(): MissionEffect
 ---@field IsComplete fun(): MissionCondition
+---@field Title fun(title: string): MissionObjectiveDeclaration objectives.lua sandbox only
+---@field CompletedWhen fun(condition: MissionCondition): MissionObjectiveDeclaration objectives.lua sandbox only
+---@field RevealedWhen fun(condition: MissionCondition): MissionObjectiveDeclaration objectives.lua sandbox only
+---@field Foreshadow fun(): MissionObjectiveDeclaration objectives.lua sandbox only
 
+---@class MissionObjectiveDeclaration
+---@field id string the objective's id, the wire identity
+---@field Title fun(title: string): MissionObjectiveDeclaration display wording; defaults to the id with underscores as spaces
+---@field CompletedWhen fun(condition: MissionCondition): MissionObjectiveDeclaration one way to complete; a second CompletedWhen is another way (OR), each compiling to its own trigger
+---@field When fun(condition: MissionCondition): MissionObjectiveDeclaration a gate on the whole objective: every way to complete must also find it true; position-free, as on a trigger
+---@field RevealedWhen fun(condition: MissionCondition): MissionObjectiveDeclaration replace the default reveal cadence with the mission's own moment
+---@field Foreshadow fun(): MissionObjectiveDeclaration draw the line greyed-out before its reveal
+---@field IsComplete fun(): MissionCondition
+---@field Complete fun(): MissionEffect the effect side, for the files that include this one
+---@field Reveal fun(): MissionEffect
+
+---@class MissionObjectiveDeclarationEntry
+---@field id string
+---@field title string
+---@field completions MissionCondition[][] disjuncts (one per CompletedWhen), each compiling to its own derived trigger; empty = a standing objective, transparent to the reveal cadence
+---@field gates MissionCondition[] the When conditions, ANDed onto every disjunct
+---@field revealedWhen MissionCondition|nil set by RevealedWhen
+---@field revealAtArm boolean|nil marked by the loader: no declared moment, no completable predecessor
+---@field foreshadow boolean
+
+--- Identity = source filename + declaration order: the unregister-by-identity
+--- key for hot reload.
 ---@class TriggerDescriptor
 ---@field id string "<filename>:<order>"
 ---@field filename string mission-relative trigger file path


### PR DESCRIPTION
objectives.lua is the definition site for every Objective(...) id the trigger files may speak: a typo is a load error naming the file. A declaration carries its wording (.Title), its completion (.CompletedWhen, .When to gate the whole objective) and the tracker's cadence — declaration order is the display order, the first line is revealed at arm and each next when its predecessor completes (.RevealedWhen overrides, .Foreshadow draws a line greyed-out early). The declarations compile into ordinary triggers through the same DSL.

Mission files link by include: a definition file's return table is what VFS.Include yields, once per load, to every file that asks — Objectives.relieve instead of a string, and a key nothing exported is a load error. The loader publishes the board to rulesparams (objective_display_order, objective_title_*, objective_revealed_*) and the mission_objectives RmlUi widget draws what the params say.
