### PR TITLE
attackrange: increased performance

### DIFF
--- a/luaui/Shaders/weapon_range_fill_composite_gl4.frag.glsl
+++ b/luaui/Shaders/weapon_range_fill_composite_gl4.frag.glsl
@@ -1,0 +1,47 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+// Screen-space pass that paints the merged fill of the attack range rings from the
+// coverage mask built by gui_attackrange_gl4.lua.
+// The mask's 8-bit red channel holds one bit per range class (1 = ground/cannon,
+// 2 = nano, 4 = AA, 8 = separate cannon); a set bit means a filled range disc of
+// that class covers the pixel.
+
+//__DEFINES__
+
+#line 20000
+
+uniform sampler2D maskTex;
+// .rgb = fill colour, .a = fill alpha of the class stored in mask bit 1 << i
+uniform vec4 fillColor0 = vec4(0.0);
+uniform vec4 fillColor1 = vec4(0.0);
+uniform vec4 fillColor2 = vec4(0.0);
+uniform vec4 fillColor3 = vec4(0.0);
+
+//__ENGINEUNIFORMBUFFERDEFS__
+
+out vec4 fragColor;
+
+// Premultiplied "over": later classes are painted on top of earlier ones, like the
+// per-class fill passes did.
+void blendOver(inout vec4 acc, vec4 fill)
+{
+	acc = acc * (1.0 - fill.a) + vec4(fill.rgb * fill.a, fill.a);
+}
+
+void main()
+{
+	// The mask covers the world viewport, gl_FragCoord is relative to the window.
+	ivec2 texel = ivec2(gl_FragCoord.xy) - ivec2(viewGeometry.zw);
+	int bits = int(texelFetch(maskTex, texel, 0).r * 255.0 + 0.5);
+	if (bits == 0) {
+		discard;
+	}
+	vec4 acc = vec4(0.0);
+	if ((bits & 1) != 0) blendOver(acc, fillColor0);
+	if ((bits & 2) != 0) blendOver(acc, fillColor1);
+	if ((bits & 4) != 0) blendOver(acc, fillColor2);
+	if ((bits & 8) != 0) blendOver(acc, fillColor3);
+	// premultiplied output, blended with (GL_ONE, GL_ONE_MINUS_SRC_ALPHA)
+	fragColor = acc;
+}

--- a/luaui/Shaders/weapon_range_fill_composite_gl4.vert.glsl
+++ b/luaui/Shaders/weapon_range_fill_composite_gl4.vert.glsl
@@ -1,0 +1,16 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+// Screen-space pass that paints the merged fill of the attack range rings from the
+// coverage mask built by gui_attackrange_gl4.lua, with one screen-sized quad.
+
+//__DEFINES__
+
+layout (location = 0) in vec4 position; // .xy is [-1, +1], .zw is [0, 1]
+
+#line 10000
+
+void main()
+{
+	gl_Position = vec4(position.xy, 0.0, 1.0);
+}

--- a/luaui/Shaders/weapon_range_rings_unified_gl4.frag.glsl
+++ b/luaui/Shaders/weapon_range_rings_unified_gl4.frag.glsl
@@ -12,11 +12,18 @@ uniform float selUnitCount = 1.0;
 uniform float selBuilderCount = 1.0;
 uniform float drawAlpha = 1.0;
 uniform float drawMode = 0.0;
-#if (DEBUG == 1)
+
+// Range coverage mask, see gui_attackrange_gl4.lua: bit (1 << class) of the 8-bit red
+// channel is set where a filled range disc of that class covers the pixel.
+#if (MASKPASS == 1)
+	uniform float maskWriteValue = 0.0; // class bit / 255, additively blended into the mask
+#else
+	uniform sampler2D maskTex;
+	uniform float maskClip = 0.0; // 1.0: hide fragments inside the mask (outer rings)
+	uniform float maskChannelBit = 1.0; // class bit to test
+#endif
 
 //__ENGINEUNIFORMBUFFERDEFS__
-
-#endif
 
 in DataVS {
 	flat vec4 v_blendedcolor;
@@ -28,8 +35,18 @@ in DataVS {
 out vec4 fragColor;
 
 void main() {
-
+#if (MASKPASS == 1)
+	fragColor = vec4(maskWriteValue);
+#else
 	fragColor = v_blendedcolor;
+	if (maskClip > 0.5) {
+		// The mask covers the world viewport, gl_FragCoord is relative to the window.
+		ivec2 texel = ivec2(gl_FragCoord.xy - viewGeometry.zw);
+		int bits = int(texelFetch(maskTex, texel, 0).r * 255.0 + 0.5);
+		if ((bits & int(maskChannelBit)) != 0) {
+			fragColor.a = 0.0; // inside the merged area of this class, not part of its outline
+		}
+	}
 	// For testing:
 	#if (DEBUG == 1)
 		if (fract(gl_FragCoord.x * 0.125) < 0.4) {
@@ -41,6 +58,7 @@ void main() {
 				fragColor.rgba *= 0.0;
 			#endif
 		}
-		
+
 	#endif
+#endif
 }

--- a/luaui/Shaders/weapon_range_rings_unified_gl4.vert.glsl
+++ b/luaui/Shaders/weapon_range_rings_unified_gl4.vert.glsl
@@ -29,6 +29,9 @@ uniform float selBuilderCount = 1.0;
 uniform float drawAlpha = 1.0;
 uniform float drawMode = 0.0;
 uniform float staticUnits = 0.0; // 1 if static units, 0 if dynamic units
+#if (MASKPASS == 1)
+	uniform float maskDepthBase = 0.1; // depth band of the class being drawn into the coverage mask
+#endif
 
 uniform sampler2D heightmapTex;
 uniform sampler2D losTex; // hmm maybe?
@@ -450,6 +453,17 @@ void main() {
 		gl_Position = cameraViewProj * vec4(circleWorldPos.xyz, 1.0);
 		//pull 16 elmos forward in Z:
 		gl_Position.z = (gl_Position.z) - 128.0 / (gl_Position.w); // send 16 elmos forward in Z
+		#if (MASKPASS == 1)
+			// Coverage mask pass: with GL_LESS against a cleared depth buffer the first disc drawn
+			// wins per pixel. Instances are drawn in order, so giving later instances a larger depth
+			// leaves the depth test a clear margin and lets the hierarchical depth test reject
+			// covered tiles outright instead of testing every fragment. maskDepthBase separates
+			// classes that share a mask channel.
+			// maskDepth stays within [0, 1): valid with zero-to-one clip control (the engine's
+			// default) as well as with the classic [-1, 1] clip volume, and below the cleared 1.0.
+			float maskDepth = maskDepthBase + float(gl_InstanceID) * (1.0 / 4096.0);
+			gl_Position.z = maskDepth * gl_Position.w;
+		#endif
 	} else {
 		// Check if PIP mode (visible area not default)
 		bool isPip = (pipVisibleArea.x != 0.0 || pipVisibleArea.y != 1.0 || pipVisibleArea.z != 0.0 || pipVisibleArea.w != 1.0);

--- a/luaui/Widgets/gui_attackrange_gl4.lua
+++ b/luaui/Widgets/gui_attackrange_gl4.lua
@@ -576,6 +576,70 @@ local shaderSourceCache = {
 		STATICUNITS = 0,
 		DEBUG = autoReload and 1 or 0,
 		MOUSEOVERALPHAMULTIPLIER = 1.0,
+		MASKPASS = 0,
+	},
+	uniformInt = {
+		heightmapTex = 0,
+		losTex = 1,
+		mapNormalTex = 2,
+		maskTex = 3,
+	},
+	uniformFloat = {
+		lineAlphaUniform = 1,
+		cannonmode = 0,
+		fadeDistOffset = 0,
+		drawMode = 0,
+		selBuilderCount = 1.0,
+		selUnitCount = 1.0,
+		inMiniMap = 0.0,
+		pipVisibleArea = { 0, 1, 0, 1 }, -- left, right, bottom, top in normalized [0,1] coords for PIP minimap
+		maskClip = 0.0,
+		maskChannelBit = 1.0,
+	},
+}
+
+------ Range coverage mask (world view) -----
+-- The merged fill and the outer rings need to know per pixel whether any filled range disc
+-- of a class covers it. The stencil path (still used for the minimap) rasterizes every disc
+-- into the stencil buffer of the main framebuffer, so hundreds of overlapping discs cost
+-- tens of times the screen area at full (multisampled) resolution. In the world view the
+-- discs are instead drawn into a private single-sample FBO with a depth test: the first disc
+-- drawn wins per pixel (instance-ordered depth) and the hierarchical depth test rejects the
+-- overlapping discs before rasterization, so the cost is proportional to the covered area
+-- and not to the summed disc areas. One screen-sized quad then paints the fill from the
+-- mask, and the outer rings read the mask instead of the stencil buffer.
+--
+-- Each ally/enemy group builds its own mask. Within a group the 8-bit red channel holds one
+-- bit per class, mirroring the stencil bit layout: 1 = ground (and cannon), 2 = nano,
+-- 4 = AA, 8 = cannon when colorConfig.cannon_separate_stencil is set. lrpc rings are not
+-- merged, they are only clipped by the cannon class like in the stencil path.
+local cannonMaskChannel = colorConfig.cannon_separate_stencil and 3 or 0
+local maskChannelClasses = { [0] = { "ground" }, { "nano" }, { "AA" }, {} }
+table.insert(maskChannelClasses[cannonMaskChannel], "cannon")
+local maskChannelFillClass = { [0] = "ground", "nano", "AA", "cannon" }
+local ringClassOrder = { "ground", "nano", "AA", "cannon", "lrpc" }
+local ringClassCannonMode = { ground = 0, nano = 0, AA = 0, cannon = 1, lrpc = 1 }
+local ringClassMaskBit = { ground = 1, nano = 2, AA = 4, cannon = 2 ^ cannonMaskChannel, lrpc = 2 ^ cannonMaskChannel }
+
+local maskFBO, maskTex, maskDepthTex
+local maskSizeX, maskSizeY = 0, 0
+local maskUnavailable = false -- creation failed, keep using the stencil path
+local fullScreenQuadVAO
+local maskShader, compositeShader
+local GL_R8 = GL.R8 or 0x8229
+local GL_DEPTH_COMPONENT16 = GL.DEPTH_COMPONENT16 or 0x81A5
+local GL_COLOR_ATTACHMENT0 = GL.COLOR_ATTACHMENT0 or 0x8CE0
+
+local maskShaderSourceCache = {
+	shaderName = "Attack Range GL4 coverage mask",
+	vssrcpath = "LuaUI/Shaders/weapon_range_rings_unified_gl4.vert.glsl",
+	fssrcpath = "LuaUI/Shaders/weapon_range_rings_unified_gl4.frag.glsl",
+	shaderConfig = {
+		MYGRAVITY = Game.gravity + 0.1,
+		STATICUNITS = 0,
+		DEBUG = 0,
+		MOUSEOVERALPHAMULTIPLIER = 1.0,
+		MASKPASS = 1,
 	},
 	uniformInt = {
 		heightmapTex = 0,
@@ -590,9 +654,84 @@ local shaderSourceCache = {
 		selBuilderCount = 1.0,
 		selUnitCount = 1.0,
 		inMiniMap = 0.0,
-		pipVisibleArea = { 0, 1, 0, 1 }, -- left, right, bottom, top in normalized [0,1] coords for PIP minimap
+		pipVisibleArea = { 0, 1, 0, 1 },
+		maskWriteValue = 0,
+		maskDepthBase = 0.1,
 	},
 }
+
+local compositeShaderSourceCache = {
+	shaderName = "Attack Range GL4 fill composite",
+	vssrcpath = "LuaUI/Shaders/weapon_range_fill_composite_gl4.vert.glsl",
+	fssrcpath = "LuaUI/Shaders/weapon_range_fill_composite_gl4.frag.glsl",
+	shaderConfig = {},
+	uniformInt = {
+		maskTex = 3,
+	},
+	uniformFloat = {
+		fillColor0 = { 0, 0, 0, 0 },
+		fillColor1 = { 0, 0, 0, 0 },
+		fillColor2 = { 0, 0, 0, 0 },
+		fillColor3 = { 0, 0, 0, 0 },
+	},
+}
+
+local function deleteMaskTargets()
+	if maskFBO then
+		gl.DeleteFBO(maskFBO)
+		maskFBO = nil
+	end
+	if maskTex then
+		gl.DeleteTexture(maskTex)
+		maskTex = nil
+	end
+	if maskDepthTex then
+		gl.DeleteTexture(maskDepthTex)
+		maskDepthTex = nil
+	end
+	maskSizeX, maskSizeY = 0, 0
+end
+
+local function createMaskTargets(vsx, vsy)
+	deleteMaskTargets()
+	local texOpts = {
+		min_filter = GL.NEAREST,
+		mag_filter = GL.NEAREST,
+		wrap_s = GL.CLAMP_TO_EDGE,
+		wrap_t = GL.CLAMP_TO_EDGE,
+		format = GL_R8,
+	}
+	maskTex = gl.CreateTexture(vsx, vsy, texOpts)
+	texOpts.format = GL_DEPTH_COMPONENT16
+	maskDepthTex = gl.CreateTexture(vsx, vsy, texOpts)
+	if maskTex and maskDepthTex then
+		maskFBO = gl.CreateFBO({
+			color0 = maskTex,
+			depth = maskDepthTex,
+			drawbuffers = { GL_COLOR_ATTACHMENT0 },
+		})
+	end
+	if not (maskFBO and gl.IsValidFBO(maskFBO)) then
+		spEcho("Attack Range GL4: could not create the range coverage mask, using the stencil path")
+		deleteMaskTargets()
+		maskUnavailable = true
+		return false
+	end
+	maskSizeX, maskSizeY = vsx, vsy
+	return true
+end
+
+-- The mask has to match the world viewport pixel for pixel, so it is (re)created on demand.
+local function maskPathAvailable()
+	if maskUnavailable or not (maskShader and compositeShader and fullScreenQuadVAO) then
+		return false
+	end
+	local vsx, vsy = Spring.GetViewGeometry()
+	if maskFBO and maskSizeX == vsx and maskSizeY == vsy then
+		return true
+	end
+	return createMaskTargets(vsx, vsy)
+end
 
 local function goodbye(reason)
 	spEcho("AttackRange GL4 widget exiting with reason: " .. reason)
@@ -866,6 +1005,13 @@ local function makeShaders()
 		goodbye("Failed to compile attackRangeShader GL4 ")
 		return false
 	end
+	-- The coverage mask shaders are optional: without them the stencil path is used.
+	maskShader = LuaShader.CheckShaderUpdates(maskShaderSourceCache, 0) or maskShader
+	compositeShader = LuaShader.CheckShaderUpdates(compositeShaderSourceCache, 0) or compositeShader
+	fullScreenQuadVAO = fullScreenQuadVAO or InstanceVBOTable.MakeTexRectVAO()
+	if not (maskShader and compositeShader and fullScreenQuadVAO) then
+		spEcho("Attack Range GL4: range coverage mask unavailable, using the stencil path")
+	end
 	return true
 end
 
@@ -1079,6 +1225,26 @@ function widget:Shutdown()
 	widgetHandler:RemoveAction("cursor_range_toggle", "p")
 	widgetHandler:RemoveAction("attack_range_inc", "p")
 	widgetHandler:RemoveAction("attack_range_dec", "p")
+
+	deleteMaskTargets()
+	if fullScreenQuadVAO then
+		fullScreenQuadVAO:Delete()
+		fullScreenQuadVAO = nil
+	end
+	if maskShader then
+		maskShader:Finalize()
+		maskShader = nil
+	end
+	if compositeShader then
+		compositeShader:Finalize()
+		compositeShader = nil
+	end
+end
+
+function widget:ViewResize()
+	-- the coverage mask is recreated at the new size on the next draw
+	deleteMaskTargets()
+	maskUnavailable = false
 end
 
 local gameFrame = 0
@@ -1276,15 +1442,178 @@ local function DRAWRINGS(primitiveType, linethickness)
 	end
 end
 
+-- Fill colour per mask channel. The alpha matches what the stencil fill produced: fill_alpha
+-- times the ring colour's alpha times internalalpha, the line alpha uniform the fill pass
+-- inherited from the previous frame's inner rings.
+local function getFillColor(channel)
+	local color = colorConfig[maskChannelFillClass[channel]].color
+	return color[1], color[2], color[3], color[4] * colorConfig.fill_alpha * colorConfig.internalalpha
+end
+
+-- Draws every filled disc of one ally/enemy group into the mask FBO (bound by the caller).
+-- Within a channel the depth test keeps only the first disc per pixel (instance-ordered depth,
+-- see the vertex shader), so the additive write sets each class bit at most once; the channels
+-- are separated by depth clears so that classes sharing a pixel all get their bit. The clears
+-- are full-surface on purpose, partial clears can defeat the hierarchical depth test.
+local function drawCoverageMask(allyState)
+	glColorMask(true, true, true, true)
+	gl.DepthMask(true)
+	glDepthTest(GL.LESS)
+	gl.Blending(GL.ONE, GL.ONE)
+	glClear(GL.COLOR_BUFFER_BIT, 0, 0, 0, 0)
+
+	maskShader:Activate()
+	maskShader:SetUniform("selUnitCount", selUnitCount)
+	maskShader:SetUniform("selBuilderCount", selBuilderCount)
+	maskShader:SetUniform("drawMode", 0.0)
+	maskShader:SetUniform("inMiniMap", 0.0)
+	maskShader:SetUniform("drawAlpha", colorConfig.fill_alpha)
+	maskShader:SetUniform("fadeDistOffset", colorConfig.outer_fade_height_difference)
+	for channel = 0, 3 do
+		local classes = maskChannelClasses[channel]
+		local anyInstances = false
+		for i = 1, #classes do
+			if attackRangeVAOs[allyState .. classes[i]].usedElements > 0 then
+				anyInstances = true
+			end
+		end
+		if anyInstances then
+			glClear(GL.DEPTH_BUFFER_BIT, 1.0)
+			maskShader:SetUniform("maskWriteValue", (2 ^ channel) / 255)
+			for i = 1, #classes do
+				local iT = attackRangeVAOs[allyState .. classes[i]]
+				if iT.usedElements > 0 then
+					maskShader:SetUniform("cannonmode", ringClassCannonMode[classes[i]])
+					-- each class of a channel gets its own depth band so a later class never
+					-- passes the depth test where an earlier one already wrote the bit
+					maskShader:SetUniform("maskDepthBase", 0.1 + (i - 1) * 0.4)
+					iT.VAO:DrawArrays(GL_TRIANGLE_FAN, iT.numVertices, 0, iT.usedElements, 0)
+				end
+			end
+		end
+	end
+	maskShader:Deactivate()
+	gl.DepthMask(false)
+end
+
+-- Paints the merged fill of one group from its coverage mask with one screen-sized quad.
+local function drawFillComposite()
+	glTexture(3, maskTex)
+	glDepthTest(false)
+	gl.Blending(GL.ONE, GL.ONE_MINUS_SRC_ALPHA) -- the shader outputs premultiplied colour
+	compositeShader:Activate()
+	compositeShader:SetUniform("fillColor0", getFillColor(0))
+	compositeShader:SetUniform("fillColor1", getFillColor(1))
+	compositeShader:SetUniform("fillColor2", getFillColor(2))
+	compositeShader:SetUniform("fillColor3", getFillColor(3))
+	fullScreenQuadVAO:DrawArrays(GL.TRIANGLES)
+	compositeShader:Deactivate()
+	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
+end
+
+-- Outer rings of one group: the merged outline, everything inside the group's mask is hidden.
+local function drawOuterRings(allyState, hasMask)
+	glDepthTest(GL_LEQUAL)
+	attackRangeShader:Activate()
+	attackRangeShader:SetUniform("selUnitCount", selUnitCount)
+	attackRangeShader:SetUniform("selBuilderCount", selBuilderCount)
+	attackRangeShader:SetUniform("inMiniMap", 0.0)
+	attackRangeShader:SetUniform("fadeDistOffset", colorConfig.outer_fade_height_difference)
+	attackRangeShader:SetUniform("lineAlphaUniform", colorConfig.externalalpha)
+	attackRangeShader:SetUniform("drawMode", 1.0)
+	attackRangeShader:SetUniform("drawAlpha", 1.0)
+	attackRangeShader:SetUniform("maskClip", hasMask and 1.0 or 0.0)
+	for i = 1, #ringClassOrder do
+		local wt = ringClassOrder[i]
+		local iT = attackRangeVAOs[allyState .. wt]
+		if iT.usedElements > 0 then
+			glLineWidth(colorConfig[wt].externallinethickness * cameraHeightFactor)
+			attackRangeShader:SetUniform("cannonmode", ringClassCannonMode[wt])
+			attackRangeShader:SetUniform("maskChannelBit", ringClassMaskBit[wt])
+			iT.VAO:DrawArrays(GL_LINE_LOOP, iT.numVertices, 0, iT.usedElements, 0)
+		end
+	end
+	attackRangeShader:Deactivate()
+end
+
+-- Inner rings of both groups: plain per-unit rings, nothing is masked.
+local function drawInnerRings()
+	glDepthTest(GL_LEQUAL)
+	attackRangeShader:Activate()
+	attackRangeShader:SetUniform("selUnitCount", selUnitCount)
+	attackRangeShader:SetUniform("selBuilderCount", selBuilderCount)
+	attackRangeShader:SetUniform("inMiniMap", 0.0)
+	attackRangeShader:SetUniform("fadeDistOffset", 0)
+	attackRangeShader:SetUniform("lineAlphaUniform", colorConfig.internalalpha)
+	attackRangeShader:SetUniform("drawMode", 2.0)
+	attackRangeShader:SetUniform("drawAlpha", 1.0)
+	attackRangeShader:SetUniform("maskClip", 0.0)
+	for _, allyState in ipairs(allyenemypairs) do
+		for i = 1, #ringClassOrder do
+			local wt = ringClassOrder[i]
+			local iT = attackRangeVAOs[allyState .. wt]
+			if iT.usedElements > 0 then
+				glLineWidth(colorConfig[wt].internallinethickness * cameraHeightFactor)
+				attackRangeShader:SetUniform("cannonmode", ringClassCannonMode[wt])
+				iT.VAO:DrawArrays(GL_LINE_LOOP, iT.numVertices, 0, iT.usedElements, 0)
+			end
+		end
+	end
+	attackRangeShader:Deactivate()
+end
+
+-- World view drawing through the coverage mask; the stencil path below stays for the minimap.
+local function drawRangesMasked()
+	if not show_selected_weapon_ranges and not isBuilding then
+		return
+	end
+	cameraHeightFactor = GetCameraHeightFactor() * 0.5 + 0.5
+	glTexture(0, "$heightmap")
+	glTexture(1, "$info")
+	if colorConfig.drawStencil then
+		for _, allyState in ipairs(allyenemypairs) do
+			local hasFill, hasRings = false, false
+			for i = 1, #ringClassOrder do
+				local wt = ringClassOrder[i]
+				if attackRangeVAOs[allyState .. wt].usedElements > 0 then
+					hasRings = true
+					hasFill = hasFill or wt ~= "lrpc" -- lrpc rings are not merged
+				end
+			end
+			if hasRings then
+				if hasFill then
+					gl.ActiveFBO(maskFBO, drawCoverageMask, allyState)
+					drawFillComposite()
+				end
+				drawOuterRings(allyState, hasFill)
+			end
+		end
+	end
+	if colorConfig.drawInnerRings then
+		drawInnerRings()
+	end
+	glTexture(0, false)
+	glTexture(1, false)
+	glTexture(3, false)
+	glDepthTest(false)
+end
+
 function widget:DrawWorld(inMiniMap)
 	if autoReload then
 		attackRangeShader = LuaShader.CheckShaderUpdates(shaderSourceCache) or attackRangeShader
+		maskShader = LuaShader.CheckShaderUpdates(maskShaderSourceCache) or maskShader
+		compositeShader = LuaShader.CheckShaderUpdates(compositeShaderSourceCache) or compositeShader
 	end
 
 	if chobbyInterface or not (selUnitCount > 0 or mouseUnit) then
 		return
 	end
 	if not Spring.IsGUIHidden() and (not WG.topbar or not WG.topbar.showingQuit()) then
+		if not inMiniMap and maskPathAvailable() then
+			drawRangesMasked()
+			return
+		end
+		-- Stencil path: the minimap (tiny discs), and the fallback when the coverage mask is unavailable.
 		-- For PIP minimap, use thicker lines since PIP is larger than engine minimap
 		local inPip = inMiniMap and WG.minimap and WG.minimap.isDrawingInPip
 		if inPip then


### PR DESCRIPTION
- in the world view, each ally/enemy group draws its discs into a private single-sample FBO (R8 mask with one bit per class, 16-bit depth). Instances get increasing depth so the first disc wins and hierarchical Z can reject the overlap. One screen quad composites the fill, and the outer rings sample the mask instead of the stencil buffer. The minimap keeps the stencil path, and any FBO or shader failure falls back to it.
- weapon_range_rings_unified_gl4.vert.glsl and the fragment shader gained the mask-pass variant and the mask read. Two new files, weapon_range_fill_composite_gl4.vert.glsl and its fragment shader, do the composite.