### PR TITLE
Scriptless builders

### DIFF
--- a/luarules/gadgets/unit_missing_build_scripts.lua
+++ b/luarules/gadgets/unit_missing_build_scripts.lua
@@ -21,6 +21,10 @@ function gadget:GetInfo()
 end
 
 local hasBuildScripts = {}
+local isBuilder = {}
+for unitDefID, def in pairs(UnitDefs) do
+	isBuilder[unitDefID] = def.isBuilder
+end
 
 local function hasBuildScript(unitID, unitDefID)
 	if hasBuildScripts[unitDefID] ~= nil then
@@ -39,18 +43,15 @@ local function hasBuildScript(unitID, unitDefID)
 		hasBuildScripts[unitDefID] = true
 		return true
 	end
-
 	hasBuildScripts[unitDefID] = false
 	return false
 end
 
 function gadget:UnitCreated(unitID, unitDefID)
-	if hasBuildScripts[unitDefID] then
+	if not isBuilder[unitDefID] then
 		return
 	end
-	local def = UnitDefs[unitDefID]
-	local isBuilder = def.canBuild or def.canRepair or def.canCapture or def.canAssist or def.canRestore or def.canResurrect 
-	if not isBuilder then
+	if hasBuildScripts[unitDefID] then
 		return
 	end
 	if hasBuildScript(unitID, unitDefID) then

--- a/luarules/gadgets/unit_missing_build_scripts.lua
+++ b/luarules/gadgets/unit_missing_build_scripts.lua
@@ -15,7 +15,7 @@ function gadget:GetInfo()
 		author = "DoodVanDaag",
 		date = "2026",
 		license = "GNU GPL, v2 or later",
-		layer = 0,
+		layer = 2, -- needs to happen after unit scripts loaded
 		enabled = true,
 	}
 end
@@ -26,15 +26,20 @@ local function hasBuildScript(unitID, unitDefID)
 	if hasBuildScripts[unitDefID] ~= nil then
 		return hasBuildScripts[unitDefID] 
 	end
+	local env = Spring.UnitScript.GetScriptEnv(unitID)
+	if env then
+		if env.script.StartBuilding then
+			hasBuildScripts[unitDefID] = true
+			return true
+		end
+		hasBuildScripts[unitDefID] = false
+		return false
+	end
 	if Spring.GetCOBScriptID(unitID, "StartBuilding") then
 		hasBuildScripts[unitDefID] = true
 		return true
 	end
-	local env = Spring.UnitScript.GetScriptEnv(unitID)
-	if env and env.script.StartBuilding then
-		hasBuildScripts[unitDefID] = true
-		return true
-	end
+
 	hasBuildScripts[unitDefID] = false
 	return false
 end

--- a/luarules/gadgets/unit_missing_build_scripts.lua
+++ b/luarules/gadgets/unit_missing_build_scripts.lua
@@ -1,0 +1,69 @@
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Allow tweaked builders",
+		desc = "Handles setting INBUILDSTANCE for builders with no build script",
+		author = "DoodVanDaag",
+		date = "2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+local hasBuildScripts = {}
+
+local function hasBuildScript(unitID, unitDefID)
+	if hasBuildScripts[unitDefID] ~= nil then
+		return hasBuildScripts[unitDefID] 
+	end
+	if Spring.GetCOBScriptID(unitID, "StartBuilding") then
+		Spring.Echo("hasBuildScript")
+		hasBuildScripts[unitDefID] = true
+		return true
+	end
+	local env = Spring.UnitScript.GetScriptEnv(unitID)
+	if env and env.script.StartBuilding then
+		Spring.Echo("hasBuildScript")
+
+		hasBuildScripts[unitDefID] = true
+		return true
+	end
+	hasBuildScripts[unitDefID] = false
+	return false
+end
+
+function gadget:UnitCreated(unitID, unitDefID)
+	if hasBuildScripts[unitDefID] then
+		return
+	end
+	local def = UnitDefs[unitDefID]
+	local isBuilder = def.canBuild or def.canRepair or def.canCapture or def.canAssist or def.canRestore or def.canResurrect 
+	if not isBuilder then
+		return
+	end
+	if hasBuildScript(unitID, unitDefID) then
+		return
+	end
+	Spring.SetUnitCOBValue(unitID, COB.INBUILDSTANCE, true)
+	Spring.SetUnitNanoPieces(unitID, {1})
+	Spring.Echo("setup for unit:"..unitID.." done")
+end
+
+function gadget:Initizalize()
+	local units = Spring.GetAllUnits()
+	for i = 1, #units do
+		local unitID = units[i]
+		local unitDefID = Spring.GetUnitDefID(unitID)
+		gadget:UnitCreated(unitID, unitDefID)
+	end
+end

--- a/luarules/gadgets/unit_missing_build_scripts.lua
+++ b/luarules/gadgets/unit_missing_build_scripts.lua
@@ -60,7 +60,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 	Spring.SetUnitNanoPieces(unitID, {1})
 end
 
-function gadget:Initizalize()
+function gadget:Initialize()
 	local units = Spring.GetAllUnits()
 	for i = 1, #units do
 		local unitID = units[i]

--- a/luarules/gadgets/unit_missing_build_scripts.lua
+++ b/luarules/gadgets/unit_missing_build_scripts.lua
@@ -27,14 +27,11 @@ local function hasBuildScript(unitID, unitDefID)
 		return hasBuildScripts[unitDefID] 
 	end
 	if Spring.GetCOBScriptID(unitID, "StartBuilding") then
-		Spring.Echo("hasBuildScript")
 		hasBuildScripts[unitDefID] = true
 		return true
 	end
 	local env = Spring.UnitScript.GetScriptEnv(unitID)
 	if env and env.script.StartBuilding then
-		Spring.Echo("hasBuildScript")
-
 		hasBuildScripts[unitDefID] = true
 		return true
 	end
@@ -56,7 +53,6 @@ function gadget:UnitCreated(unitID, unitDefID)
 	end
 	Spring.SetUnitCOBValue(unitID, COB.INBUILDSTANCE, true)
 	Spring.SetUnitNanoPieces(unitID, {1})
-	Spring.Echo("setup for unit:"..unitID.." done")
 end
 
 function gadget:Initizalize()

--- a/luarules/gadgets/unit_missing_build_scripts.lua
+++ b/luarules/gadgets/unit_missing_build_scripts.lua
@@ -3,6 +3,20 @@
 if not gadgetHandler:IsSyncedCode() then
 	return
 end
+
+local modOptions = Spring.GetModOptions()
+local tweaked = modOptions.tweakunits ~= "" or modOptions.tweakdefs ~= ""
+local i = 1
+while i <= 9 and not tweaked do
+	tweaked = modOptions["tweakunits"..i] ~= "" or modOptions["tweakdefs"..i] ~= ""
+	i = i + 1
+end
+if not tweaked then
+	Spring.Echo("No tweak detected, ignoring unit_missing_build_scripts.lua.")
+	return
+end
+
+Spring.Echo("Detected tweaked defs; loading unit_missing_build_scripts.lua.")
 -------------------------------------------------------------------------------------
 -------------------------------------------------------------------------------------
 
@@ -28,7 +42,7 @@ end
 
 local function hasBuildScript(unitID, unitDefID)
 	if hasBuildScripts[unitDefID] ~= nil then
-		return hasBuildScripts[unitDefID] 
+		return hasBuildScripts[unitDefID]
 	end
 	local env = Spring.UnitScript.GetScriptEnv(unitID)
 	if env then


### PR DESCRIPTION
Using tweak defs/units can be done to add build options to units that aren't supposed to have any.
This results in no effective building ability due to missing script functions

This PR aims at allowing such tweaks by setting INBUILDSTANCE = true and the nano piece to the root piece for any unit that has build abilities without any defined script.

Is such a feature desired? 

Test this tweak:
```lua
{
armfav = {
    workerTime = 200,
    builder = true,
    buildDistance = 200,
    buildOptions = {
        "armrad",
    },
},
corfav = {
    workerTime = 200,
    builder = true,
    buildDistance = 200,
    buildOptions = {
        "corrad",
    },
},
}
```
```ewphcm1mYXYgPSB7CiAgICB3b3JrZXJUaW1lID0gMjAwLAogICAgYnVpbGRlciA9IHRydWUsCiAgICBidWlsZERpc3RhbmNlID0gMjAwLAogICAgYnVpbGRPcHRpb25zID0gewogICAgICAgICJhcm1yYWQiLAogICAgfSwKfSwKY29yZmF2ID0gewogICAgd29ya2VyVGltZSA9IDIwMCwKICAgIGJ1aWxkZXIgPSB0cnVlLAogICAgYnVpbGREaXN0YW5jZSA9IDIwMCwKICAgIGJ1aWxkT3B0aW9ucyA9IHsKICAgICAgICAiY29ycmFkIiwKICAgIH0sCn0sCn0```

veh scouts can build radars
<img width="355" height="250" alt="image" src="https://github.com/user-attachments/assets/be34f07a-5628-4d62-881b-cc96a19cab38" />
