### PR TITLE
MissionAPI: Add trigger for units being attacked

### DIFF
--- a/luarules/gadgets/api_missions_triggers.lua
+++ b/luarules/gadgets/api_missions_triggers.lua
@@ -308,6 +308,12 @@ function gadget:Initialize()
 			or (trigger.parameters and (trigger.parameters.builderName or trigger.parameters.builderDefName))
 			or (trigger.parameters and (trigger.parameters.factoryName or trigger.parameters.factoryDefName))
 	end)
+
+	if not table.any(triggers, function(trigger)
+		return trigger.type == triggerTypes.UnitAttacked
+	end) then
+		gadgetHandler:RemoveCallIn("UnitDamaged")
+	end
 end
 
 function gadget:GameFrame(frameNumber)
@@ -440,6 +446,33 @@ end
 function gadget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
 	local transportDefID = Spring.GetUnitDefID(transportID)
 	dispatchTriggerCallin("UnitUnloaded", unitID, unitDefID, unitTeam, transportID, transportDefID, transportTeam)
+end
+
+function gadget:UnitDamaged(
+	unitID,
+	unitDefID,
+	unitTeam,
+	damage,
+	paralyzer,
+	weaponDefID,
+	projectileID,
+	attackerID,
+	attackerDefID,
+	attackerTeam
+)
+	dispatchTriggerCallin(
+		"UnitDamaged",
+		unitID,
+		unitDefID,
+		unitTeam,
+		damage,
+		paralyzer,
+		weaponDefID,
+		projectileID,
+		attackerID,
+		attackerDefID,
+		attackerTeam
+	)
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)

--- a/luarules/mission_api/triggers/unit_attacked.lua
+++ b/luarules/mission_api/triggers/unit_attacked.lua
@@ -1,0 +1,48 @@
+local ParameterTypes = GG['MissionAPI'].Modules.ParameterTypes.Types
+
+local DAMAGETYPE_CRUSHED       = Game.envDamageTypes.Crushed
+local DAMAGETYPE_KILLED_BY_LUA = Game.envDamageTypes.KilledByLua -- The lowest engine-defined damage type.
+
+-- We fail to see death and selfd damages when filtering by team because their team information is lost.
+
+local function canHaveAttacker(weaponDefID)
+	return weaponDefID >= 0 or weaponDefID == DAMAGETYPE_CRUSHED or weaponDefID < DAMAGETYPE_KILLED_BY_LUA
+end
+
+return {
+	type = 'UnitAttacked',
+	parameters = {
+		{ name = 'unitName',    required = false, type = ParameterTypes.UnitName },
+		{ name = 'unitDefName', required = false, type = ParameterTypes.UnitDefName },
+		{ name = 'teamID',      required = false, type = ParameterTypes.TeamID },
+		requiresOneOf = { 'unitName', 'unitDefName' },
+	},
+	callins = {
+		-- A dead attacker passes no attacker info. We recover attackerTeam from any projectiles when we can.
+		-- Death and self-destruct explosions use real weapons but have neither an attacker nor a projectile.
+		UnitDamaged = function(trigger, triggerID, context, unitID, unitDefID, unitTeam, damage, paralyzer,
+		                       weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+			if damage <= 0 or not canHaveAttacker(weaponDefID) then
+				return
+			end
+			if not attackerTeam and projectileID > -1 then
+				-- Best effort is fine. We aren't going to retry with the projectile's allyTeam, for example.
+				attackerTeam = Spring.GetProjectileTeamID(projectileID)
+			end
+			if not attackerTeam or Spring.AreTeamsAllied(attackerTeam, unitTeam) then
+				return
+			end
+			local parameters = trigger.parameters
+			if parameters.unitName and not context.DoesUnitHaveName(unitID, parameters.unitName) then
+				return
+			end
+			if parameters.unitDefName and parameters.unitDefName ~= UnitDefs[unitDefID].name then
+				return
+			end
+			if parameters.teamID and parameters.teamID ~= unitTeam then
+				return
+			end
+			context.ActivateTrigger(trigger)
+		end,
+	},
+}

--- a/luarules/mission_api/triggers/unit_attacked.lua
+++ b/luarules/mission_api/triggers/unit_attacked.lua
@@ -22,7 +22,7 @@ return {
 		-- Death and self-destruct explosions use real weapons but have neither an attacker nor a projectile.
 		UnitDamaged = function(trigger, triggerID, context, unitID, unitDefID, unitTeam, damage, paralyzer,
 		                       weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
-			if damage <= 0 or not canHaveAttacker(weaponDefID) then
+			if damage < 0 or not canHaveAttacker(weaponDefID) then
 				return
 			end
 			if not attackerTeam and projectileID > -1 then

--- a/singleplayer/mission-api-tests/unit_attacked_test.lua
+++ b/singleplayer/mission-api-tests/unit_attacked_test.lua
@@ -1,0 +1,142 @@
+local triggerTypes = GG['MissionAPI'].TriggerDefinitions.Types
+local actionTypes = GG['MissionAPI'].ActionDefinitions.Types
+
+-- An enemy attacks a named tank, which fires the trigger on the first hit and again on each hit
+-- while repeating. An allied pawn self-destructs beside the tank first: the blast is a real weapon
+-- with no attacker and no projectile, so nobody to blame, and must not fire the trigger. The enemy
+-- spawns out of engagement range so that it cannot open fire before the self-destruct.
+
+local triggers = {
+
+	spawnScene = {
+		type = triggerTypes.TimeElapsed,
+		parameters = {
+			seconds = 1,
+		},
+		actions = { 'spawnTarget', 'spawnAlly', 'spawnEnemy' },
+	},
+
+	-- Split off the spawn, since an order does not take on the frame its target unit is spawned.
+	allySelfDestructs = {
+		type = triggerTypes.TimeElapsed,
+		parameters = {
+			seconds = 3,
+		},
+		actions = { 'selfDestructAlly' },
+	},
+
+	enemyAttacks = {
+		type = triggerTypes.TimeElapsed,
+		parameters = {
+			seconds = 6,
+		},
+		actions = { 'orderEnemyAttack' },
+	},
+
+	-- Never fires before the enemy attacks: the self-destruct is allied, environmental damage.
+	targetAttacked = {
+		type = triggerTypes.UnitAttacked,
+		parameters = {
+			unitName = 'target',
+		},
+		actions = { 'messageTargetAttacked' },
+	},
+
+	tankAttackedRepeatedly = {
+		type = triggerTypes.UnitAttacked,
+		parameters = {
+			unitDefName = 'armstump',
+			teamID = 0,
+		},
+		settings = {
+			repeating = true,
+			maxRepeats = 3,
+		},
+		actions = { 'messageTankHit' },
+	},
+
+	-- Never fires: the tank belongs to team 0.
+	wrongTeamAttacked = {
+		type = triggerTypes.UnitAttacked,
+		parameters = {
+			unitDefName = 'armstump',
+			teamID = 1,
+		},
+		actions = { 'messageWrongTeam' },
+	},
+
+}
+
+local actions = {
+
+	spawnTarget = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armstump', x = 2400, z = 2400, team = 0, unitName = 'target' },
+			},
+		},
+	},
+
+	spawnAlly = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'armpw', x = 2440, z = 2400, team = 0, unitName = 'ally' },
+			},
+		},
+	},
+
+	spawnEnemy = {
+		type = actionTypes.SpawnUnits,
+		parameters = {
+			unitLoadout = {
+				{ unitDefName = 'corak', x = 3300, z = 2400, team = 1, unitName = 'enemy' },
+			},
+		},
+	},
+
+	selfDestructAlly = {
+		type = actionTypes.SelfDestructUnits,
+		parameters = {
+			unitName = 'ally',
+		},
+	},
+
+	orderEnemyAttack = {
+		type = actionTypes.IssueOrders,
+		parameters = {
+			unitName = 'enemy',
+			orders = {
+				{ CMD.ATTACK, { unitName = 'target' } },
+			},
+		},
+	},
+
+	messageTargetAttacked = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "The target was attacked!",
+		},
+	},
+
+	messageTankHit = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "A tank on team 0 took a hit!",
+		},
+	},
+
+	messageWrongTeam = {
+		type = actionTypes.SendMessage,
+		parameters = {
+			message = "BUG: an attack on team 0 counted for team 1!",
+		},
+	},
+
+}
+
+return {
+	Triggers = triggers,
+	Actions = actions,
+}

--- a/spec/mission_api/triggers/unit_attacked_spec.lua
+++ b/spec/mission_api/triggers/unit_attacked_spec.lua
@@ -1,0 +1,269 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+-- The trigger file reads GG['MissionAPI'].Modules.ParameterTypes and Game.envDamageTypes at load time
+-- (so, here), and Spring / UnitDefs inside its handler.
+Builders.MissionApi.new():Install()
+
+local unitDefs = Builders.UnitDefs.new():WithUnitDefs({
+	[1] = { name = "armpw" },
+	[2] = { name = "corak" },
+})
+_G.UnitDefs = unitDefs:GetUnitDefsByID()
+
+local unitAttacked = VFS.Include("luarules/mission_api/triggers/unit_attacked.lua")
+local onUnitDamaged = unitAttacked.callins.UnitDamaged
+
+describe("mission_api.triggers.unit_attacked", function()
+	before_each(function()
+		-- Teams 0 and 1 are enemies; team 2 is allied with team 0.
+		Spring.AreTeamsAllied = function(team1ID, team2ID)
+			if team1ID == team2ID then
+				return true
+			end
+			return (team1ID == 0 and team2ID == 2) or (team1ID == 2 and team2ID == 0)
+		end
+	end)
+
+	local function trigger(parameters)
+		return Builders.Trigger.new():WithParameters(parameters):Build()
+	end
+
+	local function newContext()
+		local context = Builders.TriggerContext.new():Build()
+		return context, context.timesFired
+	end
+
+	local triggerID = "t"
+
+	-- unitID 100 takes the hit. A live attacker is unitID 50 (a corak) on `attackerTeam`. The engine
+	-- reports a dead attacker with no attacker info at all; the gadget then recovers `attackerTeam`
+	-- from the projectile when there is one, which `attackerDead` models.
+	local function damaged(trigger, context, hit)
+		local attackerID, attackerDefID
+		if hit.attackerTeam and not hit.attackerDead then
+			attackerID, attackerDefID = 50, 2
+		end
+		onUnitDamaged(
+			trigger,
+			triggerID,
+			context,
+			100,
+			hit.unitDefID,
+			hit.unitTeam,
+			hit.damage,
+			hit.paralyzer or false,
+			hit.weaponDefID,
+			-1,
+			attackerID,
+			attackerDefID,
+			hit.attackerTeam
+		)
+	end
+
+	local WEAPON = 7 -- Real weaponDefIDs start at 0.
+
+	it("declares its type and parameters", function()
+		assert.are.equal("UnitAttacked", unitAttacked.type)
+		local names = {}
+		for _, parameter in ipairs(unitAttacked.parameters) do
+			names[parameter.name] = true
+		end
+		assert.is_true(names.unitName)
+		assert.is_true(names.unitDefName)
+		assert.is_true(names.teamID)
+		assert.are.same({ "unitName", "unitDefName" }, unitAttacked.parameters.requiresOneOf)
+	end)
+
+	it("fires when an enemy weapon hits a matching unit", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw", teamID = 0 }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+		})
+		assert.are.equal(1, fired())
+	end)
+
+	it("fires once per hit", function()
+		local context, fired = newContext()
+		for _ = 1, 3 do
+			damaged(trigger({ unitDefName = "armpw" }), context, {
+				unitDefID = 1,
+				unitTeam = 0,
+				damage = 50,
+				weaponDefID = WEAPON,
+				attackerTeam = 1,
+			})
+		end
+		assert.are.equal(3, fired())
+	end)
+
+	it("filters by unitName", function()
+		local context, fired = newContext()
+		context.DoesUnitHaveName = function()
+			return false
+		end
+		damaged(trigger({ unitName = "target" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by unitDefName", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "corak" }), context, {
+			unitDefID = 1, -- armpw
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("filters by teamID, which is the attacked unit's team", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw", teamID = 1 }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("counts paralyze damage as an attack", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			paralyzer = true,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+		})
+		assert.are.equal(1, fired())
+	end)
+
+	it("ignores hits that deal no damage", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 0,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("ignores damage from the unit's own team", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 0,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("ignores damage from an allied team", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 2,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("fires for a dead attacker's projectile once its team is recovered", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = 1,
+			attackerDead = true,
+		})
+		assert.are.equal(1, fired())
+	end)
+
+	-- Death and self-destruct explosions use real weapons but arrive with no attacker and no projectile.
+	it("ignores weapon damage with no team to blame", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = WEAPON,
+			attackerTeam = nil,
+		})
+		assert.are.equal(0, fired())
+	end)
+
+	it("ignores the engine's environmental damage types", function()
+		local context, fired = newContext()
+		local environmental = {
+			Game.envDamageTypes.Debris,
+			Game.envDamageTypes.GroundCollision,
+			Game.envDamageTypes.ObjectCollision,
+			Game.envDamageTypes.Fire,
+			Game.envDamageTypes.Water,
+			Game.envDamageTypes.Killed,
+			Game.envDamageTypes.AircraftCrashed,
+			Game.envDamageTypes.Kamikaze,
+			Game.envDamageTypes.SelfD,
+			Game.envDamageTypes.KilledByLua,
+		}
+		for _, weaponDefID in ipairs(environmental) do
+			damaged(trigger({ unitDefName = "armpw" }), context, {
+				unitDefID = 1,
+				unitTeam = 0,
+				damage = 50,
+				weaponDefID = weaponDefID,
+				attackerTeam = 1,
+			})
+		end
+		assert.are.equal(0, fired())
+	end)
+
+	it("counts being crushed as an attack", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = Game.envDamageTypes.Crushed,
+			attackerTeam = 1,
+		})
+		assert.are.equal(1, fired())
+	end)
+
+	-- The game registers scripted damage types (timed areas, ...) below the engine's lowest index.
+	it("counts the game's scripted damage types as attacks", function()
+		local context, fired = newContext()
+		damaged(trigger({ unitDefName = "armpw" }), context, {
+			unitDefID = 1,
+			unitTeam = 0,
+			damage = 50,
+			weaponDefID = Game.envDamageTypes.KilledByLua - 1,
+			attackerTeam = 1,
+		})
+		assert.are.equal(1, fired())
+	end)
+end)

--- a/spec/mission_api/triggers_loader_spec.lua
+++ b/spec/mission_api/triggers_loader_spec.lua
@@ -159,6 +159,7 @@ describe("mission_api.triggers_loader", function()
 			-- Event-driven triggers:
 			assert.is_function(C.MetaUnitAdded[T.UnitExists])
 			assert.is_function(C.MetaUnitRemoved[T.UnitNotExists])
+			assert.is_function(C.UnitDamaged[T.UnitAttacked])
 			assert.is_function(C.UnitDestroyed[T.UnitKilled])
 			assert.is_function(C.UnitDestroyed[T.UnitReclaimed])
 			assert.is_function(C.UnitTaken[T.UnitCaptured])


### PR DESCRIPTION
### Work done

Adds the UnitAttacked trigger for units being damaged by enemies.

The spec was to keep the params short, so this has very little filtering. A tracked unit optionally on a specific team is attacked, and that is most of what we know.

It also does not create a dwell time or similar. Damages are high-frequency events that can drain the maxRepeats of this trigger quickly. It wasn't in the scope, though.

There are defects with detection that I have left alone since the trigger is marked as a high campaign priority. It should see use soon which will prove whether it works for their needs.

Mostly, selfd and death explosions are unattributable, so we lose the ability to distinguish them from enemy or ally damages. Rather than potentially bypass a mission script, I've ignored all unattributable damages. These could be tracked in the base-game as a minor enhancement and then given handling in this trigger.