### PR TITLE
Fix recloak delay after firing with cloak disabled

### DIFF
--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -290,6 +290,7 @@ local callInLists = {
 	-- "UnitFeatureCollision",
 	-- "UnitMoveFailed",
 	"StockpileChanged",
+	"UnitWeaponFired",
 
 	"ActiveCommandChanged",
 	"CameraRotationChanged",
@@ -2428,6 +2429,12 @@ function gadgetHandler:UnitFeatureCollision(colliderID, collideeID)
 		end
 	end
 	return false
+end
+
+function gadgetHandler:UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)
+	for _, g in ipairs(self.UnitWeaponFiredList) do
+		g:UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)
+	end
 end
 
 function gadgetHandler:StockpileChanged(unitID, unitDefID, unitTeam, weaponNum, oldCount, newCount)

--- a/luarules/gadgets/unit_cloak.lua
+++ b/luarules/gadgets/unit_cloak.lua
@@ -55,8 +55,10 @@ local recloakFrame = {}
 local currentFrame = 0
 
 local canCloak = {}
+local decloakOnFire = {}
 for udid, ud in pairs(UnitDefs) do
 	if ud.canCloak then
+		decloakOnFire[udid] = ud.decloakOnFire
 		canCloak[udid] = {
 			ud.startCloaked,
 			ud.cloakCostMoving,
@@ -176,6 +178,18 @@ function gadget:AllowUnitCloak(unitID, enemyID)
 	return true
 end
 
+-- Track each shot even when neither cloak nor wantcloak is set.
+function gadget:UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)
+	if decloakOnFire[unitDefID] then
+		recloakFrame[unitID] = currentFrame + DEFAULT_DECLOAK_TIME
+	end
+end
+
+function gadget:UnitDestroyed(unitID)
+	recloakFrame[unitID] = nil
+	recloakUnit[unitID] = nil
+end
+
 function gadget:AllowUnitDecloak(unitID, objectID, weaponID)
 	recloakFrame[unitID] = currentFrame + DEFAULT_DECLOAK_TIME
 end
@@ -259,6 +273,16 @@ function gadget:UnitCreated(unitID, unitDefID)
 end
 
 function gadget:Initialize()
+	-- Older engines keep the existing AllowUnitDecloak behavior.
+	if Script.SetWatchWeaponFired then
+		for unitDefID, enabled in pairs(decloakOnFire) do
+			if enabled then
+				for _, weapon in ipairs(UnitDefs[unitDefID].weapons) do
+					Script.SetWatchWeaponFired(weapon.weaponDef, true)
+				end
+			end
+		end
+	end
 	gadgetHandler:RegisterAllowCommand(CMD_CLOAK)
 	gadgetHandler:RegisterAllowCommand(CMD_WANT_CLOAK)
 	for _, unitID in ipairs(Spring.GetAllUnits()) do

--- a/spec/luarules/unit_cloak_spec.lua
+++ b/spec/luarules/unit_cloak_spec.lua
@@ -1,0 +1,136 @@
+---@diagnostic disable: undefined-field, redundant-parameter
+
+describe("cloak delay after firing", function()
+	local gadget, watches, env
+
+	local function loadGadget(hasShotAPI)
+		watches = {}
+		local defs = {
+			{
+				canCloak = true,
+				cloakCost = 10,
+				cloakCostMoving = 20,
+				decloakOnFire = true,
+				weapons = { { weaponDef = 11 }, { weaponDef = 12 } },
+			},
+			{
+				canCloak = true,
+				cloakCost = 10,
+				cloakCostMoving = 20,
+				decloakOnFire = false,
+				weapons = { { weaponDef = 11 }, { weaponDef = 13 } },
+			},
+			{ canCloak = false, decloakOnFire = true, weapons = { { weaponDef = 14 } } },
+		}
+		gadget = {}
+		env = setmetatable({
+			gadget = gadget,
+			gadgetHandler = {
+				IsSyncedCode = function()
+					return true
+				end,
+				RegisterAllowCommand = function() end,
+			},
+			include = function() end,
+			CMD = { CLOAK = 95 },
+			CMDTYPE = { ICON_MODE = 5 },
+			CMD_WANT_CLOAK = 123,
+			GG = {},
+			UnitDefs = defs,
+			Script = {},
+			Spring = {
+				GetAllUnits = function()
+					return {}
+				end,
+				GetUnitIsStunned = function()
+					return false
+				end,
+				GetUnitDefID = function(id)
+					return id
+				end,
+				GetUnitRulesParam = function()
+					return 0
+				end,
+				GetUnitVelocity = function()
+					return 0, 0, 0, 0
+				end,
+				UseUnitResource = function()
+					return true
+				end,
+			},
+		}, { __index = _G })
+		if hasShotAPI then
+			env.Script.SetWatchWeaponFired = function(id, enabled)
+				watches[id] = enabled
+			end
+		end
+		local chunk = assert(loadfile("luarules/gadgets/unit_cloak.lua"))
+		setfenv(chunk, env)
+		chunk()
+		gadget:Initialize()
+	end
+
+	before_each(function()
+		loadGadget(true)
+	end)
+
+	it("watches only weapons of cloakable units that decloak on fire", function()
+		assert.same({ [11] = true, [12] = true }, watches)
+	end)
+
+	it("blocks cloaking for 128 frames after a shot with cloak disabled", function()
+		gadget:GameFrame(100)
+		assert.is_true(gadget:AllowUnitCloak(1))
+		gadget:UnitWeaponFired(1, 1, 0, 2)
+		assert.is_false(gadget:AllowUnitCloak(1))
+		gadget:GameFrame(227)
+		assert.is_false(gadget:AllowUnitCloak(1))
+		gadget:GameFrame(228)
+		assert.is_true(gadget:AllowUnitCloak(1))
+	end)
+
+	it("extends the delay from every shot of a burst", function()
+		gadget:GameFrame(100)
+		gadget:UnitWeaponFired(1, 1, 0, 1)
+		gadget:GameFrame(120)
+		gadget:UnitWeaponFired(1, 1, 0, 1)
+		gadget:GameFrame(228)
+		assert.is_false(gadget:AllowUnitCloak(1))
+		gadget:GameFrame(248)
+		assert.is_true(gadget:AllowUnitCloak(1))
+	end)
+
+	it("does not penalize a shared weapon on a unit that fires while cloaked", function()
+		gadget:GameFrame(100)
+		gadget:UnitWeaponFired(2, 2, 0, 1)
+		assert.is_true(gadget:AllowUnitCloak(2))
+	end)
+
+	it("preserves delays from other decloak causes", function()
+		gadget:GameFrame(100)
+		gadget:UnitWeaponFired(1, 1, 0, 1)
+		gadget:GameFrame(150)
+		gadget:AllowUnitDecloak(1, 99)
+		gadget:GameFrame(228)
+		assert.is_false(gadget:AllowUnitCloak(1))
+		gadget:GameFrame(278)
+		assert.is_true(gadget:AllowUnitCloak(1))
+	end)
+
+	it("clears the delay before a destroyed unit ID is reused", function()
+		gadget:GameFrame(100)
+		gadget:UnitWeaponFired(1, 1, 0, 1)
+		gadget:UnitDestroyed(1)
+		assert.is_true(gadget:AllowUnitCloak(1))
+	end)
+
+	it("keeps the existing decloak path available on older engines", function()
+		loadGadget(false)
+		assert.same({}, watches)
+		gadget:GameFrame(100)
+		gadget:AllowUnitDecloak(1)
+		assert.is_false(gadget:AllowUnitCloak(1))
+		gadget:GameFrame(228)
+		assert.is_true(gadget:AllowUnitCloak(1))
+	end)
+end)


### PR DESCRIPTION
### Work done

Firing with cloak disabled currently bypasses the 128-frame recloak delay: `AllowUnitDecloak` is not called when neither cloak nor wantcloak is set. This lets players shoot and immediately enable cloak.

Use `UnitWeaponFired` to renew the delay after every shot, regardless of cloak state, for cloak-capable units with `decloakOnFire`. Forward the call-in through BAR's gadget handler and watch only the relevant WeaponDefs. Check the firing UnitDef as well so shared weapons do not penalize units allowed to fire while cloaked. Preserve existing delays from other decloak causes and clear timers on unit destruction.

Fixes #6618.

#### Engine dependency

Requires https://github.com/beyond-all-reason/RecoilEngine/pull/3286 (implements https://github.com/beyond-all-reason/RecoilEngine/issues/3285), specifically `UnitWeaponFired` and `Script.SetWatchWeaponFired`. Burst-end notification alone cannot refresh the delay during a burst.

Keep this PR in draft until the engine API is available and gameplay validation is complete. Older engines retain the previous behavior through a feature check; they do not receive this fix. Direct unit-script `EmitSfx` firing outside the engine burst path is outside the new call-in's coverage.

#### Automated validation

- Seven focused Lua 5.1/Busted tests pass: shot delay and exact expiry, repeated burst shots, watch selection, shared-weapon filtering, other decloak causes, destroyed-unit ID reuse, and older-engine compatibility.
- The uncloaked-shot regression fails against the unmodified gadget: cloaking is allowed when the test expects it to be blocked. This is a mocked gadget check, not an engine simulation.
- Lua 5.1 syntax and `git diff --check` pass. StyLua passes for the cloak gadget and new spec; the handler's full-file check reports two pre-existing extra blank lines outside this diff.

#### Test steps

- [ ] With an engine containing RecoilEngine #3286, fire a shot from a cloak-capable unit while cloak is disabled, stop firing, then immediately enable cloak. Cloaking must remain blocked until at least 128 frames after the shot (actual activation follows the normal cloak update cadence).
- [ ] Repeat with cloak enabled/requested before firing; the delay must match.
- [ ] With a burst weapon, confirm every shot extends the delay, including shots before burst completion.
- [ ] Confirm units with `decloakOnFire = false` retain their behavior and enemy proximity still prevents cloaking.

### AI / LLM usage statement

OpenAI Codex implemented the change, added and ran automated regression checks, and drafted this description. Human review and in-game validation remain outstanding.
