### PR TITLE
Fix visibility typo

### DIFF
--- a/luaui/Shaders/metalspots_gl4.vert.glsl
+++ b/luaui/Shaders/metalspots_gl4.vert.glsl
@@ -32,7 +32,7 @@ float heightAtWorldPos(vec2 w){
 #define VERTEXTYPE localpos_dir_angle.w
 
 #define NOTOCCUPIED visibility.x
-#define GAMEFRAMECHANGED visibilty.y
+#define GAMEFRAMECHANGED visibility.y
 
 #define TEXTWIDTH visibility.z
 #define TEXTHEIGHT visibility.w


### PR DESCRIPTION
This is the only incorrect spelling of it I could find. All other instances are correctly spelled. Functional change, and that's why it's in it's own pr so it's easy to review.