### PR TITLE
Default spring camera to smooth terrain tracking

### DIFF
--- a/luaui/Widgets/gui_options.lua
+++ b/luaui/Widgets/gui_options.lua
@@ -5541,7 +5541,7 @@ function init()
 				BAR.I18N("ui.settings.option.select_terrain"),
 				BAR.I18N("ui.settings.option.select_smooth"),
 			},
-			value = Spring.GetConfigInt("CamSpringTrackMapHeightMode", 0) + 1,
+			value = Spring.GetConfigInt("CamSpringTrackMapHeightMode", 2) + 1,
 			description = BAR.I18N("ui.settings.option.springcamheightmode_descr"),
 			onchange = function(i, value)
 				Spring.SetConfigInt("CamSpringTrackMapHeightMode", value - 1)


### PR DESCRIPTION
## Summary
Default `CamSpringTrackMapHeightMode` to Smooth (mode 2) for players without an existing setting. BAR already enables the smooth mesh, and RecoilEngine #3012 improves this mode's height tracking.

## Testing
- `git diff --check`
- Not run: `stylua` and `luacheck` are not installed locally.