### PR TITLE
Fix builder priority stall budget

### DIFF
--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -283,7 +283,6 @@ local function UpdatePassiveBuilders(
 	clearTable(teamBuildTargetOwners)
 
 	-- First pass: check passive builders that are building, track their expense inline
-	local anyPassiveBuilding = false
 	clearTable(_passiveMetal)
 	clearTable(_passiveEnergy)
 
@@ -299,7 +298,6 @@ local function UpdatePassiveBuilders(
 				local ecost = targetCosts[2] * rate
 				_passiveMetal[builderID] = mcost
 				_passiveEnergy[builderID] = ecost
-				anyPassiveBuilding = true
 				if not buildTargets[builtUnit] then
 					buildTargets[builtUnit] = true
 					teamBuildTargetOwners[builderID] = builtUnit
@@ -315,42 +313,43 @@ local function UpdatePassiveBuilders(
 		teamsWithOwners[teamID] = nil
 	end
 
-	-- Second pass: check non-passive builders ONLY if we have passive builders building
-	if anyPassiveBuilding then
-		local teamBuilders = canBuild[teamID]
-		for builderID in pairs(teamBuilders) do
-			if not passiveTeamCons[builderID] then
-				local builtUnit = spGetUnitIsBuilding(builderID)
-				if builtUnit then
-					local targetCosts = costID[builtUnit]
-					local buildSpeed = realBuildSpeed[builderID]
-					if targetCosts and buildSpeed then
-						local rate = buildSpeed / targetCosts[3]
-						local mcost = targetCosts[1]
-						mcost = mcost <= 1 and 0 or mcost * rate
-						local ecost = targetCosts[2] * rate
-						nonPassiveConsTotalExpenseMetal = nonPassiveConsTotalExpenseMetal + mcost
-						nonPassiveConsTotalExpenseEnergy = nonPassiveConsTotalExpenseEnergy + ecost
-					end
+	-- Second pass: total high-priority builder expense over the update interval
+	local teamBuilders = canBuild[teamID]
+	for builderID in pairs(teamBuilders) do
+		if not passiveTeamCons[builderID] then
+			local builtUnit = spGetUnitIsBuilding(builderID)
+			if builtUnit then
+				local targetCosts = costID[builtUnit]
+				local buildSpeed = realBuildSpeed[builderID]
+				if targetCosts and buildSpeed then
+					local rate = buildSpeed / targetCosts[3]
+					local mcost = targetCosts[1]
+					mcost = mcost <= 1 and 0 or mcost * rate
+					local ecost = targetCosts[2] * rate
+					nonPassiveConsTotalExpenseMetal = nonPassiveConsTotalExpenseMetal + mcost
+					nonPassiveConsTotalExpenseEnergy = nonPassiveConsTotalExpenseEnergy + ecost
 				end
 			end
 		end
 	end
 
 	-- calculate how much expense passive cons will be allowed (using pre-fetched resource data)
+	-- Income/sent/received from GetTeamResources are per-second; builder expense is per-frame.
 	local intervalOverSpeed = interval / simSpeed
 
 	local mStorEff = mStor * mShare
 	local teamStallingMetal = mCur
 		- mathMax(mInc * stallMarginInc, mStorEff * stallMarginSto)
 		- 1
-		+ interval * (nonPassiveConsTotalExpenseMetal + mInc + mRec - mSent) / simSpeed
+		+ intervalOverSpeed * (mInc + mRec - mSent)
+		- nonPassiveConsTotalExpenseMetal * interval
 
 	local eStorEff = eStor * eShare
 	local teamStallingEnergy = eCur
 		- mathMax(eInc * stallMarginInc, eStorEff * stallMarginSto)
 		- 1
-		+ interval * (nonPassiveConsTotalExpenseEnergy + eInc + eRec - eSent) / simSpeed
+		+ intervalOverSpeed * (eInc + eRec - eSent)
+		- nonPassiveConsTotalExpenseEnergy * interval
 
 	-- work through passive cons allocating as much expense as we have left
 	for builderID in pairs(passiveTeamCons) do
@@ -358,8 +357,8 @@ local function UpdatePassiveBuilders(
 
 		local pMetal = _passiveMetal[builderID]
 		if pMetal then
-			local passivePullMetal = pMetal * intervalOverSpeed
-			local passivePullEnergy = _passiveEnergy[builderID] * intervalOverSpeed
+			local passivePullMetal = pMetal * interval
+			local passivePullEnergy = _passiveEnergy[builderID] * interval
 			if passivePullMetal > 0 or passivePullEnergy > 0 then
 				if
 					(teamStallingMetal - passivePullMetal <= 0 and passivePullMetal > 0)

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -338,15 +338,13 @@ local function UpdatePassiveBuilders(
 	local teamStallingMetal = mCur
 		- mathMax(mInc * stallMarginInc, mStorEff * stallMarginSto)
 		- 1
-		+ intervalOverSpeed * (mInc + mRec - mSent)
-		- nonPassiveConsTotalExpenseMetal * interval
+		+ intervalOverSpeed * (mInc + mRec - mSent - nonPassiveConsTotalExpenseMetal)
 
 	local eStorEff = eStor * eShare
 	local teamStallingEnergy = eCur
 		- mathMax(eInc * stallMarginInc, eStorEff * stallMarginSto)
 		- 1
-		+ intervalOverSpeed * (eInc + eRec - eSent)
-		- nonPassiveConsTotalExpenseEnergy * interval
+		+ intervalOverSpeed * (eInc + eRec - eSent - nonPassiveConsTotalExpenseEnergy)
 
 	-- work through passive cons allocating as much expense as we have left
 	for builderID in pairs(passiveTeamCons) do
@@ -354,8 +352,8 @@ local function UpdatePassiveBuilders(
 
 		local pMetal = _passiveMetal[builderID]
 		if pMetal then
-			local passivePullMetal = pMetal * interval
-			local passivePullEnergy = _passiveEnergy[builderID] * interval
+			local passivePullMetal = pMetal * intervalOverSpeed
+			local passivePullEnergy = _passiveEnergy[builderID] * intervalOverSpeed
 			if passivePullMetal > 0 or passivePullEnergy > 0 then
 				if
 					(teamStallingMetal - passivePullMetal <= 0 and passivePullMetal > 0)

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -282,7 +282,6 @@ local function UpdatePassiveBuilders(
 	-- Clear previous team's build target owners (reuse table to avoid GC)
 	clearTable(teamBuildTargetOwners)
 
-	-- First pass: check passive builders that are building, track their expense inline
 	clearTable(_passiveMetal)
 	clearTable(_passiveEnergy)
 
@@ -313,7 +312,6 @@ local function UpdatePassiveBuilders(
 		teamsWithOwners[teamID] = nil
 	end
 
-	-- Second pass: total high-priority builder expense over the update interval
 	local teamBuilders = canBuild[teamID]
 	for builderID in pairs(teamBuilders) do
 		if not passiveTeamCons[builderID] then
@@ -334,7 +332,6 @@ local function UpdatePassiveBuilders(
 	end
 
 	-- calculate how much expense passive cons will be allowed (using pre-fetched resource data)
-	-- Income/sent/received from GetTeamResources are per-second; builder expense is per-frame.
 	local intervalOverSpeed = interval / simSpeed
 
 	local mStorEff = mStor * mShare

--- a/luarules/gadgets/unit_builder_priority.lua
+++ b/luarules/gadgets/unit_builder_priority.lua
@@ -282,6 +282,8 @@ local function UpdatePassiveBuilders(
 	-- Clear previous team's build target owners (reuse table to avoid GC)
 	clearTable(teamBuildTargetOwners)
 
+	-- First pass: check passive builders that are building, track their expense inline
+	local anyPassiveBuilding = false
 	clearTable(_passiveMetal)
 	clearTable(_passiveEnergy)
 
@@ -297,6 +299,7 @@ local function UpdatePassiveBuilders(
 				local ecost = targetCosts[2] * rate
 				_passiveMetal[builderID] = mcost
 				_passiveEnergy[builderID] = ecost
+				anyPassiveBuilding = true
 				if not buildTargets[builtUnit] then
 					buildTargets[builtUnit] = true
 					teamBuildTargetOwners[builderID] = builtUnit
@@ -312,20 +315,23 @@ local function UpdatePassiveBuilders(
 		teamsWithOwners[teamID] = nil
 	end
 
-	local teamBuilders = canBuild[teamID]
-	for builderID in pairs(teamBuilders) do
-		if not passiveTeamCons[builderID] then
-			local builtUnit = spGetUnitIsBuilding(builderID)
-			if builtUnit then
-				local targetCosts = costID[builtUnit]
-				local buildSpeed = realBuildSpeed[builderID]
-				if targetCosts and buildSpeed then
-					local rate = buildSpeed / targetCosts[3]
-					local mcost = targetCosts[1]
-					mcost = mcost <= 1 and 0 or mcost * rate
-					local ecost = targetCosts[2] * rate
-					nonPassiveConsTotalExpenseMetal = nonPassiveConsTotalExpenseMetal + mcost
-					nonPassiveConsTotalExpenseEnergy = nonPassiveConsTotalExpenseEnergy + ecost
+	-- Second pass: check non-passive builders ONLY if we have passive builders building
+	if anyPassiveBuilding then
+		local teamBuilders = canBuild[teamID]
+		for builderID in pairs(teamBuilders) do
+			if not passiveTeamCons[builderID] then
+				local builtUnit = spGetUnitIsBuilding(builderID)
+				if builtUnit then
+					local targetCosts = costID[builtUnit]
+					local buildSpeed = realBuildSpeed[builderID]
+					if targetCosts and buildSpeed then
+						local rate = buildSpeed / targetCosts[3]
+						local mcost = targetCosts[1]
+						mcost = mcost <= 1 and 0 or mcost * rate
+						local ecost = targetCosts[2] * rate
+						nonPassiveConsTotalExpenseMetal = nonPassiveConsTotalExpenseMetal + mcost
+						nonPassiveConsTotalExpenseEnergy = nonPassiveConsTotalExpenseEnergy + ecost
+					end
 				end
 			end
 		end


### PR DESCRIPTION
The synced Builder Priority gadget throttles low-priority builders by setting build speed to 0 when the team can't afford them. The stall budget math had a bug:

Inverted sign — high-priority builder expense was added to the budget instead of subtracted, so low-priority builders were allowed to build when high-priority demand was high. Low priority builders were incorrectly given **more** budget and not less when high prio demand was high. 

<img width="1800" height="1562" alt="1_1800x1562" src="https://github.com/user-attachments/assets/72db7ccd-2226-4a14-881c-2399cc75f84e" />

Cursor used to evaluate code, hand verified and tested. 
