### PR TITLE
fix: startbox spec from leaks a zlib stub into later specs

### DIFF
--- a/spec/luarules/startbox_utilities_spec.lua
+++ b/spec/luarules/startbox_utilities_spec.lua
@@ -1,5 +1,5 @@
 -- Arrangement resolution and the whole-map fill for allyteams the arrangement does not
--- reach. Modoptions are base64 of raw JSON here, with the zlib step stubbed out.
+-- reach. Modoptions go through the spec helper's zlib and base64 stubs.
 
 local base64 = VFS.Include("common/luaUtilities/base64.lua")
 
@@ -53,9 +53,6 @@ local savedSpring = {
 
 Game.mapSizeX, Game.mapSizeZ = MAP_SIZE_X, MAP_SIZE_Z
 _G.Json = VFS.Include("common/luaUtilities/json.lua")
-VFS.ZlibDecompress = function(data)
-	return data
-end
 
 local function setUpGame(numAllyTeams, modoptions)
 	local allyTeamList = {}
@@ -83,7 +80,7 @@ local function setUpGame(numAllyTeams, modoptions)
 	Spring.GetModOptions = function()
 		local encoded = {}
 		for key, json in pairs(modoptions) do
-			encoded[key] = base64.Encode(json)
+			encoded[key] = base64.Encode(VFS.ZlibCompress(json))
 		end
 
 		return encoded


### PR DESCRIPTION
Repairs a current CI failure. Workflows stopped running on new commits for a long time and PRs that should have been in the red were approved and merged. Needs diagnosis soon.

### Work done

The spec replaced VFS.ZlibDecompress with an identity function at file scope and never restored it. Busted runs every spec file in one Lua state and sorts the file list, so spec/luaui/Include/mission_options_spec.lua ran after it with the helper's ZlibCompress paired against the _identity_ ZlibDecompress, and every decode returned nil.

Encode through the helper's ZlibCompress and drop the override.