### PR TITLE
Show fighter attack range arcs

### DIFF
--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -365,10 +365,8 @@ local function initializeUnitDefRing(unitDefID)
 			local maxangledif = 0
 
 			-- customParams (note the case), is a table of strings always
-			if
-				(weapons[weaponNum].maxAngleDif > -1)
-				and not (weaponDef.customParams and weaponDef.customParams.noattackrangearc)
-			then
+			local skipArc = weaponDef.customParams and weaponDef.customParams.noattackrangearc
+			if (weapons[weaponNum].maxAngleDif > -1) and not skipArc then
 				--spEcho(weaponDef.customParams)--, weapons[weaponNum].customParams.noattackarc)
 				local offsetdegrees = 0
 				local difffract = 0
@@ -403,6 +401,21 @@ local function initializeUnitDefRing(unitDefID)
 
 				--spEcho("weapons[weaponNum].maxAngleDif",weapons[weaponNum].maxAngleDif, maxangledif)
 				--for k,v in pairs(weapons[weaponNum]) do spEcho(k,v)end
+			elseif
+				-- onlyForward weapons (!turret, non-starburst): fire cone comes from
+				-- weapondef tolerance, exposed to Lua as WeaponDefs.maxAngle (radians).
+				-- Pack the same way as maxangledif arcs: fractional half-angle/180°.
+				not skipArc
+				and not weaponDef.turret
+				and weaponDef.type ~= "StarburstLauncher"
+				and weaponDef.maxAngle
+				and weaponDef.maxAngle > 0
+			then
+				local difffract = weaponDef.maxAngle / mathPi
+				-- fract(1.0)==0 in the shader, so keep strictly below a full ±180°
+				if difffract < 0.999 then
+					maxangledif = difffract
+				end
 			end
 
 			--if weapons[weaponNum].maxAngleDif then	spEcho(weapons[weaponNum].maxAngleDif,'for',weaponDef.name, 'saved as',maxangledif ) end

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -213,7 +213,7 @@ local unitBuilder = {}
 local unitOnOffable = {}
 local unitOnOffName = {}
 local unitDefRangeScale = {}
-local unitIsFighter = {}
+local unitIsStrafingAir = {}
 for udid, ud in pairs(UnitDefs) do
 	unitBuilder[udid] = ud.isBuilder and (ud.canAssist or ud.canReclaim) and not (ud.isFactory and #ud.buildOptions > 0)
 	if unitBuilder[udid] then
@@ -223,7 +223,7 @@ for udid, ud in pairs(UnitDefs) do
 	unitWeapons[udid] = ud.weapons
 	unitMaxWeaponRange[udid] = ud.maxWeaponRange
 	unitOnOffable[udid] = ud.onOffable
-	unitIsFighter[udid] = ud.customParams.fighter ~= nil
+	unitIsStrafingAir[udid] = ud.isStrafingAirUnit
 	if ud.customParams.onoffname then
 		unitOnOffName[udid] = ud.customParams.onoffname
 	end
@@ -403,8 +403,8 @@ local function initializeUnitDefRing(unitDefID)
 				--spEcho("weapons[weaponNum].maxAngleDif",weapons[weaponNum].maxAngleDif, maxangledif)
 				--for k,v in pairs(weapons[weaponNum]) do spEcho(k,v)end
 			elseif
-				-- Fighters use weapondef tolerance (WeaponDefs.maxAngle, radians) as a forward fire cone.
-				unitIsFighter[unitDefID]
+				-- Strafing aircraft use weapondef tolerance (WeaponDefs.maxAngle, radians) as a forward fire cone.
+				unitIsStrafingAir[unitDefID]
 				and not skipArc
 				and not weaponDef.turret
 				and weaponDef.type ~= "StarburstLauncher"

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -213,6 +213,7 @@ local unitBuilder = {}
 local unitOnOffable = {}
 local unitOnOffName = {}
 local unitDefRangeScale = {}
+local unitIsFighter = {}
 for udid, ud in pairs(UnitDefs) do
 	unitBuilder[udid] = ud.isBuilder and (ud.canAssist or ud.canReclaim) and not (ud.isFactory and #ud.buildOptions > 0)
 	if unitBuilder[udid] then
@@ -222,6 +223,7 @@ for udid, ud in pairs(UnitDefs) do
 	unitWeapons[udid] = ud.weapons
 	unitMaxWeaponRange[udid] = ud.maxWeaponRange
 	unitOnOffable[udid] = ud.onOffable
+	unitIsFighter[udid] = ud.customParams.fighter ~= nil
 	if ud.customParams.onoffname then
 		unitOnOffName[udid] = ud.customParams.onoffname
 	end
@@ -364,8 +366,7 @@ local function initializeUnitDefRing(unitDefID)
 
 			local maxangledif = 0
 
-			-- customParams (note the case), is a table of strings always
-			local skipArc = weaponDef.customParams and weaponDef.customParams.noattackrangearc
+			local skipArc = weaponDef.customParams.noattackrangearc
 			if (weapons[weaponNum].maxAngleDif > -1) and not skipArc then
 				--spEcho(weaponDef.customParams)--, weapons[weaponNum].customParams.noattackarc)
 				local offsetdegrees = 0
@@ -402,13 +403,11 @@ local function initializeUnitDefRing(unitDefID)
 				--spEcho("weapons[weaponNum].maxAngleDif",weapons[weaponNum].maxAngleDif, maxangledif)
 				--for k,v in pairs(weapons[weaponNum]) do spEcho(k,v)end
 			elseif
-				-- onlyForward weapons (!turret, non-starburst): fire cone comes from
-				-- weapondef tolerance, exposed to Lua as WeaponDefs.maxAngle (radians).
-				-- Pack the same way as maxangledif arcs: fractional half-angle/180°.
-				not skipArc
+				-- Fighters use weapondef tolerance (WeaponDefs.maxAngle, radians) as a forward fire cone.
+				unitIsFighter[unitDefID]
+				and not skipArc
 				and not weaponDef.turret
 				and weaponDef.type ~= "StarburstLauncher"
-				and weaponDef.maxAngle
 				and weaponDef.maxAngle > 0
 			then
 				local difffract = weaponDef.maxAngle / mathPi

--- a/units/Legion/Air/T2 Air/legafigdef.lua
+++ b/units/Legion/Air/T2 Air/legafigdef.lua
@@ -115,9 +115,6 @@ return {
 				turret = true,
 				weapontype = "LaserCannon",
 				weaponvelocity = 2500,
-				customparams = {
-					noattackrangearc = 1,
-				},
 				damage = {
 					commanders = 1,
 					default = 2,

--- a/units/Legion/Air/T2 Air/legionnaire.lua
+++ b/units/Legion/Air/T2 Air/legionnaire.lua
@@ -112,9 +112,6 @@ return {
 					default = 2,
 					vtol = 80,
 				},
-				customparams = {
-					noattackrangearc = 1,
-				},
 			},
 		},
 		weapons = {

--- a/units/Legion/Air/T2 Air/legvenator.lua
+++ b/units/Legion/Air/T2 Air/legvenator.lua
@@ -96,9 +96,6 @@ return {
 				weapontimer = 1,
 				weapontype = "Cannon",
 				weaponvelocity = 1600,
-				customparams = {
-					noattackrangearc = 1,
-				},
 				damage = {
 					commanders = 8,
 					default = 24,

--- a/units/Legion/Air/legcib.lua
+++ b/units/Legion/Air/legcib.lua
@@ -102,6 +102,7 @@ return {
 				customparams = {
 					nofire = true,
 					junotype = "mini",
+					norangering = 1,
 				},
 				damage = {
 					default = 1,


### PR DESCRIPTION
This is mainly for consistency between Noctua and other fighters. Previously, it showed a 360 deg firing arc, now it shows the (accurate) firing arc for all aerial fighters: t1, t2, seaplanes. 

<img width="1851" height="1325" alt="image" src="https://github.com/user-attachments/assets/a81c2576-ef72-43f5-9ff4-130957c13928" />

(related to this [one](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/9083), but in separate PR as this one is probably a bit more debatable in usefulness since figs are nigh impossible to micro for someone of my skill level anyway)


AI: Cursor used to analyze, handwrote it. 