### PR TITLE
Add difficulties JSON, include as enum

### DIFF
--- a/luarules/mission_api/difficulties.json
+++ b/luarules/mission_api/difficulties.json
@@ -1,5 +1,5 @@
-[
-	"placeholderDifficulty1",
-	"placeholderDifficulty2",
-	"placeholderDifficulty3"
-]
+{
+	"placeholderDifficulty1": 1,
+	"placeholderDifficulty2": 2,
+	"placeholderDifficulty3": 3
+}

--- a/luarules/mission_api/difficulties.json
+++ b/luarules/mission_api/difficulties.json
@@ -1,0 +1,5 @@
+[
+	"placholderDifficulty1",
+	"placholderDifficulty2",
+	"placholderDifficulty3"
+]

--- a/luarules/mission_api/difficulties.json
+++ b/luarules/mission_api/difficulties.json
@@ -1,5 +1,5 @@
 [
-	"placholderDifficulty1",
-	"placholderDifficulty2",
-	"placholderDifficulty3"
+	"placeholderDifficulty1",
+	"placeholderDifficulty2",
+	"placeholderDifficulty3"
 ]

--- a/luarules/mission_api/parameter_types.lua
+++ b/luarules/mission_api/parameter_types.lua
@@ -30,6 +30,7 @@ local types = {
 	WeaponDefName = "WeaponDefName",
 	Facing = "Facing",
 	SoundFile = "SoundFile",
+	Difficulty = "Difficulty",
 
 	-- Number Validators:
 	Number = "Number",
@@ -49,6 +50,10 @@ local types = {
 
 }
 
+-- Difficulties are read by the client, so must be available in JSON
+local difficultiesJSON = VFS.LoadFile("luarules/mission_api/difficulties.json")
+local difficulties = Json.decode(difficultiesJSON)
+
 local enums = {
 	[types.Facing] = {
 		[0] = true,
@@ -64,6 +69,8 @@ local enums = {
 		east = true,
 		west = true,
 	},
+
+	[types.Difficulty] = difficulties,
 }
 
 local enumSets = {


### PR DESCRIPTION
Add difficulty levels as a JSON array, and include as an enum in types.

Since difficulty levels need to be read by the client, they must be in JSON format. Used placeholder values while difficulty levels are decided on.

Placed file inside the mission API folder, as there does not seem to be a more suitable place for it. As difficulty levels relate only to the singleplayer content, it seems appropriate.