### PR TITLE
Attack/Set Target UI: draw damage rings for AoE at ground attack order positions

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -1035,6 +1035,42 @@ else -- UNSYNCED
 	local drawTarget = {}
 	local targetList = {}
 
+	-- Widgets cannot call into LuaRules, so the user-set ground targets of a unit
+	-- are pushed to LuaUI whenever its list changes. gui_attack_aoe draws damage
+	-- rings at these positions next to the lines and icons drawn below.
+	local LUAUI_TARGET_CALLIN = "UnitSetTargetListChanged"
+	local luauiHasCallin = false
+
+	---Sends the unit's user-set ground positions to LuaUI, `nil` when there are none.
+	---@param unitID UnitID
+	local function pushTargetListToLuaUI(unitID)
+		if not Script.LuaUI(LUAUI_TARGET_CALLIN) then
+			return
+		end
+		local unitData = targetList[unitID]
+		local positions
+		if unitData and (fullview or spGetUnitAllyTeam(unitID) == myAllyTeam) then
+			for _, targetData in ipairs(unitData.targets) do
+				if targetData.userTarget and type(targetData.target) == "table" then
+					positions = positions or {}
+					positions[#positions + 1] = targetData.target
+				end
+			end
+		end
+		Script.LuaUI[LUAUI_TARGET_CALLIN](unitID, positions)
+	end
+
+	function gadget:Update()
+		-- Resend every list when the receiving widget (re)loads or the viewpoint changes.
+		local hasCallin = Script.LuaUI(LUAUI_TARGET_CALLIN)
+		if hasCallin and not luauiHasCallin then
+			for unitID in pairs(targetList) do
+				pushTargetListToLuaUI(unitID)
+			end
+		end
+		luauiHasCallin = hasCallin
+	end
+
 	function gadget:Initialize()
 		gadgetHandler:AddChatAction(
 			"targetdrawteam",
@@ -1063,6 +1099,7 @@ else -- UNSYNCED
 		myAllyTeam = spGetMyAllyTeamID()
 		myTeam = spGetMyTeamID()
 		mySpec, fullview = spGetSpectatingState()
+		luauiHasCallin = false
 	end
 
 	function gadget:Shutdown()
@@ -1138,6 +1175,9 @@ else -- UNSYNCED
 			if index == unitData.targetIndex then
 				unitData.targetActive = false
 			end
+		elseif not targetA then
+			-- Every batch of list updates ends with a truncation or a clear.
+			pushTargetListToLuaUI(unitID)
 		end
 		--tracy.ZoneEnd()
 	end
@@ -1146,6 +1186,7 @@ else -- UNSYNCED
 		local unitData = getUnitTargetList(unitID, false)
 		if unitData then
 			table_remove(unitData.targets, index)
+			pushTargetListToLuaUI(unitID)
 		end
 	end
 

--- a/luaui/Widgets/gui_attack_aoe.lua
+++ b/luaui/Widgets/gui_attack_aoe.lua
@@ -54,6 +54,9 @@ local spGetUnitDefID = Spring.GetUnitDefID
 local spGetTeamResources = Spring.GetTeamResources
 local spGetUnitWeaponTestRange = Spring.GetUnitWeaponTestRange
 local spGetUnitStockpile = Spring.GetUnitStockpile
+local spGetUnitCommandCount = Spring.GetUnitCommandCount
+local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
+local spIsGUIHidden = Spring.IsGUIHidden
 local spGetViewGeometry = Spring.GetViewGeometry
 local spIsAboveMiniMap = Spring.IsAboveMiniMap
 local spTraceRayGroundBetweenPositions = Spring.TraceRayGroundBetweenPositions
@@ -130,6 +133,18 @@ local Config = {
 		salvoSpeed = 0.1,
 		waveDuration = 0.35,
 		fadeDuration = 0,
+	},
+	-- Persistent rings at the ground positions of queued attack orders and
+	-- user-set ground targets of selected units. Static and thin, so they read as
+	-- an order marker rather than the pulsing cursor preview.
+	Order = {
+		enabled = true,
+		refreshInterval = 0.15, -- seconds between command queue scans
+		queueDepth = 12, -- commands inspected per unit
+		maxIndicators = 24, -- unique target positions drawn at once
+		minAoe = 8, -- weapons with a smaller AoE get no rings
+		ringAlphaMult = 0.7, -- multiplied with the damage level of each ring
+		outerRingAlpha = 0.3,
 	},
 }
 
@@ -234,6 +249,11 @@ local State = {
 	aoeTerrainCircleDivs = 48,
 	aoeTerrainIntersectionSteps = 4,
 	aoeTerrainQualityID = 1,
+
+	orderTargets = {}, ---@type OrderTarget[]
+	orderRefreshSec = 0,
+	-- User-set ground targets per unit, pushed by the set target gadget
+	setTargetPositions = {}, ---@type table<integer, number[][]>
 }
 
 for udid, ud in pairs(UnitDefs) do
@@ -2310,6 +2330,148 @@ local WeaponTypeHandlers = {
 }
 
 --------------------------------------------------------------------------------
+-- ORDER INDICATORS
+--------------------------------------------------------------------------------
+-- The engine draws a ground attack exactly like a unit attack: a line ending in
+-- an icon. These rings mark the ground position of an attack order with the
+-- same damage falloff radii as the cursor preview, so the player can tell a
+-- ground attack from a unit attack and see where the shot will do damage.
+
+---@class OrderTarget
+---@field x number
+---@field y number
+---@field z number
+---@field weaponInfo WeaponInfo
+
+local function GetOrderWeaponInfo(weaponInfos, unitID, tx, ty, tz)
+	local weaponInfo = weaponInfos.primary
+	if weaponInfos.secondary and weaponInfo.range then
+		local ux, uy, uz = spGetUnitPosition(unitID)
+		if ux and distance3d(ux, uy, uz, tx, ty, tz) > weaponInfo.range then
+			weaponInfo = weaponInfos.secondary
+		end
+	end
+	local weaponType = weaponInfo.type
+	if weaponType == "dgun" or weaponType == "noexplode" then
+		return nil
+	end
+	if not weaponInfo.aoe or weaponInfo.aoe < Config.Order.minAoe then
+		return nil
+	end
+	return weaponInfo
+end
+
+local function AddOrderTarget(targets, seen, weaponInfos, unitID, tx, tz)
+	local ty = spGetGroundHeight(tx, tz)
+	local weaponInfo = GetOrderWeaponInfo(weaponInfos, unitID, tx, ty, tz)
+	if not weaponInfo then
+		return
+	end
+	if not weaponInfo.waterWeapon and ty < 0 then
+		ty = 0
+	end
+	-- Many units ordered onto the same spot with the same weapon share one indicator
+	local key = floor(tx) .. ":" .. floor(tz) .. ":" .. weaponInfo.aoe .. ":" .. weaponInfo.ee
+	if seen[key] then
+		return
+	end
+	seen[key] = true
+	targets[#targets + 1] = { x = tx, y = ty, z = tz, weaponInfo = weaponInfo }
+end
+
+local function CollectOrderTargets(targets, seen, aimUnits, cmdID)
+	local maxIndicators = Config.Order.maxIndicators
+	local queueDepth = Config.Order.queueDepth
+	for i = 1, #aimUnits do
+		if #targets >= maxIndicators then
+			return
+		end
+		local aimUnit = aimUnits[i]
+		local unitID = aimUnit.unitID
+		local weaponInfos = aimUnit.weaponInfos
+
+		local commandCount = min(spGetUnitCommandCount(unitID) or 0, queueDepth)
+		for c = 1, commandCount do
+			local id, _, _, px, _, pz, radius = spGetUnitCurrentCommand(unitID, c)
+			-- 3 params is a ground position; 1 param is a unit, 4 params an area attack
+			if id == cmdID and pz and not radius then
+				AddOrderTarget(targets, seen, weaponInfos, unitID, px, pz)
+			end
+		end
+
+		-- Set Target on ground does not appear in the command queue. The set
+		-- target gadget pushes every user-set ground position of the unit, the
+		-- same list it draws its own lines and icons from, so rings and icons
+		-- always appear together. Set Target never uses the manual fire weapon.
+		local setTargets = cmdID == CMD_ATTACK and State.setTargetPositions[unitID]
+		if setTargets then
+			for t = 1, #setTargets do
+				local position = setTargets[t]
+				AddOrderTarget(targets, seen, weaponInfos, unitID, position[1], position[3])
+			end
+		end
+	end
+end
+
+---Called by the set target gadget (unit_target_on_the_move) whenever the
+---user-set targets of a unit change; the gadget also clears the entry when
+---the unit is removed.
+---@param unitID integer
+---@param positions number[][]? ground positions as {x, y, z}, nil when there are none
+local function UnitSetTargetListChanged(unitID, positions)
+	State.setTargetPositions[unitID] = positions
+end
+
+local function UpdateOrderTargets()
+	local targets = State.orderTargets
+	for i = #targets, 1, -1 do
+		targets[i] = nil
+	end
+	if not Config.Order.enabled or not State.hasSelection then
+		return
+	end
+	local seen = {}
+	CollectOrderTargets(targets, seen, State.attackAimUnits, CMD_ATTACK)
+	CollectOrderTargets(targets, seen, State.manualAimUnits, CMD_MANUALFIRE)
+end
+
+---@param entry OrderTarget
+local function DrawOrderTarget(entry)
+	local weaponInfo = entry.weaponInfo
+	local tx, ty, tz = entry.x, entry.y, entry.z
+	local aoe, edgeEffectiveness = weaponInfo.aoe, weaponInfo.ee
+	local color = weaponInfo.color or Config.Colors.aoe
+
+	-- Damage falloff rings; a weapon with full edge effectiveness damages the
+	-- whole area equally, so only its outer circle is meaningful.
+	if edgeEffectiveness < 1 then
+		local alphaMult = Config.Order.ringAlphaMult
+		local minRingRadius = Config.General.minRingRadius
+		for _, damageLevel in ipairs(Config.Render.ringDamageLevels) do
+			local ringRadius = GetRadiusForDamageLevel(aoe, damageLevel, edgeEffectiveness)
+			if ringRadius < minRingRadius then
+				break
+			end
+			SetGlColor(damageLevel * alphaMult, color)
+			DrawCircle(tx, ty, tz, ringRadius)
+		end
+	end
+
+	SetGlColor(Config.Order.outerRingAlpha, color)
+	DrawCircle(tx, ty, tz, aoe)
+end
+
+local function DrawOrderTargets()
+	local targets = State.orderTargets
+	glLineWidth(screenLineWidthScale)
+	for i = 1, #targets do
+		DrawOrderTarget(targets[i])
+	end
+	glColor(1, 1, 1, 1)
+	glLineWidth(1)
+end
+
+--------------------------------------------------------------------------------
 -- CALLINS
 --------------------------------------------------------------------------------
 function widget:Initialize()
@@ -2321,6 +2483,7 @@ function widget:Initialize()
 	SetupDisplayLists()
 	UpdateScreenScale()
 	UpdateSelection()
+	widgetHandler:RegisterGlobal("UnitSetTargetListChanged", UnitSetTargetListChanged)
 end
 
 function widget:ViewResize()
@@ -2328,6 +2491,7 @@ function widget:ViewResize()
 end
 
 function widget:Shutdown()
+	widgetHandler:DeregisterGlobal("UnitSetTargetListChanged")
 	DeleteDisplayLists()
 end
 
@@ -2421,7 +2585,7 @@ local function DrawUnitAoe(
 	end
 end
 
-function widget:DrawWorldPreUnit()
+local function DrawCursorPreview()
 	State.isOverMinimap = false
 	local weaponInfos, aimingUnitID, aimUnits, activeCommand = GetActiveUnitInfo()
 	if not weaponInfos then
@@ -2517,6 +2681,18 @@ function widget:DrawWorldPreUnit()
 	end
 end
 
+function widget:DrawWorldPreUnit()
+	DrawCursorPreview()
+
+	local orderCount = #State.orderTargets
+	if orderCount > 0 and not spIsGUIHidden() then
+		-- Terrain circle lists are cached per quality level, so the order pass
+		-- can pick its own quality without disturbing the cursor preview.
+		SetAoeTerrainQuality(orderCount)
+		DrawOrderTargets()
+	end
+end
+
 function widget:SelectionChanged(sel)
 	State.selectionChanged = true
 end
@@ -2538,6 +2714,13 @@ function widget:Update(dt)
 		State.selChangedSec = 0
 		State.selectionChanged = nil
 		UpdateSelection()
+		State.orderRefreshSec = Config.Order.refreshInterval
+	end
+
+	State.orderRefreshSec = State.orderRefreshSec + dt
+	if State.orderRefreshSec >= Config.Order.refreshInterval then
+		State.orderRefreshSec = 0
+		UpdateOrderTargets()
 	end
 
 	local weaponInfos, aimingUnitID = GetActiveUnitInfo()


### PR DESCRIPTION
The behavior of ground attack and unit attack is fundamentally different. For example an attack targeting stop once the unit goes out of sight and turns into a ghost or dies. Ground attacks are indefinitely shooting and have to be manually advanced.

There needs to be a visual differentiation between the two.

As an added bonus, showing the area of effect of a ground attack adds valuable information to the player.

This PR offers a proposal to display ground attacks with simple concentric rings indicating the AoE. Maybe something that can be used as inspiration for an artist.

### Work done
The engine renders a ground attack exactly like a unit attack: a line ending in the attack icon (`CommandDrawer.cpp`). The concentric AoE rings are only the cursor preview in `gui_attack_aoe.lua` and disappear the moment the order is issued. Set Target on ground has the same problem; the target gadget draws a line and an icon regardless of target type.

This PR extends the Attack AoE widget with persistent order indicators:

- Every 0.15 s the widget scans the command queues of the selected units (allocation-free via `Spring.GetUnitCurrentCommand`) and collects attack / manual-fire orders that carry a ground position. Unit attacks and area attacks are skipped.
- Set Target on ground has no queue entry. Widgets cannot call into LuaRules, so the set target gadget (`unit_target_on_the_move.lua`) now pushes the user-set ground positions of a unit to LuaUI (`Script.LuaUI.UnitSetTargetListChanged`) whenever its list changes, and resends them when the callin appears or the viewpoint changes. The widget draws rings from that list, the same one the gadget draws its own lines and icons from, so every Set Target marker gets rings: shift-queued targets, targets out of range, and targets held by a secondary weapon included.
- At every target it draws thin, static rings at the radii where the weapon still deals 80/60/40/20 % damage (same falloff formula as the cursor preview) plus the outer AoE circle, so the player can see both *that* it is a ground attack and *where* it will hurt. Weapons with `edgeEffectiveness = 1` get only the outer circle because the damage is uniform inside.
- Rings use the preview's weapon-class colours (EMP, napalm, Juno keep their tints), show only while the owning unit is selected (matching the engine queue lines), hide with the GUI, and collapse duplicate positions from group orders. Capped at 24 unique targets; above 6 the terrain-conforming circles fall back to flat ones, as the preview already does.

The cursor preview itself is unchanged. All tunables live in the new `Config.Order` block.

#### Test steps
- [ ] Select an artillery unit (e.g. Arbiter, Shellshocker, Ambassador) and give it a ground attack. Expected: red damage-falloff rings stay at the target while the unit is selected.
- [ ] Shift-queue a second ground attack. Expected: a second ring set.
- [ ] Give a Set Target on ground. Expected: rings at the target position.
- [ ] Shift-queue a second Set Target on ground, and give another unit a Set Target far out of range. Expected: rings at every position that has a Set Target line and icon.
- [ ] Attack an enemy unit. Expected: no rings, the order looks as before.
- [ ] Deselect the units. Expected: rings disappear together with the engine queue lines.
- [ ] Press F5 to hide the GUI. Expected: rings hidden.

### Screenshots

Orders issued, all five units selected. From left to right: a Mauser with two shift-queued ground attacks (red lines), a Quaker with three shift-queued Set Targets on ground (yellow lines), a Quaker whose Set Target on ground is out of range (the long yellow line to the bottom left), a Banisher with a ground attack plus a Set Target on ground, and an Ambassador attacking a unit and holding a Set Target on another unit. Every ground position gets rings, the two unit targets do not.
<img width="1920" height="1080" alt="1-orders-issued" src="https://github.com/user-attachments/assets/c8d97487-3127-456b-836a-e8af41422ed5" />

Close-up of the Attack queue (red) and the Set Target queue (yellow): each queued ground position carries its own ring set, whether or not the unit is currently aiming at it.
<img width="1920" height="1080" alt="2-attack-and-settarget-queues" src="https://github.com/user-attachments/assets/3f0269d1-e373-4d9f-8bbf-4d740db64781" />

Firing: the rings stay put while the units work through their queues.
<img width="1920" height="1080" alt="3-firing" src="https://github.com/user-attachments/assets/045c60cd-9ca8-4df4-8652-42d766610f33" />

Deselected: the rings disappear together with the engine queue lines.
<img width="1920" height="1080" alt="4-deselected" src="https://github.com/user-attachments/assets/259f1669-e208-442e-a14b-be5151c7dc02" />

### AI / LLM usage statement:
Implemented with Claude Code (Claude Fable 5.1); design, review and in-game verification by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



