### PR TITLE
modules: mission variables

### DIFF
--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -24,6 +24,7 @@ local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
 local DSL = VFS.Include("modules/missions/lib/dsl.lua")
 local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
 local Objectives = VFS.Include("modules/missions/lib/objectives.lua")
+local Variables = VFS.Include("modules/missions/lib/variables.lua")
 local Events = VFS.Include("modules/missions/lib/events.lua")
 
 local MISSIONS_DIR = "modules/missions/"
@@ -31,6 +32,7 @@ local EVALUATE_PERIOD = 15 -- frames
 
 local engine = TriggerEngine.New()
 local activeMission = nil ---@type string|nil
+local variableKinds = {} ---@type table<string, string> variable name -> declared kind
 local contributedContext = {} ---@type table<string, boolean> ctx keys the required modules supplied
 
 -- Protections THIS mission holds, by unit: combat's guard is a refcount, so
@@ -82,6 +84,22 @@ local ctx = {
 	end,
 	IsObjectiveComplete = function(name)
 		return Spring.GetGameRulesParam("objective_" .. name) == 1
+	end,
+	-- A variable's value is a rules param: booleans travel as 0/1 (rules
+	-- params hold numbers and strings), so the declared kind decodes it.
+	GetVariable = function(name)
+		local raw = Spring.GetGameRulesParam("mission_var_" .. name)
+		if variableKinds[name] == "boolean" then
+			return raw == 1
+		end
+		return raw
+	end,
+	SetVariable = function(name, value)
+		if type(value) == "boolean" then
+			value = value and 1 or 0
+		end
+		Spring.SetGameRulesParam("mission_var_" .. name, value)
+		engine.OnEvent(Events.VariableChanged)
 	end,
 }
 
@@ -391,6 +409,7 @@ local function loadMission(missionName, preserve)
 	end
 	local objectiveDecls = nil ---@type MissionObjectiveDeclarationEntry[]|nil
 	local declaredObjectives = nil ---@type table<string, boolean>|nil
+	local variableDecls = nil ---@type MissionVariableEntry[]|nil
 	local parsed, err = pcall(function()
 		local function checkInputs()
 			for _, trigger in ipairs(staging.Triggers()) do
@@ -408,8 +427,15 @@ local function loadMission(missionName, preserve)
 				end
 			end
 		end
-		-- The definition site parses first: objectives.lua declares the ids the
-		-- trigger files may speak.
+		-- objectives may gate on variables, so they load first
+		local variablesPath = MISSIONS_DIR .. missionName .. "/variables.lua"
+		if VFS.FileExists(variablesPath) then
+			local file = Variables.ForFile(missionName .. "/variables.lua")
+			local exports = VFS.Include(variablesPath, { Variable = file.Variable, VFS = sandboxVFS })
+			variableDecls = file.Finalize(exports)
+			included[variablesPath] = exports or false
+		end
+
 		local objectivesPath = MISSIONS_DIR .. missionName .. "/objectives.lua"
 		if VFS.FileExists(objectivesPath) then
 			local filename = missionName .. "/objectives.lua"
@@ -523,6 +549,24 @@ local function loadMission(missionName, preserve)
 	else
 		resetObjectives()
 		resetFired()
+	end
+	variableKinds = {}
+	for _, decl in ipairs(variableDecls or {}) do
+		variableKinds[decl.name] = decl.kind
+	end
+	if not preserve then
+		for name in pairs(Spring.GetGameRulesParams()) do
+			if name:find("^mission_var_") then
+				Spring.SetGameRulesParam(name, nil)
+			end
+		end
+		for _, decl in ipairs(variableDecls or {}) do
+			local value = decl.default
+			if type(value) == "boolean" then
+				value = value and 1 or 0
+			end
+			Spring.SetGameRulesParam("mission_var_" .. decl.name, value)
+		end
 	end
 	syncWatchedCallins()
 	activeMission = missionName

--- a/modules/missions/lib/events.lua
+++ b/modules/missions/lib/events.lua
@@ -1,6 +1,7 @@
 ---@enum MissionEvents
 local Events = {
 	ObjectiveChanged = "mission.objective_changed",
+	VariableChanged = "mission.variable_changed",
 }
 
 return Events

--- a/modules/missions/lib/variables.lua
+++ b/modules/missions/lib/variables.lua
@@ -1,0 +1,148 @@
+
+local Events = VFS.Include("modules/missions/lib/events.lua")
+local Variables = {}
+
+---@param filename string mission-relative path, e.g. "cm8_ashfall/variables.lua"
+---@return { Variable: fun(name: string): MissionVariableChain, Finalize: fun(exports: table?): MissionVariableEntry[] }
+function Variables.ForFile(filename)
+	local declarations = {} ---@type MissionVariableEntry[]
+	local byChain = {} ---@type table<table, MissionVariableEntry>
+	local declared = {} ---@type table<string, boolean>
+	local finalized = false
+
+	local function checkOpen(step)
+		assert(not finalized, filename .. ": " .. step .. " after Finalize — the file already loaded")
+	end
+
+	---@param name string
+	---@return MissionVariableChain
+	local Variable = function(name)
+		checkOpen("Variable")
+		assert(type(name) == "string" and name ~= "", filename .. ": Variable expects a name string")
+		assert(not declared[name], filename .. ': Variable("' .. name .. '") declared twice')
+		declared[name] = true
+		local build = { name = name, kind = nil, default = nil } ---@type MissionVariableEntry
+		declarations[#declarations + 1] = build
+
+		local chain = {}
+		byChain[chain] = build
+
+		local function typed(kind, default)
+			checkOpen(kind)
+			assert(build.kind == nil, filename .. ': Variable("' .. name .. '") is already ' .. tostring(build.kind))
+			build.kind = kind
+			build.default = default
+			return chain
+		end
+		---@param default number
+		---@return MissionVariableChain
+		chain.Number = function(default)
+			assert(type(default) == "number", filename .. ": Number expects a number default")
+			return typed("number", default)
+		end
+		---@param default boolean
+		---@return MissionVariableChain
+		chain.Boolean = function(default)
+			assert(type(default) == "boolean", filename .. ": Boolean expects a boolean default")
+			return typed("boolean", default)
+		end
+		---@param default string
+		---@return MissionVariableChain
+		chain.String = function(default)
+			assert(type(default) == "string", filename .. ": String expects a string default")
+			return typed("string", default)
+		end
+
+		local function condition(test)
+			return {
+				inputs = { Events.VariableChanged },
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return test(ctx.GetVariable(name))
+				end,
+			}
+		end
+		local function effect(apply)
+			return {
+				---@param ctx MissionContext
+				execute = function(ctx)
+					ctx.SetVariable(name, apply(ctx.GetVariable(name)))
+				end,
+			}
+		end
+		local function number(verb)
+			assert(
+				build.kind == "number",
+				filename .. ': Variable("' .. name .. '").' .. verb .. " needs a Number variable"
+			)
+		end
+
+		---@param value number|boolean|string
+		---@return MissionCondition
+		chain.Is = function(value)
+			return condition(function(current)
+				return current == value
+			end)
+		end
+		---@param n number
+		---@return MissionCondition
+		chain.AtLeast = function(n)
+			number("AtLeast")
+			return condition(function(current)
+				return (current or 0) >= n
+			end)
+		end
+		---@param n number
+		---@return MissionCondition
+		chain.AtMost = function(n)
+			number("AtMost")
+			return condition(function(current)
+				return (current or 0) <= n
+			end)
+		end
+		---@param value number|boolean|string
+		---@return MissionEffect
+		chain.Set = function(value)
+			assert(
+				build.kind == nil or type(value) == build.kind,
+				filename .. ': Variable("' .. name .. '").Set expects a ' .. tostring(build.kind)
+			)
+			return effect(function()
+				return value
+			end)
+		end
+		---@param n number
+		---@return MissionEffect
+		chain.Add = function(n)
+			number("Add")
+			assert(type(n) == "number", filename .. ": Add expects a number")
+			return effect(function(current)
+				return (current or 0) + n
+			end)
+		end
+
+		return chain
+	end
+
+	---@param exports table<string, table>|nil what variables.lua returned
+	---@return MissionVariableEntry[]
+	local Finalize = function(exports)
+		assert(not finalized, filename .. ": Finalize called twice")
+		finalized = true
+		for _, build in ipairs(declarations) do
+			assert(
+				build.kind ~= nil,
+				filename .. ': Variable("' .. build.name .. '") has no type — Number, Boolean or String'
+			)
+		end
+		assert(
+			exports == nil or type(exports) == "table",
+			filename .. ": a variables file returns a table of its values, or nothing"
+		)
+		return declarations
+	end
+
+	return { Variable = Variable, Finalize = Finalize }
+end
+
+return Variables

--- a/modules/missions/spec/builders/mission_builder.lua
+++ b/modules/missions/spec/builders/mission_builder.lua
@@ -470,6 +470,19 @@ function MissionBuilder:Load()
 				end,
 			}, { __index = lib })
 		end,
+		["modules/missions/lib/variables.lua"] = function(lib)
+			return setmetatable({
+				ForFile = function(...)
+					local file = lib.ForFile(...)
+					local finalize = file.Finalize
+					file.Finalize = function(exports, ...)
+						self_.includes.variables = exports
+						return finalize(exports, ...)
+					end
+					return file
+				end,
+			}, { __index = lib })
+		end,
 		["modules/placement/api.lua"] = function()
 			return {
 				NearestValid = function(x, z)

--- a/modules/missions/spec/builders/mission_builder_variables_spec.lua
+++ b/modules/missions/spec/builders/mission_builder_variables_spec.lua
@@ -1,0 +1,57 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+local VARIABLES = [[
+local waves = Variable("waves_survived").Number(0)
+local alarmed = Variable("alarmed").Boolean(false)
+return { waves = waves, alarmed = alarmed }
+]]
+
+local function mission(triggers)
+	return Builders.Mission.new():WithSources("t", { ["variables.lua"] = VARIABLES, ["triggers/a.lua"] = triggers })
+end
+
+describe("variables.lua declares typed slots", function()
+	it("starts at its default, Add accumulates, AtLeast gates", function()
+		local m = mission([[
+local V = VFS.Include("modules/missions/t/variables.lua")
+When(Team.Player.Has(UnitDef("armpw"), 1)).Every(1).Do(V.waves.Add(1))
+When(V.waves.AtLeast(2)).Do(V.alarmed.Set(true))
+When(V.alarmed.Is(true)).Do(MatchFlow.Victory(Team.Player))
+]]):Arm()
+		assert.are.equal(0, m:Param("mission_var_waves_survived"))
+		assert.are.equal(0, m:Param("mission_var_alarmed"))
+		m:WithUnits(0, "armpw", 1):Step()
+		assert.are.equal(1, m:Param("mission_var_waves_survived"))
+		m:Frame(15 + 30):Step()
+		assert.are.equal(2, m:Param("mission_var_waves_survived"))
+		assert.are.equal(1, m:Param("mission_var_alarmed"))
+		m:Step()
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+
+	it("restart resets to defaults; a preserving reload keeps the value", function()
+		local m = mission([[
+local V = VFS.Include("modules/missions/t/variables.lua")
+When(Team.Player.Has(UnitDef("armpw"), 1)).Do(V.waves.Set(7))
+]])
+			:WithUnits(0, "armpw", 1)
+			:Arm()
+			:Step()
+		assert.are.equal(7, m:Param("mission_var_waves_survived"))
+		m:Reload()
+		assert.are.equal(7, m:Param("mission_var_waves_survived"))
+		m:Restart()
+		assert.are.equal(0, m:Param("mission_var_waves_survived"))
+	end)
+
+	it("a variable without a type is a load error", function()
+		local m = Builders.Mission.new():WithSources("t", {
+			["variables.lua"] = 'local x = Variable("x")\nreturn { x = x }\n',
+			["triggers/a.lua"] = 'When(Team.Player.Has(UnitDef("armpw"), 1)).Do(MatchFlow.Victory(Team.Player))\n',
+		})
+		assert.is_true(pcall(m.Arm, m))
+		assert.is_nil(m:Param("mission_active"))
+		assert.is_true(m:Logged("has no type"))
+	end)
+end)

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -23,6 +23,8 @@
 ---@class (partial) MissionContext
 ---@field GetUnitDefCount fun(teamID: integer, unitDefName: string): integer count of finished units of that def
 ---@field IsObjectiveComplete fun(name: string): boolean
+---@field GetVariable fun(name: string): number|boolean|string|nil
+---@field SetVariable fun(name: string, value: number|boolean|string)
 ---@field frame integer current game frame
 
 ---@class MissionEffect
@@ -107,3 +109,20 @@
 ---@field ForFile fun(file: MissionDslFile): { env: table<string, any>, Finalize: fun()|nil }
 ---@field Context fun(runtime: MissionRuntime): table<string, function>|nil
 ---@field Events table<string, string>|nil an enum of the bus events this module raises
+
+--- The declaration chain in variables.lua: a typed slot with a default. The
+--- value lives in the pile; the handle is both sides of it.
+---@class MissionVariableChain
+---@field Number fun(default: number): MissionVariableChain
+---@field Boolean fun(default: boolean): MissionVariableChain
+---@field String fun(default: string): MissionVariableChain
+---@field Is fun(value: number|boolean|string): MissionCondition
+---@field AtLeast fun(n: number): MissionCondition
+---@field AtMost fun(n: number): MissionCondition
+---@field Set fun(value: number|boolean|string): MissionEffect
+---@field Add fun(n: number): MissionEffect
+
+---@class MissionVariableEntry
+---@field name string
+---@field kind "number"|"boolean"|"string"
+---@field default number|boolean|string


### PR DESCRIPTION
variables.lua declares a mission's typed slots — Variable(name).Number | .Boolean | .String(default) — and the handle is both sides of the value: Is / AtLeast / AtMost as conditions, Set / Add as effects. The value lives in the rulesparam pile (mission_var_<name>, booleans as 0/1, decoded by the declared kind), so it survives a reload and reads unsynced; a fresh run resets every variable to its default. Writes raise mission.variable_changed for the conditions that read them.
