### PR TITLE
deferred lights: performance optimization

### DIFF
--- a/luaui/Shaders/deferred_lights_gl4.frag.glsl
+++ b/luaui/Shaders/deferred_lights_gl4.frag.glsl
@@ -923,6 +923,8 @@ void main(void)
 			float randomOffset = blueNoiseSample.a * (-0.25);
 			// Collect occludedness in this variable
 			float occludedness = 0.0;
+			// Skip the march where attenuation is already 0, as unoccluded only scales blendedlights, which gets multiplied by attenuation anyway. Gated per quad, as the quadGather below needs all four lanes
+			if (any(greaterThan(quadGather(attenuation), vec4(0.0)))) {
 			
 			#if 0 // This is deprecated for being slow in the WorldToScreen and ScreenToWorld conversions
 				
@@ -1086,6 +1088,7 @@ void main(void)
 					
 				}
 			#endif
+			}
 
 			float prob = 0.56;
 


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Light from shots and explosions is drawn as a volume. For every pixel inside the volume the shader checks whether it is occluded, and that check costs 16 samples from the depth buffer. The result is then multiplied by the light strength at that point, which is often zero, and everything the check computed goes in the bin. In my measurements that zero happens a lot: shots in flight above the ground, flak and air explosions, surfaces past the light radius, and the outer 1.1x shell every volume is drawn with.

This patch checks the light strength first and skips it when it is zero. The check is per quad rather than per pixel because the quadGather after the march needs all four lanes to have run it.

Measured on a late-game 8v8 replay, 1300-1800 units, 3440x1888. 116 fps became 124 fps median over nine interleaved runs. The widget went from 1.14 ms to 0.74 ms of an 8.8 ms frame.

Pixel diff on a paused frame from six camera angles shows no difference beyond what two runs of unmodified master differ by on their own.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Watch a replay with heavy fighting, artillery and flak. Lighting on the ground, on unit hulls and around explosions looks the same as before.
- [ ] Look at the edge of a light pool on flat ground while a unit is firing. The falloff is smooth, no step or ring.
- [ ] Put a unit right at the edge of an explosion light. Its shadowing does not pop.
- [ ] Check Screen Space Shadows on low, medium and high, Same as before everywhere.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
