### PR TITLE
fixes long stop message crashign the vote widget

### DIFF
--- a/luaui/Widgets/gui_vote_interface.lua
+++ b/luaui/Widgets/gui_vote_interface.lua
@@ -116,7 +116,17 @@ local function StartVote(name) -- when called without params its just to refresh
 		local progressbarHeight = math.ceil(height * 0.055)
 
 		local fontSize = height / 5 -- title only
+		local maxWidth = mathFloor(vsx * 0.5)
 		local minWidth = font:GetTextWidth("  " .. voteName .. "  ") * fontSize
+		if minWidth > maxWidth then
+			local ellipsis = "..."
+			local truncated = voteName
+			while #truncated > 1 and font:GetTextWidth("  " .. truncated .. ellipsis .. "  ") * fontSize > maxWidth do
+				truncated = truncated:sub(1, -2)
+			end
+			voteName = truncated .. ellipsis
+			minWidth = maxWidth
+		end
 		if width < minWidth then
 			width = minWidth
 		end
@@ -661,7 +671,16 @@ function widget:AddConsoleLine(lines, priority)
 					end
 					weAreVoteOwner = (ownerPlayername == myPlayerName)
 
-					local title = ssub(line, sfind(line, ' "') + 2, sfind(line, '" ', nil, true) - 1) .. "?"
+					-- Host may truncate very long vote commands, omitting the closing quote / [!vote ...] suffix
+					local titleStart = sfind(line, ' "')
+					local titleEnd = sfind(line, '" ', nil, true)
+					local title
+					if titleEnd then
+						title = ssub(line, titleStart + 2, titleEnd - 1)
+					else
+						title = ssub(line, titleStart + 2) .. "..."
+					end
+					title = title .. "?"
 					title = title:sub(1, 1):upper() .. title:sub(2)
 
 					if not isreplay then


### PR DESCRIPTION
Repro: type !stop [really really long message here]

Expected: message truncates or doesn't appear
Actual: it crashes the vote widget for everyone in game 

The error log points to the second quote no longer being in the string to be found, so it crashes on a nil
```
Error in AddConsoleLine(): [string "LuaUI/Widgets/gui_vote_interface.lua"]:664: attempt to perform arithmetic on a nil value
```

This PR fixes that by truncating long messages. 

AI: yes, for finding change.

Testing: I tested it via inspection. I can't call votes in skirmish and can't run this in multiplayer, but it looks okay? 