### PR TITLE
Share synced unit death checks through a bounded cache

### DIFF
--- a/doc/UnitDeathCache.md
+++ b/doc/UnitDeathCache.md
@@ -1,0 +1,73 @@
+# Synced unit death cache
+
+`api_unit_death_cache.lua` owns a shared, read-only lookup table for synced gadgets:
+
+```lua
+local isUnitDead = table.ensureTable(GG, "IsUnitDead")
+
+-- Equivalent to Spring.GetUnitIsDead(unitID) ~= false in full-read synced code.
+if isUnitDead[unitID] then
+    -- The unit is dead or the ID is invalid.
+end
+```
+
+The table keeps its identity, so consumers may acquire it before the provider
+loads. Use it from call-ins or Initialize after the provider has initialized,
+not while loading a consumer's file. The provider runs before consumers at
+layer -2000000000. Do not write entries or replace its metatable.
+
+A stored `false` means alive; `true` means dead or invalid. An absent entry is
+unknown: the metatable queries the engine on the next read. This API deliberately
+combines the engine's `true` and `nil` results. It is **not** a drop-in replacement
+for every GetUnitIsDead expression, and must not be used inside a restricted
+`CallAsTeam` read context or from widgets/unsynced gadgets.
+
+UnitCreated invalidates an entry (including reuse of an ID); UnitDestroyed marks
+it dead before later gadgets receive the event. Two death/invalid-entry buckets
+rotate every 10 simulation seconds. Entries expire after 10-20 seconds, without
+per-entry timestamps. Repeated hits do not extend retention. Expired entries are
+queried again, never assumed alive. Memory consists of cached live IDs, recently
+dead/invalid IDs and live carrier IDs, not a cumulative history of all deaths.
+
+## Transporters and reloads
+
+The engine sets a transporter's isDead before releasing cargo, then emits its
+UnitDestroyed. Cargo damage/unload callbacks can therefore precede that event.
+Live transporters are not cached: their reads query the engine until death is
+observed. UnitLoaded also invalidates a cached alive value when Lua forcibly
+attaches cargo to a unit without transport capacity. Initialize reconstructs
+existing carrier relationships and clears cached values, supporting gadget reload
+and initialization with existing units. Disabling the provider leaves consumers
+with an uncached engine-query metatable rather than stale values.
+
+## Consumer audit
+
+| Gadget / group | Decision |
+| --- | --- |
+| `unit_target_on_the_move.lua` | Converted the full-read `alwaysSeen` cleanup check on master. This changes no targeting rules. PR #9165's dead/crashing selection fix remains separate. |
+| `cmd_build_bugger_off.lua` | Converted its repeated strict alive check while scanning units obstructing builders. |
+| `unit_water_depth_damage.lua` | Converted its strict alive check before drowning damage. |
+| `unit_waterspeedmultiplier.lua` | Compatible strict alive check, but its movement-data lookup is still required; candidate for a later measured conversion. |
+| `unit_transport_dies_load_dies.lua` | Possible in GameFramePost; retains its engine queries for now, including its separate crashing-state query. |
+| `unit_custom_weapons_behaviours.lua`, `unit_custom_weapons_overpen.lua` | Repeated projectile checks are candidates; review each call path, including restricted team reads, before converting. |
+| `unit_shield_behaviour.lua`, `unit_lightning_splash_dmg.lua`, `unit_collision_damage_behavior.lua` | Damage/reentrant paths need dedicated consumer tests. Some checks use `not GetUnitIsDead`, whose invalid-ID semantics differ. |
+| `ai_zombies.lua`, Raptor/Scav spawners | Often pair ValidUnitID with a death check; potential savings, but require mode-specific tests. |
+| Reclaim/upgrade helpers, cloak, quick start, territorial domination, objectify, Xmas | Mixed call frequency and nil handling; not converted wholesale. |
+| `cus_gl4.lua`, `gfx_nano_particles_gl4.lua`, LuaUI widgets | Unsynced: cannot use this synced GG table. Visibility-sensitive engine queries remain necessary. |
+
+## Validation
+
+Run `runtests unit_death_cache` with cheats/developer mode on a map. The lifecycle
+test checks the real carrier-unload ordering, immediate death visibility, and
+expiry followed by rechecking an invalid ID. The unit suite covers cold reads,
+cache hits (including false), ID reuse across generations, forced carriers,
+reload, shutdown, and consumer-first table acquisition.
+
+```sh
+# With the repository's normal Lua test environment:
+busted spec/luarules/unit_death_cache_spec.lua
+```
+
+This is an optimization for repeated full-read checks, not a claim about total
+frame time. First reads, transport reads, initialization and event/bucket upkeep
+still have costs. Measure the intended workload before migrating more consumers.

--- a/luarules/gadgets/api_unit_death_cache.lua
+++ b/luarules/gadgets/api_unit_death_cache.lua
@@ -1,0 +1,113 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Unit Death Cache",
+		desc = "Share dead-or-invalid unit checks between synced gadgets",
+		author = "eun-ice",
+		license = "GNU GPL, v2 or later",
+		layer = -2000000000, -- Update membership before consumers handle lifecycle events.
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local getUnitIsDead = Spring.GetUnitIsDead
+local getUnitDefID = Spring.GetUnitDefID
+local dead = table.ensureTable(GG, "IsUnitDead")
+local transportDefs = {}
+for unitDefID, def in pairs(UnitDefs) do
+	if (def.transportCapacity or 0) > 0 then
+		transportDefs[unitDefID] = true
+	end
+end
+local liveTransports = {}
+local recentDead = {}
+local previousDead = {}
+local interval = 10 * Game.gameSpeed
+
+local function rememberDead(unitID)
+	dead[unitID] = true
+	recentDead[unitID] = true
+	previousDead[unitID] = nil
+	return true
+end
+
+-- This is a full-read synced API, not a replacement inside CallAsTeam or LuaUI.
+-- true means dead OR invalid; false means alive. Missing entries are queried lazily.
+local function lookup(_, unitID)
+	if getUnitIsDead(unitID) ~= false then
+		return rememberDead(unitID)
+	end
+	-- ForcedKillUnit releases cargo before UnitDestroyed. Nested cargo callbacks
+	-- can observe a dead transporter while its last cached value would be alive.
+	-- Keep querying live transporters until their death is observed.
+	if not liveTransports[unitID] then
+		if transportDefs[getUnitDefID(unitID)] then
+			liveTransports[unitID] = true
+		else
+			dead[unitID] = false
+		end
+	end
+	return false
+end
+
+function gadget:Initialize()
+	-- Keep the shared table identity across reloads; rebuild from engine queries.
+	for unitID in pairs(dead) do
+		dead[unitID] = nil
+	end
+	-- Reconstruct forced carriers as well as normal transports after a reload.
+	for _, unitID in ipairs(Spring.GetAllUnits()) do
+		local transportID = Spring.GetUnitTransporter(unitID)
+		if transportID then
+			liveTransports[transportID] = true
+		end
+	end
+	setmetatable(dead, { __index = lookup })
+end
+
+function gadget:UnitCreated(unitID, unitDefID)
+	dead[unitID] = nil
+	recentDead[unitID] = nil
+	previousDead[unitID] = nil
+	liveTransports[unitID] = transportDefs[unitDefID]
+end
+
+function gadget:UnitLoaded(unitID, unitDefID, unitTeam, transportID)
+	-- Lua can force cargo onto units whose definition has no transport capacity.
+	dead[transportID] = nil
+	liveTransports[transportID] = true
+end
+
+function gadget:UnitDestroyed(unitID)
+	liveTransports[unitID] = nil
+	rememberDead(unitID)
+end
+
+function gadget:GameFrame(frame)
+	if frame % interval ~= 0 then
+		return
+	end
+	-- Retain death/invalid entries for 10-20 seconds, without per-entry timestamps.
+	for unitID in pairs(previousDead) do
+		dead[unitID] = nil
+		previousDead[unitID] = nil
+	end
+	previousDead, recentDead = recentDead, previousDead
+end
+
+function gadget:Shutdown()
+	for unitID in pairs(dead) do
+		dead[unitID] = nil
+	end
+	-- Existing consumers remain correct if this gadget is disabled.
+	setmetatable(dead, {
+		__index = function(_, unitID)
+			return getUnitIsDead(unitID) ~= false
+		end,
+	})
+end

--- a/luarules/gadgets/cmd_build_bugger_off.lua
+++ b/luarules/gadgets/cmd_build_bugger_off.lua
@@ -25,7 +25,7 @@ local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGetUnitStates = Spring.GetUnitStates
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
-local spGetUnitIsDead = Spring.GetUnitIsDead
+local isUnitDead = table.ensureTable(GG, "IsUnitDead")
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
 local spGetUnitIsBuilding = Spring.GetUnitIsBuilding
 local spGetUnitPosition = Spring.GetUnitPosition
@@ -157,7 +157,7 @@ end
 
 local function ignoreBuggeroff(unitID, unitDefData)
 	return unitDefData.isImmobile
-		or spGetUnitIsDead(unitID) ~= false
+		or isUnitDead[unitID]
 		or spGetUnitIsBeingBuilt(unitID) ~= false
 		or gameFrame - (mostRecentCommandFrame[unitID] or -USER_COMMAND_TIMEOUT) < USER_COMMAND_TIMEOUT
 end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -27,7 +27,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spSetUnitTarget = Spring.SetUnitTarget
 	local spValidUnitID = Spring.ValidUnitID
 	local spGetUnitDefID = Spring.GetUnitDefID
-	local spGetUnitIsDead = Spring.GetUnitIsDead
+	local isUnitDead = table.ensureTable(GG, "IsUnitDead")
 	local spGetUnitLosState = Spring.GetUnitLosState
 	local spGetUnitTeam = Spring.GetUnitTeam
 	local spAreTeamsAllied = Spring.AreTeamsAllied
@@ -255,7 +255,6 @@ if gadgetHandler:IsSyncedCode() then
 		return bit_and(cmdOptions, OPT_INTERNAL) ~= 0
 	end
 
-
 	local function restoreCommandTarget(unitID)
 		local inCommand, options, _, param1, param2, param3 = spGetUnitCurrentCommand(unitID)
 		if not inCommand or not isAttackCommand[inCommand] then
@@ -332,7 +331,7 @@ if gadgetHandler:IsSyncedCode() then
 		if type(target) ~= "number" then
 			return false, false
 		elseif alwaysSeen then
-			local isDead = spGetUnitIsDead(target) ~= false
+			local isDead = isUnitDead[target]
 			return isDead, isDead
 		end
 		local los = spGetUnitLosState(target, allyTeam, true)

--- a/luarules/gadgets/unit_water_depth_damage.lua
+++ b/luarules/gadgets/unit_water_depth_damage.lua
@@ -44,7 +44,7 @@ local gaiaTeamID = Spring.GetGaiaTeamID()
 local waterDamageDefID = Game.envDamageTypes.Water
 local gameSpeed = Game.gameSpeed
 
-local spGetUnitIsDead = Spring.GetUnitIsDead
+local isUnitDead = table.ensureTable(GG, "IsUnitDead")
 local spAddUnitDamage = Spring.AddUnitDamage
 local spGetUnitVelocity = Spring.GetUnitVelocity
 local spGetUnitBasePosition = Spring.GetUnitBasePosition
@@ -172,7 +172,7 @@ function gadget:GameFrame(frame)
 			local posX, posY, posZ = spGetUnitPosition(unitID)
 			if not posX then
 				drowningUnitsWatch[unitID] = nil --unit no longer exists
-			elseif posY < data.drownCandidateY and spGetUnitIsDead(unitID) == false then
+			elseif posY < data.drownCandidateY and not isUnitDead[unitID] then
 				--deep enough that the movedef depth limit may be exceeded: ask the engine
 				local movableSpot = spTestMoveOrder(data.unitDefID, posX, posY, posZ, nil, nil, nil, true, true, true) --somehow, this works. Copied from elsewhere in the code, spring wiki and recoil and game repo didn't have any info on this format.
 				if not movableSpot then

--- a/luaui/Tests/unit_death_cache/test_lifecycle.lua
+++ b/luaui/Tests/unit_death_cache/test_lifecycle.lua
@@ -1,0 +1,78 @@
+local function setup()
+	Test.clearMap()
+end
+
+local function cleanup()
+	Test.clearMap()
+end
+
+local function test()
+	SyncedRun(function()
+		local dead = assert(gadgetHandler.GG.IsUnitDead, "Unit Death Cache is unavailable")
+		local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+		local y = Spring.GetGroundHeight(x, z) + 200
+		local transport = assert(Spring.CreateUnit("armatlas", x, y, z, 0, 0))
+		local cargo = assert(Spring.CreateUnit("armpw", x, y, z, 0, 0))
+		Spring.UnitAttach(transport, cargo, 0, true)
+		assert(Spring.GetUnitTransporter(cargo) == transport)
+		assert(dead[transport] == false)
+		assert((function()
+			for id, value in pairs(dead) do
+				if id == transport then
+					return value
+				end
+			end
+		end)() == nil, "live transports must not be cached")
+		local observed
+		local observer = {
+			UnitUnloaded = function(_, _, _, _, transportID)
+				if transportID == transport then
+					observed = { Spring.GetUnitIsDead(transport), dead[transport] }
+				end
+			end,
+		}
+		local list = gadgetHandler.UnitUnloadedList
+		list[#list + 1] = observer
+		local ok, err = pcall(Spring.DestroyUnit, transport, false, true)
+		for i = #list, 1, -1 do
+			if list[i] == observer then
+				table.remove(list, i)
+			end
+		end
+		assert(ok, err)
+		assert(
+			observed and observed[1] == true and observed[2] == true,
+			"cargo callback must see dead transport before its UnitDestroyed"
+		)
+	end)
+	local unitID = SyncedRun(function()
+		local dead = assert(gadgetHandler.GG.IsUnitDead, "Unit Death Cache is unavailable")
+		local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2
+		local unitID = assert(Spring.CreateUnit("armpw", x, Spring.GetGroundHeight(x, z), z, 0, 0))
+		assert(dead[unitID] == false)
+		assert((function()
+			for id, value in pairs(dead) do
+				if id == unitID then
+					return value
+				end
+			end
+		end)() == false, "live non-transport should be cached")
+		Spring.DestroyUnit(unitID, false, true)
+		assert(dead[unitID] == true, "death must be published synchronously")
+		return unitID
+	end)
+	Test.waitFrames(2 * 10 * Game.gameSpeed + 1)
+	SyncedRun(function(locals)
+		local dead = gadgetHandler.GG.IsUnitDead
+		assert((function()
+			for id, value in pairs(dead) do
+				if id == locals.unitID then
+					return value
+				end
+			end
+		end)() == nil, "death entry must expire")
+		assert(dead[locals.unitID] == true, "expired missing unit must remain invalid")
+	end)
+end
+
+return { setup = setup, test = test, cleanup = cleanup }

--- a/spec/luarules/unit_death_cache_spec.lua
+++ b/spec/luarules/unit_death_cache_spec.lua
@@ -1,0 +1,140 @@
+local function loadCache(shared, state, transports)
+	local calls = 0
+	local env = setmetatable({
+		gadget = {},
+		rawget = false,
+		rawset = false,
+		GG = shared or {},
+		Game = { gameSpeed = 30 },
+		UnitDefs = { { transportCapacity = 0 }, { transportCapacity = 1 } },
+		gadgetHandler = {
+			IsSyncedCode = function()
+				return true
+			end,
+		},
+		Spring = {
+			GetAllUnits = function()
+				return {}
+			end,
+			GetUnitTransporter = function() end,
+			GetUnitIsDead = function(id)
+				calls = calls + 1
+				return state[id]
+			end,
+			GetUnitDefID = function(id)
+				return transports and transports[id] and 2 or 1
+			end,
+		},
+	}, { __index = _G })
+	local chunk = assert(loadfile("luarules/gadgets/api_unit_death_cache.lua"))
+	setfenv(chunk, env)
+	chunk()
+	env.gadget:Initialize()
+	return env.gadget, env.GG.IsUnitDead, function()
+		return calls
+	end
+end
+
+describe("Shared unit death cache", function()
+	it("lazily caches live, dead and invalid IDs without treating false as a miss", function()
+		local _, cache, calls = loadCache(nil, { [1] = false, [2] = true })
+		for _ = 1, 20 do
+			assert.is_false(cache[1])
+			assert.is_true(cache[2])
+			assert.is_true(cache[3])
+		end
+		assert.are.equal(3, calls())
+	end)
+
+	it("updates death synchronously and resets a reused ID", function()
+		local state = { [1] = false }
+		local gadget, cache = loadCache(nil, state)
+		assert.is_false(cache[1])
+		state[1] = true
+		gadget:UnitDestroyed(1)
+		assert.is_true(cache[1])
+		gadget:GameFrame(300)
+		state[1] = false
+		gadget:UnitCreated(1, 1)
+		assert.is_false(cache[1])
+		gadget:GameFrame(600)
+		assert.is_false(rawget(cache, 1))
+	end)
+
+	it("expunges dead and invalid entries after two rotations, preserving live entries", function()
+		local gadget, cache, calls = loadCache(nil, { [1] = false })
+		assert.is_false(cache[1])
+		assert.is_true(cache[2])
+		gadget:GameFrame(300)
+		assert.is_true(rawget(cache, 2))
+		gadget:GameFrame(599)
+		assert.is_true(rawget(cache, 2))
+		gadget:GameFrame(600)
+		assert.is_nil(rawget(cache, 2))
+		assert.is_false(rawget(cache, 1))
+		assert.is_true(cache[2])
+		assert.are.equal(3, calls())
+	end)
+
+	it("does not let an old death generation erase a new death of a reused ID", function()
+		local state = { [1] = true }
+		local gadget, cache = loadCache(nil, state)
+		assert.is_true(cache[1])
+		gadget:GameFrame(300)
+		gadget:UnitCreated(1, 1)
+		gadget:UnitDestroyed(1)
+		gadget:GameFrame(600)
+		assert.is_true(rawget(cache, 1))
+		gadget:GameFrame(900)
+		assert.is_nil(rawget(cache, 1))
+	end)
+
+	it("queries transports until dead, including before their UnitDestroyed callback", function()
+		local state = { [1] = false }
+		local gadget, cache, calls = loadCache(nil, state, { [1] = true })
+		assert.is_false(cache[1]) -- existing transport after reload, no UnitCreated
+		assert.is_nil(rawget(cache, 1))
+		state[1] = true -- cargo callbacks precede transporter UnitDestroyed
+		assert.is_true(cache[1])
+		assert.are.equal(2, calls())
+		gadget:UnitDestroyed(1)
+		state[1] = false
+		gadget:UnitCreated(1, 2)
+		assert.is_false(cache[1])
+		assert.is_nil(rawget(cache, 1))
+	end)
+
+	it("invalidates an ordinary unit when Lua forces it to carry cargo", function()
+		local state = { [1] = false }
+		local gadget, cache = loadCache(nil, state)
+		assert.is_false(cache[1])
+		gadget:UnitLoaded(2, 1, 0, 1)
+		assert.is_nil(rawget(cache, 1))
+		assert.is_false(cache[1])
+		state[1] = true
+		assert.is_true(cache[1])
+	end)
+
+	it("preserves consumer references and queries current engine state on reload", function()
+		local shared, state = {}, { [1] = false }
+		local first, cache = loadCache(shared, state)
+		assert.is_false(cache[1])
+		first:Shutdown()
+		state[1] = true
+		assert.is_true(cache[1])
+		assert.is_nil(rawget(cache, 1))
+		state[1] = false
+		assert.is_false(cache[1])
+		local _, reloaded = loadCache(shared, state)
+		assert.is_true(cache == reloaded)
+		assert.is_false(cache[1])
+	end)
+
+	it("acquires a table created earlier by a consumer", function()
+		local shared = { IsUnitDead = {} }
+		local consumer = shared.IsUnitDead
+		local _, cache = loadCache(shared, {})
+		assert.is_true(cache == consumer)
+		assert.is_true(consumer[17])
+	end)
+end)


### PR DESCRIPTION
Repeated full-read unit validity checks currently cross into the engine for every consumer. This adds a synced `Unit Death Cache` gadget exposing a shared `GG.IsUnitDead[unitID]` lookup: `true` means dead or invalid, `false` means alive, and missing entries query the engine lazily.

`UnitCreated` invalidates reused IDs; `UnitDestroyed` publishes death before consumer callbacks. Two buckets expire dead/invalid entries after 10–20 simulation seconds. Reload preserves the shared table identity, and shutdown leaves an uncached fallback. Live transporters deliberately bypass alive caching: the engine releases cargo before the transporter's `UnitDestroyed`, so nested callbacks can already observe its death. Forced Lua carriers are handled through `UnitLoaded` and reload reconstruction.

The first consumers are Set Target's existing `alwaysSeen` cleanup check, builder buggeroff scans and drowning damage. `doc/UnitDeathCache.md` documents the API and audits other candidates (water speed, projectile logic, shields, transports, AI, and unsynced consumers). Restricted `CallAsTeam` reads and expressions with different invalid-ID semantics are not migrated.

This PR is based directly on master and is separate from #9165. The Set Target import and check will need reconciling with #9165 if that merges first; this PR does not include its dead/crashing behavior change.

### Validation

- Eight focused Lua tests pass, covering cache hits/misses, expiry, ID reuse, carrier handling, reload/shutdown, and consumer-first initialization.
- Real Recoil `2026.07.04` headless lifecycle test passes on Supreme Isthmus v2.1, including the nested transport-unload callback and expiration. The same new test fails on base master because the API is absent. Run `runtests unit_death_cache` with cheats/developer mode. Headless infolog check is skipped.
- Full Lua suite: 212 candidate / 204 base passes; both have the same three existing `mission_options_spec.lua` failures and one pending test. StyLua and luacheck pass on all six changed Lua files.
- Synthetic in-engine lookup benchmark: 64 live targets, 262,144 reads per round, five rounds. Median direct lookup loop: 17.564 ms; cache: 13.741 ms. This noisy microbenchmark excludes lifecycle/expiry costs and is not a whole-game performance claim.

### AI / LLM usage

OpenAI Codex assisted with implementation, consumer audit and automated validation. Draft pending human review.
