### PR TITLE
Set Target: skip dead and crashing targets during selection

### DIFF
--- a/luarules/gadgets/unit_crashing_aircraft.lua
+++ b/luarules/gadgets/unit_crashing_aircraft.lua
@@ -43,10 +43,6 @@ if gadgetHandler:IsSyncedCode() then
 	-- Shared membership; values are destruction deadlines, not booleans.
 	-- Consumers can acquire this table before the controller loads.
 	local crashing = table.ensureTable(GG, "Crashing")
-	local crashingCount = 0
-	for _ in pairs(crashing) do
-		crashingCount = crashingCount + 1
-	end
 
 	local isAircon = {}
 	local crashable = {}
@@ -90,7 +86,6 @@ if gadgetHandler:IsSyncedCode() then
 				SetAirMoveTypeData(unitID, "myGravity", moveTypeData.myGravity * gravityMult)
 			end
 			-- make it crash
-			crashingCount = crashingCount + 1
 			crashing[unitID] = GetGameFrame() + 450
 			SetUnitCOBValue(unitID, COB_CRASHING, 1)
 			SetUnitNoSelect(unitID, true)
@@ -138,7 +133,7 @@ if gadgetHandler:IsSyncedCode() then
 	local crashDestroyCount = 0
 
 	function gadget:GameFrame(gf)
-		if crashingCount > 0 and gf % 44 == 1 then
+		if gf % 44 == 1 and next(crashing) then
 			-- Collect first: DestroyUnit triggers UnitDestroyed synchronously,
 			-- which nils entries from 'crashing', invalidating the pairs() iterator
 			crashDestroyCount = 0
@@ -156,10 +151,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDefID, attackerTeamID)
-		if crashing[unitID] then
-			crashingCount = crashingCount - 1
-			crashing[unitID] = nil
-		end
+		crashing[unitID] = nil
 	end
 else -- UNSYNCED
 	local GetSpectatingState = Spring.GetSpectatingState

--- a/luarules/gadgets/unit_crashing_aircraft.lua
+++ b/luarules/gadgets/unit_crashing_aircraft.lua
@@ -40,9 +40,13 @@ if gadgetHandler:IsSyncedCode() then
 	local COM_BLAST = WeaponDefNames.commanderexplosion.id -- used to prevent them being boosted and flying far away
 	local CMD_STOP = CMD.STOP
 
-	local crashing = {}
-	GG.Crashing = crashing -- read-only reference for other gadgets
+	-- Shared membership; values are destruction deadlines, not booleans.
+	-- Consumers can acquire this table before the controller loads.
+	local crashing = table.ensureTable(GG, "Crashing")
 	local crashingCount = 0
+	for _ in pairs(crashing) do
+		crashingCount = crashingCount + 1
+	end
 
 	local isAircon = {}
 	local crashable = {}

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -28,7 +28,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spValidUnitID = Spring.ValidUnitID
 	local spGetUnitDefID = Spring.GetUnitDefID
 	local spGetUnitIsDead = Spring.GetUnitIsDead
-	local spGetUnitMoveTypeData = Spring.GetUnitMoveTypeData
+	local crashing = table.ensureTable(GG, "Crashing")
 	local spGetUnitLosState = Spring.GetUnitLosState
 	local spGetUnitTeam = Spring.GetUnitTeam
 	local spAreTeamsAllied = Spring.AreTeamsAllied
@@ -243,8 +243,7 @@ if gadgetHandler:IsSyncedCode() then
 		if spGetUnitIsDead(target) ~= false then
 			return true
 		end
-		local moveTypeData = spGetUnitMoveTypeData(target)
-		return moveTypeData and moveTypeData.aircraftState == "crashing"
+		return crashing[target] ~= nil
 	end
 
 	local function checkTarget(teamID, target)

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -28,6 +28,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spValidUnitID = Spring.ValidUnitID
 	local spGetUnitDefID = Spring.GetUnitDefID
 	local spGetUnitIsDead = Spring.GetUnitIsDead
+	local spGetUnitMoveTypeData = Spring.GetUnitMoveTypeData
 	local spGetUnitLosState = Spring.GetUnitLosState
 	local spGetUnitTeam = Spring.GetUnitTeam
 	local spAreTeamsAllied = Spring.AreTeamsAllied
@@ -238,8 +239,16 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
+	local function isDeadOrCrashing(target)
+		if spGetUnitIsDead(target) ~= false then
+			return true
+		end
+		local moveTypeData = spGetUnitMoveTypeData(target)
+		return moveTypeData and moveTypeData.aircraftState == "crashing"
+	end
+
 	local function checkTarget(teamID, target)
-		return type(target) ~= "number" or not isAlliedUnit(teamID, target)
+		return type(target) ~= "number" or (not isDeadOrCrashing(target) and not isAlliedUnit(teamID, target))
 	end
 
 	local function inReturnFire(unitID)
@@ -254,7 +263,6 @@ if gadgetHandler:IsSyncedCode() then
 	local function hasAutoTarget(cmdOptions)
 		return bit_and(cmdOptions, OPT_INTERNAL) ~= 0
 	end
-
 
 	local function restoreCommandTarget(unitID)
 		local inCommand, options, _, param1, param2, param3 = spGetUnitCurrentCommand(unitID)
@@ -331,9 +339,10 @@ if gadgetHandler:IsSyncedCode() then
 	local function wasTargetLost(target, alwaysSeen, allyTeam)
 		if type(target) ~= "number" then
 			return false, false
+		elseif isDeadOrCrashing(target) then
+			return true, true
 		elseif alwaysSeen then
-			local isDead = spGetUnitIsDead(target) ~= false
-			return isDead, isDead
+			return false, false
 		end
 		local los = spGetUnitLosState(target, allyTeam, true)
 		if not los then

--- a/luaui/Tests/set_target/test_invalid_targets.lua
+++ b/luaui/Tests/set_target/test_invalid_targets.lua
@@ -43,7 +43,8 @@ local function test()
 	end, 60)
 
 	SyncedRun(function(locals)
-		Spring.SetUnitCrashing(locals.targetA, true)
+		-- Exercise the actual damage/controller path, which publishes shared membership.
+		Spring.AddUnitDamage(locals.targetA, Spring.GetUnitHealth(locals.targetA) + 1, 0, locals.sourceID)
 		assert(Spring.GetUnitIsDead(locals.targetA) == false, "crashing target must still exist")
 		assert(Spring.GetUnitMoveTypeData(locals.targetA).aircraftState == "crashing")
 	end)

--- a/luaui/Tests/set_target/test_invalid_targets.lua
+++ b/luaui/Tests/set_target/test_invalid_targets.lua
@@ -1,0 +1,61 @@
+local function setup()
+	Test.clearMap()
+	assert(select(1, Spring.GetTeamInfo(1, false)) ~= nil, "test requires enemy team 1")
+end
+
+local function cleanup()
+	Test.clearMap()
+end
+
+local function createScenario()
+	local x, y, z
+	for candidateX = 512, Game.mapSizeX - 512, 512 do
+		for candidateZ = 512, Game.mapSizeZ - 512, 512 do
+			local height = Spring.GetGroundHeight(candidateX, candidateZ)
+			if height > 0 then
+				x, y, z = candidateX, height, candidateZ
+				break
+			end
+		end
+		if x then
+			break
+		end
+	end
+	assert(x, "test requires land for the flak turret")
+	local sourceID = assert(Spring.CreateUnit("armflak", x, y, z, 0, 0))
+	local targetA = assert(Spring.CreateUnit("corhurc", x + 200, y + 200, z, 0, 1))
+	local targetB = assert(Spring.CreateUnit("corhurc", x + 300, y + 200, z, 0, 1))
+	Spring.GiveOrderToUnitArray({ targetA, targetB }, CMD.MOVE, { x + 600, y + 200, z }, 0)
+	Spring.GiveOrderToUnit(sourceID, CMD.FIRE_STATE, { 0 }, 0)
+	return sourceID, targetA, targetB
+end
+
+local function test()
+	local sourceID, targetA, targetB = SyncedRun(createScenario)
+	-- Let units initialize before issuing player orders.
+	Test.waitFrames(30)
+	local setTarget = Game.CustomCommands.GetCommandCode("UNIT_SET_TARGET")
+	Spring.GiveOrderToUnit(sourceID, setTarget, { targetA }, 0)
+	Spring.GiveOrderToUnit(sourceID, setTarget, { targetB }, CMD.OPT_SHIFT)
+
+	Test.waitUntil(function()
+		return Spring.GetUnitRulesParam(sourceID, "unitTargetID") == targetA
+	end, 60)
+
+	SyncedRun(function(locals)
+		Spring.SetUnitCrashing(locals.targetA, true)
+		assert(Spring.GetUnitIsDead(locals.targetA) == false, "crashing target must still exist")
+		assert(Spring.GetUnitMoveTypeData(locals.targetA).aircraftState == "crashing")
+	end)
+	Test.waitUntil(function()
+		return Spring.GetUnitRulesParam(sourceID, "unitTargetID") == targetB
+	end, 10)
+	SyncedRun(function(locals)
+		Spring.DestroyUnit(locals.targetB, false, true)
+	end)
+	Test.waitUntil(function()
+		return Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget") == nil
+	end, 10)
+end
+
+return { setup = setup, test = test, cleanup = cleanup }

--- a/spec/luarules/unit_target_cleanup_spec.lua
+++ b/spec/luarules/unit_target_cleanup_spec.lua
@@ -11,7 +11,7 @@ local function loadTargetGadget()
 	end
 	local env = {
 		gadget = {},
-		GG = {},
+		GG = { Crashing = crashingTargets },
 		gadgetHandler = {
 			IsSyncedCode = function()
 				return true
@@ -71,8 +71,8 @@ local function loadTargetGadget()
 			GetUnitLosState = function()
 				return 3
 			end,
-			GetUnitMoveTypeData = function(unitID)
-				return crashingTargets[unitID] and { aircraftState = "crashing" } or {}
+			GetUnitMoveTypeData = function()
+				error("target selection must not allocate movement data")
 			end,
 			GetUnitWeaponTryTarget = function(_, _, targetID)
 				checks[#checks + 1] = targetID
@@ -209,5 +209,93 @@ describe("Set Target invalid-target cleanup", function()
 		g.update(1)
 		assert.is_nil(g.target())
 		assert.is_nil(g.env.GG.GetUnitTargetList(1))
+	end)
+end)
+
+-- Load the real controller alongside the targeting gadget, sharing only GG.
+local function loadCrashController(shared)
+	local destroyed = {}
+	local controller
+	local spring = setmetatable({
+		GetUnitHealth = function()
+			return 100
+		end,
+		GetGameFrame = function()
+			return 10
+		end,
+		GetUnitMoveTypeData = function()
+			return {}
+		end,
+		MoveCtrl = {},
+		DestroyUnit = function(id)
+			destroyed[#destroyed + 1] = id
+			controller:UnitDestroyed(id)
+		end,
+	}, {
+		__index = function()
+			return function() end
+		end,
+	})
+	local env = setmetatable({
+		gadget = {},
+		gadgetHandler = {
+			IsSyncedCode = function()
+				return true
+			end,
+		},
+		GG = shared,
+		Spring = spring,
+		COB = { CRASHING = 1 },
+		CMD = { STOP = 0 },
+		WeaponDefNames = { commanderexplosion = { id = 99 } },
+		UnitDefs = { { id = 1, canFly = true, buildSpeed = 0, customParams = {}, weapons = {} } },
+		SendToUnsynced = function() end,
+	}, { __index = _G })
+	local chunk = assert(loadfile("luarules/gadgets/unit_crashing_aircraft.lua"))
+	setfenv(chunk, env)
+	chunk()
+	controller = env.gadget
+	return controller, destroyed
+end
+
+describe("Shared crashing membership", function()
+	it("publishes controller damage to an already loaded target consumer", function()
+		local g = loadTargetGadget()
+		g.set(10)
+		g.set(20, true)
+		local shared = g.env.GG.Crashing
+		local controller = loadCrashController(g.env.GG)
+		assert.is_true(shared == g.env.GG.Crashing)
+		controller:UnitPreDamaged(10, 1, 2, 101, false, 1)
+		assert.are.equal(460, shared[10])
+		g.update(1)
+		assert.are.equal(20, g.target())
+		controller:UnitDestroyed(10)
+		assert.is_nil(shared[10])
+		-- Reusing the ID for a live unit must not retain crashing membership.
+		g.set(10)
+		assert.are.equal(10, g.env.GG.GetUnitTargetList(1)[1].target)
+	end)
+
+	it("lets later consumers acquire the same table and preserves deadlines on reload", function()
+		local shared = {}
+		local controller = loadCrashController(shared)
+		controller:UnitPreDamaged(10, 1, 2, 101, false, 1)
+		local membership = table.ensureTable(shared, "Crashing")
+		assert.are.equal(460, membership[10])
+		local reloaded, destroyed = loadCrashController(shared)
+		assert.is_true(membership == shared.Crashing)
+		reloaded:GameFrame(485)
+		assert.same({ 10 }, destroyed)
+		assert.is_nil(membership[10])
+	end)
+
+	it("does not publish nonlethal, paralyzing or excluded damage", function()
+		local shared = {}
+		local controller = loadCrashController(shared)
+		controller:UnitPreDamaged(10, 1, 2, 50, false, 1)
+		controller:UnitPreDamaged(11, 1, 2, 101, true, 1)
+		controller:UnitPreDamaged(12, 1, 2, 101, false, 99)
+		assert.same({}, shared.Crashing)
 	end)
 end)

--- a/spec/luarules/unit_target_cleanup_spec.lua
+++ b/spec/luarules/unit_target_cleanup_spec.lua
@@ -1,0 +1,213 @@
+local function loadTargetGadget()
+	local currentCommand
+	local target
+	local rules = {}
+	local events = {}
+	local checks = {}
+	local deadTargets = {}
+	local crashingTargets = {}
+	local canTarget = function(_targetID)
+		return true
+	end
+	local env = {
+		gadget = {},
+		GG = {},
+		gadgetHandler = {
+			IsSyncedCode = function()
+				return true
+			end,
+		},
+		CMD = {
+			STOP = 0,
+			ATTACK = 20,
+			FIGHT = 16,
+			GUARD = 25,
+			WAIT = 5,
+			MANUALFIRE = 105,
+			AREA_ATTACK = 21,
+			OPT_INTERNAL = 8,
+			FIRESTATE_RETURNFIRE = 1,
+		},
+		GameCMD = {
+			UNIT_SET_TARGET = 1001,
+			UNIT_SET_TARGET_NO_GROUND = 1002,
+			UNIT_CANCEL_TARGET = 1003,
+			UNIT_SET_TARGET_RECTANGLE = 1004,
+			UNIT_SET_TARGETS = 1005,
+			ATTACK_TARGETS = 1006,
+			AREA_ATTACK_GROUND = 1007,
+		},
+		CMDTYPE = { ICON = 0, ICON_UNIT_OR_AREA = 1 },
+		Game = { gameSpeed = 30 },
+		UnitDefs = {
+			{
+				canAttack = true,
+				maxWeaponRange = 1000,
+				speed = 30,
+				customParams = {},
+				weapons = { { weaponDef = 1, slavedTo = 0 } },
+			},
+		},
+		WeaponDefs = { { type = "Cannon", range = 1000, customParams = {} } },
+		Spring = {
+			ValidUnitID = function()
+				return true
+			end,
+			GetUnitDefID = function()
+				return 1
+			end,
+			GetUnitTeam = function(unitID)
+				return unitID == 1 and 1 or 2
+			end,
+			GetUnitAllyTeam = function(unitID)
+				return unitID == 1 and 1 or 2
+			end,
+			AreTeamsAllied = function(a, b)
+				return a == b
+			end,
+			GetUnitIsDead = function(unitID)
+				return deadTargets[unitID] or false
+			end,
+			GetUnitLosState = function()
+				return 3
+			end,
+			GetUnitMoveTypeData = function(unitID)
+				return crashingTargets[unitID] and { aircraftState = "crashing" } or {}
+			end,
+			GetUnitWeaponTryTarget = function(_, _, targetID)
+				checks[#checks + 1] = targetID
+				return canTarget(targetID)
+			end,
+			GetUnitWeaponTestTarget = function()
+				return true
+			end,
+			GetUnitCurrentCommand = function(_, index)
+				if currentCommand and (not index or index == 1) then
+					return unpack(currentCommand)
+				end
+			end,
+			GetUnitStates = function()
+				return 2
+			end,
+			SetUnitTarget = function(_, newTarget)
+				target = newTarget
+			end,
+			SetUnitRulesParam = function(_, key, value)
+				rules[key] = value
+			end,
+		},
+		VFS = {
+			Include = function(path)
+				return dofile(path)
+			end,
+		},
+		SendToUnsynced = function(...)
+			events[#events + 1] = { ... }
+		end,
+		CallAsTeam = function(_, fn, ...)
+			return fn(...)
+		end,
+	}
+	env.math = setmetatable({
+		bit_and = function(a, b)
+			return a % (b * 2) >= b and b or 0
+		end,
+		clamp = function(value, low, high)
+			return math.max(low, math.min(value, high))
+		end,
+	}, { __index = math })
+	env.table = setmetatable({
+		map = function(values, fn)
+			local result = {}
+			for k, v in pairs(values) do
+				local value, key = fn(v, k)
+				result[key] = value
+			end
+			return result
+		end,
+	}, { __index = table })
+	setmetatable(env, { __index = _G })
+	local chunk = assert(loadfile("luarules/gadgets/unit_target_on_the_move.lua"))
+	setfenv(chunk, env)
+	chunk()
+	return {
+		env = env,
+		checks = checks,
+		deadTargets = deadTargets,
+		crashingTargets = crashingTargets,
+		canTarget = function(fn)
+			canTarget = fn
+		end,
+		update = function(frame)
+			for i = #checks, 1, -1 do
+				checks[i] = nil
+			end
+			env.gadget:GameFrame(frame)
+		end,
+		rules = rules,
+		events = events,
+		command = function(id, targetID)
+			currentCommand = id and { id, 0, 99, targetID }
+		end,
+		target = function()
+			return target
+		end,
+		set = function(targetID, append)
+			env.gadget:AllowCommand(
+				1,
+				1,
+				1,
+				env.GameCMD.UNIT_SET_TARGET,
+				type(targetID) == "table" and targetID or { targetID },
+				{ shift = append, coded = 0 },
+				1,
+				1
+			)
+		end,
+	}
+end
+
+describe("Set Target invalid-target cleanup", function()
+	for _, kind in ipairs({ "dead", "crashing" }) do
+		it("skips a " .. kind .. " active target on the next selection update", function()
+			local g = loadTargetGadget()
+			g.set(10)
+			g.set(20, true)
+			assert.are.equal(10, g.target())
+			g[kind == "dead" and "deadTargets" or "crashingTargets"][10] = true
+			-- TryTarget deliberately still succeeds: crashing aircraft can remain targetable.
+			g.update(1)
+			assert.are.equal(20, g.target())
+			assert.same({ 20 }, g.checks)
+			assert.are.equal(1, #g.env.GG.GetUnitTargetList(1))
+		end)
+
+		it("rejects a new " .. kind .. " target", function()
+			local g = loadTargetGadget()
+			g[kind == "dead" and "deadTargets" or "crashingTargets"][10] = true
+			g.set(10)
+			assert.is_nil(g.target())
+			assert.is_nil(g.env.GG.GetUnitTargetList(1))
+		end)
+
+		it("cleans up a " .. kind .. " target while Set Target is paused", function()
+			local g = loadTargetGadget()
+			g.set(10)
+			g.command(g.env.CMD.WAIT)
+			g.update(15)
+			assert.are.equal(1, g.rules.hasPriorityTarget)
+			g[kind == "dead" and "deadTargets" or "crashingTargets"][10] = true
+			g.update(30)
+			assert.is_nil(g.rules.hasPriorityTarget)
+		end)
+	end
+
+	it("clears the assignment when its last target starts crashing", function()
+		local g = loadTargetGadget()
+		g.set(10)
+		g.crashingTargets[10] = true
+		g.update(1)
+		assert.is_nil(g.target())
+		assert.is_nil(g.env.GG.GetUnitTargetList(1))
+	end)
+end)


### PR DESCRIPTION
### Work done

Set Target skips dead and crashing units during its normal target-selection updates, so weapons can proceed to the next valid target without waiting for periodic list cleanup. New assignments to these units are rejected, and paused lists remove them on their next cleanup pass without a lost-LOS grace period.

#### Test steps

- Run `runtests set_target` with cheats and developer mode enabled on a map with land. The test queues two aircraft, marks the first as crashing, checks that targeting switches to the second, then destroys the second and checks that the assignment clears.
- The headless integration test fails on the current base and passes with this change using Recoil `2026.07.04`.
- Seven focused Lua regression tests pass. The full Lua suite has 206 passes, three pre-existing failures in `mission_options_spec.lua`, and one pending test; the unchanged base has the same three failures and pending test, with 199 passes.
- Changed files pass StyLua and luacheck.

### AI / LLM usage statement

OpenAI Codex assisted with the implementation, regression tests and automated validation. This draft is pending human review.
