### PR TITLE
fix: attached units customparams

### DIFF
--- a/luarules/gadgets/include/unit_attachments.lua
+++ b/luarules/gadgets/include/unit_attachments.lua
@@ -1,0 +1,59 @@
+-- unit_attachments.lua --------------------------------------------------------
+-- Simple common reference for multiple types of unit attachments. Provides some
+-- different approaches, preferring customParams values over piece default-name.
+
+local SECTION = "unit_attachments"
+local PIECENAME_ATTACH = "attach"
+
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitPieceMap = Spring.GetUnitPieceMap
+
+---Searches for attachment pieces via simple naming conventions.
+---
+---Custom attachment points are preferred over default ones.
+---@param unitID UnitID
+---@return integer? pieceNum index of the default attach piece
+local function resolveAttachPiece(unitID)
+	local pieceMap = spGetUnitPieceMap(unitID)
+	if not pieceMap then
+		return
+	end
+
+	local unitDefID = spGetUnitDefID(unitID)
+	local unitDef = UnitDefs[unitDefID] ---@as table
+
+	local attachedTurret = unitDef.customParams.attached_con_turret_piece
+	if attachedTurret and pieceMap[attachedTurret] then
+		return pieceMap[attachedTurret]
+	end
+
+	local attachPiece = unitDef.customParams.attach_piece
+	if attachPiece then
+		if pieceMap[attachPiece] then
+			return pieceMap[attachPiece]
+		end
+		local index = attachPiece and tonumber(attachPiece)
+		if index and table.contains(pieceMap, index) then
+			return index ---@as integer
+		end
+	end
+
+	local pieceIndex = pieceMap[PIECENAME_ATTACH]
+	if pieceIndex then
+		return pieceIndex
+	end
+
+	local messages = {}
+	for key, value in pairs({
+		[unitDef.name .. " missing attached_con_turret_piece "] = attachedTurret,
+		[unitDef.name .. " missing attach_piece "] = attachPiece,
+		[unitDef.name .. " missing piece named "] = pieceIndex,
+	}) do
+		messages[#messages + 1] = key .. value
+	end
+	Spring.Log(SECTION, LOG.WARNING, table.concat(messages))
+end
+
+return {
+	ResolveAttachPiece = resolveAttachPiece,
+}

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -101,8 +101,8 @@ local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 	if commandQueue[1] ~= nil and commandQueue[1].id < 0 then
 		-- out of range build command
 		object_radius = SpGetUnitDefDimensions(-commandQueue[1].id).radius
-		distance = math.sqrt((ux - commandQueue[1].params[1]) ^ 2 + (uz - commandQueue[1].params[3]) ^ 2)
-			- object_radius
+		tx, tz = commandQueue[1].params[1], commandQueue[1].params[3]
+		distance = math.sqrt((ux - tx) ^ 2 + (uz - tz) ^ 2) - object_radius
 	end
 	if commandQueue[1] ~= nil and commandQueue[1].id == CMD_REPAIR then
 		-- out of range repair command

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -52,6 +52,7 @@ local SpUnitAttach = Spring.UnitAttach
 local max_unit_radius = 0
 local attached_builders = {} ---@type table<integer, integer?>
 local attached_turrets = {} ---@type table<integer, integer?>
+local cobScriptTurrets = {} ---@type table<integer, true?>
 
 local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 	local transporterID = SpGetUnitTransporter(baseUnitID)
@@ -125,11 +126,12 @@ local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 		end
 	end
 	if tx and distance <= radius then
-		--let auto con turret continue its thing
-		--update heading, by calling into unit script
-		heading1 = SpGetHeadingFromVector(ux - tx, uz - tz)
-		heading2 = SpGetUnitHeading(nanoID)
-		SpCallCOBScript(nanoID, "UpdateHeading", 0, heading1 - heading2 + 32768)
+		-- probably don't even need this for COB, but w/e:
+		if cobScriptTurrets[unitDefID] then
+			local heading1 = SpGetHeadingFromVector(ux - tx, uz - tz)
+			local heading2 = SpGetUnitHeading(nanoID)
+			SpCallCOBScript(nanoID, "UpdateHeading", 0, heading1 - heading2 + 32768)
+		end
 		return
 	end
 

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -50,14 +50,8 @@ local SpUnitAttach = Spring.UnitAttach
 --repairs and reclaims start at the edge of the unit radius
 --so we need to increase our search radius by the maximum unit radius
 local max_unit_radius = 0
-function gadget:Initialize()
-	local radius = 0
-	for ix, udef in pairs(UnitDefs) do
-		dimensions = SpGetUnitDefDimensions(udef.id)
-		radius = dimensions.radius
-		max_unit_radius = math.max(radius, max_unit_radius)
-	end
-end
+local attached_builders = {} ---@type table<integer, integer?>
+local attached_turrets = {} ---@type table<integer, integer?>
 
 local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 	local transporterID = SpGetUnitTransporter(baseUnitID)
@@ -202,11 +196,26 @@ local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 	SpGiveOrderToUnit(nanoID, CMD.STOP)
 end
 
-attached_builders = {}
-attached_builder_def = {}
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
+	local hostID = attached_builders[unitID]
+	if hostID then
+		attached_turrets[hostID] = nil
+	end
 	attached_builders[unitID] = nil
-	attached_builder_def[unitID] = nil
+
+	local nanoID = attached_turrets[unitID]
+	if nanoID then
+		attached_turrets[unitID] = nil
+		attached_builders[nanoID] = nil
+	end
+end
+
+function gadget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
+	local nanoID = attached_turrets[unitID]
+	-- Best-effort since the engine can refuse transfer:
+	if nanoID and Spring.GetUnitTeam(nanoID) ~= newTeam then
+		Spring.TransferUnit(nanoID, newTeam)
+	end
 end
 
 -- customparams.attached_con_turret names the turret def to spawn and attach on finish;
@@ -216,6 +225,7 @@ end
 -- like a separate unit, rather as a "paired" set with one real and one virtual unit.
 -- Scav copies inherit the params, but historically never got a turret, so are excluded.
 local attachedTurretDef = {} -- unitDefID -> { con = defname, noSelect = bool }
+local turretDefIDs = {}
 for udid, ud in pairs(UnitDefs) do
 	local con = ud.customParams.attached_con_turret
 	if
@@ -228,6 +238,7 @@ for udid, ud in pairs(UnitDefs) do
 			con = con,
 			select = ud.customParams.attached_con_turret_select and true or false,
 		}
+		turretDefIDs[UnitDefNames[con].id] = true
 	end
 end
 
@@ -256,14 +267,32 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 		SendToUnsynced("setUnitNoGroup", nanoID, true)
 	end
 	attached_builders[nanoID] = unitID
-	attached_builder_def[nanoID] = SpGetUnitDefID(nanoID)
+	attached_turrets[unitID] = nanoID
 end
 
 function gadget:GameFrame(gameFrame)
 	if gameFrame % 15 == 0 then
 		-- go on a slowupdate cycle
 		for nanoID, baseUnitID in pairs(attached_builders) do
-			auto_repair_routine(nanoID, attached_builder_def[nanoID], baseUnitID)
+			auto_repair_routine(nanoID, SpGetUnitDefID(nanoID), baseUnitID)
+		end
+	end
+end
+
+function gadget:Initialize()
+	-- For /luarules reload, get max unit dims and reattach+register turrets.
+	local radius = 0
+	for _, udef in pairs(UnitDefs) do
+		radius = SpGetUnitDefDimensions(udef.id).radius
+		max_unit_radius = math.max(radius, max_unit_radius)
+	end
+	for _, nanoID in pairs(Spring.GetAllUnits()) do
+		if turretDefIDs[SpGetUnitDefID(nanoID)] then
+			local hostID = SpGetUnitTransporter(nanoID)
+			if hostID and attachedTurretDef[SpGetUnitDefID(hostID)] then
+				attached_builders[nanoID] = hostID
+				attached_turrets[hostID] = nanoID
+			end
 		end
 	end
 end

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -20,6 +20,7 @@ end
 local CMD_REPAIR = CMD.REPAIR
 local CMD_RECLAIM = CMD.RECLAIM
 local CMD_STOP = CMD.STOP
+local SpGetFactoryCommands = Spring.GetFactoryCommands
 local SpGetUnitCommands = Spring.GetUnitCommands
 local SpGiveOrderToUnit = Spring.GiveOrderToUnit
 local SpGetUnitPosition = Spring.GetUnitPosition
@@ -61,7 +62,9 @@ local function auto_repair_routine(nanoID, unitDefID, baseUnitID)
 		return
 	end
 	-- first, check command the body is performing
-	local commandQueue = SpGetUnitCommands(attached_builders[nanoID], 1)
+	local baseDefID = SpGetUnitDefID(baseUnitID)
+	local getQueue = (baseDefID and UnitDefs[baseDefID].isFactory) and SpGetFactoryCommands or SpGetUnitCommands
+	local commandQueue = getQueue(baseUnitID, 1) or {}
 	if commandQueue[1] ~= nil and commandQueue[1].id < 0 then
 		-- build command
 		-- The attached turret must have the same buildlist as the body for this to work correctly

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -44,6 +44,9 @@ local SpGetUnitHeading = Spring.GetUnitHeading
 local SpCallCOBScript = Spring.CallCOBScript
 local SendToUnsynced = SendToUnsynced
 
+local resolveAttachPiece = VFS.Include("luarules/gadgets/include/unit_attachments.lua").ResolveAttachPiece
+local SpUnitAttach = Spring.UnitAttach
+
 --repairs and reclaims start at the edge of the unit radius
 --so we need to increase our search radius by the maximum unit radius
 local max_unit_radius = 0
@@ -231,13 +234,19 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 	if not data then
 		return
 	end
+
+	local piece = resolveAttachPiece(unitID)
+	if not piece then
+		return
+	end
+
 	local xx, yy, zz = SpGetUnitPosition(unitID)
 	local nanoID = Spring.CreateUnit(data.con, xx, yy, zz, 0, Spring.GetUnitTeam(unitID))
 	if not nanoID then
 		-- unit limit hit or invalid spawn surface
 		return
 	end
-	Spring.UnitAttach(unitID, nanoID, 3, true)
+	Spring.UnitAttach(unitID, nanoID, piece, true)
 	-- makes the attached con turret as non-interacting as possible
 	Spring.SetUnitBlocking(nanoID, false, false, false)
 	Spring.SetUnitNoSelect(nanoID, data.noSelect)

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -213,7 +213,12 @@ end
 local attachedTurretDef = {} -- unitDefID -> { con = defname, noSelect = bool }
 for udid, ud in pairs(UnitDefs) do
 	local con = ud.customParams.attached_con_turret
-	if con and UnitDefNames[con] and not ud.customParams.isscavenger and not ud.customParams.attached_con_turret_mex then
+	if
+		con
+		and UnitDefNames[con]
+		and not ud.customParams.isscavenger
+		and not ud.customParams.attached_con_turret_mex
+	then
 		attachedTurretDef[udid] = {
 			con = con,
 			noSelect = ud.customParams.attached_con_turret_noselect and true or false,

--- a/luarules/gadgets/unit_attached_con_turret.lua
+++ b/luarules/gadgets/unit_attached_con_turret.lua
@@ -211,8 +211,10 @@ end
 
 -- customparams.attached_con_turret names the turret def to spawn and attach on finish;
 -- customparams.attached_con_turret_noselect additionally hides it from selection/groups
--- (legmohobp ships without it, keeping its turret selectable as it always was).
--- scav copies inherit the params but historically never got a turret, so they are excluded.
+--
+-- By default, attached units are hidden; they are difficult to select and should not act
+-- like a separate unit, rather as a "paired" set with one real and one virtual unit.
+-- Scav copies inherit the params, but historically never got a turret, so are excluded.
 local attachedTurretDef = {} -- unitDefID -> { con = defname, noSelect = bool }
 for udid, ud in pairs(UnitDefs) do
 	local con = ud.customParams.attached_con_turret
@@ -224,7 +226,7 @@ for udid, ud in pairs(UnitDefs) do
 	then
 		attachedTurretDef[udid] = {
 			con = con,
-			noSelect = ud.customParams.attached_con_turret_noselect and true or false,
+			select = ud.customParams.attached_con_turret_select and true or false,
 		}
 	end
 end
@@ -249,8 +251,8 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 	Spring.UnitAttach(unitID, nanoID, piece, true)
 	-- makes the attached con turret as non-interacting as possible
 	Spring.SetUnitBlocking(nanoID, false, false, false)
-	Spring.SetUnitNoSelect(nanoID, data.noSelect)
-	if data.noSelect then
+	Spring.SetUnitNoSelect(nanoID, not data.select)
+	if not data.select then
 		SendToUnsynced("setUnitNoGroup", nanoID, true)
 	end
 	attached_builders[nanoID] = unitID

--- a/luarules/gadgets/unit_attached_con_turret_mex.lua
+++ b/luarules/gadgets/unit_attached_con_turret_mex.lua
@@ -20,6 +20,7 @@ end
 local spGetUnitHealth = Spring.GetUnitHealth
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local SendToUnsynced = SendToUnsynced
+local resolveAttachPiece = VFS.Include("luarules/gadgets/include/attached_con_turret.lua").ResolveAttachPiece
 
 -- customparams.attached_con_turret_mex (the extractor def) + attached_con_turret (the con def)
 -- mark builds that split into a mex plus an attached con turret; scav copies inherit the
@@ -94,6 +95,14 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	SendToUnsynced("setUnitNoGroup", mexID, true)
 	Spring.SetUnitStealth(mexID, true)
 
+	local piece = resolveAttachPiece(mexID)
+	if not piece then
+		Spring.DestroyUnit(mexID, false, true)
+		Spring.AddTeamResource(unitTeam, "m", unitData.metal)
+		Spring.AddTeamResource(unitTeam, "e", unitData.energy)
+		return
+	end
+
 	local conID = Spring.CreateUnit(unitData.swapDefs.con, ux, uy, uz, unitFacing, unitTeam)
 	if not conID then
 		Spring.DestroyUnit(mexID, false, true)
@@ -103,8 +112,7 @@ local function doSwapMex(unitID, unitTeam, unitData)
 	end
 	Spring.SetUnitHealth(conID, unitHealth)
 
-	-- TODO: Get attachment piece by customparam.
-	Spring.UnitAttach(mexID, conID, 6, true)
+	Spring.UnitAttach(mexID, conID, piece, true)
 	Spring.SetUnitRulesParam(conID, "pairedUnitID", mexID)
 	Spring.SetUnitRulesParam(mexID, "pairedUnitID", conID)
 	pairedUnits[conID] = mexID

--- a/units/Legion/Economy/legmohobp.lua
+++ b/units/Legion/Economy/legmohobp.lua
@@ -33,6 +33,7 @@ return {
 		yardmap = "h cbbbbbbc bssssssb bsssossb bsobbssb bssbbosb bssosssb bssssssb cbbbbbbc",
 		customparams = {
 			attached_con_turret = "legmohobpct",
+			attached_con_turret_piece = "rotor",
 			usebuildinggrounddecal = true,
 			buildinggrounddecaltype = "decals/legmohobp_aoplane.dds",
 			buildinggrounddecalsizey = 8,


### PR DESCRIPTION
### Work done

The switch to generic unit attachments was meant to be an in-place swap but broke a couple things. This generalizes the logic to go along with the conversion to customparams, and tries to handle errors and unusual cases that may arise from tweaks.

Adds a generic piece name, `attach`, to act as a default single attachment point on a unit for lua to find and use. Other custom pieces are resolved before the default piece.

### Testing

Some