### PR TITLE
Terraform Brush 1.13: tileset performance controls, biome library, paint fixes

### DIFF
--- a/doc/TerraformBrush-changelog.md
+++ b/doc/TerraformBrush-changelog.md
@@ -21,6 +21,7 @@ Version numbers follow the improvements-branch scheme (`tf-brush-improvements-N`
 
 - LAYERS paint, clone-tool pastes and a project's splat swap now tell the tileset shader which region changed, so painted layers no longer vanish when zooming out. The shader serves distant ground from a baked copy that sampled the splat texture at bake time; strokes widen a dirty rectangle that is flushed to the far cache and clipmap during the drag and once more when it ends, and whole-texture changes (undo, redo, load) request a full refill.
 - The picture-in-picture widget no longer floods the log with GL errors on Mesa drivers: a uniform call was handed every return value of a multi-value function instead of only the ones the uniform takes.
+- The header's passthrough (pause) button works with the SURFACE panel (reported by Moose). The toggle saved, deactivated and restored every tool except the surface painter, so pausing with SURFACE armed left its brush owning the mouse and clicks never reached unit selection. Both submodes now stand down on pause and re-arm on unpause, LAYERS included.
 
 ## 1.12 - 2026-08-22
 

--- a/doc/TerraformBrush-changelog.md
+++ b/doc/TerraformBrush-changelog.md
@@ -4,6 +4,23 @@ Release history for the Terraform Brush map-editing suite.
 
 Version numbers follow the improvements-branch scheme (`tf-brush-improvements-N` up to 1.10, `tf-improvements-N` from 1.11): branch `N` corresponds to release `1.N`. Only versions merged into the upstream Beyond All Reason repository are listed as releases. Intermediate development branches that were folded into a later release are noted separately.
 
+## 1.13 - 2026-09-01
+
+### New
+
+- The Tileset window gained a PERFORMANCE section: HIGH, MEDIUM and LOW quality presets that drop draw-time features of the tileset shader, and the levers underneath them as sliders (foothills, stagger, far anti-tiling, cliff-tap slack, the far cache with its start and band, "Cliffs cached past" for the distance at which steep faces join the cache, and the clipmap toggle). A preset applies on top of the sliders, so HIGH is where each lever can be judged on its own.
+
+### Improvements
+
+- AUTORAMP swipe: holding the button and dragging re-fires the ramp along the path, so a whole cliff line restyles in one stroke instead of one click per segment.
+- SURFACE's per-tile FLIP buttons became one FLIP chip in the NOW PAINTING strip that flips the normal map of the selected slot, BASE included. Three buttons per tile left PICK, FLIP and X too cramped to hit; the chip dims when the selected slot has no texture.
+- The SURFACE texture picker asks the painter for its coverage readback only while a picker is open. The readback is a GPU sync, and its only reader is the picker's "already carries paint" warning.
+
+### Fixes
+
+- LAYERS paint, clone-tool pastes and a project's splat swap now tell the tileset shader which region changed, so painted layers no longer vanish when zooming out. The shader serves distant ground from a baked copy that sampled the splat texture at bake time; strokes widen a dirty rectangle that is flushed to the far cache and clipmap during the drag and once more when it ends, and whole-texture changes (undo, redo, load) request a full refill.
+- The picture-in-picture widget no longer floods the log with GL errors on Mesa drivers: a uniform call was handed every return value of a multi-value function instead of only the ones the uniform takes.
+
 ## 1.12 - 2026-08-22
 
 ### New

--- a/doc/TerraformBrush-changelog.md
+++ b/doc/TerraformBrush-changelog.md
@@ -4,11 +4,12 @@ Release history for the Terraform Brush map-editing suite.
 
 Version numbers follow the improvements-branch scheme (`tf-brush-improvements-N` up to 1.10, `tf-improvements-N` from 1.11): branch `N` corresponds to release `1.N`. Only versions merged into the upstream Beyond All Reason repository are listed as releases. Intermediate development branches that were folded into a later release are noted separately.
 
-## 1.13 - 2026-09-01
+## 1.13 - 2026-09-02
 
 ### New
 
 - The Tileset window gained a PERFORMANCE section: HIGH, MEDIUM and LOW quality presets that drop draw-time features of the tileset shader, and the levers underneath them as sliders (foothills, stagger, far anti-tiling, cliff-tap slack, the far cache with its start and band, "Cliffs cached past" for the distance at which steep faces join the cache, and the clipmap toggle). A preset applies on top of the sliders, so HIGH is where each lever can be judged on its own.
+- The BIOME LIBRARY tiles are built at runtime from the tileset shader's biome manifests (one Lua file per biome in the shader's `tilesets/` folder) instead of six hardcoded RML tiles, so a biome added on disk shows up in the picker without a UI edit; Bismuth becomes reachable for the first time. Thumbnails are GL overdraws like the EXTRA LAYER material tiles (a shipped preview drawn whole, or the base albedo as a centered crop), and each biome's skybox pick comes from its manifest instead of a name-match table in the UI.
 
 ### Improvements
 

--- a/doc/TerraformBrush-changelog.md
+++ b/doc/TerraformBrush-changelog.md
@@ -9,7 +9,7 @@ Version numbers follow the improvements-branch scheme (`tf-brush-improvements-N`
 ### New
 
 - The Tileset window gained a PERFORMANCE section: HIGH, MEDIUM and LOW quality presets that drop draw-time features of the tileset shader, and the levers underneath them as sliders (foothills, stagger, far anti-tiling, cliff-tap slack, the far cache with its start and band, "Cliffs cached past" for the distance at which steep faces join the cache, and the clipmap toggle). A preset applies on top of the sliders, so HIGH is where each lever can be judged on its own.
-- The BIOME LIBRARY tiles are built at runtime from the tileset shader's biome manifests (one Lua file per biome in the shader's `tilesets/` folder) instead of six hardcoded RML tiles, so a biome added on disk shows up in the picker without a UI edit; Bismuth becomes reachable for the first time. Thumbnails are GL overdraws like the EXTRA LAYER material tiles (a shipped preview drawn whole, or the base albedo as a centered crop), and each biome's skybox pick comes from its manifest instead of a name-match table in the UI.
+- The BIOME LIBRARY tiles are built at runtime from the tileset shader's biome manifests (one Lua file per biome in the shader's `tilesets/` folder) instead of six hardcoded RML tiles, so a biome added on disk shows up in the picker without a UI edit. Thumbnails are GL overdraws like the EXTRA LAYER material tiles (a shipped preview drawn whole, or the base albedo as a centered crop), and each biome's skybox pick comes from its manifest instead of a name-match table in the UI.
 
 ### Improvements
 

--- a/doc/TerraformBrush-changelog.md
+++ b/doc/TerraformBrush-changelog.md
@@ -21,6 +21,7 @@ Version numbers follow the improvements-branch scheme (`tf-brush-improvements-N`
 
 - LAYERS paint, clone-tool pastes and a project's splat swap now tell the tileset shader which region changed, so painted layers no longer vanish when zooming out. The shader serves distant ground from a baked copy that sampled the splat texture at bake time; strokes widen a dirty rectangle that is flushed to the far cache and clipmap during the drag and once more when it ends, and whole-texture changes (undo, redo, load) request a full refill.
 - The picture-in-picture widget no longer floods the log with GL errors on Mesa drivers: a uniform call was handed every return value of a multi-value function instead of only the ones the uniform takes.
+- The FILE dropdown stays on top of the texture thumbnails (reported by Moose). Tile previews (SURFACE palette, EXTRA LAYER, BIOME LIBRARY, skybox and splat channel grids) are GL overdraws painted after the UI renders, so an open menu was drawn under them; every pass now skips tiles the menu covers.
 - The header's passthrough (pause) button works with the SURFACE panel (reported by Moose). The toggle saved, deactivated and restored every tool except the surface painter, so pausing with SURFACE armed left its brush owning the mouse and clicks never reached unit selection. Both submodes now stand down on pause and re-arm on unpause, LAYERS included.
 
 ## 1.12 - 2026-08-22

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -1100,6 +1100,44 @@ function widgetState.pushPanelClip(el)
 	return false
 end
 
+-- The FILE dropdown must stay on top of everything, but the GL thumbnail
+-- passes run in DrawScreenPost, after RmlUi has rendered, so an open menu
+-- would be painted over (reported by Moose for the SURFACE tiles; the same
+-- held for every tile grid). Measured once per frame into widgetState.fmBox;
+-- every pass skips tiles that touch it. Element coords, y down. Gated on the
+-- data model, not the element box: an element that is not laid out can still
+-- report a stale non-zero box (the panel-down lesson above).
+function widgetState.measureFileMenuBox()
+	widgetState.fmBoxX = nil
+	local dm = widgetState.dmHandle
+	if not (dm and dm.fileMenuOpen) then
+		return
+	end
+	local doc = widgetState.document
+	local menu = doc and doc:GetElementById("tf-file-menu")
+	if not menu then
+		return
+	end
+	local w, h = menu.offset_width, menu.offset_height
+	if w and h and w > 0 and h > 0 then
+		widgetState.fmBoxX = menu.absolute_left
+		widgetState.fmBoxY = menu.absolute_top
+		widgetState.fmBoxW = w
+		widgetState.fmBoxH = h
+	end
+end
+function widgetState.underFileMenu(x, y, w, h)
+	local bx = widgetState.fmBoxX
+	if not bx then
+		return false
+	end
+	-- set together with fmBoxX; the or-defaults are for the analyzer
+	local by = widgetState.fmBoxY or 0
+	local bw = widgetState.fmBoxW or 0
+	local bh = widgetState.fmBoxH or 0
+	return x < bx + bw and x + w > bx and y < by + bh and y + h > by
+end
+
 -- Forward declaration: clearPassthrough is defined after initialModel but captured as upvalue
 -- by onCl* (and any future) model-king handlers inside initialModel.
 local clearPassthrough
@@ -14575,7 +14613,7 @@ local function drawSkyboxThumbnailPreviews()
 				local y = el.absolute_top
 				local w = el.offset_width
 				local h = el.offset_height
-				if w > 4 and h > 4 then
+				if w > 4 and h > 4 and not widgetState.underFileMenu(x, y, w, h) then
 					local glY1 = vsy - y - h
 					local glY2 = vsy - y
 					-- gl.Texture returns true on success; cubemap DDS loads as TEXTURE_CUBE_MAP
@@ -14660,7 +14698,7 @@ local function drawSurfPaletteThumbs()
 			if w > 0 and h > 0 then
 				local x = div.absolute_left
 				local y = div.absolute_top
-				if gl.Texture(0, tex) then
+				if not widgetState.underFileMenu(x, y, w, h) and gl.Texture(0, tex) then
 					-- centered crop: a full 4K tile at 52dp reads as noise, so a
 					-- quarter-window shows the material's actual character.
 					-- Entries may widen it (the picker's hover preview is big
@@ -14725,7 +14763,7 @@ widgetState.drawTs4PaletteThumbs = function()
 			if w > 0 and h > 0 then
 				local x = div.absolute_left
 				local y = div.absolute_top
-				if gl.Texture(0, tex) then
+				if not widgetState.underFileMenu(x, y, w, h) and gl.Texture(0, tex) then
 					-- centered quarter-window crop, like the surf tiles: a full
 					-- 4K tile at 52dp reads as noise
 					gl.TexRect(x, vsy - y - h, x + w, vsy - y, 0.25, 0.25, 0.75, 0.75)
@@ -14778,7 +14816,7 @@ widgetState.drawTsBiomeThumbs = function()
 			if w > 0 and h > 0 then
 				local x = div.absolute_left
 				local y = div.absolute_top
-				if gl.Texture(0, tex) then
+				if not widgetState.underFileMenu(x, y, w, h) and gl.Texture(0, tex) then
 					if els[i].crop then
 						-- a 4K albedo at 60dp reads as noise: centered quarter crop
 						gl.TexRect(x, vsy - y - h, x + w, vsy - y, 0.25, 0.25, 0.75, 0.75)
@@ -14798,6 +14836,9 @@ widgetState.drawTsBiomeThumbs = function()
 end
 
 function widget:DrawScreenPost()
+	-- FILE dropdown box, read once for every pass below to skip tiles under it.
+	widgetState.measureFileMenuBox()
+
 	-- GL-rendered cubemap previews for skybox tiles without a separate preview image.
 	drawSkyboxThumbnailPreviews()
 
@@ -15277,7 +15318,7 @@ function widget:DrawScreenPost()
 					gl.UniformInt(widgetState.spPreviewShaderChannelLoc, i - 1)
 				end
 
-				local bound = gl.Texture(0, tex)
+				local bound = not widgetState.underFileMenu(x, y, w, h) and gl.Texture(0, tex)
 
 				if logDraw then
 					Spring.Echo("[TFBrush] gl.Texture(0, " .. tex .. ") = " .. tostring(bound))

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -350,7 +350,7 @@ widgetState = { -- forward-declared above playSound so mute check works
 	-- Auto-scroll transport state (per-slider, keyed by slider element id)
 	transports = {},
 	-- Currently focused RmlUI input element (text/number boxes); cleared on blur.
-	-- Used to auto-blur when game chat is opened, so chat keys aren't stolen by RmlUI.
+	-- Used to auto-blur when game chat is opened, so Tab autocomplete isn't stolen by RmlUI.
 	focusedRmlInput = nil,
 	-- Module-shared mutable state
 	noiseManuallyHidden = false,
@@ -923,23 +923,26 @@ widgetState.applySkybox = applySkybox
 -- vary (SpaceSkybox1/2/3, EarthSkybox1/2/3, ...). namaqualand -> red desert planet
 -- is our pick (user specified only bismuth/teizer/enborelde).
 local IS_BAR = (Game.gameName or ""):find("Beyond All Reason") ~= nil
-local BIOME_SKYBOX_MATCH = {
-	bismuth = "spaceskybox", -- starry sky
-	teizer = "goldsunrise", -- sunset (bespoke desert kept the old pick)
-	protodesert = "goldsunrise", -- the renamed original Teizer stand-in set
-	enborelde = "earthskybox", -- sunny blue sky with clouds (bespoke earthlike kept the old pick)
-	prototemperate = "earthskybox", -- the renamed original Enborelde stand-in set
-	namaqualand = "redplanet", -- red desert planet
-	palehang = "allthatglitters", -- crystal-desert sky (Theta Crystals family)
-}
+-- The fragment per biome comes from its manifest (tileset_dev/tilesets/<key>.lua,
+-- field `skybox`), read through WG.TilesetTerrain.getBiomes(); nothing is
+-- hardcoded here any more, so a new biome brings its own sky.
 
 -- Resolve a biome key to a full DDS path in the skybox library, or nil if unmapped /
 -- the matching file is absent. Deterministic: lowest-sorted name wins (so *1 variants).
 local function resolveBiomeSkybox(biomeKey)
-	local frag = BIOME_SKYBOX_MATCH[biomeKey]
-	if not frag then
+	local frag
+	local T = WG.TilesetTerrain
+	local rows = T and T.getBiomes and T.getBiomes()
+	for _, b in ipairs(rows or {}) do
+		if b.key == biomeKey then
+			frag = b.skybox
+			break
+		end
+	end
+	if not frag or frag == "" then
 		return nil
 	end
+	frag = tostring(frag):lower()
 	local files = VFS.DirList("Terraform Brush/SkyBoxes/", "*.dds", VFS.RAW_FIRST) or {}
 	table.sort(files)
 	for _, fp in ipairs(files) do
@@ -965,6 +968,27 @@ local function syncSkyboxToBiome(biomeKey)
 	for _, t in ipairs(widgetState.envSkyboxThumbs or {}) do
 		t.element:SetClass("active", t.path == sky)
 	end
+end
+
+-- Pick a biome: shared by the data-model onPickBiome and the BIOME LIBRARY
+-- tiles tf_tileset.lua builds at runtime from the manifests. On widgetState,
+-- not a local: the main chunk sits near Lua 5.1's 200-local ceiling.
+widgetState.pickBiome = function(key)
+	if not (WG.TilesetTerrain and WG.TilesetTerrain.setBiome) then
+		return false
+	end
+	local ok = WG.TilesetTerrain.setBiome(key)
+	if ok then
+		playSound("click")
+		local dm = widgetState.dmHandle
+		if dm then
+			dm.tsBiome = key
+		end
+		-- Each biome is a planet: swap the skybox to match (no-op unless BAR +
+		-- toggle on, or when the manifest names no sky).
+		syncSkyboxToBiome(key)
+	end
+	return ok
 end
 
 local function tickSkyboxFade(dt)
@@ -9922,20 +9946,7 @@ local initialModel = {
 		end
 	end,
 	onPickBiome = function(_event, key)
-		if not (WG.TilesetTerrain and WG.TilesetTerrain.setBiome) then
-			return
-		end
-		local ok = WG.TilesetTerrain.setBiome(key)
-		if ok then
-			playSound("click")
-			local dm = widgetState.dmHandle
-			if dm then
-				dm.tsBiome = key
-			end
-			-- Each biome is a planet: swap the skybox to match (no-op unless BAR +
-			-- toggle on; also no-op on maps that booted without a real cubemap sky).
-			syncSkyboxToBiome(key)
-		end
+		widgetState.pickBiome(key)
 	end,
 	-- SLOT 4 mode buttons (TILESET > PLACEMENT): the fourth material suite's
 	-- weight source (plateau / detail / interm 2 / cliff 2 / off). The shader
@@ -14778,6 +14789,62 @@ widgetState.drawTs4PaletteThumbs = function()
 	gl.Color(1, 1, 1, 1)
 end
 
+-- GL thumbnails for the BIOME LIBRARY tiles (tf_tileset.lua's rebuildBiomePalette):
+-- the shipped biome_<key>.png or a manifest `thumb` drawn whole, or the base
+-- layer's albedo as a centered crop when a biome has neither. Same mechanism and
+-- gates as drawTs4PaletteThumbs above.
+widgetState.drawTsBiomeThumbs = function()
+	local dm = widgetState.dmHandle
+	if not dm or not dm.envTilesetVisible then
+		return
+	end
+	if widgetState.lobbyHidden or not widgetState.document then
+		return
+	end
+	local rootEl = widgetState.rootElement
+	if rootEl and rootEl:IsClassSet("hidden") then
+		return
+	end
+	local sec = widgetState.tsBiomeSectionEl
+	if not sec or sec:IsClassSet("hidden") then
+		return
+	end
+	local els = widgetState.tsBiomeTileEls
+	if not els or #els == 0 then
+		return
+	end
+	local _, vsy = Spring.GetViewGeometry()
+	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
+	gl.Color(1, 1, 1, 1)
+	local clipped = widgetState.pushPanelClip(els[1].el)
+	for i = 1, #els do
+		local div = els[i].el
+		local tex = els[i].tex
+		if div and tex then
+			local w = div.offset_width
+			local h = div.offset_height
+			if w > 0 and h > 0 then
+				local x = div.absolute_left
+				local y = div.absolute_top
+				if gl.Texture(0, tex) then
+					if els[i].crop then
+						-- a 4K albedo at 60dp reads as noise: centered quarter crop
+						gl.TexRect(x, vsy - y - h, x + w, vsy - y, 0.25, 0.25, 0.75, 0.75)
+					else
+						gl.TexRect(x, vsy - y - h, x + w, vsy - y, 0, 1, 1, 0)
+					end
+					gl.Texture(0, false)
+				end
+			end
+		end
+	end
+	if clipped then
+		gl.Scissor(false)
+	end
+	gl.Blending(false)
+	gl.Color(1, 1, 1, 1)
+end
+
 function widget:DrawScreenPost()
 	-- GL-rendered cubemap previews for skybox tiles without a separate preview image.
 	drawSkyboxThumbnailPreviews()
@@ -14787,6 +14854,9 @@ function widget:DrawScreenPost()
 
 	-- EXTRA LAYER material tile thumbnails (early-outs on its own window check).
 	widgetState.drawTs4PaletteThumbs()
+
+	-- BIOME LIBRARY tile thumbnails (same gates).
+	widgetState.drawTsBiomeThumbs()
 
 	-- Render splat detail texture previews into the channel div elements.
 	-- Only render when splat tool is active; avoids gl.* overlay leaking over other tools/panels.
@@ -15603,7 +15673,7 @@ function widget:Update()
 		end
 
 		-- When game chat input is open, auto-blur any focused RmlUI text input so
-		-- keystrokes reach the chat widget instead of navigating RmlUI fields.
+		-- Tab reaches the chat widget for autocomplete instead of navigating RmlUI fields.
 		if widgetState.focusedRmlInput and WG.chat and WG.chat.isInputActive() then
 			widgetState.focusedRmlInput:Blur()
 			widgetState.focusedRmlInput = nil

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -15187,7 +15187,7 @@ function widget:DrawScreenPost()
 		end
 	end
 
-	local vsx, vsy = Spring.GetViewGeometry()
+	local vsx, vsy = GetViewGeometry()
 
 	local shader = widgetState.spPreviewShader
 

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -3028,6 +3028,9 @@ local initialModel = {
 	-- SLOT 4 mode buttons in the PLACEMENT section (data-class-active =
 	-- "tsSlot4Mode == '<name>'"); synced from WG.TilesetTerrain.getSlot4Mode.
 	tsSlot4Mode = "plateau",
+	-- PERFORMANCE section quality preset (data-class-active="tsQuality == '<tier>'");
+	-- synced from WG.TilesetTerrain.getQuality.
+	tsQuality = "high",
 	tsDebugView = 0, -- active TILESET debug view (drives the DEBUG multi-toggle highlight)
 	tsMetalStyle = "", -- active METAL SPOTS style tile (data-class-active="tsMetalStyle == '<key>'")
 	-- SURFACE tool (tileset variant paint; engine = dev_surface_painter.lua,
@@ -9950,6 +9953,19 @@ local initialModel = {
 			local dm = widgetState.dmHandle
 			if dm then
 				dm.tsSlot4Mode = name
+			end
+		end
+	end,
+	onTsQuality = function(_event, name)
+		if not (WG.TilesetTerrain and WG.TilesetTerrain.setQuality) then
+			return
+		end
+		local ok = WG.TilesetTerrain.setQuality(name)
+		if ok then
+			playSound("click")
+			local dm = widgetState.dmHandle
+			if dm then
+				dm.tsQuality = name
 			end
 		end
 	end,

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -7460,14 +7460,23 @@ local initialModel = {
 			local lpSt = WG.LightPlacer and WG.LightPlacer.getState()
 			local stSt = WG.StartPosTool and WG.StartPosTool.getState()
 			local clSt = WG.CloneTool and WG.CloneTool.getState()
+			---@type table?
+			local sfPtr = WG.SurfacePainter
+			local sfSt = sfPtr and sfPtr.getState and sfPtr.getState()
 			if tfSt and tfSt.active then
 				saved = { tool = "terraform", mode = tfSt.mode }
 			elseif fpSt and fpSt.active then
 				saved = { tool = "features", mode = fpSt.mode }
 			elseif wbSt and wbSt.active then
 				saved = { tool = "weather", mode = wbSt.mode }
+			elseif widgetState.surfHardActive then
+				-- LAYERS: the splat engine runs headless under the SURFACE panel;
+				-- the pin (not the engine) tells it apart from the legacy SPLAT tool.
+				saved = { tool = "surfaceHard" }
 			elseif spSt and spSt.active then
 				saved = { tool = "splat" }
+			elseif sfSt and sfSt.active then
+				saved = { tool = "surface" }
 			elseif mbSt and mbSt.active then
 				saved = { tool = "metal", mode = mbSt.subMode }
 			elseif gbSt and gbSt.active then
@@ -7493,6 +7502,9 @@ local initialModel = {
 			if WG.SplatPainter then
 				WG.SplatPainter.deactivate()
 			end
+			if sfPtr and sfPtr.deactivate then
+				sfPtr.deactivate()
+			end
 			if WG.MetalBrush then
 				WG.MetalBrush.deactivate()
 			end
@@ -7512,6 +7524,8 @@ local initialModel = {
 			widgetState.lightActive = false
 			widgetState.startposActive = false
 			widgetState.cloneActive = false
+			widgetState.surfHardActive = false
+			widgetState.surfPickerSlot = nil -- pausing the tool closes the variant picker
 			widgetState.passthroughSaved = saved
 			widgetState.passthroughMode = true
 			local d = widgetState.dmHandle
@@ -7533,6 +7547,10 @@ local initialModel = {
 			end
 			local s = widgetState.passthroughSaved
 			widgetState.passthroughSaved = nil
+			---@type table?
+			local sfPtr = WG.SurfacePainter
+			---@type table?
+			local spPtr = WG.SplatPainter
 			if s then
 				-- Splat/Metal/Grass/StartPos expose activate(subMode), not setMode;
 				-- Weather's setMode only picks the submode without re-arming the tool.
@@ -7544,6 +7562,11 @@ local initialModel = {
 					WG.WeatherBrush.activate(s.mode or "scatter")
 				elseif s.tool == "splat" and WG.SplatPainter then
 					WG.SplatPainter.activate()
+				elseif s.tool == "surface" and sfPtr and sfPtr.activate then
+					sfPtr.activate()
+				elseif s.tool == "surfaceHard" and spPtr and spPtr.activate then
+					spPtr.activate()
+					widgetState.surfHardActive = true
 				elseif s.tool == "metal" and WG.MetalBrush then
 					WG.MetalBrush.activate(s.mode or "stamp")
 				elseif s.tool == "grass" and WG.GrassBrush then

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rcss
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rcss
@@ -3654,6 +3654,13 @@ margin-top: 3dp;
 	width: 60dp;
 	height: 60dp;
 	border-radius: 3dp;
+	/* an empty rect the widget overdraws with the thumbnail via gl.TexRect
+	   (DrawScreenPost); the tint shows until the texture is resident */
+	background-color: #26263699;
+}
+/* invisible filler so a short last row keeps the tile width */
+.tf-biome-tile.tf-biome-pad {
+	visibility: hidden;
 }
 .tf-biome-name {
 	margin-top: 2dp;

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rcss
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rcss
@@ -2972,6 +2972,10 @@ body {
 	decorator: vertical-gradient(#18463a #0d2c24);
 	box-shadow: 0dp 2dp 5dp 0dp #00000080, inset 0dp 1dp 0dp 0dp #40e0c050;
 }
+/* chip whose action has no target right now (e.g. FLIP with an empty slot selected) */
+.tf-overlay-chip.unavailable {
+	opacity: 0.4;
+}
 .tf-overlay-chip-label {
 	font-size: 1.0rem;
 	color: #9ca3af;
@@ -3768,7 +3772,9 @@ margin-top: 3dp;
 	overflow: hidden;
 }
 /* PICK / X: real buttons, because a grey glyph beside the name was invisible
-   and because selecting a slot and choosing its texture are different actions */
+   and because selecting a slot and choosing its texture are different actions.
+   (FLIP is NOT per tile: a third button here clipped into its neighbours, so
+   it lives in the NOW PAINTING strip and acts on the selected slot.) */
 .surf-slot-actions {
 	display: flex;
 	flex-direction: row;
@@ -3800,7 +3806,7 @@ margin-top: 3dp;
 	color: #ffdb8a;
 }
 .surf-slot-btn.surf-slot-x {
-	flex: 0 0 22dp;
+	flex: 0 0 26dp;
 	color: #9ca3af;
 	font-size: 1.25rem;
 }

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -17,7 +17,7 @@
 					<span class="tf-title-accent">BRUSH</span>
 					<!-- Version tracks the tf-brush-improvements-N branch this shipped from:
 					     branch N is version 1.N. -->
-					<span class="tf-title-version">1.12</span>
+					<span class="tf-title-version">1.13</span>
 				</div>
 				<div class="tf-header-top-btns">
 					<div id="btn-passthrough" class="tf-header-btn tf-passthrough-btn" data-class-active="passthroughActive" data-event-mousedown="onGuideTogglePassthrough()">

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -5887,34 +5887,10 @@
 							<div class="tf-collapsible-title">BIOME LIBRARY</div>
 						</div>
 						<div id="section-ts-library">
-							<div class="tf-biome-grid flex flex-row gap-1 mb-1">
-								<div class="tf-biome-tile" data-class-active="tsBiome == 'namaqualand'" data-event-mousedown="onPickBiome('namaqualand')">
-									<img class="tf-biome-thumb" src="/luaui/images/terraform_brush/biome_namaqualand.png" />
-									<div class="tf-biome-name">Namaqualand</div>
-								</div>
-								<div class="tf-biome-tile" data-class-active="tsBiome == 'teizer'" data-event-mousedown="onPickBiome('teizer')">
-									<img class="tf-biome-thumb" src="/luaui/images/terraform_brush/biome_teizer.png" />
-									<div class="tf-biome-name">Teizer-5</div>
-								</div>
-								<div class="tf-biome-tile" data-class-active="tsBiome == 'enborelde'" data-event-mousedown="onPickBiome('enborelde')">
-									<img class="tf-biome-thumb" src="/luaui/images/terraform_brush/biome_enborelde.png" />
-									<div class="tf-biome-name">Enborelde</div>
-								</div>
-							</div>
-							<div class="tf-biome-grid flex flex-row gap-1 mb-1">
-								<div class="tf-biome-tile" data-class-active="tsBiome == 'protodesert'" data-event-mousedown="onPickBiome('protodesert')">
-									<img class="tf-biome-thumb" src="/luaui/images/terraform_brush/biome_protodesert.png" />
-									<div class="tf-biome-name">Protodesert</div>
-								</div>
-								<div class="tf-biome-tile" data-class-active="tsBiome == 'prototemperate'" data-event-mousedown="onPickBiome('prototemperate')">
-									<img class="tf-biome-thumb" src="/luaui/images/terraform_brush/biome_prototemperate.png" />
-									<div class="tf-biome-name">Prototemperate</div>
-								</div>
-								<div class="tf-biome-tile" data-class-active="tsBiome == 'palehang'" data-event-mousedown="onPickBiome('palehang')">
-									<img class="tf-biome-thumb" src="/luaui/images/terraform_brush/biome_palehang.png" />
-									<div class="tf-biome-name">Pale Hang</div>
-								</div>
-							</div>
+							<!-- Biome tiles are built at sync from WG.TilesetTerrain.getBiomes() (one
+							     manifest per biome in tileset_dev/tilesets/); thumbnails are GL overdraws
+							     like the EXTRA LAYER material tiles (tf_tileset.lua rebuildBiomePalette). -->
+							<div id="ts-biome-grid"></div>
 							<div class="text-base text-light" style="opacity: 0.7;">Swaps all four terrain layers live.</div>
 							<div class="flex flex-row gap-1 items-center mb-1" style="margin-top: 4dp;">
 								<img id="btn-ts-skybox-sync" class="tf-icon-sm" src="/luaui/images/terraform_brush/check_on.png" style="cursor: pointer;" data-event-mousedown="onTsToggleSkyboxSync()" />

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -5924,6 +5924,70 @@
 							</div>
 						</div>
 					</div><!-- /frame-ts-library -->
+					<div class="tf-section-frame tf-collapsed" id="frame-ts-perf">
+						<div id="btn-toggle-ts-perf" class="tf-section-title-row" style="cursor: pointer;">
+							<img id="img-toggle-ts-perf" class="tf-icon-sm" src="/luaui/images/terraform_brush/plus.png" />
+							<div class="tf-collapsible-title">PERFORMANCE</div>
+							<div id="btn-ts-reset-perf" class="tf-env-reset-btn" data-event-click="onTilesetSectionReset('perf')">RESET</div>
+						</div>
+						<div id="section-ts-perf" class="hidden">
+							<div class="text-base text-light" style="opacity: 0.7;">Quality presets drop draw-time features. A preset applies on top of the sliders &#8212; pick HIGH to test each lever on its own.</div>
+							<div class="flex flex-row gap-1 mb-1" style="margin-top: 4dp;">
+								<div class="tf-mode-btn tf-s4-btn" data-class-active="tsQuality == 'high'" data-event-mousedown="onTsQuality('high')"><div class="tf-btn-text">HIGH</div></div>
+								<div class="tf-mode-btn tf-s4-btn" data-class-active="tsQuality == 'medium'" data-event-mousedown="onTsQuality('medium')"><div class="tf-btn-text">MEDIUM</div></div>
+								<div class="tf-mode-btn tf-s4-btn" data-class-active="tsQuality == 'low'" data-event-mousedown="onTsQuality('low')"><div class="tf-btn-text">LOW</div></div>
+							</div>
+							<div class="text-base text-light" style="opacity: 0.7; margin-top: 4dp;">Levers (foothills/stagger 1 = on). Parallax and Height blend live in their own sections; presets set them too. Foothills and metal spots stay on in every preset: cheap, and dropping them reads as a downgrade.</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Foothills</div>
+							<input type="range" id="ts-slider-foothills" class="tf-slider" min="0" max="1" step="1" value="1" data-event-change="onTilesetKnob('foothills')" />
+							<input type="text" id="ts-slider-foothills-numbox" class="tf-slider-numbox" readonly value="1" />
+						</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Stagger</div>
+							<input type="range" id="ts-slider-stagger" class="tf-slider" min="0" max="1" step="1" value="1" data-event-change="onTilesetKnob('stagger')" />
+							<input type="text" id="ts-slider-stagger-numbox" class="tf-slider-numbox" readonly value="1" />
+						</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Far anti-tiling</div>
+							<input type="range" id="ts-slider-detileMul" class="tf-slider" min="0" max="1" step="1" value="1" data-event-change="onTilesetKnob('detileMul')" />
+							<input type="text" id="ts-slider-detileMul-numbox" class="tf-slider-numbox" readonly value="1" />
+						</div>
+						<div class="text-base text-light" style="opacity: 0.7;">1 = a second scaled tap past ~1200 elmos hides the tile repeat (softens the texture until the C2 contrast fix lands); 0 = crisp, repeats show, three fewer taps. Only the ends matter: any value above 0 pays all the taps.</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Cliff-tap slack (deg)</div>
+							<input type="range" id="ts-slider-cliffGateDeg" class="tf-slider" min="0" max="30" step="1" value="22.0" data-event-change="onTilesetKnob('cliffGateDeg')" />
+							<input type="text" id="ts-slider-cliffGateDeg-numbox" class="tf-slider-numbox" readonly value="22.0" />
+						</div>
+						<div class="text-base text-light" style="opacity: 0.7; margin-top: 4dp;">Far cache: zoomed out, the ground becomes one tap of a baked copy of itself instead of the full stack. Start = cache texels per pixel where the handoff begins; 1.00 never magnifies the cache (never softer than live), lower engages earlier and softer. Band = crossfade width as a ratio. Steep faces stay live (a top-down bake has no texels on a wall) unless Cliffs cached past is above 0: from that many elmos per pixel of footprint (fully at twice it) walls join the cache too, which is most of the far-zoom cost. /tileset far prints the engage distances.</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Far cache</div>
+							<input type="range" id="ts-slider-farCache" class="tf-slider" min="0" max="1" step="1" value="1" data-event-change="onTilesetKnob('farCache')" />
+							<input type="text" id="ts-slider-farCache-numbox" class="tf-slider-numbox" readonly value="1" />
+						</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Far start (texels)</div>
+							<input type="range" id="ts-slider-farStart" class="tf-slider" min="0.25" max="3" step="0.05" value="1.00" data-event-change="onTilesetKnob('farStart')" />
+							<input type="text" id="ts-slider-farStart-numbox" class="tf-slider-numbox" readonly value="1.00" />
+						</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Far band (ratio)</div>
+							<input type="range" id="ts-slider-farBand" class="tf-slider" min="1.05" max="3" step="0.05" value="1.35" data-event-change="onTilesetKnob('farBand')" />
+							<input type="text" id="ts-slider-farBand-numbox" class="tf-slider-numbox" readonly value="1.35" />
+						</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Cliffs cached past (elmos/px)</div>
+							<input type="range" id="ts-slider-farCliffFp" class="tf-slider" min="0" max="6" step="0.25" value="1.50" data-event-change="onTilesetKnob('farCliffFp')" />
+							<input type="text" id="ts-slider-farCliffFp-numbox" class="tf-slider-numbox" readonly value="1.50" />
+						</div>
+						<div class="text-base text-light" style="opacity: 0.7; margin-top: 4dp;">Clipmap: finer camera-following copies of the far cache, so the baked ground serves every zoom, not only the strategic one (about -1.9 ms per frame at close and mid zoom, 4K). Off = the far cache alone. /tileset clip prints the levels.</div>
+						<div class="flex flex-row gap-1 items-center mb-1">
+							<div class="tf-slider-label text-light">Clipmap</div>
+							<input type="range" id="ts-slider-clipCache" class="tf-slider" min="0" max="1" step="1" value="1" data-event-change="onTilesetKnob('clipCache')" />
+							<input type="text" id="ts-slider-clipCache-numbox" class="tf-slider-numbox" readonly value="1" />
+						</div>
+						</div>
+					</div><!-- /frame-ts-perf -->
 
 				<div class="tf-section-frame tf-collapsed" id="frame-ts-metal">
 					<div id="btn-toggle-ts-metal" class="tf-section-title-row" style="cursor: pointer;">

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -5488,6 +5488,12 @@
 							<div class="tf-overlay-chip" data-class-active="surfErase" data-event-mousedown="onSurfEraseToggle()">
 								<div class="tf-overlay-chip-label">{{surfNowMode}}</div>
 							</div>
+							<!-- FLIP acts on the SELECTED slot (BASE included): one always-present
+							     button instead of a per-tile one, which left PICK / FLIP / X too
+							     cramped to hit. -->
+							<div id="surf-flip-sel" class="tf-overlay-chip" style="margin-left: 4dp;">
+								<div class="tf-overlay-chip-label">FLIP</div>
+							</div>
 						</div>
 						<!-- SLOT RAIL. One tile per slot, thumbnail first: the texture is what
 						     the artist picks by, so it gets the space. ONE CLICK, ONE ACTION —
@@ -5501,7 +5507,6 @@
 								<div class="surf-slot-cap text-light">BASE</div>
 								<div class="surf-slot-actions">
 									<div class="surf-slot-btn surf-slot-btn-mute">PAINT</div>
-									<div id="surf-slot-base-flip" class="surf-slot-btn">FLIP</div>
 								</div>
 							</div>
 							<div id="surf-slot-1" class="surf-slot-chip surf-slot-c1" data-class-active="surfSelSlot == 1" data-class-surf-slot-empty="!surfSlot1Assigned" data-event-mousedown="onSurfSlotSelect(1)">
@@ -5509,7 +5514,6 @@
 								<div class="surf-slot-cap surf-text-c1">1 &#183; {{surfSlot1Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-1-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 1">PICK</div>
-									<div id="surf-slot-1-flip" class="surf-slot-btn" data-if="surfSlot1Assigned">FLIP</div>
 									<div id="surf-slot-1-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot1Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5518,7 +5522,6 @@
 								<div class="surf-slot-cap surf-text-c2">2 &#183; {{surfSlot2Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-2-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 2">PICK</div>
-									<div id="surf-slot-2-flip" class="surf-slot-btn" data-if="surfSlot2Assigned">FLIP</div>
 									<div id="surf-slot-2-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot2Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5527,7 +5530,6 @@
 								<div class="surf-slot-cap surf-text-c3">3 &#183; {{surfSlot3Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-3-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 3">PICK</div>
-									<div id="surf-slot-3-flip" class="surf-slot-btn" data-if="surfSlot3Assigned">FLIP</div>
 									<div id="surf-slot-3-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot3Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5538,7 +5540,6 @@
 								<div class="surf-slot-cap surf-text-c4">4 &#183; {{surfSlot4Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-4-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 4">PICK</div>
-									<div id="surf-slot-4-flip" class="surf-slot-btn" data-if="surfSlot4Assigned">FLIP</div>
 									<div id="surf-slot-4-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot4Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5547,7 +5548,6 @@
 								<div class="surf-slot-cap surf-text-c5">5 &#183; {{surfSlot5Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-5-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 5">PICK</div>
-									<div id="surf-slot-5-flip" class="surf-slot-btn" data-if="surfSlot5Assigned">FLIP</div>
 									<div id="surf-slot-5-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot5Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5556,7 +5556,6 @@
 								<div class="surf-slot-cap surf-text-c6">6 &#183; {{surfSlot6Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-6-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 6">PICK</div>
-									<div id="surf-slot-6-flip" class="surf-slot-btn" data-if="surfSlot6Assigned">FLIP</div>
 									<div id="surf-slot-6-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot6Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5565,7 +5564,6 @@
 								<div class="surf-slot-cap surf-text-c7">7 &#183; {{surfSlot7Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-7-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 7">PICK</div>
-									<div id="surf-slot-7-flip" class="surf-slot-btn" data-if="surfSlot7Assigned">FLIP</div>
 									<div id="surf-slot-7-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot7Assigned">&#215;</div>
 								</div>
 							</div>

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.rml
@@ -5501,6 +5501,7 @@
 								<div class="surf-slot-cap text-light">BASE</div>
 								<div class="surf-slot-actions">
 									<div class="surf-slot-btn surf-slot-btn-mute">PAINT</div>
+									<div id="surf-slot-base-flip" class="surf-slot-btn">FLIP</div>
 								</div>
 							</div>
 							<div id="surf-slot-1" class="surf-slot-chip surf-slot-c1" data-class-active="surfSelSlot == 1" data-class-surf-slot-empty="!surfSlot1Assigned" data-event-mousedown="onSurfSlotSelect(1)">
@@ -5508,6 +5509,7 @@
 								<div class="surf-slot-cap surf-text-c1">1 &#183; {{surfSlot1Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-1-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 1">PICK</div>
+									<div id="surf-slot-1-flip" class="surf-slot-btn" data-if="surfSlot1Assigned">FLIP</div>
 									<div id="surf-slot-1-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot1Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5516,6 +5518,7 @@
 								<div class="surf-slot-cap surf-text-c2">2 &#183; {{surfSlot2Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-2-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 2">PICK</div>
+									<div id="surf-slot-2-flip" class="surf-slot-btn" data-if="surfSlot2Assigned">FLIP</div>
 									<div id="surf-slot-2-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot2Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5524,6 +5527,7 @@
 								<div class="surf-slot-cap surf-text-c3">3 &#183; {{surfSlot3Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-3-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 3">PICK</div>
+									<div id="surf-slot-3-flip" class="surf-slot-btn" data-if="surfSlot3Assigned">FLIP</div>
 									<div id="surf-slot-3-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot3Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5534,6 +5538,7 @@
 								<div class="surf-slot-cap surf-text-c4">4 &#183; {{surfSlot4Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-4-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 4">PICK</div>
+									<div id="surf-slot-4-flip" class="surf-slot-btn" data-if="surfSlot4Assigned">FLIP</div>
 									<div id="surf-slot-4-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot4Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5542,6 +5547,7 @@
 								<div class="surf-slot-cap surf-text-c5">5 &#183; {{surfSlot5Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-5-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 5">PICK</div>
+									<div id="surf-slot-5-flip" class="surf-slot-btn" data-if="surfSlot5Assigned">FLIP</div>
 									<div id="surf-slot-5-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot5Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5550,6 +5556,7 @@
 								<div class="surf-slot-cap surf-text-c6">6 &#183; {{surfSlot6Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-6-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 6">PICK</div>
+									<div id="surf-slot-6-flip" class="surf-slot-btn" data-if="surfSlot6Assigned">FLIP</div>
 									<div id="surf-slot-6-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot6Assigned">&#215;</div>
 								</div>
 							</div>
@@ -5558,6 +5565,7 @@
 								<div class="surf-slot-cap surf-text-c7">7 &#183; {{surfSlot7Name}}</div>
 								<div class="surf-slot-actions">
 									<div id="surf-slot-7-pick" class="surf-slot-btn" data-class-active="surfPickSlot == 7">PICK</div>
+									<div id="surf-slot-7-flip" class="surf-slot-btn" data-if="surfSlot7Assigned">FLIP</div>
 									<div id="surf-slot-7-free" class="surf-slot-btn surf-slot-x" data-if="surfSlot7Assigned">&#215;</div>
 								</div>
 							</div>

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_environment.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_environment.lua
@@ -999,6 +999,7 @@ function M.attach(doc, ctx)
 
 	-- Tileset Terrain tool (TILESET) category sections
 	envSectionToggle("btn-toggle-ts-library", "img-toggle-ts-library", "section-ts-library", true)
+	envSectionToggle("btn-toggle-ts-perf", "img-toggle-ts-perf", "section-ts-perf", false)
 	envSectionToggle("btn-toggle-ts-metal", "img-toggle-ts-metal", "section-ts-metal", false)
 	envSectionToggle("btn-toggle-ts-scale", "img-toggle-ts-scale", "section-ts-scale", true)
 	envSectionToggle("btn-toggle-ts-normals", "img-toggle-ts-normals", "section-ts-normals", false)

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
@@ -615,6 +615,15 @@ function M.sync(doc, ctx, surfState, setSummary)
 		list, bkey = T.getSurfaceVariants()
 	end
 	local pickSlot = widgetState.surfPickerSlot
+	-- The painter's coverage histogram is a gl.ReadPixels (a GPU sync) and its
+	-- only reader here is the picker's "already carries paint" warning, so the
+	-- painter computes it only while a picker is open (gated readback).
+	do
+		local sp = WG.SurfacePainter
+		if sp.setCoverageWanted then
+			sp.setCoverageWanted(pickSlot ~= nil)
+		end
+	end
 	if list then
 		local sig = paletteSig(list, bkey, surfState, pickSlot)
 		if sig ~= widgetState.surfPaletteSig then

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
@@ -133,37 +133,39 @@ function M.attach(doc, ctx)
 	end
 	-- FLIP: per-texture normal G toggle, straight through to the tileset shader
 	-- (asset-keyed there, so re-picking the same texture into another slot keeps
-	-- the flag). Base chip included — its texture is every empty slot's fallback.
-	local function hookNormalFlip(el, resolveAsset)
-		if not el then
-			return
+	-- the flag). ONE button acting on the SELECTED slot (BASE = slot 0, whose
+	-- texture is every empty slot's fallback): a FLIP on every tile left
+	-- PICK / FLIP / X too cramped to hit.
+	local function selectedSurfAsset()
+		local sp = WG.SurfacePainter
+		local st = sp and sp.getState and sp.getState()
+		if not st then
+			return nil
 		end
-		el:AddEventListener("mousedown", function(event)
+		local sel = st.selSlot or 0
+		if sel == 0 then
 			local T = WG.TilesetTerrain
-			local asset = (T and T.setNormalFlip) and resolveAsset() or nil
+			local list = T and T.getSurfaceVariants and T.getSurfaceVariants()
+			return list and list[1] and list[1].asset
+		end
+		return st["slot" .. sel]
+	end
+	widgetState.surfSelectedAsset = selectedSurfAsset
+	widgetState.surfFlipSelEl = doc:GetElementById("surf-flip-sel")
+	if widgetState.surfFlipSelEl then
+		widgetState.surfFlipSelEl:AddEventListener("mousedown", function(event)
+			local T = WG.TilesetTerrain
+			local asset = (T and T.setNormalFlip) and selectedSurfAsset() or nil
 			if asset then
 				local on = not T.getNormalFlip(asset)
 				T.setNormalFlip(asset, on)
-				el:SetClass("active", on)
+				widgetState.surfFlipSelEl:SetClass("active", on)
 				ctx.playSound(on and "toggleOn" or "toggleOff")
+			else
+				ctx.playSound("click") -- selected slot has no texture to flip
 			end
 			event:StopPropagation()
 		end, false)
-	end
-	widgetState.surfSlotFlipEls = { base = doc:GetElementById("surf-slot-base-flip") }
-	hookNormalFlip(widgetState.surfSlotFlipEls.base, function()
-		local T = WG.TilesetTerrain
-		local list = T.getSurfaceVariants and T.getSurfaceVariants()
-		return list and list[1] and list[1].asset
-	end)
-	for slot = 1, MAX_SLOTS do
-		local el = doc:GetElementById("surf-slot-" .. slot .. "-flip")
-		widgetState.surfSlotFlipEls[slot] = el
-		hookNormalFlip(el, function()
-			local sp = WG.SurfacePainter
-			local st = sp and sp.getState and sp.getState()
-			return st and st["slot" .. slot]
-		end)
 	end
 	local closeBtn = doc:GetElementById("surf-picker-close")
 	if closeBtn then
@@ -668,31 +670,25 @@ function M.sync(doc, ctx, surfState, setSummary)
 	-- Per-slot chip state, and FILL WITH NOISE stays enabled only while some
 	-- channel is both assigned and switched on.
 	local canFill = false
-	local flipEls = widgetState.surfSlotFlipEls or {}
 	for i = 1, MAX_SLOTS do
 		local asset = surfState["slot" .. i]
 		local fill = surfState["fillV" .. i]
 		setDm("surfSlot" .. i .. "Name", shortAsset(asset))
 		setDm("surfSlot" .. i .. "Assigned", asset ~= nil)
 		setDm("surfFillV" .. i, fill and true or false)
-		if flipEls[i] then
-			local fl = false
-			if asset and T and T.getNormalFlip then
-				fl = T.getNormalFlip(asset)
-			end
-			flipEls[i]:SetClass("active", fl)
-		end
 		if asset and fill then
 			canFill = true
 		end
 	end
-	if flipEls.base then
-		local baseAsset = list and list[1] and list[1].asset
+	-- The single FLIP button mirrors the SELECTED slot's flag (BASE included)
+	if widgetState.surfFlipSelEl then
+		local selAsset = widgetState.surfSelectedAsset and widgetState.surfSelectedAsset()
 		local fl = false
-		if baseAsset and T and T.getNormalFlip then
-			fl = T.getNormalFlip(baseAsset)
+		if selAsset and T and T.getNormalFlip then
+			fl = T.getNormalFlip(selAsset)
 		end
-		flipEls.base:SetClass("active", fl)
+		widgetState.surfFlipSelEl:SetClass("active", fl)
+		widgetState.surfFlipSelEl:SetClass("unavailable", selAsset == nil)
 	end
 	setDm("surfCanFill", canFill)
 	setDm("surfPickSlot", pickSlot or 0)

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
@@ -154,9 +154,10 @@ function M.attach(doc, ctx)
 	widgetState.surfFlipSelEl = doc:GetElementById("surf-flip-sel")
 	if widgetState.surfFlipSelEl then
 		widgetState.surfFlipSelEl:AddEventListener("mousedown", function(event)
+			---@type table?
 			local T = WG.TilesetTerrain
 			local asset = (T and T.setNormalFlip) and selectedSurfAsset() or nil
-			if asset then
+			if asset and T then
 				local on = not T.getNormalFlip(asset)
 				T.setNormalFlip(asset, on)
 				widgetState.surfFlipSelEl:SetClass("active", on)
@@ -609,6 +610,7 @@ function M.sync(doc, ctx, surfState, setSummary)
 	-- Palette rebuild on biome / list / selection / slot / picker-target change.
 	-- Per-slot picking replaced the old "first free slot" assignment, so there
 	-- is no unassignable state left to dim for.
+	---@type table?
 	local T = WG.TilesetTerrain
 	local list, bkey = nil, nil
 	if T and T.getSurfaceVariants then
@@ -619,8 +621,9 @@ function M.sync(doc, ctx, surfState, setSummary)
 	-- only reader here is the picker's "already carries paint" warning, so the
 	-- painter computes it only while a picker is open (gated readback).
 	do
+		---@type table?
 		local sp = WG.SurfacePainter
-		if sp.setCoverageWanted then
+		if sp and sp.setCoverageWanted then
 			sp.setCoverageWanted(pickSlot ~= nil)
 		end
 	end

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_surface.lua
@@ -131,6 +131,40 @@ function M.attach(doc, ctx)
 			end, false)
 		end
 	end
+	-- FLIP: per-texture normal G toggle, straight through to the tileset shader
+	-- (asset-keyed there, so re-picking the same texture into another slot keeps
+	-- the flag). Base chip included — its texture is every empty slot's fallback.
+	local function hookNormalFlip(el, resolveAsset)
+		if not el then
+			return
+		end
+		el:AddEventListener("mousedown", function(event)
+			local T = WG.TilesetTerrain
+			local asset = (T and T.setNormalFlip) and resolveAsset() or nil
+			if asset then
+				local on = not T.getNormalFlip(asset)
+				T.setNormalFlip(asset, on)
+				el:SetClass("active", on)
+				ctx.playSound(on and "toggleOn" or "toggleOff")
+			end
+			event:StopPropagation()
+		end, false)
+	end
+	widgetState.surfSlotFlipEls = { base = doc:GetElementById("surf-slot-base-flip") }
+	hookNormalFlip(widgetState.surfSlotFlipEls.base, function()
+		local T = WG.TilesetTerrain
+		local list = T.getSurfaceVariants and T.getSurfaceVariants()
+		return list and list[1] and list[1].asset
+	end)
+	for slot = 1, MAX_SLOTS do
+		local el = doc:GetElementById("surf-slot-" .. slot .. "-flip")
+		widgetState.surfSlotFlipEls[slot] = el
+		hookNormalFlip(el, function()
+			local sp = WG.SurfacePainter
+			local st = sp and sp.getState and sp.getState()
+			return st and st["slot" .. slot]
+		end)
+	end
 	local closeBtn = doc:GetElementById("surf-picker-close")
 	if closeBtn then
 		closeBtn:AddEventListener("mousedown", function(event)
@@ -634,15 +668,31 @@ function M.sync(doc, ctx, surfState, setSummary)
 	-- Per-slot chip state, and FILL WITH NOISE stays enabled only while some
 	-- channel is both assigned and switched on.
 	local canFill = false
+	local flipEls = widgetState.surfSlotFlipEls or {}
 	for i = 1, MAX_SLOTS do
 		local asset = surfState["slot" .. i]
 		local fill = surfState["fillV" .. i]
 		setDm("surfSlot" .. i .. "Name", shortAsset(asset))
 		setDm("surfSlot" .. i .. "Assigned", asset ~= nil)
 		setDm("surfFillV" .. i, fill and true or false)
+		if flipEls[i] then
+			local fl = false
+			if asset and T and T.getNormalFlip then
+				fl = T.getNormalFlip(asset)
+			end
+			flipEls[i]:SetClass("active", fl)
+		end
 		if asset and fill then
 			canFill = true
 		end
+	end
+	if flipEls.base then
+		local baseAsset = list and list[1] and list[1].asset
+		local fl = false
+		if baseAsset and T and T.getNormalFlip then
+			fl = T.getNormalFlip(baseAsset)
+		end
+		flipEls.base:SetClass("active", fl)
 	end
 	setDm("surfCanFill", canFill)
 	setDm("surfPickSlot", pickSlot or 0)

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
@@ -52,6 +52,16 @@ local KNOBS = {
 	{ "splatPunchPlat", "%.2f" },
 	{ "antiTileWarp", "%.0f" },
 	{ "parallaxAmp", "%.2f" },
+	-- PERFORMANCE section levers
+	{ "detileMul", "%.0f" },
+	{ "foothills", "%d" },
+	{ "stagger", "%d" },
+	{ "cliffGateDeg", "%.1f" },
+	{ "farCache", "%d" },
+	{ "farStart", "%.2f" },
+	{ "farBand", "%.2f" },
+	{ "farCliffFp", "%.2f" },
+	{ "clipCache", "%d" },
 	{ "macroVar", "%.2f" },
 	{ "macroLod", "%.1f" },
 	{ "albedoSortMode", "%d" },
@@ -122,6 +132,7 @@ local KNOBS = {
 -- because nothing in them affects an engine-rendered map.
 local TUNING_FRAMES = {
 	"frame-ts-library",
+	"frame-ts-perf",
 	"frame-ts-metal",
 	"frame-ts-scale",
 	"frame-ts-normals",
@@ -432,6 +443,14 @@ function M.sync(doc, ctx, setSummary)
 	-- widget (initial state + console-driven /tileset changes); debugView has no slider.
 	if knobs.debugView ~= nil and dm.tsDebugView ~= knobs.debugView then
 		dm.tsDebugView = knobs.debugView
+	end
+
+	-- PERFORMANCE: mirror the active quality tier to the preset buttons
+	if WG.TilesetTerrain.getQuality then
+		local q = WG.TilesetTerrain.getQuality()
+		if q and dm.tsQuality ~= q then
+			dm.tsQuality = q
+		end
 	end
 
 	if setSummary then

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
@@ -394,8 +394,10 @@ function M.sync(doc, ctx, setSummary)
 	end
 	-- BIOME LIBRARY tiles: rebuild when the manifest list, a thumbnail or the
 	-- active biome changes (covers startup, /tileset biomes reload, console picks).
-	if WG.TilesetTerrain.getBiomes then
-		local rows = WG.TilesetTerrain.getBiomes()
+	---@type table?
+	local tsT = WG.TilesetTerrain
+	if tsT and tsT.getBiomes then
+		local rows = tsT.getBiomes()
 		local sigParts = { tostring(dm.tsBiome) }
 		for i = 1, #rows do
 			sigParts[#sigParts + 1] = rows[i].key .. "=" .. tostring(rows[i].thumb)

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_tileset.lua
@@ -230,6 +230,66 @@ local function rebuildS4Palette(doc, ctx, list, current)
 	end
 end
 
+-- BIOME LIBRARY tiles: built from WG.TilesetTerrain.getBiomes(), one manifest
+-- per biome in tileset_dev/tilesets/, so a biome added on disk shows up without
+-- an RML edit. Thumbnails are GL overdraws (gui_terraform_brush.lua's
+-- drawTsBiomeThumbs), like the EXTRA LAYER material tiles above.
+local function rebuildBiomePalette(doc, ctx, rows, activeKey)
+	local widgetState = ctx.widgetState
+	local grid = doc:GetElementById("ts-biome-grid")
+	widgetState.tsBiomeSectionEl = doc:GetElementById("section-ts-library")
+	if not grid then
+		return
+	end
+	grid.inner_rml = ""
+	widgetState.tsBiomeTileEls = {}
+	local row
+	for i = 1, #rows do
+		local b = rows[i]
+		if not row or ((i - 1) % 3) == 0 then
+			row = doc:CreateElement("div")
+			row:SetClass("tf-biome-grid", true)
+			row:SetClass("flex", true)
+			row:SetClass("flex-row", true)
+			row:SetClass("gap-1", true)
+			row:SetClass("mb-1", true)
+			grid:AppendChild(row)
+		end
+		local tile = doc:CreateElement("div")
+		tile:SetClass("tf-biome-tile", true)
+		if b.key == activeKey then
+			tile:SetClass("active", true)
+		end
+		if b.file then
+			tile:SetAttribute("title", b.file)
+		end
+		local thumb = doc:CreateElement("div")
+		thumb:SetClass("tf-biome-thumb", true)
+		tile:AppendChild(thumb)
+		local name = doc:CreateElement("div")
+		name:SetClass("tf-biome-name", true)
+		name.inner_rml = b.name or b.key
+		tile:AppendChild(name)
+		tile:AddEventListener("mousedown", function(_event)
+			if widgetState.pickBiome then
+				widgetState.pickBiome(b.key)
+			end
+		end, false)
+		row:AppendChild(tile)
+		widgetState.tsBiomeTileEls[#widgetState.tsBiomeTileEls + 1] = { el = thumb, tex = b.thumb, crop = b.thumbCrop }
+	end
+	-- invisible pads keep a short last row at tile width (flex: 1 1 0)
+	local rem = #rows % 3
+	if row and rem > 0 then
+		for _ = 1, 3 - rem do
+			local pad = doc:CreateElement("div")
+			pad:SetClass("tf-biome-tile", true)
+			pad:SetClass("tf-biome-pad", true)
+			row:AppendChild(pad)
+		end
+	end
+end
+
 function M.sync(doc, ctx, setSummary)
 	if not doc or not WG.TilesetTerrain then
 		return
@@ -332,6 +392,21 @@ function M.sync(doc, ctx, setSummary)
 			end
 		end
 	end
+	-- BIOME LIBRARY tiles: rebuild when the manifest list, a thumbnail or the
+	-- active biome changes (covers startup, /tileset biomes reload, console picks).
+	if WG.TilesetTerrain.getBiomes then
+		local rows = WG.TilesetTerrain.getBiomes()
+		local sigParts = { tostring(dm.tsBiome) }
+		for i = 1, #rows do
+			sigParts[#sigParts + 1] = rows[i].key .. "=" .. tostring(rows[i].thumb)
+		end
+		local sig = table.concat(sigParts, "|")
+		if widgetState.tsBiomeSig ~= sig then
+			widgetState.tsBiomeSig = sig
+			rebuildBiomePalette(doc, ctx, rows, dm.tsBiome)
+		end
+	end
+
 	-- Material picker tiles: rebuild when the biome catalog or the pick changes
 	-- (covers startup, biome swaps and console /tileset s4).
 	if WG.TilesetTerrain.getSlot4Materials then

--- a/luaui/Widgets/cmd_clone_tool.lua
+++ b/luaui/Widgets/cmd_clone_tool.lua
@@ -1354,6 +1354,12 @@ function widget:DrawWorld()
 				end)
 			end
 			Spring.SetMapShadingTexture("$ssmf_splat_distr", fullFBO)
+			-- the tileset's far cache / clipmap bake the splat channels: tell it
+			-- the pasted rect changed (elmos) or the paste vanishes at zoom-out
+			local T = WG.TilesetTerrain
+			if T and T.refreshSurface then
+				T.refreshSurface(sp.targetX, sp.targetZ, sp.targetX + sp.sizeX, sp.targetZ + sp.sizeZ)
+			end
 		end
 	end
 

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -204,7 +204,7 @@ local pendingSnapshot = false -- set on MousePress, consumed before first stroke
 -- (Lua 5.1 ceiling), so this costs it one, not four.
 local FAR_FLUSH_S = 0.03 -- every frame or two: the tileset routes rects to its clipmap per frame and throttles minimap + far bake itself
 ---@type table
-local farInv = { dirty = nil, at = nil } -- dirty = { ax, az, bx, bz } elmos, or nil
+local farInv = {} -- dirty = { ax, az, bx, bz } elmos rect, nil when clean; at = last flush timer
 
 function farInv.mark(worldX, worldZ, radius)
 	local r = (radius or 0) * 1.5 + 16 -- rotated squares reach r*sqrt(2); fractal edges a bit past
@@ -1946,6 +1946,7 @@ function widget:DrawWorld()
 
 	local worldX, worldZ = getWorldMousePosition()
 	do
+		---@type table?
 		local tb = WG.TerraformBrush
 		if tb and tb.animateUnmouse then
 			worldX, worldZ = tb.animateUnmouse("splatPainter", worldX, worldZ, activeRadius, 1.0)
@@ -1957,6 +1958,7 @@ function widget:DrawWorld()
 		return
 	end
 	do
+		---@type table?
 		local tb2 = WG.TerraformBrush
 		local st2 = tb2 and tb2.getState and tb2.getState()
 		if st2 and (st2.symmetryHoveringOrigin or st2.symmetryDraggingOrigin) then
@@ -1969,6 +1971,7 @@ function widget:DrawWorld()
 	-- Sent every frame, mode 0 included, so releasing Ctrl retracts instantly;
 	-- inert with the tileset shader off (the uniform simply never renders).
 	do
+		---@type table?
 		local T = WG.TilesetTerrain
 		if T and T.setSurfacePreview then
 			local mode = 0

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -190,6 +190,67 @@ local MAX_UNDO_SPLAT = 20
 local undoStack = {}
 local redoStack = {}
 local pendingSnapshot = false -- set on MousePress, consumed before first stroke
+
+-- Tileset far cache / clipmap invalidation. The tileset shader serves every
+-- pixel past its handoff from a baked composite (far cache + clipmap), and that
+-- bake samples $ssmf_splat_distr at bake time: a stroke that only rewrites the
+-- texture is invisible there until something else re-bakes the region (the
+-- "layers vanish when I zoom out" report, 2026-09-01). Every executed stroke
+-- widens a dirty rect (elmos); it is flushed to WG.TilesetTerrain.refreshSurface
+-- (rect -> sub-rect far bake + clipmap edit, ~free for a brush footprint) every
+-- FAR_FLUSH_S during a drag and as soon as the drag ends. Whole-texture changes
+-- (undo, redo, load) pass no rect = a throttled whole-map refill.
+-- One table for state + helpers: widget:DrawWorld sits at 58/60 upvalues
+-- (Lua 5.1 ceiling), so this costs it one, not four.
+local FAR_FLUSH_S = 0.03 -- every frame or two: the tileset routes rects to its clipmap per frame and throttles minimap + far bake itself
+local farInv = { dirty = nil, at = nil } -- dirty = { ax, az, bx, bz } elmos, or nil
+
+function farInv.mark(worldX, worldZ, radius)
+	local r = (radius or 0) * 1.5 + 16 -- rotated squares reach r*sqrt(2); fractal edges a bit past
+	local ax, az, bx, bz = worldX - r, worldZ - r, worldX + r, worldZ + r
+	local d = farInv.dirty
+	if d then
+		if ax < d[1] then
+			d[1] = ax
+		end
+		if az < d[2] then
+			d[2] = az
+		end
+		if bx > d[3] then
+			d[3] = bx
+		end
+		if bz > d[4] then
+			d[4] = bz
+		end
+	else
+		farInv.dirty = { ax, az, bx, bz }
+	end
+end
+
+function farInv.flush(force)
+	local d = farInv.dirty
+	if not d then
+		return
+	end
+	local now = Spring.GetTimer()
+	if not force and farInv.at and Spring.DiffTimers(now, farInv.at) < FAR_FLUSH_S then
+		return
+	end
+	local T = WG.TilesetTerrain
+	if T and T.refreshSurface then
+		T.refreshSurface(d[1], d[2], d[3], d[4])
+	end
+	farInv.dirty = nil
+	farInv.at = now
+end
+
+function farInv.all()
+	farInv.dirty = nil
+	local T = WG.TilesetTerrain
+	if T and T.refreshSurface then
+		T.refreshSurface()
+	end
+end
 local pendingUndoCount = 0
 local pendingRedoCount = 0
 
@@ -1801,6 +1862,8 @@ function widget:DrawWorld()
 		lastLoadResult = executeLoadSplats(loadPath)
 		if lastLoadResult ~= "ok" then
 			Echo("[Splat Painter] Splat load " .. tostring(lastLoadResult))
+		else
+			farInv.all() -- the whole splat texture changed under the tileset bakes
 		end
 		-- The load may have created fboTex; a still-queued activation init would
 		-- rebuild it and clobber (and leak) the freshly loaded state.
@@ -1838,6 +1901,7 @@ function widget:DrawWorld()
 		pendingUndoCount = 0
 		if changed and texApplied then
 			SetMapShadingTexture(SPLAT_TEX_NAME, fboTex)
+			farInv.all()
 		end
 	end
 	if pendingRedoCount > 0 then
@@ -1854,6 +1918,7 @@ function widget:DrawWorld()
 		pendingRedoCount = 0
 		if changed and texApplied then
 			SetMapShadingTexture(SPLAT_TEX_NAME, fboTex)
+			farInv.all()
 		end
 	end
 
@@ -1867,8 +1932,15 @@ function widget:DrawWorld()
 	if #pendingPaintStrokes > 0 then
 		for _, stroke in ipairs(pendingPaintStrokes) do
 			executePaintStroke(stroke[1], stroke[2], stroke[3])
+			farInv.mark(stroke[1], stroke[2], activeRadius)
 		end
 		pendingPaintStrokes = {}
+	end
+	-- tileset far cache / clipmap: throttled (FAR_FLUSH_S); the drag's tail lands
+	-- within one throttle period after release. (No drag-state upvalue here on
+	-- purpose: DrawWorld sits at the Lua 5.1 60-upvalue ceiling.)
+	if farInv.dirty then
+		farInv.flush(false)
 	end
 
 	local worldX, worldZ = getWorldMousePosition()

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -203,6 +203,7 @@ local pendingSnapshot = false -- set on MousePress, consumed before first stroke
 -- One table for state + helpers: widget:DrawWorld sits at 58/60 upvalues
 -- (Lua 5.1 ceiling), so this costs it one, not four.
 local FAR_FLUSH_S = 0.03 -- every frame or two: the tileset routes rects to its clipmap per frame and throttles minimap + far bake itself
+---@type table
 local farInv = { dirty = nil, at = nil } -- dirty = { ax, az, bx, bz } elmos, or nil
 
 function farInv.mark(worldX, worldZ, radius)

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -4541,9 +4541,10 @@ function widget:Update(dt)
 				local es = extraState
 				local lastX, lastZ = es.autorampLastX, es.autorampLastZ
 				if not (lastX and lastZ) then
-					lastX, lastZ = worldX, worldZ
 					es.autorampLastX, es.autorampLastZ = worldX, worldZ
 				end
+				lastX = lastX or worldX
+				lastZ = lastZ or worldZ
 				local adx = worldX - lastX
 				local adz = worldZ - lastZ
 				local spacing = max(16, activeRadius * 0.5)

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -4535,16 +4535,17 @@ function widget:Update(dt)
 			lastScreenX = mx
 			lastScreenY = my
 			local worldX, worldZ = getWorldMousePosition()
-			if worldX then
+			if worldX and worldZ then
 				lockedWorldX = worldX
 				lockedWorldZ = worldZ
 				local es = extraState
-				if not es.autorampLastX then
-					es.autorampLastX = worldX
-					es.autorampLastZ = worldZ
+				local lastX, lastZ = es.autorampLastX, es.autorampLastZ
+				if not (lastX and lastZ) then
+					lastX, lastZ = worldX, worldZ
+					es.autorampLastX, es.autorampLastZ = worldX, worldZ
 				end
-				local adx = worldX - es.autorampLastX
-				local adz = worldZ - es.autorampLastZ
+				local adx = worldX - lastX
+				local adz = worldZ - lastZ
 				local spacing = max(16, activeRadius * 0.5)
 				if adx * adx + adz * adz >= spacing * spacing then
 					if es.sendAutorampAt(worldX, worldZ) then

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -2117,6 +2117,10 @@ extraState._newmapTryApplyDNTS = function()
 	local distr = mapOpts.blank_map_splatdistr
 	if type(distr) == "string" and distr ~= "" then
 		Spring.SetMapShadingTexture("$ssmf_splat_distr", registerTexName(distr) or distr)
+		-- the tileset far cache / clipmap bake the splat channels: whole refill
+		if WG.TilesetTerrain and WG.TilesetTerrain.refreshSurface then
+			WG.TilesetTerrain.refreshSurface()
+		end
 	end
 
 	local detail = mapOpts.blank_map_splatdetailtex

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -4080,6 +4080,40 @@ end
 -- where it is removed (cut), alpha scaled by how much the height changes.
 -- Handles its own display-list lifecycle so it also cleans up after the data
 -- is cleared (mode left, preview toggled off, cursor off-map).
+-- One autoramp application at a world position: builds the param tail from the
+-- live knobs and sends one message per symmetry copy (off-map copies dropped).
+-- Shared by the MousePress dab and the swipe re-fires in Update. Returns
+-- whether anything was sent.
+extraState.sendAutorampAt = function(worldX, worldZ)
+	local es = extraState
+	local paramTail = " "
+		.. activeRadius
+		.. " "
+		.. floor(es.autorampAngleDeg)
+		.. " "
+		.. string.format("%.2f", es.autorampFalloff)
+		.. " "
+		.. string.format("%.2f", es.autorampEdgeNoise)
+		.. " "
+		.. string.format("%.2f", es.autorampErosion)
+		.. " "
+		.. string.format("%.2f", es.autorampTalus)
+	local positions = es.getSymmetricPositions(worldX, worldZ, 0)
+	local sent = false
+	for _, p in ipairs(positions) do
+		if p.x >= 0 and p.x <= Game.mapSizeX and p.z >= 0 and p.z <= Game.mapSizeZ then
+			-- Seed from the target cell: deterministic per spot, so a replayed
+			-- or re-done application reproduces the same cliff.
+			local seed = (floor(p.x) * 73 + floor(p.z) * 179) % 10000
+			SendLuaRulesMsg(
+				MSG.AUTORAMP .. floor(p.x) .. " " .. floor(p.z) .. paramTail .. " " .. seed .. " " .. es.autorampStart
+			)
+			sent = true
+		end
+	end
+	return sent
+end
+
 function extraState.drawAutorampPreview(suppressed)
 	local es = extraState
 	if es.arPrevDirty then
@@ -4289,6 +4323,8 @@ function widget:Update(dt)
 		extraState.erodePhase = 0
 		rampEndX = nil
 		rampEndZ = nil
+		extraState.autorampLastX = nil
+		extraState.autorampLastZ = nil
 		if extraState.splineCacheList then
 			glDeleteList(extraState.splineCacheList)
 			extraState.splineCacheList = nil
@@ -4486,6 +4522,35 @@ function widget:Update(dt)
 		end
 		extraState.erodePhase = extraState.erodePhase + 1
 		afterBrushTick()
+	elseif activeMode == "autoramp" then
+		-- Swipe: re-fire the one-click region op along the drag path once the
+		-- cursor has moved a brush-radius fraction from the last application,
+		-- so successive cliff rebuilds knit together without hammering the
+		-- gadget every tick. A stationary hold fires nothing.
+		if mx ~= lastScreenX or my ~= lastScreenY then
+			lastScreenX = mx
+			lastScreenY = my
+			local worldX, worldZ = getWorldMousePosition()
+			if worldX then
+				lockedWorldX = worldX
+				lockedWorldZ = worldZ
+				local es = extraState
+				if not es.autorampLastX then
+					es.autorampLastX = worldX
+					es.autorampLastZ = worldZ
+				end
+				local adx = worldX - es.autorampLastX
+				local adz = worldZ - es.autorampLastZ
+				local spacing = max(16, activeRadius * 0.5)
+				if adx * adx + adz * adz >= spacing * spacing then
+					if es.sendAutorampAt(worldX, worldZ) then
+						afterBrushTick()
+					end
+					es.autorampLastX = worldX
+					es.autorampLastZ = worldZ
+				end
+			end
+		end
 	elseif activeMode == "noise" then
 		if mx ~= lastScreenX or my ~= lastScreenY then
 			lastScreenX = mx
@@ -9294,49 +9359,26 @@ function widget:MousePress(mx, my, button)
 			end
 			return true
 		end
-		-- Autoramp: single-click region op — restyle the cliff under the cursor.
-		-- Like fill, never locks a drag; each click is one atomic undo stroke.
+		-- Autoramp: region op — restyle the cliff under the cursor. A click
+		-- fires once; holding LMB and swiping re-fires along the drag path,
+		-- spaced by brush radius (see the autoramp branch in Update). The
+		-- whole swipe is one undo stroke, closed by the shared release
+		-- cleanup at the top of Update — no immediate close here.
 		if activeMode == "autoramp" then
 			local worldX, worldZ = getWorldMousePosition()
 			if worldX then
-				local es = extraState
-				local paramTail = " "
-					.. activeRadius
-					.. " "
-					.. floor(es.autorampAngleDeg)
-					.. " "
-					.. string.format("%.2f", es.autorampFalloff)
-					.. " "
-					.. string.format("%.2f", es.autorampEdgeNoise)
-					.. " "
-					.. string.format("%.2f", es.autorampErosion)
-					.. " "
-					.. string.format("%.2f", es.autorampTalus)
-				local positions = extraState.getSymmetricPositions(worldX, worldZ, 0)
-				local sent = false
-				for _, p in ipairs(positions) do
-					if p.x >= 0 and p.x <= Game.mapSizeX and p.z >= 0 and p.z <= Game.mapSizeZ then
-						-- Seed from the click cell: deterministic per spot, so a
-						-- replayed or re-done click reproduces the same cliff.
-						local seed = (floor(p.x) * 73 + floor(p.z) * 179) % 10000
-						SendLuaRulesMsg(
-							MSG.AUTORAMP
-								.. floor(p.x)
-								.. " "
-								.. floor(p.z)
-								.. paramTail
-								.. " "
-								.. seed
-								.. " "
-								.. es.autorampStart
-						)
-						sent = true
-					end
-				end
-				if sent then
+				if extraState.sendAutorampAt(worldX, worldZ) then
 					afterBrushTick()
-					closeBrushStroke()
 				end
+				-- Arm the swipe: the Update dispatch gates on lockedWorldX, and
+				-- the spacing check needs the last-applied anchor.
+				lockedWorldX = worldX
+				lockedWorldZ = worldZ
+				lockedGroundY = GetGroundHeight(worldX, worldZ)
+				lastScreenX = mx
+				lastScreenY = my
+				extraState.autorampLastX = worldX
+				extraState.autorampLastZ = worldZ
 			end
 			return true
 		end

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -15280,8 +15280,12 @@ end
 shaders.SetWaterDynamicUniforms = function()
 	local locs = shaders.waterLocs
 	gl.UniformFloat(locs.waterLevel, GetWaterLevel())
-	gl.UniformFloat(locs.gameFrames, Spring.GetGameFrame())
-	gl.UniformFloat(locs.sunDirY, select(2, gl.GetSun("pos")))
+	-- parens truncate multi-returns to one value: GetGameFrame returns a second
+	-- number and GetSun("pos") three — extra args turn this into glUniform2,
+	-- which is GL_INVALID_OPERATION on a float uniform (the set silently fails;
+	-- Mesa's debug output additionally spams the infolog every frame)
+	gl.UniformFloat(locs.gameFrames, (Spring.GetGameFrame()))
+	gl.UniformFloat(locs.sunDirY, (select(2, gl.GetSun("pos"))))
 	local lavaHdx, lavaHdz = GetLavaHeatDistort()
 	gl.UniformFloat(locs.heatDistortX, lavaHdx)
 	gl.UniformFloat(locs.heatDistortZ, lavaHdz)

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -20788,7 +20788,10 @@ function widget:DrawInMiniMap(minimapWidth, minimapHeight)
 	if interactionState.trackingPlayerID then
 		local _, _, _, teamID = spFunc.GetPlayerInfo(interactionState.trackingPlayerID, false)
 		if teamID then
-			r, g, b = Spring.GetTeamColor(teamID)
+			local tr, tg, tb = Spring.GetTeamColor(teamID)
+			if tr and tg and tb then
+				r, g, b = tr, tg, tb
+			end
 		end
 	end
 

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -15007,12 +15007,8 @@ end
 shaders.SetWaterDynamicUniforms = function()
 	local locs = shaders.waterLocs
 	gl.UniformFloat(locs.waterLevel, GetWaterLevel())
-	-- parens truncate multi-returns to one value: GetGameFrame returns a second
-	-- number and GetSun("pos") three — extra args turn this into glUniform2,
-	-- which is GL_INVALID_OPERATION on a float uniform (the set silently fails;
-	-- Mesa's debug output additionally spams the infolog every frame)
-	gl.UniformFloat(locs.gameFrames, (Spring.GetGameFrame()))
-	gl.UniformFloat(locs.sunDirY, (select(2, gl.GetSun("pos"))))
+	gl.UniformFloat(locs.gameFrames, Spring.GetGameFrame())
+	gl.UniformFloat(locs.sunDirY, select(2, gl.GetSun("pos")))
 	local lavaHdx, lavaHdz = GetLavaHeatDistort()
 	gl.UniformFloat(locs.heatDistortX, lavaHdx)
 	gl.UniformFloat(locs.heatDistortZ, lavaHdz)
@@ -20788,10 +20784,7 @@ function widget:DrawInMiniMap(minimapWidth, minimapHeight)
 	if interactionState.trackingPlayerID then
 		local _, _, _, teamID = spFunc.GetPlayerInfo(interactionState.trackingPlayerID, false)
 		if teamID then
-			local tr, tg, tb = Spring.GetTeamColor(teamID)
-			if tr and tg and tb then
-				r, g, b = tr, tg, tb
-			end
+			r, g, b = Spring.GetTeamColor(teamID)
 		end
 	end
 


### PR DESCRIPTION
Branch: `tf-brush-improvements-13` (12 commits plus a master merge since the 1.12 merge)

Continues the Terraform Brush work from the 1.12 stack. This one is mostly the repo-side half of a performance push on the tileset terrain shader (a far-field cache, a composite clipmap and quality tiers now live in the shader prototype): the UI to drive those levers, and the plumbing that keeps the shader's cached far field honest while the editor paints. Plus two workflow improvements from using the SURFACE and AUTORAMP tools in anger.

## Features

**TILESET PERFORMANCE section.** The Tileset window gains HIGH, MEDIUM and LOW quality presets that drop draw-time features of the tileset shader, with the individual levers underneath as sliders: foothills, stagger, far anti-tiling, cliff-tap slack, the far-field cache with its start distance and blend band, "Cliffs cached past" for the distance at which steep faces join the cache, and the clipmap toggle. A preset applies on top of the sliders, so HIGH is where each lever can be judged on its own. The section drives the shader through its WG API and stays out of the way when the shader widget is not running.

**BIOME LIBRARY from manifests.** The biome picker tiles are built at runtime from the tileset shader's biome manifests (one Lua file per biome in the shader's `tilesets/` folder) instead of six hardcoded RML tiles, so a biome added on disk shows up in the picker without a UI edit. Thumbnails are GL overdraws like the EXTRA LAYER material tiles (a shipped preview drawn whole, or the base albedo as a centered crop), and each biome's skybox pick comes from its manifest instead of a name-match table in the UI.

## Improvements

- **AUTORAMP swipe.** Holding the button and dragging re-fires the ramp along the path, so a whole cliff line restyles in one stroke instead of one click per segment.
- **One FLIP chip instead of per-tile FLIP buttons.** SURFACE's per-slot normal-map flip moved into a single chip in the NOW PAINTING strip that acts on the selected slot, BASE included. Three buttons per tile left PICK, FLIP and X too cramped to hit; the chip dims when the selected slot has no texture.
- **Coverage readback gated on its consumer.** The SURFACE texture picker asks the painter for its coverage readback only while a picker is open. The readback is a GPU sync, and its only reader is the picker's "already carries paint" warning.

## Fixes

- **Painted layers no longer vanish when zooming out.** The tileset shader serves distant ground from a baked composite that sampled the splat texture at bake time, so paint that landed after the bake disappeared past the handoff distance. LAYERS paint, clone-tool pastes and a project's splat swap now tell the shader which region changed: strokes widen a dirty rectangle that is flushed to the far cache and clipmap during the drag and once more when it ends, and whole-texture changes (undo, redo, project load) request a full refill.

## Also

- 1.13 changelog section in `doc/TerraformBrush-changelog.md`; header badge bumped to 1.13.

## Testing

Tested locally on generated canvases and real maps with the tileset shader running: performance presets and each lever slider, biome picker rebuild with an on-disk manifest added and removed, autoramp swipes along cliff lines, FLIP chip on every slot, and painted-layer persistence across zoom-out during and after LAYERS strokes, clone pastes and project loads.

## AI/LLM usage statement

Written and implemented with Claude Code under my direction; I reviewed the diff.
