### PR TITLE
Fix waypoint drag lines being occluded by terrain

### DIFF
--- a/luaui/Widgets/unit_waypoint_dragger_2.lua
+++ b/luaui/Widgets/unit_waypoint_dragger_2.lua
@@ -29,6 +29,7 @@ local floor = math.floor
 local glVertex = gl.Vertex
 local glBeginEnd = gl.BeginEnd
 local glColor = gl.Color
+local glDepthTest = gl.DepthTest
 local glLineStipple = gl.LineStipple
 local glDrawGroundCircle = gl.DrawGroundCircle
 
@@ -300,6 +301,7 @@ function widget:DrawWorld()
 	if not shift then
 		return
 	end
+	glDepthTest(false)
 	for _, wpData in pairs(selWayPtsTbl) do
 		local cmd = wpData[6]
 		local nx, ny, nz = wpData[1], wpData[2], wpData[3]


### PR DESCRIPTION
## Summary

- disable depth testing before drawing the waypoint drag indicator
- keep the dragged waypoint line visible instead of letting terrain occlude parts of it
- make the widget independent of OpenGL state left by earlier draw call-ins

Fixes #9044

## Videos

### Before

https://github.com/user-attachments/assets/c2e8fd83-a926-4b78-b4b1-5dc135de9488


### After

https://github.com/user-attachments/assets/227d9b4a-8bdd-4e91-8901-b0298f0924e9





## Testing

- `stylua --check luaui/Widgets/unit_waypoint_dragger_2.lua`
- Lua 5.1 syntax check with `loadfile`
- `git diff --check`
- repository-wide `emmylua_check`: no errors or warnings on the changed lines (the existing repository baseline still reports one unrelated error)

## AI / LLM usage statement

OpenAI Codex was used to identify the relevant Lua rendering path, propose and apply the two-line production-code change, run the automated checks listed above, and draft this PR description. The author reviewed the diff and its rendering-state rationale; in-game verification is being performed manually.
