### PR TITLE
Addon type: name string? => name string

### DIFF
--- a/types/Addon.lua
+++ b/types/Addon.lua
@@ -9,7 +9,7 @@ local Addon = {}
 function Addon:GetInfo() end
 
 ---@class AddonInfo
----@field name string?
+---@field name string
 ---@field desc string?
 ---@field author string?
 ---@field date string?


### PR DESCRIPTION
All our logging that uses gadget:GetInfo().name has the same emmylua warn, so this cuts out a lot of emmylua warnings. We do in fact require `name`.