### PR TITLE
fix: Mission API failing specs

### DIFF
--- a/spec/mission_api/triggers/rally_ordered_spec.lua
+++ b/spec/mission_api/triggers/rally_ordered_spec.lua
@@ -74,7 +74,7 @@ describe("mission_api.triggers.rally_ordered", function()
 		assert.is_true(names.unitName)
 		assert.is_true(names.unitDefName)
 		assert.is_true(names.teamID)
-		assert.is_true(names.fromMission)
+		assert.is_true(names.ignoreMissionActions)
 		assert.are.same({ command = true }, required)
 		assert.are.same({ "unitName", "unitDefName" }, rallyOrdered.parameters.requiresOneOf)
 	end)
@@ -157,10 +157,10 @@ describe("mission_api.triggers.rally_ordered", function()
 		assert.are.equal(0, fired())
 	end)
 
-	it("fires on mission-issued orders when fromMission is true", function()
+	it("fires on mission-issued orders when ignoreMissionActions is false", function()
 		local context, fired = newContext()
 		order(
-			trigger({ command = CMD.MOVE, unitDefName = "armlab", fromMission = true }),
+			trigger({ command = CMD.MOVE, unitDefName = "armlab", ignoreMissionActions = false }),
 			context,
 			CMD.MOVE,
 			{ 0, 0, 0 },

--- a/spec/mission_api/triggers/yet_to_implement_production_ordered_spec.lua
+++ b/spec/mission_api/triggers/yet_to_implement_production_ordered_spec.lua
@@ -62,7 +62,7 @@ describe("mission_api.triggers.yet_to_implement_production_ordered", function()
 		assert.is_true(names.unitName)
 		assert.is_true(names.unitDefName)
 		assert.is_true(names.teamID)
-		assert.is_true(names.fromMission)
+		assert.is_true(names.ignoreMissionActions)
 		assert.are.same({ buildDefName = true }, required)
 	end)
 
@@ -130,9 +130,15 @@ describe("mission_api.triggers.yet_to_implement_production_ordered", function()
 		assert.are.equal(0, fired())
 	end)
 
-	it("fires on mission-issued orders when fromMission is true", function()
+	it("fires on mission-issued orders when ignoreMissionActions is false", function()
 		local context, fired = newContext()
-		order(trigger({ buildDefName = "armpw", fromMission = true }), context, -10, nil, { issuingOrders = true })
+		order(
+			trigger({ buildDefName = "armpw", ignoreMissionActions = false }),
+			context,
+			-10,
+			nil,
+			{ issuingOrders = true }
+		)
 		assert.are.equal(1, fired())
 	end)
 end)


### PR DESCRIPTION
### Work done

Fix the production specs following the fromMission param rename. They assert on the wrong name, and in the inverse boolean sense.