### PR TITLE
add LoadFile, Json at load time in spec_helper

### DIFF
--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -306,6 +306,15 @@ _G.inspect = (function()
 	end
 end)()
 
+_G.VFS.LoadFile = function(path)
+	local file = assert(io.open(path, "rb"))
+	local contents = file:read("*a")
+	file:close()
+	return contents
+end
+
+_G.Json = _G.Json or VFS.Include("common/luaUtilities/json.lua")
+
 -- Every spec file is run in a single Lua process via busted, so their globals are
 -- left behind from one file to the next in the order they are run. Clearing GG is
 -- one way to protect against those leaks; guarded against reruns using a _G gate.


### PR DESCRIPTION
### Work done

Add some engine-provided utils at load in spec_helper for the mission api.

Fixes specs failing on the mission api since adding a loaded JSON file for stubbing client messages.