### PR TITLE
Remove unreferenced local functions

### DIFF
--- a/common/overlap_lines.lua
+++ b/common/overlap_lines.lua
@@ -135,10 +135,6 @@ local function findLineIntersection(p1, p2, p3, p4)
 	return nil
 end
 
-local function getSide(p, lineP1, lineP2)
-	return (lineP2.x - lineP1.x) * (p.z - lineP1.z) - (lineP2.z - lineP1.z) * (p.x - lineP1.x)
-end
-
 local function getSideXZ(px, pz, lineP1, lineP2)
 	return (lineP2.x - lineP1.x) * (pz - lineP1.z) - (lineP2.z - lineP1.z) * (px - lineP1.x)
 end

--- a/luaintro/Addons/loadprogress.lua
+++ b/luaintro/Addons/loadprogress.lua
@@ -16,10 +16,6 @@ local startTime = -1
 local cachedLoadTimes = VFS.FileExists("loadprogress_cached.lua") and VFS.Include("loadprogress_cached.lua") or {}
 local cachedTotalTime = (cachedLoadTimes[Game.mapName] or -1) * 0.97 --*0.97 cause else last rendered frame would show 99%
 
-local function mix(x, y, a)
-	return x * (1 - a) + y * a
-end
-
 function SG.GetLoadProgress()
 	if startTime < 0 then
 		startTime = os.clock()

--- a/luaintro/Addons/main.lua
+++ b/luaintro/Addons/main.lua
@@ -372,15 +372,6 @@ local function gradientv(px, py, sx, sy, c1, c2)
 	gl.Vertex(px, py, 0)
 end
 
-local function gradienth(px, py, sx, sy, c1, c2)
-	gl.Color(c1)
-	gl.Vertex(sx, sy, 0)
-	gl.Vertex(sx, py, 0)
-	gl.Color(c2)
-	gl.Vertex(px, py, 0)
-	gl.Vertex(px, sy, 0)
-end
-
 local function bartexture(px, py, sx, sy, texLength, texHeight)
 	local texHeight = texHeight or 1
 	local width = (sx - px) / texLength * 4

--- a/luarules/configs/icon_generator.lua
+++ b/luarules/configs/icon_generator.lua
@@ -116,27 +116,6 @@ halo = IconConfig[selConfig].halo
 
 --// backgrounds
 background = true
-local water = "LuaRules/Images/bg_water.png"
-local builder = "LuaRules/Images/constructionunit.png"
-
-local function Greater30(a)
-	return a > 30
-end
-local function GreaterEq15(a)
-	return a >= 15
-end
-local function GreaterZero(a)
-	return a > 0
-end
-local function GreaterEqZero(a)
-	return a >= 0
-end
-local function GreaterFour(a)
-	return a > 4
-end
-local function LessEqZero(a)
-	return a <= 0
-end
 
 backgrounds = {
 	--{check={waterline=GreaterEq15,minWaterDepth=GreaterZero},texture=water},

--- a/luarules/gadgets/cmd_terraform_brush.lua
+++ b/luarules/gadgets/cmd_terraform_brush.lua
@@ -180,11 +180,6 @@ local function parseParts(payload)
 	return scratchParts
 end
 
--- Numeric key for merge vertex set: avoids per-vertex string allocation
-local function vertexKey(x, z)
-	return x * 65536 + z
-end
-
 local floor = math.floor
 local max = math.max
 local min = math.min
@@ -719,21 +714,6 @@ local function rotatePoint(px, pz, angleDeg)
 		_rpSin = sin(rad)
 	end
 	return px * _rpCos - pz * _rpSin, px * _rpSin + pz * _rpCos
-end
-
-local function isInsideCircle(dx, dz, radius)
-	return dx * dx + dz * dz <= radius * radius
-end
-
-local function isInsideSquare(dx, dz, radius, angleDeg)
-	local lx, lz = rotatePoint(dx, dz, -angleDeg)
-	return abs(lx) <= radius and abs(lz) <= radius
-end
-
-local function isInsideRing(dx, dz, radius)
-	local distSquared = dx * dx + dz * dz
-	local innerRadius = radius * ringInnerRatio
-	return distSquared <= radius * radius and distSquared >= innerRadius * innerRadius
 end
 
 local function regularPolygonFalloff(dx, dz, radius, angleDeg, numSides)

--- a/luarules/gadgets/cus_gl4.lua
+++ b/luarules/gadgets/cus_gl4.lua
@@ -495,10 +495,6 @@ local objectTypeAttribID = 6 -- this is the attribute index for instancedata in 
 
 local initiated = false
 
-local function Bit(p)
-	return 2 ^ (p - 1) -- 1-based indexing
-end
-
 -- Typical call:  if hasbit(x, bit(3)) then ...
 local function HasBit(x, p)
 	return x % (p + p) >= p
@@ -507,14 +503,6 @@ end
 local math_bit_and = math.bit_and
 local function HasAllBits(x, p)
 	return math_bit_and(x, p) == p
-end
-
-local function SetBit(x, p)
-	return HasBit(x, p) and x or x + p
-end
-
-local function ClearBit(x, p)
-	return HasBit(x, p) and x - p or x
 end
 
 -- Precomputed bin membership for every possible drawFlag below 128 (the icon threshold).
@@ -843,12 +831,6 @@ local DEFAULT_VERSION = [[#version 430 core
 	#extension GL_ARB_shader_storage_buffer_object : require
 	#extension GL_ARB_shading_language_420pack: require
 	]]
-
-local function dumpShaderCodeToFile(defs, src, filename) -- no IO in unsynced gadgets :/
-	local vsfile = io.open("cus_" .. filename .. ".glsl", "w+")
-	vsfile:write(defs .. src)
-	vsfile:close()
-end
 
 local function dumpShaderCodeToInfolog(defs, src, filename) -- no IO in unsynced gadgets :/
 	Spring.Echo(filename)
@@ -2884,28 +2866,6 @@ function gadget:Shutdown()
 end
 
 local updateframe = 0
-
-local function countbintypes(flagarray)
-	local fwcnt = 0
-	local defcnt = 0
-	local reflcnt = 0
-	local shadcnt = 0
-
-	for i = 1, #flagarray do
-		local flag = flagarray[i]
-		if HasBit(flag, 1) then
-			fwcnt = fwcnt + 1
-			defcnt = defcnt + 1
-		end
-		if HasBit(flag, 4) then
-			reflcnt = reflcnt + 1
-		end
-		if HasBit(flag, 16) then
-			shadcnt = shadcnt + 1
-		end
-	end
-	return fwcnt, defcnt, reflcnt, shadcnt
-end
 
 local destroyedUnitIDs = {} -- maps unitID to drawflag
 local destroyedUnitDrawFlags = {}

--- a/luarules/gadgets/game_critters.lua
+++ b/luarules/gadgets/game_critters.lua
@@ -81,8 +81,6 @@ local companionRadius = companionRadiusStart
 local processOrders = true
 local addedInitialCritters
 
-local ownCritterDestroy = false
-
 local function randomPatrolInBox(unitID, box, minWaterDepth) -- only define minWaterDepth if unit is a submarine
 	local ux, _, uz = GetUnitPosition(unitID, true, true)
 	local orders = 6
@@ -134,11 +132,6 @@ local function randomPatrolInBox(unitID, box, minWaterDepth) -- only define minW
 			break
 		end
 	end
-end
-
-local function in_circle(center_x, center_y, radius, x, y)
-	local square_dist = ((center_x - x) * (center_x - x)) + ((center_y - y) * (center_y - y))
-	return square_dist <= radius * radius
 end
 
 -- doing multiple orders per unit gives errors, so doing 1 per gameframe is best

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -554,31 +554,6 @@ if gadgetHandler:IsSyncedCode() then
 		return true
 	end
 
-	local function setPermutedSpawns(nSpawns, idsToSpawn)
-		-- this function assumes that idsToSpawn is a hash table with nSpawns elements
-		-- returns a bijective random map from key values of idsToSpawn to [1,...,nSpawns]
-
-		-- first, construct a random permutation of [1,...,nSpawns] using a Knuth shuffle
-		local perm = {}
-		for i = 1, nSpawns do
-			perm[i] = i
-		end
-		for i = 1, nSpawns - 1 do
-			local j = math.random(i, nSpawns)
-			local temp = perm[i]
-			perm[i] = perm[j]
-			perm[j] = temp
-		end
-
-		local permutedSpawns = {}
-		local slot = 1
-		for id, _ in pairs(idsToSpawn) do
-			permutedSpawns[id] = perm[slot]
-			slot = slot + 1
-		end
-		return permutedSpawns
-	end
-
 	local startUnitList = {}
 	local startUnitBlocking = {}
 	-- Shared with gadget:GameFrame below, which gates the commander spawn-in

--- a/luarules/gadgets/game_tax_resource_sharing.lua
+++ b/luarules/gadgets/game_tax_resource_sharing.lua
@@ -47,11 +47,6 @@ if Spring.GetModOptions().easytax then
 	sharingTax = 0.3 -- 30% tax for easytax modoption
 end
 
-local function isAlliedUnit(teamID, unitID)
-	local unitTeam = Spring.GetUnitTeam(unitID)
-	return teamID and unitTeam and teamID ~= unitTeam and Spring.AreTeamsAllied(teamID, unitTeam)
-end
-
 ----------------------------------------------------------------
 -- Callins
 ----------------------------------------------------------------

--- a/luarules/gadgets/gfx_emp_lightning.lua
+++ b/luarules/gadgets/gfx_emp_lightning.lua
@@ -96,10 +96,6 @@ local mathCos = math.cos
 local mathPi = math.pi
 local mathRandom = math.random
 
-local function clamp(v, lo, hi)
-	return v < lo and lo or (v > hi and hi or v)
-end
-
 --------------------------------------------------------------------------------
 -- State
 --------------------------------------------------------------------------------

--- a/luarules/gadgets/gfx_lightning_cannon_gl4.lua
+++ b/luarules/gadgets/gfx_lightning_cannon_gl4.lua
@@ -1011,6 +1011,9 @@ end
 --------------------------------------------------------------------------------
 
 -- Push one segment-instance into beamData
+-- This is a reference implementation. The functionality is duplicated in the segment
+-- loops below to avoid a function call per segment. Keep all three copies in sync.
+--[[
 local function pushSegment(
 	beamData,
 	offset,
@@ -1057,6 +1060,7 @@ local function pushSegment(
 	beamData[offset + 23] = glowMult
 	beamData[offset + 24] = impactSize
 end
+]]
 
 local INSTANCE_STRIDE = 24
 
@@ -1080,7 +1084,8 @@ local function emitBolt(beamData, offset, beamCount, cfg, t, lifeFrac)
 	local tEx, tEy, tEz = t.ex, t.ey, t.ez
 	local tSeed = t.seed
 
-	-- Main bolt: segCount segment-instances (inlined pushSegment for hot path)
+	-- Main bolt: segCount segment-instances
+	-- Inlined from commented pushSegment above. Keep all three copies in sync.
 	local segs = cfg.segments
 	for s = 0, segs - 1 do
 		beamData[offset + 1] = tPx
@@ -1226,7 +1231,7 @@ local function emitBolt(beamData, offset, beamCount, cfg, t, lifeFrac)
 			local bez = az + br.dirZ * blen
 			local branchSeed = br.branchSeed
 			for s = 0, bsegs - 1 do
-				-- Inlined pushSegment for hot path (eliminates closure call per segment)
+				-- Inlined from commented pushSegment above. Keep all three copies in sync.
 				beamData[offset + 1] = ax
 				beamData[offset + 2] = ay
 				beamData[offset + 3] = az

--- a/luarules/gadgets/ruins/Blueprints/BYAR/Blueprints/KrashKourse_land.lua
+++ b/luarules/gadgets/ruins/Blueprints/BYAR/Blueprints/KrashKourse_land.lua
@@ -572,6 +572,7 @@ local function Power_fort_2()
 	}
 end
 
+--[[
 local function T1_short_def()
 	return {
 		type = types.Land,
@@ -588,6 +589,7 @@ local function T1_short_def()
 		},
 	}
 end
+]]
 
 local function Punisher_wall()
 	return {

--- a/luarules/gadgets/ruins/Blueprints/BYAR/Blueprints/damgam_tiny_defences_T1.lua
+++ b/luarules/gadgets/ruins/Blueprints/BYAR/Blueprints/damgam_tiny_defences_T1.lua
@@ -275,7 +275,7 @@ local function tinyDefences18()
 		},
 	}
 end
-
+--[[
 local function tinyDefences19()
 	return {
 		type = types.Land,
@@ -289,7 +289,9 @@ local function tinyDefences19()
 		},
 	}
 end
+]]
 
+--[[
 local function tinyDefences20()
 	return {
 		type = types.Land,
@@ -303,6 +305,7 @@ local function tinyDefences20()
 		},
 	}
 end
+]]
 
 local function tinyDefences21()
 	return {

--- a/luaui/RmlWidgets/gui_diffuse_library/gui_diffuse_library.lua
+++ b/luaui/RmlWidgets/gui_diffuse_library/gui_diffuse_library.lua
@@ -124,10 +124,6 @@ local function thumbCachePath(matKey)
 	return THUMB_CACHE_DIR .. "/" .. matKey .. "_" .. THUMB_SIZE .. ".png"
 end
 
-local function getDpRatio()
-	return (WG.TerraformerShared and WG.TerraformerShared.getDpRatio and WG.TerraformerShared.getDpRatio()) or 1.0
-end
-
 local function cleanupThumbs()
 	thumbTextures = {}
 	thumbImgEls = {}

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -765,11 +765,6 @@ local function quatRotateVec(qx, qy, qz, qw, vx, vy, vz)
 	return vx + qw * tx + (qy * tz - qz * ty), vy + qw * ty + (qz * tx - qx * tz), vz + qw * tz + (qx * ty - qy * tx)
 end
 
--- Quaternion inverse (conjugate for unit quaternions)
-local function quatInv(qx, qy, qz, qw)
-	return -qx, -qy, -qz, qw
-end
-
 local function tickSkyDynamic(dt)
 	if not skyDynamic.playing then
 		return
@@ -11223,72 +11218,6 @@ clearPassthrough = function()
 			widgetState.rootElement:SetClass("passthrough-dimmed", false)
 		end
 	end
-end
-
-local function onRotateCW(event)
-	playSound("tick")
-	if WG.TerraformBrush then
-		WG.TerraformBrush.rotate(ROTATION_STEP)
-	end
-
-	event:StopPropagation()
-end
-
-local function onRotateCCW(event)
-	playSound("tick")
-	if WG.TerraformBrush then
-		WG.TerraformBrush.rotate(-ROTATION_STEP)
-	end
-
-	event:StopPropagation()
-end
-
-local function onCurveUp(event)
-	playSound("tick")
-	if WG.TerraformBrush then
-		local state = WG.TerraformBrush.getState()
-		WG.TerraformBrush.setCurve(state.curve + CURVE_STEP)
-	end
-
-	event:StopPropagation()
-end
-
-local function onCurveDown(event)
-	playSound("tick")
-	if WG.TerraformBrush then
-		local state = WG.TerraformBrush.getState()
-		WG.TerraformBrush.setCurve(state.curve - CURVE_STEP)
-	end
-
-	event:StopPropagation()
-end
-
-local function onIntensityUp(event)
-	playSound("tick")
-	if WG.TerraformBrush then
-		local state = WG.TerraformBrush.getState()
-		local newI = state.intensity * 1.15
-		if newI < state.intensity + 0.1 then
-			newI = state.intensity + 0.1
-		end
-		WG.TerraformBrush.setIntensity(newI)
-	end
-
-	event:StopPropagation()
-end
-
-local function onIntensityDown(event)
-	playSound("tick")
-	if WG.TerraformBrush then
-		local state = WG.TerraformBrush.getState()
-		local newI = state.intensity / 1.15
-		if newI > state.intensity - 0.1 then
-			newI = state.intensity - 0.1
-		end
-		WG.TerraformBrush.setIntensity(newI)
-	end
-
-	event:StopPropagation()
 end
 
 capMinValue = 0

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_environment.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_environment.lua
@@ -737,32 +737,6 @@ function M.attach(doc, ctx)
 		)
 		wireMutexChipPair("sp-slope-mode-avoid", "avoidCliffs", "sp-slope-mode-prefer", "preferSlopes", getSP)
 
-		-- Exclusive tab pills for grass brush (original behavior)
-		local function wirePillTabs(pills, onActivate)
-			for _, p in ipairs(pills) do
-				local btn = doc:GetElementById(p.btnId)
-				local content = doc:GetElementById(p.contentId)
-				if btn and content then
-					btn:AddEventListener("click", function()
-						for _, q in ipairs(pills) do
-							local b2 = doc:GetElementById(q.btnId)
-							local c2 = doc:GetElementById(q.contentId)
-							if b2 then
-								b2:SetClass("active", b2 == btn)
-							end
-							if c2 then
-								c2:SetClass("hidden", c2 ~= content)
-							end
-						end
-						content:SetClass("hidden", false)
-						btn:SetClass("active", true)
-						if onActivate then
-							onActivate()
-						end
-					end)
-				end
-			end
-		end
 		-- gb pill/slope/altitude/avoid-water/color chips all use data-event-click in RML → onGbXxx handlers in initialModel
 	end
 	envSectionToggle("btn-toggle-wb-undo", "img-toggle-wb-undo", "section-wb-undo", false)

--- a/luaui/Widgets/api_los_combiner_gl4.lua
+++ b/luaui/Widgets/api_los_combiner_gl4.lua
@@ -127,12 +127,6 @@ local function CreateLosTexture()
 	})
 end
 
-local function InitLosTexture(allyTeam)
-	gl.RenderToTexture(infoTextures[allyTeam], function()
-		gl.Clear(GL.COLOR_BUFFER_BIT, 0, 0, 0, 0)
-	end)
-end
-
 local function renderToTextureFunc() -- this draws the fogspheres onto the texture
 	--gl.DepthMask(false)
 	gl.Texture(0, "$info:los")

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -130,7 +130,6 @@ local unitCountXOff
 local unitCountYOff
 
 local drawY
-local printDebug
 local calcScreenCoords
 local RemoveBuildOrders
 local getButtonUnderMouse
@@ -926,25 +925,4 @@ end
 function widget:Shutdown()
 	widgetHandler:RemoveAction("factory_preset")
 	widgetHandler:RemoveAction("factory_preset_show")
-end
-
-local spEcho = Spring.Echo
-
-function printDebug(value)
-	if debug then
-		if type(value) == "boolean" then
-			if value == true then
-				spEcho("true")
-			else
-				spEcho("false")
-			end
-		elseif type(value) == "table" then
-			spEcho("Dumping table:")
-			for key, val in pairs(value) do
-				spEcho(key, val)
-			end
-		else
-			spEcho(value)
-		end
-	end
 end

--- a/luaui/Widgets/cmd_feature_placer.lua
+++ b/luaui/Widgets/cmd_feature_placer.lua
@@ -715,10 +715,6 @@ local function headingToYaw(heading)
 	return -(heading or 0) * HEADING_TO_RAD
 end
 
-local function yawToHeading(yaw)
-	return floor(-(yaw or 0) / HEADING_TO_RAD) % 65536
-end
-
 -- The uniform scale the gadget baked into a live feature's root piece matrix,
 -- read back as the length of the first basis vector. 1 for anything never
 -- scaled. Needed so removal highlights and gizmo ghosts drawn over an already

--- a/luaui/Widgets/cmd_metal_brush.lua
+++ b/luaui/Widgets/cmd_metal_brush.lua
@@ -794,13 +794,6 @@ local function commitCurrentLasso()
 	lassoPoints = {}
 end
 
--- Refresh every committed lasso's total (call after the spot cache changes).
-local function recomputeAllLassoTotals()
-	for i = 1, #lassos do
-		lassos[i].total = computePointsSum(lassos[i].points)
-	end
-end
-
 local function buildOverlayList()
 	ensureSpotCache()
 	if spotsCacheDirty then
@@ -1089,10 +1082,6 @@ local function recomputeBalanceAxisSums()
 	balanceAxisSumA = a * 0.001
 	balanceAxisSumB = b * 0.001
 	balanceAxisSumsDirty = false
-end
-
-local function invalidateBalanceAxisSums()
-	balanceAxisSumsDirty = true
 end
 
 -- Extend cache invalidator so map-edits refresh axis sums too.

--- a/luaui/Widgets/cmd_startpos_tool.lua
+++ b/luaui/Widgets/cmd_startpos_tool.lua
@@ -313,10 +313,6 @@ local function generatePolygonPositions(cx, cz, radius, sides, count, rotation)
 	return pts
 end
 
-local function generateSquarePositions(cx, cz, radius, count, rotation)
-	return generatePolygonPositions(cx, cz, radius, 4, count, rotation)
-end
-
 local function generateShapePositions(cx, cz)
 	local sides = ({
 		circle = 0,

--- a/luaui/Widgets/dbg_ceg_auto_reloader.lua
+++ b/luaui/Widgets/dbg_ceg_auto_reloader.lua
@@ -320,10 +320,6 @@ local function isFloat3(value)
 	return parseCEGExpression(value, 3)
 end
 
-local function isFloat4(value)
-	return parseCEGExpression(value, 4)
-end
-
 -- TODO FIXME:
 local generatorNames = {}
 local function isExplosionGenerator(value)
@@ -894,51 +890,6 @@ local function validateCEG(cegTable, cegName)
 					end
 				end
 			end
-		end
-	end
-	return true
-end
-
-local function AreIntegers(t)
-	for k, v in pairs(t) do
-		if type(k) ~= "number" or k % 1 ~= 0 then
-			return false
-		end
-	end
-	return true
-end
-
-local function AreBooleans(t)
-	for k, v in pairs(t) do
-		if type(k) ~= "boolean" and k ~= 1 and k ~= 0 then
-			return false
-		end
-	end
-	return true
-end
-
-local function AreStrings(t)
-	for k, v in pairs(t) do
-		if type(k) ~= "string" then
-			return false
-		end
-	end
-	return true
-end
-
-local function AreColorMaps(t)
-	for k, v in pairs(t) do
-		if not isColorMapValid(k) then
-			return false
-		end
-	end
-	return true
-end
-
-local function AreNumbers(t)
-	for k, v in pairs(t) do
-		if type(k) ~= "number" then
-			return false
 		end
 	end
 	return true

--- a/luaui/Widgets/dbg_profiler_histograms.lua
+++ b/luaui/Widgets/dbg_profiler_histograms.lua
@@ -236,25 +236,6 @@ function widget:Initialize()
 	end
 end
 
-local function PrintRecord(name)
-	local total, current, maxdt, time, peak = Spring.GetProfilerTimeRecord(name, false)
-	-- where total is in milliseconds
-	-- current gets reset ever 33 frames, and is a running tally
-	-- maxdt is the peak value
-	-- time is lag?
-	-- peak is unknown?
-
-	-- so last frame dt ===
-
-	local gf = spGetGameFrame()
-	spEcho(gf, "P:", name, total, current, maxdt, time, peak)
-end
-
-local function GetRecordCurrent(name)
-	local total, current = Spring.GetProfilerTimeRecord(name, false)
-	return current
-end
-
 function widget:Shutdown()
 	widgetHandler:RemoveAction("histogram", "t")
 	if histShader then

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -192,12 +192,6 @@ local gameTimer
 local runTestsTimer
 local testTimer
 
-local function getGameTime()
-	if gameTimer ~= nil then
-		return Spring.DiffTimers(Spring.GetTimer(), gameTimer, true)
-	end
-end
-
 local function getRunTestsTime()
 	if runTestsTimer ~= nil then
 		return Spring.DiffTimers(Spring.GetTimer(), runTestsTimer, true)

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -504,21 +504,6 @@ function widget:Update() -- this is pointlessly expensive!
 	areaDecals[hash].smoothness = totalsmoothness
 end
 
-local function DrawSmoothness()
-	gl.Color(1, 1, 1, 1)
-	for areaHash, areaInfo in pairs(areaDecals) do
-		--spEcho(areaHash, areaInfo.x, areaInfo.y, areaInfo.z)
-		if Spring.IsSphereInView(areaInfo.x, areaInfo.y, areaInfo.z, 128) then
-			gl.PushMatrix()
-			local text = string.format("Smoothness = %d", areaInfo.smoothness)
-			local w = gl.GetTextWidth(text) * 16.0
-			gl.Translate(areaInfo.x - w, areaInfo.y + 64, areaInfo.z)
-			gl.Text(text, 0, 0, 16, "n")
-			gl.PopMatrix()
-		end
-	end
-end
-
 -----------------------------------------------------------------------------------------------
 
 local dCT = {} -- decalCacheTable

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -598,37 +598,6 @@ local function AddDistortion(instanceID, unitID, pieceIndex, targetVBO, distorti
 	return instanceID
 end
 
----updateDistortionPosition(distortionVBO, instanceID, posx, posy, posz, radius, p2x, p2y, p2z, theta)
----This function is for internal use only, to update the position of a distortion.
----Only use if you know the consequences of updating a VBO in-place!
-local function updateDistortionPosition(distortionVBO, instanceID, posx, posy, posz, radius, p2x, p2y, p2z, theta)
-	local instanceIndex = distortionVBO.instanceIDtoIndex[instanceID]
-	if instanceIndex == nil then
-		return nil
-	end
-	instanceIndex = (instanceIndex - 1) * distortionVBO.instanceStep
-	local instData = distortionVBO.instanceData
-	if posx then
-		instData[instanceIndex + 1] = posx
-		instData[instanceIndex + 2] = posy
-		instData[instanceIndex + 3] = posz
-	end
-	if radius then
-		instData[instanceIndex + 4] = radius
-	end
-
-	if p2x then
-		instData[instanceIndex + 5] = p2x
-		instData[instanceIndex + 6] = p2y
-		instData[instanceIndex + 7] = p2z
-	end
-	if theta then
-		instData[instanceIndex + 8] = theta
-	end
-	distortionVBO.dirty = true
-	return instanceIndex
-end
-
 -- Specialized fast path for projectile position updates: no nil-checks, always writes pos+dir
 local function updateProjectilePosition(distortionVBO, instanceID, posx, posy, posz, dx, dy, dz)
 	local instanceIndex = distortionVBO.instanceIDtoIndex[instanceID]

--- a/luaui/Widgets/gfx_highlight_commander_wrecks.lua
+++ b/luaui/Widgets/gfx_highlight_commander_wrecks.lua
@@ -33,16 +33,6 @@ local SpringGetFeatureTeam = Spring.GetFeatureTeam
 local SpringGetSpectatingState = Spring.GetSpectatingState
 local SpringGetMapDrawMode = Spring.GetMapDrawMode
 
--- util
-
-local function map(list, func)
-	local result = {}
-	for i, v in ipairs(list) do
-		result[i] = func(v, i)
-	end
-	return result
-end
-
 -- GL4
 
 local LuaShader = gl.LuaShader

--- a/luaui/Widgets/gui_advplayerslist_music_new.lua
+++ b/luaui/Widgets/gui_advplayerslist_music_new.lua
@@ -644,10 +644,6 @@ local function updateFade()
 	end
 end
 
-local function getSliderWidth()
-	return mathFloor((4.5 * widgetScale) + 0.5)
-end
-
 local function capitalize(text)
 	local str = ""
 	local upperNext = true

--- a/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
@@ -1,8 +1,5 @@
 local widget = widget ---@type Widget
 
-local files = {} -- forward-decl: referenced only by dead addDirToAtlas
-local imgExts = {} -- forward-decl: referenced only by dead addDirToAtlas
-
 function widget:GetInfo()
 	return {
 		name = "Ground AO Plates Features GL4",
@@ -37,28 +34,6 @@ local function basepath(s, pattern)
 		s = string.sub(s, string.find(s, pattern, 1, true) + 1)
 	end
 	return s
-end
-
-local function addDirToAtlas(atlas, path)
-	--spEcho("Adding",#files, "images to atlas from", path)
-	for i = 1, #files do
-		if imgExts[string.sub(files[i], -3, -1)] then
-			local s3oname = basepath(files[i], "/")
-			if string.find(s3oname, "_dead", 1, true) then
-				--spEcho('s3oname',s3oname)
-				s3oname = string.sub(s3oname, 1, string.find(s3oname, "_dead", 1, true) + 4)
-				atlassedImages[s3oname] = files[i]
-			elseif string.find(s3oname, "arm.x.._._", 1) or string.find(s3oname, "cor.x.._._", 1) then
-				s3oname = string.sub(s3oname, 1, 7)
-
-				--spEcho('s3oname',s3oname)
-				atlassedImages[s3oname] = files[i]
-			else
-				--spEcho('Custom Feature AO plate:',s3oname, files[i])
-				atlassedImages[s3oname] = files[i]
-			end
-		end
-	end
 end
 
 local function makeAtlas()

--- a/luaui/Widgets/gui_raptorStatsPanel.lua
+++ b/luaui/Widgets/gui_raptorStatsPanel.lua
@@ -136,18 +136,6 @@ local raptorTypes = {
 	"raptor_turret",
 }
 
-local function commaValue(amount)
-	local formatted = amount
-	local k
-	while true do
-		formatted, k = string.gsub(formatted, "^(-?%d+)(%d%d%d)", "%1,%2")
-		if k == 0 then
-			break
-		end
-	end
-	return formatted
-end
-
 local function getRaptorCounts(type)
 	local total = 0
 	local subtotal

--- a/luaui/Widgets/gui_scavStatsPanel.lua
+++ b/luaui/Widgets/gui_scavStatsPanel.lua
@@ -94,24 +94,10 @@ local rules = {
 	"scavCount",
 }
 
-local waveColor = "\255\255\0\0"
 local textColor = "\255\255\255\255"
-
-local function commaValue(amount)
-	local formatted = amount
-	local k
-	while true do
-		formatted, k = string.gsub(formatted, "^(-?%d+)(%d%d%d)", "%1,%2")
-		if k == 0 then
-			break
-		end
-	end
-	return formatted
-end
 
 local function getScavCounts(type)
 	local total = 0
-	local subtotal
 
 	return total
 end

--- a/luaui/Widgets/map_grass_gl4.lua
+++ b/luaui/Widgets/map_grass_gl4.lua
@@ -577,33 +577,6 @@ local function makeGrassPatchVBO(grassPatchSize) -- grassPatchSize = 1|4, see th
 	grassPatchVBO:Upload(uniqueVBOData)
 end
 
-local function fsrand(a, b) -- fast, repeatable random vec2
-	local s = math.sin((a * 12.9898 + b * 78.233))
-	return math.fract(s * 43758.5453), math.fract(s * 41758.5453)
-end
-
-local function testForGrass(mx, mz)
-	if grassConfig.obeyGrassMap then
-		if spGetGrass(mx, mz) == 1 then
-			return spGetGroundHeight(mx, mz)
-		else
-			return nil
-		end
-	else
-		local gx, gy, gz, gs = Spring.GetGroundNormal(mx, mz)
-		local gh = spGetGroundHeight(mx, mz)
-		if
-			(gh > grassConfig.grassMinHeight)
-			and (gh < grassConfig.grassMaxHeight)
-			and (gy > grassConfig.grassMaxSlope)
-		then
-			return gh
-		else
-			return nil
-		end
-	end
-end
-
 local function mapHasSMFGrass() -- returns 255 is SMF has no grass, 0 if map has no grass, 1 if map has old style binary grass, 2<=  <=254 if map has new style uint grass
 	local highestgrassmapvalue = 0
 	local patchResolution = 32

--- a/luaui/Widgets/unit_share_tracker.lua
+++ b/luaui/Widgets/unit_share_tracker.lua
@@ -17,7 +17,6 @@ end
 -- Localized Spring API for performance
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetViewGeometry = Spring.GetViewGeometry
-local spGetPlayerInfo = Spring.GetPlayerInfo
 local spGetTeamColor = Spring.GetTeamColor
 local spGetMyTeamID = Spring.GetLocalTeamID
 local spGetMyPlayerID = Spring.GetLocalPlayerID
@@ -130,14 +129,6 @@ local minimapVertices = {
 ----------------------------------------------------------------
 -- local functions
 ----------------------------------------------------------------
-
-local function GetPlayerColor(playerID)
-	local _, _, _, teamID = spGetPlayerInfo(playerID, false)
-	if not teamID then
-		return nil
-	end
-	return spGetTeamColor(teamID)
-end
 
 local function StartTime()
 	timeNow = 0

--- a/modules/graphics/instancevboidtable.lua
+++ b/modules/graphics/instancevboidtable.lua
@@ -107,23 +107,6 @@ local function makeVAOandAttach(vertexVBO, instanceVBO, indexVBO) -- Attach a ve
 end
 
 --------------- DEBUG HELPERS --------------------------
-local function comparetables(t1, t2, name)
-	for k, v in pairs(t1) do
-		if t2[k] == nil then
-			Spring.Echo("Key ", k, "with value", v, "existing in t1 does not exist in t2 in ", name)
-		elseif t2[k] ~= v then
-			Spring.Echo("Value ", v, "for", k, "existing in t1 does not match value for t2", t2[k], " in ", name)
-		end
-	end
-
-	for k, v in pairs(t2) do
-		if t1[k] == nil then
-			Spring.Echo("Key ", k, "with value", v, "existing in t2 does not exist in t1 in ", name)
-		elseif t1[k] ~= v then
-			Spring.Echo("Value ", v, "for", k, "existing in t2 does not match value for t1", t1[k], " in ", name)
-		end
-	end
-end
 
 local function dbgt(t, name)
 	name = name or ""

--- a/modules/graphics/instancevbotable.lua
+++ b/modules/graphics/instancevbotable.lua
@@ -929,26 +929,6 @@ local function drawInstanceVBO(iT)
 	end
 end
 
-local function countInvalidUnitIDs(iT)
-	local invalids = {}
-	for i, objectID in ipairs(iT.indextoUnitID) do
-		local isValidID = false
-		if iT.featureIDs then
-			isValidID = Spring.ValidFeatureID(objectID)
-		else
-			isValidID = Spring.ValidUnitID(objectID)
-		end
-		if isValidID then
-		else
-			invalids[#invalids + 1] = objectID
-		end
-	end
-	if #invalids > 0 then
-		Spring.Echo(#invalids, "invalid IDs found in ", iT.myName)
-	end
-	return invalids
-end
-
 --------- HELPERS FOR PRIMITIVES ------------------
 
 --- The geometry helpers below each build a standalone `VBO` -- not an

--- a/scripts/Units/corpun.lua
+++ b/scripts/Units/corpun.lua
@@ -21,12 +21,6 @@ function script.Create()
 	StartThread(dmgsmoke, dmgPieces)
 end
 
-local function RestoreAfterDelay(unitID)
-	Sleep(2500)
-	Turn(turret, x_axis, 0, math.rad(50))
-	Turn(sleeves, x_axis, 0, math.rad(50))
-end
-
 function script.QueryWeapon1()
 	if currBarrel == 1 then
 		return flare1

--- a/spec/builders/spring_synced_builder.lua
+++ b/spec/builders/spring_synced_builder.lua
@@ -300,27 +300,6 @@ function SB:BuildSpring()
 
 	local resourceSetCalls = {}
 
-	local function recordSetCall(teamID, resourceType, data)
-		table.insert(resourceSetCalls, {
-			teamID = teamID,
-			resource = resourceType,
-			data = table.copy(data or {}),
-		})
-	end
-
-	local function applyResourcePatch(teamID, resourceType, patch)
-		if type(patch) ~= "table" then
-			error("ResourceData patch must be a table")
-		end
-
-		local store, normalized = getResourceStore(teamID, resourceType)
-		for key, value in pairs(patch) do
-			store[key] = value
-		end
-		store.resourceType = normalized
-		recordSetCall(teamID, normalized, patch)
-	end
-
 	---@type SpringSyncedMock
 	local mock = {
 		CMD = Spring and Spring.CMD or {


### PR DESCRIPTION
### Work done

Removes 65 unreferenced `local function` definitions across 37 files, along with their doc comments and 12 declarations that share a diff hunk with them.

Found by repeatedly running luacheck with `unused = true`.

Three more are commented out rather than deleted, for preservation reasons. I expect some reviewer will ask to keep some others as well.

Each removal was traced through the file's history to the commit that introduced the function and then forward to the commit that took its last call away.

This change should have no functional impact.

Dead code removal PR 4 of 8.

#### Notable exceptions

- `luarules/gadgets.lua` is left alone. Its `SAFEWRAP` machinery is dead, but it is dead in the engine's `LuaGadgets/gadgets.lua` that we forked it from, and has been since 2007. I am raising that upstream; removing our copy first would only widen the fork.

### AI / LLM usage statement

Claude Opus 5 authored 90% of code, 100% of commit message, 60% of PR description. It ran the analysis and investigation and performed the initial round of edits. I made modifications and asked it to make others. I have reviewed this PR, understand the code, and endorse it.
