### PR TITLE
Aliases for the object-or-position unions

### DIFF
--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -167,7 +167,7 @@ end
 
 ---Translates TargetType integers to the ProjectileTargetType byte-integers needed in SetProjectileTarget.
 ---@param projectileID integer
----@param target integer|xyz?
+---@param target UnitOrPosition?
 ---@param targetType TargetType
 local function setProjectileTarget(projectileID, target, targetType)
 	if targetType == 1 then
@@ -397,8 +397,8 @@ weaponCustomParamKeys.guidance = {
 ---@class GuidanceEffectResult
 ---@field [1] boolean isFiring
 ---@field [2] TargetType guidanceType
----@field [3] boolean isUserTarget, nil when guidanceType is `0`
----@field [4] integer|xyz guidanceTarget, nil when guidanceType is `0`
+---@field [3] boolean? isUserTarget, nil when guidanceType is `0`
+---@field [4] (UnitOrPosition|ProjectileID)? guidanceTarget, nil when guidanceType is `0`
 
 local guidanceResults = {} ---@type table<integer, GuidanceEffectResult|xyz>
 

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -529,7 +529,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	---A single entry in a unit's target queue, as tracked on the synced side.
 	---@class UnitTargetEntry
-	---@field target UnitID|Position3D Either a target unitID or a `{x, y, z}` ground position.
+	---@field target UnitOrPosition
 	---@field alwaysSeen boolean? Target does not need to stay in sensor range to be kept.
 	---@field ignoreStop boolean? Target survives a Stop command.
 	---@field userTarget boolean? Target was set by the player rather than by Lua.
@@ -537,7 +537,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	---Returns the unit's currently active target.
 	---@param unitID UnitID
-	---@return UnitID|Position3D|nil target A unitID, a `{x, y, z}` ground position, or `nil` when untargeted.
+	---@return UnitOrPosition? target `nil` when untargeted.
 	function GG.GetUnitTarget(unitID)
 		local unitData = activeTargets[unitID]
 		local targetData = unitData and unitData.targets[unitData.currentIndex]
@@ -1068,7 +1068,7 @@ else -- UNSYNCED
 
 	---An entry in the unsynced mirror of a unit's target queue, kept for drawing.
 	---@class UnitTargetEntryUnsynced
-	---@field target UnitID|Position3D Either a target unitID or a `{x, y, z}` ground position.
+	---@field target UnitOrPosition
 	---@field userTarget boolean? Target was set by the player rather than by Lua.
 
 	---Returns the unsynced mirror of the unit's target queue.

--- a/luaui/Widgets/api_object_spotlight.lua
+++ b/luaui/Widgets/api_object_spotlight.lua
@@ -294,17 +294,16 @@ end
 -- ===========
 
 ---@alias ObjectType string
----@alias ObjectID number|number[]
 ---@alias OwnerID string
 ---@alias InstanceID number
 
----@type table<ObjectType, table<ObjectID, table<OwnerID, InstanceID>>>
+---@type table<ObjectType, table<ObjectOrPosition, table<OwnerID, InstanceID>>>
 local objectInstanceIDs = {}
 
----@type table<ObjectType, table<ObjectID, table<OwnerID, boolean>>>
+---@type table<ObjectType, table<ObjectOrPosition, table<OwnerID, boolean>>>
 local objectOwners = {}
 
----@type table<ObjectType, table<ObjectID, table<OwnerID, number>>>
+---@type table<ObjectType, table<ObjectOrPosition, table<OwnerID, number>>>
 local objectExpireTimes = {}
 
 for k in pairs(spotlightTypes) do
@@ -318,7 +317,7 @@ end
 ---removeSpotlight later is necessary to remove the spotlight.
 ---@param objectType string "unit", "feature", or "ground"
 ---@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@param objectID number|number[] unitID, featureID, or {x,y,z} table for a location
+---@param objectID ObjectOrPosition
 ---@param color table RGBA color used for the spotlight
 ---@param options table extra optional parameters
 ---@param options.duration number if specified, the spotlight will fade out over this period of seconds
@@ -402,7 +401,7 @@ end
 ---Removes the spotlight for a given object. This can be called even if a spotlight might not be present.
 ---@param objectType string "unit" or "feature", or "ground"
 ---@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@param objectID number|number[] unitID, featureID, or {x,y,z} table for a location
+---@param objectID ObjectOrPosition
 ---@return nil
 local function removeSpotlight(objectType, owner, objectID)
 	if not spotlightTypes[objectType] then
@@ -440,7 +439,7 @@ end
 ---Returns the objectID for all spotlights with the specified type and owner.
 ---@param objectType string "unit" or "feature", or "ground"
 ---@param owner string An identifier used to prevent name collisions. You can have one spotlight per objectID per owner.
----@return (number|number[])[]
+---@return ObjectOrPosition[]
 local function getSpotlights(objectType, owner)
 	return table.reduce(objectOwners[objectType], function(acc, v, k)
 		if v[owner] then

--- a/types/ObjectOrPosition.lua
+++ b/types/ObjectOrPosition.lua
@@ -1,0 +1,9 @@
+---@meta
+
+--- References to either a simulation object or a point in the world.
+
+--- A unit or a world position.
+---@alias UnitOrPosition UnitID|Position3D
+
+--- A unit or a feature, or a world position.
+---@alias ObjectOrPosition ObjectID|Position3D


### PR DESCRIPTION
### Work done

Add `types/ObjectOrPosition.lua`, naming the two "a simulation object or a point in the world" unions that were already in use under three different spellings in multiple files.

Eliminate `---@alias ObjectID` which collides with https://github.com/beyond-all-reason/RecoilEngine/pull/3231 and was also misleading.

Update a few other adjacent param types and descriptions.

Annotations only, no runtime behaviour changes.

### AI / LLM usage statement:

Claude Opus 5 wrote 80% of code, 50% of PR description, 100% of commit message. I have reviewed this change, understand it, and endorse it.