### PR TITLE
chat: keep color codes whole when wrapping lines

### DIFF
--- a/luaui/Include/chat_emoji.lua
+++ b/luaui/Include/chat_emoji.lua
@@ -237,11 +237,13 @@ local function colorSafeWords(line)
 	while pos <= len do
 		local c = sbyte(line, pos)
 		if c == 255 and pos + 3 <= len then
+			-- Inline color code: 255 followed by three color bytes, kept whole so a wrap cannot split it
 			if wordStart == 0 then
 				wordStart = pos
 			end
 			pos = pos + 4
 		elseif c == 32 or (c >= 9 and c <= 13) then
+			-- Whitespace, the same set as %s: space, tab, newline, vertical tab, form feed, carriage return
 			if wordStart > 0 then
 				count = count + 1
 				words[count] = ssub(line, wordStart, pos - 1)

--- a/luaui/Include/chat_emoji.lua
+++ b/luaui/Include/chat_emoji.lua
@@ -226,12 +226,49 @@ function ChatEmoji.HasEmojiAliasCandidate(text)
 	return sfind(text, ":", firstColon + 1, true) ~= nil
 end
 
+---@param line string
+---@return string[]
+local function colorSafeWords(line)
+	local words = {}
+	local count = 0
+	local len = #line
+	local wordStart = 0
+	local pos = 1
+	while pos <= len do
+		local c = sbyte(line, pos)
+		if c == 255 and pos + 3 <= len then
+			if wordStart == 0 then
+				wordStart = pos
+			end
+			pos = pos + 4
+		elseif c == 32 or (c >= 9 and c <= 13) then
+			if wordStart > 0 then
+				count = count + 1
+				words[count] = ssub(line, wordStart, pos - 1)
+				wordStart = 0
+			end
+			pos = pos + 1
+		else
+			if wordStart == 0 then
+				wordStart = pos
+			end
+			pos = pos + 1
+		end
+	end
+	if wordStart > 0 then
+		count = count + 1
+		words[count] = ssub(line, wordStart, len)
+	end
+
+	return words
+end
+
 function ChatEmoji.WordWrapPlain(textLines, maxWidth, usedFont, fontSize)
 	local lines = {}
 	local lineCount = 0
 	for _, line in ipairs(textLines) do
 		local linebuffer = ""
-		for word in line:gmatch("%S+") do
+		for _, word in ipairs(colorSafeWords(line)) do
 			if linebuffer ~= "" and (usedFont:GetTextWidth(linebuffer .. " " .. word) * fontSize) > maxWidth then
 				lineCount = lineCount + 1
 				lines[lineCount] = linebuffer
@@ -426,7 +463,7 @@ function ChatEmoji.WordWrapRichText(text, maxWidth, fontSize, usedFont)
 		local lineHasEmoji = likelyContainsEmoji(line)
 
 		if not lineHasEmoji then
-			for word in line:gmatch("%S+") do
+			for _, word in ipairs(colorSafeWords(line)) do
 				if linebuffer ~= "" and (usedFont:GetTextWidth(linebuffer .. " " .. word) * fontSize) > maxWidth then
 					lineCount = lineCount + 1
 					lines[lineCount] = linebuffer
@@ -439,7 +476,7 @@ function ChatEmoji.WordWrapRichText(text, maxWidth, fontSize, usedFont)
 				lines[lineCount] = linebuffer
 			end
 		else
-			for word in line:gmatch("%S+") do
+			for _, word in ipairs(colorSafeWords(line)) do
 				local wordWidth = emojiTextWidth(word, fontSize, usedFont)
 				if linebuffer ~= "" and (linebufferWidth + spaceWidth + wordWidth) > maxWidth then
 					lineCount = lineCount + 1

--- a/luaui/Include/chat_emoji.lua
+++ b/luaui/Include/chat_emoji.lua
@@ -236,8 +236,9 @@ local function colorSafeWords(line)
 	local pos = 1
 	while pos <= len do
 		local c = sbyte(line, pos)
-		if c == 255 and pos + 3 <= len then
-			-- Inline color code: 255 followed by three color bytes, kept whole so a wrap cannot split it
+		if c == 255 then
+			-- Inline color code: 255 followed by three color bytes, kept whole so a wrap cannot split it.
+			-- The font eats all four bytes even when fewer than three follow, so do the same here
 			if wordStart == 0 then
 				wordStart = pos
 			end


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Chat wrapping splits lines on whitespace with gmatch("%S+"). A color code is byte 255 plus three color bytes, and a color byte can be 32, a space to the pattern. A wrap landing there cuts the code in half, the name loses its color and a stray byte shows up as é in front of it. The wrapper now keeps a 255 and its three bytes together.

Reproduced with the replay from Vandomas/RecoilEngine-AppleSilicon#4 at 8:37, before and after in the screenshots.

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Watch a replay where a long unit share or a long chat line wraps. The second line starts cleanly, no stray glyph, and a player name keeps its color across the wrap.
- [ ] Type a long chat message with an emoji in it so it wraps. Same as before.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
