### PR TITLE
Don't lua check mapgenerator/** templates,

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,6 +10,7 @@ codes = true
 exclude_files = {
     "common/luaUtilities/**",
     ".lux/**",
+    "mapgenerator/**", -- ${PLACEHOLDER} templates, not parseable as Lua
     "recoil-lua-library/**",
 }
 


### PR DESCRIPTION
### Work done

Add `mapgenerator/**` to `.luacheckrc` since it doesn't contain a proper .lua file, but a template for one.