### PR TITLE
Make ruins not spawn anything the user blocks

### DIFF
--- a/luarules/gadgets/ai_ruins.lua
+++ b/luarules/gadgets/ai_ruins.lua
@@ -270,6 +270,9 @@ end
 
 -- CreateUnit does not snap; Pos2BuildPos uses even vs odd grid from footprint parity.
 local function createSnappedUnit(defID, x, y, z, facing, teamID)
+	if UnitDefs[defID].customParams.modoption_blocked then
+		return nil
+	end
 	x, y, z = Spring.Pos2BuildPos(defID, x, y, z, facing)
 	return Spring.CreateUnit(defID, x, y, z, facing, teamID)
 end


### PR DESCRIPTION
Super simple patch. I was being annoyed when I would play zombie games with ruins, with air disabled, and AA towers would spawn. So basically all this does, is if something is a blocked unit, ruins shouldn't spawn it.

And you can test this super easily. Go to a skirmish match, disable some unit types like fusion reactors and air, do /cheat, then /globallos, and you'll quickly notice that anti air and fusion reactors are still being spawned by ruins, despite being disabled.