### PR TITLE
Stop idle repair com & builders from chasing after planes

### DIFF
--- a/luaui/Widgets/unit_auto_repair_idle_builders.lua
+++ b/luaui/Widgets/unit_auto_repair_idle_builders.lua
@@ -86,7 +86,11 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 		end
 	end
 
-	cachedUnitDefs[unitDefID] = { radius = unitDef.radius, canReclaim = canReclaim }
+	cachedUnitDefs[unitDefID] = {
+		radius = unitDef.radius,
+		canReclaim = canReclaim,
+		canFly = unitDef.canFly,
+	}
 	if unitDef.radius > maxUnitRadius then
 		maxUnitRadius = unitDef.radius
 	end
@@ -366,18 +370,23 @@ function widget:GameFrame(frame)
 			else
 				local unitDefID = spGetUnitDefID(info.targetID)
 				local unitDef = cachedUnitDefs[unitDefID]
-				-- Check if target has left leash radius
-				local tx, _, tz = spGetUnitPosition(info.targetID)
-				local dx, dz = tx - info.homeX, tz - info.homeZ
-				local distSq = dx * dx + dz * dz
-				local leash = getLeashRadius(builderID) + unitDef.radius
-				if distSq > leash * leash then
+				if unitDef and unitDef.canFly then
+					-- Do not chase air units for idle repair.
 					sendHome(builderID, info)
 				else
-					-- Check builder is still repairing (not overridden by player)
-					local cmdID = spGetUnitCurrentCommand(builderID, 1)
-					if cmdID ~= CMD_REPAIR then
-						activeRepairs[builderID] = nil
+					-- Check if target has left leash radius
+					local tx, _, tz = spGetUnitPosition(info.targetID)
+					local dx, dz = tx - info.homeX, tz - info.homeZ
+					local distSq = dx * dx + dz * dz
+					local leash = getLeashRadius(builderID) + unitDef.radius
+					if distSq > leash * leash then
+						sendHome(builderID, info)
+					else
+						-- Check builder is still repairing (not overridden by player)
+						local cmdID = spGetUnitCurrentCommand(builderID, 1)
+						if cmdID ~= CMD_REPAIR then
+							activeRepairs[builderID] = nil
+						end
 					end
 				end
 			end
@@ -420,10 +429,14 @@ function widget:GameFrame(frame)
 						local dx, dz = tx - homePos.homeX, tz - homePos.homeZ
 						local distSq = dx * dx + dz * dz
 						local candidateDefID = spGetUnitDefID(candidateID)
-						local effectiveLeash = leash + cachedUnitDefs[candidateDefID].radius
-						if distSq <= effectiveLeash * effectiveLeash and distSq < bestDistSq then
-							bestDistSq = distSq
-							bestTarget = candidateID
+						local candidateDef = cachedUnitDefs[candidateDefID]
+						-- Skip air units so builders do not chase them with repair orders.
+						if candidateDef and not candidateDef.canFly then
+							local effectiveLeash = leash + candidateDef.radius
+							if distSq <= effectiveLeash * effectiveLeash and distSq < bestDistSq then
+								bestDistSq = distSq
+								bestTarget = candidateID
+							end
 						end
 					end
 				end


### PR DESCRIPTION
Currently, we do a cylinder check to see if there are damaged units and then try to repair those units. When those damaged units are planes zooming past you, you get maybe 2 repair ticks off and then chase after it. This happens even if your builders are on "Hold position" as the repair command (in the engine) doesn't care how far away that unit is. 

This PR fixes that by ignoring air units from idle repair. 


Comm is next to plane and ignoring it instead of chasing after it. 
<img width="634" height="526" alt="image" src="https://github.com/user-attachments/assets/99747d7e-0f41-40eb-b583-45655a7fe7fe" />


AI: Cursor assisted, manual review and testing. 

cc @Flameink 