### PR TITLE
modules: mission roster

### DIFF
--- a/luaui/Tests/missions_smoke/test_claim.lua
+++ b/luaui/Tests/missions_smoke/test_claim.lua
@@ -1,0 +1,91 @@
+---@diagnostic disable: undefined-field
+
+local ARM_TIMEOUT = 900
+
+local function countDef(teamID, defName)
+	local n = 0
+	for _, unitID in ipairs(Spring.GetTeamUnits(teamID) or {}) do
+		local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
+		if unitDef and unitDef.name == defName then
+			n = n + 1
+		end
+	end
+	return n
+end
+
+-- An enemy is a team on ANOTHER allyteam; an allied seat must not count.
+local function enemyTeamID()
+	local gaia = Spring.GetGaiaTeamID()
+	local mine = Spring.GetLocalTeamID()
+	local _, _, _, _, _, myAllyTeamID = Spring.GetTeamInfo(mine, false)
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaia and teamID ~= mine then
+			local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+			if allyTeamID ~= myAllyTeamID then
+				return teamID
+			end
+		end
+	end
+	return nil
+end
+
+local function skip()
+	if Spring.GetGameFrame() <= 0 then
+		return true
+	end
+	return enemyTeamID() == nil
+end
+
+local function setup()
+	-- Deliberately does NOT clear the map: the occupied seat IS the case.
+end
+
+local function cleanup()
+	Test.clearMap()
+end
+
+local function test()
+	local enemy = enemyTeamID()
+
+	-- PATH ONE: the seat is occupied. Every bare team is given a commander at
+	-- game start, so this is what a mission dropped into a skirmish meets.
+	local before = countDef(enemy, "armcom")
+	assert(before == 1, ("this scenario should open with exactly one enemy commander, found %d"):format(before))
+	local incumbent
+	for _, unitID in ipairs(Spring.GetTeamUnits(enemy) or {}) do
+		local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
+		if unitDef and unitDef.name == "armcom" then
+			incumbent = unitID
+		end
+	end
+
+	Spring.SendCommands("luarules mission smoke_claim")
+	Test.waitUntil(function()
+		return Spring.GetGameRulesParam("mission_active") == 1
+	end, ARM_TIMEOUT)
+	Test.waitUntil(function()
+		return Spring.GetGameRulesParam("mission_unit_mark") ~= nil
+	end, ARM_TIMEOUT)
+
+	local after = countDef(enemy, "armcom")
+	local bound = Spring.GetGameRulesParam("mission_unit_mark")
+	assert(after == 1, ("the enemy must hold exactly one commander, found %d"):format(after))
+	-- The one assertion that separates claiming from spawning: the mission's
+	-- name has to point at the unit that was already standing there.
+	assert(bound == incumbent, "the claim must bind to the commander the team already had")
+	assert(Spring.ValidUnitID(bound), "the claim is bound to a dead or unknown unit")
+	assert(Spring.GetUnitTeam(bound) == enemy, "the claim is bound to a unit on the wrong team")
+
+	Test.clearMap()
+	Test.waitUntil(function()
+		return #(Spring.GetTeamUnits(enemy) or {}) == 0
+	end, ARM_TIMEOUT)
+	Spring.SendCommands("luarules mission smoke_claim")
+	Test.waitUntil(function()
+		return (Spring.GetGameRulesParam("mission_unit_mark") or -1) ~= (bound or -1)
+	end, ARM_TIMEOUT)
+	local built = countDef(enemy, "armcom")
+	assert(built == 1, ("an empty seat must be filled with exactly one commander, found %d"):format(built))
+end
+
+return { skip = skip, setup = setup, cleanup = cleanup, test = test }

--- a/modules/missions/README.md
+++ b/modules/missions/README.md
@@ -26,13 +26,14 @@ flowchart TB
     MF --> VG
 ```
 
-`objectives.lua` declares every `Objective(...)` id the triggers may reference —
-a typo is a load error, not a silently-never-true condition. An objective
-declaration carries its wording (`.Title`), its completion (`.CompletedWhen`,
-`.When` to AND), and the tracker's cadence: declaration order is the display
-order, the first line is revealed at arm and each next when its predecessor
-completes (`.RevealedWhen` overrides, `.Foreshadow` draws a line greyed-out
-early). The declarations compile into ordinary triggers through the same DSL;
-the loader publishes the board to rulesparams (`objective_display_order`,
-`objective_title_*`, `objective_revealed_*`), and the `mission_objectives`
-widget just draws what the params say.
+Names have definition sites: `units.lua` declares every `Unit(...)` name the
+triggers may reference, and `objectives.lua` every `Objective(...)` id — in
+both cases a typo is a load error, not a silently-never-true condition. An
+objective declaration carries its wording (`.Title`), its completion
+(`.CompletedWhen`, `.When` to AND), and the tracker's cadence: declaration
+order is the display order, the first line is revealed at arm and each next
+when its predecessor completes (`.RevealedWhen` overrides, `.Foreshadow`
+draws a line greyed-out early). The declarations compile into ordinary
+triggers through the same DSL; the loader publishes the board to rulesparams
+(`objective_display_order`, `objective_title_*`, `objective_revealed_*`),
+and the `mission_objectives` widget just draws what the params say.

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -23,6 +23,7 @@ local ChatGuard = VFS.Include("modules/missions/lib/chat_guard.lua")
 local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
 local DSL = VFS.Include("modules/missions/lib/dsl.lua")
 local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
 local Objectives = VFS.Include("modules/missions/lib/objectives.lua")
 local Variables = VFS.Include("modules/missions/lib/variables.lua")
 local Events = VFS.Include("modules/missions/lib/events.lua")
@@ -35,9 +36,12 @@ local activeMission = nil ---@type string|nil
 local variableKinds = {} ---@type table<string, string> variable name -> declared kind
 local contributedContext = {} ---@type table<string, boolean> ctx keys the required modules supplied
 
--- Protections THIS mission holds, by unit: combat's guard is a refcount, so
--- every arm that fires Protect again leans another count on it — the mission
--- must unwind its own on a fresh run or the hub stays invulnerable forever.
+local namedUnits = {} ---@type table<string, integer> name -> unitID
+local unitNames = {} ---@type table<integer, string> unitID -> name
+local groupUnits = {} ---@type table<string, integer[]>
+local spawnedUnits = {} ---@type integer[] everything the roster spawned, for reload cleanup
+-- combat's guard is a refcount: every arm that fires Protect leans another count
+-- on it, so the mission must unwind its own or the hub stays invulnerable forever.
 local protectCounts = {} ---@type table<integer, integer>
 
 local function persistProtectLedger()
@@ -47,9 +51,22 @@ local function persistProtectLedger()
 	end
 	Spring.SetGameRulesParam("mission_protect_ledger", table.concat(parts, ","))
 end
+local silencedUnits = {} ---@type table<integer, boolean> spawned Neutral: holding fire until handed over
 
 ---@type MissionRuntime
 local runtime = {
+	UnitOf = function(name)
+		return namedUnits[name]
+	end,
+	GroupUnits = function(groupName)
+		return groupUnits[groupName]
+	end,
+	ReleaseHoldFire = function(unitID)
+		if silencedUnits[unitID] and Spring.ValidUnitID(unitID) then
+			Spring.GiveOrderToUnit(unitID, CMD.FIRE_STATE, { 2 }, 0)
+			silencedUnits[unitID] = nil
+		end
+	end,
 	Protections = {
 		Get = function(unitID)
 			return protectCounts[unitID] or 0
@@ -100,6 +117,23 @@ local ctx = {
 		end
 		Spring.SetGameRulesParam("mission_var_" .. name, value)
 		engine.OnEvent(Events.VariableChanged)
+	end,
+	IsUnitDestroyed = function(name)
+		return Spring.GetGameRulesParam("mission_unit_dead_" .. name) == 1
+	end,
+	IsUnitSpotted = function(name, allyTeamID)
+		if Spring.GetGameRulesParam("mission_unit_spotted_" .. name .. "_" .. allyTeamID) == 1 then
+			return true
+		end
+		-- The latch only catches the LOS edge. Vision granted with no edge to
+		-- catch (/globallos mid-game) still answers yes, and latches so the
+		-- answer survives the unit dying.
+		local unitID = namedUnits[name]
+		if unitID ~= nil and Spring.IsUnitInLos(unitID, allyTeamID) then
+			Spring.SetGameRulesParam("mission_unit_spotted_" .. name .. "_" .. allyTeamID, 1)
+			return true
+		end
+		return false
 	end,
 }
 
@@ -160,9 +194,33 @@ end
 
 local FORWARDABLE_CALLINS = { "UnitFinished", "UnitDestroyed", "UnitGiven", "UnitTaken", "UnitEnteredLos" }
 
--- Callins forward as bare bus events; a module that latches state on one
--- (the roster) supplies its own forwarder here.
-local forwarders = {}
+-- these latch roster-unit state first: conditions read "has been", not "is right now"
+local forwarders = {
+	UnitDestroyed = function(_, unitID, _, _, attackerID, _, attackerTeam)
+		local name = unitNames[unitID]
+		if name ~= nil then
+			Spring.SetGameRulesParam("mission_unit_dead_" .. name, 1)
+			Spring.Log(
+				LOG_TAG,
+				LOG.INFO,
+				"roster unit destroyed: "
+					.. name
+					.. (
+						attackerTeam ~= nil and (" (attacker team " .. tostring(attackerTeam) .. ")")
+						or " (no attacker)"
+					)
+			)
+		end
+		engine.OnEvent("UnitDestroyed")
+	end,
+	UnitEnteredLos = function(_, unitID, _, allyTeam)
+		local name = unitNames[unitID]
+		if name ~= nil then
+			Spring.SetGameRulesParam("mission_unit_spotted_" .. name .. "_" .. allyTeam, 1)
+		end
+		engine.OnEvent("UnitEnteredLos")
+	end,
+}
 
 ---@param addOnly boolean|nil a trigger armed mid-run (Protect ... Until) can only add a
 ---watch, and removing a callin from inside a callin is the handler crash combat documents
@@ -205,9 +263,108 @@ local function loadContributions()
 	return contributions
 end
 
--- Which trigger ids have been published as fired. Derived, not progress: the
--- engine's own state is the truth, this only avoids re-writing a param that
--- has not changed.
+---@param playerTeamID integer
+---@return integer|nil
+local function resolveEnemyTeam(playerTeamID)
+	local gaiaTeamID = Spring.GetGaiaTeamID()
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaiaTeamID and teamID ~= playerTeamID then
+			return teamID
+		end
+	end
+	return nil
+end
+
+---The in-memory ledger dies with a /luarules reload, so the sweep also reads
+---the persisted copy; otherwise a re-arm after a reload spawns the roster
+---twice and the orphans keep shooting.
+local function despawnRoster()
+	-- combat's refcount survives a mission reload, so an unwound arm must
+	-- give back exactly what it took or the next arm stacks on top
+	for unitID, count in pairs(protectCounts) do
+		if Spring.ValidUnitID(unitID) then
+			local combat = ModuleHandler.Get("combat")
+			for _ = 1, count do
+				combat.Unprotect(unitID)
+			end
+		end
+	end
+	protectCounts = {}
+	persistProtectLedger()
+	for _, unitID in ipairs(spawnedUnits) do
+		if Spring.ValidUnitID(unitID) then
+			Spring.DestroyUnit(unitID, false, true)
+		end
+	end
+	local persisted = Spring.GetGameRulesParam("mission_spawned_units")
+	if type(persisted) == "string" and persisted ~= "" then
+		for idText in persisted:gmatch("[^,]+") do
+			local unitID = tonumber(idText)
+			if unitID ~= nil and Spring.ValidUnitID(unitID) then
+				Spring.DestroyUnit(unitID, false, true)
+			end
+		end
+	end
+	Spring.SetGameRulesParam("mission_spawned_units", "")
+	for name in pairs(Spring.GetGameRulesParams()) do
+		if name:find("^mission_group_") then
+			Spring.SetGameRulesParam(name, nil)
+		end
+	end
+	namedUnits, unitNames, groupUnits, spawnedUnits = {}, {}, {}, {}
+	silencedUnits = {}
+end
+
+---@param entries table[]
+local function rebindRoster(entries)
+	namedUnits, unitNames, groupUnits, spawnedUnits = {}, {}, {}, {}
+	silencedUnits = {}
+	protectCounts = {}
+	local heldLedger = Spring.GetGameRulesParam("mission_protect_ledger")
+	if type(heldLedger) == "string" then
+		for unitText, countText in heldLedger:gmatch("(%d+):(%d+)") do
+			local unitID, count = tonumber(unitText), tonumber(countText)
+			if unitID ~= nil and count ~= nil and Spring.ValidUnitID(unitID) then
+				protectCounts[unitID] = count
+			end
+		end
+	end
+	local persisted = Spring.GetGameRulesParam("mission_spawned_units")
+	if type(persisted) == "string" then
+		for idText in persisted:gmatch("[^,]+") do
+			local unitID = tonumber(idText)
+			if unitID ~= nil and Spring.ValidUnitID(unitID) then
+				spawnedUnits[#spawnedUnits + 1] = unitID
+				if Spring.GetUnitNeutral ~= nil and Spring.GetUnitNeutral(unitID) then
+					silencedUnits[unitID] = true
+				end
+			end
+		end
+	end
+	for _, entry in ipairs(entries) do
+		if entry.name ~= nil then
+			local unitID = Spring.GetGameRulesParam("mission_unit_" .. entry.name)
+			if type(unitID) == "number" and Spring.ValidUnitID(unitID) then
+				namedUnits[entry.name] = unitID
+				unitNames[unitID] = entry.name
+			end
+		end
+	end
+	for name in pairs(Spring.GetGameRulesParams()) do
+		local group = name:match("^mission_group_(.+)$")
+		if group ~= nil then
+			groupUnits[group] = {}
+			for idText in tostring(Spring.GetGameRulesParam(name) or ""):gmatch("[^,]+") do
+				local unitID = tonumber(idText)
+				if unitID ~= nil and Spring.ValidUnitID(unitID) then
+					groupUnits[group][#groupUnits[group] + 1] = unitID
+				end
+			end
+		end
+	end
+	return true
+end
+
 local publishedFired = {} ---@type table<string, boolean>
 
 ---Publishes what has FIRED, deliberately not "is the condition true": a
@@ -281,8 +438,125 @@ local function readableLoadError(err)
 	return inner
 end
 
----One transaction: the incoming mission arms into a staging engine swapped in
----whole, so a file that fails to parse leaves the running mission untouched.
+---@param missionName string
+---@return MissionRosterEntry[]|nil entries nil on a load error; {} when the mission has no roster
+---@param sandboxVFS table the mission's own VFS: Include of its definition files
+---@return MissionRosterEntry[]|nil entries
+---@return table|nil exports what units.lua returned, for the files that include it
+local function parseRoster(missionName, sandboxVFS)
+	local rosterPath = MISSIONS_DIR .. missionName .. "/units.lua"
+	if not VFS.FileExists(rosterPath) then
+		return {}
+	end
+	local ok, result = pcall(function()
+		local file = Roster.ForFile(missionName .. "/units.lua")
+		local exports = VFS.Include(rosterPath, {
+			Spawn = file.Spawn,
+			Claim = file.Claim,
+			Group = file.Group,
+			UnitDef = Verbs.UnitDef,
+			VFS = sandboxVFS,
+		})
+		local entries, _, declaredGroups = file.Finalize(exports)
+		return { entries, exports, declaredGroups }
+	end)
+	if not ok then
+		Spring.Log(LOG_TAG, LOG.ERROR, readableLoadError(result))
+		return nil
+	end
+	return result[1], result[2], result[3]
+end
+
+---Runs AFTER syncWatchedCallins so spawn-time callins (a unit born inside LOS)
+---reach the latches.
+---@param entries MissionRosterEntry[]
+---@param playerTeam MissionTeam
+---@return boolean ok
+---Lowest unit id so two clients agree: GetTeamUnits order is not promised, and
+---a per-client binding would desync the moment a trigger asked about it.
+---@param teamID integer
+---@param defName string
+---@return integer|nil
+local function existingUnitOf(teamID, defName)
+	local wanted = UnitDefNames[defName]
+	if wanted == nil then
+		return nil
+	end
+	local found = nil
+	for _, unitID in ipairs(Spring.GetTeamUnits(teamID) or {}) do
+		if Spring.GetUnitDefID(unitID) == wanted.id and (found == nil or unitID < found) then
+			found = unitID
+		end
+	end
+	return found
+end
+
+local function spawnRoster(entries, playerTeam)
+	despawnRoster()
+	local teamFor = {
+		player = playerTeam.teamID,
+		gaia = Spring.GetGaiaTeamID(),
+		enemy = resolveEnemyTeam(playerTeam.teamID),
+	}
+	local allyTeams = Spring.GetAllyTeamList()
+	for _, entry in ipairs(entries) do
+		local teamID = teamFor[entry.team]
+		if teamID == nil then
+			Spring.Log(LOG_TAG, LOG.ERROR, 'roster needs an "' .. entry.team .. '" team but none exists')
+			despawnRoster()
+			return false
+		end
+		-- CreateUnit RAISES on an unknown def name; nil is the unit limit.
+		if UnitDefNames[entry.def] == nil then
+			Spring.Log(LOG_TAG, LOG.ERROR, "roster unit " .. entry.def .. ": no such unit def")
+			despawnRoster()
+			return false
+		end
+		local unitID = entry.claim and existingUnitOf(teamID, entry.def) or nil
+		local claimed = unitID ~= nil
+		if unitID == nil then
+			local x, z = entry.fx * Game.mapSizeX, entry.fz * Game.mapSizeZ
+			unitID = Spring.CreateUnit(entry.def, x, Spring.GetGroundHeight(x, z), z, 0, teamID)
+			if unitID == nil then
+				Spring.Log(LOG_TAG, LOG.ERROR, "could not spawn roster unit " .. entry.def .. " (unit limit)")
+				despawnRoster()
+				return false
+			end
+		end
+		if not claimed then
+			spawnedUnits[#spawnedUnits + 1] = unitID
+		end
+		-- a claimed unit belongs to a team that is presumably using it
+		if entry.neutral and not claimed then
+			-- Neutral only stops the unit being SHOT AT; hold fire is what stops it
+			-- shooting (the pairing ai_ruins uses)
+			Spring.SetUnitNeutral(unitID, true)
+			Spring.GiveOrderToUnit(unitID, CMD.FIRE_STATE, { 0 }, 0)
+			silencedUnits[unitID] = true
+		end
+		if entry.name ~= nil then
+			namedUnits[entry.name] = unitID
+			unitNames[unitID] = entry.name
+			Spring.SetGameRulesParam("mission_unit_" .. entry.name, unitID)
+			Spring.SetGameRulesParam("mission_unit_dead_" .. entry.name, 0)
+			-- seeded from current LOS, not 0: UnitEnteredLos is an edge, and a unit
+			-- that spawns already visible (/globallos, friendly vision) never crosses it
+			for _, allyTeamID in ipairs(allyTeams) do
+				local visible = Spring.IsUnitInLos(unitID, allyTeamID)
+				Spring.SetGameRulesParam("mission_unit_spotted_" .. entry.name .. "_" .. allyTeamID, visible and 1 or 0)
+			end
+		end
+		if entry.group ~= nil then
+			groupUnits[entry.group] = groupUnits[entry.group] or {}
+			local group = groupUnits[entry.group]
+			group[#group + 1] = unitID
+		end
+	end
+	return true
+end
+
+---Arms into a staging engine swapped in whole, so a file that fails to parse
+---leaves the running mission untouched.
 ---@param missionName string
 ---@return boolean loaded
 ---@param missionName string
@@ -329,9 +603,7 @@ local function loadMission(missionName, preserve)
 		end
 	end
 
-	-- The mission's own module system: its files link with VFS.Include, and a
-	-- definition file's return table is what an include yields — once per load,
-	-- the same table to every importer, so objectives.lua never registers twice.
+	-- an include yields the same table to every importer, so units.lua never registers twice
 	local missionDir = MISSIONS_DIR .. missionName .. "/"
 	local included = {} ---@type table<string, table|false>
 	local sandboxVFS = {}
@@ -343,7 +615,9 @@ local function loadMission(missionName, preserve)
 		end
 		local exports = included[normalized]
 		if exports == nil then
-			error(normalized .. " is not a definition file loaded before this one — include objectives.lua")
+			error(
+				normalized .. " is not a definition file loaded before this one — include units.lua or objectives.lua"
+			)
 		end
 		if exports == false then
 			error(normalized .. " returned nothing to include — return the handles the other files need")
@@ -351,7 +625,29 @@ local function loadMission(missionName, preserve)
 		return exports
 	end
 
+	-- roster parses before trigger files so a typo in a Unit name is a load
+	-- error, not a silent never-true condition
+	local rosterEntries, rosterExports, declaredGroups = parseRoster(missionName, sandboxVFS)
+	if rosterEntries == nil then
+		return false
+	end
+	included[missionDir .. "units.lua"] = rosterExports or false
+	local rosterNames = {} ---@type table<string, boolean>
+	local rosterGroups = {} ---@type table<string, boolean>
+	for _, entry in ipairs(rosterEntries) do
+		if entry.name ~= nil then
+			rosterNames[entry.name] = true
+		end
+		if entry.group ~= nil then
+			rosterGroups[entry.group] = true
+		end
+	end
+	for name in pairs(declaredGroups or {}) do
+		rosterGroups[name] = true
+	end
+
 	local contributions = loadContributions()
+	local Unit = Verbs.MakeUnit(rosterNames)
 
 	for key in pairs(contributedContext) do
 		ctx[key] = nil
@@ -390,6 +686,8 @@ local function loadMission(missionName, preserve)
 			local forFile = contribution.ForFile({
 				filename = filename,
 				Register = staging.Register,
+				names = rosterNames,
+				groups = rosterGroups,
 			})
 			for key, value in pairs(forFile.env) do
 				if env[key] ~= nil then
@@ -446,6 +744,7 @@ local function loadMission(missionName, preserve)
 				Objective = file.Objective,
 				Team = { Player = playerTeam },
 				UnitDef = Verbs.UnitDef,
+				Unit = Unit,
 				VFS = sandboxVFS,
 			}
 			local finalizeContributions = contribute(filename, env)
@@ -512,6 +811,7 @@ local function loadMission(missionName, preserve)
 				When = file.When,
 				Team = { Player = playerTeam },
 				UnitDef = Verbs.UnitDef,
+				Unit = Unit,
 				Objective = ObjectiveVerb,
 				VFS = sandboxVFS,
 			}
@@ -569,10 +869,32 @@ local function loadMission(missionName, preserve)
 		end
 	end
 	syncWatchedCallins()
+	-- CreateUnit raises; pcall keeps a bad roster from being a stack trace out of the chat action
+	local ran, spawned
+	if preserve then
+		ran, spawned = pcall(rebindRoster, rosterEntries)
+	else
+		ran, spawned = pcall(spawnRoster, rosterEntries, playerTeam)
+	end
+	if not ran then
+		Spring.Log(LOG_TAG, LOG.ERROR, tostring(spawned))
+		despawnRoster()
+	end
+	if not ran or not spawned then
+		activeMission = nil
+		Spring.SetGameRulesParam("mission_active", 0)
+		return false
+	end
 	activeMission = missionName
 	Spring.SetGameRulesParam("mission_active", 1)
 	Spring.SetGameRulesParam("mission_name", missionName)
 	publishObjectives(objectiveDecls)
+	-- a /luarules reload wipes every local; the re-arm in Initialize needs to
+	-- know what the previous life spawned
+	Spring.SetGameRulesParam("mission_spawned_units", table.concat(spawnedUnits, ","))
+	for groupName, units in pairs(groupUnits) do
+		Spring.SetGameRulesParam("mission_group_" .. groupName, table.concat(units, ","))
+	end
 	Spring.Echo(
 		"["
 			.. LOG_TAG

--- a/modules/missions/lib/roster.lua
+++ b/modules/missions/lib/roster.lua
@@ -1,0 +1,221 @@
+
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local Roster = {}
+
+local VALID_ROLES = { player = true, enemy = true, gaia = true }
+
+---@param filename string mission-relative path, e.g. "cm8_ashfall/units.lua"
+---@return { Spawn: fun(unitDef: MissionUnitDefRef, team: MissionTeamRole): MissionSpawnChain, Claim: fun(unitDef: MissionUnitDefRef, team: MissionTeamRole): MissionClaimChain, Group: fun(name: MissionUnitGroup): MissionGroupRef, Finalize: fun(exports: table?): MissionRosterEntry[], table<string, MissionUnitName>, table<string, boolean> }
+function Roster.ForFile(filename)
+	local declaredGroups = {} ---@type table<string, boolean>
+	local groupRefs = {} ---@type table<table, string>
+
+	---@param name MissionUnitGroup
+	---@return MissionGroupRef
+	local Group = function(name)
+		assert(type(name) == "string" and name ~= "", filename .. ": Group expects a group name string")
+		declaredGroups[name] = true
+		local ref = { group = name }
+		groupRefs[ref] = name
+		return ref
+	end
+
+	local function groupName(group, verb)
+		if type(group) == "table" and type(group.group) == "string" then
+			return group.group
+		end
+		assert(type(group) == "string", filename .. ": " .. verb .. " expects a group name or a Group(...)")
+		return group
+	end
+
+	local builds = {} ---@type MissionRosterEntry[]
+	local byChain = {} ---@type table<table, MissionRosterEntry>
+	local finalized = false
+
+	-- A handle is also the reference: conditions read the name at evaluate,
+	-- so a handle exported under a key and named by Finalize still resolves.
+	local function referenceVerbs(chain, build)
+		local ref = Verbs.UnitRef(function()
+			return build.name
+		end)
+		chain.IsSpotted = ref.IsSpotted
+		chain.IsDestroyed = ref.IsDestroyed
+	end
+
+	local function checkOpen(step)
+		assert(not finalized, filename .. ": " .. step .. " after Finalize — the file already loaded")
+	end
+
+	---@param unitDef MissionUnitDefRef
+	---@param team MissionTeamRole
+	---@return MissionSpawnChain
+	local Spawn = function(unitDef, team)
+		checkOpen("Spawn")
+		assert(
+			type(unitDef) == "table" and type(unitDef.name) == "string",
+			filename .. ": Spawn expects a UnitDef(...) reference"
+		)
+		assert(
+			type(team) == "string" and VALID_ROLES[team],
+			filename .. ': Spawn expects a team role: "player", "enemy" or "gaia"'
+		)
+
+		local build = { def = unitDef.name, team = team }
+		builds[#builds + 1] = build
+
+		local chain = {}
+		byChain[chain] = build
+		referenceVerbs(chain, build)
+
+		---Position as map fractions, so rosters play on any map until real
+		---maps pin real coordinates.
+		---@param fx number
+		---@param fz number
+		---@return MissionSpawnChain
+		chain.At = function(fx, fz)
+			checkOpen("At")
+			assert(
+				type(fx) == "number" and type(fz) == "number" and fx >= 0 and fx <= 1 and fz >= 0 and fz <= 1,
+				filename .. ": At expects map fractions in 0..1"
+			)
+			build.fx, build.fz = fx, fz
+			return chain
+		end
+
+		---@param name string
+		---@return MissionSpawnChain
+		chain.Named = function(name)
+			checkOpen("Named")
+			assert(type(name) == "string", filename .. ": Named expects a unit name string")
+			build.name = name
+			return chain
+		end
+
+		---@param group string
+		---@return MissionSpawnChain
+		chain.Grouped = function(group)
+			checkOpen("Grouped")
+			build.group = groupName(group, "Grouped")
+			return chain
+		end
+
+		---Standing there, not taking part. A derelict the player is meant to
+		---walk up to and inherit must not shoot them on the way in, and an
+		---abandoned base on Gaia does exactly that by default — Gaia is hostile
+		---to everyone, so its towers open fire on the discovery the mission was
+		---built around.
+		---
+		---Only a starting state, and one the mission does not have to undo:
+		---the engine drops the flag when a unit changes hands, so an inherited
+		---base defends its new owner without being told to.
+		---@return MissionSpawnChain
+		chain.Neutral = function()
+			checkOpen("Neutral")
+			build.neutral = true
+			return chain
+		end
+
+		return chain
+	end
+
+	---@param unitDef MissionUnitDefRef
+	---@param team MissionTeamRole
+	---@return MissionClaimChain
+	local Claim = function(unitDef, team)
+		checkOpen("Claim")
+		assert(
+			type(unitDef) == "table" and type(unitDef.name) == "string",
+			filename .. ": Claim expects a UnitDef(...) reference"
+		)
+		assert(
+			type(team) == "string" and VALID_ROLES[team],
+			filename .. ': Claim expects a team role: "player", "enemy" or "gaia"'
+		)
+
+		local build = { def = unitDef.name, team = team, claim = true }
+		builds[#builds + 1] = build
+
+		local chain = {}
+		byChain[chain] = build
+		referenceVerbs(chain, build)
+
+		---@param name string
+		---@return MissionClaimChain
+		chain.Named = function(name)
+			checkOpen("Named")
+			assert(type(name) == "string", filename .. ": Named expects a unit name string")
+			build.name = name
+			return chain
+		end
+
+		---@param group string
+		---@return MissionClaimChain
+		chain.Grouped = function(group)
+			checkOpen("Grouped")
+			build.group = groupName(group, "Grouped")
+			return chain
+		end
+
+		---Where to build one if the team has none. Required: a mission that
+		---cannot say what to do with an empty seat cannot arm in its own
+		---single-player game, which is the game it was written for.
+		---@param fx number
+		---@param fz number
+		---@return MissionClaimChain
+		chain.OrSpawnAt = function(fx, fz)
+			checkOpen("OrSpawnAt")
+			assert(
+				type(fx) == "number" and type(fz) == "number" and fx >= 0 and fx <= 1 and fz >= 0 and fz <= 1,
+				filename .. ": OrSpawnAt expects map fractions in 0..1"
+			)
+			build.fx, build.fz = fx, fz
+			return chain
+		end
+
+		return chain
+	end
+
+	---Validates every chain in declaration order, so a failed load spawns nothing.
+	---@return MissionRosterEntry[]
+	---@param exports table<string, table>|nil what units.lua returned: key -> handle
+	---@return MissionRosterEntry[] entries
+	---@return table<string, MissionUnitName> exportNames key -> unit name
+	local Finalize = function(exports)
+		assert(not finalized, filename .. ": Finalize called twice")
+		finalized = true
+		local exportNames = {}
+		if exports ~= nil then
+			assert(type(exports) == "table", filename .. ": a roster file returns a table of its handles, or nothing")
+			for key, handle in pairs(exports) do
+				local build = type(handle) == "table" and byChain[handle] or nil
+				if build ~= nil then
+					build.name = build.name or key
+					handle.name = build.name
+					exportNames[key] = build.name
+				end
+			end
+		end
+		local seenNames = {}
+		for order, build in ipairs(builds) do
+			local where = filename .. ": " .. (build.claim and "Claim " or "Spawn ") .. order
+			if build.fx == nil then
+				if build.claim then
+					error(where .. " has no OrSpawnAt — say where to build one when the team has none")
+				end
+				error(where .. " has no At — every spawn needs a position")
+			end
+			if build.name ~= nil then
+				if seenNames[build.name] then
+					error(where .. ": duplicate unit name " .. build.name)
+				end
+				seenNames[build.name] = true
+			end
+		end
+		return builds, exportNames, declaredGroups
+	end
+
+	return { Spawn = Spawn, Claim = Claim, Group = Group, Finalize = Finalize }
+end
+
+return Roster

--- a/modules/missions/lib/verbs.lua
+++ b/modules/missions/lib/verbs.lua
@@ -1,10 +1,3 @@
---- The three demo verbs' pure halves: UnitDef refs and the Team handle with
---- its Has condition. No Spring here — conditions read counts from the ctx the
---- engine is handed, so this specs under busted; the gadget supplies a ctx
---- backed by Spring.GetTeamUnitDefCount.
----
---- Conditions capture configuration only (team id, unit name, threshold) —
---- never progress. Dot-only surface, same rule as the chain DSL.
 
 local Verbs = {}
 
@@ -41,6 +34,57 @@ function Verbs.MakeTeam(teamID, allyTeam)
 	end
 
 	return team
+end
+
+---@param name MissionUnitName|fun(): MissionUnitName the name, or how to read it once known
+---@return MissionUnitRef
+function Verbs.UnitRef(name)
+	local function resolved()
+		local value = type(name) == "function" and name() or name
+		assert(type(value) == "string", "a roster handle was referenced before it was named")
+		return value
+	end
+	return {
+		name = type(name) == "string" and name or nil,
+		---@return MissionCondition
+		IsDestroyed = function()
+			return {
+				inputs = { "UnitDestroyed" },
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return ctx.IsUnitDestroyed(resolved())
+				end,
+			}
+		end,
+		---@param team MissionTeam
+		---@return MissionCondition
+		IsSpotted = function(team)
+			assert(
+				type(team) == "table" and type(team.allyTeam) == "number",
+				"Unit.IsSpotted expects a Team handle (e.g. Team.Player)"
+			)
+			return {
+				inputs = { "UnitEnteredLos" },
+				---@param ctx MissionContext
+				evaluate = function(ctx)
+					return ctx.IsUnitSpotted(resolved(), team.allyTeam)
+				end,
+			}
+		end,
+	}
+end
+
+---@param names table<string, boolean> the roster's declared unit names
+---@return fun(name: MissionUnitName): MissionUnitRef
+function Verbs.MakeUnit(names)
+	return function(name)
+		assert(type(name) == "string", "Unit expects a mission unit name string")
+		assert(
+			names[name],
+			'Unit("' .. name .. "\"): no such unit — units.lua Named(...) declares the mission's unit names"
+		)
+		return Verbs.UnitRef(name)
+	end
 end
 
 return Verbs

--- a/modules/missions/modoptions.lua
+++ b/modules/missions/modoptions.lua
@@ -5,7 +5,11 @@ local function missionItems()
 	local names = {}
 	for _, dir in ipairs(VFS.SubDirs("modules/missions/", "*") or {}) do
 		if #VFS.DirList(dir .. "triggers/", "*.lua") > 0 then
-			names[#names + 1] = dir:gsub("^modules/missions/", ""):gsub("[/\\]+$", "")
+			local name = dir:gsub("^modules/missions/", ""):gsub("[/\\]+$", "")
+			-- smoke_* are the headless scenario suite's fixtures, not player content
+			if not name:find("^smoke_") then
+				names[#names + 1] = name
+			end
 		end
 	end
 	table.sort(names)

--- a/modules/missions/smoke_claim/triggers/win.lua
+++ b/modules/missions/smoke_claim/triggers/win.lua
@@ -1,0 +1,1 @@
+When(Unit("mark").IsDestroyed()).Do(MatchFlow.Victory(Team.Player))

--- a/modules/missions/smoke_claim/units.lua
+++ b/modules/missions/smoke_claim/units.lua
@@ -1,0 +1,2 @@
+-- fixture for the claim machinery's headless test, not player content
+Claim(UnitDef("armcom"), "enemy").Named("mark").OrSpawnAt(0.7, 0.7)

--- a/modules/missions/spec/builders/mission_builder.lua
+++ b/modules/missions/spec/builders/mission_builder.lua
@@ -470,6 +470,21 @@ function MissionBuilder:Load()
 				end,
 			}, { __index = lib })
 		end,
+		["modules/missions/lib/roster.lua"] = function(lib)
+			return setmetatable({
+				ForFile = function(...)
+					local file = lib.ForFile(...)
+					local finalize = file.Finalize
+					file.Finalize = function(exports, ...)
+						local entries, exportNames, declaredGroups = finalize(exports, ...)
+						self_.rosters[#self_.rosters + 1] = entries
+						self_.includes.units = exports
+						return entries, exportNames, declaredGroups
+					end
+					return file
+				end,
+			}, { __index = lib })
+		end,
 		["modules/missions/lib/variables.lua"] = function(lib)
 			return setmetatable({
 				ForFile = function(...)

--- a/modules/missions/spec/builders/mission_builder_roster_spec.lua
+++ b/modules/missions/spec/builders/mission_builder_roster_spec.lua
@@ -1,0 +1,89 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+local UNITS = [[
+Spawn(UnitDef("corllt"), "gaia").At(0.4, 0.4).Named("tower").Grouped("base").Neutral()
+Spawn(UnitDef("corlab"), "gaia").At(0.42, 0.4).Grouped("base").Neutral()
+Claim(UnitDef("armcom"), "enemy").Named("boss").OrSpawnAt(0.8, 0.8)
+]]
+local WIN = [[
+When(Unit("tower").IsSpotted(Team.Player)).When(Unit("boss").IsDestroyed()).Do(MatchFlow.Victory(Team.Player))
+]]
+
+local function mission()
+	return Builders.Mission.new():WithSources("t", { ["units.lua"] = UNITS, ["triggers/a.lua"] = WIN })
+end
+
+describe("the mission builder's unit world", function()
+	it("spawns the roster inert", function()
+		local m = mission():Arm()
+		local tower = m:Units()[m:UnitOf("tower")]
+		assert.are.equal(2, tower.team)
+		assert.is_true(tower.neutral)
+		assert.are.same({ cmd = 45, params = { 0 } }, tower.orders[1])
+	end)
+
+	it("a claim binds to what is standing, or builds at OrSpawnAt", function()
+		local m = mission()
+		local incumbent = m:WithExistingUnit(1, "armcom")
+		m:Arm()
+		assert.are.equal(incumbent, m:UnitOf("boss"))
+
+		local fresh = mission():Arm()
+		assert.are.equal("armcom", fresh:Units()[fresh:UnitOf("boss")].def)
+	end)
+
+	it("Spot and Kill drive the real latches", function()
+		local m = mission():Arm():Step()
+		assert.are.equal(0, #m:Calls("matchflow"))
+		m:Spot("tower"):Step()
+		assert.are.equal(0, #m:Calls("matchflow"))
+		m:Kill("boss", 0):Step()
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+
+	it("a mission file is real Lua: a local names a value and is used later", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["units.lua"] = [[
+local pawn = UnitDef("armpw")
+Spawn(pawn, "player").At(0.5, 0.5).Named("scout")
+]],
+				["triggers/a.lua"] = [[
+local pawn = UnitDef("armpw")
+local scouted = Objective("scouted")
+When(Team.Player.Has(pawn, 3)).Do(scouted.Complete())
+When(scouted.IsComplete()).Do(MatchFlow.Victory(Team.Player))
+]],
+			})
+			:Arm()
+		assert.are.equal("armpw", m:Units()[m:UnitOf("scout")].def)
+		m:WithUnits(0, "armpw", 3):Step():Step()
+		assert.are.equal(1, m:Param("objective_scouted"))
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+
+	it("a spec speaks the roster by its handles, and reads the world by role", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["units.lua"] = 'local hub = Spawn(UnitDef("corlab"), "gaia").At(0.4, 0.4).Neutral()\nlocal boss = Claim(UnitDef("armcom"), "enemy").Named("armada_commander").OrSpawnAt(0.8, 0.8)\nreturn { hub = hub, boss = boss }\n',
+				["triggers/a.lua"] = 'local Units = VFS.Include("modules/missions/t/units.lua")\nWhen(Units.hub.IsSpotted(Team.Player)).When(Units.boss.IsDestroyed()).Do(MatchFlow.Victory(Team.Player))\n',
+			})
+			:Arm()
+		local Units = m:Includes()
+		assert.are.equal("hub", Units.hub.name)
+		assert.are.equal("armada_commander", Units.boss.name)
+		assert.are.equal(m:UnitOf("hub"), m:UnitOf(Units.hub))
+		assert.are.equal(0.8, m:Entry(Units.boss).fx)
+		local gaia = m:TeamUnits("gaia")
+		assert.are.equal(1, #gaia)
+		assert.is_true(gaia[1].neutral)
+		assert.is_true(gaia[1].holdsFire)
+		assert.is_true(m:HoldsFire(Units.hub))
+		assert.is_false(m:HoldsFire(Units.boss))
+		m:Spot(Units.hub):Kill(Units.boss, 0):Step()
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+end)

--- a/modules/missions/spec/builders/mission_builder_units_exports_spec.lua
+++ b/modules/missions/spec/builders/mission_builder_units_exports_spec.lua
@@ -1,0 +1,53 @@
+---@type Builders
+local Builders = VFS.Include("spec/builders/index.lua")
+
+describe("units.lua exports its handles", function()
+	it("an unnamed handle takes its export key as its name; a Named one keeps its name", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["units.lua"] = [[
+local tower = Spawn(UnitDef("corllt"), "gaia").At(0.4, 0.4).Neutral()
+local boss = Claim(UnitDef("armcom"), "enemy").Named("armada_commander").OrSpawnAt(0.8, 0.8)
+return { tower = tower, boss = boss }
+]],
+				["triggers/a.lua"] = 'local Units = VFS.Include("modules/missions/t/units.lua")\nWhen(Units.boss.IsDestroyed()).Do(MatchFlow.Victory(Team.Player))\n',
+			})
+			:Arm()
+		assert.is_number(m:UnitOf("tower"))
+		assert.is_number(m:UnitOf("armada_commander"))
+		assert.is_nil(m:UnitOf("boss"), "the wire identity is the Named name, the key is only the Lua name")
+		m:Kill("armada_commander", 0):Step()
+		assert.are.equal("Victory", m:Calls("matchflow")[1].method)
+	end)
+
+	it("objectives.lua can include units.lua", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["units.lua"] = 'local hub = Spawn(UnitDef("corlab"), "gaia").At(0.4, 0.4).Neutral()\nreturn { hub = hub }\n',
+				["objectives.lua"] = 'local Units = VFS.Include("modules/missions/t/units.lua")\nlocal found = Objective("found").CompletedWhen(Units.hub.IsSpotted(Team.Player))\nreturn { found = found }\n',
+				["triggers/a.lua"] = 'local Objectives = VFS.Include("modules/missions/t/objectives.lua")\nWhen(Objectives.found.IsComplete()).Do(MatchFlow.Victory(Team.Player))\n',
+			})
+			:Arm()
+			:Step()
+		assert.is_nil(m:Param("objective_found"))
+		m:Spot("hub"):Step()
+		assert.are.equal(1, m:Param("objective_found"))
+	end)
+
+	it("an exported objective handle is its own effect side", function()
+		local m = Builders.Mission
+			.new()
+			:WithSources("t", {
+				["objectives.lua"] = 'local found = Objective("found").CompletedWhen(Team.Player.Has(UnitDef("armcom"), 9))\nreturn { found = found }\n',
+				["triggers/a.lua"] = 'local O = VFS.Include("modules/missions/t/objectives.lua")\nWhen(MatchFlow.Started()).Do(O.found.Reveal())\nWhen(Team.Player.Has(UnitDef("armpw"), 1)).Do(O.found.Complete())\n',
+			})
+			:Arm()
+			:Step()
+		assert.are.equal(1, m:Param("objective_revealed_found"))
+		assert.is_nil(m:Param("objective_found"))
+		m:WithUnits(0, "armpw", 1):Step()
+		assert.are.equal(1, m:Param("objective_found"))
+	end)
+end)

--- a/modules/missions/spec/lib/dsl_spec.lua
+++ b/modules/missions/spec/lib/dsl_spec.lua
@@ -24,7 +24,7 @@ describe("mission DSL", function()
 
 	it("builds a descriptor from a terminator-free chain at Finalize", function()
 		When(alwaysTrue).Do(anEffect)
-		assert.are.equal(0, #registered) -- nothing arms before the commit point
+		assert.are.equal(0, #registered)
 		Finalize()
 
 		assert.are.equal(1, #registered)
@@ -61,11 +61,11 @@ describe("mission DSL", function()
 
 	it("a statement without a Do fails the load, naming the statement", function()
 		When(alwaysTrue).Do(anEffect)
-		When(alwaysTrue) -- half-finished
+		When(alwaysTrue)
 		assert.has_error(function()
 			Finalize()
 		end)
-		assert.are.equal(0, #registered) -- the failed load arms nothing
+		assert.are.equal(0, #registered)
 	end)
 
 	it("rejects a bare function in Do (closure-free surface)", function()
@@ -189,5 +189,56 @@ describe("mission verbs", function()
 		local team = Verbs.MakeTeam(2, 1)
 		assert.are.equal(2, team.teamID)
 		assert.are.equal(1, team.allyTeam)
+	end)
+end)
+
+describe("unit noun", function()
+	local Unit = Verbs.MakeUnit({ hub = true, device = true })
+
+	---@return MissionContext
+	local function makeCtx(dead, spotted)
+		return {
+			frame = 0,
+			IsUnitDestroyed = function(name)
+				return dead[name] == true
+			end,
+			IsUnitSpotted = function(name, allyTeamID)
+				return spotted[name .. "_" .. allyTeamID] == true
+			end,
+		}
+	end
+
+	it("IsDestroyed reads the latch through ctx and declares its input", function()
+		local condition = Unit("hub").IsDestroyed()
+		assert.are.same({ "UnitDestroyed" }, condition.inputs)
+		assert.is_false(condition.evaluate(makeCtx({}, {})))
+		assert.is_true(condition.evaluate(makeCtx({ hub = true }, {})))
+	end)
+
+	it("IsSpotted is per-allyteam and declares its input", function()
+		local team = Verbs.MakeTeam(0, 1)
+		local condition = Unit("device").IsSpotted(team)
+		assert.are.same({ "UnitEnteredLos" }, condition.inputs)
+		assert.is_false(condition.evaluate(makeCtx({}, {})))
+		assert.is_true(condition.evaluate(makeCtx({}, { device_1 = true })))
+		assert.is_false(condition.evaluate(makeCtx({}, { device_2 = true })))
+	end)
+
+	it("a name the roster never declared is a load error, not a dead condition", function()
+		local ok, err = pcall(Unit, "hubb")
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("hubb", 1, true))
+	end)
+
+	it("IsSpotted rejects a non-Team argument", function()
+		assert.has_error(function()
+			Unit("device").IsSpotted("player")
+		end)
+	end)
+
+	it("Unit rejects a non-string name", function()
+		assert.has_error(function()
+			Unit(7)
+		end)
 	end)
 end)

--- a/modules/missions/spec/lib/roster_spec.lua
+++ b/modules/missions/spec/lib/roster_spec.lua
@@ -1,0 +1,146 @@
+local Roster = VFS.Include("modules/missions/lib/roster.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+describe("mission roster DSL", function()
+	local Spawn
+	local Finalize
+
+	before_each(function()
+		local file = Roster.ForFile("cm8/units.lua")
+		Spawn = file.Spawn
+		Finalize = file.Finalize
+	end)
+
+	it("builds entries from Spawn chains at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.42, 0.42).Named("hub").Grouped("outpost_auto")
+		Spawn(Verbs.UnitDef("armcom"), "enemy").At(0.77, 0.77)
+		local entries = Finalize()
+		assert.are.same({
+			{ def = "corlab", team = "gaia", fx = 0.42, fz = 0.42, name = "hub", group = "outpost_auto" },
+			{ def = "armcom", team = "enemy", fx = 0.77, fz = 0.77 },
+		}, entries)
+	end)
+
+	it("a spawn without an At fails the load, naming the statement", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").Named("hub")
+		local ok, err = pcall(Finalize)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("Spawn 1", 1, true))
+	end)
+
+	it("rejects duplicate unit names at Finalize", function()
+		Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1).Named("hub")
+		Spawn(Verbs.UnitDef("corllt"), "gaia").At(0.2, 0.2).Named("hub")
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+
+	it("rejects a plain string where a UnitDef reference belongs", function()
+		assert.has_error(function()
+			Spawn("corlab", "gaia")
+		end)
+	end)
+
+	it("rejects an unknown team role", function()
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corlab"), "raptors")
+		end)
+	end)
+
+	it("rejects positions outside map fractions", function()
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corlab"), "gaia").At(512, 512)
+		end)
+	end)
+
+	it("rejects chain calls after Finalize", function()
+		local chain = Spawn(Verbs.UnitDef("corlab"), "gaia").At(0.1, 0.1)
+		Finalize()
+		assert.has_error(function()
+			chain.Named("late")
+		end)
+		assert.has_error(function()
+			Spawn(Verbs.UnitDef("corllt"), "gaia")
+		end)
+	end)
+
+	it("rejects Finalize twice", function()
+		Finalize()
+		assert.has_error(function()
+			Finalize()
+		end)
+	end)
+end)
+
+describe("Claim", function()
+	local function forFile()
+		return Roster.ForFile("m/units.lua")
+	end
+	local function def(name)
+		return { name = name }
+	end
+
+	it("records the intent to take an existing unit rather than add one", function()
+		local file = forFile()
+		file.Claim(def("armcom"), "enemy").Named("boss").OrSpawnAt(0.5, 0.5)
+		local entries = file.Finalize()
+		assert.are.equal(1, #entries)
+		assert.is_true(entries[1].claim)
+		assert.are.equal("armcom", entries[1].def)
+		assert.are.equal("enemy", entries[1].team)
+		assert.are.equal("boss", entries[1].name)
+	end)
+
+	it("still carries a position, for the case where there is nothing to claim", function()
+		local file = forFile()
+		file.Claim(def("armcom"), "enemy").OrSpawnAt(0.25, 0.75)
+		local entries = file.Finalize()
+		assert.are.equal(0.25, entries[1].fx)
+		assert.are.equal(0.75, entries[1].fz)
+	end)
+
+	it("a claim with no OrSpawnAt fails the load, and says which verb is missing", function()
+		local file = forFile()
+		file.Claim(def("armcom"), "enemy").Named("boss")
+		local ok, err = pcall(file.Finalize)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("OrSpawnAt", 1, true))
+		assert.is_truthy(tostring(err):find("Claim 1", 1, true))
+	end)
+
+	it("Spawn keeps its own message when it is the one missing a position", function()
+		local file = forFile()
+		file.Spawn(def("armcom"), "enemy").Named("boss")
+		local ok, err = pcall(file.Finalize)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("has no At", 1, true))
+	end)
+
+	it("Neutral is a Spawn thing, and off unless asked for", function()
+		local file = Roster.ForFile("m/units.lua")
+		file.Spawn({ name = "corllt" }, "gaia").At(0.5, 0.5).Neutral()
+		file.Spawn({ name = "corllt" }, "gaia").At(0.6, 0.6)
+		local entries = file.Finalize()
+		assert.is_true(entries[1].neutral)
+		assert.is_nil(entries[2].neutral, "a spawn is hostile unless the roster says otherwise")
+	end)
+
+	it("rejects a bad team role and a bad def, same as Spawn", function()
+		assert.has_error(function()
+			forFile().Claim(def("armcom"), "nobody")
+		end)
+		assert.has_error(function()
+			forFile().Claim("armcom", "enemy")
+		end)
+	end)
+
+	it("claimed and spawned names share one namespace", function()
+		local file = forFile()
+		file.Spawn(def("armcom"), "player").At(0, 0).Named("dup")
+		file.Claim(def("armcom"), "enemy").Named("dup").OrSpawnAt(1, 1)
+		local ok, err = pcall(file.Finalize)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("duplicate unit name dup", 1, true))
+	end)
+end)

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -6,6 +6,8 @@
 --- Alias names are LOAD-BEARING beyond the checker: the mission kit derives its
 --- semantic model from them (alias -> slot semantic, literal unions -> editor enums).
 ---@alias UnitDefName string unit def name, e.g. "armpw"
+---@alias MissionUnitName string roster unit name, declared by units.lua Named(...)
+---@alias MissionUnitGroup string roster group name, declared by units.lua Grouped(...)
 ---@alias ObjectiveName string
 ---@alias MissionTeamRole "player"|"enemy"|"gaia" spawn-time team role, resolved at arm
 --- Wall-clock seconds, never frames. An alias so an editor can name the unit the
@@ -16,15 +18,13 @@
 ---@field evaluate fun(ctx: MissionContext): boolean
 ---@field inputs string[]|nil events that can change this answer, each a member of a module's Events enum (missions/lib/events.lua, waves/lib/events.lua) or a forwarded callin; the loader refuses a name nothing raises. nil = poll every cadence
 
---- A
---- required module extends this class from its own types (`---@class
---- (partial) MissionContext`) with the functions its contribution's Context
---- supplies.
 ---@class (partial) MissionContext
 ---@field GetUnitDefCount fun(teamID: integer, unitDefName: string): integer count of finished units of that def
 ---@field IsObjectiveComplete fun(name: string): boolean
 ---@field GetVariable fun(name: string): number|boolean|string|nil
 ---@field SetVariable fun(name: string, value: number|boolean|string)
+---@field IsUnitDestroyed fun(name: string): boolean
+---@field IsUnitSpotted fun(name: string, allyTeamID: integer): boolean
 ---@field frame integer current game frame
 
 ---@class MissionEffect
@@ -59,8 +59,40 @@
 ---@field revealAtArm boolean|nil marked by the loader: no declared moment, no completable predecessor
 ---@field foreshadow boolean
 
---- Identity = source filename + declaration order: the unregister-by-identity
---- key for hot reload.
+---@class MissionUnitRef
+---@field name MissionUnitName
+---@field IsDestroyed fun(): MissionCondition
+---@field IsSpotted fun(team: MissionTeam): MissionCondition
+
+--- Positions are map fractions until real maps pin real coordinates; a chain
+--- without At fails the load.
+---@class MissionSpawnChain
+---@field At fun(fx: number, fz: number): MissionSpawnChain
+---@field Named fun(name: MissionUnitName): MissionSpawnChain
+---@field Grouped fun(group: MissionUnitGroup|MissionGroupRef): MissionSpawnChain
+---@field Neutral fun(): MissionSpawnChain starts inert: neither shoots nor is shot at, until handed over
+---@field IsSpotted fun(team: MissionTeam): MissionCondition the handle is also the reference
+---@field IsDestroyed fun(): MissionCondition
+---@field name MissionUnitName? set once the file is loaded: Named, or the export key
+
+---@class MissionClaimChain
+---@field Named fun(name: MissionUnitName): MissionClaimChain
+---@field Grouped fun(group: MissionUnitGroup|MissionGroupRef): MissionClaimChain
+---@field OrSpawnAt fun(fx: number, fz: number): MissionClaimChain
+---@field IsSpotted fun(team: MissionTeam): MissionCondition
+---@field IsDestroyed fun(): MissionCondition
+---@field name MissionUnitName? set once the file is loaded: Named, or the export key
+
+---@class MissionRosterEntry
+---@field def UnitDefName
+---@field team MissionTeamRole
+---@field fx number map-fraction position, resolved against map size at spawn
+---@field fz number
+---@field name MissionUnitName|nil declared by Named
+---@field group MissionUnitGroup|nil declared by Grouped
+---@field claim boolean|nil written by Claim: bind to an existing unit if the team has one
+---@field neutral boolean|nil written by Neutral: spawn inert, cleared when the unit changes hands
+
 ---@class TriggerDescriptor
 ---@field id string "<filename>:<order>"
 ---@field filename string mission-relative trigger file path
@@ -96,12 +128,17 @@
 ---@class MissionDslFile
 ---@field filename string mission-relative trigger file path
 ---@field Register fun(descriptor: TriggerDescriptor)
+---@field names table<string, boolean> roster unit names, for load-time validation
+---@field groups table<string, boolean> roster group names, for load-time validation
 
 ---@class MissionProtectionLedger this mission's protect refcounts, persisted across a reload
 ---@field Get fun(unitID: integer): integer
 ---@field Set fun(unitID: integer, count: integer) zero forgets the unit
 
 ---@class MissionRuntime
+---@field UnitOf fun(name: string): integer|nil the living unit a roster name binds to
+---@field GroupUnits fun(groupName: string): integer[]|nil
+---@field ReleaseHoldFire fun(unitID: integer) a spawned-Neutral unit holds fire until whoever moves it says otherwise
 ---@field Protections MissionProtectionLedger
 ---@field Log fun(level: integer, message: string)
 
@@ -110,8 +147,9 @@
 ---@field Context fun(runtime: MissionRuntime): table<string, function>|nil
 ---@field Events table<string, string>|nil an enum of the bus events this module raises
 
---- The declaration chain in variables.lua: a typed slot with a default. The
---- value lives in the pile; the handle is both sides of it.
+---@class MissionGroupRef
+---@field group MissionUnitGroup
+
 ---@class MissionVariableChain
 ---@field Number fun(default: number): MissionVariableChain
 ---@field Boolean fun(default: boolean): MissionVariableChain

--- a/tools/headless_testing/startscript_missions_smoke.txt
+++ b/tools/headless_testing/startscript_missions_smoke.txt
@@ -1,0 +1,37 @@
+[GAME]
+{
+	MapName=Supreme Isthmus v2.1;
+	GameType=Beyond All Reason $VERSION;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=TestRunner;
+	IsHost=1;
+	FixedRNGSeed = 1;
+  [MODOPTIONS]
+  {
+    debugcommands=1:cheat|2:godmode|3:globallos|30:runtestsheadless missions_smoke;
+		deathmode=neverend;
+		forceallunits=1;
+  }
+  [ALLYTEAM0]
+  {
+  }
+  [ALLYTEAM1]
+  {
+  }
+  [TEAM0]
+  {
+    allyteam=0;
+    teamleader=0;
+  }
+  [TEAM1]
+  {
+    allyteam=1;
+    teamleader=0;
+  }
+  [PLAYER0]
+  {
+    team=0;
+  }
+}


### PR DESCRIPTION
units.lua is the definition site for what a mission places: Spawn(def, team) .At(fx, fz) builds it, Claim(def, team).OrSpawnAt(...) binds to a unit the team already has, .Named(...) gives it a name the trigger files may speak, .Grouped(...) a group, .Neutral() an inert start (holding fire until whoever moves it says otherwise). Positions are map fractions. Unit(name) handles answer IsDestroyed and IsSpotted(team), both latched into rulesparams so the answer survives the unit; a name nothing declared is a load error.

The loader spawns the roster inside the arm transaction, despawns what it created on a fresh run (a persisted ledger so a /luarules reload cannot double-spawn), and binds names again on a preserving reload. The runtime a contribution receives gains UnitOf, GroupUnits and ReleaseHoldFire. The smoke_claim fixture and its headless test cover the claim path.
