### PR TITLE
module: modes

### DIFF
--- a/modoptions.lua
+++ b/modoptions.lua
@@ -42,6 +42,7 @@ local options = {
 		desc = "",
 		type = "section",
 		weight = 7,
+		mode_category = "game",
 	},
 
 	{
@@ -2766,6 +2767,10 @@ for i = 1, 9 do
 		def = "",
 		hidden = true,
 	}
+end
+
+for _, option in ipairs(VFS.Include("modules/module_handler.lua").ModOptions()) do
+	options[#options + 1] = option
 end
 
 return options

--- a/modules/README.md
+++ b/modules/README.md
@@ -290,3 +290,52 @@ end
 - Facts inform a decision and are filled before it runs; a Select makes the decision. The mode decides whose fact is live.
 - The contract is the map: every step and every fact is a name there, and every wiring mistake is a load error that points at it.
 - A gadget gathers and acts; it never decides. State it must keep lives in `state.lua`, once per Lua state.
+
+## Modes
+
+`mode_builder` turns a preset file into a ModeConfig. It has no runtime of its own; each module binds its own vocabulary over it, and preset files read as a dot-only chain. A preset is a whitelist: it claims the options it needs and says which are shown, hidden or locked, and the lobby shows exactly what it claims.
+
+### In a preset
+
+Every verb is documented where the editor shows it, `modules/modes/types/mode_policy.lua`, with the option it writes. The ones every module shares:
+
+| Thing | Why | Example |
+|---|---|---|
+| `Mode(name)` | Starts a preset. The category is not a parameter: the grammar binds every chain from a module to that module's axis, and the name only names it. | `return Mode("FFA")` |
+| `.Desc(text)` | The sentence the lobby shows under the mode's name. | `.Desc("Free for all: every player for themselves.")` |
+| `.Ranked()` | Whether the mode may count for rating. Never saying it means unranked, and the pin is written either way, so the lobby never has to pin it itself. | `.Ranked()` |
+| a claim verb | Writes one option. Verbs that pick from a list take an enum, not a string. A bare claim is a suggestion and leaves its option open. | `.End(DeathMode.OwnCommander)`, `.MaxUnits(2000)` |
+| `.Locked()` | Pins the last claim's structure; its dials stay editable. | `.Wreckage(true).Locked()` |
+| `.Sealed()` | Pins the last claim outright, dials included. | `.UnitRestrictions().Sealed()` |
+| `.Hidden()` | Keeps the last claim out of the lobby UI; its pin still applies. | `.FogOfWar(true).Hidden()` |
+| `.Unlocked()` | The last claim is fully editable. Rule verbs come back pinned, so this is how a preset opens one. | `.Allow(Transfer.Units).Unlocked()` |
+| `.Uses(contract)` | A module whose fact providers this preset makes live, besides the one that ships it. Named by its contract, never a string. | `.Uses(TechModule)` |
+| `.RetainValues()` | A non-sticky preset: picking it exposes and unlocks its claims but keeps the current values as the starting point. | `.RetainValues()` |
+
+The FFA preset, whole:
+
+```lua
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+return Mode("FFA")
+	.Desc("Free for all: every player for themselves. Losing your commander resigns you, and the fallen leave wreckage behind.")
+	.Ranked()
+	.End(DeathMode.OwnCommander)
+	.Wreckage(true).Locked()
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.EnemyTransporting("notcoms")
+	.UnitRestrictions()
+```
+
+### The game axis
+
+A match is exactly one way of being played, so there is one selector, `game_mode`, owned by the mode infrastructure rather than any flavor. The presets are Standard, FFA, Team FFA and Territorial Domination.
+
+- Section entries in a module's `modoptions.lua` can declare `mode_category` (which axis governs their options) and `mode_key` (which preset reveals them).
+- The root `modoptions.lua` appends every module's fragment through `ModuleHandler.ModOptions()`, so a module that ships options needs no change to the root file.
+- `modules/modes/lib/values.lua` is the one formatter for a mode value on the wire (booleans as `1`/`0`, numbers at float32 precision). The export widget bakes `modes.json` with it and the lobby includes it out of the game archive, so neither side carries a copy. `tools/headless_testing/startscript_modes_export.txt` runs that export headless.
+- A preset says what it makes live. The runtime walks every combination of presets at load and refuses one that leaves two providers live for one fact.

--- a/modules/enums.lua
+++ b/modules/enums.lua
@@ -2,8 +2,10 @@
 ---the commit that adds the module, so a rename follows every reader.
 ---@class Modules
 ---@field Defs string
+---@field Modes string
 local Modules = {
 	Defs = "defs",
+	Modes = "modes",
 }
 
 return { Modules = Modules }

--- a/modules/modes/enums.lua
+++ b/modules/modes/enums.lua
@@ -1,0 +1,64 @@
+local M = {}
+
+M.ModeCategories = {
+	Game = "game",
+}
+
+M.Modes = {
+	Standard = "standard",
+}
+
+---@alias DeathModeKey "neverend"|"com"|"territorial_domination"|"builders"|"killall"|"own_com"
+---@class DeathModeFields
+---@field NeverEnd "neverend" the game runs until everyone leaves
+---@field Commander "com" a team loses when its last commander dies
+---@field TerritorialDomination "territorial_domination" rounds of territory control decide it
+---@field Builders "builders" a team loses when it can no longer build
+---@field KillAll "killall" a team loses when every unit is dead
+---@field OwnCommander "own_com" a player loses when their own commander dies
+
+---@type DeathModeFields
+M.DeathMode = {
+	NeverEnd = "neverend",
+	Commander = "com",
+	TerritorialDomination = "territorial_domination",
+	Builders = "builders",
+	KillAll = "killall",
+	OwnCommander = "own_com",
+}
+
+---@alias DraftModeKey "disabled"|"random"|"captain"|"skill"|"fair"
+---@class DraftModeFields
+---@field Disabled "disabled"
+---@field Random "random"
+---@field Captain "captain"
+---@field Skill "skill"
+---@field Fair "fair"
+
+---@type DraftModeFields
+M.DraftMode = {
+	Disabled = "disabled",
+	Random = "random",
+	Captain = "captain",
+	Skill = "skill",
+	Fair = "fair",
+}
+
+---@alias AnonymousModeKey "disabled"|"global"|"local"|"disco"|"allred"
+---@class AnonymousModeFields
+---@field Disabled "disabled"
+---@field Global "global"
+---@field Local "local"
+---@field Disco "disco"
+---@field AllRed "allred"
+
+---@type AnonymousModeFields
+M.AnonymousMode = {
+	Disabled = "disabled",
+	Global = "global",
+	Local = "local",
+	Disco = "disco",
+	AllRed = "allred",
+}
+
+return M

--- a/modules/modes/lib/values.lua
+++ b/modules/modes/lib/values.lua
@@ -1,0 +1,25 @@
+---@class ModeValues
+local Values = {}
+
+---A modoption on the wire is a string. Booleans are the engine's "1"/"0".
+---Engine Lua numbers are float32, so a plain tostring leaks precision noise
+---("0.60000002"); round at float32's seven digits with %.7f, then strip the
+---trailing zeros the engine's %g would keep. Yields "0.6", "30", "-1".
+---
+---Every producer of a mode value string reads this one function: the CI
+---export that bakes modes.json, and the lobby, which includes it out of the
+---game archive. A client's "did the user deviate from the preset" compares
+---strings, so two formatters would be a bug waiting for a value.
+---@param v any
+---@return string
+function Values.ToModOption(v)
+	if type(v) == "boolean" then
+		return v and "1" or "0"
+	end
+	if type(v) == "number" then
+		return (string.format("%.7f", v):gsub("0+$", ""):gsub("%.$", ""))
+	end
+	return tostring(v)
+end
+
+return Values

--- a/modules/modes/mode_dsl.lua
+++ b/modules/modes/mode_dsl.lua
@@ -1,0 +1,211 @@
+
+local ModeBuilder = VFS.Include("modules/mode_builder.lua")
+local ModeEnums = VFS.Include("modules/modes/enums.lua")
+
+---@class GameModeDSL
+---@field DeathMode DeathModeFields the keys .End accepts
+---@field DraftMode DraftModeFields the keys .Draft accepts
+---@field AnonymousMode AnonymousModeFields the keys .Anonymous accepts
+---@field Mode fun(name: string): GameModeChain Start a preset. The category is not a parameter: the grammar binds every chain from this module to "game" — the name only names it.
+
+local M = {}
+---@cast M GameModeDSL
+M.DeathMode = ModeEnums.DeathMode
+M.DraftMode = ModeEnums.DraftMode
+M.AnonymousMode = ModeEnums.AnonymousMode
+
+---@param modeName string
+---@param verb string
+---@param enum table<string, string>
+---@param value any
+local function oneOf(modeName, verb, enum, value)
+	for _, allowed in pairs(enum) do
+		if value == allowed then
+			return
+		end
+	end
+	local keys = {}
+	for name in pairs(enum) do
+		keys[#keys + 1] = name
+	end
+	table.sort(keys)
+	error(
+		modeName
+			.. ": ."
+			.. verb
+			.. " expects one of "
+			.. verb
+			.. "Mode."
+			.. table.concat(keys, ", " .. verb .. "Mode.")
+	)
+end
+
+local RESTRICTION_KEYS = {
+	"unit_restrictions_notech15",
+	"unit_restrictions_notech2",
+	"unit_restrictions_notech3",
+	"unit_restrictions_noair",
+	"unit_restrictions_nosea",
+	"unit_restrictions_noextractors",
+	"unit_restrictions_noconverters",
+	"unit_restrictions_nofusion",
+	"unit_restrictions_notacnukes",
+	"unit_restrictions_nonukes",
+	"unit_restrictions_noantinuke",
+	"unit_restrictions_nolrpc",
+	"unit_restrictions_noendgamelrpc",
+}
+
+local function option(key, value, locked)
+	return { [key] = { value = value, locked = locked } }
+end
+
+local Serializers = {
+	["game.end"] = function(p, lock)
+		local options = option("deathmode", p.deathmode, lock.structure)
+		if p.deathmode == ModeEnums.DeathMode.TerritorialDomination then
+			options.territorial_domination_config = { value = "25_minutes", locked = false }
+			options.territorial_domination_elimination_threshold_multiplier = { value = 1.2, locked = false }
+		end
+		return options
+	end,
+	["game.wreckage"] = function(p, lock)
+		return option("ffa_wreckage", p.enabled, lock.structure)
+	end,
+	["game.shuffle"] = function(p, lock)
+		return option("teamffa_start_boxes_shuffle", p.enabled, lock.structure)
+	end,
+	["game.maxunits"] = function(p, lock)
+		return option("maxunits", p.count, lock.dial)
+	end,
+	["game.draft"] = function(p, lock)
+		return option("draft_mode", p.draft, lock.structure)
+	end,
+	["game.anonymous"] = function(p, lock)
+		return option("teamcolors_anonymous_mode", p.anonymous, lock.structure)
+	end,
+	["game.pausedcommands"] = function(p, lock)
+		return option("allowpausegameplay", p.enabled, lock.structure)
+	end,
+	["game.customwidgets"] = function(p, lock)
+		return option("allowuserwidgets", p.enabled, lock.structure)
+	end,
+	["game.unitcontrolwidgets"] = function(p, lock)
+		return option("allowunitcontrolwidgets", p.enabled, lock.structure)
+	end,
+	["game.fixedalliances"] = function(p, lock)
+		return option("fixedallies", p.enabled, lock.structure)
+	end,
+	-- stated in the player's terms; the wire keys are the Disable* inversions
+	["game.mapdeformation"] = function(p, lock)
+		return option("disablemapdamage", not p.enabled, lock.structure)
+	end,
+	["game.fogofwar"] = function(p, lock)
+		return option("disable_fogofwar", not p.enabled, lock.structure)
+	end,
+	["game.norush"] = function(p, lock)
+		return {
+			norushtimer = { value = p.minutes, locked = lock.dial },
+			norushmiddlefree = { value = p.middleFree == true, locked = lock.dial },
+		}
+	end,
+	["game.slowcomtransport"] = function(p, lock)
+		return option("comm_trans_slow", p.enabled, lock.structure)
+	end,
+	["game.unit_restrictions"] = function(_p, lock)
+		local options = {}
+		for _, key in ipairs(RESTRICTION_KEYS) do
+			options[key] = { value = false, locked = lock.dial }
+		end
+		return options
+	end,
+}
+
+---@param modeName string
+---@param verb string
+---@param value any
+local function checkBoolean(modeName, verb, value)
+	assert(type(value) == "boolean", modeName .. ": ." .. verb .. " expects true or false")
+end
+
+M.Mode = ModeBuilder.Grammar({
+	category = ModeEnums.ModeCategories.Game,
+	serializers = Serializers,
+	verbs = {
+		End = function(modeName, deathmode)
+			oneOf(modeName, "Death", ModeEnums.DeathMode, deathmode)
+			return { "game.end", deathmode = deathmode }
+		end,
+
+		Wreckage = function(modeName, enabled)
+			checkBoolean(modeName, "Wreckage", enabled)
+			return { "game.wreckage", enabled = enabled }
+		end,
+
+		ShuffleStartBoxes = function(modeName, enabled)
+			checkBoolean(modeName, "ShuffleStartBoxes", enabled)
+			return { "game.shuffle", enabled = enabled }
+		end,
+
+		MaxUnits = function(modeName, count)
+			assert(type(count) == "number", modeName .. ": .MaxUnits expects a number")
+			return { "game.maxunits", count = count }
+		end,
+
+		Draft = function(modeName, draft)
+			oneOf(modeName, "Draft", ModeEnums.DraftMode, draft)
+			return { "game.draft", draft = draft }
+		end,
+
+		Anonymous = function(modeName, anonymous)
+			oneOf(modeName, "Anonymous", ModeEnums.AnonymousMode, anonymous)
+			return { "game.anonymous", anonymous = anonymous }
+		end,
+
+		PausedCommands = function(modeName, enabled)
+			checkBoolean(modeName, "PausedCommands", enabled)
+			return { "game.pausedcommands", enabled = enabled }
+		end,
+
+		CustomWidgets = function(modeName, enabled)
+			checkBoolean(modeName, "CustomWidgets", enabled)
+			return { "game.customwidgets", enabled = enabled }
+		end,
+
+		UnitControlWidgets = function(modeName, enabled)
+			checkBoolean(modeName, "UnitControlWidgets", enabled)
+			return { "game.unitcontrolwidgets", enabled = enabled }
+		end,
+
+		FixedAlliances = function(modeName, enabled)
+			checkBoolean(modeName, "FixedAlliances", enabled)
+			return { "game.fixedalliances", enabled = enabled }
+		end,
+
+		MapDeformation = function(modeName, enabled)
+			checkBoolean(modeName, "MapDeformation", enabled)
+			return { "game.mapdeformation", enabled = enabled }
+		end,
+
+		FogOfWar = function(modeName, enabled)
+			checkBoolean(modeName, "FogOfWar", enabled)
+			return { "game.fogofwar", enabled = enabled }
+		end,
+
+		NoRush = function(modeName, minutes, middleFree)
+			assert(type(minutes) == "number", modeName .. ": .NoRush expects minutes")
+			return { "game.norush", minutes = minutes, middleFree = middleFree }
+		end,
+
+		SlowComTransport = function(modeName, enabled)
+			checkBoolean(modeName, "SlowComTransport", enabled)
+			return { "game.slowcomtransport", enabled = enabled }
+		end,
+
+		UnitRestrictions = function(_modeName)
+			return { "game.unit_restrictions" }
+		end,
+	},
+}) --[[@as fun(name: string): GameModeChain]]
+
+return M

--- a/modules/modes/modes/ffa.lua
+++ b/modules/modes/modes/ffa.lua
@@ -1,0 +1,24 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("FFA")
+	.Desc(
+		"Free for all: every player for themselves. Losing your commander resigns you, and the fallen leave wreckage behind."
+	)
+	.Ranked()
+	.End(DeathMode.OwnCommander)
+	.Wreckage(true).Locked()
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modes/standard.lua
+++ b/modules/modes/modes/standard.lua
@@ -1,0 +1,21 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("Standard")
+	.Desc("An ordinary game: no scripted mission, no PvE swarm.")
+	.Ranked()
+	.End(DeathMode.Commander)
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modes/team_ffa.lua
+++ b/modules/modes/modes/team_ffa.lua
@@ -1,0 +1,23 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("Team FFA")
+	.Desc("Several teams, every team for itself. Start boxes are dealt at random, and fallen teams leave wreckage behind.")
+	.Ranked()
+	.ShuffleStartBoxes(true).Locked()
+	.Wreckage(true).Locked()
+	.End(DeathMode.Commander)
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modes/territorial_domination.lua
+++ b/modules/modes/modes/territorial_domination.lua
@@ -1,0 +1,23 @@
+local ModeDSL = VFS.Include("modules/modes/mode_dsl.lua") ---@type GameModeDSL
+local Mode = ModeDSL.Mode
+local DeathMode, DraftMode, AnonymousMode = ModeDSL.DeathMode, ModeDSL.DraftMode, ModeDSL.AnonymousMode
+
+-- stylua: ignore
+return Mode("Territorial Domination")
+	.Desc(
+		"Teams earn points by capturing territory to stay in the game. At the end of the final round, the team with the most points wins."
+	)
+	.Ranked()
+	.End(DeathMode.TerritorialDomination).Locked()
+	.MaxUnits(2000)
+	.Draft(DraftMode.Random)
+	.Anonymous(AnonymousMode.Disabled)
+	.PausedCommands(true)
+	.CustomWidgets(true)
+	.UnitControlWidgets(true)
+	.FixedAlliances(true)
+	.MapDeformation(true)
+	.FogOfWar(true)
+	.NoRush(0)
+	.SlowComTransport(false)
+	.UnitRestrictions()

--- a/modules/modes/modoptions.lua
+++ b/modules/modes/modoptions.lua
@@ -1,0 +1,36 @@
+--- Flavors append their preset key to the items in their own commit: SPADS and unitsync accept only listed values.
+
+local ModeEnums = VFS.Include("modules/modes/enums.lua")
+
+return {
+	{
+		key = ModeEnums.ModeCategories.Game,
+		name = "Game",
+		desc = "Which game this is: one choice, everything else follows from it.",
+		type = "section",
+		weight = 8,
+	},
+
+	{
+		key = "game_mode",
+		name = "Game Mode",
+		desc = "How this match is played. Picking a mode sets everything the mode needs and locks what it depends on.",
+		type = "list",
+		section = ModeEnums.ModeCategories.Game,
+		def = ModeEnums.Modes.Standard,
+		items = {
+			{
+				key = ModeEnums.Modes.Standard,
+				name = "Standard",
+				desc = "An ordinary game: no scripted mission, no PvE swarm.",
+			},
+			{ key = "ffa", name = "FFA", desc = "Free for all: every player for themselves." },
+			{ key = "team_ffa", name = "Team FFA", desc = "Several teams, every team for itself." },
+			{
+				key = "territorial_domination",
+				name = "Territorial Domination",
+				desc = "Teams earn points by capturing territory to stay in the game.",
+			},
+		},
+	},
+}

--- a/modules/modes/module.lua
+++ b/modules/modes/module.lua
@@ -1,0 +1,5 @@
+---@type ModuleManifestFile
+return {
+	name = "modes",
+	description = "Game mode infrastructure: the game axis, preset aggregation and export",
+}

--- a/modules/modes/spec/lib/values_spec.lua
+++ b/modules/modes/spec/lib/values_spec.lua
@@ -1,0 +1,21 @@
+local Values = VFS.Include("modules/modes/lib/values.lua") ---@type ModeValues
+
+describe("mode values on the wire", function()
+	it("writes booleans as the engine reads them", function()
+		assert.are.equal("1", Values.ToModOption(true))
+		assert.are.equal("0", Values.ToModOption(false))
+	end)
+
+	it("rounds numbers at float32 precision and trims what %g would keep", function()
+		assert.are.equal("0.6", Values.ToModOption(0.6))
+		assert.are.equal("0.6", Values.ToModOption(0.60000002))
+		assert.are.equal("30", Values.ToModOption(30))
+		assert.are.equal("-1", Values.ToModOption(-1))
+		assert.are.equal("0", Values.ToModOption(0))
+		assert.are.equal("1.5", Values.ToModOption(1.5))
+	end)
+
+	it("passes strings through", function()
+		assert.are.equal("notcoms", Values.ToModOption("notcoms"))
+	end)
+end)

--- a/modules/modes/spec/modoptions_spec.lua
+++ b/modules/modes/spec/modoptions_spec.lua
@@ -1,0 +1,108 @@
+
+local fragment = VFS.Include("modules/modes/modoptions.lua")
+
+---@param key string
+---@return table|nil
+local function option(key)
+	for _, entry in ipairs(fragment) do
+		if entry.key == key then
+			return entry
+		end
+	end
+	return nil
+end
+
+describe("the game axis", function()
+	it("ships the game section, weighted to lead", function()
+		local section = option("game")
+		assert.are.equal("section", section.type)
+		assert.are.equal("Game", section.name)
+		assert.are.equal(8, section.weight)
+	end)
+
+	it("ships the selector, defaulting to standard", function()
+		local selector = option("game_mode")
+		assert.are.equal("list", selector.type)
+		assert.are.equal("standard", selector.def)
+		assert.are.equal("game", selector.section)
+		assert.are.equal("standard", selector.items[1].key)
+	end)
+
+	it("governs the Main options — the base rules belong to how the match is played", function()
+		for _, entry in ipairs(VFS.Include("modoptions.lua")) do
+			if entry.key == "options_main" and entry.type == "section" then
+				assert.are.equal("game", entry.mode_category)
+				return
+			end
+		end
+		error("options_main section not found")
+	end)
+
+	describe("the Standard preset", function()
+		local standard = VFS.Include("modules/modes/modes/standard.lua")
+
+		it("exposes an ordinary game's dials, open, at their defaults", function()
+			assert.are.equal("standard", standard.key)
+			assert.are.equal("game", standard.category)
+			assert.are.same({ value = "com", locked = false }, standard.modOptions.deathmode)
+			assert.are.same({ value = 2000, locked = false }, standard.modOptions.maxunits)
+			assert.are.same({ value = "random", locked = false }, standard.modOptions.draft_mode)
+			assert.are.same({ value = false, locked = false }, standard.modOptions.unit_restrictions_noair)
+		end)
+
+		it("does not show what it does not speak: no TD config, no FFA manners", function()
+			assert.is_nil(standard.modOptions.territorial_domination_config)
+			assert.is_nil(standard.modOptions.ffa_wreckage)
+			assert.is_nil(standard.modOptions.teamffa_start_boxes_shuffle)
+		end)
+
+		it("stays ranked and fields no bot", function()
+			assert.is_true(standard.allowRanked)
+			assert.is_nil(standard.bots)
+		end)
+	end)
+
+	describe("the FFA preset", function()
+		local ffa = VFS.Include("modules/modes/modes/ffa.lua")
+
+		it("is Standard's dials with the FFA manners", function()
+			assert.are.equal("ffa", ffa.key)
+			assert.are.same({ value = "own_com", locked = false }, ffa.modOptions.deathmode)
+			assert.are.same({ value = true, locked = true }, ffa.modOptions.ffa_wreckage)
+			assert.are.same({ value = 2000, locked = false }, ffa.modOptions.maxunits)
+			assert.is_true(ffa.allowRanked)
+		end)
+	end)
+
+	describe("the Team FFA preset", function()
+		local teamFfa = VFS.Include("modules/modes/modes/team_ffa.lua")
+
+		it("shuffles the boxes, keeps the manners, opens the rest", function()
+			assert.are.equal("team_ffa", teamFfa.key)
+			assert.are.same({ value = true, locked = true }, teamFfa.modOptions.teamffa_start_boxes_shuffle)
+			assert.are.same({ value = true, locked = true }, teamFfa.modOptions.ffa_wreckage)
+			assert.are.same({ value = "com", locked = false }, teamFfa.modOptions.deathmode)
+			assert.is_true(teamFfa.allowRanked)
+		end)
+	end)
+
+	describe("the Territorial Domination preset", function()
+		local td = VFS.Include("modules/modes/modes/territorial_domination.lua")
+
+		it("locks the end rule, which brings its own dials along", function()
+			assert.are.equal("territorial_domination", td.key)
+			assert.are.same({ value = "territorial_domination", locked = true }, td.modOptions.deathmode)
+			assert.are.same({ value = "25_minutes", locked = false }, td.modOptions.territorial_domination_config)
+			assert.are.same(
+				{ value = 1.2, locked = false },
+				td.modOptions.territorial_domination_elimination_threshold_multiplier
+			)
+			assert.is_true(td.allowRanked)
+		end)
+
+		it("keeps the round dials to itself — Standard never shows them", function()
+			local standard = VFS.Include("modules/modes/modes/standard.lua")
+			assert.is_nil(standard.modOptions.territorial_domination_config)
+		end)
+	end)
+end)

--- a/modules/modes/types/mode_policy.lua
+++ b/modules/modes/types/mode_policy.lua
@@ -1,0 +1,41 @@
+---@meta policy mode
+
+---A game mode preset under construction. Every verb claims one policy and the
+---modoptions it writes; the panel is a whitelist, so a mode shows exactly what
+---it claims. A verb's claim is followed by at most one of Locked, Sealed,
+---Unlocked or Hidden, which applies to that claim only.
+---
+---Locked pins the claim's structure (the option a player would flip) and leaves
+---its dials open; Sealed pins the dials too. Dials are the numeric follow-ons:
+---MaxUnits, NoRush, UnitRestrictions, and the round settings End brings along.
+---@class GameModeChain
+---@field Desc fun(desc: string): GameModeChain The sentence the lobby shows under the mode's name.
+---@field Ranked fun(enabled: boolean?): GameModeChain Whether the mode may count for rating. Ranked() allows it; Ranked(false), or never saying Ranked, pins ranked_game off, lockable like any claim.
+---@field Bot fun(aiName: string): GameModeChain An AI the lobby fields for this mode, by short name; repeat for more.
+---@field Uses fun(contract: table): GameModeChain A module whose fact providers this preset makes live, besides the module that ships the preset; named by its contract.lua, never a string. The mode decides who answers a slot; two live providers for one slot is a load error.
+---@field RetainValues fun(): GameModeChain A non-sticky preset (Customize): picking it exposes and unlocks its claims but keeps the current values instead of resetting the category to defaults.
+---@field Hidden fun(): GameModeChain The last claim stays out of the lobby UI; its pin still applies.
+---@field Unlocked fun(): GameModeChain The last claim is fully editable, structure and dials.
+---@field Locked fun(): GameModeChain The last claim's structure is pinned; its dials stay editable.
+---@field Sealed fun(): GameModeChain The last claim is pinned outright, dials included.
+---@field End fun(deathmode: DeathModeKey): GameModeChain How the game ends: writes deathmode. territorial_domination brings its round length and elimination dials along, open.
+---@field Wreckage fun(enabled: boolean): GameModeChain Whether a resigned or eliminated player's units stay as wreckage: writes ffa_wreckage.
+---@field ShuffleStartBoxes fun(enabled: boolean): GameModeChain Randomise which start box each team gets: writes teamffa_start_boxes_shuffle.
+---@field MaxUnits fun(count: number): GameModeChain Unit cap per player: writes maxunits, a dial.
+---@field Draft fun(draft: DraftModeKey): GameModeChain Start position drafting: writes draft_mode with the given key.
+---@field Anonymous fun(anonymous: AnonymousModeKey): GameModeChain Team colour anonymity: writes teamcolors_anonymous_mode with the given key.
+---@field PausedCommands fun(enabled: boolean): GameModeChain Whether orders may be given while paused: writes allowpausegameplay.
+---@field CustomWidgets fun(enabled: boolean): GameModeChain Whether players may run their own widgets: writes allowuserwidgets.
+---@field UnitControlWidgets fun(enabled: boolean): GameModeChain Whether widgets may control units: writes allowunitcontrolwidgets.
+---@field FixedAlliances fun(enabled: boolean): GameModeChain Whether alliances are fixed for the game: writes fixedallies.
+---@field MapDeformation fun(enabled: boolean): GameModeChain Whether weapons reshape terrain. Stated in the player's terms; writes disablemapdamage inverted.
+---@field FogOfWar fun(enabled: boolean): GameModeChain Whether the map has fog of war. Stated in the player's terms; writes disable_fogofwar inverted.
+---@field NoRush fun(minutes: number, middleFree: boolean?): GameModeChain Minutes players must stay in their start boxes, 0 for none: writes norushtimer and norushmiddlefree, both dials.
+---@field SlowComTransport fun(enabled: boolean): GameModeChain Whether carrying your own commander slows a transport: writes comm_trans_slow.
+---@field UnitRestrictions fun(): GameModeChain Claims every unit_restrictions_* toggle at off, so the panel shows them as dials the host may flip. Sealed() pins them all off; Locked() does not, they are dials.
+
+---The category is not a parameter: the grammar binds every chain from this
+---module to "game".
+---@param name string
+---@return GameModeChain
+function Mode(name) end

--- a/modules/modes/widgets/export_modes.lua
+++ b/modules/modes/widgets/export_modes.lua
@@ -1,0 +1,121 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "Modes JSON Export",
+		desc = "Exports every mode preset, all categories, to structured JSON.\nCommand: /exportmodes",
+		author = "Daniel Harvey",
+		date = "June 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = false,
+	}
+end
+
+local spEcho = Spring.Echo
+
+local SCHEMA_VERSION = 1
+local OUTPUT_PATH = "modes.json"
+
+-- One formatter for every mode value string, shared with the lobby.
+local Values = VFS.Include("modules/modes/lib/values.lua") ---@type ModeValues
+local toModOptionValue = Values.ToModOption
+
+local function collectDefaultsByCategory()
+	local defs = VFS.Include("modoptions.lua")
+	local sectionCategory = {}
+	for _, o in ipairs(defs) do
+		if o.key and o.type == "section" then
+			sectionCategory[o.key] = o.mode_category or o.key
+		end
+	end
+	local byCategory = {}
+	for _, o in ipairs(defs) do
+		if
+			o.key
+			and o.section
+			and o.def ~= nil
+			and o.type ~= "section"
+			and o.type ~= "subheader"
+			and o.type ~= "separator"
+		then
+			local category = sectionCategory[o.section] or o.section
+			byCategory[category] = byCategory[category] or {}
+			byCategory[category][o.key] = toModOptionValue(o.def)
+		end
+	end
+	return byCategory
+end
+
+local function collectModesByCategory()
+	local ModuleHandler = VFS.Include("modules/module_handler.lua")
+	local byCategory = {}
+	for _, dir in ipairs(ModuleHandler.ModeDirs()) do
+		for _, modeFile in ipairs(VFS.DirList(dir, "*.lua") or {}) do
+			local ok, mode = pcall(VFS.Include, modeFile)
+			if ok and type(mode) == "table" and mode.key and mode.category then
+				byCategory[mode.category] = byCategory[mode.category] or {}
+				byCategory[mode.category][mode.key] = mode
+			end
+		end
+	end
+	return byCategory
+end
+
+-- Full effective option set (defaults then overrides), so applying a mode resets the previous one.
+local function buildEffectiveModOptions(defaults, mode, selector)
+	local effective = {}
+	for key, value in pairs(defaults) do
+		if key ~= selector then
+			effective[key] = { value = value, locked = false }
+		end
+	end
+	for key, rule in pairs(mode.modOptions or {}) do
+		if key ~= selector and rule.value ~= nil then
+			effective[key] = { value = toModOptionValue(rule.value), locked = rule.locked == true }
+		end
+	end
+	return effective
+end
+
+local function buildExport()
+	local defaultsByCategory = collectDefaultsByCategory()
+	local modesByCategory = collectModesByCategory()
+
+	local categories = {}
+	for category, modes in pairs(modesByCategory) do
+		local selector = category .. "_mode"
+		local defaults = defaultsByCategory[category] or {}
+		local presets = {}
+		for modeKey, mode in pairs(modes) do
+			presets[modeKey] = {
+				name = mode.name,
+				desc = mode.desc,
+				allowRanked = mode.allowRanked,
+				-- PvE modes are activated by an AI's presence, so the lobby has to be told to add one.
+				bots = mode.bots,
+				modOptions = buildEffectiveModOptions(defaults, mode, selector),
+			}
+		end
+		categories[category] = { selector = selector, presets = presets }
+	end
+
+	return { schemaVersion = SCHEMA_VERSION, categories = categories }
+end
+
+local function ExportModes()
+	local file, err = io.open(OUTPUT_PATH, "w")
+	if not file then
+		spEcho("Modes JSON Export: could not open " .. OUTPUT_PATH .. ": " .. tostring(err))
+		return
+	end
+	file:write(Json.encode(buildExport()))
+	file:close()
+	spEcho("Modes JSON Export: wrote " .. OUTPUT_PATH)
+end
+
+function widget:TextCommand(command)
+	if command == "exportmodes" then
+		ExportModes()
+	end
+end

--- a/modules/module_handler.lua
+++ b/modules/module_handler.lua
@@ -152,6 +152,14 @@ function ModuleHandler.GadgetDirs(vfsMode)
 	return moduleSubdirs(LAYOUT.gadgets, vfsMode)
 end
 
+---The presets a module ships, one file each under modes/; the modes module
+---aggregates them into the game's options.
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.ModeDirs(vfsMode)
+	return moduleSubdirs(LAYOUT.modes, vfsMode)
+end
+
 ---@param filePath string
 ---@return string
 local function nameFromFile(filePath)

--- a/tools/headless_testing/startscript_modes_export.txt
+++ b/tools/headless_testing/startscript_modes_export.txt
@@ -1,0 +1,28 @@
+[GAME]
+{
+	MapName=Quicksilver Remake 1.24;
+	GameType=Beyond All Reason $VERSION;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=ModesExport;
+	IsHost=1;
+	FixedRNGSeed = 1;
+  [MODOPTIONS]
+  {
+    debugcommands=1:luaui enablewidget Modes JSON Export|2:exportmodes|3:quitforce;
+    deathmode=neverend;
+  }
+  [ALLYTEAM0]
+  {
+  }
+  [TEAM0]
+  {
+    allyteam=0;
+    teamleader=0;
+  }
+  [PLAYER0]
+  {
+    team=0;
+  }
+}

--- a/types/Spring.lua
+++ b/types/Spring.lua
@@ -65,3 +65,10 @@
 ---@class ObjectRenderingTable
 ---@field ActivateMaterial fun(objectID: integer, lod: integer)
 ---@field DeactivateMaterial fun(objectID: integer, lod: integer)
+
+--- The submodule declares Spring as a GLOBAL, not a named type, so this alias is what makes
+--- `engine: Spring` annotations resolve; `table` keeps mock injection free of false mismatches.
+---@alias Spring table
+
+--- gadget:ResourceExcess payload comes from RecoilEngine PR #2642 (still open); overflow already deducted this frame.
+---@alias ResourceExcesses table<integer, { [1]: number, [2]: number }>


### PR DESCRIPTION
Stack: **modules → defs → modes** ‖ transport → construction → economy → transfer → tech → tech core. Everything before ‖ merges alone and changes nothing; everything after is a game rule and merges when its owners say so.

The game axis, as a module: one selector, `game_mode`, the presets Standard, FFA, Team FFA and Territorial Domination, and the export the lobby reads. The grammar the presets are written in, `mode_builder`, is in the runtime PR (#8484); it has no vocabulary of its own, and this module binds the game verbs over it. A preset is a whitelist: it claims the options it needs and says which are shown, hidden or locked, and the lobby shows exactly what it claims. Every verb is documented where the editor shows it, `modules/modes/types/mode_policy.lua`, with the option it writes.

A verb lives with its option. The verbs here are for root modoptions nobody owns yet; when a module takes an option into its own `modoptions.lua`, the verb and the presets' claims on it move with it, and this axis shrinks.

What ships:

- A match is exactly one way of being played, so there is one selector, `game_mode`, owned by the mode infrastructure rather than any flavor. The presets are Standard, FFA, Team FFA and Territorial Domination (scavs and raptors would make sense here but putting them into this form met resistance so I left them alone for now).
- Section entries can declare `mode_category` (which axis governs their options) and `mode_key` (which preset reveals them).
- A bare preset verb is a suggestion and leaves its option open. `.Locked()` pins the structure, `.Sealed()` pins the dials as well. Verbs that are rules rather than suggestions come back already pinned.
- Verbs that pick from a list take an enum, not a string: `End`, `Draft` and `Anonymous` refuse anything outside `DeathMode`, `DraftMode` and `AnonymousMode`, which the DSL exports. `UnitRestrictions()` claims every `unit_restrictions_*` toggle at off, so the panel shows them as dials; only `.Sealed()` pins them, since they are dials.
- Rating is part of the preset. A mode that never says `Ranked()` is unranked and carries the `ranked_game` pin like any other claim, so the lobby never has to pin it itself.
- A preset says what it makes live. It makes the module that ships it live for the runtime's fact providers, and `.Uses(contract)` adds another, named by its contract.lua rather than a string. That is how transfer's Customize preset keeps Tech Core's tiered answers while Enabled does not. The runtime walks every combination of presets at load and refuses one that leaves two providers live for one slot (the module runtime, #8484).
- The root `modoptions.lua` appends every module's fragment through `ModuleHandler.ModOptions()`, so a module that ships options needs no change to the root file.
- `modules/modes/lib/values.lua` is the one formatter for a mode value on the wire (booleans as `1`/`0`, numbers at float32 precision). The export widget bakes `modes.json` with it and the lobby includes it out of the game archive (beyond-all-reason/BYAR-Chobby#1041), so neither side carries a copy. `tools/headless_testing/startscript_modes_export.txt` runs that export headless, which is what CI and `just spads::stage-modes` use.


The guide is [`modules/README.md`](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/module-runtime/modules/README.md) in the runtime PR; its Modes section is this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

