### PR TITLE
ci: fetch lx as a release tarball, back on ubuntu-latest

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -9,51 +9,35 @@ on:
 jobs:
   busted:
     runs-on: ubuntu-latest
-    container:
-      # The `env`/`steps` contexts are not available in `container.image`
-      # (it's evaluated before the job's steps run), so the version is the
-      # one literal here. The cache key derives its version from the running
-      # container instead (see the "Detect Fedora version" step), so the two
-      # can never disagree.
-      image: fedora:43
 
     steps:
     - uses: actions/checkout@v5
 
-    - name: Detect Fedora version
-      id: fedora
-      run: echo "version=$(rpm -E %fedora)" >> "$GITHUB_OUTPUT"
-
-    - name: Install build deps + Lua 5.1
+    - name: Install Lua 5.1
       run: |
-        # Fedora 43's `lua` package is 5.4; the 5.1 interpreter ships
-        # under the compat-lua* names (matches BAR-Devtools' dev image).
-        dnf install -y --setopt=install_weak_deps=False \
-          git gcc gcc-c++ make \
-          compat-lua compat-lua-devel \
-          gpgme
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends lua5.1 liblua5.1-0-dev
 
-    - name: Install Lux via cargo-binstall
+    - name: Install Lux
+      env:
+        LUX_VERSION: '0.28.3'
       run: |
-        # GHA containers map $HOME to /github/home (not /root), so the
-        # cargo-binstall self-install lands at $HOME/.cargo/bin -- can't
-        # hardcode /root/.cargo/bin like the local Containerfile does.
+        # Fetch the prebuilt `lx` straight from the release page. Resolving
+        # it through cargo-binstall (or the lux action) goes via the GitHub
+        # API, which sporadically rate-limits unauthenticated runners;
+        # release downloads don't count against that limit.
         curl -L --proto '=https' --tlsv1.2 -sSf \
-          https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
-          | bash
-        "$HOME/.cargo/bin/cargo-binstall" --no-confirm \
-          --version 0.28.3 \
-          --install-path /usr/local/bin \
-          lux-cli
-        ln -sf /usr/bin/lua-5.1 /usr/local/bin/lua
+          "https://github.com/nvim-neorocks/lux/releases/download/v${LUX_VERSION}/lx-x86_64-unknown-linux-gnu.tar.gz" \
+          | sudo tar -xz -C /usr/local/bin lx
+        lx --version
 
     - name: Cache Lux dependencies
       uses: actions/cache@v4
       with:
         path: .lux
-        key: lux-5.1-fedora${{ steps.fedora.outputs.version }}-${{ hashFiles('lux.lock') }}
+        key: lux-5.1-${{ runner.os }}-${{ hashFiles('lux.lock') }}
         restore-keys: |
-          lux-5.1-fedora${{ steps.fedora.outputs.version }}-
+          lux-5.1-${{ runner.os }}-
 
     - name: Run busted
       run: lx --lua-version 5.1 test


### PR DESCRIPTION
The unit test job has been sporadically failing on cargo-binstall rate limits. binstall resolves the `lux-cli` asset through the GitHub API, which is rate-limited for unauthenticated runners; the pinned release tarball (`lx-x86_64-unknown-linux-gnu.tar.gz`) is a plain download and isn't. Presumably, Lux fixed whatever was causing this version to fail originally.

With binstall gone there is no reason for the fedora container either — it only existed to host it — so the job is back on `ubuntu-latest` with apt's `lua5.1`, like every other job. Same `lx` 0.28.3 (they're up to 0.44 so that's probably worth a bump but I'm out of patience today), same test command; the `.lux` cache key returns to `lux-5.1-${{ runner.os }}-<lux.lock hash>`.

Green on my fork: https://github.com/keithharvey/bar/actions/runs/33267911114 (165 successes / 0 failures / 0 errors / 1 pending).

### LLM Disclosure
Fable