### PR TITLE
fix: widget selector cannot lie to you, stops turning off your widgets

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2796,8 +2796,6 @@ function applyOptionValue(i, newValue, skipRedrawWindow, force)
 			end
 		else
 			if widgetHandler.orderList[options[i].widget] > 0 then
-				widgetHandler:ToggleWidget(options[i].widget)
-			else
 				widgetHandler:DisableWidget(options[i].widget)
 			end
 		end

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2791,15 +2791,9 @@ function applyOptionValue(i, newValue, skipRedrawWindow, force)
 
 	if options[i].widget ~= nil and widgetHandler.orderList[options[i].widget] ~= nil then
 		if options[i].value then
-			if widgetHandler.orderList[options[i].widget] < 0.5 then
-				widgetHandler:EnableWidget(options[i].widget)
-			end
+			widgetHandler:EnableWidget(options[i].widget)
 		else
-			if widgetHandler.orderList[options[i].widget] > 0 then
-				widgetHandler:ToggleWidget(options[i].widget)
-			else
-				widgetHandler:DisableWidget(options[i].widget)
-			end
+			widgetHandler:DisableWidget(options[i].widget)
 		end
 		forceUpdate = true
 		scheduleInit = true

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -2791,9 +2791,15 @@ function applyOptionValue(i, newValue, skipRedrawWindow, force)
 
 	if options[i].widget ~= nil and widgetHandler.orderList[options[i].widget] ~= nil then
 		if options[i].value then
-			widgetHandler:EnableWidget(options[i].widget)
+			if widgetHandler.orderList[options[i].widget] < 0.5 then
+				widgetHandler:EnableWidget(options[i].widget)
+			end
 		else
-			widgetHandler:DisableWidget(options[i].widget)
+			if widgetHandler.orderList[options[i].widget] > 0 then
+				widgetHandler:ToggleWidget(options[i].widget)
+			else
+				widgetHandler:DisableWidget(options[i].widget)
+			end
 		end
 		forceUpdate = true
 		scheduleInit = true

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -392,6 +392,12 @@ local function widgetselectorCmd(_, _, params)
 	end
 end
 
+local function widgetresetCmd(_, _, params)
+	spEcho("Resetting which widgets are loaded, reloading...")
+	widgetHandler.__blankOutOrder = true
+	Spring.SendCommands("luarules reloadluaui")
+end
+
 local function factoryresetCmd(_, _, params)
 	widgetHandler.__blankOutConfig = true
 	--widgetHandler.__allowUserWidgets = false
@@ -460,6 +466,7 @@ function widget:Initialize()
 	UpdateList()
 
 	widgetHandler.actionHandler:AddAction(self, "widgetselector", widgetselectorCmd, nil, "t")
+	widgetHandler.actionHandler:AddAction(self, "widgetreset", widgetresetCmd, nil, "t")
 	widgetHandler.actionHandler:AddAction(self, "factoryreset", factoryresetCmd, nil, "t")
 	widgetHandler.actionHandler:AddAction(self, "userwidgets", userwidgetsCmd, nil, "t")
 end
@@ -1520,6 +1527,7 @@ function widget:Shutdown()
 	gl.DeleteFont(font2)
 
 	widgetHandler.actionHandler:RemoveAction(self, "widgetselector")
+	widgetHandler.actionHandler:RemoveAction(self, "reset")
 	widgetHandler.actionHandler:RemoveAction(self, "factoryreset")
 	widgetHandler.actionHandler:RemoveAction(self, "userwidgets")
 end

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -1020,7 +1020,8 @@ function widget:DrawScreen()
 				local pointed = (pointedName == name)
 				local order = widgetHandler.orderList[name]
 				local enabled = order and (order > 0)
-				local active = data.active
+				local known = widgetHandler.knownWidgets[name] -- live lookup
+				local active = known and known.active
 				if pointed and not activescrollbar then
 					pointedY = posy
 					if not pagestepped and (lmb or mmb or rmb) then

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -1418,9 +1418,11 @@ function widget:MouseRelease(x, y, mb)
 			return -1
 		end
 		if buttonID == 2 then
-			-- disable all widgets, but don't reload
+			-- disable loaded widgets, but don't reload
 			for _, namedata in ipairs(fullWidgetsList) do
-				widgetHandler:DisableWidget(namedata[1])
+				if widgetHandler:FindWidget(namedata[1]) then
+					widgetHandler:DisableWidget(namedata[1])
+				end
 			end
 			widgetHandler:SaveConfigData()
 			return -1

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -392,12 +392,6 @@ local function widgetselectorCmd(_, _, params)
 	end
 end
 
-local function widgetresetCmd(_, _, params)
-	spEcho("Resetting which widgets are loaded, reloading...")
-	widgetHandler.__blankOutOrder = true
-	Spring.SendCommands("luarules reloadluaui")
-end
-
 local function factoryresetCmd(_, _, params)
 	widgetHandler.__blankOutConfig = true
 	--widgetHandler.__allowUserWidgets = false
@@ -466,7 +460,6 @@ function widget:Initialize()
 	UpdateList()
 
 	widgetHandler.actionHandler:AddAction(self, "widgetselector", widgetselectorCmd, nil, "t")
-	widgetHandler.actionHandler:AddAction(self, "widgetreset", widgetresetCmd, nil, "t")
 	widgetHandler.actionHandler:AddAction(self, "factoryreset", factoryresetCmd, nil, "t")
 	widgetHandler.actionHandler:AddAction(self, "userwidgets", userwidgetsCmd, nil, "t")
 end
@@ -1527,7 +1520,6 @@ function widget:Shutdown()
 	gl.DeleteFont(font2)
 
 	widgetHandler.actionHandler:RemoveAction(self, "widgetselector")
-	widgetHandler.actionHandler:RemoveAction(self, "reset")
 	widgetHandler.actionHandler:RemoveAction(self, "factoryreset")
 	widgetHandler.actionHandler:RemoveAction(self, "userwidgets")
 end

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -409,6 +409,9 @@ local function loadWidgetFiles(folder, vfsMode)
 				-- LoadWidget reads raw-first, so the user's copy may have been read here instead.
 				widgetHandler:ForgetWidget(name)
 				widget = widgetHandler:LoadWidget(file, true, nil, true) -- reload reads the zip
+				if not widget then
+					Spring.Echo("Missing widget: " .. name .. "  (failed in replacing user copy)")
+				end
 			end
 		end
 
@@ -459,6 +462,7 @@ function widgetHandler:Initialize()
 			CreateSandboxedSystem()
 		end
 
+		-- The RAW passes populate seen zipOnly files.
 		Spring.Echo("LuaUI: Allowing User Widgets")
 		loadWidgetFiles(WIDGET_DIRNAME, VFS.RAW)
 		loadWidgetFiles(RML_WIDGET_DIRNAME, VFS.RAW)

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1226,7 +1226,7 @@ function widgetHandler:IsWidgetKnown(name)
 end
 
 function widgetHandler:ForgetWidget(name)
-	if not self.knownWidgets[name] then
+	if not self:IsWidgetKnown(name) then
 		return
 	end
 	local ki = self.knownWidgets[name]

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -22,7 +22,6 @@ local WIDGET_DIRNAME = LUAUI_DIRNAME .. "Widgets/"
 local RML_WIDGET_DIRNAME = LUAUI_DIRNAME .. "RmlWidgets/"
 
 local SELECTOR_BASENAME = "selector.lua"
-local SELECTOR_NAME = "Widget Selector"
 
 local SAFEWRAP = 1
 -- 0: disabled
@@ -603,14 +602,9 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 
 	self:FinalizeWidget(widget, filename, basename)
 	local name = widget.whInfo.name
-
-	-- Hiding is a game-widget privilege. A hidden user widget is unlistable, undisableable, and
-	-- loaded again on every reload, so a broken one could only be fixed by editing files.
-	local hidden = fromZip and widget.whInfo.hidden or false
-
 	if basename == SELECTOR_BASENAME then
 		self.orderList[name] = 1 -- always load the widget selector
-	elseif hidden then
+	elseif widget.whInfo.hidden then
 		self.orderList[name] = 1 -- hidden widgets back other widgets, so they always load
 	end
 
@@ -634,7 +628,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 		knownInfo.basename = widget.whInfo.basename
 		knownInfo.filename = widget.whInfo.filename
 		knownInfo.fromZip = fromZip
-		knownInfo.hidden = hidden
+		knownInfo.hidden = widget.whInfo.hidden
 		self.knownWidgets[name] = knownInfo
 		self.knownCount = self.knownCount + 1
 		self.knownChanged = true
@@ -1245,9 +1239,9 @@ function widgetHandler:DisableWidgetRaw(name)
 		end
 		Spring.Echo("Removed:  " .. ki.filename)
 		self:RemoveWidgetRaw(w) -- deactivate
+		self.orderList[name] = 0 -- disable
+		self:SaveConfigData()
 	end
-	self.orderList[name] = 0 -- disable
-	self:SaveConfigData()
 	return true
 end
 
@@ -1259,13 +1253,14 @@ function widgetHandler:ToggleWidgetRaw(name)
 	end
 	if ki.active then
 		return self:DisableWidgetRaw(name)
+	elseif self.orderList[name] <= 0 then
+		return self:EnableWidgetRaw(name)
+	else
+		-- the widget is not active, but enabled; disable it
+		self.orderList[name] = 0
+		self:SaveConfigData()
 	end
-	-- The widget is enabled but not running, so it errored out or bowed out. This is the state a
-	-- player clicks to repair, so bring it back, and only write it off when it will not even load.
-	if self:EnableWidgetRaw(name) then
-		return true
-	end
-	return self:DisableWidgetRaw(name)
+	return true
 end
 
 --------------------------------------------------------------------------------
@@ -1437,18 +1432,6 @@ function widgetHandler:Shutdown()
 	-- save config
 	if self.__blankOutConfig then
 		table.save({ allowUserWidgets = self.allowUserWidgets }, CONFIG_FILENAME, "-- Widget Custom data and order")
-	elseif self.__blankOutOrder then
-		-- Keep what each widget was configured to do, forget which widgets ran and in what order.
-		for _, w in ipairs(self.widgets) do
-			if w.GetConfigData then
-				self.configData[w.whInfo.name] = w:GetConfigData()
-			end
-		end
-		table.save(
-			{ data = self.configData, allowUserWidgets = self.allowUserWidgets },
-			CONFIG_FILENAME,
-			"-- Widget Custom data and order"
-		)
 	else
 		self:SaveConfigData()
 	end
@@ -1495,12 +1478,14 @@ function widgetHandler:ConfigureLayout(command)
 		self:SendConfigData()
 		return true
 	elseif command == "selector" then
-		-- Bring the selector back up for recovery even if its config says to disable it.
-		self:EnableWidgetRaw(SELECTOR_NAME)
-		local sw = self:FindWidget(SELECTOR_NAME)
-		if sw then
-			self:RaiseWidgetRaw(sw)
+		for _, w in ipairs(self.widgets) do
+			if w.whInfo.basename == SELECTOR_BASENAME then
+				return true -- there can only be one
+			end
 		end
+		local sw = self:LoadWidget(LUAUI_DIRNAME .. SELECTOR_BASENAME, true) -- load the game's included widget_selector.lua, instead of the default selector.lua
+		self:InsertWidgetRaw(sw)
+		self:RaiseWidgetRaw(sw)
 		return true
 	elseif string.find(command, "togglewidget") == 1 then
 		self:ToggleWidgetRaw(string.sub(command, 14))

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -622,9 +622,13 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 
 	self:FinalizeWidget(widget, filename, basename)
 	local name = widget.whInfo.name
+
+	-- Only the game gets to hide a widget: a hidden one always loads and cannot be disabled.
+	local hidden = fromZip and widget.whInfo.hidden or false
+
 	if basename == SELECTOR_BASENAME then
 		self.orderList[name] = 1 -- always load the widget selector
-	elseif widget.whInfo.hidden then
+	elseif hidden then
 		self.orderList[name] = 1 -- hidden widgets back other widgets, so they always load
 	end
 
@@ -654,7 +658,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 		knownInfo.basename = widget.whInfo.basename
 		knownInfo.filename = widget.whInfo.filename
 		knownInfo.fromZip = fromZip
-		knownInfo.hidden = widget.whInfo.hidden
+		knownInfo.hidden = hidden
 		self.knownWidgets[name] = knownInfo
 		self.knownCount = self.knownCount + 1
 		self.knownChanged = true

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -384,6 +384,7 @@ local zipOnly = {
 	["Widget Selector"] = true,
 	["Widget Profiler"] = true,
 }
+local zipWasRaw = {}
 
 local function loadWidgetFiles(folder, vfsMode)
 	local fromZip = vfsMode ~= VFS.RAW
@@ -394,12 +395,21 @@ local function loadWidgetFiles(folder, vfsMode)
 	end
 
 	for _, file in ipairs(widgetFiles) do
-		local widget = widgetHandler:LoadWidget(file, fromZip)
+		local widget = widgetHandler:LoadWidget(file, fromZip) ---@type table?
 
-		if widget and not fromZip and zipOnly[widget.whInfo.name] then
-			-- Drop what the user registered so the game's copy is not refused as a duplicate.
-			widgetHandler:ForgetWidget(widget.whInfo.name)
-			widget = nil
+		if widget and zipOnly[widget.whInfo.name] then
+			local name = widget.whInfo.name
+			if not fromZip then
+				-- Drop what the user registered so the game's copy is not refused as a duplicate.
+				Spring.Echo("Ignoring user copy: " .. file .. "  (the game provides " .. name .. ")")
+				widgetHandler:ForgetWidget(name)
+				zipWasRaw[name] = true
+				widget = nil
+			elseif zipWasRaw[name] then
+				-- LoadWidget reads raw-first, so the user's copy may have been read here instead.
+				widgetHandler:ForgetWidget(name)
+				widget = widgetHandler:LoadWidget(file, true, nil, true) -- reload reads the zip
+			end
 		end
 
 		if widget then
@@ -442,6 +452,7 @@ function widgetHandler:Initialize()
 	Spring.CreateDir(LUAUI_DIRNAME .. "Config")
 
 	unsortedWidgets = {}
+	zipWasRaw = {}
 
 	if self.allowUserWidgets and allowuserwidgets then
 		if not allowunitcontrolwidgets then

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -22,6 +22,7 @@ local WIDGET_DIRNAME = LUAUI_DIRNAME .. "Widgets/"
 local RML_WIDGET_DIRNAME = LUAUI_DIRNAME .. "RmlWidgets/"
 
 local SELECTOR_BASENAME = "selector.lua"
+local SELECTOR_NAME = "Widget Selector"
 
 local SAFEWRAP = 1
 -- 0: disabled
@@ -602,9 +603,14 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 
 	self:FinalizeWidget(widget, filename, basename)
 	local name = widget.whInfo.name
+
+	-- Hiding is a game-widget privilege. A hidden user widget is unlistable, undisableable, and
+	-- loaded again on every reload, so a broken one could only be fixed by editing files.
+	local hidden = fromZip and widget.whInfo.hidden or false
+
 	if basename == SELECTOR_BASENAME then
 		self.orderList[name] = 1 -- always load the widget selector
-	elseif widget.whInfo.hidden then
+	elseif hidden then
 		self.orderList[name] = 1 -- hidden widgets back other widgets, so they always load
 	end
 
@@ -628,7 +634,7 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 		knownInfo.basename = widget.whInfo.basename
 		knownInfo.filename = widget.whInfo.filename
 		knownInfo.fromZip = fromZip
-		knownInfo.hidden = widget.whInfo.hidden
+		knownInfo.hidden = hidden
 		self.knownWidgets[name] = knownInfo
 		self.knownCount = self.knownCount + 1
 		self.knownChanged = true
@@ -1239,9 +1245,9 @@ function widgetHandler:DisableWidgetRaw(name)
 		end
 		Spring.Echo("Removed:  " .. ki.filename)
 		self:RemoveWidgetRaw(w) -- deactivate
-		self.orderList[name] = 0 -- disable
-		self:SaveConfigData()
 	end
+	self.orderList[name] = 0 -- disable
+	self:SaveConfigData()
 	return true
 end
 
@@ -1253,14 +1259,13 @@ function widgetHandler:ToggleWidgetRaw(name)
 	end
 	if ki.active then
 		return self:DisableWidgetRaw(name)
-	elseif self.orderList[name] <= 0 then
-		return self:EnableWidgetRaw(name)
-	else
-		-- the widget is not active, but enabled; disable it
-		self.orderList[name] = 0
-		self:SaveConfigData()
 	end
-	return true
+	-- The widget is enabled but not running, so it errored out or bowed out. This is the state a
+	-- player clicks to repair, so bring it back, and only write it off when it will not even load.
+	if self:EnableWidgetRaw(name) then
+		return true
+	end
+	return self:DisableWidgetRaw(name)
 end
 
 --------------------------------------------------------------------------------
@@ -1432,6 +1437,18 @@ function widgetHandler:Shutdown()
 	-- save config
 	if self.__blankOutConfig then
 		table.save({ allowUserWidgets = self.allowUserWidgets }, CONFIG_FILENAME, "-- Widget Custom data and order")
+	elseif self.__blankOutOrder then
+		-- Keep what each widget was configured to do, forget which widgets ran and in what order.
+		for _, w in ipairs(self.widgets) do
+			if w.GetConfigData then
+				self.configData[w.whInfo.name] = w:GetConfigData()
+			end
+		end
+		table.save(
+			{ data = self.configData, allowUserWidgets = self.allowUserWidgets },
+			CONFIG_FILENAME,
+			"-- Widget Custom data and order"
+		)
 	else
 		self:SaveConfigData()
 	end
@@ -1478,14 +1495,12 @@ function widgetHandler:ConfigureLayout(command)
 		self:SendConfigData()
 		return true
 	elseif command == "selector" then
-		for _, w in ipairs(self.widgets) do
-			if w.whInfo.basename == SELECTOR_BASENAME then
-				return true -- there can only be one
-			end
+		-- Bring the selector back up for recovery even if its config says to disable it.
+		self:EnableWidgetRaw(SELECTOR_NAME)
+		local sw = self:FindWidget(SELECTOR_NAME)
+		if sw then
+			self:RaiseWidgetRaw(sw)
 		end
-		local sw = self:LoadWidget(LUAUI_DIRNAME .. SELECTOR_BASENAME, true) -- load the game's included widget_selector.lua, instead of the default selector.lua
-		self:InsertWidgetRaw(sw)
-		self:RaiseWidgetRaw(sw)
 		return true
 	elseif string.find(command, "togglewidget") == 1 then
 		self:ToggleWidgetRaw(string.sub(command, 14))

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -395,9 +395,14 @@ local function loadWidgetFiles(folder, vfsMode)
 
 	for _, file in ipairs(widgetFiles) do
 		local widget = widgetHandler:LoadWidget(file, fromZip)
-		local excludeWidget = widget and not fromZip and zipOnly[widget.whInfo.name]
 
-		if widget and not excludeWidget then
+		if widget and not fromZip and zipOnly[widget.whInfo.name] then
+			-- Drop what the user registered so the game's copy is not refused as a duplicate.
+			widgetHandler:ForgetWidget(widget.whInfo.name)
+			widget = nil
+		end
+
+		if widget then
 			table.insert(unsortedWidgets, widget)
 			Yield()
 		end
@@ -614,6 +619,12 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 		return nil
 	end
 
+	if widget.GetInfo == nil then
+		-- Do not keep widgets known but unregistered (active, no order entry)
+		Spring.Echo("Failed to load: " .. basename .. "  (no GetInfo() call)")
+		return nil
+	end
+
 	local knownInfo = self.knownWidgets[name]
 	if knownInfo and not reload then
 		if knownInfo.active then
@@ -635,11 +646,6 @@ function widgetHandler:LoadWidget(filename, fromZip, enableLocalsAccess, reload)
 	end
 	knownInfo.active = true
 	knownInfo.localsAccess = enableLocalsAccess
-
-	if widget.GetInfo == nil then
-		Spring.Echo("Failed to load: " .. basename .. "  (no GetInfo() call)")
-		return nil
-	end
 
 	-- Get widget information
 	local info = widget:GetInfo()
@@ -1071,6 +1077,9 @@ function widgetHandler:InsertWidgetRaw(widget)
 	if widget.GetInfo and widget:GetInfo().control and not widget.canControlUnits then
 		local name = widget.whInfo.name
 		if not self:ReloadUserWidgetFromGameRaw(name) then
+			if self.knownWidgets[name] then
+				self.knownWidgets[name].active = false
+			end
 			Spring.Echo("Blocked loading: " .. name .. "  (user 'unit control' widgets disabled for this game)")
 		end
 		return
@@ -1199,6 +1208,15 @@ end
 
 function widgetHandler:IsWidgetKnown(name)
 	return self.knownWidgets[name] and true or false
+end
+
+function widgetHandler:ForgetWidget(name)
+	if not self.knownWidgets[name] then
+		return
+	end
+	self.knownWidgets[name] = nil
+	self.knownCount = self.knownCount - 1
+	self.knownChanged = true
 end
 
 function widgetHandler:EnableWidgetRaw(name, enableLocalsAccess)

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1281,9 +1281,9 @@ function widgetHandler:DisableWidgetRaw(name)
 		end
 		Spring.Echo("Removed:  " .. ki.filename)
 		self:RemoveWidgetRaw(w) -- deactivate
-		self.orderList[name] = 0 -- disable
-		self:SaveConfigData()
 	end
+	self.orderList[name] = 0 -- disable
+	self:SaveConfigData()
 	return true
 end
 
@@ -1295,14 +1295,8 @@ function widgetHandler:ToggleWidgetRaw(name)
 	end
 	if ki.active then
 		return self:DisableWidgetRaw(name)
-	elseif self.orderList[name] <= 0 then
-		return self:EnableWidgetRaw(name)
-	else
-		-- the widget is not active, but enabled; disable it
-		self.orderList[name] = 0
-		self:SaveConfigData()
 	end
-	return true
+	return self:EnableWidgetRaw(name)
 end
 
 --------------------------------------------------------------------------------

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -1229,6 +1229,11 @@ function widgetHandler:ForgetWidget(name)
 	if not self.knownWidgets[name] then
 		return
 	end
+	local ki = self.knownWidgets[name]
+	local md5 = ki and table.getKeyOf(self.widgetHashes, ki.filename)
+	if md5 ~= nil then
+		self.widgetHashes[md5] = nil
+	end
 	self.knownWidgets[name] = nil
 	self.knownCount = self.knownCount - 1
 	self.knownChanged = true

--- a/luaui/barwidgets.lua
+++ b/luaui/barwidgets.lua
@@ -21,7 +21,7 @@ local CONFIG_FILENAME = LUAUI_DIRNAME .. "Config/" .. Game.gameShortName .. ".lu
 local WIDGET_DIRNAME = LUAUI_DIRNAME .. "Widgets/"
 local RML_WIDGET_DIRNAME = LUAUI_DIRNAME .. "RmlWidgets/"
 
-local SELECTOR_BASENAME = "selector.lua"
+local SELECTOR_BASENAME = "widget_selector.lua"
 
 local SAFEWRAP = 1
 -- 0: disabled


### PR DESCRIPTION
### Work done

Clicking an errored-out widget in the selector disabled it at the config level, so `/luaui reload` never brought it back. The selector then lied about the widget state, which became impossible to update.

A user clicking an err'd widget now retries the widget, and the handler's record of what is loaded is corrected, so the selector display is honest. The other way to toggle a widget is through the Options menu, which picks up the same changes.

### Addresses issue(s)

#8944 helped most users recover from bad UI state but some are locked in purgatory, still. I didn't realize in time that the UI is dishonest; this PR fixes.

This should close one category of error behind people's "broken installs" that have been fixed by, largely, reinstalling.