### PR TITLE
Fix CommandInsert appending instead of inserting with Shift+Space

### DIFF
--- a/luaui/Widgets/cmd_commandinsert.lua
+++ b/luaui/Widgets/cmd_commandinsert.lua
@@ -170,7 +170,7 @@ function widget:CommandNotify(id, params, options)
 			end
 		end
 		-- check for insert at end of queue if its shortest walk.
-		local dlen = math_sqrt(((px - cx) * (px - cx)) + ((py - cy) * (py - cy)) + ((pz - cz) * (py - cy)))
+		local dlen = math_sqrt(((px - cx) * (px - cx)) + ((py - cy) * (py - cy)) + ((pz - cz) * (pz - cz)))
 		if dlen < min_dlen then
 			--options.meta=nil
 			--options.shift=true


### PR DESCRIPTION
`cmd_commandinsert.lua` chooses between inserting an order at the nearest gap in the queue and appending it by comparing walk lengths. The append distance has typo in its z term: `(pz - cz) * (py - cy)` instead of `(pz - cz) * (pz - cz)`.

On flat ground the height difference is ~0. Also when the product went negative, `sqrt` returned NaN and failed.

This squares the z difference. Edited for brevity.