### PR TITLE
refactor: collisionvolumes as a proper lua module, re-key volumes by unitDefID

### DIFF
--- a/luarules/configs/collisionvolumes.lua
+++ b/luarules/configs/collisionvolumes.lua
@@ -115,6 +115,7 @@ local COLVOL_AXIS = { X = 0, Y = 1, Z = 2 } ---@type table<string, VolumeAxisInd
 ---@field [10]? boolean ignoreHits Returned by the getter, ignored by the setter, which reads nine.
 ---@field radius number?
 ---@field height number?
+---@field offsets? xyz aimpoint offsets, unit-space coordinates `{ x, y, z }`
 
 ---See `LuaUtils::PushColVolTable`.
 ---@class UnitDefCollisionVolume
@@ -593,6 +594,23 @@ for _, colvol in pairs(dynamicPieceCollisionVolume) do
 	shiftPieceIndex(colvol.off)
 end
 
+-- Unit volumes can append aimpoint offsets to their volume data arrays, but pieces cannot.
+-- Move all offsets to the `offsets` subtable so we can reference them clearly with pieces.
+local function shiftAimOffsets(colvol)
+	if colvol[10] then
+		colvol.offsets = { colvol[10], colvol[11], colvol[12] }
+		colvol[10], colvol[11], colvol[12] = nil, nil, nil
+	end
+end
+
+for _, colvol in pairs(staticUnitCollisionVolume) do
+	shiftAimOffsets(colvol)
+end
+for _, colvol in pairs(dynamicUnitCollisionVolume) do
+	shiftAimOffsets(colvol.on)
+	shiftAimOffsets(colvol.off)
+end
+
 -- Copies have to come after the shift to prevent double-shifting them.
 -- TODO: copied collision volumes should be declarative
 
@@ -840,33 +858,53 @@ local function getModelUnitCollisionVolume(unitDef)
 	return colvol
 end
 
--- Model-based volume applied when a unit is created, then overridden after. Piece colvols ignore this.
-local modelUnitCollisionVolume = {} ---@type table<string, ColVolUnitDef>
-
-for unitName, unitDef in pairs(UnitDefNames) do
-	if not unitDef.collisionVolume.defaultToPieceTree then
-		modelUnitCollisionVolume[unitName] = getModelUnitCollisionVolume(unitDef)
-	end
-end
-
-local unitColVolTypeIndex = {} ---@type table<string, ColVolConfigType>
+local unitColVolTypeIndex = {} ---@type table<string, ColVolConfigType?>
 for configType = 1, #colVolConfigs do
 	for unitName in pairs(colVolConfigs[configType]) do
 		unitColVolTypeIndex[unitName] = configType
 	end
 end
 
--- TODO: For now, we reunify the config tables into the consumer's tables. Later these should not merge.
-local unitCollisionVolume = {}
-local pieceCollisionVolume = {}
+-- Export module ---------------------------------------------------------------
 
-for unitName, configType in pairs(unitColVolTypeIndex) do
-	if configType == COLVOL_CONFIG.UNIT_STATIC or configType == COLVOL_CONFIG.UNIT_DYNAMIC then
-		unitCollisionVolume[unitName] = colVolConfigs[configType][unitName]
-	elseif configType == COLVOL_CONFIG.PIECE_STATIC then
-		pieceCollisionVolume[unitName] = colVolConfigs[configType][unitName]
+-- The tables above are keyed by unit name for configuration. Runtime code reads by unitDefID.
+local unitDefColVolType = {} ---@type table<integer, ColVolConfigType?>
+local unitDefColVolData = {} ---@type table<integer, UnitColVolConfig?>
+-- Model-based volume applied when a unit is created, then overridden by config. Piece colvols ignore this.
+local unitDefModelColVol = {} ---@type table<integer, UnitCollisionVolumeData?>
+
+for unitDefID, unitDef in pairs(UnitDefs) do
+	local configType = unitColVolTypeIndex[unitDef.name]
+	if configType then
+		unitDefColVolType[unitDefID] = configType
+		unitDefColVolData[unitDefID] = colVolConfigs[configType][unitDef.name]
+	end
+	local usesPieces = unitDef.collisionVolume.defaultToPieceTree
+		or configType == COLVOL_CONFIG.PIECE_STATIC
+		or configType == COLVOL_CONFIG.PIECE_DYNAMIC
+	if not usesPieces then
+		unitDefModelColVol[unitDefID] = getModelUnitCollisionVolume(unitDef)
 	end
 end
 
--- Lacks an explicit unit + dynamic table:
-return unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume, modelVolumes
+---@class CollisionVolumes
+---@field COLVOL { SHAPE: table<string, VolumeShapeIndex>, AXIS: table<string, VolumeAxisIndex>, TEST: table<string, VolumeHitTestType>, CONFIG: table<string, ColVolConfigType> }
+---@field ColVolConfigs CollisionVolumeConfigs
+---@field UnitDefColVolType table<integer, ColVolConfigType?>
+---@field UnitDefColVolData table<integer, UnitColVolConfig?>
+---@field UnitDefModelColVol table<integer, UnitCollisionVolumeData?>
+---@field PieceColVolDisabled PieceCollisionVolumeData
+---@field ModelVolumes table
+
+---@type CollisionVolumes
+local CollisionVolumes = {
+	COLVOL = { SHAPE = COLVOL_SHAPE, AXIS = COLVOL_AXIS, TEST = COLVOL_TEST, CONFIG = COLVOL_CONFIG },
+	ColVolConfigs = colVolConfigs,
+	UnitDefColVolType = unitDefColVolType,
+	UnitDefColVolData = unitDefColVolData,
+	UnitDefModelColVol = unitDefModelColVol,
+	PieceColVolDisabled = pieceColVolDisabled,
+	ModelVolumes = modelVolumes,
+}
+
+return CollisionVolumes

--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -16,16 +16,6 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
-local CollisionVolumes = include("LuaRules/Configs/CollisionVolumes.lua") ---@type CollisionVolumes
-
-local COLVOL_CONFIG = CollisionVolumes.COLVOL.CONFIG
-local unitDefColVolType = CollisionVolumes.UnitDefColVolType
-local unitDefColVolData = CollisionVolumes.UnitDefColVolData
-local unitDefModelColVol = CollisionVolumes.UnitDefModelColVol
-local pieceColVolDisabled = CollisionVolumes.PieceColVolDisabled
-local rescaleFeature3DO = CollisionVolumes.ModelVolumes.FEATURE["3do"].rescale
-local rescaleFeatureS3O = CollisionVolumes.ModelVolumes.FEATURE["s3o"].rescale
-
 local spGetFeatureDefID = Spring.GetFeatureDefID
 local spGetUnitArmored = Spring.GetUnitArmored
 local spGetUnitCollisionData = Spring.GetUnitCollisionVolumeData
@@ -37,7 +27,16 @@ local spSetUnitCollisionData = Spring.SetUnitCollisionVolumeData
 local spSetUnitMidAndAimPos = Spring.SetUnitMidAndAimPos
 local spSetUnitRadiusAndHeight = Spring.SetUnitRadiusAndHeight
 
-local featureModelType = {}
+local CollisionVolumes = include("LuaRules/Configs/CollisionVolumes.lua") ---@type CollisionVolumes
+
+local COLVOL_CONFIG = CollisionVolumes.COLVOL.CONFIG
+local unitDefColVolType = CollisionVolumes.UnitDefColVolType
+local unitDefColVolData = CollisionVolumes.UnitDefColVolData
+local unitDefModelColVol = CollisionVolumes.UnitDefModelColVol
+local pieceColVolDisabled = CollisionVolumes.PieceColVolDisabled
+local rescaleFeature3DO = CollisionVolumes.ModelVolumes.FEATURE["3do"].rescale
+
+local featureModelType = {} ---@type {[FeatureDefID?]:("3do"|"s3o")?}
 for featureDefID, featureDef in pairs(FeatureDefs) do
 	featureModelType[featureDefID] = featureDef.modeltype
 end
@@ -101,7 +100,6 @@ local function setAimOffsets(unitID, unitHeight, offsets)
 	spSetUnitMidAndAimPos(unitID, 0, unitHeight / 2, 0, offsets[1], offsets[2], offsets[3], true)
 end
 
--- Applied after the model volume when a unit is created.
 local setConfigVolume = {
 	[COLVOL_CONFIG.UNIT_STATIC] = function(unitID, colvol)
 		setUnitVolume(unitID, colvol)
@@ -127,20 +125,16 @@ local setConfigVolume = {
 -- Engine callins --------------------------------------------------------------
 
 function gadget:Initialize()
-	local allFeatures = Spring.GetAllFeatures()
-	for i = 1, #allFeatures do
-		local featureID = allFeatures[i]
-		if featureModelType[spGetFeatureDefID(featureID)] == "s3o" then
-			rescaleFeatureS3O(featureID)
+	for _, featureID in ipairs(Spring.GetAllFeatures()) do
+		local modelType = featureModelType[spGetFeatureDefID(featureID)]
+		local modelData = modelType and CollisionVolumes.ModelVolumes.FEATURE[modelType]
+		if modelData and modelData.rescale then
+			modelData.rescale(featureID)
 		end
 	end
-	local allUnits = Spring.GetAllUnits()
-	for i = 1, #allUnits do
-		local unitID = allUnits[i]
+
+	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, spGetUnitDefID(unitID))
-	end
-	for i = 1, #allFeatures do
-		gadget:FeatureCreated(allFeatures[i])
 	end
 end
 
@@ -163,14 +157,14 @@ function gadget:UnitCreated(unitID, unitDefID)
 	end
 end
 
+function gadget:UnitDestroyed(unitID)
+	popupUnits[unitID] = nil
+end
+
 function gadget:FeatureCreated(featureID)
 	if featureModelType[spGetFeatureDefID(featureID)] == "3do" then
 		rescaleFeature3DO(featureID)
 	end
-end
-
-function gadget:UnitDestroyed(unitID)
-	popupUnits[unitID] = nil
 end
 
 function gadget:GameFrame(frame)
@@ -182,15 +176,15 @@ function gadget:GameFrame(frame)
 		local armored = spGetUnitArmored(unitID) == true
 		if popup.armored ~= armored then
 			local unitHeight = spGetUnitHeight(unitID)
-			if unitHeight == nil then
-				popupUnits[unitID] = nil
-			else
+			if unitHeight then
 				popup.armored = armored
 				local colvol = armored and popup.colvol.off or popup.colvol.on
 				popup.setVolume(unitID, colvol)
 				if colvol.offsets then
 					setAimOffsets(unitID, unitHeight, colvol.offsets)
 				end
+			else
+				popupUnits[unitID] = nil
 			end
 		end
 	end

--- a/luarules/gadgets/unit_dynamic_collision_volume.lua
+++ b/luarules/gadgets/unit_dynamic_collision_volume.lua
@@ -12,210 +12,184 @@ function gadget:GetInfo()
 	}
 end
 
-if gadgetHandler:IsSyncedCode() then
-	local popupUnits = {} --list of pop-up style units
-	local unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume, modelToVolume
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
 
-	-- Localization and speedups
-	local spSetPieceCollisionData = Spring.SetUnitPieceCollisionVolumeData
-	local spGetPieceList = Spring.GetUnitPieceList
-	local spGetUnitDefID = Spring.GetUnitDefID
-	local spGetUnitCollisionData = Spring.GetUnitCollisionVolumeData
-	local spSetUnitCollisionData = Spring.SetUnitCollisionVolumeData
-	local spSetUnitRadiusAndHeight = Spring.SetUnitRadiusAndHeight
-	local spGetUnitHeight = Spring.GetUnitHeight
-	local spSetUnitMidAndAimPos = Spring.SetUnitMidAndAimPos
-	local spGetFeatureDefID = Spring.GetFeatureDefID
+local CollisionVolumes = include("LuaRules/Configs/CollisionVolumes.lua") ---@type CollisionVolumes
 
-	local spArmor = Spring.GetUnitArmored
-	local pairs = pairs
-	local featureModelType = {}
-	for featureDefID, def in pairs(FeatureDefs) do
-		featureModelType[featureDefID] = def.modeltype
+local COLVOL_CONFIG = CollisionVolumes.COLVOL.CONFIG
+local unitDefColVolType = CollisionVolumes.UnitDefColVolType
+local unitDefColVolData = CollisionVolumes.UnitDefColVolData
+local unitDefModelColVol = CollisionVolumes.UnitDefModelColVol
+local pieceColVolDisabled = CollisionVolumes.PieceColVolDisabled
+local rescaleFeature3DO = CollisionVolumes.ModelVolumes.FEATURE["3do"].rescale
+local rescaleFeatureS3O = CollisionVolumes.ModelVolumes.FEATURE["s3o"].rescale
+
+local spGetFeatureDefID = Spring.GetFeatureDefID
+local spGetUnitArmored = Spring.GetUnitArmored
+local spGetUnitCollisionData = Spring.GetUnitCollisionVolumeData
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetUnitHeight = Spring.GetUnitHeight
+local spGetUnitPieceList = Spring.GetUnitPieceList
+local spSetPieceCollisionData = Spring.SetUnitPieceCollisionVolumeData
+local spSetUnitCollisionData = Spring.SetUnitCollisionVolumeData
+local spSetUnitMidAndAimPos = Spring.SetUnitMidAndAimPos
+local spSetUnitRadiusAndHeight = Spring.SetUnitRadiusAndHeight
+
+local featureModelType = {}
+for featureDefID, featureDef in pairs(FeatureDefs) do
+	featureModelType[featureDefID] = featureDef.modeltype
+end
+
+---@class PopupUnit
+---@field colvol ColVolUnitOnOff|ColVolPieceMapOnOff
+---@field setVolume fun(unitID: integer, colvol: UnitCollisionVolumeData|ColVolPieceMap)
+---@field armored boolean? Unset until the first update.
+
+local popupUnits = {} ---@type table<integer, PopupUnit>
+
+-- Setters ---------------------------------------------------------------------
+
+local function setUnitVolume(unitID, colvol)
+	spSetUnitCollisionData(
+		unitID,
+		colvol[1],
+		colvol[2],
+		colvol[3],
+		colvol[4],
+		colvol[5],
+		colvol[6],
+		colvol[7],
+		colvol[8],
+		colvol[9]
+	)
+end
+
+local function setPieceVolume(unitID, piece, colvol)
+	spSetPieceCollisionData(
+		unitID,
+		piece,
+		colvol[9] ~= false,
+		colvol[1],
+		colvol[2],
+		colvol[3],
+		colvol[4],
+		colvol[5],
+		colvol[6],
+		colvol[7],
+		colvol[8]
+	)
+end
+
+local function setAllPieceVolumes(unitID, pieceMap)
+	for piece = 1, #spGetUnitPieceList(unitID) do
+		-- Disable all pieces not included in the config piece map for safe init:
+		setPieceVolume(unitID, piece, pieceMap[piece] or pieceColVolDisabled)
 	end
+end
 
-	local unitName = {}
-	local unitModeltype = {}
-	local canFly = {}
-	for unitDefID, def in pairs(UnitDefs) do
-		unitName[unitDefID] = def.name
-		unitModeltype[unitDefID] = def.modeltype
-		if def.canFly then
-			canFly[unitDefID] = def.canFly
-		end
-	end
-
-	function gadget:Initialize()
-		unitCollisionVolume, pieceCollisionVolume, dynamicPieceCollisionVolume, modelUnitCollisionVolume, modelToVolume =
-			include("LuaRules/Configs/CollisionVolumes.lua")
-
-		local allFeatures = Spring.GetAllFeatures()
-		for i = 1, #allFeatures do
-			local featID = allFeatures[i]
-			if featureModelType[spGetFeatureDefID(featID)] == "s3o" then
-				modelToVolume.FEATURE["s3o"].rescale(featID)
-			end
-		end
-		local allUnits = Spring.GetAllUnits()
-		for i = 1, #allUnits do
-			local unitID = allUnits[i]
-			gadget:UnitCreated(unitID, spGetUnitDefID(unitID))
-		end
-		for i = 1, #allFeatures do
-			gadget:FeatureCreated(allFeatures[i])
-		end
-	end
-
-	--Reduces the diameter of default (unspecified) collision volume for 3DO models,
-	--for S3O models it's not needed and will in fact result in wrong collision volume
-	--also handles per piece collision volume definitions
-	--also makes sure subs are underwater
-	function gadget:UnitCreated(unitID, unitDefID, unitTeam)
-		if pieceCollisionVolume[unitName[unitDefID]] then
-			local t = pieceCollisionVolume[unitName[unitDefID]]
-			for pieceIndex = 1, #spGetPieceList(unitID) do
-				local p = t[pieceIndex]
-				if p then
-					spSetPieceCollisionData(
-						unitID,
-						pieceIndex,
-						p[9] ~= false,
-						p[1],
-						p[2],
-						p[3],
-						p[4],
-						p[5],
-						p[6],
-						p[7],
-						p[8]
-					)
-				else
-					spSetPieceCollisionData(unitID, pieceIndex, false, 1, 1, 1, 0, 0, 0, 1, 1)
-				end
-			end
-			if t.offsets then
-				local o = t.offsets
-				spSetUnitMidAndAimPos(unitID, 0, spGetUnitHeight(unitID) / 2, 0, o[1], o[2], o[3], true)
-			end
-		elseif dynamicPieceCollisionVolume[unitName[unitDefID]] then
-			local t = dynamicPieceCollisionVolume[unitName[unitDefID]].on
-			for pieceIndex = 1, #spGetPieceList(unitID) do
-				local p = t[pieceIndex]
-				if p then
-					spSetPieceCollisionData(
-						unitID,
-						pieceIndex,
-						p[9] ~= false,
-						p[1],
-						p[2],
-						p[3],
-						p[4],
-						p[5],
-						p[6],
-						p[7],
-						p[8]
-					)
-				else
-					spSetPieceCollisionData(unitID, pieceIndex, false, 1, 1, 1, 0, 0, 0, 1, 1)
-				end
-			end
-		elseif modelUnitCollisionVolume[unitName[unitDefID]] then
-			local v = modelUnitCollisionVolume[unitName[unitDefID]]
-			if v[9] == nil then
-				-- The first unit created of a given model provides the missing primaryAxis value.
-				v[9] = select(9, spGetUnitCollisionData(unitID))
-			end
-			spSetUnitCollisionData(unitID, v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9])
-			if v.radius then
-				spSetUnitRadiusAndHeight(unitID, v.radius, v.height)
-			end
-		end
-
-		-- Check if a unit is pop-up type (the list must be entered manually)
-		-- If a building was constructed add it to the list for later radius and height scaling
-		-- Changed from UnitFinished to UnitCreated
-		-- Some building's scripting change their collision while still under construction
-		-- These buildings should be added to the list of popupUnits to update when they are created, not when finished
-		local un = unitName[unitDefID]
-		if unitCollisionVolume[un] then
-			popupUnits[unitID] = { name = un, state = -1, perPiece = false }
-		elseif dynamicPieceCollisionVolume[un] then
-			popupUnits[unitID] = { name = un, state = -1, perPiece = true }
+local function setNamedPieceVolumes(unitID, pieceMap)
+	for piece, colvol in pairs(pieceMap) do
+		if type(piece) == "number" then
+			setPieceVolume(unitID, piece, colvol)
 		end
 	end
+end
 
-	function gadget:FeatureCreated(featureID, allyTeam)
-		if featureModelType[spGetFeatureDefID(featureID)] == "3do" then
-			modelToVolume.FEATURE["3do"].rescale(featureID)
+local function setAimOffsets(unitID, unitHeight, offsets)
+	spSetUnitMidAndAimPos(unitID, 0, unitHeight / 2, 0, offsets[1], offsets[2], offsets[3], true)
+end
+
+-- Applied after the model volume when a unit is created.
+local setConfigVolume = {
+	[COLVOL_CONFIG.UNIT_STATIC] = function(unitID, colvol)
+		setUnitVolume(unitID, colvol)
+		if colvol.offsets then
+			setAimOffsets(unitID, spGetUnitHeight(unitID), colvol.offsets)
+		end
+	end,
+	[COLVOL_CONFIG.UNIT_DYNAMIC] = function(unitID, colvol)
+		popupUnits[unitID] = { colvol = colvol, setVolume = setUnitVolume }
+	end,
+	[COLVOL_CONFIG.PIECE_STATIC] = function(unitID, colvol)
+		setAllPieceVolumes(unitID, colvol)
+		if colvol.offsets then
+			setAimOffsets(unitID, spGetUnitHeight(unitID), colvol.offsets)
+		end
+	end,
+	[COLVOL_CONFIG.PIECE_DYNAMIC] = function(unitID, colvol)
+		setAllPieceVolumes(unitID, colvol.on)
+		popupUnits[unitID] = { colvol = colvol, setVolume = setNamedPieceVolumes }
+	end,
+}
+
+-- Engine callins --------------------------------------------------------------
+
+function gadget:Initialize()
+	local allFeatures = Spring.GetAllFeatures()
+	for i = 1, #allFeatures do
+		local featureID = allFeatures[i]
+		if featureModelType[spGetFeatureDefID(featureID)] == "s3o" then
+			rescaleFeatureS3O(featureID)
+		end
+	end
+	local allUnits = Spring.GetAllUnits()
+	for i = 1, #allUnits do
+		local unitID = allUnits[i]
+		gadget:UnitCreated(unitID, spGetUnitDefID(unitID))
+	end
+	for i = 1, #allFeatures do
+		gadget:FeatureCreated(allFeatures[i])
+	end
+end
+
+function gadget:UnitCreated(unitID, unitDefID)
+	local modelColVol = unitDefModelColVol[unitDefID]
+	if modelColVol then
+		if modelColVol[9] == nil then
+			-- The def does not give the primary axis, so the first unit of the def does.
+			modelColVol[9] = select(9, spGetUnitCollisionData(unitID))
+		end
+		setUnitVolume(unitID, modelColVol)
+		if modelColVol.radius then
+			spSetUnitRadiusAndHeight(unitID, modelColVol.radius, modelColVol.height)
 		end
 	end
 
-	--check if a pop-up type unit was destroyed
-	function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
-		if popupUnits[unitID] then
-			popupUnits[unitID] = nil
-		end
+	local configType = unitDefColVolType[unitDefID]
+	if configType then
+		setConfigVolume[configType](unitID, unitDefColVolData[unitDefID])
 	end
+end
 
-	--Dynamic adjustment of pop-up style of units' collision volumes based on unit's ARMORED status, runs twice per second
-	--rescaling of radius and height of 3DO buildings
-	function gadget:GameFrame(n)
-		if n % 15 ~= 0 then
-			return
-		end
-		local p, t, stateString, stateInt
-		for unitID, defs in pairs(popupUnits) do
-			if spArmor(unitID) then
-				stateString = "off"
-				stateInt = 0
+function gadget:FeatureCreated(featureID)
+	if featureModelType[spGetFeatureDefID(featureID)] == "3do" then
+		rescaleFeature3DO(featureID)
+	end
+end
+
+function gadget:UnitDestroyed(unitID)
+	popupUnits[unitID] = nil
+end
+
+function gadget:GameFrame(frame)
+	-- Pop-up units switch volumes with their armored state, checked twice per second.
+	if frame % 15 ~= 0 then
+		return
+	end
+	for unitID, popup in pairs(popupUnits) do
+		local armored = spGetUnitArmored(unitID) == true
+		if popup.armored ~= armored then
+			local unitHeight = spGetUnitHeight(unitID)
+			if unitHeight == nil then
+				popupUnits[unitID] = nil
 			else
-				stateString = "on"
-				stateInt = 1
-			end
-			if defs.state ~= stateInt then
-				if defs.perPiece then
-					t = dynamicPieceCollisionVolume[defs.name][stateString] ---@as table
-					for pieceIndex, piece in pairs(t) do
-						if type(pieceIndex) == "number" then
-							spSetPieceCollisionData(
-								unitID,
-								pieceIndex,
-								piece[9] ~= false,
-								piece[1],
-								piece[2],
-								piece[3],
-								piece[4],
-								piece[5],
-								piece[6],
-								piece[7],
-								piece[8]
-							)
-						end
-					end
-					if t.offsets then
-						p = t.offsets
-						local unitHeight = spGetUnitHeight(unitID)
-						if unitHeight == nil then -- had error once, hope this nil check helps
-							popupUnits[unitID] = nil
-						else
-							spSetUnitMidAndAimPos(unitID, 0, unitHeight / 2, 0, p[1], p[2], p[3], true)
-						end
-					end
-				else
-					local unitHeight = spGetUnitHeight(unitID)
-					if unitHeight == nil then -- had error once, hope this nil check helps
-						popupUnits[unitID] = nil
-					else
-						---@diagnostic disable: need-check-nil, param-type-mismatch
-						p = unitCollisionVolume[defs.name][stateString] ---@as table
-						spSetUnitCollisionData(unitID, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9])
-						if p[10] then
-							spSetUnitMidAndAimPos(unitID, 0, unitHeight / 2, 0, p[10], p[11], p[12], true)
-						end
-					end
-				end
-				if popupUnits[unitID] ~= nil then
-					popupUnits[unitID].state = stateInt
+				popup.armored = armored
+				local colvol = armored and popup.colvol.off or popup.colvol.on
+				popup.setVolume(unitID, colvol)
+				if colvol.offsets then
+					setAimOffsets(unitID, unitHeight, colvol.offsets)
 				end
 			end
 		end


### PR DESCRIPTION
### Work done

Gives a module table-return shape to collisionvolumes.lua, same as other standardization passes on these files.

Dedents the gadget, and refactors it into smaller helpers that make the callin code as small and legible as possible. This was previously considered scary code and devs avoided its maintenance. This PR stack finishes here, with the gadget as tame as possible.

This still does not set popups to their config volume on frame-one of existence. That's current behavior but probably should be considered a bug. There are many such bugs, all left alone, but hopefully legible now if you look for them.