### PR TITLE
colvols: model-based unit volumes

### DIFF
--- a/luarules/configs/collisionvolumes.lua
+++ b/luarules/configs/collisionvolumes.lua
@@ -645,24 +645,44 @@ propagateToScavCopies(dynamicPieceCollisionVolume)
 -- Units with no config volume would assume one the engine derives from their model.
 -- It does not do an adequate job for many cases, all of which are corrected below.
 
-local MODEL_TO_VOLUME = {
-	["3DO"] = {
-		SCALE = 0.68,
-		SMALL_RADIUS = 47,
-		SMALL_SCALE = 0.73,
-		VTOL_SCALE_XZ = 0.53,
-		VTOL_SCALE_Y = 0.17,
-		VTOL_HEIGHT_MIN = 13,
-		VTOL_TRANSPORT_SIZE = 16,
-		VTOL_VOLUME_TYPE = COLVOL_SHAPE.CYLINDER,
-		VTOL_VOLUME_AXIS = COLVOL_AXIS.Y,
+local modelVolumes = {
+	UNIT = {
+		["3do"] = {
+			SCALE = 0.68,
+			SMALL_RADIUS = 47,
+			SMALL_SCALE = 0.73,
+			VTOL_SCALE_XZ = 0.53,
+			VTOL_SCALE_Y = 0.17,
+			VTOL_HEIGHT_MIN = 13,
+			VTOL_TRANSPORT_SIZE = 16,
+			VTOL_VOLUME_TYPE = COLVOL_SHAPE.CYLINDER,
+			VTOL_VOLUME_AXIS = COLVOL_AXIS.Y,
+		},
+		["s3o"] = {
+			VTOL_SCALE_XZ = 1.15,
+			VTOL_SCALE_Y = 0.33,
+			VTOL_HEIGHT_MIN = 13,
+			VTOL_VOLUME_TYPE = COLVOL_SHAPE.SPHERE,
+			VTOL_VOLUME_AXIS = COLVOL_AXIS.X,
+		},
 	},
-	["S3O"] = {
-		VTOL_SCALE_XZ = 1.15,
-		VTOL_SCALE_Y = 0.33,
-		VTOL_HEIGHT_MIN = 13,
-		VTOL_VOLUME_TYPE = COLVOL_SHAPE.SPHERE,
-		VTOL_VOLUME_AXIS = COLVOL_AXIS.X,
+	FEATURE = {
+		-- Scaled every time any 3do feature is created.
+		-- 3do is largely deprecated but we support it for common asset reuse.
+		["3do"] = {
+			RADIUS_SCALE = 0.68,
+			HEIGHT_SCALE = 0.60,
+			SMALL_RADIUS = 47,
+			SMALL_RADIUS_SCALE = 0.75,
+			SMALL_HEIGHT_SCALE = 0.67,
+			HEIGHT_TO_OFFSET = -0.1323529,
+		},
+		-- Scaled only on features that exist on the map.
+		-- BAR s3o features are wrecks and heaps with exact colvol dimensions.
+		["s3o"] = {
+			HEIGHT_SCALE = 0.75,
+			HEIGHT_TO_OFFSET = -0.09,
+		},
 	},
 }
 
@@ -671,6 +691,7 @@ local isSphereShape = {
 	[COLVOL_SHAPE.SPHERE] = true,
 }
 
+---@param colvol UnitCollisionVolumeData Unit volumes only. Pieces do not default to a sphere.
 local function isDefaultSphere(colvol)
 	return isSphereShape[colvol[7]] and colvol[1] == colvol[2] and colvol[2] == colvol[3]
 end
@@ -729,10 +750,64 @@ local function rescaleUnitFromS3O(colvol, model, unitDef)
 	end
 end
 
-local rescaleUnit = {
-	["3DO"] = rescaleUnitFrom3DO,
-	["S3O"] = rescaleUnitFromS3O,
-}
+local function rescaleFeatureFrom3DO(featureID)
+	local model = modelVolumes.FEATURE["3do"]
+	local radiusScale, heightScale
+	if Spring.GetFeatureRadius(featureID) > model.SMALL_RADIUS then
+		radiusScale, heightScale = model.RADIUS_SCALE, model.HEIGHT_SCALE
+	else
+		radiusScale, heightScale = model.SMALL_RADIUS_SCALE, model.SMALL_HEIGHT_SCALE
+	end
+	---@type UnitCollisionVolumeData
+	local colvol = { Spring.GetFeatureCollisionVolumeData(featureID) }
+	if isDefaultSphere(colvol) then
+		local yOffset = colvol[5] + colvol[2] * model.HEIGHT_TO_OFFSET * radiusScale
+		Spring.SetFeatureCollisionVolumeData(
+			featureID,
+			colvol[1] * radiusScale,
+			colvol[2] * heightScale,
+			colvol[3] * radiusScale,
+			colvol[4],
+			yOffset,
+			colvol[6],
+			colvol[7],
+			colvol[8],
+			colvol[9]
+		)
+	end
+	Spring.SetFeatureRadiusAndHeight(
+		featureID,
+		Spring.GetFeatureRadius(featureID) * radiusScale,
+		Spring.GetFeatureHeight(featureID) * heightScale
+	)
+end
+
+local function rescaleFeatureFromS3O(featureID)
+	local model = modelVolumes.FEATURE["s3o"]
+	---@type UnitCollisionVolumeData
+	local colvol = { Spring.GetFeatureCollisionVolumeData(featureID) }
+	if isDefaultSphere(colvol) then
+		local yOffset = colvol[5] + colvol[2] * model.HEIGHT_TO_OFFSET
+		Spring.SetFeatureCollisionVolumeData(
+			featureID,
+			colvol[1],
+			colvol[2] * model.HEIGHT_SCALE,
+			colvol[3],
+			colvol[4],
+			yOffset,
+			colvol[6],
+			colvol[7],
+			colvol[8],
+			colvol[9]
+		)
+	end
+end
+
+modelVolumes.UNIT["3do"].rescale = rescaleUnitFrom3DO
+modelVolumes.UNIT["s3o"].rescale = rescaleUnitFromS3O
+modelVolumes.FEATURE["3do"].rescale = rescaleFeatureFrom3DO
+modelVolumes.FEATURE["s3o"].rescale = rescaleFeatureFromS3O
+modelVolumes.isDefaultSphere = isDefaultSphere
 
 -- The unitdef does not give the primaryAxis value, yet (see engine unitdefs-collisionvolume-primaryaxis).
 -- Also, accessing unitDef.model has to preload the model, which is an enormous load-time performance cost.
@@ -753,10 +828,9 @@ local function getModelUnitCollisionVolume(unitDef)
 		COLVOL_AXIS.Z,
 	}
 
-	local modelType = unitDef.modelType and unitDef.modelType:upper()
-	local model = modelType and MODEL_TO_VOLUME[modelType] ---@as any
+	local model = modelVolumes.UNIT[unitDef.modeltype] ---@as table?
 	if model then
-		rescaleUnit[modelType](colvol, model, unitDef)
+		model.rescale(colvol, model, unitDef)
 	end
 
 	if colvol[7] == COLVOL_SHAPE.CYLINDER then
@@ -795,4 +869,4 @@ for unitName, configType in pairs(unitColVolTypeIndex) do
 end
 
 -- Lacks an explicit unit + dynamic table:
-return unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume
+return unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume, modelVolumes

--- a/luarules/configs/collisionvolumes.lua
+++ b/luarules/configs/collisionvolumes.lua
@@ -79,7 +79,6 @@ Spring.SetUnitPieceCollisionVolumeData ( number unitID, number pieceIndex, boole
 	A: You need to edit the unit script and set ARMORED status to on or off depending on the
 	   unit's on/off status, unarmored for on and armored for off
 ]]
---
 
 -- Engine types ----------------------------------------------------------------
 
@@ -89,15 +88,18 @@ Spring.SetUnitPieceCollisionVolumeData ( number unitID, number pieceIndex, boole
 ---|1 CYLINDER
 ---|2 BOX
 ---|3 SPHERE
+local COLVOL_SHAPE = { ELLIPSOID = 0, CYLINDER = 1, BOX = 2, SPHERE = 3 } ---@type table<string, VolumeShapeIndex>
 
 ---@alias VolumeHitTestType
 ---|0 DISCRETE
 ---|1 CONTINUOUS
+local COLVOL_TEST = { DISCRETE = 0, CONTINUOUS = 1 } ---@type table<string, VolumeHitTestType>
 
 ---@alias VolumeAxisIndex
 ---|0 X
 ---|1 Y
 ---|2 Z
+local COLVOL_AXIS = { X = 0, Y = 1, Z = 2 } ---@type table<string, VolumeAxisIndex>
 
 ---See `LuaUtils::ParseColVolData`.
 ---@class UnitCollisionVolumeData
@@ -638,6 +640,141 @@ propagateToScavCopies(dynamicUnitCollisionVolume)
 propagateToScavCopies(staticPieceCollisionVolume)
 propagateToScavCopies(dynamicPieceCollisionVolume)
 
+-- Model conversions -----------------------------------------------------------
+
+-- Units with no config volume would assume one the engine derives from their model.
+-- It does not do an adequate job for many cases, all of which are corrected below.
+
+local MODEL_TO_VOLUME = {
+	["3DO"] = {
+		SCALE = 0.68,
+		SMALL_RADIUS = 47,
+		SMALL_SCALE = 0.73,
+		VTOL_SCALE_XZ = 0.53,
+		VTOL_SCALE_Y = 0.17,
+		VTOL_HEIGHT_MIN = 13,
+		VTOL_TRANSPORT_SIZE = 16,
+		VTOL_VOLUME_TYPE = COLVOL_SHAPE.CYLINDER,
+		VTOL_VOLUME_AXIS = COLVOL_AXIS.Y,
+	},
+	["S3O"] = {
+		VTOL_SCALE_XZ = 1.15,
+		VTOL_SCALE_Y = 0.33,
+		VTOL_HEIGHT_MIN = 13,
+		VTOL_VOLUME_TYPE = COLVOL_SHAPE.SPHERE,
+		VTOL_VOLUME_AXIS = COLVOL_AXIS.X,
+	},
+}
+
+local isSphereShape = {
+	[COLVOL_SHAPE.ELLIPSOID] = true,
+	[COLVOL_SHAPE.SPHERE] = true,
+}
+
+local function isDefaultSphere(colvol)
+	return isSphereShape[colvol[7]] and colvol[1] == colvol[2] and colvol[2] == colvol[3]
+end
+
+local function waterDepth(unitDef)
+	return unitDef.moveDef and unitDef.moveDef.depth or unitDef.maxWaterDepth
+end
+
+local function rescaleUnitFrom3DO(colvol, model, unitDef)
+	local unitCanFly = unitDef.canFly
+	local unitRadius = unitDef.radius
+
+	local scaleXZ, scaleY
+	if unitCanFly then
+		scaleXZ, scaleY = model.VTOL_SCALE_XZ, model.VTOL_SCALE_Y
+	elseif unitRadius > model.SMALL_RADIUS then
+		scaleXZ, scaleY = model.SCALE, model.SCALE
+	else
+		scaleXZ, scaleY = model.SMALL_SCALE, model.SMALL_SCALE
+	end
+
+	if isDefaultSphere(colvol) then
+		colvol[1] = colvol[1] * scaleXZ
+		colvol[2] = colvol[2] * scaleY
+		colvol[3] = colvol[3] * scaleXZ
+		if unitCanFly then
+			colvol[2] = math.max(colvol[2], model.VTOL_HEIGHT_MIN)
+			colvol[7] = model.VTOL_VOLUME_TYPE
+			colvol[9] = model.VTOL_VOLUME_AXIS
+		end
+	end
+
+	if unitCanFly and unitDef.transportCapacity > 0 then
+		colvol.radius = model.VTOL_TRANSPORT_SIZE
+		colvol.height = model.VTOL_TRANSPORT_SIZE
+	else
+		colvol.radius = unitRadius * scaleXZ
+		colvol.height = unitDef.height * scaleY
+	end
+
+	-- Underwater units need their midpoint plus model radius below the surface.
+	local depth = waterDepth(unitDef)
+	if unitDef.modCategories.underwater and depth and depth + unitRadius > 0 then
+		colvol.radius = depth - 1
+		colvol.height = unitDef.height
+	end
+end
+
+local function rescaleUnitFromS3O(colvol, model, unitDef)
+	if unitDef.canFly and isDefaultSphere(colvol) then
+		colvol[1] = colvol[1] * model.VTOL_SCALE_XZ
+		colvol[2] = math.max(colvol[2] * model.VTOL_SCALE_Y, model.VTOL_HEIGHT_MIN)
+		colvol[3] = colvol[3] * model.VTOL_SCALE_XZ
+		colvol[7] = model.VTOL_VOLUME_TYPE
+		colvol[9] = model.VTOL_VOLUME_AXIS
+	end
+end
+
+local rescaleUnit = {
+	["3DO"] = rescaleUnitFrom3DO,
+	["S3O"] = rescaleUnitFromS3O,
+}
+
+-- The unitdef does not give the primaryAxis value, yet (see engine unitdefs-collisionvolume-primaryaxis).
+-- Also, accessing unitDef.model has to preload the model, which is an enormous load-time performance cost.
+
+local function getModelUnitCollisionVolume(unitDef)
+	local defVolume = unitDef.collisionVolume
+
+	---@type UnitCollisionVolumeData
+	local colvol = {
+		defVolume.scaleX,
+		defVolume.scaleY,
+		defVolume.scaleZ,
+		defVolume.offsetX,
+		defVolume.offsetY,
+		defVolume.offsetZ,
+		COLVOL_SHAPE[defVolume.type:upper()] or COLVOL_SHAPE.SPHERE,
+		COLVOL_TEST.CONTINUOUS,
+		COLVOL_AXIS.Z,
+	}
+
+	local modelType = unitDef.modelType and unitDef.modelType:upper()
+	local model = modelType and MODEL_TO_VOLUME[modelType] ---@as any
+	if model then
+		rescaleUnit[modelType](colvol, model, unitDef)
+	end
+
+	if colvol[7] == COLVOL_SHAPE.CYLINDER then
+		colvol[9] = nil -- Not known with accuracy until the first unitdef is created for each model.
+	end
+
+	return colvol
+end
+
+-- Model-based volume applied when a unit is created, then overridden after. Piece colvols ignore this.
+local modelUnitCollisionVolume = {} ---@type table<string, ColVolUnitDef>
+
+for unitName, unitDef in pairs(UnitDefNames) do
+	if not unitDef.collisionVolume.defaultToPieceTree then
+		modelUnitCollisionVolume[unitName] = getModelUnitCollisionVolume(unitDef)
+	end
+end
+
 local unitColVolTypeIndex = {} ---@type table<string, ColVolConfigType>
 for configType = 1, #colVolConfigs do
 	for unitName in pairs(colVolConfigs[configType]) do
@@ -658,4 +795,4 @@ for unitName, configType in pairs(unitColVolTypeIndex) do
 end
 
 -- Lacks an explicit unit + dynamic table:
-return unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume
+return unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume

--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -13,9 +13,8 @@ function gadget:GetInfo()
 end
 
 if gadgetHandler:IsSyncedCode() then
-	-- Pop-up style unit and per piece collision volume definitions
 	local popupUnits = {} --list of pop-up style units
-	local unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume
+	local unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume
 
 	-- Localization and speedups
 	local spSetPieceCollisionData = Spring.SetUnitPieceCollisionVolumeData
@@ -54,7 +53,7 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:Initialize()
-		unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume =
+		unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume =
 			include("LuaRules/Configs/CollisionVolumes.lua")
 
 		local allFeatures = Spring.GetAllFeatures()
@@ -155,53 +154,15 @@ if gadgetHandler:IsSyncedCode() then
 					spSetPieceCollisionData(unitID, pieceIndex, false, 1, 1, 1, 0, 0, 0, 1, 1)
 				end
 			end
-		elseif unitModeltype[unitDefID] == "3do" then
-			local rs, hs, ws
-			local r = spGetUnitRadius(unitID)
-			if r > 47 and not canFly[unitDefID] then
-				rs, hs, ws = 0.68, 0.68, 0.68
-			elseif not canFly[unitDefID] then
-				rs, hs, ws = 0.73, 0.73, 0.73
-			else
-				rs, hs, ws = 0.53, 0.17, 0.53
+		elseif modelUnitCollisionVolume[unitName[unitDefID]] then
+			local v = modelUnitCollisionVolume[unitName[unitDefID]]
+			if v[9] == nil then
+				-- The first unit created of a given model provides the missing primaryAxis value.
+				v[9] = select(9, spGetUnitCollisionData(unitID))
 			end
-			local xs, ys, zs, xo, yo, zo, vtype, htype, axis, _ = spGetUnitCollisionData(unitID)
-			if vtype >= 3 and xs == ys and ys == zs then
-				if ys * hs < 13 and canFly[unitDefID] then -- Limit Max V height
-					spSetUnitCollisionData(unitID, xs * ws, 13, zs * rs, xo, yo, zo, 1, htype, 1)
-				elseif canFly[unitDefID] then
-					spSetUnitCollisionData(unitID, xs * ws, ys * hs, zs * rs, xo, yo, zo, 1, htype, 1)
-				else
-					spSetUnitCollisionData(unitID, xs * ws, ys * hs, zs * rs, xo, yo, zo, vtype, htype, axis)
-				end
-			end
-
-			-- set aircraft size
-			if canFly[unitDefID] and UnitDefs[unitDefID].transportCapacity > 0 then
-				spSetUnitRadiusAndHeight(unitID, 16, 16)
-			else
-				spSetUnitRadiusAndHeight(unitID, spGetUnitRadius(unitID) * rs, spGetUnitHeight(unitID) * hs)
-			end
-
-			-- make sure underwater units are really underwater (need midpoint + model radius <0)
-			local h = spGetUnitHeight(unitID)
-			local wd = UnitDefs[unitDefID].minWaterDepth
-			if UnitDefs[unitDefID].modCategories.underwater and wd and wd + r > 0 then
-				spSetUnitRadiusAndHeight(unitID, wd - 1, h)
-			end
-		elseif unitModeltype[unitDefID] == "s3o" then
-			if canFly[unitDefID] then
-				local rs, hs, ws = 1.15, 0.33, 1.15 -- dont know why 3do uses: 0.53, 0.17, 0.53
-				local xs, ys, zs, xo, yo, zo, vtype, htype, axis, _ = spGetUnitCollisionData(unitID)
-				if vtype >= 3 and xs == ys and ys == zs then
-					if ys * hs < 13 then -- Limit Max V height
-						spSetUnitCollisionData(unitID, xs * ws, 13, zs * rs, xo, yo, zo, 3, htype, 0)
-					elseif canFly[unitDefID] then
-						spSetUnitCollisionData(unitID, xs * ws, ys * hs, zs * rs, xo, yo, zo, 3, htype, 0)
-					else
-						spSetUnitCollisionData(unitID, xs * ws, ys * hs, zs * rs, xo, yo, zo, vtype, htype, axis)
-					end
-				end
+			spSetUnitCollisionData(unitID, v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9])
+			if v.radius then
+				spSetUnitRadiusAndHeight(unitID, v.radius, v.height)
 			end
 		end
 

--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -174,7 +174,7 @@ if gadgetHandler:IsSyncedCode() then
 			end
 			if defs.state ~= stateInt then
 				if defs.perPiece then
-					t = dynamicPieceCollisionVolume[defs.name][stateString]
+					t = dynamicPieceCollisionVolume[defs.name][stateString] ---@as table
 					for pieceIndex, piece in pairs(t) do
 						if type(pieceIndex) == "number" then
 							spSetPieceCollisionData(
@@ -206,7 +206,8 @@ if gadgetHandler:IsSyncedCode() then
 					if unitHeight == nil then -- had error once, hope this nil check helps
 						popupUnits[unitID] = nil
 					else
-						p = unitCollisionVolume[defs.name][stateString]
+						---@diagnostic disable: need-check-nil, param-type-mismatch
+						p = unitCollisionVolume[defs.name][stateString] ---@as table
 						spSetUnitCollisionData(unitID, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9])
 						if p[10] then
 							spSetUnitMidAndAimPos(unitID, 0, unitHeight / 2, 0, p[10], p[11], p[12], true)

--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -14,7 +14,7 @@ end
 
 if gadgetHandler:IsSyncedCode() then
 	local popupUnits = {} --list of pop-up style units
-	local unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume
+	local unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume, modelToVolume
 
 	-- Localization and speedups
 	local spSetPieceCollisionData = Spring.SetUnitPieceCollisionVolumeData
@@ -23,22 +23,15 @@ if gadgetHandler:IsSyncedCode() then
 	local spGetUnitCollisionData = Spring.GetUnitCollisionVolumeData
 	local spSetUnitCollisionData = Spring.SetUnitCollisionVolumeData
 	local spSetUnitRadiusAndHeight = Spring.SetUnitRadiusAndHeight
-	local spGetUnitRadius = Spring.GetUnitRadius
 	local spGetUnitHeight = Spring.GetUnitHeight
 	local spSetUnitMidAndAimPos = Spring.SetUnitMidAndAimPos
-	local spGetFeatureCollisionData = Spring.GetFeatureCollisionVolumeData
-	local spSetFeatureCollisionData = Spring.SetFeatureCollisionVolumeData
-	local spSetFeatureRadiusAndHeight = Spring.SetFeatureRadiusAndHeight
-	local spGetFeatureRadius = Spring.GetFeatureRadius
-	local spGetFeatureHeight = Spring.GetFeatureHeight
+	local spGetFeatureDefID = Spring.GetFeatureDefID
 
 	local spArmor = Spring.GetUnitArmored
 	local pairs = pairs
-	local is3doFeature = {}
+	local featureModelType = {}
 	for featureDefID, def in pairs(FeatureDefs) do
-		if def.modelpath:lower():find(".3do") then
-			is3doFeature[featureDefID] = true
-		end
+		featureModelType[featureDefID] = def.modeltype
 	end
 
 	local unitName = {}
@@ -53,42 +46,14 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:Initialize()
-		unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume =
+		unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume, modelToVolume =
 			include("LuaRules/Configs/CollisionVolumes.lua")
 
 		local allFeatures = Spring.GetAllFeatures()
 		for i = 1, #allFeatures do
 			local featID = allFeatures[i]
-			local modelpath = FeatureDefs[Spring.GetFeatureDefID(featID)].modelpath
-			local featureModel = modelpath:lower()
-			if featureModel:find(".3do") then
-				local rs, hs
-				if spGetFeatureRadius(featID) > 47 then
-					rs, hs = 0.68, 0.60
-				else
-					rs, hs = 0.75, 0.67
-				end
-				local xs, ys, zs, xo, yo, zo, vtype, htype, axis, _ = spGetFeatureCollisionData(featID)
-				if vtype >= 3 and xs == ys and ys == zs then
-					spSetFeatureCollisionData(
-						featID,
-						xs * rs,
-						ys * hs,
-						zs * rs,
-						xo,
-						yo - ys * 0.1323529 * rs,
-						zo,
-						vtype,
-						htype,
-						axis
-					)
-				end
-				spSetFeatureRadiusAndHeight(featID, spGetFeatureRadius(featID) * rs, spGetFeatureHeight(featID) * hs)
-			elseif featureModel:find(".s3o") then
-				local xs, ys, zs, xo, yo, zo, vtype, htype, axis, _ = spGetFeatureCollisionData(featID)
-				if vtype >= 3 and xs == ys and ys == zs then
-					spSetFeatureCollisionData(featID, xs, ys * 0.75, zs, xo, yo - ys * 0.09, zo, vtype, htype, axis)
-				end
+			if featureModelType[spGetFeatureDefID(featID)] == "s3o" then
+				modelToVolume.FEATURE["s3o"].rescale(featID)
 			end
 		end
 		local allUnits = Spring.GetAllUnits()
@@ -179,36 +144,9 @@ if gadgetHandler:IsSyncedCode() then
 		end
 	end
 
-	-- Same as for 3DO units, but for features
 	function gadget:FeatureCreated(featureID, allyTeam)
-		local featureDefID = Spring.GetFeatureDefID(featureID)
-		if is3doFeature[featureDefID] then
-			local rs, hs
-			if spGetFeatureRadius(featureID) > 47 then
-				rs, hs = 0.68, 0.60
-			else
-				rs, hs = 0.75, 0.67
-			end
-			local xs, ys, zs, xo, yo, zo, vtype, htype, axis, _ = spGetFeatureCollisionData(featureID)
-			if vtype >= 3 and xs == ys and ys == zs then
-				spSetFeatureCollisionData(
-					featureID,
-					xs * rs,
-					ys * hs,
-					zs * rs,
-					xo,
-					yo - ys * 0.09,
-					zo,
-					vtype,
-					htype,
-					axis
-				)
-			end
-			spSetFeatureRadiusAndHeight(
-				featureID,
-				spGetFeatureRadius(featureID) * rs,
-				spGetFeatureHeight(featureID) * hs
-			)
+		if featureModelType[spGetFeatureDefID(featureID)] == "3do" then
+			modelToVolume.FEATURE["3do"].rescale(featureID)
 		end
 	end
 


### PR DESCRIPTION
### Work done

Moves all engine and file-format data out of the dynamic collision volumes and into configuration. Separates the responsibilities of the gadget away from knowing what any of this is or means. The gadget now relies on the api contracts in the getters and setters provided by the engine without needing to do internal representation or other work.