### PR TITLE
Display attack range arc for missile ships

### DIFF
--- a/units/ArmShips/T2/armmship.lua
+++ b/units/ArmShips/T2/armmship.lua
@@ -186,7 +186,6 @@ return {
 				customparams = {
 					cegtag = "missiletrailcorroyspecial",
 					model = "airbomb",
-					noattackrangearc = 1,
 					number = "6",
 					speceffect = "split",
 					speceffect_def = "armmship_rocket_split",

--- a/units/CorShips/T2/cormship.lua
+++ b/units/CorShips/T2/cormship.lua
@@ -185,7 +185,6 @@ return {
 				customparams = {
 					cegtag = "missiletrailcorroyspecial",
 					model = "airbomb",
-					noattackrangearc = 1,
 					number = "8",
 					speceffect = "split",
 					speceffect_def = "cormship_rocket_split",


### PR DESCRIPTION
This was previously added in 2024 to prevent range clutter. https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3732

The problem is that some units can swivel without turning with their 360 deg turret when you use set target. Others can't and are generally much more clunky to turn. Ships in particular fall into that pattern. 

This is unexpected for the user since it will appear like set target is broken and non-functional for these ships when it is just outside their normal firing range. 

Relevant discord thread: https://discord.com/channels/549281623154229250/1520261367100080139/1520261367100080139

Before:
Shows a red range circle

After:
Shows the attack range arc
<img width="1505" height="1339" alt="image" src="https://github.com/user-attachments/assets/85e2662e-f0a1-46e1-a0de-8cf53c2d631e" />

AI: nope, didn't need it for 2 lines :) 