### PR TITLE
fix?: quotas with repeat mode

### DIFF
--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -382,9 +382,27 @@ function saveQueue(unitId, unitDef, groupNo)
 		unitQuotaIdx = WG.Quotas.isOnQuotaMode(unitId)
 	end
 
+	-- Quota-issued orders are saved separately but can't be distinguished from some player orders.
+	-- When a player alt-enqueues a build order to the front, then, we distinguish it by counting.
+	local quotaOrdersLeft = {}
+	local function isQuotaOrder(cmd)
+		if not (WG.Quotas and cmd.options.internal and cmd.options.alt) then
+			return false
+		end
+		local quotaDefID = -cmd.id
+		if not quotaOrdersLeft[quotaDefID] then
+			quotaOrdersLeft[quotaDefID] = WG.Quotas.getQuotaOrderCount(unitId, quotaDefID)
+		end
+		if quotaOrdersLeft[quotaDefID] > 0 then
+			quotaOrdersLeft[quotaDefID] = quotaOrdersLeft[quotaDefID] - 1
+			return true
+		end
+		return false
+	end
+
 	for i = #unitQ, 1, -1 do
-		if unitQ[i].id >= 0 or unitQ[i].options.internal and not unitQ[i].options.alt then -- We don't want to save these commands
-			table.remove(unitQ, i)
+		if unitQ[i].id >= 0 or (unitQ[i].options.internal and not unitQ[i].options.alt) or isQuotaOrder(unitQ[i]) then
+			table.remove(unitQ, i) -- We don't want to save these commands
 		else
 			unitQ[i].name = orderToName(unitQ[i].id)
 			unitQ[i].id = nil

--- a/luaui/Widgets/cmd_factoryqmanager.lua
+++ b/luaui/Widgets/cmd_factoryqmanager.lua
@@ -104,10 +104,10 @@ local renderPresets = false
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-local boxWidth
-local boxHeight
-local boxHeightTitle
-local boxIconBorder
+local boxWidth = 0
+local boxHeight = 0
+local boxHeightTitle = 0
+local boxIconBorder = 0
 
 local fontSizeTitle
 local fontSizeGroup

--- a/luaui/Widgets/gui_buildmenu.lua
+++ b/luaui/Widgets/gui_buildmenu.lua
@@ -866,9 +866,27 @@ function drawBuildmenuBg()
 	)
 end
 
+-- The player queue vs the widget-provided queue have different accounting due to quota mode.
+-- cellQuotas contains the live count from the widget, which we should remove from the total.
+local function getPlayerQueueCount(cellRectID, uDefID)
+	local queueCount = tonumber(cmds[cellRectID].params[1])
+	if not queueCount then
+		return nil
+	end
+	local quotaInfo = cellQuotas[uDefID]
+	if quotaInfo and WG.Quotas then
+		queueCount = queueCount - WG.Quotas.getQuotaOrderCount(quotaInfo.builderID, uDefID)
+	end
+	if queueCount < 1 then
+		return nil
+	end
+	return queueCount
+end
+
 local function drawCell(cellRectID, usedZoom, cellColor, disabled, underConstruction)
 	tracy.ZoneBeginN("W:BuildMenu:DrawCell")
 	local uDefID = -cmds[cellRectID].id
+	local queueCount = getPlayerQueueCount(cellRectID, uDefID)
 	local unitTexture = "#" .. uDefID
 	local cellRect = cellRects[cellRectID]
 	if not cellRect then
@@ -925,7 +943,7 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled, underConstruc
 				and (groups[units.unitGroup[uDefID]] and ":l" .. texprefix .. ":" .. groups[units.unitGroup[uDefID]] or nil)
 			or nil,
 		{ units.unitMetalCost[uDefID], units.unitEnergyCost[uDefID] },
-		tonumber(cmds[cellRectID].params[1])
+		queueCount
 	)
 	tracy.ZoneEnd()
 
@@ -1056,9 +1074,9 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled, underConstruc
 	end
 
 	-- factory queue number
-	if cmds[cellRectID].params[1] then
+	if queueCount then
 		local pad = math_floor(cellInnerSize * 0.03)
-		local textWidth = math_floor(font2:GetTextWidth(cmds[cellRectID].params[1] .. "  ") * cellInnerSize * 0.285)
+		local textWidth = math_floor(font2:GetTextWidth(queueCount .. "  ") * cellInnerSize * 0.285)
 		local pad2 = 0
 		RectRound(
 			cellRects[cellRectID][3] - cellPadding - iconPadding - textWidth - pad2,
@@ -1100,7 +1118,7 @@ local function drawCell(cellRectID, usedZoom, cellColor, disabled, underConstruc
 			{ 1, 1, 1, 0.1 }
 		)
 		font2:Print(
-			"\255\190\255\190" .. cmds[cellRectID].params[1],
+			"\255\190\255\190" .. queueCount,
 			cellRects[cellRectID][1] + cellPadding + math_floor(cellInnerSize * 0.96) - pad2,
 			cellRects[cellRectID][2] + cellPadding + math_floor(cellInnerSize * 0.735) - pad2,
 			cellInnerSize * 0.29,
@@ -2038,7 +2056,8 @@ function widget:MousePress(x, y, button)
 								end
 							end
 						else
-							local queueCount = tonumber(cmds[cellRectID].params[1] or 0)
+							-- Ignores the count from the quota widget.
+							local queueCount = getPlayerQueueCount(cellRectID, -uDefID) or 0
 
 							local function decreaseQuota()
 								if changeQuotas(-uDefID, modKeyMultiplier.right) and playSounds then

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -2186,6 +2186,13 @@ local function drawCell(rect)
 	local disabled = rect.opts.disabled
 	local underConstructionDim = backgroundRect.opts.builderUnderConstruction and not rect.opts.hovered and not disabled
 	local queuenr = rect.opts.queuenr
+	if queuenr and WG.Quotas then
+		-- Ignore the count from the quota widget.
+		queuenr = queuenr - WG.Quotas.getQuotaOrderCount(activeBuilderID, uid)
+		if queuenr < 1 then
+			queuenr = nil
+		end
+	end
 	local quotaNumber
 	if WG.Quotas and WG.Quotas.getQuotas()[activeBuilderID] and WG.Quotas.getQuotas()[activeBuilderID][uid] then
 		quotaNumber = WG.Quotas.getQuotas()[activeBuilderID][uid]
@@ -2938,7 +2945,9 @@ function widget:MousePress(x, y, button)
 							end
 
 							local isQuotaMode = WG.Quotas and WG.Quotas.isOnQuotaMode(activeBuilderID) and not alt
+							-- Ignore the count from the quota widget.
 							local queueCount = tonumber(cellRect.opts.queuenr or 0)
+								- (WG.Quotas and WG.Quotas.getQuotaOrderCount(activeBuilderID, unitDefID) or 0)
 							local quotas = WG.Quotas and WG.Quotas.getQuotas()
 							local currentQuota = (
 								quotas

--- a/luaui/Widgets/gui_gridmenu.lua
+++ b/luaui/Widgets/gui_gridmenu.lua
@@ -3213,10 +3213,10 @@ function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams, optio
 		return
 	end
 
-	-- If factory is in repeat, queue does not change, except if it is alt-queued
+	-- The queue does not change under repeat because the order is recycled to the back.
 	local factoryRepeat = select(4, Spring.GetUnitStates(unitID, false, true))
-
-	if factoryRepeat and not options.alt then
+	-- Internal orders are the exception; see `CFactoryCAI::DecreaseQueueCount`.
+	if factoryRepeat and not options.internal then
 		return
 	end
 

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -28,11 +28,12 @@ local unitToFactoryID = {} -- {[unitID] = factoryID, ...}
 -- - The engine marks an alt-queued factory build order internal, but only while repeat is on.
 -- - With repeat off, the internal bit reads as "quota order".
 -- - With repeat on, the internal bit reads as "quota or player priority order".
--- Track the tags of the orders we issue, instead.
+
 local quotaOrderTags = {}
 local quotaOrderCounts = {}
 local seenOrderTags = {}
 local unclaimedOrders = {}
+local unclaimedPasses = {}
 
 local possibleFactories = {}
 local factoryDefIDs = {}
@@ -103,6 +104,7 @@ local function trackQuotaOrders(factoryID)
 		quotaOrderCounts[factoryID] = nil
 		seenOrderTags[factoryID] = nil
 		unclaimedOrders[factoryID] = nil
+		unclaimedPasses[factoryID] = nil
 		return
 	end
 
@@ -137,7 +139,31 @@ local function trackQuotaOrders(factoryID)
 	quotaOrderTags[factoryID] = liveOwnedTags
 	quotaOrderCounts[factoryID] = counts
 	seenOrderTags[factoryID] = liveSeenTags
-	unclaimedOrders[factoryID] = nil
+
+	-- Keep a build order unclaimed for multiple passes so it continues to be pending.
+	if unclaimed and next(unclaimed) then
+		local passes = (unclaimedPasses[factoryID] or 0) + 1
+		if passes > 1 then
+			unclaimedOrders[factoryID] = nil
+			unclaimedPasses[factoryID] = nil
+		else
+			unclaimedPasses[factoryID] = passes
+		end
+	else
+		unclaimedOrders[factoryID] = nil
+		unclaimedPasses[factoryID] = nil
+	end
+end
+
+-- Whether a factory has any quota-issued build orders anywhere in its factory queue,
+-- including issued orders that have not arrived yet over the env/net/msg boogie wop.
+local function hasQuotaOrderPending(factoryID)
+	local counts = quotaOrderCounts[factoryID]
+	if counts and next(counts) then
+		return true
+	end
+	local unclaimed = unclaimedOrders[factoryID]
+	return (unclaimed and next(unclaimed)) ~= nil
 end
 
 -- Number of build orders in the factory's queue that this widget placed.
@@ -147,6 +173,8 @@ local function getQuotaOrderCount(factoryID, unitDefID)
 	return (counts and counts[unitDefID]) or 0
 end
 
+-- Check the head of the queue only to answer whether the factory can accept a quota order.
+-- Quota defers to enqueued-first commands that players issue (with alt) as a panic button.
 local function isFactoryUsable(factoryID)
 	local commandQueue = spGetFactoryCommands(factoryID, 2)
 	if not commandQueue then
@@ -188,12 +216,13 @@ local function appendToFactoryQueue(factoryID, unitDefID)
 	-- Claimed by tag on the next pass, once the order has reached the queue.
 	unclaimedOrders[factoryID] = unclaimedOrders[factoryID] or {}
 	unclaimedOrders[factoryID][unitDefID] = (unclaimedOrders[factoryID][unitDefID] or 0) + 1
+	unclaimedPasses[factoryID] = 0
 end
 
 local function fillQuotas()
 	for factoryID, quota in pairs(quotas) do
 		trackQuotaOrders(factoryID)
-		if isFactoryUsable(factoryID) then
+		if isFactoryUsable(factoryID) and not hasQuotaOrderPending(factoryID) then
 			for unitDefID, num in pairs(quota) do
 				if num == 0 then
 					quota[unitDefID] = nil
@@ -244,6 +273,7 @@ local function removeUnit(unitID, unitDefID, unitTeam)
 			quotaOrderCounts[unitID] = nil
 			seenOrderTags[unitID] = nil
 			unclaimedOrders[unitID] = nil
+			unclaimedPasses[unitID] = nil
 		end
 	end
 end

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -24,6 +24,16 @@ local quotas = {} -- {[factoryID] = {[unitDefID] = amount, ...}, ...}
 local builtUnits = {} -- {[factoryID] = {[unitDefID] = {[unitID] = true, ...}, ...}, ...}
 local unitToFactoryID = {} -- {[unitID] = factoryID, ...}
 
+-- Quota orders cannot be told apart from player orders by their options alone.
+-- - The engine marks an alt-queued factory build order internal, but only while repeat is on.
+-- - With repeat off, the internal bit reads as "quota order".
+-- - With repeat on, the internal bit reads as "quota or player priority order".
+-- Track the tags of the orders we issue, instead.
+local quotaOrderTags = {}
+local quotaOrderCounts = {}
+local seenOrderTags = {}
+local unclaimedOrders = {}
+
 local possibleFactories = {}
 local factoryDefIDs = {}
 local metalcosts = {}
@@ -86,6 +96,57 @@ local function getMostNeedQuota(quota, factoryID)
 	return minimumQuota, minimumUnitDefID
 end
 
+local function trackQuotaOrders(factoryID)
+	local commandQueue = spGetFactoryCommands(factoryID, -1)
+	if not commandQueue then
+		quotaOrderTags[factoryID] = nil
+		quotaOrderCounts[factoryID] = nil
+		seenOrderTags[factoryID] = nil
+		unclaimedOrders[factoryID] = nil
+		return
+	end
+
+	local ownedTags = quotaOrderTags[factoryID]
+	local seenTags = seenOrderTags[factoryID]
+	local unclaimed = unclaimedOrders[factoryID]
+
+	local liveOwnedTags = {}
+	local liveSeenTags = {}
+	local counts = {}
+
+	for i = 1, #commandQueue do
+		local command = commandQueue[i]
+		local unitDefID = -command.id
+		if unitDefID > 0 and command.options.internal then
+			local tag = command.tag
+			liveSeenTags[tag] = true
+
+			local isOurs = ownedTags and ownedTags[tag]
+			if not isOurs and not (seenTags and seenTags[tag]) and unclaimed and (unclaimed[unitDefID] or 0) > 0 then
+				unclaimed[unitDefID] = unclaimed[unitDefID] - 1
+				isOurs = true
+			end
+
+			if isOurs then
+				liveOwnedTags[tag] = unitDefID
+				counts[unitDefID] = (counts[unitDefID] or 0) + 1
+			end
+		end
+	end
+
+	quotaOrderTags[factoryID] = liveOwnedTags
+	quotaOrderCounts[factoryID] = counts
+	seenOrderTags[factoryID] = liveSeenTags
+	unclaimedOrders[factoryID] = nil
+end
+
+-- Number of build orders in the factory's queue that this widget placed.
+-- Subtract from the engine's queued count to get the count of orders by the player.
+local function getQuotaOrderCount(factoryID, unitDefID)
+	local counts = quotaOrderCounts[factoryID]
+	return (counts and counts[unitDefID]) or 0
+end
+
 local function isFactoryUsable(factoryID)
 	local commandQueue = spGetFactoryCommands(factoryID, 2)
 	if not commandQueue then
@@ -123,10 +184,15 @@ local function appendToFactoryQueue(factoryID, unitDefID)
 		{ insertPosition, -unitDefID, CMD_OPT_ALT + CMD_OPT_INTERNAL },
 		CMD_OPT_ALT + CMD_OPT_CTRL
 	)
+
+	-- Claimed by tag on the next pass, once the order has reached the queue.
+	unclaimedOrders[factoryID] = unclaimedOrders[factoryID] or {}
+	unclaimedOrders[factoryID][unitDefID] = (unclaimedOrders[factoryID][unitDefID] or 0) + 1
 end
 
 local function fillQuotas()
 	for factoryID, quota in pairs(quotas) do
+		trackQuotaOrders(factoryID)
 		if isFactoryUsable(factoryID) then
 			for unitDefID, num in pairs(quota) do
 				if num == 0 then
@@ -174,6 +240,10 @@ local function removeUnit(unitID, unitDefID, unitTeam)
 		elseif builtUnits[unitID] then
 			builtUnits[unitID] = nil
 			quotas[unitID] = nil
+			quotaOrderTags[unitID] = nil
+			quotaOrderCounts[unitID] = nil
+			seenOrderTags[unitID] = nil
+			unclaimedOrders[unitID] = nil
 		end
 	end
 end
@@ -207,6 +277,9 @@ function widget:Initialize()
 	end
 	WG.Quotas.isOnQuotaMode = function(unitID)
 		return isOnQuotaBuildMode(unitID)
+	end
+	WG.Quotas.getQuotaOrderCount = function(factoryID, unitDefID)
+		return getQuotaOrderCount(factoryID, unitDefID)
 	end
 end
 

--- a/luaui/Widgets/unit_factory_quota.lua
+++ b/luaui/Widgets/unit_factory_quota.lua
@@ -15,8 +15,8 @@ end
 -- Localized Spring API for performance
 local spGetMyTeamID = Spring.GetLocalTeamID
 
-local maxBuildProg = 0.075 -- maximum build progress that gets replaced in a repeat queue
-local maxMetal = 500 -- maximum metal cost that gets replaced in a repeat queue(7.5% of a juggernaut is still over 2k metal)
+local maxBuildProg = 0.075 -- maximum build progress that gets replaced
+local maxMetal = 500 -- maximum metal cost that gets replaced (7.5% of a juggernaut is still over 2k metal)
 
 -- factoryID is unitID of the factory
 local quotas = {} -- {[factoryID] = {[unitDefID] = amount, ...}, ...}


### PR DESCRIPTION
### Work done

Inelegant method of solution for separating the quota-mode and command-mode control planes for factory queues. Hopefully, after reviewing this, we can find a way to restructure this code to be more reasonable.

It has to take a lot of information into account: mixed unit selections, various build states, the build precedence of panic (alt) > quota > commanded, and the latency of widget commands. So the grossness might be built-in.

This should prevent bugs with repeat mode and mixed quota/commanded factory build orders.

Looking into the queue manager more, I'm unsure what role I would reduce it to, but it seems like it should be a thinner wrapper on more cleanly exposed methods from the quota widget. That may be true in general, including the build/grid menu widgets, then. I fixed it saving quota commands incorrectly when an alt-enqueued build order was also present in the factory queue.