### PR TITLE
Update faction selection text

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -929,8 +929,8 @@
 			"factions": {
 				"arm": "Outsmart your foes with tactical finesse",
 				"cor": "Smash your foes with brute force",
-				"leg": "Overwhelm your foes with rapid assault tactics",
-				"random": "Picks a Random out of the available options"
+				"leg": "Swarm your foes with overwhelming numbers",
+				"random": "Picks a random faction out of the available options"
 			}
 		},
 		"widgetselector": {


### PR DESCRIPTION
This updates the legion text to the website text, and fixes the text for the random faction. I know it's minor, but I keep being annoyed by it.

