### PR TITLE
Remove locals that are written but never read

### DIFF
--- a/luarules/gadgets/cmd_terraform_brush.lua
+++ b/luarules/gadgets/cmd_terraform_brush.lua
@@ -141,7 +141,6 @@ local importDoneCounter = 0
 -- Active drag session: all pushSnapshot/pushSnapshotFromFlat calls merge into mergeSnapshot until
 -- MERGE_END is received (sent by widget on mouse release).  No time window — MERGE_END is authoritative.
 local mergeSnapshot = nil -- the active snapshot being merged into; nil = no drag in progress
-local mergeVertexSet = nil -- set of numeric keys already in mergeSnapshot
 local mergeSnapshotLen = 0 -- explicit length of mergeSnapshot (avoids # on growing tables)
 local currentStrokeId = 0 -- incremented on each STROKE_END; tags all entries in a stroke
 local lastUndoFrame = -1 -- throttle: only one undo per game frame
@@ -432,7 +431,6 @@ local function finalizeMerge()
 		mergeSnapshot.vertexCount = mergeSnapshotLen / 3
 	end
 	mergeSnapshot = nil
-	mergeVertexSet = nil
 	mergeSnapshotLen = 0
 end
 

--- a/luarules/gadgets/dbg_gadget_profiler.lua
+++ b/luarules/gadgets/dbg_gadget_profiler.lua
@@ -390,9 +390,7 @@ else
 	local columnReserve = 0 -- width reserved left of column 0 for the detail panel (0 when none)
 	local detailColour = "\255\255\255\255"
 
-	local timersSynced = {}
 	local startTickTimer
-	local memUsageSynced = {}
 
 	local function SetDrawCallin(drawCallin)
 		-- when the profiler isn't running, the profiler gadget should have *no* draw callin
@@ -481,8 +479,6 @@ else
 			selectedCallinAvgs = {}
 
 			startTickTimer = nil
-			timersSynced = {}
-			memUsageSynced = {}
 
 			ProfilerEcho("luarules profiler killed (player " .. pID .. ")")
 		end
@@ -520,7 +516,6 @@ else
 		end
 	end
 
-	local totalLoads = {}
 	local allOverTimeSec = 0 -- currently unused
 
 	--------------------------------------------------------------------------------
@@ -601,7 +596,6 @@ else
 	end
 
 	local function ProcessCallinStats(stats, timeLoadAvgs, spaceloadAvgs, redStr, deltaTime, isSynced)
-		totalLoads = {}
 		local allOverTime = 0
 		local allOverSpace = 0
 		local n = 1

--- a/luarules/gadgets/game_replace_afk_players.lua
+++ b/luarules/gadgets/game_replace_afk_players.lua
@@ -39,7 +39,6 @@ if gadgetHandler:IsSyncedCode() then
 	local players = {}
 	local absent = {}
 	local replaced = false
-	local gameStarted = false
 
 	local gaiaTeamID = Spring.GetGaiaTeamID()
 	local SpGetPlayerList = Spring.GetPlayerList
@@ -174,7 +173,6 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:GameStart()
-		gameStarted = true
 		FindSubs(true)
 	end
 

--- a/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.lua
+++ b/luaui/RmlWidgets/gui_ceg_browser/gui_ceg_browser.lua
@@ -109,7 +109,6 @@ local hoveredCEG = ""
 local SCALE_PRESETS = { 0.75, 0.875, 1.0, 1.125, 1.25 }
 local scaleIndex = Spring.GetConfigInt("ceg_browser_scale_index", 3)
 scaleIndex = math.max(1, math.min(#SCALE_PRESETS, scaleIndex))
-local uiScale = SCALE_PRESETS[scaleIndex]
 local scaleNeedsApply = true -- apply on first Update
 
 ----------------------------------------------------------------
@@ -1252,7 +1251,6 @@ local init_model = {
 	scaleDown = function(ev)
 		if scaleIndex > 1 then
 			scaleIndex = scaleIndex - 1
-			uiScale = SCALE_PRESETS[scaleIndex]
 			scaleNeedsApply = true
 			UpdateScaleModel()
 		end
@@ -1261,7 +1259,6 @@ local init_model = {
 	scaleUp = function(ev)
 		if scaleIndex < #SCALE_PRESETS then
 			scaleIndex = scaleIndex + 1
-			uiScale = SCALE_PRESETS[scaleIndex]
 			scaleNeedsApply = true
 			UpdateScaleModel()
 		end

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -173,8 +173,6 @@ local selectedBlueprintIndex = nil
 
 local blueprintPlacementActive = false
 
-local lastExplicitlySelectedBlueprintIndex = nil
-
 local state = {
 	---@type Point|nil
 	---non-nil implies that we are dragging
@@ -428,11 +426,9 @@ local function deleteBlueprint(index)
 	elseif index == selectedBlueprintIndex then
 		-- find the closest valid blueprint, searching backwards
 		setSelectedBlueprintIndex(getPrevFilteredBlueprintIndex(selectedBlueprintIndex))
-		lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 	else -- index < selectedBlueprintIndex
 		-- keep the same blueprint selected
 		setSelectedBlueprintIndex(selectedBlueprintIndex - 1)
-		lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 	end
 end
 
@@ -814,7 +810,6 @@ local function handleBlueprintNextAction()
 	end
 
 	setSelectedBlueprintIndex(getNextFilteredBlueprintIndex())
-	lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 
 	Spring.PlaySoundFile(sounds.selectBlueprint, 0.75, nil, nil, nil, nil, nil, nil, "ui")
 
@@ -832,7 +827,6 @@ local function handleBlueprintPrevAction()
 	end
 
 	setSelectedBlueprintIndex(getPrevFilteredBlueprintIndex())
-	lastExplicitlySelectedBlueprintIndex = selectedBlueprintIndex
 
 	Spring.PlaySoundFile(sounds.selectBlueprint, 0.75, nil, nil, nil, nil, nil, nil, "ui")
 

--- a/luaui/Widgets/cmd_clone_tool.lua
+++ b/luaui/Widgets/cmd_clone_tool.lua
@@ -143,14 +143,11 @@ local historyUndoCount = 0
 local historyRedoCount = 0
 
 -- Coroutine for async operations
-local activeCoroutine = nil
 local coroutineProgress = 0
 local coroutineLabel = ""
 
 -- Splat FBO
 local splatCaptureFBO = nil
-local splatCaptureW = 0
-local splatCaptureH = 0
 local SPLAT_TEX_NAME = "$ssmf_splat_distr"
 local pendingSplatCapture = nil -- deferred GL capture (GL calls need Draw context)
 local pendingSplatPaste = nil -- deferred GL paste (GL calls need Draw context)
@@ -216,7 +213,6 @@ end
 local function deactivate()
 	active = false
 	state = "idle"
-	activeCoroutine = nil
 	coroutineProgress = 0
 	boxDrag.active = false
 end
@@ -1302,8 +1298,6 @@ function widget:DrawWorld()
 				glTexRect(-1, -1, 1, 1, sc.u0, sc.v0, sc.u1, sc.v1)
 				glTexture(0, false)
 			end)
-			splatCaptureW = sc.pw
-			splatCaptureH = sc.ph
 			local pixelData = {}
 			glRenderToTexture(splatCaptureFBO, function()
 				pixelData = glReadPixels(0, 0, sc.pw, sc.ph)

--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -121,7 +121,6 @@ local mouseDownPos
 
 local updateRate = 0.1
 local lastUpdateTime = 0
-local gameStarted
 
 local function maybeRemoveSelf()
 	if waterIsLava or voidWater or waterLevel < minHeight then
@@ -130,7 +129,6 @@ local function maybeRemoveSelf()
 end
 
 function widget:GameStart()
-	gameStarted = true
 	maybeRemoveSelf()
 end
 

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -915,7 +915,6 @@ local shiftState = { axis = nil, originX = nil, originZ = nil, wasHeld = false }
 local gridShowing = false
 local rightMouseHeld = false
 local savedModeBeforeRMB = nil
-local savedDirectionBeforeRMB = nil
 local clayMode = false
 local stampApplied = false -- stamp mode: true after first apply at current position
 
@@ -9384,7 +9383,6 @@ function widget:MousePress(mx, my, button)
 	if button == 3 then
 		if not rightMouseHeld then
 			savedModeBeforeRMB = activeMode
-			savedDirectionBeforeRMB = activeDirection
 			rightMouseHeld = true
 			setMode("lower")
 			Echo(
@@ -9511,7 +9509,6 @@ function widget:MouseRelease(mx, my, button)
 			activeDirection = nil
 		end
 		savedModeBeforeRMB = nil
-		savedDirectionBeforeRMB = nil
 		lockedWorldX = nil
 		lockedWorldZ = nil
 		lockedGroundY = nil

--- a/luaui/Widgets/dbg_frame_grapher.lua
+++ b/luaui/Widgets/dbg_frame_grapher.lua
@@ -238,7 +238,6 @@ end
 local wasgameframe = 0
 local prevframems = 0
 local lastframeduration -- shared across draw callins; read into prevframems
-local gameFrameHappened = false
 local drawspergameframe = 0
 
 local eventBuffer = {}
@@ -315,7 +314,6 @@ end
 function widget:GameFrame(n)
 	nowEvent("GameFrame")
 	wasgameframe = wasgameframe + 1
-	gameFrameHappened = true
 	if drawspergameframe ~= 2 then
 		--spEcho(drawspergameframe, "draws instead of 2", n)
 	end
@@ -453,5 +451,4 @@ function widget:DrawScreen()
 
 	wasgameframe = 0
 	prevframems = lastframeduration
-	gameFrameHappened = false
 end

--- a/luaui/Widgets/dbg_jitter_timer.lua
+++ b/luaui/Widgets/dbg_jitter_timer.lua
@@ -146,14 +146,12 @@ end
 
 local wasgameframe = 0
 local prevframems = 0
-local gameFrameHappened = false
 local drawspergameframe = 0
 local actualdrawspergameframe = 0
 
 function widget:GameFrame(n)
 	simtime = simtime + 1
 	wasgameframe = wasgameframe + 1
-	gameFrameHappened = true
 	if drawspergameframe ~= 2 then
 		--spEcho(drawspergameframe, "draws instead of 2", n)
 	end

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -492,14 +492,12 @@ function widget:Update() -- this is pointlessly expensive!
 	local step = areaResolution / 16
 	local totalsmoothness = 0
 	local prevHeight = spGetGroundHeight(updatePositionX, updatePositionZ)
-	local prevX = prevHeight
 	for x = updatePositionX, updatePositionX + areaResolution, step do
 		for z = updatePositionZ, updatePositionZ + areaResolution, step do
 			local h = spGetGroundHeight(x, z)
 			totalsmoothness = totalsmoothness + abs(h - prevHeight)
 			prevHeight = h
 		end
-		prevX = prevHeight
 	end
 	areaDecals[hash].smoothness = totalsmoothness
 end

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2088,14 +2088,12 @@ function widget:Update(dt)
 		--end
 
 		-- detect team colors changes
-		local changeDetected = false
 		local changedPlayers = {}
 		local teams = Spring.GetTeamList()
 		for i = 1, #teams do
 			local r, g, b = spGetTeamColor(teams[i])
 			if teamColorKeys[teams[i]] ~= r .. "_" .. g .. "_" .. b then
 				teamColorKeys[teams[i]] = r .. "_" .. g .. "_" .. b
-				changeDetected = true
 				for _, playerID in ipairs(Spring.GetPlayerList(teams[i])) do
 					local name = spGetPlayerInfo(playerID, false)
 					name = (

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -3218,7 +3218,6 @@ function init()
 	local currentDisplay = 1
 	local v_sx, v_sy, v_px, v_py = Spring.GetViewGeometry()
 	local displayNames = {}
-	local hasMultiDisplayOption = false
 	for index, display in ipairs(displays) do
 		if display.width > 0 then
 			displayNames[index] = index
@@ -3241,7 +3240,6 @@ function init()
 			end
 		elseif devMode or devUI then -- advSettings
 			displayNames[index] = display.name
-			hasMultiDisplayOption = true
 		end
 	end
 	local selectedDisplay = currentDisplay

--- a/luaui/Widgets/map_grass_gl4.lua
+++ b/luaui/Widgets/map_grass_gl4.lua
@@ -275,7 +275,6 @@ local grassVAO = nil
 local grassShader = nil
 local grassVertexShaderDebug = ""
 local grassFragmentShaderDebug = ""
-local grassPatchCount = 0
 
 local LuaShader = gl.LuaShader
 local InstanceVBOTable = gl.InstanceVBOTable
@@ -1130,7 +1129,6 @@ local function buildGrassTiles(cols, rows, sampleFn, jitter)
 			tileCount[tile] = offset - tileOffset[tile]
 		end
 	end
-	grassPatchCount = offset
 end
 
 local function LoadGrassTGA(filename)


### PR DESCRIPTION
### Work done

Removes 18 locals across 14 files that are declared and assigned, sometimes from several places, and read from nowhere.

Found by repeatedly running luacheck with `unused = true`.

This PR has no functional impact.

Dead code cleanup PR 8 of 8.

#### Notable exceptions

- `api_unit_tracker_gl4.lua` and `gui_pip.lua` are handled separately in #9041 and #9034
- `gui_allySelectedUnits.lua` keeps the orphaned `numVertices` with followup at https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2545#pullrequestreview-5084823472

### AI / LLM usage statement

Claude Opus 5 authored 95% of code, 100% of commit message, 75% of PR description. It ran the analysis and investigation and performed the edits. It confirmed none of the locals are referenced directly, via `debug.getlocal`, or through the manipulation in `locals_access.lua`. I have reviewed the changes, understand them, and endorse this PR.
