### PR TITLE
Attack/Set Target: Fix units ignoring Attack command after Set Target done

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -260,6 +260,22 @@ if gadgetHandler:IsSyncedCode() then
 		return bit_and(cmdOptions, OPT_INTERNAL) ~= 0
 	end
 
+	local function releaseTargetOverride(unitID)
+		local inCommand, options, _, param1, param2, param3 = spGetUnitCurrentCommand(unitID)
+		if inCommand == CMD_ATTACK then
+			local userTarget = not hasAutoTarget(options)
+			if param2 then
+				spSetUnitTarget(unitID, param1, param2, param3, false, userTarget)
+			elseif spValidUnitID(param1) then
+				spSetUnitTarget(unitID, param1, false, userTarget)
+			else
+				spSetUnitTarget(unitID, nil)
+			end
+		elseif not inCommand or not isAttackCommand[inCommand] then
+			spSetUnitTarget(unitID, nil)
+		end
+	end
+
 	local function hasUserTarget(unitID, unitData)
 		for weaponNum, check in pairs(unitData.weapons) do
 			if check then
@@ -361,7 +377,9 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function removeUnit(unitID, keeptrack)
-		if activeTargets[unitID] and not inAttackCommand(unitID) then
+		if not keeptrack and setTargetData[unitID] then
+			releaseTargetOverride(unitID)
+		elseif activeTargets[unitID] and not inAttackCommand(unitID) then
 			spSetUnitTarget(unitID, nil)
 		end
 		activeTargets[unitID] = nil

--- a/luaui/Tests/set_target/test_attack_target_restored.lua
+++ b/luaui/Tests/set_target/test_attack_target_restored.lua
@@ -1,0 +1,118 @@
+local function skip()
+	return Spring.GetGameFrame() <= 0
+		or select(1, Spring.GetTeamInfo(1, false)) == nil
+		or Game.mapName ~= "All That Glitters v2.2.3"
+end
+
+local function setup()
+	SyncedRun(function()
+		for _, unitID in ipairs(Spring.GetAllUnits()) do
+			if Spring.GetUnitTeam(unitID) ~= 1 then
+				Spring.DestroyUnit(unitID, false, true)
+			else
+				Spring.SetUnitNoSelect(unitID, true)
+				Spring.SetUnitNoDraw(unitID, true)
+			end
+		end
+		for _, featureID in ipairs(Spring.GetAllFeatures()) do
+			Spring.DestroyFeature(featureID)
+		end
+	end)
+	Spring.SendCommands("setspeed 5")
+end
+
+local function cleanup()
+	Spring.SendCommands("setspeed 1")
+	Test.clearMap()
+end
+
+local function createScenario()
+	local enemyTeamID = 1
+	local function createUnit(name, x, z, teamID)
+		local y = Spring.GetGroundHeight(x, z)
+		return assert(Spring.CreateUnit(name, x, y, z, "south", teamID))
+	end
+
+	local agitatorID = createUnit("corpun", 736, 3952, 0)
+	local tickIDs = {
+		createUnit("armflea", 621, 4471, enemyTeamID),
+		createUnit("armflea", 893, 4478, enemyTeamID),
+		createUnit("armflea", 986, 4479, enemyTeamID),
+		createUnit("armflea", 718, 4474, enemyTeamID),
+		createUnit("armflea", 790, 4480, enemyTeamID),
+	}
+	local fatboyID = createUnit("armfboy", 827, 4824, enemyTeamID)
+	local allUnits = { agitatorID, fatboyID, unpack(tickIDs) }
+	Spring.GiveOrderToUnitArray(allUnits, CMD.FIRE_STATE, { CMD.FIRESTATE_HOLDFIRE }, 0)
+	Spring.GiveOrderToUnitArray(allUnits, CMD.MOVE_STATE, { 0 }, 0)
+
+	return agitatorID, tickIDs[1], tickIDs[2], tickIDs[3], tickIDs[4], tickIDs[5], fatboyID
+end
+
+local function test()
+	local agitatorID, tick1, tick2, tick3, tick4, tick5, fatboyID = SyncedRun(createScenario)
+	local tickIDs = { tick1, tick2, tick3, tick4, tick5 }
+	local tickLookup = {}
+	for _, tickID in ipairs(tickIDs) do
+		assert(Spring.ValidUnitID(tickID), "Tick was not created at the replay position")
+		tickLookup[tickID] = true
+	end
+	assert(Spring.ValidUnitID(agitatorID), "Agitator was not created at the replay position")
+	assert(Spring.ValidUnitID(fatboyID), "Fatboy was not created at the replay position")
+	local targetY = Spring.GetGroundHeight(800, 4476)
+	Spring.GiveOrderToUnit(agitatorID, GameCMD.UNIT_SET_TARGET, { 800, targetY, 4476, 240 }, 0)
+	local function hasTickWeaponTarget()
+		for weaponNum = 1, 2 do
+			local targetType, _, targetID = Spring.GetUnitWeaponTarget(agitatorID, weaponNum)
+			if targetType == 1 and tickLookup[targetID] then
+				return true
+			end
+		end
+		return false
+	end
+	Test.waitUntil(function()
+		return hasTickWeaponTarget()
+	end, 90)
+	Spring.GiveOrderToUnit(agitatorID, CMD.ATTACK, { fatboyID }, 0)
+	Test.waitFrames(30)
+	assert(hasTickWeaponTarget(), "Set Target did not retain precedence over Attack")
+	Test.waitUntil(function()
+		for _, tickID in ipairs(tickIDs) do
+			if Spring.ValidUnitID(tickID) and not Spring.GetUnitIsDead(tickID) then
+				return false
+			end
+		end
+		return true
+	end, 1200)
+
+	Test.waitFrames(30)
+	local commandID, _, _, commandTargetID = Spring.GetUnitCurrentCommand(agitatorID)
+	local targetType1, _, targetID1 = Spring.GetUnitWeaponTarget(agitatorID, 1)
+	local targetType2, _, targetID2 = Spring.GetUnitWeaponTarget(agitatorID, 2)
+	local fatboyValid = Spring.ValidUnitID(fatboyID)
+	local fatboyDead = fatboyValid and Spring.GetUnitIsDead(fatboyID)
+	local fatboyHealth = fatboyValid and Spring.GetUnitHealth(fatboyID)
+	assert(
+		(targetType1 == 1 and targetID1 == fatboyID) or (targetType2 == 1 and targetID2 == fatboyID),
+		string.format(
+			"Agitator did not resume Fatboy target %d (valid %s, dead %s, health %s): command %s target %s, weapon targets %s/%s and %s/%s",
+			fatboyID,
+			tostring(fatboyValid),
+			tostring(fatboyDead),
+			tostring(fatboyHealth),
+			tostring(commandID),
+			tostring(commandTargetID),
+			tostring(targetType1),
+			tostring(targetID1),
+			tostring(targetType2),
+			tostring(targetID2)
+		)
+	)
+end
+
+return {
+	skip = skip,
+	setup = setup,
+	test = test,
+	cleanup = cleanup,
+}

--- a/luaui/Tests/set_target/test_attack_target_restored.lua
+++ b/luaui/Tests/set_target/test_attack_target_restored.lua
@@ -1,23 +1,9 @@
 local function skip()
-	return Spring.GetGameFrame() <= 0
-		or select(1, Spring.GetTeamInfo(1, false)) == nil
-		or Game.mapName ~= "All That Glitters v2.2.3"
+	return Spring.GetGameFrame() <= 0 or select(1, Spring.GetTeamInfo(1, false)) == nil
 end
 
 local function setup()
-	SyncedRun(function()
-		for _, unitID in ipairs(Spring.GetAllUnits()) do
-			if Spring.GetUnitTeam(unitID) ~= 1 then
-				Spring.DestroyUnit(unitID, false, true)
-			else
-				Spring.SetUnitNoSelect(unitID, true)
-				Spring.SetUnitNoDraw(unitID, true)
-			end
-		end
-		for _, featureID in ipairs(Spring.GetAllFeatures()) do
-			Spring.DestroyFeature(featureID)
-		end
-	end)
+	Test.clearMap()
 	Spring.SendCommands("setspeed 5")
 end
 
@@ -26,88 +12,84 @@ local function cleanup()
 	Test.clearMap()
 end
 
-local function createScenario()
-	local enemyTeamID = 1
-	local function createUnit(name, x, z, teamID)
-		local y = Spring.GetGroundHeight(x, z)
-		return assert(Spring.CreateUnit(name, x, y, z, "south", teamID))
+local function createScenarios()
+	return SyncedRun(function()
+		local centerX = Game.mapSizeX / 2
+		local centerZ = Game.mapSizeZ / 2
+		local function createUnit(name, xOffset, zOffset, teamID)
+			local x = centerX + xOffset
+			local z = centerZ + zOffset
+			local y = Spring.GetGroundHeight(x, z)
+			return assert(Spring.CreateUnit(name, x, y, z, "south", teamID))
+		end
+		local function createScenario(attackerName, zOffset)
+			return {
+				attackerID = createUnit(attackerName, 0, zOffset, 0),
+				setTargetID = createUnit("armflea", -250, zOffset, 1),
+				attackTargetID = createUnit("armflea", 250, zOffset, 1),
+			}
+		end
+
+		local scenarios = {
+			createScenario("corpun", -600),
+			createScenario("armfboy", 600),
+		}
+		local allUnits = {}
+		for _, scenario in ipairs(scenarios) do
+			allUnits[#allUnits + 1] = scenario.attackerID
+			allUnits[#allUnits + 1] = scenario.setTargetID
+			allUnits[#allUnits + 1] = scenario.attackTargetID
+		end
+		Spring.GiveOrderToUnitArray(allUnits, CMD.FIRE_STATE, { CMD.FIRESTATE_HOLDFIRE }, 0)
+		Spring.GiveOrderToUnitArray(allUnits, CMD.MOVE_STATE, { 0 }, 0)
+
+		return scenarios
+	end)
+end
+
+local function hasWeaponTarget(unitID, expectedTargets)
+	local unitDefID = Spring.GetUnitDefID(unitID)
+	for weaponNum = 1, #UnitDefs[unitDefID].weapons do
+		local targetType, isUserTarget, targetID = Spring.GetUnitWeaponTarget(unitID, weaponNum)
+		if targetType == 1 and isUserTarget and expectedTargets[targetID] then
+			return true
+		end
 	end
+	return false
+end
 
-	local agitatorID = createUnit("corpun", 736, 3952, 0)
-	local tickIDs = {
-		createUnit("armflea", 621, 4471, enemyTeamID),
-		createUnit("armflea", 893, 4478, enemyTeamID),
-		createUnit("armflea", 986, 4479, enemyTeamID),
-		createUnit("armflea", 718, 4474, enemyTeamID),
-		createUnit("armflea", 790, 4480, enemyTeamID),
-	}
-	local fatboyID = createUnit("armfboy", 827, 4824, enemyTeamID)
-	local allUnits = { agitatorID, fatboyID, unpack(tickIDs) }
-	Spring.GiveOrderToUnitArray(allUnits, CMD.FIRE_STATE, { CMD.FIRESTATE_HOLDFIRE }, 0)
-	Spring.GiveOrderToUnitArray(allUnits, CMD.MOVE_STATE, { 0 }, 0)
+local function hasAttackCommand(unitID, expectedTargetID)
+	local commandID, _, _, commandTargetID = Spring.GetUnitCurrentCommand(unitID)
+	return commandID == CMD.ATTACK and commandTargetID == expectedTargetID
+end
 
-	return agitatorID, tickIDs[1], tickIDs[2], tickIDs[3], tickIDs[4], tickIDs[5], fatboyID
+local function testAttackHandoff(scenario)
+	local setTargets = { [scenario.setTargetID] = true }
+
+	Spring.GiveOrderToUnit(scenario.attackerID, GameCMD.UNIT_SET_TARGET, { scenario.setTargetID }, 0)
+	Test.waitUntil(function()
+		return hasWeaponTarget(scenario.attackerID, setTargets)
+	end, 90)
+
+	Spring.GiveOrderToUnit(scenario.attackerID, CMD.ATTACK, { scenario.attackTargetID }, 0)
+	Test.waitUntil(function()
+		return hasAttackCommand(scenario.attackerID, scenario.attackTargetID)
+			and hasWeaponTarget(scenario.attackerID, setTargets)
+	end, 90)
+
+	Test.waitUntil(function()
+		return Spring.GetUnitIsDead(scenario.setTargetID) ~= false
+	end, 1200)
+
+	Test.waitUntil(function()
+		return Spring.GetUnitIsDead(scenario.attackTargetID) ~= false
+	end, 1200)
 end
 
 local function test()
-	local agitatorID, tick1, tick2, tick3, tick4, tick5, fatboyID = SyncedRun(createScenario)
-	local tickIDs = { tick1, tick2, tick3, tick4, tick5 }
-	local tickLookup = {}
-	for _, tickID in ipairs(tickIDs) do
-		assert(Spring.ValidUnitID(tickID), "Tick was not created at the replay position")
-		tickLookup[tickID] = true
+	for _, scenario in ipairs(createScenarios()) do
+		testAttackHandoff(scenario)
 	end
-	assert(Spring.ValidUnitID(agitatorID), "Agitator was not created at the replay position")
-	assert(Spring.ValidUnitID(fatboyID), "Fatboy was not created at the replay position")
-	local targetY = Spring.GetGroundHeight(800, 4476)
-	Spring.GiveOrderToUnit(agitatorID, GameCMD.UNIT_SET_TARGET, { 800, targetY, 4476, 240 }, 0)
-	local function hasTickWeaponTarget()
-		for weaponNum = 1, 2 do
-			local targetType, _, targetID = Spring.GetUnitWeaponTarget(agitatorID, weaponNum)
-			if targetType == 1 and tickLookup[targetID] then
-				return true
-			end
-		end
-		return false
-	end
-	Test.waitUntil(function()
-		return hasTickWeaponTarget()
-	end, 90)
-	Spring.GiveOrderToUnit(agitatorID, CMD.ATTACK, { fatboyID }, 0)
-	Test.waitFrames(30)
-	assert(hasTickWeaponTarget(), "Set Target did not retain precedence over Attack")
-	Test.waitUntil(function()
-		for _, tickID in ipairs(tickIDs) do
-			if Spring.ValidUnitID(tickID) and not Spring.GetUnitIsDead(tickID) then
-				return false
-			end
-		end
-		return true
-	end, 1200)
-
-	Test.waitFrames(30)
-	local commandID, _, _, commandTargetID = Spring.GetUnitCurrentCommand(agitatorID)
-	local targetType1, _, targetID1 = Spring.GetUnitWeaponTarget(agitatorID, 1)
-	local targetType2, _, targetID2 = Spring.GetUnitWeaponTarget(agitatorID, 2)
-	local fatboyValid = Spring.ValidUnitID(fatboyID)
-	local fatboyDead = fatboyValid and Spring.GetUnitIsDead(fatboyID)
-	local fatboyHealth = fatboyValid and Spring.GetUnitHealth(fatboyID)
-	assert(
-		(targetType1 == 1 and targetID1 == fatboyID) or (targetType2 == 1 and targetID2 == fatboyID),
-		string.format(
-			"Agitator did not resume Fatboy target %d (valid %s, dead %s, health %s): command %s target %s, weapon targets %s/%s and %s/%s",
-			fatboyID,
-			tostring(fatboyValid),
-			tostring(fatboyDead),
-			tostring(fatboyHealth),
-			tostring(commandID),
-			tostring(commandTargetID),
-			tostring(targetType1),
-			tostring(targetID1),
-			tostring(targetType2),
-			tostring(targetID2)
-		)
-	)
 end
 
 return {

--- a/luaui/Tests/set_target/test_clear_target_attack_handoff.lua
+++ b/luaui/Tests/set_target/test_clear_target_attack_handoff.lua
@@ -1,0 +1,77 @@
+local function skip()
+	return Spring.GetGameFrame() <= 0
+		or select(1, Spring.GetTeamInfo(1, false)) == nil
+		or Game.mapName ~= "All That Glitters v2.2.3"
+end
+
+local function setup()
+	Test.clearMap()
+	Spring.SendCommands("setspeed 5")
+end
+
+local function cleanup()
+	Spring.SendCommands("setspeed 1")
+	Test.clearMap()
+end
+
+local function createScenario()
+	local gauntletID = assert(Spring.CreateUnit("corpun", 721, 515, 3945, "south", 0))
+	local fatboyID = assert(Spring.CreateUnit("armfboy", 991, 224, 4174, "south", 1))
+
+	Spring.GiveOrderToUnit(gauntletID, CMD.FIRE_STATE, { CMD.FIRESTATE_HOLDFIRE }, 0)
+	Spring.GiveOrderToUnit(fatboyID, CMD.MOVE, { 1039.68, 221.86, 4209.592, 1051.112, 0, 4240.067 }, CMD.OPT_ALT)
+	Spring.GiveOrderToUnit(fatboyID, CMD.MOVE_STATE, { 2 }, 0)
+	Spring.GiveOrderToUnit(fatboyID, CMD.MOVE_STATE, { 0 }, 0)
+	Spring.GiveOrderToUnit(fatboyID, CMD.FIRE_STATE, { CMD.FIRESTATE_HOLDFIRE }, 0)
+
+	return gauntletID, fatboyID
+end
+
+local function test()
+	local gauntletID, fatboyID = SyncedRun(createScenario)
+	local targetX, targetY, targetZ = 712.059, 199.503, 4978.311
+
+	local function targetsSetPosition()
+		for weaponNum = 1, 2 do
+			local targetType, _, target = Spring.GetUnitWeaponTarget(gauntletID, weaponNum)
+			---@cast targetType integer
+			---@cast target float3
+			if targetType == 2 and math.abs(target[1] - targetX) < 1 and math.abs(target[3] - targetZ) < 1 then
+				return true
+			end
+		end
+		return false
+	end
+
+	local function targetsFatboy()
+		for weaponNum = 1, 2 do
+			local targetType, _, targetID = Spring.GetUnitWeaponTarget(gauntletID, weaponNum)
+			---@cast targetType integer
+			---@cast targetID integer
+			if targetType == 1 and targetID == fatboyID then
+				return true
+			end
+		end
+		return false
+	end
+
+	Spring.GiveOrderToUnit(gauntletID, GameCMD.UNIT_SET_TARGET, { targetX, targetY, targetZ, 0 }, 0)
+	Test.waitUntil(targetsSetPosition, 90)
+	Test.waitFrames(178)
+	Spring.GiveOrderToUnit(gauntletID, CMD.ATTACK, { fatboyID }, 0)
+	Test.waitFrames(241)
+	-- The Set Target may stay listed; the Attack target must be engaged while both are present.
+	assert(targetsFatboy(), "Attack order did not make the Gauntlet engage the Fatboy")
+
+	Spring.GiveOrderToUnit(gauntletID, GameCMD.UNIT_CANCEL_TARGET, {}, 0)
+	Test.waitUntil(targetsFatboy, 90)
+
+	local commandID, _, _, commandTargetID = Spring.GetUnitCurrentCommand(gauntletID)
+	assert(commandID == CMD.ATTACK and commandTargetID == fatboyID, "Clear Target changed the current Attack command")
+	for _ = 1, 300 do
+		Test.waitFrames(1)
+		assert(not targetsSetPosition(), "Gauntlet resumed shooting the cleared Set Target position")
+	end
+end
+
+return { skip = skip, setup = setup, test = test, cleanup = cleanup }


### PR DESCRIPTION
Superseded by https://github.com/beyond-all-reason/Beyond-All-Reason/pull/9124 which fixes the command priority

Fixes #8983
Fixes #9012

## Summary
- restore the queued Attack target after the final Set Target entry is removed (e.g. due to Clear Target or all Set Targets dead)
- preserve Set Target precedence while its target list is only paused
- add a minimal All That Glitters regression test using the replay positions for one Agitator, five Ticks, and one Fatboy

## Validation
- regression test fails on master for #8983: Attack command still targets the Fatboy, but both weapon targets are nil
- regression test fails on master for #9012: Attack command still targets the Fatboy, but unit is still shooting at ground
- regression tests pass with this change
- stylua --check
- Lua syntax checks
- git diff --check