### PR TITLE
Add opt-in Lua port of native attack movement

### DIFF
--- a/docs/attack-movement.md
+++ b/docs/attack-movement.md
@@ -1,0 +1,48 @@
+# Lua attack movement (opt-in)
+
+Requires RecoilEngine [PR #3330](https://github.com/beyond-all-reason/RecoilEngine/pull/3330).
+Set the startscript modoption `attackmovementmode=lua` to enable the equivalent
+port of native object/ground attack movement. `fallback` installs a callback
+that returns false; an unset option keeps the gadget disabled. On engines
+without the new APIs the gadget removes itself.
+
+The gadget preserves the native decisions, including the 90% range rule. It
+provides a baseline for subsequent policy changes for
+[RecoilEngine #3331](https://github.com/beyond-all-reason/RecoilEngine/issues/3331).
+It does not interpret `AimWeapon` returning false as a permanent refusal.
+
+`AttackCommandMovement` runs when native mobile command AI evaluates attack
+movement, before its range decisions. Return literal true to handle that update;
+false/nil delegates to native behavior. This is not a per-shot event. Effects of
+movement API calls are immediate, so returning false does not undo them.
+
+## Querying friendly and terrain blockers independently
+
+Inside the callback, `Spring.GetUnitAttackWeaponState(unitID, weaponNum,
+avoidFlags?)` returns `eligible, rotate, heading, ownerRotation, targetBorder,
+rotateReason, headingReason`. The optional mask replaces the weapon's avoidance
+flags **for this query only**. Omit it to retain native flags, as this port does.
+Set bits mean ignore; target/range checks always apply.
+
+```lua
+local flags = Game.collisionFlags
+local friendlyOnly = flags.noGround + flags.noNeutrals + flags.noFeatures + flags.noCloaked
+local terrainOnly = flags.noUnits + flags.noFeatures + flags.noCloaked
+local _, _, _, _, _, rotateReason, headingReason =
+    Spring.GetUnitAttackWeaponState(unitID, weaponNum, friendlyOnly)
+```
+
+A policy that advances through terrain obstruction but holds for friendlies can
+first check `friendlyOnly`, then query `terrainOnly` independently. That also
+handles simultaneous blockers: a single unfiltered result reports only the
+first failure. Choose rotate/heading according to the intended chassis
+orientation and combine results across the relevant weapons before deciding.
+`clear` does not imply aim readiness, reload completion or an actual shot.
+Enemy units are ignored as a category by native pre-aim avoidance. The ray
+implementation also checks cloaked units independently: `noUnits` does not
+include `noCloaked`, so both masks explicitly suppress that extra category.
+
+The shipped port deliberately does not activate that future policy. The engine
+companion includes a 56-case blocker/filter integration test and replay
+comparison instructions. The BAR spec is
+`spec/luarules/attack_movement_spec.lua`.

--- a/docs/attack-movement.md
+++ b/docs/attack-movement.md
@@ -46,3 +46,20 @@ The shipped port deliberately does not activate that future policy. The engine
 companion includes a 56-case blocker/filter integration test and replay
 comparison instructions. The BAR spec is
 `spec/luarules/attack_movement_spec.lua`.
+
+## Command cleanup
+
+`UnitCommandEnded(unitID, cmdID, cmdTag, reason)` notifies gadgets when the
+front command finishes or a command-queue operation ends/interrupts it. Reasons
+are `completed`, `removed`, `targetLost` and `interrupted`. It runs before the
+next command executes. A front insertion retains the interrupted command for
+later resumption; an immediate replacement removes it. Removing an inactive
+queued command does not generate this notification. Internal command-AI
+subtasks are not a general suspension/resumption API.
+
+Use the tag to discard command-specific Lua state. `Spring.ClearUnitGoal(unitID,
+false)` stops movement without issuing `CMD_STOP` or discarding queued commands.
+Inspect the next queued command before stopping if it should continue moving.
+The shipped equivalent port installs no cleanup policy, so enabling it still
+preserves native behavior. The engine lifecycle test demonstrates stop cleanup
+for removed/dead attack targets and preserving a queued MOVE.

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -317,6 +317,7 @@ local callInLists = {
 	"ScriptEndBurst",
 
 	-- LuaRules CallIns (note: the *PreDamaged calls belong here too)
+	"AttackCommandMovement",
 	"CommandFallback",
 	"AllowCommand",
 	"AllowStartPosition",
@@ -518,6 +519,15 @@ end
 local VFSMODE_OVERRIDE = {
 	["luagaia/gadgets/fp_featureplacer.lua"] = VFS.GAME,
 }
+
+function gadgetHandler:AttackCommandMovement(...)
+	for _, g in ipairs(self.AttackCommandMovementList) do
+		if g:AttackCommandMovement(...) == true then
+			return true
+		end
+	end
+	return false
+end
 
 function gadgetHandler:Initialize()
 	gadgetHandler:CreateQueuedReorderFuncs()

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -270,6 +270,7 @@ local callInLists = {
 	"UnitExperience",
 	"UnitIdle",
 	"UnitCmdDone",
+	"UnitCommandEnded",
 	"UnitPreDamaged",
 	"UnitDamaged",
 	"UnitStunned",
@@ -519,6 +520,12 @@ end
 local VFSMODE_OVERRIDE = {
 	["luagaia/gadgets/fp_featureplacer.lua"] = VFS.GAME,
 }
+
+function gadgetHandler:UnitCommandEnded(...)
+	for _, g in ipairs(self.UnitCommandEndedList) do
+		g:UnitCommandEnded(...)
+	end
+end
 
 function gadgetHandler:AttackCommandMovement(...)
 	for _, g in ipairs(self.AttackCommandMovementList) do

--- a/luarules/gadgets/unit_attack_movement.lua
+++ b/luarules/gadgets/unit_attack_movement.lua
@@ -1,0 +1,117 @@
+-- This file is part of Beyond All Reason (GPL v2 or later).
+local gadget = gadget ---@type Gadget
+local mode = Spring.GetModOptions().attackmovementmode
+
+function gadget:GetInfo()
+	return {
+		name = "Lua attack movement",
+		desc = "Native attack movement decisions expressed in Lua",
+		author = "Aron, OpenAI Codex",
+		date = "2026-09-08",
+		license = "GNU GPL, v2 or later",
+		layer = 100000,
+		enabled = mode == "lua" or mode == "fallback",
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local getMovementState = Spring.GetUnitAttackMovementState
+local getWeaponState = Spring.GetUnitAttackWeaponState
+local setMovement = Spring.SetUnitAttackMovement
+
+function gadget:Initialize()
+	if not (getMovementState and getWeaponState and setMovement) then
+		gadgetHandler:RemoveGadget(self)
+	end
+end
+
+-- Preserve the native decisions so this port can be compared against the engine.
+-- getWeaponState additionally returns rotate/heading failure reasons, including
+-- terrain and friendly blockers, for subsequent changes to BAR's movement policy.
+function gadget:AttackCommandMovement(unitID)
+	if mode == "fallback" then
+		return false
+	end
+	local s = getMovementState(unitID)
+	if s.object then
+		if s.skipParalyze then
+			setMovement(unitID, "finish")
+			return true
+		end
+		local rotate, heading, ownerRotation, edge = false, false, false, 0
+		for w = 1, s.numWeapons do
+			local eligible, r, h, wantRotation, border = getWeaponState(unitID, w)
+			if eligible then
+				rotate, heading, edge = r, h, border
+				if rotate then
+					break
+				end
+				ownerRotation = ownerRotation or wantRotation
+			end
+		end
+		if rotate then
+			if not s.stopToAttack and not s.holdPosition and heading and s.targetBehind and not s.hovering then
+				setMovement(unitID, "chase")
+			else
+				setMovement(unitID, "stop")
+				if s.frame > s.lastCloseInTry + s.retryTicks then
+					setMovement(unitID, "point")
+				end
+			end
+			setMovement(unitID, "attack")
+			return true
+		end
+		if s.temporary and s.holdPosition then
+			setMovement(unitID, "finish")
+			return true
+		end
+		if s.distance < s.range90 then
+			if s.hovering or s.distanceSq < 1024 or ownerRotation then
+				setMovement(unitID, "stop")
+				setMovement(unitID, "point")
+				return true
+			end
+			if s.strafeToAttack then
+				setMovement(unitID, "strafe")
+			end
+			return true
+		end
+		if s.goalDistanceSq > s.goalThresholdSq then
+			setMovement(unitID, "approach", edge)
+			if s.lastCloseInTry < s.frame + s.retryTicks then
+				if ownerRotation then
+					setMovement(unitID, "point")
+				end
+				setMovement(unitID, "closeInFrame")
+			end
+		end
+		return true
+	end
+
+	if s.manual then
+		if setMovement(unitID, "attack") then
+			setMovement(unitID, "point")
+			setMovement(unitID, "stop")
+		end
+		return true
+	end
+	for w = 1, s.numWeapons do
+		local _, _, heading = getWeaponState(unitID, w)
+		if heading then
+			if setMovement(unitID, "attack") then
+				setMovement(unitID, "stopPoint")
+				return true
+			end
+			setMovement(unitID, "point")
+		end
+	end
+	if s.distanceSq >= s.range90Sq then
+		return true
+	end
+	setMovement(unitID, "attack")
+	setMovement(unitID, "stopPoint")
+	return true
+end

--- a/spec/luarules/attack_movement_spec.lua
+++ b/spec/luarules/attack_movement_spec.lua
@@ -1,0 +1,121 @@
+---@diagnostic disable: undefined-field, redundant-parameter
+local Builders = VFS.Include("spec/builders/index.lua")
+local SCRIPT = "luarules/gadgets/unit_attack_movement.lua"
+
+describe("Lua attack movement", function()
+	---@type table<string, any>
+	local state = {}
+	---@type table[]
+	local weapons = {}
+	---@type string[]
+	local actions = {}
+	local reads = 0
+	---@type table<string, any>
+	local spring = {}
+	---@type table<string, any>
+	local handler = {}
+	---@type table<string, any>
+	local instance = {}
+	local function load(mode)
+		spring = Builders.Spring.new():WithModOption("attackmovementmode", mode):Build()
+		spring.GetUnitAttackMovementState = function()
+			reads = reads + 1
+			return state
+		end
+		spring.GetUnitAttackWeaponState = function(_, weaponNum, flags)
+			assert.is_nil(flags) -- the equivalent port must retain each weapon's native filters
+			return unpack(weapons[weaponNum])
+		end
+		spring.SetUnitAttackMovement = function(_, operation)
+			actions[#actions + 1] = operation
+			if operation == "attack" then
+				return true
+			end
+		end
+		handler = {
+			IsSyncedCode = function()
+				return true
+			end,
+			RemoveGadget = spy.new(function() end),
+		}
+		instance = {}
+		local env = setmetatable({ Spring = spring, gadgetHandler = handler, gadget = instance }, { __index = _G })
+		local chunk = assert(loadfile(SCRIPT))
+		setfenv(chunk, env)
+		chunk()
+		return instance
+	end
+	before_each(function()
+		actions, reads = {}, 0
+		state = {
+			object = true,
+			manual = false,
+			skipParalyze = false,
+			temporary = false,
+			holdPosition = false,
+			hovering = false,
+			stopToAttack = true,
+			strafeToAttack = false,
+			targetBehind = false,
+			numWeapons = 1,
+			distance = 200,
+			distanceSq = 40000,
+			range90 = 270,
+			range90Sq = 72900,
+			frame = 1000,
+			lastCloseInTry = 0,
+			retryTicks = 30,
+			goalDistanceSq = 0,
+			goalThresholdSq = 100,
+		}
+		weapons = { { true, true, true, false, 0, "clear", "clear" } }
+	end)
+	it("is opt-in and does not install replay speed or quit controls", function()
+		local g = load(nil)
+		assert.is_false(g:GetInfo().enabled)
+		assert.is_nil(g.GameFrame)
+		assert.is_nil(g.RecvFromSynced)
+	end)
+	it("removes itself on an engine without the new APIs", function()
+		local g = load("lua")
+		-- Reload so the missing function is also absent from the cached locals.
+		spring.GetUnitAttackWeaponState = nil
+		local chunk = assert(loadfile(SCRIPT))
+		setfenv(chunk, setmetatable({ Spring = spring, gadgetHandler = handler, gadget = g }, { __index = _G }))
+		chunk()
+		g:Initialize()
+		assert.spy(handler.RemoveGadget).was_called_with(handler, g)
+	end)
+	it("returns false without querying or changing movement in fallback mode", function()
+		assert.is_false(load("fallback"):AttackCommandMovement(1))
+		assert.equals(0, reads)
+		assert.same({}, actions)
+	end)
+	it("stops, points and assigns an object target with a solution", function()
+		assert.is_true(load("lua"):AttackCommandMovement(1))
+		assert.same({ "stop", "point", "attack" }, actions)
+	end)
+	for _, reason in ipairs({ "terrain", "friendly" }) do
+		it("preserves legacy close-range behavior for " .. reason, function()
+			weapons = { { true, false, false, true, 0, reason, reason } }
+			assert.is_true(load("lua"):AttackCommandMovement(1))
+			assert.same({ "stop", "point" }, actions)
+		end)
+	end
+	it("finishes a temporary hold-position order without a solution", function()
+		state.temporary, state.holdPosition = true, true
+		weapons = { { true, false, false, false, 0, "range", "range" } }
+		load("lua"):AttackCommandMovement(1)
+		assert.same({ "finish" }, actions)
+	end)
+	it("assigns a ground target before stopping and pointing", function()
+		state.object = false
+		load("lua"):AttackCommandMovement(1)
+		assert.same({ "attack", "stopPoint" }, actions)
+	end)
+	it("retains the special point-before-stop order for manual ground fire", function()
+		state.object, state.manual = false, true
+		load("lua"):AttackCommandMovement(1)
+		assert.same({ "attack", "point", "stop" }, actions)
+	end)
+end)


### PR DESCRIPTION
### Work done

Adds an opt-in Lua port of native mobile object/ground attack movement, using [RecoilEngine #3330](https://github.com/beyond-all-reason/RecoilEngine/pull/3330). This provides a behavior-preserving baseline for subsequent policy changes for [RecoilEngine #3331](https://github.com/beyond-all-reason/RecoilEngine/issues/3331).

The gadget preserves the existing branches, including the 90% range rule, and uses the same script as the replay validation. It adds first-true call-in dispatch and removes itself on engines without the API. Terrain/friendly failure reasons and query-only avoidance masks are documented for later policy changes; this draft does not yet change movement around blockers. Replay speed/quit controls and profiling are confined to the engine test harness.

`UnitCommandEnded` is also dispatched to gadgets, with completion/removal/target-loss/interruption reasons. `docs/attack-movement.md` describes cleanup through `Spring.ClearUnitGoal(unitID, false)` without issuing STOP. The equivalent movement gadget itself remains unchanged.

#### Setup

Use an engine containing #3330. In the startscript set `attackmovementmode=lua` to enable the port, or `fallback` to return false and run native movement. An unset option leaves the gadget disabled. See `docs/attack-movement.md` for filter examples.

#### Test steps

- [x] Automated: nine focused Busted tests pass, including object/ground/manual attacks, native close-range behavior for terrain/friendlies, fallback and old-engine removal.
- [x] Automated: Luacheck and StyLua pass on the new gadget/spec; Luacheck also passes on the modified handler. The new gadget/spec have no EmmyLua errors or warnings; the workspace still reports existing undefined globals in `unit_carrier_spawner.lua` and `gui_pip.lua`.
- [x] Automated: engine companion's 56 blocker/filter cases pass. A 20-minute replay has matching position/current-command snapshots at all 20 checkpoints for native and Lua execution. The false-fallback run also matches all 20 checkpoints.
- [x] Automated: ten engine lifecycle cases pass, including removed/dead attack cleanup, preserving queued MOVE, WAIT suspension and no event for inactive queued removal. The refactored engine also passes the 56 blocker cases and all 20 replay checkpoints against the native reference.
- [ ] Human review: compare object, ground and manual attacks with the option unset, `lua`, and `fallback`; movement should remain equivalent. Review mixed terrain/friendly queries independently before changing policy.

### AI / LLM usage statement

OpenAI Codex implemented the gadget, handler, tests, documentation and PR text and ran the automated checks. This is a draft; human code review and interactive validation remain pending.
