### PR TITLE
Mission API: Add triggers for transport load and unload

### DIFF
--- a/luarules/gadgets/api_missions_triggers.lua
+++ b/luarules/gadgets/api_missions_triggers.lua
@@ -431,6 +431,16 @@ function gadget:UnitIdlePost(unitID, idled)
 	dispatchTriggerCallin("UnitIdlePost", unitID, idled)
 end
 
+function gadget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
+	local transportDefID = Spring.GetUnitDefID(transportID)
+	dispatchTriggerCallin("UnitLoaded", unitID, unitDefID, unitTeam, transportID, transportDefID, transportTeam)
+end
+
+function gadget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
+	local transportDefID = Spring.GetUnitDefID(transportID)
+	dispatchTriggerCallin("UnitUnloaded", unitID, unitDefID, unitTeam, transportID, transportDefID, transportTeam)
+end
+
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
 	dispatchTriggerCallin(
 		"UnitDestroyed",

--- a/luarules/mission_api/triggers/transport_loaded.lua
+++ b/luarules/mission_api/triggers/transport_loaded.lua
@@ -1,0 +1,42 @@
+local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+
+-- Docking drones, hats, and attached turrets raise UnitLoaded as well.
+-- A transportName is checked whether it's an actual transport. A transportDefName is not.
+
+return {
+	type = 'TransportLoaded',
+	parameters = {
+		{ name = 'transportName',    required = false, type = ParameterTypes.UnitName },
+		{ name = 'transportDefName', required = false, type = ParameterTypes.UnitDefName },
+		{ name = 'teamID',           required = false, type = ParameterTypes.TeamID },
+		{ name = 'unitName',         required = false, type = ParameterTypes.UnitName },
+		{ name = 'unitDefName',      required = false, type = ParameterTypes.UnitDefName },
+		requiresOneOf = { 'transportName', 'transportDefName' },
+	},
+	callins = {
+		UnitLoaded = function(trigger, triggerID, context, unitID, unitDefID, unitTeam, transportID, transportDefID, transportTeam)
+			local parameters = trigger.parameters
+			if parameters.transportDefName then
+				if parameters.transportDefName ~= UnitDefs[transportDefID].name then
+					return
+				end
+			elseif not UnitDefs[transportDefID].isTransport then
+				return
+			end
+
+			if parameters.transportName and not context.DoesUnitHaveName(transportID, parameters.transportName) then
+				return
+			end
+			if parameters.teamID and parameters.teamID ~= transportTeam then
+				return
+			end
+			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then
+				return
+			end
+			if parameters.unitDefName and parameters.unitDefName ~= UnitDefs[unitDefID].name then
+				return
+			end
+			context.ActivateTrigger(trigger)
+		end,
+	},
+}

--- a/luarules/mission_api/triggers/transport_loaded.lua
+++ b/luarules/mission_api/triggers/transport_loaded.lua
@@ -9,8 +9,8 @@ return {
 		{ name = 'transportName',    required = false, type = ParameterTypes.UnitName },
 		{ name = 'transportDefName', required = false, type = ParameterTypes.UnitDefName },
 		{ name = 'teamID',           required = false, type = ParameterTypes.TeamID },
-		{ name = 'unitName',         required = false, type = ParameterTypes.UnitName },
-		{ name = 'unitDefName',      required = false, type = ParameterTypes.UnitDefName },
+		{ name = 'passengerName',    required = false, type = ParameterTypes.UnitName },
+		{ name = 'passengerDefName', required = false, type = ParameterTypes.UnitDefName },
 		requiresOneOf = { 'transportName', 'transportDefName' },
 	},
 	callins = {
@@ -30,10 +30,10 @@ return {
 			if parameters.teamID and parameters.teamID ~= transportTeam then
 				return
 			end
-			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then
+			if parameters.passengerName and not context.DoesUnitHaveName(unitID, parameters.passengerName) then
 				return
 			end
-			if parameters.unitDefName and parameters.unitDefName ~= UnitDefs[unitDefID].name then
+			if parameters.passengerDefName and parameters.passengerDefName ~= UnitDefs[unitDefID].name then
 				return
 			end
 			context.ActivateTrigger(trigger)

--- a/luarules/mission_api/triggers/transport_unloaded.lua
+++ b/luarules/mission_api/triggers/transport_unloaded.lua
@@ -10,8 +10,8 @@ return {
 		{ name = 'transportName',    required = false, type = ParameterTypes.UnitName },
 		{ name = 'transportDefName', required = false, type = ParameterTypes.UnitDefName },
 		{ name = 'teamID',           required = false, type = ParameterTypes.TeamID },
-		{ name = 'unitName',         required = false, type = ParameterTypes.UnitName },
-		{ name = 'unitDefName',      required = false, type = ParameterTypes.UnitDefName },
+		{ name = 'passengerName',    required = false, type = ParameterTypes.UnitName },
+		{ name = 'passengerDefName', required = false, type = ParameterTypes.UnitDefName },
 		requiresOneOf = { 'transportName', 'transportDefName' },
 	},
 	callins = {
@@ -31,10 +31,10 @@ return {
 			if parameters.teamID and parameters.teamID ~= transportTeam then
 				return
 			end
-			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then
+			if parameters.passengerName and not context.DoesUnitHaveName(unitID, parameters.passengerName) then
 				return
 			end
-			if parameters.unitDefName and parameters.unitDefName ~= UnitDefs[unitDefID].name then
+			if parameters.passengerDefName and parameters.passengerDefName ~= UnitDefs[unitDefID].name then
 				return
 			end
 			context.ActivateTrigger(trigger)

--- a/luarules/mission_api/triggers/transport_unloaded.lua
+++ b/luarules/mission_api/triggers/transport_unloaded.lua
@@ -1,0 +1,43 @@
+local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+
+-- Docking drones, hats, and attached turrets raise UnitLoaded as well.
+-- A transportName is checked whether it's an actual transport. A transportDefName is not.
+-- A transport that dies unloads its passengers in the engine, and BAR (usually) kills them.
+
+return {
+	type = 'TransportUnloaded',
+	parameters = {
+		{ name = 'transportName',    required = false, type = ParameterTypes.UnitName },
+		{ name = 'transportDefName', required = false, type = ParameterTypes.UnitDefName },
+		{ name = 'teamID',           required = false, type = ParameterTypes.TeamID },
+		{ name = 'unitName',         required = false, type = ParameterTypes.UnitName },
+		{ name = 'unitDefName',      required = false, type = ParameterTypes.UnitDefName },
+		requiresOneOf = { 'transportName', 'transportDefName' },
+	},
+	callins = {
+		UnitUnloaded = function(trigger, triggerID, context, unitID, unitDefID, unitTeam, transportID, transportDefID, transportTeam)
+			local parameters = trigger.parameters
+			if parameters.transportDefName then
+				if parameters.transportDefName ~= UnitDefs[transportDefID].name then
+					return
+				end
+			elseif not UnitDefs[transportDefID].isTransport then
+				return
+			end
+
+			if parameters.transportName and not context.DoesUnitHaveName(transportID, parameters.transportName) then
+				return
+			end
+			if parameters.teamID and parameters.teamID ~= transportTeam then
+				return
+			end
+			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then
+				return
+			end
+			if parameters.unitDefName and parameters.unitDefName ~= UnitDefs[unitDefID].name then
+				return
+			end
+			context.ActivateTrigger(trigger)
+		end,
+	},
+}

--- a/singleplayer/mission-api-tests/transport_loaded_test.lua
+++ b/singleplayer/mission-api-tests/transport_loaded_test.lua
@@ -38,7 +38,7 @@ local triggers = {
 		parameters = {
 			transportDefName = 'armatlas',
 			teamID = 0,
-			unitDefName = 'armpw',
+			passengerDefName = 'armpw',
 		},
 		actions = { 'messageAtlasLoadedPawn' },
 	},
@@ -57,7 +57,7 @@ local triggers = {
 		type = triggerTypes.TransportLoaded,
 		parameters = {
 			transportDefName = 'corvac',
-			unitDefName = 'corvacct',
+			passengerDefName = 'corvacct',
 		},
 		actions = { 'messageConstructorAttachedTurret' },
 	},

--- a/singleplayer/mission-api-tests/transport_loaded_test.lua
+++ b/singleplayer/mission-api-tests/transport_loaded_test.lua
@@ -1,0 +1,156 @@
+local triggerTypes = GG['MissionAPI'].TriggerDefinitions.Types
+local actionTypes = GG['MissionAPI'].ActionDefinitions.Types
+
+-- A transport loads and unloads a pawn. A construction vehicle with an attached turret is spawned
+-- alongside: the attachment raises the same engine call-in, and counts as a transport event only
+-- when the mission names the vehicle's definition. Docking drones behave the same way, but no
+-- carrier is a base-game land unit.
+
+local triggers = {
+
+	spawnScene = {
+		type = triggerTypes.TimeElapsed,
+		parameters = {
+			seconds = 1,
+		},
+		actions = { 'spawnDropship', 'spawnPassenger', 'spawnConstructor' },
+	},
+
+	-- Split off the spawn, since an order does not take on the frame its target unit is spawned.
+	orderTransport = {
+		type = triggerTypes.TimeElapsed,
+		parameters = {
+			seconds = 3,
+		},
+		actions = { 'orderDropshipLoadAndUnload' },
+	},
+
+	dropshipLoaded = {
+		type = triggerTypes.TransportLoaded,
+		parameters = {
+			transportName = 'dropship',
+		},
+		actions = { 'messageDropshipLoaded' },
+	},
+
+	atlasLoadedPawn = {
+		type = triggerTypes.TransportLoaded,
+		parameters = {
+			transportDefName = 'armatlas',
+			teamID = 0,
+			unitDefName = 'armpw',
+		},
+		actions = { 'messageAtlasLoadedPawn' },
+	},
+
+	dropshipUnloaded = {
+		type = triggerTypes.TransportUnloaded,
+		parameters = {
+			transportName = 'dropship',
+			unitName = 'passenger',
+		},
+		actions = { 'messageDropshipUnloaded' },
+	},
+
+	-- The construction vehicle is not a transport, so it counts only by its definition name.
+	constructorAttachedTurret = {
+		type = triggerTypes.TransportLoaded,
+		parameters = {
+			transportDefName = 'corvac',
+			unitDefName = 'corvacct',
+		},
+		actions = { 'messageConstructorAttachedTurret' },
+	},
+
+	-- Never fires: a unit name alone does not make the construction vehicle a transport.
+	constructorByNameOnly = {
+		type = triggerTypes.TransportLoaded,
+		parameters = {
+			transportName = 'constructor',
+		},
+		actions = { 'messageConstructorByNameOnly' },
+	},
+
+}
+
+local actions = {
+
+	spawnDropship = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armatlas', x = 2400, z = 2400, team = 0, unitName = 'dropship' },
+			},
+		},
+	},
+
+	spawnPassenger = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armpw', x = 2480, z = 2400, team = 0, unitName = 'passenger' },
+			},
+		},
+	},
+
+	spawnConstructor = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'corvac', x = 2200, z = 2400, team = 0, unitName = 'constructor' },
+			},
+		},
+	},
+
+	orderDropshipLoadAndUnload = {
+		type = actionTypes.IssueOrders,
+		parameters = {
+			unitName = 'dropship',
+			orders = {
+				{ CMD.LOAD_UNITS, { unitName = 'passenger' } },
+				{ CMD.UNLOAD_UNITS, { 2400, 0, 2700, 60 }, { 'shift' } },
+			},
+		},
+	},
+
+	messageDropshipLoaded = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "The dropship loaded a unit!",
+		},
+	},
+
+	messageAtlasLoadedPawn = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "An Atlas loaded a pawn!",
+		},
+	},
+
+	messageDropshipUnloaded = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "The dropship unloaded the passenger!",
+		},
+	},
+
+	messageConstructorAttachedTurret = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "The construction vehicle attached its turret!",
+		},
+	},
+
+	messageConstructorByNameOnly = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "BUG: the construction vehicle counted as a transport by unit name alone!",
+		},
+	},
+
+}
+
+return {
+	Triggers = triggers,
+	Actions = actions,
+}

--- a/spec/mission_api/triggers/transport_loaded_spec.lua
+++ b/spec/mission_api/triggers/transport_loaded_spec.lua
@@ -52,8 +52,8 @@ describe("mission_api.triggers.transport_loaded", function()
 		assert.is_true(names.transportName)
 		assert.is_true(names.transportDefName)
 		assert.is_true(names.teamID)
-		assert.is_true(names.unitName)
-		assert.is_true(names.unitDefName)
+		assert.is_true(names.passengerName)
+		assert.is_true(names.passengerDefName)
 		assert.are.same({ "transportName", "transportDefName" }, transportLoaded.parameters.requiresOneOf)
 	end)
 
@@ -84,20 +84,20 @@ describe("mission_api.triggers.transport_loaded", function()
 		assert.are.equal(0, fired())
 	end)
 
-	it("filters by unitName", function()
+	it("filters by passengerName", function()
 		local context, fired = newContext()
 		context.DoesUnitHaveName = function(unitID)
 			return unitID == 50 -- the transport has the name, the passenger does not
 		end
-		loaded(trigger({ transportName = "dropship", unitName = "passenger" }), context, 10, 0)
+		loaded(trigger({ transportName = "dropship", passengerName = "passenger" }), context, 10, 0)
 		assert.are.equal(0, fired())
 	end)
 
-	it("filters by unitDefName", function()
+	it("filters by passengerDefName", function()
 		local context, fired = newContext()
-		loaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 1) -- 1 = armpw
+		loaded(trigger({ transportDefName = "armatlas", passengerDefName = "armck" }), context, 10, 0, 1) -- 1 = armpw
 		assert.are.equal(0, fired())
-		loaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 2)
+		loaded(trigger({ transportDefName = "armatlas", passengerDefName = "armck" }), context, 10, 0, 2)
 		assert.are.equal(1, fired())
 	end)
 

--- a/spec/mission_api/triggers/transport_loaded_spec.lua
+++ b/spec/mission_api/triggers/transport_loaded_spec.lua
@@ -1,0 +1,116 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+-- The trigger file reads GG['MissionAPI'].Modules.ParameterTypes at load time, and UnitDefs inside its handler.
+Builders.MissionApi.new():Install()
+
+_G.UnitDefs = {
+	[1] = { name = "armpw", isTransport = false },
+	[2] = { name = "armck", isTransport = false },
+	[10] = { name = "armatlas", isTransport = true },
+	[11] = { name = "corvalk", isTransport = true },
+	[20] = { name = "armdronecarryland", isTransport = false },
+}
+
+local transportLoaded = VFS.Include("luarules/mission_api/triggers/transport_loaded.lua")
+local onUnitLoaded = transportLoaded.callins.UnitLoaded
+
+describe("mission_api.triggers.transport_loaded", function()
+	local function trigger(parameters)
+		return { parameters = parameters or {}, settings = {} }
+	end
+
+	local function newContext()
+		local fired = 0
+		local context = {
+			ActivateTrigger = function()
+				fired = fired + 1
+			end,
+			DoesUnitHaveName = function()
+				return true
+			end,
+		}
+		return context, function()
+			return fired
+		end
+	end
+
+	local triggerID = "t"
+
+	-- unitID 100 is the passenger and unitID 50 the transport; the gadget resolves the transport's defID.
+	local function loaded(trigger, context, transportDefID, transportTeam, unitDefID)
+		onUnitLoaded(trigger, triggerID, context, 100, unitDefID or 1, 0, 50, transportDefID, transportTeam)
+	end
+
+	it("declares its type and parameters", function()
+		assert.are.equal("TransportLoaded", transportLoaded.type)
+		local names = {}
+		for _, parameter in ipairs(transportLoaded.parameters) do
+			names[parameter.name] = true
+		end
+		assert.is_true(names.transportName)
+		assert.is_true(names.transportDefName)
+		assert.is_true(names.teamID)
+		assert.is_true(names.unitName)
+		assert.is_true(names.unitDefName)
+		assert.are.same({ "transportName", "transportDefName" }, transportLoaded.parameters.requiresOneOf)
+	end)
+
+	it("fires when a transport loads a unit", function()
+		local context, fired = newContext()
+		loaded(trigger({ transportDefName = "armatlas", teamID = 0 }), context, 10, 0)
+		assert.are.equal(1, fired())
+	end)
+
+	it("filters by transportDefName", function()
+		local context, fired = newContext()
+		loaded(trigger({ transportDefName = "corvalk" }), context, 10, 0) -- 10 = armatlas
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by teamID, which is the transport's team", function()
+		local context, fired = newContext()
+		loaded(trigger({ transportDefName = "armatlas", teamID = 9 }), context, 10, 0)
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by transportName", function()
+		local context, fired = newContext()
+		context.DoesUnitHaveName = function()
+			return false
+		end
+		loaded(trigger({ transportName = "dropship" }), context, 10, 0)
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by unitName", function()
+		local context, fired = newContext()
+		context.DoesUnitHaveName = function(unitID)
+			return unitID == 50 -- the transport has the name, the passenger does not
+		end
+		loaded(trigger({ transportName = "dropship", unitName = "passenger" }), context, 10, 0)
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by unitDefName", function()
+		local context, fired = newContext()
+		loaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 1) -- 1 = armpw
+		assert.are.equal(0, fired())
+		loaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 2)
+		assert.are.equal(1, fired())
+	end)
+
+	-- Spring.UnitAttach raises UnitLoaded for docking drones, hats, and attached turrets.
+	it("fires for a loader that is not a transport when named by definition", function()
+		local context, fired = newContext()
+		loaded(trigger({ transportDefName = "armdronecarryland" }), context, 20, 0)
+		assert.are.equal(1, fired())
+	end)
+
+	it("does not fire for a loader that is not a transport when named by unit name alone", function()
+		local context, fired = newContext()
+		loaded(trigger({ transportName = "carrier" }), context, 20, 0)
+		assert.are.equal(0, fired())
+	end)
+end)

--- a/spec/mission_api/triggers/transport_unloaded_spec.lua
+++ b/spec/mission_api/triggers/transport_unloaded_spec.lua
@@ -52,8 +52,8 @@ describe("mission_api.triggers.transport_unloaded", function()
 		assert.is_true(names.transportName)
 		assert.is_true(names.transportDefName)
 		assert.is_true(names.teamID)
-		assert.is_true(names.unitName)
-		assert.is_true(names.unitDefName)
+		assert.is_true(names.passengerName)
+		assert.is_true(names.passengerDefName)
 		assert.are.same({ "transportName", "transportDefName" }, transportUnloaded.parameters.requiresOneOf)
 	end)
 
@@ -84,20 +84,20 @@ describe("mission_api.triggers.transport_unloaded", function()
 		assert.are.equal(0, fired())
 	end)
 
-	it("filters by unitName", function()
+	it("filters by passengerName", function()
 		local context, fired = newContext()
 		context.DoesUnitHaveName = function(unitID)
 			return unitID == 50 -- the transport has the name, the passenger does not
 		end
-		unloaded(trigger({ transportName = "dropship", unitName = "passenger" }), context, 10, 0)
+		unloaded(trigger({ transportName = "dropship", passengerName = "passenger" }), context, 10, 0)
 		assert.are.equal(0, fired())
 	end)
 
-	it("filters by unitDefName", function()
+	it("filters by passengerDefName", function()
 		local context, fired = newContext()
-		unloaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 1) -- 1 = armpw
+		unloaded(trigger({ transportDefName = "armatlas", passengerDefName = "armck" }), context, 10, 0, 1) -- 1 = armpw
 		assert.are.equal(0, fired())
-		unloaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 2)
+		unloaded(trigger({ transportDefName = "armatlas", passengerDefName = "armck" }), context, 10, 0, 2)
 		assert.are.equal(1, fired())
 	end)
 

--- a/spec/mission_api/triggers/transport_unloaded_spec.lua
+++ b/spec/mission_api/triggers/transport_unloaded_spec.lua
@@ -1,0 +1,116 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+-- The trigger file reads GG['MissionAPI'].Modules.ParameterTypes at load time, and UnitDefs inside its handler.
+Builders.MissionApi.new():Install()
+
+_G.UnitDefs = {
+	[1] = { name = "armpw", isTransport = false },
+	[2] = { name = "armck", isTransport = false },
+	[10] = { name = "armatlas", isTransport = true },
+	[11] = { name = "corvalk", isTransport = true },
+	[20] = { name = "armdronecarryland", isTransport = false },
+}
+
+local transportUnloaded = VFS.Include("luarules/mission_api/triggers/transport_unloaded.lua")
+local onUnitUnloaded = transportUnloaded.callins.UnitUnloaded
+
+describe("mission_api.triggers.transport_unloaded", function()
+	local function trigger(parameters)
+		return { parameters = parameters or {}, settings = {} }
+	end
+
+	local function newContext()
+		local fired = 0
+		local context = {
+			ActivateTrigger = function()
+				fired = fired + 1
+			end,
+			DoesUnitHaveName = function()
+				return true
+			end,
+		}
+		return context, function()
+			return fired
+		end
+	end
+
+	local triggerID = "t"
+
+	-- unitID 100 is the passenger and unitID 50 the transport; the gadget resolves the transport's defID.
+	local function unloaded(trigger, context, transportDefID, transportTeam, unitDefID)
+		onUnitUnloaded(trigger, triggerID, context, 100, unitDefID or 1, 0, 50, transportDefID, transportTeam)
+	end
+
+	it("declares its type and parameters", function()
+		assert.are.equal("TransportUnloaded", transportUnloaded.type)
+		local names = {}
+		for _, parameter in ipairs(transportUnloaded.parameters) do
+			names[parameter.name] = true
+		end
+		assert.is_true(names.transportName)
+		assert.is_true(names.transportDefName)
+		assert.is_true(names.teamID)
+		assert.is_true(names.unitName)
+		assert.is_true(names.unitDefName)
+		assert.are.same({ "transportName", "transportDefName" }, transportUnloaded.parameters.requiresOneOf)
+	end)
+
+	it("fires when a transport unloads a unit", function()
+		local context, fired = newContext()
+		unloaded(trigger({ transportDefName = "armatlas", teamID = 0 }), context, 10, 0)
+		assert.are.equal(1, fired())
+	end)
+
+	it("filters by transportDefName", function()
+		local context, fired = newContext()
+		unloaded(trigger({ transportDefName = "corvalk" }), context, 10, 0) -- 10 = armatlas
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by teamID, which is the transport's team", function()
+		local context, fired = newContext()
+		unloaded(trigger({ transportDefName = "armatlas", teamID = 9 }), context, 10, 0)
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by transportName", function()
+		local context, fired = newContext()
+		context.DoesUnitHaveName = function()
+			return false
+		end
+		unloaded(trigger({ transportName = "dropship" }), context, 10, 0)
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by unitName", function()
+		local context, fired = newContext()
+		context.DoesUnitHaveName = function(unitID)
+			return unitID == 50 -- the transport has the name, the passenger does not
+		end
+		unloaded(trigger({ transportName = "dropship", unitName = "passenger" }), context, 10, 0)
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by unitDefName", function()
+		local context, fired = newContext()
+		unloaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 1) -- 1 = armpw
+		assert.are.equal(0, fired())
+		unloaded(trigger({ transportDefName = "armatlas", unitDefName = "armck" }), context, 10, 0, 2)
+		assert.are.equal(1, fired())
+	end)
+
+	-- Spring.UnitDetach raises UnitUnloaded for undocking drones and detached turrets.
+	it("fires for an unloader that is not a transport when named by definition", function()
+		local context, fired = newContext()
+		unloaded(trigger({ transportDefName = "armdronecarryland" }), context, 20, 0)
+		assert.are.equal(1, fired())
+	end)
+
+	it("does not fire for an unloader that is not a transport when named by unit name alone", function()
+		local context, fired = newContext()
+		unloaded(trigger({ transportName = "carrier" }), context, 20, 0)
+		assert.are.equal(0, fired())
+	end)
+end)

--- a/spec/mission_api/triggers_loader_spec.lua
+++ b/spec/mission_api/triggers_loader_spec.lua
@@ -180,6 +180,8 @@ describe("mission_api.triggers_loader", function()
 			assert.is_function(C.FeatureCreated[T.FeatureCreated])
 			assert.is_function(C.FeatureDestroyed[T.FeatureReclaimed])
 			assert.is_function(C.FeatureDestroyed[T.FeatureDestroyed])
+			assert.is_function(C.UnitLoaded[T.TransportLoaded])
+			assert.is_function(C.UnitUnloaded[T.TransportUnloaded])
 		end)
 
 		it("registers no callins for statistics, mission-control, and event triggers", function()


### PR DESCRIPTION
### Work done

Adds mission triggers for loading and unloading transports.

Drone carriers and hat-bearers may be "transports" in an odd sense, allowing the trigger subject to be more loosely defined, though only when an explicit unitDefID (unitDefName) is given. This is an odd quirk; I was trying to think through whether we needed a bootleg DroneDocked or not.

Includes specs and a test mission. Next up for test mission design, probably: Giving units orders on timers so we can just watch test missions play.