### PR TITLE
Set Target: release the weapon target when it is cleared or cancelled

### DIFF
--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -34,6 +34,7 @@ if gadgetHandler:IsSyncedCode() then
 	local spGetUnitsInRectangle = Spring.GetUnitsInRectangle
 	local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
 	local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
+	local spGiveOrderToUnit = Spring.GiveOrderToUnit
 	local spGetUnitWeaponTarget = Spring.GetUnitWeaponTarget
 	local spGetUnitWeaponTryTarget = Spring.GetUnitWeaponTryTarget
 	local spGetUnitWeaponTestTarget = Spring.GetUnitWeaponTestTarget
@@ -57,6 +58,7 @@ if gadgetHandler:IsSyncedCode() then
 
 	local CMD_STOP = CMD.STOP
 	local CMD_ATTACK = CMD.ATTACK
+	local CMD_REMOVE = CMD.REMOVE
 	local CMD_FIGHT = CMD.FIGHT
 	local CMD_GUARD = CMD.GUARD
 	local CMD_WAIT = CMD.WAIT
@@ -315,16 +317,38 @@ if gadgetHandler:IsSyncedCode() then
 		SendToUnsynced("targetIndex", unitID, targetIndex, true)
 	end
 
-	local function setTargetPassive(unitID, unitData)
-		if not unitData then
-			return
+	-- A mobile unit turns its weapon target into an automatic (internal) Attack
+	-- command that lives for a few seconds. When the Set Target that produced it
+	-- is released, that command would keep re-applying the old target (directly
+	-- and through restoreCommandTarget), so drop it first.
+	local function dropAutomaticAttack(unitID, targetID)
+		local inCommand, options, tag, param1, param2 = spGetUnitCurrentCommand(unitID)
+		if inCommand == CMD_ATTACK and not param2 and param1 == targetID and hasAutoTarget(options) then
+			spGiveOrderToUnit(unitID, CMD_REMOVE, { tag }, 0)
 		end
-		unitData.activeTarget = false
-		unitData.currentIndex = 1
-		spSetUnitRulesParam(unitID, "unitTargetID", nil)
+	end
+
+	local function releaseEngineTarget(unitID, unitData, releasedTarget)
+		if releasedTarget == nil and unitData and unitData.activeTarget then
+			local targetData = unitData.targets[unitData.currentIndex]
+			releasedTarget = targetData and targetData.target
+		end
+		if type(releasedTarget) == "number" then
+			dropAutomaticAttack(unitID, releasedTarget)
+		end
 		if not restoreCommandTarget(unitID) then
 			spSetUnitTarget(unitID, nil)
 		end
+	end
+
+	local function setTargetPassive(unitID, unitData, releasedTarget)
+		if not unitData then
+			return
+		end
+		releaseEngineTarget(unitID, unitData, releasedTarget)
+		unitData.activeTarget = false
+		unitData.currentIndex = 1
+		spSetUnitRulesParam(unitID, "unitTargetID", nil)
 		SendToUnsynced("targetIndex", unitID, 1, false)
 	end
 
@@ -364,8 +388,9 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	local function removeUnit(unitID, keeptrack)
-		if activeTargets[unitID] and not restoreCommandTarget(unitID) then
-			spSetUnitTarget(unitID, nil)
+		local unitData = activeTargets[unitID]
+		if unitData and not keeptrack then
+			releaseEngineTarget(unitID, unitData)
 		end
 		activeTargets[unitID] = nil
 		removeFromQueue(unitID)
@@ -480,8 +505,13 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			unitData.currentTargets[removed.target] = nil
 			if index == unitData.currentIndex then
-				unitData.currentIndex = 1
-				unitData.activeTarget = false
+				if unitData.activeTarget then
+					-- Cancelling the target the unit is firing at must stop that fire now;
+					-- the next update picks another listed target if one is attackable.
+					setTargetPassive(unitID, unitData, removed.target)
+				else
+					unitData.currentIndex = 1
+				end
 			elseif index < unitData.currentIndex then
 				unitData.currentIndex = unitData.currentIndex - 1
 			end

--- a/luarules/gadgets/unit_target_on_the_move.lua
+++ b/luarules/gadgets/unit_target_on_the_move.lua
@@ -257,7 +257,6 @@ if gadgetHandler:IsSyncedCode() then
 		return bit_and(cmdOptions, OPT_INTERNAL) ~= 0
 	end
 
-
 	local function restoreCommandTarget(unitID)
 		local inCommand, options, _, param1, param2, param3 = spGetUnitCurrentCommand(unitID)
 		if not inCommand or not isAttackCommand[inCommand] then
@@ -317,10 +316,9 @@ if gadgetHandler:IsSyncedCode() then
 		SendToUnsynced("targetIndex", unitID, targetIndex, true)
 	end
 
-	-- A mobile unit turns its weapon target into an automatic (internal) Attack
-	-- command that lives for a few seconds. When the Set Target that produced it
-	-- is released, that command would keep re-applying the old target (directly
-	-- and through restoreCommandTarget), so drop it first.
+	-- Release both unit-owned and weapon-owned targets. An automatic Attack on
+	-- the released target can restore it, so remove that command before clearing
+	-- the target. Explicit attack commands retain ownership of their targets.
 	local function dropAutomaticAttack(unitID, targetID)
 		local inCommand, options, tag, param1, param2 = spGetUnitCurrentCommand(unitID)
 		if inCommand == CMD_ATTACK and not param2 and param1 == targetID and hasAutoTarget(options) then
@@ -387,10 +385,10 @@ if gadgetHandler:IsSyncedCode() then
 		SendToUnsynced("targetList", unitID, targetCount + 1)
 	end
 
-	local function removeUnit(unitID, keeptrack)
+	local function removeUnit(unitID, keeptrack, releasedTarget)
 		local unitData = activeTargets[unitID]
 		if unitData and not keeptrack then
-			releaseEngineTarget(unitID, unitData)
+			releaseEngineTarget(unitID, unitData, releasedTarget)
 		end
 		activeTargets[unitID] = nil
 		removeFromQueue(unitID)
@@ -500,7 +498,7 @@ if gadgetHandler:IsSyncedCode() then
 		local removed = tremove(unitData.targets, index)
 		if removed then
 			if not unitData.targets[1] then
-				removeUnit(unitID)
+				removeUnit(unitID, false, unitData.activeTarget and removed.target or nil)
 				return
 			end
 			unitData.currentTargets[removed.target] = nil
@@ -538,6 +536,7 @@ if gadgetHandler:IsSyncedCode() then
 		-- Otherwise there really are targets to keep:
 		local currentTargets = unitData.currentTargets
 		local oldIndex = unitData.currentIndex
+		local oldTarget = targetList[oldIndex] and targetList[oldIndex].target
 		local currentIndex = oldIndex
 		local minIndex
 		local moveToIndex = 0
@@ -567,8 +566,11 @@ if gadgetHandler:IsSyncedCode() then
 			targetList[i] = nil
 		end
 		if currentIndex == 0 then
-			unitData.currentIndex = 1
-			unitData.activeTarget = false
+			if unitData.activeTarget then
+				setTargetPassive(unitID, unitData, oldTarget)
+			else
+				unitData.currentIndex = 1
+			end
 		else
 			unitData.currentIndex = currentIndex
 			-- The active target remains the same.

--- a/luaui/Tests/set_target/test_cancel_active_target_releases.lua
+++ b/luaui/Tests/set_target/test_cancel_active_target_releases.lua
@@ -1,0 +1,72 @@
+---@diagnostic disable: assign-type-mismatch, need-check-nil, unnecessary-assert
+
+-- Cancel Target on the entry a unit is currently firing at must release the
+-- weapon target at once. Before the fix the entry left the list but the unit
+-- kept firing at it as long as no other listed target was in range (#9176).
+
+function setup()
+	assert(select(1, Spring.GetTeamInfo(1, false)) ~= nil, "Set Target tests require enemy team 1")
+	Test.clearMap()
+end
+
+function cleanup()
+	Spring.SelectUnitArray({})
+	Test.clearMap()
+end
+
+local function createScenario()
+	local centerX = Game.mapSizeX / 2
+	local centerZ = Game.mapSizeZ / 2
+	local sourceID = assert(Spring.CreateUnit("armflak", centerX, Spring.GetGroundHeight(centerX, centerZ), centerZ, "east", 0))
+	local nearID = assert(Spring.CreateUnit("corhurc", centerX + 200, 500, centerZ, "west", 1))
+	local farID = assert(Spring.CreateUnit("corhurc", centerX + 3000, 500, centerZ, "west", 1))
+	Spring.SetUnitArmored(nearID, true, 0)
+	Spring.GiveOrderToUnitArray({ nearID, farID }, CMD.FIRE_STATE, { 0 }, 0)
+	Spring.GiveOrderToUnit(sourceID, CMD.FIRE_STATE, { 0 }, 0)
+	return sourceID, nearID, farID
+end
+
+local function weaponTarget(sourceID)
+	local targetType, _, target = Spring.GetUnitWeaponTarget(sourceID, 1)
+	if targetType == 1 then
+		return target
+	end
+	return nil
+end
+
+local function listedTargets(sourceID)
+	local ids = {}
+	for _, entry in ipairs(SyncedProxy.gadgetHandler.GG.GetUnitTargetList(sourceID) or {}) do
+		ids[#ids + 1] = entry.target
+	end
+	return table.concat(ids, ",")
+end
+
+function test()
+	local sourceID, nearID, farID = SyncedRun(createScenario)
+	Test.waitFrames(32)
+
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { farID }, 0)
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { nearID }, CMD.OPT_SHIFT)
+	Test.waitUntil(function()
+		return Spring.GetUnitRulesParam(sourceID, "unitTargetID") == nearID and weaponTarget(sourceID) == nearID
+	end, 120)
+	assertEqual(listedTargets(sourceID), farID .. "," .. nearID, "both targets are listed, the near one is active")
+
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, { nearID }, 0)
+	Test.waitFrames(2)
+	assertEqual(listedTargets(sourceID), tostring(farID), "Cancel Target removes only the cancelled entry")
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), nil, "the cancelled target is no longer the priority target")
+	assertEqual(weaponTarget(sourceID), nil, "the cancelled target is no longer the weapon target")
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget"), 1, "the remaining far target keeps the list alive")
+
+	-- It stays released: the far target is out of range, nothing else is listed.
+	Test.waitFrames(60)
+	assertEqual(weaponTarget(sourceID), nil, "the unit does not resume firing at the cancelled target")
+end
+
+return {
+	setup = setup,
+	test = test,
+	cleanup = cleanup,
+}

--- a/luaui/Tests/set_target/test_cancel_active_target_releases.lua
+++ b/luaui/Tests/set_target/test_cancel_active_target_releases.lua
@@ -17,7 +17,8 @@ end
 local function createScenario()
 	local centerX = Game.mapSizeX / 2
 	local centerZ = Game.mapSizeZ / 2
-	local sourceID = assert(Spring.CreateUnit("armflak", centerX, Spring.GetGroundHeight(centerX, centerZ), centerZ, "east", 0))
+	local sourceID =
+		assert(Spring.CreateUnit("armflak", centerX, Spring.GetGroundHeight(centerX, centerZ), centerZ, "east", 0))
 	local nearID = assert(Spring.CreateUnit("corhurc", centerX + 200, 500, centerZ, "west", 1))
 	local farID = assert(Spring.CreateUnit("corhurc", centerX + 3000, 500, centerZ, "west", 1))
 	Spring.SetUnitArmored(nearID, true, 0)
@@ -42,27 +43,49 @@ local function listedTargets(sourceID)
 	return table.concat(ids, ",")
 end
 
-function test()
+local function checkRelease(stop)
 	local sourceID, nearID, farID = SyncedRun(createScenario)
 	Test.waitFrames(32)
 
-	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { farID }, 0)
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { farID }, CMD.OPT_CTRL)
 	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { nearID }, CMD.OPT_SHIFT)
 	Test.waitUntil(function()
 		return Spring.GetUnitRulesParam(sourceID, "unitTargetID") == nearID and weaponTarget(sourceID) == nearID
 	end, 120)
 	assertEqual(listedTargets(sourceID), farID .. "," .. nearID, "both targets are listed, the near one is active")
 
-	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, { nearID }, 0)
+	if stop then
+		Spring.GiveOrderToUnit(sourceID, CMD.STOP, {}, 0)
+	else
+		Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, { nearID }, 0)
+	end
 	Test.waitFrames(2)
-	assertEqual(listedTargets(sourceID), tostring(farID), "Cancel Target removes only the cancelled entry")
-	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), nil, "the cancelled target is no longer the priority target")
+	assertEqual(
+		listedTargets(sourceID),
+		tostring(farID),
+		"only the active entry is removed; the ignoreStop target remains"
+	)
+	assertEqual(
+		Spring.GetUnitRulesParam(sourceID, "unitTargetID"),
+		nil,
+		"the cancelled target is no longer the priority target"
+	)
 	assertEqual(weaponTarget(sourceID), nil, "the cancelled target is no longer the weapon target")
-	assertEqual(Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget"), 1, "the remaining far target keeps the list alive")
+	assertEqual(
+		Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget"),
+		1,
+		"the remaining far target keeps the list alive"
+	)
 
 	-- It stays released: the far target is out of range, nothing else is listed.
 	Test.waitFrames(60)
 	assertEqual(weaponTarget(sourceID), nil, "the unit does not resume firing at the cancelled target")
+end
+
+function test()
+	checkRelease(false)
+	Test.clearMap()
+	checkRelease(true)
 end
 
 return {

--- a/luaui/Tests/set_target/test_clear_target_releases_automatic_attack.lua
+++ b/luaui/Tests/set_target/test_clear_target_releases_automatic_attack.lua
@@ -1,0 +1,88 @@
+---@diagnostic disable: assign-type-mismatch, need-check-nil, unnecessary-assert
+
+-- A mobile unit on Fire at Will turns its Set Target into an automatic
+-- (internal) Attack command with a timeout of several seconds. Clearing the
+-- Set Target must also drop that command, otherwise the unit keeps firing at
+-- the cleared target until the timeout expires (#9176).
+
+function setup()
+	assert(select(1, Spring.GetTeamInfo(1, false)) ~= nil, "Set Target tests require enemy team 1")
+	Test.clearMap()
+end
+
+function cleanup()
+	Spring.SelectUnitArray({})
+	Test.clearMap()
+end
+
+local function createScenario()
+	local centerX = Game.mapSizeX / 2
+	local centerZ = Game.mapSizeZ / 2
+	local y = Spring.GetGroundHeight(centerX, centerZ)
+	local sourceID = assert(Spring.CreateUnit("armstump", centerX, y, centerZ, "east", 0))
+	local range = UnitDefs[Spring.GetUnitDefID(sourceID)].maxWeaponRange
+	local targetID = assert(Spring.CreateUnit("armstump", centerX + range * 0.8, y, centerZ, "west", 1))
+	local otherID = assert(Spring.CreateUnit("armstump", centerX + range * 0.45, y, centerZ + 60, "west", 1))
+	for _, unitID in ipairs({ targetID, otherID }) do
+		Spring.SetUnitArmored(unitID, true, 0)
+		Spring.MoveCtrl.Enable(unitID)
+	end
+	Spring.GiveOrderToUnitArray({ targetID, otherID }, CMD.FIRE_STATE, { 0 }, 0)
+	Spring.GiveOrderToUnit(sourceID, CMD.FIRE_STATE, { 0 }, 0)
+	return sourceID, targetID, otherID
+end
+
+local function automaticAttackOn(sourceID, targetID)
+	for _, command in ipairs(Spring.GetUnitCommands(sourceID, -1)) do
+		if command.id == CMD.ATTACK and command.params[1] == targetID and command.options.internal then
+			return true
+		end
+	end
+	return false
+end
+
+local function weaponTarget(sourceID)
+	local targetType, isUserTarget, target = Spring.GetUnitWeaponTarget(sourceID, 1)
+	if targetType == 1 then
+		return target, isUserTarget
+	end
+	return nil, false
+end
+
+function test()
+	local sourceID, targetID, otherID = SyncedRun(createScenario)
+	Test.waitFrames(32)
+
+	-- Hold fire while the Set Target is given so no automatic target interferes.
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { targetID }, 0)
+	Test.waitUntil(function()
+		return Spring.GetUnitRulesParam(sourceID, "unitTargetID") == targetID and weaponTarget(sourceID) == targetID
+	end, 120)
+
+	-- On Fire at Will the engine wraps the weapon target into an internal Attack.
+	Spring.GiveOrderToUnit(sourceID, CMD.FIRE_STATE, { 2 }, 0)
+	Test.waitUntil(function()
+		return automaticAttackOn(sourceID, targetID)
+	end, 120)
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), targetID, "the Set Target stays active on Fire at Will")
+
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, {}, 0)
+	Test.waitFrames(2)
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), nil, "Clear Target removes the priority target")
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget"), nil, "Clear Target removes the list")
+	assertEqual(automaticAttackOn(sourceID, targetID), false, "Clear Target drops the automatic Attack on the cleared target")
+	local _, isUserTarget = weaponTarget(sourceID)
+	assertEqual(isUserTarget, false, "no user target remains after Clear Target")
+
+	-- The unit is free to pick an opportunity target; it must not be re-issued
+	-- an automatic Attack on the cleared target by leftover Set Target state.
+	Test.waitFrames(60)
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), nil, "the cleared target does not come back as priority target")
+	assert(Spring.ValidUnitID(otherID), "the other enemy is still there")
+end
+
+return {
+	setup = setup,
+	test = test,
+	cleanup = cleanup,
+}

--- a/luaui/Tests/set_target/test_clear_target_releases_automatic_attack.lua
+++ b/luaui/Tests/set_target/test_clear_target_releases_automatic_attack.lua
@@ -49,7 +49,7 @@ local function weaponTarget(sourceID)
 	return nil, false
 end
 
-function test()
+local function checkRelease(cancelLast)
 	local sourceID, targetID, otherID = SyncedRun(createScenario)
 	Test.waitFrames(32)
 
@@ -64,21 +64,66 @@ function test()
 	Test.waitUntil(function()
 		return automaticAttackOn(sourceID, targetID)
 	end, 120)
-	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), targetID, "the Set Target stays active on Fire at Will")
+	assertEqual(
+		Spring.GetUnitRulesParam(sourceID, "unitTargetID"),
+		targetID,
+		"the Set Target stays active on Fire at Will"
+	)
 
-	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, {}, 0)
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, cancelLast and { targetID } or {}, 0)
 	Test.waitFrames(2)
 	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), nil, "Clear Target removes the priority target")
 	assertEqual(Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget"), nil, "Clear Target removes the list")
-	assertEqual(automaticAttackOn(sourceID, targetID), false, "Clear Target drops the automatic Attack on the cleared target")
+	assertEqual(
+		automaticAttackOn(sourceID, targetID),
+		false,
+		"Clear Target drops the automatic Attack on the cleared target"
+	)
 	local _, isUserTarget = weaponTarget(sourceID)
 	assertEqual(isUserTarget, false, "no user target remains after Clear Target")
 
 	-- The unit is free to pick an opportunity target; it must not be re-issued
 	-- an automatic Attack on the cleared target by leftover Set Target state.
 	Test.waitFrames(60)
-	assertEqual(Spring.GetUnitRulesParam(sourceID, "unitTargetID"), nil, "the cleared target does not come back as priority target")
+	assertEqual(
+		Spring.GetUnitRulesParam(sourceID, "unitTargetID"),
+		nil,
+		"the cleared target does not come back as priority target"
+	)
 	assert(Spring.ValidUnitID(otherID), "the other enemy is still there")
+end
+
+local function checkExplicitAttack()
+	local sourceID, targetID = SyncedRun(createScenario)
+	Test.waitFrames(32)
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_SET_TARGET, { targetID }, 0)
+	Test.waitUntil(function()
+		return Spring.GetUnitRulesParam(sourceID, "unitTargetID") == targetID and weaponTarget(sourceID) == targetID
+	end, 120)
+	Spring.GiveOrderToUnit(sourceID, CMD.ATTACK, { targetID }, 0)
+	Test.waitFrames(2)
+	local commandID, options, tag, commandTarget = Spring.GetUnitCurrentCommand(sourceID)
+	assertEqual(commandID, CMD.ATTACK, "explicit Attack is current")
+	assertEqual(math.bit_and(options, CMD.OPT_INTERNAL), 0, "Attack belongs to the player")
+	assertEqual(commandTarget, targetID, "explicit Attack owns the same target")
+
+	Spring.GiveOrderToUnit(sourceID, GameCMD.UNIT_CANCEL_TARGET, {}, 0)
+	Test.waitFrames(2)
+	local currentID, _, currentTag = Spring.GetUnitCurrentCommand(sourceID)
+	assertEqual(currentID, CMD.ATTACK, "Clear Target preserves explicit Attack")
+	assertEqual(currentTag, tag, "the original explicit command survives")
+	local target, isUserTarget = weaponTarget(sourceID)
+	assertEqual(target, targetID, "explicit Attack retains its weapon target")
+	assertEqual(isUserTarget, true, "explicit Attack retains user target ownership")
+	assertEqual(Spring.GetUnitRulesParam(sourceID, "hasPriorityTarget"), nil, "Set Target list is cleared")
+end
+
+function test()
+	checkRelease(false)
+	Test.clearMap()
+	checkRelease(true)
+	Test.clearMap()
+	checkExplicitAttack()
 end
 
 return {


### PR DESCRIPTION
### Work done

Set Target left the unit firing at a target the player had just removed, in two ways:

1. **Clear Target / list end on mobile units.** On Fire at Will the engine wraps the unit's weapon target into an automatic (internal) Attack command with a timeout of several seconds (`CMobileCAI::MobileAutoGenerateTarget`). When the Set Target that produced it was cleared, the gadget released the weapon target, but the automatic Attack stayed at the front of the queue and re-applied the same target (directly and through `restoreCommandTarget`) until it timed out. The unit kept firing at the cleared target for up to five seconds and only then re-evaluated its targets. The gadget now removes an automatic Attack on the released target when it releases it (`dropAutomaticAttack`, used by `setTargetPassive` and `removeUnit`).
2. **Cancel Target on the active entry.** `removeTarget` only forgot the entry (`activeTarget = false`) and `updateTargetList` only releases the weapon target while `activeTarget` is still set, so a unit whose remaining listed targets were out of range kept firing at the cancelled one indefinitely. `removeTarget` now calls `setTargetPassive` for the active entry; the next update picks another listed target if one is attackable.

Behaviour after this change: clearing or cancelling the target a unit is firing at releases it in the same frame. Which opportunity target the unit picks afterwards is up to the engine's target selection, as for any unit without a Set Target.

### Addresses issue(s)

Fixes #9176

### Testing

Two new headless tests in `luaui/Tests/set_target` (`runtestsheadless set_target`, engine 2026.07.04, Supreme Isthmus):

- `test_clear_target_releases_automatic_attack.lua`: Stumpy on hold fire gets a Set Target in range, switches to Fire at Will until the engine's automatic Attack on that target appears, then Clear Target. Asserts the priority target, the list and the automatic Attack are gone two frames later, no user target remains, and the cleared target does not return as priority target.
- `test_cancel_active_target_releases.lua`: Flak with a far (out of range) and a near listed target, firing at the near one; Cancel Target on the near one. Asserts the entry is removed, weapon target and `unitTargetID` are released two frames later and stay released while only the far target remains.

Both fail on `master` (the first at the automatic-Attack assertion, the second at the weapon-target assertion) and pass with this change. `lx test` unchanged (the three `mission_options_spec` failures are present on `master`).

Reproduction of the original report: headless probe on `da09265374` with the Stumpy setup above showed the internal Attack `20(target|8)` surviving Clear Target for 150 frames before the unit switched targets; with a static unit (flak, no automatic Attack) only the Cancel Target case reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
