### PR TITLE
Mission API: Add objective activate and deactivate actions

### DIFF
--- a/luarules/gadgets/api_missions.lua
+++ b/luarules/gadgets/api_missions.lua
@@ -70,6 +70,8 @@ function gadget:Initialize()
 	GG["MissionAPI"].soundFiles = {}
 	GG["MissionAPI"].soundQueue = {}
 	GG["MissionAPI"].ManagedObjectives = {}
+	GG["MissionAPI"].ObjectiveTriggers = {}
+	GG["MissionAPI"].ObjectiveStages = {}
 	GG["MissionAPI"].Countdowns = {}
 	GG["MissionAPI"].Modules = {}
 	GG["MissionAPI"].Modules.ParameterTypes = VFS.Include("luarules/mission_api/parameter_types.lua")
@@ -98,9 +100,7 @@ function gadget:GamePreload()
 	loadoutModule.SpawnUnitLoadout(GG["MissionAPI"].UnitLoadout)
 	loadoutModule.SpawnFeatureLoadout(GG["MissionAPI"].FeatureLoadout)
 
-	if GG["MissionAPI"].CurrentStageID then
-		Spring.Echo("Stage set to: " .. GG["MissionAPI"].CurrentStageID)
-	end
+	GG["MissionAPI"].Modules.Objectives.ActivateStage(GG["MissionAPI"].CurrentStageID)
 end
 
 function gadget:GameFrame(frameNumber)

--- a/luarules/mission_api/actions/objectives/activate_objective.lua
+++ b/luarules/mission_api/actions/objectives/activate_objective.lua
@@ -1,0 +1,17 @@
+local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+
+local function activateObjective(objectiveID)
+	local objectives = GG['MissionAPI'].Modules.Objectives
+	objectives.ActivateObjective(objectiveID)
+	objectives.EchoObjectiveUpdate(objectiveID, GG['MissionAPI'].Objectives[objectiveID]) -- temp
+end
+
+return {
+	{
+		type = 'ActivateObjective',
+		parameters = {
+			{ name = 'objectiveID', required = true, type = ParameterTypes.ObjectiveID },
+		},
+		actionFunction = activateObjective,
+	}
+}

--- a/luarules/mission_api/objectives.lua
+++ b/luarules/mission_api/objectives.lua
@@ -93,7 +93,7 @@ local function exitStage(stageID, carriedOver)
 
 	for _, objectiveID in ipairs(stage.objectives) do
 		if carriedOver and carriedOver[objectiveID] then
-			-- Nothing to do?
+			-- continue
 		elseif GG["MissionAPI"].Objectives[objectiveID].completed then
 			setObjectiveActive(objectiveID, false)
 		else

--- a/luarules/mission_api/objectives.lua
+++ b/luarules/mission_api/objectives.lua
@@ -4,10 +4,134 @@
 
 local stageChanges = 0
 
-local function changeStage(stageID)
-	stageChanges = stageChanges + 1
+local function activateEventTrigger(triggerID)
+	if not triggerID then
+		return
+	end
+	GG["MissionAPI"].ActivateTrigger(GG["MissionAPI"].Triggers[triggerID])
+end
+
+-- placeholder until UI widget exists
+local function echoObjectiveUpdate(objectiveID, objective)
+	Spring.Echo(
+		"Objective updated: "
+			.. objectiveID
+			.. " | "
+			.. (objective.textKey or "")
+			.. " | progress: "
+			.. tostring(objective.progress)
+			.. " | amount: "
+			.. tostring(objective.amount)
+			.. " | active: "
+			.. tostring(objective.active)
+			.. " | completed: "
+			.. tostring(objective.completed)
+			.. (objective.failed and " (failed)" or "")
+			.. (objective.canceled and " (canceled)" or "")
+	)
+end
+
+local function setObjectiveActive(objectiveID, active)
+	GG["MissionAPI"].Objectives[objectiveID].active = active
+
+	local triggerID = GG["MissionAPI"].ObjectiveTriggers[objectiveID]
+	if triggerID then
+		GG["MissionAPI"].Triggers[triggerID].settings.active = active
+	end
+end
+
+local function activateObjective(objectiveID)
+	local objective = GG["MissionAPI"].Objectives[objectiveID]
+	if objective.active or objective.completed then
+		return
+	end
+
+	local stages = GG["MissionAPI"].ObjectiveStages[objectiveID]
+	if stages and not table.contains(stages, GG["MissionAPI"].CurrentStageID) then
+		return
+	end
+
+	objective.canceled = false
+	setObjectiveActive(objectiveID, true)
+	activateEventTrigger(objective.onActivated)
+end
+
+local function cancelObjective(objectiveID)
+	local objective = GG["MissionAPI"].Objectives[objectiveID]
+	if objective.completed or objective.canceled then
+		return
+	end
+
+	objective.canceled = true
+	setObjectiveActive(objectiveID, false)
+	activateEventTrigger(objective.onCanceled)
+	echoObjectiveUpdate(objectiveID, objective)
+end
+
+local function activateStage(stageID, carriedOver)
+	local stage = GG["MissionAPI"].Stages[stageID]
+	if not stage then
+		return
+	end
+
 	GG["MissionAPI"].CurrentStageID = stageID
 	Spring.Echo("Stage set to: " .. stageID)
+
+	for _, objectiveID in ipairs(stage.objectives) do
+		if not (carriedOver and carriedOver[objectiveID]) then
+			activateObjective(objectiveID)
+		end
+	end
+end
+
+--- Leaving a stage cancels what it lists and did not finish.
+local function exitStage(stageID, carriedOver)
+	local stage = GG["MissionAPI"].Stages[stageID]
+	if not stage then
+		return
+	end
+
+	for _, objectiveID in ipairs(stage.objectives) do
+		if carriedOver and carriedOver[objectiveID] then
+			-- Nothing to do?
+		elseif GG["MissionAPI"].Objectives[objectiveID].completed then
+			setObjectiveActive(objectiveID, false)
+		else
+			cancelObjective(objectiveID)
+		end
+	end
+end
+
+local function getCarriedObjectives(nextStage)
+	local carriedOver = {}
+	local currentStage = GG["MissionAPI"].Stages[GG["MissionAPI"].CurrentStageID]
+	if not currentStage then
+		return carriedOver
+	end
+
+	local listed = {}
+	for _, objectiveID in ipairs(currentStage.objectives) do
+		listed[objectiveID] = true
+	end
+	for _, objectiveID in ipairs(nextStage.objectives) do
+		if listed[objectiveID] then
+			carriedOver[objectiveID] = true
+		end
+	end
+	return carriedOver
+end
+
+local function changeStage(stageID)
+	local stage = GG["MissionAPI"].Stages[stageID]
+	if not stage then
+		return
+	end
+
+	local carriedOver = getCarriedObjectives(stage)
+
+	stageChanges = stageChanges + 1
+	exitStage(GG["MissionAPI"].CurrentStageID, carriedOver)
+	activateStage(stageID, carriedOver)
 end
 
 --- Advance to nextStage if the objective is completed and every other objective
@@ -38,30 +162,6 @@ local function tryAdvanceStage(objective)
 	changeStage(nextStage)
 end
 
--- placeholder until UI widget exists
-local function echoObjectiveUpdate(objectiveID, objective)
-	Spring.Echo(
-		"Objective updated: "
-			.. objectiveID
-			.. " | "
-			.. (objective.textKey or "")
-			.. " | progress: "
-			.. tostring(objective.progress)
-			.. " | amount: "
-			.. tostring(objective.amount)
-			.. " | completed: "
-			.. tostring(objective.completed)
-			.. (objective.failed and " (failed)" or "")
-	)
-end
-
-local function activateEventTrigger(triggerID)
-	if not triggerID then
-		return
-	end
-	GG["MissionAPI"].ActivateTrigger(GG["MissionAPI"].Triggers[triggerID])
-end
-
 --- Run the stage's exit routes for an objective that has completed or failed.
 --- This runs in a fixed order: the objective's event trigger, then nextStage.
 local function runExitRoutes(objective, eventTriggerID)
@@ -78,6 +178,7 @@ local function failObjective(objectiveID)
 		return
 	end
 
+	objective.canceled = false
 	objective.completed = true
 	objective.failed = true
 	runExitRoutes(objective, objective.onFailed)
@@ -121,7 +222,7 @@ local function updateObjectiveProgress(
 	end
 
 	local objective = GG["MissionAPI"].Objectives[objectiveID]
-	if objective.completed then
+	if objective.completed or not objective.active then
 		return
 	end
 
@@ -146,10 +247,13 @@ local function updateObjectiveProgress(
 end
 
 return {
+	ActivateStage = activateStage,
 	ChangeStage = changeStage,
 	TryAdvanceStage = tryAdvanceStage,
-	FailObjective = failObjective,
+	ActivateObjective = activateObjective,
+	CancelObjective = cancelObjective,
 	UpdateObjectiveProgress = updateObjectiveProgress,
+	FailObjective = failObjective,
 	OnObjectiveCompleted = onObjectiveCompleted,
 	EchoObjectiveUpdate = echoObjectiveUpdate,
 }

--- a/luarules/mission_api/objectives_loader.lua
+++ b/luarules/mission_api/objectives_loader.lua
@@ -26,7 +26,7 @@ local function processRawObjectives(rawObjectives, rawTriggers, rawActions, stag
 	)
 
 	-- Build objective-to-stages mapping from stages structure
-	local objectiveToStages = {}
+	local objectiveToStages = GG["MissionAPI"].ObjectiveStages
 	for stageID, stageData in pairs(stages or {}) do
 		if type(stageData) == "table" and type(stageData.objectives) == "table" then
 			for _, objectiveID in ipairs(stageData.objectives) do
@@ -40,6 +40,10 @@ local function processRawObjectives(rawObjectives, rawTriggers, rawActions, stag
 
 	for objectiveID, objective in pairs(objectives) do
 		local objectiveStages = objectiveToStages[objectiveID] or {}
+
+		if type(objective) == "table" then
+			objective.active = false
+		end
 
 		if type(objectiveID) == "string" and type(objective) == "table" and type(objective.trigger) == "table" then
 			local amount = objective.amount
@@ -71,6 +75,7 @@ local function processRawObjectives(rawObjectives, rawTriggers, rawActions, stag
 						stages = objectiveStages,
 						repeating = isRepeating,
 						maxRepeats = maxRepeats,
+						active = false,
 					},
 					actions = { actionID },
 				}
@@ -81,6 +86,8 @@ local function processRawObjectives(rawObjectives, rawTriggers, rawActions, stag
 						objectiveID = objectiveID,
 					},
 				}
+
+				GG["MissionAPI"].ObjectiveTriggers[objectiveID] = triggerID
 			end
 		end
 	end

--- a/luarules/mission_api/objectives_schema.lua
+++ b/luarules/mission_api/objectives_schema.lua
@@ -6,6 +6,8 @@ local parameters = {
 	amount = Types.Quantity,
 	nextStage = Types.StageID,
 	coop = Types.Boolean,
+	onActivated = Types.TriggerID,
+	onCanceled = Types.TriggerID,
 	onCompleted = Types.TriggerID,
 	onFailed = Types.TriggerID,
 }

--- a/luarules/mission_api/validation.lua
+++ b/luarules/mission_api/validation.lua
@@ -794,6 +794,8 @@ end
 
 -- Objective fields that each name an Event trigger the objective raises.
 local objectiveEventFields = {
+	"onActivated",
+	"onCanceled",
 	"onCompleted",
 	"onFailed",
 }

--- a/singleplayer/mission-api-tests/stages_and_objectives_test.lua
+++ b/singleplayer/mission-api-tests/stages_and_objectives_test.lua
@@ -7,7 +7,7 @@ local stages = {
 		objectives = { 'wait3secs' }
 	},
 	secondStage = {
-		objectives = { 'buildBots' }
+		objectives = { 'buildBots', 'patience' }
 	},
 	thirdStage = {
 		objectives = { 'buildBots', 'destroyBots', 'noLosses' }
@@ -40,6 +40,18 @@ local objectives = {
 		onCompleted = 'botsBuilt',
 	},
 
+	-- Never completes in time, so leaving the second stage cancels it.
+	patience = {
+		textKey = "wait_forever",
+		trigger = {
+			type = triggerTypes.TimeElapsed,
+			parameters = {
+				seconds = 3600, -- long
+			},
+		},
+		onCanceled = 'reportPatienceCanceled',
+	},
+
 	destroyBots = {
 		textKey = "destroy_all_bots",
 		amount = 0,
@@ -56,6 +68,20 @@ local objectives = {
 	noLosses = {
 		textKey = "lose_no_units",
 		onFailed = 'reportFailure',
+	},
+
+	-- Listed in no stage; an action activates it.
+	killDestroyers = {
+		textKey = "kill_both_destroyers",
+		amount = 2,
+		trigger = {
+			type = triggerTypes.TotalUnitsKilled,
+			parameters = {
+				unitDefName = 'armllt',
+				teamID = 0,
+			},
+		},
+		onActivated = 'announceDestroyers',
 	},
 }
 
@@ -77,7 +103,17 @@ local triggers = {
 
 	botsBuilt = {
 		type = triggerTypes.Event,
-		actions = { 'changeToThirdStage', 'spawnBotDestroyer' },
+		actions = { 'changeToThirdStage', 'spawnBotDestroyer', 'activateKillDestroyers' },
+	},
+
+	reportPatienceCanceled = {
+		type = triggerTypes.Event,
+		actions = { 'announcePatienceCanceled' },
+	},
+
+	announceDestroyers = {
+		type = triggerTypes.Event,
+		actions = { 'announceDestroyers' },
 	},
 
 	failOnLoss = {
@@ -122,6 +158,27 @@ local actions = {
 			unitLoadout = {
 				{ unitDefName = 'armllt', x = 1800, z = 2200, team = 1, quantity = 2 },
 			},
+		},
+	},
+
+	activateKillDestroyers = {
+		type = actionTypes.ActivateObjective,
+		parameters = {
+			objectiveID = 'killDestroyers',
+		},
+	},
+
+	announcePatienceCanceled = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "MissionTest: patience canceled",
+		},
+	},
+
+	announceDestroyers = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "MissionTest: killDestroyers activated",
 		},
 	},
 

--- a/spec/builders/mission_api_builder.lua
+++ b/spec/builders/mission_api_builder.lua
@@ -19,6 +19,8 @@ local PARAMETER_TYPES_PATH = "luarules/mission_api/parameter_types.lua"
 ---@field Triggers table
 ---@field Actions table
 ---@field CurrentStageID string?
+---@field ObjectiveTriggers table
+---@field ObjectiveStages table
 ---@field UnitLoadout table
 ---@field FeatureLoadout table
 ---@field ActionDefinitions table
@@ -36,8 +38,11 @@ local PARAMETER_TYPES_PATH = "luarules/mission_api/parameter_types.lua"
 ---@field playSound table
 ---@field enqueueSound table
 ---@field processSoundQueue table
+---@field activateStage table
 ---@field changeStage table
 ---@field tryAdvanceStage table
+---@field activateObjective table
+---@field cancelObjective table
 ---@field failObjective table
 ---@field onObjectiveCompleted table
 ---@field updateObjectiveProgress table
@@ -80,13 +85,13 @@ function MB.new()
 		featureLoadout = {},
 		actionDefinitions = {},
 		triggerDefinitions = {},
+		objectiveTriggers = {},
 		currentStageID = nil,
 		moduleOverrides = {},
 		realParameterTypes = true,
 	}, MB)
 end
 
----@param self MissionApiBuilder
 ---@param difficulty number
 ---@return MissionApiBuilder
 function MB:WithDifficulty(difficulty)
@@ -95,7 +100,6 @@ function MB:WithDifficulty(difficulty)
 end
 
 ---Seed a tracked unit; bidirectional maps are built for you.
----@param self MissionApiBuilder
 ---@param name string
 ---@param unitID number
 ---@return MissionApiBuilder
@@ -104,7 +108,6 @@ function MB:WithTrackedUnit(name, unitID)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param name string
 ---@param featureID number
 ---@return MissionApiBuilder
@@ -113,7 +116,6 @@ function MB:WithTrackedFeature(name, featureID)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param name string
 ---@param position table
 ---@return MissionApiBuilder
@@ -122,7 +124,6 @@ function MB:WithMarker(name, position)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param objectiveID string
 ---@param objective table
 ---@return MissionApiBuilder
@@ -131,7 +132,6 @@ function MB:WithObjective(objectiveID, objective)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param stageID string
 ---@param stage table
 ---@return MissionApiBuilder
@@ -140,7 +140,6 @@ function MB:WithStage(stageID, stage)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param stageID string
 ---@return MissionApiBuilder
 function MB:WithCurrentStage(stageID)
@@ -148,7 +147,6 @@ function MB:WithCurrentStage(stageID)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param triggerID string
 ---@param trigger table
 ---@return MissionApiBuilder
@@ -157,7 +155,17 @@ function MB:WithTrigger(triggerID, trigger)
 	return self
 end
 
----@param self MissionApiBuilder
+---Seed an objective's synthesized trigger, named and related as objectives_loader.lua does.
+---@param objectiveID string
+---@param trigger table?
+---@return MissionApiBuilder
+function MB:WithObjectiveTrigger(objectiveID, trigger)
+	local triggerID = "__objective_" .. objectiveID
+	self.triggers[triggerID] = trigger or { settings = { active = false } }
+	self.objectiveTriggers[objectiveID] = triggerID
+	return self
+end
+
 ---@param actionID string
 ---@param action table
 ---@return MissionApiBuilder
@@ -166,7 +174,6 @@ function MB:WithAction(actionID, action)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param objectiveID string
 ---@param metadata table
 ---@return MissionApiBuilder
@@ -176,7 +183,6 @@ function MB:WithManagedObjective(objectiveID, metadata)
 end
 
 ---Seed a countdown, shaped as countdowns.lua AddCountdown() creates them.
----@param self MissionApiBuilder
 ---@param countdownID string
 ---@param countdown table?
 ---@return MissionApiBuilder
@@ -185,7 +191,6 @@ function MB:WithCountdown(countdownID, countdown)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param soundfile string
 ---@param duration number
 ---@return MissionApiBuilder
@@ -194,7 +199,6 @@ function MB:WithSoundFile(soundfile, duration)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param loadout table
 ---@return MissionApiBuilder
 function MB:WithUnitLoadout(loadout)
@@ -202,7 +206,6 @@ function MB:WithUnitLoadout(loadout)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param loadout table
 ---@return MissionApiBuilder
 function MB:WithFeatureLoadout(loadout)
@@ -210,7 +213,6 @@ function MB:WithFeatureLoadout(loadout)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param definitions table
 ---@return MissionApiBuilder
 function MB:WithActionDefinitions(definitions)
@@ -218,7 +220,6 @@ function MB:WithActionDefinitions(definitions)
 	return self
 end
 
----@param self MissionApiBuilder
 ---@param definitions table
 ---@return MissionApiBuilder
 function MB:WithTriggerDefinitions(definitions)
@@ -227,7 +228,6 @@ function MB:WithTriggerDefinitions(definitions)
 end
 
 ---Replace a whole module, or merge individual functions into it.
----@param self MissionApiBuilder
 ---@param moduleName string e.g. 'Loadout', 'Sounds', 'Objectives', 'Tracking'
 ---@param moduleTable table
 ---@return MissionApiBuilder
@@ -240,18 +240,14 @@ function MB:WithModule(moduleName, moduleTable)
 end
 
 ---Leave Modules.ParameterTypes unset instead of loading the real module.
----@param self MissionApiBuilder
 ---@return MissionApiBuilder
 function MB:WithoutParameterTypes()
 	self.realParameterTypes = false
 	return self
 end
 
----@param self MissionApiBuilder
 ---@return MissionApiMock
 function MB:Build()
-	local instance = self
-
 	local trackedUnitIDs = {}
 	local trackedUnitNames = {}
 	local trackedFeatureIDs = {}
@@ -294,11 +290,20 @@ function MB:Build()
 		trackedIDs[name] = nil
 	end
 
-	for _, entry in ipairs(instance.trackedUnits) do
+	for _, entry in ipairs(self.trackedUnits) do
 		trackEntity(entry.name, entry.id, trackedUnitIDs, trackedUnitNames)
 	end
-	for _, entry in ipairs(instance.trackedFeatures) do
+	for _, entry in ipairs(self.trackedFeatures) do
 		trackEntity(entry.name, entry.id, trackedFeatureIDs, trackedFeatureNames)
+	end
+
+	-- Mirrors objectives_loader.lua so stages list their objectives.
+	local objectiveStages = {}
+	for stageID, stage in pairs(self.stages) do
+		for _, objectiveID in ipairs(stage.objectives or {}) do
+			local sequence = ensureTable(objectiveStages, objectiveID)
+			sequence[#sequence + 1] = stageID
+		end
 	end
 
 	local spawnUnitCalls = {}
@@ -307,11 +312,14 @@ function MB:Build()
 	local playSoundCalls = {}
 	local enqueueSoundCalls = {}
 	local processSoundQueueCalls = {}
+	local activateStageCalls = {}
 	local changeStageCalls = {}
 	local tryAdvanceCalls = {}
+	local activateObjectiveCalls = {}
+	local updateProgressCalls = {}
+	local cancelObjectiveCalls = {}
 	local failObjectiveCalls = {}
 	local onObjectiveCompletedCalls = {}
-	local updateProgressCalls = {}
 	local echoCalls = {}
 	local activateTriggerCalls = {}
 
@@ -381,11 +389,20 @@ function MB:Build()
 	}
 
 	local objectives = {
+		ActivateStage = function(stageID)
+			activateStageCalls[#activateStageCalls + 1] = { stageID = stageID }
+		end,
 		ChangeStage = function(stageID)
 			changeStageCalls[#changeStageCalls + 1] = { stageID = stageID }
 		end,
 		TryAdvanceStage = function(objective)
 			tryAdvanceCalls[#tryAdvanceCalls + 1] = { objective = objective }
+		end,
+		ActivateObjective = function(objectiveID)
+			activateObjectiveCalls[#activateObjectiveCalls + 1] = { objectiveID = objectiveID }
+		end,
+		CancelObjective = function(objectiveID)
+			cancelObjectiveCalls[#cancelObjectiveCalls + 1] = { objectiveID = objectiveID }
 		end,
 		FailObjective = function(objectiveID)
 			failObjectiveCalls[#failObjectiveCalls + 1] = { objectiveID = objectiveID }
@@ -422,11 +439,11 @@ function MB:Build()
 		Objectives = objectives,
 	}
 
-	if instance.realParameterTypes then
+	if self.realParameterTypes then
 		modules.ParameterTypes = VFS.Include(PARAMETER_TYPES_PATH)
 	end
 
-	for moduleName, override in pairs(instance.moduleOverrides) do
+	for moduleName, override in pairs(self.moduleOverrides) do
 		local target = ensureTable(modules, moduleName)
 		for key, value in pairs(override) do
 			target[key] = value
@@ -435,25 +452,27 @@ function MB:Build()
 
 	---@type MissionApiMock
 	local mock = {
-		Difficulty = instance.difficulty,
+		Difficulty = self.difficulty,
 		trackedUnitIDs = trackedUnitIDs,
 		trackedUnitNames = trackedUnitNames,
 		trackedFeatureIDs = trackedFeatureIDs,
 		trackedFeatureNames = trackedFeatureNames,
-		markerNames = instance.markerNames,
-		soundFiles = instance.soundFiles,
-		soundQueue = instance.soundQueue,
-		ManagedObjectives = instance.managedObjectives,
-		Countdowns = instance.countdowns,
-		Objectives = instance.objectives,
-		Stages = instance.stages,
-		Triggers = instance.triggers,
-		Actions = instance.actions,
-		CurrentStageID = instance.currentStageID,
-		UnitLoadout = instance.unitLoadout,
-		FeatureLoadout = instance.featureLoadout,
-		ActionDefinitions = instance.actionDefinitions,
-		TriggerDefinitions = instance.triggerDefinitions,
+		markerNames = self.markerNames,
+		soundFiles = self.soundFiles,
+		soundQueue = self.soundQueue,
+		ManagedObjectives = self.managedObjectives,
+		Countdowns = self.countdowns,
+		Objectives = self.objectives,
+		Stages = self.stages,
+		Triggers = self.triggers,
+		Actions = self.actions,
+		CurrentStageID = self.currentStageID,
+		UnitLoadout = self.unitLoadout,
+		FeatureLoadout = self.featureLoadout,
+		ObjectiveTriggers = self.objectiveTriggers,
+		ObjectiveStages = objectiveStages,
+		ActionDefinitions = self.actionDefinitions,
+		TriggerDefinitions = self.triggerDefinitions,
 		Modules = modules,
 		ActivateTrigger = function(trigger)
 			activateTriggerCalls[#activateTriggerCalls + 1] =
@@ -469,8 +488,11 @@ function MB:Build()
 			playSound = playSoundCalls,
 			enqueueSound = enqueueSoundCalls,
 			processSoundQueue = processSoundQueueCalls,
+			activateStage = activateStageCalls,
 			changeStage = changeStageCalls,
 			tryAdvanceStage = tryAdvanceCalls,
+			activateObjective = activateObjectiveCalls,
+			cancelObjective = cancelObjectiveCalls,
 			failObjective = failObjectiveCalls,
 			onObjectiveCompleted = onObjectiveCompletedCalls,
 			updateObjectiveProgress = updateProgressCalls,
@@ -485,11 +507,14 @@ function MB:Build()
 				playSoundCalls,
 				enqueueSoundCalls,
 				processSoundQueueCalls,
+				activateStageCalls,
 				changeStageCalls,
 				tryAdvanceCalls,
+				activateObjectiveCalls,
+				updateProgressCalls,
+				cancelObjectiveCalls,
 				failObjectiveCalls,
 				onObjectiveCompletedCalls,
-				updateProgressCalls,
 				echoCalls,
 				activateTriggerCalls,
 			}
@@ -510,7 +535,6 @@ end
 local installedTable = nil
 
 ---Build the mock and install it as GG['MissionAPI'].
----@param self MissionApiBuilder
 ---@return MissionApiMock
 function MB:Install()
 	local mock = self:Build()

--- a/spec/mission_api/actions/objectives/activate_objective_spec.lua
+++ b/spec/mission_api/actions/objectives/activate_objective_spec.lua
@@ -1,0 +1,37 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+Builders.MissionApi.new():Install()
+
+local actions = VFS.Include("luarules/mission_api/actions/objectives/activate_objective.lua")
+local action = actions[1]
+local summarizeSchema = require("mission_api.schema_spec_helper")
+
+describe("mission_api.actions.activate_objective", function()
+	local missionApi
+
+	before_each(function()
+		missionApi = Builders.MissionApi.new():WithObjective("obj1", { completed = false, active = false }):Install()
+	end)
+
+	it("declares its type and parameters", function()
+		assert.are.same({
+			type = "ActivateObjective",
+			objectiveID = "ObjectiveID!",
+		}, summarizeSchema(action))
+	end)
+
+	it("delegates to ActivateObjective", function()
+		action.actionFunction("obj1")
+		assert.are.equal(1, #missionApi.calls.activateObjective)
+		assert.are.equal("obj1", missionApi.calls.activateObjective[1].objectiveID)
+	end)
+
+	it("echoes the objective", function() -- temp
+		action.actionFunction("obj1")
+		assert.are.equal(1, #missionApi.calls.echoObjectiveUpdate)
+		assert.are.equal("obj1", missionApi.calls.echoObjectiveUpdate[1].objectiveID)
+		assert.are.equal(missionApi.Objectives.obj1, missionApi.calls.echoObjectiveUpdate[1].objective)
+	end)
+end)

--- a/spec/mission_api/objectives_loader_spec.lua
+++ b/spec/mission_api/objectives_loader_spec.lua
@@ -1,0 +1,69 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+local RegisterMissionApiModules = require("mission_api.spec_helper")
+
+-- The real trigger definitions, for the managed-or-synthesized split.
+-- (Trigger files read GG['MissionAPI'].Modules at include time.)
+Builders.MissionApi.new():Install()
+RegisterMissionApiModules()
+local triggerDefinitions = VFS.Include("luarules/mission_api/triggers_loader.lua").LoadTriggerDefinitions()
+
+local ObjectivesLoader = VFS.Include("luarules/mission_api/objectives_loader.lua")
+
+describe("mission_api.objectives_loader", function()
+	describe("ProcessRawObjectives", function()
+		local ACTION_TYPES = { UpdateObjective = 1 }
+
+		local function process(rawObjectives, stages)
+			local missionApi = Builders.MissionApi
+				.new()
+				:WithActionDefinitions({ Types = ACTION_TYPES })
+				:WithTriggerDefinitions(triggerDefinitions)
+				:Install()
+			local rawTriggers = {}
+			local objectives = ObjectivesLoader.ProcessRawObjectives(rawObjectives, rawTriggers, {}, stages or {})
+			return objectives, rawTriggers, missionApi
+		end
+
+		local function timed(seconds)
+			return {
+				textKey = "t",
+				trigger = { type = triggerDefinitions.Types.TimeElapsed, parameters = { seconds = seconds } },
+			}
+		end
+
+		it("creates every objective inactive", function()
+			local objectives = process({ timed = timed(1), bare = { textKey = "b" } })
+			assert.is_false(objectives.timed.active)
+			assert.is_false(objectives.bare.active)
+		end)
+
+		it("synthesizes a disabled trigger for a non-managed objective and records it", function()
+			local _, rawTriggers, missionApi = process({ timed = timed(1) })
+			assert.is_false(rawTriggers.__objective_timed.settings.active)
+			assert.are.equal("__objective_timed", missionApi.ObjectiveTriggers.timed)
+		end)
+
+		it("records the stages that list each objective", function()
+			local _, _, missionApi = process({ a = { textKey = "a" }, b = { textKey = "b" }, c = { textKey = "c" } }, {
+				s1 = { objectives = { "a" } },
+				s2 = { objectives = { "b" } },
+			})
+			assert.are.same({ "s1" }, missionApi.ObjectiveStages.a)
+			assert.are.same({ "s2" }, missionApi.ObjectiveStages.b)
+			assert.is_nil(missionApi.ObjectiveStages.c)
+		end)
+
+		it("records no trigger for a managed objective", function()
+			local kills = {
+				textKey = "k",
+				amount = 2,
+				trigger = { type = triggerDefinitions.Types.TotalUnitsKilled, parameters = { teamID = 0 } },
+			}
+			local _, rawTriggers, missionApi = process({ kills = kills })
+			assert.is_nil(rawTriggers.__objective_kills)
+			assert.is_nil(missionApi.ObjectiveTriggers.kills)
+		end)
+	end)
+end)

--- a/spec/mission_api/objectives_spec.lua
+++ b/spec/mission_api/objectives_spec.lua
@@ -29,10 +29,333 @@ describe("mission_api.objectives", function()
 	end)
 
 	describe("ChangeStage", function()
-		it("sets the current stage ID", function()
-			Objectives.ChangeStage("stage2")
+		it("makes the stage current and activates the objectives it lists", function()
+			install(
+				mission()
+					:WithStage("s1")
+					:WithStage("s2", { objectives = { "listed" } })
+					:WithObjective("listed", { active = false, completed = false })
+					:WithObjective("unlisted", { active = false, completed = false })
+					:WithCurrentStage("s1")
+			)
 
-			assert.are.equal("stage2", missionApi.CurrentStageID)
+			Objectives.ChangeStage("s2")
+
+			assert.are.equal("s2", missionApi.CurrentStageID)
+			assert.is_true(missionApi.Objectives.listed.active)
+			assert.is_false(missionApi.Objectives.unlisted.active)
+		end)
+
+		it("takes every objective the left stage lists out of play, triggers included, and no other", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "unfinished", "finished" } })
+					:WithStage("s2")
+					:WithObjective("unfinished", { active = true, completed = false })
+					:WithObjective("finished", { active = true, completed = true })
+					:WithObjective("free", { active = true, completed = false })
+					:WithObjectiveTrigger("unfinished", { settings = { active = true } })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.ChangeStage("s2")
+
+			assert.is_false(missionApi.Objectives.unfinished.active)
+			assert.is_false(missionApi.Triggers.__objective_unfinished.settings.active)
+			assert.is_false(missionApi.Objectives.finished.active)
+			assert.is_true(missionApi.Objectives.free.active)
+		end)
+
+		it("cancels the unfinished objectives the left stage lists, and not the finished ones", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "unfinished", "finished" } })
+					:WithStage("s2")
+					:WithObjective("unfinished", { active = true, completed = false, onCanceled = "gone" })
+					:WithObjective("finished", { active = true, completed = true, onCanceled = "kept" })
+					:WithTrigger("gone", { type = T.Event })
+					:WithTrigger("kept", { type = T.Event })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.ChangeStage("s2")
+
+			assert.is_true(missionApi.Objectives.unfinished.canceled)
+			assert.is_nil(missionApi.Objectives.finished.canceled)
+			assert.are.equal(1, #missionApi.calls.activateTrigger)
+			assert.are.equal(missionApi.Triggers.gone, missionApi.calls.activateTrigger[1].trigger)
+		end)
+
+		it("carries an objective listed by both stages over untouched", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "carried" } })
+					:WithStage("s2", { objectives = { "carried" } })
+					:WithObjective(
+						"carried",
+						{ active = true, completed = false, onActivated = "on", onCanceled = "off" }
+					)
+					:WithObjectiveTrigger("carried", { settings = { active = true } })
+					:WithTrigger("on", { type = T.Event })
+					:WithTrigger("off", { type = T.Event })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.ChangeStage("s2")
+
+			assert.is_true(missionApi.Objectives.carried.active)
+			assert.is_true(missionApi.Triggers.__objective_carried.settings.active)
+			assert.is_nil(missionApi.Objectives.carried.canceled)
+			assert.are.equal(0, #missionApi.calls.activateTrigger)
+		end)
+
+		it("does nothing for a stage that does not exist", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "obj1" } })
+					:WithObjective("obj1", { active = true, completed = false })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.ChangeStage("nowhere")
+
+			assert.are.equal("s1", missionApi.CurrentStageID)
+			assert.is_true(missionApi.Objectives.obj1.active)
+			assert.is_nil(missionApi.Objectives.obj1.canceled)
+		end)
+	end)
+
+	describe("ActivateStage", function()
+		it("makes the stage current and activates every objective it lists", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "a", "b" } })
+					:WithObjective("a", { active = false, completed = false })
+					:WithObjective("b", { active = false, completed = false })
+					:WithObjective("c", { active = false, completed = false })
+			)
+
+			Objectives.ActivateStage("s1")
+
+			assert.are.equal("s1", missionApi.CurrentStageID)
+			assert.is_true(missionApi.Objectives.a.active)
+			assert.is_true(missionApi.Objectives.b.active)
+			assert.is_false(missionApi.Objectives.c.active)
+		end)
+
+		it("activates the trigger each listed objective names in onActivated, once the stage is current", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "a", "b" } })
+					:WithObjective("a", { active = false, completed = false, onActivated = "beganA" })
+					:WithObjective("b", { active = false, completed = false, onActivated = "beganB" })
+					:WithTrigger("beganA", { type = T.Event })
+					:WithTrigger("beganB", { type = T.Event })
+			)
+
+			Objectives.ActivateStage("s1")
+
+			assert.are.equal(2, #missionApi.calls.activateTrigger)
+			assert.are.equal("s1", missionApi.calls.activateTrigger[1].stageID)
+			assert.are.equal("s1", missionApi.calls.activateTrigger[2].stageID)
+		end)
+
+		it("does nothing for a stage that does not exist", function()
+			install(mission():WithObjective("a", { active = false, completed = false }))
+
+			Objectives.ActivateStage("nowhere")
+
+			assert.is_nil(missionApi.CurrentStageID)
+			assert.is_false(missionApi.Objectives.a.active)
+		end)
+	end)
+
+	describe("ActivateObjective", function()
+		it("flips the objective on and enables its synthesized trigger", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = false, completed = false })
+					:WithObjectiveTrigger("obj1", { settings = { active = false } })
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.active)
+			assert.is_true(missionApi.Triggers.__objective_obj1.settings.active)
+		end)
+
+		it("flips on an objective that has no synthesized trigger", function()
+			install(mission():WithObjective("obj1", { active = false, completed = false }))
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.active)
+		end)
+
+		it("activates the trigger the objective names in onActivated", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = false, completed = false, onActivated = "began" })
+					:WithTrigger("began", { type = T.Event })
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.are.equal(1, #missionApi.calls.activateTrigger)
+			assert.are.equal(missionApi.Triggers.began, missionApi.calls.activateTrigger[1].trigger)
+		end)
+
+		it("clears the canceled mark", function()
+			install(mission():WithObjective("obj1", { active = false, completed = false, canceled = true }))
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.active)
+			assert.is_false(missionApi.Objectives.obj1.canceled)
+		end)
+
+		it("is a no-op on an active objective", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = true, completed = false, onActivated = "began" })
+					:WithTrigger("began", { type = T.Event })
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.active)
+			assert.are.equal(0, #missionApi.calls.activateTrigger)
+		end)
+
+		it("is a no-op on a completed objective", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = false, completed = true, onActivated = "began" })
+					:WithObjectiveTrigger("obj1", { settings = { active = false } })
+					:WithTrigger("began", { type = T.Event })
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_false(missionApi.Objectives.obj1.active)
+			assert.is_false(missionApi.Triggers.__objective_obj1.settings.active)
+			assert.are.equal(0, #missionApi.calls.activateTrigger)
+		end)
+
+		it("is denied for a listed objective while none of its stages is current", function()
+			install(
+				mission()
+					:WithStage("s1")
+					:WithStage("s2", { objectives = { "obj1" } })
+					:WithObjective("obj1", { active = false, completed = false, onActivated = "began" })
+					:WithObjectiveTrigger("obj1", { settings = { active = false } })
+					:WithTrigger("began", { type = T.Event })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_false(missionApi.Objectives.obj1.active)
+			assert.is_false(missionApi.Triggers.__objective_obj1.settings.active)
+			assert.are.equal(0, #missionApi.calls.activateTrigger)
+		end)
+
+		it("is allowed for a listed objective while one of its stages is current", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "obj1" } })
+					:WithStage("s2", { objectives = { "obj1" } })
+					:WithObjective("obj1", { active = false, completed = false })
+					:WithCurrentStage("s2")
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.active)
+		end)
+
+		it("is allowed from any stage for an objective listed in no stage", function()
+			install(
+				mission()
+					:WithStage("s1")
+					:WithObjective("obj1", { active = false, completed = false })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.ActivateObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.active)
+		end)
+	end)
+
+	describe("CancelObjective", function()
+		it("marks the objective canceled and takes it out of play, unfinished", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = true, completed = false })
+					:WithObjectiveTrigger("obj1", { settings = { active = true } })
+			)
+
+			Objectives.CancelObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.canceled)
+			assert.is_false(missionApi.Objectives.obj1.active)
+			assert.is_false(missionApi.Triggers.__objective_obj1.settings.active)
+			assert.is_false(missionApi.Objectives.obj1.completed)
+		end)
+
+		it("activates the trigger the objective names in onCanceled", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = true, completed = false, onCanceled = "gone" })
+					:WithTrigger("gone", { type = T.Event })
+			)
+
+			Objectives.CancelObjective("obj1")
+
+			assert.are.equal(1, #missionApi.calls.activateTrigger)
+			assert.are.equal(missionApi.Triggers.gone, missionApi.calls.activateTrigger[1].trigger)
+		end)
+
+		it("is a no-op on a completed objective", function()
+			install(mission():WithObjective("obj1", { active = false, completed = true }))
+
+			Objectives.CancelObjective("obj1")
+
+			assert.is_nil(missionApi.Objectives.obj1.canceled)
+		end)
+
+		it("is a no-op on a canceled objective", function()
+			install(
+				mission()
+					:WithObjective("obj1", { active = false, completed = false, canceled = true, onCanceled = "gone" })
+					:WithTrigger("gone", { type = T.Event })
+			)
+
+			Objectives.CancelObjective("obj1")
+
+			assert.are.equal(0, #missionApi.calls.activateTrigger)
+		end)
+
+		it("leaves the gate unsatisfied until the objective is activated and completed", function()
+			install(
+				mission()
+					:WithStage("s1", { objectives = { "obj1", "obj2" } })
+					:WithStage("s2")
+					:WithObjective("obj1", { active = true, completed = false, nextStage = "s2" })
+					:WithObjective("obj2", { active = true, completed = true, nextStage = "s2" })
+					:WithCurrentStage("s1")
+			)
+
+			Objectives.CancelObjective("obj1")
+			assert.are.equal("s1", missionApi.CurrentStageID)
+
+			Objectives.ActivateObjective("obj1")
+			assert.is_false(missionApi.Objectives.obj1.canceled)
+
+			missionApi.Objectives.obj1.completed = true
+			Objectives.OnObjectiveCompleted(missionApi.Objectives.obj1)
+			assert.are.equal("s2", missionApi.CurrentStageID)
 		end)
 	end)
 
@@ -42,7 +365,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = false, nextStage = "s2" })
+					:WithObjective("obj1", { active = true, completed = false, nextStage = "s2" })
 					:WithCurrentStage("s1")
 			)
 
@@ -55,7 +378,7 @@ describe("mission_api.objectives", function()
 			install(
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
-					:WithObjective("obj1", { completed = true })
+					:WithObjective("obj1", { active = true, completed = true })
 					:WithCurrentStage("s1")
 			)
 
@@ -68,7 +391,7 @@ describe("mission_api.objectives", function()
 			install(
 				mission()
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = true, nextStage = "s2" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2" })
 					:WithCurrentStage("nowhere")
 			)
 
@@ -82,7 +405,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = true, nextStage = "s2" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2" })
 					:WithCurrentStage("s1")
 			)
 
@@ -96,8 +419,8 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1", "obj2" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = true, nextStage = "s2" })
-					:WithObjective("obj2", { completed = false, nextStage = "s2" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2" })
+					:WithObjective("obj2", { active = true, completed = false, nextStage = "s2" })
 					:WithCurrentStage("s1")
 			)
 
@@ -115,8 +438,8 @@ describe("mission_api.objectives", function()
 					:WithStage("s1", { objectives = { "obj1", "obj2" } })
 					:WithStage("s2")
 					:WithStage("s3")
-					:WithObjective("obj1", { completed = true, nextStage = "s2" })
-					:WithObjective("obj2", { completed = false, nextStage = "s3" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2" })
+					:WithObjective("obj2", { active = true, completed = false, nextStage = "s3" })
 					:WithCurrentStage("s1")
 			)
 
@@ -131,8 +454,19 @@ describe("mission_api.objectives", function()
 	-- records for a managed objective: the trigger's parameters, the stages that
 	-- list the objective, and the amount to reach.
 	describe("UpdateObjectiveProgress", function()
+		it("counts an event for an inactive objective without evaluating completion", function()
+			install(mission():WithObjective("obj1", { active = false, completed = false }))
+			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 1 }
+
+			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
+
+			assert.are.equal(1, metadata._count)
+			assert.is_nil(missionApi.Objectives.obj1.progress)
+			assert.is_false(missionApi.Objectives.obj1.completed)
+		end)
+
 		it("ignores an event for another team", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 1 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 1, "armwar", nil, 1, metadata)
@@ -142,7 +476,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("ignores an event for another unitDefName", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0, unitDefName = "corak" }, stages = {}, amount = 1 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
@@ -151,7 +485,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("ignores an event without the unitName it watches", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0, unitName = "bots" }, stages = {}, amount = 1 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", {}, 1, metadata)
@@ -166,7 +500,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("objStage", { objectives = { "obj1" } })
 					:WithStage("otherStage")
-					:WithObjective("obj1", { completed = false })
+					:WithObjective("obj1", { active = true, completed = false })
 					:WithCurrentStage("otherStage")
 			)
 			local metadata = { parameters = { teamID = 0 }, stages = { "objStage" }, amount = 1 }
@@ -182,7 +516,7 @@ describe("mission_api.objectives", function()
 			install(
 				mission()
 					:WithStage("objStage", { objectives = { "obj1" } })
-					:WithObjective("obj1", { completed = false })
+					:WithObjective("obj1", { active = true, completed = false })
 					:WithCurrentStage("objStage")
 			)
 			local metadata = { parameters = { teamID = 0 }, stages = { "objStage" }, amount = 1 }
@@ -194,7 +528,12 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("evaluates completion in any stage when the objective is listed in none", function()
-			install(mission():WithStage("s1"):WithObjective("obj1", { completed = false }):WithCurrentStage("s1"))
+			install(
+				mission()
+					:WithStage("s1")
+					:WithObjective("obj1", { active = true, completed = false })
+					:WithCurrentStage("s1")
+			)
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 1 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
@@ -203,7 +542,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("completes on the first event when there is no amount", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = nil }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
@@ -212,7 +551,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("completes when the count reaches the amount", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 2 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
@@ -223,7 +562,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("completes an amount = 0 objective when the count returns to zero", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 0 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
@@ -234,7 +573,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("freezes the objective's progress once completed", function()
-			install(mission():WithObjective("obj1", { completed = true, progress = 3 }))
+			install(mission():WithObjective("obj1", { active = true, completed = true, progress = 3 }))
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 3, _count = 3 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, -1, metadata)
@@ -247,7 +586,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = false, nextStage = "s2" })
+					:WithObjective("obj1", { active = true, completed = false, nextStage = "s2" })
 					:WithCurrentStage("s1")
 			)
 			local metadata = { parameters = { teamID = 0 }, stages = { "s1" }, amount = 1 }
@@ -260,7 +599,7 @@ describe("mission_api.objectives", function()
 		it("activates the trigger named by onCompleted on completion", function()
 			install(
 				mission()
-					:WithObjective("obj1", { completed = false, onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = false, onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 			)
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 1 }
@@ -274,7 +613,7 @@ describe("mission_api.objectives", function()
 		it("activates nothing before completion", function()
 			install(
 				mission()
-					:WithObjective("obj1", { completed = false, onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = false, onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 			)
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 2 }
@@ -287,7 +626,7 @@ describe("mission_api.objectives", function()
 
 	describe("FailObjective", function()
 		it("completes the objective and marks it failed", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 
 			Objectives.FailObjective("obj1")
 
@@ -295,8 +634,17 @@ describe("mission_api.objectives", function()
 			assert.is_true(missionApi.Objectives.obj1.failed)
 		end)
 
+		it("fails a canceled objective and clears the mark", function()
+			install(mission():WithObjective("obj1", { active = false, completed = false, canceled = true }))
+
+			Objectives.FailObjective("obj1")
+
+			assert.is_true(missionApi.Objectives.obj1.failed)
+			assert.is_false(missionApi.Objectives.obj1.canceled)
+		end)
+
 		it("is a no-op on a completed objective", function()
-			install(mission():WithObjective("obj1", { completed = true }))
+			install(mission():WithObjective("obj1", { active = true, completed = true }))
 
 			Objectives.FailObjective("obj1")
 
@@ -304,7 +652,7 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("does not mark a success as failed", function()
-			install(mission():WithObjective("obj1", { completed = false }))
+			install(mission():WithObjective("obj1", { active = true, completed = false }))
 			local metadata = { parameters = { teamID = 0 }, stages = {}, amount = 1 }
 
 			Objectives.UpdateObjectiveProgress("obj1", 0, "armwar", nil, 1, metadata)
@@ -316,7 +664,7 @@ describe("mission_api.objectives", function()
 		it("activates the trigger the objective names in onFailed", function()
 			install(
 				mission()
-					:WithObjective("obj1", { completed = false, onFailed = "failed" })
+					:WithObjective("obj1", { active = true, completed = false, onFailed = "failed" })
 					:WithTrigger("failed", { type = T.Event })
 			)
 
@@ -329,7 +677,7 @@ describe("mission_api.objectives", function()
 		it("leaves the trigger named in onCompleted alone", function()
 			install(
 				mission()
-					:WithObjective("obj1", { completed = false, onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = false, onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 			)
 
@@ -343,7 +691,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = false, nextStage = "s2", onFailed = "failed" })
+					:WithObjective("obj1", { active = true, completed = false, nextStage = "s2", onFailed = "failed" })
 					:WithTrigger("failed", { type = T.Event })
 					:WithCurrentStage("s1")
 			)
@@ -359,7 +707,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = false, nextStage = "s2" })
+					:WithObjective("obj1", { active = true, completed = false, nextStage = "s2" })
 					:WithCurrentStage("s1")
 			)
 
@@ -374,7 +722,7 @@ describe("mission_api.objectives", function()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
 					:WithStage("s9")
-					:WithObjective("obj1", { completed = false, nextStage = "s2", onFailed = "failed" })
+					:WithObjective("obj1", { active = true, completed = false, nextStage = "s2", onFailed = "failed" })
 					:WithTrigger("failed", { type = T.Event })
 					:WithCurrentStage("s1")
 			)
@@ -392,7 +740,7 @@ describe("mission_api.objectives", function()
 		it("activates the trigger the objective names in onCompleted", function()
 			install(
 				mission()
-					:WithObjective("obj1", { completed = true, onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = true, onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 					:WithTrigger("other", { type = T.Event })
 			)
@@ -404,7 +752,11 @@ describe("mission_api.objectives", function()
 		end)
 
 		it("activates nothing when the objective names no trigger", function()
-			install(mission():WithObjective("obj1", { completed = true }):WithTrigger("done", { type = T.Event }))
+			install(
+				mission()
+					:WithObjective("obj1", { active = true, completed = true })
+					:WithTrigger("done", { type = T.Event })
+			)
 
 			Objectives.OnObjectiveCompleted(missionApi.Objectives.obj1)
 
@@ -416,7 +768,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = true, nextStage = "s2", onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2", onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 					:WithCurrentStage("s1")
 			)
@@ -432,7 +784,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = true, nextStage = "s2", onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2", onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 					:WithCurrentStage("s1")
 			)
@@ -448,7 +800,7 @@ describe("mission_api.objectives", function()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
 					:WithStage("s9")
-					:WithObjective("obj1", { completed = true, nextStage = "s2", onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2", onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 					:WithCurrentStage("s1")
 			)
@@ -467,7 +819,7 @@ describe("mission_api.objectives", function()
 				mission()
 					:WithStage("s1", { objectives = { "obj1" } })
 					:WithStage("s2")
-					:WithObjective("obj1", { completed = true, nextStage = "s2", onCompleted = "done" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2", onCompleted = "done" })
 					:WithTrigger("done", { type = T.Event })
 					:WithCurrentStage("s1")
 			)
@@ -486,8 +838,8 @@ describe("mission_api.objectives", function()
 					:WithStage("s1", { objectives = { "obj1", "obj2" } })
 					:WithStage("s2")
 					:WithStage("s3")
-					:WithObjective("obj1", { completed = true, nextStage = "s2", onCompleted = "done" })
-					:WithObjective("obj2", { completed = true, nextStage = "s3" })
+					:WithObjective("obj1", { active = true, completed = true, nextStage = "s2", onCompleted = "done" })
+					:WithObjective("obj2", { active = true, completed = true, nextStage = "s3" })
 					:WithTrigger("done", { type = T.Event })
 					:WithCurrentStage("s1")
 			)

--- a/spec/mission_api/validation_spec.lua
+++ b/spec/mission_api/validation_spec.lua
@@ -271,6 +271,17 @@ describe("mission_api.validation", function()
 			)
 		end)
 
+		it("passes for an objective naming Event triggers in onActivated and onCanceled", function()
+			GG["MissionAPI"].Triggers = {
+				began = { type = triggerTypes.Event, actions = { "ok" } },
+				gone = { type = triggerTypes.Event, actions = { "ok" } },
+			}
+			validation.ValidateObjectives({
+				withEvents = { textKey = "ok", onActivated = "began", onCanceled = "gone" },
+			})
+			assert.are.same({}, logged)
+		end)
+
 		it("logs an error when onFailed names a trigger that is not an Event", function()
 			GG["MissionAPI"].Triggers = {
 				timer = { type = triggerTypes.TimeElapsed, parameters = { seconds = 1 }, actions = { "ok" } },


### PR DESCRIPTION
### Work done

Adds the `active` flag on objectives, and the `ActivateObjective` action, and a `cancelObjective` method (not an action, yet).

Objectives are inactive at load and activated later. Inline triggers are synthesized with `settings.active = false`.

Entering a stage activates its listed objectives (and their triggers). The initial stage is entered via the `GamePreload` callin, after loadouts are done spawning.

Leaving a stage deactivates its listed objectives (and their triggers).

`ActivateObjective(objectiveID)` cannot activate an objective if it is listed by any non-current stage.