### PR TITLE
Fix Gaia storage going negative after ruins spawn during loading

### DIFF
--- a/luarules/gadgets/game_team_resources.lua
+++ b/luarules/gadgets/game_team_resources.lua
@@ -19,6 +19,7 @@ end
 local minStorageMetal = 1000
 local minStorageEnergy = 1000
 local mathMax = math.max
+local gaiaTeamID = Spring.GetGaiaTeamID()
 
 local function GetTeamPlayerCounts()
 	local teamPlayerCounts = {}
@@ -33,7 +34,7 @@ local function GetTeamPlayerCounts()
 	return teamPlayerCounts
 end
 
-local function setup(addResources)
+local function setup(addResources, skipGaia)
 	local startMetalStorage = Spring.GetModOptions().startmetalstorage
 	local startEnergyStorage = Spring.GetModOptions().startenergystorage
 	local startMetal = Spring.GetModOptions().startmetal
@@ -49,6 +50,11 @@ local function setup(addResources)
 	end
 
 	local teamList = Spring.GetTeamList()
+	if skipGaia then
+		teamList = table.filterArray(teamList, function(teamID)
+			return teamID ~= gaiaTeamID
+		end)
+	end
 	for i = 1, #teamList do
 		local teamID = teamList[i]
 
@@ -103,7 +109,7 @@ end
 
 function gadget:GameStart()
 	-- reset because commander added additional storage as well
-	setup()
+	setup(false, true)
 end
 
 function gadget:TeamDied(teamID)


### PR DESCRIPTION
Work done

Since now spawn at GamePreload (since #8842).
The team resource setup runs at GameStart to account for commanders adding storage, and it resets every team's storage, including Gaia. That wipes Gaia's storage from all the ruins, and every storage ruin that later dies additionally substracts it. Gaia's storage goes negative and defensive ruins are no longer able to attack.

Fix: the GameStart reset skips Gaia. Gaia has no commander, so the reset has no purpose for it, and it keeps the storage its ruins provide. The initial setup at load is unchanged.

Reported by Cookiebee, cause identified by Damgam.

Test steps
- [x] Spectate a Ruins game (Very dense makes it obvious) and watch Gaia's resources in the player list
- [x] Destroy or capture a few storage or generator ruins
- [x] Gaia's storage stays positive and energy-firing ruin defences keep returning fire (on master the bar goes negative and they stop)

Before:
<img width="642" height="364" alt="negative storage" src="https://github.com/user-attachments/assets/18e3849c-416b-4407-9e3c-be2aaed6ae1a" />

After:
<img width="773" height="517" alt="Ruins have storage" src="https://github.com/user-attachments/assets/29b3cbce-8635-4607-9459-020474a72e0a" />

AI usage statement:
Used Claude Fable to help write the optimal fix