### PR TITLE
Assign unused multiple-return values to _

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ You should prefer common functions, then, over potential shortcuts. For example,
 * Do not avoid newlines in code. Add extra newlines after blocks (loops, if/then statements) to aid future readers and reviewers. You can skip some extra newlines, like between immediately-nested if/elseif/else/then/end statements.
 * Do not keep dead code. This includes all dead (unreachable), unused (not called), or removed (commented) code in any file. Delete all code not in active use.
 * Do not keep throwaway debug code. Logging invalid or unexpected state is ok, as is debug code gated behind a debug flag.
+* Consume all function returns, assigning unused ones to `_`, or to `_name` where the name documents what is being discarded.
 
 #### Lua 5.1 hard limits
 

--- a/luaintro/Addons/main.lua
+++ b/luaintro/Addons/main.lua
@@ -482,7 +482,7 @@ function addon.DrawLoadScreen()
 
 	-- background
 	local scale = 1
-	local ssx, ssy, spx, spy = Spring.GetScreenGeometry()
+	local ssx, _, _, _ = Spring.GetScreenGeometry()
 	if ssx / vsx < 1 then -- adjust when window is larger than the screen resolution
 		--scale = ssx / vsx
 		--xDiv = xDiv * scale	-- this doesn't work
@@ -501,7 +501,7 @@ function addon.DrawLoadScreen()
 	-- tip
 	local tipTextSize = height * 0.7
 	local tipTextLineHeight = tipTextSize * 1.17
-	local wrappedTipText, numLines = font2:WrapText(randomTip, vsx * 1.35)
+	local wrappedTipText, _ = font2:WrapText(randomTip, vsx * 1.35)
 	local tipLines = lines(wrappedTipText)
 	local tipPosYtop = posY
 		+ (height / vsy)

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -1433,7 +1433,7 @@ function gadgetHandler:GamePaused(playerID, paused)
 end
 
 function gadgetHandler:RecvFromSynced(...)
-	local arg1, arg2 = ...
+	local arg1, _ = ...
 	if arg1 == CHAT_ACTION_REQUEST then
 		BroadcastChatActionSnapshot("unsynced", self.actionHandler.textActions)
 		return true

--- a/luarules/gadgets/cmd_clone_tool.lua
+++ b/luarules/gadgets/cmd_clone_tool.lua
@@ -181,7 +181,7 @@ end
 -- Handle terrain clone: "$clone_terrain$count x z h x z h ..."
 -- ---------------------------------------------------------------------------
 local function handleCloneTerrain(payload)
-	local parts, count = parseParts(payload)
+	local parts, _ = parseParts(payload)
 	local vertexCount = tonumber(parts[1]) or 0
 	if vertexCount == 0 then
 		return
@@ -211,7 +211,7 @@ end
 -- Handle metal clone: "$clone_metal$count mx mz val mx mz val ..."
 -- ---------------------------------------------------------------------------
 local function handleCloneMetal(payload)
-	local parts, count = parseParts(payload)
+	local parts, _ = parseParts(payload)
 	local entryCount = tonumber(parts[1]) or 0
 	if entryCount == 0 then
 		return
@@ -250,7 +250,7 @@ end
 local gaiaTeamID = Spring.GetGaiaTeamID()
 
 local function handleCloneFeatures(payload)
-	local parts, count = parseParts(payload)
+	local parts, _ = parseParts(payload)
 	local entryCount = tonumber(parts[1]) or 0
 	spEcho("[Clone Gadget] Features recv: " .. entryCount)
 	if entryCount == 0 then
@@ -332,7 +332,7 @@ local function handleTerrainGrid(payload)
 	if not pendingPaste then
 		return
 	end
-	local parts, cnt = parseParts(payload)
+	local parts, _ = parseParts(payload)
 	local rowStart = tonumber(parts[1]) or 0
 	local rowCount = tonumber(parts[2]) or 0
 	local cols = pendingPaste.srcCols

--- a/luarules/gadgets/cmd_idle_players.lua
+++ b/luarules/gadgets/cmd_idle_players.lua
@@ -219,7 +219,7 @@ if gadgetHandler:IsSyncedCode() then
 		local previousPresent = playerInfoTableEntry.present
 		playerInfoTableEntry.present = afk == 0
 		playerInfoTable[playerID] = playerInfoTableEntry
-		local name, active, spectator, teamID, allyTeamID, ping = GetPlayerInfo(playerID, false)
+		local name, _, spectator, _, allyTeamID, _ = GetPlayerInfo(playerID, false)
 		if not spectator and name ~= nil then
 			if currentGameFrame > minTimeToTake * gameSpeed then
 				if previousPresent and not playerInfoTableEntry.present then

--- a/luarules/gadgets/game_replace_afk_players.lua
+++ b/luarules/gadgets/game_replace_afk_players.lua
@@ -253,7 +253,7 @@ else
 	local revealed = false
 
 	local function colourNames(teamID)
-		local nameColourR, nameColourG, nameColourB, nameColourA = Spring.GetTeamColor(teamID)
+		local nameColourR, nameColourG, nameColourB, _ = Spring.GetTeamColor(teamID)
 		return ColorString(nameColourR, nameColourG, nameColourB)
 	end
 

--- a/luarules/gadgets/gfx_fire_gl4.lua
+++ b/luarules/gadgets/gfx_fire_gl4.lua
@@ -2084,7 +2084,7 @@ function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weap
 	if damage and damage < 1 then
 		return
 	end
-	local ux, uy, uz = spGetUnitPosition(unitID)
+	local ux, uy, _ = spGetUnitPosition(unitID)
 	if not ux or uy < 0 then
 		return
 	end -- underwater: no fire

--- a/luarules/gadgets/gfx_projectile_effects.lua
+++ b/luarules/gadgets/gfx_projectile_effects.lua
@@ -182,7 +182,7 @@ local allWatchedProjectileIDs = {}
 local waterIsLava = Spring.GetModOptions().map_waterislava
 
 function gadget:Initialize()
-	local minheight, maxheight = Spring.GetGroundExtremes()
+	local minheight, _ = Spring.GetGroundExtremes()
 	if minheight > 100 then
 		mapHasWater = false
 	end

--- a/luarules/gadgets/gfx_raptor_scum_gl4.lua
+++ b/luarules/gadgets/gfx_raptor_scum_gl4.lua
@@ -666,8 +666,8 @@ elseif not BAR.Utilities.Gametype.IsScavengers() then -- UNSYNCED
 			return
 		end
 
-		local planeVBO, numVertices = InstanceVBOTable.makePlaneVBO(1, 1, resolution, resolution)
-		local planeIndexVBO, numIndices = InstanceVBOTable.makePlaneIndexVBO(resolution, resolution, true)
+		local planeVBO, _ = InstanceVBOTable.makePlaneVBO(1, 1, resolution, resolution)
+		local planeIndexVBO, _ = InstanceVBOTable.makePlaneIndexVBO(resolution, resolution, true)
 
 		scumVBO.vertexVBO = planeVBO
 		scumVBO.indexVBO = planeIndexVBO
@@ -937,7 +937,7 @@ elseif not BAR.Utilities.Gametype.IsScavengers() then -- UNSYNCED
 			return
 		end
 		if debugmode then
-			local mx, my, mb = Spring.GetMouseState()
+			local mx, my, _ = Spring.GetMouseState()
 			local _, coords = Spring.TraceScreenRay(mx, my, true)
 			if coords and (IsPosInScum(coords[1], coords[2], coords[3])) then
 				Spring.Echo("Inscum", numscums, IsPosInScum(coords[1], coords[2], coords[3]))

--- a/luarules/gadgets/gfx_reclaim_fx.lua
+++ b/luarules/gadgets/gfx_reclaim_fx.lua
@@ -128,7 +128,7 @@ if gadgetHandler:IsSyncedCode() then
 			local fdef = featureList[Spring.GetFeatureDefID(featureID)]
 			if fdef and fdef.minx then
 				local x, y, z = fx, fy, fz
-				local rm, mm, re, me, rl = Spring.GetFeatureResources(featureID)
+				local rm, mm, re, me, _ = Spring.GetFeatureResources(featureID)
 				if me ~= nil and me > 0 then
 					local numFx = math.max(math.floor(me / 250), 15)
 					local posMultiplier = 0.5

--- a/luarules/gadgets/gfx_tree_feller.lua
+++ b/luarules/gadgets/gfx_tree_feller.lua
@@ -401,7 +401,7 @@ if gadgetHandler:IsSyncedCode() then
 			local featureID = allFeatures[i]
 			local featureDefID = Spring.GetFeatureDefID(featureID)
 			if IsLikelyTreeFeature(featureID, featureDefID) then
-				local fx, fy, fz = GetFeaturePosition(featureID)
+				local fx, fy, _ = GetFeaturePosition(featureID)
 				if fx and fy <= lavaLevel then
 					DestroyFeature(featureID)
 				end
@@ -522,10 +522,10 @@ if gadgetHandler:IsSyncedCode() then
 
 		local ppx, ppy, ppz
 		if fx ~= nil then
-			local health, maxhealth, _ = GetFeatureHealth(featureID)
+			local health, _, _ = GetFeatureHealth(featureID)
 			if dmg >= health then
 				local fire
-				local _, maxMetal, _, maxEnergy, reclaimLeft = GetFeatureResources(featureID)
+				local _, maxMetal, _, maxEnergy, _ = GetFeatureResources(featureID)
 				local dissapearSpeed = 1.7
 				local size = "medium"
 				if treeScaleY[featureDefID] then

--- a/luarules/gadgets/gfx_watersplash.lua
+++ b/luarules/gadgets/gfx_watersplash.lua
@@ -137,7 +137,7 @@ function gadget:Explosion(weaponID, px, py, pz, ownerID)
 end
 
 function gadget:Initialize()
-	local minHeight, maxHeight = Spring.GetGroundExtremes()
+	local minHeight, _ = Spring.GetGroundExtremes()
 	if minHeight < 100 then
 		for wDefID, wDef in pairs(WeaponDefs) do
 			if wDef.damageAreaOfEffect ~= nil and wDef.damageAreaOfEffect > 8 and not weaponNoSplash[wDefID] then

--- a/luarules/gadgets/gui_territorial_domination.lua
+++ b/luarules/gadgets/gui_territorial_domination.lua
@@ -285,7 +285,7 @@ local function initializeAllyColors()
 		local allyID = select(6, Spring.GetTeamInfo(teamID))
 		if allyID and not allyColors[allyID] then
 			if allyID ~= gaiaAllyTeamID then
-				local r, g, b, a = Spring.GetTeamColor(teamID)
+				local r, g, b, _ = Spring.GetTeamColor(teamID)
 				allyColors[allyID] = { r, g, b, SQUARE_ALPHA }
 			else
 				allyColors[allyID] = blankColor

--- a/luarules/gadgets/map_explosion_deformation_fix.lua
+++ b/luarules/gadgets/map_explosion_deformation_fix.lua
@@ -21,7 +21,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 	-- explosions. Unlike engine restoration it does this with an infrequent poll, so hitting between nuke
 	-- crater and nuke damage is unlikely.
 	if Spring.ValidUnitID(unitID) then
-		local b1, b2, b3, b4, b5, b6, b7 = Spring.GetUnitBlocking(unitID)
+		local b1, b2, b3, b4, b5, b6, _ = Spring.GetUnitBlocking(unitID)
 		Spring.SetUnitBlocking(unitID, b1, b2, b3, b4, b5, b6, false)
 	end
 end

--- a/luarules/gadgets/map_lava.lua
+++ b/luarules/gadgets/map_lava.lua
@@ -573,8 +573,8 @@ else -- UNSYCNED
 		-- numverts = 128 * 384 * 384 *2 tris then we will get 280k tris ....
 		local xsquares = 3 * Game.mapSizeX / elmosPerSquare
 		local zsquares = 3 * Game.mapSizeZ / elmosPerSquare
-		local vertexBuffer, vertexBufferSize = InstanceVBOTable.makePlaneVBO(1, 1, xsquares, zsquares)
-		local indexBuffer, indexBufferSize = InstanceVBOTable.makePlaneIndexVBO(xsquares, zsquares)
+		local vertexBuffer, _ = InstanceVBOTable.makePlaneVBO(1, 1, xsquares, zsquares)
+		local indexBuffer, _ = InstanceVBOTable.makePlaneIndexVBO(xsquares, zsquares)
 		lavaPlaneVAO = gl.GetVAO()
 		lavaPlaneVAO:AttachVertexBuffer(vertexBuffer)
 		lavaPlaneVAO:AttachIndexBuffer(indexBuffer)

--- a/luarules/gadgets/unit_carrier_spawner.lua
+++ b/luarules/gadgets/unit_carrier_spawner.lua
@@ -1327,7 +1327,7 @@ local function updateCarrier(carrierID, carrierMetaData, frame)
 			local droneInFormation = droneData.inFormation
 			local droneDistance = diag((carrierx - sx), (carrierz - sz))
 
-			local droneCurrentHealth, droneMaxHealth = spGetUnitHealth(subUnitID)
+			local droneCurrentHealth, _ = spGetUnitHealth(subUnitID)
 			local droneAlive = true
 
 			if droneDocked and droneData.maxAmmo > 0 then

--- a/luarules/gadgets/unit_juno_rework_damage.lua
+++ b/luarules/gadgets/unit_juno_rework_damage.lua
@@ -115,7 +115,7 @@ if gadgetHandler:IsSyncedCode() then
 					Spring.SpawnCEG("juno-damage", px, py + 8, pz, 0, 1, 0)
 				end
 
-				local health, maxHealth, paralyzeDamage, capture, build = Spring.GetUnitHealth(uID)
+				local _, maxHealth, _, _, _ = Spring.GetUnitHealth(uID)
 				Spring.AddUnitDamage(uID, maxHealth * 3, stunDuration, 99, weaponID) --no weapon ID, no stun. with weapon ID, infinite loops, even with the 99 exclusion. -1 does not work.
 				--aID check removed as -probably- only useful for kill crediting?
 			end
@@ -209,7 +209,7 @@ if gadgetHandler:IsSyncedCode() then
 							--does the cyl search above not already do this...?
 							if (dx * dx + dz * dz) > (q * (radius - width)) * (q * (radius - width)) then
 								-- linear and not O(n^2)
-								local health, maxHealth, paralyzeDamage, capture, build = Spring.GetUnitHealth(unitID)
+								local _, maxHealth, paralyzeDamage, _, _ = Spring.GetUnitHealth(unitID)
 								--Spring.Echo(paralyzeDamage, maxHealth*1.2)
 								if paralyzeDamage < maxHealth * 1.2 then --try to prevent excessive stun times, also needless restuns
 									Spring.AddUnitDamage(

--- a/luarules/gadgets/unit_paralyze_damage_limit.lua
+++ b/luarules/gadgets/unit_paralyze_damage_limit.lua
@@ -246,7 +246,7 @@ function gadget:UnitDamaged(
 		return
 	end
 
-	local uHealth, uMaxHealth, uParalyze = spGetUnitHealth(unitID)
+	local uHealth, uMaxHealth, _ = spGetUnitHealth(unitID)
 
 	-- Support for paralyzeOnMaxHealth Feature
 	local effectiveHP = Game.paralyzeOnMaxHealth and uMaxHealth or uHealth

--- a/luarules/gadgets/unit_respawning.lua
+++ b/luarules/gadgets/unit_respawning.lua
@@ -153,7 +153,7 @@ if gadgetHandler:IsSyncedCode() then
 			local allPlayers = Spring.GetPlayerList()
 			local notificationEvent
 			for _, playerID in ipairs(allPlayers) do
-				local playerName, active, isSpectator, teamID, allyTeamID = Spring.GetPlayerInfo(playerID, true)
+				local _, _, isSpectator, teamID, _ = Spring.GetPlayerInfo(playerID, true)
 				if teamID and unitTeam and not isSpectator then
 					if teamID == unitTeam then
 						notificationEvent = "RespawningCommanders/CommanderTransposed"
@@ -200,7 +200,7 @@ if gadgetHandler:IsSyncedCode() then
 				local blockedIncrement = 1
 				for i = 1, 500, blockedIncrement do
 					local x, y, z = spGetUnitPosition(unitID)
-					local blockType, blockID = Spring.GetGroundBlocked(x - i, z - i)
+					local blockType, _ = Spring.GetGroundBlocked(x - i, z - i)
 					local groundH = Spring.GetGroundHeight(x - i, z - i)
 
 					if respawnMetaList[unitID].effigy_offset == 0 then
@@ -279,7 +279,7 @@ if gadgetHandler:IsSyncedCode() then
 
 				local allPlayers = Spring.GetPlayerList()
 				for _, playerID in ipairs(allPlayers) do
-					local playerName, active, isSpectator, teamID, allyTeamID = Spring.GetPlayerInfo(playerID, true)
+					local _, _, _, teamID, _ = Spring.GetPlayerInfo(playerID, true)
 					if teamID == commanderTeam then
 						GG.notifications.queueNotification(
 							"RespawningCommanders/CommanderEffigyLost",
@@ -343,7 +343,7 @@ if gadgetHandler:IsSyncedCode() then
 		local meta = respawnMetaList[unitID]
 		if meta then
 			if meta.respawn_condition == "health" then
-				local h, mh = spGetUnitHealth(unitID)
+				local h, _ = spGetUnitHealth(unitID)
 				local currentTime = spGetGameSeconds()
 				if
 					meta.effigyID

--- a/luarules/gadgets/unit_timeslow.lua
+++ b/luarules/gadgets/unit_timeslow.lua
@@ -47,7 +47,7 @@ local function updateSlow(unitID, state)
 	--Spring.Echo("hornet upd slow unit id " .. unitID .. "  state.slowDamage " .. state.slowDamage)--  .. "  max slow factor " .. MAX_SLOW_FACTOR)
 
 	-- overslow seems to be a stacked slow aside from the existing, purpose unclear
-	local health, maxHealth, paralyzeDamage, capture, build = spGetUnitHealth(unitID)
+	local health, maxHealth, paralyzeDamage, _, _ = spGetUnitHealth(unitID)
 	if health then
 		local maxSlow = health * (MAX_SLOW_FACTOR + (state.extraSlowBound or 0))
 		if paralyzeDamage > maxSlow then

--- a/luarules/gadgets/unit_water_depth_damage.lua
+++ b/luarules/gadgets/unit_water_depth_damage.lua
@@ -121,7 +121,7 @@ function gadget:UnitEnteredWater(unitID, unitDefID, unitTeam)
 				spSpawnCEG(largeSplashCEG, posX, posY, posZ)
 				spPlaySoundFile("xplodep3", 0.5, posX, posY, posZ, "sfx")
 				if defData then
-					local health, maxHealth = spGetUnitHealth(unitID)
+					local health, _ = spGetUnitHealth(unitID)
 					local damage = (defData.fallDamage * velLength) * (fallDamageCompoundingFactor ^ velLength)
 					if damage >= health then
 						if spGetUnitRulesParam(unitID, "unit_effigy") then

--- a/luaui/Include/AtlasOnDemand.lua
+++ b/luaui/Include/AtlasOnDemand.lua
@@ -518,7 +518,7 @@ local function MakeAtlasOnDemand(config)
 		local width = math.ceil(textparams.font:GetTextWidth(textparams.text) * textparams.size)
 
 		-- Height needs to take into account outlines as well! (and maybe even
-		local textheight, textdescender, numlines = textparams.font:GetTextHeight(textparams.text) -- See https://springrts.com/wiki/GetTextHeight
+		local textheight, textdescender, _ = textparams.font:GetTextHeight(textparams.text) -- See https://springrts.com/wiki/GetTextHeight
 		local height = math.ceil((textheight + textdescender) * textparams.size)
 		textdescender = -1 * textdescender * textparams.size -- descender is negative for 'b' ?
 		if self.debug then

--- a/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/gui_terraform_brush.lua
@@ -10922,7 +10922,7 @@ local initialModel = {
 		if not WG.DiffusePainter or not WG.DiffusePainter.getFractal then
 			return
 		end
-		local amt, freq = WG.DiffusePainter.getFractal()
+		local amt, _ = WG.DiffusePainter.getFractal()
 		if WG.DiffusePainter.setFractal then
 			WG.DiffusePainter.setFractal((amt or 0) + (delta or 0) / 100, nil)
 		end

--- a/luaui/RmlWidgets/gui_terraform_brush/tf_environment.lua
+++ b/luaui/RmlWidgets/gui_terraform_brush/tf_environment.lua
@@ -1181,7 +1181,7 @@ function M.attach(doc, ctx)
 	end, function()
 		return (select(3, gl.GetSun("pos"))) * 10000
 	end, function(val)
-		local sx, sy, sz = gl.GetSun("pos")
+		local sx, sy, _ = gl.GetSun("pos")
 		Spring.SetSunDirection(sx, sy, val)
 		Spring.SetSunLighting({
 			groundShadowDensity = gl.GetSun("shadowDensity"),
@@ -1718,7 +1718,7 @@ function M.attach(doc, ctx)
 		local x, y, z, angle = gl.GetAtmosphere("skyAxisAngle")
 		return (angle or 0) * 100
 	end, function(val)
-		local x, y, z, angle = gl.GetAtmosphere("skyAxisAngle")
+		local x, y, z, _ = gl.GetAtmosphere("skyAxisAngle")
 		Spring.SetAtmosphere({ skyAxisAngle = { x, y, z, val } })
 	end)
 	local function skyAxisSlider(axis, idx)

--- a/luaui/Widgets/__defs_write.lua
+++ b/luaui/Widgets/__defs_write.lua
@@ -180,7 +180,7 @@ if customparamDefsDetected then
 					else
 						-- round to 5dp, convert to string, then remove trailing 0s after decimal point
 						v = string.format("%.5f", v)
-						local a, b = string.find(v, ".")
+						local a, _ = string.find(v, ".")
 						if a ~= nil then
 							v = string.reverse(v)
 							while string.sub(v, 1, 1) == "0" do

--- a/luaui/Widgets/api_blueprint.lua
+++ b/luaui/Widgets/api_blueprint.lua
@@ -444,7 +444,7 @@ local function getBuildPositionsGrid(blueprint, startPos, endPos, spacing)
 	startPos = snapBlueprint(blueprint, startPos, blueprint.facing)
 	endPos = snapBlueprint(blueprint, endPos, blueprint.facing)
 
-	local xStep, zStep, xNum, zNum, delta = calculateSteps(blueprint, startPos, endPos, spacing)
+	local xStep, zStep, xNum, zNum, _ = calculateSteps(blueprint, startPos, endPos, spacing)
 
 	local result = {}
 	local z = startPos[3]
@@ -471,7 +471,7 @@ local function getBuildPositionsBox(blueprint, startPos, endPos, spacing)
 	startPos = snapBlueprint(blueprint, startPos, blueprint.facing)
 	endPos = snapBlueprint(blueprint, endPos, blueprint.facing)
 
-	local xStep, zStep, xNum, zNum, delta = calculateSteps(blueprint, startPos, endPos, spacing)
+	local xStep, zStep, xNum, zNum, _ = calculateSteps(blueprint, startPos, endPos, spacing)
 
 	local result = {}
 

--- a/luaui/Widgets/camera_middle_mouse_alternate.lua
+++ b/luaui/Widgets/camera_middle_mouse_alternate.lua
@@ -43,12 +43,12 @@ local drawing = false
 function widget:Update(dt)
 	if active then
 		local speedFactor = Spring.GetConfigInt("OverheadScrollSpeed", 10)
-		local x, y, lmb, mmb, rmb = spGetMouseState()
+		local x, y, _, mmb, _ = spGetMouseState()
 		local cs = spGetCameraState()
 		local speed = dt * speedFactor
 
 		if cs.name == "free" then
-			local a, c, m, s = spGetModKeyState()
+			local _, c, _, _ = spGetModKeyState()
 			if c then
 				return
 			end
@@ -131,7 +131,7 @@ end
 function widget:MouseWheel(up, value)
 	-- Get the current camera state and mod key state
 	local cameraState = Spring.GetCameraState()
-	local altDown, ctrlDown, metaDown, shiftDown = Spring.GetModKeyState()
+	local altDown, _, _, _ = Spring.GetModKeyState()
 
 	-- If the Alt key is down, adjust the camera height
 	if altDown then

--- a/luaui/Widgets/camera_player_tv.lua
+++ b/luaui/Widgets/camera_player_tv.lua
@@ -79,7 +79,7 @@ local ColorIsDark = BAR.Utilities.Color.ColorIsDark
 local aiTeams = {}
 local teamColorKeys = {}
 for i = 1, #teamList do
-	local r, g, b, a = spGetTeamColor(teamList[i])
+	local r, g, b, _ = spGetTeamColor(teamList[i])
 	teamColorKeys[teamList[i]] = r .. "_" .. g .. "_" .. b
 	local _, _, _, isAiTeam = Spring.GetTeamInfo(teamList[i], false)
 	if isAiTeam then
@@ -109,7 +109,7 @@ local function tsOrderPlayers()
 		local playerID = playersList[i]
 		local playerTs = playersTS[playerID]
 		if playerTs then
-			local _, _, spec, teamID = spGetPlayerInfo(playerID, false)
+			local _, _, spec, _ = spGetPlayerInfo(playerID, false)
 			if not spec then
 				count = count + 1
 				local orderedPlayer = tsOrderedPlayers[count]
@@ -721,7 +721,7 @@ function widget:Update(dt)
 		-- check if team colors have changed
 		local detectedChanges = false
 		for i = 1, #teamList do
-			local r, g, b, a = spGetTeamColor(teamList[i])
+			local r, g, b, _ = spGetTeamColor(teamList[i])
 			if teamColorKeys[teamList[i]] ~= r .. "_" .. g .. "_" .. b then
 				teamColorKeys[teamList[i]] = r .. "_" .. g .. "_" .. b
 				detectedChanges = true
@@ -878,7 +878,7 @@ local function drawContent()
 		gl.PushMatrix()
 		gl.CallList(drawlist[1])
 		gl.PopMatrix()
-		local mx, my, mb = spGetMouseState()
+		local mx, my, _ = spGetMouseState()
 		if
 			showTrackingButtons
 			and not aiTeams[myTeamID]
@@ -934,7 +934,7 @@ local function drawContent()
 					prevLockPlayerID = lockPlayerID
 					lockPlayerID = WG.lockcamera.GetPlayerID()
 				end
-				local name, _, spec, teamID, _, _, _, _, _ = spGetPlayerInfo(myTeamPlayerID, false)
+				local name, _, spec, _, _, _, _, _, _ = spGetPlayerInfo(myTeamPlayerID, false)
 				name = (
 					(WG.playernames and WG.playernames.getPlayername) and WG.playernames.getPlayername(myTeamPlayerID)
 				) or name
@@ -1125,7 +1125,7 @@ function widget:Initialize()
 	end
 
 	for _, playerID in ipairs(playersList) do
-		local _, _, spec, team = spGetPlayerInfo(playerID, false)
+		local _, _, spec, _ = spGetPlayerInfo(playerID, false)
 		if not spec then
 			playersTS[playerID] = GetSkill(playerID)
 		end

--- a/luaui/Widgets/cmd_blueprint.lua
+++ b/luaui/Widgets/cmd_blueprint.lua
@@ -971,7 +971,7 @@ function widget:MouseWheel(up, value)
 		return
 	end
 
-	local alt, ctrl, meta, shift = unpack(state.modKeys or {})
+	local alt, _, _, _ = unpack(state.modKeys or {})
 
 	if not alt then
 		return

--- a/luaui/Widgets/cmd_context_build.lua
+++ b/luaui/Widgets/cmd_context_build.lua
@@ -215,7 +215,7 @@ function widget:DrawWorld()
 		return
 	end
 
-	local x, y, lmb, mmb, rmb = spGetMouseState()
+	local _, _, lmb, _, _ = spGetMouseState()
 
 	if mouseDownPos and lmb then
 		-- currently doing a build drag, don't swap buildings

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -536,7 +536,7 @@ function widget:MouseMove(mx, my, dx, dy, mButton)
 		if pathCandidate then
 			-- For the first path command, use raw shift state to decide whether to clear queue
 			-- This ensures queue is cleared unless user explicitly holds shift
-			local alt, ctrl, meta, _ = GetModKeys()
+			local _, ctrl, meta, _ = GetModKeys()
 			local _, _, _, rawShift = spGetModKeyState()
 			if spGetInvertQueueKey() then
 				rawShift = not rawShift
@@ -567,7 +567,7 @@ function widget:MouseMove(mx, my, dx, dy, mButton)
 
 				-- Only add command if it's not too close to any previous position
 				if not tooClose then
-					local alt, ctrl, meta, shift = GetModKeys()
+					local _, ctrl, meta, _ = GetModKeys()
 					local cmdOpts = GetCmdOpts(false, ctrl, meta, true, usingRMB)
 
 					GiveNotifyingOrder(usingCmd, pos, cmdOpts)

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -813,7 +813,7 @@ function DrawBoxes()
 	end
 	local heightAll = boxHeightTitle + itemCount * (boxHeight + boxOuterMargin)
 
-	local x, y, z = CalcDrawCoords(selUnit, heightAll)
+	local x, y, _ = CalcDrawCoords(selUnit, heightAll)
 
 	local coordsChanged = false
 	if x ~= lastBoxX or y ~= lastBoxY then

--- a/luaui/Widgets/cmd_line-build_hotkey_ignore.lua
+++ b/luaui/Widgets/cmd_line-build_hotkey_ignore.lua
@@ -16,9 +16,9 @@ end
 function widget:KeyPress(key, mods, isRepeat)
 	if not mods.alt and mods.shift then
 		if key ~= KEYSYMS.UP and key ~= KEYSYMS.DOWN and key ~= KEYSYMS.LEFT and key ~= KEYSYMS.RIGHT then -- Don't ignore arrow keys
-			local x, y, leftPressed, middlePressed, rightPressed, offscreen = Spring.GetMouseState()
+			local _, _, leftPressed, _, _, _ = Spring.GetMouseState()
 			if leftPressed then
-				local idx, cmd_id, cmd_type, cmd_name = Spring.GetActiveCommand()
+				local _, cmd_id, _, _ = Spring.GetActiveCommand()
 				if cmd_id and cmd_id < 0 then
 					return true
 				end

--- a/luaui/Widgets/cmd_metal_brush.lua
+++ b/luaui/Widgets/cmd_metal_brush.lua
@@ -432,7 +432,7 @@ local function loadMetalMap()
 	local mapName = Game.mapName or "unknown"
 	local filename = SAVE_DIR .. mapName .. "_metalmap.lua"
 
-	local chunk, err = loadfile(filename)
+	local chunk, _err = loadfile(filename)
 	if not chunk then
 		Echo("[Metal Brush] No saved metal map found: " .. filename)
 		return

--- a/luaui/Widgets/cmd_share_unit.lua
+++ b/luaui/Widgets/cmd_share_unit.lua
@@ -201,7 +201,7 @@ local function colourNames(teamId)
 	if tonumber(teamId) < 0 then
 		return ""
 	end
-	local nameColourR, nameColourG, nameColourB, nameColourA = Spring.GetTeamColor(teamId)
+	local nameColourR, nameColourG, nameColourB, _ = Spring.GetTeamColor(teamId)
 	return BAR.Utilities.Color.ToString(nameColourR, nameColourG, nameColourB)
 end
 

--- a/luaui/Widgets/cmd_splat_painter.lua
+++ b/luaui/Widgets/cmd_splat_painter.lua
@@ -245,7 +245,7 @@ local function isPointValid(px, pz)
 	end
 
 	-- Slope checks
-	local nx, ny, nz = GetGroundNormal(px, pz)
+	local nx, ny, _ = GetGroundNormal(px, pz)
 	if nx then
 		if sf.avoidCliffs then
 			local cosMax = cos(sf.slopeMax * pi / 180)

--- a/luaui/Widgets/cmd_startpos_tool.lua
+++ b/luaui/Widgets/cmd_startpos_tool.lua
@@ -2029,7 +2029,7 @@ function widget:MouseWheel(up, value)
 		return false
 	end
 
-	local altHeld, ctrlHeld, _, shiftHeld = Spring.GetModKeyState()
+	local altHeld, ctrlHeld, _, _ = Spring.GetModKeyState()
 
 	if subMode == "shape" or subMode == "express" then
 		if altHeld then

--- a/luaui/Widgets/cmd_terraform_brush.lua
+++ b/luaui/Widgets/cmd_terraform_brush.lua
@@ -219,7 +219,7 @@ local function loadKeybindsFromDisk()
 	if VFS.FileExists(KEYBINDS_FILE, VFS.RAW) then
 		local raw = VFS.LoadFile(KEYBINDS_FILE, VFS.RAW)
 		if raw then
-			local fn, err = loadstring(raw)
+			local fn, _err = loadstring(raw)
 			if fn then
 				local ok, data = pcall(fn)
 				if ok and type(data) == "table" then

--- a/luaui/Widgets/cmd_weather_brush.lua
+++ b/luaui/Widgets/cmd_weather_brush.lua
@@ -1283,7 +1283,7 @@ function widget:MouseWheel(up, value)
 		return false
 	end
 
-	local alt, ctrl, meta, shift = Spring.GetModKeyState()
+	local alt, ctrl, _, _ = Spring.GetModKeyState()
 
 	if ctrl and alt then
 		local delta = up and 0.1 or -0.1

--- a/luaui/Widgets/dbg_ceg_auto_reloader.lua
+++ b/luaui/Widgets/dbg_ceg_auto_reloader.lua
@@ -298,7 +298,7 @@ end
 
 local function isInteger(value)
 	-- seems like cegops are allowed here too!
-	local res, err = isFloat(value)
+	local res, _err = isFloat(value)
 	if res then
 		return true
 	end

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -266,8 +266,8 @@ local function initGL4(DPATname)
 		smallDecalVAO:AttachVertexBuffer(decalVBO.instanceVBO)
 		decalVBO.VAO = smallDecalVAO
 	else
-		local planeVBOsmall, numVerticesSmall = InstanceVBOTable.makePlaneVBO(1, 1, 4, 4)
-		local planeIndexVBOsmall, numIndicesSmall = InstanceVBOTable.makePlaneIndexVBO(4, 4)
+		local planeVBOsmall, _ = InstanceVBOTable.makePlaneVBO(1, 1, 4, 4)
+		local planeIndexVBOsmall, _ = InstanceVBOTable.makePlaneIndexVBO(4, 4)
 		decalVBO.vertexVBO = planeVBOsmall
 		decalVBO.indexVBO = planeIndexVBOsmall
 		decalVBO.VAO = InstanceVBOTable.makeVAOandAttach(decalVBO.vertexVBO, decalVBO.instanceVBO, decalVBO.indexVBO)

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1957,7 +1957,7 @@ end
 
 local function PrintProjectileInfo(projectileID)
 	local px, py, pz = spGetProjectilePosition(projectileID)
-	local weapon, piece = Spring.GetProjectileType(projectileID)
+	local weapon, _ = Spring.GetProjectileType(projectileID)
 	local weaponDefID = weapon and Spring.GetProjectileDefID(projectileID)
 	BAR.Debug.TraceFullEcho()
 end

--- a/luaui/Widgets/gfx_distortion_gl4.lua
+++ b/luaui/Widgets/gfx_distortion_gl4.lua
@@ -1143,7 +1143,7 @@ end
 
 local function PrintProjectileInfo(projectileID)
 	local px, py, pz = spGetProjectilePosition(projectileID)
-	local weapon, piece = Spring.GetProjectileType(projectileID)
+	local weapon, _ = Spring.GetProjectileType(projectileID)
 	local weaponDefID = weapon and Spring.GetProjectileDefID(projectileID)
 	BAR.Debug.TraceFullEcho()
 end

--- a/luaui/Widgets/gfx_dof.lua
+++ b/luaui/Widgets/gfx_dof.lua
@@ -393,7 +393,7 @@ end
 
 local function FilterCalculation()
 	local cpx, cpy, cpz = spGetCameraPosition()
-	local gmin, gmax = Spring.GetGroundExtremes()
+	local gmin, _ = Spring.GetGroundExtremes()
 	local effectiveHeight = cpy - math_max(0, gmin)
 	cpy = 3.5 * math_sqrt(effectiveHeight) * math_log(effectiveHeight)
 	glUniform(eyePosLoc, cpx, cpy, cpz)

--- a/luaui/Widgets/gfx_highlight_commander_wrecks.lua
+++ b/luaui/Widgets/gfx_highlight_commander_wrecks.lua
@@ -173,7 +173,7 @@ local function shouldHighlight(unitName)
 end
 
 local function addHighlight(featureID, noUpload)
-	local m, dm, e, de, rl, rt = Spring.GetFeatureResources(featureID)
+	local m, _, _, _, _, _ = Spring.GetFeatureResources(featureID)
 	if m > 0 then
 		local x, y, z = Spring.GetFeaturePosition(featureID)
 		y = Spring.GetGroundHeight(x, z) - 50 --account for deformable terrain

--- a/luaui/Widgets/gfx_paralyze_effect.lua
+++ b/luaui/Widgets/gfx_paralyze_effect.lua
@@ -459,7 +459,7 @@ local function init()
 	local allUnits = spGetAllUnits()
 	for i = 1, #allUnits do
 		local unitID = allUnits[i]
-		local health, maxHealth, paralyzeDamage, capture, build = spGetUnitHealth(unitID)
+		local _, _, paralyzeDamage, _, _ = spGetUnitHealth(unitID)
 		if paralyzeDamage and paralyzeDamage > 0 then
 			widget:UnitCreated(unitID, spGetUnitDefID(unitID))
 		end
@@ -481,7 +481,7 @@ function widget:UnitCreated(unitID, unitDefID)
 		DrawParalyzedUnitGL4(unitID, unitDefID)
 	end
 
-	local health, maxHealth, paralyzeDamage, capture, build = spGetUnitHealth(unitID)
+	local _, _, paralyzeDamage, _, _ = spGetUnitHealth(unitID)
 	if paralyzeDamage and paralyzeDamage > 0 then
 		DrawParalyzedUnitGL4(unitID, unitDefID)
 	end
@@ -521,7 +521,7 @@ function widget:GameFrame(n)
 	if TESTMODE == false then
 		if n % 3 == 0 then
 			for unitID, index in pairs(paralyzedDrawUnitVBOTable.instanceIDtoIndex) do
-				local health, maxHealth, paralyzeDamage, capture, build = spGetUnitHealth(unitID)
+				local _, maxHealth, paralyzeDamage, _, _ = spGetUnitHealth(unitID)
 				if paralyzeDamage == 0 or paralyzeDamage == nil then
 					toremove[unitID] = true
 				else

--- a/luaui/Widgets/gfx_ssao.lua
+++ b/luaui/Widgets/gfx_ssao.lua
@@ -253,7 +253,7 @@ local function shaderDefinesChangedCallback(name, value, index, oldvalue)
 	end
 end
 
-local vsx, vsy = spGetViewGeometry()
+local vsx, _ = spGetViewGeometry()
 
 local shaderDefinedSliders = {
 	windowtitle = "SSAO Defines",

--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -3224,7 +3224,7 @@ function DrawCamera(posY, active)
 end
 
 function colourNames(teamID, returnRgb)
-	local nameColourR, nameColourG, nameColourB, nameColourA = sp.GetTeamColor(teamID)
+	local nameColourR, nameColourG, nameColourB, _ = sp.GetTeamColor(teamID)
 	if (not mySpecStatus) and anonymousMode ~= "disabled" and teamID ~= myTeamID then
 		nameColourR, nameColourG, nameColourB = anonymousTeamColor[1], anonymousTeamColor[2], anonymousTeamColor[3]
 	end
@@ -4035,7 +4035,7 @@ function widget:MousePress(x, y, button)
 	end
 
 	if button == 1 then
-		local alt, ctrl, meta, shift = Spring.GetModKeyState()
+		local alt, ctrl, _, _ = Spring.GetModKeyState()
 		sliderPosition = nil
 		shareAmount = 0
 

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -230,7 +230,7 @@ for udid, ud in pairs(UnitDefs) do
 	end
 end
 
-local chunk, err = loadfile("LuaUI/config/AttackRangeConfig2.lua")
+local chunk, _err = loadfile("LuaUI/config/AttackRangeConfig2.lua")
 if chunk then
 	local tmp = {}
 	setfenv(chunk, tmp)
@@ -713,7 +713,7 @@ local function AddSelectedUnit(unitID, mouseover, newRange)
 		end
 	end
 
-	local x, y, z, mpx, mpy, mpz, apx, apy, apz = spGetUnitPosition(unitID, true, true)
+	local x, y, z, mpx, mpy, mpz, _, _, _ = spGetUnitPosition(unitID, true, true)
 
 	--for weaponNum = 1, #weapons do
 	local addedRings = 0
@@ -766,7 +766,7 @@ local function AddSelectedUnit(unitID, mouseover, newRange)
 			-- This is quite important to pass in as posscale.y!
 			-- Need to cache weaponID of the respective weapon for this to work
 			-- also assumes that weapons are centered onto drawpos
-			local wpx, wpy, wpz, wdx, wdy, wdz = spGetUnitWeaponVectors(unitID, weaponID)
+			local _, wpy, _, _, _, _ = spGetUnitWeaponVectors(unitID, weaponID)
 			--spEcho("unitID", unitID,"weaponID", weaponID, "y", y, "mpy",  mpy,"wpy", wpy)
 
 			-- Now this is a truly terrible hack, we cache each unitDefID's max weapon turret height at position 18 in the table
@@ -1191,7 +1191,7 @@ function widget:Update(dt)
 	end
 
 	if gameFrame % 3 == 2 then
-		local cmdIndex, cmdID, cmdType, cmdName = GetActiveCommand()
+		local _, cmdID, _, _ = GetActiveCommand()
 		if shift_only then
 			if shifted then
 				toggleShowSelectedRanges(true)

--- a/luaui/Widgets/gui_awards.lua
+++ b/luaui/Widgets/gui_awards.lua
@@ -58,7 +58,7 @@ local function colourNames(teamID)
 	if teamID < 0 then
 		return ""
 	end
-	local nameColourR, nameColourG, nameColourB, nameColourA = Spring.GetTeamColor(teamID)
+	local nameColourR, nameColourG, nameColourB, _ = Spring.GetTeamColor(teamID)
 	return BAR.Utilities.Color.ToString(nameColourR, nameColourG, nameColourB)
 end
 

--- a/luaui/Widgets/gui_buildbar.lua
+++ b/luaui/Widgets/gui_buildbar.lua
@@ -886,7 +886,7 @@ function widget:Update(dt)
 				unitDefID = unitBuildDefID
 				-- Progress will be drawn separately every frame
 			elseif unfinished_facs[facInfo.unitID] then
-				local isBeingBuilt, progress = GetUnitIsBeingBuilt(facInfo.unitID)
+				local isBeingBuilt, _ = GetUnitIsBeingBuilt(facInfo.unitID)
 				-- Keep showing factory icon when it's being built
 				-- Progress for unfinished factory will be drawn separately
 				if not isBeingBuilt then

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -1569,7 +1569,7 @@ function widget:DrawScreen()
 						local uDefID = -cmd.id
 						WG.buildmenu.hoverID = uDefID
 						gl.Color(1, 1, 1, 1)
-						local alt, ctrl, meta, shift = Spring.GetModKeyState()
+						local _, _, meta, _ = Spring.GetModKeyState()
 						if WG.tooltip and not meta then
 							-- when meta: unitstats does the tooltip
 							local text

--- a/luaui/Widgets/gui_cache_icons.lua
+++ b/luaui/Widgets/gui_cache_icons.lua
@@ -16,7 +16,7 @@ end
 local spGetGameFrame = Spring.GetGameFrame
 
 local iconTypes = VFS.Include("gamedata/icontypes.lua")
-local vsx, vsy = Spring.GetViewGeometry()
+local vsx, _ = Spring.GetViewGeometry()
 local delayedCacheUnitIcons
 local delayedCacheUnitIconsTimer = 0
 local cachedUnitIcons = false

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2858,7 +2858,7 @@ drawTextInput = function()
 			glCallList(textInputDlist)
 			drawChatInputCursor()
 			-- button hover
-			local x, y, b = spGetMouseState()
+			local x, y, _ = spGetMouseState()
 			if state.hasActiveCommand() then
 				return
 			end

--- a/luaui/Widgets/gui_clearmapmarks.lua
+++ b/luaui/Widgets/gui_clearmapmarks.lua
@@ -72,7 +72,7 @@ end
 
 local function updatePosition(force)
 	if WG.advplayerlist_api ~= nil then
-		local vsx, vsy = Spring.GetViewGeometry()
+		local vsx, _ = Spring.GetViewGeometry()
 		local margin = WG.FlowUI.elementPadding
 		xPos = vsx - margin
 		local prevPos = advplayerlistPos
@@ -154,7 +154,7 @@ function widget:MouseRelease(mx, my, mb)
 		if Script.LuaUI("ClearMapMarks") then
 			Script.LuaUI.ClearMapMarks()
 		end
-		local alt, ctrl, meta, shift = Spring.GetModKeyState()
+		local _, ctrl, _, _ = Spring.GetModKeyState()
 		if ctrl then
 			continuouslyClean = not continuouslyClean
 			WG.clearmapmarks.continuous = continuouslyClean

--- a/luaui/Widgets/gui_defenserange_gl4.lua
+++ b/luaui/Widgets/gui_defenserange_gl4.lua
@@ -658,7 +658,7 @@ local function UnitDetected(unitID, unitDefID, unitTeam, noUpload)
 
 	--local weapons = unitWeapons[unitDefID]
 	local alliedUnit = (Spring.GetUnitAllyTeam(unitID) == myAllyTeam)
-	local x, y, z, mpx, mpy, mpz, apx, apy, apz = spGetUnitPosition(unitID, true, true)
+	local x, _, z, _, _, _, _, _, _ = spGetUnitPosition(unitID, true, true)
 
 	--for weaponNum = 1, #weapons do
 	local addedrings = 0
@@ -673,8 +673,8 @@ local function UnitDetected(unitID, unitDefID, unitTeam, noUpload)
 			local weaponID = i
 			local ringParams = unitDefRings[unitDefID].rings[i]
 			if ringParams then
-				local x, y, z, mpx, mpy, mpz, apx, apy, apz = spGetUnitPosition(unitID, true, true)
-				local wpx, wpy, wpz, wdx, wdy, wdz = Spring.GetUnitWeaponVectors(unitID, weaponID)
+				local _, y, _, mpx, mpy, mpz, _, _, _ = spGetUnitPosition(unitID, true, true)
+				local _, wpy, _, _, _, _ = Spring.GetUnitWeaponVectors(unitID, weaponID)
 				--spEcho("Defranges: unitID", unitID,x,y,z,"weaponID", weaponID, "y", y, "mpy",  mpy,"wpy", wpy)
 
 				-- Now this is a truly terrible hack, we cache each unitDefID's max weapon turret height at position 18 in the table
@@ -828,7 +828,7 @@ function widget:PlayerChanged(playerID)
 	--spEcho("GetMyTeamID", GetMyTeamID)
 	]]
 	--
-	local nowspec, nowfullview = spGetSpectatingState()
+	local nowspec, _ = spGetSpectatingState()
 	local nowmyAllyTeam = Spring.GetLocalAllyTeamID()
 	-- When we start, check if there are >2 allyteams
 	local reinit = false
@@ -978,7 +978,7 @@ function widget:Update(dt)
 			-- Ergo we should rather gate addition on buttonConfig in visibleUnitCreated
 			-- instead of during the draw pass
 
-			local mx, my, lp, mp, rp, offscreen = Spring.GetMouseState()
+			local mx, my, _, _, _, _ = Spring.GetMouseState()
 			local _, coords = Spring.TraceScreenRay(mx, my, true)
 			--spEcho(cmdID, "Attempting to draw rings at")
 			--spEcho(mx, my, coords[1], coords[2], coords[3])

--- a/luaui/Widgets/gui_factionpicker.lua
+++ b/luaui/Widgets/gui_factionpicker.lua
@@ -168,7 +168,7 @@ local function drawFactionpicker()
 			local text = BAR.I18N("ui.factionPicker.factions." .. factions[i].faction)
 			local tooltip = ""
 			local maxWidth = WG.tooltip.getFontsize() * 80
-			local textLines, numLines = font2:WrapText(text, maxWidth)
+			local textLines, _ = font2:WrapText(text, maxWidth)
 			tooltip = tooltip .. string.gsub(textLines, "[\n]", "\n") .. "\n"
 			WG.tooltip.AddTooltip(
 				"factionpicker_" .. i,

--- a/luaui/Widgets/gui_flanking_icons.lua
+++ b/luaui/Widgets/gui_flanking_icons.lua
@@ -72,7 +72,7 @@ local function AddPrimitiveAtUnit(unitID, gameframe, noupload) -- since the icon
 	gameframe = gameframe or spGetGameFrame()
 
 	local radius = spGetUnitRadius(unitID) * 3 or 64
-	local mode, modilityAdd, minDamage, maxDamage, dirX, dirY, dirZ, bonusnumber = spGetUnitFlanking(unitID)
+	local _, _, _, _, dirX, _, dirZ, _ = spGetUnitFlanking(unitID)
 
 	local flankingangle = 0
 	if dirX then

--- a/luaui/Widgets/gui_gameinfo.lua
+++ b/luaui/Widgets/gui_gameinfo.lua
@@ -517,7 +517,7 @@ function widget:DrawScreen()
 		end
 		showOnceMore = false
 
-		local x, y, pressed = Spring.GetMouseState()
+		local x, y, _ = Spring.GetMouseState()
 		if
 			math_isInRect(x, y, screenX, screenY - screenHeight, screenX + screenWidth, screenY)
 			or math_isInRect(x, y, titleRect[1], titleRect[2], titleRect[3], titleRect[4])

--- a/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
+++ b/luaui/Widgets/gui_ground_ao_plates_features_gl4.lua
@@ -278,7 +278,7 @@ function givefeaturesCmd(_, line)
 		end
 	end
 	if #matches > 0 then
-		local mx, my, mb = Spring.GetMouseState()
+		local mx, my, _ = Spring.GetMouseState()
 		local _, coords = Spring.TraceScreenRay(mx, my, true)
 		local maxx = math.ceil(math.sqrt(#matches))
 		local size = 80

--- a/luaui/Widgets/gui_healthbars_gl4.lua
+++ b/luaui/Widgets/gui_healthbars_gl4.lua
@@ -1262,7 +1262,7 @@ function widget:GameFrame(n)
 	-- check EMP'd units
 	if (n + 1) % 3 == 0 then
 		for unitID, oldempvalue in pairs(unitEmpDamagedWatch) do
-			local health, maxHealth, newparalyzeDamage, capture, build = spGetUnitHealth(unitID)
+			local _, maxHealth, newparalyzeDamage, _, _ = spGetUnitHealth(unitID)
 			if newparalyzeDamage and oldempvalue ~= newparalyzeDamage then
 				if newparalyzeDamage == 0 then
 					unitEmpDamagedWatch[unitID] = nil
@@ -1280,7 +1280,7 @@ function widget:GameFrame(n)
 	if (n + 2) % 3 == 0 then
 		for unitID, paralyzetime in pairs(unitParalyzedWatch) do
 			if Spring.GetUnitIsStunned(unitID) then
-				local health, maxHealth, paralyzeDamage, capture, build = spGetUnitHealth(unitID)
+				local _, maxHealth, paralyzeDamage, _, _ = spGetUnitHealth(unitID)
 				--uniformcache[1] = math.floor((paralyzeDamage - maxHealth)) / (maxHealth * empDecline))
 				if paralyzeDamage then
 					-- this returns something like 1.20 which somehow turns into seconds somewhere unsearchable, currently wrong display

--- a/luaui/Widgets/gui_idle_builders.lua
+++ b/luaui/Widgets/gui_idle_builders.lua
@@ -535,7 +535,7 @@ end
 
 local function checkUnitGroupsPos(isViewresize)
 	if WG.unitgroups then
-		local px, py, sx, sy = WG.unitgroups.getPosition()
+		local _, py, sx, _ = WG.unitgroups.getPosition()
 		local oldPosX, oldPosY = posX, posY
 		posY = py / vsy
 		posX = (sx + widgetSpaceMargin) / vsx

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -2332,7 +2332,7 @@ local function drawEngineTooltip()
 		local fontSize = (height * vsy * 0.11) * (0.95 - ((1 - ui_scale) * 0.5))
 		if showEngineTooltip then
 			-- display default plaintext engine tooltip
-			local text, numLines = font:WrapText(currentTooltip, contentWidth * (loadedFontSize / fontSize))
+			local text, _ = font:WrapText(currentTooltip, contentWidth * (loadedFontSize / fontSize))
 			font:Begin(true)
 			font:SetTextColor(1, 1, 1, 1)
 			font:SetOutlineColor(0.1, 0.1, 0.1, 1)
@@ -2598,7 +2598,7 @@ local function LeftMouseButton(unitDefID, unitTable)
 end
 
 local function MiddleMouseButton(unitDefID, unitTable)
-	local alt, ctrl, meta, shift = spGetModKeyState()
+	local _, ctrl, _, _ = spGetModKeyState()
 	if ctrl then
 		-- center the view on the entire selection
 		Spring.SendCommands(viewSelectionCmd)
@@ -2614,7 +2614,7 @@ local function MiddleMouseButton(unitDefID, unitTable)
 end
 
 local function RightMouseButton(unitDefID, unitTable)
-	local alt, ctrl, meta, shift = spGetModKeyState()
+	local _, ctrl, _, _ = spGetModKeyState()
 
 	-- remove selected units of icon type
 	-- Clear and reuse map table instead of creating new one
@@ -2999,7 +2999,7 @@ function widget:DrawScreen()
 				--local cells = cellHovered and { [cellHovered] = selectionCells[cellHovered] } or selectionCells
 				-- description
 				if cellHovered then
-					local text, numLines = font:WrapText(
+					local text, _ = font:WrapText(
 						unitDefInfo[selectionCells[cellHovered]].description,
 						(backgroundRect[3] - backgroundRect[1]) * (loadedFontSize / 16)
 					)

--- a/luaui/Widgets/gui_keybind_info.lua
+++ b/luaui/Widgets/gui_keybind_info.lua
@@ -636,7 +636,7 @@ function widget:DrawScreen()
 		end
 		showOnceMore = false
 
-		local x, y, pressed = Spring.GetMouseState()
+		local x, y, _ = Spring.GetMouseState()
 		if math_isInRect(x, y, screenX, screenY - screenHeight, screenX + screenWidth, screenY) then
 			Spring.SetMouseCursor("cursornormal")
 		end

--- a/luaui/Widgets/gui_messages.lua
+++ b/luaui/Widgets/gui_messages.lua
@@ -67,7 +67,7 @@ function widget:ViewResize()
 	if buildmenuBottomPosition then
 		posY = 0.21
 		if WG.ordermenu then
-			local oposX, oposY, owidth, oheight = WG.ordermenu.getPosition()
+			local _, oposY, _, _ = WG.ordermenu.getPosition()
 			if oposY > 0.5 then
 				posY = 0.16
 			end

--- a/luaui/Widgets/gui_metalspots.lua
+++ b/luaui/Widgets/gui_metalspots.lua
@@ -486,7 +486,7 @@ local function InitializeSpots(mSpots)
 				spotsCount = spotsCount + 1
 				mySpots[spotsCount] = mySpot
 
-				local ally, enemy, changed = IsSpotOccupied(mySpot)
+				local ally, enemy, _ = IsSpotOccupied(mySpot)
 				local occupied = ally or enemy
 
 				local uvcoords = valueToUVs[value]
@@ -528,7 +528,7 @@ local function UpdateSpotValues() -- This will only get called on playerchanged
 		spot.value = value
 
 		if spot.scale < maxScale and valueNumber > 0.001 and valueNumber < maxValue then
-			local ally, enemy, changed = IsSpotOccupied(spot)
+			local ally, enemy, _ = IsSpotOccupied(spot)
 			local occupied = ally or enemy
 			local uvcoords = valueToUVs[spot.value]
 			if uvcoords then

--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -405,7 +405,7 @@ function widget:ViewResize()
 end
 
 local function detectWater()
-	local _, _, mapMinHeight, mapMaxHeight = Spring.GetGroundExtremes()
+	local _, _, mapMinHeight, _ = Spring.GetGroundExtremes()
 	if mapMinHeight <= -2 then
 		waterDetected = true
 		Spring.SendCommands("water " .. desiredWaterValue)
@@ -1592,7 +1592,7 @@ end
 function widget:CommandNotify(cmdID, cmdParams, cmdOptions)
 	if show then
 		--on window
-		local mx, my, ml = Spring.GetMouseState()
+		local mx, my, _ = Spring.GetMouseState()
 		if math_isInRect(mx, my, windowRect[1], windowRect[2], windowRect[3], windowRect[4]) then
 			return true
 		elseif titleRect and math_isInRect(mx, my, titleRect[1], titleRect[2], titleRect[3], titleRect[4]) then
@@ -10312,7 +10312,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b, a = gl.GetMapRendering("splatTexMults")
+				local r, _, _, _ = gl.GetMapRendering("splatTexMults")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10332,7 +10332,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b, a = gl.GetMapRendering("splatTexMults")
+				local _, g, _, _ = gl.GetMapRendering("splatTexMults")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10352,7 +10352,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b, a = gl.GetMapRendering("splatTexMults")
+				local _, _, b, _ = gl.GetMapRendering("splatTexMults")
 				options[i].value = b
 			end,
 			onchange = function(i, value)
@@ -10376,7 +10376,7 @@ function init()
 				options[i].value = a
 			end,
 			onchange = function(i, value)
-				local r, g, b, a = gl.GetMapRendering("splatTexMults")
+				local r, g, b, _ = gl.GetMapRendering("splatTexMults")
 				Spring.SetMapRenderingParams({ splatTexMults = { r, g, b, value } })
 			end,
 		},
@@ -10393,7 +10393,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b, a = gl.GetMapRendering("splatTexScales")
+				local r, _, _, _ = gl.GetMapRendering("splatTexScales")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10413,7 +10413,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b, a = gl.GetMapRendering("splatTexScales")
+				local _, g, _, _ = gl.GetMapRendering("splatTexScales")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10433,7 +10433,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b, a = gl.GetMapRendering("splatTexScales")
+				local _, _, b, _ = gl.GetMapRendering("splatTexScales")
 				options[i].value = b
 			end,
 			onchange = function(i, value)
@@ -10457,7 +10457,7 @@ function init()
 				options[i].value = a
 			end,
 			onchange = function(i, value)
-				local r, g, b, a = gl.GetMapRendering("splatTexScales")
+				local r, g, b, _ = gl.GetMapRendering("splatTexScales")
 				Spring.SetMapRenderingParams({ splatTexScales = { r, g, b, value } })
 			end,
 		},
@@ -10518,7 +10518,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("ambient")
+				local r, _, _ = gl.GetSun("ambient")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10539,7 +10539,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("ambient")
+				local _, g, _ = gl.GetSun("ambient")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10564,7 +10564,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetSun("ambient")
+				local r, g, _ = gl.GetSun("ambient")
 				Spring.SetSunLighting({ groundAmbientColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10584,7 +10584,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("diffuse")
+				local r, _, _ = gl.GetSun("diffuse")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10605,7 +10605,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("diffuse")
+				local _, g, _ = gl.GetSun("diffuse")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10630,7 +10630,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetSun("diffuse")
+				local r, g, _ = gl.GetSun("diffuse")
 				Spring.SetSunLighting({ groundDiffuseColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10650,7 +10650,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("specular")
+				local r, _, _ = gl.GetSun("specular")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10671,7 +10671,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("specular")
+				local _, g, _ = gl.GetSun("specular")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10696,7 +10696,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetSun("specular")
+				local r, g, _ = gl.GetSun("specular")
 				Spring.SetSunLighting({ groundSpecularColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10716,7 +10716,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("ambient", "unit")
+				local r, _, _ = gl.GetSun("ambient", "unit")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10737,7 +10737,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("ambient", "unit")
+				local _, g, _ = gl.GetSun("ambient", "unit")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10762,7 +10762,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetSun("ambient", "unit")
+				local r, g, _ = gl.GetSun("ambient", "unit")
 				Spring.SetSunLighting({ unitAmbientColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10782,7 +10782,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("diffuse", "unit")
+				local r, _, _ = gl.GetSun("diffuse", "unit")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10803,7 +10803,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("diffuse", "unit")
+				local _, g, _ = gl.GetSun("diffuse", "unit")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10828,7 +10828,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetSun("diffuse", "unit")
+				local r, g, _ = gl.GetSun("diffuse", "unit")
 				Spring.SetSunLighting({ unitDiffuseColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10848,7 +10848,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("specular", "unit")
+				local r, _, _ = gl.GetSun("specular", "unit")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10869,7 +10869,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetSun("specular", "unit")
+				local _, g, _ = gl.GetSun("specular", "unit")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10894,7 +10894,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetSun("specular", "unit")
+				local r, g, _ = gl.GetSun("specular", "unit")
 				Spring.SetSunLighting({ unitSpecularColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10912,7 +10912,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetAtmosphere("sunColor")
+				local r, _, _ = gl.GetAtmosphere("sunColor")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10933,7 +10933,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetAtmosphere("sunColor")
+				local _, g, _ = gl.GetAtmosphere("sunColor")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -10958,7 +10958,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetAtmosphere("sunColor")
+				local r, g, _ = gl.GetAtmosphere("sunColor")
 				Spring.SetAtmosphere({ sunColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -10978,7 +10978,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetAtmosphere("skyColor")
+				local r, _, _ = gl.GetAtmosphere("skyColor")
 				options[i].value = r
 			end,
 			onchange = function(i, value)
@@ -10999,7 +10999,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local r, g, b = gl.GetAtmosphere("skyColor")
+				local _, g, _ = gl.GetAtmosphere("skyColor")
 				options[i].value = g
 			end,
 			onchange = function(i, value)
@@ -11024,7 +11024,7 @@ function init()
 				options[i].value = b
 			end,
 			onchange = function(i, value)
-				local r, g, b = gl.GetAtmosphere("skyColor")
+				local r, g, _ = gl.GetAtmosphere("skyColor")
 				Spring.SetAtmosphere({ skyColor = { r, g, value } })
 				Spring.SendCommands("luarules updatesun")
 			end,
@@ -11083,7 +11083,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local x, y, z, angle = gl.GetAtmosphere("skyAxisAngle")
+				local x, _, _, _ = gl.GetAtmosphere("skyAxisAngle")
 				options[i].value = x
 			end,
 			onchange = function(i, value)
@@ -11104,7 +11104,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local x, y, z, angle = gl.GetAtmosphere("skyAxisAngle")
+				local _, y, _, _ = gl.GetAtmosphere("skyAxisAngle")
 				options[i].value = y
 			end,
 			onchange = function(i, value)
@@ -11125,7 +11125,7 @@ function init()
 			value = 0,
 			description = "",
 			onload = function(i)
-				local x, y, z, angle = gl.GetAtmosphere("skyAxisAngle")
+				local _, _, z, _ = gl.GetAtmosphere("skyAxisAngle")
 				options[i].value = z
 			end,
 			onchange = function(i, value)
@@ -12359,7 +12359,7 @@ function init()
 			local desc = data.desc or ""
 			if desc ~= "" and WG.tooltip then
 				local maxWidth = WG.tooltip.getFontsize() * 90
-				local textLines, numLines = font:WrapText(desc, maxWidth)
+				local textLines, _ = font:WrapText(desc, maxWidth)
 				desc = string.gsub(textLines, "[\n]", "\n")
 			end
 			if data.author and data.author ~= "" then

--- a/luaui/Widgets/gui_pregameui.lua
+++ b/luaui/Widgets/gui_pregameui.lua
@@ -215,7 +215,7 @@ end
 
 local ihavejoined = false
 function widget:GameSetup(state, ready, playerStates)
-	local spec, fullview = Spring.GetSpectatingState()
+	local spec, _ = Spring.GetSpectatingState()
 	-- sends a "I arrived" message
 	-- NOTE: Spring.GetGameRulesParam("player_" .. Spring.GetMyPlayerID() .. "_joined") seems to be always nil!
 	if

--- a/luaui/Widgets/gui_pregameui_draft.lua
+++ b/luaui/Widgets/gui_pregameui_draft.lua
@@ -971,7 +971,7 @@ end
 
 local ihavejoined = false
 function widget:GameSetup(state, ready, playerStates)
-	local spec, fullview = Spring.GetSpectatingState()
+	local spec, _ = Spring.GetSpectatingState()
 	-- sends a "I arrived" message
 	-- NOTE: Spring.GetGameRulesParam("player_" .. Spring.GetMyPlayerID() .. "_joined") seems to be always nil!
 	if

--- a/luaui/Widgets/gui_scavenger_info.lua
+++ b/luaui/Widgets/gui_scavenger_info.lua
@@ -237,7 +237,7 @@ function widget:DrawScreen()
 		end
 		showOnceMore = false
 
-		local x, y, pressed = Spring.GetMouseState()
+		local x, y, _ = Spring.GetMouseState()
 		if
 			math_isInRect(x, y, screenX, screenY - screenHeight, screenX + screenWidth, screenY)
 			or math_isInRect(x, y, titleRect[1], titleRect[2], titleRect[3], titleRect[4])

--- a/luaui/Widgets/gui_spectatingstats.lua
+++ b/luaui/Widgets/gui_spectatingstats.lua
@@ -95,7 +95,7 @@ local function GetAllyTeamStats(allyTeamID)
 	local builders = 0
 	local buildspeed = 0
 	if not allyTeamName[allyTeamID] then
-		local _, playerID, _, isAiTeam = Spring.GetTeamInfo(teamlist[1], false)
+		local _, playerID, _, _ = Spring.GetTeamInfo(teamlist[1], false)
 		local name = (WG.playernames and WG.playernames.getPlayername) and WG.playernames.getPlayername(playerID)
 			or Spring.GetPlayerInfo(playerID, false)
 		allyTeamName[allyTeamID] = ColorString(Spring.GetTeamColor(teamlist[1])) .. name

--- a/luaui/Widgets/gui_spectator_hud.lua
+++ b/luaui/Widgets/gui_spectator_hud.lua
@@ -449,7 +449,7 @@ local function buildUnitCache()
 		update = function(unitID, value)
 			local reclaimMetal = 0
 			local reclaimEnergy = 0
-			local metalMake, metalUse, energyMake, energyUse = Spring.GetUnitResources(unitID)
+			local metalMake, _, energyMake, _ = Spring.GetUnitResources(unitID)
 			if metalMake then
 				if value[1] then
 					reclaimMetal = metalMake - value[1]
@@ -469,7 +469,7 @@ local function buildUnitCache()
 	unitCache.energyConverters = {
 		add = nil,
 		update = function(unitID, value)
-			local metalMake, metalUse, energyMake, energyUse = Spring.GetUnitResources(unitID)
+			local metalMake, _, _, _ = Spring.GetUnitResources(unitID)
 			if metalMake then
 				return metalMake
 			end

--- a/luaui/Widgets/gui_unitgroups.lua
+++ b/luaui/Widgets/gui_unitgroups.lua
@@ -352,7 +352,7 @@ local function drawContent()
 
 	if numGroups > 0 then
 		local hoveredGroup = -1
-		local x, y, b, b2, b3 = spGetMouseState()
+		local x, y, b, _, _ = spGetMouseState()
 		if groupButtons then
 			for i, v in pairs(groupButtons) do
 				if

--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -109,7 +109,7 @@ local function StartVote(name) -- when called without params its just to refresh
 		end
 
 		local color1, color2, w
-		local x, y, b = spGetMouseState()
+		local x, y, _ = spGetMouseState()
 
 		local width = mathFloor((vsy / 6) * ui_scale) * 2 -- *2 so it ensures number can be divided cleanly by 2
 		local height = mathFloor((vsy / 23) * ui_scale) * 2 -- *2 so it ensures number can be divided cleanly by 2
@@ -626,7 +626,7 @@ function widget:GameFrame(n)
 end
 
 local function colourNames(teamID)
-	local nameColourR, nameColourG, nameColourB, nameColourA = Spring.GetTeamColor(teamID)
+	local nameColourR, nameColourG, nameColourB, _ = Spring.GetTeamColor(teamID)
 	--if (not mySpecStatus) and anonymousMode ~= "disabled" and teamID ~= myTeamID then
 	--	nameColourR, nameColourG, nameColourB = anonymousTeamColor[1], anonymousTeamColor[2], anonymousTeamColor[3]
 	--end
@@ -695,7 +695,7 @@ function widget:AddConsoleLine(lines, priority)
 					if isResignVote or isResignVoteMyTeam then
 						local players = Spring.GetPlayerList()
 						for _, pID in ipairs(players) do
-							local name, _, spec, teamID, allyTeamID = Spring.GetPlayerInfo(pID, false)
+							local name, _, _, teamID, _ = Spring.GetPlayerInfo(pID, false)
 							name = (
 								(WG.playernames and WG.playernames.getPlayername) and WG.playernames.getPlayername(pID)
 							) or name
@@ -846,7 +846,7 @@ function widget:DrawScreen()
 	if voteDlist then
 		if not WG.topbar or not WG.topbar.showingQuit() then
 			if eligibleToVote then
-				local x, y, b = spGetMouseState()
+				local x, y, _ = spGetMouseState()
 				if hovered then
 					StartVote() -- refresh
 				elseif

--- a/luaui/Widgets/logo_adjuster.lua
+++ b/luaui/Widgets/logo_adjuster.lua
@@ -99,7 +99,7 @@ function widget:Update(dt)
 		sec = 0
 		local gameFrame = spGetGameFrame()
 		if gameFrame > 0 then
-			local _, gameSpeed, isPaused = Spring.GetGameSpeed()
+			local _, gameSpeed, _ = Spring.GetGameSpeed()
 			local newPaused = false
 			if gameFrame == previousGameFrame or gameSpeed == 0 then -- when host (admin) paused its just gamespeed 0
 				newPaused = true

--- a/luaui/Widgets/stats_damage.lua
+++ b/luaui/Widgets/stats_damage.lua
@@ -40,7 +40,7 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	unitHumanName[unitDefID] = unitDef.translatedHumanName
 end
 
-local chunk, err = loadfile(STATS_FILE)
+local chunk, _err = loadfile(STATS_FILE)
 if chunk then
 	local tmp = {}
 	setfenv(chunk, tmp)

--- a/luaui/Widgets/unit_alt_set_target_type.lua
+++ b/luaui/Widgets/unit_alt_set_target_type.lua
@@ -278,7 +278,7 @@ end
 
 local function handleSelectionLine()
 	local _, cmdID = spGetActiveCommand()
-	local alt, ctrl, meta, shift = spGetModKeyState()
+	local alt, ctrl, meta, _ = spGetModKeyState()
 	local correctCommand = cmdID == CMD_SET_TARGET and alt and not ctrl and not meta
 	if not correctCommand then
 		clear()

--- a/luaui/Widgets/unit_area_reclaim_enemy.lua
+++ b/luaui/Widgets/unit_area_reclaim_enemy.lua
@@ -57,8 +57,8 @@ function widget:CommandNotify(id, params, options)
 
 	local cx, cy, cz, cr = unpack(params)
 
-	local mx, my, mz = spWorldToScreenCoords(cx, cy, cz)
-	local cType, id = spTraceScreenRay(mx, my)
+	local mx, my, _ = spWorldToScreenCoords(cx, cy, cz)
+	local cType, _ = spTraceScreenRay(mx, my)
 
 	if not (cType == "unit" or cType == "ground") then
 		return

--- a/luaui/Widgets/unit_stateprefs.lua
+++ b/luaui/Widgets/unit_stateprefs.lua
@@ -268,7 +268,7 @@ end
 
 function widget:GameFrame(n)
 	if Spring.GetGameState then
-		local finishedLoading, loadedFromSave, locallyPaused, lagging = Spring.GetGameState()
+		local _, loadedFromSave, _, _ = Spring.GetGameState()
 		if loadedFromSave then
 			widgetHandler:RemoveCallIn("GameFrame", self)
 			return

--- a/luaui/Widgets/widget_selector.lua
+++ b/luaui/Widgets/widget_selector.lua
@@ -1229,11 +1229,11 @@ function widget:DrawScreen()
 			local tooltip = ""
 			local maxWidth = WG.tooltip.getFontsize() * 90
 			if d.desc and d.desc ~= "" then
-				local textLines, numLines = font:WrapText(d.desc, maxWidth)
+				local textLines, _ = font:WrapText(d.desc, maxWidth)
 				tooltip = tooltip .. WhiteStr .. string.gsub(textLines, "[\n]", "\n" .. WhiteStr) .. "\n"
 			end
 			if d.author and d.author ~= "" then
-				local textLines, numLines = font:WrapText(d.author, maxWidth)
+				local textLines, _ = font:WrapText(d.author, maxWidth)
 				tooltip = tooltip
 					.. "\255\175\175\175"
 					.. BAR.I18N("ui.widgetselector.author")

--- a/luaui/configs/DistortionGL4WeaponsConfig.lua
+++ b/luaui/configs/DistortionGL4WeaponsConfig.lua
@@ -3226,7 +3226,7 @@ for name, distortionList in pairs(explosionDistortionsNames) do
 		explosionDistortions[WeaponDefNames[name].id] = distortionList
 	end
 	-- loop through each distortion in the list and add them to the scavenger variant
-	local scavName, paramsScav = applyScavVariants(name, distortionList)
+	local scavName, _ = applyScavVariants(name, distortionList)
 	if scavName and WeaponDefNames[scavName] then
 		explosionDistortions[WeaponDefNames[scavName].id] = {}
 		for _, distortion in ipairs(distortionList) do


### PR DESCRIPTION
### Work done

Assigns `_` to the 296 multiple-return values that nothing reads, across 164 declarations in 80 files.

`local x, y, z = Spring.GetUnitPosition(unitID)` where nothing reads `z` becomes `local x, y, _ = ...`.

Replaces #9032, which deleted those names instead of assigning them.

`CONTRIBUTING.md` gains the convention this applies.

PR 3b of 8 in my current dead code elimination effort.

#### Notable exceptions

- Five sites read `_err` rather than `_`, because the value being dropped is an error message the caller ignores.
- `gui_attackrange_gl4.lua` keeps `x` and `z` at line 716, read by the `if false then` block at line 787 that luacheck does not count as a use.
- Three declarations bind nothing but unused names, making them dead statements rather than incomplete ones, and are left for a change that can delete them.

### Test steps
- [ ] Play a game with the default widget set and confirm the UI behaves as on master.
- [ ] Exercise the touched widgets in particular: build menu, chat, player list, options, attack and defense range rings, health bars, idle builders.

Nothing should change; every renamed value was already being discarded.

### AI / LLM usage statement

Claude Opus 5 authored 90% of code, 100% of commit message, 90% of PR description. It ran the analysis and performed the edits. I played a skirmish and noticed nothing amiss, and reviewed the changes.