### PR TITLE
type check: stop penalizing code deletions by requiring they always remove type warnings

### DIFF
--- a/.github/scripts/emmylua_compare.py
+++ b/.github/scripts/emmylua_compare.py
@@ -616,6 +616,8 @@ def main():
     delta_ceiling = int(
         args.warn_total_per_kloc * args.changed_file_lines_delta / 1000.0
     )
+    # A negative delta would mean shrinking a file requires fixing type warnings.
+    delta_ceiling = max(0, delta_ceiling)
     budget = {
         "added": added,
         "resolved": resolved,


### PR DESCRIPTION
### Work done

Clamps `delta_ceiling` at zero in `emmylua_compare.py`, so a change that shrinks the files it touches no longer loses type-warning allowance for doing so.

Without this, a change is required to fix 3 warnings per hundred lines it deletes, which makes any sizeable deletion unmergeable no matter how clean it is.

#### Setup

Affects CI only. No game or Lua behavior changes.

### Test steps

- [ ] Confirm this PR's own `emmylua_check` run passes, since it touches `.github/scripts/**` and so triggers the type check with no Lua files changed.
- [ ] Confirm a growing PR still reports the same allowance it would have before.
- [ ] Confirm a PR that genuinely adds warnings still fails.

I reproduced the comparison locally against https://github.com/beyond-all-reason/Beyond-All-Reason/pull/9018, rebuilding both sides with three `emmylua_check` runs each as the workflow does. It fails on master with 10388 warnings against an allowance of 10382, and passes with this change at an allowance of 10391, with the warning count itself unmoved.

### AI / LLM usage statement

Claude Opus 5 authored 10% of code, 100% of commit message, 80% of PR description. It diagnosed the failure by reproducing the workflow's comparison locally and proposed the clamp in a less clean/readable way, which I rewrote. I have reviewed this PR, understand the change being made, and endorse it.