### PR TITLE
Mission api/fix transfer trigger flags

### DIFF
--- a/luarules/mission_api/triggers/unit_captured.lua
+++ b/luarules/mission_api/triggers/unit_captured.lua
@@ -24,7 +24,11 @@ return {
 				return
 			end
 			-- The mission action gifts allied units even when captured=true is passed:
-			if not (captured or GG['MissionAPI'].capturingUnits) then
+			local isCapture = captured
+			if GG['MissionAPI'].transferringUnits then
+				isCapture = GG['MissionAPI'].capturingUnits
+			end
+			if not isCapture then
 				return
 			end
 			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then

--- a/luarules/mission_api/triggers/unit_received.lua
+++ b/luarules/mission_api/triggers/unit_received.lua
@@ -24,7 +24,11 @@ return {
 				return
 			end
 			-- The mission action gifts allied units even when captured=true is passed:
-			if captured or GG['MissionAPI'].capturingUnits then
+			local isCapture = captured
+			if GG['MissionAPI'].transferringUnits then
+				isCapture = GG['MissionAPI'].capturingUnits
+			end
+			if isCapture then
 				return
 			end
 			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then


### PR DESCRIPTION
### Work done

Fix an odd detail in the captured/received transfer trigger specs.

The captured flags that are detected vs. declared can disagree, so just always choose to believe that the declared flag is correct. That puts the onus on the mission action's fence to be always-correct, but it is hard to argue that it ever should be wrong.