### PR TITLE
Use `pr-`/`br-` instead of `pr:`/`br:` for rapid branches

### DIFF
--- a/.github/workflows/rapid-build.yml
+++ b/.github/workflows/rapid-build.yml
@@ -37,10 +37,10 @@ jobs:
         run: |
           if [ -z "${PR_OR_BRANCH//[0-9]/}" ]; then
             commit="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_OR_BRANCH" --jq .head.sha)"
-            echo "branch=pr:$PR_OR_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "branch=pr-$PR_OR_BRANCH" >> "$GITHUB_OUTPUT"
           else
             commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$PR_OR_BRANCH" --jq .object.sha)"
-            echo "branch=br:$PR_OR_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "branch=br-$PR_OR_BRANCH" >> "$GITHUB_OUTPUT"
           fi
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
       - uses: beyond-all-reason/rapid-hosting/action@main


### PR DESCRIPTION
Workaround for https://github.com/beyond-all-reason/pr-downloader/issues/74

Policy change applied in https://github.com/beyond-all-reason/rapid-hosting/commit/b4a7a7ea2deb83ed89b02d4cb2e531311e0f4b00

Same context as https://github.com/beyond-all-reason/Beyond-All-Reason/pull/9107
