### PR TITLE
Added GUI to gui_spectatingstats.lua

### DIFF
--- a/luaui/Widgets/gui_spectatingstats.lua
+++ b/luaui/Widgets/gui_spectatingstats.lua
@@ -12,16 +12,49 @@ function widget:GetInfo()
 	}
 end
 
-local lastupdate = os.clock() - 10
-local allyTeamList = Spring.GetAllyTeamList()
-local numAllyTeams = #allyTeamList - 1
-local allyTeamName = {}
-local textcolor = "\255\200\200\200"
-
+local vsx, vsy = Spring.GetViewGeometry()
+local fps = Game.gameSpeed
 local spGetUnitDefID = Spring.GetUnitDefID
+local spIsGUIHidden = Spring.IsGUIHidden
+local glCreateList = gl.CreateList
+local glDeleteList = gl.DeleteList
+local glCallList = gl.CallList
+local glTranslate = gl.Translate
+local glPushMatrix = gl.PushMatrix
+local glPopMatrix = gl.PopMatrix
+local ceil = math.ceil
+local floor = math.floor
+local subString = string.sub
+local flowUIDrawElement
+local exo2Font
 local isSinglePlayer = BAR.Utilities.Gametype.IsSinglePlayer()
 
-local ColorString = BAR.Utilities.Color.ToString
+local updateIntervalSeconds = 1.5
+local titles = {"Units", "Army", "(DPS)", "Defenses", "(DPS)", "Builders", "(BP)"}
+local numColumns = #titles
+local columnWidths = {}
+local titleFontSize = 17
+local statsFontSize = 16
+local titleFontHeight = 0
+local statsFontHeight = 0
+local titleColor = {1, 1, 1, 1}--White
+local verticalPadding = 9
+local horizontalPadding = 9
+local columnGap = 8
+local titleRowMarginBottom = 12
+local statsRowMarginBottom = 4
+
+local allyTeams = {}
+local numAllyTeams = 0
+-- average color of all member teams
+local allyTeamColors = {}
+local lastUpdate = os.clock() - 10
+local displayList
+-- bottom left corner
+local posX, posY = vsx*0.72, vsy*0.68
+local sizeX, sizeY = 0, 0
+-- whether the user is holding mouse down on the UI box
+local mouseDepressed = false
 
 local weaponShowGroups = { ["0"] = true, ["1"] = true }
 local weaponHideRoles = { secondary = true }
@@ -48,7 +81,7 @@ end
 
 local unitdefMobileDps = {}
 local unitdefStaticDps = {}
-local unitdefBuildespeed = {}
+local unitdefBuildSpeed = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
 	local totalDps = 0
 	local weapons = unitDef.weapons
@@ -75,32 +108,75 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 		end
 	end
 	if unitDef.buildSpeed > 0 then
-		unitdefBuildespeed[unitDefID] = unitDef.buildSpeed
+		unitdefBuildSpeed[unitDefID] = unitDef.buildSpeed
 	end
 end
 
 function widget:Initialize()
+	
 	if not Spring.GetSpectatingState() and not isSinglePlayer then
 		widgetHandler:RemoveWidget()
 	end
+	
+	local gaiaAllyTeamID
+	if Spring.GetGaiaTeamID() then
+		gaiaAllyTeamID = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID()))
+	end
+	
+	for _, allyTeamId in ipairs(Spring.GetAllyTeamList()) do
+		if allyTeamId ~= gaiaAllyTeamID then
+			allyTeams[#allyTeams+1] = allyTeamId
+			numAllyTeams = numAllyTeams + 1
+			
+			local red, green, blue = 0, 0, 0
+			local numTeamsOnAllyTeam = 0
+			
+			for _, teamId in ipairs(Spring.GetTeamList(allyTeamId)) do
+				-- color average computed using squares (https://youtu.be/LKnqECcg6Gw)
+				local teamRed, teamGreen, teamBlue = Spring.GetTeamColor(teamId)
+				red = red + teamRed ^ 2
+				green = green + teamGreen ^ 2
+				blue = blue + teamBlue ^ 2
+				numTeamsOnAllyTeam = numTeamsOnAllyTeam + 1
+			end
+			
+			-- r g b a = 1 2 3 4
+			local averageColor = {math.sqrt(red/numTeamsOnAllyTeam), math.sqrt(green/numTeamsOnAllyTeam), math.sqrt(blue/numTeamsOnAllyTeam), 1}
+			allyTeamColors[allyTeamId] = averageColor
+		end
+	end
+	
+	vsx, vsy = Spring.GetViewGeometry()
+	widget:ViewResize(vsx, vsy)
+	
+	statsFontHeight = exo2Font:GetTextHeight("0.00Q") * statsFontSize
+	local maxStatWidth = exo2Font:GetTextWidth("0.00M") * statsFontSize
+	for i = 1, numColumns do
+		local title = titles[i]
+		local titleWidth = exo2Font:GetTextWidth(title) * titleFontSize
+		columnWidths[i] = math.max(titleWidth, maxStatWidth)
+		titleFontHeight = math.max(exo2Font:GetTextHeight(title) * titleFontSize, titleFontHeight)
+	end
+	
 end
 
-local function GetAllyTeamStats(allyTeamID)
-	local teamlist = Spring.GetTeamList(allyTeamID)
+function widget:ViewResize(vs_x, vs_y)
+	vsx = vs_x
+	vsy = vs_y
+	flowUIDrawElement = WG.FlowUI.Draw.Element
+	exo2Font = WG.fonts.getFont("fonts/Exo2-SemiBold.otf")
+end
+
+local function getAllyTeamStats(allyTeamID)
+	local teamList = Spring.GetTeamList(allyTeamID)
 	local unitCount = 0
 	local armyCount = 0
 	local armyDps = 0
 	local defenseCount = 0
 	local defenseDps = 0
 	local builders = 0
-	local buildspeed = 0
-	if not allyTeamName[allyTeamID] then
-		local _, playerID, _, isAiTeam = Spring.GetTeamInfo(teamlist[1], false)
-		local name = (WG.playernames and WG.playernames.getPlayername) and WG.playernames.getPlayername(playerID)
-			or Spring.GetPlayerInfo(playerID, false)
-		allyTeamName[allyTeamID] = ColorString(Spring.GetTeamColor(teamlist[1])) .. name
-	end
-	for i, teamID in ipairs(teamlist) do
+	local buildSpeed = 0
+	for i, teamID in ipairs(teamList) do
 		local units = Spring.GetTeamUnits(teamID)
 		unitCount = unitCount + #units
 		for _, unitID in ipairs(units) do
@@ -112,42 +188,118 @@ local function GetAllyTeamStats(allyTeamID)
 				defenseCount = defenseCount + 1
 				defenseDps = defenseDps + unitdefStaticDps[unitDefID]
 			end
-			if unitdefBuildespeed[unitDefID] then
+			if unitdefBuildSpeed[unitDefID] then
 				builders = builders + 1
-				buildspeed = buildspeed + unitdefBuildespeed[unitDefID]
+				buildSpeed = buildSpeed + unitdefBuildSpeed[unitDefID]
 			end
 		end
 	end
-	return unitCount, armyCount, armyDps, defenseCount, defenseDps, builders, buildspeed
+	return unitCount, armyCount, armyDps, defenseCount, defenseDps, builders, buildSpeed
+end
+
+local scaleSuffixes = {"", "K", "M", "B", "T", "q", "Q", "s", "S", "O", "N"}
+local function formatNumber(number)
+	local i = 1
+	while number >= 1000 do
+		number = number / 1000
+		i = i + 1
+	end
+	local endIndex = number >= 100 and 3 or 4
+	return subString(tostring(number), 1, endIndex) .. (scaleSuffixes[i] or "-")
+end
+
+local function buildDisplayList()
+	
+	local scale = Spring.GetConfigFloat("ui_scale", 1)
+	local scaledTitleFontHeight = ceil(titleFontHeight * scale)
+	local scaledStatsFontHeight = ceil(statsFontHeight * scale)
+	local scaledHorizontalPadding = ceil(horizontalPadding * scale)
+	local scaledVerticalPadding = ceil(verticalPadding * scale)
+	local scaledColumnGap = ceil(columnGap * scale)
+	local scaledTitleRowMarginBottom = ceil(titleRowMarginBottom * scale)
+	local scaledStatsRowMarginBottom = ceil(statsRowMarginBottom * scale)
+	local scaledColumnWidths = {}
+	local scaledTotalWidth = 0
+	for i = 1, numColumns, 1 do
+		local scaledColumnWidth = ceil(columnWidths[i] * scale)
+		scaledColumnWidths[i] = scaledColumnWidth
+		scaledTotalWidth = scaledTotalWidth + scaledColumnWidth
+	end
+	scaledTotalWidth = scaledTotalWidth + (2 * scaledHorizontalPadding) + (scaledColumnGap * (numColumns - 1))
+	local scaledTotalHeight = (2 * scaledVerticalPadding) + scaledTitleFontHeight + scaledTitleRowMarginBottom +
+						((scaledStatsFontHeight + scaledStatsRowMarginBottom) * numAllyTeams) - scaledStatsRowMarginBottom
+	
+	sizeX = scaledTotalWidth
+	sizeY = scaledTotalHeight
+	
+	glDeleteList(displayList)
+	displayList = glCreateList(function ()
+		
+		flowUIDrawElement(1e-6, 1e-6, scaledTotalWidth, scaledTotalHeight)
+		
+		local yBaseline = scaledVerticalPadding
+		for i = 1, numAllyTeams do
+			local allyTeamID = allyTeams[i]
+			local allyTeamColor = allyTeamColors[allyTeamID]
+			exo2Font:SetTextColor(allyTeamColor)
+			local allyTeamStats = {getAllyTeamStats(allyTeamID)}
+			
+			local xRight = scaledTotalWidth - scaledHorizontalPadding
+			for j = numColumns, 1, -1 do
+				exo2Font:Print(formatNumber(allyTeamStats[j]), xRight, yBaseline, scaledStatsFontHeight, "xro")
+				xRight = xRight - scaledColumnWidths[j] - scaledColumnGap
+			end
+			
+			yBaseline = yBaseline + scaledStatsRowMarginBottom + statsFontSize
+		end
+		
+		exo2Font:SetTextColor(titleColor)
+		--yBaseline = yBaseline + scaledTitleRowMarginBottom - scaledStatsRowMarginBottom
+		yBaseline = scaledTotalHeight - scaledVerticalPadding - scaledTitleFontHeight
+		local xRight = scaledTotalWidth - scaledHorizontalPadding
+		for i = numColumns, 1, -1 do
+			exo2Font:Print(titles[i], xRight, yBaseline, scaledTitleFontHeight, "xro")
+			xRight = xRight - scaledColumnWidths[i] - scaledColumnGap
+		end
+		
+	end)
 end
 
 function widget:DrawScreen()
-	if lastupdate + 1 < os.clock() then
-		lastupdate = os.clock()
-		for i, allyTeamID in ipairs(allyTeamList) do
-			if i <= numAllyTeams then
-				local unitCount, armyCount, armyDps, defenseCount, defenseDps, builders, buildspeed =
-					GetAllyTeamStats(allyTeamID)
-				local text = string.format(
-					allyTeamName[allyTeamID]
-						.. textcolor
-						.. ": %d units, %d army (%d DPS), defenses %d (%d DPS), builders %d (%d bp)",
-					unitCount,
-					armyCount,
-					armyDps,
-					defenseCount,
-					defenseDps,
-					builders,
-					buildspeed
-				)
-				Spring.Echo(text)
-			end
-		end
+	if spIsGUIHidden() then
+		return
+	end
+	if lastUpdate + updateIntervalSeconds < os.clock() then
+		lastUpdate = os.clock()
+		buildDisplayList()
+	end
+	glPushMatrix()
+	glTranslate(posX, posY, 0)
+	glCallList(displayList)
+	glPopMatrix()
+end
+
+function widget:MousePress(x, y, button)
+	if button ~= 1 then
+		return false
+	end
+	x = x - posX
+	y = y - posY
+	if x >= 0 and x <= sizeX and y >= 0 and y <= sizeY then
+		mouseDepressed = true
+		return true
+	end
+	return false
+end
+
+function widget:MouseRelease(x, y, button)
+	mouseDepressed = false
+	return false
+end
+
+function widget:MouseMove(x, y, dx, dy, button)
+	if mouseDepressed then
+		posX = posX + dx
+		posY = posY + dy
 	end
 end
-
-function widget:GetConfigData()
-	return {}
-end
-
-function widget:SetConfigData(data) end

--- a/luaui/Widgets/gui_spectatingstats.lua
+++ b/luaui/Widgets/gui_spectatingstats.lua
@@ -13,7 +13,6 @@ function widget:GetInfo()
 end
 
 local vsx, vsy = Spring.GetViewGeometry()
-local fps = Game.gameSpeed
 local spGetUnitDefID = Spring.GetUnitDefID
 local spIsGUIHidden = Spring.IsGUIHidden
 local glCreateList = gl.CreateList
@@ -23,7 +22,6 @@ local glTranslate = gl.Translate
 local glPushMatrix = gl.PushMatrix
 local glPopMatrix = gl.PopMatrix
 local ceil = math.ceil
-local floor = math.floor
 local subString = string.sub
 local flowUIDrawElement
 local exo2Font


### PR DESCRIPTION
<!--
PR Template! Please make sure to give your PR a relevant title so a squash merge remains descriptive
If any commented sections are not relevant to this PR, remove them.
Please fill out the uncommented sections with any relevant information.
-->

### Work done

Adds a basic GUI to the spectator stats widget so that it is not just echoing stats to the console. The UI can be seen in the image below and can be moved around the screen by dragging it with the mouse. The numbers are abbreviated to 3 digits with suffixes such as "K", "M", "B", etc.


#### Addresses Issue(s)
- [#2172](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2172)

<!-- If relevant
#### Setup
Describe any setup requirements to test this work (Specific settings, widgets, etc))
-->

#### Test steps
- [ ] Load into a game as spectator and enable the widget to see it


### Screenshots:

#### Before:
<img width="657" height="35" alt="Image of console echo" src="https://github.com/user-attachments/assets/27985195-c88c-4c9a-b040-256ae0af32cb" />

#### After:
<img width="440" height="130" alt="Image of UI element (4 teams)" src="https://github.com/user-attachments/assets/07d0448c-21cf-4993-b428-04c773e45d00" />
<img width="442" height="93" alt="Image of UI element (2 teams)" src="https://github.com/user-attachments/assets/fef74233-423a-4780-a6d0-2ca19ad0166d" />


### AI / LLM usage statement:
No LLM was used.

