### PR TITLE
Make Legion T2 Radar & Jammer ship vulnerable to Juno

### DIFF
--- a/units/Legion/Ships/T2/leganavyradjamship.lua
+++ b/units/Legion/Ships/T2/leganavyradjamship.lua
@@ -35,6 +35,7 @@ return {
 		turnrate = 350,
 		waterline = 0,
 		customparams = {
+			juno_kill = true,
 			model_author = "Beherith",
 			normaltex = "unittextures/leg_normal.dds",
 			off_on_stun = "true",


### PR DESCRIPTION
Before: 
Legion T2 Jammer ship is briefly turned off by juno (not even for the full juno duration)

After:
They get killed by junos just like their arm/cortex counterparts.
<img width="1118" height="824" alt="image" src="https://github.com/user-attachments/assets/afb427a2-5fa3-465c-a32d-bdfc18319df8" />
