### PR TITLE
Use new ID aliases in type annotations

### DIFF
--- a/common/springUtilities/teamFunctions.lua
+++ b/common/springUtilities/teamFunctions.lua
@@ -216,19 +216,19 @@ return {
 			return getSettings().isHoliday
 		end,
 	},
-	---@return integer? scavTeamID Team ID for the scavenger team.
+	---@return TeamID? scavTeamID
 	GetScavTeamID = function()
 		return getSettings().scavTeamID
 	end,
-	---@return integer? scavAllyTeamID Team ID for the scavenger ally team.
+	---@return AllyTeamID? scavAllyTeamID
 	GetScavAllyTeamID = function()
 		return getSettings().scavAllyTeamID
 	end,
-	---@return integer? raptorTeamID Team ID for the raptor team.
+	---@return TeamID? raptorTeamID
 	GetRaptorTeamID = function()
 		return getSettings().raptorTeamID
 	end,
-	---@return integer? raptorAllyTeamID Team ID for the raptor ally team.
+	---@return AllyTeamID? raptorAllyTeamID
 	GetRaptorAllyTeamID = function()
 		return getSettings().raptorAllyTeamID
 	end,

--- a/luarules/callins/synthetic_callins.lua
+++ b/luarules/callins/synthetic_callins.lua
@@ -117,13 +117,13 @@ local function makeStopMarking(marked, list, count)
 end
 
 ---Marked IDs this frame, as a set.
----@alias SummaryMarked table<integer, true>
+---@alias SummaryMarked table<ObjectID, true>
 
 ---Marked IDs this frame, as an array.
----@alias SummaryList integer[]
+---@alias SummaryList ObjectID[]
 
 ---Signed sums per marked ID, kept while active.
----@alias SummaryTotals table<integer, number>
+---@alias SummaryTotals table<ObjectID, number>
 
 ---@class SummaryCount
 ---@field [1] integer? the batch size; nil is inactive
@@ -132,7 +132,7 @@ end
 ---@field [1] true? whether accumulating totals
 
 ---Sticky-state per marked ID, kept while active.
----@alias SummaryLatched table<integer, true>
+---@alias SummaryLatched table<ObjectID, true>
 
 local function createSummary(callinName)
 	if not syntheticCallinSummaries[callinName] then
@@ -174,6 +174,9 @@ local function createSummary(callinName)
 			active[1] = true
 		elseif active[1] then
 			for i = 1, count[1] or 0 do
+				-- ObjectID is a union of two integer aliases, which the checker will not
+				-- accept as the key of a table it is clearing an entry from.
+				---@diagnostic disable-next-line: inject-field
 				totals[list[i]] = nil
 			end
 			active[1] = nil

--- a/luarules/gadgets/gfx_wade_fx.lua
+++ b/luarules/gadgets/gfx_wade_fx.lua
@@ -18,7 +18,7 @@ end
 
 ---@class WadeUnitData
 ---@field id integer
----@field unitID integer
+---@field unitID UnitID
 ---@field h number
 ---@field ceg string
 

--- a/luarules/gadgets/unit_custom_weapons_behaviours.lua
+++ b/luarules/gadgets/unit_custom_weapons_behaviours.lua
@@ -166,7 +166,7 @@ local function getTargetPositionWithError(projectileID)
 end
 
 ---Translates TargetType integers to the ProjectileTargetType byte-integers needed in SetProjectileTarget.
----@param projectileID integer
+---@param projectileID ProjectileID
 ---@param target UnitOrPosition?
 ---@param targetType TargetType
 local function setProjectileTarget(projectileID, target, targetType)
@@ -191,7 +191,7 @@ do
 		team = -1,
 	}
 
-	---@return integer weaponDefID
+	---@return WeaponDefID weaponDefID
 	---@return ProjectileParams projectileParams
 	---@return number parentSpeed
 	getProjectileArgs = function(params, projectileID)

--- a/luarules/gadgets/unit_shield_behaviour.lua
+++ b/luarules/gadgets/unit_shield_behaviour.lua
@@ -14,7 +14,7 @@ if not gadgetHandler:IsSyncedCode() then
 	return false
 end
 
----@alias ShieldPreDamagedCallback fun(projectileID:integer, attackerID:integer, shieldWeaponIndex:integer, shieldUnitID:integer, bounceProjectile:boolean, beamWeaponIndex:integer?, beamUnitID:integer?, startX:number?, startY:number?, startZ:number?, hitX:number, hitY:number, hitZ:number): boolean? (default := `false`)
+---@alias ShieldPreDamagedCallback fun(projectileID:ProjectileID, attackerID:UnitID, shieldWeaponIndex:integer, shieldUnitID:UnitID, bounceProjectile:boolean, beamWeaponIndex:integer?, beamUnitID:UnitID?, startX:number?, startY:number?, startZ:number?, hitX:number, hitY:number, hitZ:number): boolean? (default := `false`)
 
 local mathMax = math.max
 local mathMin = math.min
@@ -992,7 +992,7 @@ end
 ---@param x number
 ---@param y number
 ---@param z number
----@param shieldUnitID integer
+---@param shieldUnitID UnitID
 ---@return boolean?
 local function isInShield(x, y, z, shieldUnitID)
 	local sx, sy, sz, sr = getUnitShieldPosition(shieldUnitID)

--- a/luaui/Include/select_api.lua
+++ b/luaui/Include/select_api.lua
@@ -358,7 +358,7 @@ end
 --- Applies the filter function to the unit represented by the unit ID to determine if the unit
 --- passes the filter.
 ---
---- @param uid integer The unit ID
+--- @param uid UnitID
 --- @param filterFunctions table List of filter functions
 --- @return boolean? passes Whether the unit passes the filter, nil if the unit doesn't exist
 function SelectApi.unitPassesFilter(uid, filterFunctions)

--- a/luaui/Widgets/dbg_ffa_startpoints_picker.lua
+++ b/luaui/Widgets/dbg_ffa_startpoints_picker.lua
@@ -52,7 +52,7 @@ local spGetUnitPosition = Spring.GetUnitPosition
 local StartPoint = {}
 StartPoint.__index = StartPoint
 
----@param unitID integer
+---@param unitID UnitID
 ---@return StartPoint
 function StartPoint:new(unitID)
 	self = setmetatable({}, self)
@@ -86,7 +86,7 @@ function StartPoints:getInstance()
 	self = setmetatable({}, StartPoints)
 	StartPoints.instance = self
 
-	---@param unitID integer
+	---@param unitID UnitID
 	---@return integer?, StartPoint? # index and start point if found, nil and nil otherwise
 	function StartPoints:get(unitID)
 		for index, startPoint in ipairs(self) do
@@ -97,7 +97,7 @@ function StartPoints:getInstance()
 		return nil, nil
 	end
 
-	---@param unitID integer
+	---@param unitID UnitID
 	---@return boolean # true if start point was added, false otherwise
 	function StartPoints:add(unitID)
 		local startPoint = StartPoint:new(unitID)
@@ -109,7 +109,7 @@ function StartPoints:getInstance()
 		return false
 	end
 
-	---@param unitID integer
+	---@param unitID UnitID
 	---@return boolean # true if start point was removed, false otherwise
 	function StartPoints:remove(unitID)
 		local startPoint = StartPoint:new(unitID)
@@ -133,7 +133,7 @@ startPoints = StartPoints:getInstance()
 local Layout = {}
 Layout.__index = Layout
 
----@param unitIDs integer[] sequence of unitID
+---@param unitIDs UnitID[]
 ---@return Layout
 function Layout:new(unitIDs)
 	self = setmetatable({}, Layout)

--- a/modules/commands.lua
+++ b/modules/commands.lua
@@ -66,7 +66,7 @@ local function unpackInsertParams(cmdParams)
 end
 
 ---Efficiently repack a command's `cmdParams` table in-place to use with `CMD_INSERT`.
----@param unitID integer
+---@param unitID UnitID
 ---@param cmdID integer|CMD
 ---@param cmdParams number[]|CMD[]
 ---@param cmdOptions CommandOptions
@@ -78,7 +78,7 @@ local function giveInsertOrderToUnit(unitID, cmdID, cmdParams, cmdOptions, cmdTa
 end
 
 ---Resend a modified command, repacking its `cmdParams` table if it was an inserted command.
----@param unitID integer
+---@param unitID UnitID
 ---@param cmdID integer|CMD
 ---@param cmdParams number[]|CMD[]
 ---@param cmdOptions CommandOptions
@@ -120,7 +120,7 @@ local function isQueuingUnitCommand(unitID, cmdID)
 end
 
 ---Test a command for its anticipated position in the unit's command queue.
----@param unitID integer
+---@param unitID UnitID
 ---@param tagOrIndex integer
 ---@param options CommandOptions
 ---@param insertOptions CommandOptions?

--- a/modules/graphics/instancevbotable.lua
+++ b/modules/graphics/instancevbotable.lua
@@ -16,7 +16,7 @@ local gldebugannotations = (Spring.GetConfigInt("gldebugannotations") == 1)
 ---@field myName string
 ---@field instanceIDtoIndex table<any, integer>
 ---@field indextoInstanceID table<integer, any>
----@field indextoUnitID table<integer, integer>?
+---@field indextoUnitID table<integer, UnitID>?
 ---@field unitIDattribID integer?
 ---@field layout table[]
 ---@field dirty boolean
@@ -551,7 +551,7 @@ Here is how you upload starting from 1st element and starting from 4th element i
 ---@param instanceID string|number|nil Key for later reference; `nil` auto-generates one.
 ---@param updateExisting boolean? Allow overwriting an element with the same key.
 ---@param noUpload boolean? Skip the upload, to batch several operations.
----@param unitID integer? Bind the instance to a unit, so the buffer tracks it.
+---@param unitID UnitID? Bind the instance to a unit, so the buffer tracks it.
 ---@return string|number|nil instanceID The key it was filed under; `nil` on failure.
 local function pushElementInstance(iT, thisInstance, instanceID, updateExisting, noUpload, unitID)
 	-- iT: instanceTable created with makeInstanceTable

--- a/types/Callins.lua
+++ b/types/Callins.lua
@@ -6,18 +6,18 @@
 -- Adding `...: any` makes these pass type checking.
 
 ---@class Callins
----@field ActiveCommandChanged fun(self, cmdID: integer?, cmdType: integer?)?
----@field UnitCreated fun(self, unitID: integer, unitDefID: integer, unitTeam: integer, builderID: integer?, ...: any)?
----@field UnitDestroyed fun(self, unitID: integer, unitDefID: integer, unitTeam: integer, attackerID: integer?, attackerDefID: integer?, attackerTeam: integer?, weaponDefID: integer, ...: any)?
----@field UnitGiven fun(self, unitID: integer, unitDefID: integer, newTeam: integer, oldTeam: integer, ...: any)?
----@field UnitTaken fun(self, unitID: integer, unitDefID: integer, newTeam: integer, oldTeam: integer, ...: any)?
+---@field ActiveCommandChanged fun(self, cmdID: (integer|CMD)?, cmdType: integer?)?
+---@field UnitCreated fun(self, unitID: UnitID, unitDefID: UnitDefID, unitTeam: TeamID, builderID: UnitID?, ...: any)?
+---@field UnitDestroyed fun(self, unitID: UnitID, unitDefID: UnitDefID, unitTeam: TeamID, attackerID: UnitID?, attackerDefID: UnitDefID?, attackerTeam: TeamID?, weaponDefID: WeaponDefID, ...: any)?
+---@field UnitGiven fun(self, unitID: UnitID, unitDefID: UnitDefID, newTeam: TeamID, oldTeam: TeamID, ...: any)?
+---@field UnitTaken fun(self, unitID: UnitID, unitDefID: UnitDefID, newTeam: TeamID, oldTeam: TeamID, ...: any)?
 ---@field GameFrame fun(self, frame: integer, ...: any)?
----@field PlayerChanged fun(self, playerID: integer, ...: any)?
+---@field PlayerChanged fun(self, playerID: PlayerID, ...: any)?
 ---@field ViewResize fun(self, viewSizeX: integer, viewSizeY: integer, ...: any)?
 ---@field MouseMove fun(self, x: number, y: number, dx: number, dy: number, button: number, ...: any): boolean?
 ---@field MousePress fun(self, x: number, y: number, button: number, ...: any): boolean?
 ---@field MouseRelease fun(self, x: number, y: number, button: number, ...: any): boolean|integer
 ---@field TextInput fun(self, utf8: string, ...: any): boolean?
----@field UnitFinished fun(self, unitID: integer, unitDefID: integer, unitTeam: integer, ...: any)?
----@field FeatureCreated fun(self, featureID: integer, allyTeamID: integer, ...: any)?
----@field FeatureDestroyed fun(self, featureID: integer, allyTeamID: integer|boolean?, ...: any)?
+---@field UnitFinished fun(self, unitID: UnitID, unitDefID: UnitDefID, unitTeam: TeamID, ...: any)?
+---@field FeatureCreated fun(self, featureID: FeatureID, allyTeamID: AllyTeamID, ...: any)?
+---@field FeatureDestroyed fun(self, featureID: FeatureID, allyTeamID: AllyTeamID|boolean?, ...: any)?

--- a/types/Spring.lua
+++ b/types/Spring.lua
@@ -1,18 +1,18 @@
 ---@class UnitScriptTable
----@field CallAsUnit fun(unitID: integer, fn: function, ...: any): any
+---@field CallAsUnit fun(unitID: UnitID, fn: function, ...: any): any
 ---@field WaitForMove fun(pieceNum: integer, axis: integer)
 ---@field WaitForTurn fun(pieceNum: integer, axis: integer)
 ---@field WaitForScale fun(pieceNum: integer)
----@field GetUnitCOBValue fun(unitID: integer, cobVal: integer, ...: any): integer
----@field SetUnitCOBValue fun(unitID: integer, cobVal: integer, param: integer|boolean): nil
+---@field GetUnitCOBValue fun(unitID: UnitID, cobVal: integer, ...: any): integer
+---@field SetUnitCOBValue fun(unitID: UnitID, cobVal: integer, param: integer|boolean): nil
 ---@field Sleep fun(ms: number)
 ---@field StartThread fun(fn: function, ...: any)
 ---@field SetSignalMask fun(mask: integer)
 ---@field Signal fun(mask: integer)
 ---@field Hide fun(pieceNum: integer)
 ---@field Show fun(pieceNum: integer)
----@field GetScriptEnv fun(unitID: integer): table
----@field GetLongestReloadTime fun(unitID: integer): number
+---@field GetScriptEnv fun(unitID: UnitID): table
+---@field GetLongestReloadTime fun(unitID: UnitID): number
 
 -- Engine types (temporary -- will move to recoil-lua-library when eco branch merges)
 ---@class ResourceData
@@ -63,5 +63,5 @@
 
 --- BAR extends engine `ObjectRenderingTable` in `luarules/Utilities/unitrendering.lua`.
 ---@class ObjectRenderingTable
----@field ActivateMaterial fun(objectID: integer, lod: integer)
----@field DeactivateMaterial fun(objectID: integer, lod: integer)
+---@field ActivateMaterial fun(objectID: ObjectID, lod: integer)
+---@field DeactivateMaterial fun(objectID: ObjectID, lod: integer)

--- a/types/SyntheticCallins.lua
+++ b/types/SyntheticCallins.lua
@@ -18,13 +18,13 @@
 ---Runs for every unit gained by a team, regardless of how it was gained.
 ---
 ---Dispatch: g:UnitCreated, g:UnitGiven.
----@field MetaUnitAdded? fun(self, unitID: integer, unitDefID: integer, unitTeam: integer)
+---@field MetaUnitAdded? fun(self, unitID: UnitID, unitDefID: UnitDefID, unitTeam: TeamID)
 ---
 ---
 ---Runs for every unit lost to a team, regardless of how it was lost.
 ---
 ---Dispatch: g:UnitDestroyed, g:UnitTaken.
----@field MetaUnitRemoved? fun(self, unitID: integer, unitDefID: integer, unitTeam: integer)
+---@field MetaUnitRemoved? fun(self, unitID: UnitID, unitDefID: UnitDefID, unitTeam: TeamID)
 ---
 ---
 ---Optionally replaces the autotarget search radius for a unit's command AI.
@@ -32,7 +32,7 @@
 ---Any return value of zero or less discontinues the chain and prevents the search.
 ---
 ---Dispatch: g:AllowWeaponTarget (with target and weapon args both equal to -1)
----@field UnitAutoTargetRange? fun(self, attackerID: integer, autoTargetRange: number): number
+---@field UnitAutoTargetRange? fun(self, attackerID: UnitID, autoTargetRange: number): number
 ---
 ---
 ---Runs for every unit that received a build step.
@@ -40,7 +40,7 @@
 ---
 ---Mark: g:AllowUnitBuildStep, GG.AccumulateUnitBuildStep.
 ---Dispatch: g:GameFramePost.
----@field UnitBuildStepPost? fun(self, unitID: integer)
+---@field UnitBuildStepPost? fun(self, unitID: UnitID)
 ---
 ---
 ---Runs for every feature that received a build step.
@@ -48,7 +48,7 @@
 ---
 ---Mark: g:AllowFeatureBuildStep, GG.AccumulateFeatureBuildStep.
 ---Dispatch: g:GameFramePost.
----@field FeatureBuildStepPost? fun(self, featureID: integer)
+---@field FeatureBuildStepPost? fun(self, featureID: FeatureID)
 ---
 ---
 ---Runs for every unit that received a build step, with the sum of its steps.
@@ -60,7 +60,7 @@
 ---
 ---Accumulate: g:AllowUnitBuildStep, GG.AccumulateUnitBuildStep.
 ---Dispatch: g:GameFramePost.
----@field UnitBuildStepTotal? fun(self, unitID: integer, part: number)
+---@field UnitBuildStepTotal? fun(self, unitID: UnitID, part: number)
 ---
 ---
 ---Runs for every feature that received a build step, with the sum of its steps.
@@ -72,7 +72,7 @@
 ---
 ---Accumulate: g:AllowFeatureBuildStep, GG.AccumulateFeatureBuildStep.
 ---Dispatch: g:GameFramePost.
----@field FeatureBuildStepTotal? fun(self, featureID: integer, part: number)
+---@field FeatureBuildStepTotal? fun(self, featureID: FeatureID, part: number)
 ---
 ---
 ---Runs for every unit that ran out of work, or that found some again.
@@ -83,4 +83,4 @@
 ---
 ---Mark: g:UnitIdle, g:UnitCommand, g:UnitTaken, g:UnitDestroyed.
 ---Dispatch: g:GameFramePost.
----@field UnitIdlePost? fun(self, unitID: integer, idled: boolean)
+---@field UnitIdlePost? fun(self, unitID: UnitID, idled: boolean)

--- a/types/UnitDef.lua
+++ b/types/UnitDef.lua
@@ -2,5 +2,5 @@
 
 --- Minimal unit definition stub for widget code paths that only need stable fields.
 ---@class UnitDef
----@field id integer
+---@field id UnitDefID
 ---@field name string?


### PR DESCRIPTION
### Work done

Use the new types from https://github.com/beyond-all-reason/RecoilEngine/pull/3231 to replace bare `integer` and `number` types where used in BAR, mostly in existing Callin annotations.

Use `ObjectID` where two callers share a table, one inserting `UnitID` and the other `FeatureID`.

Remove redundant parameter descriptions.

Annotations only, no runtime changes.

### AI / LLM usage statement:

Claude Opus 5 authored 90% of code, 25% of PR description, 100% of commit message. I have reviewed the changes, understand them, and endorse them.