### PR TITLE
Mission API: Add trigger on mission started

### DIFF
--- a/luarules/gadgets/api_missions_triggers.lua
+++ b/luarules/gadgets/api_missions_triggers.lua
@@ -310,6 +310,10 @@ function gadget:Initialize()
 	end)
 end
 
+function gadget:GameStart()
+	dispatchTriggerCallin("GameStart")
+end
+
 function gadget:GameFrame(frameNumber)
 	if frameNumber % Game.gameSpeed == 0 then
 		-- Reset reclaim income counters (read by ResourceIncome handlers):

--- a/luarules/mission_api/triggers/mission_started.lua
+++ b/luarules/mission_api/triggers/mission_started.lua
@@ -1,0 +1,12 @@
+-- Immediately after the UI is present and usable and before any interactive gameplay.
+-- PreGame happened already, so loadouts are spawned and the initial stage is active.
+-- Some effects may take a single frame to occur; we may miss them here at frame 0.
+return {
+	type = 'MissionStarted',
+	parameters = {},
+	callins = {
+		GameStart = function(trigger, triggerID, context)
+			context.ActivateTrigger(trigger)
+		end,
+	},
+}

--- a/spec/mission_api/triggers/mission_started_spec.lua
+++ b/spec/mission_api/triggers/mission_started_spec.lua
@@ -1,0 +1,28 @@
+require("spec_helper")
+
+local Builders = VFS.Include("spec/builders/index.lua")
+
+local missionStarted = VFS.Include("luarules/mission_api/triggers/mission_started.lua")
+local onGameStart = missionStarted.callins.GameStart
+local summarizeSchema = require("mission_api.schema_spec_helper")
+
+describe("mission_api.triggers.mission_started", function()
+	it("declares its type and takes no parameters", function()
+		assert.are.same({ type = "MissionStarted" }, summarizeSchema(missionStarted))
+	end)
+	
+	it("fires when the game starts", function()
+		local context = Builders.TriggerContext.new():Build()
+		onGameStart(Builders.Trigger.new():Build(), "t", context)
+		assert.are.equal(1, context.timesFired())
+	end)
+
+	-- Attempt to check that we never restart. I don't think we can test this here.
+	it("can be fired by nothing but GameStart", function()
+		local callinNames = {}
+		for callinName in pairs(missionStarted.callins) do
+			callinNames[#callinNames + 1] = callinName
+		end
+		assert.are.same({ "GameStart" }, callinNames)
+	end)
+end)

--- a/spec/mission_api/triggers/mission_started_spec.lua
+++ b/spec/mission_api/triggers/mission_started_spec.lua
@@ -10,7 +10,7 @@ describe("mission_api.triggers.mission_started", function()
 	it("declares its type and takes no parameters", function()
 		assert.are.same({ type = "MissionStarted" }, summarizeSchema(missionStarted))
 	end)
-	
+
 	it("fires when the game starts", function()
 		local context = Builders.TriggerContext.new():Build()
 		onGameStart(Builders.Trigger.new():Build(), "t", context)


### PR DESCRIPTION
### Work done

Adds the `MissionStarted` trigger, dispatch, and spec.

There is no test mission because we do not have anything that would rely on this trigger, at the moment. A frame-1 check can use TimeElapsed and there are other frame-0 timings that already were possible.

The choice of `gadget:GameStart` places the trigger in the ordering with broader capabilities. A pre-mission trigger would lack hooks into UI and other code.

The name might give the interpretation that the trigger is raised before literally anything happens in a mission, though. It also would be sensible for trigger order to go `MissionStarted` > `StageEntered` on the initial stage.