### PR TITLE
Fix enemy fire-state display in godmode

### DIFF
--- a/modules/custom_firestate_defs.lua
+++ b/modules/custom_firestate_defs.lua
@@ -91,7 +91,18 @@ function customFirestateDefs.getUnitUserFirestate(unitID)
 			return rulesState
 		end
 	end
-	return customFirestateDefs.fromEngineFirestate(select(1, Spring.GetUnitStates(unitID, false)))
+	local engineState = Spring.GetUnitStates(unitID, false)
+	if engineState == nil and Spring.IsGodModeEnabled() then
+		-- Godmode permits controlling enemies without granting GetUnitStates read access.
+		local cmdIndex = Spring.FindUnitCmdDesc(unitID, CMD.FIRE_STATE)
+		local cmdDescs = cmdIndex and Spring.GetUnitCmdDescs(unitID, cmdIndex, cmdIndex)
+		local cmdDesc = cmdDescs and cmdDescs[1]
+		engineState = cmdDesc and cmdDesc.params and tonumber(cmdDesc.params[1])
+		if engineState == nil then
+			return nil
+		end
+	end
+	return customFirestateDefs.fromEngineFirestate(engineState)
 end
 
 function customFirestateDefs.stateLabel(cmd)


### PR DESCRIPTION
### Work done

Fix the order menu showing an enemy unit as "Fire at will" again after changing its fire state in godmode and reselecting it, even when the unit received the command.

`Spring.GetUnitStates` can return no value for enemy units because godmode control does not grant allied read access. The shared fire-state reader previously converted that missing value to "Fire at will". Only when `Spring.IsGodModeEnabled()` is true, it now falls back to the unit's fire-state command description and returns nil if neither source is available. Custom fire-state rules parameters retain priority. With godmode disabled, the previous behavior is preserved, including the default for unavailable states; no command descriptions are queried by the fallback.

#### Test steps

- [x] Reproduced the incorrect fallback with mocked Spring APIs before the fix; nine Lua checks cover own/enemy units, all four engine fire states, custom Defend priority, and missing/invalid units.
- [x] 120 additional mocked checks compare godmode-disabled results against the implementation before this PR, covering valid/invalid units, both modoption settings, available/missing engine states and custom rules states. All match, and the fallback never queries command descriptions without godmode.
- [x] `stylua --check modules/custom_firestate_defs.lua` and `git diff --check` pass.
- [ ] In a local game with cheats and godmode enabled, select an enemy unit, change its fire state, deselect and reselect it. Verify the menu keeps showing the actual state. Repeat with left/right click and an own-team unit, then with godmode disabled. In-game validation is still pending.

### AI / LLM usage statement

OpenAI Codex investigated the bug, implemented the change, ran the mocked checks, and prepared this PR.
