### PR TITLE
Name the resource spot builder's unit tables

### DIFF
--- a/luaui/Widgets/api_resource_spot_builder.lua
+++ b/luaui/Widgets/api_resource_spot_builder.lua
@@ -46,14 +46,32 @@ local isPregame = Spring.GetGameFrame() == 0 and not Spring.GetSpectatingState()
 ------------------------------------------------------------
 -- unit tables
 ------------------------------------------------------------
+
+--- What one builder can put on a resource spot. Every unit of a given unit def
+--- shares one of these, so the instance and the def registries below hold the
+--- same tables under different keys.
+---@class ResourceSpotConstructor
+---@field buildings integer How many entries `building` holds, and the cursor the fill loop appends at.
+---@field building (-UnitDefID)[] Build commands, i.e. negated extractor unit def IDs.
+
+---@type table<UnitID, ResourceSpotConstructor?>
 local mexConstructors = {}
+---@type table<UnitDefID, ResourceSpotConstructor?>
 local mexConstructorsDef = {}
+--- Extractors, by how much metal each one pulls from a spot.
+---@type table<UnitDefID, number?>
 local mexBuildings = {}
 
+---@type table<UnitID, ResourceSpotConstructor?>
 local geoConstructors = {}
+---@type table<UnitDefID, ResourceSpotConstructor?>
 local geoConstructorsDef = {}
+--- Geothermal plants and how much energy each one makes.
+---@type table<UnitDefID, number?>
 local geoBuildings = {}
 
+--- Extractors that only produce metal or energy, so every faction has one.
+---@type table<UnitDefID, true?>
 local standardExtractors = {}
 ------------------------------------------------------------
 -- populate unit tables

--- a/luaui/Widgets/cmd_area_mex.lua
+++ b/luaui/Widgets/cmd_area_mex.lua
@@ -71,7 +71,7 @@ end
 ---Finds all builders among selected units that can make the specified building, and gets their average position.
 ---When useQueueEnd is true, uses the position of the last queued command instead of the unit's current position.
 ---@param units table selected units
----@param constructorIds table All mex constructors
+---@param constructorIds table<UnitID, ResourceSpotConstructor?> All mex constructors
 ---@param buildingId number Specific mex that we want to build
 ---@param useQueueEnd boolean Whether to use the end-of-queue position (for shift-queuing)
 ---@return table { x, z }


### PR DESCRIPTION
### Work done

Types the six unit tables in `api_resource_spot_builder`, naming the record its mex and geo constructor registries share, so `cmd_area_mex`'s `constructorIds` parameter can say what it takes instead of `table`.

Typing the three def-keyed lookup tables surfaces eleven latent warnings, none introduced here: two on dead code to be eliminated in another PR, and the rest where a unit def ID used as a key is typed `number` or is an unguarded `Spring.GetUnitDefID` result. Four are cleared by #9003 / #9008.

Annotations only, no runtime changes.

### AI / LLM usage statement:

Claude Opus 5 authored 90% of code, 100% of commit message, 50% of PR description. I have reviewed the annotation changes, understand them, and endorse them.