### PR TITLE
Fix widget selector filter input when opened via chat command.

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -3653,6 +3653,8 @@ function widget:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
 								end
 							end
 						end
+						commitInputHistory(executedInput)
+						cancelChatInput()
 						Spring.SendCommands(command)
 					else
 						local badWord = findBadWords(inputText)
@@ -3674,12 +3676,13 @@ function widget:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
 							end
 						end
 						lastMessage = inputText
+						commitInputHistory(executedInput)
+						cancelChatInput()
 					end
-					commitInputHistory(executedInput)
 				else
 					ensureInputHistoryDraft()
+					cancelChatInput()
 				end
-				cancelChatInput()
 			end
 		else
 			cancelChatInput()


### PR DESCRIPTION
Close chat input before running slash commands so cancelChatInput no longer tears down text ownership after commands like /widgetselector claim it.

Currently we tear down the Chat input after every command. Some commands (like /widgetselector) use chat for the filter. This breaks text input for /widgetselector (when invoked via /widgetselector, f11 goes through a different code path)

This fix tears down chat before the command executes so any commands that open a chat don't have it automatically closed. 

Tested:
confirmed that /widgetselector now allows you to filter. Confirmed via inspection that other code paths still close chat. 


Cursor used for understanding code, wrote, tested manually. 
