### PR TITLE
add json doctor to blueprints

### DIFF
--- a/common/luaUtilities/json.lua
+++ b/common/luaUtilities/json.lua
@@ -22,7 +22,7 @@
 --   0.9.50.1 BAR changes by Beherith: fix issue when decoding empty arrays.
 --	 0.9.50 Radical performance improvement on decode from Eike Decker. Many thanks!
 --	 0.9.40 Changed licence to MIT License (MIT)
---   0.9.20 Introduction of local Lua functions for private functions (removed _ function prefix). 
+--   0.9.20 Introduction of local Lua functions for private functions (removed _ function prefix).
 --          Fixed Lua 5.1 compatibility issues.
 --   		Introduced json.null to have null values in associative arrays.
 --          encode() performance improvement (more than 50%) through table.concat rather than ..
@@ -63,55 +63,54 @@ end
 --- Encodes an arbitrary Lua object / variable.
 -- @param v The Lua object / variable to be JSON encoded.
 -- @return String containing the JSON encoding in internal Lua string format (i.e. not unicode)
-local function encode (v)
+local function encode(v)
 	-- Handle nil values
-	if v==nil then
-	return "null"
+	if v == nil then
+		return "null"
 	end
-	
-	local vtype = base.type(v)  
+
+	local vtype = base.type(v)
 
 	-- Handle strings
-	if vtype=='string' then    
-	return '"' .. encodeString(v) .. '"'	    -- Need to handle encoding in string
+	if vtype == "string" then
+		return '"' .. encodeString(v) .. '"' -- Need to handle encoding in string
 	end
-	
-	-- Handle booleans
-	if vtype=='number' or vtype=='boolean' then
-	return base.tostring(v)
-	end
-	
-	-- Handle tables
-	if vtype=='table' then
-	local rval = {}
-	-- Consider arrays separately
-	local bArray, maxCount = isArray(v)
-	if bArray then
-		for i = 1,maxCount do
-		table.insert(rval, encode(v[i]))
-		end
-	else	-- An object, not an array
-		for i,j in base.pairs(v) do
-		if isEncodable(i) and isEncodable(j) then
-			table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
-		end
-		end
-	end
-	if bArray then
-		return '[' .. table.concat(rval,',') ..']'
-	else
-		return '{' .. table.concat(rval,',') .. '}'
-	end
-	end
-	
-	-- Handle null values
-	if vtype=='function' and v==null then
-	return 'null'
-	end
-	
-	base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
-end
 
+	-- Handle booleans
+	if vtype == "number" or vtype == "boolean" then
+		return base.tostring(v)
+	end
+
+	-- Handle tables
+	if vtype == "table" then
+		local rval = {}
+		-- Consider arrays separately
+		local bArray, maxCount = isArray(v)
+		if bArray then
+			for i = 1, maxCount do
+				table.insert(rval, encode(v[i]))
+			end
+		else -- An object, not an array
+			for i, j in base.pairs(v) do
+				if isEncodable(i) and isEncodable(j) then
+					table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
+				end
+			end
+		end
+		if bArray then
+			return "[" .. table.concat(rval, ",") .. "]"
+		else
+			return "{" .. table.concat(rval, ",") .. "}"
+		end
+	end
+
+	-- Handle null values
+	if vtype == "function" and v == null then
+		return "null"
+	end
+
+	base.assert(false, "encode attempt to encode unsupported type " .. vtype .. ":" .. base.tostring(v))
+end
 
 -- A code point as the Lua decimal escapes for its UTF-8 bytes, so the result survives
 -- being handed to loadstring below. Always three digits, or a digit following in the
@@ -125,8 +124,12 @@ local function utf8Escapes(code)
 	elseif code < 0x10000 then
 		bytes = { 0xE0 + math.floor(code / 0x1000), 0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40 }
 	else
-		bytes = { 0xF0 + math.floor(code / 0x40000), 0x80 + math.floor(code / 0x1000) % 0x40,
-			0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40 }
+		bytes = {
+			0xF0 + math.floor(code / 0x40000),
+			0x80 + math.floor(code / 0x1000) % 0x40,
+			0x80 + math.floor(code / 0x40) % 0x40,
+			0x80 + code % 0x40,
+		}
 	end
 
 	for i = 1, #bytes do
@@ -210,19 +213,20 @@ end
 -- This just involves back-quoting inverted commas, back-quotes and newlines, I think ;-)
 -- @param s The string to return as a JSON encoded (i.e. backquoted string)
 -- @return The string appropriately escaped.
-local qrep = {["\\"]="\\\\", ['"']='\\"',['\b']='\\b',['\f']='\\f',['\n']='\\n',['\r']='\\r',['\t']='\\t'}
+local qrep =
+	{ ["\\"] = "\\\\", ['"'] = '\\"', ["\b"] = "\\b", ["\f"] = "\\f", ["\n"] = "\\n", ["\r"] = "\\r", ["\t"] = "\\t" }
 
 -- Writing control characters produces a broken file unless properly escaped.
 -- All shorthand escapes are listed above; the rest must encode into \uXXXX,
 -- which we also decode on the way in to keep a single properly copied json.
-for byte=0,0x1f do
+for byte = 0, 0x1f do
 	local char = string.char(byte)
 	if not qrep[char] then
-	qrep[char] = string.format("\\u%04x", byte)
+		qrep[char] = string.format("\\u%04x", byte)
 	end
 end
 function encodeString(s)
-	return (tostring(s):gsub('[%z\1-\31"\\]',qrep))
+	return (tostring(s):gsub('[%z\1-\31"\\]', qrep))
 end
 
 -- Determines whether the given Lua type is an array or a table / dictionary.
@@ -232,23 +236,29 @@ end
 -- @param t The table to evaluate as an array
 -- @return boolean, number True if the table can be represented as an array, false otherwise. If true,
 -- the second returned value is the maximum
--- number of indexed elements in the array. 
+-- number of indexed elements in the array.
 function isArray(t)
-	-- Next we count all the elements, ensuring that any non-indexed elements are not-encodable 
+	-- Next we count all the elements, ensuring that any non-indexed elements are not-encodable
 	-- (with the possible exception of 'n')
 	local maxIndex = 0
-	for k,v in base.pairs(t) do
-	if (base.type(k)=='number' and math.floor(k)==k and 1<=k) then	-- k,v is an indexed pair
-		if (not isEncodable(v)) then return false end	-- All array elements must be encodable
-		maxIndex = math.max(maxIndex,k)
-	else
-		if (k=='n') then
-		if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
-		else -- Else of (k=='n')
-		if isEncodable(v) then return false end
-		end  -- End of (k~='n')
-	end -- End of k,v not an indexed pair
-	end  -- End of loop across all pairs
+	for k, v in base.pairs(t) do
+		if base.type(k) == "number" and math.floor(k) == k and 1 <= k then -- k,v is an indexed pair
+			if not isEncodable(v) then
+				return false
+			end -- All array elements must be encodable
+			maxIndex = math.max(maxIndex, k)
+		else
+			if k == "n" then
+				if v ~= table.getn(t) then
+					return false
+				end -- False if n does not hold the number of elements
+			else -- Else of (k=='n')
+				if isEncodable(v) then
+					return false
+				end
+			end -- End of (k~='n')
+		end -- End of k,v not an indexed pair
+	end -- End of loop across all pairs
 	return true, maxIndex
 end
 
@@ -259,7 +269,8 @@ end
 -- @return boolean True if the object should be JSON encoded, false if it should be ignored.
 function isEncodable(o)
 	local t = base.type(o)
-	return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null) 
+	return (t == "string" or t == "boolean" or t == "number" or t == "nil" or t == "table")
+		or (t == "function" and o == null)
 end
 
 local instrumentedDecode
@@ -269,10 +280,12 @@ do
 	local error = base.error
 	local assert = base.assert
 	local print = base.print
-	if Spring and Spring.Echo then print = Spring.Echo end
+	if Spring and Spring.Echo then
+		print = Spring.Echo
+	end
 	local tonumber = base.tonumber
 	-- initialize some values to be used in decoding function
-	
+
 	-- initializes a table to contain a byte=>table mapping
 	-- the table contains tokens (byte values) as keys and maps them on other
 	-- token tables (mostly, the boolean value 'true' is used to indicate termination
@@ -280,7 +293,7 @@ do
 	-- the token table's purpose is, that it allows scanning a sequence of bytes
 	-- until something interesting has been found (e.g. a token that is not expected)
 	-- name is a descriptor for the table to be printed in error messages
-	local function init_token_table (tt)
+	local function init_token_table(tt)
 		local struct = {}
 		local value
 		function struct:link(other_tt)
@@ -288,188 +301,220 @@ do
 			return struct
 		end
 		function struct:to(chars)
-			for i=1,#chars do 
+			for i = 1, #chars do
 				tt[chars:byte(i)] = value
 			end
 			return struct
 		end
-		return function (name)
+		return function(name)
 			tt.name = name
 			return struct
 		end
 	end
-	
+
 	-- keep "named" byte values at hands
-	local 
-		c_esc,
-		c_e,
-		c_l,
-		c_r,
-		c_u,
-		c_f,
-		c_a,
-		c_s,
-		c_slash = ("\\elrufas/"):byte(1,9)
-	
+	local c_esc, c_e, c_l, c_r, c_u, c_f, c_a, c_s, c_slash = ("\\elrufas/"):byte(1, 9)
+
 	-- token tables - tt_doublequote_string = strDoubleQuot, tt_singlequote_string = strSingleQuot
-	local 
-		tt_object_key,
-		tt_object_colon,
-		tt_object_value,
-		tt_doublequote_string,
-		tt_singlequote_string,
-		tt_array_value,
-		tt_array_separator,
-		tt_numeric,
-		tt_boolean,
-		tt_null,
-		tt_comment_start,
-		tt_comment_middle,
-		tt_ignore --< tt_ignore is special - marked tokens will be tt_ignored
-			= {},{},{},{},{},{},{},{},{},{},{},{},{},{}
-			--= {myname = "tt_object_key"},{myname = "tt_object_colon"},{myname = "tt_object_value"},{myname = "tt_doublequote_string"},{myname = "tt_singlequote_string"},{myname = "tt_array_value"},{myname = "tt_array_separator"},{myname = "tt_numeric"},{myname = "tt_boolean"},{myname = "tt_null"},{myname = "tt_comment_start"},{myname = "tt_comment_middle"},{myname = "tt_ignore"}
-	
+	local tt_object_key, tt_object_colon, tt_object_value, tt_doublequote_string, tt_singlequote_string, tt_array_value, tt_array_separator, tt_numeric, tt_boolean, tt_null, tt_comment_start, tt_comment_middle, tt_ignore --< tt_ignore is special - marked tokens will be tt_ignored
+		=
+			{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+	--= {myname = "tt_object_key"},{myname = "tt_object_colon"},{myname = "tt_object_value"},{myname = "tt_doublequote_string"},{myname = "tt_singlequote_string"},{myname = "tt_array_value"},{myname = "tt_array_separator"},{myname = "tt_numeric"},{myname = "tt_boolean"},{myname = "tt_null"},{myname = "tt_comment_start"},{myname = "tt_comment_middle"},{myname = "tt_ignore"}
+
 	-- strings to be used in certain token tables
 	local strchars = "" -- all valid string characters (all except newlines)
 	local allchars = "" -- all characters that are valid in comments
 	--local escapechar = {}
-	for i=0,0xff do 
+	for i = 0, 0xff do
 		local c = string.char(i)
-		if c~="\n" and c~="\r" then strchars = strchars .. c end
+		if c ~= "\n" and c ~= "\r" then
+			strchars = strchars .. c
+		end
 		allchars = allchars .. c
 		--escapechar[i] = "\\" .. string.char(i)
 	end
-	
---[[	
+
+	--[[	
 	charstounescape = "\"\'\\bfnrt/";
 	unescapechars = "\"'\\\b\f\n\r\t\/";
 	for i=1,#charstounescape do
 		escapechar[ charstounescape:byte(i) ] = unescapechars:sub(i,i)
 	end
-]]--
+]]
+	--
 
 	-- obj key reader, expects the end of the object or a quoted string as key
-	init_token_table (tt_object_key) "tt_object_key: object (' or \" or } or , expected)" 
-		:link(tt_singlequote_string) :to "'"
-		:link(tt_doublequote_string) :to '"'
-		:link(true)                  :to "}"
-		:link(tt_object_key)         :to ","
-		:link(tt_comment_start)      :to "/"
-		:link(tt_ignore)             :to " \t\r\n"
-	
-	
+	init_token_table(tt_object_key)("tt_object_key: object (' or \" or } or , expected)")
+		:link(tt_singlequote_string)
+		:to("'")
+		:link(tt_doublequote_string)
+		:to('"')
+		:link(true)
+		:to("}")
+		:link(tt_object_key)
+		:to(",")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+
 	-- after the key, a colon is expected (or comment)
-	init_token_table (tt_object_colon) "tt_object_colon: object (: expected)" 
-		:link(tt_object_value)       :to ":"  
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_ignore)             :to" \t\r\n"
-		
+	init_token_table(tt_object_colon)("tt_object_colon: object (: expected)")
+		:link(tt_object_value)
+		:to(":")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+
 	-- as values, anything is possible, numbers, arrays, objects, boolean, null, strings
-	init_token_table (tt_object_value) "tt_object_value: object ({ or [ or ' or \" or number or boolean or null expected)"
-		:link(tt_object_key)         :to "{" 
-		:link(tt_array_separator)    :to "[" 
-		:link(tt_singlequote_string) :to "'" 
-		:link(tt_doublequote_string) :to '"' 
-		:link(tt_numeric)            :to "0123456789.-" 
-		:link(tt_boolean)            :to "tf" 
-		:link(tt_null)               :to "n" 
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_ignore)             :to " \t\r\n"
-		--:link(true)					 :to "]"
-		
+	init_token_table(tt_object_value)("tt_object_value: object ({ or [ or ' or \" or number or boolean or null expected)")
+		:link(tt_object_key)
+		:to("{")
+		:link(tt_array_separator)
+		:to("[")
+		:link(tt_singlequote_string)
+		:to("'")
+		:link(tt_doublequote_string)
+		:to('"')
+		:link(tt_numeric)
+		:to("0123456789.-")
+		:link(tt_boolean)
+		:to("tf")
+		:link(tt_null)
+		:to("n")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+	--:link(true)					 :to "]"
+
 	-- token tables for reading strings
-	init_token_table (tt_doublequote_string) "tt_doublequote_string: double quoted string"
-		:link(tt_ignore)             :to (strchars)
-		:link(c_esc)                 :to "\\"
-		:link(true)                  :to '"'
-		
-	init_token_table (tt_singlequote_string) "single quoted string"
-		:link(tt_ignore)             :to (strchars)
-		:link(c_esc)                 :to "\\" 
-		:link(true)                  :to "'"
-		
+	init_token_table(tt_doublequote_string)("tt_doublequote_string: double quoted string")
+		:link(tt_ignore)
+		:to(strchars)
+		:link(c_esc)
+		:to("\\")
+		:link(true)
+		:to('"')
+
+	init_token_table(tt_singlequote_string)("single quoted string")
+		:link(tt_ignore)
+		:to(strchars)
+		:link(c_esc)
+		:to("\\")
+		:link(true)
+		:to("'")
+
 	-- array reader that expects termination of the array or a comma that indicates the next value
-	init_token_table (tt_array_value) "tt_array_value: array (, or ] expected)"
-		:link(tt_array_separator)    :to "," 
-		:link(true)                  :to "]"
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_ignore)             :to " \t\r\n"
-	
+	init_token_table(tt_array_value)("tt_array_value: array (, or ] expected)")
+		:link(tt_array_separator)
+		:to(",")
+		:link(true)
+		:to("]")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+
 	-- a value, pretty similar to tt_object_value
-	init_token_table (tt_array_separator) "tt_array_separator: array ({ or [ or ' or \" or number or boolean or null expected)"
-		:link(tt_object_key)         :to "{" 
-		:link(tt_array_separator)    :to "[" 
-		:link(tt_singlequote_string) :to "'" 
-		:link(tt_doublequote_string) :to '"'  
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_numeric)            :to "0123456789.-" 
-		:link(tt_boolean)            :to "tf" 
-		:link(tt_null)               :to "n" 
-		:link(tt_ignore)             :to " \t\r\n"
-		:link(true)    :to "]" 
-	
+	init_token_table(tt_array_separator)("tt_array_separator: array ({ or [ or ' or \" or number or boolean or null expected)")
+		:link(tt_object_key)
+		:to("{")
+		:link(tt_array_separator)
+		:to("[")
+		:link(tt_singlequote_string)
+		:to("'")
+		:link(tt_doublequote_string)
+		:to('"')
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_numeric)
+		:to("0123456789.-")
+		:link(tt_boolean)
+		:to("tf")
+		:link(tt_null)
+		:to("n")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+		:link(true)
+		:to("]")
+
 	-- valid number tokens
-	init_token_table (tt_numeric) "tt_numeric: number"
-		:link(tt_ignore)             :to "0123456789.-Ee"
-		
+	init_token_table(tt_numeric)("tt_numeric: number"):link(tt_ignore):to("0123456789.-Ee")
+
 	-- once a comment has been started with /, a * is expected
-	init_token_table (tt_comment_start) "comment start (* expected)"
-		:link(tt_comment_middle)     :to "*"
-		
+	init_token_table(tt_comment_start)("comment start (* expected)"):link(tt_comment_middle):to("*")
+
 	-- now everything is allowed, watch out for * though. The next char is then checked manually
-	init_token_table (tt_comment_middle) "comment end"
-		:link(tt_ignore)             :to (allchars)
-		:link(true)                  :to "*"
-		
-	function decode (js_string)
+	init_token_table(tt_comment_middle)("comment end"):link(tt_ignore):to(allchars):link(true):to("*")
+
+	function decode(js_string)
 		local pos = 1 -- position in the string
-		
+
 		-- read the next byte value
-		local function next_byte () pos = pos + 1 return js_string:byte(pos-1) end
-		
+		local function next_byte()
+			pos = pos + 1
+			return js_string:byte(pos - 1)
+		end
+
 		-- in case of error, report the location using line numbers
-		local function location () 
+		local function location()
 			local n = ("\n"):byte()
-			local line,lpos = 1,0
-			for i=1,pos do 
+			local line, lpos = 1, 0
+			for i = 1, pos do
 				if js_string:byte(i) == n then
-					line,lpos = line + 1,1
+					line, lpos = line + 1, 1
 				else
 					lpos = lpos + 1
 				end
 			end
-			return "Line "..line.." character "..lpos
+			return "Line " .. line .. " character " .. lpos
 		end
-		
+
 		-- debug func
 		--local function status (str)
 		--	print(str.." ("..s:sub(math.max(1,p-10),p+10)..")")
 		--end
-		
+
 		-- read the next token, according to the passed token table
-		local function next_token (tok)
+		local function next_token(tok)
 			while pos <= #js_string do
-				local b = js_string:byte(pos) 
+				local b = js_string:byte(pos)
 				local t = tok[b]
-				if not t then 
-					error("Unexpected character at "..location()..": "..
-						string.char(b).." ("..b..") when reading "..tok.name.."\nContext: \n"..
-						js_string:sub(math.max(1,pos-30),pos+30).."\n"..(" "):rep(pos+math.min(-1,30-pos)).."^")
+				if not t then
+					error(
+						"Unexpected character at "
+							.. location()
+							.. ": "
+							.. string.char(b)
+							.. " ("
+							.. b
+							.. ") when reading "
+							.. tok.name
+							.. "\nContext: \n"
+							.. js_string:sub(math.max(1, pos - 30), pos + 30)
+							.. "\n"
+							.. (" "):rep(pos + math.min(-1, 30 - pos))
+							.. "^"
+					)
 				end
 				pos = pos + 1
-				if t~=tt_ignore then return t end
+				if t ~= tt_ignore then
+					return t
+				end
 			end
-			error("unexpected termination of JSON while looking for "..tok.name)
+			error("unexpected termination of JSON while looking for " .. tok.name)
 		end
-		
+
 		-- read a string, double and single quoted ones
-		local function read_string (tok)
+		local function read_string(tok)
 			local start = pos
 			local rewrite = false
 			--local returnString = {}
 			repeat
 				local t = next_token(tok)
-				if t == c_esc then 
+				if t == c_esc then
 					-- pos sits on the escaped character. u and / are the two JSON escapes Lua
 					-- has no equivalent for, and the interpreters disagree on them: 5.1 quietly
 					-- drops the backslash while LuaJIT refuses to compile at all. Neither can be
@@ -484,15 +529,15 @@ do
 					--start = pos
 				end -- jump over escaped chars, no matter what
 			until t == true
-			local literal = js_string:sub(start-1, pos-1)
+			local literal = js_string:sub(start - 1, pos - 1)
 			if rewrite then
 				literal = rewriteJsonOnlyEscapes(literal)
 			end
-			return (base.loadstring("return " .. literal) ())
+			return (base.loadstring("return " .. literal)())
 
 			-- We consider the situation where no escaped chars were encountered separately,
 			-- and use the fastest possible return in this case.
-			
+
 			--if 0 == #returnString then
 			--	return js_string:sub(start,pos-2)
 			--else
@@ -501,135 +546,176 @@ do
 			--end
 			--return js_string:sub(start,pos-2)
 		end
-		
-		local function read_num ()
+
+		local function read_num()
 			local start = pos
 			while pos <= #js_string do
 				local b = js_string:byte(pos)
-				if not tt_numeric[b] then break end
+				if not tt_numeric[b] then
+					break
+				end
 				pos = pos + 1
 			end
-			return tonumber(js_string:sub(start-1,pos-1))
+			return tonumber(js_string:sub(start - 1, pos - 1))
 		end
-		
+
 		-- read_bool and read_null are both making an assumption that I have not tested:
-		-- I would expect that the string extraction is more expensive than actually 
+		-- I would expect that the string extraction is more expensive than actually
 		-- making manual comparison of the byte values
-		local function read_bool () 
+		local function read_bool()
 			pos = pos + 3
-			local a,b,c,d = js_string:byte(pos-3,pos)
-			if a == c_r and b == c_u and c == c_e then return true end
+			local a, b, c, d = js_string:byte(pos - 3, pos)
+			if a == c_r and b == c_u and c == c_e then
+				return true
+			end
 			pos = pos + 1
-			if a ~= c_a or b ~= c_l or c ~= c_s or d ~= c_e then 
-				error("Invalid boolean: "..js_string:sub(math.max(1,pos-5),pos+5)) 
+			if a ~= c_a or b ~= c_l or c ~= c_s or d ~= c_e then
+				error("Invalid boolean: " .. js_string:sub(math.max(1, pos - 5), pos + 5))
 			end
 			return false
 		end
-		
-		-- same as read_bool: only last 
-		local function read_null ()
+
+		-- same as read_bool: only last
+		local function read_null()
 			pos = pos + 3
-			local u,l1,l2 = js_string:byte(pos-3,pos-1)
-			if u == c_u and l1 == c_l and l2 == c_l then return nil end
-			error("Invalid value (expected null):"..js_string:sub(pos-4,pos-1)..
-				" ("..js_string:byte(pos-1).."="..js_string:sub(pos-1,pos-1).." / "..c_l..")")
+			local u, l1, l2 = js_string:byte(pos - 3, pos - 1)
+			if u == c_u and l1 == c_l and l2 == c_l then
+				return nil
+			end
+			error(
+				"Invalid value (expected null):"
+					.. js_string:sub(pos - 4, pos - 1)
+					.. " ("
+					.. js_string:byte(pos - 1)
+					.. "="
+					.. js_string:sub(pos - 1, pos - 1)
+					.. " / "
+					.. c_l
+					.. ")"
+			)
 		end
-		
-		local read_object_value,read_object_key,read_array,read_value,read_comment
-	
+
+		local read_object_value, read_object_key, read_array, read_value, read_comment
+
 		-- read a value depending on what token was returned, might require info what was used (in case of comments)
-		function read_value (t,fromt)
-			if t == tt_object_key         then return read_object_key({}) end
-			if t == tt_array_separator    then return read_array({}) end
-			if t == tt_singlequote_string or t == tt_doublequote_string then return read_string(t) end
-			if t == tt_numeric            then return read_num() end
-			if t == tt_boolean            then return read_bool() end	
-			if t == tt_null               then return read_null() end
-			if t == tt_comment_start      then return read_value(read_comment(fromt)) end
-			error("unexpected termination - "..js_string:sub(math.max(1,pos-10),pos+10))
+		function read_value(t, fromt)
+			if t == tt_object_key then
+				return read_object_key({})
+			end
+			if t == tt_array_separator then
+				return read_array({})
+			end
+			if t == tt_singlequote_string or t == tt_doublequote_string then
+				return read_string(t)
+			end
+			if t == tt_numeric then
+				return read_num()
+			end
+			if t == tt_boolean then
+				return read_bool()
+			end
+			if t == tt_null then
+				return read_null()
+			end
+			if t == tt_comment_start then
+				return read_value(read_comment(fromt))
+			end
+			error("unexpected termination - " .. js_string:sub(math.max(1, pos - 10), pos + 10))
 		end
-		
-		-- read comments until something noncomment like surfaces, using the token reader which was 
+
+		-- read comments until something noncomment like surfaces, using the token reader which was
 		-- used when stumbling over this comment
-		function read_comment (fromt)
+		function read_comment(fromt)
 			while true do
 				next_token(tt_comment_start)
 				while true do
 					local t = next_token(tt_comment_middle)
 					if next_byte() == c_slash then
 						local t = next_token(fromt)
-						if t~= tt_comment_start then return t end
+						if t ~= tt_comment_start then
+							return t
+						end
 						break
 					end
 				end
 			end
 		end
-		
+
 		-- read arrays, empty array expected as o arg
-		function read_array (o,i)
+		function read_array(o, i)
 			--if not i then status "arr open" end
 			i = i or 1
 			-- loop until ...
 			while true do
-				
+
 				-- At this point, the array might be empty!
 				local next_tokenvalue = next_token(tt_array_separator)
-				if next_tokenvalue == true then return o end
-				
+				if next_tokenvalue == true then
+					return o
+				end
+
 				o[i] = read_value(next_tokenvalue, tt_array_separator)
 				local t = next_token(tt_array_value)
 				if t == tt_comment_start then
 					t = read_comment(tt_array_value)
 				end
-				if t == true then  -- ... we found a terminator token
+				if t == true then -- ... we found a terminator token
 					--status "arr close"
-					return o 
+					return o
 				end
-				i = i + 1			
+				i = i + 1
 			end
 		end
-		
+
 		-- object value reading
-		function read_object_value (o)
+		function read_object_value(o)
 			local t = next_token(tt_object_value)
-			return read_value(t,tt_object_value)
+			return read_value(t, tt_object_value)
 		end
-		
+
 		-- object key reading, might also terminate the object
-		function read_object_key (o)
-			
+		function read_object_key(o)
+
 			while true do
 				local t = next_token(tt_object_key)
 				if t == tt_comment_start then
 					t = read_comment(tt_object_key)
 				end
-				if t == true then return o end
-				if t == tt_object_key then return read_object_key(o) end
+				if t == true then
+					return o
+				end
+				if t == tt_object_key then
+					return read_object_key(o)
+				end
 				local k = read_string(t)
-				
+
 				if next_token(tt_object_colon) == tt_comment_start then
 					t = read_comment(tt_object_colon)
 				end
-				
+
 				local v = read_object_value(o)
 				o[k] = v
 			end
 		end
-		
+
 		-- now let's read data from our string and pretend it's an object value
 		local r = read_object_value()
-		if pos<=#js_string then
+		if pos <= #js_string then
 			-- not sure about what to do with dangling characters
 			--error("Dangling characters in JSON code ("..location()..")")
 		end
-		
+
 		return r
 	end
 
-	instrumentedDecode = function (js_string)
-		if tracy then tracy.ZoneBeginN("Json:Decode") end 
+	instrumentedDecode = function(js_string)
+		if tracy then
+			tracy.ZoneBeginN("Json:Decode")
+		end
 		local localret = decode(js_string)
-		if tracy then tracy.ZoneEnd() end 
+		if tracy then
+			tracy.ZoneEnd()
+		end
 		return localret
 	end
 end

--- a/common/luaUtilities/json.lua
+++ b/common/luaUtilities/json.lua
@@ -57,59 +57,59 @@ local isEncodable
 --- The null function allows one to specify a null value in an associative array (which is otherwise
 -- discarded if you set the value with 'nil' in Lua. Simply set t = { first=json.null }
 local function null()
-  return null -- so json.null() will also return null ;-)
+	return null -- so json.null() will also return null ;-)
 end
 
 --- Encodes an arbitrary Lua object / variable.
 -- @param v The Lua object / variable to be JSON encoded.
 -- @return String containing the JSON encoding in internal Lua string format (i.e. not unicode)
 local function encode (v)
-  -- Handle nil values
-  if v==nil then
-    return "null"
-  end
-  
-  local vtype = base.type(v)  
+	-- Handle nil values
+	if v==nil then
+	return "null"
+	end
+	
+	local vtype = base.type(v)  
 
-  -- Handle strings
-  if vtype=='string' then    
-    return '"' .. encodeString(v) .. '"'	    -- Need to handle encoding in string
-  end
-  
-  -- Handle booleans
-  if vtype=='number' or vtype=='boolean' then
-    return base.tostring(v)
-  end
-  
-  -- Handle tables
-  if vtype=='table' then
-    local rval = {}
-    -- Consider arrays separately
-    local bArray, maxCount = isArray(v)
-    if bArray then
-      for i = 1,maxCount do
-        table.insert(rval, encode(v[i]))
-      end
-    else	-- An object, not an array
-      for i,j in base.pairs(v) do
-        if isEncodable(i) and isEncodable(j) then
-          table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
-        end
-      end
-    end
-    if bArray then
-      return '[' .. table.concat(rval,',') ..']'
-    else
-      return '{' .. table.concat(rval,',') .. '}'
-    end
-  end
-  
-  -- Handle null values
-  if vtype=='function' and v==null then
-    return 'null'
-  end
-  
-  base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
+	-- Handle strings
+	if vtype=='string' then    
+	return '"' .. encodeString(v) .. '"'	    -- Need to handle encoding in string
+	end
+	
+	-- Handle booleans
+	if vtype=='number' or vtype=='boolean' then
+	return base.tostring(v)
+	end
+	
+	-- Handle tables
+	if vtype=='table' then
+	local rval = {}
+	-- Consider arrays separately
+	local bArray, maxCount = isArray(v)
+	if bArray then
+		for i = 1,maxCount do
+		table.insert(rval, encode(v[i]))
+		end
+	else	-- An object, not an array
+		for i,j in base.pairs(v) do
+		if isEncodable(i) and isEncodable(j) then
+			table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
+		end
+		end
+	end
+	if bArray then
+		return '[' .. table.concat(rval,',') ..']'
+	else
+		return '{' .. table.concat(rval,',') .. '}'
+	end
+	end
+	
+	-- Handle null values
+	if vtype=='function' and v==null then
+	return 'null'
+	end
+	
+	base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
 end
 
 
@@ -210,9 +210,19 @@ end
 -- This just involves back-quoting inverted commas, back-quotes and newlines, I think ;-)
 -- @param s The string to return as a JSON encoded (i.e. backquoted string)
 -- @return The string appropriately escaped.
-local qrep = {["\\"]="\\\\", ['"']='\\"',['\n']='\\n',['\t']='\\t'}
+local qrep = {["\\"]="\\\\", ['"']='\\"',['\b']='\\b',['\f']='\\f',['\n']='\\n',['\r']='\\r',['\t']='\\t'}
+
+-- Writing control characters produces a broken file unless properly escaped.
+-- All shorthand escapes are listed above; the rest must encode into \uXXXX,
+-- which we also decode on the way in to keep a single properly copied json.
+for byte=0,0x1f do
+	local char = string.char(byte)
+	if not qrep[char] then
+	qrep[char] = string.format("\\u%04x", byte)
+	end
+end
 function encodeString(s)
-  return tostring(s):gsub('["\\\n\t]',qrep)
+	return (tostring(s):gsub('[%z\1-\31"\\]',qrep))
 end
 
 -- Determines whether the given Lua type is an array or a table / dictionary.
@@ -224,22 +234,22 @@ end
 -- the second returned value is the maximum
 -- number of indexed elements in the array. 
 function isArray(t)
-  -- Next we count all the elements, ensuring that any non-indexed elements are not-encodable 
-  -- (with the possible exception of 'n')
-  local maxIndex = 0
-  for k,v in base.pairs(t) do
-    if (base.type(k)=='number' and math.floor(k)==k and 1<=k) then	-- k,v is an indexed pair
-      if (not isEncodable(v)) then return false end	-- All array elements must be encodable
-      maxIndex = math.max(maxIndex,k)
-    else
-      if (k=='n') then
-        if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
-      else -- Else of (k=='n')
-        if isEncodable(v) then return false end
-      end  -- End of (k~='n')
-    end -- End of k,v not an indexed pair
-  end  -- End of loop across all pairs
-  return true, maxIndex
+	-- Next we count all the elements, ensuring that any non-indexed elements are not-encodable 
+	-- (with the possible exception of 'n')
+	local maxIndex = 0
+	for k,v in base.pairs(t) do
+	if (base.type(k)=='number' and math.floor(k)==k and 1<=k) then	-- k,v is an indexed pair
+		if (not isEncodable(v)) then return false end	-- All array elements must be encodable
+		maxIndex = math.max(maxIndex,k)
+	else
+		if (k=='n') then
+		if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
+		else -- Else of (k=='n')
+		if isEncodable(v) then return false end
+		end  -- End of (k~='n')
+	end -- End of k,v not an indexed pair
+	end  -- End of loop across all pairs
+	return true, maxIndex
 end
 
 --- Determines whether the given Lua object / table / variable can be JSON encoded. The only
@@ -248,8 +258,8 @@ end
 -- @param o The object to examine.
 -- @return boolean True if the object should be JSON encoded, false if it should be ignored.
 function isEncodable(o)
-  local t = base.type(o)
-  return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null) 
+	local t = base.type(o)
+	return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null) 
 end
 
 local instrumentedDecode
@@ -531,8 +541,7 @@ do
 		function read_value (t,fromt)
 			if t == tt_object_key         then return read_object_key({}) end
 			if t == tt_array_separator    then return read_array({}) end
-			if t == tt_singlequote_string or 
-			   t == tt_doublequote_string then return read_string(t) end
+			if t == tt_singlequote_string or t == tt_doublequote_string then return read_string(t) end
 			if t == tt_numeric            then return read_num() end
 			if t == tt_boolean            then return read_bool() end	
 			if t == tt_null               then return read_null() end

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -505,12 +505,16 @@
 			}
 		},
 		"blueprint": {
+			"section": "Blueprints",
 			"cursor_active": "Blueprint #%{index}",
 			"cursor_none": "No Blueprints",
 			"hotkey_next": "Next",
 			"hotkey_prev": "Previous",
 			"hotkey_delete": "Delete",
-			"hotkey_none": "<none>"
+			"hotkey_none": "<none>",
+			"file_damaged": "Could not read %{file}.",
+			"save_failed": "Could not save to %{file}.",
+			"entry_kept": "Could not load '%{name}'."
 		},
 		"ignore": {
 			"unknown": "unknown accountID",

--- a/luaui/Include/blueprints/json_doctor.lua
+++ b/luaui/Include/blueprints/json_doctor.lua
@@ -19,10 +19,11 @@
 
 ---@class BlueprintsJsonReading
 ---@field outcome string one of the outcomes below
----@field entries table[] blueprint-shaped entries, in file order
+---@field entries table[] blueprint-shaped entries, in file order and without gaps
 ---@field entryIndices number[] where each of those sat in the file, for naming it
 ---@field setAside any[] entries that are not blueprints at all, kept verbatim
 ---@field messages BlueprintsJsonMessage[] what to tell the player, in order
+---@field repairs string[] what had to be put right to read the file
 
 local Doctor = {}
 
@@ -34,6 +35,9 @@ Doctor.LOADED = "loaded"
 
 ---The file holds blueprints we could not read. Writing is refused.
 Doctor.DAMAGED = "damaged"
+
+---A null in the list left a gap, and the entries past it were closed back up.
+Doctor.REPAIR_GAP = "gap"
 
 Doctor.PENDING_SUFFIX = ".pending"
 Doctor.BACKUP_SUFFIX = ".backup"
@@ -49,7 +53,8 @@ end
 ---@return BlueprintsJsonReading
 function Doctor.read(path)
 	---@type BlueprintsJsonReading
-	local reading = { outcome = Doctor.ABSENT, entries = {}, entryIndices = {}, setAside = {}, messages = {} }
+	local reading =
+		{ outcome = Doctor.ABSENT, entries = {}, entryIndices = {}, setAside = {}, messages = {}, repairs = {} }
 
 	local content = VFS.LoadFile(path)
 
@@ -84,17 +89,35 @@ function Doctor.read(path)
 		savedBlueprints = {}
 	end
 
-	-- A table we cannot walk with ipairs holds blueprints that would be read as
-	-- none and then saved as none, which is how a full library turns into an
-	-- empty one.
-	if type(savedBlueprints) ~= "table" or (#savedBlueprints == 0 and next(savedBlueprints) ~= nil) then
+	if type(savedBlueprints) ~= "table" then
 		reading.outcome = Doctor.DAMAGED
 		addMessage(reading.messages, "ui.blueprint.file_damaged", { file = path })
 		return reading
 	end
 
-	for i, entry in ipairs(savedBlueprints) do
-		if type(entry) == "table" then
+	local count, highestIndex = 0, 0
+	for key in pairs(savedBlueprints) do
+		count = count + 1
+		if type(key) == "number" and key > highestIndex then
+			highestIndex = key
+		end
+	end
+
+	if count > highestIndex then
+		reading.outcome = Doctor.DAMAGED
+		addMessage(reading.messages, "ui.blueprint.file_damaged", { file = path })
+		return reading
+	end
+
+	if count < highestIndex then
+		reading.repairs[#reading.repairs + 1] = Doctor.REPAIR_GAP
+	end
+
+	for i = 1, highestIndex do
+		local entry = savedBlueprints[i]
+		if entry == nil then
+			--Nothing was stored here, so there is nothing to keep.
+		elseif type(entry) == "table" then
 			reading.entries[#reading.entries + 1] = entry
 			reading.entryIndices[#reading.entryIndices + 1] = i
 		else

--- a/luaui/Include/blueprints/json_doctor.lua
+++ b/luaui/Include/blueprints/json_doctor.lua
@@ -1,0 +1,167 @@
+-- Reading and writing LuaUI/Config/blueprints.json.
+--
+-- The game writes blueprint names empty, so every named blueprint in a real file
+-- got there by hand or by being pasted from someone else. The file is a player
+-- authored input, and the two rules that follow from that are:
+--
+--   A file we could not read in full is the only copy of what is in it, so it is
+--   never written over. That is what the outcome of a read is for.
+--
+--   A write that is interrupted must leave the file that was already there. The
+--   new contents go to a pending file and are swapped in once they are complete.
+--
+-- Messages come back as keys and parameters rather than text, so this stays free
+-- of Spring and BAR and can be read on its own.
+
+---@class BlueprintsJsonMessage
+---@field key string an i18n key under ui.blueprint
+---@field params table|nil
+
+---@class BlueprintsJsonReading
+---@field outcome string one of the outcomes below
+---@field entries table[] blueprint-shaped entries, in file order
+---@field entryIndices number[] where each of those sat in the file, for naming it
+---@field setAside any[] entries that are not blueprints at all, kept verbatim
+---@field messages BlueprintsJsonMessage[] what to tell the player, in order
+
+local Doctor = {}
+
+---Nothing to lose: there is no file, or it holds nothing. Writing is allowed.
+Doctor.ABSENT = "absent"
+
+---Every entry in the file was accounted for. Writing is allowed.
+Doctor.LOADED = "loaded"
+
+---The file holds blueprints we could not read. Writing is refused.
+Doctor.DAMAGED = "damaged"
+
+Doctor.PENDING_SUFFIX = ".pending"
+Doctor.BACKUP_SUFFIX = ".backup"
+
+---@param messages BlueprintsJsonMessage[]
+---@param key string
+---@param params table|nil
+local function addMessage(messages, key, params)
+	messages[#messages + 1] = { key = key, params = params }
+end
+
+---@param path string
+---@return BlueprintsJsonReading
+function Doctor.read(path)
+	---@type BlueprintsJsonReading
+	local reading = { outcome = Doctor.ABSENT, entries = {}, entryIndices = {}, setAside = {}, messages = {} }
+
+	local content = VFS.LoadFile(path)
+
+	-- Unreadable, undecodable and unrecognized all leave the player doing the same
+	-- thing: opening the file. They are one message, not three.
+	if not content then
+		-- Having no file at all is the ordinary first run. Having one we cannot
+		-- read is not, and it must not be written over.
+		if VFS.FileExists(path) then
+			reading.outcome = Doctor.DAMAGED
+			addMessage(reading.messages, "ui.blueprint.file_damaged", { file = path })
+		end
+		return reading
+	end
+
+	-- An empty file has nothing in it to lose, so it is the first run again.
+	if content:match("^%s*$") then
+		return reading
+	end
+
+	local decodedOK, decoded = pcall(Json.decode, content) ---@cast decoded table?
+
+	if not decodedOK or type(decoded) ~= "table" then
+		reading.outcome = Doctor.DAMAGED
+		addMessage(reading.messages, "ui.blueprint.file_damaged", { file = path })
+		return reading
+	end
+
+	local savedBlueprints = decoded.savedBlueprints
+
+	if savedBlueprints == nil and next(decoded) == nil then
+		savedBlueprints = {}
+	end
+
+	-- A table we cannot walk with ipairs holds blueprints that would be read as
+	-- none and then saved as none, which is how a full library turns into an
+	-- empty one.
+	if type(savedBlueprints) ~= "table" or (#savedBlueprints == 0 and next(savedBlueprints) ~= nil) then
+		reading.outcome = Doctor.DAMAGED
+		addMessage(reading.messages, "ui.blueprint.file_damaged", { file = path })
+		return reading
+	end
+
+	for i, entry in ipairs(savedBlueprints) do
+		if type(entry) == "table" then
+			reading.entries[#reading.entries + 1] = entry
+			reading.entryIndices[#reading.entryIndices + 1] = i
+		else
+			addMessage(reading.messages, "ui.blueprint.entry_kept", { name = "#" .. i })
+			reading.setAside[#reading.setAside + 1] = entry
+		end
+	end
+
+	reading.outcome = Doctor.LOADED
+	return reading
+end
+
+---@param path string
+---@param entries any[] everything to write, including entries that were set aside
+---@param outcome string the outcome of the read this write follows
+---@return BlueprintsJsonMessage[] messages
+function Doctor.write(path, entries, outcome)
+	---@type BlueprintsJsonMessage[]
+	local messages = {}
+
+	-- Refusing and failing both come out as "your blueprints were not saved, and
+	-- the file you had is still there", which is the whole of what to say.
+	if outcome == Doctor.DAMAGED then
+		addMessage(messages, "ui.blueprint.save_failed", { file = path })
+		return messages
+	end
+
+	local encodedOK, encoded = pcall(Json.encode, { savedBlueprints = entries })
+
+	if not encodedOK or type(encoded) ~= "string" then
+		addMessage(messages, "ui.blueprint.save_failed", { file = path })
+		return messages
+	end
+
+	local pendingPath = path .. Doctor.PENDING_SUFFIX
+	local backupPath = path .. Doctor.BACKUP_SUFFIX
+
+	local file = io.open(pendingPath, "w")
+
+	if not file then
+		addMessage(messages, "ui.blueprint.save_failed", { file = path })
+		return messages
+	end
+
+	local written = file:write(encoded)
+	local closed = file:close()
+
+	if not written or not closed then
+		os.remove(pendingPath)
+		addMessage(messages, "ui.blueprint.save_failed", { file = path })
+		return messages
+	end
+
+	-- Rotate rather than overwrite. The previous file becomes the backup, which
+	-- also clears the way for the rename on platforms that will not replace an
+	-- existing target. Both of these fail harmlessly on a first save.
+	os.remove(backupPath)
+	os.rename(path, backupPath)
+
+	-- The new contents are left in the pending file and the previous ones in the
+	-- backup, both beside the file itself. That is more than the player can act
+	-- on, so it is the same line as any other save that did not happen.
+	if not os.rename(pendingPath, path) then
+		addMessage(messages, "ui.blueprint.save_failed", { file = path })
+	end
+
+	return messages
+end
+
+return Doctor

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -136,6 +136,11 @@ local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
 local currentLayout
 local actionHotkeys
 
+local Doctor = VFS.Include("luaui/Include/blueprints/json_doctor.lua")
+---Doctor loading state
+---@type string|nil
+local loadOutcome = nil
+
 ---maximum number of units in a saved blueprint
 local BLUEPRINT_UNIT_LIMIT = 100
 
@@ -1130,53 +1135,73 @@ end
 
 ---@param serializedBlueprint SerializedBlueprint
 ---@return Blueprint|nil
-local function deserializeBlueprint(serializedBlueprint, index)
+local function buildBlueprint(serializedBlueprint)
 	local blueprint = WG.api_blueprint.createBlueprintFromSerialized(serializedBlueprint)
 
-	if not blueprint or not table.any(blueprint.units, function(u)
+	if blueprint then
+		postProcessBlueprint(blueprint)
+	end
+
+	return blueprint
+end
+
+---Prints one line to the console under the section the strings belong to, so the
+---prefix is translated with them rather than baked into each one.
+---@param key string
+---@param params table|nil
+local function notify(key, params)
+	FeedbackForUser("[" .. BAR.I18N("ui.blueprint.section") .. "] " .. BAR.I18N(key, params))
+end
+
+---@param serializedBlueprint SerializedBlueprint
+---@return Blueprint|nil
+local function deserializeBlueprint(serializedBlueprint, index)
+	-- The file is written by hand as often as by us, so a blueprint can be any
+	-- shape at all. Building one is allowed to fail; the entry is set aside and
+	-- written back untouched, which is the only copy the player has of it.
+	local built, blueprint = pcall(buildBlueprint, serializedBlueprint)
+
+	if not built or not blueprint or not table.any(blueprint.units, function(u)
 		return u.unitDefID ~= nil
 	end) then
 		local name = serializedBlueprint.name
 		if not name or name == "" then
 			name = "#" .. tostring(index)
 		end
-		FeedbackForUser(
-			string.format(
-				"[Blueprint] Blueprint '%s' was filtered out as it contains no valid or substitutable units.",
-				name
-			)
-		)
+		notify("ui.blueprint.entry_kept", { name = name })
 		return nil
 	end
 
-	postProcessBlueprint(blueprint)
 	return blueprint
 end
 
+---@param messages BlueprintsJsonMessage[]
+local function reportToUser(messages)
+	for _, entry in ipairs(messages) do
+		notify(entry.key, entry.params)
+	end
+end
+
+---Reads the blueprints file through the doctor and remembers what it found, which
+---is what decides whether the save on shutdown is allowed to write over it.
 local function loadBlueprintsFromFile()
-	local content = VFS.LoadFile(BLUEPRINT_FILE_PATH)
-
-	if not content then
-		FeedbackForUser("Failed to read blueprints file: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	local decoded = Json.decode(content)
-	---@cast decoded table?
-
-	if decoded == nil then
-		FeedbackForUser("Failed to decode blueprints file JSON: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	if type(decoded.savedBlueprints) ~= "table" then
-		decoded.savedBlueprints = {}
-	end
-
 	blueprints = {}
 	filteredOutSerializedBlueprints = {}
-	for i, serializedBlueprint in ipairs(decoded.savedBlueprints) do
-		local blueprint = deserializeBlueprint(serializedBlueprint, i)
+	setSelectedBlueprintIndex(nil)
+
+	local reading = Doctor.read(BLUEPRINT_FILE_PATH)
+
+	loadOutcome = reading.outcome
+	reportToUser(reading.messages)
+
+	-- Entries the doctor could make nothing of are written back untouched, so
+	-- they travel with the ones we fail to build below.
+	table.append(filteredOutSerializedBlueprints, reading.setAside)
+
+	for i, serializedBlueprint in ipairs(reading.entries) do
+		-- Numbered by where it sits in the file, matching what the doctor calls
+		-- the entries it set aside itself.
+		local blueprint = deserializeBlueprint(serializedBlueprint, reading.entryIndices[i])
 		if blueprint then
 			tableInsert(blueprints, blueprint)
 		else
@@ -1184,45 +1209,18 @@ local function loadBlueprintsFromFile()
 		end
 	end
 
-	if #blueprints == 0 then
-		setSelectedBlueprintIndex(nil)
-	elseif not selectedBlueprintIndex or selectedBlueprintIndex > #blueprints then
+	if #blueprints > 0 and (not selectedBlueprintIndex or selectedBlueprintIndex > #blueprints) then
 		setSelectedBlueprintIndex(1)
 	end
 end
 
 local function saveBlueprintsToFile()
-	local file = io.open(BLUEPRINT_FILE_PATH, "w")
-
-	if not file then
-		FeedbackForUser("Failed to open blueprints file for writing: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	local activeSerializedBps = table.map(blueprints, serializeBlueprint)
 	local allSerializedBpsToSave = {}
-	table.append(allSerializedBpsToSave, activeSerializedBps)
+	table.append(allSerializedBpsToSave, table.map(blueprints, serializeBlueprint))
 	table.append(allSerializedBpsToSave, filteredOutSerializedBlueprints)
 
-	if #allSerializedBpsToSave == 0 then
-		allSerializedBpsToSave = {}
-	end
-
-	local encoded = Json.encode({
-		savedBlueprints = allSerializedBpsToSave,
-	})
-
-	if encoded == nil then
-		FeedbackForUser("Failed to encode blueprints file JSON: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	file:write(encoded)
-
-	file:close()
+	reportToUser(Doctor.write(BLUEPRINT_FILE_PATH, allSerializedBpsToSave, loadOutcome))
 end
-
-local loadedBlueprints = false
 
 function widget:Initialize()
 	if Spring.GetModOptions().scenariooptions then
@@ -1243,7 +1241,6 @@ function widget:Initialize()
 	WG.cmd_blueprint.nextBlueprintUnitID = nextBlueprintUnitID
 
 	loadBlueprintsFromFile()
-	loadedBlueprints = true
 
 	widgetHandler.actionHandler:AddAction(self, "blueprint_create", handleBlueprintCreateAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_next", handleBlueprintNextAction, nil, "p")
@@ -1267,7 +1264,7 @@ function widget:Shutdown()
 
 	updateBuildingGridState(false)
 
-	if loadedBlueprints then
+	if loadOutcome then
 		saveBlueprintsToFile()
 	end
 

--- a/spec/common/json_spec.lua
+++ b/spec/common/json_spec.lua
@@ -93,16 +93,58 @@ describe("json string escapes", function()
 		-- characters or pushes the rest of the literal out of step, so it has to be caught
 		-- where it is parsed rather than surfacing as a loadstring failure later.
 		it("is rejected rather than silently dropped", function()
-			assert.has_error(function() Json.decode([[{"a":"\u47"}]]) end)
-			assert.has_error(function() Json.decode([[{"a":"\uZZZZ"}]]) end)
-			assert.has_error(function() Json.decode([[{"a":"\u"}]]) end)
-			assert.has_error(function() Json.decode([[{"a":"x\u47y"}]]) end)
+			assert.has_error(function()
+				Json.decode([[{"a":"\u47"}]])
+			end)
+			assert.has_error(function()
+				Json.decode([[{"a":"\uZZZZ"}]])
+			end)
+			assert.has_error(function()
+				Json.decode([[{"a":"\u"}]])
+			end)
+			assert.has_error(function()
+				Json.decode([[{"a":"x\u47y"}]])
+			end)
 		end)
 
 		it("names the escape it choked on", function()
 			local ok, err = pcall(Json.decode, [[{"a":"\uZZZZ"}]])
 			assert.is_false(ok)
 			assert.is_truthy(tostring(err):find("\uZZZZ", 1, true))
+		end)
+	end)
+
+	describe("control characters on the way out", function()
+		-- JSON has no literal control characters and the decoder has no token for most
+		-- of them, so encoding one raw produced a file this module could not read back.
+		local function roundTrip(text)
+			return Json.decode(Json.encode({ a = text })).a
+		end
+
+		it("escapes the ones with a shorthand", function()
+			assert.are.equal([[{"a":"\b\f\n\r\t"}]], Json.encode({ a = "\b\f\n\r\t" }))
+		end)
+
+		it("escapes the rest as code points", function()
+			local encoded = Json.encode({ a = string.char(0, 27, 31) })
+
+			assert.is_truthy(encoded:find("u0000", 1, true))
+			assert.is_truthy(encoded:find("u001b", 1, true))
+			assert.is_truthy(encoded:find("u001f", 1, true))
+			assert.is_nil(encoded:find(string.char(0), 1, true))
+		end)
+
+		it("reads back every control character it writes", function()
+			for byte = 0, 0x1f do
+				local text = "a" .. string.char(byte) .. "b"
+				assert.are.equal(text, roundTrip(text), "byte " .. byte)
+			end
+		end)
+
+		it("leaves printable characters alone", function()
+			local text = "eco/lab " .. string.char(195, 169)
+
+			assert.are.equal('{"a":"' .. text .. '"}', Json.encode({ a = text }))
 		end)
 	end)
 
@@ -117,8 +159,7 @@ describe("json string escapes", function()
 			assert.is_table(decoded, path .. " failed to decode")
 			-- Asserting the value, not just that it parsed: an interpreter that treats an
 			-- unknown escape as the bare character decodes happily but corrupts the string.
-			assert.are.equal(true,
-				decoded.cmd.set.AutoAddBuiltUnitsToFactoryGroup:find("factory's", 1, true) ~= nil)
+			assert.are.equal(true, decoded.cmd.set.AutoAddBuiltUnitsToFactoryGroup:find("factory's", 1, true) ~= nil)
 		end)
 	end)
 end)

--- a/spec/luaui/Widgets/cmd_blueprint_load_spec.lua
+++ b/spec/luaui/Widgets/cmd_blueprint_load_spec.lua
@@ -1,0 +1,460 @@
+-- cmd_blueprint's blueprints.json load and save paths.
+--
+-- Names are always written empty by the game (createBlueprint sets name = ""),
+-- so every non-empty name in a real blueprints.json got there by hand or by
+-- being pasted from someone else. The file is a user-authored input and these
+-- specs cover what the loader does with the malformed ones users produce.
+--
+-- The two paths are locals called from Initialize and Shutdown, so the widget is
+-- loaded into a sandbox with its own io/os/VFS and both are driven directly. The
+-- point of most of these cases is the pairing: a file we could not read in full
+-- is the player's only copy of what is in it, so the load has to report and the
+-- save has to refuse.
+---@diagnostic disable: undefined-field, redundant-parameter
+
+local WIDGET_PATH = "luaui/Widgets/cmd_blueprint.lua"
+local DOCTOR_PATH = "luaui/Include/blueprints/json_doctor.lua"
+local BLUEPRINT_PATH = "LuaUI/Config/blueprints.json"
+local PENDING_PATH = BLUEPRINT_PATH .. ".pending"
+local BACKUP_PATH = BLUEPRINT_PATH .. ".backup"
+
+local Json = VFS.Include("common/luaUtilities/json.lua")
+
+-- Two buildings is enough: one that resolves and one that does not.
+local UNIT_DEFS = {
+	[10] = { name = "armmex", isBuilding = true, xsize = 4, zsize = 4, customParams = {}, buildOptions = {} },
+	[11] = { name = "armsolar", isBuilding = true, xsize = 4, zsize = 4, customParams = {}, buildOptions = {} },
+}
+
+---Renders an i18n call as key plus sorted parameters, so the specs assert on keys
+---rather than on wording that is expected to change.
+local function fakeI18N(key, params)
+	if not params then
+		return key
+	end
+	local parts = {}
+	for name, value in pairs(params) do
+		parts[#parts + 1] = name .. "=" .. tostring(value)
+	end
+	table.sort(parts)
+	return key .. "|" .. table.concat(parts, ",")
+end
+
+---Load cmd_blueprint into a sandbox with a one-file disk, then run Initialize.
+---@param content string|nil the blueprints file's contents, or nil for no file
+---@param options table|nil unreadable: the file exists but cannot be read
+---@return table
+local function loadWith(content, options)
+	options = options or {}
+
+	local env = setmetatable({}, { __index = _G })
+
+	-- Paths map to contents; false marks a file that exists but will not read.
+	local disk = {}
+	if options.unreadable then
+		disk[BLUEPRINT_PATH] = false
+	elseif content ~= nil then
+		disk[BLUEPRINT_PATH] = content
+	end
+
+	local echoes = {}
+	local writes = {}
+	local unitDefNames = {}
+	for defID, def in pairs(UNIT_DEFS) do
+		unitDefNames[def.name] = { id = defID }
+	end
+
+	---@diagnostic disable-next-line: missing-fields
+	env.widget = {}
+	env.Json = Json
+	env.UnitDefs = UNIT_DEFS
+	env.UnitDefNames = unitDefNames
+	env.BAR = setmetatable({ I18N = fakeI18N }, { __index = _G.BAR })
+	env.GameCMD = setmetatable({}, {
+		__index = function()
+			return 40000
+		end,
+	})
+	env.CMDTYPE = setmetatable({}, {
+		__index = function()
+			return 1
+		end,
+	})
+	env.Platform = { isHeadless = true, gl = false }
+	env.widgetHandler = {
+		RemoveWidget = function() end,
+		actionHandler = {
+			AddAction = function() end,
+			RemoveAction = function() end,
+		},
+	}
+
+	env.Spring = setmetatable({
+		Echo = function(...)
+			local parts = {}
+			for i = 1, select("#", ...) do
+				parts[i] = tostring((select(i, ...)))
+			end
+			table.insert(echoes, table.concat(parts, " "))
+		end,
+		GetModOptions = function()
+			return {}
+		end,
+		GetSelectedUnits = function()
+			return {}
+		end,
+		GetLocalTeamID = function()
+			return 0
+		end,
+		GetUnitDefID = function()
+			return nil
+		end,
+		GetViewGeometry = function()
+			return 1920, 1080, 0, 0
+		end,
+		GetConfigString = function(_, fallback)
+			return fallback
+		end,
+		GetSelectionBox = function()
+			return nil
+		end,
+	}, { __index = _G.Spring })
+
+	env.VFS = setmetatable({
+		LoadFile = function(path)
+			local stored = disk[path]
+			if stored == false then
+				return nil
+			end
+			return stored
+		end,
+		FileExists = function(path)
+			return disk[path] ~= nil
+		end,
+		Include = function(path, ...)
+			-- Reads the live keybindings, which the sandbox has none of.
+			if path == "luaui/Include/action_hotkeys.lua" then
+				return {}
+			end
+			-- The doctor is the code under test here, not a dependency to stub.
+			-- Running it in this environment is also what the engine does: an
+			-- include with no environment of its own inherits its caller's.
+			if path == DOCTOR_PATH then
+				local doctor = assert(loadfile(DOCTOR_PATH))
+				setfenv(doctor, env)
+				return doctor()
+			end
+			return _G.VFS.Include(path, ...)
+		end,
+	}, { __index = _G.VFS })
+
+	env.io = setmetatable({
+		open = function(path, mode)
+			if mode ~= "w" or options.openFails then
+				return nil
+			end
+			local buffer = {}
+			return {
+				write = function(_, text)
+					if options.writeFails then
+						return nil
+					end
+					buffer[#buffer + 1] = text
+					return true
+				end,
+				close = function()
+					disk[path] = table.concat(buffer)
+					table.insert(writes, path)
+					return true
+				end,
+			}
+		end,
+	}, { __index = _G.io })
+
+	env.os = setmetatable({
+		remove = function(path)
+			if disk[path] == nil then
+				return nil
+			end
+			disk[path] = nil
+			return true
+		end,
+		rename = function(from, to)
+			if disk[from] == nil then
+				return nil
+			end
+			disk[to] = disk[from]
+			disk[from] = nil
+			return true
+		end,
+	}, { __index = _G.os })
+
+	-- Mirrors api_blueprint.createBlueprintFromSerialized: no validation beyond
+	-- "has a units table", unit names resolved through UnitDefNames, unresolved
+	-- names kept as originalName with a nil unitDefID.
+	env.WG = {
+		api_blueprint = {
+			createBlueprintFromSerialized = function(serialized)
+				if not serialized or not serialized.units then
+					return nil
+				end
+				local result = table.copy(serialized)
+				result.units = {}
+				for _, unit in ipairs(serialized.units) do
+					local named = unitDefNames[unit.unitName]
+					table.insert(result.units, {
+						blueprintUnitID = 1,
+						position = unit.position,
+						facing = unit.facing,
+						unitDefID = named and named.id,
+						originalName = unit.unitName,
+					})
+				end
+				if #result.units == 0 then
+					return nil
+				end
+				return result
+			end,
+			getBlueprintDimensions = function()
+				return 0, 0
+			end,
+			getBuildingDimensions = function()
+				return 4, 4
+			end,
+			setActiveBlueprint = function() end,
+			setBlueprintPositions = function() end,
+		},
+	}
+
+	local chunk = assert(loadfile(WIDGET_PATH))
+	setfenv(chunk, env)
+	chunk()
+
+	local ok, err = pcall(env.widget.Initialize, env.widget)
+
+	local result = {
+		env = env,
+		disk = disk,
+		writes = writes,
+		echoes = echoes,
+		ok = ok,
+		err = ok and nil or tostring(err),
+	}
+
+	function result.shutdown()
+		assert(pcall(env.widget.Shutdown, env.widget))
+		return result
+	end
+
+	function result.saved()
+		return Json.decode(disk[BLUEPRINT_PATH]).savedBlueprints
+	end
+
+	return result
+end
+
+local function blueprintEntry(name, unitName)
+	return {
+		name = name,
+		spacing = 0,
+		facing = 0,
+		ordered = true,
+		units = { { unitName = unitName, facing = 0, position = { 0, 0, 0 } } },
+	}
+end
+
+local function fileWith(...)
+	return Json.encode({ savedBlueprints = { ... } })
+end
+
+local function echoMatching(result, text)
+	for _, line in ipairs(result.echoes) do
+		if line:find(text, 1, true) then
+			return line
+		end
+	end
+	return nil
+end
+
+describe("cmd_blueprint blueprints.json", function()
+	describe("files it reads", function()
+		it("loads a well-formed file without comment", function()
+			local result = loadWith(fileWith(blueprintEntry("", "armmex"), blueprintEntry("", "armsolar")))
+
+			assert.is_true(result.ok, result.err)
+			assert.are.same({}, result.echoes)
+		end)
+
+		it("says nothing when there is no file yet", function()
+			local result = loadWith(nil)
+
+			assert.is_true(result.ok, result.err)
+			assert.are.same({}, result.echoes)
+		end)
+
+		it("says nothing when the old file is empty", function()
+			local result = loadWith("   \n")
+
+			assert.is_true(result.ok, result.err)
+			assert.are.same({}, result.echoes)
+		end)
+
+		it("names a blueprint whose units all fail to resolve, and keeps it", function()
+			local result = loadWith(fileWith(blueprintEntry("junk", "notaunit")))
+
+			assert.is_true(result.ok, result.err)
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.entry_kept|name=junk"))
+		end)
+
+		it("names an entry that is not a blueprint at all, and keeps it", function()
+			local result = loadWith([[{"savedBlueprints":[1,2]}]])
+
+			assert.is_true(result.ok, result.err)
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.entry_kept|name=#1"))
+			assert.are.same({ 1, 2 }, result.shutdown().saved())
+		end)
+
+		it("keeps an escaped forward slash in a name (regression, #8666)", function()
+			local result = loadWith([[{"savedBlueprints":[{"name":"eco\/lab","units":[]}]}]])
+
+			assert.is_true(result.ok, result.err)
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.entry_kept|name=eco/lab"))
+		end)
+
+		it("reads back a name it wrote itself", function()
+			-- encodeString used to escape only " \ \n \t, so a control character
+			-- went out raw and produced a file the decoder had no token for.
+			local encoded = Json.encode({ savedBlueprints = { blueprintEntry("two\rlines", "armmex") } })
+
+			assert.is_nil(encoded:find("\r", 1, true))
+			assert.is_true(loadWith(encoded).ok)
+		end)
+	end)
+
+	-- Reading nothing out of a file that holds something used to be followed by
+	-- saving that nothing back over it. Every case here has to survive shutdown.
+	describe("files it cannot read", function()
+		local function assertRefusesToSave(content, key, options)
+			local result = loadWith(content, options)
+			local before = result.disk[BLUEPRINT_PATH]
+
+			assert.is_true(result.ok, result.err)
+			assert.is_not_nil(echoMatching(result, key))
+
+			result.shutdown()
+
+			assert.are.same({}, result.writes)
+			assert.are.equal(before, result.disk[BLUEPRINT_PATH])
+			assert.is_nil(result.disk[PENDING_PATH])
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.save_failed"))
+
+			return result
+		end
+
+		it("reports a file that exists but will not read", function()
+			assertRefusesToSave(nil, "ui.blueprint.file_damaged", { unreadable = true })
+		end)
+
+		it("reports a file truncated mid-write", function()
+			local full = fileWith(blueprintEntry("", "armmex"))
+			assertRefusesToSave(full:sub(1, #full - 20), "ui.blueprint.file_damaged")
+		end)
+
+		it("reports a UTF-8 BOM", function()
+			assertRefusesToSave("\239\187\191" .. fileWith(blueprintEntry("", "armmex")), "ui.blueprint.file_damaged")
+		end)
+
+		it("reports curly quotes from a chat client", function()
+			assertRefusesToSave("{\226\128\156savedBlueprints\226\128\157:[]}", "ui.blueprint.file_damaged")
+		end)
+
+		it("reports a // comment, though /* */ is accepted", function()
+			assertRefusesToSave('{\n// mine\n"savedBlueprints":[]}', "ui.blueprint.file_damaged")
+			assert.is_true(loadWith('{/* mine */"savedBlueprints":[]}').ok)
+		end)
+
+		it("reports a comma dropped between two blueprints", function()
+			assertRefusesToSave(
+				[[{"savedBlueprints":[{"name":"a","units":[]} {"name":"b","units":[]}]}]],
+				"ui.blueprint.file_damaged"
+			)
+		end)
+
+		it("reports a malformed \\u escape", function()
+			assertRefusesToSave([[{"savedBlueprints":[{"name":"\u00zz","units":[]}]}]], "ui.blueprint.file_damaged")
+		end)
+
+		it("reports savedBlueprints as an object rather than a list", function()
+			-- ipairs walks none of it, so this used to load zero blueprints in
+			-- silence and then write that zero back.
+			assertRefusesToSave([[{"savedBlueprints":{"first":{"name":"a","units":[]}}}]], "ui.blueprint.file_damaged")
+		end)
+
+		it("reports a document that is not an object", function()
+			assertRefusesToSave("[1,2,3]", "ui.blueprint.file_damaged")
+		end)
+
+		it("names the file it is leaving alone", function()
+			local result = loadWith("{")
+
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.file_damaged|file=" .. BLUEPRINT_PATH))
+		end)
+	end)
+
+	describe("saving", function()
+		it("writes through a pending file and keeps the previous one as a backup", function()
+			local original = fileWith(blueprintEntry("", "armmex"))
+			local result = loadWith(original).shutdown()
+
+			assert.are.equal(original, result.disk[BACKUP_PATH])
+			assert.is_nil(result.disk[PENDING_PATH])
+			assert.are.equal(1, #result.saved())
+		end)
+
+		it("creates the file when there was none", function()
+			local result = loadWith(nil).shutdown()
+
+			assert.are.same({}, result.saved())
+			assert.is_nil(result.disk[BACKUP_PATH])
+		end)
+
+		it("leaves the previous file alone when the write fails", function()
+			local original = fileWith(blueprintEntry("", "armmex"))
+			local result = loadWith(original, { writeFails = true }).shutdown()
+
+			assert.are.equal(original, result.disk[BLUEPRINT_PATH])
+			assert.is_nil(result.disk[PENDING_PATH])
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.save_failed"))
+		end)
+
+		it("leaves the previous file alone when it cannot be opened for writing", function()
+			local original = fileWith(blueprintEntry("", "armmex"))
+			local result = loadWith(original, { openFails = true }).shutdown()
+
+			assert.are.equal(original, result.disk[BLUEPRINT_PATH])
+			assert.is_not_nil(echoMatching(result, "ui.blueprint.save_failed"))
+		end)
+
+		it("writes blueprints it could not use back unchanged", function()
+			local result = loadWith(fileWith(blueprintEntry("junk", "notaunit"))).shutdown()
+			local saved = result.saved()
+
+			assert.are.equal(1, #saved)
+			assert.are.equal("junk", saved[1].name)
+			assert.are.equal("notaunit", saved[1].units[1].unitName)
+		end)
+	end)
+
+	describe("the strings it prints", function()
+		it("has an English entry for every key the widget uses", function()
+			local file = assert(io.open("language/en/interface.json", "r"))
+			local interface = Json.decode(file:read("*a"))
+			file:close()
+			local blueprint = interface.ui.blueprint
+
+			for _, key in ipairs({ "section", "entry_kept", "file_damaged", "save_failed" }) do
+				assert.is_string(blueprint[key], key)
+			end
+		end)
+	end)
+end)

--- a/spec/luaui/Widgets/cmd_blueprint_load_spec.lua
+++ b/spec/luaui/Widgets/cmd_blueprint_load_spec.lua
@@ -314,6 +314,41 @@ describe("cmd_blueprint blueprints.json", function()
 			assert.are.same({ 1, 2 }, result.shutdown().saved())
 		end)
 
+		it("closes a gap left by a null, keeping what is past it", function()
+			local result = loadWith('{"savedBlueprints":[{"name":"a","units":[]},null,{"name":"c","units":[]}]}')
+
+			assert.is_true(result.ok, result.err)
+
+			local saved = result.shutdown().saved()
+
+			assert.are.equal(2, #saved)
+			assert.are.equal("a", saved[1].name)
+			assert.are.equal("c", saved[2].name)
+		end)
+
+		it("keeps blueprints in the order the file had them", function()
+			local result = loadWith(
+				fileWith(
+					blueprintEntry("first", "armmex"),
+					blueprintEntry("second", "armsolar"),
+					blueprintEntry("third", "armmex")
+				)
+			)
+
+			local saved = result.shutdown().saved()
+
+			assert.are.equal("first", saved[1].name)
+			assert.are.equal("second", saved[2].name)
+			assert.are.equal("third", saved[3].name)
+		end)
+
+		it("accepts a null at the end of the list, which holds nothing", function()
+			local result = loadWith('{"savedBlueprints":[{"name":"a","units":[]},null]}')
+
+			assert.is_true(result.ok, result.err)
+			assert.are.equal(1, #result.shutdown().saved())
+		end)
+
 		it("keeps an escaped forward slash in a name (regression, #8666)", function()
 			local result = loadWith([[{"savedBlueprints":[{"name":"eco\/lab","units":[]}]}]])
 


### PR DESCRIPTION
### Work done

User logs are full of blueprints errors. That is bad.

This stops blueprints getting deleted all over, and adds some more logging, while reducing the logging noise. It adds the basic code I'd use to set up a repair shop, the "doctor", which tries to make user blueprints usable across e.g. modoptions and whatever else.

Also added a layer of safety, .pending and .backup, for handling in-progress writes and rejected files, and checks for gaps in the blueprint entries (and actually does mend these, at the moment, though incompletely).

This has planned work, so added specs.

### Addresses issue(s)

Fixes any bad blueprint bringing down the blueprints widget.

Fixes odd edges erasing the user's blueprints file.

Handles blueprints specs not actually exercising any load steps.

### Future work

Plan is to add repairs to the json doctor:

- object <--> list swaps in the json (we love json, folks)
- typed: name, spacing, facing, ordered
- clamp facing 0 to 3
- typed position "x,y,z" rewritten as x, y, z fields
- remove unsalvageable units(?) unclear, modded/tweaked units should be fine, and recently-deprecated units often survive in user tweaks for a long time
- utf-8 BOM, leading whitespace, trailing garbage
- line comments `//`
- curly quotes from chat client grr why
- unescaped backslashes, currently silently eaten (oh god), which is the worst possible handling lmao, `C:\users\whoiam` loads as `C:Userswhoiam`, awful
- idk