### PR TITLE
Fix console color wrapping

### DIFF
--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -1728,7 +1728,9 @@ local function processAddConsoleLine(gameFrame, line, orgLineID, reprocessID)
 			end
 		end
 
-		line = colorConsoleStr .. lineColor .. line
+		if string.byte(line, 1) ~= 255 then
+			line = (lineColor ~= "" and lineColor or colorConsoleStr) .. line
+		end
 	end
 
 	if not bypassThisMessage then


### PR DESCRIPTION
I don't think stuff like this is easily testable.. because to test you have to be on the dev mode, but that's only for singleplayer.. regardless, you can clone it as a widget and have it echo the same thing. So that's how I tested this change. Below is what the ingame behaviour is. 

<img width="1920" height="1080" alt="Screenshot from 2026-09-10 20-18-58" src="https://github.com/user-attachments/assets/dd483daa-5631-4b42-955e-7a6569af2381" />

The text "RESIGNED" is in white, instead of in red, due to some funky wrapping shenanigans.

This is basically how it goes

Line 1: \255\255\040\040YOU QUEUED TOO MUCH BUILDINGS TOO MANY TIMES, YOU HAVE BEEN FORCE 

Line 2: RESIGNED! <--- uh oh, no color stringy here!