### PR TITLE
Mission API: Add objective failed trigger and failure state

### DIFF
--- a/luarules/mission_api/actions/objectives/fail_objective.lua
+++ b/luarules/mission_api/actions/objectives/fail_objective.lua
@@ -1,0 +1,15 @@
+local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+
+local function failObjective(objectiveID)
+	GG['MissionAPI'].Modules.Objectives.FailObjective(objectiveID)
+end
+
+return {
+	{
+		type = 'FailObjective',
+		parameters = {
+			{ name = 'objectiveID', required = true, type = ParameterTypes.ObjectiveID },
+		},
+		actionFunction = failObjective,
+	}
+}

--- a/luarules/mission_api/objectives.lua
+++ b/luarules/mission_api/objectives.lua
@@ -51,6 +51,7 @@ local function echoObjectiveUpdate(objectiveID, objective)
 			.. tostring(objective.amount)
 			.. " | completed: "
 			.. tostring(objective.completed)
+			.. (objective.failed and " (failed)" or "")
 	)
 end
 
@@ -61,7 +62,19 @@ local function activateEventTrigger(triggerID)
 	GG["MissionAPI"].ActivateTrigger(GG["MissionAPI"].Triggers[triggerID])
 end
 
---- Run the stage's exit routes for an objective that has just completed.
+local function failObjective(objectiveID)
+	local objective = GG["MissionAPI"].Objectives[objectiveID]
+	if objective.completed then
+		return
+	end
+
+	objective.completed = true
+	objective.failed = true
+	runExitRoutes(objective, objective.onFailed)
+	echoObjectiveUpdate(objectiveID, objective)
+end
+
+--- Run the stage's exit routes for an objective that has completed or failed.
 --- This runs in a fixed order: the objective's event trigger, then nextStage.
 local function runExitRoutes(objective, eventTriggerID)
 	local stageChangesBefore = stageChanges
@@ -135,7 +148,8 @@ end
 return {
 	ChangeStage = changeStage,
 	TryAdvanceStage = tryAdvanceStage,
-	OnObjectiveCompleted = onObjectiveCompleted,
+	FailObjective = failObjective,
 	UpdateObjectiveProgress = updateObjectiveProgress,
+	OnObjectiveCompleted = onObjectiveCompleted,
 	EchoObjectiveUpdate = echoObjectiveUpdate,
 }

--- a/luarules/mission_api/objectives.lua
+++ b/luarules/mission_api/objectives.lua
@@ -62,6 +62,16 @@ local function activateEventTrigger(triggerID)
 	GG["MissionAPI"].ActivateTrigger(GG["MissionAPI"].Triggers[triggerID])
 end
 
+--- Run the stage's exit routes for an objective that has completed or failed.
+--- This runs in a fixed order: the objective's event trigger, then nextStage.
+local function runExitRoutes(objective, eventTriggerID)
+	local stageChangesBefore = stageChanges
+	activateEventTrigger(eventTriggerID)
+	if stageChanges == stageChangesBefore then
+		tryAdvanceStage(objective)
+	end
+end
+
 local function failObjective(objectiveID)
 	local objective = GG["MissionAPI"].Objectives[objectiveID]
 	if objective.completed then
@@ -72,16 +82,6 @@ local function failObjective(objectiveID)
 	objective.failed = true
 	runExitRoutes(objective, objective.onFailed)
 	echoObjectiveUpdate(objectiveID, objective)
-end
-
---- Run the stage's exit routes for an objective that has completed or failed.
---- This runs in a fixed order: the objective's event trigger, then nextStage.
-local function runExitRoutes(objective, eventTriggerID)
-	local stageChangesBefore = stageChanges
-	activateEventTrigger(eventTriggerID)
-	if stageChanges == stageChangesBefore then
-		tryAdvanceStage(objective)
-	end
 end
 
 local function onObjectiveCompleted(objective)

--- a/luarules/mission_api/objectives_schema.lua
+++ b/luarules/mission_api/objectives_schema.lua
@@ -7,6 +7,7 @@ local parameters = {
 	nextStage = Types.StageID,
 	coop = Types.Boolean,
 	onCompleted = Types.TriggerID,
+	onFailed = Types.TriggerID,
 }
 
 return {

--- a/luarules/mission_api/validation.lua
+++ b/luarules/mission_api/validation.lua
@@ -795,6 +795,7 @@ end
 -- Objective fields that each name an Event trigger the objective raises.
 local objectiveEventFields = {
 	"onCompleted",
+	"onFailed",
 }
 
 -- The TriggerID validator has already reported a trigger that does not exist.

--- a/singleplayer/mission-api-tests/stages_and_objectives_test.lua
+++ b/singleplayer/mission-api-tests/stages_and_objectives_test.lua
@@ -10,7 +10,7 @@ local stages = {
 		objectives = { 'buildBots' }
 	},
 	thirdStage = {
-		objectives = { 'buildBots', 'destroyBots' }
+		objectives = { 'buildBots', 'destroyBots', 'noLosses' }
 	}
 }
 
@@ -51,6 +51,12 @@ local objectives = {
 			},
 		},
 	},
+
+	-- Has no trigger of its own; an action fails it.
+	noLosses = {
+		textKey = "lose_no_units",
+		onFailed = 'reportFailure',
+	},
 }
 
 local triggers = {
@@ -72,6 +78,23 @@ local triggers = {
 	botsBuilt = {
 		type = triggerTypes.Event,
 		actions = { 'changeToThirdStage', 'spawnBotDestroyer' },
+	},
+
+	failOnLoss = {
+		type = triggerTypes.TotalUnitsLost,
+		settings = {
+			stages = { 'thirdStage' },
+		},
+		parameters = {
+			teamID = 0,
+			quantity = 1,
+		},
+		actions = { 'failNoLosses' },
+	},
+
+	reportFailure = {
+		type = triggerTypes.Event,
+		actions = { 'announceLoss' },
 	},
 }
 
@@ -99,6 +122,20 @@ local actions = {
 			unitLoadout = {
 				{ unitDefName = 'armllt', x = 1800, z = 2200, team = 1, quantity = 2 },
 			},
+		},
+	},
+
+	failNoLosses = {
+		type = actionTypes.FailObjective,
+		parameters = {
+			objectiveID = 'noLosses',
+		},
+	},
+
+	announceLoss = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "A unit was lost. Objective failed.",
 		},
 	},
 }

--- a/spec/builders/mission_api_builder.lua
+++ b/spec/builders/mission_api_builder.lua
@@ -38,6 +38,7 @@ local PARAMETER_TYPES_PATH = "luarules/mission_api/parameter_types.lua"
 ---@field processSoundQueue table
 ---@field changeStage table
 ---@field tryAdvanceStage table
+---@field failObjective table
 ---@field onObjectiveCompleted table
 ---@field updateObjectiveProgress table
 ---@field echoObjectiveUpdate table
@@ -308,6 +309,7 @@ function MB:Build()
 	local processSoundQueueCalls = {}
 	local changeStageCalls = {}
 	local tryAdvanceCalls = {}
+	local failObjectiveCalls = {}
 	local onObjectiveCompletedCalls = {}
 	local updateProgressCalls = {}
 	local echoCalls = {}
@@ -384,6 +386,9 @@ function MB:Build()
 		end,
 		TryAdvanceStage = function(objective)
 			tryAdvanceCalls[#tryAdvanceCalls + 1] = { objective = objective }
+		end,
+		FailObjective = function(objectiveID)
+			failObjectiveCalls[#failObjectiveCalls + 1] = { objectiveID = objectiveID }
 		end,
 		OnObjectiveCompleted = function(objective)
 			onObjectiveCompletedCalls[#onObjectiveCompletedCalls + 1] = { objective = objective }
@@ -466,6 +471,7 @@ function MB:Build()
 			processSoundQueue = processSoundQueueCalls,
 			changeStage = changeStageCalls,
 			tryAdvanceStage = tryAdvanceCalls,
+			failObjective = failObjectiveCalls,
 			onObjectiveCompleted = onObjectiveCompletedCalls,
 			updateObjectiveProgress = updateProgressCalls,
 			echoObjectiveUpdate = echoCalls,
@@ -481,6 +487,7 @@ function MB:Build()
 				processSoundQueueCalls,
 				changeStageCalls,
 				tryAdvanceCalls,
+				failObjectiveCalls,
 				onObjectiveCompletedCalls,
 				updateProgressCalls,
 				echoCalls,

--- a/spec/mission_api/actions/objectives/fail_objective_spec.lua
+++ b/spec/mission_api/actions/objectives/fail_objective_spec.lua
@@ -1,0 +1,28 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+Builders.MissionApi.new():Install()
+
+local actions = VFS.Include("luarules/mission_api/actions/objectives/fail_objective.lua")
+local action = actions[1]
+local summarizeSchema = require("mission_api.schema_spec_helper")
+
+describe("mission_api.actions.fail_objective", function()
+	local missionApi
+
+	before_each(function()
+		missionApi = Builders.MissionApi.new():WithObjective("obj1", { active = true, completed = false }):Install()
+	end)
+
+	it("declares its type and parameters", function()
+		assert.are.same({ type = "FailObjective", objectiveID = "ObjectiveID!" }, summarizeSchema(action))
+	end)
+
+	it("delegates to FailObjective", function()
+		action.actionFunction("obj1")
+
+		assert.are.equal(1, #missionApi.calls.failObjective)
+		assert.are.equal("obj1", missionApi.calls.failObjective[1].objectiveID)
+	end)
+end)

--- a/spec/mission_api/objectives_spec.lua
+++ b/spec/mission_api/objectives_spec.lua
@@ -285,6 +285,109 @@ describe("mission_api.objectives", function()
 		end)
 	end)
 
+	describe("FailObjective", function()
+		it("completes the objective and marks it failed", function()
+			install(mission():WithObjective("obj1", { completed = false }))
+
+			Objectives.FailObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.completed)
+			assert.is_true(missionApi.Objectives.obj1.failed)
+		end)
+
+		it("is a no-op on a completed objective", function()
+			install(mission():WithObjective("obj1", { completed = true }))
+
+			Objectives.FailObjective("obj1")
+
+			assert.is_nil(missionApi.Objectives.obj1.failed)
+		end)
+
+		it("does not mark a success as failed", function()
+			install(mission():WithObjective("obj1", { completed = false }))
+			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 1 }
+
+			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
+
+			assert.is_true(missionApi.Objectives.obj1.completed)
+			assert.is_nil(missionApi.Objectives.obj1.failed)
+		end)
+
+		it("activates the trigger the objective names in onFailed", function()
+			install(
+				mission()
+					:WithObjective("obj1", { completed = false, onFailed = "failed" })
+					:WithTrigger("failed", { type = T.Event })
+			)
+
+			Objectives.FailObjective("obj1")
+
+			assert.are.equal(1, #missionApi.calls.activateTrigger)
+			assert.are.equal(missionApi.Triggers.failed, missionApi.calls.activateTrigger[1].trigger)
+		end)
+
+		it("leaves the trigger named in onCompleted alone", function()
+			install(
+				mission()
+					:WithObjective("obj1", { completed = false, onCompleted = "done" })
+					:WithTrigger("done", { type = T.Event })
+			)
+
+			Objectives.FailObjective("obj1")
+
+			assert.are.equal(0, #missionApi.calls.activateTrigger)
+		end)
+
+		it("activates the trigger while the objective's stage is still current", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "obj1" } })
+					:WithStage("s2")
+					:WithObjective("obj1", { completed = false, nextStage = "s2", onFailed = "failed" })
+					:WithTrigger("failed", { type = T.Event })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.FailObjective("obj1")
+
+			assert.are.equal("s1", missionApi.calls.activateTrigger[1].stageID)
+			assert.are.equal("s2", missionApi.CurrentStageID)
+		end)
+
+		it("advances the stage through the gate, so a failure cannot softlock it", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "obj1" } })
+					:WithStage("s2")
+					:WithObjective("obj1", { completed = false, nextStage = "s2" })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.FailObjective("obj1")
+
+			assert.are.equal("s2", missionApi.CurrentStageID)
+		end)
+
+		it("lets a stage change from the trigger stand instead of running the gate", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "obj1" } })
+					:WithStage("s2")
+					:WithStage("s9")
+					:WithObjective("obj1", { completed = false, nextStage = "s2", onFailed = "failed" })
+					:WithTrigger("failed", { type = T.Event })
+					:WithCurrentStage("s1")
+			)
+			missionApi.ActivateTrigger = function()
+				Objectives.ChangeStage("s9")
+			end
+
+			Objectives.FailObjective("obj1")
+
+			assert.are.equal("s9", missionApi.CurrentStageID)
+		end)
+	end)
+
 	describe("OnObjectiveCompleted", function()
 		it("activates the trigger the objective names in onCompleted", function()
 			install(

--- a/spec/mission_api/validation_spec.lua
+++ b/spec/mission_api/validation_spec.lua
@@ -271,6 +271,20 @@ describe("mission_api.validation", function()
 			)
 		end)
 
+		it("logs an error when onFailed names a trigger that is not an Event", function()
+			GG["MissionAPI"].Triggers = {
+				timer = { type = triggerTypes.TimeElapsed, parameters = { seconds = 1 }, actions = { "ok" } },
+			}
+			validation.ValidateObjectives({
+				withEvent = { textKey = "ok", onFailed = "timer" },
+			})
+			assert.is_true(
+				hasError(
+					"Objective event must name an Event trigger. Objective: withEvent, Field: onFailed, Trigger: timer"
+				)
+			)
+		end)
+
 		it("logs an error for missing textKey", function()
 			validation.ValidateObjectives({ noText = {} })
 			assert.is_true(hasError("Objective missing textKey: noText"))


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Adds the `onFailed` event and `FailObjective` action in the objectives module.

An objective can be completed successfully or unsuccessfully, and failure always completes, so always counts toward advancing its stage. This keeps failures from softlocking a mission.

The `onFailed` event allows mission authors to choose an alternate stage progression based on failure conditions, but the default is to advance to `nextStage` with no regard to success or failure. Implicit mission structure is kept very simple.

The mission script action for failure is delayed until later, kept with the rest of the objective state actions.