### PR TITLE
fix: prevent user data loss, add file reader/writers with some basic data safety baked in

### DIFF
--- a/common/json_doctor.lua
+++ b/common/json_doctor.lua
@@ -1,0 +1,161 @@
+-- json_doctor.lua ---------------------------------------------------------------
+-- Reads and writes a JSON file holding a list of records under one named key.
+--
+-- The list is the part worth having help with. A JSON null decodes to a gap, and
+-- ipairs stops at the first gap, so a list read with ipairs can silently end early
+-- and then be written back that short. Reading the whole list and closing the gaps
+-- is what this does, along with saying whether the file can be written back at all.
+--
+-- It knows nothing about what the records are. Deciding whether one is usable, and
+-- what to tell anyone about it, belongs to the caller.
+----------------------------------------------------------------------------------
+
+local UserFile = VFS.Include("common/user_files.lua")
+if not UserFile then
+	return
+end
+
+local Json = Json or VFS.Include("common/luaUtilities/json.lua")
+if not Json then
+	return
+end
+
+local UserFileRead = UserFile.Read
+local UserFileWrite = UserFile.Write
+local USERFILE_OK = UserFile.OK
+local USERFILE_ABSENT = UserFile.ABSENT
+local USERFILE_DAMAGED = UserFile.DAMAGED
+
+---The four lists below are read in pairs: `entries[i]` sit at `entryIndices[i]`.
+---@class JsonDoctorReading
+---@field status "ok"|"absent"|"damaged"
+---@field entries table[] the records, in file order and without gaps
+---@field entryIndices number[] where each record sat in the file
+---@field setAside any[] list items that are not records, kept verbatim
+---@field setAsideIndices number[] where each of those sat in the file
+---@field repairs string[] what had to be put right to read the list
+---@field document table everything in the file that is not the list
+
+---A null in the list left a gap, and the items past it were closed back up.
+local REPAIR_GAP = "gap"
+
+---Reads the list stored under `listKey`.
+---
+---A `damaged` file holds records we could not read so will refuse to rewrite.
+---An `absent` file does not check for backups and allows writing to the path.
+---@param path string
+---@param listKey string the key the list is stored under
+---@return JsonDoctorReading
+local function read(path, listKey)
+	---@type JsonDoctorReading
+	local reading = {
+		status = USERFILE_ABSENT,
+		entries = {},
+		entryIndices = {},
+		setAside = {},
+		setAsideIndices = {},
+		repairs = {},
+		document = {},
+	}
+
+	local decoded, status = UserFileRead(path, Json.decode)
+
+	if status == USERFILE_ABSENT then
+		return reading
+	end
+
+	if status == USERFILE_DAMAGED or type(decoded) ~= "table" then
+		reading.status = USERFILE_DAMAGED
+		return reading
+	end
+
+	local list = decoded[listKey]
+
+	-- A file with no list in it is not damaged, just a file with no entries;
+	-- it could contain other keys, hold other lists, or just be an empty doc.
+	if list == nil then
+		list = {}
+	end
+
+	if type(list) ~= "table" then
+		reading.status = USERFILE_DAMAGED
+		return reading
+	end
+
+	-- Never throw away the non-list contents of the file.
+	decoded[listKey] = nil
+	reading.document = decoded
+
+	local count, highestIndex = 0, 0
+	for key in pairs(list) do
+		count = count + 1
+		if type(key) == "number" and key > highestIndex then
+			highestIndex = math.floor(key)
+		end
+	end
+
+	if count > highestIndex then
+		reading.status = USERFILE_DAMAGED
+		return reading
+	end
+
+	if count < highestIndex then
+		reading.repairs[#reading.repairs + 1] = REPAIR_GAP
+	end
+
+	for i = 1, highestIndex do
+		local item = list[i]
+		if item == nil then
+			-- gap in a list
+		elseif type(item) == "table" then
+			reading.entries[#reading.entries + 1] = item
+			reading.entryIndices[#reading.entryIndices + 1] = i
+		else
+			reading.setAside[#reading.setAside + 1] = item
+			reading.setAsideIndices[#reading.setAsideIndices + 1] = i
+		end
+	end
+
+	reading.status = USERFILE_OK
+
+	return reading
+end
+
+---Writes the list back into the file the reading came from.
+---@param path string
+---@param listKey string
+---@param entries any[] everything to write, including items that were set aside
+---@param reading JsonDoctorReading the reading this write follows
+---@return boolean written
+local function write(path, listKey, entries, reading)
+	-- Write operations take a "reading" rather than a status so there's no way
+	-- to ask to write without having looked at the file. This is inconvenient,
+	-- but we are in unsynced and possibly in widget space where user code roams.
+	if type(reading) ~= "table" or reading.status == nil then
+		Spring.Log("json_doctor", LOG.ERROR, "Writing " .. path .. " without a reading of it.")
+		return false
+	end
+
+	if reading.status ~= USERFILE_OK and reading.status ~= USERFILE_ABSENT then
+		return false
+	end
+
+	local document = reading.document
+	document[listKey] = entries
+
+	local success, text = pcall(Json.encode, document)
+	if not success or type(text) ~= "string" then
+		return false
+	end
+
+	return UserFileWrite(path, text)
+end
+
+return {
+	Read = read,
+	Write = write,
+	OK = USERFILE_OK,
+	ABSENT = USERFILE_ABSENT,
+	DAMAGED = USERFILE_DAMAGED,
+	REPAIR_GAP = REPAIR_GAP,
+}

--- a/common/luaUtilities/json.lua
+++ b/common/luaUtilities/json.lua
@@ -22,7 +22,7 @@
 --   0.9.50.1 BAR changes by Beherith: fix issue when decoding empty arrays.
 --	 0.9.50 Radical performance improvement on decode from Eike Decker. Many thanks!
 --	 0.9.40 Changed licence to MIT License (MIT)
---   0.9.20 Introduction of local Lua functions for private functions (removed _ function prefix). 
+--   0.9.20 Introduction of local Lua functions for private functions (removed _ function prefix).
 --          Fixed Lua 5.1 compatibility issues.
 --   		Introduced json.null to have null values in associative arrays.
 --          encode() performance improvement (more than 50%) through table.concat rather than ..
@@ -63,55 +63,54 @@ end
 --- Encodes an arbitrary Lua object / variable.
 -- @param v The Lua object / variable to be JSON encoded.
 -- @return String containing the JSON encoding in internal Lua string format (i.e. not unicode)
-local function encode (v)
+local function encode(v)
 	-- Handle nil values
-	if v==nil then
-	return "null"
+	if v == nil then
+		return "null"
 	end
-	
-	local vtype = base.type(v)  
+
+	local vtype = base.type(v)
 
 	-- Handle strings
-	if vtype=='string' then    
-	return '"' .. encodeString(v) .. '"'	    -- Need to handle encoding in string
+	if vtype == "string" then
+		return '"' .. encodeString(v) .. '"' -- Need to handle encoding in string
 	end
-	
-	-- Handle booleans
-	if vtype=='number' or vtype=='boolean' then
-	return base.tostring(v)
-	end
-	
-	-- Handle tables
-	if vtype=='table' then
-	local rval = {}
-	-- Consider arrays separately
-	local bArray, maxCount = isArray(v)
-	if bArray then
-		for i = 1,maxCount do
-		table.insert(rval, encode(v[i]))
-		end
-	else	-- An object, not an array
-		for i,j in base.pairs(v) do
-		if isEncodable(i) and isEncodable(j) then
-			table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
-		end
-		end
-	end
-	if bArray then
-		return '[' .. table.concat(rval,',') ..']'
-	else
-		return '{' .. table.concat(rval,',') .. '}'
-	end
-	end
-	
-	-- Handle null values
-	if vtype=='function' and v==null then
-	return 'null'
-	end
-	
-	base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
-end
 
+	-- Handle booleans
+	if vtype == "number" or vtype == "boolean" then
+		return base.tostring(v)
+	end
+
+	-- Handle tables
+	if vtype == "table" then
+		local rval = {}
+		-- Consider arrays separately
+		local bArray, maxCount = isArray(v)
+		if bArray then
+			for i = 1, maxCount do
+				table.insert(rval, encode(v[i]))
+			end
+		else -- An object, not an array
+			for i, j in base.pairs(v) do
+				if isEncodable(i) and isEncodable(j) then
+					table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
+				end
+			end
+		end
+		if bArray then
+			return "[" .. table.concat(rval, ",") .. "]"
+		else
+			return "{" .. table.concat(rval, ",") .. "}"
+		end
+	end
+
+	-- Handle null values
+	if vtype == "function" and v == null then
+		return "null"
+	end
+
+	base.assert(false, "encode attempt to encode unsupported type " .. vtype .. ":" .. base.tostring(v))
+end
 
 -- A code point as the Lua decimal escapes for its UTF-8 bytes, so the result survives
 -- being handed to loadstring below. Always three digits, or a digit following in the
@@ -125,8 +124,12 @@ local function utf8Escapes(code)
 	elseif code < 0x10000 then
 		bytes = { 0xE0 + math.floor(code / 0x1000), 0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40 }
 	else
-		bytes = { 0xF0 + math.floor(code / 0x40000), 0x80 + math.floor(code / 0x1000) % 0x40,
-			0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40 }
+		bytes = {
+			0xF0 + math.floor(code / 0x40000),
+			0x80 + math.floor(code / 0x1000) % 0x40,
+			0x80 + math.floor(code / 0x40) % 0x40,
+			0x80 + code % 0x40,
+		}
 	end
 
 	for i = 1, #bytes do
@@ -210,19 +213,20 @@ end
 -- This just involves back-quoting inverted commas, back-quotes and newlines, I think ;-)
 -- @param s The string to return as a JSON encoded (i.e. backquoted string)
 -- @return The string appropriately escaped.
-local qrep = {["\\"]="\\\\", ['"']='\\"',['\b']='\\b',['\f']='\\f',['\n']='\\n',['\r']='\\r',['\t']='\\t'}
+local qrep =
+	{ ["\\"] = "\\\\", ['"'] = '\\"', ["\b"] = "\\b", ["\f"] = "\\f", ["\n"] = "\\n", ["\r"] = "\\r", ["\t"] = "\\t" }
 
 -- Writing control characters produces a broken file unless properly escaped.
 -- All shorthand escapes are listed above; the rest must encode into \uXXXX,
 -- which we also decode on the way in to keep a single properly copied json.
-for byte=0,0x1f do
+for byte = 0, 0x1f do
 	local char = string.char(byte)
 	if not qrep[char] then
-	qrep[char] = string.format("\\u%04x", byte)
+		qrep[char] = string.format("\\u%04x", byte)
 	end
 end
 function encodeString(s)
-	return (tostring(s):gsub('[%z\1-\31"\\]',qrep))
+	return (tostring(s):gsub('[%z\1-\31"\\]', qrep))
 end
 
 -- Determines whether the given Lua type is an array or a table / dictionary.
@@ -232,23 +236,29 @@ end
 -- @param t The table to evaluate as an array
 -- @return boolean, number True if the table can be represented as an array, false otherwise. If true,
 -- the second returned value is the maximum
--- number of indexed elements in the array. 
+-- number of indexed elements in the array.
 function isArray(t)
-	-- Next we count all the elements, ensuring that any non-indexed elements are not-encodable 
+	-- Next we count all the elements, ensuring that any non-indexed elements are not-encodable
 	-- (with the possible exception of 'n')
 	local maxIndex = 0
-	for k,v in base.pairs(t) do
-	if (base.type(k)=='number' and math.floor(k)==k and 1<=k) then	-- k,v is an indexed pair
-		if (not isEncodable(v)) then return false end	-- All array elements must be encodable
-		maxIndex = math.max(maxIndex,k)
-	else
-		if (k=='n') then
-		if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
-		else -- Else of (k=='n')
-		if isEncodable(v) then return false end
-		end  -- End of (k~='n')
-	end -- End of k,v not an indexed pair
-	end  -- End of loop across all pairs
+	for k, v in base.pairs(t) do
+		if base.type(k) == "number" and math.floor(k) == k and 1 <= k then -- k,v is an indexed pair
+			if not isEncodable(v) then
+				return false
+			end -- All array elements must be encodable
+			maxIndex = math.max(maxIndex, k)
+		else
+			if k == "n" then
+				if v ~= table.getn(t) then
+					return false
+				end -- False if n does not hold the number of elements
+			else -- Else of (k=='n')
+				if isEncodable(v) then
+					return false
+				end
+			end -- End of (k~='n')
+		end -- End of k,v not an indexed pair
+	end -- End of loop across all pairs
 	return true, maxIndex
 end
 
@@ -259,7 +269,8 @@ end
 -- @return boolean True if the object should be JSON encoded, false if it should be ignored.
 function isEncodable(o)
 	local t = base.type(o)
-	return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null) 
+	return (t == "string" or t == "boolean" or t == "number" or t == "nil" or t == "table")
+		or (t == "function" and o == null)
 end
 
 local instrumentedDecode
@@ -269,10 +280,12 @@ do
 	local error = base.error
 	local assert = base.assert
 	local print = base.print
-	if Spring and Spring.Echo then print = Spring.Echo end
+	if Spring and Spring.Echo then
+		print = Spring.Echo
+	end
 	local tonumber = base.tonumber
 	-- initialize some values to be used in decoding function
-	
+
 	-- initializes a table to contain a byte=>table mapping
 	-- the table contains tokens (byte values) as keys and maps them on other
 	-- token tables (mostly, the boolean value 'true' is used to indicate termination
@@ -280,7 +293,7 @@ do
 	-- the token table's purpose is, that it allows scanning a sequence of bytes
 	-- until something interesting has been found (e.g. a token that is not expected)
 	-- name is a descriptor for the table to be printed in error messages
-	local function init_token_table (tt)
+	local function init_token_table(tt)
 		local struct = {}
 		local value
 		function struct:link(other_tt)
@@ -288,188 +301,220 @@ do
 			return struct
 		end
 		function struct:to(chars)
-			for i=1,#chars do 
+			for i = 1, #chars do
 				tt[chars:byte(i)] = value
 			end
 			return struct
 		end
-		return function (name)
+		return function(name)
 			tt.name = name
 			return struct
 		end
 	end
-	
+
 	-- keep "named" byte values at hands
-	local 
-		c_esc,
-		c_e,
-		c_l,
-		c_r,
-		c_u,
-		c_f,
-		c_a,
-		c_s,
-		c_slash = ("\\elrufas/"):byte(1,9)
-	
+	local c_esc, c_e, c_l, c_r, c_u, c_f, c_a, c_s, c_slash = ("\\elrufas/"):byte(1, 9)
+
 	-- token tables - tt_doublequote_string = strDoubleQuot, tt_singlequote_string = strSingleQuot
-	local 
-		tt_object_key,
-		tt_object_colon,
-		tt_object_value,
-		tt_doublequote_string,
-		tt_singlequote_string,
-		tt_array_value,
-		tt_array_separator,
-		tt_numeric,
-		tt_boolean,
-		tt_null,
-		tt_comment_start,
-		tt_comment_middle,
-		tt_ignore --< tt_ignore is special - marked tokens will be tt_ignored
-			= {},{},{},{},{},{},{},{},{},{},{},{},{},{}
-			--= {myname = "tt_object_key"},{myname = "tt_object_colon"},{myname = "tt_object_value"},{myname = "tt_doublequote_string"},{myname = "tt_singlequote_string"},{myname = "tt_array_value"},{myname = "tt_array_separator"},{myname = "tt_numeric"},{myname = "tt_boolean"},{myname = "tt_null"},{myname = "tt_comment_start"},{myname = "tt_comment_middle"},{myname = "tt_ignore"}
-	
+	local tt_object_key, tt_object_colon, tt_object_value, tt_doublequote_string, tt_singlequote_string, tt_array_value, tt_array_separator, tt_numeric, tt_boolean, tt_null, tt_comment_start, tt_comment_middle, tt_ignore --< tt_ignore is special - marked tokens will be tt_ignored
+		=
+			{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+	--= {myname = "tt_object_key"},{myname = "tt_object_colon"},{myname = "tt_object_value"},{myname = "tt_doublequote_string"},{myname = "tt_singlequote_string"},{myname = "tt_array_value"},{myname = "tt_array_separator"},{myname = "tt_numeric"},{myname = "tt_boolean"},{myname = "tt_null"},{myname = "tt_comment_start"},{myname = "tt_comment_middle"},{myname = "tt_ignore"}
+
 	-- strings to be used in certain token tables
 	local strchars = "" -- all valid string characters (all except newlines)
 	local allchars = "" -- all characters that are valid in comments
 	--local escapechar = {}
-	for i=0,0xff do 
+	for i = 0, 0xff do
 		local c = string.char(i)
-		if c~="\n" and c~="\r" then strchars = strchars .. c end
+		if c ~= "\n" and c ~= "\r" then
+			strchars = strchars .. c
+		end
 		allchars = allchars .. c
 		--escapechar[i] = "\\" .. string.char(i)
 	end
-	
---[[	
+
+	--[[	
 	charstounescape = "\"\'\\bfnrt/";
 	unescapechars = "\"'\\\b\f\n\r\t\/";
 	for i=1,#charstounescape do
 		escapechar[ charstounescape:byte(i) ] = unescapechars:sub(i,i)
 	end
-]]--
+]]
+	--
 
 	-- obj key reader, expects the end of the object or a quoted string as key
-	init_token_table (tt_object_key) "tt_object_key: object (' or \" or } or , expected)" 
-		:link(tt_singlequote_string) :to "'"
-		:link(tt_doublequote_string) :to '"'
-		:link(true)                  :to "}"
-		:link(tt_object_key)         :to ","
-		:link(tt_comment_start)      :to "/"
-		:link(tt_ignore)             :to " \t\r\n"
-	
-	
+	init_token_table(tt_object_key)("tt_object_key: object (' or \" or } or , expected)")
+		:link(tt_singlequote_string)
+		:to("'")
+		:link(tt_doublequote_string)
+		:to('"')
+		:link(true)
+		:to("}")
+		:link(tt_object_key)
+		:to(",")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+
 	-- after the key, a colon is expected (or comment)
-	init_token_table (tt_object_colon) "tt_object_colon: object (: expected)" 
-		:link(tt_object_value)       :to ":"  
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_ignore)             :to" \t\r\n"
-		
+	init_token_table(tt_object_colon)("tt_object_colon: object (: expected)")
+		:link(tt_object_value)
+		:to(":")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+
 	-- as values, anything is possible, numbers, arrays, objects, boolean, null, strings
-	init_token_table (tt_object_value) "tt_object_value: object ({ or [ or ' or \" or number or boolean or null expected)"
-		:link(tt_object_key)         :to "{" 
-		:link(tt_array_separator)    :to "[" 
-		:link(tt_singlequote_string) :to "'" 
-		:link(tt_doublequote_string) :to '"' 
-		:link(tt_numeric)            :to "0123456789.-" 
-		:link(tt_boolean)            :to "tf" 
-		:link(tt_null)               :to "n" 
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_ignore)             :to " \t\r\n"
-		--:link(true)					 :to "]"
-		
+	init_token_table(tt_object_value)("tt_object_value: object ({ or [ or ' or \" or number or boolean or null expected)")
+		:link(tt_object_key)
+		:to("{")
+		:link(tt_array_separator)
+		:to("[")
+		:link(tt_singlequote_string)
+		:to("'")
+		:link(tt_doublequote_string)
+		:to('"')
+		:link(tt_numeric)
+		:to("0123456789.-")
+		:link(tt_boolean)
+		:to("tf")
+		:link(tt_null)
+		:to("n")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+	--:link(true)					 :to "]"
+
 	-- token tables for reading strings
-	init_token_table (tt_doublequote_string) "tt_doublequote_string: double quoted string"
-		:link(tt_ignore)             :to (strchars)
-		:link(c_esc)                 :to "\\"
-		:link(true)                  :to '"'
-		
-	init_token_table (tt_singlequote_string) "single quoted string"
-		:link(tt_ignore)             :to (strchars)
-		:link(c_esc)                 :to "\\" 
-		:link(true)                  :to "'"
-		
+	init_token_table(tt_doublequote_string)("tt_doublequote_string: double quoted string")
+		:link(tt_ignore)
+		:to(strchars)
+		:link(c_esc)
+		:to("\\")
+		:link(true)
+		:to('"')
+
+	init_token_table(tt_singlequote_string)("single quoted string")
+		:link(tt_ignore)
+		:to(strchars)
+		:link(c_esc)
+		:to("\\")
+		:link(true)
+		:to("'")
+
 	-- array reader that expects termination of the array or a comma that indicates the next value
-	init_token_table (tt_array_value) "tt_array_value: array (, or ] expected)"
-		:link(tt_array_separator)    :to "," 
-		:link(true)                  :to "]"
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_ignore)             :to " \t\r\n"
-	
+	init_token_table(tt_array_value)("tt_array_value: array (, or ] expected)")
+		:link(tt_array_separator)
+		:to(",")
+		:link(true)
+		:to("]")
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+
 	-- a value, pretty similar to tt_object_value
-	init_token_table (tt_array_separator) "tt_array_separator: array ({ or [ or ' or \" or number or boolean or null expected)"
-		:link(tt_object_key)         :to "{" 
-		:link(tt_array_separator)    :to "[" 
-		:link(tt_singlequote_string) :to "'" 
-		:link(tt_doublequote_string) :to '"'  
-		:link(tt_comment_start)      :to "/" 
-		:link(tt_numeric)            :to "0123456789.-" 
-		:link(tt_boolean)            :to "tf" 
-		:link(tt_null)               :to "n" 
-		:link(tt_ignore)             :to " \t\r\n"
-		:link(true)    :to "]" 
-	
+	init_token_table(tt_array_separator)("tt_array_separator: array ({ or [ or ' or \" or number or boolean or null expected)")
+		:link(tt_object_key)
+		:to("{")
+		:link(tt_array_separator)
+		:to("[")
+		:link(tt_singlequote_string)
+		:to("'")
+		:link(tt_doublequote_string)
+		:to('"')
+		:link(tt_comment_start)
+		:to("/")
+		:link(tt_numeric)
+		:to("0123456789.-")
+		:link(tt_boolean)
+		:to("tf")
+		:link(tt_null)
+		:to("n")
+		:link(tt_ignore)
+		:to(" \t\r\n")
+		:link(true)
+		:to("]")
+
 	-- valid number tokens
-	init_token_table (tt_numeric) "tt_numeric: number"
-		:link(tt_ignore)             :to "0123456789.-Ee"
-		
+	init_token_table(tt_numeric)("tt_numeric: number"):link(tt_ignore):to("0123456789.-Ee")
+
 	-- once a comment has been started with /, a * is expected
-	init_token_table (tt_comment_start) "comment start (* expected)"
-		:link(tt_comment_middle)     :to "*"
-		
+	init_token_table(tt_comment_start)("comment start (* expected)"):link(tt_comment_middle):to("*")
+
 	-- now everything is allowed, watch out for * though. The next char is then checked manually
-	init_token_table (tt_comment_middle) "comment end"
-		:link(tt_ignore)             :to (allchars)
-		:link(true)                  :to "*"
-		
-	function decode (js_string)
+	init_token_table(tt_comment_middle)("comment end"):link(tt_ignore):to(allchars):link(true):to("*")
+
+	function decode(js_string)
 		local pos = 1 -- position in the string
-		
+
 		-- read the next byte value
-		local function next_byte () pos = pos + 1 return js_string:byte(pos-1) end
-		
+		local function next_byte()
+			pos = pos + 1
+			return js_string:byte(pos - 1)
+		end
+
 		-- in case of error, report the location using line numbers
-		local function location () 
+		local function location()
 			local n = ("\n"):byte()
-			local line,lpos = 1,0
-			for i=1,pos do 
+			local line, lpos = 1, 0
+			for i = 1, pos do
 				if js_string:byte(i) == n then
-					line,lpos = line + 1,1
+					line, lpos = line + 1, 1
 				else
 					lpos = lpos + 1
 				end
 			end
-			return "Line "..line.." character "..lpos
+			return "Line " .. line .. " character " .. lpos
 		end
-		
+
 		-- debug func
 		--local function status (str)
 		--	print(str.." ("..s:sub(math.max(1,p-10),p+10)..")")
 		--end
-		
+
 		-- read the next token, according to the passed token table
-		local function next_token (tok)
+		local function next_token(tok)
 			while pos <= #js_string do
-				local b = js_string:byte(pos) 
+				local b = js_string:byte(pos)
 				local t = tok[b]
-				if not t then 
-					error("Unexpected character at "..location()..": "..
-						string.char(b).." ("..b..") when reading "..tok.name.."\nContext: \n"..
-						js_string:sub(math.max(1,pos-30),pos+30).."\n"..(" "):rep(pos+math.min(-1,30-pos)).."^")
+				if not t then
+					error(
+						"Unexpected character at "
+							.. location()
+							.. ": "
+							.. string.char(b)
+							.. " ("
+							.. b
+							.. ") when reading "
+							.. tok.name
+							.. "\nContext: \n"
+							.. js_string:sub(math.max(1, pos - 30), pos + 30)
+							.. "\n"
+							.. (" "):rep(pos + math.min(-1, 30 - pos))
+							.. "^"
+					)
 				end
 				pos = pos + 1
-				if t~=tt_ignore then return t end
+				if t ~= tt_ignore then
+					return t
+				end
 			end
-			error("unexpected termination of JSON while looking for "..tok.name)
+			error("unexpected termination of JSON while looking for " .. tok.name)
 		end
-		
+
 		-- read a string, double and single quoted ones
-		local function read_string (tok)
+		local function read_string(tok)
 			local start = pos
 			local rewrite = false
 			--local returnString = {}
 			repeat
 				local t = next_token(tok)
-				if t == c_esc then 
+				if t == c_esc then
 					-- pos sits on the escaped character. u and / are the two JSON escapes Lua
 					-- has no equivalent for, and the interpreters disagree on them: 5.1 quietly
 					-- drops the backslash while LuaJIT refuses to compile at all. Neither can be
@@ -484,15 +529,15 @@ do
 					--start = pos
 				end -- jump over escaped chars, no matter what
 			until t == true
-			local literal = js_string:sub(start-1, pos-1)
+			local literal = js_string:sub(start - 1, pos - 1)
 			if rewrite then
 				literal = rewriteJsonOnlyEscapes(literal)
 			end
-			return (base.loadstring("return " .. literal) ())
+			return (base.loadstring("return " .. literal)())
 
 			-- We consider the situation where no escaped chars were encountered separately,
 			-- and use the fastest possible return in this case.
-			
+
 			--if 0 == #returnString then
 			--	return js_string:sub(start,pos-2)
 			--else
@@ -501,135 +546,176 @@ do
 			--end
 			--return js_string:sub(start,pos-2)
 		end
-		
-		local function read_num ()
+
+		local function read_num()
 			local start = pos
 			while pos <= #js_string do
 				local b = js_string:byte(pos)
-				if not tt_numeric[b] then break end
+				if not tt_numeric[b] then
+					break
+				end
 				pos = pos + 1
 			end
-			return tonumber(js_string:sub(start-1,pos-1))
+			return tonumber(js_string:sub(start - 1, pos - 1))
 		end
-		
+
 		-- read_bool and read_null are both making an assumption that I have not tested:
-		-- I would expect that the string extraction is more expensive than actually 
+		-- I would expect that the string extraction is more expensive than actually
 		-- making manual comparison of the byte values
-		local function read_bool () 
+		local function read_bool()
 			pos = pos + 3
-			local a,b,c,d = js_string:byte(pos-3,pos)
-			if a == c_r and b == c_u and c == c_e then return true end
+			local a, b, c, d = js_string:byte(pos - 3, pos)
+			if a == c_r and b == c_u and c == c_e then
+				return true
+			end
 			pos = pos + 1
-			if a ~= c_a or b ~= c_l or c ~= c_s or d ~= c_e then 
-				error("Invalid boolean: "..js_string:sub(math.max(1,pos-5),pos+5)) 
+			if a ~= c_a or b ~= c_l or c ~= c_s or d ~= c_e then
+				error("Invalid boolean: " .. js_string:sub(math.max(1, pos - 5), pos + 5))
 			end
 			return false
 		end
-		
-		-- same as read_bool: only last 
-		local function read_null ()
+
+		-- same as read_bool: only last
+		local function read_null()
 			pos = pos + 3
-			local u,l1,l2 = js_string:byte(pos-3,pos-1)
-			if u == c_u and l1 == c_l and l2 == c_l then return nil end
-			error("Invalid value (expected null):"..js_string:sub(pos-4,pos-1)..
-				" ("..js_string:byte(pos-1).."="..js_string:sub(pos-1,pos-1).." / "..c_l..")")
+			local u, l1, l2 = js_string:byte(pos - 3, pos - 1)
+			if u == c_u and l1 == c_l and l2 == c_l then
+				return nil
+			end
+			error(
+				"Invalid value (expected null):"
+					.. js_string:sub(pos - 4, pos - 1)
+					.. " ("
+					.. js_string:byte(pos - 1)
+					.. "="
+					.. js_string:sub(pos - 1, pos - 1)
+					.. " / "
+					.. c_l
+					.. ")"
+			)
 		end
-		
-		local read_object_value,read_object_key,read_array,read_value,read_comment
-	
+
+		local read_object_value, read_object_key, read_array, read_value, read_comment
+
 		-- read a value depending on what token was returned, might require info what was used (in case of comments)
-		function read_value (t,fromt)
-			if t == tt_object_key         then return read_object_key({}) end
-			if t == tt_array_separator    then return read_array({}) end
-			if t == tt_singlequote_string or t == tt_doublequote_string then return read_string(t) end
-			if t == tt_numeric            then return read_num() end
-			if t == tt_boolean            then return read_bool() end	
-			if t == tt_null               then return read_null() end
-			if t == tt_comment_start      then return read_value(read_comment(fromt)) end
-			error("unexpected termination - "..js_string:sub(math.max(1,pos-10),pos+10))
+		function read_value(t, fromt)
+			if t == tt_object_key then
+				return read_object_key({})
+			end
+			if t == tt_array_separator then
+				return read_array({})
+			end
+			if t == tt_singlequote_string or t == tt_doublequote_string then
+				return read_string(t)
+			end
+			if t == tt_numeric then
+				return read_num()
+			end
+			if t == tt_boolean then
+				return read_bool()
+			end
+			if t == tt_null then
+				return read_null()
+			end
+			if t == tt_comment_start then
+				return read_value(read_comment(fromt))
+			end
+			error("unexpected termination - " .. js_string:sub(math.max(1, pos - 10), pos + 10))
 		end
-		
-		-- read comments until something noncomment like surfaces, using the token reader which was 
+
+		-- read comments until something noncomment like surfaces, using the token reader which was
 		-- used when stumbling over this comment
-		function read_comment (fromt)
+		function read_comment(fromt)
 			while true do
 				next_token(tt_comment_start)
 				while true do
 					local t = next_token(tt_comment_middle)
 					if next_byte() == c_slash then
 						local t = next_token(fromt)
-						if t~= tt_comment_start then return t end
+						if t ~= tt_comment_start then
+							return t
+						end
 						break
 					end
 				end
 			end
 		end
-		
+
 		-- read arrays, empty array expected as o arg
-		function read_array (o,i)
+		function read_array(o, i)
 			--if not i then status "arr open" end
 			i = i or 1
 			-- loop until ...
 			while true do
-				
+
 				-- At this point, the array might be empty!
 				local next_tokenvalue = next_token(tt_array_separator)
-				if next_tokenvalue == true then return o end
-				
+				if next_tokenvalue == true then
+					return o
+				end
+
 				o[i] = read_value(next_tokenvalue, tt_array_separator)
 				local t = next_token(tt_array_value)
 				if t == tt_comment_start then
 					t = read_comment(tt_array_value)
 				end
-				if t == true then  -- ... we found a terminator token
+				if t == true then -- ... we found a terminator token
 					--status "arr close"
-					return o 
+					return o
 				end
-				i = i + 1			
+				i = i + 1
 			end
 		end
-		
+
 		-- object value reading
-		function read_object_value (o)
+		function read_object_value(o)
 			local t = next_token(tt_object_value)
-			return read_value(t,tt_object_value)
+			return read_value(t, tt_object_value)
 		end
-		
+
 		-- object key reading, might also terminate the object
-		function read_object_key (o)
-			
+		function read_object_key(o)
+
 			while true do
 				local t = next_token(tt_object_key)
 				if t == tt_comment_start then
 					t = read_comment(tt_object_key)
 				end
-				if t == true then return o end
-				if t == tt_object_key then return read_object_key(o) end
+				if t == true then
+					return o
+				end
+				if t == tt_object_key then
+					return read_object_key(o)
+				end
 				local k = read_string(t)
-				
+
 				if next_token(tt_object_colon) == tt_comment_start then
 					t = read_comment(tt_object_colon)
 				end
-				
+
 				local v = read_object_value(o)
 				o[k] = v
 			end
 		end
-		
+
 		-- now let's read data from our string and pretend it's an object value
 		local r = read_object_value()
-		if pos<=#js_string then
+		if pos <= #js_string then
 			-- not sure about what to do with dangling characters
 			--error("Dangling characters in JSON code ("..location()..")")
 		end
-		
+
 		return r
 	end
 
-	instrumentedDecode = function (js_string)
-		if tracy then tracy.ZoneBeginN("Json:Decode") end 
+	instrumentedDecode = function(js_string)
+		if tracy then
+			tracy.ZoneBeginN("Json:Decode")
+		end
 		local localret = decode(js_string)
-		if tracy then tracy.ZoneEnd() end 
+		if tracy then
+			tracy.ZoneEnd()
+		end
 		return localret
 	end
 end

--- a/common/luaUtilities/json.lua
+++ b/common/luaUtilities/json.lua
@@ -57,59 +57,59 @@ local isEncodable
 --- The null function allows one to specify a null value in an associative array (which is otherwise
 -- discarded if you set the value with 'nil' in Lua. Simply set t = { first=json.null }
 local function null()
-  return null -- so json.null() will also return null ;-)
+	return null -- so json.null() will also return null ;-)
 end
 
 --- Encodes an arbitrary Lua object / variable.
 -- @param v The Lua object / variable to be JSON encoded.
 -- @return String containing the JSON encoding in internal Lua string format (i.e. not unicode)
 local function encode (v)
-  -- Handle nil values
-  if v==nil then
-    return "null"
-  end
-  
-  local vtype = base.type(v)  
+	-- Handle nil values
+	if v==nil then
+	return "null"
+	end
+	
+	local vtype = base.type(v)  
 
-  -- Handle strings
-  if vtype=='string' then    
-    return '"' .. encodeString(v) .. '"'	    -- Need to handle encoding in string
-  end
-  
-  -- Handle booleans
-  if vtype=='number' or vtype=='boolean' then
-    return base.tostring(v)
-  end
-  
-  -- Handle tables
-  if vtype=='table' then
-    local rval = {}
-    -- Consider arrays separately
-    local bArray, maxCount = isArray(v)
-    if bArray then
-      for i = 1,maxCount do
-        table.insert(rval, encode(v[i]))
-      end
-    else	-- An object, not an array
-      for i,j in base.pairs(v) do
-        if isEncodable(i) and isEncodable(j) then
-          table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
-        end
-      end
-    end
-    if bArray then
-      return '[' .. table.concat(rval,',') ..']'
-    else
-      return '{' .. table.concat(rval,',') .. '}'
-    end
-  end
-  
-  -- Handle null values
-  if vtype=='function' and v==null then
-    return 'null'
-  end
-  
-  base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
+	-- Handle strings
+	if vtype=='string' then    
+	return '"' .. encodeString(v) .. '"'	    -- Need to handle encoding in string
+	end
+	
+	-- Handle booleans
+	if vtype=='number' or vtype=='boolean' then
+	return base.tostring(v)
+	end
+	
+	-- Handle tables
+	if vtype=='table' then
+	local rval = {}
+	-- Consider arrays separately
+	local bArray, maxCount = isArray(v)
+	if bArray then
+		for i = 1,maxCount do
+		table.insert(rval, encode(v[i]))
+		end
+	else	-- An object, not an array
+		for i,j in base.pairs(v) do
+		if isEncodable(i) and isEncodable(j) then
+			table.insert(rval, '"' .. encodeString(i) .. '":' .. encode(j))
+		end
+		end
+	end
+	if bArray then
+		return '[' .. table.concat(rval,',') ..']'
+	else
+		return '{' .. table.concat(rval,',') .. '}'
+	end
+	end
+	
+	-- Handle null values
+	if vtype=='function' and v==null then
+	return 'null'
+	end
+	
+	base.assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. base.tostring(v))
 end
 
 
@@ -210,9 +210,19 @@ end
 -- This just involves back-quoting inverted commas, back-quotes and newlines, I think ;-)
 -- @param s The string to return as a JSON encoded (i.e. backquoted string)
 -- @return The string appropriately escaped.
-local qrep = {["\\"]="\\\\", ['"']='\\"',['\n']='\\n',['\t']='\\t'}
+local qrep = {["\\"]="\\\\", ['"']='\\"',['\b']='\\b',['\f']='\\f',['\n']='\\n',['\r']='\\r',['\t']='\\t'}
+
+-- Writing control characters produces a broken file unless properly escaped.
+-- All shorthand escapes are listed above; the rest must encode into \uXXXX,
+-- which we also decode on the way in to keep a single properly copied json.
+for byte=0,0x1f do
+	local char = string.char(byte)
+	if not qrep[char] then
+	qrep[char] = string.format("\\u%04x", byte)
+	end
+end
 function encodeString(s)
-  return tostring(s):gsub('["\\\n\t]',qrep)
+	return (tostring(s):gsub('[%z\1-\31"\\]',qrep))
 end
 
 -- Determines whether the given Lua type is an array or a table / dictionary.
@@ -224,22 +234,22 @@ end
 -- the second returned value is the maximum
 -- number of indexed elements in the array. 
 function isArray(t)
-  -- Next we count all the elements, ensuring that any non-indexed elements are not-encodable 
-  -- (with the possible exception of 'n')
-  local maxIndex = 0
-  for k,v in base.pairs(t) do
-    if (base.type(k)=='number' and math.floor(k)==k and 1<=k) then	-- k,v is an indexed pair
-      if (not isEncodable(v)) then return false end	-- All array elements must be encodable
-      maxIndex = math.max(maxIndex,k)
-    else
-      if (k=='n') then
-        if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
-      else -- Else of (k=='n')
-        if isEncodable(v) then return false end
-      end  -- End of (k~='n')
-    end -- End of k,v not an indexed pair
-  end  -- End of loop across all pairs
-  return true, maxIndex
+	-- Next we count all the elements, ensuring that any non-indexed elements are not-encodable 
+	-- (with the possible exception of 'n')
+	local maxIndex = 0
+	for k,v in base.pairs(t) do
+	if (base.type(k)=='number' and math.floor(k)==k and 1<=k) then	-- k,v is an indexed pair
+		if (not isEncodable(v)) then return false end	-- All array elements must be encodable
+		maxIndex = math.max(maxIndex,k)
+	else
+		if (k=='n') then
+		if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
+		else -- Else of (k=='n')
+		if isEncodable(v) then return false end
+		end  -- End of (k~='n')
+	end -- End of k,v not an indexed pair
+	end  -- End of loop across all pairs
+	return true, maxIndex
 end
 
 --- Determines whether the given Lua object / table / variable can be JSON encoded. The only
@@ -248,8 +258,8 @@ end
 -- @param o The object to examine.
 -- @return boolean True if the object should be JSON encoded, false if it should be ignored.
 function isEncodable(o)
-  local t = base.type(o)
-  return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null) 
+	local t = base.type(o)
+	return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null) 
 end
 
 local instrumentedDecode
@@ -531,8 +541,7 @@ do
 		function read_value (t,fromt)
 			if t == tt_object_key         then return read_object_key({}) end
 			if t == tt_array_separator    then return read_array({}) end
-			if t == tt_singlequote_string or 
-			   t == tt_doublequote_string then return read_string(t) end
+			if t == tt_singlequote_string or t == tt_doublequote_string then return read_string(t) end
 			if t == tt_numeric            then return read_num() end
 			if t == tt_boolean            then return read_bool() end	
 			if t == tt_null               then return read_null() end

--- a/common/user_files.lua
+++ b/common/user_files.lua
@@ -1,0 +1,215 @@
+-- user_files.lua --------------------------------------------------------------
+-- This module adds common directories for copying, backups, and pending writes.
+-- It provides a simple methodology for ingesting files containing users' data
+-- without producing bad patterns, e.g. writing back out a misread user file.
+-- Pending and interrupted write operations leave the existing file as it was.
+--------------------------------------------------------------------------------
+
+if not io or not os then
+	return
+end
+
+if not VFS then
+	Spring.Log("user_file", LOG.ERROR, "No VFS present when loading user_files.")
+	return
+end
+
+local SUFFIX_PENDING = ".pending"
+local SUFFIX_BACKUP = ".backup"
+
+local STATUS_OK = "ok"
+local STATUS_ABSENT = "absent"
+local STATUS_DAMAGED = "damaged"
+
+---An interrupted write leaves both of these behind. The pending copy is the
+---newer of the two, and is only ever written in full, so it is tried first.
+local RECOVERY_ORDERED = { SUFFIX_PENDING, SUFFIX_BACKUP }
+
+---@param path string
+---@param decode nil|fun(contents: string): any
+---@return nil|any value
+---@return "ok"|"absent"|"damaged" status
+local function readFile(path, decode)
+	local contents = VFS.LoadFile(path)
+
+	if not contents then
+		return nil, VFS.FileExists(path) and STATUS_DAMAGED or STATUS_ABSENT
+	end
+
+	if contents:match("^%s*$") then
+		return nil, STATUS_ABSENT
+	end
+
+	if not decode then
+		return contents, STATUS_OK
+	end
+
+	local decoded, value = pcall(decode, contents)
+
+	if not decoded or value == nil then
+		return nil, STATUS_DAMAGED
+	end
+
+	return value, STATUS_OK
+end
+
+---Reads a file, optionally through a decoder.
+---@param path string
+---@param decode nil|fun(contents: string): any a decoder such as Json.decode
+---@return nil|any value the contents, or whatever the decoder made of them
+---@return "ok"|"absent"|"damaged" status
+local function read(path, decode)
+	if VFS.FileExists(path) then
+		return readFile(path, decode)
+	end
+
+	for _, suffix in ipairs(RECOVERY_ORDERED) do
+		local value, status = readFile(path .. suffix, decode)
+		if status == STATUS_OK then
+			return value, status
+		end
+	end
+
+	return nil, STATUS_ABSENT
+end
+
+---Puts a finished pending file in place of `path`, keeping the old one alongside.
+---@param path string
+---@param pending string
+---@param options nil|{ backup: boolean }
+---@return boolean written
+local function commit(path, pending, options)
+	-- Existing file-level backups do not survive a new write operation.
+	local backup = path .. SUFFIX_BACKUP
+	os.remove(backup)
+	local hasBackup = os.rename(path, backup) ~= nil
+
+	-- os.rename requires _both_ file paths to be inside the write directory,
+	-- so the rename can be refused even when the write (io.open) was allowed.
+	if os.rename(pending, path) == nil then
+		-- Nothing reached `path`, so put back what we moved aside and take the
+		-- pending copy with us, leaving the directory as we found it.
+		if hasBackup then
+			os.rename(backup, path)
+		end
+
+		os.remove(pending)
+
+		return false
+	end
+
+	-- `backup = false` still copies (see above); we just clean up afterward.
+	if options and options.backup == false then
+		os.remove(backup)
+	end
+
+	return true
+end
+
+---@class UserFileWriter
+---@field write fun(self: UserFileWriter, text: string) writes, as a file handle does
+---@field close fun(self: UserFileWriter): boolean puts the finished result in place
+---@field abort fun(self: UserFileWriter) discards it, leaving the file as it was
+
+---Opens a write that only reaches `path` once it is closed cleanly.
+---
+---Stands in for an `io.open` handle where the contents arrive a piece at a time,
+---so a large file does not have to be held in memory whole to be written safely.
+---@param path string
+---@param options nil|{ backup: boolean } backup = false skips the rotation
+---@return UserFileWriter? writer `nil` the file could not be opened
+local function open(path, options)
+	local pending = path .. SUFFIX_PENDING
+	local file = io.open(pending, "w")
+	if not file then
+		return nil
+	end
+
+	local failed = false
+	local writer = {}
+
+	function writer:write(text)
+		if file and not file:write(text) then
+			failed = true
+		end
+	end
+
+	function writer:abort()
+		if not file then
+			return
+		end
+
+		file:close()
+		file = nil
+
+		os.remove(pending)
+	end
+
+	function writer:close()
+		if not file then
+			return false
+		end
+
+		local closed = file:close()
+		file = nil
+
+		if failed or not closed then
+			os.remove(pending)
+			return false
+		end
+
+		return commit(path, pending, options)
+	end
+
+	return writer
+end
+
+---Writes a file into a *.pending copy, keeping the previous copy as *.backup.
+---@param path string
+---@param contents string
+---@param options nil|{ backup: boolean } backup = false skips the rotation
+---@return boolean written
+local function write(path, contents, options)
+	local writer = open(path, options)
+	if not writer then
+		return false
+	end
+
+	writer:write(contents)
+
+	return writer:close()
+end
+
+---Create a copy of a file beforehand when the engine handles the write.
+---
+---The engine truncates files it saves or writes into, which we cannot make safe,
+---so the best we can do is create a retrievable copy of its contents somewhere.
+---@param path string
+---@return boolean? created `false` the copy failed; `nil` nothing to copy
+local function temp(path)
+	local file = io.open(path, "r")
+	if not file then
+		return
+	end
+
+	local contents = file:read("*a")
+	file:close()
+
+	if contents and contents ~= "" then
+		return write(path .. SUFFIX_BACKUP, contents, { backup = false })
+	end
+end
+
+return {
+	Read = read,
+	Write = write,
+	Open = open,
+	Temp = temp,
+
+	OK = STATUS_OK,
+	ABSENT = STATUS_ABSENT,
+	DAMAGED = STATUS_DAMAGED,
+
+	PENDING_SUFFIX = SUFFIX_PENDING,
+	BACKUP_SUFFIX = SUFFIX_BACKUP,
+}

--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -505,12 +505,16 @@
 			}
 		},
 		"blueprint": {
+			"section": "Blueprints",
 			"cursor_active": "Blueprint #%{index}",
 			"cursor_none": "No Blueprints",
 			"hotkey_next": "Next",
 			"hotkey_prev": "Previous",
 			"hotkey_delete": "Delete",
-			"hotkey_none": "<none>"
+			"hotkey_none": "<none>",
+			"file_damaged": "Could not read %{file}.",
+			"save_failed": "Could not save to %{file}.",
+			"entry_kept": "Could not load '%{name}'."
 		},
 		"ignore": {
 			"unknown": "unknown accountID",

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -136,6 +136,10 @@ local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
 local currentLayout
 local actionHotkeys
 
+local JsonDoctor = VFS.Include("common/json_doctor.lua")
+---@type JsonDoctorReading|nil
+local fileReading = nil
+
 ---maximum number of units in a saved blueprint
 local BLUEPRINT_UNIT_LIMIT = 100
 
@@ -162,6 +166,7 @@ local CMD_BLUEPRINT_CREATE_DESCRIPTION = {
 }
 
 local BLUEPRINT_FILE_PATH = "LuaUI/Config/blueprints.json"
+local BLUEPRINT_FILE_KEY = "savedBlueprints"
 
 ---@type Blueprint[]
 local blueprints = {}
@@ -1130,53 +1135,82 @@ end
 
 ---@param serializedBlueprint SerializedBlueprint
 ---@return Blueprint|nil
-local function deserializeBlueprint(serializedBlueprint, index)
+local function buildBlueprint(serializedBlueprint)
 	local blueprint = WG.api_blueprint.createBlueprintFromSerialized(serializedBlueprint)
 
-	if not blueprint or not table.any(blueprint.units, function(u)
+	if blueprint then
+		postProcessBlueprint(blueprint)
+	end
+
+	return blueprint
+end
+
+---Prints one line to the console under the section the strings belong to, so the
+---prefix is translated with them rather than baked into each one.
+---@param key string
+---@param params table|nil
+local function notify(key, params)
+	FeedbackForUser("[" .. BAR.I18N("ui.blueprint.section") .. "] " .. BAR.I18N(key, params))
+end
+
+local ENTRY_MESSAGE_LIMIT = 10 -- Complete logs are not useful. We do not care.
+local entryMessagesSent = 0
+
+---@param key string
+---@param params table|nil
+local function notifyEntry(key, params)
+	entryMessagesSent = entryMessagesSent + 1
+	if entryMessagesSent <= ENTRY_MESSAGE_LIMIT then
+		notify(key, params)
+	end
+end
+
+---@param serializedBlueprint SerializedBlueprint
+---@return Blueprint|nil
+local function deserializeBlueprint(serializedBlueprint, index)
+	-- The file is written by hand as often as by us, so a blueprint can be any
+	-- shape at all. Building one is allowed to fail; the entry is set aside and
+	-- written back untouched, which is the only copy the player has of it.
+	local built, blueprint = pcall(buildBlueprint, serializedBlueprint)
+
+	if not built or not blueprint or not table.any(blueprint.units, function(u)
 		return u.unitDefID ~= nil
 	end) then
 		local name = serializedBlueprint.name
 		if not name or name == "" then
 			name = "#" .. tostring(index)
 		end
-		FeedbackForUser(
-			string.format(
-				"[Blueprint] Blueprint '%s' was filtered out as it contains no valid or substitutable units.",
-				name
-			)
-		)
+		notifyEntry("ui.blueprint.entry_kept", { name = name })
 		return nil
 	end
 
-	postProcessBlueprint(blueprint)
 	return blueprint
 end
 
+---Reads the blueprints file through the doctor and remembers what it found, which
+---is what decides whether the save on shutdown is allowed to write over it.
 local function loadBlueprintsFromFile()
-	local content = VFS.LoadFile(BLUEPRINT_FILE_PATH)
-
-	if not content then
-		FeedbackForUser("Failed to read blueprints file: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	local decoded = Json.decode(content)
-	---@cast decoded table?
-
-	if decoded == nil then
-		FeedbackForUser("Failed to decode blueprints file JSON: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	if type(decoded.savedBlueprints) ~= "table" then
-		decoded.savedBlueprints = {}
-	end
-
 	blueprints = {}
 	filteredOutSerializedBlueprints = {}
-	for i, serializedBlueprint in ipairs(decoded.savedBlueprints) do
-		local blueprint = deserializeBlueprint(serializedBlueprint, i)
+	entryMessagesSent = 0
+	setSelectedBlueprintIndex(nil)
+
+	local reading = JsonDoctor.Read(BLUEPRINT_FILE_PATH, BLUEPRINT_FILE_KEY)
+
+	fileReading = reading
+
+	if reading.status == JsonDoctor.DAMAGED then
+		notify("ui.blueprint.file_damaged", { file = BLUEPRINT_FILE_PATH })
+		return
+	end
+
+	for i, item in ipairs(reading.setAside) do
+		notifyEntry("ui.blueprint.entry_kept", { name = "#" .. reading.setAsideIndices[i] })
+		tableInsert(filteredOutSerializedBlueprints, item)
+	end
+
+	for i, serializedBlueprint in ipairs(reading.entries) do
+		local blueprint = deserializeBlueprint(serializedBlueprint, reading.entryIndices[i])
 		if blueprint then
 			tableInsert(blueprints, blueprint)
 		else
@@ -1184,45 +1218,20 @@ local function loadBlueprintsFromFile()
 		end
 	end
 
-	if #blueprints == 0 then
-		setSelectedBlueprintIndex(nil)
-	elseif not selectedBlueprintIndex or selectedBlueprintIndex > #blueprints then
+	if #blueprints > 0 and (not selectedBlueprintIndex or selectedBlueprintIndex > #blueprints) then
 		setSelectedBlueprintIndex(1)
 	end
 end
 
 local function saveBlueprintsToFile()
-	local file = io.open(BLUEPRINT_FILE_PATH, "w")
-
-	if not file then
-		FeedbackForUser("Failed to open blueprints file for writing: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	local activeSerializedBps = table.map(blueprints, serializeBlueprint)
 	local allSerializedBpsToSave = {}
-	table.append(allSerializedBpsToSave, activeSerializedBps)
+	table.append(allSerializedBpsToSave, table.map(blueprints, serializeBlueprint))
 	table.append(allSerializedBpsToSave, filteredOutSerializedBlueprints)
 
-	if #allSerializedBpsToSave == 0 then
-		allSerializedBpsToSave = {}
+	if not JsonDoctor.Write(BLUEPRINT_FILE_PATH, BLUEPRINT_FILE_KEY, allSerializedBpsToSave, fileReading) then
+		notify("ui.blueprint.save_failed", { file = BLUEPRINT_FILE_PATH })
 	end
-
-	local encoded = Json.encode({
-		savedBlueprints = allSerializedBpsToSave,
-	})
-
-	if encoded == nil then
-		FeedbackForUser("Failed to encode blueprints file JSON: " .. BLUEPRINT_FILE_PATH)
-		return
-	end
-
-	file:write(encoded)
-
-	file:close()
 end
-
-local loadedBlueprints = false
 
 function widget:Initialize()
 	if Spring.GetModOptions().scenariooptions then
@@ -1243,7 +1252,6 @@ function widget:Initialize()
 	WG.cmd_blueprint.nextBlueprintUnitID = nextBlueprintUnitID
 
 	loadBlueprintsFromFile()
-	loadedBlueprints = true
 
 	widgetHandler.actionHandler:AddAction(self, "blueprint_create", handleBlueprintCreateAction, nil, "p")
 	widgetHandler.actionHandler:AddAction(self, "blueprint_next", handleBlueprintNextAction, nil, "p")
@@ -1267,7 +1275,7 @@ function widget:Shutdown()
 
 	updateBuildingGridState(false)
 
-	if loadedBlueprints then
+	if fileReading and fileReading.status ~= JsonDoctor.DAMAGED then
 		saveBlueprintsToFile()
 	end
 

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -29,6 +29,7 @@ local version = 1.5 -- used to toggle previously default enabled/disabled widget
 local newerVersion = false -- configdata will set this true if it's a newer version
 
 local keyLayouts = VFS.Include("luaui/configs/keyboard_layouts.lua")
+local UserFile = VFS.Include("common/user_files.lua")
 
 local languageCodes = { "en", "fr", "ru", "es" }
 languageCodes = table.merge(languageCodes, table.invert(languageCodes))
@@ -5198,9 +5199,14 @@ function init()
 
 				local isCustom = keyLayouts.keybindingPresets.Custom == keyFile
 
-				if isCustom and not VFS.FileExists(keyFile) then
-					Spring.SendCommands("keysave " .. keyFile)
-					Spring.Echo("Preset Custom selected, file saved at: " .. keyFile)
+				if isCustom then
+					-- VFS might not list a file the engine wrote out earlier in the session,
+					-- but `keysave` will truncate its contents anyway; so guarantee a backup:
+					UserFile.Temp(keyFile)
+					if not VFS.FileExists(keyFile) then
+						Spring.SendCommands("keysave " .. keyFile)
+						Spring.Echo("Preset Custom selected, file saved at: " .. keyFile)
+					end
 				end
 
 				Spring.SetConfigString("KeybindingFile", keyFile)

--- a/luaui/savetable.lua
+++ b/luaui/savetable.lua
@@ -15,6 +15,13 @@ if table.save then
 	return
 end
 
+local UserFile = VFS.Include("common/user_files.lua")
+
+if not UserFile then
+	Spring.Log("savetable", LOG.ERROR, "No file access; table.save is unavailable.")
+	return
+end
+
 local indentString = "\t"
 
 local savedTables = {}
@@ -166,19 +173,39 @@ local function SaveTable(t, file, indent)
 	end
 end
 
+---@return boolean written
 function table.save(t, filename, header)
-	local file = io.open(filename, "w")
-	if file == nil then
-		return
+	-- SaveTable raises on a recursive table, so a widget storing a cyclic table
+	-- is capable of taking the entire config file down with it for all widgets.
+	-- The writer keeps everything in a pending file until it closes out clean.
+	local writer = UserFile.Open(filename)
+	if not writer then
+		return false
 	end
+
 	if header then
-		file:write(header .. "\n")
+		writer:write(header .. "\n")
 	end
-	file:write("return ")
-	SaveTable(t, file, "")
-	file:write("}\n")
-	file:close()
-	for k, v in pairs(savedTables) do
+	writer:write("return ")
+
+	local saved, err = pcall(SaveTable, t, writer, "")
+
+	for k in pairs(savedTables) do
 		savedTables[k] = nil
 	end
+
+	if not saved then
+		writer:abort()
+		error(err, 0)
+	end
+
+	writer:write("}\n")
+
+	local written = writer:close()
+
+	if not written then
+		Spring.Log("savetable", LOG.ERROR, "Could not write " .. tostring(filename) .. "; it is unchanged.")
+	end
+
+	return written
 end

--- a/spec/common/json_spec.lua
+++ b/spec/common/json_spec.lua
@@ -93,16 +93,58 @@ describe("json string escapes", function()
 		-- characters or pushes the rest of the literal out of step, so it has to be caught
 		-- where it is parsed rather than surfacing as a loadstring failure later.
 		it("is rejected rather than silently dropped", function()
-			assert.has_error(function() Json.decode([[{"a":"\u47"}]]) end)
-			assert.has_error(function() Json.decode([[{"a":"\uZZZZ"}]]) end)
-			assert.has_error(function() Json.decode([[{"a":"\u"}]]) end)
-			assert.has_error(function() Json.decode([[{"a":"x\u47y"}]]) end)
+			assert.has_error(function()
+				Json.decode([[{"a":"\u47"}]])
+			end)
+			assert.has_error(function()
+				Json.decode([[{"a":"\uZZZZ"}]])
+			end)
+			assert.has_error(function()
+				Json.decode([[{"a":"\u"}]])
+			end)
+			assert.has_error(function()
+				Json.decode([[{"a":"x\u47y"}]])
+			end)
 		end)
 
 		it("names the escape it choked on", function()
 			local ok, err = pcall(Json.decode, [[{"a":"\uZZZZ"}]])
 			assert.is_false(ok)
 			assert.is_truthy(tostring(err):find("\uZZZZ", 1, true))
+		end)
+	end)
+
+	describe("control characters on the way out", function()
+		-- JSON has no literal control characters and the decoder has no token for most
+		-- of them, so encoding one raw produced a file this module could not read back.
+		local function roundTrip(text)
+			return Json.decode(Json.encode({ a = text })).a
+		end
+
+		it("escapes the ones with a shorthand", function()
+			assert.are.equal([[{"a":"\b\f\n\r\t"}]], Json.encode({ a = "\b\f\n\r\t" }))
+		end)
+
+		it("escapes the rest as code points", function()
+			local encoded = Json.encode({ a = string.char(0, 27, 31) })
+
+			assert.is_truthy(encoded:find("u0000", 1, true))
+			assert.is_truthy(encoded:find("u001b", 1, true))
+			assert.is_truthy(encoded:find("u001f", 1, true))
+			assert.is_nil(encoded:find(string.char(0), 1, true))
+		end)
+
+		it("reads back every control character it writes", function()
+			for byte = 0, 0x1f do
+				local text = "a" .. string.char(byte) .. "b"
+				assert.are.equal(text, roundTrip(text), "byte " .. byte)
+			end
+		end)
+
+		it("leaves printable characters alone", function()
+			local text = "eco/lab " .. string.char(195, 169)
+
+			assert.are.equal('{"a":"' .. text .. '"}', Json.encode({ a = text }))
 		end)
 	end)
 
@@ -117,8 +159,7 @@ describe("json string escapes", function()
 			assert.is_table(decoded, path .. " failed to decode")
 			-- Asserting the value, not just that it parsed: an interpreter that treats an
 			-- unknown escape as the bare character decodes happily but corrupts the string.
-			assert.are.equal(true,
-				decoded.cmd.set.AutoAddBuiltUnitsToFactoryGroup:find("factory's", 1, true) ~= nil)
+			assert.are.equal(true, decoded.cmd.set.AutoAddBuiltUnitsToFactoryGroup:find("factory's", 1, true) ~= nil)
 		end)
 	end)
 end)


### PR DESCRIPTION
### Work done

I found more issues than I thought I would find when looking at a json repair shop for blueprints. This became almost a mandate-level review. I made it, so here it is, drafted, but I am sick and I am tired. Someone look at this pls soon because even if you don't, some version of this is making its way into code.

This closes the decode-encode loop so user json files are fully loopable, even when they put stupid stuff in them.

This prevents many categories of errors in gadgets and widgets, including error categories that would refuse to load user configs over a single invalid character and instantly overwrite that file (with no contents, rip). We have been bricking widgets and user data on repeat since the dawn of time. See commit commentary.