### PR TITLE
Eliminate AllyTeamID alias made redundant by upstream

### DIFF
--- a/luaui/Widgets/map_start_position_suggestions.lua
+++ b/luaui/Widgets/map_start_position_suggestions.lua
@@ -120,8 +120,6 @@ local glUseShader = gl.UseShader
 ---@field positions ModOptionPositions
 ---@field team ModOptionTeams[]
 
----@alias AllyTeamID number
-
 ---@class WidgetMapPosition
 ---@field x number
 ---@field z number


### PR DESCRIPTION
This alias is handled by https://github.com/beyond-all-reason/RecoilEngine/pull/3231 which has been merged and will make it into recoil-lua-library on the next update there and here.