### PR TITLE
chat: flush the unit share summary by sim frame

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -1770,9 +1770,15 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 	end
 end
 
-local function addLastUnitShareMessage()
+local function addLastUnitShareMessage(gameFrame)
 	if not lastUnitShare then
 		return
+	end
+	for _, unitShare in pairs(lastUnitShare) do
+		-- half a second: shares from one action can be spread over several sim frames by the network
+		if gameFrame - unitShare.frame < 15 then
+			return
+		end
 	end
 	for _, unitShare in pairs(lastUnitShare) do
 		local oldTeamName = teamNames[unitShare.oldTeamID]
@@ -1816,9 +1822,11 @@ function widget:UnitTaken(unitID, _, oldTeamID, newTeamID)
 			oldTeamID = oldTeamID,
 			newTeamID = newTeamID,
 			unitIDs = {},
+			frame = spGetGameFrame(),
 		}
 	end
 	lastUnitShare[key].unitIDs[#lastUnitShare[key].unitIDs + 1] = unitID
+	lastUnitShare[key].frame = spGetGameFrame()
 end
 
 drawGameTime = function(gameFrame)
@@ -2039,8 +2047,9 @@ local function processChatLineGL(i)
 end
 
 local uiSec = 0
-function widget:GameFrame()
+function widget:GameFrame(gameFrame)
 	state.gameFrameHappened = true
+	addLastUnitShareMessage(gameFrame)
 end
 
 function widget:Update(dt)
@@ -2059,8 +2068,6 @@ function widget:Update(dt)
 		Spring.SDLStartTextInput()
 		updateTextInputDlist = true
 	end
-
-	addLastUnitShareMessage()
 
 	cursorBlinkTimer = cursorBlinkTimer + dt
 	if cursorBlinkTimer > cursorBlinkDuration then


### PR DESCRIPTION


<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done
Unit shares are collected into one summary line, but the summary was flushed in widget:Update, so shares from consecutive sim frames became one line or two depending on the frame rate. On a client drawing 100+ fps every sim frame gets its own line, on a slower one they merge. The summary now goes out two sim frames after the last share, the same on every machine and in replays

Seen in the replay from Vandomas/RecoilEngine-AppleSilicon#4 at 8:37: two shares in frames 15520 and 15521 showed as two lines on a fast client and as one on a slow one

<!-- If relevant
#### Addresses Issue(s)
- Issue URL
-->

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Share several units at once. One line, shared N units to, at any frame rate.
- [ ] Share one unit, wait, share another. Two lines.

<!-- If relevant
### Screenshots:
If you're making visible changes, add before/after screenshots or videos of the major
changes so it's easier for reviewers to see what is different in this PR

#### BEFORE:
(screenshot from master)

#### AFTER:
(screenshot from branch)
-->

<!-- If relevant
### AI / LLM usage statement:
Tell us if you used an AI or LLM in the creation of this code, which AI tool was used, and to what extent.
-->
