### PR TITLE
reuse single instance copies of unit selections

### DIFF
--- a/luaui/Widgets/api_unit_selection.lua
+++ b/luaui/Widgets/api_unit_selection.lua
@@ -1,0 +1,237 @@
+local widget = widget ---@type Widget
+
+function widget:GetInfo()
+	return {
+		name = "API Unit Selection",
+		desc = "Shared views of the current selection: a unit array, grouped by unitdef, and by capability.",
+		author = "efrec",
+		date = "September 2026",
+		license = "GNU GPL, v2 or later",
+		layer = -999999, -- Reads SelectionChanged before widgets that rewrite it.
+		enabled = true,
+		hidden = true, -- disable toggling off the API
+	}
+end
+
+local spGetSelectedUnits = Spring.GetSelectedUnits
+local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
+local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
+local spGetUnitDefID = Spring.GetUnitDefID
+
+local UnitSelection = table.ensureTable(WG, "UnitSelection")
+
+--------------------------------------------------------------------------------
+-- Capability sets -------------------------------------------------------------
+
+-- TODO: In a mixed selection of factories and non-factories, how to group them?
+
+---@type table<string, fun(unitDef: table): boolean>
+local capabilityTests = {
+	attack = function(unitDef)
+		return unitDef.canAttack and unitDef.maxWeaponRange > 0
+	end,
+	capture = function(unitDef)
+		return unitDef.canCapture
+	end,
+	guard = function(unitDef)
+		return unitDef.canGuard
+	end,
+	repairs = function(unitDef)
+		-- Assist without repair is buildframes only, so has to check its target.
+		return unitDef.canRepair or unitDef.canAssist
+	end,
+	reclaim = function(unitDef)
+		return unitDef.canReclaim
+	end,
+	resurrect = function(unitDef)
+		return unitDef.canResurrect
+	end,
+	transport = function(unitDef)
+		return unitDef.transportSize and unitDef.transportSize > 0
+	end,
+}
+
+local capableDefs = {} ---@type table<string?, table<UnitDefID, true>?>
+
+---Lazy-build unitdef capability sets on first use.
+---@param key string
+---@return table<UnitDefID, true>|nil
+local function getCapableDefs(key)
+	local defs = capableDefs[key]
+	if defs then
+		return defs
+	end
+
+	local test = capabilityTests[key]
+	if not test then
+		return nil
+	end
+
+	defs = {}
+	for unitDefID, unitDef in pairs(UnitDefs) do
+		if test(unitDef) then
+			defs[unitDefID] = true
+		end
+	end
+	capableDefs[key] = defs
+	return defs
+end
+
+--------------------------------------------------------------------------------
+-- Selection state -------------------------------------------------------------
+
+local selectionCount = 0
+local version = 0
+local stale = true
+
+-- Each view is stamped with the version it was built from, the flat array included.
+local selection, selectionVersion = {}, -1 ---@type UnitID[], integer
+local byUnitDefID, byUnitDefIDVersion = nil, -1
+local capableUnits, capableUnitsVersion = {}, {}
+
+local function update()
+	stale = false
+	version = version + 1
+	selectionCount = spGetSelectedUnitsCount()
+end
+
+local function currentVersion()
+	if stale then
+		update()
+	end
+	return version
+end
+
+local function currentSelection()
+	if selectionVersion ~= currentVersion() then
+		selection, selectionVersion = spGetSelectedUnits(), version
+	end
+	return selection
+end
+
+--------------------------------------------------------------------------------
+-- Interface methods -----------------------------------------------------------
+
+---Increments when the cached selection is rebuilt.
+---@return integer
+function UnitSelection.GetVersion()
+	return currentVersion()
+end
+
+---Marks the cache stale for a widget to call `Spring.SelectUnitArray`.
+function UnitSelection.Invalidate()
+	stale = true
+end
+
+---The number of units in-selection.
+---@return integer
+function UnitSelection.GetCount()
+	currentVersion()
+	return selectionCount
+end
+
+---Gets the current selection. This is shared across callers, so copy as needed.
+---@return UnitID[]
+function UnitSelection.GetUnits()
+	return currentSelection()
+end
+
+---Gets the current selection, grouped by unitDefID.
+---@return table<UnitDefID?, UnitID[]?>
+function UnitSelection.GetUnitsByDefID()
+	if byUnitDefIDVersion ~= currentVersion() then
+		byUnitDefID, byUnitDefIDVersion = spGetSelectedUnitsSorted(), version
+	end
+	return byUnitDefID ---@as table<UnitDefID?, UnitID[]?>
+end
+
+---Gets the selected units that can perform the named capability; nil when empty.
+---
+---This has an odd edge for better performance: When all units have the required
+---capability, the base selection is returned, which is a commonly shared table.
+---Copy that table as needed when mutating it.
+---@param name string
+---@return UnitID[]|nil
+function UnitSelection.GetCapableUnits(name)
+	local units = currentSelection()
+	if capableUnitsVersion[name] == version then
+		return capableUnits[name]
+	end
+
+	local defs = getCapableDefs(name)
+	if not defs then
+		Spring.Log("UnitSelection", LOG.WARN, "unknown capability " .. tostring(name))
+		return nil
+	end
+
+	local capable = units ---@as UnitID[]?
+	local firstDrop
+	for index = 1, selectionCount do
+		if not defs[spGetUnitDefID(units[index])] then
+			firstDrop = index
+			break
+		end
+	end
+
+	---@cast firstDrop integer?
+
+	if firstDrop then
+		local keep, count = {}, firstDrop - 1
+		for index = 1, count do
+			keep[index] = units[index]
+		end
+		for index = firstDrop + 1, selectionCount do
+			local unitID = units[index]
+			if defs[spGetUnitDefID(unitID)] then
+				count = count + 1
+				keep[count] = unitID
+			end
+		end
+		capable = count > 0 and keep or nil
+	elseif selectionCount == 0 then
+		capable = nil
+	end
+
+	capableUnits[name], capableUnitsVersion[name] = capable, version
+	return capable
+end
+
+---Add a capability that GetCapableUnits then uses in filters.
+---
+---Takes either a set of unit defs or a test for building one.
+---@param name string
+---@param defsOrTest table<UnitDefID, true>|fun(unitDef: UnitDef): boolean
+function UnitSelection.RegisterCapability(name, defsOrTest)
+	local defs, test
+	if type(defsOrTest) == "table" then
+		defs = defsOrTest
+	elseif type(defsOrTest) == "function" then
+		test = defsOrTest
+	end
+	if not defs and not test then
+		return false
+	end
+	capableDefs[name] = defs
+	capabilityTests[name] = test
+	capableUnitsVersion[name] = nil
+	return true
+end
+
+--------------------------------------------------------------------------------
+-- Engine callins --------------------------------------------------------------
+
+function widget:SelectionChanged()
+	stale = true
+end
+
+function widget:PlayerChanged()
+	stale = true
+end
+
+function widget:Initialize()
+	WG.UnitSelection = UnitSelection
+end
+
+function widget:Shutdown()
+	WG.UnitSelection = nil
+end

--- a/luaui/Widgets/cmd_area_commands_filter.lua
+++ b/luaui/Widgets/cmd_area_commands_filter.lua
@@ -25,7 +25,6 @@ local mathFloor = math.floor
 local mathMax = math.max
 
 local spGiveOrderToUnitArray = Spring.GiveOrderToUnitArray
-local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetUnitsInCylinder = Spring.GetUnitsInCylinder
 local spWorldToScreenCoords = Spring.WorldToScreenCoords
 local spTraceScreenRay = Spring.TraceScreenRay
@@ -51,6 +50,7 @@ local UNIT = "unit"
 local commandLimit = 2000
 
 local myAllyTeamID
+local getCapableUnits
 
 ---------------------------------------------------------------------------------------
 --- Target sorting logic (pick the closest first)
@@ -98,18 +98,6 @@ for defId, def in pairs(UnitDefs) do
 	unitMass[defId] = def.mass
 	unitXSize[defId] = def.xsize
 	cantBeTransported[defId] = def.cantBeTransported
-end
-
-local canAttack, canCapture, canReclaim = {}, {}, {}
-local canGuard, canRepair, canResurrect = {}, {}, {}
-
-for unitDefID, unitDef in pairs(UnitDefs) do
-	canAttack[unitDefID] = unitDef.canAttack and unitDef.maxWeaponRange > 0 or nil
-	canCapture[unitDefID] = unitDef.canCapture or nil
-	canGuard[unitDefID] = unitDef.canGuard or nil
-	canRepair[unitDefID] = unitDef.canRepair or unitDef.canAssist or nil -- assist without repair is nanoframes only, decided per target
-	canReclaim[unitDefID] = unitDef.canReclaim or nil
-	canResurrect[unitDefID] = unitDef.canResurrect or nil
 end
 
 --- @return table<number,table<number>> Map of transportId -> array of passengerIds
@@ -394,9 +382,9 @@ end
 ---@field handle function
 ---@field allowedTargetTypes table
 ---@field targetAllegiance number AllUnits = -1, MyUnits = -2, AllyUnits = -3, EnemyUnits = -4
----@field capableDefs table<number, true>
+---@field capability string
 
-local function commandConfig(targetTypes, targetAllegiance, capableDefs, handler)
+local function commandConfig(targetTypes, targetAllegiance, capability, handler)
 	local allowedTargetTypes = {}
 	for _, targetType in ipairs(targetTypes) do
 		allowedTargetTypes[targetType] = true
@@ -405,49 +393,22 @@ local function commandConfig(targetTypes, targetAllegiance, capableDefs, handler
 	config.handle = handler or defaultHandler
 	config.allowedTargetTypes = allowedTargetTypes
 	config.targetAllegiance = targetAllegiance
-	config.capableDefs = capableDefs
+	config.capability = capability
 	return config
 end
 
 ---@type table<number, CommandConfig>
 local allowedCommands = {
-	[CMD.ATTACK] = commandConfig({ UNIT }, ENEMY_UNITS, canAttack),
-	[CMD.CAPTURE] = commandConfig({ UNIT }, ENEMY_UNITS, canCapture),
-	[GameCMD.UNIT_SET_TARGET] = commandConfig({ UNIT }, ENEMY_UNITS, canAttack),
-	[GameCMD.UNIT_SET_TARGET_NO_GROUND] = commandConfig({ UNIT }, ENEMY_UNITS, canAttack),
-	[CMD.GUARD] = commandConfig({ UNIT }, ALLY_UNITS, canGuard),
-	[CMD.REPAIR] = commandConfig({ UNIT }, ALLY_UNITS, canRepair),
-	[CMD.RECLAIM] = commandConfig({ UNIT, FEATURE }, ALL_UNITS, canReclaim),
-	[CMD.LOAD_UNITS] = commandConfig({ UNIT }, ALL_UNITS, transportDefs, loadUnitsHandler),
-	[CMD.RESURRECT] = commandConfig({ FEATURE }, nil, canResurrect),
+	[CMD.ATTACK] = commandConfig({ UNIT }, ENEMY_UNITS, "attack"),
+	[CMD.CAPTURE] = commandConfig({ UNIT }, ENEMY_UNITS, "capture"),
+	[GameCMD.UNIT_SET_TARGET] = commandConfig({ UNIT }, ENEMY_UNITS, "attack"),
+	[GameCMD.UNIT_SET_TARGET_NO_GROUND] = commandConfig({ UNIT }, ENEMY_UNITS, "attack"),
+	[CMD.GUARD] = commandConfig({ UNIT }, ALLY_UNITS, "guard"),
+	[CMD.REPAIR] = commandConfig({ UNIT }, ALLY_UNITS, "repairs"),
+	[CMD.RECLAIM] = commandConfig({ UNIT, FEATURE }, ALL_UNITS, "reclaim"),
+	[CMD.LOAD_UNITS] = commandConfig({ UNIT }, ALL_UNITS, "transport", loadUnitsHandler),
+	[CMD.RESURRECT] = commandConfig({ FEATURE }, nil, "resurrect"),
 }
-
-local function getCapableUnits(selectedUnits, capableDefs)
-	local firstDrop
-	for index = 1, #selectedUnits do
-		if not capableDefs[spGetUnitDefID(selectedUnits[index])] then
-			firstDrop = index
-			break
-		end
-	end
-
-	if not firstDrop then
-		return selectedUnits[1] and selectedUnits or nil
-	end
-
-	local keep, count = {}, firstDrop - 1
-	for index = 1, count do
-		keep[index] = selectedUnits[index]
-	end
-	for index = firstDrop + 1, #selectedUnits do
-		local unitID = selectedUnits[index]
-		if capableDefs[spGetUnitDefID(unitID)] then
-			count = count + 1
-			keep[count] = unitID
-		end
-	end
-	return count > 0 and keep or nil
-end
 
 local function filterUnits(targetId, cmdX, cmdZ, radius, options, targetAllegiance)
 	local ctrl = options.ctrl
@@ -551,7 +512,7 @@ function widget:CommandNotify(cmdId, params, options)
 		return false
 	end
 
-	local capableUnits = getCapableUnits(spGetSelectedUnits(), currentCommand.capableDefs)
+	local capableUnits = getCapableUnits(currentCommand.capability)
 	if not capableUnits then
 		return false
 	end
@@ -588,7 +549,14 @@ end
 local function initialize()
 	if spGetSpectatingState() then
 		widgetHandler:RemoveWidget()
+		return
 	end
+	if not WG.UnitSelection then
+		Spring.Echo("Area Command Filter: the unit selection API is missing, disabling")
+		widgetHandler:RemoveWidget()
+		return
+	end
+	getCapableUnits = WG.UnitSelection.GetCapableUnits
 	myAllyTeamID = spGetMyAllyTeamID()
 end
 

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -14,10 +14,6 @@ function widget:GetInfo()
 	}
 end
 
--- Localized Spring API for performance
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
-
 -- Behavior:
 -- To give a line command: select command, then right click & drag
 -- To give a command within an area: select command, then left click and drag
@@ -193,8 +189,7 @@ local CMD_OPT_SHIFT = CMD.OPT_SHIFT
 local CMD_OPT_RIGHT = CMD.OPT_RIGHT
 
 local keyShift = 304
-local selectedUnits = spGetSelectedUnits()
-local selectedUnitsCount = spGetSelectedUnitsCount()
+local getSelectedUnits, getSelectedUnitsCount
 
 --------------------------------------------------------------------------------
 -- Helper Functions
@@ -271,7 +266,8 @@ end
 
 local function GetExecutingUnits(cmdID)
 	local units = {}
-	for i = 1, selectedUnitsCount do
+	local selectedUnits = getSelectedUnits()
+	for i = 1, getSelectedUnitsCount() do
 		local uID = selectedUnits[i]
 		if CanUnitExecute(uID, cmdID) then
 			units[#units + 1] = uID
@@ -403,11 +399,6 @@ local function GiveNotifyingOrderToUnit(uArr, oArr, uID, cmdID, cmdParams, cmdOp
 	return
 end
 
-function widget:SelectionChanged(sel)
-	selectedUnits = sel
-	selectedUnitsCount = spGetSelectedUnitsCount()
-end
-
 --------------------------------------------------------------------------------
 -- Mouse/keyboard Callins
 --------------------------------------------------------------------------------
@@ -490,7 +481,7 @@ function widget:MousePress(mx, my, mButton)
 	local alt, ctrl, meta, shift = spGetModKeyState()
 
 	-- Is this line a path candidate (We don't do a path off an overridden command)
-	pathCandidate = (not overriddenCmd) and selectedUnitsCount == 1 and (not shift or repeatForSingleUnit)
+	pathCandidate = (not overriddenCmd) and getSelectedUnitsCount() == 1 and (not shift or repeatForSingleUnit)
 
 	-- Initialize path positions tracking
 	pathPositions = {}
@@ -596,7 +587,7 @@ function widget:MouseRelease(mx, my, mButton)
 		end
 	end
 
-	if selectedUnitsCount == 1 and not shift then
+	if getSelectedUnitsCount() == 1 and not shift then
 		spSetActiveCommand(0) -- Deselect command
 	end
 
@@ -653,7 +644,7 @@ function widget:MouseRelease(mx, my, mButton)
 
 		if
 			fDists[#fNodes] < adjustedMinFormationLength
-			or (usingCmd == CMD.UNLOAD_UNIT and fDists[#fNodes] < 64 * (selectedUnitsCount - 1))
+			or (usingCmd == CMD.UNLOAD_UNIT and fDists[#fNodes] < 64 * (getSelectedUnitsCount() - 1))
 		then
 			-- We should check if any units are able to execute it,
 			-- but the order is small enough network-wise that the tiny bug potential isn't worth it.
@@ -805,7 +796,7 @@ local function DrawFormationDotQuads(dotSize, lengthPerUnit)
 end
 
 local function DrawFormationDots(zoomY)
-	local lengthPerUnit = lineLength / (selectedUnitsCount - 1)
+	local lengthPerUnit = lineLength / (getSelectedUnitsCount() - 1)
 	local dotSize = sqrt(zoomY * 0.24)
 	SetColor(usingCmd, 1)
 	if (lengthPerUnit < 64) and (usingCmd == CMD.UNLOAD_UNIT) then
@@ -847,7 +838,7 @@ function widget:RecvLuaMsg(msg, playerID)
 end
 
 function widget:DrawWorld()
-	if chobbyInterface or #fNodes <= 1 or selectedUnitsCount <= 1 or lineLength <= 0 then
+	if chobbyInterface or #fNodes <= 1 or getSelectedUnitsCount() <= 1 or lineLength <= 0 then
 		return
 	end
 
@@ -1375,6 +1366,14 @@ function stepFiveStar(colcover, rowcover, row, col, n, starscol, primescol)
 end
 
 function widget:Initialize()
+	if WG.UnitSelection then
+		getSelectedUnits = WG.UnitSelection.GetUnits
+		getSelectedUnitsCount = WG.UnitSelection.GetCount
+	else
+		getSelectedUnits = Spring.GetSelectedUnits
+		getSelectedUnitsCount = Spring.GetSelectedUnitsCount
+	end
+
 	WG.customformations = {}
 	WG.customformations.getRepeatForSingleUnit = function()
 		return repeatForSingleUnit
@@ -1408,7 +1407,7 @@ function widget:Initialize()
 		-- Add first node
 		if AddFNode(worldPos) then
 			local alt, ctrl, meta, shift = spGetModKeyState()
-			pathCandidate = selectedUnitsCount == 1 and (not shift or repeatForSingleUnit)
+			pathCandidate = getSelectedUnitsCount() == 1 and (not shift or repeatForSingleUnit)
 			return true
 		end
 		return false
@@ -1506,7 +1505,7 @@ function widget:Initialize()
 
 			if
 				fDists[#fNodes] < adjustedMinFormationLength
-				or (usingCmd == CMD.UNLOAD_UNIT and fDists[#fNodes] < 64 * (selectedUnitsCount - 1))
+				or (usingCmd == CMD.UNLOAD_UNIT and fDists[#fNodes] < 64 * (getSelectedUnitsCount() - 1))
 			then
 				-- Single-click style order
 				if usingCmd == CMD_MOVE and #fNodes > 0 then
@@ -1604,7 +1603,7 @@ function widget:Initialize()
 	end
 
 	WG.customformations.GetSelectedUnitsCount = function()
-		return selectedUnitsCount
+		return getSelectedUnitsCount()
 	end
 
 	WG.customformations.GetFormationOrders = function()

--- a/luaui/Widgets/cmd_customformations2.lua
+++ b/luaui/Widgets/cmd_customformations2.lua
@@ -189,7 +189,8 @@ local CMD_OPT_SHIFT = CMD.OPT_SHIFT
 local CMD_OPT_RIGHT = CMD.OPT_RIGHT
 
 local keyShift = 304
-local getSelectedUnits, getSelectedUnitsCount
+-- replaced in init via selections api:
+local getSelectedUnits, getSelectedUnitsCount = Spring.GetSelectedUnits, Spring.GetSelectedUnitsCount
 
 --------------------------------------------------------------------------------
 -- Helper Functions

--- a/luaui/Widgets/cmd_default_set_target.lua
+++ b/luaui/Widgets/cmd_default_set_target.lua
@@ -20,9 +20,9 @@ local rebindKeys = false
 local CMD_UNIT_SET_TARGET = GameCMD.UNIT_SET_TARGET
 
 local IsUnitAllied = Spring.IsUnitAllied
-local GetSelectedUnitsCounts = Spring.GetSelectedUnitsCounts
 local GetActionHotKeys = Spring.GetActionHotKeys
 local SendCommmands = Spring.SendCommands
+local getCapableUnits
 
 local hotKeys = {}
 local gameStarted
@@ -35,6 +35,16 @@ for udid, ud in pairs(UnitDefs) do
 	then
 		hasSetTarget[udid] = true
 	end
+end
+
+local function selectionCanSetTarget()
+	-- Fallback for no selection api:
+	for unitDefID in pairs(Spring.GetSelectedUnitsSorted()) do
+		if hasSetTarget[unitDefID] then
+			return true
+		end
+	end
+	return false
 end
 
 local function maybeRemoveSelf()
@@ -54,6 +64,14 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:Initialize()
+	if WG.UnitSelection then
+		WG.UnitSelection.RegisterCapability("settarget", hasSetTarget)
+		getCapableUnits = WG.UnitSelection.GetCapableUnits
+		selectionCanSetTarget = function()
+			return getCapableUnits("settarget") ~= nil
+		end
+	end
+
 	if Spring.IsReplay() or spGetGameFrame() > 0 then
 		if maybeRemoveSelf() then
 			return
@@ -78,9 +96,7 @@ function widget:DefaultCommand(type, id, cmd)
 	if type ~= "unit" or IsUnitAllied(id) then
 		return
 	end
-	for unitDefID in pairs(GetSelectedUnitsCounts()) do
-		if hasSetTarget[unitDefID] then
-			return CMD_UNIT_SET_TARGET
-		end
+	if selectionCanSetTarget() then
+		return CMD_UNIT_SET_TARGET
 	end
 end

--- a/luaui/Widgets/gui_attack_aoe.lua
+++ b/luaui/Widgets/gui_attack_aoe.lua
@@ -41,7 +41,7 @@ local spGetGroundHeight = Spring.GetGroundHeight
 local spGetActiveCommand = Spring.GetActiveCommand
 local spGetCameraPosition = Spring.GetCameraPosition
 local spGetMouseState = Spring.GetMouseState
-local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
+local getSelectedUnitsByDefID = Spring.GetSelectedUnitsSorted -- replaced in init
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGetUnitVelocity = Spring.GetUnitVelocity
 local spGetUnitExperience = Spring.GetUnitExperience
@@ -1313,7 +1313,7 @@ local function UpdateSelection()
 	State.manualAimUnits = {}
 	ClearStarburstPredictions()
 
-	local sel = spGetSelectedUnitsSorted()
+	local sel = getSelectedUnitsByDefID()
 	for unitDefID, unitIDs in pairs(sel) do
 		local currCost = Cache.UnitProperties.cost[unitDefID] * #unitIDs
 		local manualWeaponInfos = Cache.manualWeaponInfos[unitDefID]
@@ -2313,6 +2313,8 @@ local WeaponTypeHandlers = {
 -- CALLINS
 --------------------------------------------------------------------------------
 function widget:Initialize()
+	getSelectedUnitsByDefID = WG.UnitSelection and WG.UnitSelection.GetUnitsByDefID or Spring.GetSelectedUnitsSorted
+
 	-- shader has to be created before setting up unit defs
 	napalmShader = LuaShader.CheckShaderUpdates(shaderSourceCache, 0)
 	for unitDefID, unitDef in pairs(UnitDefs) do

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -210,8 +210,6 @@ local function refreshUnitDefs()
 end
 
 local spIsUnitSelected = Spring.IsUnitSelected
-local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
-local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetActiveCommand = Spring.GetActiveCommand
 local spGetActiveCmdDescs = Spring.GetActiveCmdDescs
 local spGetCmdDescIndex = Spring.GetCmdDescIndex
@@ -221,7 +219,9 @@ local spGetMouseState = Spring.GetMouseState
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
 local spGetUnitIsBuilding = Spring.GetUnitIsBuilding
 
-local SelectedUnitsCount = spGetSelectedUnitsCount()
+local selectedUnitsCount = 0
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced in init
+local getSelectedUnitsCount = Spring.GetSelectedUnitsCount -- replaced in init
 
 local string_sub = string.sub
 local os_clock = os.clock
@@ -582,7 +582,7 @@ local function RefreshCommands()
 	if WG.Quotas then
 		tracy.ZoneBeginN("W:BuildMenu:RefreshCommands:Quotas")
 		local quotas = WG.Quotas.getQuotas()
-		for _, factoryID in ipairs(spGetSelectedUnits()) do
+		for _, factoryID in ipairs(getSelectedUnits()) do
 			if quotas[factoryID] then
 				for uDefID, quotaValue in pairs(quotas[factoryID]) do
 					cellQuotas[uDefID] = {
@@ -743,9 +743,9 @@ function widget:Update(dt)
 				or selBuilderDefsTemp1
 			clearTable(currentSelBuilderDefs)
 
-			SelectedUnitsCount = spGetSelectedUnitsCount()
-			if SelectedUnitsCount > 0 then
-				local sel = Spring.GetSelectedUnits()
+			selectedUnitsCount = getSelectedUnitsCount()
+			if selectedUnitsCount > 0 then
+				local sel = getSelectedUnits()
 				for _, unitID in ipairs(sel) do
 					local uDefID = spGetUnitDefID(unitID)
 					if units.isFactory[uDefID] then
@@ -1259,7 +1259,7 @@ function drawBuildmenu()
 	tracy.ZoneBeginN("W:BuildMenu:DrawBuildmenu:Buildable")
 	local finishedBuildable = {}
 	if selectedFactoryCount > 0 then
-		for _, unitID in ipairs(spGetSelectedUnits()) do
+		for _, unitID in ipairs(getSelectedUnits()) do
 			local defID = spGetUnitDefID(unitID)
 			if units.isFactory and units.isFactory[defID] and not spGetUnitIsBeingBuilt(unitID) then
 				local opts = unitBuildOptions[defID]
@@ -1899,7 +1899,7 @@ function widget:GameFrame(n)
 		return
 	end
 	local finishedCount = 0
-	for _, unitID in ipairs(spGetSelectedUnits()) do
+	for _, unitID in ipairs(getSelectedUnits()) do
 		local defID = spGetUnitDefID(unitID)
 		if units.isFactory and units.isFactory[defID] then
 			if not spGetUnitIsBeingBuilt(unitID) then
@@ -1921,7 +1921,7 @@ local function setPreGamestartDefID(uDefID)
 end
 
 local function isOnQuotaBuildMode(targetDefID)
-	for _, unitID in ipairs(spGetSelectedUnits()) do
+	for _, unitID in ipairs(getSelectedUnits()) do
 		local uDefID = spGetUnitDefID(unitID)
 		if units.isFactory[uDefID] and table.contains(unitBuildOptions[uDefID], targetDefID) then
 			return WG.Quotas and WG.Quotas.isOnQuotaMode(unitID)
@@ -1933,7 +1933,7 @@ end
 local function updateQuotaNumber(unitDefID, count)
 	if WG.Quotas then
 		local quotaChanged = false
-		for _, builderID in ipairs(Spring.GetSelectedUnits()) do
+		for _, builderID in ipairs(getSelectedUnits()) do
 			local uDefID = spGetUnitDefID(builderID)
 			if units.isFactory[uDefID] and table.contains(unitBuildOptions[uDefID], unitDefID) then
 				local quotas = WG.Quotas.getQuotas()
@@ -2228,6 +2228,9 @@ local function bindBuildUnits(widget)
 end
 
 function widget:Initialize()
+	getSelectedUnits = WG.UnitSelection and WG.UnitSelection.GetUnits or Spring.GetSelectedUnits
+	getSelectedUnitsCount = WG.UnitSelection and WG.UnitSelection.GetCount or Spring.GetSelectedUnitsCount
+
 	refreshUnitDefs()
 
 	local blockedUnitsData = unitBlocking.getBlockedUnitDefs()
@@ -2258,7 +2261,7 @@ function widget:Initialize()
 	end
 
 	widget:ViewResize()
-	widget:SelectionChanged(spGetSelectedUnits())
+	widget:SelectionChanged(getSelectedUnits())
 
 	WG.buildmenu = {}
 	WG.buildmenu.getGroups = function()

--- a/luaui/Widgets/gui_given_units.lua
+++ b/luaui/Widgets/gui_given_units.lua
@@ -28,6 +28,7 @@ local spIsGUIHidden = Spring.IsGUIHidden
 local spGetUnitDefID = Spring.GetUnitDefID
 local spIsUnitInView = Spring.IsUnitInView
 local spGetCameraDirection = Spring.GetCameraDirection
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced in init
 
 local drawList
 local givenUnits = {}
@@ -83,6 +84,8 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:Initialize()
+	getSelectedUnits = WG.UnitSelection and WG.UnitSelection.GetUnits or Spring.GetSelectedUnits
+
 	if Spring.IsReplay() or spGetGameFrame() > 0 then
 		maybeRemoveSelf()
 	end
@@ -99,25 +102,23 @@ function widget:Update(dt)
 		sec = 0
 		if selectionChanged then
 			selectionChanged = nil
-			local selectedUnitsCount = Spring.GetSelectedUnitsSorted()
-			for uDID, unit in pairs(selectedUnitsCount) do
-				for i = 1, #unit do
-					local unitID = unit[i]
-					if givenUnits[unitID] then
-						local currentAlpha = 1
-							- (
-								(os.clock() - (givenUnits[unitID].osClock + (timeoutTime - timeoutFadeTime)))
-								/ timeoutFadeTime
-							)
-						if currentAlpha > 1 then
-							currentAlpha = 1
-						end
-						givenUnits[unitID].selected = os.clock() - (selectedFadeTime * (1 - currentAlpha))
-						--givenUnits[unitID].selectedGameSecs = Spring.GetGameSeconds() + UnitDefs[spGetUnitDefID(unitID)].selfDCountdown
-					else
-						-- uncomment line below for testing
-						-- AddGivenUnit(unitID)
+			local selectedUnits = getSelectedUnits()
+			for i = 1, #selectedUnits do
+				local unitID = selectedUnits[i]
+				if givenUnits[unitID] then
+					local currentAlpha = 1
+						- (
+							(os.clock() - (givenUnits[unitID].osClock + (timeoutTime - timeoutFadeTime)))
+							/ timeoutFadeTime
+						)
+					if currentAlpha > 1 then
+						currentAlpha = 1
 					end
+					givenUnits[unitID].selected = os.clock() - (selectedFadeTime * (1 - currentAlpha))
+					--givenUnits[unitID].selectedGameSecs = Spring.GetGameSeconds() + UnitDefs[spGetUnitDefID(unitID)].selfDCountdown
+				else
+					-- uncomment line below for testing
+					-- AddGivenUnit(unitID)
 				end
 			end
 		end

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -30,7 +30,6 @@ local spGetCmdDescIndex = Spring.GetCmdDescIndex
 local spGetActiveCommand = Spring.GetActiveCommand
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitIsBeingBuilt = Spring.GetUnitIsBeingBuilt
-local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 
 local math_floor = math.floor
@@ -44,6 +43,8 @@ local GL_ONE = GL.ONE
 
 local CMD_OPT_CTRL = CMD.OPT_CTRL
 local CMD_OPT_SHIFT = CMD.OPT_SHIFT
+
+local getSelectedUnitsByDefID = Spring.GetSelectedUnitsSorted -- replaced in init
 
 -------------------------------------------------------------------------------
 --- STATIC VALUES
@@ -635,7 +636,7 @@ local function updateQuotaNumber(unitDefID, quantity)
 	end
 	local cellRect = cellRects[cellId]
 	if WG.Quotas then
-		for _, builderID in ipairs(Spring.GetSelectedUnitsSorted()[activeBuilder]) do
+		for _, builderID in ipairs(getSelectedUnitsByDefID()[activeBuilder]) do
 			local quotas = WG.Quotas.getQuotas()
 			quotas[builderID] = quotas[builderID] or {}
 			quotas[builderID][unitDefID] = quotas[builderID][unitDefID] or 0
@@ -1209,7 +1210,7 @@ local function setPregameBlueprint(uDefID)
 end
 
 local function queueUnit(uDefID, opts, quantity)
-	local sel = spGetSelectedUnitsSorted()
+	local sel = getSelectedUnitsByDefID()
 	for unitDefID, unitIds in pairs(sel) do
 		if units.isFactory[unitDefID] then
 			for _, uid in ipairs(unitIds) do
@@ -1366,7 +1367,7 @@ end
 ---@param index number
 ---@return nil
 local function setActiveBuilder(index, selectedUnitsSorted)
-	selectedUnitsSorted = selectedUnitsSorted or spGetSelectedUnitsSorted()
+	selectedUnitsSorted = selectedUnitsSorted or getSelectedUnitsByDefID()
 
 	for i = 1, maxBuilderRects do
 		local rect = builderRects[i]
@@ -1414,6 +1415,8 @@ local function cycleBuilder()
 end
 
 function widget:Initialize()
+	getSelectedUnitsByDefID = WG.unit_selection and WG.unit_selection.GetUnitsByDefID or Spring.GetSelectedUnitsSorted
+
 	refreshUnitDefs()
 
 	local blockedUnitsData = unitBlocking.getBlockedUnitDefs()
@@ -3241,7 +3244,7 @@ function widget:SelectionChanged(newSel)
 
 	-- Here we do selected sorted to save the GetUnitDefIDs we would have to do
 	-- if we used the newSel
-	local selectedUnitsSorted = spGetSelectedUnitsSorted()
+	local selectedUnitsSorted = getSelectedUnitsByDefID()
 	for unitDefID, unitIDs in pairs(selectedUnitsSorted) do
 		if units.isBuilder[unitDefID] then
 			selectedBuilders[unitDefID] = #unitIDs

--- a/luaui/Widgets/gui_info.lua
+++ b/luaui/Widgets/gui_info.lua
@@ -96,19 +96,13 @@ local anonymousName = "?????"
 local dlistGuishader, bgpadding, ViewResizeUpdate, texOffset, displayMode
 local loadedFontSize, font, font2, font2, cfgDisplayUnitID, cfgDisplayUnitDefID, rankTextures
 local cellRect, cellPadding, cornerSize, cellsize, cellHovered
-local gridHeight, selUnitsSorted, selUnitsCounts, selectionCells, customInfoArea, contentPadding
+local gridHeight, selUnitsSorted, selectionCells, customInfoArea, contentPadding
 local displayUnitID, displayUnitDefID, doUpdateClock
 local contentWidth, bfcolormap, selUnitTypes
 
 local RectRound, UiElement, UiUnit, elementCorner
 
 local spGetCurrentTooltip = Spring.GetCurrentTooltip
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetSelectedUnitsCounts = Spring.GetSelectedUnitsCounts
-local spGetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
-local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
-local SelectedUnitsCount = Spring.GetSelectedUnitsCount()
-local selectedUnits = Spring.GetSelectedUnits()
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetFeatureDefID = Spring.GetFeatureDefID
 local spTraceScreenRay = Spring.TraceScreenRay
@@ -146,6 +140,13 @@ local GL_ONE_MINUS_SRC_ALPHA = GL.ONE_MINUS_SRC_ALPHA
 local GL_ONE = GL.ONE
 
 local hideBuildlist
+
+local selUnitsCounts = {} -- per-def counts, filled alongside selUnitsSorted
+local selectedUnitsCount = 0
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced in init via api_unit_selection
+local getSelectedUnitsCount = Spring.GetSelectedUnitsCount
+local getSelectedUnitsByDefID = function() end
+local invalidateSelection = function() end
 
 -- Reverse armor type table
 local armorIndex = {}
@@ -851,6 +852,12 @@ function widget:Initialize()
 	tracy.ZoneBeginN("W:Info:Initialize")
 	isPregame = Spring.GetGameFrame() < 1
 
+	local api = WG.UnitSelection
+	getSelectedUnits = api and api.GetUnits or Spring.GetSelectedUnits
+	getSelectedUnitsCount = api and api.GetCount or Spring.GetSelectedUnitsCount
+	getSelectedUnitsByDefID = api and api.GetUnitsByDefID or Spring.GetSelectedUnitsSorted
+	invalidateSelection = api and api.Invalidate or function() end
+
 	tracy.ZoneBeginN("W:Info:Initialize:RefreshUnitInfo")
 	refreshUnitInfo()
 	tracy.ZoneEnd()
@@ -976,7 +983,7 @@ function widget:Update(dt)
 
 	-- Early exit for common case
 	if not alwaysShow and ((cameraPanMode and not doUpdate) or mouseOffScreen) and not isPregame then
-		if SelectedUnitsCount == 0 then
+		if selectedUnitsCount == 0 then
 			if dlistGuishader then
 				WG.guishader.DeleteDlist("info")
 				dlistGuishader = nil
@@ -1051,7 +1058,7 @@ function widget:Update(dt)
 		displayUnitDefID = nil
 	end
 
-	if not alwaysShow and (cameraPanMode or mouseOffScreen) and SelectedUnitsCount == 0 and not isPregame then
+	if not alwaysShow and (cameraPanMode or mouseOffScreen) and selectedUnitsCount == 0 and not isPregame then
 		tracy.ZoneEnd()
 		return
 	end
@@ -1217,8 +1224,7 @@ end
 local function drawSelection()
 	tracy.ZoneBeginN("W:Info:DrawSelection")
 	tracy.ZoneBeginN("W:Info:DrawSelection:Query")
-	selUnitsCounts = spGetSelectedUnitsCounts()
-	selUnitsSorted = spGetSelectedUnitsSorted()
+	selUnitsSorted = getSelectedUnitsByDefID()
 	selUnitTypes = 0
 
 	-- Reuse existing table instead of creating new one
@@ -1231,12 +1237,18 @@ local function drawSelection()
 		end
 	end
 
+	-- Counts for every selected def, so the panel may not have a cell for each.
+	for uDefID in pairs(selUnitsCounts) do
+		selUnitsCounts[uDefID] = nil
+	end
+	for uDefID, unitsForDef in pairs(selUnitsSorted) do
+		selUnitsCounts[uDefID] = #unitsForDef
+	end
+
 	for k, uDefID in pairs(unitOrder) do
 		if selUnitsSorted[uDefID] then
-			if type(selUnitsSorted[uDefID]) == "table" then
-				selUnitTypes = selUnitTypes + 1
-				selectionCells[selUnitTypes] = uDefID
-			end
+			selUnitTypes = selUnitTypes + 1
+			selectionCells[selUnitTypes] = uDefID
 		end
 	end
 	tracy.ZoneEnd()
@@ -1250,7 +1262,7 @@ local function drawSelection()
 	font2:SetOutlineColor(0, 0, 0, 1)
 	font2:Print(
 		tooltipTextColor
-			.. #selectedUnits
+			.. selectedUnitsCount
 			.. tooltipLabelTextColor
 			.. "  "
 			.. getCachedTranslation("ui.info.unitsselected"),
@@ -1291,7 +1303,7 @@ local function drawSelection()
 	-- Limit to first 50 units to avoid frame drops during large selections
 	local totalMetalMake, totalMetalUse, totalEnergyMake, totalEnergyUse = 0, 0, 0, 0
 	local totalKills = 0
-	local unitsToCheck = cellHovered and selUnitsSorted[selectionCells[cellHovered]] or selectedUnits
+	local unitsToCheck = cellHovered and selUnitsSorted[selectionCells[cellHovered]] or getSelectedUnits()
 	local maxUnitsToCheck = math.min(50, #unitsToCheck)
 	tracy.ZoneBeginN("W:Info:DrawSelection:ResourceTotals")
 	for i = 1, maxUnitsToCheck do
@@ -1667,7 +1679,7 @@ local function drawUnitInfo()
 	tracy.ZoneBeginN("W:Info:DrawUnitInfo:Header")
 
 	local unitNameColor = tooltipTitleColor
-	if SelectedUnitsCount > 0 then
+	if selectedUnitsCount > 0 then
 		if
 			displayMode ~= "unitdef"
 			or (
@@ -2517,7 +2529,7 @@ local function drawEngineTooltip()
 			end
 		end
 	else
-		if cameraPanMode and #selectedUnits > 0 then
+		if cameraPanMode and selectedUnitsCount > 0 then
 			checkChanges()
 		else
 			emptyInfo = true
@@ -2585,8 +2597,8 @@ local function LeftMouseButton(unitDefID, unitTable)
 			spSelectUnitArray(units, shift)
 		end
 	end
-	selectedUnits = spGetSelectedUnits()
-	SelectedUnitsCount = spGetSelectedUnitsCount()
+	invalidateSelection()
+	selectedUnitsCount = getSelectedUnitsCount()
 	if acted then
 		Spring.PlaySoundFile(sound_button, 0.5, "ui")
 	end
@@ -2599,12 +2611,13 @@ local function MiddleMouseButton(unitDefID, unitTable)
 		Spring.SendCommands(viewSelectionCmd)
 	else
 		-- center the view on this type on unit
+		local previousSelection = getSelectedUnits()
 		spSelectUnitArray(unitTable)
 		Spring.SendCommands(viewSelectionCmd)
-		spSelectUnitArray(selectedUnits)
+		spSelectUnitArray(previousSelection)
 	end
-	selectedUnits = spGetSelectedUnits()
-	SelectedUnitsCount = spGetSelectedUnitsCount()
+	invalidateSelection()
+	selectedUnitsCount = getSelectedUnitsCount()
 	Spring.PlaySoundFile(sound_button, 0.5, "ui")
 end
 
@@ -2616,6 +2629,7 @@ local function RightMouseButton(unitDefID, unitTable)
 	for k in pairs(rightMouseButtonMap) do
 		rightMouseButtonMap[k] = nil
 	end
+	local selectedUnits = getSelectedUnits()
 	for i = 1, #selectedUnits do
 		rightMouseButtonMap[selectedUnits[i]] = true
 	end
@@ -2626,8 +2640,8 @@ local function RightMouseButton(unitDefID, unitTable)
 		end
 	end
 	spSelectUnitMap(rightMouseButtonMap)
-	selectedUnits = spGetSelectedUnits()
-	SelectedUnitsCount = spGetSelectedUnitsCount()
+	invalidateSelection()
+	selectedUnitsCount = getSelectedUnitsCount()
 	Spring.PlaySoundFile(sound_button2, 0.5, "ui")
 end
 
@@ -2796,7 +2810,7 @@ function widget:DrawScreen()
 	glBlending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 	local x, y, b, b2, b3, mouseOffScreen, cameraPanMode = spGetMouseState()
 
-	if not alwaysShow and (cameraPanMode or mouseOffScreen) and SelectedUnitsCount == 0 and not isPregame then
+	if not alwaysShow and (cameraPanMode or mouseOffScreen) and selectedUnitsCount == 0 and not isPregame then
 		if dlistGuishader then
 			WG.guishader.DeleteDlist("info")
 			dlistGuishader = nil
@@ -3179,10 +3193,10 @@ function checkChanges()
 		displayMode = "unit"
 		displayUnitID = hoverData
 		displayUnitDefID = spGetUnitDefID(displayUnitID)
-		if not displayUnitDefID and SelectedUnitsCount >= 1 then
-			if SelectedUnitsCount == 1 then
-				displayUnitID = selectedUnits[1]
-				displayUnitDefID = spGetUnitDefID(selectedUnits[1])
+		if not displayUnitDefID and selectedUnitsCount >= 1 then
+			if selectedUnitsCount == 1 then
+				displayUnitID = getSelectedUnits()[1]
+				displayUnitDefID = spGetUnitDefID(displayUnitID)
 			else
 				displayMode = "selection"
 			end
@@ -3232,9 +3246,9 @@ function checkChanges()
 		end
 
 		-- selected unit
-	elseif SelectedUnitsCount == 1 then
+	elseif selectedUnitsCount == 1 then
 		displayMode = "unit"
-		displayUnitID = selectedUnits[1]
+		displayUnitID = getSelectedUnits()[1]
 		if displayUnitID then
 			displayUnitDefID = spGetUnitDefID(displayUnitID)
 			if lastUpdateClock + 0.4 < os_clock() then
@@ -3243,7 +3257,7 @@ function checkChanges()
 			end
 		end
 		-- selection
-	elseif SelectedUnitsCount > 1 then
+	elseif selectedUnitsCount > 1 then
 		displayMode = "selection"
 
 		-- tooltip text
@@ -3279,19 +3293,14 @@ end
 
 function widget:SelectionChanged(sel)
 	tracy.ZoneBeginN("W:Info:SelectionChanged")
-	local newSelectedUnitsCount = spGetSelectedUnitsCount()
-	if SelectedUnitsCount ~= 0 and newSelectedUnitsCount == 0 then
+	local newSelectedUnitsCount = #sel
+	if selectedUnitsCount ~= 0 and newSelectedUnitsCount == 0 then
 		doUpdate = true
-		SelectedUnitsCount = 0
-		-- Clear existing table instead of creating new one
-		for i = #selectedUnits, 1, -1 do
-			selectedUnits[i] = nil
-		end
+		selectedUnitsCount = 0
 		clearSelectionUnitpicWarmQueue()
 	end
 	if newSelectedUnitsCount > 0 then
-		SelectedUnitsCount = newSelectedUnitsCount
-		selectedUnits = sel
+		selectedUnitsCount = newSelectedUnitsCount
 		queueSelectionUnitpicWarmFromSelection(sel)
 		-- Adaptive throttling: increase delay based on selection size
 		local throttleDelay = 0.01

--- a/luaui/Widgets/gui_ordermenu.lua
+++ b/luaui/Widgets/gui_ordermenu.lua
@@ -17,10 +17,10 @@ local mathCeil = math.ceil
 local mathFloor = math.floor
 
 -- Localized Spring API for performance
-local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetGameFrame = Spring.GetGameFrame
 local spGetViewGeometry = Spring.GetViewGeometry
 local spGetSpectatingState = Spring.GetSpectatingState
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced at init
 
 local keyConfig = VFS.Include("luaui/configs/keyboard_layouts.lua")
 local CustomFirestateDefs = VFS.Include("modules/custom_firestate_defs.lua")
@@ -29,7 +29,7 @@ local CANCEL_TARGET_CMD_ID = 34924
 local currentLayout
 
 local function resolveHotkeyTargetVirtualIndex(optWords)
-	local selectedUnits = spGetSelectedUnits()
+	local selectedUnits = getSelectedUnits()
 	if #selectedUnits == 0 then
 		return nil
 	end
@@ -194,7 +194,6 @@ local commandTextCache = {}
 -- Cached WAIT command state (computed once per refresh, not per drawCell call)
 local cachedWaitState = nil
 local hasWaitCommand = false
-local cachedFirstUnit = nil -- first selected unit, avoids spGetSelectedUnits() table alloc
 
 -- Cancel target button visibility tracking
 ---@type number
@@ -417,8 +416,7 @@ local function computeWaitState()
 		cachedWaitState = nil
 		return
 	end
-	-- Use cached first unit instead of calling spGetSelectedUnits() which allocates a large table
-	local ref = cachedFirstUnit
+	local ref = getSelectedUnits()[1]
 	if ref and Spring.ValidUnitID(ref) and Spring.FindUnitCmdDesc(ref, CMD.WAIT) then
 		local commandQueue
 		if isFactory[Spring.GetUnitDefID(ref)] then
@@ -455,6 +453,7 @@ local function refreshCommands()
 
 	-- cancelTargetLastState is kept current by SelectionChanged and by the poll in Update
 	local cancelTargetRelevant = cancelTargetLastState
+	local firstSelectedUnit = getSelectedUnits()[1]
 
 	local activeCmdDescs = spGetActiveCmdDescs()
 	for _, command in ipairs(activeCmdDescs) do
@@ -475,8 +474,8 @@ local function refreshCommands()
 					-- intentionally empty, no action to take
 				elseif isStateCommand[command.id] then
 					stateCommandsCount = stateCommandsCount + 1
-					if command.id == CMD.FIRE_STATE and cachedFirstUnit and Spring.ValidUnitID(cachedFirstUnit) then
-						local virtualIndex = OrderMenuFirestate.resolveVirtualIndex(cachedFirstUnit)
+					if command.id == CMD.FIRE_STATE and firstSelectedUnit and Spring.ValidUnitID(firstSelectedUnit) then
+						local virtualIndex = OrderMenuFirestate.resolveVirtualIndex(firstSelectedUnit)
 						stateCommandsTemp[stateCommandsCount] = virtualIndex
 								and OrderMenuFirestate.buildCmdDesc(command, virtualIndex)
 							or command
@@ -712,6 +711,8 @@ local function reloadBindings()
 end
 
 function widget:Initialize()
+	getSelectedUnits = WG.UnitSelection and WG.UnitSelection.GetUnits or Spring.GetSelectedUnits
+
 	OrderMenuFirestate.init({
 		onOrderGiven = function()
 			doUpdate = true
@@ -721,7 +722,7 @@ function widget:Initialize()
 	reloadBindings()
 	activeCommand = select(4, spGetActiveCommand())
 	widget:ViewResize()
-	widget:SelectionChanged(spGetSelectedUnits())
+	widget:SelectionChanged(getSelectedUnits())
 
 	WG.ordermenu = {}
 	WG.ordermenu.getPosition = function()
@@ -874,7 +875,7 @@ function widget:Update(dt)
 	if cancelTargetPollSec > 0.1 then
 		cancelTargetPollSec = 0
 		if #commands > 0 or alwaysShow then
-			local selected = Spring.GetSelectedUnits()
+			local selected = getSelectedUnits()
 			local hasTarget = selectionHasPriorityTarget(selected)
 			if hasTarget ~= cancelTargetLastState then
 				cancelTargetLastState = hasTarget
@@ -1852,9 +1853,6 @@ end
 function widget:SelectionChanged(sel)
 	clickCountDown = 2
 	clickedCellDesiredState = nil
-
-	-- Cache first selected unit to avoid spGetSelectedUnits() table allocation later
-	cachedFirstUnit = sel[1] or nil
 
 	-- Update cancel target state using the selection already provided here
 	cancelTargetLastState = selectionHasPriorityTarget(sel)

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -1564,6 +1564,8 @@ local pools = {
 -- each of which allocates a new Lua table with N entries (N = selected unit count).
 local frameSel = nil -- Cached array from Spring.GetSelectedUnits() (lazy, set on first use)
 local frameSelCount = 0 -- Cached count from Spring.GetSelectedUnitsCount() (set at start of DrawScreen)
+-- The per-frame cache sits atop the shared unit selections api, also.
+local getSelectedUnits
 
 -- Tracked-player selected-unit cache for PIP.
 -- Filled incrementally by selectedUnits call-ins; seeded once from WG allyselectedunits
@@ -2386,7 +2388,6 @@ local spFunc = {
 	GetUnitWorkerTask = Spring.GetUnitWorkerTask,
 	GetUnitCurrentBuildPower = Spring.GetUnitCurrentBuildPower,
 	ValidUnitID = Spring.ValidUnitID,
-	GetSelectedUnitsCount = Spring.GetSelectedUnitsCount,
 }
 
 -- Map/game constants
@@ -2628,7 +2629,7 @@ local buttons = {
 		tooltipActiveKey = "ui.pip.untrack",
 		command = "pip_track",
 		OnPress = function()
-			local selectedUnits = Spring.GetSelectedUnits()
+			local selectedUnits = getSelectedUnits()
 			if #selectedUnits > 0 then
 				-- Add selected units to tracking (or start tracking if not already)
 				if interactionState.areTracking then
@@ -8443,7 +8444,7 @@ local function IssueCommandAtPoint(cmdID, wx, wz, usingRMB, forceQueue, radius)
 	if id then
 		-- For LOAD_UNITS command, give order only to transport units
 		if cmdID == CMD.LOAD_UNITS then
-			local selectedUnits = Spring.GetSelectedUnits()
+			local selectedUnits = getSelectedUnits()
 			local transports = {}
 
 			-- Collect all transport units (using cache)
@@ -8485,7 +8486,7 @@ local function IssueCommandAtPoint(cmdID, wx, wz, usingRMB, forceQueue, radius)
 			if radius and radius > 0 then
 				-- For area LOAD_UNITS command, give order only to transport units individually
 				if cmdID == CMD.LOAD_UNITS then
-					local selectedUnits = Spring.GetSelectedUnits()
+					local selectedUnits = getSelectedUnits()
 
 					-- Give order to each transport unit individually (using cache)
 					-- This allows the engine to distribute targets naturally across multiple transports
@@ -9003,6 +9004,8 @@ function RegisterPipGlobalApis(pipApi)
 end
 
 function widget:Initialize()
+	getSelectedUnits = WG.UnitSelection and WG.UnitSelection.GetUnits or Spring.GetSelectedUnits
+
 	RebuildAllUnitsCache()
 
 	-- Avoid lazy texture loads stalling the first button-strip draw on hover.
@@ -14185,7 +14188,7 @@ local function DrawUnitsAndFeatures(cachedSelectedUnits)
 		if interactionState.trackingPlayerID then
 			selectedSet = GetTrackedPlayerSelections(interactionState.trackingPlayerID)
 		else
-			local selUnits2 = cachedSelectedUnits or Spring.GetSelectedUnits()
+			local selUnits2 = cachedSelectedUnits or getSelectedUnits()
 			local set = pools.selectedSet
 			if not set then
 				set = {}
@@ -15534,7 +15537,7 @@ local function DrawBuildCursorWithRotation()
 			local mexBuildings = WG.resource_spot_builder and WG.resource_spot_builder.GetMexBuildings()
 			if mexBuildings then
 				if not frameSel then
-					frameSel = Spring.GetSelectedUnits()
+					frameSel = getSelectedUnits
 				end
 				local selectedUnits = frameSel
 				local mexConstructors = WG.resource_spot_builder and WG.resource_spot_builder.GetMexConstructors()
@@ -16626,7 +16629,7 @@ end
 -- Called inside R2T context for the oversized unitsTex
 local function RenderExpensiveLayers()
 	if not frameSel then
-		frameSel = Spring.GetSelectedUnits()
+		frameSel = getSelectedUnits
 	end
 	local cachedSelectedUnits = frameSel
 
@@ -16716,7 +16719,7 @@ end
 local function RenderPipContents()
 	-- Use frame-cached selected units to avoid redundant API call
 	if not frameSel then
-		frameSel = Spring.GetSelectedUnits()
+		frameSel = getSelectedUnits
 	end
 	local cachedSelectedUnits = frameSel
 
@@ -19045,7 +19048,7 @@ local function HandleHoverAndCursor(mx, my)
 			if not defaultCmd or defaultCmd == 0 then
 				if frameSelCount > 0 then
 					if not frameSel then
-						frameSel = Spring.GetSelectedUnits()
+						frameSel = getSelectedUnits
 					end
 					local selectedUnits = frameSel
 					-- Check if hovering over an enemy unit with units that can attack
@@ -19095,7 +19098,7 @@ local function HandleHoverAndCursor(mx, my)
 			elseif defaultCmd == CMD.ATTACK and lastHoveredUnitID and not Spring.IsUnitAllied(lastHoveredUnitID) then
 				-- Hovering over enemy unit with units that can attack
 				if not frameSel then
-					frameSel = Spring.GetSelectedUnits()
+					frameSel = getSelectedUnits
 				end
 				if CanSelectedUnitsAttackTarget(frameSel, lastHoveredUnitID) then
 					Spring.SetMouseCursor("Attack")
@@ -19766,8 +19769,8 @@ function widget:DrawScreen()
 		pools.RunDeferredPipMaintenance(maintenanceDt)
 	end
 
-	-- Cache selected units count once per frame (avoids 5+ redundant GetSelectedUnits calls)
-	frameSelCount = spFunc.GetSelectedUnitsCount()
+	-- Cache unit selection once per frame: The draw path below reads it several times.
+	frameSelCount = getSelectedUnitsCount()
 	frameSel = nil -- Lazy: full array fetched only when needed
 
 	HandleHoverAndCursor(mx, my)
@@ -21286,10 +21289,7 @@ function widget:Update(dt)
 			end
 		-- No active command - check if we should highlight for transport loading or attack
 		elseif unitID then
-			if not frameSel then
-				frameSel = Spring.GetSelectedUnits()
-			end
-			local selectedUnits = frameSel
+			local selectedUnits = FrameSelectedUnits()
 			local shouldHighlight = false
 			local isAlly = Spring.IsUnitAllied(unitID)
 
@@ -22914,7 +22914,7 @@ function widget:DefaultCommand()
 			if Spring.IsUnitAllied(uID) then
 				return CMD.GUARD
 			else
-				if CanSelectedUnitsAttackTarget(Spring.GetSelectedUnits(), uID) then
+				if CanSelectedUnitsAttackTarget(getSelectedUnits(), uID) then
 					return CMD.ATTACK
 				end
 				return CMD.MOVE
@@ -23790,7 +23790,7 @@ function widget:MousePress(mx, my, mButton)
 			-- Button row
 			if my <= render.dim.b + render.usedButtonSize then
 				-- Calculate visible buttons
-				local selectedUnits = Spring.GetSelectedUnits()
+				local selectedUnits = getSelectedUnits()
 				local hasSelection = #selectedUnits > 0
 				local isTracking = interactionState.areTracking ~= nil
 				local isTrackingPlayer = interactionState.trackingPlayerID ~= nil
@@ -24001,7 +24001,7 @@ function widget:MousePress(mx, my, mButton)
 					else
 						-- Start box selection instead
 						-- Save current selection before starting box selection
-						interactionState.selectionBeforeBox = Spring.GetSelectedUnits()
+						interactionState.selectionBeforeBox = Spring.GetSelectedUnits() -- copied to outlive the event
 
 						interactionState.areBoxSelecting = true
 						interactionState.boxSelectStartX = mx
@@ -24053,7 +24053,7 @@ function widget:MousePress(mx, my, mButton)
 					if uID then
 						if Spring.IsUnitAllied(uID) then
 							-- Check if we should use LOAD_UNITS command
-							local selectedUnits = Spring.GetSelectedUnits()
+							local selectedUnits = getSelectedUnits()
 							local canLoadTarget = false
 
 							-- Check if any transport in selection can load this target unit
@@ -24082,7 +24082,7 @@ function widget:MousePress(mx, my, mButton)
 								overrideTarget = uID
 							end
 						else
-							if CanSelectedUnitsAttackTarget(Spring.GetSelectedUnits(), uID) then
+							if CanSelectedUnitsAttackTarget(getSelectedUnits(), uID) then
 								cmdID = CMD.ATTACK
 								overrideTarget = uID
 							else
@@ -24114,7 +24114,7 @@ function widget:MousePress(mx, my, mButton)
 						-- Start formation with world position
 						-- Note: third parameter is fromMinimap, not shift behavior
 						-- Check if we should queue commands (only for single unit)
-						local selectedUnits = Spring.GetSelectedUnits()
+						local selectedUnits = getSelectedUnits()
 						local shouldQueue = selectedUnits and #selectedUnits == 1
 
 						-- Don't set pipForceShift yet - first command should replace, not queue
@@ -24596,7 +24596,7 @@ function widget:MouseMove(mx, my, dx, dy, mButton)
 				local _, ctrl, _, shift = Spring.GetModKeyState()
 				if ctrl then
 					-- Deselect mode
-					local currentSelection = Spring.GetSelectedUnits()
+					local currentSelection = getSelectedUnits()
 					local newSelection = {}
 					local unitsToDeselect = {}
 					local boxCount = #unitsInBox
@@ -24847,7 +24847,7 @@ function widget:MouseRelease(mx, my, mButton)
 				if ctrl then
 					-- Ctrl+click: toggle selection
 					if spFunc.IsUnitSelected(uID) then
-						local currentSelection = Spring.GetSelectedUnits()
+						local currentSelection = getSelectedUnits()
 						local newSelection = {}
 						for i = 1, #currentSelection do
 							if currentSelection[i] ~= uID then
@@ -24908,7 +24908,7 @@ function widget:MouseRelease(mx, my, mButton)
 
 			if interactionState.areBoxDeselecting then
 				-- Final deselection - remove units in box from current selection
-				local currentSelection = Spring.GetSelectedUnits()
+				local currentSelection = getSelectedUnits()
 				local newSelection = {}
 				-- Create a set for fast lookup of units to deselect
 				local unitsToDeselect = {}
@@ -24950,7 +24950,7 @@ function widget:MouseRelease(mx, my, mButton)
 					-- Ctrl+click: toggle selection (add if not selected, remove if selected)
 					if spFunc.IsUnitSelected(uID) then
 						-- Deselect it
-						local currentSelection = Spring.GetSelectedUnits()
+						local currentSelection = getSelectedUnits()
 						local newSelection = {}
 						for i = 1, #currentSelection do
 							if currentSelection[i] ~= uID then
@@ -25105,7 +25105,7 @@ function widget:MouseRelease(mx, my, mButton)
 			if uID then
 				if Spring.IsUnitAllied(uID) then
 					-- Check if we should use LOAD_UNITS command
-					local selectedUnits = Spring.GetSelectedUnits()
+					local selectedUnits = getSelectedUnits()
 					local canLoadTarget = false
 
 					-- Check if any transport in selection can load this target unit
@@ -25122,7 +25122,7 @@ function widget:MouseRelease(mx, my, mButton)
 						cmdID = CMD.GUARD
 					end
 				else
-					if CanSelectedUnitsAttackTarget(Spring.GetSelectedUnits(), uID) then
+					if CanSelectedUnitsAttackTarget(getSelectedUnits(), uID) then
 						cmdID = CMD.ATTACK
 					else
 						cmdID = CMD.MOVE

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -19770,7 +19770,7 @@ function widget:DrawScreen()
 	end
 
 	-- Cache unit selection once per frame: The draw path below reads it several times.
-	frameSelCount = getSelectedUnitsCount()
+	frameSelCount = Spring.GetSelectedUnitsCount()
 	frameSel = nil -- Lazy: full array fetched only when needed
 
 	HandleHoverAndCursor(mx, my)
@@ -21289,7 +21289,10 @@ function widget:Update(dt)
 			end
 		-- No active command - check if we should highlight for transport loading or attack
 		elseif unitID then
-			local selectedUnits = FrameSelectedUnits()
+			if not frameSel then
+				frameSel = getSelectedUnits
+			end
+			local selectedUnits = frameSel
 			local shouldHighlight = false
 			local isAlly = Spring.IsUnitAllied(unitID)
 

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -1564,8 +1564,7 @@ local pools = {
 -- each of which allocates a new Lua table with N entries (N = selected unit count).
 local frameSel = nil -- Cached array from Spring.GetSelectedUnits() (lazy, set on first use)
 local frameSelCount = 0 -- Cached count from Spring.GetSelectedUnitsCount() (set at start of DrawScreen)
--- The per-frame cache sits atop the shared unit selections api, also.
-local getSelectedUnits
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced at init
 
 -- Tracked-player selected-unit cache for PIP.
 -- Filled incrementally by selectedUnits call-ins; seeded once from WG allyselectedunits

--- a/luaui/Widgets/gui_pip.lua
+++ b/luaui/Widgets/gui_pip.lua
@@ -9,7 +9,7 @@ pipNumber = pipNumber or 1
 
 -- Special mode flags
 local isMinimapMode = (pipNumber == 0) -- When pipNumber == 0, act as minimap replacement
-local minimapModeMinZoom = nil -- Calculated zoom to fit entire map (only used in minimap mode)
+local minimapModeMinZoom = nil ---@type boolean? Calculated zoom to fit entire map (only used in minimap mode)
 local pipModeMinZoom = nil -- Dynamic min zoom calculated from PIP/map dimensions (normal PIP mode)
 
 -- Minimap mode API state (updated each frame, avoids per-frame closure allocations)
@@ -97,7 +97,7 @@ local function getActionHotkey(action)
 		return ""
 	end
 	-- Find shortest hotkey
-	local key = hotkeys[1]
+	local key = hotkeys[1] ---@type string
 	for i = 2, #hotkeys do
 		if hotkeys[i]:len() < key:len() then
 			key = hotkeys[i]
@@ -305,7 +305,7 @@ local state = {
 
 -- Consolidated rendering state
 local render = {
-	uiScale = tonumber(Spring.GetConfigFloat("ui_scale", 1) or 1),
+	uiScale = tonumber(Spring.GetConfigFloat("ui_scale", 1.0)) or 1.0,
 	vsx = nil,
 	vsy = nil,
 	widgetScale = nil,
@@ -644,6 +644,7 @@ local pipTV = {
 -- TV Mode: Add an event to the ring buffer
 -- type: 'combat', 'explosion', 'death', 'finished', 'marker'
 function pipTV.AddEvent(x, z, weight, eventType)
+	---@cast miscState.tvEnabled boolean
 	if not miscState.tvEnabled then
 		return
 	end
@@ -663,6 +664,7 @@ function pipTV.AddEvent(x, z, weight, eventType)
 	ev.weight = weight or 1
 	ev.time = os.clock()
 	ev.type = eventType or "combat"
+	---@cast pipTV.eventCount integer
 	if pipTV.eventCount < maxEv then
 		pipTV.eventCount = pipTV.eventCount + 1
 	end
@@ -688,7 +690,7 @@ function pipTV.BuildHotspots(now)
 	-- Process each event, merge into nearby hotspot or create new one
 	local events = pipTV.events
 	for i = 1, pipTV.eventCount do
-		local ev = events[i]
+		local ev = events[i] ---@type table?
 		if ev then
 			local age = now - ev.time
 			if age < decayTime and (not losFilter or Spring.IsPosInLos(ev.x, 0, ev.z, losFilter)) then
@@ -745,7 +747,7 @@ function pipTV.GetVarietyBonus(x, z, now)
 	local varietyRadius = config.tvHotspotRadius * 2
 	local varietyRadiusSq = varietyRadius * varietyRadius
 	for i = 1, pipTV.director.visitedCount do
-		local v = visited[i]
+		local v = visited[i] ---@type table?
 		if v then
 			local age = now - v.time
 			if age < 30 then -- 30s memory for visited areas
@@ -780,6 +782,7 @@ function pipTV.RecordVisit(x, z)
 	v.x = x
 	v.z = z
 	v.time = os.clock()
+	---@cast dir.visitedCount integer
 	if dir.visitedCount < 20 then
 		dir.visitedCount = dir.visitedCount + 1
 	end
@@ -933,11 +936,11 @@ function pipTV.ScanAnticipation(now)
 	-- Weight scales with target cost: T1 buildings (200-500) → 1.5, T2 eco/factories (1000+) → 3.0+
 	tracy.ZoneBeginN("W:PIP:TV:AirRaidPairs")
 	for i = 1, airAttackerCount do
-		local aa = airAttackers[i]
+		local aa = airAttackers[i] ---@type table
 		local bestWeight = 0
 		local bestX, bestZ
 		for j = 1, hvbCount do
-			local hv = highValueBuildings[j]
+			local hv = highValueBuildings[j] ---@type table
 			if hv.ally ~= aa.ally then -- Different alliance = enemy
 				local dx = aa.x - hv.x
 				local dz = aa.z - hv.z
@@ -962,9 +965,9 @@ function pipTV.ScanAnticipation(now)
 	-- Check low-HP commanders near enemy ground units
 	tracy.ZoneBeginN("W:PIP:TV:CommanderDanger")
 	for i = 1, lowHPCommanderCount do
-		local lc = lowHPCommanders[i]
+		local lc = lowHPCommanders[i] ---@type table
 		for j = 1, groundCount do
-			local gp = groundUnitPositions[j]
+			local gp = groundUnitPositions[j] ---@type table
 			if gp.ally ~= lc.ally then
 				local dx = lc.x - gp.x
 				local dz = lc.z - gp.z
@@ -982,9 +985,9 @@ function pipTV.ScanAnticipation(now)
 	-- Check low-HP expensive eco buildings near enemy ground units
 	tracy.ZoneBeginN("W:PIP:TV:EcoDanger")
 	for i = 1, lowHPEcoCount do
-		local le = lowHPEcoBuildings[i]
+		local le = lowHPEcoBuildings[i] ---@type table
 		for j = 1, groundCount do
-			local gp = groundUnitPositions[j]
+			local gp = groundUnitPositions[j] ---@type table
 			if gp.ally ~= le.ally then
 				local dx = le.x - gp.x
 				local dz = le.z - gp.z

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -13,7 +13,6 @@ function widget:GetInfo()
 end
 
 -- Localized Spring API for performance
-local spGetSelectedUnits = Spring.GetSelectedUnits
 local spGetUnitTeam = Spring.GetUnitTeam
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitPosition = Spring.GetUnitPosition
@@ -80,8 +79,8 @@ local GL_POINTS = GL.POINTS
 local selUnits = {}
 local nextSelUnits = {}
 local updateSelection = true
-local selectedUnits = spGetSelectedUnits()
-local pendingSelectedUnits = nil
+local selectedUnits = {}
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced in init
 local drawCallinsEnabled = true
 
 local unitTeam = {}
@@ -404,8 +403,7 @@ local function RemovePrimitive(unitID, noUpload, skipDrawCallinUpdate)
 	end
 end
 
-function widget:SelectionChanged(sel)
-	pendingSelectedUnits = sel
+function widget:SelectionChanged()
 	updateSelection = true
 end
 
@@ -466,8 +464,7 @@ function widget:Update(dt)
 	end
 
 	if updateSelection then
-		selectedUnits = pendingSelectedUnits or spGetSelectedUnits()
-		pendingSelectedUnits = nil
+		selectedUnits = getSelectedUnits()
 		updateSelection = false
 
 		local oldSelUnits = selUnits
@@ -708,6 +705,8 @@ local function init()
 end
 
 function widget:Initialize()
+	getSelectedUnits = WG.UnitSelection and WG.UnitSelection.GetUnits or Spring.GetSelectedUnits
+
 	if not gl.CreateShader then -- no shader support, so just remove the widget itself, especially for headless
 		widgetHandler:RemoveWidget()
 		return

--- a/luaui/Widgets/gui_transport_weight_limit.lua
+++ b/luaui/Widgets/gui_transport_weight_limit.lua
@@ -18,8 +18,9 @@ local mathCos = math.cos
 
 -- Localized Spring API for performance
 local spGetUnitDefID = Spring.GetUnitDefID
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
+
+-- Replaced in init via selection api
+local getSelectedUnits, getSelectedUnitsCount = Spring.GetSelectedUnits, Spring.GetSelectedUnitsCount
 
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
@@ -95,12 +96,14 @@ local function DrawCircleLine()
 	end)
 end
 
-local selectedUnits = {}
-local selectedUnitsCount = 0
-
 function widget:Initialize()
-	selectedUnits = spGetSelectedUnits()
-	selectedUnitsCount = spGetSelectedUnitsCount()
+	if WG.UnitSelection then
+		getSelectedUnits = WG.UnitSelection.GetUnits
+		getSelectedUnitsCount = WG.UnitSelection.GetCount
+	else
+		getSelectedUnits = Spring.GetSelectedUnits
+		getSelectedUnitsCount = Spring.GetSelectedUnitsCount
+	end
 	circleList = gl.CreateList(DrawCircleLine)
 end
 
@@ -108,9 +111,7 @@ function widget:Shutdown()
 	gl.DeleteList(circleList)
 end
 
-function widget:SelectionChanged(sel)
-	selectedUnits = sel
-	selectedUnitsCount = spGetSelectedUnitsCount()
+function widget:SelectionChanged()
 	unitsToDraw = {}
 end
 
@@ -119,6 +120,7 @@ function widget:GameFrame(n)
 		return
 	end
 
+	local selectedUnitsCount = getSelectedUnitsCount()
 	if selectedUnitsCount < 1 or selectedUnitsCount > 20 then
 		return
 	end
@@ -131,7 +133,8 @@ function widget:GameFrame(n)
 	end
 
 	activeTransportDefs = {}
-	for i = 1, #selectedUnits do
+	local selectedUnits = getSelectedUnits()
+	for i = 1, selectedUnitsCount do
 		local transID = selectedUnits[i]
 		local transDefID = spGetUnitDefID(transID)
 

--- a/luaui/Widgets/gui_turret_trans_range.lua
+++ b/luaui/Widgets/gui_turret_trans_range.lua
@@ -28,7 +28,7 @@ local color
 --------------------------------------------------------------------------------
 local CMD_UNLOAD_UNITS = CMD.UNLOAD_UNITS
 local spGetActiveCmd = Spring.GetActiveCommand
-local GetSelectedUnitsSorted = Spring.GetSelectedUnitsSorted
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced in init
 local glColor = gl.Color
 local glLineWidth = gl.LineWidth
 local glDrawGroundCircle = gl.DrawGroundCircle
@@ -64,6 +64,10 @@ local function DrawNanoRange(x, y, z, range)
 	glLineWidth(1)
 end
 
+function widget:Initialize()
+	getSelectedUnits = WG.UnitSelection and WG.UnitSelection.GetUnits or Spring.GetSelectedUnits
+end
+
 function widget:UnitLoaded(unitID, unitDefID, teamID, transportID)
 	if isTransportableBuilding[unitDefID] then
 		range = turretRange[unitDefID]
@@ -84,16 +88,15 @@ function widget:DrawWorldPreUnit()
 	if cmdId ~= CMD_UNLOAD_UNITS then
 		return
 	end
-	local sel = GetSelectedUnitsSorted()
+	local sel = getSelectedUnits()
 	local ranges = {}
-	for _, unitIds in pairs(sel) do
-		for _, unitId in pairs(unitIds) do
-			if transportWithBuilding[unitId] then
-				table.insert(ranges, {
-					unitDefID = transportWithBuilding[unitId],
-					range = turretRange[transportWithBuilding[unitId]],
-				})
-			end
+	for i = 1, #sel do
+		local unitId = sel[i]
+		if transportWithBuilding[unitId] then
+			table.insert(ranges, {
+				unitDefID = transportWithBuilding[unitId],
+				range = turretRange[transportWithBuilding[unitId]],
+			})
 		end
 	end
 	if #ranges == 0 then

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -21,8 +21,6 @@ local tableSort = table.sort
 local tableSortStable = table.sortStable
 
 -- Localized Spring API for performance
-local spGetSelectedUnits = Spring.GetSelectedUnits
-local spGetSelectedUnitsCount = Spring.GetSelectedUnitsCount
 local spGetSpectatingState = Spring.GetSpectatingState
 
 local texts = {}
@@ -105,6 +103,7 @@ include("keysym.h.lua")
 -- Globals
 ------------------------------------------------------------------------------------
 local useSelection = true
+local getSelectedUnits = Spring.GetSelectedUnits -- replaced in init
 
 local customFontSize = 14
 local fontSize = customFontSize
@@ -444,6 +443,12 @@ local function disableStats()
 end
 
 function widget:Initialize()
+	if WG.UnitSelection then
+		getSelectedUnits = WG.UnitSelection.GetUnits
+	else
+		getSelectedUnits = Spring.GetSelectedUnits
+	end
+
 	texts = BAR.I18N("ui.unitstats")
 
 	widget:ViewResize(vsx, vsy)
@@ -498,14 +503,6 @@ function widget:ViewResize(n_vsx, n_vsy)
 	invalidateContent()
 end
 
-local selectedUnits = spGetSelectedUnits()
-local selectedUnitsCount = spGetSelectedUnitsCount()
-if useSelection then
-	function widget:SelectionChanged(sel)
-		selectedUnits = sel
-		selectedUnitsCount = spGetSelectedUnitsCount()
-	end
-end
 
 local function computeContent(uDefID, uID, shiftBool)
 	local shift = shiftBool
@@ -1269,7 +1266,8 @@ function widget:DrawScreen()
 		uID = unitID
 	end
 	if useSelection then
-		if selectedUnitsCount >= 1 then
+		local selectedUnits = getSelectedUnits()
+		if selectedUnits[1] then
 			uID = selectedUnits[1]
 		end
 	end

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -503,7 +503,6 @@ function widget:ViewResize(n_vsx, n_vsy)
 	invalidateContent()
 end
 
-
 local function computeContent(uDefID, uID, shiftBool)
 	local shift = shiftBool
 
@@ -868,10 +867,11 @@ local function computeContent(uDefID, uID, shiftBool)
 		end
 
 		if range > 0 then
-			local oRld = max(0.00000000001, uWep.stockpile == true and uWep.stockpileTime/30 or uWep.reload)
-			if uID and useExp and not ((uWep.stockpile and uWep.stockpileTime)) then
-				oRld = spGetUnitWeaponState(uID, weaponNumber, "reloadTimeXP") or
-				       spGetUnitWeaponState(uID, weaponNumber, "reloadTime")   or oRld
+			local oRld = max(0.00000000001, uWep.stockpile == true and uWep.stockpileTime / 30 or uWep.reload)
+			if uID and useExp and not (uWep.stockpile and uWep.stockpileTime) then
+				oRld = spGetUnitWeaponState(uID, weaponNumber, "reloadTimeXP")
+					or spGetUnitWeaponState(uID, weaponNumber, "reloadTime")
+					or oRld
 			end
 
 			local wpnName = uWep.description
@@ -989,12 +989,21 @@ local function computeContent(uDefID, uID, shiftBool)
 						local duration = custom.area_onhit_time
 						dps = max(dps + areaDps, areaDps * duration / dpsCycle)
 					end
-					damageString = texts.dps.." = "..(format(yellow .. "%d", dps))..white.."; "..texts.burst.." = "..(format(yellow .. "%d", burstDamage)) .. white .. (wepCount > 1 and (" ("..texts.each..").") or ("."))
+					damageString = texts.dps
+						.. " = "
+						.. (format(yellow .. "%d", dps))
+						.. white
+						.. "; "
+						.. texts.burst
+						.. " = "
+						.. (format(yellow .. "%d", burstDamage))
+						.. white
+						.. (wepCount > 1 and (" (" .. texts.each .. ").") or ".")
 					-- Smart priority weapons should use the same weapon group number. But they should not add up their combined damages/DPS.
 					-- This is lazy for not verifying that the display group numbers are matching; assume the weapon set is set up correctly.
 					if not (hasSmartPriority and isWeaponBackup[wDefId]) then
-						totaldps = totaldps + wepCount*dps
-						totalbDamages = totalbDamages + wepCount* burstDamage
+						totaldps = totaldps + wepCount * dps
+						totalbDamages = totalbDamages + wepCount * burstDamage
 					end
 				end
 				DrawText(texts.dmg .. ":", damageString)

--- a/luaui/Widgets/unit_dgun_stall_assist.lua
+++ b/luaui/Widgets/unit_dgun_stall_assist.lua
@@ -14,6 +14,7 @@ end
 
 -- Localized Spring API for performance
 local spGetGameFrame = Spring.GetGameFrame
+local getSelectedUnitsByDefID = Spring.GetSelectedUnitsSorted -- replaced in init
 
 local watchForTime = 3 --How long to monitor the energy level after the dgun command is given
 
@@ -25,6 +26,27 @@ local targetEnergy = 0
 local waitedUnits = nil -- nil / waitedUnits[1..n] = uID
 local shouldWait = {}
 local isFactory = {}
+
+-- The energy a def's manual fire costs, with a margin.
+local manualFireEnergy = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	if unitDef.canManualFire then
+		for _, weaponDef in pairs(unitDef.wDefs) do
+			if weaponDef.manualFire and weaponDef.energyCost and weaponDef.energyCost > 0 then
+				manualFireEnergy[unitDefID] = weaponDef.energyCost * 1.2
+				break
+			end
+		end
+	end
+end
+
+local function selectedManualFireEnergy()
+	for unitDefID in pairs(getSelectedUnitsByDefID()) do
+		if manualFireEnergy[unitDefID] then
+			return manualFireEnergy[unitDefID]
+		end
+	end
+end
 
 local gameStarted
 
@@ -67,6 +89,8 @@ function widget:PlayerChanged(playerID)
 end
 
 function widget:Initialize()
+	getSelectedUnitsByDefID = WG.UnitSelection and WG.UnitSelection.GetUnitsByDefID or Spring.GetSelectedUnitsSorted
+
 	if Spring.IsReplay() or spGetGameFrame() > 0 then
 		maybeRemoveSelf()
 	end
@@ -84,24 +108,9 @@ end
 function widget:Update(dt)
 	local _, activeCmdID = spGetActiveCommand()
 	if activeCmdID == CMD_DGUN then
-		local selection = Spring.GetSelectedUnitsCounts()
-		local stallUnitSelected = false
-
-		for uDefID, _ in next, selection do
-			local uDef = UnitDefs[uDefID]
-			if uDef and uDef.canManualFire then
-				--Look for the weapondef with manual fire and energy cost
-				for _, wDef in next, uDef.wDefs do
-					if wDef.manualFire and wDef.energyCost and wDef.energyCost > 0 then
-						stallUnitSelected = true
-						targetEnergy = wDef.energyCost * 1.2 --Add some margin above the energy cost
-						break
-					end
-				end
-			end
-		end
-
-		if stallUnitSelected then
+		local energy = selectedManualFireEnergy()
+		if energy then
+			targetEnergy = energy
 			watchTime = watchForTime
 		end
 	else


### PR DESCRIPTION
### Work done

Small API for unit selections. Some widgets were getting the selected units array up to five times per frame, while others were already efficiently caching this result. This takes a single unit selection update and reuses it while it remains unchanged.

Performance gains are predictably small. This does almost nothing but reduce allocations to a single instance. That optimization tends to come into effect when it's most useful, handling massive unit selections in late game.

A few widgets were easily optimized on this approach, though. Dgun stall assist was not precached well and now runs a light loop over a memoized result.

The API allows widgets to register their own cached unitdef results and reuse them. This is mostly used in the area commands filters to distribute targets fairly to the units that can execute the actual order. Unit capabilities are not fully checked on every selection change, since this includes units dying etc, instead relying on the load being relatively low from consumers as long as GetUnitDefID callouts are minimized.

Working well in my tests but my micro-benchmark rig doesn't give me very good alloc stats.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>