### PR TITLE
Use integer and new ID aliases to replace number and integer types

### DIFF
--- a/luaui/Include/unitBlocking.lua
+++ b/luaui/Include/unitBlocking.lua
@@ -3,7 +3,7 @@
 local unitBlocking = {}
 
 --- Gets blocked unit definitions from TeamRulesParams
----@param unitDefIDs? number[] Optional array of specific UnitDefIDs to check. If nil, checks all blocked units for the current team.
+---@param unitDefIDs? UnitDefID[] If `nil`, checks all blocked units for the current team.
 ---@return table<number, table<string, boolean>> blockedUnits Table where keys are UnitDefIDs and values are tables of blocking reasons (reason -> true)
 ---@usage
 ---   -- Get all blocked units

--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -38,8 +38,8 @@ local tableInsert = table.insert
 ---@alias Point number[]
 
 ---@class BlueprintUnit
----@field blueprintUnitID number a globally unique ID for this unit
----@field unitDefID number
+---@field blueprintUnitID integer a globally unique ID for this unit
+---@field unitDefID UnitDefID
 ---@field position Point
 ---@field facing number
 
@@ -565,7 +565,7 @@ end
 --- Gives build orders for a blueprint to a set of builders.
 ---@param blueprint Blueprint The blueprint to build.
 ---@param buildPositions table The locations to build the blueprint at.
----@param builders number[] A list of builder unit IDs.
+---@param builders UnitID[]
 ---@param isBuildSplit boolean If true, split the work among builders. If false, builders of the same faction work together.
 ---@param cmdOpts table Command options.
 local function placeBlueprint(blueprint, buildPositions, builders, isBuildSplit, cmdOpts)
@@ -679,7 +679,7 @@ end
 ---Synchronize the building and outline instances with the given list of build positions.
 ---@param blueprint Blueprint
 ---@param buildPositions StartPoints
----@param teamID number
+---@param teamID TeamID
 local function updateInstances(blueprint, buildPositions, teamID)
 	if isHeadless then
 		return

--- a/luaui/Widgets/api_build_orders.lua
+++ b/luaui/Widgets/api_build_orders.lua
@@ -17,17 +17,17 @@ function widget:GetInfo()
 end
 
 ---@class BuilderInfo
----@field unitID number
----@field unitDefID number
+---@field unitID UnitID
+---@field unitDefID UnitDefID
 ---@field side string
 ---@field buildSpeed number
 
 ---@class BuildingInfo
----@field unitDefID number
+---@field unitDefID UnitDefID
 ---@field position number[] { x, y, z }
 ---@field facing? number
 
----@param builderID number
+---@param builderID UnitID
 ---@return BuilderInfo
 local function getBuilderInfo(builderID)
 	local unitDefID = Spring.GetUnitDefID(builderID)
@@ -79,7 +79,7 @@ local function canBuild(builderGroup, building, side, allowSubstitution)
 	return false
 end
 
----@param builders number[]
+---@param builders UnitID[]
 ---@return table<number, BuilderInfo[]> -- Groups builders by their unitDefID
 local function groupBuilders(builders)
 	local builderGroups = {}

--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -201,8 +201,8 @@ local function getBestExtractorFromBuilders(units, constructorIds, extractors)
 end
 
 ---Whether an allied extractor can be replaced: higher techlevel or same-tier higher yield always upgrades; otherwise specialty extractors (does more than just produce metal/energy) may replace standard extractors/other specialty extractors.
----@param currentExtractorUuid number uuid of current extractor
----@param newExtractorId number unitDefID of new extractor
+---@param currentExtractorUuid UnitID
+---@param newExtractorId UnitDefID
 ---@return boolean
 local function extractorCanBeUpgraded(currentExtractorUuid, newExtractorId)
 	local isAllied = Spring.AreTeamsAllied(spGetMyTeamID(), spGetUnitTeam(currentExtractorUuid))

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -54,7 +54,7 @@ function widget:Initialize()
 end
 
 ---Gets the position of the last command in a unit's queue, or nil if the queue is empty
----@param unitID number
+---@param unitID UnitID
 ---@return number|nil x
 ---@return number|nil z
 local function getLastQueuedPosition(unitID)
@@ -72,7 +72,7 @@ end
 ---When useQueueEnd is true, uses the position of the last queued command instead of the unit's current position.
 ---@param units table selected units
 ---@param constructorIds table<UnitID, ResourceSpotConstructor?> All mex constructors
----@param buildingId number Specific mex that we want to build
+---@param buildingId UnitDefID Specific mex that we want to build
 ---@param useQueueEnd boolean Whether to use the end-of-queue position (for shift-queuing)
 ---@return table { x, z }
 local function getAvgPositionOfValidBuilders(units, constructorIds, buildingId, useQueueEnd)

--- a/luaui/Widgets/cmd_buildsplit.lua
+++ b/luaui/Widgets/cmd_buildsplit.lua
@@ -68,7 +68,7 @@ local function getBuilderInfos(unitIDs)
 	return builders
 end
 
----@param builderIDs number[]
+---@param builderIDs UnitID[]
 ---@param buildings BuildingInfo[]
 ---@param cmdOpts table
 local function splitBuildings(builderIDs, buildings, cmdOpts)

--- a/luaui/Widgets/gfx_DrawFeatureShape_GL4.lua
+++ b/luaui/Widgets/gfx_DrawFeatureShape_GL4.lua
@@ -264,7 +264,7 @@ end
 ---Callers own the lifetime of everything they submit: pair every call that
 ---creates a ghost with StopDrawFeatureShapeGL4, or batch-remove with
 ---StopDrawFeatureShapesGL4(ownerID).
----@param featureDefID number which featureDef to draw
+---@param featureDefID FeatureDefID which featureDef to draw
 ---@param px number world position
 ---@param py number world position
 ---@param pz number world position
@@ -277,7 +277,7 @@ end
 ---@param tintB number optional tint target colour
 ---@param tintAmount number optional how much to blend the tint in [0-1], default 0
 ---@param scale number optional uniform model scale, default 1 (matches the root-piece-matrix scale the feature placer applies)
----@param updateID number optional a uniqueID returned earlier, to move that ghost instead of adding one
+---@param updateID integer? optional a uniqueID returned earlier, to move that ghost instead of adding one
 ---@param ownerID any optional tag so a widget can batch-remove everything it submitted
 ---@return number|nil uniqueID pass to StopDrawFeatureShapeGL4 to stop drawing it
 local function DrawFeatureShapeGL4(
@@ -344,7 +344,7 @@ local function DrawFeatureShapeGL4(
 	return updateID
 end
 
----@param handleID number a uniqueID returned by DrawFeatureShapeGL4
+---@param handleID integer a uniqueID returned by DrawFeatureShapeGL4
 ---@return any ownerID the owner the handle was registered under, if any
 local function StopDrawFeatureShapeGL4(handleID)
 	if handleID == nil then

--- a/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
+++ b/luaui/Widgets/gfx_DrawUnitShape_GL4.lua
@@ -255,17 +255,17 @@ end
 ---DrawUnitGL4(unitID, unitDefID, px, py, pz, rotationY, alpha, teamID, teamcoloroverride, highlight, updateID, ownerID)
 ---Draw a copy of an actual unit, with all of its animations too. That unit must be in view. For things like highlighting under construction stuff.
 ---note that widgets are responsible for stopping the drawing of every unit that they submit! They may use RemoveMyDraws(ownerID). Note that prompt removal when widget:VisibleUnitRemoved(unitID) is essential here!
----@param unitID number the actual unitID that you want to draw
----@param unitDefID number which unitDef do you want to draw
+---@param unitID UnitID the actual unitID that you want to draw
+---@param unitDefID UnitDefID which unitDef do you want to draw
 ---@param px number optional where in the world to do you want to draw it
 ---@param py number optional where in the world to do you want to draw it
 ---@param pz number optional where in the world to do you want to draw it
 ---@param rotationY number optional Angle in radians on how much to rotate the unit around Y, 0 means it faces south, (+Z), pi/2 points west (-X) -pi/2 points east
 ---@param alpha number optional the transparency level of the unit
----@param teamID number optional which teams teamcolor should this unit get, leave nil if you want to keep the original teamID
+---@param teamID TeamID? optional which teams teamcolor should this unit get, leave `nil` if you want to keep the original teamID
 ---@param teamcoloroverride number optional much we should mix the teamcolor into the model color [0-1]
 ---@param highlight number optional how much we should add a highlighting animation to the unit (blends white with [0-1])
----@param updateID number optional specify the previous uniqueID if you want to update it
+---@param updateID integer? optional specify the previous uniqueID if you want to update it
 ---@param ownerID any optional unique identifier so that widgets can batch remove all of their own stuff
 ---@return uniqueID number a unique handler ID number that you should store and call StopDrawUnitGL4(uniqueID) with to stop drawing it
 local function DrawUnitGL4(
@@ -331,16 +331,16 @@ end
 ---DrawUnitShapeGL4(unitDefID, px, py, pz, rotationY, alpha, teamID, teamcoloroverride, highlight, updateID, ownerID)
 ---Draw a static unit shape model anywhere. Like for ghosted buildings
 ---note that widgets are responsible for stopping the drawing of every unit that they submit! They may use RemoveMyDraws(ownerID)
----@param unitDefID number which unitDef do you want to draw
+---@param unitDefID UnitDefID which unitDef do you want to draw
 ---@param px number where in the world to do you want to draw it
 ---@param py number where in the world to do you want to draw it
 ---@param pz number where in the world to do you want to draw it
 ---@param rotationY number Angle in radians on how much to rotate the unit around Y, 0 means it faces south, (+Z), pi/2 points west (-X) -pi/2 points east
 ---@param alpha number optional the transparency level of the unit
----@param teamID number optional which teams teamcolor should this unit get, leave nil if you want to keep the original teamID
+---@param teamID TeamID? optional which teams teamcolor should this unit get, leave `nil` if you want to keep the original teamID
 ---@param teamcoloroverride number optional much we should mix the teamcolor into the model color [0-1]
 ---@param highlight number optional how much we should add a highlighting animation to the unit (blends white with [0-1])
----@param updateID number optional specify the previous uniqueID if you want to update it
+---@param updateID integer? optional specify the previous uniqueID if you want to update it
 ---@param ownerID any optional unique identifier so that widgets can batch remove all of their own stuff
 ---@return uniqueID number a unique handler ID number that you should store and call StopDrawUnitGL4(uniqueID) with to stop drawing it
 local function DrawUnitShapeGL4(
@@ -395,7 +395,7 @@ local function DrawUnitShapeGL4(
 end
 
 ---StopDrawUnitGL4(uniqueID)
----@param uniqueID number the unique id of whatever you want to stop drawing
+---@param uniqueID integer the unique id of whatever you want to stop drawing
 ---@return the ownerID the uniqueID was associated to
 local function StopDrawUnitGL4(uniqueID)
 	if corDrawUnitVBOTable.instanceIDtoIndex[uniqueID] then
@@ -412,7 +412,7 @@ local function StopDrawUnitGL4(uniqueID)
 end
 
 ---StopDrawUnitGL4(uniqueID)
----@param uniqueID number the unique id of whatever you want to stop drawing
+---@param uniqueID integer the unique id of whatever you want to stop drawing
 ---@return the ownerID the uniqueID was associated to
 local function StopDrawUnitShapeGL4(uniqueID)
 	if uniqueIDtoUnitShapeVBOTable[uniqueID] then

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -635,7 +635,7 @@ end
 ---InitializeLight(lightTable, unitID)
 ---Takes a light definition table, and tries to check whether its already been initialized, if not, it inits it in-place
 ---@param lightTable table
----@param unitID number
+---@param unitID UnitID
 local function InitializeLight(lightTable, unitID)
 	if not lightTable.initComplete then -- late init
 		-- do the table to flattable conversion, if it doesn't exist yet
@@ -1419,7 +1419,7 @@ end
 ---Remove a light
 ---@param lightshape string 'point'|'beam'|'cone'
 ---@param instanceID any the ID of the light to remove
----@param unitID number make this non-nil to remove it from a unit
+---@param unitID UnitID? make this non-nil to remove it from a unit
 ---@returns the same instanceID on success, nil if the light was not found
 local function RemoveLight(lightshape, instanceID, unitID, noUpload)
 	if unitID then

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -463,7 +463,7 @@ end
 ---InitializeDistortion(distortionTable, unitID)
 ---Takes a distortion definition table, and tries to check whether its already been initialized, if not, it inits it in-place
 ---@param distortionTable table
----@param unitID number
+---@param unitID UnitID
 local function InitializeDistortion(distortionTable, unitID)
 	if not distortionTable.initComplete then -- late init
 		-- do the table to flattable conversion, if it doesn't exist yet
@@ -686,7 +686,7 @@ end
 ---Remove a distortion
 ---@param distortionshape string 'point'|'beam'|'cone'
 ---@param instanceID any the ID of the distortion to remove
----@param unitID number make this non-nil to remove it from a unit
+---@param unitID UnitID? make this non-nil to remove it from a unit
 ---@returns the same instanceID on success, nil if the distortion was not found
 local function RemoveDistortion(distortionshape, instanceID, unitID, noUpload)
 	if unitID then

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -2356,7 +2356,7 @@ function widget:Initialize()
 	---@field bottom CostLine?
 
 	---Override the cost display for a specific unit in the build menu
-	---@param unitDefID number The unit definition ID to override costs for
+	---@param unitDefID UnitDefID The unit definition ID to override costs for
 	---@param costData CostData Cost override configuration table with optional properties
 	WG.buildmenu.setCostOverride = function(unitDefID, costData)
 		if unitDefID and costData then
@@ -2366,7 +2366,7 @@ function widget:Initialize()
 	end
 
 	---Clear cost overrides for a specific unit or all units
-	---@param unitDefID number? The unit definition ID to clear overrides for. If nil or not provided, clears all cost overrides.
+	---@param unitDefID UnitDefID? The unit definition ID to clear overrides for. If nil or not provided, clears all cost overrides.
 	WG.buildmenu.clearCostOverrides = function(unitDefID)
 		if unitDefID then
 			costOverrides[unitDefID] = nil
@@ -2381,7 +2381,7 @@ function widget:Initialize()
 	---Highlight a build option to draw the player's attention to it with a pulsing
 	---inner outline and a soft inner glow. Non-destructive: does not affect input or
 	---block hover/selection visuals. Subsequent calls update the existing highlight.
-	---@param unitDefID number The unit definition ID to highlight.
+	---@param unitDefID UnitDefID The unit definition ID to highlight.
 	---@param color number[]? Optional {r,g,b} in 0..1. Defaults to a warm yellow.
 	WG.buildmenu.setHighlight = function(unitDefID, color)
 		if not unitDefID then
@@ -2397,7 +2397,7 @@ function widget:Initialize()
 	end
 
 	---Remove a highlight previously set via setHighlight.
-	---@param unitDefID number
+	---@param unitDefID UnitDefID
 	WG.buildmenu.removeHighlight = function(unitDefID)
 		if unitDefID and highlights[unitDefID] then
 			highlights[unitDefID] = nil
@@ -2414,7 +2414,7 @@ function widget:Initialize()
 	end
 
 	---Returns true if there is an active highlight for the given unitDefID.
-	---@param unitDefID number
+	---@param unitDefID UnitDefID
 	---@return boolean
 	WG.buildmenu.hasHighlight = function(unitDefID)
 		return unitDefID ~= nil and highlights[unitDefID] ~= nil

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -1575,7 +1575,7 @@ function widget:Initialize()
 	---@field bottom CostLine?
 
 	---Override the cost display for a specific unit in the grid menu
-	---@param unitDefID number The unit definition ID to override costs for
+	---@param unitDefID UnitDefID The unit definition ID to override costs for
 	---@param costData CostData Cost override configuration table with optional properties
 	WG.gridmenu.setCostOverride = function(unitDefID, costData)
 		if unitDefID and costData then
@@ -1586,7 +1586,7 @@ function widget:Initialize()
 	end
 
 	---Clear cost overrides for a specific unit or all units
-	---@param unitDefID number? The unit definition ID to clear overrides for. If nil or not provided, clears all cost overrides.
+	---@param unitDefID UnitDefID? The unit definition ID to clear overrides for. If nil or not provided, clears all cost overrides.
 	WG.gridmenu.clearCostOverrides = function(unitDefID)
 		if unitDefID then
 			costOverrides[unitDefID] = nil
@@ -1602,7 +1602,7 @@ function widget:Initialize()
 	---Highlight a build option to draw the player's attention to it with a pulsing
 	---inner outline and a soft inner glow. Non-destructive: does not affect input or
 	---block hover/selection visuals. Subsequent calls update the existing highlight.
-	---@param unitDefID number The unit definition ID to highlight.
+	---@param unitDefID UnitDefID The unit definition ID to highlight.
 	---@param color number[]? Optional {r,g,b} in 0..1. Defaults to a warm yellow.
 	local function setHighlight(unitDefID, color)
 		if not unitDefID then

--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -727,7 +727,7 @@ function widget:Initialize()
 	---Highlight a command in the order menu with an animated pulsing outline +
 	---inner glow. Subsequent calls update the existing highlight (without
 	---restarting the pulse phase).
-	---@param cmdID number The command ID (e.g. CMD.MOVE, CMD.ATTACK) to highlight.
+	---@param cmdID integer|CMD The command ID (e.g. CMD.MOVE, CMD.ATTACK) to highlight.
 	---@param color number[]? Optional {r,g,b} in 0..1. Defaults to a warm yellow.
 	WG.ordermenu.setHighlight = function(cmdID, color)
 		if not cmdID then

--- a/spec/builders/spring_synced_builder.lua
+++ b/spec/builders/spring_synced_builder.lua
@@ -198,7 +198,7 @@ function SB:WithGameFrame(frame)
 end
 
 ---@param self SpringSyncedBuilder
----@param teamID number
+---@param teamID TeamID
 ---@param key string
 ---@param value any
 ---@return SpringSyncedBuilder
@@ -893,7 +893,7 @@ end
 ---Register a unit definition. Accepts either a UnitDefBuilder or a (defID, defTable) pair.
 ---Delegates to the shared UnitDefsBuilder registry.
 ---@overload fun(self: SpringSyncedBuilder, udb: UnitDefBuilder): SpringSyncedBuilder
----@param defID number
+---@param defID UnitDefID
 ---@param def table
 ---@return SpringSyncedBuilder
 function SB:WithUnitDef(defID, def)

--- a/spec/builders/spring_unsynced_builder.lua
+++ b/spec/builders/spring_unsynced_builder.lua
@@ -31,7 +31,7 @@ end
 
 ---Register a unit definition. Delegates to the underlying UnitDefsBuilder.
 ---@overload fun(self: SpringUnsyncedBuilder, udb: UnitDefBuilder): SpringUnsyncedBuilder
----@param defID number
+---@param defID UnitDefID
 ---@param def table
 ---@return SpringUnsyncedBuilder
 function SUB:WithUnitDef(defID, def)
@@ -40,7 +40,7 @@ function SUB:WithUnitDef(defID, def)
 end
 
 ---Place a live unit instance on the map. Errors if the def is not registered.
----@param unitID number
+---@param unitID UnitID
 ---@param defIDOrName number|string
 ---@return SpringUnsyncedBuilder
 function SUB:WithUnit(unitID, defIDOrName)

--- a/spec/builders/team_builder.lua
+++ b/spec/builders/team_builder.lua
@@ -276,7 +276,7 @@ function TeamBuilder:WithEnergyReceived(received)
 end
 
 ---@param self TeamBuilder
----@param playerId number
+---@param playerId PlayerID
 ---@param opts table|nil
 ---@return TeamBuilder
 function TeamBuilder:WithPlayer(playerId, opts)
@@ -304,7 +304,7 @@ function TeamBuilder:WithPlayer(playerId, opts)
 end
 
 ---@param self TeamBuilder
----@param playerId number
+---@param playerId PlayerID
 ---@return TeamBuilder
 function TeamBuilder:WithLeader(playerId)
 	self.leader = playerId

--- a/spec/builders/unit_def_builder.lua
+++ b/spec/builders/unit_def_builder.lua
@@ -25,7 +25,7 @@ function UDB.new(name)
 	}, UDB)
 end
 
----@param defID number
+---@param defID UnitDefID
 ---@return UnitDefBuilder
 function UDB:WithDefID(defID)
 	self._defID = defID

--- a/spec/builders/unit_defs_builder.lua
+++ b/spec/builders/unit_defs_builder.lua
@@ -29,7 +29,7 @@ end
 
 ---Register a unit definition. Accepts either a UnitDefBuilder or a (defID, defTable) pair.
 ---@overload fun(self: UnitDefsBuilder, udb: UnitDefBuilder): UnitDefsBuilder
----@param defID number
+---@param defID UnitDefID
 ---@param def table
 ---@return UnitDefsBuilder
 function UDFB:WithUnitDef(defID, def)
@@ -55,7 +55,7 @@ end
 ---Register a live unit instance. defIDOrName accepts either a numeric defID
 ---or the name of a previously-registered def. Errors loudly if the def has
 ---not been registered (via WithUnitDef or WithRealUnitDefs).
----@param unitID number
+---@param unitID UnitID
 ---@param defIDOrName number|string
 ---@return UnitDefsBuilder
 function UDFB:WithUnit(unitID, defIDOrName)
@@ -166,7 +166,7 @@ function UDFB:GetUnitDefNames()
 	return self._names
 end
 
----@param unitID number
+---@param unitID UnitID
 ---@return number|nil
 function UDFB:GetUnitDefID(unitID)
 	return self._instances[unitID]

--- a/types/Spring.lua
+++ b/types/Spring.lua
@@ -35,7 +35,7 @@
 
 -- TODO: delete when recoil-lua-library publishes TeamData types
 ---@class TeamData
----@field id number
+---@field id TeamID
 ---@field name string
 ---@field leader number
 ---@field isDead boolean
@@ -44,7 +44,7 @@
 ---@field allyTeam number
 
 ---@class PlayerData
----@field id number
+---@field id PlayerID
 ---@field name string
 ---@field active boolean
 ---@field spectator boolean


### PR DESCRIPTION
### Work done

https://github.com/beyond-all-reason/RecoilEngine/pull/3231 will appear in our `recoil-lua-library` soon and the type check failure on this PR will clear.

This PR uses the new aliases where appropriate.

It also updates some bare `number` to `integer`, and a few related comments and other annotations.

Annotations only, no runtime changes.

### AI / LLM usage statement:

Claude Opus 5 authored 90% of code, 100% of commit message, 10% of this PR description. I have reviewed the code, understand it, and endorse it.