### PR TITLE
Hide wind and tidal animations with the topbar indicators

### DIFF
--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -2925,7 +2925,7 @@ function widget:DrawScreen()
 		glPopMatrix()
 	end
 
-	if displayTidalSpeed and dlist.tidal2 then
+	if cache.showIndicators and displayTidalSpeed and dlist.tidal2 then
 		local tidalSkewCX = tidalarea[1]
 			+ ((tidalarea[3] - tidalarea[1]) / 2)
 			- (cfg.useSkew and (tidalarea[4] - tidalarea[2]) * skewTan * 0.5 or 0)

--- a/luaui/Widgets/gui_top_bar.lua
+++ b/luaui/Widgets/gui_top_bar.lua
@@ -2917,7 +2917,7 @@ function widget:DrawScreen()
 		glCallList(dlist.blendBg)
 	end
 
-	if dlist.wind1 then
+	if cache.showIndicators and dlist.wind1 then
 		glPushMatrix()
 		glCallList(dlist.wind1)
 		glRotate(windRotation, 0, 0, 1)


### PR DESCRIPTION
Hides the spinning wind blades and the tidal wave animation when the topbar indicators are turned off.

Both were drawing on their own after setIndicatorsVisible(false) took the panel out from under them, which is what a map editor session does. The wind background, the no-wind caption, the current wind text and the tidal readouts all already check cache.showIndicators; these two draw sites were the ones that missed it.

AI disclosure: written with assistance from Claude Code.
