### PR TITLE
Stop pre placed units from blocking start position placement

### DIFF
--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -422,6 +422,18 @@ if gadgetHandler:IsSyncedCode() then
 	----------------------------------------------------------------
 	-- Startpoints
 	----------------------------------------------------------------
+	local function hasBlockingFeature(x, z, unitDefID)
+		local halfFootprint = UnitDefs[unitDefID].xsize * Game.squareSize / 2
+		local features =
+			Spring.GetFeaturesInRectangle(x - halfFootprint, z - halfFootprint, x + halfFootprint, z + halfFootprint)
+		for i = 1, #features do
+			if Spring.GetFeatureBlocking(features[i]) then
+				return true
+			end
+		end
+		return false
+	end
+
 	local _unitType = {}
 	--- @return boolean untraversable if the unit can not traverse the passed in x/z position
 	local function isFootingUntraversable(x, y, z, unitDefID)
@@ -439,12 +451,12 @@ if gadgetHandler:IsSyncedCode() then
 
 		if type == 2 then
 			return not (
-				Spring.TestMoveOrder(unitDefID, x, y, z)
-				and Spring.TestMoveOrder(unitDefID, x, y, z, 1, 0, 0)
-				and Spring.TestMoveOrder(unitDefID, x, y, z, 0, 0, 1)
-				and Spring.TestMoveOrder(unitDefID, x, y, z, -1, 0, 0)
-				and Spring.TestMoveOrder(unitDefID, x, y, z, 0, 0, -1)
-			)
+				Spring.TestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, false)
+				and Spring.TestMoveOrder(unitDefID, x, y, z, 1, 0, 0, true, false)
+				and Spring.TestMoveOrder(unitDefID, x, y, z, 0, 0, 1, true, false)
+				and Spring.TestMoveOrder(unitDefID, x, y, z, -1, 0, 0, true, false)
+				and Spring.TestMoveOrder(unitDefID, x, y, z, 0, 0, -1, true, false)
+			) or hasBlockingFeature(x, z, unitDefID)
 		end
 
 		return Spring.TestBuildOrder(unitDefID, x, y, z, "s") == 0


### PR DESCRIPTION
Work done

Ruins exist before start positions are chosen (since #8842).
The start footing check (isFootingUntraversable) used TestMoveOrder with its default object test, so any spot occupied by a ruin was rejected. 

Fix: the placement check now ignores units when deciding if a spot is valid, since any ruin there is cleared when the commander spawns. Everything else is checked as before.

Test steps
- [x]  In a Ruins game, place your start on a spot you know holds a ruin (eg. most mexes) accepted, and the spawn clearing removes it
- [x]  Place on a large rock or wreck feature: still refused
- [x]  Place on steep or unwalkable terrain: still refused

Before

https://github.com/user-attachments/assets/b7f99ca2-dbd5-4dff-9d9d-7023c7af6ba3

After

https://github.com/user-attachments/assets/20c5add6-ce5e-488d-8a4a-a0263a3671e1
 
AI statement:
Used Claude Fable to assist with writing the most optimal fix.



