### PR TITLE
Give unboxed allyteams a whole-map start box

### DIFF
--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -246,8 +246,7 @@ local function buildWholeMapEntry()
 end
 
 -- resolveArrangement will settle for an arrangement covering fewer allyteams than the game
--- has. A missing entry reads as "no config, ask the engine", and the engine has nothing to
--- say for an allyteam the host never sent a rect for.
+-- has, and a missing entry sends each consumer off to its own engine-rect fallback.
 local function fillUnboxedAllyTeams(config, activeAllyTeams)
 	for _, allyTeamID in ipairs(activeAllyTeams) do
 		local entry = config[allyTeamID]

--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -65,21 +65,21 @@ local function decodeModoption(raw)
 	return parsed
 end
 
-local function getActiveAllyTeamCount()
+local function getActiveAllyTeams()
 	local gaiaAllyTeamID
 	local gaiaTeamID = Spring.GetGaiaTeamID()
 	if gaiaTeamID then
 		gaiaAllyTeamID = Spring.GetTeamAllyTeamID(gaiaTeamID)
 	end
 
-	local count = 0
+	local active = {}
 	for _, atID in ipairs(Spring.GetAllyTeamList()) do
 		if atID ~= gaiaAllyTeamID then
-			count = count + 1
+			active[#active + 1] = atID
 		end
 	end
 
-	return count
+	return active
 end
 
 -- Will match any spare boxes, but will not leave any teams without a box.
@@ -226,6 +226,37 @@ local function transformArrangement(arrangement)
 	return config
 end
 
+local function buildWholeMapEntry()
+	local mapSizeX, mapSizeZ = Game.mapSizeX, Game.mapSizeZ
+
+	return {
+		boxes = {
+			{
+				{ 0, 0 },
+				{ 0, mapSizeZ },
+				{ mapSizeX, mapSizeZ },
+				{ mapSizeX, 0 },
+			},
+		},
+		startpoints = { { mapSizeX * 0.5, mapSizeZ * 0.5 } },
+		nameLong = "Anywhere",
+		nameShort = "Any",
+		wholeMap = true,
+	}
+end
+
+-- resolveArrangement will settle for an arrangement covering fewer allyteams than the game
+-- has. A missing entry reads as "no config, ask the engine", and the engine has nothing to
+-- say for an allyteam the host never sent a rect for.
+local function fillUnboxedAllyTeams(config, activeAllyTeams)
+	for _, allyTeamID in ipairs(activeAllyTeams) do
+		local entry = config[allyTeamID]
+		if not (entry and entry.boxes and #entry.boxes > 0) then
+			config[allyTeamID] = buildWholeMapEntry()
+		end
+	end
+end
+
 local function buildFallback()
 	local mapSizeX = Game.mapSizeX
 	local mapSizeZ = Game.mapSizeZ
@@ -292,17 +323,18 @@ local function buildFallback()
 end
 
 local function ParseBoxes()
-	local numTeams = getActiveAllyTeamCount()
+	local activeAllyTeams = getActiveAllyTeams()
 
 	local modoptions = Spring.GetModOptions()
 	local parsedOverride = decodeModoption(modoptions.mapmetadata_startbox_override)
 	local parsedSet = decodeModoption(modoptions.mapmetadata_startboxes_set)
 
-	local arrangement, configSource = resolveArrangement(parsedOverride, parsedSet, numTeams)
+	local arrangement, configSource = resolveArrangement(parsedOverride, parsedSet, #activeAllyTeams)
 
 	local startBoxConfig
 	if arrangement then
 		startBoxConfig = transformArrangement(arrangement)
+		fillUnboxedAllyTeams(startBoxConfig, activeAllyTeams)
 	else
 		startBoxConfig = buildFallback()
 		configSource = "fallback"
@@ -413,8 +445,9 @@ end
 -- against the wrong axis. A box covering everything restricts nothing, which is what
 -- those callers were really asking about.
 local function HasStartbox(allyTeamID)
-	if GetEntry(allyTeamID) then
-		return true
+	local entry = GetEntry(allyTeamID)
+	if entry then
+		return not entry.wholeMap
 	end
 
 	local xmin, zmin, xmax, zmax = Spring.GetAllyTeamStartBox(allyTeamID)

--- a/luarules/gadgets/include/startbox_utilities.lua
+++ b/luarules/gadgets/include/startbox_utilities.lua
@@ -65,21 +65,21 @@ local function decodeModoption(raw)
 	return parsed
 end
 
-local function getActiveAllyTeams()
+local function getActiveAllyTeamCount()
 	local gaiaAllyTeamID
 	local gaiaTeamID = Spring.GetGaiaTeamID()
 	if gaiaTeamID then
 		gaiaAllyTeamID = Spring.GetTeamAllyTeamID(gaiaTeamID)
 	end
 
-	local active = {}
+	local count = 0
 	for _, atID in ipairs(Spring.GetAllyTeamList()) do
 		if atID ~= gaiaAllyTeamID then
-			active[#active + 1] = atID
+			count = count + 1
 		end
 	end
 
-	return active
+	return count
 end
 
 -- Will match any spare boxes, but will not leave any teams without a box.
@@ -245,12 +245,10 @@ local function buildWholeMapEntry()
 	}
 end
 
--- resolveArrangement will settle for an arrangement covering fewer allyteams than the game
--- has, and a missing entry sends each consumer off to its own engine-rect fallback.
-local function fillUnboxedAllyTeams(config, activeAllyTeams)
-	for _, allyTeamID in ipairs(activeAllyTeams) do
-		local entry = config[allyTeamID]
-		if not (entry and entry.boxes and #entry.boxes > 0) then
+-- resolveArrangement settles for an arrangement covering fewer allyteams than the game has.
+local function fillUnboxedAllyTeams(config, numTeams)
+	for allyTeamID = 0, numTeams - 1 do
+		if not config[allyTeamID] then
 			config[allyTeamID] = buildWholeMapEntry()
 		end
 	end
@@ -322,18 +320,18 @@ local function buildFallback()
 end
 
 local function ParseBoxes()
-	local activeAllyTeams = getActiveAllyTeams()
+	local numTeams = getActiveAllyTeamCount()
 
 	local modoptions = Spring.GetModOptions()
 	local parsedOverride = decodeModoption(modoptions.mapmetadata_startbox_override)
 	local parsedSet = decodeModoption(modoptions.mapmetadata_startboxes_set)
 
-	local arrangement, configSource = resolveArrangement(parsedOverride, parsedSet, #activeAllyTeams)
+	local arrangement, configSource = resolveArrangement(parsedOverride, parsedSet, numTeams)
 
 	local startBoxConfig
 	if arrangement then
 		startBoxConfig = transformArrangement(arrangement)
-		fillUnboxedAllyTeams(startBoxConfig, activeAllyTeams)
+		fillUnboxedAllyTeams(startBoxConfig, numTeams)
 	else
 		startBoxConfig = buildFallback()
 		configSource = "fallback"

--- a/luaui/Widgets/gfx_norush_timer_gl4.lua
+++ b/luaui/Widgets/gfx_norush_timer_gl4.lua
@@ -143,7 +143,13 @@ local function BuildStartPolygons()
 		-- colour each zone gets, and pairs() would let two clients disagree about it.
 		for _, allyTeamID in ipairs(Spring.GetAllyTeamList()) do
 			local entry = startBoxConfig[allyTeamID]
-			if allyTeamID ~= gaiaAllyTeamID and allyTeamID ~= pveAllyTeamID and entry and entry.boxes then
+			if
+				allyTeamID ~= gaiaAllyTeamID
+				and allyTeamID ~= pveAllyTeamID
+				and entry
+				and entry.boxes
+				and not entry.wholeMap
+			then
 				for _, polygon in ipairs(entry.boxes) do
 					polygons[#polygons + 1] = { team = ColourTeamOf(allyTeamID), poly = polygon }
 				end

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -932,7 +932,12 @@ local function InitStartPolygons()
 				activeAllyTeams[atID] = true
 			end
 			for allyTeamID, entry in pairs(startBoxConfig) do
-				if allyTeamID ~= gaiaAllyTeamID and activeAllyTeams[allyTeamID] and entry.boxes then
+				if
+					allyTeamID ~= gaiaAllyTeamID
+					and activeAllyTeams[allyTeamID]
+					and entry.boxes
+					and not entry.wholeMap
+				then
 					for _, polygon in ipairs(entry.boxes) do
 						StartPolygons[#StartPolygons + 1] = { team = allyTeamID, poly = polygon }
 					end

--- a/spec/luarules/startbox_utilities_spec.lua
+++ b/spec/luarules/startbox_utilities_spec.lua
@@ -16,16 +16,16 @@ local function arrangement(...)
 	return '{"startboxes":[' .. table.concat({ ... }, ",") .. "]}"
 end
 
-local function set(pairsByTeamCount)
+local function set(arrangementsByTeamCount)
 	local parts = {}
-	for _, pair in ipairs(pairsByTeamCount) do
-		parts[#parts + 1] = string.format('"%s":%s', pair[1], pair[2])
+	for _, entry in ipairs(arrangementsByTeamCount) do
+		parts[#parts + 1] = string.format('"%s":%s', entry[1], entry[2])
 	end
 
 	return "{" .. table.concat(parts, ",") .. "}"
 end
 
--- Slices of a 200x200 arrangement space, one per team, so every box is real and none of
+-- Slices of the 200x200 arrangement space, one per team, so every box is real and none of
 -- them covers the map.
 local function evenArrangement(numBoxes)
 	local boxes = {}
@@ -37,7 +37,25 @@ local function evenArrangement(numBoxes)
 	return arrangement(unpack(boxes))
 end
 
-local savedSpring, savedGame, savedJson, savedZlib
+local SHORT_SET = set({
+	{ "2", evenArrangement(2) },
+	{ "3", evenArrangement(3) },
+	{ "4", evenArrangement(4) },
+})
+
+local savedSpring = {
+	GetAllyTeamList = Spring.GetAllyTeamList,
+	GetGaiaTeamID = Spring.GetGaiaTeamID,
+	GetTeamAllyTeamID = Spring.GetTeamAllyTeamID,
+	GetAllyTeamStartBox = Spring.GetAllyTeamStartBox,
+	GetModOptions = Spring.GetModOptions,
+}
+
+Game.mapSizeX, Game.mapSizeZ = MAP_SIZE_X, MAP_SIZE_Z
+_G.Json = VFS.Include("common/luaUtilities/json.lua")
+VFS.ZlibDecompress = function(data)
+	return data
+end
 
 local function setUpGame(numAllyTeams, modoptions)
 	local allyTeamList = {}
@@ -64,7 +82,7 @@ local function setUpGame(numAllyTeams, modoptions)
 	end
 	Spring.GetModOptions = function()
 		local encoded = {}
-		for key, json in pairs(modoptions or {}) do
+		for key, json in pairs(modoptions) do
 			encoded[key] = base64.Encode(json)
 		end
 
@@ -72,40 +90,25 @@ local function setUpGame(numAllyTeams, modoptions)
 	end
 end
 
+-- Freshly included every time: the library caches its parse for the life of the module.
+local function load(numAllyTeams, modoptions)
+	setUpGame(numAllyTeams, modoptions)
+	local lib = VFS.Include(MODULE_PATH)
+
+	return lib, lib.ParseBoxes()
+end
+
 describe("startbox_utilities", function()
-	before_each(function()
-		savedSpring = {
-			GetAllyTeamList = Spring.GetAllyTeamList,
-			GetGaiaTeamID = Spring.GetGaiaTeamID,
-			GetTeamAllyTeamID = Spring.GetTeamAllyTeamID,
-			GetAllyTeamStartBox = Spring.GetAllyTeamStartBox,
-			GetModOptions = Spring.GetModOptions,
-		}
-		savedGame = { mapSizeX = Game.mapSizeX, mapSizeZ = Game.mapSizeZ }
-		savedJson = _G.Json
-		savedZlib = VFS.ZlibDecompress
-
-		Game.mapSizeX, Game.mapSizeZ = MAP_SIZE_X, MAP_SIZE_Z
-		_G.Json = VFS.Include("common/luaUtilities/json.lua")
-		VFS.ZlibDecompress = function(data)
-			return data
-		end
-	end)
-
 	after_each(function()
 		for key, value in pairs(savedSpring) do
 			Spring[key] = value
 		end
-		Game.mapSizeX, Game.mapSizeZ = savedGame.mapSizeX, savedGame.mapSizeZ
-		_G.Json = savedJson
-		VFS.ZlibDecompress = savedZlib
 	end)
 
 	describe("an arrangement that covers every allyteam", function()
 		it("gives every allyteam its own box", function()
-			setUpGame(5, { mapmetadata_startboxes_set = set({ { "5", evenArrangement(5) } }) })
-
-			local config, source, explicit = VFS.Include(MODULE_PATH).ParseBoxes()
+			local _, config, source, explicit =
+				load(5, { mapmetadata_startboxes_set = set({ { "5", evenArrangement(5) } }) })
 
 			assert.are.equal("modoption_set", source)
 			assert.is_true(explicit)
@@ -117,31 +120,19 @@ describe("startbox_utilities", function()
 	end)
 
 	describe("an arrangement smaller than the allyteam count", function()
-		local config, lib
-
-		before_each(function()
-			setUpGame(5, {
-				mapmetadata_startboxes_set = set({
-					{ "2", evenArrangement(2) },
-					{ "3", evenArrangement(3) },
-					{ "4", evenArrangement(4) },
-				}),
-			})
-			lib = VFS.Include(MODULE_PATH)
-			config = lib.ParseBoxes()
-		end)
-
 		it("leaves the arranged allyteams alone", function()
+			local _, config = load(5, { mapmetadata_startboxes_set = SHORT_SET })
+
 			for allyTeamID = 0, 3 do
 				assert.is_nil(config[allyTeamID].wholeMap)
 			end
 		end)
 
 		it("gives the unarranged allyteam the whole map", function()
-			local entry = config[4]
+			local lib, config = load(5, { mapmetadata_startboxes_set = SHORT_SET })
 
-			assert.is_true(entry.wholeMap)
-			assert.are.equal(1, #entry.boxes)
+			assert.is_true(config[4].wholeMap)
+			assert.are.equal(1, #config[4].boxes)
 
 			local xmin, zmin, xmax, zmax = lib.GetBounds(4)
 			assert.are.equal(0, xmin)
@@ -151,26 +142,30 @@ describe("startbox_utilities", function()
 		end)
 
 		it("counts a whole-map box as no box at all", function()
+			local lib = load(5, { mapmetadata_startboxes_set = SHORT_SET })
+
 			assert.is_true(lib.HasStartbox(0))
 			assert.is_false(lib.HasStartbox(4))
 		end)
 
 		it("puts nowhere out of bounds for the unarranged allyteam", function()
+			local lib = load(5, { mapmetadata_startboxes_set = SHORT_SET })
+
 			assert.is_true(lib.IsInside(4, 10, 10))
 			assert.is_true(lib.IsInside(4, MAP_SIZE_X - 10, MAP_SIZE_Z - 10))
 			assert.is_false(lib.IsInside(0, MAP_SIZE_X - 10, MAP_SIZE_Z - 10))
 		end)
 
 		it("skips the gaia allyteam", function()
+			local _, config = load(5, { mapmetadata_startboxes_set = SHORT_SET })
+
 			assert.is_nil(config[GAIA_ALLY_TEAM_ID])
 		end)
 	end)
 
 	describe("no arrangement at all", function()
 		it("keeps the hardcoded fallback to two boxes", function()
-			setUpGame(5, {})
-
-			local config, source, explicit = VFS.Include(MODULE_PATH).ParseBoxes()
+			local _, config, source, explicit = load(5, {})
 
 			assert.are.equal("fallback", source)
 			assert.is_false(explicit)

--- a/spec/luarules/startbox_utilities_spec.lua
+++ b/spec/luarules/startbox_utilities_spec.lua
@@ -1,0 +1,182 @@
+-- Arrangement resolution and the whole-map fill for allyteams the arrangement does not
+-- reach. Modoptions are base64 of raw JSON here, with the zlib step stubbed out.
+
+local base64 = VFS.Include("common/luaUtilities/base64.lua")
+
+local MODULE_PATH = "luarules/gadgets/include/startbox_utilities.lua"
+local MAP_SIZE_X, MAP_SIZE_Z = 4096, 4096
+local GAIA_TEAM_ID = 99
+local GAIA_ALLY_TEAM_ID = 50
+
+local function rect(x1, z1, x2, z2)
+	return string.format('{"poly":[{"x":%d,"y":%d},{"x":%d,"y":%d}]}', x1, z1, x2, z2)
+end
+
+local function arrangement(...)
+	return '{"startboxes":[' .. table.concat({ ... }, ",") .. "]}"
+end
+
+local function set(pairsByTeamCount)
+	local parts = {}
+	for _, pair in ipairs(pairsByTeamCount) do
+		parts[#parts + 1] = string.format('"%s":%s', pair[1], pair[2])
+	end
+
+	return "{" .. table.concat(parts, ",") .. "}"
+end
+
+-- Slices of a 200x200 arrangement space, one per team, so every box is real and none of
+-- them covers the map.
+local function evenArrangement(numBoxes)
+	local boxes = {}
+	local width = math.floor(200 / numBoxes)
+	for i = 1, numBoxes do
+		boxes[i] = rect((i - 1) * width, 0, ((i - 1) * width) + 10, 200)
+	end
+
+	return arrangement(unpack(boxes))
+end
+
+local savedSpring, savedGame, savedJson, savedZlib
+
+local function setUpGame(numAllyTeams, modoptions)
+	local allyTeamList = {}
+	for i = 1, numAllyTeams do
+		allyTeamList[i] = i - 1
+	end
+	allyTeamList[numAllyTeams + 1] = GAIA_ALLY_TEAM_ID
+
+	Spring.GetAllyTeamList = function()
+		return allyTeamList
+	end
+	Spring.GetGaiaTeamID = function()
+		return GAIA_TEAM_ID
+	end
+	Spring.GetTeamAllyTeamID = function(teamID)
+		if teamID == GAIA_TEAM_ID then
+			return GAIA_ALLY_TEAM_ID
+		end
+
+		return teamID
+	end
+	Spring.GetAllyTeamStartBox = function()
+		return 0, 0, MAP_SIZE_X, MAP_SIZE_Z
+	end
+	Spring.GetModOptions = function()
+		local encoded = {}
+		for key, json in pairs(modoptions or {}) do
+			encoded[key] = base64.Encode(json)
+		end
+
+		return encoded
+	end
+end
+
+describe("startbox_utilities", function()
+	before_each(function()
+		savedSpring = {
+			GetAllyTeamList = Spring.GetAllyTeamList,
+			GetGaiaTeamID = Spring.GetGaiaTeamID,
+			GetTeamAllyTeamID = Spring.GetTeamAllyTeamID,
+			GetAllyTeamStartBox = Spring.GetAllyTeamStartBox,
+			GetModOptions = Spring.GetModOptions,
+		}
+		savedGame = { mapSizeX = Game.mapSizeX, mapSizeZ = Game.mapSizeZ }
+		savedJson = _G.Json
+		savedZlib = VFS.ZlibDecompress
+
+		Game.mapSizeX, Game.mapSizeZ = MAP_SIZE_X, MAP_SIZE_Z
+		_G.Json = VFS.Include("common/luaUtilities/json.lua")
+		VFS.ZlibDecompress = function(data)
+			return data
+		end
+	end)
+
+	after_each(function()
+		for key, value in pairs(savedSpring) do
+			Spring[key] = value
+		end
+		Game.mapSizeX, Game.mapSizeZ = savedGame.mapSizeX, savedGame.mapSizeZ
+		_G.Json = savedJson
+		VFS.ZlibDecompress = savedZlib
+	end)
+
+	describe("an arrangement that covers every allyteam", function()
+		it("gives every allyteam its own box", function()
+			setUpGame(5, { mapmetadata_startboxes_set = set({ { "5", evenArrangement(5) } }) })
+
+			local config, source, explicit = VFS.Include(MODULE_PATH).ParseBoxes()
+
+			assert.are.equal("modoption_set", source)
+			assert.is_true(explicit)
+			for allyTeamID = 0, 4 do
+				assert.is_not_nil(config[allyTeamID])
+				assert.is_nil(config[allyTeamID].wholeMap)
+			end
+		end)
+	end)
+
+	describe("an arrangement smaller than the allyteam count", function()
+		local config, lib
+
+		before_each(function()
+			setUpGame(5, {
+				mapmetadata_startboxes_set = set({
+					{ "2", evenArrangement(2) },
+					{ "3", evenArrangement(3) },
+					{ "4", evenArrangement(4) },
+				}),
+			})
+			lib = VFS.Include(MODULE_PATH)
+			config = lib.ParseBoxes()
+		end)
+
+		it("leaves the arranged allyteams alone", function()
+			for allyTeamID = 0, 3 do
+				assert.is_nil(config[allyTeamID].wholeMap)
+			end
+		end)
+
+		it("gives the unarranged allyteam the whole map", function()
+			local entry = config[4]
+
+			assert.is_true(entry.wholeMap)
+			assert.are.equal(1, #entry.boxes)
+
+			local xmin, zmin, xmax, zmax = lib.GetBounds(4)
+			assert.are.equal(0, xmin)
+			assert.are.equal(0, zmin)
+			assert.are.equal(MAP_SIZE_X, xmax)
+			assert.are.equal(MAP_SIZE_Z - 1, zmax)
+		end)
+
+		it("counts a whole-map box as no box at all", function()
+			assert.is_true(lib.HasStartbox(0))
+			assert.is_false(lib.HasStartbox(4))
+		end)
+
+		it("puts nowhere out of bounds for the unarranged allyteam", function()
+			assert.is_true(lib.IsInside(4, 10, 10))
+			assert.is_true(lib.IsInside(4, MAP_SIZE_X - 10, MAP_SIZE_Z - 10))
+			assert.is_false(lib.IsInside(0, MAP_SIZE_X - 10, MAP_SIZE_Z - 10))
+		end)
+
+		it("skips the gaia allyteam", function()
+			assert.is_nil(config[GAIA_ALLY_TEAM_ID])
+		end)
+	end)
+
+	describe("no arrangement at all", function()
+		it("keeps the hardcoded fallback to two boxes", function()
+			setUpGame(5, {})
+
+			local config, source, explicit = VFS.Include(MODULE_PATH).ParseBoxes()
+
+			assert.are.equal("fallback", source)
+			assert.is_false(explicit)
+			assert.is_not_nil(config[0])
+			assert.is_not_nil(config[1])
+			assert.is_nil(config[2])
+		end)
+	end)
+end)


### PR DESCRIPTION
Gives any allyteam the metadata arrangement does not reach an explicit whole-map start box instead of no entry at all. Follows up on #7513.

This started as a fix for a fifth player spawning off the map in a 5 way FFA and it is not one. SPADS runs the ffa and duel presets on startpostype 1, so the engine places everyone from the map's own fixed start positions and boxes never place anyone; that spawn bug is a separate change to the Startbox Config gadget. This PR still matters in those presets for everything that asks the config table where a team belongs, like raptor and scavenger burrow placement.

AI disclosure: written with assistance from Claude Code.
