### PR TITLE
Allow widgets to update NightMode NightFactor via synced message channel Allowing tree (+rock, grass) brightness to be affected independently and locally

### DIFF
--- a/luarules/gadgets/map_nightmode.lua
+++ b/luarules/gadgets/map_nightmode.lua
@@ -71,7 +71,26 @@ for i = 1, #mapList + 1 do
 	end
 end
 
-if not gadgetHandler:IsSyncedCode() then
+local PACKET_HEADER = "atonf"
+local PACKET_HEADER_LENGTH = string.len(PACKET_HEADER)
+local PH_B1 = string.byte(PACKET_HEADER, 1)
+
+if gadgetHandler:IsSyncedCode() then
+	-- This is the synced part of the gadget, which handles RecvLuaMsg
+	function gadget:RecvLuaMsg(msg, playerID)
+		if
+			#msg < PACKET_HEADER_LENGTH
+			or string.byte(msg, 1) ~= PH_B1
+			or string.sub(msg, 1, PACKET_HEADER_LENGTH) ~= PACKET_HEADER
+		then
+			return
+		end
+        -- Forward to unsynced gadget
+        SendToUnsynced("NightModeMsg", playerID, msg)
+        return true
+    end
+else
+	-- UNSYNCED PART OF THE GADGET
 	--[[
 		Spring.SetSunLighting({ groundAmbientColor = { transitionred * gar, transitiongreen * gag, transitionblue * gab } })
 		Spring.SetSunLighting({ unitAmbientColor = { transitionred * uar, transitiongreen * uag, transitionblue * uab } })
@@ -88,6 +107,7 @@ if not gadgetHandler:IsSyncedCode() then
 		Spring.SetSunLighting({ groundShadowDensity = transition * shadowdensity, modelShadowDensity = transition * shadowdensity })
 	]]
 	--
+	local myPlayerID = Spring.GetLocalPlayerID()
 
 	local function tablecopy(t)
 		local copy = {}
@@ -190,7 +210,7 @@ if not gadgetHandler:IsSyncedCode() then
 			Spring.SetAtmosphere(lightandatmos.atmosphere)
 		end
 		--if lightandatmos.lighting then Spring.SetSunLighting({groundShadowDensity = lightandatmos.lighting.groundShadowDensity}) end -- for some godforsaken reason, this needs to be set TWICE!
-		if lightandatmos.lighting then
+		if lightandatmos.lighting or lightandatmos.nightFactor then
 			Spring.SetSunLighting({})
 		end -- for some godforsaken reason, this needs to be set TWICE!
 
@@ -458,6 +478,28 @@ if not gadgetHandler:IsSyncedCode() then
 		lastSunChanged = df
 	end
 
+	local function NightModeMsg(_, playerID, msg)
+		if playerID ~= myPlayerID then return end
+
+		-- Strip header
+		local csv = msg:sub(7)  -- skip "atonf "
+
+		local r, g, b, shadow, altitude =
+			csv:match("([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)")
+
+		if r then
+			SetLightingAndAtmosphere({
+				nightFactor = {
+					red      = tonumber(r),
+					green    = tonumber(g),
+					blue     = tonumber(b),
+					shadow   = tonumber(shadow),
+					altitude = tonumber(altitude),
+				}
+			})
+		end
+	end
+
 	function gadget:Initialize()
 		initial_atmosphere_lighting = GetLightingAndAtmosphere()
 		for i, nightConf in ipairs(nightModeConfig) do
@@ -472,6 +514,7 @@ if not gadgetHandler:IsSyncedCode() then
 		gadgetHandler:AddChatAction("NightModeToggle", NightModeToggle)
 		gadgetHandler:AddChatAction("PrintSun", PrintSun)
 		gadgetHandler:RegisterGlobal("NightModeParams", { r = 1, g = 1, b = 1, s = 1, a = 1 })
+		gadgetHandler:AddSyncAction("NightModeMsg", NightModeMsg)
 	end
 
 	function gadget:Shutdown()
@@ -480,6 +523,11 @@ if not gadgetHandler:IsSyncedCode() then
 		gadgetHandler:RemoveSyncAction("MixLightingAndAtmosphere")
 		gadgetHandler:RemoveChatAction("NightMode")
 		gadgetHandler:RemoveChatAction("NightModeToggle")
+		gadgetHandler:RemoveSyncAction("NightModeMsg")
 		SetLightingAndAtmosphere(initial_atmosphere_lighting)
 	end
+
+
+
 end
+


### PR DESCRIPTION
Allowing tree (+rock, grass) brightness to be affected independently and locally

<!--
Allow widgets to update NightMode nightFactor via synced message channel
-->

### Work done
Nightmode Gadget [https://docs.google.com/document/d/16mvYJX8WJ8cNjGe_3zhrymTOzPoSkFprr78i_vpH7yA/edit?tab=t.0#heading=h.txra2fiy4etx](url)

Is an optional mode that moves the sun and darkens the features of the world.
In the gadget it sets GG.NightFactor which affects brightness of trees through the file cus_gl4.lua [https://github.com/beyond-all-reason/Beyond-All-Reason/blob/50a434d498e85210ee95b0304736e8fab2b981d8/luarules/gadgets/cus_gl4.lua#L3121](url)

This PR aims to add an option for widgets to update GG.NightFactor through the gadget's function SetLightingAndAtmosphere

- gadget:RecvLuaMsg(msg, playerID) was added to a synced part of the gadget and paired with NightModeMsg(_, playerID, msg) in the unsynced part of the gadget to receive the message following this example [https://github.com/beyond-all-reason/Beyond-All-Reason/blob/db7ca67e203ddd9b0a800fdfaba6a47a3de3930c/luarules/gadgets/game_message.lua#L30](url)

- This is important for players who want to use or work on atmospheric widgets that are local to the user, and want to update feature brightness the same way "Map NightMode" can

#### Setup
Widgets can change NightFactor by doing something like this:

```
local testNightFactors = {
  {1.0, 1.0, 1.0, 1.0, 1.0},   -- day (no change)
  {0.5, 0.5, 0.6, 0.8, 0.8},   -- mild dusk
  {0.25,0.25,0.30,0.6, 0.6},   -- deep dusk
  {0.15,0.15,0.18,0.1, 0.1},   -- night
}
local nfIndex = 1

local function SetNightFactorOnly(nf)
    -- nf = {r, g, b, shadow, altitude}
    local csv = string.format("%f,%f,%f,%f,%f",
        nf[1], nf[2], nf[3], nf[4], nf[5]
    )
    Spring.Echo("Setting NightFactor to: " .. csv)
    Spring.SendLuaRulesMsg("atonf " .. csv)
end
```



### Screenshots:

#### BEFORE:
(all you can do without changing GG.NightFactor)
<img width="798" height="654" alt="1788517089snap" src="https://github.com/user-attachments/assets/da7dd82d-76cf-43c5-a641-d6bf10681cfd" />

#### AFTER:
(what trees look like when you activate the mode or adjust NightFactor
<img width="780" height="584" alt="1788517002snap" src="https://github.com/user-attachments/assets/e53b1627-679c-4ad3-ba24-79261745d75c" />

### AI / LLM usage statement:
Bing was used for related work and instrumentation but the solutions and final code came from me



