### PR TITLE
Stop unused start boxes moving FFA and duel spawns

### DIFF
--- a/luarules/gadgets/game_startbox_config.lua
+++ b/luarules/gadgets/game_startbox_config.lua
@@ -18,6 +18,8 @@ end
 
 local PolygonLib = VFS.Include("common/lib_polygon.lua")
 
+local SPAWN_CHOOSE_IN_GAME = 2
+
 local startBoxConfig
 local configSource
 local isExplicitConfig = false
@@ -26,11 +28,20 @@ function gadget:Initialize()
 	local StartboxLib = VFS.Include("luarules/gadgets/include/startbox_utilities.lua")
 	startBoxConfig, configSource, isExplicitConfig = StartboxLib.GetConfig()
 
-	-- Expand the engine AABB for each active allyTeam to cover the polygon bounds.
-	-- Without this, the engine silently drops clicks outside its default AABB and never
-	-- calls AllowStartPosition, making polygons that extend beyond the lobby's
-	-- rectangle unreachable.
-	if isExplicitConfig and startBoxConfig then
+	-- Only choose-in-game places by start box. Other modes take the map's own start
+	-- positions, and the engine clamps every incoming position into the allyteam's rect
+	-- before Lua sees it (NETMSG_STARTPOS), so any rect at all drags valid positions onto
+	-- its edges. Widen to the whole map, which makes that clamp a no-op.
+	if Game.startPosType ~= SPAWN_CHOOSE_IN_GAME then
+		local allyTeamList = Spring.GetAllyTeamList()
+		for _, allyTeamID in ipairs(allyTeamList) do
+			Spring.SetAllyTeamStartBox(allyTeamID, 0, 0, Game.mapSizeX, Game.mapSizeZ)
+		end
+	elseif isExplicitConfig and startBoxConfig then
+		-- Expand the engine AABB for each active allyTeam to cover the polygon bounds.
+		-- Without this, the engine silently drops clicks outside its default AABB and never
+		-- calls AllowStartPosition, making polygons that extend beyond the lobby's
+		-- rectangle unreachable.
 		local allyTeamList = Spring.GetAllyTeamList()
 		for _, allyTeamID in ipairs(allyTeamList) do
 			local entry = startBoxConfig[allyTeamID]


### PR DESCRIPTION
Widens every allyteam's start box to the whole map in the modes that do not place by start box.

The engine clamps every incoming start position into that allyteam's rect before Lua sees it, so in FFA and duel, where everyone is placed from the map's own start positions, a rect nobody is placing by still drags them onto its edge and people spawn in water and die. The lobby cannot fix it: it writes those rects whatever the mode and never gets told startpostype.

Related to #9137, which fills in allyteams the metadata arrangement misses. Different bug, same corner of the code.

AI disclosure: written with assistance from Claude Code.
