### PR TITLE
Fix commando gun color

### DIFF
--- a/units/CorBots/T2/cormando.lua
+++ b/units/CorBots/T2/cormando.lua
@@ -111,7 +111,7 @@ return {
 				proximitypriority = -1,
 				range = 300,
 				reloadtime = 0.5,
-				rgbcolor = "0.85,0.3,0.2",
+				rgbcolor = "0.85 0.3 0.2",
 				soundhit = "xplosml5",
 				soundhitwet = "sizzle",
 				soundstart = "lasrfir5",


### PR DESCRIPTION
### Work done
Fixed a typo in commando lua def which was not coloring the laser blaster. 

#### Addresses Issue(s)
Looks like it was meant to be red, which tracks with light damage 'lasers' 

### Screenshots:

#### BEFORE:
<img width="1117" height="851" alt="image-17" src="https://github.com/user-attachments/assets/9cbe112a-810e-427a-a21d-103fcb38c7e5" />


#### after
<img width="940" height="648" alt="image-41" src="https://github.com/user-attachments/assets/7966b260-7bec-4ad4-bf0b-c811851b2b07" />
